### PR TITLE
Remove HTTP category from snippet metadata

### DIFF
--- a/web/src/config/snippetMetadata.ts
+++ b/web/src/config/snippetMetadata.ts
@@ -30,7 +30,6 @@ const CATEGORY_TYPE: Record<SnippetCategory, string> = {
   "Dictionary": "dict",
   "Date & Time": "str",
   "UUID": "str",
-  "HTTP": "str",
   "JSON": "str",
   "Streaming": "str",
 };


### PR DESCRIPTION
## Summary
Removed the "HTTP" category entry from the snippet metadata configuration.

## Changes
- Removed the `"HTTP": "str"` mapping from the `CATEGORY_TYPE` object in `snippetMetadata.ts`

## Details
This change removes HTTP as a supported snippet category type. The HTTP category was previously mapped to the "str" type identifier, but is no longer needed in the snippet categorization system.

https://claude.ai/code/session_01DuVfR5rqktf1HUKpinkdRN