### PR TITLE
ci: switch agent workflows to claude code oauth auth

### DIFF
--- a/.github/workflows/dead-code-cleanup.yaml
+++ b/.github/workflows/dead-code-cleanup.yaml
@@ -47,10 +47,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/dependency-cleanup.yaml
+++ b/.github/workflows/dependency-cleanup.yaml
@@ -47,10 +47,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -40,10 +40,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/performance-optimization.yaml
+++ b/.github/workflows/performance-optimization.yaml
@@ -47,10 +47,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -68,10 +68,8 @@ jobs:
       - name: Run Claude Code
         if: env.QUALITY_FAILED == '1'
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -57,10 +57,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -63,10 +63,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |

--- a/.github/workflows/type-safety.yaml
+++ b/.github/workflows/type-safety.yaml
@@ -65,10 +65,8 @@ jobs:
       - name: Run Claude Code
         if: env.TYPE_ISSUES == '1'
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: |


### PR DESCRIPTION
Align all agent-driven workflows with the claude.yml / claude-code-review.yml
example by swapping the z.ai API routing (ANTHROPIC_BASE_URL + ZAI_API_KEY)
for claude_code_oauth_token. Keeps prompts and allowed-tools unchanged.

https://claude.ai/code/session_01AZ4V3g1VD8nvqShpA3nRej