### PR TITLE
Improve electron test coverage

### DIFF
--- a/electron/src/__tests__/window.test.ts
+++ b/electron/src/__tests__/window.test.ts
@@ -1,8 +1,9 @@
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, dialog } from 'electron';
 import path from 'path';
-import { createWindow, handleActivation } from '../window';
+import { createWindow, handleActivation, forceQuit } from '../window';
 import { setMainWindow, getMainWindow } from '../state';
 import { isAppQuitting } from '../main';
+import { logMessage } from '../logger';
 
 // Mocking dependencies
 jest.mock('electron', () => {
@@ -234,6 +235,17 @@ describe('Window Module', () => {
       // Should attempt to create a new window
       // We're not actually testing the createWindow function again, just that it's called
       expect(getMainWindow).toHaveBeenCalled();
+    });
+  });
+
+  describe('forceQuit', () => {
+    it('logs error, shows dialog and exits', () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+      forceQuit('fatal');
+      expect(logMessage).toHaveBeenCalledWith('Force quitting application: fatal', 'error');
+      expect(dialog.showErrorBox).toHaveBeenCalledWith('Critical Error', 'fatal');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
     });
   });
 });

--- a/electron/src/__tests__/workflowWindow.test.ts
+++ b/electron/src/__tests__/workflowWindow.test.ts
@@ -1,0 +1,41 @@
+import { BrowserWindow, Menu, app } from 'electron';
+import { createWorkflowWindow, isWorkflowWindow, baseUrl } from '../workflowWindow';
+
+jest.mock('electron', () => {
+  const mockBrowserWindow = jest.fn().mockImplementation(() => ({
+    id: 1,
+    setBackgroundColor: jest.fn(),
+    loadURL: jest.fn(),
+    on: jest.fn(),
+  }));
+  return {
+    BrowserWindow: Object.assign(mockBrowserWindow, { getAllWindows: jest.fn() }),
+    Menu: { setApplicationMenu: jest.fn() },
+    app: { isPackaged: false },
+    screen: {},
+  };
+});
+
+describe('workflowWindow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates and tracks workflow window', () => {
+    const win = createWorkflowWindow('123');
+
+    expect(Menu.setApplicationMenu).toHaveBeenCalledWith(null);
+    expect(BrowserWindow).toHaveBeenCalled();
+    expect(win.setBackgroundColor).toHaveBeenCalledWith('#111111');
+    expect(win.loadURL).toHaveBeenCalledWith(`${baseUrl}?workflow_id=123`);
+    expect(isWorkflowWindow(win)).toBe(true);
+
+    const closedHandler = (win.on as jest.Mock).mock.calls.find(([e]) => e === 'closed')[1];
+    closedHandler();
+    expect(isWorkflowWindow(win)).toBe(false);
+  });
+
+  it('returns false for unknown windows', () => {
+    expect(isWorkflowWindow({ id: 99 } as any)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- cover edge cases in forceQuit
- add workflowWindow tests

## Testing
- `cd electron && npm run lint`
- `cd electron && npm run typecheck`
- `cd electron && npm test`
- `cd electron && npm run test:coverage`