### PR TITLE
Add comments for clarity in React hooks and providers

### DIFF
--- a/web/src/contexts/NodeContext.tsx
+++ b/web/src/contexts/NodeContext.tsx
@@ -16,6 +16,9 @@ interface NodeContextValue {
   workflowId: string;
 }
 
+// Context wrapper around a NodeStore instance. Components can use the custom
+// hooks below to access node state and actions with equality checks to minimize
+// unnecessary re-renders.
 export const NodeContext = createContext<NodeContextValue | null>(null);
 
 export const useNodes = <T,>(selector: (state: NodeStoreState) => T): T => {
@@ -41,6 +44,9 @@ export const NodeProvider: React.FC<{
   workflowId: string;
 }> = ({ children, workflowId }) => {
   const store = useWorkflowManager((state) => state.getNodeStore(workflowId));
+
+  // If the store isn't ready yet we display a small loading indicator. This
+  // occurs while workflows are being fetched or initialized.
 
   if (!store) {
     return (

--- a/web/src/hooks/useCreateNode.ts
+++ b/web/src/hooks/useCreateNode.ts
@@ -5,6 +5,10 @@ import { useReactFlow } from "@xyflow/react";
 import { useCreateLoopNode } from "./nodes/useCreateLoopNode";
 import { useNodes } from "../contexts/NodeContext";
 
+// This hook encapsulates the logic for creating a new node in the graph.
+// It handles translating screen coordinates to ReactFlow coordinates and
+// delegates loop node creation to `useCreateLoopNode`.
+
 export const useCreateNode = (
   centerPosition: { x: number; y: number } | undefined = undefined
 ) => {
@@ -20,6 +24,9 @@ export const useCreateNode = (
   const createLoopNode = useCreateLoopNode();
 
   const handleCreateNode = useCallback(
+    // Create a node at the last click position or at the provided center
+    // position. Loop nodes are expanded into a group with input and output
+    // child nodes handled by `createLoopNode`.
     (metadata: NodeMetadata) => {
       if (!reactFlowInstance) return;
 

--- a/web/src/providers/MenuProvider.tsx
+++ b/web/src/providers/MenuProvider.tsx
@@ -6,6 +6,10 @@ import {
   useEffect
 } from "react";
 
+// MenuProvider exposes a simple pub/sub mechanism for Electron menu events.
+// Components can register handlers to respond to menu actions emitted from the
+// main process via `window.api`.
+
 type MenuEventHandler = (data: any) => void;
 
 interface MenuContextType {
@@ -32,10 +36,12 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [globalHandler]);
 
+  // Allow components to subscribe to menu events
   const registerHandler = useCallback((handler: MenuEventHandler) => {
     handlers.current.add(handler);
   }, []);
 
+  // Remove a previously registered handler
   const unregisterHandler = useCallback((handler: MenuEventHandler) => {
     handlers.current.delete(handler);
   }, []);


### PR DESCRIPTION
## Summary
- document functionality in `useCreateNode` hook
- add context explanation in `NodeContext`
- clarify `MenuProvider` usage

## Testing
- `cd web && npm run lint`
- `npm run typecheck`
- `npm test`
- `cd ../apps && npm run lint`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`
