### PR TITLE
Add Node Packs docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ NodeTool was created to give anyone the power of modern AI while keeping full co
 - **Global Chat** – start conversations from anywhere in the workspace. See
   [Global Chat](global-chat.md).
 - **API and extensions** – connect NodeTool to other apps with Python scripts.
+- **Node Packs** – install extra nodes from the [NodeTool Packs Registry](node-packs.md).
 
 For a deeper look at how these pieces interact, read the
 [Architecture Overview](architecture.md).

--- a/docs/node-packs.md
+++ b/docs/node-packs.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Node Packs
+---
+
+Node Packs extend NodeTool with additional nodes and integrations. Packs are distributed through the public registry and can be installed directly from the app.
+
+### Finding packs
+
+Open **Settings** and choose **Packs** to browse what is available. Each entry lists the new nodes it adds and any extra requirements.
+
+### Installing or removing packs
+
+- Click **Install** to add a pack. The download happens in the background and new nodes appear in the Node Menu when it finishes.
+- Use **Uninstall** to remove a pack you no longer need.
+- Packs can also be updated from the same screen when new versions are released.
+
+### Command line alternative
+
+If you prefer the terminal, run `nodetool package list -a` to see every pack. Install one with `pip install git+https://github.com/nodetool-ai/<pack-name>`. Advanced users can manage versions this way.
+
+### Publishing your own pack
+
+The NodeTool Packs Registry on GitHub explains how to create and publish packs. Following those guidelines lets others discover and install your work easily.
+


### PR DESCRIPTION
## Summary
- add docs for Node Packs and link from index

## Testing
- `npm run lint` in web/apps/electron
- `npm run typecheck` in web/apps/electron
- `npm test` in web/electron

------
https://chatgpt.com/codex/tasks/task_b_685882144df8832f9b28f8ee9414444c