### PR TITLE
Add Hugo docs skeleton and GitHub Pages workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,45 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.115.4'
+          extended: true
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build with Hugo
+        run: hugo --minify -s docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -264,3 +264,7 @@ Manage packs easily through the **NodeTool UI**:
 Alternatively, install directly via `pip` (see [Development Setup](#3-install-optional-node-packs-as-needed)).
 
 Refer to the [NodeTool Registry repository](https://github.com/nodetool-ai/nodetool-registry) for detailed guidelines on creating and publishing packs.
+
+## 📚 Documentation
+
+The documentation site is built with [Hugo](https://gohugo.io/documentation/) using the [Docsy](https://www.docsy.dev/docs/) theme. Source files live in the [`docs/`](docs/) directory. Updates to `main` are automatically deployed to GitHub Pages via the `hugo.yml` workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# NodeTool Documentation
+
+This directory contains the Hugo site for the NodeTool docs. It uses the [Docsy](https://www.docsy.dev/) theme.
+
+## Local development
+
+Install the extended version of [Hugo](https://gohugo.io/documentation/), then run:
+
+```bash
+hugo server -s docs -D
+```
+
+The site will be available at <http://localhost:1313>.

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -1,0 +1,7 @@
+---
+title: "NodeTool Docs"
+linkTitle: "Docs"
+weight: 1
+---
+
+Welcome to the NodeTool documentation.

--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Overview"
+weight: 1
+---
+
+Start writing documentation here.

--- a/docs/content/en/docs/getting-started.md
+++ b/docs/content/en/docs/getting-started.md
@@ -1,0 +1,6 @@
+---
+title: "Getting Started"
+weight: 10
+---
+
+This page will guide you through the basics of using NodeTool.

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,0 +1,10 @@
+baseURL = "https://example.com/"
+title = "NodeTool Documentation"
+languageCode = "en-us"
+theme = "docsy"
+canonifyURLs = true
+enableGitInfo = true
+
+[module]
+  [[module.imports]]
+    path = "github.com/google/docsy"


### PR DESCRIPTION
## Summary
- add a basic Hugo site under `docs/` configured with the Docsy theme
- document local docs development in `docs/README.md`
- add GitHub Actions workflow to build and deploy docs to Pages
- mention documentation site in main README

## Testing
- `npm run lint` / `npm run typecheck` / `npm test` in `web`
- `npm run lint` / `npm run typecheck` / `npm test` in `electron`
- `npm run lint` / `npm run typecheck` / `npm test` in `apps`
