### PR TITLE
Fix web tests

### DIFF
--- a/web/src/lib/websocket/WebSocketManager.ts
+++ b/web/src/lib/websocket/WebSocketManager.ts
@@ -224,10 +224,22 @@ export class WebSocketManager extends EventEmitter {
   private async handleMessage(event: MessageEvent): Promise<void> {
     try {
       let data: any;
-      
-      if (this.config.binaryType === 'arraybuffer' && event.data instanceof ArrayBuffer) {
-        const decoded = decode(new Uint8Array(event.data));
-        data = decoded;
+
+      if (this.config.binaryType === 'arraybuffer') {
+        if (event.data instanceof ArrayBuffer) {
+          const decoded = decode(new Uint8Array(event.data));
+          data = decoded;
+        } else if (
+          event.data instanceof Blob ||
+          (event.data && typeof (event.data as any).arrayBuffer === 'function')
+        ) {
+          const buf = await (event.data as Blob).arrayBuffer();
+          data = decode(new Uint8Array(buf));
+        } else if (typeof event.data === 'string') {
+          data = JSON.parse(event.data);
+        } else {
+          data = event.data;
+        }
       } else if (typeof event.data === 'string') {
         data = JSON.parse(event.data);
       } else {

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -21,7 +21,7 @@ import { uuidv4 } from "./uuidv4";
 import { WebSocketManager, ConnectionState } from "../lib/websocket/WebSocketManager";
 
 // Include additional runtime statuses used during message streaming
-type ChatStatus = ConnectionState | "loading" | "streaming";
+type ChatStatus = ConnectionState | "loading" | "streaming" | "error";
 
 interface Thread {
   id: string;
@@ -276,9 +276,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
         set({ error: null });
 
         if (!wsManager || !wsManager.isConnected()) {
-          const error = "Not connected to chat service";
-          set({ error });
-          throw new Error(error);
+          set({ error: "Not connected to chat service" });
+          return;
         }
 
         // Ensure we have a thread
@@ -518,6 +517,7 @@ function handleWebSocketMessage(
       });
     } else if (update.status === "failed") {
       set({
+        status: "error",
         error: update.error,
         progress: { current: 0, total: 0 },
         statusMessage: update.error || null

--- a/web/src/stores/__tests__/WorkflowChatStore.test.ts
+++ b/web/src/stores/__tests__/WorkflowChatStore.test.ts
@@ -118,9 +118,11 @@ describe('WorkflowChatStore', () => {
   });
 
   it('handles string output_update messages', async () => {
-    await store.getState().connect({ id: 'wf1' } as WorkflowAttributes);
-    const socket = (store.getState() as any).socket as unknown as MockWebSocket;
+    const connectPromise = store.getState().connect({ id: 'wf1' } as WorkflowAttributes);
+    const wsManager = (store.getState() as any).wsManager as any;
+    const socket = wsManager.getWebSocket() as MockWebSocket;
     socket.onopen?.();
+    await connectPromise;
 
     const sendUpdate = async (value: string) => {
       const update: OutputUpdate = {
@@ -147,9 +149,11 @@ describe('WorkflowChatStore', () => {
   });
 
   it('handles image output_update messages', async () => {
-    await store.getState().connect({ id: 'wf1' } as WorkflowAttributes);
-    const socket = (store.getState() as any).socket as unknown as MockWebSocket;
+    const connectPromise = store.getState().connect({ id: 'wf1' } as WorkflowAttributes);
+    const wsManager = (store.getState() as any).wsManager as any;
+    const socket = wsManager.getWebSocket() as MockWebSocket;
     socket.onopen?.();
+    await connectPromise;
     const img = new Uint8Array([1, 2, 3]);
     const update: OutputUpdate = {
       type: 'output_update',


### PR DESCRIPTION
## Summary
- handle Blob messages in WebSocketManager
- improve GlobalChatStore sendMessage, job update handling
- cleanup wsManager in tests and adjust expectations
- ensure WorkflowChatStore connect helper waits correctly

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685837b7a608832f87fae3ae3c547ed3