### PR TITLE
🎨 Palette: Restore keyboard accessibility to button primitives

### DIFF
--- a/web/src/components/ui_primitives/CircularActionButton.tsx
+++ b/web/src/components/ui_primitives/CircularActionButton.tsx
@@ -170,6 +170,11 @@ export interface CircularActionButtonProps {
    * @default false
    */
   disableRipple?: boolean;
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 const getThemeColor = (theme: Theme, colorKey: string): string => {
@@ -215,7 +220,8 @@ export const CircularActionButton = memo(
         nodrag = true,
         className,
         sx,
-        disableRipple = false
+        disableRipple = false,
+        tabIndex = 0
       },
       ref
     ) => {
@@ -288,7 +294,7 @@ export const CircularActionButton = memo(
       const button = (
         <IconButton
           ref={ref}
-          tabIndex={-1}
+          tabIndex={tabIndex}
           aria-label={typeof tooltip === "string" ? tooltip : undefined}
           className={cn(
             "circular-action-button",

--- a/web/src/components/ui_primitives/DownloadButton.tsx
+++ b/web/src/components/ui_primitives/DownloadButton.tsx
@@ -80,6 +80,11 @@ export interface DownloadButtonProps {
    * Additional sx styles
    */
   sx?: object;
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 export const DownloadButton = memo(
@@ -96,7 +101,8 @@ export const DownloadButton = memo(
         disabled = false,
         isLoading = false,
         className,
-        sx
+        sx,
+        tabIndex = 0
       },
       ref
     ) => {
@@ -130,7 +136,7 @@ export const DownloadButton = memo(
           >
             <Button
               ref={ref}
-              tabIndex={-1}
+              tabIndex={tabIndex}
               aria-label={tooltip}
               className={cn(
                 "download-button",
@@ -165,7 +171,7 @@ export const DownloadButton = memo(
         >
           <IconButton
             ref={ref}
-            tabIndex={-1}
+            tabIndex={tabIndex}
             aria-label={tooltip}
             className={cn(
               "download-button",

--- a/web/src/components/ui_primitives/NavButton.tsx
+++ b/web/src/components/ui_primitives/NavButton.tsx
@@ -78,6 +78,11 @@ export interface NavButtonProps extends CommonButtonProps {
    * Additional sx props
    */
   sx?: ButtonProps["sx"];
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 /**
@@ -97,6 +102,7 @@ export const NavButton = memo(
         navSize = "medium",
         className,
         sx,
+        tabIndex = 0,
         ...props
       },
       ref
@@ -165,7 +171,7 @@ export const NavButton = memo(
                 active && "active",
                 className
               )}
-              tabIndex={-1}
+              tabIndex={tabIndex}
               sx={baseStyles}
               onClick={props.onClick}
               disabled={props.disabled}
@@ -188,7 +194,7 @@ export const NavButton = memo(
             className
           )}
           startIcon={icon}
-          tabIndex={-1}
+          tabIndex={tabIndex}
           sx={{
             ...baseStyles,
             textTransform: "none",

--- a/web/src/components/ui_primitives/PlaybackButton.tsx
+++ b/web/src/components/ui_primitives/PlaybackButton.tsx
@@ -84,6 +84,11 @@ export interface PlaybackButtonProps
    * @default "medium"
    */
   buttonSize?: "small" | "medium" | "large";
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 /**
@@ -103,6 +108,7 @@ export const PlaybackButton = memo(
         buttonSize = "medium",
         className,
         sx,
+        tabIndex = 0,
         ...props
       },
       ref
@@ -220,7 +226,7 @@ export const PlaybackButton = memo(
               className
             )}
             onClick={handleClick}
-            tabIndex={-1}
+            tabIndex={tabIndex}
             sx={{
               ...sizeStyles,
               ...colorStyles,

--- a/web/src/components/ui_primitives/SettingsButton.tsx
+++ b/web/src/components/ui_primitives/SettingsButton.tsx
@@ -74,6 +74,11 @@ export interface SettingsButtonProps {
    * Additional sx styles
    */
   sx?: object;
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 export const SettingsButton = memo(
@@ -88,7 +93,8 @@ export const SettingsButton = memo(
         nodrag = true,
         disabled = false,
         className,
-        sx
+        sx,
+        tabIndex = 0
       },
       ref
     ) => {
@@ -120,7 +126,7 @@ export const SettingsButton = memo(
         >
           <IconButton
             ref={ref}
-            tabIndex={-1}
+            tabIndex={tabIndex}
             className={cn(
               "settings-button",
               nodrag && editorClassNames.nodrag,

--- a/web/src/components/ui_primitives/ToolbarIconButton.tsx
+++ b/web/src/components/ui_primitives/ToolbarIconButton.tsx
@@ -71,6 +71,11 @@ export interface ToolbarIconButtonProps
    * Will be shown as a compact badge
    */
   shortcut?: string[];
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 /**
@@ -90,6 +95,7 @@ export const ToolbarIconButton = memo(
         className,
         size = "small",
         sx,
+        tabIndex = 0,
         ...props
       },
       ref
@@ -158,7 +164,7 @@ export const ToolbarIconButton = memo(
               className
             )}
             size={size}
-            tabIndex={-1}
+            tabIndex={tabIndex}
             sx={{
               ...variantStyles,
               ...(active && {

--- a/web/src/components/ui_primitives/UploadButton.tsx
+++ b/web/src/components/ui_primitives/UploadButton.tsx
@@ -86,6 +86,11 @@ export interface UploadButtonProps {
    * Additional sx styles
    */
   sx?: object;
+  /**
+   * Tab index for keyboard navigation
+   * @default 0
+   */
+  tabIndex?: number;
 }
 
 export const UploadButton = memo(
@@ -103,7 +108,8 @@ export const UploadButton = memo(
         multiple = true,
         accept,
         className,
-        sx
+        sx,
+        tabIndex = 0
       },
       ref
     ) => {
@@ -156,7 +162,7 @@ export const UploadButton = memo(
             >
               <Button
                 ref={ref}
-                tabIndex={-1}
+                tabIndex={tabIndex}
                 className={cn(
                   "upload-button",
                   nodrag && editorClassNames.nodrag,
@@ -187,7 +193,7 @@ export const UploadButton = memo(
             >
               <IconButton
                 ref={ref}
-                tabIndex={-1}
+                tabIndex={tabIndex}
                 className={cn(
                   "upload-button",
                   nodrag && editorClassNames.nodrag,


### PR DESCRIPTION
💡 **What:** Added a configurable `tabIndex` prop (defaulting to 0) to standard button UI primitives (`SettingsButton`, `UploadButton`, `CircularActionButton`, `ToolbarIconButton`, `NavButton`, `PlaybackButton`, `DownloadButton`).
🎯 **Why:** To resolve a systemic accessibility issue where hardcoded `tabIndex={-1}` values were completely hiding these buttons from keyboard and screen reader users when used in standard UI lists, panels, and toolbars.
📸 **Before/After:** Visually identical. DOM structure now allows `<button tabIndex="0">` when previously forced to `-1`.
♿ **Accessibility:** Restored keyboard tabbing order (`Tab` and `Shift+Tab`) navigation to these fundamental controls across the app. Components utilizing roving tabindex patterns can now explicitly override the default via the new prop.

---
*PR created automatically by Jules for task [11989675447073978708](https://jules.google.com/task/11989675447073978708) started by @georgi*