### PR TITLE
fix: improve ollama detection and health checks

### DIFF
--- a/electron/src/server.ts
+++ b/electron/src/server.ts
@@ -20,7 +20,7 @@ import { updateTrayMenu } from "./tray";
 import { LOG_FILE } from "./logger";
 import { createWorkflowWindow } from "./workflowWindow";
 import { Watchdog } from "./watchdog";
-import { ensureOllamaInstalled } from "./ollama";
+import { ensureOllamaInstalled, isOllamaResponsive } from "./ollama";
 
 let backendWatchdog: Watchdog | null = null;
 let ollamaWatchdog: Watchdog | null = null;
@@ -78,6 +78,13 @@ async function findAvailablePort(
  * Starts the Ollama server on a custom port using Watchdog
  */
 async function startOllamaServer(): Promise<void> {
+  const existingPort = 11434;
+  if (await isOllamaResponsive(existingPort)) {
+    serverState.ollamaPort = existingPort;
+    logMessage(`Detected running Ollama instance on port ${existingPort}`);
+    return;
+  }
+
   const basePort = serverState.ollamaPort ?? 11435;
   const selectedPort = await findAvailablePort(basePort);
   serverState.ollamaPort = selectedPort;

--- a/electron/src/watchdog.ts
+++ b/electron/src/watchdog.ts
@@ -184,11 +184,18 @@ export class Watchdog {
   }
 
   private async isHealthy(): Promise<boolean> {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 2000);
     try {
-      const res = await fetch(this.opts.healthUrl, { method: "GET" });
+      const res = await fetch(this.opts.healthUrl, {
+        method: "GET",
+        signal: controller.signal,
+      });
       return res.ok;
     } catch {
       return false;
+    } finally {
+      clearTimeout(id);
     }
   }
 


### PR DESCRIPTION
## Summary
- improve Ollama detection on Windows and verify default port responsiveness
- detect running Ollama service before spawning and start watchdog with timeout
- add request timeout to watchdog health checks to avoid Windows hangs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6899d4a31a58832f8537fb61216f9673