### PR TITLE
Hd edges with gradients

### DIFF
--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -42,6 +42,7 @@ import { isEqual } from "lodash";
 import ThemeNodes from "../themes/ThemeNodes";
 import AxisMarker from "../node_editor/AxisMarker";
 import ConnectionLine from "../node_editor/ConnectionLine";
+import EdgeGradientDefinitions from "../node_editor/EdgeGradientDefinitions";
 import useSelect from "../../hooks/nodes/useSelect";
 import ConnectableNodes from "../context_menus/ConnectableNodes";
 import useMetadataStore from "../../stores/MetadataStore";
@@ -403,6 +404,9 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
         onDoubleClick={handleDoubleClick}
         proOptions={proOptions}
         panActivationKeyCode=""
+        defaultEdgeOptions={{
+          style: { strokeWidth: 2, stroke: "url(#edge-gradient)" }
+        }}
         // onSelectionChange={onSelectionChange}
         // edgeTypes={edgeTypes}
         // onNodeClick={onNodeClick}
@@ -423,6 +427,7 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
         <AxisMarker />
         <ContextMenus />
         <ConnectableNodes />
+        <EdgeGradientDefinitions />
       </ReactFlow>
     </div>
   );

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -291,12 +291,16 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
   const defaultViewport = useMemo(() => ({ x: 0, y: 0, zoom: 1.5 }), []);
   const reactFlowInstance = useReactFlow();
 
-  const processedEdges = useProcessedEdges({
+  const { processedEdges, activeGradientKeys } = useProcessedEdges({
     edges,
     getNode,
     dataTypes: DATA_TYPES,
     getMetadata
   });
+  const activeGradientKeysArray = useMemo(
+    () => Array.from(activeGradientKeys),
+    [activeGradientKeys]
+  );
 
   const fitScreen = useCallback(() => {
     if (reactFlowInstance) {
@@ -433,7 +437,10 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
         <AxisMarker />
         <ContextMenus />
         <ConnectableNodes />
-        <EdgeGradientDefinitions dataTypes={DATA_TYPES} />
+        <EdgeGradientDefinitions
+          dataTypes={DATA_TYPES}
+          activeGradientKeys={activeGradientKeysArray}
+        />
       </ReactFlow>
     </div>
   );

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -293,6 +293,7 @@ const ReactFlowWrapper: React.FC<ReactFlowWrapperProps> = ({
 
   const { processedEdges, activeGradientKeys } = useProcessedEdges({
     edges,
+    nodes,
     getNode,
     dataTypes: DATA_TYPES,
     getMetadata

--- a/web/src/components/node_editor/EdgeGradientDefinitions.tsx
+++ b/web/src/components/node_editor/EdgeGradientDefinitions.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const EdgeGradientDefinitions: React.FC = () => {
+  return (
+    <svg style={{ height: 0, width: 0, position: "absolute" }}>
+      <defs>
+        <linearGradient id="edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop
+            offset="0%"
+            style={{ stopColor: "rgb(128,0,128)", stopOpacity: 1 }}
+          />
+          <stop
+            offset="100%"
+            style={{ stopColor: "rgb(255,192,203)", stopOpacity: 1 }}
+          />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
+
+export default EdgeGradientDefinitions;

--- a/web/src/components/node_editor/EdgeGradientDefinitions.tsx
+++ b/web/src/components/node_editor/EdgeGradientDefinitions.tsx
@@ -1,41 +1,42 @@
 import React from "react";
-import { DataType } from "../../config/data_types"; // Corrected import
+import { DataType } from "../../config/data_types";
 
 interface EdgeGradientDefinitionsProps {
   dataTypes: DataType[];
+  activeGradientKeys: string[]; // Changed from all dataTypes to specific keys
 }
 
 const EdgeGradientDefinitions: React.FC<EdgeGradientDefinitionsProps> = ({
-  dataTypes
+  dataTypes,
+  activeGradientKeys
 }) => {
   const gradients: JSX.Element[] = [];
 
-  // Gradients for connections
-  dataTypes.forEach((sourceType) => {
-    dataTypes.forEach((targetType) => {
-      if (sourceType.slug === targetType.slug) {
-        return; // Skip if types are the same
-      }
-      gradients.push(
-        <linearGradient
-          id={`gradient-${sourceType.slug}-${targetType.slug}`}
-          x1="0%"
-          y1="0%"
-          x2="100%"
-          y2="0%"
-          key={`grad-${sourceType.slug}-${targetType.slug}`}
-        >
-          <stop
-            offset="0%"
-            style={{ stopColor: sourceType.color, stopOpacity: 1 }}
-          />
-          <stop
-            offset="100%"
-            style={{ stopColor: targetType.color, stopOpacity: 1 }}
-          />
-        </linearGradient>
-      );
-    });
+  activeGradientKeys.forEach((key) => {
+    // key is like "gradient-slug1-slug2"
+    const parts = key.replace("gradient-", "").split("-");
+    if (parts.length !== 2) return; // Should not happen with correct keys
+
+    const slug1 = parts[0];
+    const slug2 = parts[1];
+
+    const sourceType = dataTypes.find((dt) => dt.slug === slug1);
+    const targetType = dataTypes.find((dt) => dt.slug === slug2);
+
+    if (!sourceType || !targetType) return; // Should find types if slugs are valid
+
+    gradients.push(
+      <linearGradient id={key} x1="0%" y1="0%" x2="100%" y2="0%" key={key}>
+        <stop
+          offset="0%"
+          style={{ stopColor: sourceType.color, stopOpacity: 1 }}
+        />
+        <stop
+          offset="100%"
+          style={{ stopColor: targetType.color, stopOpacity: 1 }}
+        />
+      </linearGradient>
+    );
   });
 
   return (

--- a/web/src/components/node_editor/EdgeGradientDefinitions.tsx
+++ b/web/src/components/node_editor/EdgeGradientDefinitions.tsx
@@ -1,20 +1,46 @@
 import React from "react";
+import { DataType } from "../../config/data_types"; // Corrected import
 
-const EdgeGradientDefinitions: React.FC = () => {
-  return (
-    <svg style={{ height: 0, width: 0, position: "absolute" }}>
-      <defs>
-        <linearGradient id="edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+interface EdgeGradientDefinitionsProps {
+  dataTypes: DataType[];
+}
+
+const EdgeGradientDefinitions: React.FC<EdgeGradientDefinitionsProps> = ({
+  dataTypes
+}) => {
+  const gradients: JSX.Element[] = [];
+
+  // Gradients for connections
+  dataTypes.forEach((sourceType) => {
+    dataTypes.forEach((targetType) => {
+      if (sourceType.slug === targetType.slug) {
+        return; // Skip if types are the same
+      }
+      gradients.push(
+        <linearGradient
+          id={`gradient-${sourceType.slug}-${targetType.slug}`}
+          x1="0%"
+          y1="0%"
+          x2="100%"
+          y2="0%"
+          key={`grad-${sourceType.slug}-${targetType.slug}`}
+        >
           <stop
             offset="0%"
-            style={{ stopColor: "rgb(128,0,128)", stopOpacity: 1 }}
+            style={{ stopColor: sourceType.color, stopOpacity: 1 }}
           />
           <stop
             offset="100%"
-            style={{ stopColor: "rgb(255,192,203)", stopOpacity: 1 }}
+            style={{ stopColor: targetType.color, stopOpacity: 1 }}
           />
         </linearGradient>
-      </defs>
+      );
+    });
+  });
+
+  return (
+    <svg style={{ height: 0, width: 0, position: "absolute" }}>
+      <defs>{gradients}</defs>
     </svg>
   );
 };

--- a/web/src/components/themes/GenerateCSS.tsx
+++ b/web/src/components/themes/GenerateCSS.tsx
@@ -23,20 +23,16 @@ export const generateCSS = (() => {
           stroke-width: 2;
           stroke: ${color};
         }
-        .react-flow__edge .react-flow__edge-default .${slug} .selected .react-flow__edge-path{
           stroke: ${color};
-        }
         .react-flow g.custom-connection-line rect.${slug} {
           stroke-width: 2;
           fill: ${color};
         }
-        .react-flow .react-flow__edge.${slug} .react-flow__edge-path,
-        .react-flow .react-flow__edge.${slug} .react-flow__edge-textwrapper .react-flow__edge-textbg {
-          stroke-width: 2;
-          stroke: ${color};
+        .react-flow .react-flow__edge.${slug} .react-flow__edge-path {
+          stroke-width: 2; 
         }
         .react-flow .react-flow__edge.${slug} .react-flow__edge-textwrapper .react-flow__edge-textbg {
-          fill: ${color};
+          fill: ${color}; 
         }
         .react-flow__edge.${slug} .react-flow__edge-textwrapper .react-flow__edge-text {
           stroke-width: 2;

--- a/web/src/components/themes/GenerateCSS.tsx
+++ b/web/src/components/themes/GenerateCSS.tsx
@@ -23,7 +23,6 @@ export const generateCSS = (() => {
           stroke-width: 2;
           stroke: ${color};
         }
-          stroke: ${color};
         .react-flow g.custom-connection-line rect.${slug} {
           stroke-width: 2;
           fill: ${color};

--- a/web/src/config/data_types.tsx
+++ b/web/src/config/data_types.tsx
@@ -103,7 +103,7 @@ export { iconMap };
 //   return { SvgIcon };
 // }
 
-interface DataType {
+export interface DataType {
   value: string;
   label: string;
   namespace: string;

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Edge, Node } from "@xyflow/react";
-import { DataType } from "../config/data_types"; // Removed DATA_TYPES import, will pass dataTypes as prop
-import { NodeMetadata } from "../stores/ApiTypes"; // Assuming NodeMetadata is exported
+import { DataType } from "../config/data_types";
+import { NodeMetadata } from "../stores/ApiTypes";
 
 interface ProcessedEdgesOptions {
   edges: Edge[];
@@ -24,7 +24,6 @@ export function useProcessedEdges({
   getMetadata
 }: ProcessedEdgesOptions): ProcessedEdgesResult {
   return useMemo(() => {
-    const startTime = performance.now();
     const activeGradientKeys = new Set<string>();
 
     const processedResultEdges = edges.map((edge) => {
@@ -99,7 +98,10 @@ export function useProcessedEdges({
       };
     });
 
-    const endTime = performance.now();
     return { processedEdges: processedResultEdges, activeGradientKeys };
+    // `nodes` is a necessary dependency here to ensure correct edge type determination
+    // when workflows are loaded, as `getNode`'s output depends on the `nodes` array being
+    // fully populated.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edges, nodes, getNode, dataTypes, getMetadata]);
 }

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import { Edge, Node } from "@xyflow/react";
+import { DataType } from "../config/data_types"; // Removed DATA_TYPES import, will pass dataTypes as prop
+import { NodeMetadata } from "../stores/ApiTypes"; // Assuming NodeMetadata is exported
+
+interface ProcessedEdgesOptions {
+  edges: Edge[];
+  getNode: (id: string) => Node | undefined;
+  dataTypes: DataType[];
+  getMetadata: (nodeType: string) => NodeMetadata | undefined;
+}
+
+export function useProcessedEdges({
+  edges,
+  getNode,
+  dataTypes,
+  getMetadata
+}: ProcessedEdgesOptions): Edge[] {
+  return useMemo(() => {
+    const startTime = performance.now();
+
+    const processed = edges.map((edge) => {
+      const sourceNode = getNode(edge.source);
+      const targetNode = getNode(edge.target);
+
+      let sourceTypeSlug = "any";
+      let sourceColor =
+        dataTypes.find((dt) => dt.slug === "any")?.color || "#888";
+      let targetTypeSlug = "any";
+
+      if (sourceNode && sourceNode.type && edge.sourceHandle) {
+        const sourceMetadata = getMetadata(sourceNode.type);
+        if (sourceMetadata && sourceMetadata.outputs) {
+          const outputInfo = sourceMetadata.outputs.find(
+            (o) => o.name === edge.sourceHandle
+          );
+          if (outputInfo && outputInfo.type && outputInfo.type.type) {
+            const typeInfoFromDataTypes = dataTypes.find(
+              (dt) =>
+                dt.value === outputInfo.type.type ||
+                dt.name === outputInfo.type.type ||
+                dt.slug === outputInfo.type.type
+            );
+            if (typeInfoFromDataTypes) {
+              sourceTypeSlug = typeInfoFromDataTypes.slug;
+              sourceColor = typeInfoFromDataTypes.color;
+            }
+          }
+        }
+      }
+
+      if (targetNode && targetNode.type && edge.targetHandle) {
+        const targetMetadata = getMetadata(targetNode.type);
+        if (targetMetadata && targetMetadata.properties) {
+          const inputInfo = targetMetadata.properties.find(
+            (p) => p.name === edge.targetHandle
+          );
+          if (inputInfo && inputInfo.type && inputInfo.type.type) {
+            const targetTypeString = inputInfo.type.type;
+            const typeInfoFromDataTypes = dataTypes.find(
+              (dt) =>
+                dt.value === targetTypeString ||
+                dt.name === targetTypeString ||
+                dt.slug === targetTypeString
+            );
+            if (typeInfoFromDataTypes) {
+              targetTypeSlug = typeInfoFromDataTypes.slug;
+            }
+          }
+        }
+      }
+
+      const strokeStyle =
+        sourceTypeSlug === targetTypeSlug
+          ? sourceColor
+          : `url(#gradient-${sourceTypeSlug}-${targetTypeSlug})`;
+
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: strokeStyle,
+          strokeWidth: 2
+        }
+      };
+    });
+
+    const endTime = performance.now();
+    console.log(
+      `[useProcessedEdges] Edge colors recalculated for ${
+        edges.length
+      } edges in ${(endTime - startTime).toFixed(2)} ms`
+    );
+    return processed;
+  }, [edges, getNode, dataTypes, getMetadata]);
+}

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -5,6 +5,7 @@ import { NodeMetadata } from "../stores/ApiTypes"; // Assuming NodeMetadata is e
 
 interface ProcessedEdgesOptions {
   edges: Edge[];
+  nodes: Node[];
   getNode: (id: string) => Node | undefined;
   dataTypes: DataType[];
   getMetadata: (nodeType: string) => NodeMetadata | undefined;
@@ -17,6 +18,7 @@ interface ProcessedEdgesResult {
 
 export function useProcessedEdges({
   edges,
+  nodes,
   getNode,
   dataTypes,
   getMetadata
@@ -34,6 +36,7 @@ export function useProcessedEdges({
         dataTypes.find((dt) => dt.slug === "any")?.color || "#888";
       let targetTypeSlug = "any";
 
+      // --- Source Type Detection ---
       if (sourceNode && sourceNode.type && edge.sourceHandle) {
         const sourceMetadata = getMetadata(sourceNode.type);
         if (sourceMetadata && sourceMetadata.outputs) {
@@ -41,11 +44,12 @@ export function useProcessedEdges({
             (o) => o.name === edge.sourceHandle
           );
           if (outputInfo && outputInfo.type && outputInfo.type.type) {
+            const typeString = outputInfo.type.type;
             const typeInfoFromDataTypes = dataTypes.find(
               (dt) =>
-                dt.value === outputInfo.type.type ||
-                dt.name === outputInfo.type.type ||
-                dt.slug === outputInfo.type.type
+                dt.value === typeString ||
+                dt.name === typeString ||
+                dt.slug === typeString
             );
             if (typeInfoFromDataTypes) {
               sourceTypeSlug = typeInfoFromDataTypes.slug;
@@ -55,6 +59,7 @@ export function useProcessedEdges({
         }
       }
 
+      // --- Target Type Detection ---
       if (targetNode && targetNode.type && edge.targetHandle) {
         const targetMetadata = getMetadata(targetNode.type);
         if (targetMetadata && targetMetadata.properties) {
@@ -62,12 +67,12 @@ export function useProcessedEdges({
             (p) => p.name === edge.targetHandle
           );
           if (inputInfo && inputInfo.type && inputInfo.type.type) {
-            const targetTypeString = inputInfo.type.type;
+            const typeString = inputInfo.type.type;
             const typeInfoFromDataTypes = dataTypes.find(
               (dt) =>
-                dt.value === targetTypeString ||
-                dt.name === targetTypeString ||
-                dt.slug === targetTypeString
+                dt.value === typeString ||
+                dt.name === typeString ||
+                dt.slug === typeString
             );
             if (typeInfoFromDataTypes) {
               targetTypeSlug = typeInfoFromDataTypes.slug;
@@ -75,7 +80,6 @@ export function useProcessedEdges({
           }
         }
       }
-
       let strokeStyle;
       if (sourceTypeSlug === targetTypeSlug) {
         strokeStyle = sourceColor;
@@ -96,13 +100,6 @@ export function useProcessedEdges({
     });
 
     const endTime = performance.now();
-    console.log(
-      `[useProcessedEdges] Edge colors recalculated for ${
-        edges.length
-      } edges in ${(endTime - startTime).toFixed(
-        2
-      )} ms. Active gradient keys: ${activeGradientKeys.size}`
-    );
     return { processedEdges: processedResultEdges, activeGradientKeys };
-  }, [edges, getNode, dataTypes, getMetadata]);
+  }, [edges, nodes, getNode, dataTypes, getMetadata]);
 }


### PR DESCRIPTION
Refactor: Optimized Edge Styling with Dynamic Type-Based Colors and On-Demand Gradients

**Dynamic Edges**: 
Edges are now styled with a solid color for same-type connections or a linear gradient for different-type connections, based on the handle data types.

On-demand SVG gradient generation: creating gradients only as needed by active edges. 

Improved Load Behavior: Corrected an issue where edges did not receive proper type-based styling upon initial workflow load.

Code Centralization: Edge styling logic is now consolidated within a new useProcessedEdges hook, and redundant CSS for edge coloring has been removed.

![image](https://github.com/user-attachments/assets/08fbf1ad-36a9-4c30-b0aa-f42d1f342db3)
