### PR TITLE
Refactor ExampleGrid into smaller components

### DIFF
--- a/web/src/components/workflows/SearchBar.tsx
+++ b/web/src/components/workflows/SearchBar.tsx
@@ -1,0 +1,89 @@
+/** @jsxImportSource @emotion/react */
+import {
+  Box,
+  TextField,
+  Tooltip,
+  Switch,
+  FormControlLabel,
+  IconButton,
+  InputAdornment
+} from "@mui/material";
+import { Clear as ClearIcon } from "@mui/icons-material";
+import {
+  TOOLTIP_ENTER_DELAY,
+  TOOLTIP_LEAVE_DELAY
+} from "../../config/constants";
+
+interface SearchBarProps {
+  inputValue: string;
+  nodesOnlySearch: boolean;
+  onInputChange: (value: string) => void;
+  onToggleNodeSearch: (checked: boolean) => void;
+  onClear: () => void;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({
+  inputValue,
+  nodesOnlySearch,
+  onInputChange,
+  onToggleNodeSearch,
+  onClear
+}) => {
+  return (
+    <Box className="search-container">
+      <TextField
+        className="search-field"
+        style={{
+          transition: "background-color 0.3s ease",
+          backgroundColor: nodesOnlySearch
+            ? "var(--palette-primary-dark)"
+            : "transparent"
+        }}
+        placeholder={
+          nodesOnlySearch
+            ? "Find examples that use a specific node..."
+            : "Find examples by name or description..."
+        }
+        variant="outlined"
+        size="small"
+        value={inputValue}
+        onChange={(e) => onInputChange(e.target.value)}
+        slotProps={{
+          input: {
+            endAdornment: inputValue && (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="clear search"
+                  onClick={onClear}
+                  edge="end"
+                  size="small"
+                >
+                  <ClearIcon />
+                </IconButton>
+              </InputAdornment>
+            )
+          }
+        }}
+      />
+      <Tooltip
+        title="Search for Nodes used in the example workflows"
+        enterDelay={TOOLTIP_ENTER_DELAY}
+        leaveDelay={TOOLTIP_LEAVE_DELAY}
+      >
+        <FormControlLabel
+          className="search-switch"
+          control={
+            <Switch
+              checked={nodesOnlySearch}
+              onChange={(e) => onToggleNodeSearch(e.target.checked)}
+              size="small"
+            />
+          }
+          label="Node Search"
+        />
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default SearchBar;

--- a/web/src/components/workflows/TagFilter.tsx
+++ b/web/src/components/workflows/TagFilter.tsx
@@ -1,0 +1,68 @@
+/** @jsxImportSource @emotion/react */
+import { Box, Button, Tooltip } from "@mui/material";
+import { Workflow } from "../../stores/ApiTypes";
+import {
+  TOOLTIP_ENTER_DELAY,
+  TOOLTIP_LEAVE_DELAY
+} from "../../config/constants";
+
+interface TagFilterProps {
+  tags: Record<string, Workflow[]>;
+  selectedTag: string | null;
+  onSelectTag: (tag: string | null) => void;
+}
+
+const TagFilter: React.FC<TagFilterProps> = ({ tags, selectedTag, onSelectTag }) => {
+  return (
+    <Box className="tag-menu">
+      <div className="button-row">
+        <Tooltip
+          title="Basic examples to get started"
+          enterDelay={TOOLTIP_ENTER_DELAY}
+          leaveDelay={TOOLTIP_LEAVE_DELAY}
+        >
+          <Button
+            onClick={() => onSelectTag("getting-started")}
+            variant="outlined"
+            className={selectedTag === "getting-started" ? "selected" : ""}
+          >
+            Getting Started
+          </Button>
+        </Tooltip>
+        {Object.keys(tags)
+          .filter((tag) => tag !== "start")
+          .sort((a, b) => a.localeCompare(b))
+          .map((tag) => (
+            <Tooltip
+              key={tag}
+              title={`Show ${tag} examples`}
+              enterDelay={TOOLTIP_ENTER_DELAY}
+              leaveDelay={TOOLTIP_LEAVE_DELAY}
+            >
+              <Button
+                onClick={() => onSelectTag(tag)}
+                variant="outlined"
+                className={selectedTag === tag ? "selected" : ""}
+              >
+                {tag}
+              </Button>
+            </Tooltip>
+          ))}
+        <Tooltip
+          title="Show all example workflows"
+          enterDelay={TOOLTIP_ENTER_DELAY}
+          leaveDelay={TOOLTIP_LEAVE_DELAY}
+        >
+          <Button
+            onClick={() => onSelectTag(null)}
+            className={selectedTag === null ? "selected" : ""}
+          >
+            SHOW ALL
+          </Button>
+        </Tooltip>
+      </div>
+    </Box>
+  );
+};
+
+export default TagFilter;

--- a/web/src/components/workflows/WorkflowCard.tsx
+++ b/web/src/components/workflows/WorkflowCard.tsx
@@ -1,0 +1,84 @@
+/** @jsxImportSource @emotion/react */
+import { Box, Typography, CircularProgress, Fade } from "@mui/material";
+import { Workflow } from "../../stores/ApiTypes";
+import { BASE_URL } from "../../stores/ApiClient";
+import { getNodeDisplayName, getNodeNamespace } from "../../utils/nodeDisplay";
+
+interface WorkflowCardProps {
+  workflow: Workflow;
+  matchedNodes: { text: string }[];
+  nodesOnlySearch: boolean;
+  isLoading: boolean;
+  onClick: (workflow: Workflow) => void;
+}
+
+const WorkflowCard: React.FC<WorkflowCardProps> = ({
+  workflow,
+  matchedNodes,
+  nodesOnlySearch,
+  isLoading,
+  onClick
+}) => {
+  return (
+    <Box
+      className={`workflow ${isLoading ? "loading" : ""}`}
+      onClick={() => onClick(workflow)}
+    >
+      {isLoading && (
+        <Fade in={true}>
+          <Box className="loading-overlay">
+            <CircularProgress size={40} color="secondary" />
+            <Typography className="loading-text">
+              Creating new workflow from example...
+            </Typography>
+          </Box>
+        </Fade>
+      )}
+      <Typography variant="h3" component={"h3"}>
+        {workflow.name}
+      </Typography>
+      <Box className="image-wrapper">
+        <img
+          width="200px"
+          src={
+            BASE_URL +
+            "/api/assets/packages/" +
+            workflow.package_name +
+            "/" +
+            workflow.name +
+            ".jpg"
+          }
+          alt={" "}
+        />
+        <Typography className="package-name" component={"p"}>
+          {workflow.package_name?.replace("nodetool-", "").toUpperCase()}
+        </Typography>
+        {nodesOnlySearch && matchedNodes.length > 0 && (
+          <Box
+            className="matched-nodes"
+            sx={{ mt: 1, display: "flex", gap: 0.5, flexWrap: "wrap" }}
+          >
+            {matchedNodes.map((match, idx) => (
+              <Typography key={idx} className="matched-item">
+                {getNodeDisplayName(match.text) && (
+                  <>
+                    <span className="matched-item-name">
+                      {getNodeDisplayName(match.text)}
+                    </span>
+                  </>
+                )}
+                <span className="matched-item-namespace">
+                  {getNodeNamespace(match.text)}
+                </span>
+              </Typography>
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      <Typography className="description">{workflow.description}</Typography>
+    </Box>
+  );
+};
+
+export default WorkflowCard;


### PR DESCRIPTION
## Summary
- extract search bar UI to `SearchBar` component
- extract tag filtering to `TagFilter` component
- extract workflow card to `WorkflowCard` component
- keep orchestration in `ExampleGrid`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: 20 failed, 214 passed)*
- `cd apps && npm run lint`
- `npm run typecheck`
- `npm test`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683adbe93d50832fb075a63823ecb654