### PR TITLE
docs(web): align app route docs with current routes

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -14,9 +14,9 @@ Important paths:
 Use `npm start` to run the editor locally. Production builds are generated with
 `npm run build` and then packaged with the Electron app.
 
-## Mini App Routes
+## Mini App & Standalone Routes
 
-The application supports two types of mini app routes for running workflows:
+The application supports multiple app-focused routes:
 
 ### Full Mini App (`/apps/:workflowId`)
 
@@ -24,6 +24,7 @@ The full mini app includes the standard application chrome (header, left panel, 
 - Access via: `http://localhost:3000/apps/{workflow-id}`
 - Built as part of the main application bundle
 - Includes navigation and additional UI features
+- `workflowId` is optional (`/apps` opens the app page without preselecting a workflow)
 
 ### Standalone Mini App (`/miniapp/:workflowId`)
 
@@ -33,3 +34,10 @@ A lightweight, standalone version with minimal UI for embedding or fast loading:
 - No application header, panels, or navigation
 - Optimized for fast load times with React code splitting
 - Perfect for sharing workflows as standalone apps
+
+### Standalone Chat (`/standalone-chat/:thread_id?`)
+
+A full-page chat route that keeps side/bottom panels while removing the standard app header:
+- Access via: `/standalone-chat` or `/standalone-chat/{thread-id}`
+- Uses the standalone chat container UI with optional thread deep-linking
+- Useful for chat-first experiences that still need panel tooling


### PR DESCRIPTION
### Motivation
- Bring the Web UI README inline with the actual routes implemented in `web/src/index.tsx`, clarifying `/apps` behavior and documenting the existing standalone chat route.

### Description
- Updated `web/README.md` to rename the section to "Mini App & Standalone Routes", document that `/apps/:workflowId` accepts an optional `workflowId` (so `/apps` is valid), and add documentation for the `/standalone-chat/:thread_id?` route.

### Testing
- Ran `make typecheck` (passed), `make lint` (passed with warnings), and `make test` (most suites passed; two timing-sensitive performance tests failed: `src/utils/__tests__/PrefixTreeSearch.test.ts` and `src/__tests__/performance/componentPerformance.test.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c556f63b8832d857f3ccdfbb3baf0)