### PR TITLE
Gate auto-preview on generative node flag

### DIFF
--- a/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
+++ b/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
@@ -19,6 +19,7 @@ export class TextToSpeechNode extends BaseNode {
     "- Create audiobooks";
   static readonly metadataOutputTypes = { output: "audio" };
   static readonly requiredSettings = ["ELEVENLABS_API_KEY"];
+  static readonly autoSaveAsset = true;
 
   @prop({
     type: "enum",

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -230,6 +230,13 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
     spec.tags.length > 0 ? spec.tags.join(", ") : "fal, ai";
   const description = `${descFirstLine}\n${descSecondLine}`;
   const isImageOutput = spec.outputType === "image";
+  // Generative outputs — auto-save assets and auto-show result preview in UI
+  const isGenerativeOutput = [
+    "image",
+    "video",
+    "audio",
+    "model_3d"
+  ].includes(spec.outputType);
 
   // Capture spec in closure for process/genProcess
   const endpointId = spec.endpointId;
@@ -293,6 +300,12 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
     value: ["FAL_API_KEY"],
     configurable: true
   });
+  if (isGenerativeOutput) {
+    Object.defineProperty(FalNodeClass, "autoSaveAsset", {
+      value: true,
+      configurable: true
+    });
+  }
 
   if (isImageOutput) {
     Object.defineProperty(FalNodeClass, "metadataOutputTypes", {

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -241,6 +241,10 @@ export function createKieNodeClass(spec: KieManifestEntry): NodeClass {
   const title = spec.title || toTitle(spec.className);
   const description = spec.description;
   const isImageOutput = spec.outputType === "image";
+  // Generative outputs — auto-save assets and auto-show result preview in UI
+  const isGenerativeOutput = ["image", "audio", "video"].includes(
+    spec.outputType
+  );
   const specRef = spec;
 
   const KieNodeClass = class extends BaseNode {
@@ -318,6 +322,12 @@ export function createKieNodeClass(spec: KieManifestEntry): NodeClass {
     value: true,
     configurable: true
   });
+  if (isGenerativeOutput) {
+    Object.defineProperty(KieNodeClass, "autoSaveAsset", {
+      value: true,
+      configurable: true
+    });
+  }
   Object.defineProperty(KieNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType },
     configurable: true

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -178,6 +178,10 @@ export function createReplicateNodeClass(
   const descSecondLine =
     spec.tags.length > 0 ? spec.tags.join(", ") : "replicate, ai";
   const description = `${descFirstLine}\n${descSecondLine}`;
+  // Generative outputs — auto-save assets and auto-show result preview in UI
+  const isGenerativeOutput = ["image", "video", "audio"].includes(
+    spec.outputType
+  );
   const specRef = spec;
 
   const ReplicateNodeClass = class extends BaseNode {
@@ -209,6 +213,12 @@ export function createReplicateNodeClass(
     value: ["REPLICATE_API_TOKEN"],
     configurable: true
   });
+  if (isGenerativeOutput) {
+    Object.defineProperty(ReplicateNodeClass, "autoSaveAsset", {
+      value: true,
+      configurable: true
+    });
+  }
   Object.defineProperty(ReplicateNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType === "dict" ? "any" : spec.outputType },
     configurable: true

--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -484,21 +484,12 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
   const isConstantInputLockedResult =
     nodeType.isConstantNode && hasConnectedInput;
 
-  // Only auto-switch to result view for nodes with visual output types
-  const VISUAL_OUTPUT_TYPES = new Set([
-    "image",
-    "video",
-    "audio",
-    "model_3d",
-    "model3d"
-  ]);
-  const hasVisualOutput = useMemo(
-    () =>
-      metadata?.outputs?.some((o: OutputSlot) =>
-        VISUAL_OUTPUT_TYPES.has(o.type.type)
-      ) ?? false,
-    [metadata]
-  );
+  // Only auto-switch to result view for generative nodes (marked via
+  // `auto_save_asset` by providers like fal, kie, replicate, elevenlabs,
+  // gemini/openai image+audio, etc.). Non-generative nodes with visual
+  // outputs (e.g. pass-through image transforms) keep the inputs view
+  // visible until the user explicitly clicks the results toggle.
+  const isGenerativeNode = Boolean(metadata?.auto_save_asset);
 
   // Manage overlay visibility based on node status, result, and user preference
   useEffect(() => {
@@ -523,11 +514,12 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
     ) {
       setShowResultOverlay(true);
     }
-    // When node completes with a visual result, show results by default
-    // (unless user explicitly opted out). Non-visual nodes stay on inputs.
+    // When a generative node completes, show the rendered result by default
+    // (unless the user explicitly opted out). Non-generative nodes stay on
+    // their inputs view — users can toggle results manually via the header.
     else if (
       result &&
-      hasVisualOutput &&
+      isGenerativeNode &&
       !nodeType.isOutputNode &&
       !nodeType.isConstantNode &&
       status === "completed"
@@ -539,7 +531,7 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
   }, [
     result,
     isConstantInputLockedResult,
-    hasVisualOutput,
+    isGenerativeNode,
     nodeType.isOutputNode,
     nodeType.isConstantNode,
     status,

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -88,6 +88,13 @@ export interface NodeMetadata extends BaseNodeMetadata {
    * Populated by the backend from node metadata; used to show install prompts.
    */
   required_runtimes?: string[];
+  /**
+   * Marks a node as generative — its outputs should be auto-saved as assets
+   * by the backend, and the UI uses this flag to auto-show the result preview
+   * once the node completes. Set by generative providers (fal, kie, replicate,
+   * elevenlabs, gemini, openai image/audio nodes, etc.).
+   */
+  auto_save_asset?: boolean;
 }
 export type SettingWithValue = components["schemas"]["SettingWithValue"];
 export type TypeMetadata = components["schemas"]["TypeMetadata-Input"];


### PR DESCRIPTION
Only auto-switch nodes to the render result preview when they're
marked generative (auto_save_asset). Non-generative nodes with visual
outputs (e.g. pass-through image transforms) stay on their inputs view
until the user clicks the result toggle in the header.

Mark fal, kie, replicate, and elevenlabs text-to-speech nodes as
generative so their image/video/audio/model_3d outputs get the same
auto-save + auto-preview treatment as the built-in gemini/openai
generation nodes.

https://claude.ai/code/session_01MCTMmie2jisSLLoNLAMpqM