### PR TITLE
Refactor dev scripts and improve child process handling

### DIFF
--- a/packages/websocket/tests/child-shutdown.test.ts
+++ b/packages/websocket/tests/child-shutdown.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import { resolve } from "node:path";
-import {
-  getTsxWatchCommand,
-  registerChildShutdownHandlers
-} from "../../../scripts/child-shutdown.mjs";
+import { registerChildShutdownHandlers } from "../../../scripts/child-shutdown.mjs";
+import { getTsxWatchCommand } from "../../../scripts/dev-commands.mjs";
 
 class FakeProcess extends EventEmitter {
   exit = vi.fn();
@@ -48,6 +46,138 @@ describe("registerChildShutdownHandlers", () => {
     expect(processLike.exit).toHaveBeenCalledWith(130);
   });
 
+  it("kills the child and exits with code 143 on SIGTERM", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(5678);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "win32",
+      child,
+      processLike,
+      killTree
+    });
+
+    processLike.emit("SIGTERM");
+
+    expect(killTree).toHaveBeenCalledWith(5678);
+    expect(processLike.exit).toHaveBeenCalledWith(143);
+  });
+
+  it("also handles SIGBREAK on Windows", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(9012);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "win32",
+      child,
+      processLike,
+      killTree
+    });
+
+    processLike.emit("SIGBREAK");
+
+    expect(killTree).toHaveBeenCalledWith(9012);
+    expect(processLike.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("kills the child process group on Unix SIGINT", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(4321);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "linux",
+      child,
+      processLike,
+      killTree
+    });
+
+    processLike.emit("SIGINT");
+
+    expect(killTree).toHaveBeenCalledWith(4321);
+    expect(processLike.exit).toHaveBeenCalledWith(130);
+  });
+
+  it("does not register SIGBREAK on Unix", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(4321);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "linux",
+      child,
+      processLike,
+      killTree
+    });
+
+    // SIGBREAK is a Windows-only signal; the Unix branch should not listen
+    // for it, so emitting it must not trigger a kill/exit.
+    processLike.emit("SIGBREAK");
+
+    expect(killTree).not.toHaveBeenCalled();
+    expect(processLike.exit).not.toHaveBeenCalled();
+  });
+
+  it("kills the child on parent exit without calling processLike.exit again", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(2468);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "linux",
+      child,
+      processLike,
+      killTree
+    });
+
+    processLike.emit("exit");
+
+    expect(killTree).toHaveBeenCalledWith(2468);
+    expect(processLike.exit).not.toHaveBeenCalled();
+  });
+
+  it("removes listeners when the child exits so the parent stays alive", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(1357);
+    const killTree = vi.fn();
+
+    registerChildShutdownHandlers({
+      platform: "linux",
+      child,
+      processLike,
+      killTree
+    });
+
+    child.emit("exit");
+    processLike.emit("SIGINT");
+
+    expect(killTree).not.toHaveBeenCalled();
+    expect(processLike.exit).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the child has no pid", () => {
+    const processLike = new FakeProcess();
+    const child = new FakeChild(undefined);
+    const killTree = vi.fn();
+
+    const cleanup = registerChildShutdownHandlers({
+      platform: "linux",
+      child,
+      processLike,
+      killTree
+    });
+
+    processLike.emit("SIGINT");
+
+    expect(killTree).not.toHaveBeenCalled();
+    expect(processLike.exit).not.toHaveBeenCalled();
+    expect(typeof cleanup).toBe("function");
+  });
+});
+
+describe("getTsxWatchCommand", () => {
   it("uses the repo-local tsx CLI through node", () => {
     const repoRoot = resolve(import.meta.dirname, "../../..");
 

--- a/scripts/child-shutdown.mjs
+++ b/scripts/child-shutdown.mjs
@@ -1,5 +1,4 @@
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
 
 function getExitCodeForSignal(signal) {
   if (signal === "SIGINT") {
@@ -24,19 +23,33 @@ export function killProcessTree(pid, platform = process.platform) {
   }
 
   try {
+    // Negative PID signals the whole process group — required when the child
+    // was spawned with `detached: true` (its own process group), because a
+    // terminal SIGINT in the parent does not propagate there.
     process.kill(-pid, "SIGTERM");
   } catch {
     // Child already exited.
   }
 }
 
+/**
+ * Register parent-process signal handlers that kill a spawned child (and its
+ * process group) before exiting.
+ *
+ * Behaves on both Windows and Unix — on Windows the tree is killed via
+ * `taskkill /F /T`, on Unix via `process.kill(-pid, SIGTERM)`. Historically
+ * this was a no-op off Windows under the assumption that terminal signals
+ * reach the child via the shared process group; that assumption breaks as
+ * soon as a caller uses `detached: true` (e.g. `run-websocket-dev.mjs`), so
+ * the handlers now run on every platform.
+ */
 export function registerChildShutdownHandlers({
   child,
   processLike = process,
   platform = process.platform,
   killTree = (pid) => killProcessTree(pid, platform)
 }) {
-  if (platform !== "win32" || !child?.pid) {
+  if (!child?.pid) {
     return () => {};
   }
 
@@ -60,7 +73,11 @@ export function registerChildShutdownHandlers({
     processLike.exit(getExitCodeForSignal(signal));
   };
 
-  for (const signal of ["SIGINT", "SIGTERM", "SIGBREAK"]) {
+  const signals = platform === "win32"
+    ? ["SIGINT", "SIGTERM", "SIGBREAK"]
+    : ["SIGINT", "SIGTERM"];
+
+  for (const signal of signals) {
     const listener = () => exitWithSignal(signal);
     listeners.push([signal, listener]);
     processLike.once(signal, listener);
@@ -75,11 +92,4 @@ export function registerChildShutdownHandlers({
 
   child.once("exit", cleanup);
   return cleanup;
-}
-
-export function getTsxWatchCommand(repoRoot, entrypoint) {
-  return {
-    command: process.execPath,
-    args: [resolve(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"), "--watch", entrypoint]
-  };
 }

--- a/scripts/dev-commands.mjs
+++ b/scripts/dev-commands.mjs
@@ -1,0 +1,12 @@
+import { resolve } from "node:path";
+
+/**
+ * Build the command and args required to run an entrypoint with the
+ * repo-local tsx CLI under `--watch`.
+ */
+export function getTsxWatchCommand(repoRoot, entrypoint) {
+  return {
+    command: process.execPath,
+    args: [resolve(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"), "--watch", entrypoint]
+  };
+}

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -15,7 +15,8 @@ import { spawn } from "node:child_process";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { getTsxWatchCommand, registerChildShutdownHandlers } from "./child-shutdown.mjs";
+import { registerChildShutdownHandlers } from "./child-shutdown.mjs";
+import { getTsxWatchCommand } from "./dev-commands.mjs";
 
 const mode = process.argv[2] ?? "server";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -74,7 +75,3 @@ const child = spawn(command, args, {
 
 registerChildShutdownHandlers({ child });
 child.on("exit", (code) => process.exit(code ?? 1));
-if (process.platform !== "win32") {
-  process.on("SIGINT", () => { child.kill("SIGINT"); });
-  process.on("SIGTERM", () => { child.kill("SIGTERM"); });
-}

--- a/scripts/run-websocket-dev.mjs
+++ b/scripts/run-websocket-dev.mjs
@@ -38,10 +38,16 @@ if (!(buildMode in buildCommands)) {
 function isPortInUse(hostname, portNumber) {
   return new Promise((resolveCheck) => {
     const socket = net.createConnection({ host: hostname, port: portNumber });
+    socket.setTimeout(2000);
 
     socket.once("connect", () => {
       socket.end();
       resolveCheck(true);
+    });
+
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolveCheck(false);
     });
 
     socket.once("error", (error) => {

--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -646,10 +646,6 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
     ]
   );
 
-  if (!metadata) {
-    throw new Error("Metadata is not loaded for node " + id);
-  }
-
   const onToggleAdvancedFields = useCallback(() => {
     setShowAdvancedFields(!showAdvancedFields);
     // Reset node height to auto-size when toggling advanced fields

--- a/web/src/components/node/NodeHeader.tsx
+++ b/web/src/components/node/NodeHeader.tsx
@@ -202,19 +202,6 @@ export const NodeHeader: React.FC<NodeHeaderProps> = ({
     []
   );
 
-  const _handleOpenContextMenu = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      openContextMenu(
-        "node-context-menu",
-        id,
-        event.clientX,
-        event.clientY,
-        "node-header"
-      );
-    },
-    [id, openContextMenu]
-  );
   const handleHeaderContextMenu = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       event.preventDefault();

--- a/web/src/hooks/useCreateNode.ts
+++ b/web/src/hooks/useCreateNode.ts
@@ -8,8 +8,7 @@ import { useRecentNodesStore } from "../stores/RecentNodesStore";
 import useMetadataStore from "../stores/MetadataStore";
 import { findSnippetByNodeType } from "../config/snippetMetadata";
 import { inferOutputKeysFromCode, inferInputKeysFromCode } from "../utils/codeOutputInference";
-
-const CODE_NODE_TYPE = "nodetool.code.Code";
+import { CODE_NODE_TYPE } from "../components/node/codeNodeUi";
 
 /**
  * Hook for creating new nodes in the workflow editor.


### PR DESCRIPTION
## Summary
This PR refactors development scripts to improve code organization and enhances child process shutdown handling to work reliably across all platforms, particularly when processes are spawned with `detached: true`.

## Key Changes

- **Extracted `getTsxWatchCommand` to new module**: Moved `getTsxWatchCommand` from `child-shutdown.mjs` to a new `dev-commands.mjs` file to separate concerns between command building and process lifecycle management.

- **Enhanced child shutdown handlers**: 
  - Removed Windows-only platform check, making handlers work on all platforms (Unix and Windows)
  - Added proper signal handling for both Windows (`SIGINT`, `SIGTERM`, `SIGBREAK`) and Unix (`SIGINT`, `SIGTERM`)
  - Improved documentation explaining the need for process group signaling when `detached: true` is used
  - Removed redundant signal handlers from `dev-server.mjs` in favor of centralized `registerChildShutdownHandlers`

- **Improved port availability check**: Added timeout handling to `isPortInUse` in `run-websocket-dev.mjs` to prevent hanging on unresponsive hosts.

- **Code cleanup**:
  - Removed unused `_handleOpenContextMenu` callback from `NodeHeader.tsx`
  - Removed unnecessary metadata existence check from `BaseNode.tsx`
  - Consolidated `CODE_NODE_TYPE` constant import in `useCreateNode.ts`

- **Expanded test coverage**: Added comprehensive test cases for `registerChildShutdownHandlers` covering SIGTERM, SIGBREAK, platform-specific behavior, listener cleanup, and edge cases.

## Implementation Details

The refactoring ensures that child processes spawned with `detached: true` (which create their own process group) are properly terminated when the parent receives signals. This is achieved by using negative PIDs in `process.kill(-pid, signal)` on Unix systems, which targets the entire process group rather than just the child process.

https://claude.ai/code/session_01R5MKueK2CmTaDhDyEaKqGv