### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 > **🎯 Privacy by design** • **🔓 Own your stack** • **🚀 Production ready**
 
 Nodetool lets you design agents that work with your data. Use any model to analyze data, generate visuals, or automate
-workdlows.
+workflows.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- fix the "workdlows" typo in the README introduction so the overview reads clearly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691770905be4832db7e16e782b7819c0)