### PR TITLE
Use import.meta.env in web

### DIFF
--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.ts',
@@ -9,8 +9,10 @@ export default {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: 'tsconfig.json',
+      useESM: true,
     }],
   },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverageFrom: [

--- a/web/src/components/node_menu/RenderNamespaces.tsx
+++ b/web/src/components/node_menu/RenderNamespaces.tsx
@@ -60,7 +60,7 @@ const RenderNamespaces: React.FC<RenderNamespacesProps> = ({
 
         const finalIsHighlightedPropForChild = highlightDueToActiveSearch;
 
-        if (process.env.NODE_ENV === "development" && DEBUG_SEARCH) {
+        if (import.meta.env.NODE_ENV === "development" && DEBUG_SEARCH) {
           console.log(
             `RenderNamespaces: path='${currentFullPath}', isSearchActive=${isSearchTermPresentAndEffective}, searchCount=${searchResultCount}, highlightDueToSearch=${highlightDueToActiveSearch}, finalPropValue=${finalIsHighlightedPropForChild}`
           );

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -7,8 +7,9 @@ import { createClient } from "@supabase/supabase-js";
  * the repository and allows easy configuration for different deployments.
  */
 
-const supabaseUrl: string | undefined = process.env.VITE_SUPABASE_URL;
-const supabaseAnonKey: string | undefined = process.env.VITE_SUPABASE_ANON_KEY;
+// Vite exposes environment variables via `import.meta.env`
+const supabaseUrl: string | undefined = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey: string | undefined = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn(

--- a/web/src/stores/__tests__/WorkflowChatStore.test.ts
+++ b/web/src/stores/__tests__/WorkflowChatStore.test.ts
@@ -10,6 +10,13 @@ import { Message, WorkflowAttributes, OutputUpdate } from '../ApiTypes';
 
 jest.mock('../workflowUpdates', () => ({ handleUpdate: jest.fn() }));
 jest.mock('../ApiClient', () => ({ CHAT_URL: 'ws://test/chat', isLocalhost: true }));
+jest.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } })
+    }
+  }
+}));
 jest.mock('loglevel', () => ({
   __esModule: true,
   default: {


### PR DESCRIPTION
## Summary
- replace `process.env` usage with `import.meta.env`
- adjust jest config to support ESM
- mock Supabase client in `WorkflowChatStore` test

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps` *(fails: `no-require-imports`)*
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`