### PR TITLE
Add user guide for first-time installation

### DIFF
--- a/docs/content/en/docs/installation.md
+++ b/docs/content/en/docs/installation.md
@@ -1,0 +1,30 @@
+---
+title: "Installing NodeTool"
+weight: 5
+---
+
+NodeTool includes a small setup process the first time you run it. Follow these steps to get started.
+
+## Download the installer
+
+1. Visit [nodetool.ai](https://nodetool.ai) and download the build for Windows, macOS, or Linux.
+2. Run the downloaded file to start NodeTool.
+
+## Choose where to install
+
+When NodeTool starts it asks where to keep its Python environment. You can:
+
+- **Use the default location** – recommended for most users.
+- **Pick a custom folder** – choose any folder with enough free space (about 20 GB is a good idea).
+
+Select your preferred option to continue.
+
+## Select extra packages
+
+Next you can choose optional features such as cloud AI services, document tools, and audio or image processing. Tick the boxes you need now. You can add more later.
+
+## Let NodeTool download the files
+
+After you click **Install**, NodeTool downloads and unpacks everything it needs. This may take a few minutes depending on your connection. Progress is shown on screen.
+
+Once the download completes, NodeTool opens automatically and you can start building workflows.


### PR DESCRIPTION
## Summary
- add new documentation page describing the installation steps

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm test` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
