### PR TITLE
Fix show more button visibility

### DIFF
--- a/web/src/styles/nodes.css
+++ b/web/src/styles/nodes.css
@@ -299,6 +299,7 @@
 .react-flow.zoomed-out .loop-node .outputs,
 .react-flow.zoomed-out .preview-node-content,
 .react-flow.zoomed-out .model-button,
+.react-flow.zoomed-out .expand-button-container,
 .react-flow.zoomed-out .tool-call-container,
 .react-flow.zoomed-out .node-chunk {
   opacity: 0;


### PR DESCRIPTION
## Summary
- hide advanced fields "Show more" button when zoomed out

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `cd apps && npm run lint`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`
