### PR TITLE
Refactor WorkflowManager context utilities

### DIFF
--- a/web/src/hooks/useWebSocketUpdatesStore.ts
+++ b/web/src/hooks/useWebSocketUpdatesStore.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+import {
+  createWebSocketUpdatesStore,
+  WebSocketUpdatesStore
+} from "../stores/WebSocketUpdatesStore";
+
+export const useWebSocketUpdatesStore = (): WebSocketUpdatesStore => {
+  const [store] = useState(() => createWebSocketUpdatesStore());
+
+  useEffect(() => {
+    store.getState().connect();
+    return () => store.getState().disconnect();
+  }, [store]);
+
+  return store;
+};

--- a/web/src/utils/workflowStorage.ts
+++ b/web/src/utils/workflowStorage.ts
@@ -1,0 +1,25 @@
+export const STORAGE_KEYS = {
+  CURRENT_WORKFLOW: "currentWorkflowId",
+  OPEN_WORKFLOWS: "openWorkflows"
+} as const;
+
+export const getCurrentWorkflow = () =>
+  localStorage.getItem(STORAGE_KEYS.CURRENT_WORKFLOW);
+
+export const getOpenWorkflows = (): string[] =>
+  JSON.parse(localStorage.getItem(STORAGE_KEYS.OPEN_WORKFLOWS) || "[]");
+
+import { debounce } from "lodash";
+
+export const setCurrentWorkflow = debounce((workflowId: string) => {
+  localStorage.setItem(STORAGE_KEYS.CURRENT_WORKFLOW, workflowId);
+}, 100);
+
+export const setOpenWorkflows = debounce((workflowIds: string[]) => {
+  localStorage.setItem(STORAGE_KEYS.OPEN_WORKFLOWS, JSON.stringify(workflowIds));
+}, 100);
+
+export const removeOpenWorkflow = (workflowId: string) => {
+  const updated = getOpenWorkflows().filter((id) => id !== workflowId);
+  setOpenWorkflows(updated);
+};


### PR DESCRIPTION
## Summary
- move localStorage logic to workflowStorage util
- add hook for websocket update store management
- use new utilities inside WorkflowManagerProvider

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: GlobalChatStore tests fail)*
- `cd apps && npm run lint`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683adc93afec832fb390ebcc10218462