### PR TITLE
⚡ Refactor useJobReconnection to use Promise.all

### DIFF
--- a/web/src/hooks/useJobReconnection.ts
+++ b/web/src/hooks/useJobReconnection.ts
@@ -28,64 +28,70 @@ export const useJobReconnection = () => {
       );
 
       // Reconnect to each running job
-      runningJobs.forEach(async (job) => {
-        try {
-          log.debug("JobReconnection: processing job", job);
-          // Fetch the workflow for this job
-          const { data: workflow, error } = await client.GET(
-            "/api/workflows/{id}",
-            {
-              params: {
-                path: { id: job.workflow_id }
+      const reconnectJobs = async () => {
+        await Promise.all(
+          runningJobs.map(async (job) => {
+            try {
+              log.debug("JobReconnection: processing job", job);
+              // Fetch the workflow for this job
+              const { data: workflow, error } = await client.GET(
+                "/api/workflows/{id}",
+                {
+                  params: {
+                    path: { id: job.workflow_id }
+                  }
+                }
+              );
+
+              if (error || !workflow) {
+                log.error(
+                  `Failed to fetch workflow ${job.workflow_id} for job ${job.id}:`,
+                  error
+                );
+                return;
               }
+
+              log.debug("JobReconnection: fetched workflow", workflow);
+              // Get the workflow runner store for this workflow
+              const runnerStore = getWorkflowRunnerStore(job.workflow_id);
+
+              // Determine initial state from job's run_state
+              const runState = (job as any).run_state;
+              let initialState: "running" | "paused" | "suspended" | undefined;
+              if (runState?.status === "suspended") {
+                initialState = "suspended";
+              } else if (runState?.status === "paused") {
+                initialState = "paused";
+              } else {
+                initialState = "running";
+              }
+
+              // Reconnect with workflow context and initial state
+              await runnerStore.getState().reconnectWithWorkflow(job.id, workflow);
+
+              // Set proper state after reconnection based on run_state
+              if (initialState && initialState !== "running") {
+                runnerStore.setState({
+                  state: initialState,
+                  statusMessage:
+                    runState?.suspension_reason ||
+                    (initialState === "suspended"
+                      ? "Workflow suspended"
+                      : "Workflow paused")
+                });
+              }
+
+              log.info(
+                `Reconnected to job ${job.id} for workflow ${workflow.name} (state: ${initialState})`
+              );
+            } catch (error) {
+              log.error(`Error reconnecting to job ${job.id}:`, error);
             }
-          );
+          })
+        );
+      };
 
-          if (error || !workflow) {
-            log.error(
-              `Failed to fetch workflow ${job.workflow_id} for job ${job.id}:`,
-              error
-            );
-            return;
-          }
-
-          log.debug("JobReconnection: fetched workflow", workflow);
-          // Get the workflow runner store for this workflow
-          const runnerStore = getWorkflowRunnerStore(job.workflow_id);
-
-          // Determine initial state from job's run_state
-          const runState = (job as any).run_state;
-          let initialState: "running" | "paused" | "suspended" | undefined;
-          if (runState?.status === "suspended") {
-            initialState = "suspended";
-          } else if (runState?.status === "paused") {
-            initialState = "paused";
-          } else {
-            initialState = "running";
-          }
-
-          // Reconnect with workflow context and initial state
-          await runnerStore.getState().reconnectWithWorkflow(job.id, workflow);
-
-          // Set proper state after reconnection based on run_state
-          if (initialState && initialState !== "running") {
-            runnerStore.setState({
-              state: initialState,
-              statusMessage:
-                runState?.suspension_reason ||
-                (initialState === "suspended"
-                  ? "Workflow suspended"
-                  : "Workflow paused")
-            });
-          }
-
-          log.info(
-            `Reconnected to job ${job.id} for workflow ${workflow.name} (state: ${initialState})`
-          );
-        } catch (error) {
-          log.error(`Error reconnecting to job ${job.id}:`, error);
-        }
-      });
+      reconnectJobs();
     }
   }, [runningJobs, isSuccess]);
 


### PR DESCRIPTION
💡 **What:**
- Replaced `runningJobs.forEach(async (job) => { ... })` with `await Promise.all(runningJobs.map(async (job) => { ... }))` inside an async IIFE within the `useEffect`.
- Updated `web/src/hooks/__tests__/useJobReconnection.test.tsx` to fix a bug in the store mock and add better assertions.

🎯 **Why:**
- **Correctness:** `forEach` does not wait for async callbacks, leading to unhandled promises and inability to track completion. `Promise.all` ensures all operations are awaited.
- **Testing:** The previous tests were not verifying the actual side effects (store updates) because the mock was incomplete. The improved tests now verify that the reconnection logic actually runs.

📊 **Measured Improvement:**
- Verified that tests pass and logic is sound.
- No direct runtime speedup (parallel execution is preserved), but robustness and testability are improved.


---
*PR created automatically by Jules for task [8828753665675257372](https://jules.google.com/task/8828753665675257372) started by @georgi*