### PR TITLE
Add noscroll class

### DIFF
--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -444,7 +444,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({ value }) => {
       case "boolean": {
         const boolStr = String(value).toUpperCase();
         return (
-          <div className="output value nodrag" css={styles}>
+          <div className="output value nodrag noscroll" css={styles}>
             <ButtonGroup className="actions">
               <Tooltip
                 title="Copy to Clipboard"
@@ -488,7 +488,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({ value }) => {
         );
       default:
         return (
-          <div className="output value nodrag" css={styles}>
+          <div className="output value nodrag noscroll" css={styles}>
             {value !== null && (
               <>
                 <ButtonGroup className="actions">

--- a/web/src/components/node/PlanningUpdateDisplay.tsx
+++ b/web/src/components/node/PlanningUpdateDisplay.tsx
@@ -48,7 +48,7 @@ const PlanningUpdateDisplay: React.FC<PlanningUpdateDisplayProps> = ({
 
   if (planningUpdate.status === "Failed") {
     return (
-      <div className="planning-update-container" css={styles}>
+      <div className="planning-update-container noscroll" css={styles}>
         <h3 className="ai-animated-heading">
           {planningUpdate.phase} <em>{planningUpdate.status}</em>
         </h3>
@@ -56,7 +56,7 @@ const PlanningUpdateDisplay: React.FC<PlanningUpdateDisplayProps> = ({
     );
   }
   return (
-    <div className="planning-update-container" css={styles}>
+    <div className="planning-update-container noscroll" css={styles}>
       <h3 className="ai-animated-heading">
         {planningUpdate.phase} <em>{planningUpdate.status}</em>
       </h3>

--- a/web/src/components/node/TaskView.tsx
+++ b/web/src/components/node/TaskView.tsx
@@ -30,7 +30,7 @@ interface TaskViewProps {
 
 const TaskView: React.FC<TaskViewProps> = ({ task }) => {
   return (
-    <div css={styles}>
+    <div css={styles} className="noscroll">
       <Paper className="task-container" elevation={1}>
         <Typography variant="h6" className="task-title">
           Task: {task.title}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -202,3 +202,11 @@ img::selection {
   background-color: white;
   opacity: 8%;
 }
+
+/* Hide scrollbars for text outputs */
+.noscroll {
+  scrollbar-width: none;
+}
+.noscroll::-webkit-scrollbar {
+  display: none;
+}

--- a/web/src/utils/MarkdownRenderer.tsx
+++ b/web/src/utils/MarkdownRenderer.tsx
@@ -99,7 +99,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   return (
     <>
       <div
-        className="output markdown"
+        className="output markdown noscroll"
         css={styles}
         ref={containerRef}
         tabIndex={0}


### PR DESCRIPTION
## Summary
- hide scrollbars for output text with `.noscroll`
- mark MarkdownRenderer output as noscroll
- mark OutputRenderer text containers as noscroll
- mark PlanningUpdate and Task views as noscroll

## Testing
- `npm test --silent` *(fails: jest not found)*