### PR TITLE
⚡ Fix N+1 API call in CollectionStore upload

### DIFF
--- a/web/src/stores/CollectionStore.ts
+++ b/web/src/stores/CollectionStore.ts
@@ -197,7 +197,6 @@ export const useCollectionStore = create<CollectionStore>()(
             });
           } finally {
             completed++;
-            await get().fetchCollections();
             set((state) => ({
               indexProgress: state.indexProgress
                 ? {
@@ -209,6 +208,7 @@ export const useCollectionStore = create<CollectionStore>()(
           }
         }
 
+        await get().fetchCollections();
         set({ indexProgress: null, indexErrors: errors });
       }
     }),

--- a/web/src/stores/__tests__/CollectionStore.benchmark.test.ts
+++ b/web/src/stores/__tests__/CollectionStore.benchmark.test.ts
@@ -1,0 +1,61 @@
+
+import { act } from "@testing-library/react";
+import { useCollectionStore } from "../CollectionStore";
+import { client } from "../ApiClient";
+
+// Mock the client module
+jest.mock("../ApiClient", () => ({
+  client: {
+    GET: jest.fn(),
+    POST: jest.fn(),
+    DELETE: jest.fn()
+  }
+}));
+
+// Use 'any' to bypass strict typing for mocked API responses
+const mockClient = client as any;
+
+describe("CollectionStore Benchmark", () => {
+  beforeEach(() => {
+    useCollectionStore.setState({
+      collections: null,
+      isLoading: false,
+      error: null,
+      deleteTarget: null,
+      showForm: false,
+      dragOverCollection: null,
+      indexProgress: null,
+      indexErrors: [],
+      selectedCollections: []
+    });
+    jest.clearAllMocks();
+  });
+
+  it("reproduction: should call fetchCollections multiple times for multiple files", async () => {
+    const mockFile1 = new File(["content1"], "test1.txt", { type: "text/plain" });
+    const mockFile2 = new File(["content2"], "test2.txt", { type: "text/plain" });
+    const mockFile3 = new File(["content3"], "test3.txt", { type: "text/plain" });
+
+    const mockEvent = {
+      preventDefault: jest.fn(),
+      dataTransfer: {
+        files: [mockFile1, mockFile2, mockFile3]
+      }
+    } as unknown as React.DragEvent<HTMLDivElement>;
+
+    mockClient.POST.mockResolvedValue({ data: { path: "/test.txt" }, error: null });
+    mockClient.GET.mockResolvedValue({ data: { collections: [] }, error: null });
+
+    const handler = useCollectionStore.getState().handleDrop("collection1");
+
+    await act(async () => {
+      await handler(mockEvent);
+    });
+
+    // POST is called for every file upload (3 times).
+    expect(mockClient.POST).toHaveBeenCalledTimes(3);
+
+    // After optimization, GET should be called only once for the entire batch.
+    expect(mockClient.GET).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
💡 **What:** Moved `fetchCollections` call outside the file upload loop in `CollectionStore.ts`.
🎯 **Why:** Previously, `fetchCollections` was called after every single file upload, causing N+1 API calls for N files. This was inefficient and caused unnecessary network traffic and potential UI flickering.
📊 **Measured Improvement:** Verified with a benchmark test (`CollectionStore.benchmark.test.ts`) that `GET /api/collections/` is now called only once for a batch of 3 files, compared to 3 times previously.

---
*PR created automatically by Jules for task [9313285557358950907](https://jules.google.com/task/9313285557358950907) started by @georgi*