### PR TITLE
Add tests for web utils

### DIFF
--- a/web/src/utils/__tests__/createAssetFile.test.ts
+++ b/web/src/utils/__tests__/createAssetFile.test.ts
@@ -1,0 +1,50 @@
+import { createAssetFile } from '../createAssetFile';
+
+describe('createAssetFile', () => {
+  it('creates a file for single image output', async () => {
+    const data = { 0: 1, 1: 2 };
+    const [result] = createAssetFile({ type: 'image', data }, 'abc');
+
+    expect(result.filename).toBe('preview_abc.png');
+    expect(result.type).toBe('image/png');
+    expect(result.file.name).toBe('preview_abc.png');
+    expect(result.file.type).toBe('image/png');
+    expect(result.file).toBeInstanceOf(File);
+    expect(result.file.size).toBeGreaterThan(0);
+  });
+
+  it('creates multiple files when given an array of outputs', () => {
+    const outputs = [
+      { type: 'text', data: 'hello' },
+      { type: 'audio', data: { 0: 1 } }
+    ];
+
+    const results = createAssetFile(outputs, 'id');
+    expect(results).toHaveLength(2);
+    expect(results[0].filename).toBe('preview_id_0.txt');
+    expect(results[1].filename).toBe('preview_id_1.mp3');
+  });
+
+  it('converts dataframes to CSV files', async () => {
+    const output = {
+      type: 'dataframe',
+      data: {
+        columns: [{ name: 'a' }, { name: 'b' }],
+        data: [ [1, 2], [3, 4] ]
+      }
+    };
+    const [result] = createAssetFile(output, 'id');
+    expect(result.filename).toBe('preview_id.csv');
+    expect(result.type).toBe('text/csv');
+    expect(result.file).toBeInstanceOf(File);
+    expect(result.file.name).toBe('preview_id.csv');
+  });
+
+  it('handles unknown types as plain text', async () => {
+    const output = { foo: 'bar' } as any;
+    const [result] = createAssetFile(output, 'test');
+    expect(result.filename).toBe('preview_test.txt');
+    expect(result.type).toBe('text/plain');
+    expect(result.file).toBeInstanceOf(File);
+  });
+});

--- a/web/src/utils/__tests__/formatDateAndTime.test.ts
+++ b/web/src/utils/__tests__/formatDateAndTime.test.ts
@@ -1,0 +1,53 @@
+import log from 'loglevel';
+import {
+  secondsToHMS,
+  prettyDate,
+  relativeTime,
+  getTimestampForFilename
+} from '../formatDateAndTime';
+import { DateTime } from 'luxon';
+
+describe('formatDateAndTime utilities', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-02T03:04:05Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('secondsToHMS converts seconds to hh:mm:ss', () => {
+    expect(secondsToHMS(3661)).toBe('01:01:01');
+  });
+
+  test('prettyDate formats normal dates in 12h format', () => {
+    expect(prettyDate('2023-01-02 03:04:05')).toBe('2023-01-02 | 03:04:05 AM');
+  });
+
+  test('prettyDate verbose with 24h time', () => {
+    const year = new Date().getFullYear();
+    const str = `${year}-05-15 13:30:00`;
+    const iso = str.replace(' ', 'T');
+    const dt = DateTime.fromISO(iso);
+    const expected = dt.toFormat('d. MMMM  | HH:mm');
+    expect(prettyDate(str, 'verbose', { timeFormat: '24h' })).toBe(expected);
+  });
+
+  test('prettyDate returns "Invalid Date" and logs warning on bad input', () => {
+    const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => {});
+    expect(prettyDate('not-a-date')).toBe('Invalid Date');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('relativeTime computes human readable difference', () => {
+    const hourAgo = new Date(Date.now() - 3600 * 1000);
+    expect(relativeTime(hourAgo)).toBe('1 hour ago');
+    expect(relativeTime(new Date())).toBe('just now');
+  });
+
+  test('getTimestampForFilename uses the frozen time', () => {
+    expect(getTimestampForFilename()).toBe('2023-01-02_03-04-05');
+    expect(getTimestampForFilename(false)).toBe('2023-01-02');
+  });
+});

--- a/web/src/utils/__tests__/getFileExtension.test.ts
+++ b/web/src/utils/__tests__/getFileExtension.test.ts
@@ -1,0 +1,15 @@
+import { getFileExtension } from '../getFileExtension';
+
+describe('getFileExtension', () => {
+  test('returns extension for standard file', () => {
+    expect(getFileExtension('image.png')).toBe('png');
+  });
+
+  test('returns empty string for files without extension', () => {
+    expect(getFileExtension('README')).toBe('');
+  });
+
+  test('returns empty string for hidden files', () => {
+    expect(getFileExtension('.gitignore')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- increase test coverage in web utils
- test createAssetFile utility
- test date & time formatting helpers
- test getFileExtension helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`