### PR TITLE
Allow unbounded numeric inputs

### DIFF
--- a/web/src/components/inputs/NumberInput.tsx
+++ b/web/src/components/inputs/NumberInput.tsx
@@ -139,7 +139,8 @@ const NumberInput: React.FC<InputProps> = (props) => {
         }
 
         if (isNaN(finalValue)) {
-          finalValue = props.value ?? props.min ?? props.max ?? 0;
+          finalValue =
+            props.value ?? state.originalValue ?? props.min ?? props.max ?? 0;
         }
         if (typeof props.min === "number") {
           finalValue = Math.max(props.min, finalValue);
@@ -164,7 +165,7 @@ const NumberInput: React.FC<InputProps> = (props) => {
         }));
       }
     },
-    [props, state.localValue]
+    [props, state.localValue, state.originalValue]
   );
 
   const handleMouseDown = useCallback(

--- a/web/src/components/inputs/NumberInput.tsx
+++ b/web/src/components/inputs/NumberInput.tsx
@@ -38,6 +38,7 @@ export interface InputProps {
   hideLabel?: boolean;
   tabIndex?: number;
   zoomAffectsDragging?: boolean;
+  showSlider?: boolean;
 }
 
 export interface NumberInputState {
@@ -56,6 +57,9 @@ export interface NumberInputState {
 
 const NumberInput: React.FC<InputProps> = (props) => {
   const theme = useTheme();
+  const sliderVisible =
+    props.showSlider ??
+    (typeof props.min === "number" && typeof props.max === "number");
   const [state, setState] = useState<NumberInputState>({
     isDefault: false,
     localValue: props.value?.toString() ?? "",
@@ -135,12 +139,14 @@ const NumberInput: React.FC<InputProps> = (props) => {
         }
 
         if (isNaN(finalValue)) {
-          finalValue = props.min ?? 0;
+          finalValue = props.min ?? props.max ?? 0;
         }
-        finalValue = Math.max(
-          props.min ?? 0,
-          Math.min(props.max ?? 4096, finalValue)
-        );
+        if (typeof props.min === "number") {
+          finalValue = Math.max(props.min, finalValue);
+        }
+        if (typeof props.max === "number") {
+          finalValue = Math.min(props.max, finalValue);
+        }
         setInputIsFocused(false);
         setState((prevState) => ({
           ...prevState,
@@ -315,13 +321,15 @@ const NumberInput: React.FC<InputProps> = (props) => {
           />
         )}
       </div>
-      <RangeIndicator
-        value={props.value}
-        min={props.min || 0}
-        max={props.max || 4096}
-        isDragging={state.isDragging}
-        isEditable={inputIsFocused}
-      />
+      {sliderVisible && (
+        <RangeIndicator
+          value={props.value}
+          min={props.min as number}
+          max={props.max as number}
+          isDragging={state.isDragging}
+          isEditable={inputIsFocused}
+        />
+      )}
       <SpeedDisplay
         speedFactor={speedFactorState}
         mousePosition={mousePosition}
@@ -337,6 +345,7 @@ export default memo(NumberInput, (prevProps, nextProps) => {
     prevProps.min === nextProps.min &&
     prevProps.max === nextProps.max &&
     prevProps.inputType === nextProps.inputType &&
-    prevProps.hideLabel === nextProps.hideLabel
+    prevProps.hideLabel === nextProps.hideLabel &&
+    prevProps.showSlider === nextProps.showSlider
   );
 });

--- a/web/src/components/inputs/NumberInput.tsx
+++ b/web/src/components/inputs/NumberInput.tsx
@@ -57,9 +57,9 @@ export interface NumberInputState {
 
 const NumberInput: React.FC<InputProps> = (props) => {
   const theme = useTheme();
-  const sliderVisible =
-    props.showSlider ??
-    (typeof props.min === "number" && typeof props.max === "number");
+  const hasBounds =
+    typeof props.min === "number" && typeof props.max === "number";
+  const sliderVisible = (props.showSlider ?? hasBounds) && hasBounds;
   const [state, setState] = useState<NumberInputState>({
     isDefault: false,
     localValue: props.value?.toString() ?? "",
@@ -139,7 +139,7 @@ const NumberInput: React.FC<InputProps> = (props) => {
         }
 
         if (isNaN(finalValue)) {
-          finalValue = props.min ?? props.max ?? 0;
+          finalValue = props.value ?? props.min ?? props.max ?? 0;
         }
         if (typeof props.min === "number") {
           finalValue = Math.max(props.min, finalValue);
@@ -321,15 +321,17 @@ const NumberInput: React.FC<InputProps> = (props) => {
           />
         )}
       </div>
-      {sliderVisible && (
-        <RangeIndicator
-          value={props.value}
-          min={props.min as number}
-          max={props.max as number}
-          isDragging={state.isDragging}
-          isEditable={inputIsFocused}
-        />
-      )}
+      {sliderVisible &&
+        typeof props.min === "number" &&
+        typeof props.max === "number" && (
+          <RangeIndicator
+            value={props.value}
+            min={props.min}
+            max={props.max}
+            isDragging={state.isDragging}
+            isEditable={inputIsFocused}
+          />
+        )}
       <SpeedDisplay
         speedFactor={speedFactorState}
         mousePosition={mousePosition}

--- a/web/src/components/inputs/NumberInput.utils.ts
+++ b/web/src/components/inputs/NumberInput.utils.ts
@@ -6,25 +6,29 @@ import {
 } from "./NumberInput";
 
 export const calculateStep = (
-  min: number,
-  max: number,
+  min: number | undefined,
+  max: number | undefined,
   inputType: "int" | "float"
 ): number => {
-  const range = max - min;
   let baseStep: number;
+  if (typeof min === "number" && typeof max === "number") {
+    const range = max - min;
 
-  if (inputType === "float") {
-    if (range <= 1) baseStep = 0.01;
-    else if (range <= 20) baseStep = 0.5;
-    else if (range > 20 && range <= 100) baseStep = 0.5;
-    else baseStep = Math.pow(6, Math.floor(Math.log10(range)) - 2);
+    if (inputType === "float") {
+      if (range <= 1) baseStep = 0.01;
+      else if (range <= 20) baseStep = 0.5;
+      else if (range > 20 && range <= 100) baseStep = 0.5;
+      else baseStep = Math.pow(6, Math.floor(Math.log10(range)) - 2);
+    } else {
+      if (range <= 20) baseStep = 0.1;
+      else if (range <= 1000) baseStep = 1;
+      else if (range > 1000 && range <= 5000) baseStep = 16;
+      else if (range > 5000 && range <= 10000) baseStep = 32;
+      else if (range > 10000) baseStep = 64;
+      else baseStep = Math.pow(6, Math.floor(Math.log10(range)) - 1);
+    }
   } else {
-    if (range <= 20) baseStep = 0.1;
-    else if (range <= 1000) baseStep = 1;
-    else if (range > 1000 && range <= 5000) baseStep = 16;
-    else if (range > 5000 && range <= 10000) baseStep = 32;
-    else if (range > 10000) baseStep = 64;
-    else baseStep = Math.pow(6, Math.floor(Math.log10(range)) - 1);
+    baseStep = inputType === "float" ? 0.1 : 1;
   }
   return baseStep;
 };
@@ -69,8 +73,8 @@ export const getEffectiveSliderWidth = (
 
 export const applyValueConstraints = (
   value: number,
-  min: number,
-  max: number,
+  min: number | undefined,
+  max: number | undefined,
   inputType: "int" | "float",
   decimalPlaces: number,
   baseStep?: number
@@ -79,7 +83,7 @@ export const applyValueConstraints = (
 
   // Snap to step if baseStep is provided and greater than zero
   if (baseStep && baseStep > 0) {
-    const reference = min; // align step snapping relative to the minimum value
+    const reference = min ?? 0; // align step snapping relative to the minimum value
     constrainedValue =
       reference +
       Math.round((constrainedValue - reference) / baseStep) * baseStep;
@@ -92,6 +96,12 @@ export const applyValueConstraints = (
     constrainedValue = Math.round(constrainedValue);
   }
 
-  // Clamp to min/max bounds
-  return Math.max(min, Math.min(max, constrainedValue));
+  // Clamp to min/max bounds if they exist
+  if (typeof min === "number") {
+    constrainedValue = Math.max(min, constrainedValue);
+  }
+  if (typeof max === "number") {
+    constrainedValue = Math.min(max, constrainedValue);
+  }
+  return constrainedValue;
 };

--- a/web/src/components/inputs/NumberInput.utils.ts
+++ b/web/src/components/inputs/NumberInput.utils.ts
@@ -81,6 +81,13 @@ export const applyValueConstraints = (
 ): number => {
   let constrainedValue = value;
 
+  if (typeof min === "number" && typeof max === "number" && min > max) {
+    console.warn(`Invalid bounds: min (${min}) > max (${max})`);
+    const temp = min;
+    min = max;
+    max = temp;
+  }
+
   // Snap to step if baseStep is provided and greater than zero
   if (baseStep && baseStep > 0) {
     const reference = min ?? 0; // align step snapping relative to the minimum value

--- a/web/src/components/inputs/NumberInput.utils.ts
+++ b/web/src/components/inputs/NumberInput.utils.ts
@@ -5,6 +5,9 @@ import {
   SHIFT_SLOWDOWN_DIVIDER
 } from "./NumberInput";
 
+// Throttle repeated warnings for invalid bounds.
+let warnedInvalidBounds = false;
+
 export const calculateStep = (
   min: number | undefined,
   max: number | undefined,
@@ -82,7 +85,10 @@ export const applyValueConstraints = (
   let constrainedValue = value;
 
   if (typeof min === "number" && typeof max === "number" && min > max) {
-    console.warn(`Invalid bounds: min (${min}) > max (${max})`);
+    if (!warnedInvalidBounds) {
+      console.warn(`Invalid bounds: min (${min}) > max (${max})`);
+      warnedInvalidBounds = true;
+    }
     const temp = min;
     min = max;
     max = temp;

--- a/web/src/components/properties/FloatProperty.tsx
+++ b/web/src/components/properties/FloatProperty.tsx
@@ -10,8 +10,10 @@ const FloatProperty = (props: PropertyProps) => {
 
   const value = typeof props.value === "number" ? props.value : 0;
 
-  const min = typeof props.property.min === "number" ? props.property.min : 0;
-  const max = typeof props.property.max === "number" ? props.property.max : 100;
+  const min =
+    typeof props.property.min === "number" ? props.property.min : undefined;
+  const max =
+    typeof props.property.max === "number" ? props.property.max : undefined;
 
   return (
     <>

--- a/web/src/components/properties/IntegerProperty.tsx
+++ b/web/src/components/properties/IntegerProperty.tsx
@@ -11,9 +11,10 @@ const IntegerProperty = (props: PropertyProps) => {
 
   const value = Number.isInteger(props.value) ? props.value : 0;
 
-  const min = typeof props.property.min === "number" ? props.property.min : 0;
+  const min =
+    typeof props.property.min === "number" ? props.property.min : undefined;
   const max =
-    typeof props.property.max === "number" ? props.property.max : 4096;
+    typeof props.property.max === "number" ? props.property.max : undefined;
 
   return (
     <>

--- a/web/src/hooks/useNumberInput.ts
+++ b/web/src/hooks/useNumberInput.ts
@@ -13,6 +13,8 @@ import {
   applyValueConstraints
 } from "../components/inputs/NumberInput.utils";
 
+const UNBOUNDED_DRAG_SCALE = 0.1;
+
 export const useValueCalculation = () => {
   const calculateStepCb = useCallback(calculateStep, []);
   const calculateDecimalPlacesCb = useCallback(calculateDecimalPlaces, []);
@@ -116,7 +118,7 @@ export const useDragHandling = (
           const range = props.max - props.min;
           rawValueChange = visualPercentage * range;
         } else {
-          rawValueChange = deltaX * baseStep;
+          rawValueChange = deltaX * baseStep * UNBOUNDED_DRAG_SCALE;
         }
 
         // Step 3: Apply modifiers (speedFactor for vertical slowdown + shift)

--- a/web/src/hooks/useNumberInput.ts
+++ b/web/src/hooks/useNumberInput.ts
@@ -13,7 +13,9 @@ import {
   applyValueConstraints
 } from "../components/inputs/NumberInput.utils";
 
-const UNBOUNDED_DRAG_SCALE = 0.1;
+// Multiplier for drag speed when inputs are unbounded.
+// Slightly higher value keeps the feel responsive without huge jumps.
+const UNBOUNDED_DRAG_SCALE = 0.25;
 
 export const useValueCalculation = () => {
   const calculateStepCb = useCallback(calculateStep, []);

--- a/web/src/hooks/useNumberInput.ts
+++ b/web/src/hooks/useNumberInput.ts
@@ -85,8 +85,8 @@ export const useDragHandling = (
       //---------------------------------------------------------------------
 
       const baseStep = calculateStep(
-        props.min ?? 0,
-        props.max ?? 4096,
+        props.min,
+        props.max,
         props.inputType || "float"
       );
 
@@ -108,8 +108,16 @@ export const useDragHandling = (
         const visualPercentage = deltaX / visualScreenWidth;
 
         // Step 2: Convert to raw value change
-        const range = (props.max ?? 4096) - (props.min ?? 0);
-        const rawValueChange = visualPercentage * range;
+        let rawValueChange: number;
+        if (
+          typeof props.min === "number" &&
+          typeof props.max === "number"
+        ) {
+          const range = props.max - props.min;
+          rawValueChange = visualPercentage * range;
+        } else {
+          rawValueChange = deltaX * baseStep;
+        }
 
         // Step 3: Apply modifiers (speedFactor for vertical slowdown + shift)
         const effectiveSpeedFactor =
@@ -129,8 +137,8 @@ export const useDragHandling = (
 
       newValue = applyValueConstraints(
         newValue,
-        props.min ?? 0,
-        props.max ?? 4096,
+        props.min,
+        props.max,
         props.inputType || "float",
         newDecimalPlaces,
         isWithinDeadZone ? baseStep : undefined


### PR DESCRIPTION
## Summary
- support undefined min/max for `FloatProperty` and `IntegerProperty`
- add optional slider toggle to `NumberInput`
- skip clamping when limits are not provided
- update drag logic for unbounded ranges

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: 'InferenceProviderModel' export missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872ac274978832fac8eceecae2f5290