### PR TITLE
perf(web): optimize edge subscriptions in property components

### DIFF
--- a/web/src/components/properties/CollectionProperty.tsx
+++ b/web/src/components/properties/CollectionProperty.tsx
@@ -10,14 +10,14 @@ import Select from "../inputs/Select";
 
 const CollectionProperty = (props: PropertyProps) => {
   const id = `collection-${props.property.name}-${props.propertyIndex}`;
-  const edges = useNodes((state) => state.edges);
-  const isConnected = useMemo(() => {
-    return edges.some(
+
+  const isConnected = useNodes((state) => {
+    return state.edges.some(
       (edge) =>
         edge.target === props.nodeId &&
         edge.targetHandle === props.property.name
     );
-  }, [edges, props.nodeId, props.property.name]);
+  });
 
   const { data, error, isLoading } = useQuery<CollectionList>({
     queryKey: ["collections"],

--- a/web/src/components/properties/ModelProperty.tsx
+++ b/web/src/components/properties/ModelProperty.tsx
@@ -56,15 +56,15 @@ const styles = (theme: Theme) =>
 const ModelProperty = (props: PropertyProps) => {
   const id = `folder-${props.property.name}-${props.propertyIndex}`;
   const modelType = props.property.type.type;
-  const edges = useNodes((state) => state.edges);
   const theme = useTheme();
-  const isConnected = useMemo(() => {
-    return edges.some(
+
+  const isConnected = useNodes((state) => {
+    return state.edges.some(
       (edge) =>
         edge.target === props.nodeId &&
         edge.targetHandle === props.property.name
     );
-  }, [edges, props.nodeId, props.property.name]);
+  });
 
   const modelClass = useMemo(
     () => `model-type-${modelType.replace(/\./g, "-")}`,

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { useEffect, useRef, useState, useCallback, memo } from "react";
+import { shallow } from "zustand/shallow";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import TextEditorModal from "./TextEditorModal";
@@ -80,7 +81,8 @@ const StringProperty = ({
         };
       },
       [nodeId, nodeType, property.name]
-    )
+    ),
+    shallow
   );
 
   const showTextEditor = !isConnected;

--- a/workspace/bolt-property-edge-subscriptions.md
+++ b/workspace/bolt-property-edge-subscriptions.md
@@ -1,0 +1,26 @@
+# ⚡ Bolt: Property Edge Subscriptions
+
+## 💡 What
+Refactored `ImageSizeProperty`, `ModelProperty`, `CollectionProperty`, and `StringProperty` to optimize their `useNodes` selectors that depend on `state.edges`.
+- `ModelProperty` and `CollectionProperty` now use a specific `state.edges.some(...)` check inside the `useNodes` selector, rather than returning the entire `edges` array and computing `some(...)` in a `useMemo`.
+- `StringProperty` now uses `shallow` equality from `zustand/shallow` to prevent re-renders when its returned object (`{ isConnected, stringInputConfig }`) contains identical primitive values.
+- `ImageSizeProperty` already had a good specific selector, so it was left untouched.
+
+## 🎯 Why
+Previously, properties like `ModelProperty` and `CollectionProperty` subscribed to the entire `state.edges` array. Since React Flow updates this array reference on *every* edge change in the entire graph (additions, removals, animations, status updates), these property components would re-render continuously, even if the edge changes were completely unrelated to them. This caused significant main thread overhead during workflow execution and editing in large graphs.
+
+## 📊 Impact
+- **Eliminates Unnecessary Re-renders:** These property components now only re-render when their specific connection status changes (e.g., when a wire is specifically connected to or disconnected from their property handle).
+- **Reduces Main Thread Work:** Prevents O(N) component re-renders per frame where N is the number of property fields in the visible graph.
+- **Improved Responsiveness:** Smoother editing and execution experience, especially in dense workflows with many dropdowns and properties.
+
+## 🔬 Measurement
+Verify by opening a workflow with many dropdowns/properties (e.g., multiple Model or String properties).
+Use React DevTools "Highlight updates when components render".
+Before: Adding an unrelated edge or seeing animated edges causes all these property fields to flash.
+After: Adding an unrelated edge does NOT cause these property fields to flash.
+
+## 🧪 Testing
+- Ran `make typecheck`: Passed.
+- Ran `make lint`: Passed.
+- Ran `make test-web`: All tests passed.

--- a/workspace/bolt.md
+++ b/workspace/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-02-17 - Optimizing NodeExplorer Drag Performance
 **Learning:** Components subscribing to `state.nodes` re-render on every drag frame because ReactFlow updates the `nodes` array reference and node object references (for position updates). Components that only display node data (like `NodeExplorer`) but not position suffer from excessive re-renders.
 **Action:** Use `useNodes` with a custom equality function that checks for structural equality of `id`, `type`, and referential equality of `data`, ignoring `position` and other volatile fields. This effectively decouples the component from drag updates.
+
+## 2024-05-24 - Zustand store usage in hooks
+**Learning:** When using selectors that return primitive values calculated from large arrays (`state.edges.filter(...).length`), the component still re-renders if the array reference changes (which it does on every edge update) even if the primitive value remains the same, UNLESS you provide a custom equality function or ensure the state being selected doesn't change reference unnecessarily.
+**Action:** In hooks like `useNodeEditorShortcuts`, avoid selecting derived scalar values from volatile arrays without an equality function or better yet, avoid the subscription if the value can be computed imperatively when needed.


### PR DESCRIPTION
# ⚡ Bolt: Property Edge Subscriptions

## 💡 What
Refactored `ModelProperty`, `CollectionProperty`, and `StringProperty` to optimize their `useNodes` selectors that depend on `state.edges`.
- `ModelProperty` and `CollectionProperty` now use a specific `state.edges.some(...)` check inside the `useNodes` selector, rather than returning the entire `edges` array and computing `some(...)` in a `useMemo`.
- `StringProperty` now uses `shallow` equality from `zustand/shallow` to prevent re-renders when its returned object (`{ isConnected, stringInputConfig }`) contains identical primitive values.
- `ImageSizeProperty` already had a good specific selector, so it was left untouched.

## 🎯 Why
Previously, properties like `ModelProperty` and `CollectionProperty` subscribed to the entire `state.edges` array. Since React Flow updates this array reference on *every* edge change in the entire graph (additions, removals, animations, status updates), these property components would re-render continuously, even if the edge changes were completely unrelated to them. This caused significant main thread overhead during workflow execution and editing in large graphs.

## 📊 Impact
- **Eliminates Unnecessary Re-renders:** These property components now only re-render when their specific connection status changes (e.g., when a wire is specifically connected to or disconnected from their property handle).
- **Reduces Main Thread Work:** Prevents O(N) component re-renders per frame where N is the number of property fields in the visible graph.
- **Improved Responsiveness:** Smoother editing and execution experience, especially in dense workflows with many dropdowns and properties.

## 🧪 Testing
- Ran `make typecheck`: Passed.
- Ran `make lint`: Passed.
- Ran `make test-web`: All tests passed.

---
*PR created automatically by Jules for task [14288697342123367157](https://jules.google.com/task/14288697342123367157) started by @georgi*