### PR TITLE
Restore Inspector panel

### DIFF
--- a/web/src/components/common/CopyToClipboardButton.tsx
+++ b/web/src/components/common/CopyToClipboardButton.tsx
@@ -66,7 +66,7 @@ export const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
         className="copy-to-clipboard-button"
         onClick={handleCopy}
         size={size}
-        // title={title}
+        title={title}
         sx={{ color: "var(--c_gray4)" }}
         {...props}
       >

--- a/web/src/components/hugging_face/ModelDownloadList.tsx
+++ b/web/src/components/hugging_face/ModelDownloadList.tsx
@@ -47,7 +47,7 @@ const ModelDownloadList: React.FC<ModelDownloadListProps> = ({ models }) => {
                     key={model.id}
                     model={model}
                     showModelStats={false}
-                    handleDelete={() => {}}
+                    handleModelDelete={() => {}}
                   />
                   // <ModelCard
                   //   model={model}

--- a/web/src/components/node/SubTaskView.tsx
+++ b/web/src/components/node/SubTaskView.tsx
@@ -64,7 +64,9 @@ interface SubTaskViewProps {
 }
 
 const SubTaskView: React.FC<SubTaskViewProps> = ({ subtask }) => {
-  const hasDependencies = subtask.input_tasks.length > 0;
+  const hasDependencies = (subtask as any).input_tasks
+    ? (subtask as any).input_tasks.length > 0
+    : false;
   const isRunning = subtask.start_time > 0 && !subtask.completed;
 
   return (

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { Drawer, IconButton, Tooltip } from "@mui/material";
+import Inspector from "../Inspector";
+import { useResizeRightPanel } from "../../hooks/handlers/useResizeRightPanel";
+import { useRightPanelStore } from "../../stores/RightPanelStore";
+import { memo } from "react";
+import { isEqual } from "lodash";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+
+const PANEL_WIDTH_COLLAPSED = "52px";
+
+const styles = (theme: any) =>
+  css({
+    ".panel-container": {
+      flexShrink: 0,
+      position: "absolute",
+      backgroundColor: theme.palette.c_gray1
+    },
+    ".panel-right": {
+      boxShadow: "0 4px 10px rgba(0, 0, 0, 0.3)",
+      borderLeft: "1px solid var(--c_gray2)",
+      backgroundColor: "var(--c_gray1)",
+      position: "absolute",
+      overflow: "hidden",
+      width: "100%",
+      padding: "0",
+      top: "72px",
+      height: "calc(-72px + 100vh)"
+    },
+
+    ".panel-button": {
+      position: "absolute",
+      zIndex: 1200,
+      width: "40px",
+      height: "calc(100vh - 75px)",
+      backgroundColor: "transparent",
+      border: 0,
+      borderRadius: 0,
+      top: "72px",
+      cursor: "e-resize",
+      transition: "background-color 0.3s ease",
+
+      "& svg": {
+        fontSize: "0.8em !important",
+        color: "var(--c_gray5)",
+        opacity: 0,
+        marginLeft: "1px",
+        transition: "all 0.5s ease"
+      },
+
+      "&:hover": {
+        backgroundColor: "#33333344",
+        "& svg": {
+          opacity: 1,
+          fontSize: "1em !important"
+        }
+      }
+    },
+    ".vertical-toolbar": {
+      width: "50px",
+      display: "flex",
+      flexDirection: "column",
+      backgroundColor: "transparent",
+      "& .MuiIconButton-root": {
+        padding: "14px",
+        borderRadius: "5px",
+        position: "relative",
+        transition: "all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)",
+
+        "&.active": {
+          backgroundColor: `${theme.palette.action.selected}88`,
+          boxShadow: `0 0 15px ${theme.palette.primary.main}40`,
+          "&::before": {
+            content: '""',
+            position: "absolute",
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: "3px",
+            backgroundColor: theme.palette.primary.main,
+            boxShadow: `0 0 10px ${theme.palette.primary.main}`
+          },
+          "&::after": {
+            content: '""',
+            position: "absolute",
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            background: `linear-gradient(135deg, ${theme.palette.primary.main}40, transparent)`,
+            borderRadius: "5px"
+          }
+        },
+        "&:hover": {
+          backgroundColor: `${theme.palette.action.hover}88`,
+          boxShadow: `0 0 15px ${theme.palette.action.hover}40`,
+          "&::after": {
+            content: '""',
+            position: "absolute",
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            background: `linear-gradient(135deg, ${theme.palette.primary.main}20, transparent)`,
+            borderRadius: "2px"
+          }
+        }
+      }
+    },
+    ".panel-content": {
+      display: "flex",
+      flex: 1,
+      height: "100%",
+      border: "0"
+    }
+  });
+
+const VerticalToolbar = memo(function VerticalToolbar({ handlePanelToggle }: { handlePanelToggle: () => void }) {
+  const panelVisible = useRightPanelStore((state) => state.panel.isVisible);
+  return (
+    <div className="vertical-toolbar">
+      <Tooltip title="Inspector" placement="left">
+        <IconButton tabIndex={-1} onClick={handlePanelToggle} className={panelVisible ? "active" : ""}>
+          <InfoOutlinedIcon />
+        </IconButton>
+      </Tooltip>
+    </div>
+  );
+});
+
+const PanelRight: React.FC = () => {
+  const {
+    ref: panelRef,
+    size: panelSize,
+    isVisible,
+    isDragging,
+    handleMouseDown,
+    handlePanelToggle
+  } = useResizeRightPanel("right");
+
+  return (
+    <div css={styles} className="panel-container" style={{ width: isVisible ? `${panelSize}px` : "60px" }}>
+      <IconButton
+        disableRipple={true}
+        className={"panel-button panel-button-right"}
+        edge="end"
+        color="inherit"
+        tabIndex={-1}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          handleMouseDown(e);
+        }}
+        style={{
+          right: isVisible ? `${Math.max(panelSize + 14, 25)}px` : "0px"
+        }}
+      >
+        <InfoOutlinedIcon />
+      </IconButton>
+      <Drawer
+        PaperProps={{
+          ref: panelRef,
+          className: `panel panel-right ${isDragging ? "dragging" : ""}`,
+          style: { width: isVisible ? `${panelSize}px` : PANEL_WIDTH_COLLAPSED }
+        }}
+        variant="persistent"
+        anchor="right"
+        open={true}
+      >
+        <div className="panel-content panel-right">
+          <VerticalToolbar handlePanelToggle={() => handlePanelToggle("inspector")}/>
+          {isVisible && <Inspector />}
+        </div>
+      </Drawer>
+    </div>
+  );
+};
+
+export default memo(PanelRight, isEqual);

--- a/web/src/hooks/handlers/useResizeRightPanel.ts
+++ b/web/src/hooks/handlers/useResizeRightPanel.ts
@@ -1,0 +1,101 @@
+import { useCallback, useRef } from "react";
+import { useRightPanelStore, RightPanelView } from "../../stores/RightPanelStore";
+
+const DEFAULT_PANEL_SIZE = 300;
+const MIN_DRAG_SIZE = 60;
+const MIN_PANEL_SIZE = DEFAULT_PANEL_SIZE;
+const MAX_PANEL_SIZE = 600;
+
+export const useResizeRightPanel = (panelPosition: "left" | "right" = "right") => {
+  const panel = useRightPanelStore((state) => state.panel);
+  const startDragX = useRef(0);
+  const startDragSize = useRef(0);
+
+  const actions = useRightPanelStore(
+    useCallback(
+      (state) => ({
+        setSize: state.setSize,
+        setVisibility: state.setVisibility,
+        setIsDragging: state.setIsDragging,
+        setHasDragged: state.setHasDragged,
+        handleViewChange: state.handleViewChange
+      }),
+      []
+    )
+  );
+
+  const ref = useRef<HTMLDivElement>(null);
+  const dragThreshold = 20;
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      startDragX.current = event.clientX;
+      startDragSize.current = panel.panelSize || DEFAULT_PANEL_SIZE;
+      actions.setIsDragging(true);
+      actions.setHasDragged(false);
+
+      let hasMoved = false;
+
+      const handleMouseMove = (event: MouseEvent) => {
+        hasMoved = true;
+        const deltaX = event.clientX - startDragX.current;
+        let newSize = startDragSize.current;
+
+        if (panelPosition === "left") {
+          newSize = startDragSize.current + deltaX;
+        } else {
+          newSize = startDragSize.current - deltaX;
+        }
+
+        newSize = Math.max(MIN_DRAG_SIZE, Math.min(newSize, MAX_PANEL_SIZE));
+        actions.setSize(newSize);
+
+        if (Math.abs(deltaX) > dragThreshold) {
+          actions.setHasDragged(true);
+        }
+      };
+
+      const handleMouseUp = () => {
+        if (!hasMoved) {
+          actions.handleViewChange(panel.activeView);
+        } else {
+          let finalSize = Math.max(MIN_DRAG_SIZE, panel.panelSize || DEFAULT_PANEL_SIZE);
+
+          let visible = true;
+          if (finalSize < MIN_PANEL_SIZE) {
+            finalSize = MIN_DRAG_SIZE;
+            visible = false;
+          }
+
+          if (finalSize !== panel.panelSize) {
+            actions.setSize(finalSize);
+          }
+          actions.setVisibility(visible);
+        }
+
+        actions.setIsDragging(false);
+        setTimeout(() => actions.setHasDragged(false), 0);
+
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+
+      event.preventDefault();
+    },
+    [panelPosition, panel.panelSize, panel.activeView, actions]
+  );
+
+  return {
+    ref,
+    size: panel.panelSize,
+    isVisible: panel.isVisible,
+    isDragging: panel.isDragging || false,
+    handleMouseDown,
+    handlePanelToggle: (view: RightPanelView) => actions.handleViewChange(view)
+  };
+};
+
+export default useResizeRightPanel;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -12,6 +12,7 @@ import {
 import ErrorBoundary from "./ErrorBoundary";
 
 import PanelLeft from "./components/panels/PanelLeft";
+import PanelRight from "./components/panels/PanelRight";
 
 import { CircularProgress, CssBaseline } from "@mui/material";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
@@ -146,6 +147,7 @@ function getRoutes() {
             >
               <PanelLeft />
               <TabsNodeEditor />
+              <PanelRight />
             </div>
           </FetchCurrentWorkflow>
         </ProtectedRoute>

--- a/web/src/stores/RightPanelStore.ts
+++ b/web/src/stores/RightPanelStore.ts
@@ -1,0 +1,103 @@
+/**
+ * RightPanelStore manages the right-side panel state.
+ */
+import { create } from "zustand";
+
+export type RightPanelView = "inspector";
+
+interface PanelState {
+  panelSize: number;
+  isVisible: boolean;
+  isDragging: boolean;
+  hasDragged: boolean;
+  minWidth: number;
+  maxWidth: number;
+  defaultWidth: number;
+  activeView: RightPanelView;
+}
+
+interface ResizePanelState {
+  panel: PanelState;
+  setSize: (newSize: number) => void;
+  setIsDragging: (isDragging: boolean) => void;
+  setHasDragged: (hasDragged: boolean) => void;
+  initializePanelSize: (size?: number) => void;
+  setActiveView: (view: RightPanelView) => void;
+  closePanel: () => void;
+  handleViewChange: (view: RightPanelView) => void;
+  setVisibility: (isVisible: boolean) => void;
+}
+
+const DEFAULT_PANEL_SIZE = 300;
+const MIN_DRAG_SIZE = 60;
+const MIN_PANEL_SIZE = DEFAULT_PANEL_SIZE - 100;
+const MAX_PANEL_SIZE = 600;
+
+const createInitialState = (): PanelState => ({
+  panelSize: DEFAULT_PANEL_SIZE,
+  isVisible: false,
+  isDragging: false,
+  hasDragged: false,
+  minWidth: MIN_DRAG_SIZE,
+  maxWidth: MAX_PANEL_SIZE,
+  defaultWidth: DEFAULT_PANEL_SIZE,
+  activeView: "inspector"
+});
+
+export const useRightPanelStore = create<ResizePanelState>()((set, get) => ({
+  panel: createInitialState(),
+
+  setSize: (newSize) =>
+    set((state) => {
+      if (newSize <= MIN_DRAG_SIZE) {
+        return { panel: { ...state.panel, panelSize: MIN_DRAG_SIZE } };
+      }
+      const validSize = Math.min(newSize, MAX_PANEL_SIZE);
+      return { panel: { ...state.panel, panelSize: validSize } };
+    }),
+
+  setIsDragging: (isDragging) =>
+    set((state) => ({ panel: { ...state.panel, isDragging } })),
+
+  setHasDragged: (hasDragged) =>
+    set((state) => ({ panel: { ...state.panel, hasDragged } })),
+
+  initializePanelSize: (size) => {
+    const validSize = Math.max(
+      MIN_PANEL_SIZE,
+      Math.min(size || DEFAULT_PANEL_SIZE, MAX_PANEL_SIZE)
+    );
+    set((state) => ({ panel: { ...state.panel, panelSize: validSize } }));
+  },
+
+  setActiveView: (view) =>
+    set((state) => ({ panel: { ...state.panel, activeView: view } })),
+
+  closePanel: () =>
+    set((state) => ({
+      panel: { ...state.panel, panelSize: MIN_DRAG_SIZE, isVisible: false }
+    })),
+
+  setVisibility: (isVisible) =>
+    set((state) => ({ panel: { ...state.panel, isVisible } })),
+
+  handleViewChange: (view) => {
+    const { panel } = get();
+    if (panel.activeView === view) {
+      if (!panel.isVisible && panel.panelSize < MIN_PANEL_SIZE) {
+        set((state) => ({
+          panel: { ...state.panel, panelSize: MIN_PANEL_SIZE, isVisible: true }
+        }));
+      } else {
+        set((state) => ({
+          panel: { ...state.panel, isVisible: !state.panel.isVisible }
+        }));
+      }
+    } else {
+      set((state) => ({
+        panel: { ...state.panel, activeView: view, isVisible: true }
+      }));
+    }
+  }
+}));
+


### PR DESCRIPTION
## Summary
- implement RightPanelStore and resize handler
- add PanelRight component with Inspector
- mount PanelRight in the editor
- sync copy button title attribute
- update tests and fix typecheck errors

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `cd apps && npm run lint`
- `npm run typecheck`
- `cd ../electron && npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68502c08dab8832fbf50481a5efb112d