### PR TITLE
Add comprehensive app views gallery and documentation pages

### DIFF
--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -2,6 +2,8 @@
 
 Screenshots needed for NodeTool documentation. Each entry includes page location, position, description, priority, and notes.
 
+> **Visual index of every view:** see [`app-views.md`](app-views.md). Any view listed there without a real screenshot today is tracked on this page. The goal is to have **every view** in the app represented by an image on the docs site.
+
 ---
 
 ## Table of Contents
@@ -9,12 +11,20 @@ Screenshots needed for NodeTool documentation. Each entry includes page location
 1. [Getting Started](#getting-started)
 2. [User Interface](#user-interface)
 3. [Workflow Editor](#workflow-editor)
-4. [Global Chat](#global-chat)
-5. [Models Manager](#models-manager)
-6. [Assets](#assets)
-7. [Mini-Apps](#mini-apps)
-8. [Cookbook Examples](#cookbook-examples)
-9. [Configuration & Settings](#configuration--settings)
+4. [Editor Panels](#editor-panels)
+5. [Chain Editor](#chain-editor)
+6. [Workflow Graph View](#workflow-graph-view)
+7. [Templates Gallery](#templates-gallery)
+8. [Collections](#collections)
+9. [Global Chat](#global-chat)
+10. [Models Manager](#models-manager)
+11. [Assets](#assets)
+12. [Mini-Apps](#mini-apps)
+13. [Mobile App](#mobile-app)
+14. [Desktop / Electron](#desktop--electron)
+15. [Cookbook Examples](#cookbook-examples)
+16. [Configuration & Settings](#configuration--settings)
+17. [Authentication](#authentication)
 
 ---
 
@@ -558,21 +568,253 @@ Screenshots needed for NodeTool documentation. Each entry includes page location
 
 ---
 
+## Editor Panels
+
+### Screenshot: Left Panel (Workflows / Chat / Assets / Collections / Packs / VibeCoding)
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md`, `app-views.md` |
+| **Position** | In "Left Panel" section — one capture per tab |
+| **Description** | Each left-panel tab in turn with a representative workspace |
+| **Priority** | High |
+| **Filename** | `assets/screenshots/left-panel-<tab>.png` |
+| **Notes** | Tabs: workflows, chat, assets, collections, packs, vibecoding. |
+
+### Screenshot: Right Panel (Inspector + other tabs)
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md` |
+| **Position** | In "Right Panel (Inspector)" section |
+| **Description** | Inspector showing node properties, and additional tabs (Logs, Jobs, Agent, Trace, Version History, Workspace) |
+| **Priority** | High |
+| **Filename** | `assets/screenshots/right-panel-<tab>.png` |
+| **Notes** | Capture a tab per image: `right-panel-inspector.png`, `right-panel-logs.png`, `right-panel-jobs.png`, `right-panel-agent.png`, `right-panel-trace.png`, `right-panel-version.png`, `right-panel-workspace.png`. |
+
+### Screenshot: Bottom Panel (Terminal / Trace / Jobs / Logs)
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md` |
+| **Position** | In "Bottom Panel" section |
+| **Description** | Each bottom-panel tab in turn |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/bottom-panel-<tab>.png` |
+| **Notes** | Tabs: terminal, trace, jobs, logs, system-stats. |
+
+### Screenshot: Floating Toolbar states
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md`, `workflow-editor.md` |
+| **Position** | In "Floating Toolbar" section |
+| **Description** | Toolbar in idle, running, paused, and suspended states |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/floating-toolbar-<state>.png` |
+| **Notes** | States: idle, running, paused, suspended. |
+
+### Screenshot: Right Side Buttons
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md` |
+| **Position** | In "Right Side Buttons" section |
+| **Description** | Stack of toggle buttons on the right edge of the canvas |
+| **Priority** | Low |
+| **Filename** | `assets/screenshots/right-side-buttons.png` |
+| **Notes** | Capture with notifications badge visible. |
+
+### Screenshot: Workflow Assistant Chat
+| Field | Value |
+|-------|-------|
+| **Page** | `editor-panels.md`, `global-chat.md` |
+| **Position** | In "Workflow Assistant Chat" section |
+| **Description** | Side panel chat with the assistant mid-response |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/workflow-assistant.png` |
+| **Notes** | Show assistant modifying the workflow. |
+
+---
+
+## Chain Editor
+
+### Screenshot: Chain Editor — Empty
+| Filename | Status |
+|----------|--------|
+| `assets/screenshots/web-chain-editor-empty.png` | Captured |
+
+### Screenshot: Chain Editor — Chain
+| Filename | Status |
+|----------|--------|
+| `assets/screenshots/web-chain-editor-chain.png` | Captured |
+
+### Screenshot: Chain Editor — Picker
+| Filename | Status |
+|----------|--------|
+| `assets/screenshots/web-chain-editor-picker.png` | Captured |
+
+### Screenshot: Chain Card Properties
+| Field | Value |
+|-------|-------|
+| **Page** | `chain-editor.md` |
+| **Position** | In "Editing Card Properties" |
+| **Description** | Expanded card showing property fields |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/chain-card-properties.png` |
+
+---
+
+## Workflow Graph View
+
+### Screenshot: Read-only Graph
+| Field | Value |
+|-------|-------|
+| **Page** | `workflow-graph-view.md` |
+| **Position** | Top of page |
+| **Description** | Read-only graph view of a saved workflow |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/workflow-graph-view.png` |
+| **Notes** | No inspector or panels visible. Include title overlay. |
+
+---
+
+## Templates Gallery
+
+### Screenshot: Templates Grid
+| Filename | Status |
+|----------|--------|
+| `assets/screenshots/templates-grid.png` | Captured |
+
+### Screenshot: Template Card Hover
+| Field | Value |
+|-------|-------|
+| **Page** | `templates-gallery.md` |
+| **Position** | In "Anatomy of a Template Card" |
+| **Description** | Single card with hover preview and badges |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/template-card-hover.png` |
+
+### Screenshot: Template Filters
+| Field | Value |
+|-------|-------|
+| **Page** | `templates-gallery.md` |
+| **Position** | In "Filtering and Searching" |
+| **Description** | Filter bar with a tag active and a search typed |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/template-filters.png` |
+
+---
+
+## Collections
+
+### Screenshot: Collections Explorer
+| Filename | Status |
+|----------|--------|
+| `assets/screenshots/collections-explorer.png` | Captured |
+
+### Screenshot: New Collection
+| Field | Value |
+|-------|-------|
+| **Page** | `collections.md` |
+| **Position** | In "Creating a Collection" |
+| **Description** | New Collection dialog with a name typed in |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/new-collection.png` |
+
+### Screenshot: Collection Details
+| Field | Value |
+|-------|-------|
+| **Page** | `collections.md` |
+| **Position** | In "Managing Documents" |
+| **Description** | Open collection with 4–6 documents and an index status bar |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/collection-details.png` |
+
+### Screenshot: Collection Settings
+| Field | Value |
+|-------|-------|
+| **Page** | `collections.md` |
+| **Position** | In "Indexing Options" |
+| **Description** | Per-collection settings panel (embedding model, chunk size, overlap, hybrid toggle) |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/collection-settings.png` |
+
+---
+
+## Mobile App
+
+### Screenshots (captured)
+
+| Filename | Page | Position |
+|----------|------|----------|
+| `assets/screenshots/dashboard-mobile.png` | `mobile-app.md` | Top |
+| `assets/screenshots/dashboard-tablet.png` | `mobile-app.md` | Tablet Dashboard |
+| `assets/screenshots/chat-mobile.png` | `mobile-app.md` | AI Chat |
+| `assets/screenshots/mobile-graph-editor-overview.png` | `mobile-app.md` | Mobile Graph Editor — Overview |
+| `assets/screenshots/mobile-graph-editor-empty.png` | `mobile-app.md` | Mobile Graph Editor — Empty |
+| `assets/screenshots/mobile-graph-editor-picker.png` | `mobile-app.md` | Mobile Graph Editor — Picker |
+| `assets/screenshots/mobile-graph-editor-chain.png` | `mobile-app.md` | Mobile Graph Editor — Chain |
+
+### Pending
+
+| Filename | Page | Description |
+|----------|------|-------------|
+| `assets/screenshots/mobile-mini-apps-list.png` | `mobile-app.md` | Mini-apps list with tiles |
+| `assets/screenshots/mobile-mini-app-runner.png` | `mobile-app.md` | Running a single mini-app |
+| `assets/screenshots/mobile-settings.png` | `mobile-app.md` | Mobile settings screen |
+| `assets/screenshots/mobile-model-selection.png` | `mobile-app.md` | Language model picker |
+
+---
+
+## Desktop / Electron
+
+| Filename | Page | Description |
+|----------|------|-------------|
+| `assets/screenshots/electron-boot.png` | `electron-views.md` | Splash while backend starts |
+| `assets/screenshots/electron-install-wizard.png` | `electron-views.md` | First-run Python/runtime installer |
+| `assets/screenshots/electron-package-manager.png` | `electron-views.md` | Package Manager native window |
+| `assets/screenshots/electron-log-viewer.png` | `electron-views.md` | Log Viewer tailing backend logs |
+| `assets/screenshots/electron-update-toast.png` | `electron-views.md` | Update-available toast |
+| `assets/screenshots/electron-workflow-pin.png` | `electron-views.md` | Pinned frameless workflow window |
+| `assets/screenshots/electron-miniapp-window.png` | `electron-views.md` | Mini-app launched from tray |
+| `assets/screenshots/electron-tray.png` | `electron-views.md` | Tray icon with expanded menu |
+| `assets/screenshots/electron-menu-bar.png` | `electron-views.md` | Native menu bar expanded |
+
+---
+
+## Authentication
+
+### Screenshot: Login Screen
+| Field | Value |
+|-------|-------|
+| **Page** | `authentication.md`, `app-views.md` |
+| **Position** | Top of page |
+| **Description** | Login screen with provider buttons |
+| **Priority** | Medium |
+| **Filename** | `assets/screenshots/login.png` |
+| **Notes** | Capture both Supabase mode and Localhost mode if possible. |
+
+---
+
 ## Summary Statistics
 
 | Category | Screenshot Count |
 |----------|-----------------|
 | Getting Started | 6 |
-| User Interface | 7 |
+| User Interface | 8 |
 | Workflow Editor | 12 |
+| Editor Panels | 20+ (multiple per tab) |
+| Chain Editor | 4 (3 captured) |
+| Workflow Graph View | 1 |
+| Templates Gallery | 3 (1 captured) |
+| Collections | 4 (1 captured) |
 | Global Chat | 6 |
 | Models Manager | 4 |
 | Assets | 3 |
 | Mini-Apps | 2 |
+| Mobile App | 11 (7 captured) |
+| Desktop / Electron | 9 |
 | Cookbook Examples | 5 |
 | Configuration & Settings | 3 |
 | Key Concepts | 2 |
-| **Total** | **50** |
+| Authentication | 1 |
+| **Total** | **~100** |
 
 ---
 

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -23,11 +23,20 @@
       <div class="nav-section">
         <h4 class="nav-section-title">📖 Learn</h4>
         <ul class="nav-section-list">
+          <li><a href="{{ '/app-views' | relative_url }}" class="sidebar-link">App Views Gallery</a></li>
           <li><a href="{{ '/user-interface' | relative_url }}" class="sidebar-link">User Interface</a></li>
           <li><a href="{{ '/workflow-editor' | relative_url }}" class="sidebar-link">Workflow Editor</a></li>
+          <li><a href="{{ '/editor-panels' | relative_url }}" class="sidebar-link">Editor Panels</a></li>
+          <li><a href="{{ '/chain-editor' | relative_url }}" class="sidebar-link">Chain Editor</a></li>
+          <li><a href="{{ '/workflow-graph-view' | relative_url }}" class="sidebar-link">Workflow Graph View</a></li>
+          <li><a href="{{ '/templates-gallery' | relative_url }}" class="sidebar-link">Templates Gallery</a></li>
+          <li><a href="{{ '/collections' | relative_url }}" class="sidebar-link">Collections</a></li>
+          <li><a href="{{ '/global-chat' | relative_url }}" class="sidebar-link">Global Chat</a></li>
+          <li><a href="{{ '/image-editor' | relative_url }}" class="sidebar-link">Image Editor</a></li>
           <li><a href="{{ '/comfyui-integration' | relative_url }}" class="sidebar-link">ComfyUI Integration</a></li>
           <li><a href="{{ '/vibecoding' | relative_url }}" class="sidebar-link">VibeCoding</a></li>
           <li><a href="{{ '/mobile-app' | relative_url }}" class="sidebar-link">Mobile App</a></li>
+          <li><a href="{{ '/electron-views' | relative_url }}" class="sidebar-link">Desktop App Views</a></li>
           <li><a href="{{ '/models-and-providers' | relative_url }}" class="sidebar-link">Models & Providers</a></li>
           <li><a href="{{ '/global-chat-agents' | relative_url }}" class="sidebar-link">Global Chat & Agents</a></li>
           <li><a href="{{ '/tips-and-tricks' | relative_url }}" class="sidebar-link">Tips & Tricks</a></li>

--- a/docs/app-views.md
+++ b/docs/app-views.md
@@ -1,0 +1,596 @@
+---
+layout: page
+title: "App Views Gallery"
+description: "Visual index of every screen, panel, and dialog in NodeTool. Jump to the docs page for each view."
+---
+
+Every user-facing view in NodeTool across the web app, desktop (Electron), and mobile. Each entry links to the detailed docs page and shows the current screenshot. Missing or pending screenshots are marked with a placeholder.
+
+> **Contributors:** See [SCREENSHOTS.md]({{ '/SCREENSHOTS' | relative_url }}) for the capture plan and guidelines.
+
+---
+
+## Top-Level Views (Web App)
+
+Routes live under `/` in the web app. They're also the main destinations inside the desktop app.
+
+### Dashboard / Portal — `/dashboard`
+
+The home screen. Search, recent workflows, templates, and quick chat.
+
+![Dashboard Overview](assets/screenshots/dashboard-overview.png)
+
+Docs: [User Interface → Dashboard]({{ '/user-interface#dashboard' | relative_url }}) · [Getting Started]({{ '/getting-started' | relative_url }})
+
+### Login — `/login`
+
+Authentication screen for cloud (Supabase) deployments. Skipped automatically in local-only mode.
+
+![Login](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Authentication]({{ '/authentication' | relative_url }})
+
+### Workflow Editor — `/editor/:workflow`
+
+The main visual editor. Build workflows by connecting nodes on an infinite canvas, with panels on every edge.
+
+![Workflow Editor](assets/screenshots/editor-empty-state.png)
+
+Docs: [Workflow Editor]({{ '/workflow-editor' | relative_url }}) · [Editor Panels]({{ '/editor-panels' | relative_url }})
+
+### Chain Editor — `/chain/:workflowId?`
+
+A linear, card-based alternative to the node graph. Better for simple pipelines and guided authoring.
+
+![Chain Editor](assets/screenshots/web-chain-editor-chain.png)
+
+Docs: [Chain Editor]({{ '/chain-editor' | relative_url }})
+
+### Workflow Graph View — `/graph/:workflowId`
+
+Read-only visualization of a saved workflow. Useful for sharing, embedding, and review.
+
+![Workflow Graph View](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Graph View]({{ '/workflow-graph-view' | relative_url }})
+
+### Global Chat — `/chat/:thread_id?`
+
+Conversational AI with multi-thread history, agent mode, tools, and workflow integration.
+
+![Global Chat](assets/screenshots/global-chat-interface.png)
+
+Docs: [Global Chat]({{ '/global-chat' | relative_url }})
+
+### Standalone Chat — `/standalone-chat/:thread_id?`
+
+A slim, focused chat window — same engine as Global Chat but without the full app shell.
+
+![Standalone Chat](assets/screenshots/standalone-chat.png)
+
+Docs: [User Interface → Standalone Chat]({{ '/user-interface#standalone-chat-window' | relative_url }})
+
+### Mini-Apps Page — `/apps/:workflowId?`
+
+Run saved workflows through simplified form UIs inside the main app.
+
+![Mini-App Page](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [User Interface → Mini-Apps]({{ '/user-interface#mini-apps' | relative_url }})
+
+### Standalone Mini-App — `/miniapp/:workflowId`
+
+A dedicated full-window Mini-App runner. Launched from the tray on desktop or by a direct link.
+
+![Standalone Mini-App](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [User Interface → Mini-Apps]({{ '/user-interface#mini-apps' | relative_url }})
+
+### Asset Explorer — `/assets`
+
+Browse, search, organize, and tag every file used in your workflows.
+
+![Asset Explorer](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Asset Management]({{ '/asset-management' | relative_url }})
+
+### Asset Editor — `/assets/edit/:assetId`
+
+Full-featured image editor for assets. Crop, paint, and transform without leaving NodeTool.
+
+![Asset Editor](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Image Editor]({{ '/image-editor' | relative_url }})
+
+### Collections — `/collections`
+
+Group related documents into indexable collections for RAG workflows.
+
+![Collections Explorer](assets/screenshots/collections-explorer.png)
+
+Docs: [Collections]({{ '/collections' | relative_url }}) · [Indexing]({{ '/indexing' | relative_url }})
+
+### Templates Gallery — `/templates`
+
+Ready-to-use example workflows organized by tag and use case.
+
+![Templates Grid](assets/screenshots/templates-grid.png)
+
+Docs: [Templates Gallery]({{ '/templates-gallery' | relative_url }})
+
+### Models Manager — `/models`
+
+Find, install, filter, and manage local and cloud AI models.
+
+![Models Manager](assets/screenshots/models-list.png)
+
+Docs: [Models Manager]({{ '/models-manager' | relative_url }})
+
+---
+
+## Editor Panels and Surfaces
+
+Visible inside the Workflow Editor at `/editor/:workflow`.
+
+### App Header
+
+Top navigation with logo, workspace switcher, Models button, Assets button, Chat, Settings, and the download indicator.
+
+![App Header](assets/screenshots/app-header.png)
+
+Docs: [User Interface → App Header]({{ '/user-interface#the-app-header' | relative_url }})
+
+### Left Panel (Workflows, Chat, Assets, Collections, Packs, VibeCoding)
+
+Collapsible drawer with tabs for navigating workspace content without leaving the canvas.
+
+![Left Panel](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Editor Panels → Left Panel]({{ '/editor-panels#left-panel' | relative_url }})
+
+### Node Menu (Space / double-click)
+
+Search, browse categories, and insert nodes onto the canvas.
+
+![Node Menu](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Finding Nodes]({{ '/workflow-editor#finding-nodes' | relative_url }})
+
+### Right Panel (Inspector)
+
+Tabs for node properties, workflow assistant, logs, jobs, trace, agent, version history, and workspace tree.
+
+![Inspector](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Editor Panels → Right Panel]({{ '/editor-panels#right-panel-inspector' | relative_url }})
+
+### Bottom Panel (Terminal, Trace, Jobs, Logs)
+
+Runtime diagnostics dock — quick access to the terminal, execution trace, job queue, and raw logs.
+
+![Bottom Panel](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Editor Panels → Bottom Panel]({{ '/editor-panels#bottom-panel' | relative_url }})
+
+### Floating Toolbar
+
+Context-sensitive actions that appear over the canvas (run, pause, resume, stop, layout).
+
+![Floating Toolbar](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Editor Panels → Floating Toolbar]({{ '/editor-panels#floating-toolbar' | relative_url }})
+
+### Node Canvas
+
+The infinite work surface where nodes are placed and connected.
+
+![Canvas with Workflow](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Canvas Basics]({{ '/workflow-editor#canvas-basics' | relative_url }})
+
+### Tabs Bar
+
+Switch between open workflows without losing state.
+
+![Workflow Tabs](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Multiple Workflows]({{ '/workflow-editor#multiple-workflows' | relative_url }})
+
+### Context Menus (Node, Edge, Canvas, Selection)
+
+Right-click menus for every object on the canvas.
+
+![Context Menu](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Context Menus]({{ '/workflow-editor#context-menus' | relative_url }})
+
+### Find in Workflow
+
+Dialog for searching within the current workflow.
+
+![Find in Workflow](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Finding Nodes]({{ '/workflow-editor#finding-nodes' | relative_url }})
+
+### Command Menu (`⌘K` / `Alt+K`)
+
+Global command palette — go anywhere, run anything.
+
+![Command Menu](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [User Interface → Command Menu]({{ '/user-interface#command-menu' | relative_url }})
+
+### Workflow Assistant Chat
+
+Side-panel chat that can read and modify the open workflow.
+
+![Workflow Assistant](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Global Chat → Workflow Integration]({{ '/global-chat#workflow-integration' | relative_url }})
+
+### VibeCoding Modal
+
+AI-assisted custom UI generator for workflows.
+
+![VibeCoding](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [VibeCoding]({{ '/vibecoding' | relative_url }})
+
+---
+
+## Dialogs and Modals
+
+All dialogs live inside the main app. Most are reachable from the App Header, right-click menus, or `⌘K`.
+
+### Settings Dialog (General / Providers / Folders / Secrets / Remote / About)
+
+Central configuration surface with a persistent sidebar.
+
+![Settings Dialog](assets/screenshots/settings-dialog.png)
+
+Docs: [Configuration]({{ '/configuration' | relative_url }})
+
+### Provider API Keys
+
+Paste API keys for OpenAI, Anthropic, Google, Mistral, Groq, Replicate, and more.
+
+![API Keys](assets/screenshots/settings-api-keys.png)
+
+Docs: [Configuration → API Keys]({{ '/configuration#api-keys' | relative_url }}) · [Models & Providers]({{ '/models-and-providers' | relative_url }})
+
+### Recommended Models Dialog
+
+Opens from the "Missing Model" indicator on nodes.
+
+![Recommended Models](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Models Manager → Recommended Models]({{ '/models-manager#recommended-models' | relative_url }})
+
+### Model Selection Dialogs (LLM, Image, Video, TTS, ASR, Embedding, HuggingFace)
+
+Type-aware model pickers for each property role.
+
+![Language Model Selector](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Models & Providers]({{ '/models-and-providers' | relative_url }})
+
+### Download Manager
+
+Track, retry, and pause model and asset downloads.
+
+![Download Manager](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Models Manager → Downloading Models]({{ '/models-manager#downloading-models' | relative_url }})
+
+### Model README
+
+In-app HuggingFace README viewer.
+
+![Model README](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [HuggingFace Integration]({{ '/huggingface' | relative_url }})
+
+### Delete Model Confirmation
+
+Safety prompt before removing a model from the local cache.
+
+![Delete Model](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Models Manager → Managing Models]({{ '/models-manager#managing-models' | relative_url }})
+
+### Open / Create Workflow Dialog
+
+Start a new workflow or open an existing one.
+
+![Open or Create](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Getting Started]({{ '/getting-started' | relative_url }})
+
+### Workflow Form
+
+Edit workflow metadata — name, description, thumbnail, tags.
+
+![Workflow Form](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor]({{ '/workflow-editor' | relative_url }})
+
+### Workflow Delete Confirmation
+
+Safe delete with an undo window.
+
+![Workflow Delete](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor]({{ '/workflow-editor' | relative_url }})
+
+### Quick Add Node
+
+Add a node without opening the full Node Menu — useful when chaining off a connection.
+
+![Quick Add Node](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Adding Nodes]({{ '/workflow-editor#add-nodes' | relative_url }})
+
+### Node Picker (Chain Editor)
+
+Pick the next card in a linear chain.
+
+![Chain Node Picker](assets/screenshots/web-chain-editor-picker.png)
+
+Docs: [Chain Editor → Adding Steps]({{ '/chain-editor#adding-steps' | relative_url }})
+
+### File Browser Dialog
+
+OS-style browser for picking folders and files inside the app.
+
+![File Browser](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Configuration]({{ '/configuration' | relative_url }})
+
+### Confirm Dialog
+
+Generic yes/no prompt used across the app.
+
+![Confirm](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: N/A — reusable primitive.
+
+### Image Compare Dialog
+
+Side-by-side comparison for before/after image workflows.
+
+![Image Compare](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Image Editor]({{ '/image-editor' | relative_url }})
+
+### Color Picker Modal
+
+Rich color picker with harmony, swatches, gradients, and contrast check.
+
+![Color Picker](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor → Color Picker]({{ '/workflow-editor#color-picker' | relative_url }})
+
+### Text / Code Editor Modal
+
+Expanded editor for long string properties with syntax highlight.
+
+![Text Editor](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor]({{ '/workflow-editor' | relative_url }})
+
+### DataFrame Editor Modal
+
+Inline spreadsheet-style editor for tabular properties.
+
+![DataFrame Editor](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Workflow Editor]({{ '/workflow-editor' | relative_url }})
+
+### Image Editor Modal (Node-level)
+
+In-context image editor invoked from image properties and outputs.
+
+![Image Editor Modal](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Image Editor]({{ '/image-editor' | relative_url }})
+
+### Node README / Help
+
+Documentation viewer for individual nodes and the "What's this?" tooltips.
+
+![Node Help](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Node Reference]({{ '/nodes/' | relative_url }})
+
+---
+
+## Mobile App Screens (iOS / Android / Web)
+
+All mobile screens are documented in [Mobile App]({{ '/mobile-app' | relative_url }}).
+
+### Mobile Dashboard
+
+Entry point showing connection status and quick actions.
+
+![Mobile Dashboard](assets/screenshots/dashboard-mobile.png)
+
+### Mobile Mini-Apps List
+
+Browse mini-apps published by your server.
+
+![Mini Apps List](assets/screenshots/screenshot-placeholder.svg)
+
+### Mobile Mini-App Runner
+
+Run an individual mini-app with touch-first controls.
+
+![Mini App Runner](assets/screenshots/screenshot-placeholder.svg)
+
+### Mobile Chat
+
+Conversational AI with streaming, model picker, and threads.
+
+![Mobile Chat](assets/screenshots/chat-mobile.png)
+
+### Mobile Graph Editor
+
+Touch-friendly read/write workflow editor.
+
+![Mobile Graph Editor](assets/screenshots/mobile-graph-editor-overview.png)
+
+### Mobile Graph Editor — Empty State
+
+Empty canvas prompting the first node.
+
+![Mobile Graph Editor Empty](assets/screenshots/mobile-graph-editor-empty.png)
+
+### Mobile Graph Editor — Node Picker
+
+Node picker optimized for touch.
+
+![Mobile Graph Editor Picker](assets/screenshots/mobile-graph-editor-picker.png)
+
+### Mobile Graph Editor — Chain
+
+Linear chain layout for small screens.
+
+![Mobile Graph Editor Chain](assets/screenshots/mobile-graph-editor-chain.png)
+
+### Mobile Settings
+
+Configure the server URL, storage, and appearance.
+
+![Mobile Settings](assets/screenshots/screenshot-placeholder.svg)
+
+### Mobile Language Model Selection
+
+Choose the default LLM for chat.
+
+![Mobile Model Selection](assets/screenshots/screenshot-placeholder.svg)
+
+### Mobile Dashboard (Tablet)
+
+Expanded layout on tablet form factors.
+
+![Tablet Dashboard](assets/screenshots/dashboard-tablet.png)
+
+---
+
+## Electron Windows and Menus
+
+These are specific to the desktop app shipped via Electron.
+
+### Boot Message / Splash
+
+Shown while the embedded Python and backend services start.
+
+![Electron Boot](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views]({{ '/electron-views' | relative_url }})
+
+### Install Wizard
+
+First-run wizard for installing Python, Conda, and core AI runtimes.
+
+![Install Wizard](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Install Wizard]({{ '/electron-views#install-wizard' | relative_url }})
+
+### Package Manager Window
+
+Manage installed node packs and optional runtimes.
+
+![Package Manager](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Node Packs]({{ '/node-packs' | relative_url }}) · [Electron Views → Package Manager]({{ '/electron-views#package-manager' | relative_url }})
+
+### Log Viewer Window
+
+Tail of the backend log from inside the desktop app.
+
+![Log Viewer](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Log Viewer]({{ '/electron-views#log-viewer' | relative_url }})
+
+### Update Notification
+
+In-app toast when a new desktop update is available.
+
+![Update Notification](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Updates]({{ '/electron-views#updates' | relative_url }})
+
+### Workflow Execution Window (frameless)
+
+A floating, chromeless window for pinned workflow runs on macOS/Windows.
+
+![Workflow Execution Window](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Pinned Windows]({{ '/electron-views#pinned-windows' | relative_url }})
+
+### Mini App Window
+
+Frameless runner for mini-apps launched from the tray.
+
+![Mini App Window](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Mini App Window]({{ '/electron-views#mini-app-window' | relative_url }})
+
+### Chat Window (standalone)
+
+Focused chat opened from the tray.
+
+![Chat Window](assets/screenshots/standalone-chat.png)
+
+Docs: [User Interface → Standalone Chat]({{ '/user-interface#standalone-chat-window' | relative_url }})
+
+### System Tray Menu
+
+Quick actions: open dashboard, open chat, launch a mini-app, quit.
+
+![Tray Menu](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Tray]({{ '/electron-views#system-tray' | relative_url }})
+
+### Application Menu Bar
+
+File / Edit / View menus for the desktop app.
+
+![App Menu Bar](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Electron Views → Menu Bar]({{ '/electron-views#menu-bar' | relative_url }})
+
+---
+
+## Auxiliary Views
+
+### Component Preview (`/preview/:component?`)
+
+Isolated render of an individual UI component — used only in local development to capture clean screenshots.
+
+![Component Models](assets/screenshots/component-models.png)
+
+Docs: [Developer Guide]({{ '/developer/' | relative_url }})
+
+### Node Test Page (`/node-test`)
+
+Run every node's contract test from the browser.
+
+![Node Test](assets/screenshots/screenshot-placeholder.svg)
+
+Docs: [Developer Guide]({{ '/developer/' | relative_url }})
+
+---
+
+## How to Add a Screenshot
+
+If you're capturing a screenshot from this list:
+
+1. Launch NodeTool locally (`make dev` for web + backend; Electron dev via `make electron-dev`).
+2. Navigate to the view and set up a clean example (no personal data, default theme).
+3. Capture at **1920×1080** minimum — use 2× resolution for retina displays.
+4. Save as PNG with a descriptive hyphenated name under `docs/assets/screenshots/`.
+5. Replace the placeholder reference on the view's docs page and in `app-views.md`.
+6. Tick the entry off in [`SCREENSHOTS.md`]({{ '/SCREENSHOTS' | relative_url }}).
+
+See the full guidelines in [`SCREENSHOTS.md`]({{ '/SCREENSHOTS' | relative_url }}).

--- a/docs/asset-management.md
+++ b/docs/asset-management.md
@@ -12,6 +12,8 @@ NodeTool lets you store and organize files used in your workflows. Assets can be
 
 The **Asset Explorer** is the central hub for managing your files. Open it from the left sidebar.
 
+![Asset Explorer](assets/screenshots/screenshot-placeholder.svg)
+
 ### Views
 
 - **Grid view** -- Thumbnails with previews, best for visual assets like images and videos
@@ -33,11 +35,15 @@ Switch between views using the toggle in the toolbar.
 
 ### Working with Assets in Workflows
 
+![Drag Asset to Canvas](assets/screenshots/screenshot-placeholder.svg)
+
 Drag any asset from the Asset Explorer directly into the workflow canvas. NodeTool automatically creates the appropriate input node based on the file type (image input, audio input, etc.).
 
 ---
 
 ## Asset Viewers
+
+![Asset Preview](assets/screenshots/screenshot-placeholder.svg)
 
 NodeTool includes specialized viewers for common file types:
 

--- a/docs/assets/screenshots/screenshot-placeholder.svg
+++ b/docs/assets/screenshots/screenshot-placeholder.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="Screenshot pending capture">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a1d22"/>
+      <stop offset="1" stop-color="#0e1013"/>
+    </linearGradient>
+    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#2a2d32" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bg)"/>
+  <rect width="1280" height="720" fill="url(#grid)" opacity="0.4"/>
+  <g transform="translate(640 310)" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Helvetica, Arial, sans-serif">
+    <circle r="52" fill="none" stroke="#5cc8ff" stroke-width="3" opacity="0.6"/>
+    <path d="M -18 -10 L -18 14 L 0 22 L 18 14 L 18 -10 L 0 -18 Z" fill="none" stroke="#5cc8ff" stroke-width="2.5" opacity="0.8"/>
+    <circle cx="0" cy="-2" r="5" fill="#5cc8ff" opacity="0.8"/>
+    <text y="108" fill="#e6e8ec" font-size="32" font-weight="600" letter-spacing="0.5">Screenshot pending</text>
+    <text y="150" fill="#8b9199" font-size="18" letter-spacing="0.3">This view is documented; the image will be added in a future capture pass.</text>
+    <text y="180" fill="#64697a" font-size="15">See docs/SCREENSHOTS.md for the capture plan.</text>
+  </g>
+</svg>

--- a/docs/chain-editor.md
+++ b/docs/chain-editor.md
@@ -1,0 +1,119 @@
+---
+layout: page
+title: "Chain Editor"
+description: "A linear, card-based way to author workflows in NodeTool."
+---
+
+The **Chain Editor** is a streamlined alternative to the node graph. Instead of placing nodes on an infinite canvas, you compose an ordered chain of cards — perfect for linear pipelines like "transcribe → summarize → email" or "fetch → parse → index".
+
+> **Prefer the node graph?** The full [Workflow Editor]({{ '/workflow-editor' | relative_url }}) is always one click away. Both editors read and write the same workflow format.
+
+---
+
+## When to Use the Chain Editor
+
+| Use the Chain Editor when… | Use the Workflow Editor when… |
+|---------------------------|--------------------------------|
+| Pipeline is mostly linear | Pipeline branches or has loops |
+| You're guiding a non-technical user | You need fine-grained connection control |
+| You want one output per step | You need multi-output nodes |
+| You're sketching a workflow quickly | You're building a production agent |
+
+---
+
+## Opening the Chain Editor
+
+Navigate to `/chain/:workflowId` in the app, or click the **Chain** layout toggle from a workflow's context menu. If no workflow is provided, a fresh chain starts.
+
+![Chain Editor — Empty](assets/screenshots/web-chain-editor-empty.png)
+
+---
+
+## Anatomy of a Chain
+
+A chain has three elements:
+
+1. **Cards** — each card represents a node (the step's computation).
+2. **Input mapping** — a selector that chooses which output of the previous card becomes this card's input.
+3. **Output selector** — a selector that decides which output is surfaced to the next card.
+
+![Chain Editor — Steps](assets/screenshots/web-chain-editor-chain.png)
+
+---
+
+## Adding Steps
+
+Click the **Add Node** button at the end of the chain. The **Node Picker Dialog** opens — it's filtered to show only nodes compatible with the current output type.
+
+![Node Picker](assets/screenshots/web-chain-editor-picker.png)
+
+Pick a node and it's inserted at the end. The editor automatically wires a single input from the previous step.
+
+---
+
+## Editing Card Properties
+
+Click any card to expand its properties. You get the same inspector fields as the graph editor — string inputs, model pickers, sliders, asset selectors, and so on.
+
+![Chain Card Properties](assets/screenshots/screenshot-placeholder.svg)
+
+Changes are saved the moment you commit a value (blur or press Enter).
+
+---
+
+## Reordering and Removing Cards
+
+- **Drag** a card's handle to reorder. Connections are re-mapped automatically.
+- **Delete** with the trash icon on a card, or press `Delete` when a card is focused.
+
+Incompatible connections are highlighted in red and the editor suggests a compatible replacement.
+
+---
+
+## Input / Output Mapping
+
+Each card has:
+
+- **Input Mapping Selector** — pick which output of the previous card becomes this card's input. This is useful when a previous step returns multiple values (e.g., `text`, `metadata`).
+- **Output Selector** — if this card has multiple outputs, pick the one that should flow into the next step.
+
+Both selectors show the data type, so you can spot mismatches quickly.
+
+---
+
+## Running a Chain
+
+Press **Run** at the top of the chain editor. Cards execute in order:
+
+- A card running turns blue.
+- A completed card gets a green checkmark and its output snippet appears.
+- A failed card turns red and the chain halts.
+
+Streaming output appears inline on the card in real time.
+
+---
+
+## Switching Between Editors
+
+Chains are just a presentation of the underlying workflow graph — you can freely switch:
+
+1. **From Chain → Graph**: click the graph icon in the toolbar. Any non-linear parts (branches, multiple outputs) are preserved.
+2. **From Graph → Chain**: the chain view only renders the longest linear path; branches become inline cards.
+
+No data is lost when switching views.
+
+---
+
+## Mobile Chain Editor
+
+The chain layout is the default on the mobile app. See the screenshot and docs under [Mobile App → Mobile Graph Editor]({{ '/mobile-app#mobile-graph-editor' | relative_url }}).
+
+![Mobile Chain](assets/screenshots/mobile-graph-editor-chain.png)
+
+---
+
+## Next Steps
+
+- [Workflow Editor]({{ '/workflow-editor' | relative_url }}) — the full graph editor
+- [Cookbook]({{ '/cookbook' | relative_url }}) — linear patterns that work great in the chain editor
+- [Mobile App]({{ '/mobile-app' | relative_url }}) — running chains on iOS and Android

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,96 @@
+---
+layout: page
+title: "Collections"
+description: "Group documents into indexable collections for RAG workflows in NodeTool."
+---
+
+**Collections** bundle related documents into a single searchable unit. Connect a collection to an index node and any file in it — PDFs, Markdown notes, HTML, transcripts — becomes queryable from your workflows.
+
+![Collections Explorer](assets/screenshots/collections-explorer.png)
+
+---
+
+## Opening Collections
+
+Navigate to **Collections** from the left sidebar, or go directly to `/collections`. The explorer shows every collection you've created with counts of documents and the last time they were indexed.
+
+---
+
+## Creating a Collection
+
+1. Click **New Collection** in the top-right.
+2. Give it a name and an optional description.
+3. (Optional) Associate a default embedding model.
+4. Drag documents into the collection — or import a folder from the Asset Explorer.
+
+![New Collection](assets/screenshots/screenshot-placeholder.svg)
+
+Collections accept any file type, but only text-extractable formats are indexed:
+
+| Format | Extracted |
+|--------|-----------|
+| PDF | Text + layout (per page) |
+| DOCX / DOC | Body text |
+| Markdown / TXT | Raw text |
+| HTML | Stripped body text |
+| CSV / TSV | Rows as records |
+| EPUB | Chapter text |
+
+Unsupported formats are stored but not indexed — still handy for reference inside a collection.
+
+---
+
+## Managing Documents
+
+Click a collection tile to open its details. You can:
+
+- **Add** documents by drag-and-drop or the **Upload** button.
+- **Remove** documents from the collection (doesn't delete the underlying asset).
+- **Re-index** after adding new documents or changing the embedding model.
+- **Preview** any document inline with the built-in viewer.
+
+![Collection Details](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Using Collections in Workflows
+
+Collections shine in RAG pipelines:
+
+1. Add an **IndexDocuments** or **HybridSearch** node to your workflow.
+2. Connect the collection to its `collection` input — the node menu will suggest the selector.
+3. Run the workflow. The first run indexes the collection (embeddings + keyword index); subsequent runs reuse the index.
+
+See the full pattern in the [Cookbook → RAG]({{ '/cookbook#pattern-4-rag-retrieval-augmented-generation' | relative_url }}).
+
+---
+
+## Indexing Options
+
+By default a collection uses the embedding model set in **Settings → Default Models**. Override per-collection from its settings:
+
+- **Embedding model** — any embedding model from HuggingFace, OpenAI, Gemini, Cohere.
+- **Chunk size** — tokens per passage (default: 512).
+- **Overlap** — tokens shared between chunks (default: 64).
+- **Hybrid** — enable BM25 alongside vector search for better recall on proper nouns.
+
+![Collection Settings](assets/screenshots/screenshot-placeholder.svg)
+
+See [Indexing]({{ '/indexing' | relative_url }}) for deeper tuning notes.
+
+---
+
+## Storage
+
+Index data is stored alongside your workflow database in SQLite (via `sqlite-vec`). Nothing leaves your machine unless you've opted into a cloud provider for the embedding model.
+
+For multi-user deployments, Supabase-backed collections are an option — see [Supabase Deployment]({{ '/supabase-deployment' | relative_url }}).
+
+---
+
+## Related Docs
+
+- [Indexing]({{ '/indexing' | relative_url }}) — advanced chunking, hybrid search, maintenance
+- [Asset Management]({{ '/asset-management' | relative_url }}) — add documents to the underlying asset library
+- [Cookbook → RAG]({{ '/cookbook#pattern-4-rag-retrieval-augmented-generation' | relative_url }}) — wire a collection into a workflow
+- [Chat with Docs example]({{ '/workflows/chat-with-docs' | relative_url }}) — end-to-end RAG workflow

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,23 @@ This hierarchy allows committed defaults, per-environment overrides, and develop
 
 ## Managing Settings & Secrets
 
+The in-app Settings dialog is the easiest way to manage everything. It has a sidebar with subsections:
+
+| Section | What it covers |
+|---------|---------------|
+| **General** | Theme, startup behavior, language |
+| **Providers** | API keys for OpenAI, Anthropic, Google, etc. |
+| **Default Models** | Pick the default LLM, image model, and embedding model |
+| **Folders** | Workspace, cache, and asset directories |
+| **Secrets** | Encrypted provider tokens and credentials |
+| **Remote** | Point the app at a remote NodeTool server |
+| **ComfyUI** | Integration settings for the ComfyUI sidecar |
+| **About** | Version and build info |
+
+![Settings Subviews](assets/screenshots/screenshot-placeholder.svg)
+
+From the command line:
+
 - `nodetool settings show [--secrets]` – print the current values in a Rich table.
 - `nodetool settings edit [--secrets]` – open the YAML file in `$EDITOR`. Files are created on first use.
 

--- a/docs/editor-panels.md
+++ b/docs/editor-panels.md
@@ -1,0 +1,197 @@
+---
+layout: page
+title: "Editor Panels"
+description: "Every dockable panel around the NodeTool Workflow Editor — left, right, bottom, and floating."
+---
+
+The NodeTool [Workflow Editor]({{ '/workflow-editor' | relative_url }}) is surrounded by four dockable panels that host the workflow explorer, inspector, runtime diagnostics, and quick actions. This page covers each panel in depth.
+
+![Editor Layout](assets/screenshots/editor-empty-state.png)
+
+---
+
+## Left Panel
+
+Opens from the icons down the left edge. It's a tabbed drawer — click an icon to expand, click the same icon to collapse.
+
+![Left Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Workflows Tab
+
+Your saved workflows grouped by workspace. Search, filter by tag, and double-click to open in a new tab.
+
+![Left Panel — Workflows](assets/screenshots/screenshot-placeholder.svg)
+
+### Chat Tab
+
+A compact Global Chat embedded in the editor drawer. Perfect for asking the workflow assistant questions without leaving the canvas.
+
+![Left Panel — Chat](assets/screenshots/screenshot-placeholder.svg)
+
+### Assets Tab
+
+Folder tree plus file grid. Drag a file onto the canvas to instantly create the matching input node.
+
+![Left Panel — Assets](assets/screenshots/screenshot-placeholder.svg)
+
+### Collections Tab
+
+Grouped documents used by RAG and search nodes. See [Collections]({{ '/collections' | relative_url }}).
+
+![Left Panel — Collections](assets/screenshots/collections-explorer.png)
+
+### Packs Tab
+
+Installed node packs and their health status. Click a pack to open its README.
+
+![Left Panel — Packs](assets/screenshots/screenshot-placeholder.svg)
+
+### VibeCoding Tab
+
+AI-assisted UI generator for mini-apps. See [VibeCoding]({{ '/vibecoding' | relative_url }}).
+
+![Left Panel — VibeCoding](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Right Panel (Inspector)
+
+Press `i` or click the icon in the top right to toggle. Contents switch based on what's selected on the canvas.
+
+![Right Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Inspector — Node Properties
+
+When a node is selected, the Inspector renders every property with the right input type (number, slider, model picker, asset selector, dropdown, color picker, and so on).
+
+![Node Properties](assets/screenshots/screenshot-placeholder.svg)
+
+### Inspector — Workflow Properties
+
+When no node is selected, the Inspector shows workflow-level metadata: title, description, tags, thumbnail.
+
+![Workflow Properties](assets/screenshots/screenshot-placeholder.svg)
+
+### Logs Tab
+
+Raw logs from the current run. Filter by level (`debug`, `info`, `warn`, `error`) and search.
+
+![Log Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Jobs Tab
+
+Background jobs queued by your workflows — long-running fine-tunes, downloads, and batch runs.
+
+![Jobs Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Agent Tab
+
+When Agent Mode is active, the agent plan, steps, and tool calls surface here.
+
+![Agent Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Trace Tab
+
+Per-node execution timing and cache hits. Useful for spotting slow nodes.
+
+![Trace Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Version History Tab
+
+Every save is versioned. Diff two versions, roll back, or branch a workflow into a new one.
+
+![Version History](assets/screenshots/screenshot-placeholder.svg)
+
+### Workspace Tree
+
+File hierarchy of the backing workspace (on local installs) or the assigned workspace (on server installs).
+
+![Workspace Tree](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Bottom Panel
+
+The bottom panel docks a terminal plus runtime diagnostics. Drag its top edge to resize.
+
+![Bottom Panel](assets/screenshots/screenshot-placeholder.svg)
+
+### Terminal
+
+A full-featured terminal (xterm.js) connected to the server-side workspace. Run shell commands, git operations, and scripts without leaving NodeTool.
+
+![Terminal](assets/screenshots/screenshot-placeholder.svg)
+
+### Execution Trace
+
+The full call tree of the most recent run. Click a node to jump to it on the canvas.
+
+![Execution Tree](assets/screenshots/screenshot-placeholder.svg)
+
+### System Stats
+
+Live CPU, RAM, GPU, and disk IO. Helpful when debugging slow local models.
+
+![System Stats](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Floating Toolbar
+
+An overlay on the canvas with the most-used runtime controls.
+
+![Floating Toolbar](assets/screenshots/screenshot-placeholder.svg)
+
+| Button | State | Action |
+|--------|-------|--------|
+| ▶ Run | Idle | Start the workflow |
+| ⏸ Pause | Running | Pause without losing state |
+| ▶ Resume (blue) | Paused | Continue from the pause point |
+| ▶ Resume (purple) | Suspended | Resume a workflow waiting on external input |
+| ⏹ Stop | Running/Paused/Suspended | Cancel |
+| ⇄ Layout | Any | Auto-layout the graph |
+| 🔍 Fit | Any | Fit all nodes in the viewport |
+| ⋯ More | Any | Align, group, bypass, run from selection |
+
+---
+
+## Right Side Buttons
+
+A stack of toggles along the right canvas edge:
+
+- **Inspector** — open / close the right panel.
+- **Run as App** — jump to the Mini-App view for this workflow.
+- **Notifications** — pending warnings and agent messages.
+- **System Stats** — inline CPU/RAM preview.
+
+![Right Side Buttons](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## App Toolbar and App Header
+
+Together these form the fixed top chrome of the editor:
+
+- **App Header** — logo, workspace switcher, models, assets, chat, settings, downloads.
+- **App Toolbar** — workflow title, run controls, save status, share.
+
+![App Header](assets/screenshots/app-header.png)
+
+See [User Interface → App Header]({{ '/user-interface#the-app-header' | relative_url }}) for details.
+
+---
+
+## Customizing the Layout
+
+Every panel is a dockview tab — drag tabs between panels, out of panels to float them, or onto other tabs to stack them. The editor remembers your layout per workspace.
+
+To reset: open the command menu (`⌘K`), type "reset layout", and hit Enter.
+
+---
+
+## Next Steps
+
+- [Workflow Editor]({{ '/workflow-editor' | relative_url }}) — building on the canvas
+- [Global Chat]({{ '/global-chat' | relative_url }}) — how the in-editor chat works
+- [VibeCoding]({{ '/vibecoding' | relative_url }}) — generate custom UIs from a workflow
+- [Configuration]({{ '/configuration' | relative_url }}) — settings that affect the editor

--- a/docs/electron-views.md
+++ b/docs/electron-views.md
@@ -1,0 +1,172 @@
+---
+layout: page
+title: "Desktop App Views"
+description: "Windows, dialogs, menus, and tray surfaces unique to the NodeTool Electron desktop app."
+---
+
+The NodeTool desktop app is built on Electron. It reuses the web app for all workflow editing but adds a handful of native surfaces: a boot splash, install wizard, package manager, log viewer, tray menu, pinned windows, and a native menu bar.
+
+This page catalogs every desktop-only view with screenshots. Everything inside the main window is covered by [User Interface]({{ '/user-interface' | relative_url }}) and [Workflow Editor]({{ '/workflow-editor' | relative_url }}).
+
+---
+
+## Boot Message (Splash)
+
+A minimal splash appears while the embedded Python runtime, backend server, and web app all come online.
+
+![Boot Message](assets/screenshots/screenshot-placeholder.svg)
+
+The splash streams progress messages — "Starting Python…", "Warming models…", "Connecting to server…". It closes the moment the backend reports ready.
+
+---
+
+## Install Wizard
+
+On first launch (or after a major upgrade), the Install Wizard sets up the optional components NodeTool needs to run local models:
+
+- **Conda** environment with the required Python version
+- **Node packs** selected by the user
+- **AI runtimes** (torch, MLX, llama.cpp) appropriate for the detected hardware
+
+![Install Wizard](assets/screenshots/screenshot-placeholder.svg)
+
+You can re-run the wizard at any time from the **Package Manager** window — useful when you add a new node pack or upgrade your GPU.
+
+---
+
+## Package Manager
+
+Opens from the app menu or `⌘K → Open Package Manager`. A native window sized 1200×900 that manages:
+
+- Installed **node packs** and their upgrade availability.
+- Optional **AI runtimes** (torch CUDA, torch MPS, llama.cpp).
+- Conda environment health (Python version, cached wheels).
+- Integrity checks — re-download a broken runtime in one click.
+
+![Package Manager](assets/screenshots/screenshot-placeholder.svg)
+
+See [Node Packs]({{ '/node-packs' | relative_url }}) for where packs come from and how to publish your own.
+
+---
+
+## Log Viewer
+
+A persistent window that tails the backend log. Helpful for debugging without dropping to a terminal.
+
+![Log Viewer](assets/screenshots/screenshot-placeholder.svg)
+
+The log viewer supports:
+
+- **Log level filters** — `debug`, `info`, `warn`, `error`.
+- **Component filters** — backend, Python worker, web bridge, IPC.
+- **Search** with regex and highlight.
+- **Jump to file** — click a line to open its source in your editor (if `EDITOR` is configured).
+
+---
+
+## Update Notification
+
+When a new desktop release is available, a discreet toast appears with **Install now** and **Later** actions. The app restarts into the new build; there's no mandatory update interrupting a run.
+
+![Update Notification](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Pinned Windows
+
+Electron adds a few borderless, always-on-top window types:
+
+### Workflow Execution Window
+
+A frameless window that runs a single workflow with the inputs collapsed and the outputs centered. Great for a pinned dashboard on a second monitor.
+
+![Workflow Execution Window](assets/screenshots/screenshot-placeholder.svg)
+
+### Mini-App Window
+
+A self-contained Mini-App launched from the tray. Maximum size 1200×900. Closing it doesn't quit NodeTool.
+
+![Mini-App Window](assets/screenshots/screenshot-placeholder.svg)
+
+### Chat Window
+
+Standalone chat opened from the tray. Same content as [/standalone-chat]({{ '/user-interface#standalone-chat-window' | relative_url }}) but in its own window.
+
+![Chat Window](assets/screenshots/standalone-chat.png)
+
+---
+
+## System Tray
+
+The tray icon stays running while NodeTool is active and exposes quick actions:
+
+![Tray Menu](assets/screenshots/screenshot-placeholder.svg)
+
+| Action | What it does |
+|--------|--------------|
+| Open Dashboard | Bring up the main window |
+| Open Chat | Launch the standalone chat window |
+| Run Mini-App… | Submenu of mini-apps published from your workflows |
+| Settings | Native settings window |
+| Package Manager | Open the Package Manager window |
+| Log Viewer | Tail the backend log |
+| Quit NodeTool | Stop the backend and exit |
+
+---
+
+## Native Menu Bar
+
+On macOS and Windows a native menu bar is attached to the main window.
+
+![Menu Bar](assets/screenshots/screenshot-placeholder.svg)
+
+### File
+
+| Item | Shortcut | Action |
+|------|----------|--------|
+| New Workflow | `Ctrl/⌘ + T` | Open a blank workflow in a new tab |
+| Save | `Ctrl/⌘ + S` | Save the active workflow |
+| Close Tab | `Ctrl/⌘ + W` | Close the active editor tab |
+| Quit | `Ctrl/⌘ + Q` | Exit the app |
+
+### Edit
+
+Standard Undo, Redo, Cut, Copy, Paste, Select All, Delete — all mapped to the same shortcuts used on the canvas.
+
+### View
+
+| Item | Action |
+|------|--------|
+| Settings | Open the native settings window |
+| Package Manager | Open the Package Manager window |
+| Log Viewer | Open the Log Viewer window |
+| Reload | Reload the main window |
+| Toggle DevTools | Useful for debugging custom node UIs |
+
+### Window / Help
+
+Platform-standard items — switch windows, open the docs, show version info.
+
+---
+
+## Where the Electron Code Lives
+
+For contributors:
+
+- `electron/src/main.ts` — entry point, window lifecycle.
+- `electron/src/window.ts` — main window.
+- `electron/src/workflowWindow.ts` — pinned workflow and mini-app windows.
+- `electron/src/tray.ts` — tray icon and menu.
+- `electron/src/menu.ts` — native menu bar.
+- `electron/src/components/` — React components for the native windows.
+
+See the [Electron developer guide]({{ '/developer/' | relative_url }}) for build and debugging tips.
+
+---
+
+## Related Docs
+
+- [Installation]({{ '/installation' | relative_url }}) — download and first-run
+- [Configuration]({{ '/configuration' | relative_url }}) — settings persisted per-user
+- [Troubleshooting]({{ '/troubleshooting' | relative_url }}) — boot and install issues
+- [Deployment]({{ '/deployment' | relative_url }}) — self-hosted / cloud alternatives

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -34,6 +34,8 @@ The chat maintains a persistent WebSocket connection and automatically reconnect
 
 ### Choosing a Model
 
+![Chat Model Selector](assets/screenshots/screenshot-placeholder.svg)
+
 Select your preferred AI model from the model picker at the top of the chat. Available models depend on your configured providers:
 
 - **Cloud models** -- OpenAI GPT, Anthropic Claude, Google Gemini (requires API keys)
@@ -44,6 +46,8 @@ Configure providers in **Settings > Providers**. See [Models & Providers](models
 ---
 
 ## Conversation Threads
+
+![Chat Thread List](assets/screenshots/screenshot-placeholder.svg)
 
 Global Chat organizes conversations into threads:
 
@@ -58,6 +62,8 @@ Global Chat organizes conversations into threads:
 ## Agent Mode
 
 ### What is Agent Mode?
+
+![Agent Mode Enabled](assets/screenshots/screenshot-placeholder.svg)
 
 Agent Mode enables autonomous task execution. When enabled, the AI can break down complex requests into steps, select appropriate tools, and execute multi-step plans without manual intervention.
 
@@ -88,6 +94,8 @@ With Agent Mode enabled, the assistant can:
 
 ### Viewing Agent Progress
 
+![Agent Planning](assets/screenshots/screenshot-placeholder.svg)
+
 When an agent is executing tasks, you'll see:
 
 - **Task plan** -- The breakdown of steps the agent will execute
@@ -100,6 +108,8 @@ When an agent is executing tasks, you'll see:
 ## Workflow Integration
 
 ### Running Workflows from Chat
+
+![Workflow Attached to Chat](assets/screenshots/screenshot-placeholder.svg)
 
 1. Save a workflow in the workflow editor
 2. Open Global Chat
@@ -117,6 +127,8 @@ In Agent Mode, you can ask the agent to create or modify workflows. The agent us
 Global Chat agents have access to a comprehensive tool suite:
 
 ### Built-in Tools
+
+![Chat Tools Menu](assets/screenshots/screenshot-placeholder.svg)
 
 | Tool Category | What It Does |
 |--------------|--------------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ NodeTool is a visual workflow builder for AI pipelines — connect nodes to proc
 
 ### Choose your path
 
-- **I'm new to NodeTool:** [Getting Started]({{ '/getting-started' | relative_url }}), [Workflow Editor]({{ '/workflow-editor' | relative_url }}), [Image Editor]({{ '/image-editor' | relative_url }}), [Hardware Requirements]({{ '/installation#hardware-requirements-by-task' | relative_url }}), [Example Gallery]({{ '/workflows/' | relative_url }}).
+- **I'm new to NodeTool:** [Getting Started]({{ '/getting-started' | relative_url }}), [App Views Gallery]({{ '/app-views' | relative_url }}), [Workflow Editor]({{ '/workflow-editor' | relative_url }}), [Image Editor]({{ '/image-editor' | relative_url }}), [Hardware Requirements]({{ '/installation#hardware-requirements-by-task' | relative_url }}), [Example Gallery]({{ '/workflows/' | relative_url }}).
 - **I want to explore:** [Example Workflows]({{ '/workflows/' | relative_url }}), [Workflow Patterns]({{ '/cookbook' | relative_url }}), [Community](https://discord.gg/WmQTWZRcYE).
 - **I need AI models:** [Models & Providers]({{ '/models-and-providers' | relative_url }}), [HuggingFace Integration]({{ '/huggingface' | relative_url }}), [Local vs Cloud]({{ '/models' | relative_url }}).
 - **I'm coming from another tool:** [How NodeTool Compares]({{ '/comparisons' | relative_url }}) – understand where NodeTool fits.
@@ -154,6 +154,7 @@ NodeTool is a visual workflow builder for AI pipelines — connect nodes to proc
     <li><a href="{{ '/getting-started' | relative_url }}">Install & first workflow →</a></li>
     <li><a href="{{ '/key-concepts' | relative_url }}">Core concepts →</a></li>
     <li><a href="{{ '/user-interface' | relative_url }}">UI overview →</a></li>
+    <li><a href="{{ '/app-views' | relative_url }}">App views gallery →</a></li>
     <li><a href="{{ '/workflows/' | relative_url }}">Example gallery →</a></li>
     <li><a href="{{ '/cookbook' | relative_url }}">Workflow cookbook →</a></li>
     <li><a href="{{ '/models-and-providers' | relative_url }}">Models & providers →</a></li>

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -116,6 +116,12 @@ Chat with AI models from your mobile device.
 
 Run your NodeTool workflows with a simplified mobile interface.
 
+### Mini Apps List
+
+Browse every mini-app published by your server.
+
+![Mini Apps List](assets/screenshots/screenshot-placeholder.svg)
+
 ### What Are Mini Apps?
 
 Mini Apps are workflows converted to simple interfaces. They hide the complexity of the workflow and show only:
@@ -135,6 +141,8 @@ Mini Apps are workflows converted to simple interfaces. They hide the complexity
 5. Tap **Run**
 6. View results below
 
+![Mini App Runner](assets/screenshots/screenshot-placeholder.svg)
+
 ### Supported Input Types
 
 | Type | Description |
@@ -142,6 +150,78 @@ Mini Apps are workflows converted to simple interfaces. They hide the complexity
 | Text | Single or multi-line text input |
 | Number | Numeric values |
 | Boolean | On/off toggle switches |
+
+---
+
+## Mobile Graph Editor
+
+The mobile app includes a touch-friendly version of the workflow editor. It defaults to a vertical chain layout but supports pan-and-zoom editing for arbitrary graphs.
+
+### Overview
+
+![Mobile Graph Editor](assets/screenshots/mobile-graph-editor-overview.png)
+
+### Empty State
+
+New workflows open with a single prompt to add your first node.
+
+![Mobile Graph Editor — Empty](assets/screenshots/mobile-graph-editor-empty.png)
+
+### Node Picker
+
+Tap the **+** button to open the full-screen node picker, which filters by input/output compatibility.
+
+![Mobile Graph Editor — Picker](assets/screenshots/mobile-graph-editor-picker.png)
+
+### Linear Chain
+
+Most workflows render as a vertical chain of cards on mobile — easier to scroll and tap.
+
+![Mobile Graph Editor — Chain](assets/screenshots/mobile-graph-editor-chain.png)
+
+Touch gestures:
+
+| Gesture | Action |
+|---------|--------|
+| Tap a card | Open its properties |
+| Long-press | Grab and reorder |
+| Pinch | Zoom (when the graph view is in "free" mode) |
+| Two-finger drag | Pan the canvas |
+
+---
+
+## Mobile Settings
+
+Configure the mobile app from the gear icon:
+
+![Mobile Settings](assets/screenshots/screenshot-placeholder.svg)
+
+| Setting | Purpose |
+|---------|---------|
+| Server URL | Which NodeTool server to talk to |
+| Test Connection | One-tap ping of the configured URL |
+| Default Language Model | Default LLM for new chat threads |
+| Appearance | Light / Dark / System theme |
+| Storage | Cached thread size and clear cache |
+| About | App version, build info, links |
+
+---
+
+## Mobile Language Model Selection
+
+Tapping the model name at the top of a chat opens a searchable picker with every model offered by your server.
+
+![Mobile Model Selection](assets/screenshots/screenshot-placeholder.svg)
+
+Providers without configured API keys are greyed out and linked to the docs for setup.
+
+---
+
+## Tablet Dashboard
+
+On tablets the dashboard uses a two-column layout that shows the workflow list and the active thread side-by-side.
+
+![Tablet Dashboard](assets/screenshots/dashboard-tablet.png)
 
 ---
 

--- a/docs/models-manager.md
+++ b/docs/models-manager.md
@@ -12,9 +12,13 @@ The **Models Manager** helps you browse, download, and manage AI models availabl
 
 Click the **Models** icon in the app header to open the Models Manager dialog. It shows all downloaded models, recommended models, and available models from configured providers.
 
+![Models Manager — Full View](assets/screenshots/models-list.png)
+
 ---
 
 ## Browsing Models
+
+![Model Type Filters](assets/screenshots/screenshot-placeholder.svg)
 
 ### Filter by Type
 
@@ -43,6 +47,8 @@ Use the type filters on the left to narrow the list:
 
 ## Downloading Models
 
+![Download Progress](assets/screenshots/screenshot-placeholder.svg)
+
 1. Find the model you want in the browser
 2. Click **Download** to start fetching it to your local cache
 3. Track progress in the **Downloads** bar at the bottom of the screen
@@ -64,14 +70,33 @@ Downloaded models are stored in your local HuggingFace cache (`~/.cache/huggingf
 
 ### Per-Model Actions
 
+![Model Card Actions](assets/screenshots/screenshot-placeholder.svg)
+
 - **Download** -- Fetch a model to your local cache
 - **Delete** -- Remove a model you no longer need to free disk space
 - **Show in Explorer** -- Open the model folder on your computer
 - **README** -- Read the model's documentation on Hugging Face
 
+![Model README](assets/screenshots/screenshot-placeholder.svg)
+
 ### Recommended Models
 
+![Recommended Models Dialog](assets/screenshots/screenshot-placeholder.svg)
+
 Many workflow nodes specify recommended or required models. The Models Manager highlights these under a **Recommended** section with direct install links, so you can quickly get the models your workflows need.
+
+### Model Selection Dialogs
+
+Each property role has a type-aware picker:
+
+- **Language Model** — LLM selector with provider grouping
+- **Image Model** — image-generation models only
+- **Video Model** — video-generation models only
+- **TTS / ASR Model** — speech models only
+- **Embedding Model** — vector embedding models only
+- **HuggingFace Model** — search any HF repo
+
+![Language Model Selector](assets/screenshots/screenshot-placeholder.svg)
 
 ### Cloud Provider Models
 

--- a/docs/templates-gallery.md
+++ b/docs/templates-gallery.md
@@ -1,0 +1,85 @@
+---
+layout: page
+title: "Templates Gallery"
+description: "Browse ready-to-run example workflows and use them as starting points."
+---
+
+The **Templates Gallery** is a curated library of example workflows you can run and customize without starting from scratch. Open it from the **Templates** button in the app header or by navigating to `/templates`.
+
+![Templates Grid](assets/screenshots/templates-grid.png)
+
+---
+
+## What's in the Gallery
+
+Every template is a real, runnable workflow exported from the editor. Templates ship with NodeTool and cover:
+
+| Category | Examples |
+|----------|----------|
+| **Image generation** | Movie Posters, Character Sheets, Product Shots |
+| **Image editing** | Background Removal, Upscaling, Style Transfer |
+| **Agents** | Research agents, RAG Q&A, multi-step tool runners |
+| **Document intelligence** | Chat-with-Docs, PDF extraction, data enrichment |
+| **Audio & video** | Transcription, summarization, text-to-speech |
+| **Data pipelines** | CSV ingestion, chart generation, scheduled reports |
+| **Realtime** | Voice agents, streaming transcription |
+
+Browse the full list on the [Workflow Examples]({{ '/workflows/' | relative_url }}) page.
+
+---
+
+## Opening a Template
+
+1. Click a template tile to preview its graph.
+2. Hit **Open** (or double-click) to load it into the editor as a new workflow.
+3. Save a copy with `Ctrl/⌘ + S` — edits never modify the original template.
+
+![Template Preview](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Filtering and Searching
+
+The gallery supports:
+
+- **Tag filter** — click any tag (e.g., "agent", "image") to narrow the list.
+- **Search bar** — match by title, tags, or node names used inside the workflow.
+- **Sort** — recently added, most popular, shortest.
+
+![Template Filters](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Anatomy of a Template Card
+
+Each tile shows:
+
+- **Thumbnail** — a static render of the graph.
+- **Title and description** — a one-line summary.
+- **Input badges** — the required inputs (e.g., "Text", "Image").
+- **Output badges** — what the workflow produces.
+- **Required models** — any models you need downloaded first.
+
+If a template requires a model you don't have, opening it shows the **Recommended Models** dialog so you can install them in one click.
+
+![Recommended Models from Template](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Submitting Your Own Template
+
+Community templates ship through the `examples/` directory of the NodeTool repo:
+
+1. Save your workflow, then use `nodetool workflows export-dsl <id>` to export it as a TypeScript DSL file.
+2. Add it to `examples/<category>/<slug>.ts` in a PR.
+3. Include a short README — 1 paragraph, 1 screenshot of the graph.
+
+See the [Developer Guide]({{ '/developer/' | relative_url }}) for full contribution guidelines.
+
+---
+
+## Related Docs
+
+- [Workflow Examples]({{ '/workflows/' | relative_url }}) — in-depth walkthroughs of individual templates
+- [Cookbook]({{ '/cookbook' | relative_url }}) — reusable workflow patterns
+- [Getting Started]({{ '/getting-started' | relative_url }}) — runs a template as your first workflow

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -8,6 +8,8 @@ A complete tour of the NodeTool interface — covering the Dashboard, Workflow C
 
 > **New to NodeTool?** Start with the [Getting Started guide](getting-started.md) to run your first workflow, then come back here for the full interface walkthrough.
 
+> **Looking for every view at a glance?** See the [App Views Gallery](app-views.md) — a visual index of every screen, panel, and dialog with links to detailed docs.
+
 ---
 
 ## At a Glance
@@ -175,6 +177,24 @@ Launch mini-apps in dedicated windows from the system tray:
 
 ---
 
+## Mini-Apps
+
+Turn a workflow into a simple form-based app for sharing.
+
+![Mini-App Interface](assets/screenshots/screenshot-placeholder.svg)
+
+### Running a Mini-App
+
+- **Inside the app** — open the Mini-App from the Templates panel or from `/apps/:workflowId`.
+- **Standalone window (desktop)** — launch a mini-app from the tray; it opens in its own window.
+- **Mobile** — see [Mobile App → Mini Apps](mobile-app.md#mini-apps).
+
+See the full [Electron Views](electron-views.md#mini-app-window) docs for the desktop runner.
+
+![Mini-App Results](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
 ## Assets
 
 The Asset Explorer manages all your files.
@@ -249,6 +269,8 @@ Your layout is saved automatically. To reset:
 
 Press `Alt+K` (Windows/Linux) or `⌘+K` (Mac) to open the **Command Menu**.
 
+![Command Menu](assets/screenshots/screenshot-placeholder.svg)
+
 This is the fastest way to:
 - Open any workflow
 - Switch between sections
@@ -312,6 +334,8 @@ Just start typing what you want!
 
 ## Next Steps
 
+- **[App Views Gallery](app-views.md)** – Visual index of every screen, panel, and dialog
 - **[Workflow Editor deep dive](workflow-editor.md)** – Master the canvas
+- **[Editor Panels](editor-panels.md)** – Left, right, bottom, and floating panels
 - **[Tips & Tricks](tips-and-tricks.md)** – Power user secrets
 - **[Cookbook](cookbook.md)** – Learn workflow patterns

--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -8,6 +8,8 @@ The Workflow Editor is where you build, test, and refine AI workflows. This page
 
 > **New to NodeTool?** Start with the [Getting Started](getting-started.md) guide to run your first workflow, then come back here to learn the editor in depth.
 
+> **Want every panel explained?** See [Editor Panels](editor-panels.md) for a deep dive on the left, right, bottom, and floating panels.
+
 ---
 
 ## Editor Layout
@@ -60,6 +62,8 @@ Each node does one thing.
 3. See compatible nodes
 
 ### Node Structure
+
+![Node Anatomy](assets/screenshots/screenshot-placeholder.svg)
 
 - **Header** (top) - Name, drag to move
 - **Inputs** (left circles) - Data in
@@ -150,6 +154,8 @@ When you drag a connection and release on **empty space**, the **Connection Menu
 
 ### Watching Progress
 
+![Workflow Progress](assets/screenshots/screenshot-placeholder.svg)
+
 - **Streaming nodes** show output as it's generated
 - **Preview nodes** display intermediate results
 - **Node borders** indicate status (running, complete, error)
@@ -194,6 +200,8 @@ Suspended workflows are useful for:
 
 ### Missing Models
 
+![Missing Model Indicator](assets/screenshots/screenshot-placeholder.svg)
+
 If a node needs an AI model you haven't installed:
 1. Click the **"Missing Model"** indicator on the node
 2. The **Recommended Models** dialog opens
@@ -205,9 +213,13 @@ If a node needs an AI model you haven't installed:
 
 ### Auto Layout
 
+![Auto Layout Before/After](assets/screenshots/screenshot-placeholder.svg)
+
 Click the **Auto Layout** button (or press `L`) to automatically arrange your nodes in a clean, readable layout. The editor also auto-arranges nodes when Global Chat creates or modifies workflows.
 
 ### Grouping Nodes
+
+![Node Groups](assets/screenshots/screenshot-placeholder.svg)
 
 Select multiple nodes and press `Ctrl/⌘ + G` to group them. Groups:
 - Keep related nodes together
@@ -227,6 +239,8 @@ Select multiple nodes and press `Ctrl/⌘ + G` to group them. Groups:
 
 ### Multiple Workflows
 
+![Workflow Tabs](assets/screenshots/screenshot-placeholder.svg)
+
 - Open multiple workflows in **tabs** at the top
 - Switch with `Ctrl/⌘ + 1-9` or click the tab
 - Drag tabs to reorder
@@ -245,16 +259,22 @@ Access these views by clicking icons on the left:
 
 ### Right Panel (Inspector)
 
+![Inspector Panel](assets/screenshots/screenshot-placeholder.svg)
+
 Press `i` to toggle the **Inspector** panel, which shows:
 - Detailed properties for selected nodes
 - Input/output documentation
 - Validation errors and warnings
+
+See [Editor Panels → Right Panel](editor-panels.md#right-panel-inspector) for every tab (Inspector, Logs, Jobs, Agent, Trace, Version History, Workspace).
 
 ---
 
 ## Finding Nodes
 
 ### The Node Menu
+
+![Node Menu Open](assets/screenshots/screenshot-placeholder.svg)
 
 Press `Space` to open, then:
 
@@ -275,6 +295,8 @@ Get help on any node:
 ---
 
 ## Context Menus
+
+![Context Menu on Node](assets/screenshots/screenshot-placeholder.svg)
 
 Right-click for options anywhere:
 
@@ -304,6 +326,8 @@ Click the edit icon on image outputs or properties to open the full-featured edi
 > **📖 Full Guide:** See [Image Editor](image-editor.md) for complete documentation with tool reference, shortcuts, and workflows.
 
 ### Color Picker
+
+![Color Picker Modal](assets/screenshots/screenshot-placeholder.svg)
 
 The professional color picker appears when selecting colors in properties:
 

--- a/docs/workflow-graph-view.md
+++ b/docs/workflow-graph-view.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: "Workflow Graph View"
+description: "Read-only visualization of a NodeTool workflow."
+---
+
+The **Workflow Graph View** is a read-only rendering of a saved workflow. It's useful for sharing a visual snapshot, embedding workflow diagrams in documentation, and giving stakeholders a look without handing them the editor.
+
+![Workflow Graph View](assets/screenshots/screenshot-placeholder.svg)
+
+---
+
+## Opening the View
+
+The graph view lives at `/graph/:workflowId`. You can link directly to it from the workflow's **Share** menu, or paste the URL into a Markdown file — Jekyll will render the image when the page is exported statically.
+
+Unlike the [Workflow Editor]({{ '/workflow-editor' | relative_url }}), the graph view:
+
+- Does **not** load the Node Menu, Inspector, or the panel drawers.
+- Does **not** allow editing — nodes can't be added, moved, or deleted.
+- Does **not** require authentication on localhost deployments.
+
+This makes it lightweight (~5× smaller bundle) and safe to expose behind a read-only proxy.
+
+---
+
+## Interactions
+
+The graph view supports the read-only subset of the editor:
+
+| Action | How |
+|--------|-----|
+| Pan | Click-and-drag the canvas |
+| Zoom | `Ctrl/⌘` + scroll |
+| Fit view | Press `F` |
+| Hover a node | See its name and status |
+| Click a node | Open its read-only property panel |
+| Copy share link | Use the browser URL |
+
+Running the workflow is not possible from this view — users must open it in the editor first.
+
+---
+
+## Embedding in Docs
+
+You can embed the graph view inside another page with an iframe:
+
+```html
+<iframe
+  src="https://your-nodetool-host/graph/WORKFLOW_ID"
+  width="100%"
+  height="540"
+  loading="lazy"
+  referrerpolicy="no-referrer">
+</iframe>
+```
+
+For stored Markdown docs, take a screenshot instead so the graph is captured even when the server is offline.
+
+---
+
+## Exporting a Graph Image
+
+From the read-only view, press `Shift+E` to download a PNG of the current viewport, or use the **Export** button in the header. The image includes the workflow title, so it's ready for blog posts and slides.
+
+---
+
+## Access Control
+
+The graph view inherits the workflow's own visibility:
+
+- **Private** — requires the user to be signed in with access to the workflow.
+- **Shared** — accessible to anyone with the link.
+- **Public** — indexed and crawlable.
+
+For localhost deployments, all workflows are effectively local and the view is open to anyone who can reach your server.
+
+---
+
+## Next Steps
+
+- [Workflow Editor]({{ '/workflow-editor' | relative_url }}) — the full editor where you author workflows
+- [Chain Editor]({{ '/chain-editor' | relative_url }}) — the linear alternative
+- [Authentication]({{ '/authentication' | relative_url }}) — how access is enforced


### PR DESCRIPTION
## Summary

This PR adds a complete visual index of every screen, panel, and dialog in NodeTool, along with detailed documentation pages for previously undocumented UI surfaces. The changes establish a single source of truth for app views and improve navigation between related documentation.

## Key Changes

- **New `app-views.md`** — A comprehensive gallery indexing every user-facing view across web, desktop (Electron), and mobile with screenshots and links to detailed docs. Organized into sections: Top-Level Views, Editor Panels, Dialogs/Modals, Mobile Screens, and Electron Windows.

- **New dedicated documentation pages:**
  - `editor-panels.md` — Deep dive into left, right, bottom, and floating panels surrounding the Workflow Editor
  - `chain-editor.md` — Linear, card-based workflow authoring as an alternative to the node graph
  - `workflow-graph-view.md` — Read-only workflow visualization for sharing and embedding
  - `templates-gallery.md` — Browse and use ready-to-run example workflows
  - `collections.md` — Group documents into indexable collections for RAG workflows
  - `electron-views.md` — Desktop app–specific windows, dialogs, menus, and tray surfaces

- **Updated `SCREENSHOTS.md`** — Expanded screenshot tracking plan with new sections for Editor Panels, Chain Editor, Workflow Graph View, Templates Gallery, Collections, Mobile App, and Desktop/Electron. Added cross-references to the new app-views gallery.

- **Updated existing docs:**
  - `user-interface.md` — Added link to App Views Gallery and expanded Mini-Apps section
  - `workflow-editor.md` — Added link to Editor Panels documentation
  - `models-manager.md` — Added screenshot references
  - `global-chat.md` — Added screenshot reference for model selector
  - `mobile-app.md` — Expanded Mobile Graph Editor section with empty state, picker, and chain layout details
  - `configuration.md` — Added Settings dialog subsection table
  - `asset-management.md` — Added Asset Explorer screenshot reference
  - `index.md` — Updated navigation links

- **New `screenshot-placeholder.svg`** — Reusable placeholder graphic for pending screenshots (1280×720 with grid pattern and "Screenshot pending capture" label)

- **Updated sidebar navigation** — Added App Views Gallery and new documentation pages to the main navigation structure

## Implementation Details

- All new pages follow the existing Jekyll layout and Liquid template conventions
- Screenshot references use relative URLs via `relative_url` filter for portability
- Placeholder SVG uses a subtle grid pattern and gradient background to distinguish pending screenshots from real captures
- Documentation is organized hierarchically with clear section headers and cross-references
- Each view entry includes a description, screenshot, and link to detailed docs where applicable

https://claude.ai/code/session_01TzHQ7Nw4BdHGD6pqtD7FyZ