### PR TITLE
Add navigation README files

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,8 @@
+# Apps
+
+Mini-app frontends built with React and Vite. These packages allow shipping simplified UI wrappers around NodeTool workflows.
+
+* **src** - components and stores for app UIs
+* `index.html` - entry point
+
+Install dependencies with `npm install` and build with `npm run build`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation Site
+
+This folder contains the Jekyll site used for NodeTool's public documentation.
+
+The `api` and `getting-started.md` guides live here along with assets.

--- a/electron/README.md
+++ b/electron/README.md
@@ -1,0 +1,8 @@
+# Electron
+
+Desktop wrapper for NodeTool. Starts the Python backend and serves the bundled web UI.
+
+* **src** - main and preload processes
+* **resources** - icons and other assets used during packaging
+
+Use `npm start` for development after building the web and apps UIs.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# NodeTool API Examples
+
+Simple Node.js scripts demonstrating how to run workflows via the NodeTool HTTP and WebSocket APIs.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+# Build and Release Scripts
+
+Helper scripts used to publish NodeTool packages and generate changelogs.
+
+* `changelog.py` - update CHANGELOG from git tags
+* `release.py` - create release archives

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,9 @@
+# Web
+
+This directory contains the React based editor that powers the NodeTool web interface.
+
+* **src** - application source code with components, stores and context providers.
+* **public** - static assets served by Vite.
+* **index.html** - entry point for development.
+
+Run `npm install` then `npm start` to develop locally. Build with `npm run build`.

--- a/workflow_runner/README.md
+++ b/workflow_runner/README.md
@@ -1,0 +1,5 @@
+# Workflow Runner Demo
+
+A minimal static UI showing how to trigger NodeTool workflows via browser JavaScript.
+
+Files here demonstrate WebSocket integration with the backend.


### PR DESCRIPTION
## Summary
- document web editor folder
- describe apps directory
- outline electron wrapper
- add docs site README
- document scripts and workflow runner examples

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` in `apps` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
