### PR TITLE
🎨 Palette: Improve screen reader accessibility of EmptyState component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2023-10-27 - Explicit tabIndex={0} on native buttons is a functional no-op
 **Learning:** Adding `tabIndex={0}` to components that wrap native HTML buttons or MUI `IconButton` elements does not actively change or improve keyboard accessibility, as they are inherently focusable and included in the tab order by default. It fails the requirement to provide an "immediate, visible impact" on UX.
 **Action:** Focus on semantic accessibility improvements, such as ensuring screen readers receive appropriate context (e.g., dynamically generating `aria-label` for stateful or count-based components like `NotificationBadge`), rather than redundant HTML attributes. When writing verification scripts for the `/layouttest` page, remember to write logic to switch to the correct tab category before trying to select elements.
+
+## 2026-03-11 - EmptyState Accessibility
+**Learning:** Dynamically rendered UI components indicating empty content, search no-results, or errors (e.g., `EmptyState`), should act as live regions for screen readers. However, redundantly appending the visible text into an `aria-label` can cause screen readers to read the text twice or ignore the semantic structure of the inner HTML.
+**Action:** Apply `role="status"` to ensure they are announced appropriately by screen readers, but let the `role="status"` naturally announce the text content within the children instead of redundantly defining an `aria-label`.

--- a/web/src/components/ui_primitives/EmptyState.tsx
+++ b/web/src/components/ui_primitives/EmptyState.tsx
@@ -108,7 +108,11 @@ export const EmptyState: React.FC<EmptyStateProps> = memo(({
   const descriptionVariant = size === "small" ? "caption" : "body2";
 
   return (
-    <Box css={styles(theme, size)} className={`empty-state ${className || ""}`}>
+    <Box
+      css={styles(theme, size)}
+      className={`empty-state ${className || ""}`}
+      role="status"
+    >
       {displayIcon}
       <Typography variant={titleVariant} className="empty-title">
         {displayTitle}


### PR DESCRIPTION
**💡 What:** Added `role="status"` to the root `Box` wrapper of the `EmptyState` component.

**🎯 Why:** For screen reader users, dynamically rendering an empty state (e.g., after filtering a list to 0 items, or deleting the last item) will now be announced as a status update (like "Nothing here yet"), keeping them informed of the application's state without being overly intrusive (like `role="alert"`). The role inherently picks up the text of the child elements (title and description) without needing a redundant `aria-label`.

**📸 Before/After:** No visual changes. This is purely a semantic DOM change.

**♿ Accessibility:** `EmptyState` component will now be properly announced by screen readers when dynamically appearing on screen as a status live region.

---
*PR created automatically by Jules for task [15716674018041510237](https://jules.google.com/task/15716674018041510237) started by @georgi*