### PR TITLE
Remove unused function

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -193,12 +193,6 @@ const AppWrapper = () => {
       });
   }, []); // Empty dependency array ensures this runs only once on mount
 
-  // Helper to navigate to the newly created workflow
-  // This function seems unused in the current context of AppWrapper's return,
-  // but keeping it in case it's used by other parts or intended for future use.
-  const handleWorkflowCreated = (workflowId: string) => {
-    window.location.href = `/editor/${workflowId}`;
-  };
 
   return (
     <React.StrictMode>


### PR DESCRIPTION
## Summary
- remove `handleWorkflowCreated` helper from `web/src/index.tsx`

## Testing
- `npm run lint` within `web`
- `npm run typecheck` *(fails: Property 'socket' does not exist on type 'GlobalChatState')*
- `npm test` *(fails: various TypeScript errors)*
- `npm run lint` within `apps`
- `npm run typecheck` within `apps`
- `npm run lint` within `electron`
- `npm run typecheck` within `electron`
- `npm test` within `electron`


------
https://chatgpt.com/codex/tasks/task_b_68582d9e7684832fabaeb2ad4c7eb574