### PR TITLE
Fix reactflow warning about missing edges

### DIFF
--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -857,6 +857,7 @@ export const createNodeStore = (
             } else {
               set({ edges });
             }
+
             get().setWorkflowDirty(true);
           },
           validateConnection: (

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -72,6 +72,55 @@ export const DEFAULT_NODE_WIDTH = 200;
 const undo_limit = 1000;
 const AUTO_SAVE_INTERVAL = 60000; // 1 minute
 
+/**
+ * Validates if an edge is valid based on node existence and handle validity
+ */
+const isValidEdge = (
+  edge: Edge,
+  nodeMap: Map<string, Node<NodeData>>,
+  metadata: Record<string, NodeMetadata>
+): boolean => {
+  const sourceNode = nodeMap.get(edge.source);
+  const targetNode = nodeMap.get(edge.target);
+
+  // Basic validation: nodes must exist
+  if (!sourceNode || !targetNode || !sourceNode.type || !targetNode.type) {
+    return false;
+  }
+
+  const sourceMetadata = metadata[sourceNode.type];
+  const targetMetadata = metadata[targetNode.type];
+
+  // If metadata is missing, we can't validate handles properly
+  // But we should still check basic handle requirements
+  if (!sourceMetadata || !targetMetadata) {
+    // At minimum, edges must have handles specified
+    if (!edge.sourceHandle || !edge.targetHandle) {
+      return false;
+    }
+    // Allow the edge for now - it will be validated again when metadata loads
+    return true;
+  }
+
+  // Validate source handle
+  const hasValidSourceHandle = sourceMetadata.outputs.some(
+    (output) => output.name === edge.sourceHandle
+  );
+  if (!hasValidSourceHandle) {
+    return false;
+  }
+
+  // Validate target handle
+  const hasValidTargetHandle =
+    targetMetadata.is_dynamic ||
+    targetMetadata.properties.some((prop) => prop.name === edge.targetHandle);
+  if (!hasValidTargetHandle) {
+    return false;
+  }
+
+  return true;
+};
+
 export interface NodeStoreState {
   shouldAutoLayout: boolean;
   setShouldAutoLayout: (value: boolean) => void;
@@ -171,28 +220,74 @@ const sanitizeGraph = (
     return sanitizedNode;
   });
 
-  const sanitizedEdges = edges.reduce((acc, edge) => {
+  const sanitizedEdges = edges.filter((edge) => {
+    if (isValidEdge(edge, nodeMap, metadata)) {
+      return true;
+    }
+
+    // Log detailed information about why the edge was removed
     const sourceNode = nodeMap.get(edge.source);
     const targetNode = nodeMap.get(edge.target);
-    if (sourceNode && targetNode && sourceNode.type && targetNode.type) {
+
+    if (!sourceNode || !targetNode) {
+      log.warn(
+        `Edge ${edge.id} references non-existent nodes. Source: ${
+          edge.source
+        } (${sourceNode ? "exists" : "missing"}), Target: ${edge.target} (${
+          targetNode ? "exists" : "missing"
+        }). Removing edge.`
+      );
+    } else if (!sourceNode.type || !targetNode.type) {
+      log.warn(
+        `Edge ${edge.id} connects nodes without types. Source type: ${sourceNode.type}, Target type: ${targetNode.type}. Removing edge.`
+      );
+    } else {
       const sourceMetadata = metadata[sourceNode.type];
       const targetMetadata = metadata[targetNode.type];
-      if (!sourceMetadata || !targetMetadata) {
-        acc.push(edge);
-      } else if (
-        sourceMetadata.outputs.some(
+
+      if (sourceMetadata && targetMetadata) {
+        const hasValidSourceHandle = sourceMetadata.outputs.some(
           (output) => output.name === edge.sourceHandle
-        ) &&
-        (targetMetadata.is_dynamic ||
+        );
+        const hasValidTargetHandle =
+          targetMetadata.is_dynamic ||
           targetMetadata.properties.some(
             (prop) => prop.name === edge.targetHandle
-          ))
-      ) {
-        acc.push(edge);
+          );
+
+        if (!hasValidSourceHandle) {
+          log.warn(
+            `Edge ${edge.id} references invalid source handle "${
+              edge.sourceHandle
+            }" on node ${edge.source} (type: ${
+              sourceNode.type
+            }). Available outputs: ${sourceMetadata.outputs
+              .map((o) => o.name)
+              .join(", ")}. Removing edge.`
+          );
+        } else if (!hasValidTargetHandle) {
+          log.warn(
+            `Edge ${edge.id} references invalid target handle "${
+              edge.targetHandle
+            }" on node ${edge.target} (type: ${
+              targetNode.type
+            }). Available properties: ${targetMetadata.properties
+              .map((p) => p.name)
+              .join(", ")}. Removing edge.`
+          );
+        }
       }
     }
-    return acc;
-  }, [] as Edge[]);
+
+    return false;
+  });
+
+  const removedEdgeCount = edges.length - sanitizedEdges.length;
+  if (removedEdgeCount > 0) {
+    log.info(
+      `Sanitized graph: removed ${removedEdgeCount} invalid edge(s) out of ${edges.length} total edges.`
+    );
+  }
 
   return { nodes: sanitizedNodes, edges: sanitizedEdges };
 };
@@ -250,6 +345,23 @@ export const createNodeStore = (
             addNodeType(node.type, PlaceholderNode);
           }
         }
+
+        // Subscribe to metadata changes to re-sanitize edges when metadata loads
+        const unsubscribeMetadata = useMetadataStore.subscribe((state) => {
+          // Re-sanitize edges when metadata becomes available
+          const currentState = get();
+          const metadataCount = Object.keys(state.metadata).length;
+          const edgeCount = currentState.edges.length;
+
+          if (metadataCount > 0 && edgeCount > 0) {
+            const { edges: sanitizedEdges } = sanitizeGraph(
+              currentState.nodes,
+              currentState.edges,
+              state.metadata
+            );
+            set({ edges: sanitizedEdges });
+          }
+        });
 
         return {
           shouldAutoLayout: state?.shouldAutoLayout || false,
@@ -553,7 +665,25 @@ export const createNodeStore = (
             get().setWorkflowDirty(true);
           },
           addEdge: (edge: Edge): void => {
-            set({ edges: [...get().edges, edge] });
+            // Validate the edge before adding it
+            const sourceNode = get().findNode(edge.source);
+            const targetNode = get().findNode(edge.target);
+
+            if (!sourceNode || !targetNode) {
+              log.warn(
+                `Cannot add edge ${edge.id}: source or target node not found`
+              );
+              return;
+            }
+
+            // Ensure handles are properly set
+            const sanitizedEdge = {
+              ...edge,
+              sourceHandle: edge.sourceHandle || null,
+              targetHandle: edge.targetHandle || null
+            };
+
+            set({ edges: [...get().edges, sanitizedEdge] });
             get().setWorkflowDirty(true);
           },
           updateEdge: (edge: Edge): void => {
@@ -700,7 +830,16 @@ export const createNodeStore = (
             get().setWorkflowDirty(true);
           },
           setEdges: (edges: Edge[]): void => {
-            set({ edges });
+            // Sanitize edges when setting them directly
+            const metadata = useMetadataStore.getState().metadata;
+            const nodes = get().nodes;
+            const { edges: sanitizedEdges } = sanitizeGraph(
+              nodes,
+              edges,
+              metadata
+            );
+
+            set({ edges: sanitizedEdges });
             get().setWorkflowDirty(true);
           },
           validateConnection: (
@@ -708,20 +847,24 @@ export const createNodeStore = (
             srcNode: Node<NodeData>,
             targetNode: Node<NodeData>
           ): boolean => {
+            // Basic validation: ensure handles are provided
+            if (!connection.sourceHandle || !connection.targetHandle) {
+              return false;
+            }
+
             const srcMetadata = useMetadataStore
               .getState()
               .getMetadata(srcNode.type as string);
             const targetMetadata = useMetadataStore
               .getState()
               .getMetadata(targetNode.type as string);
-            if (
-              !srcMetadata ||
-              !targetMetadata ||
-              !connection.sourceHandle ||
-              !connection.targetHandle
-            ) {
-              return false;
+
+            // If either node doesn't have metadata (placeholder nodes), allow connection
+            if (!srcMetadata || !targetMetadata) {
+              return true;
             }
+
+            // Check for existing connection
             const edges = get().edges;
             const existingConnection = edges.find(
               (edge) =>
@@ -733,13 +876,30 @@ export const createNodeStore = (
             if (existingConnection) {
               return false;
             }
+
+            // Validate source handle exists
             const srcHandle = connection.sourceHandle;
-            const srcOutput = srcMetadata?.outputs.find(
+            const srcOutput = srcMetadata.outputs.find(
               (output: OutputSlot) => output.name === srcHandle
             );
-            const srcType = srcOutput?.type;
+            if (!srcOutput) {
+              return false;
+            }
+
+            // Validate target handle exists (for non-dynamic nodes)
             const targetHandle = connection.targetHandle;
-            const targetProperty = targetMetadata?.properties.find(
+            const hasValidTargetHandle =
+              targetMetadata.is_dynamic ||
+              targetMetadata.properties.some(
+                (property: Property) => property.name === targetHandle
+              );
+            if (!hasValidTargetHandle) {
+              return false;
+            }
+
+            // Validate type compatibility
+            const srcType = srcOutput.type;
+            const targetProperty = targetMetadata.properties.find(
               (property: Property) => property.name === targetHandle
             );
             const targetType = targetProperty?.type || {
@@ -747,6 +907,7 @@ export const createNodeStore = (
               optional: false,
               type_args: []
             };
+
             return (
               srcType !== undefined &&
               targetType !== undefined &&

--- a/web/src/stores/__tests__/NodeStore.test.ts
+++ b/web/src/stores/__tests__/NodeStore.test.ts
@@ -5,10 +5,16 @@ import { createNodeStore } from "../NodeStore";
 import { NodeData } from "../NodeData";
 import useErrorStore from "../ErrorStore";
 import useResultsStore from "../ResultsStore";
+import useMetadataStore from "../MetadataStore";
+import { NodeMetadata } from "../ApiTypes";
 
-const makeNode = (id: string, workflowId: string): Node<NodeData> => ({
+const makeNode = (
+  id: string,
+  workflowId: string,
+  type: string = "test"
+): Node<NodeData> => ({
   id,
-  type: "test",
+  type,
   position: { x: 0, y: 0 },
   targetPosition: Position.Left,
   data: {
@@ -19,17 +25,69 @@ const makeNode = (id: string, workflowId: string): Node<NodeData> => ({
   }
 });
 
-const makeEdge = (source: string, target: string): Edge => ({
+const makeEdge = (
+  source: string,
+  target: string,
+  sourceHandle?: string,
+  targetHandle?: string
+): Edge => ({
   id: `${source}-${target}`,
   source,
   target,
-  sourceHandle: null,
-  targetHandle: null
+  sourceHandle: sourceHandle || null,
+  targetHandle: targetHandle || null
 });
 
+const mockMetadata: Record<string, NodeMetadata> = {
+  test: {
+    node_type: "test",
+    title: "Test Node",
+    description: "A test node",
+    namespace: "test",
+    layout: "default",
+    the_model_info: {},
+    recommended_models: [],
+    basic_fields: [],
+    outputs: [
+      {
+        name: "output1",
+        type: { type: "str", optional: false, type_args: [] },
+        stream: false
+      }
+    ],
+    properties: [
+      {
+        name: "input1",
+        type: { type: "str", optional: false, type_args: [] },
+        default: ""
+      }
+    ],
+    is_dynamic: false
+  },
+  dynamic_test: {
+    node_type: "dynamic_test",
+    title: "Dynamic Test Node",
+    description: "A dynamic test node",
+    namespace: "test",
+    layout: "default",
+    the_model_info: {},
+    recommended_models: [],
+    basic_fields: [],
+    outputs: [
+      {
+        name: "output1",
+        type: { type: "str", optional: false, type_args: [] },
+        stream: false
+      }
+    ],
+    properties: [],
+    is_dynamic: true
+  }
+};
 describe("NodeStore node management", () => {
   const originalError = useErrorStore.getState();
   const originalResults = useResultsStore.getState();
+  const originalMetadata = useMetadataStore.getState();
   let store: ReturnType<typeof createNodeStore>;
 
   beforeEach(() => {
@@ -39,11 +97,16 @@ describe("NodeStore node management", () => {
       { ...originalResults, clearResults: jest.fn() },
       true
     );
+    useMetadataStore.setState(
+      { ...originalMetadata, metadata: mockMetadata },
+      true
+    );
   });
 
   afterEach(() => {
     useErrorStore.setState(originalError, true);
     useResultsStore.setState(originalResults, true);
+    useMetadataStore.setState(originalMetadata, true);
   });
 
   test("addNode adds a node and sets workflow dirty", () => {
@@ -144,5 +207,217 @@ describe("NodeStore node management", () => {
     ]);
 
     expect(store.getState().workflowIsDirty).toBe(false);
+  });
+});
+
+describe("Edge Validation", () => {
+  const originalMetadata = useMetadataStore.getState();
+  let store: ReturnType<typeof createNodeStore>;
+
+  beforeEach(() => {
+    store = createNodeStore();
+    useMetadataStore.setState(
+      { ...originalMetadata, metadata: mockMetadata },
+      true
+    );
+  });
+
+  afterEach(() => {
+    useMetadataStore.setState(originalMetadata, true);
+  });
+
+  test("should validate edges with existing nodes and handles", () => {
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    const nodeB = makeNode("b", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeA);
+    store.getState().addNode(nodeB);
+
+    const validEdge = makeEdge("a", "b", "output1", "input1");
+    store.getState().addEdge(validEdge);
+
+    expect(store.getState().edges).toHaveLength(1);
+    expect(store.getState().edges[0].id).toBe("a-b");
+  });
+
+  test("should reject edges with missing source nodes", () => {
+    const nodeB = makeNode("b", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeB);
+
+    const invalidEdge = makeEdge("nonexistent", "b", "output1", "input1");
+    store.getState().addEdge(invalidEdge);
+
+    expect(store.getState().edges).toHaveLength(0);
+  });
+
+  test("should reject edges with missing target nodes", () => {
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeA);
+
+    const invalidEdge = makeEdge("a", "nonexistent", "output1", "input1");
+    store.getState().addEdge(invalidEdge);
+
+    expect(store.getState().edges).toHaveLength(0);
+  });
+
+  test("should handle missing metadata gracefully", () => {
+    // Clear metadata
+    useMetadataStore.setState({ ...originalMetadata, metadata: {} }, true);
+
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    const nodeB = makeNode("b", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeA);
+    store.getState().addNode(nodeB);
+
+    const edge = makeEdge("a", "b", "output1", "input1");
+    store.getState().addEdge(edge);
+
+    // Should allow edge when metadata is missing but handles are specified
+    expect(store.getState().edges).toHaveLength(1);
+  });
+
+  test("should support dynamic nodes", () => {
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    const nodeB = makeNode("b", store.getState().workflow.id, "dynamic_test");
+    store.getState().addNode(nodeA);
+    store.getState().addNode(nodeB);
+
+    const validEdge = makeEdge("a", "b", "output1", "any_handle");
+    store.getState().addEdge(validEdge);
+
+    expect(store.getState().edges).toHaveLength(1);
+  });
+
+  test("should reject edges with invalid source handles", () => {
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    const nodeB = makeNode("b", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeA);
+    store.getState().addNode(nodeB);
+
+    const invalidEdge = makeEdge("a", "b", "invalid_output", "input1");
+    store.getState().addEdge(invalidEdge);
+
+    expect(store.getState().edges).toHaveLength(0);
+  });
+
+  test("should reject edges with invalid target handles on non-dynamic nodes", () => {
+    const nodeA = makeNode("a", store.getState().workflow.id, "test");
+    const nodeB = makeNode("b", store.getState().workflow.id, "test");
+    store.getState().addNode(nodeA);
+    store.getState().addNode(nodeB);
+
+    const invalidEdge = makeEdge("a", "b", "output1", "invalid_input");
+    store.getState().addEdge(invalidEdge);
+
+    expect(store.getState().edges).toHaveLength(0);
+  });
+});
+
+describe("Graph Sanitization", () => {
+  const originalMetadata = useMetadataStore.getState();
+  let store: ReturnType<typeof createNodeStore>;
+
+  beforeEach(() => {
+    useMetadataStore.setState(
+      { ...originalMetadata, metadata: mockMetadata },
+      true
+    );
+  });
+
+  afterEach(() => {
+    useMetadataStore.setState(originalMetadata, true);
+  });
+
+  test("should remove invalid edges and preserve valid ones", () => {
+    const nodeA = makeNode("a", "test-workflow", "test");
+    const nodeB = makeNode("b", "test-workflow", "test");
+    const validEdge = makeEdge("a", "b", "output1", "input1");
+    const invalidEdge = makeEdge("a", "b", "invalid_output", "input1");
+
+    const workflow = {
+      id: "test-workflow",
+      name: "Test Workflow",
+      access: "private" as const,
+      description: "",
+      thumbnail: "",
+      tags: [],
+      settings: {},
+      updated_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+      graph: {
+        nodes: [nodeA, nodeB].map((n) => ({
+          id: n.id,
+          type: n.type!,
+          data: n.data.properties,
+          dynamic_properties: {},
+          ui_properties: {
+            position: n.position,
+            selected: false,
+            selectable: true
+          }
+        })),
+        edges: [validEdge, invalidEdge].map((e) => ({
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          sourceHandle: e.sourceHandle!,
+          targetHandle: e.targetHandle!,
+          ui_properties: {}
+        }))
+      }
+    };
+
+    store = createNodeStore(workflow);
+
+    // Should only have the valid edge
+    expect(store.getState().edges).toHaveLength(1);
+    expect(store.getState().edges[0].sourceHandle).toBe("output1");
+    expect(store.getState().edges[0].targetHandle).toBe("input1");
+  });
+
+  test("should report statistics about removed edges", () => {
+    const consoleSpy = jest.spyOn(console, "info").mockImplementation();
+
+    const nodeA = makeNode("a", "test-workflow", "test");
+    const nodeB = makeNode("b", "test-workflow", "test");
+    const invalidEdge1 = makeEdge("a", "b", "invalid_output", "input1");
+    const invalidEdge2 = makeEdge("a", "b", "output1", "invalid_input");
+
+    const workflow = {
+      id: "test-workflow",
+      name: "Test Workflow",
+      access: "private" as const,
+      description: "",
+      thumbnail: "",
+      tags: [],
+      settings: {},
+      updated_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+      graph: {
+        nodes: [nodeA, nodeB].map((n) => ({
+          id: n.id,
+          type: n.type!,
+          data: n.data.properties,
+          dynamic_properties: {},
+          ui_properties: {
+            position: n.position,
+            selected: false,
+            selectable: true
+          }
+        })),
+        edges: [invalidEdge1, invalidEdge2].map((e) => ({
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          sourceHandle: e.sourceHandle!,
+          targetHandle: e.targetHandle!,
+          ui_properties: {}
+        }))
+      }
+    };
+
+    store = createNodeStore(workflow);
+
+    expect(store.getState().edges).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 });

--- a/web/src/stores/graphEdgeToReactFlowEdge.ts
+++ b/web/src/stores/graphEdgeToReactFlowEdge.ts
@@ -6,9 +6,9 @@ export const graphEdgeToReactFlowEdge = (edge: GraphEdge): Edge => {
   return {
     id: edge.id || uuidv4(),
     source: edge.source,
-    sourceHandle: edge.sourceHandle,
+    sourceHandle: edge.sourceHandle || null,
     target: edge.target,
-    targetHandle: edge.targetHandle,
+    targetHandle: edge.targetHandle || null,
     className: edge.ui_properties?.className
   };
 };


### PR DESCRIPTION
fixes constant warnings from reactflow if edge input or output is not found.

hook.js:608 [React Flow]: Couldn't create edge for source handle id: "output", edge id: 7b4eff36-a9c7-476c-bb33-717862f49b50. Help: https://reactflow.dev/error#008

refactored sanitize functions.