### PR TITLE
Fix left panel collapse logic

### DIFF
--- a/web/src/hooks/handlers/useResizePanel.ts
+++ b/web/src/hooks/handlers/useResizePanel.ts
@@ -62,14 +62,22 @@ export const useResizePanel = (panelPosition: "left" | "right" = "left") => {
           // If we didn't move, treat it as a click and toggle the current view
           actions.handleViewChange(panel.activeView);
         } else {
-          // Ensure final size respects minimum
-          const finalSize = Math.max(
+          // Ensure final size respects minimum and collapse if below threshold
+          let finalSize = Math.max(
             MIN_DRAG_SIZE,
             panel.panelSize || DEFAULT_PANEL_SIZE
           );
+
+          let visible = true;
+          if (finalSize < MIN_PANEL_SIZE) {
+            finalSize = MIN_DRAG_SIZE;
+            visible = false;
+          }
+
           if (finalSize !== panel.panelSize) {
             actions.setSize(finalSize);
           }
+          actions.setVisibility(visible);
         }
 
         actions.setIsDragging(false);

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -116,7 +116,7 @@ export const usePanelStore = create<ResizePanelState>()((set, get) => ({
 
   closePanel: () => {
     set((state) => ({
-      panel: { ...state.panel, panelSize: MIN_DRAG_SIZE }
+      panel: { ...state.panel, panelSize: MIN_DRAG_SIZE, isVisible: false }
     }));
   },
 


### PR DESCRIPTION
## Summary
- collapse panel in store
- handle collapsing in resize hook

## Testing
- `npm run lint` (fails: A `require()` style import is forbidden)
- `npm run typecheck`
- `npm test`
- `npm run lint` in apps
- `npm run typecheck` in apps
- `npm run lint` in electron
- `npm run typecheck` in electron
- `npm test` in electron
