### PR TITLE
Add docstrings for scripts

### DIFF
--- a/build.py
+++ b/build.py
@@ -47,6 +47,7 @@ class BuildError(Exception):
 
 
 class Build:
+    """Manage building and packaging of the Nodetool application."""
     def __init__(
         self,
         clean_build: bool = False,
@@ -82,6 +83,7 @@ class Build:
         env: dict | None = None,
         ignore_error: bool = False,
     ) -> int:
+        """Execute a shell command and stream output to the logger."""
         # Remove the conda run wrapper since we're using base environment
         logger.info(" ".join(command))
 
@@ -97,6 +99,7 @@ class Build:
         )
 
         def stream_output(pipe, log_func):
+            """Forward each line from *pipe* to *log_func*."""
             for line in iter(pipe.readline, ""):
                 log_func(line.strip())
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,8 +1,12 @@
+"""Utility script for updating the CHANGELOG using Anthropic."""
+
 import subprocess
 import os
 import requests
 from datetime import datetime, timedelta
 import anthropic
+
+"""Utility script for updating the CHANGELOG using Anthropic."""
 import dotenv
 
 dotenv.load_dotenv()
@@ -13,12 +17,14 @@ ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 
 # Function to get git log
 def get_git_log(since_date):
+    """Return the git commit log entries since *since_date*."""
     cmd = f"git log --since='{since_date}' --pretty=format:'%h - %s (%an, %ad)' --date=short"
     return subprocess.check_output(cmd, shell=True).decode("utf-8")
 
 
 # Function to read existing CHANGELOG.md
 def read_changelog():
+    """Return the contents of the existing CHANGELOG.md file."""
     if os.path.exists("CHANGELOG.md"):
         with open("CHANGELOG.md", "r") as f:
             return f.read()
@@ -27,12 +33,14 @@ def read_changelog():
 
 # Function to write updated CHANGELOG.md
 def write_changelog(content):
+    """Write *content* to CHANGELOG.md."""
     with open("CHANGELOG.md", "w") as f:
         f.write(content)
 
 
 # Function to get the last date from CHANGELOG.md
 def get_last_changelog_date(changelog):
+    """Extract and return the most recent date entry from the changelog."""
     lines = changelog.split("\n")
     for line in lines:
         if line.startswith("## "):
@@ -45,6 +53,7 @@ def get_last_changelog_date(changelog):
 
 # Function to update CHANGELOG using Anthropic API
 def update_changelog_with_anthropic(git_log, existing_changelog):
+    """Return an updated changelog generated via Anthropic."""
     client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
 
     system_prompt = f"""
@@ -90,6 +99,7 @@ def update_changelog_with_anthropic(git_log, existing_changelog):
 
 # Main function
 def main():
+    """Update CHANGELOG.md with entries generated from recent commits."""
     existing_changelog = read_changelog()
     last_date = get_last_changelog_date(existing_changelog)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,3 +1,5 @@
+"""Simple script to bump application version and create a Git tag."""
+
 import re
 import subprocess
 from pathlib import Path
@@ -6,18 +8,21 @@ from pathlib import Path
 def update_version_in_file(
     file_path: Path, regex: str, new_version: str, count: int = 1
 ):
+    """Replace version strings in *file_path* matching *regex* with *new_version*."""
     content = file_path.read_text()
     updated_content = re.sub(regex, new_version, content, count=count)
     file_path.write_text(updated_content)
 
 
 def update_version_in_package_json(file_path: Path, new_version: str):
+    """Update the version field in a package.json file."""
     version_regex = r'"version": ".*?"'
     new_version_line = f'"version": "{new_version}"'
     update_version_in_file(file_path, version_regex, new_version_line)
 
 
 def update_version_in_constants_ts(new_version: str):
+    """Write the new version string to the constants.ts file."""
     constants_file = Path("web/src/config/constants.ts")
     version_regex = r'export const VERSION = ".*?"'
     new_version_line = f'export const VERSION = "{new_version}"'
@@ -25,6 +30,7 @@ def update_version_in_constants_ts(new_version: str):
 
 
 def git_commit_and_tag(new_version: str):
+    """Commit any version changes and create a tag."""
     print(
         subprocess.run(
             [
@@ -45,6 +51,7 @@ def git_commit_and_tag(new_version: str):
 
 
 def main():
+    """Interactively update version numbers and create a Git tag."""
     new_version = input("Enter the new version: ").strip()
 
     update_version_in_constants_ts(new_version)

--- a/web/llm_lint.py
+++ b/web/llm_lint.py
@@ -1,9 +1,12 @@
+"""Helper for generating documentation suggestions using Anthropic."""
+
 import sys
 import anthropic
 import os
 
 
 def get_files(folder):
+    """Return all TypeScript source files within *folder*."""
     files = []
     for file in os.listdir(folder):
         if file.endswith(".ts") or file.endswith(".tsx"):
@@ -12,6 +15,7 @@ def get_files(folder):
 
 
 def get_content(*folders):
+    """Concatenate the contents of all TypeScript files in *folders*."""
     content = ""
     for folder in folders:
         for file in get_files(folder):


### PR DESCRIPTION
## Summary
- document Build class and helper functions in `build.py`
- add docstrings in `scripts/changelog.py`
- add docstrings in `scripts/release.py`
- document helper methods in `web/llm_lint.py`

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
