### PR TITLE
Use native Omit type

### DIFF
--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -14,7 +14,6 @@ import {
   TaskUpdate,
   PlanningUpdate
 } from "./ApiTypes";
-import { Omit } from "lodash";
 import { uuidv4 } from "./uuidv4";
 import { useAuth } from "./useAuth";
 import { useNotificationStore, Notification } from "./NotificationStore";


### PR DESCRIPTION
## Summary
- remove lodash Omit import and rely on TypeScript's built‑in `Omit`

## Testing
- `npm --prefix web run typecheck` *(fails: Cannot find module '@emotion/react', etc.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies to use the built-in TypeScript utility type, with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->