### PR TITLE
Add store tests for apps

### DIFF
--- a/apps/jest.setup.ts
+++ b/apps/jest.setup.ts
@@ -6,3 +6,19 @@ if (typeof globalThis.structuredClone !== 'function') {
     return JSON.parse(JSON.stringify(obj));
   };
 }
+
+// Polyfill TextEncoder/TextDecoder for jsdom environment
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const util = require('util');
+  if (typeof globalThis.TextEncoder === 'undefined') {
+    // @ts-ignore
+    globalThis.TextEncoder = util.TextEncoder;
+  }
+  if (typeof globalThis.TextDecoder === 'undefined') {
+    // @ts-ignore
+    globalThis.TextDecoder = util.TextDecoder;
+  }
+} catch {
+  // ignore if util import fails
+}

--- a/apps/src/__tests__/stores/ChatStore.test.ts
+++ b/apps/src/__tests__/stores/ChatStore.test.ts
@@ -1,0 +1,54 @@
+import useChatStore from '../../stores/ChatStore';
+
+const initialState = useChatStore.getState();
+
+// Helper to reset store state between tests
+const resetStore = () => {
+  useChatStore.setState(initialState, true);
+};
+
+describe('ChatStore', () => {
+  afterEach(() => {
+    resetStore();
+  });
+
+  test('appendMessage adds to messages', () => {
+    const message = {
+      type: 'message',
+      role: 'user',
+      name: 'User',
+      content: 'hello',
+    } as any;
+
+    useChatStore.getState().appendMessage(message);
+
+    expect(useChatStore.getState().messages).toHaveLength(1);
+    expect(useChatStore.getState().messages[0]).toMatchObject(message);
+  });
+
+  test('resetMessages clears messages', () => {
+    const message = {
+      type: 'message',
+      role: 'user',
+      name: 'User',
+      content: 'hello',
+    } as any;
+
+    useChatStore.getState().appendMessage(message);
+    expect(useChatStore.getState().messages).toHaveLength(1);
+
+    useChatStore.getState().resetMessages();
+    expect(useChatStore.getState().messages).toHaveLength(0);
+  });
+
+  test('setDroppedFiles updates droppedFiles', () => {
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+    useChatStore.getState().setDroppedFiles([file]);
+    expect(useChatStore.getState().droppedFiles).toEqual([file]);
+  });
+
+  test('setSelectedTools updates selectedTools', () => {
+    useChatStore.getState().setSelectedTools(['tool1', 'tool2']);
+    expect(useChatStore.getState().selectedTools).toEqual(['tool1', 'tool2']);
+  });
+});

--- a/apps/src/__tests__/stores/WorkflowRunner.test.ts
+++ b/apps/src/__tests__/stores/WorkflowRunner.test.ts
@@ -1,0 +1,27 @@
+import { useWorkflowRunner } from '../../stores/WorkflowRunner';
+
+describe('WorkflowRunner store', () => {
+  const initialState = useWorkflowRunner.getState();
+
+  afterEach(() => {
+    useWorkflowRunner.setState(initialState, true);
+    jest.useRealTimers();
+  });
+
+  test('addNotification and removeNotification manage notifications', () => {
+    jest.useFakeTimers();
+    useWorkflowRunner.getState().addNotification({ type: 'error', content: 'oops' });
+    expect(useWorkflowRunner.getState().notifications).toHaveLength(1);
+    const id = useWorkflowRunner.getState().notifications[0].id;
+
+    // advance timers to trigger auto removal (10s for error)
+    jest.advanceTimersByTime(10000);
+    expect(useWorkflowRunner.getState().notifications).toHaveLength(0);
+
+    // add another and remove manually
+    useWorkflowRunner.getState().addNotification({ type: 'info', content: 'info' });
+    const id2 = useWorkflowRunner.getState().notifications[0].id;
+    useWorkflowRunner.getState().removeNotification(id2);
+    expect(useWorkflowRunner.getState().notifications).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ChatStore and WorkflowRunner in `apps`
- polyfill TextEncoder/TextDecoder in Jest setup to allow msgpack usage

## Testing
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm test` in `apps`
- `npm run lint` && `npm run typecheck` && `npm test` in `web`
- `npm run lint` && `npm run typecheck` && `npm test` in `electron`
