### PR TITLE
Fix e2e navigation targets

### DIFF
--- a/web/tests/e2e/app-loads.spec.ts
+++ b/web/tests/e2e/app-loads.spec.ts
@@ -28,12 +28,12 @@ if (process.env.JEST_WORKER_ID) {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
       
-      // Try to navigate to workflows page
-      await page.goto("/workflows");
+      // Try to navigate to dashboard page
+      await page.goto("/dashboard");
       await page.waitForLoadState("networkidle");
       
       // Check URL changed
-      await expect(page).toHaveURL(/\/workflows/);
+      await expect(page).toHaveURL(/\/dashboard/);
     });
 
     test("should connect to backend API", async ({ page }) => {

--- a/web/tests/e2e/performance-test.spec.ts
+++ b/web/tests/e2e/performance-test.spec.ts
@@ -29,25 +29,18 @@ if (process.env.CI === "true") {
     page
   }) => {
     // Enable performance monitoring
-    await page.goto("/", { waitUntil: "networkidle" });
+    await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+    // Navigate to editor via the AppHeader button to create a workflow if needed
+    const editorButton = page.locator(".editor-button");
+    await expect(editorButton).toBeVisible({ timeout: 30000 });
+    await editorButton.click();
+    await page.waitForLoadState("networkidle");
 
     // Wait for the editor to load
-    await page.waitForSelector('[data-testid="workflow-editor"]', {
-      timeout: 30000
-    });
+    await page.waitForSelector(".react-flow__pane", { timeout: 30000 });
 
     console.log("Editor loaded, creating workflow...");
-
-    // Create a new workflow or use existing
-    const workflowsLink = page.locator('a[href*="/workflows"]');
-    if (await workflowsLink.isVisible()) {
-      await workflowsLink.click();
-      await page.waitForLoadState("networkidle");
-    }
-
-    // Navigate to editor
-    await page.goto("/editor", { waitUntil: "networkidle" });
-    await page.waitForTimeout(2000);
 
     // Get the React Flow pane
     const reactFlowPane = page.locator(".react-flow__pane");


### PR DESCRIPTION
### Motivation
- E2E tests referenced a removed or incorrect route (`/workflows`) and fragile editor selectors which caused flaky failures during navigation and editor startup.
- The performance test relied on direct `/editor` navigation and a non-existent test id, making it brittle across UI changes.

### Description
- Updated `web/tests/e2e/app-loads.spec.ts` to navigate to `/dashboard` and assert the dashboard URL instead of `/workflows`.
- Modified `web/tests/e2e/performance-test.spec.ts` to start from `/dashboard`, click the AppHeader editor button (`.editor-button`) to open the editor, and wait for the React Flow pane via `.react-flow__pane` instead of the removed data-testid.
- Removed the previous direct navigation to `/editor` and the old workflow link lookup to make the performance flow more robust to UI changes.

### Testing
- Ran `make typecheck` which completed successfully with no type errors.
- Ran `make lint` which completed successfully with no lint errors.
- Ran `make test` (unit/integration suites) and all test suites passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a3f935e4832d9b1e664783808c62)