### PR TITLE
🎨 Palette: Add aria-labels to core icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,6 @@
 ## 2026-02-27 - Hidden Focus Traps in State Buttons
 **Learning:** `StateIconButton` (used for ThemeToggle, AgentMode) had hardcoded `tabIndex={-1}`, making critical global controls keyboard-inaccessible. This pattern of "canvas-first" components breaking standard UI accessibility persists.
 **Action:** When auditing UI primitives, check if they are "dual-use" (canvas vs. panel) and ensure `tabIndex` is configurable, defaulting to `0`.
+## 2024-06-18 - Missing ARIA Labels on Core UI Primitives
+**Learning:** Many core icon-based UI primitives (like `CircularActionButton`, `ToolbarIconButton`, `DownloadButton`, `PlaybackButton`) in this application were missing `aria-label`s, rendering them inaccessible to screen readers despite having visual tooltips. The tooltips were not automatically functioning as accessible names. Furthermore, grouped buttons (like in `ActionButtonGroup`) lacked semantic grouping structure (`role="group"`).
+**Action:** When creating or modifying custom icon-only components, always extract the string value from the `tooltip` prop (e.g., `typeof tooltip === 'string' ? tooltip : undefined`) to explicitly set the `aria-label` attribute on the underlying `IconButton` or `button` element. Use `role="group"` and `aria-label` for logical groupings of actions to provide proper context to screen readers.

--- a/web/src/components/ui_primitives/ActionButtonGroup.tsx
+++ b/web/src/components/ui_primitives/ActionButtonGroup.tsx
@@ -112,6 +112,10 @@ export interface ActionButtonGroupProps {
    * Divider color
    */
   dividerColor?: string;
+  /**
+   * ARIA label for the group
+   */
+  "aria-label"?: string;
 }
 
 export const ActionButtonGroup = memo(
@@ -133,7 +137,8 @@ export const ActionButtonGroup = memo(
         backgroundColor,
         border,
         divider = false,
-        dividerColor
+        dividerColor,
+        "aria-label": ariaLabel
       },
       ref
     ) => {
@@ -169,6 +174,8 @@ export const ActionButtonGroup = memo(
       return (
         <Box
           ref={ref}
+          role="group"
+          aria-label={ariaLabel}
           className={cn(
             "action-button-group",
             nodrag && editorClassNames.nodrag,

--- a/web/src/components/ui_primitives/CircularActionButton.tsx
+++ b/web/src/components/ui_primitives/CircularActionButton.tsx
@@ -289,6 +289,7 @@ export const CircularActionButton = memo(
         <IconButton
           ref={ref}
           tabIndex={-1}
+          aria-label={typeof tooltip === "string" ? tooltip : undefined}
           className={cn(
             "circular-action-button",
             nodrag && editorClassNames.nodrag,

--- a/web/src/components/ui_primitives/DownloadButton.tsx
+++ b/web/src/components/ui_primitives/DownloadButton.tsx
@@ -131,6 +131,7 @@ export const DownloadButton = memo(
             <Button
               ref={ref}
               tabIndex={-1}
+              aria-label={tooltip}
               className={cn(
                 "download-button",
                 nodrag && editorClassNames.nodrag,
@@ -165,6 +166,7 @@ export const DownloadButton = memo(
           <IconButton
             ref={ref}
             tabIndex={-1}
+            aria-label={tooltip}
             className={cn(
               "download-button",
               nodrag && editorClassNames.nodrag,

--- a/web/src/components/ui_primitives/PlaybackButton.tsx
+++ b/web/src/components/ui_primitives/PlaybackButton.tsx
@@ -210,6 +210,7 @@ export const PlaybackButton = memo(
         >
           <IconButton
             ref={ref}
+            aria-label={getTooltip()}
             className={cn(
               "playback-button",
               nodrag && editorClassNames.nodrag,

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -183,6 +183,7 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
                 >
                   <IconButton
                     className="clear-button"
+                    aria-label={clearTooltip}
                     onClick={handleClear}
                     size="small"
                   >

--- a/web/src/components/ui_primitives/ToolbarIconButton.tsx
+++ b/web/src/components/ui_primitives/ToolbarIconButton.tsx
@@ -151,6 +151,7 @@ export const ToolbarIconButton = memo(
         >
           <IconButton
             ref={ref}
+            aria-label={typeof tooltip === "string" ? tooltip : undefined}
             className={cn(
               "toolbar-icon-button",
               nodrag && editorClassNames.nodrag,


### PR DESCRIPTION
💡 **What**: Added explicit `aria-label` attributes to multiple core UI primitives (e.g., `CircularActionButton`, `ToolbarIconButton`, `DownloadButton`, `PlaybackButton`, and `SearchInput`) and introduced `role="group"` support to `ActionButtonGroup`.

🎯 **Why**: Icon-only buttons lacked accessible names for screen readers, making navigation difficult for visually impaired users. Tooltips provide visual context but don't automatically translate to semantic names in this setup.

♿ **Accessibility**:
- Screen readers can now correctly announce the purpose of icon-only buttons by extracting the string value of their tooltips.
- Clustered buttons in `ActionButtonGroup` now have semantic `role="group"` and accept an `aria-label` to provide context.

---
*PR created automatically by Jules for task [6377366905046791805](https://jules.google.com/task/6377366905046791805) started by @georgi*