### PR TITLE
Fix ESLint error in apps

### DIFF
--- a/apps/jest.setup.ts
+++ b/apps/jest.setup.ts
@@ -8,8 +8,9 @@ if (typeof globalThis.structuredClone !== 'function') {
 }
 
 // Polyfill TextEncoder/TextDecoder for msgpack
+import { TextEncoder as NodeTextEncoder, TextDecoder as NodeTextDecoder } from 'util';
+
 if (typeof globalThis.TextEncoder === 'undefined') {
-  const { TextEncoder, TextDecoder } = require('util');
-  globalThis.TextEncoder = TextEncoder;
-  globalThis.TextDecoder = TextDecoder;
+  globalThis.TextEncoder = NodeTextEncoder as unknown as typeof globalThis.TextEncoder;
+  globalThis.TextDecoder = NodeTextDecoder as unknown as typeof globalThis.TextDecoder;
 }


### PR DESCRIPTION
## Summary
- use ES module import in `apps/jest.setup.ts`

## Testing
- `npm run lint` in apps
- `npm run typecheck` in apps
- `npm run lint` in web
- `npm run typecheck` in web
- `npm test` in web
- `npm run lint` in electron
- `npm run typecheck` in electron
- `npm test` in electron