### PR TITLE
🎨 Palette: Add ARIA labels to ModelFiltersBar icon buttons

### DIFF
--- a/web/src/components/model_menu/ModelFiltersBar.tsx
+++ b/web/src/components/model_menu/ModelFiltersBar.tsx
@@ -69,6 +69,7 @@ const ModelFiltersBar: React.FC<ModelFiltersBarProps> = () => {
           onClick={(e) => setTypeAnchor(e.currentTarget)}
           size="small"
           color={selectedTypes.length || openType ? "primary" : "default"}
+          aria-label="Filter by Type"
         >
           <CategoryIcon fontSize="small" />
         </IconButton>
@@ -99,6 +100,7 @@ const ModelFiltersBar: React.FC<ModelFiltersBarProps> = () => {
           onClick={(e) => setSizeAnchor(e.currentTarget)}
           size="small"
           color={sizeBucket || openSize ? "primary" : "default"}
+          aria-label="Filter by Size"
         >
           <StraightenIcon fontSize="small" />
         </IconButton>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to the "Filter by Type" and "Filter by Size" `IconButton` components in `web/src/components/model_menu/ModelFiltersBar.tsx`.

### 🎯 Why
These buttons use icon-only representations (`CategoryIcon` and `StraightenIcon`) and did not provide accessible names for screen readers. Adding `aria-label`s makes these crucial filtering tools accessible to all users. 

### 📸 Before/After
Visually unchanged. The enhancement is at the DOM level for assistive technologies. 

### ♿ Accessibility
- Improved screen reader accessibility for the `ModelFiltersBar` component.
- The `IconButton` components for "Filter by Type" and "Filter by Size" now explicitly state their purpose via the `aria-label` attribute.

---
*PR created automatically by Jules for task [11351861829881351556](https://jules.google.com/task/11351861829881351556) started by @georgi*