### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 > **🎯 Privacy by design** • **🔓 Own your stack** • **🚀 Production ready**
 
 Nodetool lets you design agents that work with your data. Use any model to analyze data, generate visuals, or automate
-workdlows.
+workflows.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- fix a misspelling of "workflows" in the README introduction

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176b282168832db39c04bbbe2b34cb)