### PR TITLE
Fix chat composer theme param and accessibility

### DIFF
--- a/web/src/components/chat/composer/ChatComposer.tsx
+++ b/web/src/components/chat/composer/ChatComposer.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React, { useRef, useState, useCallback } from "react";
+import { useTheme } from "@mui/material/styles";
 import { MessageContent } from "../../../stores/ApiTypes";
 import { useKeyPressedStore } from "../../../stores/KeyPressedStore";
 import { FilePreview } from "./FilePreview";
@@ -29,6 +30,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
   onStop,
   disabled = false
 }) => {
+  const theme = useTheme();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [prompt, setPrompt] = useState("");
 
@@ -90,7 +92,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
   const isDisabled = disabled || status === "loading" || status === "error";
 
   return (
-    <div css={createStyles}>
+    <div css={createStyles(theme)}>
       <div
         className={`compose-message ${isDragging ? "dragging" : ""}`}
         onDragOver={handleDragOver}

--- a/web/src/components/chat/composer/FilePreview.tsx
+++ b/web/src/components/chat/composer/FilePreview.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import FileIcon from "@mui/icons-material/InsertDriveFile";
 import { DroppedFile } from "../types/chat.types";
 
+const isValidImageDataUri = (uri: string) =>
+  /^data:image\/(jpeg|jpg|png|gif|webp);base64,/.test(uri);
+
 interface FilePreviewProps {
   file: DroppedFile;
   onRemove: () => void;
@@ -9,7 +12,7 @@ interface FilePreviewProps {
 
 export const FilePreview: React.FC<FilePreviewProps> = ({ file, onRemove }) => (
   <div className="file-preview">
-    {file.type.startsWith("image/") ? (
+    {file.type.startsWith("image/") && isValidImageDataUri(file.dataUri) ? (
       <img src={file.dataUri} alt={file.name} />
     ) : (
       <div className="file-icon-wrapper">
@@ -17,8 +20,13 @@ export const FilePreview: React.FC<FilePreviewProps> = ({ file, onRemove }) => (
         <div className="file-name">{file.name}</div>
       </div>
     )}
-    <div className="remove-button" onClick={onRemove}>
+    <button
+      className="remove-button"
+      onClick={onRemove}
+      aria-label={`Remove file ${file.name}`}
+      type="button"
+    >
       ×
-    </div>
+    </button>
   </div>
 );

--- a/web/src/components/chat/thread/EmptyThreadList.styles.ts
+++ b/web/src/components/chat/thread/EmptyThreadList.styles.ts
@@ -1,0 +1,9 @@
+import { css } from "@emotion/react";
+
+export const createStyles = (theme: any) =>
+  css({
+    padding: "2em",
+    textAlign: "center",
+    color: theme.palette.c_gray3,
+    fontSize: "0.9em"
+  });

--- a/web/src/components/chat/thread/EmptyThreadList.tsx
+++ b/web/src/components/chat/thread/EmptyThreadList.tsx
@@ -1,15 +1,12 @@
+/** @jsxImportSource @emotion/react */
 import React from "react";
+import { useTheme } from "@mui/material/styles";
+import { createStyles } from "./EmptyThreadList.styles";
 
 export const EmptyThreadList: React.FC = () => {
+  const theme = useTheme();
   return (
-    <li
-      style={{
-        padding: "2em",
-        textAlign: "center",
-        color: "#666",
-        fontSize: "0.9em"
-      }}
-    >
+    <li css={createStyles(theme)}>
       No conversations yet. Click &ldquo;New Chat&rdquo; to start.
     </li>
   );

--- a/web/src/components/chat/thread/ThreadItem.tsx
+++ b/web/src/components/chat/thread/ThreadItem.tsx
@@ -30,7 +30,7 @@ export const ThreadItem: React.FC<ThreadItemProps> = ({
         }}
         data-microtip-position="left"
         aria-label="Delete conversation"
-        role="tooltip"
+        role="button"
       >
         <DeleteIcon />
       </IconButton>


### PR DESCRIPTION
## Summary
- use theme in ChatComposer styles
- validate image data URIs and use a button for removing files
- style EmptyThreadList with Emotion
- correct ARIA role for ThreadItem delete button

## Testing
- `cd web && npm run lint`
- `npm run typecheck` *(fails: Property 'showToolbar' does not exist on type)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683aab418a1c832f95e1f60e62b641cb