### PR TITLE
Add basic property component tests

### DIFF
--- a/web/src/components/properties/__tests__/BoolProperty.test.tsx
+++ b/web/src/components/properties/__tests__/BoolProperty.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+jest.mock('../../themes/ThemeNodes', () => ({
+  __esModule: true,
+  default: { palette: {}, fontSizeNormal: '', fontFamily1: '', fontSizeSmall: '' }
+}));
+jest.mock('../../themes/ThemeNodetool', () => ({ __esModule: true, default: {} }));
+jest.mock('../../../config/data_types', () => ({}));
+jest.mock('../../../stores/ApiClient', () => ({ client: { GET: jest.fn() } }));
+
+import BoolProperty from '../BoolProperty';
+
+const defaultProps = {
+  property: { name: 'enabled', type: { type: 'bool', optional: false, type_args: [] } } as any,
+  propertyIndex: '0',
+  value: false,
+  onChange: jest.fn(),
+  nodeId: 'node1',
+  nodeType: 'test.node',
+};
+
+describe('BoolProperty', () => {
+  it('renders a switch and label', () => {
+    render(<BoolProperty {...defaultProps} />);
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  it('calls onChange when toggled', () => {
+    const onChange = jest.fn();
+    render(<BoolProperty {...defaultProps} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/web/src/components/properties/__tests__/NonEditableProperty.test.tsx
+++ b/web/src/components/properties/__tests__/NonEditableProperty.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NonEditableProperty from '../NonEditableProperty';
+
+jest.mock('../../themes/ThemeNodes', () => ({
+  __esModule: true,
+  default: { palette: {}, fontSizeNormal: '', fontFamily1: '', fontSizeSmall: '' }
+}));
+jest.mock('../../themes/ThemeNodetool', () => ({ __esModule: true, default: {} }));
+
+const defaultProps = {
+  property: { name: 'readonly', type: { type: 'str', optional: false, type_args: [] } } as any,
+  propertyIndex: '0',
+  value: '',
+  onChange: jest.fn(),
+  nodeId: 'node1',
+  nodeType: 'test.node',
+};
+
+describe('NonEditableProperty', () => {
+  it('renders only the label', () => {
+    render(<NonEditableProperty {...defaultProps} />);
+    expect(screen.getByText('Readonly')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add jest tests for BoolProperty and NonEditableProperty

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `cd apps && npm run lint || true`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`
