### PR TITLE
Fix FolderProperty refresh after folder creation

### DIFF
--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -276,6 +276,8 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     );
     get().add(folder);
     get().invalidateQueries(["assets", { parent_id: parent_id }]);
+    // Also invalidate the folder list so components like FolderProperty refresh
+    get().invalidateQueries(["assets", { content_type: "folder" }]);
     return folder;
   },
   /**


### PR DESCRIPTION
## Summary
- invalidate folder list query when creating a folder so FolderProperty updates

## Testing
- `npm run lint` *(fails: React hook order errors)*
- `npm run typecheck` *(fails: cannot find modules / TS errors)*