### PR TITLE
Add tests for provider components

### DIFF
--- a/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
+++ b/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { ConnectableNodesProvider } from "../ConnectableNodesProvider";
+import useConnectableNodes from "../../stores/ConnectableNodesStore";
+
+// Mock metadata store
+jest.mock("../../stores/MetadataStore", () => {
+  const getState = jest.fn(() => ({ metadata: {} }));
+  return { __esModule: true, default: { getState } };
+});
+// Access the mocked getState function
+const { default: metadataStore } = require("../../stores/MetadataStore");
+const getState = (metadataStore as any).getState as jest.Mock;
+
+// Mock filter utilities
+const mockFilterByInput = jest.fn();
+const mockFilterByOutput = jest.fn();
+jest.mock("../../components/node_menu/typeFilterUtils", () => ({
+  filterTypesByInputType: (metadata: any, type: any) => mockFilterByInput(metadata, type),
+  filterTypesByOutputType: (metadata: any, type: any) => mockFilterByOutput(metadata, type)
+}));
+
+const sampleType = {
+  type: "test",
+  optional: false,
+  type_args: [],
+  type_name: "test"
+};
+
+function setup(active = true) {
+  let ctx: any;
+  function Consumer() {
+    ctx = useConnectableNodes();
+    return null;
+  }
+  render(
+    <ConnectableNodesProvider active={active}>
+      <Consumer />
+    </ConnectableNodesProvider>
+  );
+  return () => ctx!;
+}
+
+
+describe('ConnectableNodesProvider', () => {
+  beforeEach(() => {
+    mockFilterByInput.mockClear();
+    mockFilterByOutput.mockClear();
+    getState.mockReturnValue({ metadata: {} });
+  });
+
+  test('initial state values are set correctly', () => {
+    const getCtx = setup();
+    const ctx = getCtx();
+    expect(ctx.nodeMetadata).toEqual([]);
+    expect(ctx.filterType).toBeNull();
+    expect(ctx.typeMetadata).toBeNull();
+    expect(ctx.isVisible).toBe(false);
+    expect(ctx.menuPosition).toBeNull();
+    expect(ctx.sourceHandle).toBeNull();
+    expect(ctx.targetHandle).toBeNull();
+    expect(ctx.nodeId).toBeNull();
+  });
+
+  test('state updates through setters', () => {
+    const getCtx = setup();
+    act(() => {
+      const ctx = getCtx();
+      ctx.setFilterType('input');
+      ctx.setTypeMetadata(sampleType);
+      ctx.setSourceHandle('s');
+      ctx.setTargetHandle('t');
+      ctx.setNodeId('id');
+    });
+    const ctx = getCtx();
+    expect(ctx.filterType).toBe('input');
+    expect(ctx.typeMetadata).toEqual(sampleType);
+    expect(ctx.sourceHandle).toBe('s');
+    expect(ctx.targetHandle).toBe('t');
+    expect(ctx.nodeId).toBe('id');
+  });
+
+  test('showMenu and hideMenu manage visibility when active', () => {
+    const getCtx = setup();
+    act(() => {
+      getCtx().showMenu({ x: 1, y: 2 });
+    });
+    expect(getCtx().isVisible).toBe(true);
+    expect(getCtx().menuPosition).toEqual({ x: 1, y: 2 });
+    act(() => {
+      getCtx().hideMenu();
+    });
+    expect(getCtx().isVisible).toBe(false);
+    expect(getCtx().menuPosition).toBeNull();
+  });
+
+  test('showMenu does nothing when inactive', () => {
+    const getCtx = setup(false);
+    act(() => {
+      getCtx().showMenu({ x: 5, y: 6 });
+    });
+    expect(getCtx().isVisible).toBe(false);
+    expect(getCtx().menuPosition).toBeNull();
+  });
+
+  test('getConnectableNodes returns empty when typeMetadata or filterType missing', () => {
+    const getCtx = setup();
+    const result = getCtx().getConnectableNodes();
+    expect(result).toEqual([]);
+    expect(mockFilterByInput).not.toHaveBeenCalled();
+    expect(mockFilterByOutput).not.toHaveBeenCalled();
+  });
+
+  test('getConnectableNodes uses filterTypesByInputType when filterType="input"', () => {
+    const metadata = { a: 'b' } as any;
+    getState.mockReturnValue({ metadata });
+    mockFilterByInput.mockReturnValue(['in']);
+    const getCtx = setup();
+    act(() => {
+      const ctx = getCtx();
+      ctx.setFilterType('input');
+      ctx.setTypeMetadata(sampleType);
+    });
+    const result = getCtx().getConnectableNodes();
+    expect(mockFilterByInput).toHaveBeenCalledWith(Object.values(metadata), sampleType);
+    expect(result).toEqual(['in']);
+  });
+
+  test('getConnectableNodes uses filterTypesByOutputType when filterType="output"', () => {
+    const metadata = { a: 'b' } as any;
+    getState.mockReturnValue({ metadata });
+    mockFilterByOutput.mockReturnValue(['out']);
+    const getCtx = setup();
+    act(() => {
+      const ctx = getCtx();
+      ctx.setFilterType('output');
+      ctx.setTypeMetadata(sampleType);
+    });
+    const result = getCtx().getConnectableNodes();
+    expect(mockFilterByOutput).toHaveBeenCalledWith(Object.values(metadata), sampleType);
+    expect(result).toEqual(['out']);
+  });
+});

--- a/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
+++ b/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, act } from "@testing-library/react";
 import { ConnectableNodesProvider } from "../ConnectableNodesProvider";
 import useConnectableNodes from "../../stores/ConnectableNodesStore";
+import metadataStore from "../../stores/MetadataStore";
 
 // Mock metadata store
 jest.mock("../../stores/MetadataStore", () => {
@@ -9,7 +10,6 @@ jest.mock("../../stores/MetadataStore", () => {
   return { __esModule: true, default: { getState } };
 });
 // Access the mocked getState function
-const { default: metadataStore } = require("../../stores/MetadataStore");
 const getState = (metadataStore as any).getState as jest.Mock;
 
 // Mock filter utilities

--- a/web/src/providers/__tests__/ContextMenuProvider.test.tsx
+++ b/web/src/providers/__tests__/ContextMenuProvider.test.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { ContextMenuProvider } from "../ContextMenuProvider";
+import useContextMenu from "../../stores/ContextMenuStore";
+
+function setup(active = true) {
+  let ctx: any;
+  function Consumer() {
+    ctx = useContextMenu();
+    return null;
+  }
+  const utils = render(
+    <ContextMenuProvider active={active}>
+      <Consumer />
+    </ContextMenuProvider>
+  );
+  return { getCtx: () => ctx!, ...utils };
+}
+
+describe('ContextMenuProvider', () => {
+  let addSpy: jest.SpyInstance;
+  let removeSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    addSpy = jest.spyOn(document, 'addEventListener');
+    removeSpy = jest.spyOn(document, 'removeEventListener');
+    (document as any).elementFromPoint = () => null;
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+    delete (document as any).elementFromPoint;
+  });
+
+  test('openContextMenu sets state when active', () => {
+    const { getCtx } = setup();
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 10, 20);
+      jest.advanceTimersByTime(0);
+    });
+    expect(getCtx().openMenuType).toBe('menu');
+    expect(getCtx().nodeId).toBe('id');
+    expect(getCtx().menuPosition).toEqual({ x: 10, y: 20 });
+  });
+
+  test('openContextMenu does nothing when inactive', () => {
+    const { getCtx } = setup(false);
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0);
+    });
+    expect(getCtx().openMenuType).toBeNull();
+  });
+
+  test('openContextMenu validates click position', () => {
+    const el = document.createElement('div');
+    el.classList.add('inside');
+    (document as any).elementFromPoint = () => el;
+    const { getCtx } = setup();
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0, 'inside');
+    });
+    expect(getCtx().openMenuType).toBe('menu');
+  });
+
+  test('mouseup listener added after timeout', () => {
+    const { getCtx } = setup();
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0);
+    });
+    expect(addSpy).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(addSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+  });
+
+  test('closeContextMenu resets state and removes listener', () => {
+    const { getCtx } = setup();
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0);
+      jest.advanceTimersByTime(500);
+    });
+    const handler = addSpy.mock.calls[0][1] as any;
+    act(() => {
+      getCtx().closeContextMenu();
+    });
+    expect(removeSpy).toHaveBeenCalledWith('mouseup', handler);
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(getCtx().openMenuType).toBeNull();
+  });
+
+  test('clickOutsideHandler closes when clicking outside', () => {
+    const { getCtx } = setup();
+    const boundary = document.createElement('div');
+    boundary.classList.add('ignore');
+    (document as any).elementFromPoint = () => boundary;
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0, 'ignore');
+      jest.advanceTimersByTime(500);
+    });
+    const handler = addSpy.mock.calls[0][1] as any;
+    const outside = document.createElement('div');
+    (document as any).elementFromPoint = () => outside;
+    act(() => {
+      handler({ target: outside } as any);
+      jest.advanceTimersByTime(50);
+    });
+    expect(getCtx().openMenuType).toBeNull();
+  });
+
+  test('clickOutsideHandler keeps menu open when clicking inside', () => {
+    const { getCtx } = setup();
+    const boundary = document.createElement('div');
+    boundary.classList.add('inside');
+    (document as any).elementFromPoint = () => boundary;
+    document.body.appendChild(boundary);
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0, 'inside');
+      jest.advanceTimersByTime(500);
+    });
+    const handler = addSpy.mock.calls[0][1] as any;
+    const insideChild = document.createElement('span');
+    boundary.appendChild(insideChild);
+    act(() => {
+      handler({ target: insideChild } as any);
+      jest.advanceTimersByTime(50);
+    });
+    expect(getCtx().openMenuType).toBe('menu');
+  });
+
+  test('previous listeners removed when opening new menu', () => {
+    const { getCtx } = setup();
+    act(() => {
+      getCtx().openContextMenu('menu', 'id', 0, 0);
+      jest.advanceTimersByTime(500);
+    });
+    const firstHandler = addSpy.mock.calls[0][1] as any;
+    act(() => {
+      getCtx().openContextMenu('menu2', 'id', 1, 1);
+    });
+    expect(removeSpy).toHaveBeenCalledWith('mouseup', firstHandler);
+  });
+});

--- a/web/src/providers/__tests__/MenuProvider.test.tsx
+++ b/web/src/providers/__tests__/MenuProvider.test.tsx
@@ -1,0 +1,76 @@
+import React, { useContext } from "react";
+import { render, act } from "@testing-library/react";
+import { MenuProvider, MenuContext } from "../MenuProvider";
+
+function setup(withApi = true) {
+  const onMenuEvent = jest.fn();
+  const unregisterMenuEvent = jest.fn();
+  if (withApi) {
+    (window as any).api = { onMenuEvent, unregisterMenuEvent };
+  } else {
+    (window as any).api = undefined;
+  }
+  let ctx: any = null;
+  function Consumer() {
+    ctx = useContext(MenuContext)!;
+    return null;
+  }
+  const utils = render(
+    <MenuProvider>
+      <Consumer />
+    </MenuProvider>
+  );
+  return { ctx: () => ctx!, onMenuEvent, unregisterMenuEvent, unmount: utils.unmount };
+}
+
+describe('MenuProvider', () => {
+  test('registerHandler and unregisterHandler manage handlers', () => {
+    const { ctx, onMenuEvent } = setup(true);
+    const globalHandler = onMenuEvent.mock.calls[0][0];
+    const handler = jest.fn();
+    act(() => {
+      ctx().registerHandler(handler);
+    });
+    act(() => {
+      globalHandler({ foo: 'bar' });
+    });
+    expect(handler).toHaveBeenCalledWith({ foo: 'bar' });
+
+    act(() => {
+      ctx().unregisterHandler(handler);
+      globalHandler({ foo: 'baz' });
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('multiple handlers receive events', () => {
+    const { ctx, onMenuEvent } = setup(true);
+    const globalHandler = onMenuEvent.mock.calls[0][0];
+    const h1 = jest.fn();
+    const h2 = jest.fn();
+    act(() => {
+      ctx().registerHandler(h1);
+      ctx().registerHandler(h2);
+    });
+    act(() => {
+      globalHandler({ a: 1 });
+    });
+    expect(h1).toHaveBeenCalledWith({ a: 1 });
+    expect(h2).toHaveBeenCalledWith({ a: 1 });
+  });
+
+  test('event listener cleanup on unmount', () => {
+    const { onMenuEvent, unregisterMenuEvent, unmount } = setup(true);
+    const handler = onMenuEvent.mock.calls[0][0];
+    unmount();
+    expect(unregisterMenuEvent).toHaveBeenCalledWith(handler);
+  });
+
+  test('works when window.api is undefined', () => {
+    expect(() => {
+      const { unmount } = setup(false);
+      unmount();
+    }).not.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for ConnectableNodesProvider, ContextMenuProvider and MenuProvider

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `cd ../apps && npm run lint` *(fails: eslint error)*
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`
