### PR TITLE
Update docs index

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -1,7 +1,39 @@
 ---
-title: "NodeTool Docs"
-linkTitle: "Docs"
+title: "NodeTool"
+linkTitle: "Home"
 weight: 1
 ---
 
-Welcome to the NodeTool documentation.
+NodeTool is a desktop app for building AI-powered workflows with simple drag-and-drop tools. It lets you combine local or cloud models with your everyday apps without writing code.
+
+### Why it exists
+
+NodeTool was created to give anyone the power of modern AI while keeping full control over their data. Run open-source models on your computer or connect to providers like OpenAI and Gemini. Automate tasks, experiment with new ideas and share results without needing a programming background.
+
+### What you can do
+
+- **Visual workflow editor** – link nodes to process text, images, audio or video.
+- **Local and cloud models** – use models from Hugging Face or online services.
+- **Advanced agents** – build multi-step agents that can plan, reason and browse the web.
+- **Vector search & RAG** – index your documents and ask questions about them.
+- **System tray access** – launch workflows and manage your clipboard from anywhere.
+- **Mini‑app builder** – turn a workflow into a standalone application.
+- **Chat interface** – create custom chatbots for your projects.
+- **API and extensions** – connect NodeTool to other apps with Python scripts.
+
+### Real-world examples
+
+- Summarize incoming emails or generate daily digests.
+- Research topics online and produce structured reports.
+- Create images and descriptions for social media posts.
+- Ask questions about PDFs or other files you upload.
+
+### Get started
+
+1. Download NodeTool for Windows, macOS or Linux.
+2. Open the app and pick a template or start from a blank canvas.
+3. Drag nodes, connect them and click **Run** to see results in real time.
+
+### Join the community
+
+Share your ideas, ask questions or contribute on GitHub and Discord. We’re excited to see what you build!


### PR DESCRIPTION
## Summary
- expand docs index page with overview and features of NodeTool

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
