### PR TITLE
Fix eslint issues

### DIFF
--- a/electron/eslint.config.mjs
+++ b/electron/eslint.config.mjs
@@ -27,6 +27,7 @@ export default [
       "vite.config.ts",
       "dist-electron/**/*",
       "dist-web/**/*",
+      "jest.config.ts",
     ],
   },
   {

--- a/electron/src/__tests__/window.test.ts
+++ b/electron/src/__tests__/window.test.ts
@@ -5,9 +5,9 @@ import { setMainWindow, getMainWindow } from '../state';
 import { isAppQuitting } from '../main';
 
 // Mocking dependencies
-jest.mock('electron', () => {
-  return require('../__mocks__/electron');
-});
+import * as electronMock from '../__mocks__/electron';
+
+jest.mock('electron', () => electronMock);
 
 jest.mock('../logger', () => ({
   logMessage: jest.fn(),

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -255,16 +255,13 @@ const typeFor = (value: any): string => {
 };
 
 const OutputRenderer: React.FC<OutputRendererProps> = ({ value }) => {
-  // Do not render anything for undefined, null, empty string, empty array or empty object
-  if (
+  const shouldRender = !(
     value === undefined ||
     value === null ||
     (typeof value === "string" && value.trim() === "") ||
     (Array.isArray(value) && value.length === 0) ||
     (typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0)
-  ) {
-    return null;
-  }
+  );
 
   const { writeClipboard } = useClipboard();
   const addNotification = useNotificationStore(
@@ -522,7 +519,12 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({ value }) => {
           </div>
         );
     }
+
   }, [value, type, onDoubleClickAsset, handleCopyToClipboard]);
+
+  if (!shouldRender) {
+    return null;
+  }
 
   return (
     <>

--- a/web/src/hooks/handlers/useDropHandler.ts
+++ b/web/src/hooks/handlers/useDropHandler.ts
@@ -126,8 +126,6 @@ export const useDropHandler = () => {
     [
       reactFlow,
       user,
-      findNode,
-      isGroup,
       createNode,
       addNode,
       getAsset,


### PR DESCRIPTION
## Summary
- ignore `jest.config.ts` during linting
- avoid using `require` in tests
- ensure hooks run consistently in `OutputRenderer`
- clean up dependencies array in `useDropHandler`

## Testing
- `npm run lint` in electron
- `npm run lint` in web
- `npm run lint` in apps