### PR TITLE
feat(web): redesign mobile side panels as bottom sheets

### DIFF
--- a/web/src/components/menus/MobilePaneMenu.tsx
+++ b/web/src/components/menus/MobilePaneMenu.tsx
@@ -2,8 +2,6 @@
 import React, { useCallback } from "react";
 import { useReactFlow } from "@xyflow/react";
 import {
-  Dialog,
-  DialogContent,
   List,
   ListItem,
   ListItemButton,
@@ -11,7 +9,7 @@ import {
   ListItemText,
   useTheme
 } from "@mui/material";
-import { Divider } from "../ui_primitives";
+import { Divider, MobileBottomSheet } from "../ui_primitives";
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 
@@ -26,9 +24,6 @@ import ChatIcon from "@mui/icons-material/Chat";
 import ImageIcon from "@mui/icons-material/Image";
 import SupportAgentIcon from "@mui/icons-material/SupportAgent";
 
-//primitives
-import { CloseButton } from "../ui_primitives";
-
 //behaviours
 import { useCopyPaste } from "../../hooks/handlers/useCopyPaste";
 import { useClipboard } from "../../hooks/browser/useClipboard";
@@ -42,38 +37,12 @@ import {
 
 const styles = (theme: Theme) =>
   css({
-    ".mobile-pane-menu-dialog": {
-      "& .MuiDialog-paper": {
-        borderRadius: "0px",
-        maxWidth: "100vw",
-        width: "100vw",
-        maxHeight: "100vh",
-        backgroundColor: theme.vars.palette.grey[900],
-        backgroundImage: "none"
-      }
-    },
-    ".menu-header": {
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "space-between",
-      padding: "56px 24px 8px 24px", /* Added 40px top padding for header + 16px original */
-      backgroundColor: theme.vars.palette.grey[900],
-      borderBottom: `1px solid ${theme.vars.palette.grey[700]}`
-    },
-    ".menu-title": {
-      fontSize: "1.2rem",
-      fontWeight: 600,
-      color: theme.vars.palette.grey[0]
-    },
-    ".menu-content": {
-      padding: "0 8px 16px 8px",
-      backgroundColor: theme.vars.palette.grey[900]
-    },
+    padding: "0 8px 16px 8px",
     ".menu-item": {
       borderRadius: "8px",
       margin: "2px 0",
       "&:hover": {
-        backgroundColor: theme.vars.palette.grey[800]
+        backgroundColor: theme.vars.palette.action.hover
       },
       "&.disabled": {
         opacity: 0.5,
@@ -99,12 +68,10 @@ const styles = (theme: Theme) =>
       fontWeight: 600,
       textTransform: "uppercase",
       letterSpacing: "0.05em",
-      color: theme.vars.palette.grey[300],
-      padding: "16px 16px 8px 16px",
-      marginTop: "8px",
-      backgroundColor: theme.vars.palette.grey[900],
+      color: theme.vars.palette.text.secondary,
+      padding: "12px 16px 6px 16px",
       "&:first-of-type": {
-        marginTop: 0
+        paddingTop: "4px"
       }
     }
   });
@@ -210,26 +177,13 @@ const MobilePaneMenu: React.FC<MobilePaneMenuProps> = ({ open, onClose }) => {
   }, [handleAction, createNode, addNode, getViewportCenter]);
 
   return (
-    <Dialog
+    <MobileBottomSheet
       open={open}
       onClose={onClose}
-      className="mobile-pane-menu-dialog"
-      css={styles(theme)}
-      maxWidth={false}
-      fullScreen
-      PaperProps={{
-        elevation: 0
-      }}
-      BackdropProps={{
-        style: { backgroundColor: `rgba(${theme.vars.palette.background.defaultChannel} / 0.8)` }
-      }}
+      title="Canvas Menu"
+      ariaLabel="Canvas actions and node insertion"
     >
-      <div className="menu-header">
-        <div className="menu-title">Canvas Menu</div>
-        <CloseButton onClick={onClose} buttonSize="small" tooltip="Close" />
-      </div>
-
-      <DialogContent className="menu-content">
+      <div className="menu-content" css={styles(theme)}>
         <List dense>
           {/* General Actions */}
           <div className="menu-section-title">Actions</div>
@@ -367,16 +321,16 @@ const MobilePaneMenu: React.FC<MobilePaneMenuProps> = ({ open, onClose }) => {
               <ListItemIcon className="menu-item-icon">
                 <GroupWorkIcon />
               </ListItemIcon>
-              <ListItemText 
+              <ListItemText
                 className="menu-item-text"
-                primary="Add Group" 
+                primary="Add Group"
                 secondary="Group container for nodes"
               />
             </ListItemButton>
           </ListItem>
         </List>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </MobileBottomSheet>
   );
 };
 

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -379,7 +379,8 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
     isRightPanelVisible,
     rightPanelSize,
     bottomPanelVisible,
-    bottomPanelSize
+    bottomPanelSize,
+    isMobile
   );
 
   const instantUpdate = useSettingsStore((state) => state.settings.instantUpdate);

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -23,7 +23,8 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { TOOLTIP_ENTER_DELAY, TOOLBAR_WIDTH, PANEL_RESIZE_HANDLE_WIDTH } from "../../config/constants";
 import ThemeToggle from "../ui/ThemeToggle";
 import PanelHeadline from "../ui/PanelHeadline";
-import { ScrollArea, Tooltip, Divider } from "../ui_primitives";
+import { ScrollArea, Tooltip, Divider, MobileBottomSheet } from "../ui_primitives";
+import MenuIcon from "@mui/icons-material/Menu";
 // Icons
 import CodeIcon from "@mui/icons-material/Code";
 import GridViewIcon from "@mui/icons-material/GridView";
@@ -422,6 +423,240 @@ const PanelContent = memo(function PanelContent({
   );
 });
 
+// ---------------------------------------------------------------------------
+// Mobile variant — the left panel becomes a launcher FAB + bottom sheet.
+// ---------------------------------------------------------------------------
+
+const MOBILE_LAUNCHER_TOP = 64; // sits just below the 56px mobile AppHeader
+const MOBILE_LAUNCHER_TOP_STANDALONE = 8;
+
+const mobileLauncherStyles = (theme: Theme, hasHeader: boolean) =>
+  css({
+    position: "fixed",
+    top: `${hasHeader ? MOBILE_LAUNCHER_TOP : MOBILE_LAUNCHER_TOP_STANDALONE}px`,
+    left: 8,
+    zIndex: 1100,
+    backgroundColor: theme.vars.palette.background.paper,
+    color: theme.vars.palette.text.primary,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+    padding: "8px",
+    borderRadius: "10px",
+    "&:hover": {
+      backgroundColor: theme.vars.palette.action.hover
+    },
+    "&.active": {
+      backgroundColor: theme.vars.palette.primary.main,
+      color: theme.vars.palette.primary.contrastText,
+      "&:hover": {
+        backgroundColor: theme.vars.palette.primary.dark
+      }
+    },
+    "& svg": {
+      fontSize: "1.25rem"
+    }
+  });
+
+const mobileHeaderExtrasStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "4px",
+    padding: "8px 12px",
+    overflowX: "auto",
+    WebkitOverflowScrolling: "touch",
+    "& .tab-button": {
+      padding: "6px 10px",
+      borderRadius: "8px",
+      color: theme.vars.palette.text.secondary,
+      minWidth: "auto",
+      "&.active": {
+        backgroundColor: `${theme.vars.palette.action.selected}66`,
+        color: theme.vars.palette.primary.main,
+        boxShadow: `0 0 0 1px ${theme.vars.palette.primary.main}44 inset`
+      },
+      "& svg": {
+        fontSize: "1.1rem"
+      }
+    }
+  });
+
+const MobilePanelLeft: React.FC<{
+  activeView: LeftPanelView;
+  isVisible: boolean;
+  hasHeader: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onViewChange: (view: LeftPanelView) => void;
+  handlePanelToggle: (view: LeftPanelView) => void;
+}> = ({
+  activeView,
+  isVisible,
+  hasHeader,
+  onOpen,
+  onClose,
+  onViewChange,
+  handlePanelToggle
+}) => {
+    const theme = useTheme();
+
+    // Shared modal stores (Collections / Models / Workspaces)
+    const isCollectionsOpen = useCollectionsManagerStore((state) => state.isOpen);
+    const setCollectionsOpen = useCollectionsManagerStore(
+      (state) => state.setIsOpen
+    );
+    const isModelsOpen = useModelManagerStore((state) => state.isOpen);
+    const setModelsOpen = useModelManagerStore((state) => state.setIsOpen);
+    const isWorkspacesOpen = useWorkspaceManagerStore((state) => state.isOpen);
+    const setWorkspacesOpen = useWorkspaceManagerStore(
+      (state) => state.setIsOpen
+    );
+
+    const showModelsWorkspaces =
+      getIsElectronDetails().isElectron || !isProduction;
+
+    const handleSheetViewChange = useCallback(
+      (view: LeftPanelView) => {
+        // On mobile we never want tapping a tab to close the sheet — just switch
+        // the active view. Fall back to the toggle helper only when the sheet is
+        // currently closed (so the caller can open it via the FAB).
+        onViewChange(view);
+      },
+      [onViewChange]
+    );
+
+    const launcherTitle =
+      activeView === "assets" ? "Assets" : "Workflows";
+
+    return (
+      <>
+        <IconButton
+          className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
+          css={mobileLauncherStyles(theme, hasHeader)}
+          onClick={isVisible ? onClose : onOpen}
+          aria-label={isVisible ? "Close panel" : "Open workflows panel"}
+          aria-expanded={isVisible}
+          tabIndex={-1}
+        >
+          <MenuIcon />
+        </IconButton>
+
+        <MobileBottomSheet
+          open={isVisible}
+          onClose={onClose}
+          title={launcherTitle}
+          ariaLabel="Workflows and assets panel"
+          headerExtras={
+            <div css={mobileHeaderExtrasStyles(theme)}>
+              <Tooltip title="Workflows" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+                <IconButton
+                  className={`tab-button ${activeView === "workflowGrid" ? "active" : ""}`}
+                  onClick={() => handleSheetViewChange("workflowGrid")}
+                  aria-label="Show workflows"
+                  tabIndex={-1}
+                >
+                  <GridViewIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Assets" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+                <IconButton
+                  className={`tab-button ${activeView === "assets" ? "active" : ""}`}
+                  onClick={() => handleSheetViewChange("assets")}
+                  aria-label="Show assets"
+                  tabIndex={-1}
+                >
+                  <IconForType
+                    iconName="asset"
+                    showTooltip={false}
+                    iconSize="small"
+                  />
+                </IconButton>
+              </Tooltip>
+
+              <Box sx={{ flex: 1 }} />
+
+              <Tooltip title="Collections" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+                <IconButton
+                  className="tab-button"
+                  onClick={() => setCollectionsOpen(true)}
+                  aria-label="Open collections"
+                  tabIndex={-1}
+                >
+                  <DatasetIcon />
+                </IconButton>
+              </Tooltip>
+              {showModelsWorkspaces && (
+                <>
+                  <Tooltip title="Models" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+                    <IconButton
+                      className="tab-button"
+                      onClick={() => setModelsOpen(true)}
+                      aria-label="Open model manager"
+                      tabIndex={-1}
+                    >
+                      <IconForType
+                        iconName="model"
+                        showTooltip={false}
+                        iconSize="small"
+                      />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Workspaces" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+                    <IconButton
+                      className="tab-button"
+                      onClick={() => setWorkspacesOpen(true)}
+                      aria-label="Open workspaces manager"
+                      tabIndex={-1}
+                    >
+                      <FolderOpenIcon />
+                    </IconButton>
+                  </Tooltip>
+                </>
+              )}
+            </div>
+          }
+        >
+          <Box
+            sx={{
+              height: "65vh",
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden"
+            }}
+          >
+            <ContextMenuProvider>
+              <ContextMenus />
+              <PanelContent
+                activeView={activeView}
+                handlePanelToggle={handlePanelToggle}
+              />
+            </ContextMenuProvider>
+          </Box>
+        </MobileBottomSheet>
+
+        {/* Modals are owned by this subtree on mobile too */}
+        <CollectionsManager
+          open={isCollectionsOpen}
+          onClose={() => setCollectionsOpen(false)}
+        />
+        {showModelsWorkspaces && (
+          <>
+            <ModelsManager
+              open={isModelsOpen}
+              onClose={() => setModelsOpen(false)}
+            />
+            <WorkspacesManager
+              open={isWorkspacesOpen}
+              onClose={() => setWorkspacesOpen(false)}
+            />
+          </>
+        )}
+      </>
+    );
+  };
+
+MobilePanelLeft.displayName = "MobilePanelLeft";
+
 const PanelLeft: React.FC = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -448,6 +683,7 @@ const PanelLeft: React.FC = () => {
 
   const activeView =
     usePanelStore((state) => state.panel.activeView) || "workflowGrid";
+  const setVisibility = usePanelStore((state) => state.setVisibility);
 
   const onViewChange = useCallback(
     (view: LeftPanelView) => {
@@ -460,8 +696,32 @@ const PanelLeft: React.FC = () => {
     handlePanelToggle(activeView);
   }, [handlePanelToggle, activeView]);
 
+  const handleMobileOpen = useCallback(() => {
+    // Ensure the sheet always opens to the current activeView (setting it if
+    // collapsed).
+    handlePanelToggle(activeView);
+  }, [handlePanelToggle, activeView]);
+
+  const handleMobileClose = useCallback(() => {
+    setVisibility(false);
+  }, [setVisibility]);
+
+  if (isMobile) {
+    return (
+      <MobilePanelLeft
+        activeView={activeView as LeftPanelView}
+        isVisible={isVisible}
+        hasHeader={hasHeader}
+        onOpen={handleMobileOpen}
+        onClose={handleMobileClose}
+        onViewChange={onViewChange}
+        handlePanelToggle={handlePanelToggle}
+      />
+    );
+  }
+
   return (
-    <div css={styles(theme, hasHeader, isMobile)} className="panel-left-container">
+    <div css={styles(theme, hasHeader, false)} className="panel-left-container">
       {/* Fixed toolbar - always on the left edge */}
       <ContextMenuProvider>
         <ContextMenus />
@@ -477,12 +737,8 @@ const PanelLeft: React.FC = () => {
             ref={panelRef}
             className={`drawer-content ${isDragging ? "dragging" : ""}`}
             style={{
-              width: `${isMobile
-                ? Math.min(panelSize - TOOLBAR_WIDTH, Math.floor(window.innerWidth * 0.75) - TOOLBAR_WIDTH)
-                : Math.max(panelSize - TOOLBAR_WIDTH, 250)
-                }px`,
-              minWidth: "250px",
-              maxWidth: isMobile ? `calc(75vw - ${TOOLBAR_WIDTH}px)` : "none"
+              width: `${Math.max(panelSize - TOOLBAR_WIDTH, 250)}px`,
+              minWidth: "250px"
             }}
           >
             {/* Resize handle on right edge */}

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Box } from "@mui/material";
+import { Box, IconButton, useMediaQuery } from "@mui/material";
 import Inspector from "../Inspector";
 import { useResizeRightPanel } from "../../hooks/handlers/useResizeRightPanel";
 import { useRightPanelStore, type RightPanelView } from "../../stores/RightPanelStore";
@@ -20,7 +20,7 @@ import { setFrontendToolRuntimeState } from "../../lib/tools/frontendToolRuntime
 import type { NodeStore } from "../../stores/NodeStore";
 import { getWorkflowRunnerStore } from "../../stores/WorkflowRunner";
 
-import { TOOLBAR_WIDTH, PANEL_RESIZE_HANDLE_WIDTH } from "../../config/constants";
+import { TOOLBAR_WIDTH, PANEL_RESIZE_HANDLE_WIDTH, TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import WorkflowAssistantChat from "./WorkflowAssistantChat";
 import LogPanel from "./LogPanel";
 import PanelHeadline from "../ui/PanelHeadline";
@@ -30,6 +30,19 @@ import { VersionHistoryPanel } from "../version";
 import ContextMenus from "../context_menus/ContextMenus";
 import WorkflowForm from "../workflows/WorkflowForm";
 import AgentPanel from "./AgentPanel";
+import { MobileBottomSheet, Tooltip } from "../ui_primitives";
+
+// Icons for mobile tab rail
+import CenterFocusWeakIcon from "@mui/icons-material/CenterFocusWeak";
+import ArticleIcon from "@mui/icons-material/Article";
+import FolderIcon from "@mui/icons-material/Folder";
+import HistoryIcon from "@mui/icons-material/History";
+import SettingsIcon from "@mui/icons-material/Settings";
+import WorkHistoryIcon from "@mui/icons-material/WorkHistory";
+import FolderSpecialIcon from "@mui/icons-material/FolderSpecial";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+import TuneIcon from "@mui/icons-material/Tune";
+import SvgFileIcon from "../SvgFileIcon";
 
 const HEADER_AREA_HEIGHT = 77; // Total header area offset (AppHeader + toolbar row)
 
@@ -145,9 +158,169 @@ const ChatAgentPanel = memo(function ChatAgentPanel({
   return <AgentPanel />;
 });
 
+/* ------------------------------------------------------------------ */
+/*  MobilePanelRight – bottom-sheet variant used on small viewports    */
+/* ------------------------------------------------------------------ */
+
+const MOBILE_LAUNCHER_TOP = 64; // matches mobile AppHeader offset used in PanelLeft
+
+const mobileLauncherStyles = (theme: Theme) =>
+  css({
+    position: "fixed",
+    top: `${MOBILE_LAUNCHER_TOP}px`,
+    right: 8,
+    zIndex: 1100,
+    backgroundColor: theme.vars.palette.background.paper,
+    color: theme.vars.palette.text.primary,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+    padding: "8px",
+    borderRadius: "10px",
+    "&:hover": {
+      backgroundColor: theme.vars.palette.action.hover
+    },
+    "&.active": {
+      backgroundColor: theme.vars.palette.primary.main,
+      color: theme.vars.palette.primary.contrastText,
+      "&:hover": {
+        backgroundColor: theme.vars.palette.primary.dark
+      }
+    },
+    "& svg": {
+      fontSize: "1.25rem"
+    }
+  });
+
+const mobileTabRailStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    flexWrap: "nowrap",
+    gap: "4px",
+    padding: "8px 12px",
+    overflowX: "auto",
+    WebkitOverflowScrolling: "touch",
+    "& .tab-button": {
+      padding: "6px 10px",
+      borderRadius: "8px",
+      color: theme.vars.palette.text.secondary,
+      minWidth: "auto",
+      flexShrink: 0,
+      "&.active": {
+        backgroundColor: `${theme.vars.palette.action.selected}66`,
+        color: theme.vars.palette.primary.main,
+        boxShadow: `0 0 0 1px ${theme.vars.palette.primary.main}44 inset`
+      },
+      "& svg": {
+        fontSize: "1.1rem"
+      }
+    }
+  });
+
+const RIGHT_VIEW_LABELS: Record<RightPanelView, string> = {
+  inspector: "Inspector",
+  assistant: "Assistant",
+  agent: "Agent",
+  workspace: "Workspace",
+  versions: "Versions",
+  workflow: "Settings",
+  workflowAssets: "Assets",
+  jobs: "Jobs",
+  logs: "Logs"
+};
+
+interface MobilePanelRightProps {
+  activeView: RightPanelView;
+  isVisible: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  setView: (view: RightPanelView) => void;
+  children: React.ReactNode;
+}
+
+const MobilePanelRight: React.FC<MobilePanelRightProps> = ({
+  activeView,
+  isVisible,
+  onOpen,
+  onClose,
+  setView,
+  children
+}) => {
+  const theme = useTheme();
+
+  const renderTabButton = (
+    view: RightPanelView,
+    label: string,
+    icon: React.ReactNode
+  ) => (
+    <Tooltip title={label} placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+      <IconButton
+        className={`tab-button ${activeView === view ? "active" : ""}`}
+        onClick={() => setView(view)}
+        aria-label={label}
+        tabIndex={-1}
+      >
+        {icon}
+      </IconButton>
+    </Tooltip>
+  );
+
+  return (
+    <>
+      <IconButton
+        className={`panel-right-mobile-launcher ${isVisible ? "active" : ""}`}
+        css={mobileLauncherStyles(theme)}
+        onClick={isVisible ? onClose : onOpen}
+        aria-label={isVisible ? "Close panel" : "Open inspector panel"}
+        aria-expanded={isVisible}
+        tabIndex={-1}
+      >
+        <TuneIcon />
+      </IconButton>
+
+      <MobileBottomSheet
+        open={isVisible}
+        onClose={onClose}
+        title={RIGHT_VIEW_LABELS[activeView] ?? "Panel"}
+        ariaLabel="Inspector and workflow panels"
+        headerExtras={
+          <div css={mobileTabRailStyles(theme)}>
+            {renderTabButton("inspector", "Inspector", <CenterFocusWeakIcon />)}
+            {renderTabButton(
+              "assistant",
+              "Assistant",
+              <SvgFileIcon iconName="assistant" svgProp={{ width: 18, height: 18 }} />
+            )}
+            {renderTabButton("agent", "Agent", <SmartToyIcon />)}
+            {renderTabButton("workspace", "Workspace", <FolderIcon />)}
+            {renderTabButton("workflow", "Settings", <SettingsIcon />)}
+            {renderTabButton("workflowAssets", "Assets", <FolderSpecialIcon />)}
+            {renderTabButton("versions", "Versions", <HistoryIcon />)}
+            {renderTabButton("logs", "Logs", <ArticleIcon />)}
+            {renderTabButton("jobs", "Jobs", <WorkHistoryIcon />)}
+          </div>
+        }
+      >
+        <Box
+          sx={{
+            height: "65vh",
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden"
+          }}
+        >
+          {children}
+        </Box>
+      </MobileBottomSheet>
+    </>
+  );
+};
+
+MobilePanelRight.displayName = "MobilePanelRight";
+
 const PanelRight: React.FC = () => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const {
     ref: panelRef,
     size: panelSize,
@@ -159,6 +332,7 @@ const PanelRight: React.FC = () => {
 
   const activeView = useRightPanelStore((state) => state.panel.activeView);
   const setActiveView = useRightPanelStore((state) => state.setActiveView);
+  const setVisibility = useRightPanelStore((state) => state.setVisibility);
 
   const activeNodeStore = useWorkflowManager((state) =>
     state.currentWorkflowId
@@ -366,6 +540,126 @@ const PanelRight: React.FC = () => {
   const handleWorkflowAssetsToggle = useCallback(() => handlePanelToggle("workflowAssets"), [handlePanelToggle]);
   const handleAgentToggle = useCallback(() => handlePanelToggle("agent"), [handlePanelToggle]);
 
+  const handleMobileSheetClose = useCallback(
+    () => setVisibility(false),
+    [setVisibility]
+  );
+  const handleMobileSheetOpen = useCallback(
+    () => setVisibility(true),
+    [setVisibility]
+  );
+  const mobileSetView = useCallback(
+    (view: RightPanelView) => {
+      // On mobile, tapping a tab should always keep the sheet open and switch.
+      setActiveView(view);
+      setVisibility(true);
+    },
+    [setActiveView, setVisibility]
+  );
+
+  // The view-specific body is shared between desktop (in the fixed drawer) and
+  // mobile (inside a bottom sheet).
+  const panelBody = (
+    <ContextMenuProvider>
+      <ReactFlowProvider>
+        {activeView === "logs" ? (
+          <LogPanel />
+        ) : activeView === "jobs" ? (
+          <Box
+            className="jobs-panel"
+            sx={{
+              width: "100%",
+              height: "100%",
+              overflow: "auto",
+              padding: "0 1em"
+            }}
+          >
+            <PanelHeadline title="Jobs" />
+            <JobsPanel />
+          </Box>
+        ) : activeView === "workspace" ? (
+          <Box
+            className="workspace-panel"
+            sx={{
+              width: "100%",
+              height: "100%",
+              overflow: "hidden"
+            }}
+          >
+            <WorkspaceTree />
+          </Box>
+        ) : activeView === "versions" ? (
+          currentWorkflowId ? (
+            <VersionHistoryPanel
+              workflowId={currentWorkflowId}
+              onRestore={handleRestoreVersion}
+              onClose={() => handlePanelToggle("versions")}
+            />
+          ) : null
+        ) : activeView === "workflow" ? (
+          activeNodeStore && currentWorkflowId && currentWorkflow ? (
+            <Box
+              className="workflow-panel"
+              sx={{
+                width: "100%",
+                height: "100%",
+                overflow: "auto"
+              }}
+            >
+              <WorkflowForm
+                workflow={currentWorkflow}
+                onClose={handleWorkflowToggle}
+              />
+            </Box>
+          ) : null
+        ) : activeView === "workflowAssets" ? (
+          <Box
+            className="workflow-assets-panel"
+            sx={{
+              width: "100%",
+              height: "100%",
+              overflow: "hidden",
+              display: "flex",
+              flexDirection: "column",
+              padding: "0 1em"
+            }}
+          >
+            <PanelHeadline title="Workflow Assets" />
+            <Box className="workflow-assets-panel-inner" sx={{ flex: 1, overflow: "hidden" }}>
+              <WorkflowAssetPanel />
+            </Box>
+          </Box>
+        ) : (activeView === "assistant" || activeView === "agent") ? (
+          <ChatAgentPanel
+            activeTab={activeView}
+            activeNodeStore={activeNodeStore}
+          />
+        ) : (
+          activeNodeStore && (
+            <NodeContext.Provider value={activeNodeStore}>
+              <ContextMenus />
+              {activeView === "inspector" && <Inspector />}
+            </NodeContext.Provider>
+          )
+        )}
+      </ReactFlowProvider>
+    </ContextMenuProvider>
+  );
+
+  if (isMobile) {
+    return (
+      <MobilePanelRight
+        activeView={activeView}
+        isVisible={isVisible}
+        onOpen={handleMobileSheetOpen}
+        onClose={handleMobileSheetClose}
+        setView={mobileSetView}
+      >
+        {panelBody}
+      </MobilePanelRight>
+    );
+  }
+
   return (
     <div css={styles(theme)} className="panel-right-container">
       {/* Drawer content - appears left of toolbar when visible */}
@@ -383,92 +677,7 @@ const PanelRight: React.FC = () => {
             aria-label="Resize panel"
             tabIndex={-1}
           />
-          <div className="panel-inner-content">
-            <ContextMenuProvider>
-              <ReactFlowProvider>
-                {activeView === "logs" ? (
-                  <LogPanel />
-                ) : activeView === "jobs" ? (
-                  <Box
-                    className="jobs-panel"
-                    sx={{
-                      width: "100%",
-                      height: "100%",
-                      overflow: "auto",
-                      padding: "0 1em"
-                    }}
-                  >
-                    <PanelHeadline title="Jobs" />
-                    <JobsPanel />
-                  </Box>
-                ) : activeView === "workspace" ? (
-                  <Box
-                    className="workspace-panel"
-                    sx={{
-                      width: "100%",
-                      height: "100%",
-                      overflow: "hidden"
-                    }}
-                  >
-                    <WorkspaceTree />
-                  </Box>
-                ) : activeView === "versions" ? (
-                  currentWorkflowId ? (
-                    <VersionHistoryPanel
-                      workflowId={currentWorkflowId}
-                      onRestore={handleRestoreVersion}
-                      onClose={() => handlePanelToggle("versions")}
-                    />
-                  ) : null
-                ) : activeView === "workflow" ? (
-                  activeNodeStore && currentWorkflowId && currentWorkflow ? (
-                    <Box
-                      className="workflow-panel"
-                      sx={{
-                        width: "100%",
-                        height: "100%",
-                        overflow: "auto"
-                      }}
-                    >
-                      <WorkflowForm
-                        workflow={currentWorkflow}
-                        onClose={handleWorkflowToggle}
-                      />
-                    </Box>
-                  ) : null
-                ) : activeView === "workflowAssets" ? (
-                  <Box
-                    className="workflow-assets-panel"
-                    sx={{
-                      width: "100%",
-                      height: "100%",
-                      overflow: "hidden",
-                      display: "flex",
-                      flexDirection: "column",
-                      padding: "0 1em"
-                    }}
-                  >
-                    <PanelHeadline title="Workflow Assets" />
-                    <Box className="workflow-assets-panel-inner" sx={{ flex: 1, overflow: "hidden" }}>
-                      <WorkflowAssetPanel />
-                    </Box>
-                  </Box>
-                ) : (activeView === "assistant" || activeView === "agent") ? (
-                  <ChatAgentPanel
-                    activeTab={activeView}
-                    activeNodeStore={activeNodeStore}
-                  />
-                ) : (
-                  activeNodeStore && (
-                    <NodeContext.Provider value={activeNodeStore}>
-                      <ContextMenus />
-                      {activeView === "inspector" && <Inspector />}
-                    </NodeContext.Provider>
-                  )
-                )}
-              </ReactFlowProvider>
-            </ContextMenuProvider>
-          </div>
+          <div className="panel-inner-content">{panelBody}</div>
         </div>
       )}
 

--- a/web/src/components/ui_primitives/MobileBottomSheet.tsx
+++ b/web/src/components/ui_primitives/MobileBottomSheet.tsx
@@ -1,0 +1,141 @@
+/**
+ * MobileBottomSheet
+ *
+ * A bottom-anchored sheet for mobile viewports. Slides up from the bottom
+ * edge, has rounded top corners, a drag-handle affordance, and an optional
+ * header with a close button. Used to replace fixed side panels on small
+ * screens where horizontal space is at a premium.
+ */
+
+import React, { memo } from "react";
+import { SwipeableDrawer } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { CloseButton } from "./CloseButton";
+import { Text } from "./Text";
+import { FlexRow } from "./FlexRow";
+
+export interface MobileBottomSheetProps {
+  /** Whether the sheet is open */
+  open: boolean;
+  /** Close handler — invoked when the user taps the scrim, swipes down, or hits the close button */
+  onClose: () => void;
+  /** Open handler — required by SwipeableDrawer for swipe-to-open; we disable discovery swipe below, so this is effectively a no-op */
+  onOpen?: () => void;
+  /** Optional title shown in the header row. If omitted, no header is rendered (sheet has just the drag handle and content). */
+  title?: React.ReactNode;
+  /** Optional secondary row under the title (e.g. a tab rail) */
+  headerExtras?: React.ReactNode;
+  /** Max height of the sheet. Accepts any CSS size value. */
+  maxHeight?: string;
+  /** Content rendered in the scrollable body area. */
+  children: React.ReactNode;
+  /** Set to false to hide the drag handle at the top */
+  showDragHandle?: boolean;
+  /** Set to false to hide the close button in the header row */
+  showClose?: boolean;
+  /** Optional ARIA label applied to the sheet container for screen readers */
+  ariaLabel?: string;
+}
+
+const getSx = (theme: Theme, maxHeight: string): SxProps<Theme> => ({
+  "& .MuiDrawer-paper": {
+    maxHeight,
+    height: "auto",
+    borderTopLeftRadius: "16px",
+    borderTopRightRadius: "16px",
+    backgroundColor: theme.vars.palette.background.default,
+    backgroundImage: "none",
+    overflow: "hidden",
+    display: "flex",
+    flexDirection: "column",
+    boxShadow: "0 -8px 32px rgba(0, 0, 0, 0.25)"
+  },
+  "& .sheet-drag-handle": {
+    display: "flex",
+    justifyContent: "center",
+    padding: "8px 0 4px 0",
+    flexShrink: 0,
+    "&::after": {
+      content: '""',
+      display: "block",
+      width: "40px",
+      height: "4px",
+      borderRadius: "2px",
+      backgroundColor: theme.vars.palette.grey[600]
+    }
+  },
+  "& .sheet-header": {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "8px 16px 8px 20px",
+    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    flexShrink: 0
+  },
+  "& .sheet-header-extras": {
+    flexShrink: 0,
+    borderBottom: `1px solid ${theme.vars.palette.divider}`
+  },
+  "& .sheet-body": {
+    flex: 1,
+    overflow: "auto",
+    WebkitOverflowScrolling: "touch"
+  }
+});
+
+const MobileBottomSheetInternal: React.FC<MobileBottomSheetProps> = ({
+  open,
+  onClose,
+  onOpen,
+  title,
+  headerExtras,
+  maxHeight = "80vh",
+  children,
+  showDragHandle = true,
+  showClose = true,
+  ariaLabel
+}) => {
+  const theme = useTheme();
+
+  const handleOpen = React.useCallback(() => {
+    onOpen?.();
+  }, [onOpen]);
+
+  return (
+    <SwipeableDrawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      onOpen={handleOpen}
+      // Disable edge-swipe to open so it doesn't conflict with canvas gestures.
+      disableSwipeToOpen
+      disableDiscovery
+      ModalProps={{ keepMounted: false }}
+      sx={getSx(theme, maxHeight)}
+      aria-label={ariaLabel}
+    >
+      {showDragHandle && (
+        <div
+          className="sheet-drag-handle"
+          role="presentation"
+          aria-hidden="true"
+        />
+      )}
+      {title && (
+        <FlexRow className="sheet-header" align="center">
+          <Text size="big" weight={600} sx={{ lineHeight: 1.2 }}>
+            {title}
+          </Text>
+          {showClose && (
+            <CloseButton onClick={onClose} buttonSize="small" tooltip="Close" />
+          )}
+        </FlexRow>
+      )}
+      {headerExtras && <div className="sheet-header-extras">{headerExtras}</div>}
+      <div className="sheet-body">{children}</div>
+    </SwipeableDrawer>
+  );
+};
+
+export const MobileBottomSheet = memo(MobileBottomSheetInternal);

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -287,6 +287,9 @@ export type { SkeletonProps } from "./Skeleton";
 export { DrawerPanel } from "./DrawerPanel";
 export type { DrawerPanelProps } from "./DrawerPanel";
 
+export { MobileBottomSheet } from "./MobileBottomSheet";
+export type { MobileBottomSheetProps } from "./MobileBottomSheet";
+
 // Phase 4 - Additional primitives
 
 export { Checkbox } from "./Checkbox";

--- a/web/src/hooks/__tests__/useFloatingToolbarPosition.test.ts
+++ b/web/src/hooks/__tests__/useFloatingToolbarPosition.test.ts
@@ -59,6 +59,16 @@ describe("useFloatingToolbarPosition", () => {
     });
   });
 
+  it("skips right-panel horizontal offset on mobile", () => {
+    const { result } = renderHook(() =>
+      useFloatingToolbarPosition(true, 300, false, 0, true)
+    );
+
+    // On mobile the right panel renders as a bottom sheet, so the toolbar
+    // should stay centered (no `right`/`left`/`transform` override).
+    expect(result.current).toEqual({ bottom: "20px" });
+  });
+
   it("respects minimum bottom offset of 80px", () => {
     const { result } = renderHook(() =>
       useFloatingToolbarPosition(false, 0, true, 10)

--- a/web/src/hooks/useFloatingToolbarPosition.ts
+++ b/web/src/hooks/useFloatingToolbarPosition.ts
@@ -7,19 +7,22 @@ import { useMemo } from "react";
  * @param rightPanelSize - Width of the right panel in pixels
  * @param bottomPanelVisible - Whether the bottom panel is visible
  * @param bottomPanelSize - Height of the bottom panel in pixels
+ * @param isMobile - When true, skip the side-panel horizontal offset (mobile
+ *   renders the right panel as a bottom sheet, not a fixed side panel).
  * @returns CSS style object for toolbar positioning
  */
 export const useFloatingToolbarPosition = (
   isRightPanelVisible: boolean,
   rightPanelSize: number,
   bottomPanelVisible: boolean,
-  bottomPanelSize: number
+  bottomPanelSize: number,
+  isMobile: boolean = false
 ): React.CSSProperties => {
   return useMemo(() => {
     const style: React.CSSProperties = {};
 
-    // Adjust horizontal position when right panel is visible
-    if (isRightPanelVisible) {
+    // Adjust horizontal position when right panel is visible (desktop only).
+    if (isRightPanelVisible && !isMobile) {
       style.left = "auto";
       style.transform = "none";
       style.right = `${Math.max(rightPanelSize + 20, 72)}px`;
@@ -40,5 +43,11 @@ export const useFloatingToolbarPosition = (
     }
 
     return style;
-  }, [isRightPanelVisible, rightPanelSize, bottomPanelVisible, bottomPanelSize]);
+  }, [
+    isRightPanelVisible,
+    rightPanelSize,
+    bottomPanelVisible,
+    bottomPanelSize,
+    isMobile
+  ]);
 };


### PR DESCRIPTION
Replace the awkward squeezed-to-75vw side panels on mobile with a
consistent bottom-sheet pattern:

- New MobileBottomSheet primitive (SwipeableDrawer with rounded top,
  drag handle, title row, optional tab rail) under ui_primitives/.
- PanelLeft: on mobile, hide the vertical toolbar and render the
  workflows/assets content inside the bottom sheet. A small hamburger
  FAB pinned to the top-left toggles the sheet; a horizontal tab rail
  in the sheet header switches views and exposes the Collections,
  Models, and Workspaces modals.
- PanelRight: on mobile, hide the vertical toolbar and render the
  Inspector/Assistant/Agent/Workspace/Settings/Assets/Versions/Logs/Jobs
  views inside the bottom sheet. A TuneIcon FAB pinned top-right toggles
  the sheet; the tab rail switches between views without closing.
- MobilePaneMenu (FloatingToolBar canvas menu): converted from a
  fullscreen Dialog to the same MobileBottomSheet primitive for visual
  consistency.
- useFloatingToolbarPosition: accept an isMobile flag and skip the
  right-panel horizontal offset, since the right panel no longer takes
  horizontal space on mobile.

Desktop behavior is unchanged; all mobile branches are gated on
theme.breakpoints.down("sm").