### PR TITLE
Implement auto-save when renaming workflow

### DIFF
--- a/web/src/components/editor/TabsBar.tsx
+++ b/web/src/components/editor/TabsBar.tsx
@@ -27,6 +27,7 @@ const TabsBar = ({ workflows }: TabsBarProps) => {
     reorderWorkflows,
     updateWorkflow,
     removeWorkflow,
+    saveWorkflow,
     currentWorkflowId,
     createNewWorkflow
   } = useWorkflowManager((state) => ({
@@ -35,6 +36,7 @@ const TabsBar = ({ workflows }: TabsBarProps) => {
     removeWorkflow: state.removeWorkflow,
     reorderWorkflows: state.reorderWorkflows,
     updateWorkflow: state.updateWorkflow,
+    saveWorkflow: state.saveWorkflow,
     currentWorkflowId: state.currentWorkflowId,
     createNewWorkflow: state.createNew
   }));
@@ -103,14 +105,16 @@ const TabsBar = ({ workflows }: TabsBarProps) => {
   }, []);
 
   const handleNameChange = useCallback(
-    (workflowId: string, newName: string) => {
+    async (workflowId: string, newName: string) => {
       const workflow = getWorkflow(workflowId);
       if (workflow) {
-        updateWorkflow({ ...workflow, name: newName });
+        const updatedWorkflow = { ...workflow, name: newName };
+        updateWorkflow(updatedWorkflow);
+        await saveWorkflow(updatedWorkflow);
       }
       setEditingWorkflowId(null);
     },
-    [getWorkflow, updateWorkflow]
+    [getWorkflow, updateWorkflow, saveWorkflow]
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
## Summary
- auto-save workflow after changing its name in `TabHeader`

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`
