### PR TITLE
Group settings into collapsible folders in sidebar

### DIFF
--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -265,29 +265,47 @@ function SettingsMenu({ buttonText = "" }: SettingsMenuProps) {
     });
   };
 
-  // Tab 0: General sidebar sections
+  // Tab 0: General sidebar folders
   const generalSidebarSections = [
     {
-      category: "General",
+      category: "Workspace",
       items: [
         { id: "editor", label: "Editor" },
-        { id: "canvas-navigation", label: "Canvas & Navigation" },
-        { id: "default-models", label: "Default Models" },
-        { id: "autosave", label: "Autosave" },
         { id: "appearance", label: "Appearance" }
       ]
+    },
+    {
+      category: "Canvas",
+      items: [{ id: "canvas-navigation", label: "Canvas & Navigation" }]
+    },
+    {
+      category: "AI",
+      items: [{ id: "default-models", label: "Default Models" }]
+    },
+    {
+      category: "History",
+      items: [{ id: "autosave", label: "Autosave" }]
     }
   ];
 
-  // Tab 1: API & Keys sidebar sections
+  // Tab 1: API & Keys sidebar folders
   const apiKeysSidebarSections = [
     {
-      category: "API & Keys",
+      category: "Credentials",
       items: [
         { id: "api-keys", label: "API Keys" },
-        { id: "api-settings", label: "API Settings" },
-        { id: "folders", label: "Folders" }
+        ...(session?.access_token && !isLocalhost
+          ? [{ id: "nodetool-api-token", label: "Nodetool API Token" }]
+          : [])
       ]
+    },
+    {
+      category: "Configuration",
+      items: [{ id: "api-settings", label: "API Settings" }]
+    },
+    {
+      category: "Storage",
+      items: [{ id: "folders", label: "Folders" }]
     }
   ];
 

--- a/web/src/components/menus/SettingsSidebar.tsx
+++ b/web/src/components/menus/SettingsSidebar.tsx
@@ -1,13 +1,18 @@
-import { useCallback, memo } from "react";
+import { useCallback, memo, useState, useEffect } from "react";
+import FolderIcon from "@mui/icons-material/Folder";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 interface SidebarItem {
   id: string;
   label: string;
 }
 
-interface SidebarSection {
+export interface SidebarSection {
   category: string;
   items: SidebarItem[];
+  /** Whether this folder should be collapsed by default */
+  defaultCollapsed?: boolean;
 }
 
 interface SettingsSidebarProps {
@@ -32,25 +37,124 @@ const SettingsSidebar = ({
     [onSectionClick]
   );
 
+  // Track open/closed state per folder category
+  const [openFolders, setOpenFolders] = useState<Record<string, boolean>>(() =>
+    sections.reduce<Record<string, boolean>>((acc, section) => {
+      acc[section.category] = !section.defaultCollapsed;
+      return acc;
+    }, {})
+  );
+
+  // When sections change (e.g. tab switch), initialise any new folders as open
+  useEffect(() => {
+    setOpenFolders((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      sections.forEach((section) => {
+        if (!(section.category in next)) {
+          next[section.category] = !section.defaultCollapsed;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [sections]);
+
+  // Auto-expand the folder that contains the active section
+  useEffect(() => {
+    if (!activeSection) return;
+    const owner = sections.find((s) =>
+      s.items.some((item) => item.id === activeSection)
+    );
+    if (owner && openFolders[owner.category] === false) {
+      setOpenFolders((prev) => ({ ...prev, [owner.category]: true }));
+    }
+  }, [activeSection, sections, openFolders]);
+
+  const toggleFolder = useCallback((category: string) => {
+    setOpenFolders((prev) => ({ ...prev, [category]: !prev[category] }));
+  }, []);
+
+  const handleFolderKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const category = event.currentTarget.dataset.category;
+        if (category) {
+          toggleFolder(category);
+        }
+      }
+    },
+    [toggleFolder]
+  );
+
+  const handleFolderClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const category = event.currentTarget.dataset.category;
+      if (category) {
+        toggleFolder(category);
+      }
+    },
+    [toggleFolder]
+  );
+
   return (
     <div className="settings-sidebar">
-      {sections.map((section, index) => (
-        <div key={`section-${index}`}>
-          <div className="settings-sidebar-category">{section.category}</div>
-          {section.items.map((item, itemIndex) => (
+      {sections.map((section, index) => {
+        const isOpen = openFolders[section.category] !== false;
+        return (
+          <div key={`section-${index}`} className="settings-sidebar-folder">
             <div
-              key={`${item.id}-${itemIndex}`}
-              data-section-id={item.id}
-              className={`settings-sidebar-item ${
-                activeSection === item.id ? "active" : ""
-              }`}
-              onClick={handleItemClick}
+              className={`settings-sidebar-category${isOpen ? " open" : ""}`}
+              data-category={section.category}
+              role="button"
+              tabIndex={0}
+              aria-expanded={isOpen}
+              aria-controls={`settings-folder-${index}`}
+              onClick={handleFolderClick}
+              onKeyDown={handleFolderKeyDown}
             >
-              {item.label}
+              <ExpandMoreIcon
+                className="settings-sidebar-chevron"
+                fontSize="small"
+              />
+              {isOpen ? (
+                <FolderOpenIcon
+                  className="settings-sidebar-folder-icon"
+                  fontSize="small"
+                />
+              ) : (
+                <FolderIcon
+                  className="settings-sidebar-folder-icon"
+                  fontSize="small"
+                />
+              )}
+              <span className="settings-sidebar-category-label">
+                {section.category}
+              </span>
             </div>
-          ))}
-        </div>
-      ))}
+            {isOpen && (
+              <div
+                id={`settings-folder-${index}`}
+                className="settings-sidebar-folder-items"
+              >
+                {section.items.map((item, itemIndex) => (
+                  <div
+                    key={`${item.id}-${itemIndex}`}
+                    data-section-id={item.id}
+                    className={`settings-sidebar-item ${
+                      activeSection === item.id ? "active" : ""
+                    }`}
+                    onClick={handleItemClick}
+                  >
+                    {item.label}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/web/src/components/menus/aboutSidebarUtils.ts
+++ b/web/src/components/menus/aboutSidebarUtils.ts
@@ -1,17 +1,23 @@
 interface SidebarSection {
   category: string;
   items: Array<{ id: string; label: string }>;
+  defaultCollapsed?: boolean;
 }
 
 export const getAboutSidebarSections = (): SidebarSection[] => {
   return [
     {
-      category: "About",
+      category: "Application",
       items: [
         { id: "application", label: "Application" },
         { id: "operating-system", label: "Operating System" },
+        { id: "features", label: "Features & Versions" }
+      ]
+    },
+    {
+      category: "Resources",
+      items: [
         { id: "installation-paths", label: "Installation Paths" },
-        { id: "features", label: "Features & Versions" },
         { id: "links", label: "Links" }
       ]
     }

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -83,8 +83,20 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     padding: "1.5em 0",
     overflowY: "auto"
   },
+  ".settings-sidebar-folder": {
+    display: "flex",
+    flexDirection: "column",
+    "& + &": {
+      marginTop: "0.25em"
+    }
+  },
+  ".settings-sidebar-folder-items": {
+    display: "flex",
+    flexDirection: "column",
+    paddingBottom: "0.25em"
+  },
   ".settings-sidebar-item": {
-    padding: "0.25em 1.5em",
+    padding: "0.25em 1.5em 0.25em 2.75em",
     cursor: "pointer",
     fontSize: theme.fontSizeSmall,
     color: theme.vars.palette.grey[0],
@@ -102,13 +114,44 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     }
   },
   ".settings-sidebar-category": {
-    padding: "1em 1.5em 0.5em",
-    color: "var(--palette-primary-main)",
+    display: "flex",
+    alignItems: "center",
+    gap: "0.4em",
+    padding: "0.6em 1em 0.4em 0.75em",
+    color: theme.vars.palette.grey[0],
     fontSize: theme.fontSizeSmaller,
-    fontWeight: "500",
-    letterSpacing: "0.05em",
+    fontWeight: "600",
+    letterSpacing: "0.04em",
     textTransform: "uppercase",
-    opacity: "0.8"
+    opacity: "0.85",
+    cursor: "pointer",
+    userSelect: "none",
+    transition: "all 0.15s ease",
+    borderRadius: "4px",
+    outline: "none",
+    "&:hover": {
+      opacity: 1,
+      backgroundColor: theme.vars.palette.action.hover
+    },
+    "&:focus-visible": {
+      boxShadow: `0 0 0 2px ${theme.vars.palette.primary.main}`
+    },
+    "&.open .settings-sidebar-chevron": {
+      transform: "rotate(0deg)"
+    },
+    ".settings-sidebar-chevron": {
+      fontSize: "1rem",
+      color: theme.vars.palette.text.secondary,
+      transition: "transform 0.18s ease",
+      transform: "rotate(-90deg)"
+    },
+    ".settings-sidebar-folder-icon": {
+      fontSize: "1.05rem",
+      color: "var(--palette-primary-main)"
+    },
+    ".settings-sidebar-category-label": {
+      flex: 1
+    }
   },
   ".sticky-header": {
     position: "sticky",


### PR DESCRIPTION
The settings dialog previously rendered one flat list of items per
tab under a single category header. With the settings surface growing
(editor, canvas, autosave, default models, API keys, storage paths,
etc.) this made scanning and navigation harder than it needed to be.

- Split each tab into multiple named folder categories (Workspace /
  Canvas / AI / History for General; Credentials / Configuration /
  Storage for API & Keys; Application / Resources for About).
- Turn category headers into collapsible folder buttons with folder
  and chevron icons, keyboard-activatable via Enter/Space and wired
  up with aria-expanded/aria-controls.
- Auto-expand the folder that owns the active section so clicks from
  elsewhere still reveal the target item.
- Surface the Nodetool API Token section in the sidebar when
  available.

https://claude.ai/code/session_01JwKZGkUiA83R7oGGce7sW5