### PR TITLE
Add models manager docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ For a deeper look at how these pieces interact, read the
 Want more details? Check out our [Getting Started](getting-started.md) guide and the
 [Tips and Tricks](tips-and-tricks.md) page for shortcuts and workflow ideas.
 Explore the manual for deep dives into the [Workflow Editor](workflow-editor.md),
-[Asset Management](asset-management.md) and the [Desktop App](desktop-app.md).
+[Asset Management](asset-management.md), the [Models Manager](models-manager.md) and the [Desktop App](desktop-app.md).
 
 ### Join the community
 

--- a/docs/models-manager.md
+++ b/docs/models-manager.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Models Manager
+---
+
+The **Models Manager** helps you keep track of the AI models available on your system.
+
+### Opening the manager
+
+- Click the **model** icon on the right side of the editor.
+- A dialog appears showing downloaded and recommended models.
+
+### Browsing your models
+
+- Use the **Downloaded** and **Recommended** buttons to switch views.
+- Filter models by type using the list on the left.
+- Search by name or repository to quickly find what you need.
+- Toggle between grid and list layouts for a different view.
+
+### Managing files
+
+- Click **Download** to fetch a model to your local cache.
+- Use **Show in Explorer** to open the model folder on your computer.
+- Press **Delete** to remove a model you no longer need.
+- Select **README** on Hugging Face models to read documentation.
+
+Downloads continue even if you close the manager. Progress is shown in the bottom bar of the app.


### PR DESCRIPTION
## Summary
- document the Models Manager UI
- link the new page from the docs index

## Testing
- `npm run lint` (web)
- `npm run typecheck` (web)
- `npm test` (web)
- `npm run lint` (apps)
- `npm run typecheck` (apps)
- `npm test` (apps)
- `npm run lint` (electron)
- `npm run typecheck` (electron)
- `npm test` (electron)


------
https://chatgpt.com/codex/tasks/task_b_6858815ef624832fba5dc1f55a8f2b90