### PR TITLE
Load Supabase and API config from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,19 @@ pip install git+https://github.com/nodetool-ai/nodetool-huggingface --extra-inde
 
 _Note:_ Some packs like `nodetool-huggingface` may require specific PyTorch versions or CUDA drivers. Use the `--extra-index-url` when necessary.
 
-### 4. Run NodeTool Backend & Web UI
+### 4. Configure Environment Variables
+
+Create a `.env` file inside the `web` directory (you can copy `web/.env.example` as a starting point). Set the following variables to match your deployment:
+
+```bash
+VITE_API_URL=http://localhost:8000            # URL of the NodeTool API server
+VITE_SUPABASE_URL=https://your-supabase.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+These variables are loaded by Vite at build time and allow you to point the UI at a different backend or Supabase project without changing the source code.
+
+### 5. Run NodeTool Backend & Web UI
 
 Ensure the `nodetool` Conda environment is active.
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables for NodeTool web UI
+# Copy this file to `.env` and adjust the values for your deployment.
+
+# Base URL of the NodeTool API server
+VITE_API_URL=http://localhost:8000
+
+# Supabase credentials used for authentication
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -1,12 +1,22 @@
 import { createClient } from "@supabase/supabase-js";
 
-// TODO: Move these to environment variables (.env file and deployment settings)
-const supabaseUrl = "https://zmytgmyiwfmdajmxjbag.supabase.co";
-const supabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InpteXRnbXlpd2ZtZGFqbXhqYmFnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU4NTkyMTQsImV4cCI6MjA2MTQzNTIxNH0.vlsrFP-nQzfeg2pftlKoVejollw_3AK7YI80jRGsSkA";
+/**
+ * Create the Supabase client using credentials from environment variables.
+ * The variables should be provided in a Vite-compatible `.env` file or
+ * through the deployment environment. This keeps sensitive data out of
+ * the repository and allows easy configuration for different deployments.
+ */
+
+const supabaseUrl: string | undefined = process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey: string | undefined = process.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error("Supabase URL and Anon Key must be provided.");
+  console.warn(
+    "Supabase credentials not found in environment. Using test placeholders."
+  );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(
+  supabaseUrl ?? "http://localhost",
+  supabaseAnonKey ?? "public-anon-key"
+);

--- a/web/src/stores/ApiClient.ts
+++ b/web/src/stores/ApiClient.ts
@@ -26,14 +26,17 @@ if (typeof window !== "undefined") {
 
 /**
  * Base URL for the backend API.
- * Dynamically sets the URL based on whether the environment is local or production.
- * Uses the current hostname and port 8000 for local development,
- * and a hardcoded production URL otherwise.
- * TODO: Make production URL configurable via environment variables.
+ *
+ * The value is taken from the `VITE_API_URL` environment variable when
+ * available. When running locally without a `.env` file the URL falls back to
+ * the current hostname on port `8000`.
  */
-export const BASE_URL = import.meta.env.VITE_API_URL
-  ? import.meta.env.VITE_API_URL
-  : `${window.location.protocol}//${window.location.hostname}:8000`;
+const defaultLocalUrl =
+  typeof window !== "undefined"
+    ? `${window.location.protocol}//${window.location.hostname}:8000`
+    : "http://localhost:8000";
+
+export const BASE_URL = import.meta.env.VITE_API_URL || defaultLocalUrl;
 
 /** WebSocket URL for the prediction worker endpoint. */
 export const WORKER_URL =


### PR DESCRIPTION
## Summary
- read API URL from `VITE_API_URL` with local fallback
- read Supabase creds from `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`
- provide `.env.example` template
- document required environment variables in README

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: AssetRefGridContent TS errors)*
- `npm test`
