### PR TITLE
Add manual documentation pages

### DIFF
--- a/docs/asset-management.md
+++ b/docs/asset-management.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: Asset Management
+---
+
+NodeTool lets you store and organise files used in your workflows. Assets can be images, audio clips, PDFs or any other resources referenced by nodes.
+
+### Browsing assets
+
+- Use the **Asset Explorer** to navigate folders and upload new files.
+- Switch between grid or table views to inspect metadata.
+- Preview common formats directly in the editor with the built‑in viewers.
+
+### Metadata and tags
+
+- Assets keep track of basic metadata like size and type.
+- Tag files to make searching easier when projects grow large.
+
+### Document indexing
+
+- Text‑based files can be indexed for vector search.
+- Combine the index with language models for Retrieval‑Augmented Generation.
+
+Assets are stored locally in your user directory so you keep full control of your data.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: Desktop App
+---
+
+The Electron wrapper packages the web editor into a cross‑platform desktop application. It also adds native integrations not available in the browser.
+
+### System tray
+
+- Quick access to your workflows from a tray icon.
+- Run workflows or open the chat overlay without launching the full editor.
+- Background updates keep everything in sync.
+
+### Mini apps
+
+- Workflows can be exported as standalone apps via the **Apps** project.
+- Each app bundles only the components it needs, keeping downloads small.
+
+### Updating
+
+- Automatic update checks ensure you always have the latest features.
+- Logs can be viewed during installation to track progress.
+
+Use `npm run build` in the `electron` folder to generate a distributable package.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ NodeTool was created to give anyone the power of modern AI while keeping full co
 
 Want more details? Check out our [Getting Started](getting-started.md) guide and the
 [Tips and Tricks](tips-and-tricks.md) page for shortcuts and workflow ideas.
+Explore the manual for deep dives into the [Workflow Editor](workflow-editor.md),
+[Asset Management](asset-management.md) and the [Desktop App](desktop-app.md).
 
 ### Join the community
 

--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Workflow Editor
+---
+
+The workflow editor is where you design and run AI pipelines. Nodes represent tasks and edges define how data flows between them.
+
+### Creating nodes
+
+- Press the **Space** key or double‑click the canvas to open the node menu.
+- Search or browse namespaces to find the node you need.
+- Drag nodes onto the canvas and connect their inputs and outputs.
+
+### Managing the graph
+
+- Use the toolbar to **save** your workflow or arrange nodes automatically with **Auto Layout**.
+- Undo and redo changes using <kbd>Ctrl+Z</kbd> / <kbd>Ctrl+Shift+Z</kbd>.
+- Right‑click to open context menus for nodes, inputs and the canvas.
+
+### Running workflows
+
+- Click the **Run** button or press <kbd>Ctrl+Enter</kbd> to execute the workflow.
+- Status updates and results stream back in real time.
+- Workflows can run locally or dispatch jobs to remote workers.
+
+### Tabs and panels
+
+- Multiple workflows can be open in tabs at once.
+- Panels on the left provide access to assets, settings and logs.
+
+For a quick introduction see the [Getting Started guide](getting-started.md).


### PR DESCRIPTION
## Summary
- add manual pages for workflow editor, assets and desktop app
- reference the new pages from the docs index

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web` *(fails: type errors)*
- `npm test` in `web` *(fails: tests failing)*
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm test` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`


------
https://chatgpt.com/codex/tasks/task_b_685829d8bb70832fad448ba1118c0705