### PR TITLE
Add additional unit tests

### DIFF
--- a/web/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/web/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ProtectedRoute from '../ProtectedRoute';
+import { useNavigate } from 'react-router-dom';
+import useAuth from '../../stores/useAuth';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../../stores/useAuth', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('ProtectedRoute', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    (useNavigate as unknown as jest.Mock).mockReturnValue(mockNavigate);
+    jest.clearAllMocks();
+  });
+
+  it('redirects to /login when logged_out', async () => {
+    (useAuth as unknown as jest.Mock).mockReturnValue({ state: 'logged_out' });
+    render(
+      <ProtectedRoute>
+        <div>secure</div>
+      </ProtectedRoute>
+    );
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'));
+  });
+
+  it('shows loading spinner when state is loading', () => {
+    (useAuth as unknown as jest.Mock).mockReturnValue({ state: 'loading' });
+    render(
+      <ProtectedRoute>
+        <div>secure</div>
+      </ProtectedRoute>
+    );
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders children when logged_in', () => {
+    (useAuth as unknown as jest.Mock).mockReturnValue({ state: 'logged_in' });
+    render(
+      <ProtectedRoute>
+        <div>secure</div>
+      </ProtectedRoute>
+    );
+    expect(screen.getByText('secure')).toBeInTheDocument();
+  });
+});

--- a/web/src/stores/__tests__/PanelStore.test.ts
+++ b/web/src/stores/__tests__/PanelStore.test.ts
@@ -1,0 +1,45 @@
+import { usePanelStore } from '../PanelStore';
+
+describe('PanelStore', () => {
+  const initialState = usePanelStore.getState();
+  const { minWidth, maxWidth, defaultWidth } = initialState.panel;
+  const minPanelSize = defaultWidth - 100;
+
+  afterEach(() => {
+    usePanelStore.setState(initialState, true);
+  });
+
+  test('setSize clamps values', () => {
+    usePanelStore.getState().setSize(0);
+    expect(usePanelStore.getState().panel.panelSize).toBe(minWidth);
+
+    usePanelStore.getState().setSize(2000);
+    expect(usePanelStore.getState().panel.panelSize).toBe(maxWidth);
+  });
+
+  test('handleViewChange toggles visibility for same view', () => {
+    usePanelStore.getState().handleViewChange('assets');
+    expect(usePanelStore.getState().panel.activeView).toBe('assets');
+    expect(usePanelStore.getState().panel.isVisible).toBe(true);
+
+    usePanelStore.getState().handleViewChange('assets');
+    expect(usePanelStore.getState().panel.isVisible).toBe(false);
+  });
+
+  test('collapsed panel expands when reopened', () => {
+    usePanelStore.setState({
+      ...usePanelStore.getState(),
+      panel: {
+        ...usePanelStore.getState().panel,
+        panelSize: minWidth,
+        isVisible: false,
+        activeView: 'workflowGrid'
+      }
+    }, true);
+
+    usePanelStore.getState().handleViewChange('workflowGrid');
+    const panel = usePanelStore.getState().panel;
+    expect(panel.panelSize).toBeGreaterThanOrEqual(minPanelSize);
+    expect(panel.isVisible).toBe(true);
+  });
+});

--- a/web/src/stores/__tests__/SettingsStore.test.ts
+++ b/web/src/stores/__tests__/SettingsStore.test.ts
@@ -1,0 +1,28 @@
+import { useSettingsStore, defaultSettings } from '../SettingsStore';
+
+describe('SettingsStore', () => {
+  const initialState = useSettingsStore.getState();
+
+  afterEach(() => {
+    useSettingsStore.setState(initialState, true);
+    localStorage.clear();
+  });
+
+  test('setGridSnap updates value', () => {
+    useSettingsStore.getState().setGridSnap(5);
+    expect(useSettingsStore.getState().settings.gridSnap).toBe(5);
+  });
+
+  test('updateSettings merges partial settings', () => {
+    useSettingsStore.getState().updateSettings({ panControls: 'RMB', alertBeforeTabClose: false });
+    const settings = useSettingsStore.getState().settings;
+    expect(settings.panControls).toBe('RMB');
+    expect(settings.alertBeforeTabClose).toBe(false);
+  });
+
+  test('resetSettings restores defaults', () => {
+    useSettingsStore.getState().setGridSnap(3);
+    useSettingsStore.getState().resetSettings();
+    expect(useSettingsStore.getState().settings.gridSnap).toBe(defaultSettings.gridSnap);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for panel state store
- add tests for settings store
- add tests for `ProtectedRoute` component
- fix type errors in AssetRef components

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
