### PR TITLE
Route bypassed node inputs to outputs when types match

### DIFF
--- a/packages/kernel/src/graph-utils.ts
+++ b/packages/kernel/src/graph-utils.ts
@@ -4,7 +4,8 @@
  * Port of src/nodetool/workflows/graph_utils.py.
  */
 
-import type { Edge, NodeDescriptor } from "@nodetool/protocol";
+import type { Edge, GraphData, NodeDescriptor } from "@nodetool/protocol";
+import { isControlEdge, TypeMetadata } from "@nodetool/protocol";
 import { Graph } from "./graph.js";
 
 /**
@@ -95,4 +96,188 @@ export function getDownstreamSubgraph(
   );
 
   return { initialEdges, nodes, edges: filteredEdges };
+}
+
+// ---------------------------------------------------------------------------
+// Bypass rewriting
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if a node is marked as bypassed via ui_properties.bypassed.
+ */
+export function isNodeBypassed(node: NodeDescriptor): boolean {
+  const ui = node.ui_properties;
+  if (!ui || typeof ui !== "object") return false;
+  return (ui as Record<string, unknown>).bypassed === true;
+}
+
+/**
+ * Look up the declared type string of a node's output handle.
+ */
+function getOutputTypeString(
+  node: NodeDescriptor | undefined,
+  handle: string
+): string | undefined {
+  if (!node) return undefined;
+  return node.outputs?.[handle];
+}
+
+/**
+ * Look up the declared type string of a node's input (property) handle.
+ *
+ * Checks propertyTypes first (the authoritative map after graph load),
+ * then falls back to the property value's `type` field for backwards
+ * compatibility with raw graph payloads.
+ */
+function getInputTypeString(
+  node: NodeDescriptor | undefined,
+  handle: string
+): string | undefined {
+  if (!node) return undefined;
+  const fromPropertyTypes = node.propertyTypes?.[handle];
+  if (fromPropertyTypes) return fromPropertyTypes;
+  const props = node.properties as Record<string, unknown> | undefined;
+  if (props) {
+    const val = props[handle];
+    if (typeof val === "object" && val !== null && "type" in val) {
+      const t = (val as { type: unknown }).type;
+      if (typeof t === "string") return t;
+    } else if (typeof val === "string") {
+      return val;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Return true when two type strings are compatible according to
+ * TypeMetadata rules. Missing type info on either side is treated as
+ * compatible ("any") so that bypass still works on dynamic nodes where
+ * handle types are not statically declared.
+ */
+function typesCompatible(
+  sourceType: string | undefined,
+  targetType: string | undefined
+): boolean {
+  if (!sourceType || !targetType) return true;
+  try {
+    const s = TypeMetadata.fromString(sourceType);
+    const t = TypeMetadata.fromString(targetType);
+    return s.isCompatibleWith(t);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Rewrite a graph to route around nodes marked with
+ * `ui_properties.bypassed === true`.
+ *
+ * For each bypassed node and each of its outgoing data edges, we look for
+ * an incoming data edge whose source output type is compatible with the
+ * outgoing edge's target input type. If one is found, a new edge is
+ * created directly from the upstream source to the downstream target,
+ * preserving the downstream handle and any edge metadata (id, ui_properties,
+ * edge_type). Outgoing edges with no type-compatible input are dropped.
+ *
+ * When multiple incoming edges would match an outgoing edge, preference is
+ * given to an incoming edge whose targetHandle matches the outgoing edge's
+ * sourceHandle (name match), falling back to the first type-compatible one.
+ *
+ * Chained bypassed nodes (A → B(bypassed) → C(bypassed) → D) are handled
+ * by iterating until no further bypassed node can be rewritten — each
+ * iteration replaces bypassed sources with their already-resolved upstream
+ * source so that a chain collapses into a direct edge from the first
+ * non-bypassed source to the first non-bypassed target.
+ *
+ * Control edges (edge_type === "control") touching a bypassed node are
+ * dropped: bypassing intentionally removes the node from execution, so
+ * control connections to/from it no longer have a meaningful target.
+ */
+export function rewriteBypassedNodes(data: GraphData): GraphData {
+  const bypassedIds = new Set(
+    data.nodes.filter(isNodeBypassed).map((n) => n.id)
+  );
+  if (bypassedIds.size === 0) {
+    return data;
+  }
+
+  const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+  let currentEdges: Edge[] = [...data.edges];
+  const processed = new Set<string>();
+
+  // Iterate: process bypassed nodes whose bypassed predecessors have all
+  // already been resolved. This guarantees a chain collapses in source→
+  // target order.
+  let didChange = true;
+  while (didChange) {
+    didChange = false;
+
+    for (const bypassId of bypassedIds) {
+      if (processed.has(bypassId)) continue;
+
+      const incoming = currentEdges.filter((e) => e.target === bypassId);
+      const hasUnprocessedBypassedUpstream = incoming.some(
+        (e) => bypassedIds.has(e.source) && !processed.has(e.source)
+      );
+      if (hasUnprocessedBypassedUpstream) continue;
+
+      const incomingData = incoming.filter((e) => !isControlEdge(e));
+      const outgoing = currentEdges.filter((e) => e.source === bypassId);
+      const outgoingData = outgoing.filter((e) => !isControlEdge(e));
+
+      const reroutedEdges: Edge[] = [];
+      for (const outEdge of outgoingData) {
+        const targetNode = nodeById.get(outEdge.target);
+        const targetInputType = getInputTypeString(
+          targetNode,
+          outEdge.targetHandle
+        );
+
+        // Prefer an incoming edge whose target handle matches the
+        // outgoing source handle (name-based pairing), then fall back to
+        // the first incoming edge whose source output type is compatible
+        // with the downstream target's input type.
+        const candidates: Edge[] = [];
+        for (const inEdge of incomingData) {
+          const sourceNode = nodeById.get(inEdge.source);
+          const sourceOutputType = getOutputTypeString(
+            sourceNode,
+            inEdge.sourceHandle
+          );
+          if (!typesCompatible(sourceOutputType, targetInputType)) continue;
+          if (inEdge.targetHandle === outEdge.sourceHandle) {
+            candidates.unshift(inEdge);
+          } else {
+            candidates.push(inEdge);
+          }
+        }
+
+        const matched = candidates[0];
+        if (!matched) continue;
+
+        reroutedEdges.push({
+          ...outEdge,
+          source: matched.source,
+          sourceHandle: matched.sourceHandle
+        });
+      }
+
+      // Drop all edges touching the bypassed node and append the rerouted
+      // ones.  Control edges attached to the bypassed node are dropped
+      // here — bypassing removes the node from execution entirely.
+      currentEdges = currentEdges.filter(
+        (e) => e.source !== bypassId && e.target !== bypassId
+      );
+      currentEdges.push(...reroutedEdges);
+
+      processed.add(bypassId);
+      didChange = true;
+    }
+  }
+
+  // Remove bypassed nodes themselves from the node list.
+  const remainingNodes = data.nodes.filter((n) => !bypassedIds.has(n.id));
+
+  return { nodes: remainingNodes, edges: currentEdges };
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -23,7 +23,9 @@ export { NodeInputs, NodeOutputs, type NodeOutputsOptions } from "./io.js";
 export {
   findNodeOrThrow,
   getNodeInputTypes,
-  getDownstreamSubgraph
+  getDownstreamSubgraph,
+  isNodeBypassed,
+  rewriteBypassedNodes
 } from "./graph-utils.js";
 export {
   TriggerWorkflowManager,

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -27,6 +27,7 @@ const log = createLogger("nodetool.kernel.runner");
 import type { ProcessingContext } from "@nodetool/runtime";
 import { isControlEdge, isDataEdge } from "@nodetool/protocol";
 import { Graph } from "./graph.js";
+import { rewriteBypassedNodes } from "./graph-utils.js";
 import { NodeInbox } from "./inbox.js";
 import { NodeActor, type NodeExecutor } from "./actor.js";
 
@@ -210,7 +211,13 @@ export class WorkflowRunner {
         jobId: request.job_id,
         workflowId: request.workflow_id
       });
-      this._graph = new Graph(graphData);
+      // Rewrite the graph to route around nodes marked
+      // `ui_properties.bypassed === true`. Each outgoing edge of a
+      // bypassed node is re-attached to the matching upstream source
+      // (by type compatibility); outgoing edges with no compatible
+      // upstream are dropped, as is the bypassed node itself.
+      const effectiveGraph = rewriteBypassedNodes(graphData);
+      this._graph = new Graph(effectiveGraph);
 
       // Python parity: _filter_invalid_edges — silently remove edges
       // whose source or target node doesn't exist in the graph.

--- a/packages/kernel/tests/bypass-rewrite.test.ts
+++ b/packages/kernel/tests/bypass-rewrite.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for rewriteBypassedNodes — routing inputs to outputs of bypassed
+ * nodes when types are compatible.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  rewriteBypassedNodes,
+  isNodeBypassed
+} from "../src/graph-utils.js";
+import type { NodeDescriptor, Edge, GraphData } from "@nodetool/protocol";
+
+function makeNode(
+  id: string,
+  overrides: Partial<NodeDescriptor> = {}
+): NodeDescriptor {
+  return {
+    id,
+    type: overrides.type ?? "test.Node",
+    ...overrides
+  };
+}
+
+function bypassed(
+  id: string,
+  overrides: Partial<NodeDescriptor> = {}
+): NodeDescriptor {
+  return makeNode(id, {
+    ...overrides,
+    ui_properties: {
+      ...(overrides.ui_properties as Record<string, unknown> | undefined),
+      bypassed: true
+    }
+  });
+}
+
+describe("isNodeBypassed", () => {
+  it("returns false when ui_properties is missing", () => {
+    expect(isNodeBypassed(makeNode("n1"))).toBe(false);
+  });
+
+  it("returns false when ui_properties.bypassed is not true", () => {
+    expect(
+      isNodeBypassed(makeNode("n1", { ui_properties: { bypassed: false } }))
+    ).toBe(false);
+    expect(
+      isNodeBypassed(
+        makeNode("n1", { ui_properties: { bypassed: "yes" } as never })
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when ui_properties.bypassed === true", () => {
+    expect(
+      isNodeBypassed(makeNode("n1", { ui_properties: { bypassed: true } }))
+    ).toBe(true);
+  });
+});
+
+describe("rewriteBypassedNodes", () => {
+  it("returns the input unchanged when no nodes are bypassed", () => {
+    const data: GraphData = {
+      nodes: [makeNode("A"), makeNode("B")],
+      edges: [{ source: "A", sourceHandle: "out", target: "B", targetHandle: "in" }]
+    };
+    const result = rewriteBypassedNodes(data);
+    expect(result).toBe(data);
+  });
+
+  it("routes input to output when types match (single in, single out)", () => {
+    // A(out: string) --> B(bypassed, in: string, out: string) --> C(in: string)
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      makeNode("C", { propertyTypes: { in: "string" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.nodes.map((n) => n.id)).toEqual(["A", "C"]);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: "A",
+      sourceHandle: "out",
+      target: "C",
+      targetHandle: "in"
+    });
+  });
+
+  it("drops outgoing edges that have no type-compatible input", () => {
+    // A(out: string) --> B(bypassed, in_text: string, out_image: image)
+    //                    B --> C(in: image)
+    // No compatible input for the image output, so the edge B->C is dropped.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out_image: "image" },
+        propertyTypes: { in_text: "string" }
+      }),
+      makeNode("C", { propertyTypes: { in: "image" } })
+    ];
+    const edges: Edge[] = [
+      {
+        source: "A",
+        sourceHandle: "out",
+        target: "B",
+        targetHandle: "in_text"
+      },
+      {
+        source: "B",
+        sourceHandle: "out_image",
+        target: "C",
+        targetHandle: "in"
+      }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.nodes.map((n) => n.id)).toEqual(["A", "C"]);
+    // Incoming edge to B is dropped, outgoing edge to C is dropped (no match).
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it("routes only the type-compatible input when multiple inputs exist", () => {
+    // A(out: image)  \
+    // M(out: mask)    > B(bypassed, image: image, mask: mask, out: image) --> C(in: image)
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "image" } }),
+      makeNode("M", { outputs: { out: "mask" } }),
+      bypassed("B", {
+        outputs: { out: "image" },
+        propertyTypes: { image: "image", mask: "mask" }
+      }),
+      makeNode("C", { propertyTypes: { in: "image" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "image" },
+      { source: "M", sourceHandle: "out", target: "B", targetHandle: "mask" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(["A", "C", "M"]);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: "A",
+      sourceHandle: "out",
+      target: "C",
+      targetHandle: "in"
+    });
+  });
+
+  it("prefers a name-matched incoming handle when multiple types match", () => {
+    // A(out: any) --> text --> B(bypassed)
+    // D(out: any) --> other --> B(bypassed) -- text --> C
+    // The outgoing sourceHandle is "text", so the incoming whose
+    // targetHandle === "text" wins over the other compatible input.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "any" } }),
+      makeNode("D", { outputs: { out: "any" } }),
+      bypassed("B", {
+        outputs: { text: "any" },
+        propertyTypes: { text: "any", other: "any" }
+      }),
+      makeNode("C", { propertyTypes: { in: "any" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "text" },
+      { source: "D", sourceHandle: "out", target: "B", targetHandle: "other" },
+      { source: "B", sourceHandle: "text", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe("A");
+  });
+
+  it("collapses a chain of bypassed nodes", () => {
+    // A --> B(bypassed) --> C(bypassed) --> D
+    // all string, all compatible.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      bypassed("C", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      makeNode("D", { propertyTypes: { in: "string" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" },
+      { source: "C", sourceHandle: "out", target: "D", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(["A", "D"]);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: "A",
+      sourceHandle: "out",
+      target: "D",
+      targetHandle: "in"
+    });
+  });
+
+  it("preserves edge metadata (id, ui_properties) on rerouted edges", () => {
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      makeNode("C", { propertyTypes: { in: "string" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      {
+        id: "edge-B-C",
+        source: "B",
+        sourceHandle: "out",
+        target: "C",
+        targetHandle: "in",
+        ui_properties: { label: "my-edge" }
+      }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      id: "edge-B-C",
+      source: "A",
+      sourceHandle: "out",
+      target: "C",
+      targetHandle: "in",
+      ui_properties: { label: "my-edge" }
+    });
+  });
+
+  it("treats missing type info on either side as compatible", () => {
+    // Dynamic nodes often have no propertyTypes or outputs. Bypassing
+    // should still route through so the user isn't silently left without
+    // any connections.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A"),
+      bypassed("B"),
+      makeNode("C")
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: "A",
+      target: "C"
+    });
+  });
+
+  it("allows numeric widening via TypeMetadata compatibility rules", () => {
+    // A outputs int, target expects float — compatible via numeric widening.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "int" } }),
+      bypassed("B", {
+        outputs: { out: "float" },
+        propertyTypes: { in: "int" }
+      }),
+      makeNode("C", { propertyTypes: { in: "float" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe("A");
+  });
+
+  it("supports fan-out: one incoming routes to multiple outgoing edges", () => {
+    // A --> B(bypassed) --> C
+    //       B ------------> D
+    // Both outgoing edges should be rerouted from A.
+    const nodes: NodeDescriptor[] = [
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      makeNode("C", { propertyTypes: { in: "string" } }),
+      makeNode("D", { propertyTypes: { in: "string" } })
+    ];
+    const edges: Edge[] = [
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "D", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.edges).toHaveLength(2);
+    const targets = result.edges.map((e) => e.target).sort();
+    expect(targets).toEqual(["C", "D"]);
+    expect(result.edges.every((e) => e.source === "A")).toBe(true);
+  });
+
+  it("drops control edges touching a bypassed node", () => {
+    // Agent --control--> B(bypassed) --out--> C
+    // A --in--> B(bypassed) --out--> C
+    // Control edge to B is dropped; data routing A -> C is preserved.
+    const nodes: NodeDescriptor[] = [
+      makeNode("Agent"),
+      makeNode("A", { outputs: { out: "string" } }),
+      bypassed("B", {
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" }
+      }),
+      makeNode("C", { propertyTypes: { in: "string" } })
+    ];
+    const edges: Edge[] = [
+      {
+        source: "Agent",
+        sourceHandle: "ctrl",
+        target: "B",
+        targetHandle: "__control__",
+        edge_type: "control"
+      },
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+    ];
+
+    const result = rewriteBypassedNodes({ nodes, edges });
+
+    expect(result.nodes.map((n) => n.id).sort()).toEqual([
+      "A",
+      "Agent",
+      "C"
+    ]);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: "A",
+      target: "C"
+    });
+  });
+});

--- a/packages/kernel/tests/bypass-runner.test.ts
+++ b/packages/kernel/tests/bypass-runner.test.ts
@@ -1,0 +1,191 @@
+/**
+ * End-to-end tests for the bypass routing integration in WorkflowRunner.
+ *
+ * Verifies that nodes marked with `ui_properties.bypassed === true` are
+ * skipped at execution time and that their inputs are routed to
+ * downstream targets when types match.
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner } from "../src/runner.js";
+import type { NodeDescriptor, Edge } from "@nodetool/protocol";
+import type { NodeExecutor } from "../src/actor.js";
+
+function simpleExecutor(
+  fn: (inputs: Record<string, unknown>) => Record<string, unknown>
+): NodeExecutor {
+  return {
+    async process(inputs) {
+      return fn(inputs);
+    }
+  };
+}
+
+function makeRunner(executors: Record<string, NodeExecutor>): WorkflowRunner {
+  return new WorkflowRunner("test-job", {
+    resolveExecutor: (node) => {
+      const exec = executors[node.id] ?? executors[node.type];
+      if (!exec) return simpleExecutor(() => ({}));
+      return exec;
+    }
+  });
+}
+
+describe("WorkflowRunner – bypassed nodes", () => {
+  it("skips a bypassed node and routes the input straight through", async () => {
+    // input(value: string) → double(bypassed, a: string → result: string) → output(value: string)
+    // With bypass, "double" never runs — the input flows directly to "output".
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      {
+        id: "double",
+        type: "test.Double",
+        outputs: { result: "string" },
+        propertyTypes: { a: "string" },
+        ui_properties: { bypassed: true }
+      },
+      { id: "output", type: "test.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "double",
+        targetHandle: "a"
+      },
+      {
+        source: "double",
+        sourceHandle: "result",
+        target: "output",
+        targetHandle: "value"
+      }
+    ];
+
+    let doubleRan = false;
+    const runner = makeRunner({
+      "test.Double": simpleExecutor(() => {
+        doubleRan = true;
+        return { result: "SHOULD_NOT_APPEAR" };
+      }),
+      "test.Output": simpleExecutor((inputs) => ({ value: inputs.value }))
+    });
+
+    const result = await runner.run(
+      { job_id: "j-bypass-1", params: { x: "hello" } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(doubleRan).toBe(false);
+    expect(result.outputs.result).toContain("hello");
+  });
+
+  it("drops outgoing edges whose types do not match any input", async () => {
+    // text_input(string) → transform(bypassed, in: string → out: image)
+    // → display(image). No matching input for `out: image`, edge dropped,
+    // display receives no input and its list stays empty.
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "text_input",
+        type: "test.Input",
+        name: "text",
+        outputs: { value: "string" }
+      },
+      {
+        id: "transform",
+        type: "test.Transform",
+        outputs: { out: "image" },
+        propertyTypes: { in: "string" },
+        ui_properties: { bypassed: true }
+      },
+      {
+        id: "display",
+        type: "test.Output",
+        name: "out",
+        propertyTypes: { value: "image" }
+      }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "text_input",
+        sourceHandle: "value",
+        target: "transform",
+        targetHandle: "in"
+      },
+      {
+        source: "transform",
+        sourceHandle: "out",
+        target: "display",
+        targetHandle: "value"
+      }
+    ];
+
+    const displayInputs: Array<Record<string, unknown>> = [];
+    const runner = makeRunner({
+      "test.Output": simpleExecutor((inputs) => {
+        displayInputs.push(inputs);
+        return { value: inputs.value };
+      })
+    });
+
+    const result = await runner.run(
+      { job_id: "j-bypass-2", params: { text: "ignored" } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    // No compatible route means display never receives the upstream
+    // string value — the dropped edge never delivers anything.
+    expect(displayInputs.some((i) => i.value === "ignored")).toBe(false);
+  });
+
+  it("collapses a chain of bypassed nodes into a single edge", async () => {
+    // input → A(bypassed) → B(bypassed) → output
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      {
+        id: "A",
+        type: "test.Noop",
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" },
+        ui_properties: { bypassed: true }
+      },
+      {
+        id: "B",
+        type: "test.Noop",
+        outputs: { out: "string" },
+        propertyTypes: { in: "string" },
+        ui_properties: { bypassed: true }
+      },
+      { id: "output", type: "test.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      { source: "input", sourceHandle: "value", target: "A", targetHandle: "in" },
+      { source: "A", sourceHandle: "out", target: "B", targetHandle: "in" },
+      {
+        source: "B",
+        sourceHandle: "out",
+        target: "output",
+        targetHandle: "value"
+      }
+    ];
+
+    let anyRan = false;
+    const runner = makeRunner({
+      "test.Noop": simpleExecutor(() => {
+        anyRan = true;
+        return { out: "SHOULD_NOT_APPEAR" };
+      }),
+      "test.Output": simpleExecutor((inputs) => ({ value: inputs.value }))
+    });
+
+    const result = await runner.run(
+      { job_id: "j-bypass-3", params: { x: "chain" } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(anyRan).toBe(false);
+    expect(result.outputs.result).toContain("chain");
+  });
+});


### PR DESCRIPTION
Nodes flagged with ui_properties.bypassed === true are now rewritten
out of the graph before execution: each outgoing data edge is rerouted
to the upstream source whose output type is compatible with the
downstream target's input type, using TypeMetadata compatibility rules.
Outgoing edges with no compatible input are dropped. Chains of
bypassed nodes collapse into a single edge, and control edges touching
a bypassed node are dropped since the node no longer executes.

https://claude.ai/code/session_01EGD17vSPyaWK6Xb9NTJNZ8