### PR TITLE
Add graph-native agent planner that builds workflow DAGs directly

### DIFF
--- a/packages/agents/src/agent-step-executor.ts
+++ b/packages/agents/src/agent-step-executor.ts
@@ -132,6 +132,7 @@ export class AgentStepExecutor implements NodeExecutor {
       context.set(this.node.id, result);
     }
 
-    return { result };
+    // Use "output" as the handle name so downstream nodes can connect via .output
+    return { output: result, result };
   }
 }

--- a/packages/agents/src/agent-step-executor.ts
+++ b/packages/agents/src/agent-step-executor.ts
@@ -1,0 +1,137 @@
+/**
+ * AgentStepExecutor -- a NodeExecutor adapter that wraps StepExecutor.
+ *
+ * This bridges the agent system into the kernel: when WorkflowRunner encounters
+ * a node of type "nodetool.agents.AgentStep", it resolves to this executor.
+ * The executor creates a StepExecutor internally, runs the LLM tool-calling
+ * loop, forwards ProcessingMessages via context.emit(), and returns the
+ * final result as a Record for downstream kernel routing.
+ */
+
+import type { NodeExecutor } from "@nodetool/runtime";
+import type { ProcessingContext, BaseProvider } from "@nodetool/runtime";
+import type {
+  NodeDescriptor,
+  ProcessingMessage,
+  StepResult
+} from "@nodetool/protocol";
+import { StepExecutor } from "./step-executor.js";
+import type { Tool } from "./tools/base-tool.js";
+import type { Step, Task } from "./types.js";
+import { randomUUID } from "node:crypto";
+
+export interface AgentStepExecutorOptions {
+  provider: BaseProvider;
+  model: string;
+  tools: Tool[];
+  systemPrompt?: string;
+  maxTokenLimit?: number;
+  maxIterations?: number;
+}
+
+/**
+ * Build a Step object from a NodeDescriptor with AgentStep properties.
+ */
+function stepFromDescriptor(node: NodeDescriptor): Step {
+  const props = (node.properties ?? {}) as Record<string, unknown>;
+  return {
+    id: node.id,
+    instructions:
+      typeof props["instructions"] === "string" ? props["instructions"] : "",
+    completed: false,
+    dependsOn: [],
+    outputSchema:
+      typeof props["output_schema"] === "string"
+        ? props["output_schema"]
+        : undefined,
+    tools: Array.isArray(props["tools"])
+      ? (props["tools"] as string[])
+      : undefined,
+    logs: []
+  };
+}
+
+/**
+ * Format upstream inputs (arriving via kernel edges) into a context string
+ * that gets prepended to the step instructions.
+ */
+function formatUpstreamContext(inputs: Record<string, unknown>): string {
+  const entries = Object.entries(inputs).filter(
+    ([, v]) => v !== undefined && v !== null
+  );
+  if (entries.length === 0) return "";
+
+  const sections = entries.map(([key, value]) => {
+    const serialized =
+      typeof value === "string" ? value : JSON.stringify(value, null, 2);
+    return `## Input "${key}":\n${serialized}`;
+  });
+  return (
+    "# Upstream Results\n\n" + sections.join("\n\n") + "\n\n---\n\n"
+  );
+}
+
+export class AgentStepExecutor implements NodeExecutor {
+  private readonly node: NodeDescriptor;
+  private readonly opts: AgentStepExecutorOptions;
+
+  constructor(node: NodeDescriptor, opts: AgentStepExecutorOptions) {
+    this.node = node;
+    this.opts = opts;
+  }
+
+  async process(
+    inputs: Record<string, unknown>,
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    const step = stepFromDescriptor(this.node);
+    const task: Task = {
+      id: randomUUID(),
+      title: step.instructions.slice(0, 80),
+      steps: [step]
+    };
+
+    // Prepend upstream results to step instructions
+    const upstreamContext = formatUpstreamContext(inputs);
+    if (upstreamContext) {
+      step.instructions = upstreamContext + step.instructions;
+    }
+
+    // Filter tools if the step specifies a subset
+    let tools = this.opts.tools;
+    if (step.tools && step.tools.length > 0) {
+      const allowedNames = new Set(step.tools);
+      tools = tools.filter((t) => allowedNames.has(t.name));
+    }
+
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: context!,
+      provider: this.opts.provider,
+      model: this.opts.model,
+      tools,
+      systemPrompt: this.opts.systemPrompt,
+      maxTokenLimit: this.opts.maxTokenLimit,
+      maxIterations: this.opts.maxIterations
+    });
+
+    let result: unknown = null;
+    for await (const msg of executor.execute()) {
+      // Forward processing messages for UI updates
+      if (context) {
+        context.emit(msg);
+      }
+      if (msg.type === "step_result") {
+        result = (msg as StepResult).result;
+      }
+    }
+
+    // Also store in context for backwards compat with code reading from context
+    if (context) {
+      context.set(this.node.id, result);
+    }
+
+    return { result };
+  }
+}

--- a/packages/agents/src/agent-workflow-runner.ts
+++ b/packages/agents/src/agent-workflow-runner.ts
@@ -1,0 +1,124 @@
+/**
+ * AgentWorkflowRunner -- executes a graph plan via the kernel's WorkflowRunner.
+ *
+ * Takes a GraphData (produced by GraphPlanner) and runs it through the kernel.
+ * Agent step nodes are resolved via AgentStepExecutor; deterministic nodes
+ * are resolved via the provided NodeRegistry.
+ */
+
+import { WorkflowRunner } from "@nodetool/kernel";
+import type { NodeRegistry } from "@nodetool/node-sdk";
+import type { BaseProvider, ProcessingContext } from "@nodetool/runtime";
+import type {
+  GraphData,
+  ProcessingMessage,
+  NodeUpdate
+} from "@nodetool/protocol";
+import { createLogger } from "@nodetool/config";
+import { AGENT_STEP_NODE_TYPE } from "./graph-builder.js";
+import { AgentStepExecutor } from "./agent-step-executor.js";
+import type { Tool } from "./tools/base-tool.js";
+import { randomUUID } from "node:crypto";
+
+const log = createLogger("nodetool.agents.workflow-runner");
+
+export interface AgentWorkflowRunnerOptions {
+  provider: BaseProvider;
+  model: string;
+  registry: NodeRegistry;
+  tools: Tool[];
+  context: ProcessingContext;
+  systemPrompt?: string;
+  maxTokenLimit?: number;
+  maxStepIterations?: number;
+}
+
+export class AgentWorkflowRunner {
+  private readonly opts: AgentWorkflowRunnerOptions;
+
+  constructor(opts: AgentWorkflowRunnerOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * Execute a graph plan and yield ProcessingMessages.
+   */
+  async *execute(
+    graphData: GraphData
+  ): AsyncGenerator<ProcessingMessage> {
+    const jobId = randomUUID();
+    const { provider, model, registry, tools, context } = this.opts;
+    const collectedMessages: ProcessingMessage[] = [];
+
+    // Capture messages emitted during execution
+    const originalOnMessage = (context as unknown as Record<string, unknown>)[
+      "_onMessage"
+    ] as ((msg: ProcessingMessage) => void) | null;
+
+    const captureMessage = (msg: ProcessingMessage): void => {
+      collectedMessages.push(msg);
+      if (originalOnMessage) {
+        originalOnMessage(msg);
+      }
+    };
+
+    const runner = new WorkflowRunner(jobId, {
+      resolveExecutor: (node: { id: string; type: string }) => {
+        if (node.type === AGENT_STEP_NODE_TYPE) {
+          return new AgentStepExecutor(node, {
+            provider,
+            model,
+            tools,
+            systemPrompt: this.opts.systemPrompt,
+            maxTokenLimit: this.opts.maxTokenLimit,
+            maxIterations: this.opts.maxStepIterations
+          });
+        }
+        return registry.resolve(node);
+      },
+      executionContext: context
+    });
+
+    log.info("Executing agent graph", {
+      jobId,
+      nodes: graphData.nodes.length,
+      edges: graphData.edges.length
+    });
+
+    const result = await runner.run({ job_id: jobId }, graphData);
+
+    // Yield all collected messages
+    for (const msg of collectedMessages) {
+      yield msg;
+    }
+
+    // Yield messages from the runner result
+    if (result.messages) {
+      for (const msg of result.messages) {
+        yield msg;
+      }
+    }
+
+    if (result.status === "failed") {
+      throw new Error(result.error ?? "Workflow execution failed");
+    }
+
+    // Surface node-level errors
+    const nodeErrors = (result.messages ?? []).filter(
+      (m: ProcessingMessage): m is NodeUpdate =>
+        m.type === "node_update" && (m as NodeUpdate).status === "error"
+    );
+    if (nodeErrors.length > 0) {
+      log.error("Node execution errors", {
+        count: nodeErrors.length,
+        first: nodeErrors[0].error
+      });
+    }
+
+    log.info("Agent graph execution complete", {
+      jobId,
+      status: result.status,
+      outputKeys: Object.keys(result.outputs)
+    });
+  }
+}

--- a/packages/agents/src/graph-builder.ts
+++ b/packages/agents/src/graph-builder.ts
@@ -1,0 +1,248 @@
+/**
+ * GraphBuilder -- stateful in-memory graph accumulator for the graph planner.
+ *
+ * The planner LLM calls add_node / add_edge tools which mutate a shared
+ * GraphBuilder instance. Once the LLM calls finish_graph, the builder
+ * validates and produces a GraphData object for WorkflowRunner.
+ */
+
+import type { NodeDescriptor, Edge, GraphData } from "@nodetool/protocol";
+
+/** The virtual node type used for LLM-driven agent steps. */
+export const AGENT_STEP_NODE_TYPE = "nodetool.agents.AgentStep";
+
+export class GraphBuilder {
+  private readonly _nodes = new Map<string, NodeDescriptor>();
+  private readonly _edges: Edge[] = [];
+  private _built = false;
+
+  /** All node IDs currently in the graph. */
+  get nodeIds(): ReadonlySet<string> {
+    return new Set(this._nodes.keys());
+  }
+
+  /** Number of nodes in the graph. */
+  get nodeCount(): number {
+    return this._nodes.size;
+  }
+
+  /** Number of edges in the graph. */
+  get edgeCount(): number {
+    return this._edges.length;
+  }
+
+  /** Check whether a node ID is already registered. */
+  hasNode(id: string): boolean {
+    return this._nodes.has(id);
+  }
+
+  /** Get a node descriptor by ID. */
+  getNode(id: string): NodeDescriptor | undefined {
+    return this._nodes.get(id);
+  }
+
+  /**
+   * Add a node to the graph.
+   * Returns an array of validation errors (empty = success).
+   */
+  addNode(
+    id: string,
+    type: string,
+    properties?: Record<string, unknown>,
+    name?: string
+  ): string[] {
+    const errors: string[] = [];
+    if (this._built) {
+      errors.push("Graph has already been finalized.");
+      return errors;
+    }
+    if (!id || typeof id !== "string") {
+      errors.push("Node id must be a non-empty string.");
+      return errors;
+    }
+    if (!type || typeof type !== "string") {
+      errors.push("Node type must be a non-empty string.");
+      return errors;
+    }
+    if (this._nodes.has(id)) {
+      errors.push(`Duplicate node id: '${id}'.`);
+      return errors;
+    }
+
+    const descriptor: NodeDescriptor = {
+      id,
+      type,
+      name: name ?? id,
+      properties: properties ?? {}
+    };
+
+    this._nodes.set(id, descriptor);
+    return errors;
+  }
+
+  /**
+   * Add an edge connecting two nodes.
+   * Returns an array of validation errors (empty = success).
+   */
+  addEdge(
+    source: string,
+    sourceHandle: string,
+    target: string,
+    targetHandle: string
+  ): string[] {
+    const errors: string[] = [];
+    if (this._built) {
+      errors.push("Graph has already been finalized.");
+      return errors;
+    }
+    if (!this._nodes.has(source)) {
+      errors.push(`Source node '${source}' does not exist.`);
+    }
+    if (!this._nodes.has(target)) {
+      errors.push(`Target node '${target}' does not exist.`);
+    }
+    if (!sourceHandle) {
+      errors.push("sourceHandle must be a non-empty string.");
+    }
+    if (!targetHandle) {
+      errors.push("targetHandle must be a non-empty string.");
+    }
+    if (source === target) {
+      errors.push("Self-loops are not allowed.");
+    }
+    if (errors.length > 0) return errors;
+
+    // Check for duplicate edge
+    const isDuplicate = this._edges.some(
+      (e) =>
+        e.source === source &&
+        e.sourceHandle === sourceHandle &&
+        e.target === target &&
+        e.targetHandle === targetHandle
+    );
+    if (isDuplicate) {
+      errors.push(
+        `Duplicate edge: ${source}.${sourceHandle} → ${target}.${targetHandle}`
+      );
+      return errors;
+    }
+
+    this._edges.push({ source, sourceHandle, target, targetHandle });
+    return errors;
+  }
+
+  /**
+   * Validate the full graph: cycle detection, dangling edge references,
+   * and at least one node.
+   * Returns an array of errors (empty = valid).
+   */
+  validate(): string[] {
+    const errors: string[] = [];
+
+    if (this._nodes.size === 0) {
+      errors.push("Graph must contain at least one node.");
+      return errors;
+    }
+
+    // Check edge references
+    for (const edge of this._edges) {
+      if (!this._nodes.has(edge.source)) {
+        errors.push(
+          `Edge references non-existent source node '${edge.source}'.`
+        );
+      }
+      if (!this._nodes.has(edge.target)) {
+        errors.push(
+          `Edge references non-existent target node '${edge.target}'.`
+        );
+      }
+    }
+
+    // Cycle detection via Kahn's algorithm
+    const inDegree = new Map<string, number>();
+    const adjList = new Map<string, string[]>();
+    for (const id of this._nodes.keys()) {
+      inDegree.set(id, 0);
+      adjList.set(id, []);
+    }
+    for (const edge of this._edges) {
+      if (adjList.has(edge.source) && inDegree.has(edge.target)) {
+        adjList.get(edge.source)!.push(edge.target);
+        inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+      }
+    }
+
+    const queue: string[] = [];
+    for (const [id, deg] of inDegree) {
+      if (deg === 0) queue.push(id);
+    }
+    let visited = 0;
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+      visited++;
+      for (const neighbor of adjList.get(id) ?? []) {
+        const newDeg = (inDegree.get(neighbor) ?? 1) - 1;
+        inDegree.set(neighbor, newDeg);
+        if (newDeg === 0) queue.push(neighbor);
+      }
+    }
+    if (visited < this._nodes.size) {
+      errors.push("Graph contains a cycle.");
+    }
+
+    return errors;
+  }
+
+  /**
+   * Finalize and return the graph as GraphData.
+   * Throws if validation fails.
+   */
+  build(): GraphData {
+    const errors = this.validate();
+    if (errors.length > 0) {
+      throw new Error(
+        `Graph validation failed:\n${errors.map((e) => `- ${e}`).join("\n")}`
+      );
+    }
+    this._built = true;
+
+    // Topological sort for deterministic node ordering
+    const inDegree = new Map<string, number>();
+    const adjList = new Map<string, string[]>();
+    for (const id of this._nodes.keys()) {
+      inDegree.set(id, 0);
+      adjList.set(id, []);
+    }
+    for (const edge of this._edges) {
+      adjList.get(edge.source)!.push(edge.target);
+      inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+    }
+
+    const queue: string[] = [];
+    for (const [id, deg] of inDegree) {
+      if (deg === 0) queue.push(id);
+    }
+    const sorted: string[] = [];
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+      sorted.push(id);
+      for (const neighbor of adjList.get(id) ?? []) {
+        const newDeg = (inDegree.get(neighbor) ?? 1) - 1;
+        inDegree.set(neighbor, newDeg);
+        if (newDeg === 0) queue.push(neighbor);
+      }
+    }
+
+    const nodes = sorted.map((id) => this._nodes.get(id)!);
+    const edges = [...this._edges];
+
+    return { nodes, edges };
+  }
+
+  /** Reset the builder for reuse. */
+  reset(): void {
+    this._nodes.clear();
+    this._edges.length = 0;
+    this._built = false;
+  }
+}

--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -48,9 +48,17 @@ NODE TYPES:
 - Agent step nodes (type: "nodetool.agents.AgentStep") — for work requiring LLM reasoning.
   Required properties: instructions (string).
   Optional properties: tools (string array), output_schema (JSON schema string).
+  Input handles: "input" (receives upstream data). Output handles: "output" (text result).
+  IMPORTANT: For LLM tasks, always use "nodetool.agents.AgentStep" — NOT "nodetool.agents.Agent".
+  AgentStep nodes automatically use the configured model. Do NOT use registry Agent nodes
+  as they require a complex model property that cannot be set via add_node.
 
 RULES:
 - SEARCH before building. Don't guess node types — verify with search_nodes and get_node_info.
+- INSPECT before adding. Always call get_node_info to see exact property names, types, and defaults.
+- SET PROPERTIES: When adding a node, pass all required properties in the "properties" argument.
+  For example, a constant String node needs properties: { "value": "your text here" }.
+  Nodes without correct properties will produce empty/default outputs!
 - MAXIMIZE parallelism: nodes without data dependencies run concurrently automatically.
 - Use deterministic nodes when possible (cheaper, faster, reproducible).
 - Use agent step nodes ONLY when no deterministic node can do the job.
@@ -296,13 +304,20 @@ export class GraphPlanner {
       }
 
       // Execute tool calls and build message history
-      const assistantContent = content || undefined;
-      if (assistantContent) {
-        messages.push({ role: "assistant", content: assistantContent });
-      }
+      const toolCalls = pendingToolCalls.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        args: tc.args
+      }));
+      messages.push({
+        role: "assistant",
+        content: content || undefined,
+        toolCalls
+      });
 
       for (const tc of pendingToolCalls) {
         totalToolCalls++;
+        log.debug("Tool call", { name: tc.name, args: tc.args });
         const tool = toolMap.get(tc.name);
         if (!tool) {
           messages.push({

--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -1,0 +1,373 @@
+/**
+ * GraphPlanner -- builds a workflow graph directly via LLM tool calling.
+ *
+ * Instead of producing a TaskPlan with prose steps, this planner gives the LLM
+ * tools to search for nodes, inspect their metadata, and build a DAG node-by-node.
+ * The result is a GraphData that goes straight to WorkflowRunner.
+ */
+
+import type {
+  BaseProvider,
+  ProcessingContext,
+  Message
+} from "@nodetool/runtime";
+import type { NodeRegistry } from "@nodetool/node-sdk";
+import { createLogger } from "@nodetool/config";
+import type {
+  GraphData,
+  ProcessingMessage,
+  Chunk,
+  PlanningUpdate
+} from "@nodetool/protocol";
+
+import type { Tool } from "./tools/base-tool.js";
+import { GraphBuilder } from "./graph-builder.js";
+import { AddNodeTool } from "./tools/add-node-tool.js";
+import { AddEdgeTool } from "./tools/add-edge-tool.js";
+import { FinishGraphTool } from "./tools/finish-graph-tool.js";
+import { LocalSearchNodesTool } from "./tools/local-search-nodes-tool.js";
+import { LocalGetNodeInfoTool } from "./tools/local-get-node-info-tool.js";
+import { LocalListNodesTool } from "./tools/local-list-nodes-tool.js";
+
+const log = createLogger("nodetool.agents.graph-planner");
+
+const MAX_RETRIES = 3;
+const MAX_TOOL_CALLS_PER_TURN = 50;
+
+const DEFAULT_GRAPH_PLANNING_SYSTEM_PROMPT = `You are a WorkflowArchitect. Build a workflow graph to achieve the user's objective.
+
+WORKFLOW:
+1. SEARCH first: Use search_nodes to find relevant deterministic nodes for the task.
+   Search by capability (e.g. "resize image", "split text", "http request").
+2. INSPECT: Use get_node_info to see exact input/output names and types before using a node.
+3. BUILD: Use add_node for each node, add_edge to connect them.
+4. FINALIZE: Call finish_graph when done.
+
+NODE TYPES:
+- Deterministic nodes (from registry) — fast, cheap, reproducible. Always prefer these.
+- Agent step nodes (type: "nodetool.agents.AgentStep") — for work requiring LLM reasoning.
+  Required properties: instructions (string).
+  Optional properties: tools (string array), output_schema (JSON schema string).
+
+RULES:
+- SEARCH before building. Don't guess node types — verify with search_nodes and get_node_info.
+- MAXIMIZE parallelism: nodes without data dependencies run concurrently automatically.
+- Use deterministic nodes when possible (cheaper, faster, reproducible).
+- Use agent step nodes ONLY when no deterministic node can do the job.
+- Every node needs a unique id (snake_case).
+- Connect outputs to inputs with add_edge, using the exact handle names from get_node_info.
+- Call finish_graph when you're done building.`;
+
+const GRAPH_CREATION_PROMPT_TEMPLATE = `Build a workflow graph to achieve this objective.
+
+Objective: {{objective}}
+
+Available execution tools for agent step nodes:
+{{toolsInfo}}
+
+Output schema (for the final result of the workflow):
+{{outputSchema}}`;
+
+export interface GraphPlannerOptions {
+  provider: BaseProvider;
+  model: string;
+  registry: NodeRegistry;
+  tools?: Tool[];
+  systemPrompt?: string;
+  outputSchema?: Record<string, unknown>;
+  inputs?: Record<string, unknown>;
+  maxRetries?: number;
+  threadId?: string;
+}
+
+export class GraphPlanner {
+  private readonly provider: BaseProvider;
+  private readonly model: string;
+  private readonly registry: NodeRegistry;
+  private readonly tools: Tool[];
+  private readonly systemPrompt: string;
+  private readonly outputSchema: Record<string, unknown> | undefined;
+  private readonly inputs: Record<string, unknown>;
+  private readonly maxRetries: number;
+  private readonly threadId?: string;
+
+  constructor(opts: GraphPlannerOptions) {
+    this.provider = opts.provider;
+    this.model = opts.model;
+    this.registry = opts.registry;
+    this.tools = opts.tools ?? [];
+    this.systemPrompt =
+      opts.systemPrompt ?? DEFAULT_GRAPH_PLANNING_SYSTEM_PROMPT;
+    this.outputSchema = opts.outputSchema;
+    this.inputs = opts.inputs ?? {};
+    this.maxRetries = opts.maxRetries ?? MAX_RETRIES;
+    this.threadId = opts.threadId;
+  }
+
+  /**
+   * Build a workflow graph from an objective using LLM tool calling.
+   * Returns null on repeated failure.
+   */
+  async *plan(
+    objective: string,
+    _context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage, GraphData | null> {
+    const toolsInfo = this.formatToolsInfo();
+
+    const userPrompt = GRAPH_CREATION_PROMPT_TEMPLATE.replace(
+      "{{objective}}",
+      objective
+    )
+      .replace("{{toolsInfo}}", toolsInfo)
+      .replace(
+        "{{outputSchema}}",
+        this.outputSchema
+          ? JSON.stringify(this.outputSchema, null, 2)
+          : "None specified"
+      );
+
+    const messages: Message[] = [
+      { role: "system", content: this.systemPrompt },
+      { role: "user", content: userPrompt }
+    ];
+
+    yield {
+      type: "planning_update",
+      phase: "initialization",
+      status: "started",
+      content: "Starting graph-native planning..."
+    } satisfies PlanningUpdate;
+
+    for (let attempt = 0; attempt < this.maxRetries; attempt++) {
+      log.debug("Building workflow graph", {
+        objective: objective.slice(0, 60),
+        attempt: attempt + 1
+      });
+
+      yield {
+        type: "planning_update",
+        phase: "generation",
+        status: "running",
+        content:
+          attempt > 0
+            ? `Retry attempt ${attempt + 1}/${this.maxRetries}...`
+            : "Building workflow graph..."
+      } satisfies PlanningUpdate;
+
+      const result = yield* this.runToolLoop(messages);
+
+      if (result.graph) {
+        log.info("Graph built", {
+          nodes: result.graph.nodes.length,
+          edges: result.graph.edges.length
+        });
+
+        yield {
+          type: "planning_update",
+          phase: "complete",
+          status: "success",
+          content: `Graph built: ${result.graph.nodes.length} nodes, ${result.graph.edges.length} edges`
+        } satisfies PlanningUpdate;
+
+        return result.graph;
+      }
+
+      const errorMsg =
+        result.error ?? `Graph was not finalized on attempt ${attempt + 1}`;
+
+      log.warn("Graph building retry", {
+        attempt: attempt + 1,
+        reason: errorMsg
+      });
+
+      yield {
+        type: "planning_update",
+        phase: "validation",
+        status: "failed",
+        content: errorMsg
+      } satisfies PlanningUpdate;
+
+      // Feed error back to LLM for retry
+      messages.push({
+        role: "user",
+        content: `Error: ${errorMsg}. Please fix the issues and call finish_graph again.`
+      });
+    }
+
+    log.error("Graph building failed", { attempts: this.maxRetries });
+
+    yield {
+      type: "chunk",
+      content: `\nFailed to build workflow graph after ${this.maxRetries} attempts.\n`,
+      done: true
+    } satisfies Chunk;
+
+    yield {
+      type: "planning_update",
+      phase: "complete",
+      status: "failed",
+      content: `Graph building failed after ${this.maxRetries} attempts`
+    } satisfies PlanningUpdate;
+
+    return null;
+  }
+
+  /**
+   * Run the multi-turn tool-calling loop.
+   * The LLM can call search/inspect/add tools multiple times before finish_graph.
+   */
+  private async *runToolLoop(
+    messages: Message[]
+  ): AsyncGenerator<
+    ProcessingMessage,
+    { graph?: GraphData; error?: string }
+  > {
+    const builder = new GraphBuilder();
+    const addNodeTool = new AddNodeTool(builder, this.registry);
+    const addEdgeTool = new AddEdgeTool(builder, this.registry);
+    const finishGraphTool = new FinishGraphTool(builder);
+    const searchNodesTool = new LocalSearchNodesTool(this.registry);
+    const getNodeInfoTool = new LocalGetNodeInfoTool(this.registry);
+    const listNodesTool = new LocalListNodesTool(this.registry);
+
+    const allTools: Tool[] = [
+      searchNodesTool,
+      getNodeInfoTool,
+      listNodesTool,
+      addNodeTool,
+      addEdgeTool,
+      finishGraphTool
+    ];
+
+    const providerTools = allTools.map((t) => t.toProviderTool());
+    const toolMap = new Map(allTools.map((t) => [t.name, t]));
+
+    let totalToolCalls = 0;
+
+    // Multi-turn loop: LLM may need multiple turns to search, inspect, then build
+    while (totalToolCalls < MAX_TOOL_CALLS_PER_TURN) {
+      let content = "";
+      const pendingToolCalls: Array<{
+        name: string;
+        args: Record<string, unknown>;
+        id: string;
+      }> = [];
+
+      const stream = this.provider.generateMessagesTraced({
+        messages: [...messages],
+        model: this.model,
+        tools: providerTools,
+        threadId: this.threadId
+      });
+
+      for await (const item of stream) {
+        if (
+          "type" in item &&
+          (item as unknown as Record<string, unknown>)["type"] === "chunk"
+        ) {
+          const chunk = item as { content?: string };
+          if (typeof chunk.content === "string") {
+            content += chunk.content;
+            yield {
+              type: "chunk",
+              content: chunk.content,
+              done: false
+            } satisfies Chunk;
+          }
+        }
+        if ("name" in item && typeof item.name === "string") {
+          pendingToolCalls.push({
+            name: item.name,
+            args: (item.args as Record<string, unknown>) ?? {},
+            id: (item as { id?: string }).id ?? randomUUID()
+          });
+        }
+      }
+
+      // No tool calls — LLM finished without calling finish_graph
+      if (pendingToolCalls.length === 0) {
+        if (finishGraphTool.graph) {
+          return { graph: finishGraphTool.graph };
+        }
+        return {
+          error:
+            "LLM stopped without calling finish_graph. Please build the graph and call finish_graph."
+        };
+      }
+
+      // Execute tool calls and build message history
+      const assistantContent = content || undefined;
+      if (assistantContent) {
+        messages.push({ role: "assistant", content: assistantContent });
+      }
+
+      for (const tc of pendingToolCalls) {
+        totalToolCalls++;
+        const tool = toolMap.get(tc.name);
+        if (!tool) {
+          messages.push({
+            role: "tool",
+            toolCallId: tc.id,
+            content: JSON.stringify({ error: `Unknown tool: ${tc.name}` })
+          });
+          continue;
+        }
+
+        const result = await tool.process(
+          {} as ProcessingContext,
+          tc.args
+        );
+
+        messages.push({
+          role: "tool",
+          toolCallId: tc.id,
+          content:
+            typeof result === "string" ? result : JSON.stringify(result)
+        });
+
+        // Check if finish_graph succeeded
+        if (tc.name === "finish_graph" && finishGraphTool.graph) {
+          return { graph: finishGraphTool.graph };
+        }
+
+        // If finish_graph failed with validation errors, continue the loop
+        // so the LLM can fix them
+      }
+    }
+
+    return {
+      error: `Exceeded maximum tool calls (${MAX_TOOL_CALLS_PER_TURN})`
+    };
+  }
+
+  private formatToolsInfo(): string {
+    if (this.tools.length === 0) return "No execution tools available.";
+
+    const lines: string[] = ["Available execution tools for agent step nodes:"];
+    for (const tool of this.tools) {
+      let schemaInfo = "";
+      const schema = tool.inputSchema;
+      if (schema && typeof schema === "object" && "properties" in schema) {
+        const props = Object.keys(
+          schema.properties as Record<string, unknown>
+        );
+        const required = Array.isArray(schema.required)
+          ? (schema.required as string[])
+          : [];
+        const propDetails = props.map((p) => {
+          const isReq = required.includes(p) ? " (required)" : "";
+          return `${p}${isReq}`;
+        });
+        if (propDetails.length > 0) {
+          schemaInfo = ` | Args: ${propDetails.join(", ")}`;
+        }
+      }
+      lines.push(`- ${tool.name}: ${tool.description}${schemaInfo}`);
+    }
+    return lines.join("\n");
+  }
+}
+
+function randomUUID(): string {
+  return crypto.randomUUID();
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -116,6 +116,20 @@ export type { ControlNodeInfo } from "./tools/control-tool.js";
 export { CreatePlanTool } from "./tools/create-plan-tool.js";
 export { CreateTaskPlanTool } from "./tools/create-task-tool.js";
 
+// Graph-native planner tools
+export { AddNodeTool } from "./tools/add-node-tool.js";
+export { AddEdgeTool } from "./tools/add-edge-tool.js";
+export { FinishGraphTool } from "./tools/finish-graph-tool.js";
+export {
+  LocalSearchNodesTool
+} from "./tools/local-search-nodes-tool.js";
+export {
+  LocalGetNodeInfoTool
+} from "./tools/local-get-node-info-tool.js";
+export {
+  LocalListNodesTool
+} from "./tools/local-list-nodes-tool.js";
+
 // Shared JS sandbox engine
 export { buildSandbox, runInSandbox, serializeResult } from "./js-sandbox.js";
 export type { RunSandboxOptions, RunSandboxResult } from "./js-sandbox.js";
@@ -155,6 +169,15 @@ export { TaskExecutor } from "./task-executor.js";
 export type { TaskExecutorOptions } from "./task-executor.js";
 export { ParallelTaskExecutor } from "./parallel-task-executor.js";
 export type { ParallelTaskExecutorOptions } from "./parallel-task-executor.js";
+
+// Graph-native planning & execution
+export { GraphBuilder, AGENT_STEP_NODE_TYPE } from "./graph-builder.js";
+export { GraphPlanner } from "./graph-planner.js";
+export type { GraphPlannerOptions } from "./graph-planner.js";
+export { AgentStepExecutor } from "./agent-step-executor.js";
+export type { AgentStepExecutorOptions } from "./agent-step-executor.js";
+export { AgentWorkflowRunner } from "./agent-workflow-runner.js";
+export type { AgentWorkflowRunnerOptions } from "./agent-workflow-runner.js";
 
 // Multi-agent team system
 export {

--- a/packages/agents/src/multi-mode-agent.ts
+++ b/packages/agents/src/multi-mode-agent.ts
@@ -29,6 +29,9 @@ import { TeamExecutor } from "./team/team-executor.js";
 import { SubAgentPlanner } from "./sub-agent-planner.js";
 import type { Tool } from "./tools/base-tool.js";
 import type { AgentMode, Step, SubAgentConfig, Task, TaskPlan } from "./types.js";
+import type { NodeRegistry } from "@nodetool/node-sdk";
+import { GraphPlanner } from "./graph-planner.js";
+import { AgentWorkflowRunner } from "./agent-workflow-runner.js";
 import { randomUUID } from "node:crypto";
 
 const log = createLogger("nodetool.agents.multi-mode-agent");
@@ -55,6 +58,10 @@ export interface MultiModeAgentOptions {
   maxStepIterations?: number;
   /** Pre-defined task, skipping planning. */
   task?: Task;
+  /** Use graph-native planner (builds DAG directly instead of TaskPlan). */
+  useGraphPlanner?: boolean;
+  /** Node registry for graph planner (required when useGraphPlanner is true). */
+  registry?: NodeRegistry;
 
   // --- Loop mode options ---
   /** Maximum iterations for loop mode. */
@@ -83,6 +90,8 @@ export class MultiModeAgent extends BaseAgent {
   private readonly numSubAgents: number;
   private readonly teamStrategy: "coordinator" | "autonomous" | "hybrid";
   private readonly maxConcurrency: number;
+  private readonly useGraphPlanner: boolean;
+  private readonly registry?: NodeRegistry;
 
   constructor(opts: MultiModeAgentOptions) {
     super({
@@ -106,6 +115,8 @@ export class MultiModeAgent extends BaseAgent {
     this.numSubAgents = opts.numSubAgents ?? 3;
     this.teamStrategy = opts.teamStrategy ?? "coordinator";
     this.maxConcurrency = opts.maxConcurrency ?? 5;
+    this.useGraphPlanner = opts.useGraphPlanner ?? false;
+    this.registry = opts.registry;
 
     if (opts.task) {
       this.task = opts.task;
@@ -204,6 +215,12 @@ export class MultiModeAgent extends BaseAgent {
       return;
     }
 
+    // Graph-native planner: build DAG directly
+    if (this.useGraphPlanner && this.registry) {
+      yield* this.executeGraphPlanMode(context);
+      return;
+    }
+
     log.info("Planning phase started", { name: this.name });
     yield {
       type: "log_update",
@@ -296,6 +313,81 @@ export class MultiModeAgent extends BaseAgent {
     // If no task_result was captured, use the final task's result
     if (this.results === null) {
       this.results = executor.getFinalResult();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Graph plan mode: GraphPlanner -> WorkflowRunner
+  // ---------------------------------------------------------------------------
+
+  private async *executeGraphPlanMode(
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage> {
+    log.info("Graph planning phase started", { name: this.name });
+
+    yield {
+      type: "log_update",
+      node_id: "graph_planner",
+      node_name: this.name,
+      content: `Building workflow graph for: ${this.objective.slice(0, 100)}...`,
+      severity: "info"
+    } satisfies LogUpdate;
+
+    const planner = new GraphPlanner({
+      provider: this.provider,
+      model: this.planningModel,
+      registry: this.registry!,
+      tools: this.tools,
+      systemPrompt: this.systemPrompt || undefined,
+      outputSchema: this.outputSchema,
+      inputs: this.inputs
+    });
+
+    const planGen = planner.plan(this.objective, context);
+    let planResult = await planGen.next();
+    while (!planResult.done) {
+      yield planResult.value;
+      planResult = await planGen.next();
+    }
+    const graphData = planResult.value;
+
+    if (!graphData) {
+      throw new Error("GraphPlanner failed to build a workflow graph.");
+    }
+
+    log.info("Graph planning complete", {
+      name: this.name,
+      nodes: graphData.nodes.length,
+      edges: graphData.edges.length
+    });
+
+    yield {
+      type: "log_update",
+      node_id: "graph_executor",
+      node_name: this.name,
+      content: `Executing workflow: ${graphData.nodes.length} nodes, ${graphData.edges.length} edges...`,
+      severity: "info"
+    } satisfies LogUpdate;
+
+    const runner = new AgentWorkflowRunner({
+      provider: this.provider,
+      model: this.model,
+      registry: this.registry!,
+      tools: [...this.tools],
+      context,
+      systemPrompt: this.systemPrompt || undefined,
+      maxTokenLimit: this.maxTokenLimit,
+      maxStepIterations: this.maxStepIterations
+    });
+
+    for await (const item of runner.execute(graphData)) {
+      if (item.type === "step_result") {
+        const stepResult = item as StepResult;
+        if (stepResult.is_task_result) {
+          this.results = stepResult.result;
+        }
+      }
+      yield item;
     }
   }
 

--- a/packages/agents/src/tools/add-edge-tool.ts
+++ b/packages/agents/src/tools/add-edge-tool.ts
@@ -1,0 +1,118 @@
+/**
+ * AddEdgeTool -- planner tool that connects two nodes in the graph.
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { NodeRegistry } from "@nodetool/node-sdk";
+import { Tool } from "./base-tool.js";
+import { AGENT_STEP_NODE_TYPE, type GraphBuilder } from "../graph-builder.js";
+
+const ADD_EDGE_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    source: {
+      type: "string" as const,
+      description: "ID of the source node"
+    },
+    source_handle: {
+      type: "string" as const,
+      description: "Output slot name on the source node"
+    },
+    target: {
+      type: "string" as const,
+      description: "ID of the target node"
+    },
+    target_handle: {
+      type: "string" as const,
+      description: "Input property name on the target node"
+    }
+  },
+  required: ["source", "source_handle", "target", "target_handle"] as string[]
+};
+
+export class AddEdgeTool extends Tool {
+  readonly name = "add_edge";
+  readonly description =
+    "Connect two nodes by creating an edge from a source output to a target input.";
+  readonly inputSchema: Record<string, unknown> = ADD_EDGE_INPUT_SCHEMA;
+
+  constructor(
+    private readonly builder: GraphBuilder,
+    private readonly registry: NodeRegistry
+  ) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const source = params["source"] as string | undefined;
+    const sourceHandle = params["source_handle"] as string | undefined;
+    const target = params["target"] as string | undefined;
+    const targetHandle = params["target_handle"] as string | undefined;
+
+    if (!source || !sourceHandle || !target || !targetHandle) {
+      return {
+        status: "error",
+        errors: [
+          "All fields required: source, source_handle, target, target_handle"
+        ]
+      };
+    }
+
+    // Validate handles against registry metadata for deterministic nodes
+    const validationErrors: string[] = [];
+
+    const sourceNode = this.builder.getNode(source);
+    if (sourceNode && sourceNode.type !== AGENT_STEP_NODE_TYPE) {
+      const meta = this.registry.getMetadata(sourceNode.type);
+      if (meta) {
+        const outputNames = meta.outputs.map((o: { name: string }) => o.name);
+        if (outputNames.length > 0 && !outputNames.includes(sourceHandle)) {
+          validationErrors.push(
+            `Source node '${source}' (${sourceNode.type}) has no output '${sourceHandle}'. Available: ${outputNames.join(", ")}`
+          );
+        }
+      }
+    }
+
+    const targetNode = this.builder.getNode(target);
+    if (targetNode && targetNode.type !== AGENT_STEP_NODE_TYPE) {
+      const meta = this.registry.getMetadata(targetNode.type);
+      if (meta) {
+        const inputNames = meta.properties.map((p: { name: string }) => p.name);
+        if (inputNames.length > 0 && !inputNames.includes(targetHandle)) {
+          validationErrors.push(
+            `Target node '${target}' (${targetNode.type}) has no input '${targetHandle}'. Available: ${inputNames.join(", ")}`
+          );
+        }
+      }
+    }
+
+    if (validationErrors.length > 0) {
+      return { status: "error", errors: validationErrors };
+    }
+
+    const errors = this.builder.addEdge(
+      source,
+      sourceHandle,
+      target,
+      targetHandle
+    );
+    if (errors.length > 0) {
+      return { status: "error", errors };
+    }
+
+    return {
+      status: "edge_added",
+      from: `${source}.${sourceHandle}`,
+      to: `${target}.${targetHandle}`,
+      total_edges: this.builder.edgeCount
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Connecting ${params["source"]}.${params["source_handle"]} → ${params["target"]}.${params["target_handle"]}`;
+  }
+}

--- a/packages/agents/src/tools/add-node-tool.ts
+++ b/packages/agents/src/tools/add-node-tool.ts
@@ -1,0 +1,115 @@
+/**
+ * AddNodeTool -- planner tool that adds a node to the graph being built.
+ *
+ * The LLM calls this to add either:
+ * - A deterministic workflow node (type from NodeRegistry)
+ * - An agent step node (type: "nodetool.agents.AgentStep")
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { NodeRegistry } from "@nodetool/node-sdk";
+import { Tool } from "./base-tool.js";
+import { AGENT_STEP_NODE_TYPE, type GraphBuilder } from "../graph-builder.js";
+
+const ADD_NODE_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    id: {
+      type: "string" as const,
+      description: "Unique identifier for this node (snake_case recommended)"
+    },
+    type: {
+      type: "string" as const,
+      description:
+        'Fully-qualified node type from registry, or "nodetool.agents.AgentStep" for LLM-driven steps'
+    },
+    properties: {
+      type: "object" as const,
+      description:
+        "Input properties for the node. For AgentStep nodes: instructions (required), tools (optional), output_schema (optional)"
+    },
+    name: {
+      type: "string" as const,
+      description: "Optional human-readable name for the node"
+    }
+  },
+  required: ["id", "type"] as string[]
+};
+
+export class AddNodeTool extends Tool {
+  readonly name = "add_node";
+  readonly description =
+    "Add a node to the workflow graph. Use a registry node type for deterministic work, " +
+    'or "nodetool.agents.AgentStep" for tasks requiring LLM reasoning.';
+  readonly inputSchema: Record<string, unknown> = ADD_NODE_INPUT_SCHEMA;
+
+  constructor(
+    private readonly builder: GraphBuilder,
+    private readonly registry: NodeRegistry
+  ) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const id = params["id"] as string | undefined;
+    const type = params["type"] as string | undefined;
+    const properties = (params["properties"] as Record<string, unknown>) ?? {};
+    const name = params["name"] as string | undefined;
+
+    if (!id || typeof id !== "string") {
+      return { status: "error", errors: ["id must be a non-empty string."] };
+    }
+    if (!type || typeof type !== "string") {
+      return { status: "error", errors: ["type must be a non-empty string."] };
+    }
+
+    // Validate node type
+    const isAgentStep = type === AGENT_STEP_NODE_TYPE;
+    if (!isAgentStep && !this.registry.has(type)) {
+      // Check loaded metadata for Python-only nodes
+      const meta = this.registry.getMetadata(type);
+      if (!meta) {
+        return {
+          status: "error",
+          errors: [
+            `Unknown node type: '${type}'. Use search_nodes to find available types.`
+          ]
+        };
+      }
+    }
+
+    // Validate agent step properties
+    if (isAgentStep) {
+      const instructions = properties["instructions"];
+      if (!instructions || typeof instructions !== "string") {
+        return {
+          status: "error",
+          errors: [
+            'AgentStep nodes require an "instructions" property (non-empty string).'
+          ]
+        };
+      }
+    }
+
+    const errors = this.builder.addNode(id, type, properties, name);
+    if (errors.length > 0) {
+      return { status: "error", errors };
+    }
+
+    return {
+      status: "node_added",
+      id,
+      type,
+      total_nodes: this.builder.nodeCount
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const id = params["id"] ?? "?";
+    const type = params["type"] ?? "?";
+    return `Adding node: ${id} (${type})`;
+  }
+}

--- a/packages/agents/src/tools/add-node-tool.ts
+++ b/packages/agents/src/tools/add-node-tool.ts
@@ -10,6 +10,9 @@ import type { ProcessingContext } from "@nodetool/runtime";
 import type { NodeRegistry } from "@nodetool/node-sdk";
 import { Tool } from "./base-tool.js";
 import { AGENT_STEP_NODE_TYPE, type GraphBuilder } from "../graph-builder.js";
+import { createLogger } from "@nodetool/config";
+
+const log = createLogger("nodetool.agents.add-node-tool");
 
 const ADD_NODE_INPUT_SCHEMA = {
   type: "object" as const,
@@ -23,24 +26,28 @@ const ADD_NODE_INPUT_SCHEMA = {
       description:
         'Fully-qualified node type from registry, or "nodetool.agents.AgentStep" for LLM-driven steps'
     },
-    properties: {
+    node_properties: {
       type: "object" as const,
       description:
-        "Input properties for the node. For AgentStep nodes: instructions (required), tools (optional), output_schema (optional)"
+        'Configuration values for the node. Example: {"value": "Hello World"} for a String constant, ' +
+        '{"delimiter": " "} for a Split node. Use get_node_info to see available properties. ' +
+        "Pass {} if no configuration is needed (e.g. the node only receives input via edges)."
     },
     name: {
       type: "string" as const,
       description: "Optional human-readable name for the node"
     }
   },
-  required: ["id", "type"] as string[]
+  required: ["id", "type"] as string[],
+  additionalProperties: true as const
 };
 
 export class AddNodeTool extends Tool {
   readonly name = "add_node";
   readonly description =
-    "Add a node to the workflow graph. Use a registry node type for deterministic work, " +
-    'or "nodetool.agents.AgentStep" for tasks requiring LLM reasoning.';
+    "Add a node to the workflow graph. Set node configuration either via node_properties object " +
+    "or as direct parameters (e.g. value: \"Hello World\" for a String constant). " +
+    'Use a registry node type for deterministic work, or "nodetool.agents.AgentStep" for LLM reasoning.';
   readonly inputSchema: Record<string, unknown> = ADD_NODE_INPUT_SCHEMA;
 
   constructor(
@@ -56,8 +63,21 @@ export class AddNodeTool extends Tool {
   ): Promise<unknown> {
     const id = params["id"] as string | undefined;
     const type = params["type"] as string | undefined;
-    const properties = (params["properties"] as Record<string, unknown>) ?? {};
     const name = params["name"] as string | undefined;
+
+    // Accept properties from node_properties, properties, or any extra params
+    const knownKeys = new Set(["id", "type", "name", "node_properties", "properties"]);
+    const extraProps: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(params)) {
+      if (!knownKeys.has(k)) {
+        extraProps[k] = v;
+      }
+    }
+    const properties = (params["node_properties"] as Record<string, unknown>) ??
+      (params["properties"] as Record<string, unknown>) ??
+      (Object.keys(extraProps).length > 0 ? extraProps : {});
+
+    log.debug("add_node", { id, type, properties });
 
     if (!id || typeof id !== "string") {
       return { status: "error", errors: ["id must be a non-empty string."] };
@@ -99,12 +119,28 @@ export class AddNodeTool extends Tool {
       return { status: "error", errors };
     }
 
-    return {
+    // Include set properties in response and warn if none were set
+    const propsSet = Object.keys(properties);
+    const meta = !isAgentStep ? this.registry.getMetadata(type) : null;
+    const configurableProps = meta?.properties
+      ?.filter((p: { name: string }) => p.name !== "text" && p.name !== "input") // skip edge-connected inputs
+      ?.map((p: { name: string; default: unknown }) => `${p.name} (default: ${JSON.stringify(p.default)})`) ?? [];
+
+    const result: Record<string, unknown> = {
       status: "node_added",
       id,
       type,
+      properties_set: propsSet,
       total_nodes: this.builder.nodeCount
     };
+
+    if (propsSet.length === 0 && configurableProps.length > 0) {
+      result["warning"] =
+        `No node_properties were set. This node has configurable properties: [${configurableProps.join(", ")}]. ` +
+        `If any need non-default values, remove this node and re-add with node_properties set.`;
+    }
+
+    return result;
   }
 
   userMessage(params: Record<string, unknown>): string {

--- a/packages/agents/src/tools/finish-graph-tool.ts
+++ b/packages/agents/src/tools/finish-graph-tool.ts
@@ -1,0 +1,60 @@
+/**
+ * FinishGraphTool -- planner tool that validates and finalizes the graph.
+ *
+ * Called by the LLM when it's done building the graph. Runs full validation
+ * (cycle detection, connectivity) and produces the GraphData.
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { GraphData } from "@nodetool/protocol";
+import { Tool } from "./base-tool.js";
+import type { GraphBuilder } from "../graph-builder.js";
+
+const FINISH_GRAPH_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {},
+  required: [] as string[]
+};
+
+export class FinishGraphTool extends Tool {
+  readonly name = "finish_graph";
+  readonly description =
+    "Validate and finalize the workflow graph. Call this when you are done adding nodes and edges.";
+  readonly inputSchema: Record<string, unknown> = FINISH_GRAPH_INPUT_SCHEMA;
+
+  /** The finalized graph, available after a successful call. */
+  private _graph: GraphData | null = null;
+
+  get graph(): GraphData | null {
+    return this._graph;
+  }
+
+  constructor(private readonly builder: GraphBuilder) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    _params: Record<string, unknown>
+  ): Promise<unknown> {
+    const errors = this.builder.validate();
+    if (errors.length > 0) {
+      return {
+        status: "validation_failed",
+        errors
+      };
+    }
+
+    this._graph = this.builder.build();
+
+    return {
+      status: "graph_finalized",
+      nodes: this._graph.nodes.length,
+      edges: this._graph.edges.length
+    };
+  }
+
+  userMessage(_params: Record<string, unknown>): string {
+    return "Finalizing workflow graph";
+  }
+}

--- a/packages/agents/src/tools/local-get-node-info-tool.ts
+++ b/packages/agents/src/tools/local-get-node-info-tool.ts
@@ -1,0 +1,90 @@
+/**
+ * LocalGetNodeInfoTool -- get full metadata for a specific node type.
+ *
+ * Local version of GetNodeInfoTool (from mcp-tools.ts) that queries
+ * the registry directly instead of via REST API.
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { NodeRegistry, NodeMetadata } from "@nodetool/node-sdk";
+import { Tool } from "./base-tool.js";
+
+function typeMetaToString(
+  tm: NodeMetadata["properties"][number]["type"]
+): string {
+  const args = (tm.type_args ?? []).map(typeMetaToString).filter(Boolean);
+  return args.length > 0 ? `${tm.type}[${args.join(", ")}]` : tm.type;
+}
+
+const GET_NODE_INFO_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    node_type: {
+      type: "string" as const,
+      description:
+        "Fully-qualified node type (e.g. 'nodetool.text.Concat')"
+    }
+  },
+  required: ["node_type"] as string[]
+};
+
+export class LocalGetNodeInfoTool extends Tool {
+  readonly name = "get_node_info";
+  readonly description =
+    "Get detailed metadata for a node type including all inputs, outputs, types, and defaults. " +
+    "Use this before add_node to verify exact property names and types.";
+  readonly inputSchema: Record<string, unknown> = GET_NODE_INFO_INPUT_SCHEMA;
+
+  constructor(private readonly registry: NodeRegistry) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const nodeType = params["node_type"] as string | undefined;
+    if (!nodeType) {
+      return { status: "error", errors: ["node_type is required"] };
+    }
+
+    const meta = this.registry.getMetadata(nodeType);
+    if (!meta) {
+      return {
+        status: "error",
+        errors: [
+          `Node type '${nodeType}' not found. Use search_nodes to find available types.`
+        ]
+      };
+    }
+
+    return {
+      node_type: meta.node_type,
+      title: meta.title,
+      description: meta.description,
+      namespace: meta.namespace,
+      properties: meta.properties.map((p: NodeMetadata["properties"][number]) => ({
+        name: p.name,
+        type: typeMetaToString(p.type),
+        default: p.default,
+        description: p.description ?? undefined,
+        required: p.required ?? false,
+        min: p.min ?? undefined,
+        max: p.max ?? undefined,
+        values: p.values ?? undefined
+      })),
+      outputs: meta.outputs.map((o: NodeMetadata["outputs"][number]) => ({
+        name: o.name,
+        type: typeMetaToString(o.type)
+      })),
+      is_streaming_output: meta.is_streaming_output ?? false,
+      is_streaming_input: meta.is_streaming_input ?? false,
+      required_settings: meta.required_settings ?? [],
+      required_runtimes: meta.required_runtimes ?? []
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Getting info for node type ${params["node_type"]}`;
+  }
+}

--- a/packages/agents/src/tools/local-list-nodes-tool.ts
+++ b/packages/agents/src/tools/local-list-nodes-tool.ts
@@ -1,0 +1,87 @@
+/**
+ * LocalListNodesTool -- list available node types from the registry.
+ *
+ * Local version of ListNodesTool (from mcp-tools.ts) that queries
+ * the registry directly instead of via REST API.
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { NodeRegistry, NodeMetadata } from "@nodetool/node-sdk";
+import { Tool } from "./base-tool.js";
+
+function firstSentence(text: string): string {
+  const dot = text.indexOf(".");
+  if (dot > 0 && dot < 120) return text.slice(0, dot + 1);
+  return text.length > 120 ? text.slice(0, 117) + "..." : text;
+}
+
+const LIST_NODES_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    namespace: {
+      type: "string" as const,
+      description:
+        "Optional namespace prefix filter (e.g. 'nodetool.text', 'lib.image')"
+    },
+    limit: {
+      type: "number" as const,
+      description: "Maximum number of nodes to return (default 50)",
+      default: 50
+    }
+  },
+  required: [] as string[]
+};
+
+export class LocalListNodesTool extends Tool {
+  readonly name = "list_nodes";
+  readonly description =
+    "List available node types, optionally filtered by namespace. " +
+    "Use this to browse what deterministic nodes are available.";
+  readonly inputSchema: Record<string, unknown> = LIST_NODES_INPUT_SCHEMA;
+
+  constructor(private readonly registry: NodeRegistry) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const namespace = params["namespace"] as string | undefined;
+    const limit =
+      typeof params["limit"] === "number" ? params["limit"] : 50;
+
+    let allMetadata = this.registry.listMetadata();
+
+    if (namespace) {
+      allMetadata = allMetadata.filter(
+        (m: NodeMetadata) =>
+          m.namespace === namespace ||
+          m.namespace.startsWith(namespace + ".") ||
+          m.node_type.startsWith(namespace + ".")
+      );
+    }
+
+    // Group by namespace for overview
+    const namespaces = new Map<string, number>();
+    for (const m of allMetadata) {
+      namespaces.set(m.namespace, (namespaces.get(m.namespace) ?? 0) + 1);
+    }
+
+    const limited = allMetadata.slice(0, limit);
+    return {
+      total: allMetadata.length,
+      namespaces: Object.fromEntries(namespaces),
+      nodes: limited.map((m: NodeMetadata) => ({
+        type: m.node_type,
+        title: m.title,
+        description: firstSentence(m.description)
+      }))
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const ns = params["namespace"];
+    return ns ? `Listing nodes in namespace ${ns}` : "Listing available nodes";
+  }
+}

--- a/packages/agents/src/tools/local-search-nodes-tool.ts
+++ b/packages/agents/src/tools/local-search-nodes-tool.ts
@@ -1,0 +1,144 @@
+/**
+ * LocalSearchNodesTool -- search the NodeRegistry by keyword.
+ *
+ * Local version of SearchNodesTool (from mcp-tools.ts) that queries
+ * the registry directly instead of via REST API.
+ */
+
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { NodeRegistry, NodeMetadata } from "@nodetool/node-sdk";
+import { Tool } from "./base-tool.js";
+
+function typeMetaToString(
+  tm: NodeMetadata["properties"][number]["type"]
+): string {
+  const args = (tm.type_args ?? []).map(typeMetaToString).filter(Boolean);
+  return args.length > 0 ? `${tm.type}[${args.join(", ")}]` : tm.type;
+}
+
+function firstSentence(text: string): string {
+  const dot = text.indexOf(".");
+  if (dot > 0 && dot < 120) return text.slice(0, dot + 1);
+  return text.length > 120 ? text.slice(0, 117) + "..." : text;
+}
+
+function matchesQuery(meta: NodeMetadata, terms: string[]): boolean {
+  const haystack = [
+    meta.node_type,
+    meta.title,
+    meta.description,
+    meta.namespace
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return terms.every((term) => haystack.includes(term.toLowerCase()));
+}
+
+interface CompactSearchResult {
+  type: string;
+  title: string;
+  description: string;
+  inputs: Array<{ name: string; type: string }>;
+  outputs: Array<{ name: string; type: string }>;
+}
+
+function toCompact(meta: NodeMetadata): CompactSearchResult {
+  return {
+    type: meta.node_type,
+    title: meta.title,
+    description: firstSentence(meta.description),
+    inputs: meta.properties.map((p: NodeMetadata["properties"][number]) => ({
+      name: p.name,
+      type: typeMetaToString(p.type)
+    })),
+    outputs: meta.outputs.map((o: NodeMetadata["outputs"][number]) => ({
+      name: o.name,
+      type: typeMetaToString(o.type)
+    }))
+  };
+}
+
+const SEARCH_NODES_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    query: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description:
+        "Search terms to match against node type, title, and description"
+    },
+    n_results: {
+      type: "number" as const,
+      description: "Maximum number of results to return (default 10)",
+      default: 10
+    },
+    input_type: {
+      type: "string" as const,
+      description: "Optional filter: only nodes with this input type"
+    },
+    output_type: {
+      type: "string" as const,
+      description: "Optional filter: only nodes with this output type"
+    }
+  },
+  required: ["query"] as string[]
+};
+
+export class LocalSearchNodesTool extends Tool {
+  readonly name = "search_nodes";
+  readonly description =
+    "Search for available nodes by keyword. Use this to find deterministic nodes before building the graph.";
+  readonly inputSchema: Record<string, unknown> = SEARCH_NODES_INPUT_SCHEMA;
+
+  constructor(private readonly registry: NodeRegistry) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const queryArr = (params["query"] as string[]) ?? [];
+    const maxResults =
+      typeof params["n_results"] === "number" ? params["n_results"] : 10;
+    const inputType = params["input_type"] as string | undefined;
+    const outputType = params["output_type"] as string | undefined;
+
+    if (queryArr.length === 0) {
+      return { status: "error", errors: ["query must be a non-empty array"] };
+    }
+
+    const allMetadata = this.registry.listMetadata();
+    let results = allMetadata.filter((meta: NodeMetadata) => matchesQuery(meta, queryArr));
+
+    if (inputType) {
+      results = results.filter((meta: NodeMetadata) =>
+        meta.properties.some(
+          (p: NodeMetadata["properties"][number]) =>
+            typeMetaToString(p.type).toLowerCase() === inputType.toLowerCase()
+        )
+      );
+    }
+
+    if (outputType) {
+      results = results.filter((meta: NodeMetadata) =>
+        meta.outputs.some(
+          (o: NodeMetadata["outputs"][number]) =>
+            typeMetaToString(o.type).toLowerCase() === outputType.toLowerCase()
+        )
+      );
+    }
+
+    const limited = results.slice(0, maxResults);
+    return {
+      total: results.length,
+      results: limited.map(toCompact)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const query = (params["query"] as string[]) ?? [];
+    return `Searching for nodes: ${query.join(", ")}`;
+  }
+}

--- a/packages/agents/tests/add-node-tool.test.ts
+++ b/packages/agents/tests/add-node-tool.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import { GraphBuilder, AGENT_STEP_NODE_TYPE } from "../src/graph-builder.js";
+import { AddNodeTool } from "../src/tools/add-node-tool.js";
+import { AddEdgeTool } from "../src/tools/add-edge-tool.js";
+import { FinishGraphTool } from "../src/tools/finish-graph-tool.js";
+
+function mockRegistry(knownTypes: string[] = []) {
+  const metadataMap = new Map<string, { node_type: string; properties: Array<{ name: string }>; outputs: Array<{ name: string }> }>();
+  for (const t of knownTypes) {
+    metadataMap.set(t, {
+      node_type: t,
+      properties: [{ name: "input" }],
+      outputs: [{ name: "output" }]
+    });
+  }
+
+  return {
+    has: (type: string) => knownTypes.includes(type),
+    getMetadata: (type: string) => metadataMap.get(type) ?? null
+  } as any;
+}
+
+function mockContext() {
+  return {} as any;
+}
+
+describe("AddNodeTool", () => {
+  it("adds a deterministic node from registry", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry(["nodetool.text.Split"]);
+    const tool = new AddNodeTool(builder, registry);
+
+    const result = (await tool.process(mockContext(), {
+      id: "split",
+      type: "nodetool.text.Split",
+      properties: { delimiter: "," }
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("node_added");
+    expect(builder.nodeCount).toBe(1);
+    expect(builder.getNode("split")?.type).toBe("nodetool.text.Split");
+  });
+
+  it("adds an agent step node", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry();
+    const tool = new AddNodeTool(builder, registry);
+
+    const result = (await tool.process(mockContext(), {
+      id: "step1",
+      type: AGENT_STEP_NODE_TYPE,
+      properties: {
+        instructions: "Summarize the input text"
+      }
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("node_added");
+    expect(builder.nodeCount).toBe(1);
+  });
+
+  it("rejects unknown node types", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry();
+    const tool = new AddNodeTool(builder, registry);
+
+    const result = (await tool.process(mockContext(), {
+      id: "bad",
+      type: "nodetool.nonexistent.Node"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("error");
+    expect((result.errors as string[])[0]).toContain("Unknown node type");
+  });
+
+  it("rejects agent step without instructions", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry();
+    const tool = new AddNodeTool(builder, registry);
+
+    const result = (await tool.process(mockContext(), {
+      id: "step",
+      type: AGENT_STEP_NODE_TYPE,
+      properties: {}
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("error");
+    expect((result.errors as string[])[0]).toContain("instructions");
+  });
+
+  it("rejects duplicate ids", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry(["test.Node"]);
+    const tool = new AddNodeTool(builder, registry);
+
+    await tool.process(mockContext(), { id: "a", type: "test.Node" });
+    const result = (await tool.process(mockContext(), {
+      id: "a",
+      type: "test.Node"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("error");
+    expect((result.errors as string[])[0]).toContain("Duplicate");
+  });
+});
+
+describe("AddEdgeTool", () => {
+  it("adds a valid edge", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry(["test.Node"]);
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+
+    const tool = new AddEdgeTool(builder, registry);
+    const result = (await tool.process(mockContext(), {
+      source: "a",
+      source_handle: "output",
+      target: "b",
+      target_handle: "input"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("edge_added");
+    expect(builder.edgeCount).toBe(1);
+  });
+
+  it("validates handle names against registry", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry(["test.Node"]);
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+
+    const tool = new AddEdgeTool(builder, registry);
+    const result = (await tool.process(mockContext(), {
+      source: "a",
+      source_handle: "nonexistent_output",
+      target: "b",
+      target_handle: "input"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("error");
+    expect((result.errors as string[])[0]).toContain("nonexistent_output");
+  });
+
+  it("allows any handle name for agent step nodes", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry();
+    builder.addNode("step1", AGENT_STEP_NODE_TYPE, {
+      instructions: "Do something"
+    });
+    builder.addNode("step2", AGENT_STEP_NODE_TYPE, {
+      instructions: "Do something else"
+    });
+
+    const tool = new AddEdgeTool(builder, registry);
+    const result = (await tool.process(mockContext(), {
+      source: "step1",
+      source_handle: "result",
+      target: "step2",
+      target_handle: "context"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("edge_added");
+  });
+});
+
+describe("FinishGraphTool", () => {
+  it("finalizes a valid graph", async () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+    builder.addEdge("a", "out", "b", "in");
+
+    const tool = new FinishGraphTool(builder);
+    const result = (await tool.process(
+      mockContext(),
+      {}
+    )) as Record<string, unknown>;
+
+    expect(result.status).toBe("graph_finalized");
+    expect(result.nodes).toBe(2);
+    expect(result.edges).toBe(1);
+    expect(tool.graph).not.toBeNull();
+    expect(tool.graph!.nodes).toHaveLength(2);
+  });
+
+  it("returns validation errors for cycles", async () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+    builder.addEdge("a", "out", "b", "in");
+    builder.addEdge("b", "out", "a", "in");
+
+    const tool = new FinishGraphTool(builder);
+    const result = (await tool.process(
+      mockContext(),
+      {}
+    )) as Record<string, unknown>;
+
+    expect(result.status).toBe("validation_failed");
+    expect((result.errors as string[]).some((e) => e.includes("cycle"))).toBe(
+      true
+    );
+    expect(tool.graph).toBeNull();
+  });
+});

--- a/packages/agents/tests/graph-builder.test.ts
+++ b/packages/agents/tests/graph-builder.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { GraphBuilder, AGENT_STEP_NODE_TYPE } from "../src/graph-builder.js";
+
+describe("GraphBuilder", () => {
+  it("adds nodes and builds a valid graph", () => {
+    const builder = new GraphBuilder();
+    expect(builder.addNode("a", "test.NodeA")).toEqual([]);
+    expect(builder.addNode("b", "test.NodeB")).toEqual([]);
+    expect(builder.addEdge("a", "output", "b", "input")).toEqual([]);
+
+    const graph = builder.build();
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.nodes[0].id).toBe("a");
+    expect(graph.nodes[1].id).toBe("b");
+  });
+
+  it("rejects duplicate node ids", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    const errors = builder.addNode("a", "test.Node");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Duplicate");
+  });
+
+  it("rejects edges with non-existent nodes", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    const errors = builder.addEdge("a", "output", "missing", "input");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("missing");
+  });
+
+  it("rejects self-loops", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    const errors = builder.addEdge("a", "out", "a", "in");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Self-loops");
+  });
+
+  it("detects cycles", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+    builder.addNode("c", "test.Node");
+    builder.addEdge("a", "out", "b", "in");
+    builder.addEdge("b", "out", "c", "in");
+    builder.addEdge("c", "out", "a", "in");
+
+    const errors = builder.validate();
+    expect(errors.some((e) => e.includes("cycle"))).toBe(true);
+  });
+
+  it("requires at least one node", () => {
+    const builder = new GraphBuilder();
+    const errors = builder.validate();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("at least one node");
+  });
+
+  it("rejects duplicate edges", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+    builder.addEdge("a", "out", "b", "in");
+    const errors = builder.addEdge("a", "out", "b", "in");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Duplicate edge");
+  });
+
+  it("topologically sorts nodes", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("c", "test.Node");
+    builder.addNode("a", "test.Node");
+    builder.addNode("b", "test.Node");
+    builder.addEdge("a", "out", "b", "in");
+    builder.addEdge("b", "out", "c", "in");
+
+    const graph = builder.build();
+    const ids = graph.nodes.map((n) => n.id);
+    expect(ids.indexOf("a")).toBeLessThan(ids.indexOf("b"));
+    expect(ids.indexOf("b")).toBeLessThan(ids.indexOf("c"));
+  });
+
+  it("stores properties on nodes", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("step1", AGENT_STEP_NODE_TYPE, {
+      instructions: "Do something",
+      tools: ["browser"]
+    });
+    const graph = builder.build();
+    expect(graph.nodes[0].properties).toEqual({
+      instructions: "Do something",
+      tools: ["browser"]
+    });
+  });
+
+  it("prevents adding after build", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.build();
+    const errors = builder.addNode("b", "test.Node");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("finalized");
+  });
+
+  it("supports parallel nodes (diamond shape)", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("source", "test.Source");
+    builder.addNode("left", "test.Process");
+    builder.addNode("right", "test.Process");
+    builder.addNode("sink", "test.Sink");
+    builder.addEdge("source", "out", "left", "in");
+    builder.addEdge("source", "out", "right", "in");
+    builder.addEdge("left", "out", "sink", "left_in");
+    builder.addEdge("right", "out", "sink", "right_in");
+
+    const graph = builder.build();
+    expect(graph.nodes).toHaveLength(4);
+    expect(graph.edges).toHaveLength(4);
+    // Source must come before left, right, and sink
+    const ids = graph.nodes.map((n) => n.id);
+    expect(ids.indexOf("source")).toBeLessThan(ids.indexOf("sink"));
+  });
+
+  it("resets for reuse", () => {
+    const builder = new GraphBuilder();
+    builder.addNode("a", "test.Node");
+    builder.build();
+    builder.reset();
+    expect(builder.nodeCount).toBe(0);
+    expect(builder.edgeCount).toBe(0);
+    builder.addNode("b", "test.Node");
+    const graph = builder.build();
+    expect(graph.nodes).toHaveLength(1);
+  });
+});

--- a/packages/agents/tests/local-node-tools.test.ts
+++ b/packages/agents/tests/local-node-tools.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import { LocalSearchNodesTool } from "../src/tools/local-search-nodes-tool.js";
+import { LocalGetNodeInfoTool } from "../src/tools/local-get-node-info-tool.js";
+import { LocalListNodesTool } from "../src/tools/local-list-nodes-tool.js";
+import type { NodeMetadata } from "@nodetool/node-sdk";
+
+function createMetadata(overrides: Partial<NodeMetadata> = {}): NodeMetadata {
+  return {
+    title: "Test Node",
+    description: "A test node for unit testing.",
+    namespace: "test",
+    node_type: "test.TestNode",
+    properties: [
+      {
+        name: "input",
+        type: { type: "str", type_args: [] },
+        default: "",
+        title: "Input"
+      }
+    ],
+    outputs: [{ name: "output", type: { type: "str", type_args: [] } }],
+    ...overrides
+  };
+}
+
+function mockRegistry(metadataList: NodeMetadata[]) {
+  return {
+    listMetadata: () => metadataList,
+    getMetadata: (nodeType: string) =>
+      metadataList.find((m) => m.node_type === nodeType) ?? undefined
+  } as any;
+}
+
+function mockContext() {
+  return {} as any;
+}
+
+describe("LocalSearchNodesTool", () => {
+  const allNodes = [
+    createMetadata({
+      node_type: "nodetool.text.Split",
+      title: "Split Text",
+      description: "Split text by delimiter.",
+      namespace: "nodetool.text"
+    }),
+    createMetadata({
+      node_type: "nodetool.text.Concat",
+      title: "Concat Text",
+      description: "Concatenate strings.",
+      namespace: "nodetool.text"
+    }),
+    createMetadata({
+      node_type: "lib.image.Resize",
+      title: "Resize Image",
+      description: "Resize an image to target dimensions.",
+      namespace: "lib.image",
+      properties: [
+        {
+          name: "image",
+          type: { type: "image", type_args: [] },
+          title: "Image"
+        },
+        {
+          name: "width",
+          type: { type: "int", type_args: [] },
+          title: "Width"
+        }
+      ],
+      outputs: [
+        { name: "output", type: { type: "image", type_args: [] } }
+      ]
+    })
+  ];
+
+  it("searches by keyword", async () => {
+    const tool = new LocalSearchNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      query: ["split"]
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(1);
+    const results = result.results as Array<Record<string, unknown>>;
+    expect(results[0].type).toBe("nodetool.text.Split");
+  });
+
+  it("searches with multiple terms", async () => {
+    const tool = new LocalSearchNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      query: ["resize", "image"]
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(1);
+    const results = result.results as Array<Record<string, unknown>>;
+    expect(results[0].type).toBe("lib.image.Resize");
+  });
+
+  it("returns compact results with inputs and outputs", async () => {
+    const tool = new LocalSearchNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      query: ["text"]
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(2);
+    const results = result.results as Array<Record<string, unknown>>;
+    expect(results[0]).toHaveProperty("inputs");
+    expect(results[0]).toHaveProperty("outputs");
+  });
+
+  it("limits results", async () => {
+    const tool = new LocalSearchNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      query: ["text"],
+      n_results: 1
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(2);
+    expect((result.results as unknown[]).length).toBe(1);
+  });
+
+  it("filters by output type", async () => {
+    const tool = new LocalSearchNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      query: ["resize"],
+      output_type: "image"
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(1);
+  });
+});
+
+describe("LocalGetNodeInfoTool", () => {
+  const meta = createMetadata({
+    node_type: "nodetool.text.Split",
+    title: "Split Text",
+    description: "Split text by delimiter.",
+    namespace: "nodetool.text",
+    properties: [
+      {
+        name: "text",
+        type: { type: "str", type_args: [] },
+        title: "Text",
+        description: "Text to split"
+      },
+      {
+        name: "delimiter",
+        type: { type: "str", type_args: [] },
+        title: "Delimiter",
+        default: "\\n"
+      }
+    ],
+    outputs: [
+      { name: "output", type: { type: "list", type_args: [{ type: "str", type_args: [] }] } }
+    ]
+  });
+
+  it("returns full metadata for a known type", async () => {
+    const tool = new LocalGetNodeInfoTool(mockRegistry([meta]));
+    const result = (await tool.process(mockContext(), {
+      node_type: "nodetool.text.Split"
+    })) as Record<string, unknown>;
+
+    expect(result.node_type).toBe("nodetool.text.Split");
+    expect(result.title).toBe("Split Text");
+    const props = result.properties as Array<Record<string, unknown>>;
+    expect(props).toHaveLength(2);
+    expect(props[0].name).toBe("text");
+    expect(props[0].type).toBe("str");
+    const outputs = result.outputs as Array<Record<string, unknown>>;
+    expect(outputs[0].type).toBe("list[str]");
+  });
+
+  it("returns error for unknown type", async () => {
+    const tool = new LocalGetNodeInfoTool(mockRegistry([]));
+    const result = (await tool.process(mockContext(), {
+      node_type: "unknown.Node"
+    })) as Record<string, unknown>;
+
+    expect(result.status).toBe("error");
+  });
+});
+
+describe("LocalListNodesTool", () => {
+  const allNodes = [
+    createMetadata({ node_type: "nodetool.text.Split", namespace: "nodetool.text" }),
+    createMetadata({ node_type: "nodetool.text.Concat", namespace: "nodetool.text" }),
+    createMetadata({ node_type: "lib.image.Resize", namespace: "lib.image" })
+  ];
+
+  it("lists all nodes", async () => {
+    const tool = new LocalListNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {})) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.total).toBe(3);
+    expect((result.nodes as unknown[]).length).toBe(3);
+    const namespaces = result.namespaces as Record<string, number>;
+    expect(namespaces["nodetool.text"]).toBe(2);
+    expect(namespaces["lib.image"]).toBe(1);
+  });
+
+  it("filters by namespace", async () => {
+    const tool = new LocalListNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      namespace: "nodetool.text"
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(2);
+  });
+
+  it("limits results", async () => {
+    const tool = new LocalListNodesTool(mockRegistry(allNodes));
+    const result = (await tool.process(mockContext(), {
+      limit: 1
+    })) as Record<string, unknown>;
+
+    expect(result.total).toBe(3);
+    expect((result.nodes as unknown[]).length).toBe(1);
+  });
+});


### PR DESCRIPTION
Instead of producing TaskPlan with prose steps, the new GraphPlanner gives the
LLM tools to search for nodes (search_nodes, get_node_info, list_nodes), add
them to a graph (add_node, add_edge), and finalize (finish_graph). Each node
is either a deterministic registry node or an LLM-driven AgentStep. The
resulting GraphData goes straight to WorkflowRunner via AgentWorkflowRunner.

New files:
- GraphBuilder: stateful graph accumulator with cycle detection
- AddNodeTool/AddEdgeTool/FinishGraphTool: planner tools for graph construction
- LocalSearchNodesTool/LocalGetNodeInfoTool/LocalListNodesTool: registry search
- AgentStepExecutor: NodeExecutor adapter wrapping StepExecutor
- GraphPlanner: multi-turn LLM planner using search-then-build strategy
- AgentWorkflowRunner: executes graph plans via kernel WorkflowRunner

Wired into MultiModeAgent via useGraphPlanner option (opt-in, old path intact).

https://claude.ai/code/session_012gpz4WfjiXaY1NhXnPpDQB