### PR TITLE
Fix dashboard new workflow button

### DIFF
--- a/web/src/components/dashboard/WorkflowsList.tsx
+++ b/web/src/components/dashboard/WorkflowsList.tsx
@@ -167,7 +167,10 @@ const WorkflowsList: React.FC<WorkflowsListProps> = ({
               startIcon={<AddIcon />}
               onClick={handleCreateNewWorkflow}
               size="small"
-            ></Button>
+              aria-label="Create New Workflow"
+            >
+              New Workflow
+            </Button>
           </Tooltip>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- add the missing label and aria label to the dashboard's New Workflow button so it is visible and accessible again

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175ab57684832d9771f5e61ecc1b65)