### PR TITLE
feat(mobile): add asset view screens

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -10,6 +10,8 @@ import SettingsScreen from './src/screens/SettingsScreen';
 import ChatScreen from './src/screens/ChatScreen';
 import LanguageModelSelectionScreen from './src/screens/LanguageModelSelectionScreen';
 import GraphEditorScreen from './src/screens/GraphEditorScreen';
+import AssetsScreen from './src/screens/AssetsScreen';
+import AssetViewerScreen from './src/screens/AssetViewerScreen';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { apiService } from './src/services/api';
 import { useTheme } from './src/hooks/useTheme';
@@ -100,6 +102,16 @@ export default function App() {
               name="LanguageModelSelection"
               component={LanguageModelSelectionScreen}
               options={{ title: 'Select Provider' }}
+            />
+            <Stack.Screen
+              name="Assets"
+              component={AssetsScreen}
+              options={{ title: 'Assets' }}
+            />
+            <Stack.Screen
+              name="AssetViewer"
+              component={AssetViewerScreen}
+              options={{ title: 'Asset' }}
             />
           </Stack.Navigator>
         </NavigationContainer>

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -10,4 +10,11 @@ export type RootStackParamList = {
   Settings: undefined;
   Chat: undefined;
   LanguageModelSelection: undefined;
+  Assets: {
+    parentId?: string;
+    folderName?: string;
+  } | undefined;
+  AssetViewer: {
+    assetId: string;
+  };
 };

--- a/mobile/src/screens/AssetViewerScreen.tsx
+++ b/mobile/src/screens/AssetViewerScreen.tsx
@@ -1,0 +1,705 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  TextInput,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  Share,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Video, ResizeMode, Audio } from 'expo-av';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp } from '@react-navigation/native';
+import { apiService, Asset } from '../services/api';
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type AssetViewerScreenProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'AssetViewer'>;
+  route: RouteProp<RootStackParamList, 'AssetViewer'>;
+};
+
+function formatBytes(bytes?: number | null): string {
+  if (bytes == null || bytes <= 0) return 'Unknown size';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return `${size.toFixed(size < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatDuration(seconds?: number | null): string | null {
+  if (seconds == null) return null;
+  const total = Math.floor(seconds);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export default function AssetViewerScreen({ navigation, route }: AssetViewerScreenProps) {
+  const { assetId } = route.params;
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const [asset, setAsset] = useState<Asset | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+  const [isSavingRename, setIsSavingRename] = useState(false);
+  const [isAudioPlaying, setIsAudioPlaying] = useState(false);
+  const [audioPosition, setAudioPosition] = useState(0);
+  const [audioDuration, setAudioDuration] = useState(0);
+  const soundRef = useRef<Audio.Sound | null>(null);
+
+  const loadAsset = useCallback(async () => {
+    try {
+      setLoadError(null);
+      const data = await apiService.getAsset(assetId);
+      setAsset(data);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Failed to load asset';
+      setLoadError(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [assetId]);
+
+  useEffect(() => {
+    loadAsset();
+  }, [loadAsset]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: asset?.name || 'Asset',
+    });
+  }, [navigation, asset?.name]);
+
+  // Audio playback lifecycle
+  useEffect(() => {
+    const uri = asset?.get_url;
+    const isAudio = asset?.content_type?.startsWith('audio/');
+    if (!uri || !isAudio) return;
+
+    let isCancelled = false;
+    (async () => {
+      try {
+        const { sound, status } = await Audio.Sound.createAsync(
+          { uri },
+          { shouldPlay: false },
+          (s) => {
+            if (!s.isLoaded) return;
+            setAudioPosition(s.positionMillis || 0);
+            setIsAudioPlaying(s.isPlaying);
+            if (s.didJustFinish) {
+              setIsAudioPlaying(false);
+              setAudioPosition(0);
+            }
+          }
+        );
+        if (isCancelled) {
+          await sound.unloadAsync();
+          return;
+        }
+        soundRef.current = sound;
+        if (status.isLoaded && status.durationMillis) {
+          setAudioDuration(status.durationMillis);
+        }
+      } catch (err) {
+        console.error('Failed to load audio:', err);
+      }
+    })();
+
+    return () => {
+      isCancelled = true;
+      const existing = soundRef.current;
+      soundRef.current = null;
+      if (existing) {
+        existing.unloadAsync().catch(() => undefined);
+      }
+    };
+  }, [asset?.get_url, asset?.content_type]);
+
+  const toggleAudio = useCallback(async () => {
+    const sound = soundRef.current;
+    if (!sound) return;
+    try {
+      if (isAudioPlaying) {
+        await sound.pauseAsync();
+      } else {
+        await sound.playAsync();
+      }
+    } catch (err) {
+      console.error('Audio playback error:', err);
+    }
+  }, [isAudioPlaying]);
+
+  const handleOpenRename = useCallback(() => {
+    if (!asset) return;
+    setRenameValue(asset.name);
+    setIsRenaming(true);
+  }, [asset]);
+
+  const handleRename = useCallback(async () => {
+    if (!asset) return;
+    const newName = renameValue.trim();
+    if (!newName || newName === asset.name) {
+      setIsRenaming(false);
+      return;
+    }
+    try {
+      setIsSavingRename(true);
+      const updated = await apiService.updateAsset(asset.id, {
+        name: newName,
+        parent_id: null,
+        content_type: null,
+      });
+      setAsset(updated);
+      setIsRenaming(false);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Failed to rename';
+      Alert.alert('Error', msg);
+    } finally {
+      setIsSavingRename(false);
+    }
+  }, [asset, renameValue]);
+
+  const handleDelete = useCallback(() => {
+    if (!asset) return;
+    Alert.alert(
+      'Delete asset?',
+      `This will permanently delete "${asset.name}".`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await apiService.deleteAsset(asset.id);
+              navigation.goBack();
+            } catch (error: unknown) {
+              const msg = error instanceof Error ? error.message : 'Failed to delete';
+              Alert.alert('Error', msg);
+            }
+          },
+        },
+      ]
+    );
+  }, [asset, navigation]);
+
+  const handleShare = useCallback(async () => {
+    if (!asset?.get_url) return;
+    try {
+      await Share.share({
+        message: asset.get_url,
+        url: asset.get_url,
+        title: asset.name,
+      });
+    } catch (error: unknown) {
+      console.error('Share failed:', error);
+    }
+  }, [asset]);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (loadError || !asset) {
+    return (
+      <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={[styles.errorIconWrap, { backgroundColor: colors.primaryMuted }]}>
+          <Ionicons name="alert-circle-outline" size={40} color={colors.error} />
+        </View>
+        <Text style={[styles.errorText, { color: colors.text }]}>
+          Could not load asset
+        </Text>
+        {loadError ? (
+          <Text style={[styles.errorSubtext, { color: colors.textSecondary }]}>
+            {loadError}
+          </Text>
+        ) : null}
+        <TouchableOpacity
+          style={[styles.actionButton, shadows.small, { backgroundColor: colors.primary }]}
+          onPress={loadAsset}
+          accessibilityRole="button"
+          accessibilityLabel="Retry"
+        >
+          <Ionicons name="refresh-outline" size={18} color="#FFFFFF" style={{ marginRight: 8 }} />
+          <Text style={styles.actionButtonText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const contentType = asset.content_type || '';
+  const isImage = contentType.startsWith('image/');
+  const isVideo = contentType.startsWith('video/');
+  const isAudio = contentType.startsWith('audio/');
+  const url = asset.get_url;
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+    >
+      <View style={[styles.previewContainer, { backgroundColor: colors.surfaceElevated }]}>
+        {isImage && url ? (
+          <Image
+            source={{ uri: url }}
+            style={styles.previewImage}
+            resizeMode="contain"
+            accessibilityLabel={asset.name}
+          />
+        ) : isVideo && url ? (
+          <Video
+            source={{ uri: url }}
+            style={styles.previewVideo}
+            useNativeControls
+            resizeMode={ResizeMode.CONTAIN}
+            isLooping={false}
+          />
+        ) : isAudio ? (
+          <View style={styles.audioPreview}>
+            <View style={[styles.audioIconWrap, { backgroundColor: colors.primaryMuted }]}>
+              <Ionicons name="musical-notes" size={48} color={colors.primary} />
+            </View>
+            <TouchableOpacity
+              onPress={toggleAudio}
+              style={[styles.audioPlayButton, { backgroundColor: colors.primary }]}
+              accessibilityRole="button"
+              accessibilityLabel={isAudioPlaying ? 'Pause audio' : 'Play audio'}
+            >
+              <Ionicons
+                name={isAudioPlaying ? 'pause' : 'play'}
+                size={28}
+                color={colors.textOnPrimary}
+              />
+            </TouchableOpacity>
+            <View style={[styles.audioProgress, { backgroundColor: colors.borderLight }]}>
+              <View
+                style={[
+                  styles.audioProgressFill,
+                  {
+                    backgroundColor: colors.primary,
+                    width: audioDuration > 0
+                      ? `${Math.min(100, (audioPosition / audioDuration) * 100)}%`
+                      : '0%',
+                  },
+                ]}
+              />
+            </View>
+            <Text style={[styles.audioTime, { color: colors.textSecondary }]}>
+              {formatAudioTime(audioPosition)} / {formatAudioTime(audioDuration)}
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.filePreview}>
+            <View style={[styles.fileIconWrap, { backgroundColor: colors.primaryMuted }]}>
+              <Ionicons
+                name={iconForContentType(contentType)}
+                size={56}
+                color={colors.primary}
+              />
+            </View>
+            <Text style={[styles.fileTypeText, { color: colors.textSecondary }]}>
+              {contentType || 'Unknown type'}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <View style={styles.infoSection}>
+        <Text style={[styles.assetName, { color: colors.text }]} numberOfLines={2}>
+          {asset.name}
+        </Text>
+        <Text style={[styles.assetMeta, { color: colors.textSecondary }]}>
+          {contentType || 'Unknown'} · {formatBytes(asset.size)}
+        </Text>
+      </View>
+
+      <View style={[styles.detailCard, shadows.small, { backgroundColor: colors.cardBg, borderColor: colors.borderLight }]}>
+        <DetailRow label="Name" value={asset.name} colors={colors} />
+        <DetailRow label="Type" value={contentType || 'Unknown'} colors={colors} />
+        <DetailRow label="Size" value={formatBytes(asset.size)} colors={colors} />
+        {formatDuration(asset.duration) && (
+          <DetailRow
+            label="Duration"
+            value={formatDuration(asset.duration) as string}
+            colors={colors}
+          />
+        )}
+        <DetailRow label="Created" value={formatDate(asset.created_at)} colors={colors} />
+        <DetailRow label="ID" value={asset.id} colors={colors} mono last />
+      </View>
+
+      <View style={styles.actionsRow}>
+        <TouchableOpacity
+          style={[styles.actionButton, { backgroundColor: colors.primary }]}
+          onPress={handleOpenRename}
+          accessibilityRole="button"
+          accessibilityLabel="Rename asset"
+        >
+          <Ionicons name="create-outline" size={18} color="#FFFFFF" style={{ marginRight: 6 }} />
+          <Text style={styles.actionButtonText}>Rename</Text>
+        </TouchableOpacity>
+        {url && (
+          <TouchableOpacity
+            style={[styles.actionButtonOutline, { backgroundColor: colors.surface, borderColor: colors.border }]}
+            onPress={handleShare}
+            accessibilityRole="button"
+            accessibilityLabel="Share asset"
+          >
+            <Ionicons name="share-outline" size={18} color={colors.text} style={{ marginRight: 6 }} />
+            <Text style={[styles.actionButtonOutlineText, { color: colors.text }]}>Share</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          style={[styles.actionButtonOutline, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          onPress={handleDelete}
+          accessibilityRole="button"
+          accessibilityLabel="Delete asset"
+        >
+          <Ionicons name="trash-outline" size={18} color={colors.error} style={{ marginRight: 6 }} />
+          <Text style={[styles.actionButtonOutlineText, { color: colors.error }]}>Delete</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Modal
+        visible={isRenaming}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setIsRenaming(false)}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.modalBackdrop}
+        >
+          <View style={[styles.modalCard, shadows.large, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Rename asset</Text>
+            <TextInput
+              style={[
+                styles.modalInput,
+                {
+                  color: colors.text,
+                  borderColor: colors.border,
+                  backgroundColor: colors.inputBg,
+                },
+              ]}
+              value={renameValue}
+              onChangeText={setRenameValue}
+              placeholder="Asset name"
+              placeholderTextColor={colors.textTertiary}
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect={false}
+              selectTextOnFocus
+            />
+            <View style={styles.modalActions}>
+              <TouchableOpacity
+                style={[styles.actionButtonOutline, { backgroundColor: colors.surface, borderColor: colors.border }]}
+                onPress={() => setIsRenaming(false)}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel rename"
+                disabled={isSavingRename}
+              >
+                <Text style={[styles.actionButtonOutlineText, { color: colors.text }]}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.actionButton, { backgroundColor: colors.primary }]}
+                onPress={handleRename}
+                accessibilityRole="button"
+                accessibilityLabel="Save rename"
+                disabled={isSavingRename}
+              >
+                {isSavingRename ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.actionButtonText}>Save</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </ScrollView>
+  );
+}
+
+function formatAudioTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function iconForContentType(contentType: string): keyof typeof Ionicons.glyphMap {
+  if (contentType === 'folder') return 'folder';
+  if (contentType.startsWith('image/')) return 'image-outline';
+  if (contentType.startsWith('video/')) return 'film-outline';
+  if (contentType.startsWith('audio/')) return 'musical-notes-outline';
+  if (contentType.startsWith('text/')) return 'document-text-outline';
+  if (contentType.includes('pdf')) return 'document-text-outline';
+  if (contentType.includes('json') || contentType.includes('xml')) return 'code-outline';
+  if (contentType.includes('zip') || contentType.includes('archive')) return 'archive-outline';
+  return 'document-outline';
+}
+
+type DetailRowProps = {
+  label: string;
+  value: string;
+  colors: {
+    text: string;
+    textSecondary: string;
+    borderLight: string;
+  };
+  mono?: boolean;
+  last?: boolean;
+};
+
+function DetailRow({ label, value, colors, mono, last }: DetailRowProps) {
+  return (
+    <View
+      style={[
+        styles.detailRow,
+        !last && { borderBottomColor: colors.borderLight, borderBottomWidth: StyleSheet.hairlineWidth },
+      ]}
+    >
+      <Text style={[styles.detailLabel, { color: colors.textSecondary }]}>{label}</Text>
+      <Text
+        style={[
+          styles.detailValue,
+          { color: colors.text },
+          mono && styles.detailValueMono,
+        ]}
+        selectable
+        numberOfLines={mono ? 1 : 2}
+        ellipsizeMode={mono ? 'middle' : 'tail'}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  previewContainer: {
+    width: '100%',
+    aspectRatio: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  previewImage: {
+    width: '100%',
+    height: '100%',
+  },
+  previewVideo: {
+    width: '100%',
+    height: '100%',
+  },
+  filePreview: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fileIconWrap: {
+    width: 120,
+    height: 120,
+    borderRadius: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  fileTypeText: {
+    fontSize: 13,
+  },
+  audioPreview: {
+    width: '100%',
+    paddingHorizontal: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  audioIconWrap: {
+    width: 96,
+    height: 96,
+    borderRadius: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  audioPlayButton: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  audioProgress: {
+    width: '100%',
+    height: 6,
+    borderRadius: 3,
+    overflow: 'hidden',
+    marginBottom: 8,
+  },
+  audioProgressFill: {
+    height: '100%',
+  },
+  audioTime: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+  },
+  infoSection: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 12,
+  },
+  assetName: {
+    fontSize: 22,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginBottom: 6,
+  },
+  assetMeta: {
+    fontSize: 14,
+  },
+  detailCard: {
+    marginHorizontal: 16,
+    marginTop: 8,
+    padding: 12,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    paddingVertical: 10,
+    alignItems: 'flex-start',
+  },
+  detailLabel: {
+    fontSize: 13,
+    width: 80,
+    marginRight: 8,
+  },
+  detailValue: {
+    flex: 1,
+    fontSize: 14,
+  },
+  detailValueMono: {
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    fontSize: 12,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    gap: 10,
+    flexWrap: 'wrap',
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  actionButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  actionButtonOutline: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  actionButtonOutlineText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  errorIconWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  errorText: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 6,
+  },
+  errorSubtext: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  modalBackdrop: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  modalCard: {
+    width: '100%',
+    maxWidth: 420,
+    borderRadius: 16,
+    padding: 20,
+  },
+  modalTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    marginBottom: 16,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+  },
+});

--- a/mobile/src/screens/AssetsScreen.tsx
+++ b/mobile/src/screens/AssetsScreen.tsx
@@ -1,0 +1,478 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+  Alert,
+  TextInput,
+  Image,
+  Dimensions,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp } from '@react-navigation/native';
+import { apiService, Asset } from '../services/api';
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type AssetsScreenProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Assets'>;
+  route: RouteProp<RootStackParamList, 'Assets'>;
+};
+
+const GRID_COLUMNS = 3;
+const GRID_GAP = 10;
+const GRID_PADDING = 16;
+
+type LoadMode = 'folder' | 'search';
+
+export default function AssetsScreen({ navigation, route }: AssetsScreenProps) {
+  const parentId = route.params?.parentId;
+  const folderName = route.params?.folderName;
+  const isRootFolder = !parentId;
+
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [loadMode, setLoadMode] = useState<LoadMode>('folder');
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const screenWidth = Dimensions.get('window').width;
+  const itemSize = useMemo(() => {
+    const totalGaps = GRID_GAP * (GRID_COLUMNS - 1);
+    const available = screenWidth - GRID_PADDING * 2 - totalGaps;
+    return Math.floor(available / GRID_COLUMNS);
+  }, [screenWidth]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: folderName || 'Assets',
+    });
+  }, [navigation, folderName]);
+
+  const loadAssets = useCallback(async () => {
+    try {
+      setLoadError(null);
+      if (debouncedQuery.trim().length >= 2) {
+        setLoadMode('search');
+        const result = await apiService.searchAssets({
+          query: debouncedQuery.trim(),
+          page_size: 200,
+        });
+        setAssets((result.assets || []) as unknown as Asset[]);
+      } else {
+        setLoadMode('folder');
+        const result = await apiService.listAssets({
+          parent_id: parentId ?? null,
+          page_size: 500,
+        });
+        setAssets(result.assets || []);
+      }
+    } catch (error: unknown) {
+      console.error('Failed to load assets:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Network Error';
+      setLoadError(errorMessage);
+      setAssets([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [parentId, debouncedQuery]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    loadAssets();
+  }, [loadAssets]);
+
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleSearchChange = useCallback((text: string) => {
+    setSearchQuery(text);
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+    }
+    searchTimerRef.current = setTimeout(() => {
+      setDebouncedQuery(text);
+    }, 300);
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+    }
+    setSearchQuery('');
+    setDebouncedQuery('');
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await loadAssets();
+    setIsRefreshing(false);
+  }, [loadAssets]);
+
+  const handleAssetPress = useCallback((asset: Asset) => {
+    if (asset.content_type === 'folder') {
+      navigation.push('Assets', {
+        parentId: asset.id,
+        folderName: asset.name,
+      });
+    } else {
+      navigation.navigate('AssetViewer', { assetId: asset.id });
+    }
+  }, [navigation]);
+
+  const handleAssetLongPress = useCallback((asset: Asset) => {
+    Alert.alert(
+      asset.name,
+      asset.content_type,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => confirmDelete(asset),
+        },
+      ]
+    );
+  }, []);
+
+  const confirmDelete = useCallback((asset: Asset) => {
+    Alert.alert(
+      'Delete asset?',
+      `This will permanently delete "${asset.name}".`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await apiService.deleteAsset(asset.id);
+              setAssets((prev) => prev.filter((a) => a.id !== asset.id));
+            } catch (error: unknown) {
+              const msg = error instanceof Error ? error.message : 'Failed to delete asset';
+              Alert.alert('Error', msg);
+            }
+          },
+        },
+      ]
+    );
+  }, []);
+
+  const renderAsset = useCallback(({ item }: { item: Asset }) => {
+    const isFolder = item.content_type === 'folder';
+    const isImage = item.content_type?.startsWith('image/');
+    const isVideo = item.content_type?.startsWith('video/');
+    const isAudio = item.content_type?.startsWith('audio/');
+    const thumb = item.thumb_url || (isImage ? item.get_url : null);
+
+    let iconName: keyof typeof Ionicons.glyphMap = 'document-outline';
+    if (isFolder) iconName = 'folder';
+    else if (isImage) iconName = 'image-outline';
+    else if (isVideo) iconName = 'film-outline';
+    else if (isAudio) iconName = 'musical-notes-outline';
+    else if (item.content_type?.startsWith('text/')) iconName = 'document-text-outline';
+
+    return (
+      <TouchableOpacity
+        style={[
+          styles.card,
+          shadows.small,
+          {
+            width: itemSize,
+            backgroundColor: colors.cardBg,
+            borderColor: colors.borderLight,
+          },
+        ]}
+        onPress={() => handleAssetPress(item)}
+        onLongPress={() => handleAssetLongPress(item)}
+        accessibilityRole="button"
+        accessibilityLabel={`${isFolder ? 'Folder' : 'Asset'} ${item.name}`}
+        activeOpacity={0.7}
+      >
+        <View
+          style={[
+            styles.thumbContainer,
+            { width: itemSize, height: itemSize, backgroundColor: colors.primaryMuted },
+          ]}
+        >
+          {thumb ? (
+            <Image
+              source={{ uri: thumb }}
+              style={styles.thumbImage}
+              resizeMode="cover"
+            />
+          ) : (
+            <Ionicons name={iconName} size={36} color={colors.primary} />
+          )}
+          {isVideo && (
+            <View style={styles.playOverlay}>
+              <Ionicons name="play-circle" size={30} color="#FFFFFF" />
+            </View>
+          )}
+        </View>
+        <View style={styles.cardLabel}>
+          <Text
+            style={[styles.cardName, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {item.name}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }, [colors, shadows, itemSize, handleAssetPress, handleAssetLongPress]);
+
+  const renderEmpty = () => {
+    if (isLoading) return null;
+    const searchActive = debouncedQuery.trim().length >= 2;
+    return (
+      <View style={styles.emptyContainer}>
+        <View style={[styles.emptyIconWrap, { backgroundColor: colors.primaryMuted }]}>
+          <Ionicons
+            name={loadError ? 'cloud-offline-outline' : searchActive ? 'search-outline' : 'folder-open-outline'}
+            size={36}
+            color={colors.primary}
+          />
+        </View>
+        <Text style={[styles.emptyText, { color: colors.text }]}>
+          {loadError
+            ? 'Could not load assets'
+            : searchActive
+              ? `No results for "${searchQuery}"`
+              : 'No assets yet'}
+        </Text>
+        {loadError ? (
+          <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+            {loadError}
+          </Text>
+        ) : (
+          <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+            {searchActive
+              ? 'Try a different search term.'
+              : isRootFolder
+                ? 'Upload assets from the desktop app or a workflow to see them here.'
+                : 'This folder is empty.'}
+          </Text>
+        )}
+      </View>
+    );
+  };
+
+  if (isLoading && assets.length === 0) {
+    return (
+      <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={[styles.loadingIconWrap, { backgroundColor: colors.primaryMuted }]}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+        <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+          Loading assets...
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.searchContainer, { backgroundColor: colors.background }]}>
+        <View
+          style={[
+            styles.searchBar,
+            { backgroundColor: colors.inputBg, borderColor: colors.borderLight },
+          ]}
+        >
+          <Ionicons
+            name="search"
+            size={18}
+            color={colors.textTertiary}
+            style={styles.searchIcon}
+          />
+          <TextInput
+            style={[styles.searchInput, { color: colors.text }]}
+            placeholder={isRootFolder ? 'Search all assets...' : 'Search in folder...'}
+            placeholderTextColor={colors.textTertiary}
+            value={searchQuery}
+            onChangeText={handleSearchChange}
+            autoCapitalize="none"
+            autoCorrect={false}
+            clearButtonMode="while-editing"
+            accessibilityLabel="Search assets"
+          />
+          {searchQuery.length > 0 && (
+            <TouchableOpacity
+              onPress={clearSearch}
+              accessibilityLabel="Clear search"
+            >
+              <Ionicons name="close-circle" size={18} color={colors.textTertiary} />
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      <FlatList
+        data={assets}
+        renderItem={renderAsset}
+        keyExtractor={(item) => item.id}
+        numColumns={GRID_COLUMNS}
+        columnWrapperStyle={styles.columnWrapper}
+        contentContainerStyle={[
+          styles.listContent,
+          {
+            paddingBottom: insets.bottom + 24,
+          },
+          assets.length === 0 && styles.listContentEmpty,
+        ]}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            tintColor={colors.primary}
+            colors={[colors.primary]}
+          />
+        }
+        ListHeaderComponent={
+          loadMode === 'search' && assets.length > 0 ? (
+            <Text style={[styles.listHeader, { color: colors.textSecondary }]}>
+              {assets.length} result{assets.length === 1 ? '' : 's'}
+            </Text>
+          ) : null
+        }
+        ListEmptyComponent={renderEmpty}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  loadingIconWrap: {
+    width: 72,
+    height: 72,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  loadingText: {
+    fontSize: 15,
+  },
+  searchContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 14,
+    height: 42,
+  },
+  searchIcon: {
+    marginRight: 10,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    paddingVertical: 0,
+  },
+  listContent: {
+    paddingHorizontal: GRID_PADDING,
+    paddingTop: 8,
+  },
+  listContentEmpty: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  listHeader: {
+    fontSize: 13,
+    marginBottom: 12,
+    marginLeft: 2,
+  },
+  columnWrapper: {
+    justifyContent: 'flex-start',
+    gap: GRID_GAP,
+    marginBottom: GRID_GAP,
+  },
+  card: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  thumbContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
+  },
+  thumbImage: {
+    width: '100%',
+    height: '100%',
+  },
+  playOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.15)',
+  },
+  cardLabel: {
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+  cardName: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingTop: 40,
+  },
+  emptyIconWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  emptyText: {
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: -0.2,
+    marginBottom: 6,
+    textAlign: 'center',
+  },
+  emptySubtext: {
+    fontSize: 14,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/screens/MiniAppsListScreen.tsx
+++ b/mobile/src/screens/MiniAppsListScreen.tsx
@@ -174,6 +174,14 @@ export default function MiniAppsListScreen({ navigation }: MiniAppsListScreenPro
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.headerButton, { backgroundColor: colors.primaryMuted }]}
+            onPress={() => navigation.navigate('Assets')}
+            accessibilityRole="button"
+            accessibilityLabel="Open assets"
+          >
+            <Ionicons name="images-outline" size={20} color={colors.primary} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.headerButton, { backgroundColor: colors.primaryMuted }]}
             onPress={() => navigation.navigate('Chat')}
             accessibilityRole="button"
             accessibilityLabel="Open chat"

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,6 +1,12 @@
 import createClient, { type Middleware } from 'openapi-fetch';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { paths } from '../api';
+import { paths, components } from '../api';
+
+export type Asset = components["schemas"]["Asset"];
+export type AssetList = components["schemas"]["AssetList"];
+export type AssetUpdateRequest = components["schemas"]["AssetUpdateRequest"];
+export type AssetSearchResult = components["schemas"]["AssetSearchResult"];
+export type AssetWithPath = components["schemas"]["AssetWithPath"];
 
 const API_HOST_KEY = '@nodetool_api_host';
 const DEFAULT_API_HOST = 'http://localhost:7777';
@@ -154,6 +160,56 @@ class ApiService {
     });
     if (error) { throw error; }
     return data as paths["/api/workflows/"]["post"]["responses"][200]["content"]["application/json"];
+  }
+
+  async listAssets(params: {
+    parent_id?: string | null;
+    content_type?: string | null;
+    cursor?: string | null;
+    page_size?: number | null;
+  } = {}): Promise<AssetList> {
+    const { data, error } = await this.client.GET('/api/assets/', {
+      params: { query: params },
+    });
+    if (error) { throw error; }
+    return data as AssetList;
+  }
+
+  async getAsset(id: string): Promise<Asset> {
+    const { data, error } = await this.client.GET('/api/assets/{id}', {
+      params: { path: { id } },
+    });
+    if (error) { throw error; }
+    return data as Asset;
+  }
+
+  async searchAssets(params: {
+    query: string;
+    content_type?: string | null;
+    page_size?: number | null;
+    cursor?: string | null;
+  }): Promise<AssetSearchResult> {
+    const { data, error } = await this.client.GET('/api/assets/search', {
+      params: { query: params },
+    });
+    if (error) { throw error; }
+    return data as AssetSearchResult;
+  }
+
+  async updateAsset(id: string, update: AssetUpdateRequest): Promise<Asset> {
+    const { data, error } = await this.client.PUT('/api/assets/{id}', {
+      params: { path: { id } },
+      body: update,
+    });
+    if (error) { throw error; }
+    return data as Asset;
+  }
+
+  async deleteAsset(id: string): Promise<void> {
+    const { error } = await this.client.DELETE('/api/assets/{id}', {
+      params: { path: { id } },
+    });
+    if (error) { throw error; }
   }
 
   getWebSocketUrl(path: string): string {


### PR DESCRIPTION
Introduces an asset browser and asset viewer for the mobile app, letting
users explore folders, preview images/video/audio, rename, share and
delete assets directly from their device.

- AssetsScreen: grid-based folder browser with thumbnails, debounced
  global search, folder drill-down, long-press delete, and pull-to-refresh
- AssetViewerScreen: image/video/audio previews (expo-av), metadata
  detail panel, and rename/share/delete actions
- services/api: new listAssets / getAsset / searchAssets / updateAsset /
  deleteAsset methods and exported Asset component types
- navigation: Assets and AssetViewer routes registered in App.tsx
- MiniAppsListScreen: adds an Assets entry to the top-right header