### PR TITLE
Add new tests for utils and error boundary

### DIFF
--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '../ErrorBoundary';
+import { useRouteError } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  useRouteError: jest.fn(),
+}));
+
+describe('ErrorBoundary', () => {
+  const mockReload = jest.fn();
+
+  beforeEach(() => {
+    (useRouteError as jest.Mock).mockReturnValue(new Error('boom'));
+    Object.defineProperty(window, 'location', {
+      value: { reload: mockReload },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    mockReload.mockReset();
+  });
+
+  it('renders error info', () => {
+    render(<ErrorBoundary />);
+    expect(screen.getByText('NodeTool has encountered an error')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('refreshes page when button clicked', () => {
+    render(<ErrorBoundary />);
+    fireEvent.click(screen.getByRole('button', { name: /refresh the page/i }));
+    expect(mockReload).toHaveBeenCalled();
+  });
+});

--- a/web/src/utils/__tests__/ColorUtils.test.ts
+++ b/web/src/utils/__tests__/ColorUtils.test.ts
@@ -1,0 +1,42 @@
+import chroma from 'chroma-js';
+import {
+  hexToRgba,
+  darkenHexColor,
+  lightenHexColor,
+  adjustSaturation,
+  createLinearGradient,
+  simulateOpacity
+} from '../ColorUtils';
+
+describe('ColorUtils', () => {
+  test('hexToRgba converts hex and alpha', () => {
+    expect(hexToRgba('#ff0000', 0.5)).toBe('rgba(255, 0, 0, 0.5)');
+  });
+
+  test('darkenHexColor darkens color', () => {
+    const expected = chroma('#ff0000').darken(0.2).hex();
+    expect(darkenHexColor('#ff0000', 20)).toBe(expected);
+  });
+
+  test('lightenHexColor lightens color', () => {
+    const expected = chroma('#0000ff').brighten(0.1).hex();
+    expect(lightenHexColor('#0000ff', 10)).toBe(expected);
+  });
+
+  test('adjustSaturation adjusts saturation', () => {
+    const expected = chroma('#00ff00').set('hsl.s', `*${1 + 0.2}`).hex();
+    expect(adjustSaturation('#00ff00', 20)).toBe(expected);
+  });
+
+  test('createLinearGradient builds gradient string', () => {
+    const start = '#123456';
+    const end = darkenHexColor(start, 10);
+    const expected = `linear-gradient(to bottom, ${hexToRgba(start, 1)}, ${hexToRgba(end, 1)})`;
+    expect(createLinearGradient(start, 10)).toBe(expected);
+  });
+
+  test('simulateOpacity mixes colors', () => {
+    const expected = chroma.mix('#fff', '#ff0000', 0.5, 'rgb').hex();
+    expect(simulateOpacity('#ff0000', 0.5)).toBe(expected);
+  });
+});

--- a/web/src/utils/__tests__/NodeTypeMapping.test.ts
+++ b/web/src/utils/__tests__/NodeTypeMapping.test.ts
@@ -1,0 +1,32 @@
+import {
+  contentTypeToNodeType,
+  inputForType,
+  outputForType,
+  constantForType
+} from '../NodeTypeMapping';
+
+describe('NodeTypeMapping', () => {
+  test('contentTypeToNodeType maps known types', () => {
+    expect(contentTypeToNodeType('image/jpeg')).toBe('image');
+    expect(contentTypeToNodeType('application/pdf')).toBe('document');
+    expect(contentTypeToNodeType('unknown/unknown')).toBeNull();
+  });
+
+  test('inputForType returns correct mapping', () => {
+    expect(inputForType('str')).toBe('nodetool.input.StringInput');
+    expect(inputForType('image')).toBe('nodetool.input.ImageInput');
+    expect(inputForType('bogus' as any)).toBeNull();
+  });
+
+  test('outputForType returns correct mapping', () => {
+    expect(outputForType('text')).toBe('nodetool.output.TextOutput');
+    expect(outputForType('audio')).toBe('nodetool.output.AudioOutput');
+    expect(outputForType('bogus' as any)).toBeNull();
+  });
+
+  test('constantForType returns correct mapping', () => {
+    expect(constantForType('float')).toBe('nodetool.constant.Float');
+    expect(constantForType('folder')).toBe('nodetool.input.Folder');
+    expect(constantForType('bogus' as any)).toBeNull();
+  });
+});

--- a/web/src/utils/__tests__/isUrlAccessible.test.ts
+++ b/web/src/utils/__tests__/isUrlAccessible.test.ts
@@ -1,0 +1,28 @@
+import { isUrlAccessible } from '../isUrlAccessible';
+import log from 'loglevel';
+
+describe('isUrlAccessible', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    jest.spyOn(log, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (fetch as jest.Mock).mockReset();
+    (log.error as jest.Mock).mockRestore();
+  });
+
+  it('returns true for successful HEAD request', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const result = await isUrlAccessible('https://example.com');
+    expect(fetch).toHaveBeenCalledWith('https://example.com', { method: 'HEAD' });
+    expect(result).toBe(true);
+  });
+
+  it('logs error and returns false when fetch throws', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await isUrlAccessible('https://bad.com');
+    expect(result).toBe(false);
+    expect(log.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ErrorBoundary
- add tests for ColorUtils helpers
- add tests for NodeTypeMapping util
- add tests for url accessibility helper

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*
- `npm run typecheck` *(fails: command not found)*