### PR TITLE
Increase electron test coverage

### DIFF
--- a/electron/src/__tests__/logger.behavior.test.ts
+++ b/electron/src/__tests__/logger.behavior.test.ts
@@ -1,0 +1,117 @@
+import path from 'path';
+
+describe('logger.logMessage', () => {
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('logs messages, emits server log events, and writes to file', async () => {
+    jest.unmock('../logger');
+
+    const mkdirMock = jest.fn().mockResolvedValue(undefined);
+    const appendFileMock = jest.fn().mockResolvedValue(undefined);
+    jest.doMock('fs', () => ({
+      promises: {
+        mkdir: mkdirMock,
+        appendFile: appendFileMock,
+      },
+    }));
+
+    const emitServerLogMock = jest.fn();
+    jest.doMock('../events', () => ({
+      emitServerLog: emitServerLogMock,
+    }));
+
+    const electronLogSpies = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    jest.doMock('electron-log', () => electronLogSpies);
+
+    const getSystemDataPathMock = jest
+      .fn()
+      .mockImplementation((relativePath: string) =>
+        path.join('/mock/system', relativePath),
+      );
+    jest.doMock('../config', () => ({
+      getSystemDataPath: getSystemDataPathMock,
+    }));
+
+    const loggerModule = await import('../logger');
+
+    await loggerModule.logMessage('  hello world  ');
+
+    expect(electronLogSpies.info).toHaveBeenCalledWith('hello world');
+    expect(emitServerLogMock).toHaveBeenCalledWith('hello world');
+    expect(getSystemDataPathMock).toHaveBeenCalledWith(
+      path.join('logs', 'nodetool.log'),
+    );
+    expect(mkdirMock).toHaveBeenCalledWith(
+      path.join('/mock/system', 'logs'),
+      { recursive: true },
+    );
+    expect(appendFileMock).toHaveBeenCalledWith(
+      loggerModule.LOG_FILE,
+      'hello world\n',
+    );
+  });
+
+  it('continues when file system operations fail and logs errors', async () => {
+    jest.unmock('../logger');
+
+    const mkdirError = new Error('mkdir failed');
+    const appendError = new Error('append failed');
+    const mkdirMock = jest.fn().mockRejectedValue(mkdirError);
+    const appendFileMock = jest.fn().mockRejectedValue(appendError);
+    jest.doMock('fs', () => ({
+      promises: {
+        mkdir: mkdirMock,
+        appendFile: appendFileMock,
+      },
+    }));
+
+    const emitServerLogMock = jest.fn();
+    jest.doMock('../events', () => ({
+      emitServerLog: emitServerLogMock,
+    }));
+
+    const electronLogSpies = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    jest.doMock('electron-log', () => electronLogSpies);
+
+    const getSystemDataPathMock = jest
+      .fn()
+      .mockImplementation((relativePath: string) =>
+        path.join('/mock/system', relativePath),
+      );
+    jest.doMock('../config', () => ({
+      getSystemDataPath: getSystemDataPathMock,
+    }));
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const loggerModule = await import('../logger');
+
+    await expect(loggerModule.logMessage('issue detected', 'error')).resolves.toBeUndefined();
+
+    expect(electronLogSpies.error).toHaveBeenCalledWith('issue detected');
+    expect(emitServerLogMock).toHaveBeenCalledWith('issue detected');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to create log directory:', mkdirError);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to write to log file:', appendError);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/electron/src/__tests__/menu.test.ts
+++ b/electron/src/__tests__/menu.test.ts
@@ -1,0 +1,110 @@
+describe('buildMenu', () => {
+  const mockIpcChannels = () => {
+    jest.doMock('../types.d', () => ({
+      IpcChannels: {
+        MENU_EVENT: 'menu-event',
+      },
+    }));
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('does nothing when no main window is available', async () => {
+    mockIpcChannels();
+
+    const buildFromTemplateMock = jest.fn();
+    const setApplicationMenuMock = jest.fn();
+
+    jest.doMock('electron', () => ({
+      Menu: {
+        buildFromTemplate: buildFromTemplateMock,
+        setApplicationMenu: setApplicationMenuMock,
+      },
+      shell: {
+        openExternal: jest.fn(),
+      },
+    }));
+
+    jest.doMock('../state', () => ({
+      getMainWindow: jest.fn().mockReturnValue(null),
+    }));
+
+    jest.doMock('../window', () => ({
+      createPackageManagerWindow: jest.fn(),
+    }));
+
+    const menuModule = await import('../menu');
+    menuModule.buildMenu();
+
+    expect(buildFromTemplateMock).not.toHaveBeenCalled();
+    expect(setApplicationMenuMock).not.toHaveBeenCalled();
+  });
+
+  it('builds menu and wires commands when window exists', async () => {
+    mockIpcChannels();
+
+    const sendMock = jest.fn();
+    const createPackageManagerWindowMock = jest.fn();
+
+    const buildFromTemplateMock = jest
+      .fn()
+      .mockImplementation((template) => ({ template }));
+    const setApplicationMenuMock = jest.fn();
+    const openExternalMock = jest.fn().mockResolvedValue(undefined);
+
+    jest.doMock('electron', () => ({
+      Menu: {
+        buildFromTemplate: buildFromTemplateMock,
+        setApplicationMenu: setApplicationMenuMock,
+      },
+      shell: {
+        openExternal: openExternalMock,
+      },
+    }));
+
+    jest.doMock('../state', () => ({
+      getMainWindow: jest.fn().mockReturnValue({
+        webContents: {
+          send: sendMock,
+        },
+      }),
+    }));
+
+    jest.doMock('../window', () => ({
+      createPackageManagerWindow: createPackageManagerWindowMock,
+    }));
+
+    const menuModule = await import('../menu');
+    menuModule.buildMenu();
+
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(1);
+    const template = buildFromTemplateMock.mock.calls[0][0] as Array<Record<string, any>>;
+
+    // Trigger save command
+    const fileMenu = template.find((item) => item.label === 'File');
+    const saveItem = fileMenu?.submenu?.find((item: any) => item.label === 'Save');
+    saveItem?.click();
+    expect(sendMock).toHaveBeenCalledWith('menu-event', { type: 'saveWorkflow' });
+
+    // Trigger package manager command
+    const toolsMenu = template.find((item) => item.label === 'Tools');
+    const packageManagerItem = toolsMenu?.submenu?.find(
+      (item: any) => item.label === 'Package Manager',
+    );
+    packageManagerItem?.click();
+    expect(createPackageManagerWindowMock).toHaveBeenCalled();
+
+    // Trigger help command
+    const helpMenu = template.find((item) => item.role === 'help');
+    const learnMoreItem = helpMenu?.submenu?.find(
+      (item: any) => item.label === 'Learn More',
+    );
+    await learnMoreItem?.click?.();
+    expect(openExternalMock).toHaveBeenCalledWith('https://nodetool.ai');
+
+    expect(setApplicationMenuMock).toHaveBeenCalledWith({ template });
+  });
+});


### PR DESCRIPTION
## Summary
- add logger behavior tests that exercise log emission, fs interactions, and error handling
- add menu tests to verify menu building skips missing windows and dispatches expected commands

## Testing
- npm test -- --coverage --watchAll=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ea81dc74832d99630ebc5b76fbd0)