### PR TITLE
fix(web): remove recursive elkjs alias breaking Cloudflare Pages build

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -60,7 +60,6 @@ export default defineConfig(async ({ mode }) => {
       alias: {
         "@nodetool/protocol": resolve(configDir, "../packages/protocol/src/index.ts"),
         "monaco-editor": resolve(rootNodeModules, "monaco-editor"),
-        "elkjs": "elkjs/lib/elk.bundled.js",
       },
     },
     plugins: [


### PR DESCRIPTION
The `"elkjs": "elkjs/lib/elk.bundled.js"` alias in web/vite.config.ts
caused Vite/Rollup to infinitely expand the prefix. `web/src/core/graph.ts`
already imports `"elkjs/lib/elk.bundled.js"` directly, so when Rollup
resolved that import, the alias's prefix-match replaced `"elkjs"` with
`"elkjs/lib/elk.bundled.js"`, producing
`"elkjs/lib/elk.bundled.js/lib/elk.bundled.js"` — ENOENT during production
build.

Cloudflare Pages build log on 4e69611:

  [vite:load-fallback] Could not load
  elkjs/lib/elk.bundled.js/lib/elk.bundled.js
  (imported by src/core/graph.ts)

No code imports bare `"elkjs"`, so the alias is unused; removing it
restores the production build.

https://claude.ai/code/session_01C5diR76pYdnqMYj9Md9N3x