### PR TITLE
Add GitHub markdown styles for chat

### DIFF
--- a/web/src/components/chat/ChatTheme.tsx
+++ b/web/src/components/chat/ChatTheme.tsx
@@ -1,0 +1,45 @@
+import { Theme, createTheme } from "@mui/material/styles";
+import type {} from "@mui/material/themeCssVarsAugmentation";
+import { paletteDark } from "../themes/paletteDark";
+import { paletteLight } from "../themes/paletteLight";
+
+import "@fontsource/inter";
+import "@fontsource/inter/200.css";
+import "@fontsource/inter/300.css";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/600.css";
+
+import "@fontsource/jetbrains-mono/200.css";
+import "@fontsource/jetbrains-mono/300.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/600.css";
+
+const ThemeChat: Theme = createTheme({
+  defaultColorScheme: "dark",
+  colorSchemes: {
+    dark: { palette: paletteDark },
+    light: { palette: paletteLight }
+  },
+  cssVariables: {
+    colorSchemeSelector: "[data-mui-color-scheme]",
+    cssVarPrefix: ""
+  },
+  fontSizeGiant: "2em",
+  fontSizeBigger: "1.25em",
+  fontSizeBig: "1.125em",
+  fontSizeNormal: "16px",
+  fontSizeSmall: "0.875em",
+  fontSizeSmaller: "0.75em",
+  fontSizeTiny: "0.65em",
+  fontSizeTinyer: "0.55em",
+  fontFamily1: "'Inter', Arial, sans-serif",
+  fontFamily2: "'JetBrains Mono', 'Inter', Arial, sans-serif",
+  typography: {
+    fontFamily: "'Inter', sans-serif",
+    fontSize: 14
+  },
+  spacing: 4,
+  shape: { borderRadius: 4 }
+});
+
+export default ThemeChat;

--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { useCallback, useMemo } from "react";
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
+import ThemeChat from "../ChatTheme";
 import { Message, MessageContent } from "../../../stores/ApiTypes";
 import ChatThreadView from "../thread/ChatThreadView";
 import ChatInputSection from "./ChatInputSection";
@@ -91,25 +93,27 @@ const ChatView = ({
   );
 
   return (
-    <div className="chat-view" css={styles}>
-      <ChatThreadView
-        messages={messages}
-        status={status}
-        progress={progress}
-        total={total}
-        progressMessage={progressMessage}
-      />
+    <MuiThemeProvider theme={ThemeChat}>
+      <div className="chat-view" css={styles}>
+        <ChatThreadView
+          messages={messages}
+          status={status}
+          progress={progress}
+          total={total}
+          progressMessage={progressMessage}
+        />
 
-      <ChatInputSection
-        status={status}
-        onSendMessage={handleSendMessage}
-        onStop={onStop}
-        selectedTools={selectedTools}
-        onToolsChange={onToolsChange}
-        selectedModel={model}
-        onModelChange={onModelChange}
-      />
-    </div>
+        <ChatInputSection
+          status={status}
+          onSendMessage={handleSendMessage}
+          onStop={onStop}
+          selectedTools={selectedTools}
+          onToolsChange={onToolsChange}
+          selectedModel={model}
+          onModelChange={onModelChange}
+        />
+      </div>
+    </MuiThemeProvider>
   );
 };
 

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import "./github-markdown-dark.css";
+import "./github-markdown-light.css";
 
 interface ChatMarkdownProps {
   content: string;
@@ -22,7 +24,7 @@ const styles = (theme: any) =>
 
 const ChatMarkdown: React.FC<ChatMarkdownProps> = ({ content }) => {
   return (
-    <div css={styles} className="markdown">
+    <div css={styles} className="markdown markdown-body">
       <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
         {content || ""}
       </ReactMarkdown>

--- a/web/src/components/chat/message/github-markdown-dark.css
+++ b/web/src/components/chat/message/github-markdown-dark.css
@@ -1,0 +1,24 @@
+.markdown-body {
+  color-scheme: dark;
+  background-color: #0d1117;
+  color: #c9d1d9;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.markdown-body a {
+  color: #58a6ff;
+}
+
+.markdown-body pre {
+  background-color: #161b22;
+  padding: 16px;
+  overflow: auto;
+  border-radius: 6px;
+}
+
+.markdown-body code {
+  background-color: rgba(110,118,129,0.4);
+  padding: .2em .4em;
+  border-radius: 6px;
+}

--- a/web/src/components/chat/message/github-markdown-light.css
+++ b/web/src/components/chat/message/github-markdown-light.css
@@ -1,0 +1,24 @@
+.markdown-body {
+  color-scheme: light;
+  background-color: #ffffff;
+  color: #24292f;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.markdown-body a {
+  color: #0969da;
+}
+
+.markdown-body pre {
+  background-color: #f6f8fa;
+  padding: 16px;
+  overflow: auto;
+  border-radius: 6px;
+}
+
+.markdown-body code {
+  background-color: rgba(175,184,193,0.2);
+  padding: .2em .4em;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary
- style chat markdown content with GitHub markdown CSS
- provide new MUI theme for chat components
- wrap chat views with the dedicated chat theme

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b7126fe08832f968790a34378dce1