### PR TITLE
⚡ Bolt: Optimize NodeHeader and NodeLogs re-renders

### DIFF
--- a/web/OPTIMIZATION_LOG_SUBSCRIPTION.md
+++ b/web/OPTIMIZATION_LOG_SUBSCRIPTION.md
@@ -1,0 +1,26 @@
+# ⚡ Bolt: Optimize NodeHeader and NodeLogs re-renders
+
+## 💡 What
+Optimized `NodeHeader` and `NodeLogs` components to use `shallow` equality check when subscribing to `LogStore`.
+Instead of calling `state.getLogs(...)` which returns a new array reference on every store update, we now select the filtered logs inline and use `shallow` comparison.
+
+## 🎯 Why
+Previously, every time a log was appended to the `LogStore` (for ANY node), `state.getLogs` would run for EVERY `NodeHeader` (and `NodeLogs`).
+Because `filter` returns a new array reference, every `NodeHeader` component would re-render, even if the logs for that specific node hadn't changed.
+In a workflow with many nodes (N) and frequent log updates, this caused O(N) re-renders per log, leading to main thread blocking and UI lag.
+
+## 📊 Impact
+- **Reduces re-renders by ~99%** (for N=100 nodes) during log heavy operations.
+- `NodeHeader` only re-renders when logs for *its* specific node change.
+- `NodeLogs` only re-renders when logs for *its* specific node change.
+
+## 🔬 Measurement
+A performance regression test was added in `web/src/__tests__/performance/LogStoreReRender.test.tsx`.
+It verifies that:
+1. Adding a log for Node A does NOT trigger a re-render for Node B's component.
+2. Adding a log for Node A DOES trigger a re-render for Node A's component.
+
+## 🧪 Testing
+Ran `make test-web`.
+Verified `src/__tests__/performance/LogStoreReRender.test.tsx` passes.
+Verified existing tests pass.

--- a/web/src/__tests__/performance/LogStoreReRender.test.tsx
+++ b/web/src/__tests__/performance/LogStoreReRender.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import useLogsStore from '../../stores/LogStore';
+import { shallow } from 'zustand/shallow';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+
+// Mock component that mimics NodeHeader's log subscription
+const TestComponent = ({ workflowId, nodeId, onRender }: { workflowId: string, nodeId: string, onRender: () => void }) => {
+  // Simulate the inefficient selector
+  const logs = useLogsStore((state) => state.getLogs(workflowId, nodeId));
+
+  onRender();
+  return <div>Log count: {logs.length}</div>;
+};
+
+// Optimized component
+const OptimizedComponent = ({ workflowId, nodeId, onRender }: { workflowId: string, nodeId: string, onRender: () => void }) => {
+  const logs = useStoreWithEqualityFn(
+    useLogsStore,
+    (state) => state.logs.filter((log) => log.workflowId === workflowId && log.nodeId === nodeId),
+    shallow
+  );
+
+  onRender();
+  return <div>Log count: {logs.length}</div>;
+};
+
+describe('LogStore Performance', () => {
+  beforeEach(() => {
+    useLogsStore.getState().clearLogs();
+  });
+
+  it('re-renders TestComponent when unrelated logs are added', () => {
+    const renderCount = jest.fn();
+    render(<TestComponent workflowId="wf1" nodeId="node1" onRender={renderCount} />);
+
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    // Add log for UNRELATED node
+    act(() => {
+      useLogsStore.getState().appendLog({
+        workflowId: 'wf1',
+        nodeId: 'node2', // Different node
+        workflowName: 'wf',
+        nodeName: 'n2',
+        content: 'test',
+        severity: 'info',
+        timestamp: 123
+      });
+    });
+
+    // It SHOULD re-render because getLogs returns a new array reference
+    expect(renderCount).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT re-render OptimizedComponent when unrelated logs are added', () => {
+    const renderCount = jest.fn();
+    render(<OptimizedComponent workflowId="wf1" nodeId="node1" onRender={renderCount} />);
+
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    // Add log for UNRELATED node
+    act(() => {
+      useLogsStore.getState().appendLog({
+        workflowId: 'wf1',
+        nodeId: 'node2', // Different node
+        workflowName: 'wf',
+        nodeName: 'n2',
+        content: 'test',
+        severity: 'info',
+        timestamp: 123
+      });
+    });
+
+    // It should NOT re-render because shallow equality check passes
+    expect(renderCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-renders OptimizedComponent when RELATED logs are added', () => {
+    const renderCount = jest.fn();
+    render(<OptimizedComponent workflowId="wf1" nodeId="node1" onRender={renderCount} />);
+
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    // Add log for RELATED node
+    act(() => {
+      useLogsStore.getState().appendLog({
+        workflowId: 'wf1',
+        nodeId: 'node1', // Same node
+        workflowName: 'wf',
+        nodeName: 'n1',
+        content: 'test',
+        severity: 'info',
+        timestamp: 123
+      });
+    });
+
+    // It SHOULD re-render
+    expect(renderCount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/node/NodeHeader.tsx
+++ b/web/src/components/node/NodeHeader.tsx
@@ -2,6 +2,8 @@
 import { css } from "@emotion/react";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import useLogsStore from "../../stores/LogStore";
+import { shallow } from "zustand/shallow";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 import { memo, useCallback, useMemo, useState } from "react";
 import isEqual from "lodash/isEqual";
 import { NodeData } from "../../stores/NodeData";
@@ -59,7 +61,16 @@ export const NodeHeader: React.FC<NodeHeaderProps> = ({
   const openContextMenu = useContextMenuStore((state) => state.openContextMenu);
   const updateNode = useNodes((state) => state.updateNode);
   const nodeWorkflowId = useNodes((state) => state.workflow?.id);
-  const logs = useLogsStore((state) => state.getLogs(workflowId || nodeWorkflowId || "", id));
+  // Use shallow equality to avoid re-rendering when logs for other nodes change
+  const targetWorkflowId = workflowId || nodeWorkflowId || "";
+  const logs = useStoreWithEqualityFn(
+    useLogsStore,
+    (state) =>
+      state.logs.filter(
+        (log) => log.workflowId === targetWorkflowId && log.nodeId === id
+      ),
+    shallow
+  );
   const [logsDialogOpen, setLogsDialogOpen] = useState(false);
 
   const logCount = logs?.length || 0;

--- a/web/src/components/node/NodeLogs.tsx
+++ b/web/src/components/node/NodeLogs.tsx
@@ -17,6 +17,8 @@ import {
   Box
 } from "@mui/material";
 import useLogsStore from "../../stores/LogStore";
+import { shallow } from "zustand/shallow";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 import isEqual from "lodash/isEqual";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import ListAltIcon from "@mui/icons-material/ListAlt";
@@ -61,7 +63,14 @@ export const NodeLogsDialog: React.FC<NodeLogsDialogProps> = memo(
   ({ id, workflowId, open, onClose }) => {
     const theme = useTheme();
     const logsRef = useRef<HTMLDivElement>(null);
-    const logs = useLogsStore((state) => state.getLogs(workflowId, id));
+    const logs = useStoreWithEqualityFn(
+      useLogsStore,
+      (state) =>
+        state.logs.filter(
+          (log) => log.workflowId === workflowId && log.nodeId === id
+        ),
+      shallow
+    );
     const [selectedSeverities, setSelectedSeverities] = useState<Severity[]>(
       []
     );
@@ -225,7 +234,14 @@ NodeLogsDialog.displayName = "NodeLogsDialog";
 
 export const NodeLogs: React.FC<NodeLogsProps> = ({ id, workflowId }) => {
   const theme = useTheme();
-  const logs = useLogsStore((state) => state.getLogs(workflowId, id));
+  const logs = useStoreWithEqualityFn(
+    useLogsStore,
+    (state) =>
+      state.logs.filter(
+        (log) => log.workflowId === workflowId && log.nodeId === id
+      ),
+    shallow
+  );
   const [open, setOpen] = useState(false);
 
   const count = logs?.length || 0;

--- a/workspace/bolt.md
+++ b/workspace/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - Optimizing Log Subscriptions with Zustand
+**Learning:** Zustand's default selector equality is strict equality (`===`). If a selector returns a new reference (like `array.filter()` does), the component will re-render on EVERY store update, even if the data content is identical. This is O(N) re-renders for N components.
+**Action:** Use `useStoreWithEqualityFn` (from `zustand/traditional`) with `shallow` equality (from `zustand/shallow`) when selecting derived arrays or objects to prevent unnecessary re-renders.


### PR DESCRIPTION
💡 What:
Optimized `NodeHeader` and `NodeLogs` components to use `shallow` equality check when subscribing to `LogStore`.
Instead of calling `state.getLogs(...)` which returns a new array reference on every store update, we now select the filtered logs inline and use `shallow` comparison via `useStoreWithEqualityFn`.

🎯 Why:
Previously, every time a log was appended to the `LogStore` (for ANY node), `state.getLogs` would run for EVERY `NodeHeader` (and `NodeLogs`).
Because `filter` returns a new array reference, every `NodeHeader` component would re-render, even if the logs for that specific node hadn't changed.
In a workflow with many nodes (N) and frequent log updates, this caused O(N) re-renders per log, leading to main thread blocking and UI lag.

📊 Impact:
- **Reduces re-renders by ~99%** (for N=100 nodes) during log heavy operations.
- `NodeHeader` only re-renders when logs for *its* specific node change.
- `NodeLogs` only re-renders when logs for *its* specific node change.

🔬 Measurement:
A performance regression test was added in `web/src/__tests__/performance/LogStoreReRender.test.tsx`.
It verifies that adding a log for Node A does NOT trigger a re-render for Node B's component.

🧪 Testing:
Ran `make test-web`.
Verified `src/__tests__/performance/LogStoreReRender.test.tsx` passes.

---
*PR created automatically by Jules for task [16473126117143751573](https://jules.google.com/task/16473126117143751573) started by @georgi*