### PR TITLE
Add folder READMEs

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,15 @@
+# Apps
+
+This package contains the code for building standalone mini-apps from NodeTool workflows.
+It is a Vite + React project that shares components with the main web editor.
+The compiled assets are bundled with the Electron desktop app so users can run
+custom apps outside of the full editor.
+
+Key folders:
+
+- `src/components` – React components used across generated apps
+- `src/stores` – Zustand stores for app state management
+- `src/styles` – Shared styling for app UIs
+
+Run `npm start` during development to launch a local server. Use `npm run build`
+to produce a static build that can be packaged with Electron.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+This directory contains the sources for the NodeTool documentation site. The site
+is built with Jekyll and published to <https://nodetool.ai>.
+
+Key locations:
+
+- `index.md` – landing page for the docs site
+- `getting-started.md` – quick start guide for new users
+- `api/` – reference for the HTTP and WebSocket APIs
+- `assets/` – images and static files used in the documentation
+
+Run `bundle exec jekyll serve` from this folder to preview the docs locally.

--- a/electron/README.md
+++ b/electron/README.md
@@ -1,0 +1,14 @@
+# Electron Desktop App
+
+This folder contains the Electron wrapper that packages NodeTool into a desktop application.
+It bundles the web editor and apps into a cross-platform executable and adds
+native integrations such as the system tray, file access, and auto-updates.
+
+Key folders:
+
+- `src/` – main process code and preload scripts
+- `assets/` – icons and other static resources used by Electron
+- `resources/` – templates and additional files bundled into the app
+
+Run `npm start` to launch the desktop app in development mode. Use `npm run build`
+to produce a distributable package.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Examples
+
+Small Node.js scripts demonstrating how to interact with the NodeTool API.
+These samples show running a workflow via HTTP streaming or through the
+WebSocket runner.
+
+- `run_workflow_streaming.js` – uses HTTP long polling / streaming
+- `run_workflow_websocket.js` – communicates with a worker over WebSockets
+
+Run the examples with `node <script>` after starting a local NodeTool server.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# Scripts
+
+Utility scripts used during development and release.
+
+- `changelog.py` – generates the CHANGELOG from git history
+- `release.py` – bumps version numbers and builds release artifacts
+- `release/` – helper scripts invoked by CI during publishing
+
+These scripts are typically executed manually by maintainers.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,15 @@
+# Web UI
+
+This folder contains the React/TypeScript code for the NodeTool visual editor.
+The application is built with Vite and ReactFlow and provides the drag‑and‑drop
+interface for creating and running workflows.
+
+Important paths:
+
+- `src/` – all front-end source code
+- `src/components/` – reusable UI components
+- `src/stores/` – state management with custom stores
+- `public/` – static assets served by the dev server
+
+Use `npm start` to run the editor locally. Production builds are generated with
+`npm run build` and then packaged with the Electron app.

--- a/workflow_runner/README.md
+++ b/workflow_runner/README.md
@@ -1,0 +1,14 @@
+# Workflow Runner
+
+A lightweight web interface that connects to the NodeTool backend via WebSockets.
+It can be served as a static page and is used by the desktop app to display
+workflow progress and chat logs during execution.
+
+Files:
+
+- `index.html` – entry point for the runner UI
+- `js/` – frontend logic for connecting to the WebSocket API
+- `styles/` – simple styling for the runner page
+
+Open `index.html` in a browser after starting the NodeTool server to see live
+workflow updates.


### PR DESCRIPTION
## Summary
- document the purpose of top-level directories with new README files

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps` *(fails: cannot find module `@eslint/compat`)*
- `npm run typecheck` in `apps` *(fails: missing type definitions)*
- `npm test` in `apps` *(fails: jest not found)*
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`