### PR TITLE
Prevent multiple edges per input

### DIFF
--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -94,7 +94,9 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
     onEdgesChange,
     onEdgeUpdate,
     shouldFitToScreen,
-    setShouldFitToScreen
+    setShouldFitToScreen,
+    validateConnection,
+    findNode
   } = useNodes((state) => ({
     nodes: state.nodes,
     edges: state.edges,
@@ -102,7 +104,9 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
     onEdgesChange: state.onEdgesChange,
     onEdgeUpdate: state.onEdgeUpdate,
     shouldFitToScreen: state.shouldFitToScreen,
-    setShouldFitToScreen: state.setShouldFitToScreen
+    setShouldFitToScreen: state.setShouldFitToScreen,
+    validateConnection: state.validateConnection,
+    findNode: state.findNode
   }));
   const { loadingState } = useWorkflowManager((state) => ({
     loadingState: state.getLoadingState(workflowId)
@@ -341,6 +345,13 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
         elevateEdgesOnSelect={true}
         connectionLineComponent={ConnectionLine}
         connectionRadius={settings.connectionSnap}
+        isValidConnection={(connection) => {
+          if (!connection.source || !connection.target) return true;
+          const src = findNode(connection.source);
+          const tgt = findNode(connection.target);
+          if (!src || !tgt) return false;
+          return validateConnection(connection, src, tgt);
+        }}
         attributionPosition="bottom-left"
         selectNodesOnDrag={settings.selectNodesOnDrag}
         onClick={handleClick}


### PR DESCRIPTION
## Summary
- block multiple connections to the same input handle
- enforce validation when reconnecting edges
- expose validation to ReactFlow via `isValidConnection`
- remove `ignoreEdgeId` option from `validateConnection`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/compat)*
- `npm run typecheck` *(fails: missing dependencies)*