### PR TITLE
Fix short message width in ChatThreadView

### DIFF
--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -23,6 +23,7 @@ export const createStyles = (theme: any) => ({
   chatMessagesList: css({
     listStyleType: "none",
     maxWidth: "1000px",
+    width: "100%",
     padding: "2em 0 0",
     margin: "0",
 


### PR DESCRIPTION
## Summary
- ensure ChatThreadView message list fills available width

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`


------
https://chatgpt.com/codex/tasks/task_b_683ab22ba8d4832f9ee523cb23ce2a31