### PR TITLE
Show live console output in Package Manager UI

### DIFF
--- a/electron/pages/PackageManager.tsx
+++ b/electron/pages/PackageManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import "./packages.css";
 import {
   PackageModel,
@@ -41,6 +41,12 @@ const PackageManager: React.FC = () => {
 
   const [activeTab, setActiveTab] = useState<"all" | "installed" | "available" | "updates" | "runtimes">("all");
 
+  // Live console output from package manager commands (uv / micromamba)
+  const MAX_CONSOLE_LINES = 500;
+  const [consoleLogs, setConsoleLogs] = useState<string[]>([]);
+  const [isConsoleCollapsed, setIsConsoleCollapsed] = useState(false);
+  const consoleBodyRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     initialize();
   }, []);
@@ -78,6 +84,44 @@ const PackageManager: React.FC = () => {
   useEffect(() => {
     loadRuntimes();
   }, [loadRuntimes]);
+
+  // Subscribe to server-log events. The main process emits these for every
+  // stdout/stderr line from uv (pip install/uninstall/update) and micromamba
+  // (runtime install/uninstall), giving us a live console feed.
+  useEffect(() => {
+    const api = window.electronAPI;
+    const onLog =
+      api?.server?.onLog ?? api?.onServerLog ?? window.api?.server?.onLog;
+    if (typeof onLog !== "function") return;
+
+    const unsubscribe = onLog((message: string) => {
+      setConsoleLogs((prev) => {
+        const next = prev.length >= MAX_CONSOLE_LINES
+          ? prev.slice(prev.length - MAX_CONSOLE_LINES + 1)
+          : prev.slice();
+        next.push(message);
+        return next;
+      });
+    });
+    return () => {
+      if (typeof unsubscribe === "function") unsubscribe();
+    };
+  }, []);
+
+  // Auto-scroll to newest console line.
+  useEffect(() => {
+    if (isConsoleCollapsed) return;
+    const body = consoleBodyRef.current;
+    if (body) body.scrollTop = body.scrollHeight;
+  }, [consoleLogs, isConsoleCollapsed]);
+
+  const handleClearConsole = useCallback(() => {
+    setConsoleLogs([]);
+  }, []);
+
+  const handleToggleConsole = useCallback(() => {
+    setIsConsoleCollapsed((prev) => !prev);
+  }, []);
 
   const handleInstallRuntime = useCallback(async (runtimeId: RuntimePackageId) => {
     const api = window.electronAPI;
@@ -642,6 +686,64 @@ const PackageManager: React.FC = () => {
           </div>
         )}
         </>
+        )}
+      </div>
+
+      <div
+        className={`pm-console ${isConsoleCollapsed ? "collapsed" : ""}`}
+      >
+        <div className="pm-console-header">
+          <div className="pm-console-title">
+            <span className="pm-console-indicator" />
+            Console output
+            {consoleLogs.length > 0 && (
+              <span className="pm-console-count">
+                ({consoleLogs.length})
+              </span>
+            )}
+          </div>
+          <div className="pm-console-actions">
+            <button
+              type="button"
+              className="pm-console-button"
+              onClick={handleClearConsole}
+              disabled={consoleLogs.length === 0}
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              className="pm-console-button"
+              onClick={handleToggleConsole}
+            >
+              {isConsoleCollapsed ? "Show" : "Hide"}
+            </button>
+          </div>
+        </div>
+        {!isConsoleCollapsed && (
+          <div
+            className="pm-console-body"
+            ref={consoleBodyRef}
+            role="log"
+            aria-live="polite"
+            aria-label="Package manager console output"
+          >
+            {consoleLogs.length === 0 ? (
+              <div className="pm-console-empty">
+                Console output will appear here when you install, update, or
+                uninstall a package.
+              </div>
+            ) : (
+              consoleLogs.map((line, i) => (
+                <div
+                  key={`${i}-${line.length}`}
+                  className="pm-console-line"
+                >
+                  {line}
+                </div>
+              ))
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/electron/pages/packages.css
+++ b/electron/pages/packages.css
@@ -549,3 +549,108 @@ h1 {
   font-size: 13px;
   text-align: center;
 }
+
+/* Live console output panel */
+.pm-console {
+  flex-shrink: 0;
+  background-color: var(--bg-panel);
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  max-height: 40vh;
+}
+
+.pm-console.collapsed {
+  max-height: none;
+}
+
+.pm-console-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 24px;
+  background-color: var(--bg-panel);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.pm-console.collapsed .pm-console-header {
+  border-bottom: none;
+}
+
+.pm-console-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.pm-console-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--success);
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.5);
+}
+
+.pm-console-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 400;
+}
+
+.pm-console-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.pm-console-button {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.pm-console-button:hover:not(:disabled) {
+  color: var(--text-main);
+  border-color: var(--bg-hover);
+  background-color: var(--bg-hover);
+}
+
+.pm-console-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pm-console-body {
+  flex: 1;
+  min-height: 140px;
+  overflow-y: auto;
+  padding: 10px 24px;
+  background-color: #0b0b0b;
+  font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #d0d0d0;
+}
+
+.pm-console-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.pm-console-empty {
+  color: var(--text-muted);
+  font-family: inherit;
+  font-style: italic;
+}

--- a/electron/src/components/PackageManager.tsx
+++ b/electron/src/components/PackageManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   PackageInfo,
   PackageModel,
@@ -12,6 +12,8 @@ interface PackageManagerProps {
   onSkip: () => void;
 }
 
+const MAX_CONSOLE_LINES = 500;
+
 const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
   const [availablePackages, setAvailablePackages] = useState<PackageInfo[]>([]);
   const [installedPackages, setInstalledPackages] = useState<PackageModel[]>(
@@ -24,6 +26,9 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
   const [installing, setInstalling] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [installLocation, setInstallLocation] = useState<string>("");
+  const [consoleLogs, setConsoleLogs] = useState<string[]>([]);
+  const [isConsoleCollapsed, setIsConsoleCollapsed] = useState(false);
+  const consoleBodyRef = useRef<HTMLDivElement | null>(null);
 
   const loadRuntimeStatuses = useCallback(async () => {
     try {
@@ -66,6 +71,41 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
   useEffect(() => {
     loadPackages();
   }, [loadPackages]);
+
+  // Stream live command output from the main process into the console panel.
+  // `server-log` is broadcast for every stdout/stderr line from uv and
+  // micromamba during install/uninstall/update operations.
+  useEffect(() => {
+    const unsubscribe = window.api.server.onLog((message: string) => {
+      setConsoleLogs((prev) => {
+        const next = prev.length >= MAX_CONSOLE_LINES
+          ? prev.slice(prev.length - MAX_CONSOLE_LINES + 1)
+          : prev.slice();
+        next.push(message);
+        return next;
+      });
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  // Auto-scroll the console to the newest line when logs arrive.
+  useEffect(() => {
+    if (isConsoleCollapsed) return;
+    const body = consoleBodyRef.current;
+    if (body) {
+      body.scrollTop = body.scrollHeight;
+    }
+  }, [consoleLogs, isConsoleCollapsed]);
+
+  const handleClearConsole = useCallback(() => {
+    setConsoleLogs([]);
+  }, []);
+
+  const handleToggleConsole = useCallback(() => {
+    setIsConsoleCollapsed((prev) => !prev);
+  }, []);
 
   const handleSelectLocation = useCallback(async () => {
     try {
@@ -468,6 +508,66 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
             </div>
           )}
         </div>
+      </div>
+
+      <div
+        className={`package-console ${
+          isConsoleCollapsed ? "collapsed" : ""
+        }`}
+      >
+        <div className="package-console-header">
+          <div className="package-console-title">
+            <span className="package-console-indicator" />
+            Console output
+            {consoleLogs.length > 0 && (
+              <span className="package-console-count">
+                ({consoleLogs.length})
+              </span>
+            )}
+          </div>
+          <div className="package-console-actions">
+            <button
+              type="button"
+              className="package-console-button"
+              onClick={handleClearConsole}
+              disabled={consoleLogs.length === 0}
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              className="package-console-button"
+              onClick={handleToggleConsole}
+            >
+              {isConsoleCollapsed ? "Show" : "Hide"}
+            </button>
+          </div>
+        </div>
+        {!isConsoleCollapsed && (
+          <div
+            className="package-console-body"
+            ref={consoleBodyRef}
+            role="log"
+            aria-live="polite"
+            aria-label="Package manager console output"
+          >
+            {consoleLogs.length === 0 ? (
+              <div className="package-console-empty">
+                Console output will appear here when you install, update, or
+                uninstall a package.
+              </div>
+            ) : (
+              consoleLogs.map((line, i) => (
+                <div
+                  key={`${i}-${line.length}`}
+                  className="package-console-line"
+                >
+                  {line}
+                </div>
+              ))
+            )}
+          </div>
+        )}
       </div>
 
       <div

--- a/electron/src/components/index.css
+++ b/electron/src/components/index.css
@@ -206,7 +206,109 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 24px;
-  height: calc(100vh - 200px);
+  height: calc(100vh - 480px);
+  min-height: 300px;
+}
+
+.package-console {
+  margin-top: 20px;
+  background: var(--c_bg_secondary);
+  border: 1px solid var(--c_border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.package-console-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--c_border);
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.package-console.collapsed .package-console-header {
+  border-bottom: none;
+}
+
+.package-console-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c_text_secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.package-console-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--c_success);
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.5);
+}
+
+.package-console-count {
+  font-size: 11px;
+  color: var(--c_text_tertiary);
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 400;
+}
+
+.package-console-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.package-console-button {
+  background: transparent;
+  color: var(--c_text_tertiary);
+  border: 1px solid var(--c_border);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.package-console-button:hover:not(:disabled) {
+  color: var(--c_text_primary);
+  border-color: var(--c_border_hover);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.package-console-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.package-console-body {
+  max-height: 240px;
+  min-height: 140px;
+  overflow-y: auto;
+  padding: 10px 14px;
+  background: #0b0b0b;
+  font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #d0d0d0;
+}
+
+.package-console-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.package-console-empty {
+  color: var(--c_text_tertiary);
+  font-family: inherit;
+  font-style: italic;
 }
 
 .package-section {

--- a/electron/src/installer.ts
+++ b/electron/src/installer.ts
@@ -597,6 +597,8 @@ async function executeMicromambaCommand(
   const micromambaProcess = spawn(micromambaExecutable, args, {
     env,
     stdio: "pipe",
+    // Prevent a console window from flashing on Windows while micromamba runs.
+    windowsHide: true,
   });
 
   let lockErrorDetected = false;

--- a/electron/src/packageManager.ts
+++ b/electron/src/packageManager.ts
@@ -552,6 +552,8 @@ async function runUvCommand(
     const process = spawn(command[0], command.slice(1), {
       env,
       stdio: "pipe",
+      // Prevent a console window from flashing on Windows while uv runs.
+      windowsHide: true,
     });
 
     if (options?.stdin && process.stdin) {

--- a/electron/src/python.ts
+++ b/electron/src/python.ts
@@ -176,6 +176,8 @@ async function canImportNodeToolWorker(
       {
         stdio: "ignore",
         env: getProcessEnv(),
+        // Prevent a console window from flashing on Windows.
+        windowsHide: true,
       }
     );
 
@@ -353,6 +355,8 @@ async function runCommand(command: string[]): Promise<void> {
   const updateProcess = spawn(executable, command.slice(1), {
     stdio: "pipe",
     env: getProcessEnv(),
+    // Prevent a console window from flashing on Windows during pip operations.
+    windowsHide: true,
   });
 
   logMessage(`Running command: ${command.join(" ")}`);

--- a/electron/src/torchruntime.ts
+++ b/electron/src/torchruntime.ts
@@ -46,6 +46,8 @@ async function isTorchruntimeInstalled(): Promise<boolean> {
         {
           env: getProcessEnv(),
           stdio: "pipe",
+          // Prevent a console window from flashing on Windows.
+          windowsHide: true,
         }
       );
 
@@ -82,6 +84,8 @@ async function installTorchruntime(): Promise<void> {
       {
         env: getProcessEnv(),
         stdio: "pipe",
+        // Prevent a console window from flashing on Windows.
+        windowsHide: true,
       }
     );
 
@@ -144,6 +148,8 @@ except Exception as e:
       {
         env: getProcessEnv(),
         stdio: "pipe",
+        // Prevent a console window from flashing on Windows.
+        windowsHide: true,
       }
     );
 


### PR DESCRIPTION
Subscribes the Package Manager views to the existing `server-log` IPC
broadcast so users can watch uv / micromamba stdout and stderr stream in
real time while a package or runtime is being installed, updated, or
uninstalled. The console panel is collapsible, auto-scrolls to the
newest line, keeps a 500-line buffer, and includes a Clear action.