### PR TITLE
Add basic serverState unit tests

### DIFF
--- a/web/src/__mocks__/fixtures.ts
+++ b/web/src/__mocks__/fixtures.ts
@@ -1,0 +1,21 @@
+export const mockAsset = {
+  id: 'asset123',
+  name: 'test-asset.jpg',
+  content_type: 'image/jpeg',
+  created_at: '2024-01-01T00:00:00Z',
+  get_url: 'https://example.com/asset123.jpg'
+};
+
+export const mockUser = {
+  id: 'user123',
+  name: 'Test User'
+};
+
+export const mockNodeMetadata = {
+  title: 'Test Node',
+  node_type: 'test.node',
+  namespace: 'test',
+  properties: [],
+  outputs: [],
+  recommended_models: []
+};

--- a/web/src/serverState/__tests__/tryCacheFiles.test.ts
+++ b/web/src/serverState/__tests__/tryCacheFiles.test.ts
@@ -1,0 +1,48 @@
+import { tryCacheFiles, tryCacheRepos } from '../tryCacheFiles';
+import { client } from '../../stores/ApiClient';
+
+jest.mock('../../stores/ApiClient', () => ({
+  client: {
+    POST: jest.fn()
+  }
+}));
+
+describe('tryCacheFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('successfully caches files and returns data', async () => {
+    (client.POST as jest.Mock).mockResolvedValue({ data: { ok: true }, error: null });
+
+    const files = ['file1', 'file2'];
+    const result = await tryCacheFiles(files as any);
+
+    expect(client.POST).toHaveBeenCalledWith('/api/models/huggingface/try_cache_files', { body: files });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('throws error with descriptive message when API fails', async () => {
+    (client.POST as jest.Mock).mockResolvedValue({ data: null, error: 'fail' });
+    await expect(tryCacheFiles(['file'] as any)).rejects.toThrow('Failed to check if file is cached: fail');
+  });
+});
+
+describe('tryCacheRepos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('successfully caches repos and returns data', async () => {
+    (client.POST as jest.Mock).mockResolvedValue({ data: { ok: true }, error: null });
+    const repos = ['repo1'];
+    const result = await tryCacheRepos(repos);
+    expect(client.POST).toHaveBeenCalledWith('/api/models/huggingface/try_cache_repos', { body: repos });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('throws error with descriptive message when API fails', async () => {
+    (client.POST as jest.Mock).mockResolvedValue({ data: null, error: 'boom' });
+    await expect(tryCacheRepos(['repo1'])).rejects.toThrow('Failed to check if repo is cached: boom');
+  });
+});

--- a/web/src/serverState/__tests__/useAsset.test.tsx
+++ b/web/src/serverState/__tests__/useAsset.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react';
+import { useAsset } from '../useAsset';
+import { useQuery } from '@tanstack/react-query';
+import { mockAsset } from '../../__mocks__/fixtures';
+
+const mockGetAsset = jest.fn();
+jest.mock('../../stores/AssetStore', () => ({
+  __esModule: true,
+  useAssetStore: jest.fn((selector: any) => selector({ get: mockGetAsset }))
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  __esModule: true,
+  useQuery: jest.fn()
+}));
+
+describe('useAsset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useQuery as jest.Mock).mockReturnValue({ data: mockAsset });
+  });
+
+  it('returns asset and uri when audio asset provided', () => {
+    const { result } = renderHook(() =>
+      useAsset({ audio: { asset_id: '123', uri: 'my://uri' } as any })
+    );
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['asset', '123'], enabled: true })
+    );
+    expect(result.current.asset).toEqual(mockAsset);
+    expect(result.current.uri).toBe('my://uri');
+  });
+
+  it('query is disabled when no asset id', () => {
+    renderHook(() => useAsset({ image: {} as any }));
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['asset', undefined], enabled: false })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add fixtures for tests
- test tryCacheFiles functions
- test useAsset hook with mock store

## Testing
- `cd web && npm run lint`
- `npm run typecheck`
- `npm test`
- `cd ../apps && npm run lint`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`
