### PR TITLE
Fix README dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,11 @@ Ensure the `nodetool` Conda environment is active.
 
 **Option A: Run Backend with Web UI (for Development)**
 
-This starts the backend server and serves the web UI directly. Hot-reloading is enabled.
+This command starts the backend server and serves the web UI directly with hot reloading enabled.
 
 ```bash
-# On macOS and Linux:
-./scripts/server
-
-# On Windows:
-.\scripts\server.bat
+# On macOS / Linux / Windows:
+nodetool serve
 ```
 
 Access the UI in your browser at `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- fix instructions for starting NodeTool during development

## Testing
- `npm test` *(fails: jest not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified and unified the instructions for running the backend server and web UI in development mode, providing a single cross-platform command and clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->