### PR TITLE
Fix highlight color parsing and selection distribution

### DIFF
--- a/web/src/components/ui_primitives/HighlightText.tsx
+++ b/web/src/components/ui_primitives/HighlightText.tsx
@@ -6,7 +6,10 @@ import type { Theme } from "@mui/material/styles";
 
 // Convert hex color to RGB values
 const hexToRgb = (hex: string) => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const normalizedHex = hex.trim();
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+    normalizedHex
+  );
   if (!result) {return null;}
   return `${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(
     result[3],

--- a/web/src/hooks/useSelectionActions.ts
+++ b/web/src/hooks/useSelectionActions.ts
@@ -19,6 +19,13 @@ interface SelectionActionsReturn {
 }
 
 const NODE_WIDTH = 280;
+const HORIZONTAL_SPACING = 40;
+const VERTICAL_SPACING = 20;
+
+const getNodeWidth = (node: { measured?: { width?: number } }) =>
+  node.measured?.width ?? NODE_WIDTH;
+const getNodeHeight = (node: { measured?: { height?: number } }) =>
+  node.measured?.height ?? 0;
 
 export const useSelectionActions = (): SelectionActionsReturn => {
   const getSelectedNodes = useNodes((state) => state.getSelectedNodes);
@@ -182,13 +189,12 @@ export const useSelectionActions = (): SelectionActionsReturn => {
     });
 
     const leftMostX = Math.min(...sortedByX.map((n) => n.position.x));
-    const rightMostX = Math.max(...sortedByX.map((n) => n.position.x));
-    const count = sortedByX.length;
 
     const positionMap = new Map<string, number>();
-    sortedByX.forEach((node, index) => {
-      const newX = leftMostX + (index * (rightMostX - leftMostX)) / (count - 1);
-      positionMap.set(node.id, newX);
+    let currentX = leftMostX;
+    sortedByX.forEach((node) => {
+      positionMap.set(node.id, currentX);
+      currentX += getNodeWidth(node) + HORIZONTAL_SPACING;
     });
 
     reactFlow.setNodes((currentNodes) =>
@@ -217,13 +223,12 @@ export const useSelectionActions = (): SelectionActionsReturn => {
     });
 
     const topMostY = Math.min(...sortedByY.map((n) => n.position.y));
-    const bottomMostY = Math.max(...sortedByY.map((n) => n.position.y));
-    const count = sortedByY.length;
 
     const positionMap = new Map<string, number>();
-    sortedByY.forEach((node, index) => {
-      const newY = topMostY + (index * (bottomMostY - topMostY)) / (count - 1);
-      positionMap.set(node.id, newY);
+    let currentY = topMostY;
+    sortedByY.forEach((node) => {
+      positionMap.set(node.id, currentY);
+      currentY += getNodeHeight(node) + VERTICAL_SPACING;
     });
 
     reactFlow.setNodes((currentNodes) =>

--- a/web/src/utils/__tests__/highlightText.test.ts
+++ b/web/src/utils/__tests__/highlightText.test.ts
@@ -64,6 +64,12 @@ describe("highlightText utilities", () => {
       expect(hexToRgb("#AbCdEf")).toBe("171, 205, 239");
     });
 
+    it("trims whitespace around hex values", () => {
+      expect(hexToRgb("  #ff0000")).toBe("255, 0, 0");
+      expect(hexToRgb("#00ff00  ")).toBe("0, 255, 0");
+      expect(hexToRgb("  0000ff  ")).toBe("0, 0, 255");
+    });
+
     it("returns null for invalid hex formats", () => {
       expect(hexToRgb("invalid")).toBeNull();
       expect(hexToRgb("#fff")).toBeNull(); // 3-digit not supported

--- a/web/src/utils/highlightText.ts
+++ b/web/src/utils/highlightText.ts
@@ -7,7 +7,10 @@ export const escapeHtml = (text: string): string => {
 
 // Convert hex color to RGB values
 export const hexToRgb = (hex: string) => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const normalizedHex = hex.trim();
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+    normalizedHex
+  );
   if (!result) {return null;}
   return `${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(
     result[3],


### PR DESCRIPTION
### Motivation
- Trim whitespace from hex color inputs so CSS variable values and padded strings parse correctly when computing highlight colors.
- Make node distribution deterministic by spacing nodes based on their measured sizes instead of stretching across existing positions.

### Description
- Trim hex input in `hexToRgb` used by `web/src/utils/highlightText.ts` and `web/src/components/ui_primitives/HighlightText.tsx` to handle surrounding whitespace before regex parsing.
- Update `useSelectionActions` (`web/src/hooks/useSelectionActions.ts`) to introduce `HORIZONTAL_SPACING` and `VERTICAL_SPACING` and compute positions using node measured widths/heights via helper functions `getNodeWidth`/`getNodeHeight`.
- Add unit test coverage for trimmed hex values in `web/src/utils/__tests__/highlightText.test.ts` to verify whitespace handling.

### Testing
- Ran `make typecheck` and it completed successfully with no type errors.
- Ran `make lint` and the linter completed with no errors reported.
- Ran `make test` and the full test suite passed, including `useSelectionActions` and `highlightText` unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b8fe3950832d9c2cf33c0557adf6)