### PR TITLE
🎨 Palette: Add keyboard accessibility to ThemeToggleButton

### DIFF
--- a/web/src/components/ui_primitives/ThemeToggleButton.tsx
+++ b/web/src/components/ui_primitives/ThemeToggleButton.tsx
@@ -32,6 +32,8 @@ export interface ThemeToggleButtonProps {
   darkLabel?: string;
   /** Custom class name */
   className?: string;
+  /** Tab index for keyboard navigation */
+  tabIndex?: number;
 }
 
 export const ThemeToggleButtonInternal: React.FC<ThemeToggleButtonProps> = ({
@@ -39,7 +41,8 @@ export const ThemeToggleButtonInternal: React.FC<ThemeToggleButtonProps> = ({
   buttonSize = "small",
   lightLabel = "Light",
   darkLabel = "Dark",
-  className
+  className,
+  tabIndex = 0
 }) => {
   const theme = useTheme();
   const { mode, setMode } = useColorScheme();
@@ -66,6 +69,7 @@ export const ThemeToggleButtonInternal: React.FC<ThemeToggleButtonProps> = ({
           icon={<LightModeIcon fontSize="small" />}
           checkedIcon={<DarkModeIcon fontSize="small" />}
           size={buttonSize === "large" ? "medium" : "small"}
+          tabIndex={tabIndex}
         />
       </Box>
     );
@@ -82,6 +86,7 @@ export const ThemeToggleButtonInternal: React.FC<ThemeToggleButtonProps> = ({
           onClick={handleToggle}
           size={buttonSize}
           aria-label={tooltipText}
+          tabIndex={tabIndex}
         >
           {isDark ? <LightModeIcon fontSize={buttonSize} /> : <DarkModeIcon fontSize={buttonSize} />}
         </IconButton>
@@ -97,6 +102,7 @@ export const ThemeToggleButtonInternal: React.FC<ThemeToggleButtonProps> = ({
           onClick={handleToggle}
           size={buttonSize}
           aria-label={tooltipText}
+          tabIndex={tabIndex}
         >
           {isDark ? <LightModeIcon fontSize={buttonSize} /> : <DarkModeIcon fontSize={buttonSize} />}
         </IconButton>

--- a/web/src/components/ui_primitives/__tests__/ThemeToggleButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ThemeToggleButton.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import { ThemeToggleButtonInternal } from "../ThemeToggleButton";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("@mui/material/styles", () => {
+  const actual = jest.requireActual("@mui/material/styles");
+  return {
+    ...actual,
+    useColorScheme: () => ({ mode: "dark", setMode: jest.fn() }),
+  };
+});
+
+describe("ThemeToggleButton", () => {
+  it("renders correctly", () => {
+    const { container } = render(
+      <ThemeProvider theme={mockTheme}>
+        <ThemeToggleButtonInternal />
+      </ThemeProvider>
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it("accepts and applies tabIndex prop", () => {
+    const { container } = render(
+      <ThemeProvider theme={mockTheme}>
+        <ThemeToggleButtonInternal tabIndex={-1} />
+      </ThemeProvider>
+    );
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute("tabIndex")).toBe("-1");
+  });
+});


### PR DESCRIPTION
💡 **What:** Added an optional `tabIndex` prop to `ThemeToggleButton` which passes the value down to the underlying `Switch` and `IconButton` components.
🎯 **Why:** To improve keyboard navigation and accessibility, allowing the `ThemeToggleButton` to participate properly in custom focus management sequences or be removed from the tab order (`tabIndex={-1}`) when hidden inside inactive panels/drawers.
♿ **Accessibility:** This directly addresses the need for programmatic keyboard focus management, allowing more precise screen-reader and keyboard interactions without relying solely on default DOM focus orders.

---
*PR created automatically by Jules for task [11705338451192504194](https://jules.google.com/task/11705338451192504194) started by @georgi*