### PR TITLE
🎨 Palette: Add ARIA labels to Editor Toolbar buttons

### DIFF
--- a/web/src/components/textEditor/EditorToolbar.tsx
+++ b/web/src/components/textEditor/EditorToolbar.tsx
@@ -110,6 +110,7 @@ const EditorToolbar = ({
                 onClick={onUndo}
                 disabled={!canUndo}
                 size="small"
+                aria-label="Undo"
               >
                 <UndoIcon fontSize="small" />
               </IconButton>
@@ -122,6 +123,7 @@ const EditorToolbar = ({
                 onClick={onRedo}
                 disabled={!canRedo}
                 size="small"
+                aria-label="Redo"
               >
                 <RedoIcon fontSize="small" />
               </IconButton>
@@ -136,6 +138,7 @@ const EditorToolbar = ({
             className="toolbar-button"
             onClick={onToggleFind}
             size="small"
+            aria-label="Find & Replace"
           >
             <SearchIcon fontSize="small" />
           </IconButton>
@@ -148,6 +151,7 @@ const EditorToolbar = ({
             className={`toolbar-button ${wordWrapEnabled ? "active" : ""}`}
             onClick={onToggleWordWrap}
             size="small"
+            aria-label="Toggle Word Wrap"
           >
             <WrapTextIcon fontSize="small" />
           </IconButton>
@@ -157,6 +161,7 @@ const EditorToolbar = ({
             className={`toolbar-button ${isCodeBlock ? "active" : ""}`}
             onClick={onFormatCodeBlock}
             size="small"
+            aria-label="Format as Code Block"
           >
             <CodeIcon fontSize="small" />
           </IconButton>

--- a/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
+++ b/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
@@ -2,43 +2,23 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import EditorToolbar from "../EditorToolbar";
-import mockTheme from "../../../__mocks__/themeMock";
-
-// Mock MUI components
-jest.mock("@mui/material/Tooltip", () => ({
-  __esModule: true,
-  default: ({ children, title }: { children: React.ReactNode; title?: string }) => (
-    <div data-tooltip={title}>{children}</div>
-  )
-}));
-
-jest.mock("@mui/material/IconButton", () => ({
-  __esModule: true,
-  default: ({ children, disabled, onClick, className, "aria-label": ariaLabel, ...rest }: any) => (
-    <button
-      disabled={disabled}
-      onClick={onClick}
-      className={className}
-      aria-label={ariaLabel}
-      data-testid="icon-button"
-      {...rest}
-    >
-      {children}
-    </button>
-  )
-}));
-
-jest.mock("@mui/material/Box", () => ({
-  __esModule: true,
-  default: ({ children, className }: any) => (
-    <div className={className}>
-      {children}
-    </div>
-  )
-}));
+import { createTheme, extendTheme } from "@mui/material/styles";
 
 describe("EditorToolbar", () => {
   const renderWithTheme = (props: any = {}) => {
+    const mockTheme = extendTheme({
+      colorSchemes: {
+        light: {
+          palette: {
+            background: { default: '#000000' },
+            primary: { main: '#1976d2', light: '#42a5f5' },
+            grey: { 100: '#f5f5f5', 300: '#e0e0e0', 600: '#757575' },
+            common: { white: '#ffffff' }
+          }
+        }
+      }
+    });
+
     return render(
       <ThemeProvider theme={mockTheme}>
         <EditorToolbar {...props} />
@@ -49,10 +29,12 @@ describe("EditorToolbar", () => {
   it("has proper ARIA labels for accessibility", () => {
     renderWithTheme({ readOnly: false });
 
-    expect(screen.getByLabelText("Undo")).toBeInTheDocument();
-    expect(screen.getByLabelText("Redo")).toBeInTheDocument();
-    expect(screen.getByLabelText("Find & Replace")).toBeInTheDocument();
-    expect(screen.getByLabelText("Toggle Word Wrap")).toBeInTheDocument();
-    expect(screen.getByLabelText("Format as Code Block")).toBeInTheDocument();
+    // Material-UI Tooltip sets aria-label on the wrapper, while we explicitly set it on the button
+    // This query matches both elements, so we use getAllByLabelText
+    expect(screen.getAllByLabelText("Undo")[0]).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Redo")[0]).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Find & Replace")[0]).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Toggle Word Wrap")[0]).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Format as Code Block")[0]).toBeInTheDocument();
   });
 });

--- a/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
+++ b/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import EditorToolbar from "../EditorToolbar";
-import { createTheme, extendTheme } from "@mui/material/styles";
+import { extendTheme } from "@mui/material/styles";
 
 describe("EditorToolbar", () => {
-  const renderWithTheme = (props: any = {}) => {
+  const renderWithTheme = (props: Partial<React.ComponentProps<typeof EditorToolbar>> = {}) => {
     const mockTheme = extendTheme({
       colorSchemes: {
         light: {

--- a/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
+++ b/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
@@ -29,12 +29,10 @@ describe("EditorToolbar", () => {
   it("has proper ARIA labels for accessibility", () => {
     renderWithTheme({ readOnly: false });
 
-    // Material-UI Tooltip sets aria-label on the wrapper, while we explicitly set it on the button
-    // This query matches both elements, so we use getAllByLabelText
-    expect(screen.getAllByLabelText("Undo")[0]).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Redo")[0]).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Find & Replace")[0]).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Toggle Word Wrap")[0]).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Format as Code Block")[0]).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Redo" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Find & Replace" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle Word Wrap" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Format as Code Block" })).toBeInTheDocument();
   });
 });

--- a/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
+++ b/web/src/components/textEditor/__tests__/EditorToolbar.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import EditorToolbar from "../EditorToolbar";
+import mockTheme from "../../../__mocks__/themeMock";
+
+// Mock MUI components
+jest.mock("@mui/material/Tooltip", () => ({
+  __esModule: true,
+  default: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div data-tooltip={title}>{children}</div>
+  )
+}));
+
+jest.mock("@mui/material/IconButton", () => ({
+  __esModule: true,
+  default: ({ children, disabled, onClick, className, "aria-label": ariaLabel, ...rest }: any) => (
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      className={className}
+      aria-label={ariaLabel}
+      data-testid="icon-button"
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}));
+
+jest.mock("@mui/material/Box", () => ({
+  __esModule: true,
+  default: ({ children, className }: any) => (
+    <div className={className}>
+      {children}
+    </div>
+  )
+}));
+
+describe("EditorToolbar", () => {
+  const renderWithTheme = (props: any = {}) => {
+    return render(
+      <ThemeProvider theme={mockTheme}>
+        <EditorToolbar {...props} />
+      </ThemeProvider>
+    );
+  };
+
+  it("has proper ARIA labels for accessibility", () => {
+    renderWithTheme({ readOnly: false });
+
+    expect(screen.getByLabelText("Undo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Redo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Find & Replace")).toBeInTheDocument();
+    expect(screen.getByLabelText("Toggle Word Wrap")).toBeInTheDocument();
+    expect(screen.getByLabelText("Format as Code Block")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### 💡 What
Added descriptive `aria-label` attributes to the 5 icon-only buttons (Undo, Redo, Find & Replace, Toggle Word Wrap, Format as Code Block) in `EditorToolbar.tsx`. Also added a corresponding unit test to ensure these labels remain.

### 🎯 Why
These buttons use visual tooltips but lacked explicit `aria-label` attributes on the underlying `<IconButton>` elements. Without an accessible name, screen readers announce them as unlabeled buttons, making the code editor toolbar difficult to use for users relying on assistive technology.

### ♿ Accessibility
This improvement gives each toolbar action a clear, descriptive accessible name, directly addressing WCAG success criteria for non-text content.

---
*PR created automatically by Jules for task [15398605720289334116](https://jules.google.com/task/15398605720289334116) started by @georgi*