### PR TITLE
Fix asset drag-to-dropzone

### DIFF
--- a/web/src/hooks/assets/__tests__/useAssetSelection.test.ts
+++ b/web/src/hooks/assets/__tests__/useAssetSelection.test.ts
@@ -37,6 +37,7 @@ jest.mock('../../../stores/AssetGridStore', () => {
   };
 });
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { assetGridStore } = require('../../../stores/AssetGridStore');
 
 const pressed: Record<string, boolean> = {};

--- a/web/src/hooks/handlers/useFileDrop.ts
+++ b/web/src/hooks/handlers/useFileDrop.ts
@@ -31,6 +31,32 @@ export function useFileDrop(props: FileDropProps): {
       event.preventDefault();
       event.stopPropagation();
 
+      const assetJSON = event.dataTransfer.getData("asset");
+      if (assetJSON) {
+        try {
+          const asset = JSON.parse(assetJSON) as Asset;
+          const assetType = asset.content_type.split("/")[0];
+          if (
+            props.type === "all" ||
+            assetType === props.type ||
+            (props.type === "document" &&
+              (assetType === "application" || assetType === "text"))
+          ) {
+            props.onChangeAsset?.(asset);
+            props.onChange?.(asset.get_url as string);
+          } else {
+            notificationStore.addNotification({
+              type: "error",
+              alert: true,
+              content: `Invalid file type. Please drop a ${props.type} file.`
+            });
+          }
+        } catch {
+          /* Ignore JSON parse errors */
+        }
+        return;
+      }
+
       // Handle text data transfer
       if (event.dataTransfer.items && !event.dataTransfer.files.length) {
         const items = event.dataTransfer.items;


### PR DESCRIPTION
## Summary
- handle dropped assets in `useFileDrop`
- satisfy lint for tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
