### PR TITLE
Memoize EditableInput styles and keydown handler

### DIFF
--- a/web/src/components/inputs/EditableInput.tsx
+++ b/web/src/components/inputs/EditableInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect } from "react";
+import React, { useState, useCallback, useRef, useEffect, useMemo } from "react";
 
 interface EditableInputProps {
   value: string;
@@ -92,6 +92,30 @@ const EditableInput: React.FC<EditableInputProps> = ({
     }
   }, [isFocused]);
 
+  const inputStyle = useMemo<React.CSSProperties>(
+    () => ({
+      position: "absolute",
+      width: isFocused ? `${Math.max(value.length * 12, 50)}px` : "0px",
+      color: isFocused ? "inherit" : "transparent",
+      backgroundColor: isFocused ? "inherit" : "transparent",
+      opacity: isFocused ? 1 : 0.001,
+      pointerEvents: isFocused ? "auto" : "none",
+      zIndex: isFocused ? 1 : "auto"
+    }),
+    [isFocused, value.length]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" || event.code === "NumpadEnter") {
+        event.preventDefault();
+        event.stopPropagation();
+        _onBlur(event as unknown as React.FocusEvent<HTMLInputElement>);
+      }
+    },
+    [_onBlur]
+  );
+
   return (
     <div className="editable-input-container">
       <input
@@ -100,28 +124,14 @@ const EditableInput: React.FC<EditableInputProps> = ({
         className={`edit-value nodrag${
           isDefault ? " default" : ""
         } edit-value-input`}
-        style={{
-          position: "absolute",
-          width: isFocused ? `${Math.max(value.length * 12, 50)}px` : "0px",
-          color: isFocused ? "inherit" : "transparent",
-          backgroundColor: isFocused ? "inherit" : "transparent",
-          opacity: isFocused ? 1 : 0.001,
-          pointerEvents: isFocused ? "auto" : "none",
-          zIndex: isFocused ? 1 : "auto"
-        }}
+        style={inputStyle}
         value={value}
         onChange={onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
         tabIndex={tabIndex}
         autoFocus={false}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.code === "NumpadEnter") {
-            e.preventDefault();
-            e.stopPropagation();
-            _onBlur(e as unknown as React.FocusEvent<HTMLInputElement>);
-          }
-        }}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation

- Reduce unnecessary re-renders and stabilize handler references in the `EditableInput` component by avoiding recreated inline objects and functions.
- Follow React best practices for performance and readability by memoizing style objects and event handlers.

### Description

- Imported `useMemo` and memoized the inline `style` object for the input as `inputStyle` with type `React.CSSProperties`.
- Extracted the inline `onKeyDown` logic into a stable `handleKeyDown` using `useCallback` and replaced the previous inline handler.
- Replaced the previous inline `style` prop with the memoized `inputStyle` and swapped the inline key handler for `handleKeyDown`.

### Testing

- Ran `make typecheck` and the TypeScript checks passed successfully.
- Ran `make lint` and linting completed with no blocking errors.
- Ran `make test` which executed the web, electron, and mobile test suites and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a4cc0f74832d87d338dbb61e913c)