### PR TITLE
Add utility tests

### DIFF
--- a/web/src/utils/__tests__/browser.test.ts
+++ b/web/src/utils/__tests__/browser.test.ts
@@ -1,0 +1,49 @@
+import { getIsElectronDetails } from '../browser';
+
+describe('getIsElectronDetails', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    delete (window as any).process;
+    Object.defineProperty(Object.getPrototypeOf(navigator), 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('returns false when no electron signals are present', () => {
+    const details = getIsElectronDetails();
+    expect(details).toEqual({
+      isElectron: false,
+      isRendererProcess: false,
+      hasElectronVersionInWindowProcess: false,
+      hasElectronInUserAgent: false,
+    });
+  });
+
+  it('detects renderer process', () => {
+    (window as any).process = { type: 'renderer' };
+    const details = getIsElectronDetails();
+    expect(details.isElectron).toBe(true);
+    expect(details.isRendererProcess).toBe(true);
+  });
+
+  it('detects electron version in process', () => {
+    (window as any).process = { versions: { electron: '1.0.0' } };
+    const details = getIsElectronDetails();
+    expect(details.isElectron).toBe(true);
+    expect(details.hasElectronVersionInWindowProcess).toBe(true);
+  });
+
+  it('detects electron user agent', () => {
+    Object.defineProperty(Object.getPrototypeOf(navigator), 'userAgent', {
+      value: 'MyApp Electron/22.0',
+      configurable: true,
+      writable: true,
+    });
+    const details = getIsElectronDetails();
+    expect(details.isElectron).toBe(true);
+    expect(details.hasElectronInUserAgent).toBe(true);
+  });
+});

--- a/web/src/utils/__tests__/titleizeString.test.ts
+++ b/web/src/utils/__tests__/titleizeString.test.ts
@@ -1,0 +1,15 @@
+import { titleizeString } from '../titleizeString';
+
+describe('titleizeString', () => {
+  it('converts underscores and spaces to title case words', () => {
+    expect(titleizeString('hello_world test')).toBe('Hello World Test');
+  });
+
+  it('handles uppercase input gracefully', () => {
+    expect(titleizeString('HELLO')).toBe('Hello');
+  });
+
+  it('ignores repeated separators', () => {
+    expect(titleizeString('foo__bar  baz')).toBe('Foo Bar Baz');
+  });
+});


### PR DESCRIPTION
## Summary
- improve test coverage for web utilities
- test `titleizeString` for text formatting
- test `getIsElectronDetails` for environment detection

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run typecheck`
- `npm --prefix web test`
