### PR TITLE
Handle missing workflows in node search utility

### DIFF
--- a/web/src/utils/__tests__/findMatchingNodesInWorkflows.test.ts
+++ b/web/src/utils/__tests__/findMatchingNodesInWorkflows.test.ts
@@ -91,9 +91,8 @@ describe("findMatchingNodesInWorkflows", () => {
     });
 
     it("should handle null workflows gracefully", () => {
-      // The actual function tries to map over null, which throws an error
-      // This is expected behavior - the function doesn't handle null input
-      expect(() => findMatchingNodesInWorkflows(null as any, "test")).toThrow();
+      const results = findMatchingNodesInWorkflows(null as any, "test");
+      expect(results).toEqual([]);
     });
 
     it("should return empty array when workflows is empty", () => {

--- a/web/src/utils/findMatchingNodesInWorkflows.ts
+++ b/web/src/utils/findMatchingNodesInWorkflows.ts
@@ -23,7 +23,11 @@ export const findMatchingNodesInWorkflows = (
   fuseThreshold: number = FUSE_THRESHOLD,
   fuseMinMatchCharLengthFactor: number = FUSE_MIN_MATCH_FACTOR
 ): SearchResult[] => {
-  if (!searchQuery.trim() || !workflows || workflows.length === 0) {
+  if (!workflows || workflows.length === 0) {
+    return [];
+  }
+
+  if (!searchQuery.trim()) {
     return workflows.map((workflow) => ({
       workflow,
       fuseScore: 1,


### PR DESCRIPTION
### Motivation
- Prevent a crash when callers pass a null/undefined workflows list to the node search utility `findMatchingNodesInWorkflows`.
- Keep the empty-query behavior intact where an empty or whitespace `searchQuery` returns every workflow with score `1`.
- Make the function behavior predictable for consumers and improve robustness when workflow data is missing.

### Description
- Add a guard in `findMatchingNodesInWorkflows` to return an empty array when `workflows` is `null`, `undefined`, or empty. 
- Preserve the previous behavior of returning all workflows with `fuseScore: 1` when `searchQuery` is empty or whitespace. 
- Update the unit test in `web/src/utils/__tests__/findMatchingNodesInWorkflows.test.ts` to expect an empty array for a `null` workflows input. 
- Modified files: `web/src/utils/findMatchingNodesInWorkflows.ts` and `web/src/utils/__tests__/findMatchingNodesInWorkflows.test.ts`.

### Testing
- Ran `make typecheck`, which completed successfully with no type errors. 
- Ran `make lint`, which completed successfully with no lint errors. 
- Ran `make test`, and the full test suite passed (web, electron, and mobile tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a4be9e9c832d935bfc595724fd93)