### PR TITLE
Add responsive mobile layout for chat and dashboard

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -287,6 +287,21 @@ const styles = (theme: any) =>
         gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
         gap: theme.spacing(2)
       }
+    },
+
+    "@media (max-width: 480px)": {
+      "&": {
+        padding: theme.spacing(1),
+        gap: theme.spacing(1)
+      },
+      ".section": {
+        padding: theme.spacing(1)
+      },
+      ".workflow-controls": {
+        flexDirection: "column",
+        alignItems: "stretch",
+        gap: theme.spacing(1)
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- improve `GlobalChat` layout for small screens
- close chat sidebar on thread actions
- add menu drawer and toggle on mobile
- tweak dashboard spacing at narrow widths

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `cd apps && npm run lint`
- `cd apps && npm run typecheck`
- `cd electron && npm run lint`
- `cd electron && npm run typecheck`
- `cd electron && npm test`


------
https://chatgpt.com/codex/tasks/task_b_6839f1ea973c832f8a659619238a4eb5