### PR TITLE
Expand node editor docs

### DIFF
--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -28,4 +28,33 @@ The workflow editor is where you design and run AI pipelines. Nodes represent ta
 - Multiple workflows can be open in tabs at once.
 - Panels on the left provide access to assets, settings and logs.
 
+### Node menu
+
+- Press **Space** or double‑click the canvas to open the floating menu.
+- Search or browse namespaces and drag the menu anywhere on screen.
+- Filter nodes by their input or output types when connecting handles.
+- Press **Esc** to close the menu.
+
+### Keyboard shortcuts
+
+- <kbd>F</kbd> fits the graph to the window or focuses on the selection.
+- <kbd>Ctrl+=</kbd> / <kbd>Ctrl+-</kbd> zoom in and out.
+- <kbd>Ctrl+C</kbd>, <kbd>Ctrl+V</kbd> and <kbd>Ctrl+X</kbd> copy, paste or cut nodes.
+- <kbd>Ctrl+D</kbd> duplicates nodes horizontally; <kbd>Ctrl+Shift+D</kbd> stacks them vertically.
+- <kbd>Ctrl+G</kbd> groups the current selection.
+- <kbd>Arrow keys</kbd> nudge nodes in any direction.
+- <kbd>Ctrl+Z</kbd> / <kbd>Ctrl+Shift+Z</kbd> undo and redo.
+- <kbd>Ctrl+1</kbd>…<kbd>Ctrl+9</kbd> jump directly between open tabs.
+
+### Context menus
+
+- Right‑click nodes, handles or the canvas for extra options.
+- Release a connection on empty space to create a compatible node automatically.
+
+### Documentation and help
+
+- Hover a node in the menu to see its description, inputs and outputs.
+- Open documentation in a draggable window and add the node directly from there.
+- Press <kbd>i</kbd> to toggle the inspector panel for detailed properties.
+
 For a quick introduction see the [Getting Started guide](getting-started.md).


### PR DESCRIPTION
## Summary
- extend workflow-editor doc with additional details on the node editor

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run lint` in apps
- `npm run typecheck` in apps
- `npm run lint` in electron
- `npm run typecheck` in electron
- `npm test` in electron

------
https://chatgpt.com/codex/tasks/task_b_6858812181ac832fb88f2d7a7a2bf969