### PR TITLE
Add Global Chat docs

### DIFF
--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Global Chat
+---
+
+Global Chat lets you talk to NodeTool from anywhere in the app. It manages multiple conversations and works with the AI model and tools you select.
+
+### Opening the chat
+
+- Click the **Chat** icon in the left sidebar or choose a recent thread on the Dashboard.
+- The chat view fills the screen with your conversation list on the left.
+
+### Managing threads
+
+- Use **New Chat** at the top of the list to start a fresh conversation.
+- Click a thread to switch to it. Each item shows a preview of your first message and when it was last updated.
+- Remove a thread with the delete button.
+
+### Composing messages
+
+- Type in the message box and press **Enter** to send.
+- Drag files onto the input to include images, audio or video.
+- Use the stop button to cancel streaming if needed.
+
+### Models and tools
+
+- Pick an AI model from the **Model** menu.
+- Optional tool selectors let the assistant search online or run workflow nodes.
+- **Agent Mode** allows the assistant to decide when to use tools.
+- **Help Mode** asks the assistant to explain its reasoning.
+
+### Status indicators
+
+- Progress bars appear when NodeTool processes your request.
+- The chat reconnects automatically if the connection drops.
+
+Use **Back to Editor** at the top of the screen to return to your workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ NodeTool was created to give anyone the power of modern AI while keeping full co
 - **System tray access** – launch workflows and manage your clipboard from anywhere.
 - **Mini‑app builder** – turn a workflow into a standalone application.
 - **Chat interface** – create custom chatbots for your projects.
+- **Global Chat** – start conversations from anywhere in the workspace. See
+  [Global Chat](global-chat.md).
 - **API and extensions** – connect NodeTool to other apps with Python scripts.
 
 For a deeper look at how these pieces interact, read the


### PR DESCRIPTION
## Summary
- document how Global Chat works from the user's perspective
- link the new page from the docs index

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`


------
https://chatgpt.com/codex/tasks/task_b_68585545af38832fbc18dd3253562786