### PR TITLE
Honor default Python version override

### DIFF
--- a/build.py
+++ b/build.py
@@ -130,7 +130,7 @@ class Build:
     def __init__(
         self,
         clean_build: bool = False,
-        python_version: str = "3.11",
+        python_version: str = DEFAULT_PYTHON_VERSION,
     ):
         """Initialize the build configuration and computed paths.
 


### PR DESCRIPTION
## Summary
- ensure the Build helper reuses the shared DEFAULT_PYTHON_VERSION constant
- this allows the PYTHON_VERSION environment variable to influence conda builds

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691770a1c3e0832da831741a5f3093e4)