### PR TITLE
Add settings documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ Want more details? Check out our [Getting Started](getting-started.md) guide and
 [Tips and Tricks](tips-and-tricks.md) page for shortcuts and workflow ideas.
 Explore the manual for deep dives into the [Workflow Editor](workflow-editor.md),
 [Asset Management](asset-management.md) and the [Desktop App](desktop-app.md).
+For adjusting preferences, see the [Settings](settings.md) page.
 
 ### Join the community
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Settings
+---
+
+NodeTool provides two categories of settings that let you tailor the experience to your workflow.
+
+### Interface preferences
+
+Use the **Settings** panel in the left sidebar to adjust how the editor behaves. You can:
+
+- Control snapping for nodes and connections to keep layouts tidy.
+- Choose whether panning happens with the left or right mouse button.
+- Decide how selections are made when dragging over nodes.
+- Pick if workflows and assets are sorted by name or by date.
+- Set the size for items in the asset browser.
+- Switch between 12h and 24h time display.
+- Enable warnings before closing a workflow tab.
+- Toggle automatic node selection when dragging.
+- Show or hide the welcome dialog on startup.
+
+These options are stored locally so that each user has their own preferences.
+
+### Service configuration
+
+Some features, such as external AI services or custom model folders, require additional information. The **Remote Settings** dialog groups these options by provider. Typical examples include API keys for services like OpenAI and paths for local model directories. Secrets can be edited securely and are saved on your machine in an encrypted form.
+
+Changing these settings may require restarting the desktop app for changes to take effect.


### PR DESCRIPTION
## Summary
- document app settings for end users
- link the new page from the docs index

## Testing
- `npm run lint` in `web`
- `npm run typecheck` in `web`
- `npm test` in `web`
- `npm run lint` in `apps`
- `npm run typecheck` in `apps`
- `npm run lint` in `electron`
- `npm run typecheck` in `electron`
- `npm test` in `electron`


------
https://chatgpt.com/codex/tasks/task_b_685881c81e94832f8eca5c3da9ed5e9b