### PR TITLE
Fix Hugo build workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           hugo-version: '0.115.4'
           extended: true
+      - name: Install Docsy theme
+        run: hugo mod get github.com/google/docsy
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build with Hugo


### PR DESCRIPTION
## Summary
- install Docsy theme in CI before building the docs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run lint` in apps
- `npm run typecheck` in apps
- `npm test` in apps
- `npm run lint` in electron
- `npm run typecheck` in electron
- `npm test` in electron