### PR TITLE
Add utils tests

### DIFF
--- a/web/src/utils/__tests__/errorHandling.test.ts
+++ b/web/src/utils/__tests__/errorHandling.test.ts
@@ -1,0 +1,33 @@
+import { createErrorMessage, AppError } from '../errorHandling';
+
+describe('createErrorMessage', () => {
+  it('handles error objects with detail', () => {
+    const err = { detail: 'bad things happened' };
+    const result = createErrorMessage(err, 'Oops');
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.message).toBe('Oops');
+    expect((result as AppError).detail).toBe('bad things happened');
+  });
+
+  it('handles string errors', () => {
+    const result = createErrorMessage('something broke', 'Failed');
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.message).toBe('Failed');
+    expect((result as AppError).detail).toBe('something broke');
+  });
+
+  it('handles Error instances', () => {
+    const err = new Error('nope');
+    const result = createErrorMessage(err, 'Failed');
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.message).toBe('Failed');
+    expect((result as AppError).detail).toBe('nope');
+  });
+
+  it('handles unknown error types', () => {
+    const result = createErrorMessage(42 as any, 'Unknown');
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.message).toBe('Unknown');
+    expect((result as AppError).detail).toBeUndefined();
+  });
+});

--- a/web/src/utils/__tests__/highlightText.test.ts
+++ b/web/src/utils/__tests__/highlightText.test.ts
@@ -1,0 +1,42 @@
+// Mock ThemeNodetool to avoid heavy imports
+jest.mock('../../components/themes/ThemeNodetool', () => ({
+  __esModule: true,
+  default: { palette: { c_hl1: '#ff0000' } }
+}));
+
+import { highlightText, escapeHtml, hexToRgb, formatBulletList } from '../highlightText';
+import { NodeMetadata } from '../../stores/ApiTypes';
+
+describe('highlightText utilities', () => {
+  it('escapeHtml converts special characters', () => {
+    expect(escapeHtml('<div>&</div>')).toBe('&lt;div&gt;&amp;&lt;/div&gt;');
+  });
+
+  it('hexToRgb converts hex colors', () => {
+    expect(hexToRgb('#ffffff')).toBe('255, 255, 255');
+    expect(hexToRgb('invalid')).toBeNull();
+  });
+
+  it('formatBulletList converts lines to list', () => {
+    const result = formatBulletList('a\nb');
+    expect(result).toBe('<ul><li>a</li>\n<li>b</li></ul>');
+  });
+
+  it('returns plain text when no search info', () => {
+    const result = highlightText('hello', 'title', null, undefined);
+    expect(result.html).toBe('hello');
+    expect(result.highlightedWords).toEqual([]);
+  });
+
+  it('highlights matched text', () => {
+    const searchInfo: NodeMetadata['searchInfo'] = {
+      matches: [
+        { key: 'title', value: 'hello world', indices: [[0, 4]] }
+      ]
+    };
+    const result = highlightText('hello world', 'title', 'hello', searchInfo);
+    expect(result.highlightedWords).toEqual(['hello']);
+    expect(result.html).toContain('<span class="highlight"');
+    expect(result.html).toContain('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- increase coverage for `errorHandling` and `highlightText`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm test -- --coverage --maxWorkers=2`
