### PR TITLE
Improve release workflow: sync versions and handle Windows installer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   release-build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-latest
@@ -47,6 +48,27 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
+
+      - name: Sync package versions to release tag
+        if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.version != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION_NO_V="${VERSION#v}"
+          VERSION_NO_V="${VERSION_NO_V//\//-}"
+          export VERSION_NO_V
+          echo "Syncing package.json versions to ${VERSION_NO_V}"
+          node -e '
+            const fs = require("fs");
+            const version = process.env.VERSION_NO_V;
+            const files = ["package.json", "electron/package.json", "web/package.json"];
+            for (const p of files) {
+              const pkg = JSON.parse(fs.readFileSync(p, "utf8"));
+              pkg.version = version;
+              fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + "\n");
+              console.log(`Updated ${p} to ${version}`);
+            }
+          '
 
       - name: Install Apple Certificate
         if: matrix.os == 'macos-latest'
@@ -228,6 +250,29 @@ jobs:
         run: |
           cd electron
           npx electron-builder --config electron-builder.json --win --x64 --prepackaged dist/win-unpacked --publish never
+
+      - name: Locate built Windows installer
+        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
+        shell: bash -l {0}
+        run: |
+          set -euo pipefail
+          if [ ! -f "${INSTALLER_PATH}" ]; then
+            echo "Expected installer not at ${INSTALLER_PATH}; searching dist for Setup exe"
+            FOUND="$(ls -1 "${DIST_DIR}"/*Setup*.exe 2>/dev/null | head -n 1 || true)"
+            if [ -z "${FOUND}" ] || [ ! -f "${FOUND}" ]; then
+              echo "Could not find any Setup installer .exe in ${DIST_DIR}"
+              ls -la "${DIST_DIR}" || true
+              exit 1
+            fi
+            TARGET="${DIST_DIR}/Nodetool-Setup-${VERSION}.exe"
+            if [ "${FOUND}" != "${TARGET}" ]; then
+              echo "Renaming ${FOUND} -> ${TARGET}"
+              mv -f "${FOUND}" "${TARGET}"
+            fi
+            echo "INSTALLER_PATH=${TARGET}" >> "${GITHUB_ENV}"
+          else
+            echo "Installer found at ${INSTALLER_PATH}"
+          fi
 
       - name: Sign installer exe (SSL.com eSigner)
         if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
This PR enhances the GitHub Actions release workflow to better handle version synchronization and Windows installer artifact management during tagged releases.

## Key Changes
- **Add `fail-fast: false` to matrix strategy**: Ensures all matrix jobs complete even if one fails, improving reliability of multi-platform builds
- **Add version sync step**: Automatically updates `package.json` version fields across the monorepo (root, electron, and web packages) to match the release tag version, removing the 'v' prefix and normalizing path separators
- **Add Windows installer locator step**: Implements robust logic to find and rename the built Windows installer executable to a consistent naming convention (`Nodetool-Setup-{VERSION}.exe`) when building from tags, with fallback search and validation

## Implementation Details
- Version sync only runs on tagged releases or manual workflow dispatch with version input
- The installer locator step searches the dist directory for Setup executables if the expected path doesn't exist, providing helpful diagnostics if no installer is found
- Both new steps are conditional and only execute during tagged releases to avoid unnecessary operations on regular builds

https://claude.ai/code/session_01T3UWzEkuwGxT6z2h1YscQ6