### PR TITLE
🎨 Palette: Make StateIconButton keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-05-23 - Inconsistent Accessible Names in Primitives
 **Learning:** `RefreshButton` was missing `aria-label` while other primitives had it, causing it to be invisible to screen readers (and Playwright `get_by_role` with name). Even if `Tooltip` is present, the interactive element must have an accessible name.
 **Action:** Always verify `aria-label` on icon-only buttons, even if a Tooltip is used.
+
+## 2026-02-27 - Hidden Focus Traps in State Buttons
+**Learning:** `StateIconButton` (used for ThemeToggle, AgentMode) had hardcoded `tabIndex={-1}`, making critical global controls keyboard-inaccessible. This pattern of "canvas-first" components breaking standard UI accessibility persists.
+**Action:** When auditing UI primitives, check if they are "dual-use" (canvas vs. panel) and ensure `tabIndex` is configurable, defaulting to `0`.

--- a/web/src/components/ui_primitives/StateIconButton.tsx
+++ b/web/src/components/ui_primitives/StateIconButton.tsx
@@ -125,6 +125,15 @@ export interface StateIconButtonProps {
     | "warning"
     | "info"
     | "success";
+  /**
+   * Accessible label for the button
+   */
+  ariaLabel?: string;
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 export const StateIconButton = memo(
@@ -144,7 +153,9 @@ export const StateIconButton = memo(
         nodrag = true,
         className,
         sx,
-        color = "default"
+        color = "default",
+        ariaLabel,
+        tabIndex = 0
       },
       ref
     ) => {
@@ -173,10 +184,14 @@ export const StateIconButton = memo(
         icon
       );
 
+      const label = ariaLabel || (typeof tooltip === "string" ? tooltip : undefined);
+
       const button = (
         <IconButton
           ref={ref}
-          tabIndex={-1}
+          tabIndex={tabIndex}
+          aria-label={label}
+          aria-pressed={isActive}
           className={cn(
             "state-icon-button",
             isActive && "active",

--- a/web/src/components/ui_primitives/__tests__/StateIconButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/StateIconButton.test.tsx
@@ -340,4 +340,83 @@ describe("StateIconButton", () => {
     // Note: In real implementation, stopPropagation is called, 
     // but in tests it might still propagate due to mock setup
   });
+
+  it("sets tabIndex to 0 by default", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton icon={<MockIcon />} onClick={mockOnClick} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("allows overriding tabIndex", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton
+          icon={<MockIcon />}
+          onClick={mockOnClick}
+          tabIndex={-1}
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("sets aria-label from tooltip string", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton
+          icon={<MockIcon />}
+          onClick={mockOnClick}
+          tooltip="Accessible Label"
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("aria-label", "Accessible Label");
+  });
+
+  it("sets aria-label from ariaLabel prop", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton
+          icon={<MockIcon />}
+          onClick={mockOnClick}
+          tooltip={<span>Tooltip content</span>}
+          ariaLabel="Explicit Label"
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("aria-label", "Explicit Label");
+  });
+
+  it("sets aria-pressed when isActive is true", () => {
+    const { rerender } = render(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton
+          icon={<MockIcon />}
+          onClick={mockOnClick}
+          isActive={true}
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("aria-pressed", "true");
+
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <StateIconButton
+          icon={<MockIcon />}
+          onClick={mockOnClick}
+          isActive={false}
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("icon-button")).toHaveAttribute("aria-pressed", "false");
+  });
 });

--- a/web/web_output.log
+++ b/web/web_output.log
@@ -1,0 +1,25 @@
+
+> nodetool@0.6.3-rc.28 start
+> vite --host 0.0.0.0 --port 3000 --strictPort --clearScreen false
+
+Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+
+  VITE v6.4.1  ready in 532 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: http://192.168.0.2:3000/
+11:16:37 AM [vite] http proxy error: /api/settings/
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+11:16:37 AM [vite] http proxy error: /api/threads/
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+11:16:37 AM [vite] http proxy error: /api/nodes/metadata
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+11:16:52 AM [vite] (client) hmr update /src/components/LayoutTest.tsx


### PR DESCRIPTION
This PR improves the accessibility of the `StateIconButton` component, which is used for key UI elements like the Theme Toggle and Agent Mode Toggle.

Previously, `StateIconButton` had `tabIndex={-1}` hardcoded, making it impossible to focus these buttons using keyboard navigation.

Changes:
- Removed hardcoded `tabIndex={-1}`.
- Added `tabIndex` prop (defaulting to `0`).
- Added `ariaLabel` prop (falling back to tooltip text if string).
- Added `aria-pressed` attribute reflecting `isActive` state.
- Added unit tests for these new props.

Verified with Playwright script checking for correct `tabIndex` and focusability on the Theme Toggle button.

---
*PR created automatically by Jules for task [11813950754389498351](https://jules.google.com/task/11813950754389498351) started by @georgi*