### PR TITLE
Add API and socket hooks

### DIFF
--- a/web/src/components/chat/containers/GlobalChat.tsx
+++ b/web/src/components/chat/containers/GlobalChat.tsx
@@ -10,7 +10,7 @@ import ChatView from "./ChatView";
 import ThreadList from "../thread/ThreadList";
 import BackToEditorButton from "../../panels/BackToEditorButton";
 import BackToDashboardButton from "../../dashboard/BackToDashboardButton";
-import useGlobalChatStore from "../../../stores/GlobalChatStore";
+import { useChatSocket } from "../../../hooks/useChatSocket";
 import { Message } from "../../../stores/ApiTypes";
 import { DEFAULT_MODEL } from "../../../config/constants";
 
@@ -31,7 +31,7 @@ const GlobalChat: React.FC = () => {
     switchThread,
     deleteThread,
     stopGeneration
-  } = useGlobalChatStore();
+  } = useChatSocket();
 
   const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);

--- a/web/src/components/workflows/WorkflowList.tsx
+++ b/web/src/components/workflows/WorkflowList.tsx
@@ -11,8 +11,7 @@ import {
   WorkflowAttributes,
   WorkflowList as WorkflowListType
 } from "../../stores/ApiTypes";
-import { client } from "../../stores/ApiClient";
-import { createErrorMessage } from "../../utils/errorHandling";
+import { useWorkflowApi } from "../../hooks/useWorkflowApi";
 import { isEqual } from "lodash";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
@@ -55,18 +54,6 @@ const styles = (theme: any) =>
     }
   });
 
-const loadWorkflows = async (cursor?: string, limit?: number) => {
-  cursor = cursor || "";
-  const { data, error } = await client.GET("/api/workflows/", {
-    params: {
-      query: { cursor, limit, columns: "name,id,updated_at,description,tags" }
-    }
-  });
-  if (error) {
-    throw createErrorMessage(error, "Failed to load workflows");
-  }
-  return data;
-};
 
 const WorkflowList = () => {
   const [filterValue, setFilterValue] = useState("");
@@ -85,6 +72,8 @@ const WorkflowList = () => {
   const [selectedWorkflows, setSelectedWorkflows] = useState<string[]>([]);
   const pageSize = 200;
   const [workflowToEdit, setWorkflowToEdit] = useState<Workflow | null>(null);
+
+  const { loadWorkflows } = useWorkflowApi();
 
   const { data, isLoading, error, isError } = useQuery<WorkflowListType, Error>(
     {

--- a/web/src/hooks/useChatSocket.ts
+++ b/web/src/hooks/useChatSocket.ts
@@ -1,0 +1,21 @@
+import useGlobalChatStore from "../stores/GlobalChatStore";
+
+export const useChatSocket = () =>
+  useGlobalChatStore((state) => ({
+    connect: state.connect,
+    disconnect: state.disconnect,
+    sendMessage: state.sendMessage,
+    stopGeneration: state.stopGeneration,
+    status: state.status,
+    progress: state.progress,
+    statusMessage: state.statusMessage,
+    error: state.error,
+    currentThreadId: state.currentThreadId,
+    getCurrentMessages: state.getCurrentMessages,
+    threads: state.threads,
+    createNewThread: state.createNewThread,
+    switchThread: state.switchThread,
+    deleteThread: state.deleteThread,
+    updateThreadTitle: state.updateThreadTitle,
+    resetMessages: state.resetMessages
+  }));

--- a/web/src/hooks/useWorkflowApi.ts
+++ b/web/src/hooks/useWorkflowApi.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+import { client } from "../stores/ApiClient";
+import { createErrorMessage } from "../utils/errorHandling";
+import { WorkflowList } from "../stores/ApiTypes";
+
+export const useWorkflowApi = () => {
+  const loadWorkflows = useCallback(
+    async (cursor = "", limit?: number): Promise<WorkflowList> => {
+      const { data, error } = await client.GET("/api/workflows/", {
+        params: { query: { cursor, limit, columns: "name,id,updated_at,description,tags" } }
+      });
+      if (error) {
+        throw createErrorMessage(error, "Failed to load workflows");
+      }
+      return data as WorkflowList;
+    },
+    []
+  );
+
+  return { loadWorkflows };
+};


### PR DESCRIPTION
## Summary
- add `useWorkflowApi` hook for workflow API calls
- add `useChatSocket` hook for chat websocket interaction
- switch components to use new hooks

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web` *(fails: GlobalChatStore tests)*
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`


------
https://chatgpt.com/codex/tasks/task_b_683add3d6584832fb9a2d8a6ce152171