### PR TITLE
Add ChatStore tests

### DIFF
--- a/apps/jest.setup.ts
+++ b/apps/jest.setup.ts
@@ -6,3 +6,10 @@ if (typeof globalThis.structuredClone !== 'function') {
     return JSON.parse(JSON.stringify(obj));
   };
 }
+
+// Polyfill TextEncoder/TextDecoder for msgpack
+if (typeof globalThis.TextEncoder === 'undefined') {
+  const { TextEncoder, TextDecoder } = require('util');
+  globalThis.TextEncoder = TextEncoder;
+  globalThis.TextDecoder = TextDecoder;
+}

--- a/apps/src/__tests__/stores/ChatStore.test.ts
+++ b/apps/src/__tests__/stores/ChatStore.test.ts
@@ -1,0 +1,33 @@
+import useChatStore from '../../stores/ChatStore';
+
+describe('ChatStore', () => {
+  const initialState = useChatStore.getState();
+  beforeEach(() => {
+    useChatStore.setState(initialState, true);
+  });
+
+  test('appendMessage adds a message', () => {
+    const message = { role: 'user', type: 'message', content: 'hello', workflow_id: '1', name: 'user' } as any;
+    useChatStore.getState().appendMessage(message);
+    expect(useChatStore.getState().messages).toContain(message);
+  });
+
+  test('resetMessages clears messages', () => {
+    const message = { role: 'user', type: 'message', content: 'hello', workflow_id: '1', name: 'user' } as any;
+    useChatStore.getState().appendMessage(message);
+    expect(useChatStore.getState().messages.length).toBe(1);
+    useChatStore.getState().resetMessages();
+    expect(useChatStore.getState().messages.length).toBe(0);
+  });
+
+  test('setDroppedFiles updates droppedFiles', () => {
+    const file = new File(['data'], 'test.txt');
+    useChatStore.getState().setDroppedFiles([file]);
+    expect(useChatStore.getState().droppedFiles).toEqual([file]);
+  });
+
+  test('setSelectedTools updates selectedTools', () => {
+    useChatStore.getState().setSelectedTools(['t1', 't2']);
+    expect(useChatStore.getState().selectedTools).toEqual(['t1', 't2']);
+  });
+});


### PR DESCRIPTION
## Summary
- increase test coverage for apps by adding new tests for ChatStore
- polyfill TextEncoder/TextDecoder for jest in apps

## Testing
- `npm run lint` in apps
- `npm run typecheck` in apps
- `npm test` in apps
- `npm run lint` in web
- `npm run typecheck` in web
- `npm test` in web
- `npm run lint` in electron
- `npm run typecheck` in electron
- `npm test` in electron