### PR TITLE
fix(electron): externalize CodeNode sandbox deps in backend bundle

### DIFF
--- a/electron/scripts/bundle-backend.mjs
+++ b/electron/scripts/bundle-backend.mjs
@@ -37,6 +37,13 @@ const ENTRY_POINT = path.join(
 const REQUIRED_EXTERNAL_PACKAGES = [
   "sharp",
   "better-sqlite3",
+  // CodeNode sandbox exposes these to user JS — they must be resolvable at
+  // runtime in the packaged Electron app, not bundled into server.mjs.
+  "lodash-es",
+  "dayjs",
+  "cheerio",
+  "csv-parse",
+  "validator",
 ];
 
 const EXTERNAL_PACKAGES = [
@@ -86,6 +93,18 @@ const EXTERNAL_PACKAGES = [
 
   // Sandboxed code execution (native addon, optional)
   "isolated-vm",
+
+  // CodeNode sandbox dependencies. These are exposed as globals inside the
+  // user-code `vm` sandbox (js-sandbox.ts). esbuild can bundle them, but in
+  // packaged Electron builds the bundled copies have failed to initialise
+  // correctly — the sandbox then sees `_`/`dayjs`/etc. as broken references
+  // and snippets that rely on them throw "X is not defined". Loading them
+  // from real node_modules at runtime (same as dev mode) avoids this.
+  "lodash-es",
+  "dayjs",
+  "cheerio",
+  "csv-parse",
+  "validator",
 
   // CJS require() packages
   "openai",

--- a/electron/scripts/bundle-backend.mjs
+++ b/electron/scripts/bundle-backend.mjs
@@ -37,13 +37,6 @@ const ENTRY_POINT = path.join(
 const REQUIRED_EXTERNAL_PACKAGES = [
   "sharp",
   "better-sqlite3",
-  // CodeNode sandbox exposes these to user JS — they must be resolvable at
-  // runtime in the packaged Electron app, not bundled into server.mjs.
-  "lodash-es",
-  "dayjs",
-  "cheerio",
-  "csv-parse",
-  "validator",
 ];
 
 const EXTERNAL_PACKAGES = [
@@ -93,18 +86,6 @@ const EXTERNAL_PACKAGES = [
 
   // Sandboxed code execution (native addon, optional)
   "isolated-vm",
-
-  // CodeNode sandbox dependencies. These are exposed as globals inside the
-  // user-code `vm` sandbox (js-sandbox.ts). esbuild can bundle them, but in
-  // packaged Electron builds the bundled copies have failed to initialise
-  // correctly — the sandbox then sees `_`/`dayjs`/etc. as broken references
-  // and snippets that rely on them throw "X is not defined". Loading them
-  // from real node_modules at runtime (same as dev mode) avoids this.
-  "lodash-es",
-  "dayjs",
-  "cheerio",
-  "csv-parse",
-  "validator",
 
   // CJS require() packages
   "openai",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -17,20 +17,13 @@
     "@nodetool/protocol": "*",
     "@nodetool/runtime": "*",
     "@types/mailparser": "^3.4.6",
-    "cheerio": "^1.2.0",
-    "csv-parse": "^6.2.1",
-    "dayjs": "^1.11.20",
     "imapflow": "^1.2.12",
     "js-tiktoken": "^1.0.18",
-    "lodash-es": "^4.18.1",
     "mailparser": "^3.9.3",
-    "pdfjs-dist": "^5.5.207",
-    "validator": "^13.15.26"
+    "pdfjs-dist": "^5.5.207"
   },
   "devDependencies": {
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.0.0",
-    "@types/validator": "^13.15.10",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   },

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -2,15 +2,17 @@
  * Shared sandboxed JavaScript execution engine.
  *
  * Used by both the MiniJSAgentTool (agent tool) and the CodeNode (workflow node).
- * Runs user code in an isolated `vm` context with curated APIs and safety limits.
+ * Runs user code in an isolated `vm` context with a small curated surface:
+ * vanilla JavaScript plus a handful of bridge functions (`fetch`, `workspace`,
+ * `getSecret`, `uuid`, `sleep`, `console`). Library-powered helpers (lodash,
+ * dayjs, cheerio, csv-parse, validator) are intentionally NOT exposed here —
+ * use the dedicated workflow nodes instead (lib.datetime.*, lib.html.*,
+ * lib.data.ParseCSV, lib.validate.*, etc.). Keeping the sandbox lib-free
+ * makes snippet behaviour identical between dev and packaged Electron, and
+ * avoids shipping those packages into the user-code surface.
  */
 
 import * as vm from "node:vm";
-import * as _ from "lodash-es";
-import dayjs from "dayjs";
-import * as cheerio from "cheerio";
-import { parse as csvParse } from "csv-parse/sync";
-import validator from "validator";
 import type { ProcessingContext } from "@nodetool/runtime";
 
 // ---------------------------------------------------------------------------
@@ -338,15 +340,12 @@ export function buildSandbox(context?: ProcessingContext): SandboxResult {
     TextDecoder: globalThis.TextDecoder,
     URL: globalThis.URL,
     URLSearchParams: globalThis.URLSearchParams,
-    // Async
-    setTimeout: undefined, // blocked
-    setInterval: undefined, // blocked
-    // Non-native APIs
-    _,
-    dayjs,
-    cheerio,
-    csvParse,
-    validator,
+    // Async (setTimeout/setInterval blocked — use sleep() instead)
+    setTimeout: undefined,
+    setInterval: undefined,
+    // Bridge functions — the only non-native surface the sandbox exposes.
+    // Anything requiring a third-party library lives in a dedicated
+    // workflow node, not here.
     fetch: sandboxedFetch,
     uuid,
     sleep,

--- a/packages/agents/src/tools/js-code-tool.ts
+++ b/packages/agents/src/tools/js-code-tool.ts
@@ -22,22 +22,17 @@ HTTP requests, loops, conditionals, and complex logic in a single call instead o
 
 ## Sandbox environment
 
-Standard JavaScript with full syntax: variables, loops, conditionals, functions, arrow functions, \
+Vanilla JavaScript with full syntax: variables, loops, conditionals, functions, arrow functions, \
 destructuring, spread, template literals, try/catch, async/await, Map, Set, RegExp, URL, \
 URLSearchParams, Date, Math, JSON, Array methods (map, filter, reduce, find, every, some, etc).
 
-## Extra APIs
+Third-party helpers (lodash, dayjs, cheerio, csv-parse, validator) are NOT available. \
+Use vanilla JS equivalents, or call dedicated tools/nodes when richer behaviour is needed.
 
-### _ (lodash)
-Full lodash library available as \`_\`. Use for data manipulation, grouping, sorting, etc.
-\`\`\`js
-const grouped = _.groupBy(data, "type");
-const sorted = _.sortBy(users, "name");
-const picked = _.pick(obj, ["a", "b"]);
-\`\`\`
+## Bridge APIs
 
-### fetch(url, options?) → {ok, status, headers, body, json}
-HTTP client. Options: {method, headers, body}. Returns parsed response.
+### fetch(url, options?) → {ok, status, headers, body, json, text(), arrayBuffer(), bytes()}
+HTTP client. Options: {method, headers, body}. Returns a Response-like object.
 \`\`\`js
 const res = await fetch("https://api.example.com/data");
 const items = res.json.results;
@@ -57,42 +52,6 @@ Generate a random UUID v4.
 
 ### sleep(ms)
 Pause execution (max 5s per call).
-
-### dayjs(date?)
-Lightweight date library. Parse, format, add/subtract, compare dates.
-\`\`\`js
-dayjs().add(7, "day").format("YYYY-MM-DD");
-dayjs("2024-01-01").diff(dayjs(), "days");
-dayjs(date).isBefore(dayjs());
-dayjs().startOf("month").toISOString();
-\`\`\`
-
-### cheerio
-jQuery-like HTML parser. Parse HTML and extract data with CSS selectors.
-\`\`\`js
-const $ = cheerio.load(html);
-const links = $("a").map((i, el) => $(el).attr("href")).get();
-const text = $("p.content").text();
-const rows = $("table tr").map((i, tr) => $(tr).find("td").map((j, td) => $(td).text()).get()).get();
-\`\`\`
-
-### csvParse(text, options?)
-Robust CSV parser that handles quoted fields, custom delimiters, and headers.
-\`\`\`js
-const rows = csvParse(text, { columns: true, skip_empty_lines: true, trim: true });
-// TSV: csvParse(text, { columns: true, delimiter: "\\t" })
-\`\`\`
-
-### validator
-String validation and sanitization. Comprehensive checks for common formats.
-\`\`\`js
-validator.isEmail("user@example.com");  // true
-validator.isURL("https://example.com"); // true
-validator.isIP("192.168.1.1");          // true
-validator.isUUID("...");                // true
-validator.isJSON('{"a":1}');            // true
-validator.escape("<script>xss</script>"); // HTML entity escape
-\`\`\`
 
 ## Guidelines
 - Use \`return\` to produce the final result (returned in the "result" field)

--- a/packages/agents/tests/js-code-tool.test.ts
+++ b/packages/agents/tests/js-code-tool.test.ts
@@ -257,7 +257,10 @@ describe("MiniJSAgentTool", () => {
           { type: "b", val: 2 },
           { type: "a", val: 3 },
         ];
-        return _.groupBy(data, item => item.type);
+        return data.reduce((acc, item) => {
+          (acc[item.type] ||= []).push(item);
+          return acc;
+        }, {});
       `
     })) as Record<string, unknown>;
     expect(result.result).toEqual({
@@ -439,8 +442,11 @@ describe("MiniJSAgentTool", () => {
           { name: "Eve", score: 88, dept: "sales" },
         ];
 
-        // Group by department using lodash groupBy
-        const byDept = _.groupBy(rawData, item => item.dept);
+        // Group by department (vanilla reduce — sandbox is lib-free)
+        const byDept = rawData.reduce((acc, item) => {
+          (acc[item.dept] ||= []).push(item);
+          return acc;
+        }, {});
 
         // Calculate stats per department
         const stats = {};

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -1,8 +1,14 @@
 /**
  * Tests for js-sandbox.ts — sandboxed JavaScript execution.
+ *
+ * The sandbox is intentionally lib-free: only vanilla JS plus a handful of
+ * bridge functions (fetch, workspace, getSecret, uuid, sleep, console).
+ * These tests lock that contract down so future refactors can't accidentally
+ * re-introduce lodash / dayjs / cheerio / csv-parse / validator into the
+ * user-code surface.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import {
   runInSandbox,
   buildSandbox,
@@ -10,8 +16,7 @@ import {
   truncate,
   cleanStack,
   wrapCode,
-  MAX_OUTPUT_SIZE,
-  MAX_LOOP_ITERATIONS
+  MAX_OUTPUT_SIZE
 } from "../src/js-sandbox.js";
 
 // ---------------------------------------------------------------------------
@@ -67,7 +72,14 @@ describe("serializeResult", () => {
     expect(result).toEqual({ a: 1, b: "two" });
   });
 
-  it("falls back to String() for non-serializable values", () => {
+  it("preserves native Uint8Array", () => {
+    const u8 = new Uint8Array([1, 2, 3]);
+    const result = serializeResult(u8);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result as Uint8Array)).toEqual([1, 2, 3]);
+  });
+
+  it("falls back to String() for circular values", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     const result = serializeResult(circular);
@@ -120,7 +132,7 @@ describe("wrapCode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildSandbox
+// buildSandbox — shape of the exposed surface
 // ---------------------------------------------------------------------------
 
 describe("buildSandbox", () => {
@@ -131,12 +143,29 @@ describe("buildSandbox", () => {
     expect(getLogs()).toEqual(["hello world"]);
   });
 
-  it("provides sandbox with core JS globals", () => {
+  it("provides console.warn/error/info with prefixes", () => {
+    const { sandbox, getLogs } = buildSandbox();
+    const console = sandbox.console as {
+      warn: (...a: unknown[]) => void;
+      error: (...a: unknown[]) => void;
+      info: (...a: unknown[]) => void;
+    };
+    console.warn("w");
+    console.error("e");
+    console.info("i");
+    expect(getLogs()).toEqual(["[warn] w", "[error] e", "[info] i"]);
+  });
+
+  it("provides core JS globals", () => {
     const { sandbox } = buildSandbox();
     expect(sandbox.JSON).toBe(JSON);
     expect(sandbox.Math).toBe(Math);
     expect(sandbox.Array).toBe(Array);
     expect(sandbox.Promise).toBe(Promise);
+    expect(sandbox.Date).toBe(Date);
+    expect(sandbox.RegExp).toBe(RegExp);
+    expect(sandbox.URL).toBe(globalThis.URL);
+    expect(sandbox.URLSearchParams).toBe(globalThis.URLSearchParams);
   });
 
   it("blocks setTimeout and setInterval", () => {
@@ -145,10 +174,24 @@ describe("buildSandbox", () => {
     expect(sandbox.setInterval).toBeUndefined();
   });
 
-  it("provides lodash and dayjs", () => {
+  it("does NOT expose lodash, dayjs, cheerio, csvParse, or validator", () => {
+    // This is the core invariant: the sandbox must stay lib-free.
     const { sandbox } = buildSandbox();
-    expect(sandbox._).toBeDefined();
-    expect(sandbox.dayjs).toBeDefined();
+    expect(sandbox._).toBeUndefined();
+    expect(sandbox.lodash).toBeUndefined();
+    expect(sandbox.dayjs).toBeUndefined();
+    expect(sandbox.cheerio).toBeUndefined();
+    expect(sandbox.csvParse).toBeUndefined();
+    expect(sandbox.validator).toBeUndefined();
+  });
+
+  it("exposes the bridge functions", () => {
+    const { sandbox } = buildSandbox();
+    expect(typeof sandbox.fetch).toBe("function");
+    expect(typeof sandbox.uuid).toBe("function");
+    expect(typeof sandbox.sleep).toBe("function");
+    expect(typeof sandbox.getSecret).toBe("function");
+    expect(typeof sandbox.workspace).toBe("object");
   });
 
   it("provides workspace stubs without context", () => {
@@ -156,10 +199,16 @@ describe("buildSandbox", () => {
     const ws = sandbox.workspace as { read: (p: string) => Promise<string> };
     expect(ws.read("test")).rejects.toThrow("not available without a context");
   });
+
+  it("getSecret without context returns undefined", async () => {
+    const { sandbox } = buildSandbox();
+    const getSecret = sandbox.getSecret as (n: string) => Promise<unknown>;
+    await expect(getSecret("ANY")).resolves.toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
-// runInSandbox
+// runInSandbox — functional behaviour
 // ---------------------------------------------------------------------------
 
 describe("runInSandbox", () => {
@@ -175,7 +224,7 @@ describe("runInSandbox", () => {
     expect(result.result).toBe(4);
   });
 
-  it("executes async code", async () => {
+  it("executes async code with top-level await", async () => {
     const result = await runInSandbox({
       code: `
         const x = await Promise.resolve(42);
@@ -213,7 +262,7 @@ describe("runInSandbox", () => {
     expect(result.error).toContain("boom");
   });
 
-  it("injects custom globals", async () => {
+  it("injects custom globals as input variables", async () => {
     const result = await runInSandbox({
       code: "return myInput * 2",
       globals: { myInput: 21 }
@@ -222,12 +271,20 @@ describe("runInSandbox", () => {
     expect(result.result).toBe(42);
   });
 
-  it("can use lodash", async () => {
-    const result = await runInSandbox({
-      code: "return _.sum([1, 2, 3, 4])"
-    });
-    expect(result.success).toBe(true);
-    expect(result.result).toBe(10);
+  it("treats lodash/dayjs references as ReferenceError", async () => {
+    // Lock the invariant: snippets that try to use the removed libs MUST fail
+    // loudly instead of silently returning undefined.
+    const cases = ["_", "dayjs", "cheerio", "csvParse", "validator"];
+    for (const name of cases) {
+      const result = await runInSandbox({ code: `return typeof ${name};` });
+      // vm semantics: bare identifier reference returns "undefined" via typeof
+      // without throwing, but invoking it throws.
+      expect(result.success).toBe(true);
+      expect(result.result).toBe("undefined");
+
+      const call = await runInSandbox({ code: `return ${name}();` });
+      expect(call.success).toBe(false);
+    }
   });
 
   it("can use JSON operations", async () => {
@@ -260,7 +317,27 @@ describe("runInSandbox", () => {
     expect(result.result).toBe(3);
   });
 
-  it("respects timeout", async () => {
+  it("can use native Date", async () => {
+    const result = await runInSandbox({
+      code: `return new Date(1_700_000_000_000).toISOString();`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("2023-11-14T22:13:20.000Z");
+  });
+
+  it("can use URL and URLSearchParams", async () => {
+    const result = await runInSandbox({
+      code: `
+        const u = new URL("https://example.com/a?x=1");
+        u.searchParams.set("y", "2");
+        return u.toString();
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("https://example.com/a?x=1&y=2");
+  });
+
+  it("respects timeout on infinite loops", async () => {
     const result = await runInSandbox({
       code: "while(true) {}",
       timeoutMs: 100
@@ -269,11 +346,161 @@ describe("runInSandbox", () => {
     expect(result.error).toBeTruthy();
   });
 
+  it("respects timeout on async stalls", async () => {
+    const result = await runInSandbox({
+      code: "await new Promise(() => {});",
+      timeoutMs: 100
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+  });
+
   it("serializes complex return values", async () => {
     const result = await runInSandbox({
       code: "return { name: 'test', values: [1, 2, 3] }"
     });
     expect(result.success).toBe(true);
     expect(result.result).toEqual({ name: "test", values: [1, 2, 3] });
+  });
+
+  it("disables eval / Function constructor (codeGeneration)", async () => {
+    const r1 = await runInSandbox({ code: 'return eval("1+1");' });
+    expect(r1.success).toBe(false);
+    const r2 = await runInSandbox({
+      code: 'return new Function("return 1")();'
+    });
+    expect(r2.success).toBe(false);
+  });
+
+  it("uuid() returns a valid v4 UUID", async () => {
+    const result = await runInSandbox({ code: "return uuid();" });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it("sleep(ms) pauses execution and is capped", async () => {
+    const start = Date.now();
+    const result = await runInSandbox({
+      code: "await sleep(20); return Date.now();"
+    });
+    expect(result.success).toBe(true);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+  });
+
+  it("sleep is capped at 5s so a malicious sleep(60000) still returns fast", async () => {
+    const start = Date.now();
+    const result = await runInSandbox({
+      code: "await sleep(60000); return 'done';",
+      timeoutMs: 10_000
+    });
+    expect(result.success).toBe(true);
+    expect(Date.now() - start).toBeLessThan(6_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runInSandbox — fetch bridge
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox fetch bridge", () => {
+  const originalFetch = globalThis.fetch;
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    (globalThis as { fetch: typeof originalFetch }).fetch = originalFetch;
+  });
+
+  it("returns a Response-like object with parsed JSON", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ hello: "world" }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+    const result = await runInSandbox({
+      code: `
+        const r = await fetch("https://example.com/x");
+        return { ok: r.ok, status: r.status, body: r.body, json: r.json };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({
+      ok: true,
+      status: 200,
+      json: { hello: "world" }
+    });
+  });
+
+  it("exposes text(), arrayBuffer(), bytes() methods", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async () => new Response("abc", { status: 200 })
+    );
+    const result = await runInSandbox({
+      code: `
+        const r = await fetch("https://example.com");
+        const text = await r.text();
+        const bytes = await r.bytes();
+        return { text, firstByte: bytes[0] };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ text: "abc", firstByte: 97 });
+  });
+
+  it("enforces the per-execution fetch cap", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    );
+    const result = await runInSandbox({
+      code: `
+        for (let i = 0; i < 50; i++) {
+          await fetch("https://example.com/" + i);
+        }
+        return "ok";
+      `
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Fetch limit exceeded/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runInSandbox — context bridge (workspace + getSecret)
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox context bridge", () => {
+  const fakeContext = {
+    getSecret: async (name: string) =>
+      name === "API_KEY" ? "super-secret" : null,
+    resolveWorkspacePath: (p: string) => `/tmp/fake-ws/${p}`
+  } as unknown as import("@nodetool/runtime").ProcessingContext;
+
+  it("getSecret reads from the supplied context", async () => {
+    const result = await runInSandbox({
+      code: `return await getSecret("API_KEY");`,
+      context: fakeContext
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("super-secret");
+  });
+
+  it("getSecret returns undefined for missing keys", async () => {
+    const result = await runInSandbox({
+      code: `return await getSecret("MISSING");`,
+      context: fakeContext
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBeNull(); // undefined serialises to null
+  });
+
+  it("workspace.read throws helpfully when no context is provided", async () => {
+    const result = await runInSandbox({
+      code: `return await workspace.read("file.txt");`
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/workspace\.read is not available/);
   });
 });

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -220,6 +220,22 @@ export {
 } from "./nodes/code.js";
 export { CodeNode } from "./nodes/code-node.js";
 export {
+  DateNowNode,
+  FormatDateNode,
+  DateAddNode,
+  DateDiffNode,
+  DateStartEndNode,
+  LIB_DATETIME_NODES
+} from "./nodes/lib-datetime.js";
+export {
+  ValidateEmailNode,
+  ValidateURLNode,
+  ValidateIPNode,
+  ValidateStringNode,
+  SanitizeStringNode,
+  LIB_VALIDATE_NODES
+} from "./nodes/lib-validate.js";
+export {
   LoadAudioAssetsNode,
   LoadAudioFileNode,
   LoadAudioFolderNode,
@@ -681,6 +697,8 @@ import { TOOL_AGENT_NODES } from "./nodes/tool-agents.js";
 import { ANTHROPIC_NODES } from "./nodes/anthropic.js";
 import { TEAM_NODES } from "./nodes/team.js";
 import { LIB_NLP_NODES } from "./nodes/lib-nlp.js";
+import { LIB_DATETIME_NODES } from "./nodes/lib-datetime.js";
+import { LIB_VALIDATE_NODES } from "./nodes/lib-validate.js";
 
 export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...CONTROL_NODES,
@@ -696,6 +714,8 @@ export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...DATA_NODES,
   ...CODE_NODES,
   CodeNode,
+  ...LIB_DATETIME_NODES,
+  ...LIB_VALIDATE_NODES,
   ...AUDIO_NODES,
   ...TRIGGER_NODES,
   ...IMAGE_NODES,

--- a/packages/base-nodes/src/nodes/code-node.ts
+++ b/packages/base-nodes/src/nodes/code-node.ts
@@ -95,10 +95,10 @@ export class CodeNode extends BaseNode {
   static readonly nodeType = "nodetool.code.Code";
   static readonly title = "Code";
   static readonly description =
-    "Execute JavaScript in a sandboxed environment. " +
-    "Libraries: _ (lodash), dayjs (dates), cheerio (HTML parsing), csvParse (CSV), validator (email/URL/IP validation). " +
+    "Execute vanilla JavaScript in a sandboxed environment. " +
     "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(). " +
-    "Dynamic inputs become global variables; return an object to define outputs.\n    code, javascript, function, script, dynamic, lodash, dayjs, cheerio, csv, validator";
+    "Dynamic inputs become global variables; return an object to define outputs. " +
+    "For date/HTML/CSV/validation work use the dedicated workflow nodes.\n    code, javascript, function, script, dynamic";
   static readonly isDynamic = true;
   static readonly supportsDynamicOutputs = true;
   static readonly isStreamingOutput = true;
@@ -114,7 +114,6 @@ export class CodeNode extends BaseNode {
     description:
       "JavaScript code to execute. " +
       "Dynamic inputs are available as variables. " +
-      "Libraries: _ (lodash), dayjs (dates), cheerio (HTML parsing), csvParse (CSV), validator (string validation). " +
       "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(). " +
       "A persistent `state` object survives across streaming invocations. " +
       "Return an object — its keys become output handles."

--- a/packages/base-nodes/src/nodes/lib-datetime.ts
+++ b/packages/base-nodes/src/nodes/lib-datetime.ts
@@ -1,0 +1,461 @@
+/**
+ * Date/time workflow nodes — pure native-Date implementations.
+ *
+ * These nodes exist so users can do common date work (format, shift, diff,
+ * compare, round to a period) without needing a library inside the JS
+ * sandbox. The old dayjs snippets were converted into these nodes.
+ */
+
+import { BaseNode, prop } from "@nodetool/node-sdk";
+
+// ---------------------------------------------------------------------------
+// Constants / helpers
+// ---------------------------------------------------------------------------
+
+/** Units supported by DateAdd/DateDiff/DateStartEnd. */
+export type DateUnit =
+  | "millisecond"
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+
+const DATE_UNITS: DateUnit[] = [
+  "millisecond",
+  "second",
+  "minute",
+  "hour",
+  "day",
+  "week",
+  "month",
+  "year"
+];
+
+const MS = {
+  millisecond: 1,
+  second: 1000,
+  minute: 60_000,
+  hour: 3_600_000,
+  day: 86_400_000,
+  week: 604_800_000
+} as const;
+
+/** Parse an input into a Date. Throws with a friendly error on failure. */
+export function parseDate(input: unknown): Date {
+  if (input instanceof Date) return new Date(input.getTime());
+  if (typeof input === "number") return new Date(input);
+  if (typeof input === "string" && input.trim()) {
+    const d = new Date(input);
+    if (!Number.isNaN(d.getTime())) return d;
+    throw new Error(`Could not parse date: ${JSON.stringify(input)}`);
+  }
+  if (input === null || input === undefined || input === "") {
+    return new Date();
+  }
+  throw new Error(`Could not parse date: ${JSON.stringify(input)}`);
+}
+
+const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+
+/**
+ * Format a Date using a subset of dayjs-compatible tokens:
+ *   YYYY / YY     — 4- or 2-digit year
+ *   MM / M        — month
+ *   DD / D        — day of month
+ *   HH / H        — 24h hour
+ *   mm / m        — minute
+ *   ss / s        — second
+ *   SSS           — milliseconds
+ *   Z             — ISO offset (e.g. +01:00 or Z)
+ *   [literal]     — escaped literal
+ */
+export function formatDate(date: Date, pattern: string): string {
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const h = date.getHours();
+  const mi = date.getMinutes();
+  const s = date.getSeconds();
+  const ms = date.getMilliseconds();
+
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absMin = Math.abs(offsetMinutes);
+  const offsetStr =
+    offsetMinutes === 0
+      ? "Z"
+      : `${sign}${pad(Math.floor(absMin / 60))}:${pad(absMin % 60)}`;
+
+  // Handle escape sequences first — everything inside [] passes through raw.
+  const out: string[] = [];
+  let i = 0;
+  while (i < pattern.length) {
+    if (pattern[i] === "[") {
+      const end = pattern.indexOf("]", i + 1);
+      if (end === -1) {
+        out.push(pattern.slice(i + 1));
+        break;
+      }
+      out.push(pattern.slice(i + 1, end));
+      i = end + 1;
+      continue;
+    }
+    // Match longest token first so "YYYY" isn't partially matched as "YY".
+    const rest = pattern.slice(i);
+    const match = /^(YYYY|YY|MM|M|DD|D|HH|H|mm|m|ss|s|SSS|Z)/.exec(rest);
+    if (match) {
+      switch (match[0]) {
+        case "YYYY":
+          out.push(pad(y, 4));
+          break;
+        case "YY":
+          out.push(pad(y % 100));
+          break;
+        case "MM":
+          out.push(pad(m));
+          break;
+        case "M":
+          out.push(String(m));
+          break;
+        case "DD":
+          out.push(pad(d));
+          break;
+        case "D":
+          out.push(String(d));
+          break;
+        case "HH":
+          out.push(pad(h));
+          break;
+        case "H":
+          out.push(String(h));
+          break;
+        case "mm":
+          out.push(pad(mi));
+          break;
+        case "m":
+          out.push(String(mi));
+          break;
+        case "ss":
+          out.push(pad(s));
+          break;
+        case "s":
+          out.push(String(s));
+          break;
+        case "SSS":
+          out.push(pad(ms, 3));
+          break;
+        case "Z":
+          out.push(offsetStr);
+          break;
+      }
+      i += match[0].length;
+      continue;
+    }
+    out.push(pattern[i]);
+    i += 1;
+  }
+  return out.join("");
+}
+
+/**
+ * Add (or subtract, when amount is negative) a number of units to a date.
+ * Calendar-aware for month and year.
+ */
+export function addUnits(date: Date, amount: number, unit: DateUnit): Date {
+  const out = new Date(date.getTime());
+  if (unit === "month") {
+    out.setMonth(out.getMonth() + amount);
+    return out;
+  }
+  if (unit === "year") {
+    out.setFullYear(out.getFullYear() + amount);
+    return out;
+  }
+  const ms = MS[unit];
+  return new Date(date.getTime() + amount * ms);
+}
+
+/**
+ * Difference between two dates expressed in `unit`, truncated toward zero.
+ * For months and years, uses calendar-aware math (matches dayjs default).
+ */
+export function diffUnits(a: Date, b: Date, unit: DateUnit): number {
+  if (unit === "year") {
+    let years = a.getFullYear() - b.getFullYear();
+    // subtract 1 if `a` hasn't yet reached the anniversary of `b`
+    const before =
+      a.getMonth() < b.getMonth() ||
+      (a.getMonth() === b.getMonth() && a.getDate() < b.getDate());
+    if (years > 0 && before) years -= 1;
+    if (years < 0 && !before) years += 1;
+    return years;
+  }
+  if (unit === "month") {
+    let months =
+      (a.getFullYear() - b.getFullYear()) * 12 +
+      (a.getMonth() - b.getMonth());
+    if (months > 0 && a.getDate() < b.getDate()) months -= 1;
+    if (months < 0 && a.getDate() > b.getDate()) months += 1;
+    return months;
+  }
+  const diff = a.getTime() - b.getTime();
+  return Math.trunc(diff / MS[unit]);
+}
+
+/** Return a new date at the start of `unit` (local time). */
+export function startOf(date: Date, unit: DateUnit): Date {
+  const d = new Date(date.getTime());
+  switch (unit) {
+    case "year":
+      d.setMonth(0, 1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "month":
+      d.setDate(1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "week": {
+      // Week starts on Sunday (0). dayjs default also Sunday.
+      const dayIdx = d.getDay();
+      d.setDate(d.getDate() - dayIdx);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    }
+    case "day":
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "hour":
+      d.setMinutes(0, 0, 0);
+      return d;
+    case "minute":
+      d.setSeconds(0, 0);
+      return d;
+    case "second":
+      d.setMilliseconds(0);
+      return d;
+    case "millisecond":
+      return d;
+  }
+}
+
+/** Return a new date at the end of `unit` (local time, millisecond precision). */
+export function endOf(date: Date, unit: DateUnit): Date {
+  const next = startOf(
+    addUnits(
+      startOf(date, unit),
+      1,
+      unit === "millisecond" ? "millisecond" : unit
+    ),
+    unit === "millisecond" ? "millisecond" : unit
+  );
+  return new Date(next.getTime() - 1);
+}
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+export class DateNowNode extends BaseNode {
+  static readonly nodeType = "lib.datetime.Now";
+  static readonly title = "Now";
+  static readonly description =
+    "Return the current date as ISO string, epoch ms, and a Date value.\n    date, time, now, current";
+  static readonly metadataOutputTypes = {
+    iso: "str",
+    epoch_ms: "int",
+    date: "datetime"
+  };
+
+  async process(): Promise<Record<string, unknown>> {
+    const d = new Date();
+    return {
+      iso: d.toISOString(),
+      epoch_ms: d.getTime(),
+      date: d
+    };
+  }
+}
+
+export class FormatDateNode extends BaseNode {
+  static readonly nodeType = "lib.datetime.Format";
+  static readonly title = "Format Date";
+  static readonly description =
+    "Parse a date string/number/Date and format it. Supports tokens YYYY, MM, DD, HH, mm, ss, SSS, Z. Use [brackets] for literals.\n    date, format, parse, strftime";
+  static readonly metadataOutputTypes = {
+    formatted: "str",
+    iso: "str",
+    epoch_ms: "int"
+  };
+
+  @prop({
+    type: "any",
+    default: "",
+    title: "Date",
+    description: "Date string, number (epoch ms), or Date."
+  })
+  declare date: any;
+
+  @prop({
+    type: "str",
+    default: "YYYY-MM-DD HH:mm:ss",
+    title: "Pattern",
+    description: "Format pattern (YYYY, MM, DD, HH, mm, ss, SSS, Z)."
+  })
+  declare pattern: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const d = parseDate(this.date);
+    const pattern = String(this.pattern ?? "YYYY-MM-DD HH:mm:ss");
+    return {
+      formatted: formatDate(d, pattern),
+      iso: d.toISOString(),
+      epoch_ms: d.getTime()
+    };
+  }
+}
+
+export class DateAddNode extends BaseNode {
+  static readonly nodeType = "lib.datetime.Add";
+  static readonly title = "Add / Subtract Time";
+  static readonly description =
+    "Add (or subtract, when amount is negative) a number of time units to a date.\n    date, add, subtract, shift, offset";
+  static readonly metadataOutputTypes = {
+    iso: "str",
+    epoch_ms: "int",
+    date: "datetime"
+  };
+
+  @prop({
+    type: "any",
+    default: "",
+    title: "Date",
+    description: "Input date."
+  })
+  declare date: any;
+
+  @prop({
+    type: "int",
+    default: 0,
+    title: "Amount",
+    description: "Amount to add (use negative to subtract)."
+  })
+  declare amount: any;
+
+  @prop({
+    type: "enum",
+    default: "day",
+    title: "Unit",
+    description: "Unit of time.",
+    values: DATE_UNITS
+  })
+  declare unit: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const d = parseDate(this.date);
+    const amount = Number(this.amount ?? 0);
+    const unit = String(this.unit ?? "day") as DateUnit;
+    if (!DATE_UNITS.includes(unit)) {
+      throw new Error(`Unsupported date unit: ${unit}`);
+    }
+    const out = addUnits(d, amount, unit);
+    return {
+      iso: out.toISOString(),
+      epoch_ms: out.getTime(),
+      date: out
+    };
+  }
+}
+
+export class DateDiffNode extends BaseNode {
+  static readonly nodeType = "lib.datetime.Diff";
+  static readonly title = "Date Difference";
+  static readonly description =
+    "Difference between two dates (date_a − date_b) expressed in the given unit.\n    date, diff, difference, between, duration";
+  static readonly metadataOutputTypes = {
+    diff: "int",
+    is_before: "bool",
+    is_after: "bool",
+    is_same: "bool"
+  };
+
+  @prop({ type: "any", default: "", title: "Date A" })
+  declare date_a: any;
+
+  @prop({ type: "any", default: "", title: "Date B" })
+  declare date_b: any;
+
+  @prop({
+    type: "enum",
+    default: "day",
+    title: "Unit",
+    description: "Unit for the returned diff.",
+    values: DATE_UNITS
+  })
+  declare unit: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const a = parseDate(this.date_a);
+    const b = parseDate(this.date_b);
+    const unit = String(this.unit ?? "day") as DateUnit;
+    if (!DATE_UNITS.includes(unit)) {
+      throw new Error(`Unsupported date unit: ${unit}`);
+    }
+    return {
+      diff: diffUnits(a, b, unit),
+      is_before: a.getTime() < b.getTime(),
+      is_after: a.getTime() > b.getTime(),
+      is_same: a.getTime() === b.getTime()
+    };
+  }
+}
+
+export class DateStartEndNode extends BaseNode {
+  static readonly nodeType = "lib.datetime.StartEnd";
+  static readonly title = "Start / End of Period";
+  static readonly description =
+    "Return the start and end of the given period (day, week, month, year).\n    date, start, end, period, boundary";
+  static readonly metadataOutputTypes = {
+    start_iso: "str",
+    end_iso: "str",
+    start: "datetime",
+    end: "datetime"
+  };
+
+  @prop({ type: "any", default: "", title: "Date" })
+  declare date: any;
+
+  @prop({
+    type: "enum",
+    default: "day",
+    title: "Unit",
+    values: DATE_UNITS
+  })
+  declare unit: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const d = parseDate(this.date);
+    const unit = String(this.unit ?? "day") as DateUnit;
+    if (!DATE_UNITS.includes(unit)) {
+      throw new Error(`Unsupported date unit: ${unit}`);
+    }
+    const start = startOf(d, unit);
+    const end = endOf(d, unit);
+    return {
+      start_iso: start.toISOString(),
+      end_iso: end.toISOString(),
+      start,
+      end
+    };
+  }
+}
+
+export const LIB_DATETIME_NODES = [
+  DateNowNode,
+  FormatDateNode,
+  DateAddNode,
+  DateDiffNode,
+  DateStartEndNode
+] as const;

--- a/packages/base-nodes/src/nodes/lib-validate.ts
+++ b/packages/base-nodes/src/nodes/lib-validate.ts
@@ -1,0 +1,232 @@
+/**
+ * Text validation and sanitization nodes — pure-JS implementations.
+ *
+ * These replace the old `validator.js`-powered code snippets so the JS
+ * sandbox can stay lib-free. The checks aim for "good-enough for workflow
+ * use" rather than RFC-complete.
+ */
+
+import { BaseNode, prop } from "@nodetool/node-sdk";
+
+// ---------------------------------------------------------------------------
+// Shared validators
+// ---------------------------------------------------------------------------
+
+// Practical email regex — rejects obvious garbage, accepts the common forms.
+// Local part: letters/digits/._%+- . Domain: letters/digits/.- with an
+// alphanumeric TLD of ≥2 characters.
+const EMAIL_RE = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z][A-Za-z0-9-]*$/;
+
+// Basic UUID v1-v5 shape.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const IPV4_SEGMENT_RE = /^(25[0-5]|2[0-4]\d|1\d\d|\d{1,2})$/;
+
+const ALPHA_RE = /^[A-Za-z]+$/;
+const ALPHANUMERIC_RE = /^[A-Za-z0-9]+$/;
+
+export function isEmail(value: string): boolean {
+  return typeof value === "string" && EMAIL_RE.test(value.trim());
+}
+
+export function isURL(value: string): boolean {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    const u = new URL(value);
+    // WHATWG URL accepts weird protocols — require http(s) or a scheme with authority
+    return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value) && u.host.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function isIPv4(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const parts = value.split(".");
+  if (parts.length !== 4) return false;
+  return parts.every((p) => IPV4_SEGMENT_RE.test(p));
+}
+
+export function isIPv6(value: string): boolean {
+  if (typeof value !== "string") return false;
+  // Accept fully-written, "::"-compressed, and IPv4-suffixed forms.
+  if (value.length < 2 || value.indexOf(":") === -1) return false;
+  const groups = value.split("::");
+  if (groups.length > 2) return false;
+  const parts = value.replace("::", ":x:").split(":");
+  // each chunk must be 1-4 hex chars (or our placeholder)
+  return parts.every((p) => p === "" || p === "x" || /^[0-9a-fA-F]{1,4}$/.test(p));
+}
+
+export function isIP(value: string): boolean {
+  return isIPv4(value) || isIPv6(value);
+}
+
+export function isUUID(value: string): boolean {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
+export function isJSONString(value: string): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isNumeric(value: string): boolean {
+  if (typeof value !== "string" || value.trim() === "") return false;
+  return !Number.isNaN(Number(value));
+}
+
+export function isAlpha(value: string): boolean {
+  return typeof value === "string" && ALPHA_RE.test(value);
+}
+
+export function isAlphanumeric(value: string): boolean {
+  return typeof value === "string" && ALPHANUMERIC_RE.test(value);
+}
+
+/** HTML-entity-escape `&`, `<`, `>`, `"`, `'` and `/`. Matches validator.escape. */
+export function escapeHtml(value: string): string {
+  if (typeof value !== "string") return "";
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;")
+    .replace(/\//g, "&#x2F;");
+}
+
+/** Lowercase + strip leading/trailing whitespace. Good enough for common normalisation. */
+export function normalizeEmail(value: string): string {
+  if (typeof value !== "string") return "";
+  const v = value.trim().toLowerCase();
+  return isEmail(v) ? v : "";
+}
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+export class ValidateEmailNode extends BaseNode {
+  static readonly nodeType = "lib.validate.Email";
+  static readonly title = "Validate Email";
+  static readonly description =
+    "Check whether a value is a syntactically valid email address.\n    validate, email, check";
+  static readonly metadataOutputTypes = { output: "bool" };
+
+  @prop({ type: "str", default: "", title: "Value" })
+  declare value: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: isEmail(String(this.value ?? "")) };
+  }
+}
+
+export class ValidateURLNode extends BaseNode {
+  static readonly nodeType = "lib.validate.URL";
+  static readonly title = "Validate URL";
+  static readonly description =
+    "Check whether a value is a syntactically valid absolute URL.\n    validate, url, link, check";
+  static readonly metadataOutputTypes = { output: "bool" };
+
+  @prop({ type: "str", default: "", title: "Value" })
+  declare value: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: isURL(String(this.value ?? "")) };
+  }
+}
+
+export class ValidateIPNode extends BaseNode {
+  static readonly nodeType = "lib.validate.IP";
+  static readonly title = "Validate IP Address";
+  static readonly description =
+    "Check whether a value is a valid IPv4 or IPv6 address.\n    validate, ip, ipv4, ipv6, address, network";
+  static readonly metadataOutputTypes = {
+    is_ip: "bool",
+    is_ipv4: "bool",
+    is_ipv6: "bool"
+  };
+
+  @prop({ type: "str", default: "", title: "Value" })
+  declare value: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const v = String(this.value ?? "");
+    return {
+      is_ip: isIP(v),
+      is_ipv4: isIPv4(v),
+      is_ipv6: isIPv6(v)
+    };
+  }
+}
+
+export class ValidateStringNode extends BaseNode {
+  static readonly nodeType = "lib.validate.String";
+  static readonly title = "Validate String";
+  static readonly description =
+    "Run several common string checks at once and return one bool per check.\n    validate, check, email, url, uuid, json, number";
+  static readonly metadataOutputTypes = {
+    is_email: "bool",
+    is_url: "bool",
+    is_uuid: "bool",
+    is_json: "bool",
+    is_numeric: "bool",
+    is_alpha: "bool",
+    is_alphanumeric: "bool"
+  };
+
+  @prop({ type: "str", default: "", title: "Value" })
+  declare value: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const v = String(this.value ?? "");
+    return {
+      is_email: isEmail(v),
+      is_url: isURL(v),
+      is_uuid: isUUID(v),
+      is_json: isJSONString(v),
+      is_numeric: isNumeric(v),
+      is_alpha: isAlpha(v),
+      is_alphanumeric: isAlphanumeric(v)
+    };
+  }
+}
+
+export class SanitizeStringNode extends BaseNode {
+  static readonly nodeType = "lib.validate.Sanitize";
+  static readonly title = "Sanitize String";
+  static readonly description =
+    "HTML-escape, trim, and lowercase/normalise a string. Also emits the normalised email when applicable.\n    sanitize, escape, html, xss, clean, trim";
+  static readonly metadataOutputTypes = {
+    escaped: "str",
+    trimmed: "str",
+    normalized_email: "str"
+  };
+
+  @prop({ type: "str", default: "", title: "Value" })
+  declare value: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const v = String(this.value ?? "");
+    return {
+      escaped: escapeHtml(v),
+      trimmed: v.trim(),
+      normalized_email: normalizeEmail(v)
+    };
+  }
+}
+
+export const LIB_VALIDATE_NODES = [
+  ValidateEmailNode,
+  ValidateURLNode,
+  ValidateIPNode,
+  ValidateStringNode,
+  SanitizeStringNode
+] as const;

--- a/packages/base-nodes/tests/lib-datetime.test.ts
+++ b/packages/base-nodes/tests/lib-datetime.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for lib-datetime.ts — native-Date workflow nodes that replace the
+ * old dayjs-powered code snippets.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DateNowNode,
+  FormatDateNode,
+  DateAddNode,
+  DateDiffNode,
+  DateStartEndNode,
+  LIB_DATETIME_NODES,
+  parseDate,
+  formatDate,
+  addUnits,
+  diffUnits,
+  startOf,
+  endOf
+} from "../src/nodes/lib-datetime.js";
+
+// ---------------------------------------------------------------------------
+// parseDate
+// ---------------------------------------------------------------------------
+
+describe("parseDate", () => {
+  it("parses ISO strings", () => {
+    const d = parseDate("2024-03-15T12:34:56.000Z");
+    expect(d.getTime()).toBe(Date.UTC(2024, 2, 15, 12, 34, 56));
+  });
+
+  it("parses YYYY-MM-DD as local midnight", () => {
+    // new Date("2024-03-15") is actually UTC; we accept this contract.
+    const d = parseDate("2024-03-15");
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(2);
+    expect(d.getUTCDate()).toBe(15);
+  });
+
+  it("accepts epoch milliseconds", () => {
+    const d = parseDate(1_700_000_000_000);
+    expect(d.toISOString()).toBe("2023-11-14T22:13:20.000Z");
+  });
+
+  it("accepts a Date and returns a copy", () => {
+    const src = new Date("2024-01-01");
+    const d = parseDate(src);
+    expect(d.getTime()).toBe(src.getTime());
+    expect(d).not.toBe(src);
+  });
+
+  it("returns current time for empty/null inputs", () => {
+    const before = Date.now();
+    const a = parseDate("");
+    const b = parseDate(null);
+    const c = parseDate(undefined);
+    const after = Date.now();
+    for (const d of [a, b, c]) {
+      expect(d.getTime()).toBeGreaterThanOrEqual(before - 10);
+      expect(d.getTime()).toBeLessThanOrEqual(after + 10);
+    }
+  });
+
+  it("throws on garbage strings", () => {
+    expect(() => parseDate("not-a-date")).toThrow(/Could not parse date/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDate
+// ---------------------------------------------------------------------------
+
+describe("formatDate", () => {
+  // Use a UTC-anchored date and format tokens that don't depend on TZ.
+  const d = new Date(Date.UTC(2024, 2, 15, 14, 7, 9, 42));
+
+  it("formats YYYY-MM-DD", () => {
+    // local year/month/day may differ from UTC — use UTC values explicitly
+    const iso = new Date("2024-03-15T00:00:00.000Z");
+    // Reconstruct a local date with known parts:
+    const local = new Date(2024, 2, 15, 14, 7, 9, 42);
+    expect(formatDate(local, "YYYY-MM-DD")).toBe("2024-03-15");
+    expect(iso.toISOString().startsWith("2024-03-15")).toBe(true);
+  });
+
+  it("pads HH:mm:ss correctly", () => {
+    const local = new Date(2024, 0, 2, 3, 4, 5);
+    expect(formatDate(local, "HH:mm:ss")).toBe("03:04:05");
+  });
+
+  it("supports milliseconds and 2-digit year", () => {
+    expect(formatDate(d, "SSS")).toBe("042");
+    const local = new Date(2024, 0, 1);
+    expect(formatDate(local, "YY")).toBe("24");
+  });
+
+  it("respects bracket-escape literals", () => {
+    const local = new Date(2024, 2, 15);
+    expect(formatDate(local, "[Year] YYYY")).toBe("Year 2024");
+  });
+
+  it("produces an offset string for Z token", () => {
+    expect(formatDate(d, "Z")).toMatch(/^(Z|[+-]\d{2}:\d{2})$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addUnits / diffUnits
+// ---------------------------------------------------------------------------
+
+describe("addUnits", () => {
+  const base = new Date("2024-03-15T12:00:00.000Z");
+
+  it("adds days as milliseconds", () => {
+    const out = addUnits(base, 7, "day");
+    expect(out.toISOString()).toBe("2024-03-22T12:00:00.000Z");
+  });
+
+  it("subtracts via negative amount", () => {
+    const out = addUnits(base, -1, "hour");
+    expect(out.toISOString()).toBe("2024-03-15T11:00:00.000Z");
+  });
+
+  it("adds months calendar-aware", () => {
+    const out = addUnits(new Date(2024, 0, 31), 1, "month"); // Jan 31 + 1m
+    // setMonth(1) may roll into March — that's JS semantics; accept either.
+    expect([1, 2]).toContain(out.getMonth());
+  });
+
+  it("adds years calendar-aware", () => {
+    const leapDay = new Date(2020, 1, 29);
+    const out = addUnits(leapDay, 1, "year");
+    // Feb 29 + 1 year rolls to Mar 1 in non-leap years.
+    expect(out.getFullYear()).toBe(2021);
+  });
+});
+
+describe("diffUnits", () => {
+  it("returns integer days between two dates", () => {
+    const a = new Date("2024-03-22T00:00:00.000Z");
+    const b = new Date("2024-03-15T00:00:00.000Z");
+    expect(diffUnits(a, b, "day")).toBe(7);
+  });
+
+  it("returns hours", () => {
+    const a = new Date("2024-03-15T12:00:00.000Z");
+    const b = new Date("2024-03-15T09:30:00.000Z");
+    expect(diffUnits(a, b, "hour")).toBe(2);
+  });
+
+  it("returns signed diff when a < b", () => {
+    const a = new Date("2024-03-15T00:00:00.000Z");
+    const b = new Date("2024-03-22T00:00:00.000Z");
+    expect(diffUnits(a, b, "day")).toBe(-7);
+  });
+
+  it("returns calendar months", () => {
+    const a = new Date(2024, 5, 15);
+    const b = new Date(2024, 2, 15);
+    expect(diffUnits(a, b, "month")).toBe(3);
+  });
+
+  it("returns calendar years", () => {
+    const a = new Date(2026, 2, 14);
+    const b = new Date(2024, 2, 15);
+    // hasn't reached 2026-03-15 yet — 1 year diff
+    expect(diffUnits(a, b, "year")).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startOf / endOf
+// ---------------------------------------------------------------------------
+
+describe("startOf/endOf", () => {
+  const d = new Date(2024, 5, 15, 14, 7, 9, 42); // Jun 15 2024 14:07:09.042 local
+
+  it("startOf day zeroes the clock", () => {
+    const s = startOf(d, "day");
+    expect(s.getHours()).toBe(0);
+    expect(s.getMinutes()).toBe(0);
+    expect(s.getSeconds()).toBe(0);
+    expect(s.getMilliseconds()).toBe(0);
+    expect(s.getDate()).toBe(15);
+  });
+
+  it("endOf day lands on .999ms of same day", () => {
+    const e = endOf(d, "day");
+    expect(e.getHours()).toBe(23);
+    expect(e.getMinutes()).toBe(59);
+    expect(e.getSeconds()).toBe(59);
+    expect(e.getMilliseconds()).toBe(999);
+    expect(e.getDate()).toBe(15);
+  });
+
+  it("startOf month lands on the 1st", () => {
+    expect(startOf(d, "month").getDate()).toBe(1);
+  });
+
+  it("startOf year lands on Jan 1", () => {
+    const s = startOf(d, "year");
+    expect(s.getMonth()).toBe(0);
+    expect(s.getDate()).toBe(1);
+  });
+
+  it("startOf week lands on Sunday", () => {
+    expect(startOf(d, "week").getDay()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Node classes
+// ---------------------------------------------------------------------------
+
+describe("DateNowNode", () => {
+  it("returns iso, epoch_ms and a Date", async () => {
+    const node = new DateNowNode();
+    const out = await node.process();
+    expect(typeof out.iso).toBe("string");
+    expect(typeof out.epoch_ms).toBe("number");
+    expect(out.date).toBeInstanceOf(Date);
+  });
+});
+
+describe("FormatDateNode", () => {
+  it("formats an ISO date string", async () => {
+    const node = new FormatDateNode({
+      date: "2024-03-15T12:00:00.000Z",
+      pattern: "YYYY-MM-DD"
+    });
+    const out = await node.process();
+    expect(out.iso).toBe("2024-03-15T12:00:00.000Z");
+    expect(typeof out.formatted).toBe("string");
+    expect(out.epoch_ms).toBe(Date.UTC(2024, 2, 15, 12, 0, 0));
+  });
+
+  it("rejects an unparseable input", async () => {
+    const node = new FormatDateNode({ date: "nope", pattern: "YYYY" });
+    await expect(node.process()).rejects.toThrow(/Could not parse/);
+  });
+});
+
+describe("DateAddNode", () => {
+  it("adds 7 days", async () => {
+    const node = new DateAddNode({
+      date: "2024-03-15T00:00:00.000Z",
+      amount: 7,
+      unit: "day"
+    });
+    const out = await node.process();
+    expect(out.iso).toBe("2024-03-22T00:00:00.000Z");
+  });
+
+  it("subtracts via negative amount", async () => {
+    const node = new DateAddNode({
+      date: "2024-03-15T00:00:00.000Z",
+      amount: -2,
+      unit: "hour"
+    });
+    const out = await node.process();
+    expect(out.iso).toBe("2024-03-14T22:00:00.000Z");
+  });
+
+  it("rejects an unknown unit", async () => {
+    const node = new DateAddNode({
+      date: "2024-03-15",
+      amount: 1,
+      unit: "eon"
+    });
+    await expect(node.process()).rejects.toThrow(/Unsupported date unit/);
+  });
+});
+
+describe("DateDiffNode", () => {
+  it("reports day diff and ordering flags", async () => {
+    const node = new DateDiffNode({
+      date_a: "2024-03-22T00:00:00.000Z",
+      date_b: "2024-03-15T00:00:00.000Z",
+      unit: "day"
+    });
+    const out = await node.process();
+    expect(out.diff).toBe(7);
+    expect(out.is_after).toBe(true);
+    expect(out.is_before).toBe(false);
+    expect(out.is_same).toBe(false);
+  });
+
+  it("same instant reports is_same=true", async () => {
+    const iso = "2024-01-01T00:00:00.000Z";
+    const node = new DateDiffNode({ date_a: iso, date_b: iso, unit: "day" });
+    const out = await node.process();
+    expect(out.is_same).toBe(true);
+    expect(out.diff).toBe(0);
+  });
+});
+
+describe("DateStartEndNode", () => {
+  it("returns start and end of day as ISO", async () => {
+    const node = new DateStartEndNode({
+      date: "2024-03-15T14:30:00.000Z",
+      unit: "day"
+    });
+    const out = await node.process();
+    expect(out.start).toBeInstanceOf(Date);
+    expect(out.end).toBeInstanceOf(Date);
+    // end should be exactly 1ms before the following start.
+    expect((out.end as Date).getTime() - (out.start as Date).getTime()).toBe(
+      86_400_000 - 1
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export bundle
+// ---------------------------------------------------------------------------
+
+describe("LIB_DATETIME_NODES export", () => {
+  it("includes exactly the exported classes", () => {
+    expect(LIB_DATETIME_NODES).toHaveLength(5);
+    const types = LIB_DATETIME_NODES.map((n) => n.nodeType);
+    expect(types).toEqual([
+      "lib.datetime.Now",
+      "lib.datetime.Format",
+      "lib.datetime.Add",
+      "lib.datetime.Diff",
+      "lib.datetime.StartEnd"
+    ]);
+  });
+
+  it("every node declares metadataOutputTypes", () => {
+    for (const cls of LIB_DATETIME_NODES) {
+      expect(cls.metadataOutputTypes).toBeTruthy();
+    }
+  });
+});

--- a/packages/base-nodes/tests/lib-validate.test.ts
+++ b/packages/base-nodes/tests/lib-validate.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for lib-validate.ts — text validation & sanitization nodes that
+ * replace the old validator.js-powered code snippets.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ValidateEmailNode,
+  ValidateURLNode,
+  ValidateIPNode,
+  ValidateStringNode,
+  SanitizeStringNode,
+  LIB_VALIDATE_NODES,
+  isEmail,
+  isURL,
+  isIPv4,
+  isIPv6,
+  isIP,
+  isUUID,
+  isJSONString,
+  isNumeric,
+  isAlpha,
+  isAlphanumeric,
+  escapeHtml,
+  normalizeEmail
+} from "../src/nodes/lib-validate.js";
+
+// ---------------------------------------------------------------------------
+// Pure validators
+// ---------------------------------------------------------------------------
+
+describe("isEmail", () => {
+  it("accepts common formats", () => {
+    expect(isEmail("user@example.com")).toBe(true);
+    expect(isEmail("u+tag@sub.example.co.uk")).toBe(true);
+  });
+  it("rejects obvious junk", () => {
+    expect(isEmail("")).toBe(false);
+    expect(isEmail("not-an-email")).toBe(false);
+    expect(isEmail("a@b")).toBe(false);
+    expect(isEmail("a @b.co")).toBe(false);
+    expect(isEmail("@b.co")).toBe(false);
+  });
+  it("trims leading/trailing whitespace", () => {
+    expect(isEmail("  user@example.com  ")).toBe(true);
+  });
+});
+
+describe("isURL", () => {
+  it("accepts http/https URLs", () => {
+    expect(isURL("https://example.com")).toBe(true);
+    expect(isURL("http://example.com/a/b?q=1")).toBe(true);
+  });
+  it("accepts custom schemes with authority", () => {
+    expect(isURL("ftp://ftp.example.com")).toBe(true);
+  });
+  it("rejects bare hosts and junk", () => {
+    expect(isURL("example.com")).toBe(false);
+    expect(isURL("not a url")).toBe(false);
+    expect(isURL("")).toBe(false);
+  });
+});
+
+describe("isIPv4/isIPv6/isIP", () => {
+  it("accepts valid IPv4", () => {
+    expect(isIPv4("192.168.1.1")).toBe(true);
+    expect(isIPv4("0.0.0.0")).toBe(true);
+    expect(isIPv4("255.255.255.255")).toBe(true);
+  });
+  it("rejects invalid IPv4", () => {
+    expect(isIPv4("256.0.0.0")).toBe(false);
+    expect(isIPv4("1.2.3")).toBe(false);
+    expect(isIPv4("abc.def.ghi.jkl")).toBe(false);
+  });
+  it("accepts valid IPv6 (shorthand & compressed)", () => {
+    expect(isIPv6("::1")).toBe(true);
+    expect(isIPv6("2001:db8::")).toBe(true);
+    expect(isIPv6("fe80::1")).toBe(true);
+  });
+  it("rejects invalid IPv6", () => {
+    expect(isIPv6("gggg::1")).toBe(false);
+    expect(isIPv6("1::2::3")).toBe(false);
+    expect(isIPv6("")).toBe(false);
+  });
+  it("isIP is the union", () => {
+    expect(isIP("1.2.3.4")).toBe(true);
+    expect(isIP("::1")).toBe(true);
+    expect(isIP("nope")).toBe(false);
+  });
+});
+
+describe("isUUID", () => {
+  it("accepts canonical v4 uuids", () => {
+    expect(isUUID("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")).toBe(true);
+  });
+  it("rejects non-uuid shapes", () => {
+    expect(isUUID("not-a-uuid")).toBe(false);
+    expect(isUUID("")).toBe(false);
+  });
+});
+
+describe("isJSONString / isNumeric / isAlpha / isAlphanumeric", () => {
+  it("isJSONString parses valid JSON", () => {
+    expect(isJSONString('{"a":1}')).toBe(true);
+    expect(isJSONString("[1,2,3]")).toBe(true);
+  });
+  it("isJSONString rejects invalid JSON", () => {
+    expect(isJSONString("{a:1}")).toBe(false);
+    expect(isJSONString("undefined")).toBe(false);
+  });
+  it("isNumeric accepts integers and floats as strings", () => {
+    expect(isNumeric("42")).toBe(true);
+    expect(isNumeric("-1.5")).toBe(true);
+    expect(isNumeric("abc")).toBe(false);
+    expect(isNumeric("")).toBe(false);
+  });
+  it("isAlpha / isAlphanumeric", () => {
+    expect(isAlpha("Hello")).toBe(true);
+    expect(isAlpha("Hello1")).toBe(false);
+    expect(isAlphanumeric("Hello1")).toBe(true);
+    expect(isAlphanumeric("Hello 1")).toBe(false);
+  });
+});
+
+describe("escapeHtml / normalizeEmail", () => {
+  it("escapes HTML-sensitive characters", () => {
+    expect(escapeHtml('<a href="x">&y</a>')).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&amp;y&lt;&#x2F;a&gt;"
+    );
+  });
+  it("normalizeEmail lowercases and trims", () => {
+    expect(normalizeEmail("  User@Example.COM  ")).toBe("user@example.com");
+  });
+  it("normalizeEmail returns empty string for invalid input", () => {
+    expect(normalizeEmail("not-an-email")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+describe("ValidateEmailNode", () => {
+  it("returns true for a valid email", async () => {
+    const node = new ValidateEmailNode({ value: "a@b.co" });
+    expect(await node.process()).toEqual({ output: true });
+  });
+  it("returns false for garbage", async () => {
+    const node = new ValidateEmailNode({ value: "nope" });
+    expect(await node.process()).toEqual({ output: false });
+  });
+});
+
+describe("ValidateURLNode", () => {
+  it("returns true for https URLs", async () => {
+    const node = new ValidateURLNode({ value: "https://example.com" });
+    expect(await node.process()).toEqual({ output: true });
+  });
+  it("returns false for bare hostnames", async () => {
+    const node = new ValidateURLNode({ value: "example.com" });
+    expect(await node.process()).toEqual({ output: false });
+  });
+});
+
+describe("ValidateIPNode", () => {
+  it("reports ipv4", async () => {
+    const node = new ValidateIPNode({ value: "192.168.1.1" });
+    expect(await node.process()).toEqual({
+      is_ip: true,
+      is_ipv4: true,
+      is_ipv6: false
+    });
+  });
+  it("reports ipv6", async () => {
+    const node = new ValidateIPNode({ value: "::1" });
+    expect(await node.process()).toEqual({
+      is_ip: true,
+      is_ipv4: false,
+      is_ipv6: true
+    });
+  });
+});
+
+describe("ValidateStringNode", () => {
+  it("returns a full set of boolean flags", async () => {
+    const node = new ValidateStringNode({
+      value: "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+    });
+    const out = await node.process();
+    expect(out.is_uuid).toBe(true);
+    expect(out.is_email).toBe(false);
+    expect(out.is_url).toBe(false);
+    expect(out.is_json).toBe(false);
+    expect(out.is_numeric).toBe(false);
+    expect(out.is_alpha).toBe(false);
+    expect(out.is_alphanumeric).toBe(false);
+  });
+});
+
+describe("SanitizeStringNode", () => {
+  it("escapes html, trims, and normalises email-like input", async () => {
+    const node = new SanitizeStringNode({
+      value: "  <b>User@Example.COM</b>  "
+    });
+    const out = await node.process();
+    expect(out.escaped).toBe(
+      "  &lt;b&gt;User@Example.COM&lt;&#x2F;b&gt;  "
+    );
+    expect(out.trimmed).toBe("<b>User@Example.COM</b>");
+    expect(out.normalized_email).toBe("");
+  });
+  it("returns a normalised email for plain input", async () => {
+    const node = new SanitizeStringNode({ value: "  Foo@BAR.com  " });
+    const out = await node.process();
+    expect(out.normalized_email).toBe("foo@bar.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export bundle
+// ---------------------------------------------------------------------------
+
+describe("LIB_VALIDATE_NODES export", () => {
+  it("includes exactly the exported classes", () => {
+    expect(LIB_VALIDATE_NODES).toHaveLength(5);
+    const types = LIB_VALIDATE_NODES.map((n) => n.nodeType);
+    expect(types).toEqual([
+      "lib.validate.Email",
+      "lib.validate.URL",
+      "lib.validate.IP",
+      "lib.validate.String",
+      "lib.validate.Sanitize"
+    ]);
+  });
+});

--- a/web/src/config/__tests__/codeSnippets.test.ts
+++ b/web/src/config/__tests__/codeSnippets.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the Code node snippet library.
+ *
+ * These assertions lock down the contract that snippets are vanilla JS only —
+ * no lodash, dayjs, cheerio, csv-parse, or validator. Anything that needs
+ * those libraries must live in a dedicated workflow node.
+ */
+
+import { CODE_SNIPPETS, SNIPPET_CATEGORIES } from "../codeSnippets";
+
+describe("CODE_SNIPPETS", () => {
+  it("is non-empty", () => {
+    expect(CODE_SNIPPETS.length).toBeGreaterThan(0);
+  });
+
+  it("has unique snippet ids", () => {
+    const ids = CODE_SNIPPETS.map((s) => s.id);
+    const unique = new Set(ids);
+    expect(ids.length).toBe(unique.size);
+  });
+
+  it("references only known categories", () => {
+    for (const snippet of CODE_SNIPPETS) {
+      expect(SNIPPET_CATEGORIES).toContain(snippet.category);
+    }
+  });
+
+  it("never calls removed library globals (_, dayjs, cheerio, csvParse, validator)", () => {
+    const FORBIDDEN = [
+      { name: "lodash", pattern: /\b_\.[a-zA-Z]/ },
+      { name: "dayjs", pattern: /\bdayjs\s*\(/ },
+      { name: "cheerio", pattern: /\bcheerio\./ },
+      { name: "csv-parse", pattern: /\bcsvParse\s*\(/ },
+      { name: "validator", pattern: /\bvalidator\.[a-zA-Z]/ }
+    ];
+    const offenders: string[] = [];
+    for (const snippet of CODE_SNIPPETS) {
+      for (const { name, pattern } of FORBIDDEN) {
+        if (pattern.test(snippet.code)) {
+          offenders.push(`${snippet.id} uses ${name}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("each snippet has non-empty title, description, code, and tags", () => {
+    for (const s of CODE_SNIPPETS) {
+      expect(s.title.trim().length).toBeGreaterThan(0);
+      expect(s.description.trim().length).toBeGreaterThan(0);
+      expect(s.code.trim().length).toBeGreaterThan(0);
+      expect(s.tags.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/config/codeSnippets.ts
+++ b/web/src/config/codeSnippets.ts
@@ -426,7 +426,11 @@ return { output: list.flat(Infinity) };`,
     title: "Chunk",
     description: "Split a list into chunks of a given size",
     category: "List",
-    code: `return { output: _.chunk(list, size) };`,
+    code: `const chunks = [];
+for (let i = 0; i < list.length; i += size) {
+  chunks.push(list.slice(i, i + size));
+}
+return { output: chunks };`,
     tags: ["chunk", "batch", "partition", "group"],
   },
   {
@@ -470,9 +474,14 @@ return { output: result };`,
   {
     id: "list-shuffle",
     title: "Shuffle",
-    description: "Randomly shuffle a list",
+    description: "Randomly shuffle a list (Fisher-Yates)",
     category: "List",
-    code: "return { output: _.shuffle(list) };",
+    code: `const arr = [...list];
+for (let i = arr.length - 1; i > 0; i--) {
+  const j = Math.floor(Math.random() * (i + 1));
+  [arr[i], arr[j]] = [arr[j], arr[i]];
+}
+return { output: arr };`,
     tags: ["shuffle", "random", "randomize"],
   },
   {
@@ -506,7 +515,12 @@ return { output: a.filter(x => !setB.has(x)) };`,
     title: "Group By",
     description: "Group items by a key",
     category: "List",
-    code: "return { output: _.groupBy(items, key) };",
+    code: `const groups = {};
+for (const item of items) {
+  const k = item[key];
+  (groups[k] ||= []).push(item);
+}
+return { output: groups };`,
     tags: ["group", "groupBy", "categorize", "bucket"],
   },
   {
@@ -524,9 +538,13 @@ return { output: a.filter(x => !setB.has(x)) };`,
   {
     id: "dict-get",
     title: "Get Value",
-    description: "Get a value from a dictionary by key (supports dot paths)",
+    description: "Get a value from a dictionary by key (supports dot paths like 'a.b.c')",
     category: "Dictionary",
-    code: "return { output: _.get(dict, key) };",
+    code: `const value = String(key).split(".").reduce(
+  (acc, k) => (acc == null ? acc : acc[k]),
+  dict
+);
+return { output: value };`,
     tags: ["get", "access", "key", "value", "path"],
   },
   {
@@ -590,7 +608,10 @@ return { output: rest };`,
     title: "Pick Keys",
     description: "Select specific keys from a dictionary",
     category: "Dictionary",
-    code: "return { output: _.pick(dict, ['key1', 'key2']) };",
+    code: `const picked = ['key1', 'key2'];
+return { output: Object.fromEntries(
+  Object.entries(dict).filter(([k]) => picked.includes(k))
+) };`,
     tags: ["pick", "select", "subset", "pluck"],
   },
   {
@@ -598,7 +619,10 @@ return { output: rest };`,
     title: "Omit Keys",
     description: "Remove specific keys from a dictionary",
     category: "Dictionary",
-    code: "return { output: _.omit(dict, ['key1', 'key2']) };",
+    code: `const omitted = ['key1', 'key2'];
+return { output: Object.fromEntries(
+  Object.entries(dict).filter(([k]) => !omitted.includes(k))
+) };`,
     tags: ["omit", "exclude", "remove", "without"],
   },
   {
@@ -624,7 +648,9 @@ return { output: maxKey };`,
     title: "Map Values",
     description: "Transform all values in a dictionary",
     category: "Dictionary",
-    code: "return { output: _.mapValues(dict, v => v * 2) };",
+    code: `return { output: Object.fromEntries(
+  Object.entries(dict).map(([k, v]) => [k, v * 2])
+) };`,
     tags: ["map", "transform", "values"],
   },
 
@@ -767,9 +793,13 @@ return { output: re.test(value) };`,
   {
     id: "json-path",
     title: "Get JSON Path",
-    description: "Extract a value using dot-path notation",
+    description: "Extract a value using dot-path notation (e.g. 'user.address.city')",
     category: "JSON",
-    code: `return { output: _.get(data, path) };`,
+    code: `const value = String(path).split(".").reduce(
+  (acc, k) => (acc == null ? acc : acc[k]),
+  data
+);
+return { output: value };`,
     tags: ["json", "path", "dot", "nested", "extract", "get"],
   },
   {
@@ -1148,179 +1178,7 @@ return { output: current.length === 1 ? current[0] : current };`,
     tags: ["json", "jsonpath", "extract", "nested", "wildcard"],
   },
 
-  // ---------------------------------------------------------------------------
-  // Date & Time (dayjs-powered)
-  // ---------------------------------------------------------------------------
-  {
-    id: "dayjs-format",
-    title: "Format Date (dayjs)",
-    description: "Parse and format dates with dayjs",
-    category: "Date & Time",
-    code: `return {
-  formatted: dayjs(dateString).format("YYYY-MM-DD HH:mm"),
-  iso: dayjs(dateString).toISOString(),
-  relative: dayjs(dateString).fromNow?.() ?? "N/A"
-};`,
-    tags: ["dayjs", "format", "date", "parse"],
-  },
-  {
-    id: "dayjs-add-subtract",
-    title: "Add / Subtract Time (dayjs)",
-    description: "Add or subtract time from a date",
-    category: "Date & Time",
-    code: `const d = dayjs(dateString);
-return {
-  plus7days: d.add(7, "day").format("YYYY-MM-DD"),
-  minus1month: d.subtract(1, "month").format("YYYY-MM-DD"),
-  plus2hours: d.add(2, "hour").format("YYYY-MM-DD HH:mm")
-};`,
-    tags: ["dayjs", "add", "subtract", "offset", "shift"],
-  },
-  {
-    id: "dayjs-diff",
-    title: "Date Difference (dayjs)",
-    description: "Calculate difference between two dates",
-    category: "Date & Time",
-    code: `const a = dayjs(dateA), b = dayjs(dateB);
-return {
-  days: a.diff(b, "day"),
-  hours: a.diff(b, "hour"),
-  months: a.diff(b, "month")
-};`,
-    tags: ["dayjs", "diff", "difference", "between", "duration"],
-  },
-  {
-    id: "dayjs-compare",
-    title: "Compare Dates (dayjs)",
-    description: "Check if a date is before, after, or same as another",
-    category: "Date & Time",
-    code: `const a = dayjs(dateA), b = dayjs(dateB);
-return {
-  isBefore: a.isBefore(b),
-  isAfter: a.isAfter(b),
-  isSame: a.isSame(b, "day")
-};`,
-    tags: ["dayjs", "compare", "before", "after", "same"],
-  },
-  {
-    id: "dayjs-start-end",
-    title: "Start / End of Period (dayjs)",
-    description: "Get the start or end of a day, week, month, or year",
-    category: "Date & Time",
-    code: `const d = dayjs(dateString);
-return {
-  startOfWeek: d.startOf("week").format("YYYY-MM-DD"),
-  endOfMonth: d.endOf("month").format("YYYY-MM-DD"),
-  startOfYear: d.startOf("year").format("YYYY-MM-DD")
-};`,
-    tags: ["dayjs", "start", "end", "week", "month", "year"],
-  },
-
-  // ---------------------------------------------------------------------------
-  // HTML Parsing (cheerio)
-  // ---------------------------------------------------------------------------
-  {
-    id: "html-extract-links",
-    title: "Extract Links from HTML",
-    description: "Parse HTML and extract all anchor hrefs",
-    category: "Text",
-    code: `const $ = cheerio.load(html);
-const links = $("a").map((i, el) => ({
-  text: $(el).text().trim(),
-  href: $(el).attr("href") || ""
-})).get();
-return { output: links };`,
-    tags: ["html", "cheerio", "links", "anchor", "href", "scrape"],
-  },
-  {
-    id: "html-extract-images",
-    title: "Extract Images from HTML",
-    description: "Parse HTML and extract all image sources",
-    category: "Text",
-    code: `const $ = cheerio.load(html);
-const images = $("img").map((i, el) => ({
-  src: $(el).attr("src") || "",
-  alt: $(el).attr("alt") || ""
-})).get();
-return { output: images };`,
-    tags: ["html", "cheerio", "images", "img", "src", "scrape"],
-  },
-  {
-    id: "html-extract-text",
-    title: "HTML to Text",
-    description: "Strip all HTML tags and get plain text",
-    category: "Text",
-    code: `const $ = cheerio.load(html);
-return { output: $.text().trim() };`,
-    tags: ["html", "cheerio", "text", "strip", "plain"],
-  },
-  {
-    id: "html-select",
-    title: "CSS Selector Query",
-    description: "Extract content using CSS selectors",
-    category: "Text",
-    code: `const $ = cheerio.load(html);
-const results = $(selector).map((i, el) => $(el).text().trim()).get();
-return { output: results };`,
-    tags: ["html", "cheerio", "css", "selector", "query", "dom"],
-  },
-
-  // ---------------------------------------------------------------------------
-  // Validation (validator.js)
-  // ---------------------------------------------------------------------------
-  {
-    id: "validate-email",
-    title: "Validate Email",
-    description: "Check if a string is a valid email address",
-    category: "Boolean & Logic",
-    code: `return { output: validator.isEmail(value) };`,
-    tags: ["validate", "email", "check", "validator"],
-  },
-  {
-    id: "validate-url",
-    title: "Validate URL",
-    description: "Check if a string is a valid URL",
-    category: "Boolean & Logic",
-    code: `return { output: validator.isURL(value) };`,
-    tags: ["validate", "url", "check", "validator", "link"],
-  },
-  {
-    id: "validate-ip",
-    title: "Validate IP Address",
-    description: "Check if a string is a valid IPv4 or IPv6 address",
-    category: "Boolean & Logic",
-    code: `return {
-  isIP: validator.isIP(value),
-  isIPv4: validator.isIP(value, 4),
-  isIPv6: validator.isIP(value, 6)
-};`,
-    tags: ["validate", "ip", "address", "ipv4", "ipv6", "network"],
-  },
-  {
-    id: "validate-multiple",
-    title: "Validate String",
-    description: "Common string validations (email, URL, UUID, phone, etc.)",
-    category: "Boolean & Logic",
-    code: `return {
-  isEmail: validator.isEmail(value),
-  isURL: validator.isURL(value),
-  isUUID: validator.isUUID(value),
-  isJSON: validator.isJSON(value),
-  isNumeric: validator.isNumeric(value),
-  isAlpha: validator.isAlpha(value)
-};`,
-    tags: ["validate", "check", "email", "url", "uuid", "json", "number"],
-  },
-  {
-    id: "validate-sanitize",
-    title: "Sanitize Input",
-    description: "Escape and sanitize user input for safety",
-    category: "Text",
-    code: `return {
-  escaped: validator.escape(value),        // HTML entity escape
-  trimmed: validator.trim(value),
-  normalized: validator.normalizeEmail(value) || value
-};`,
-    tags: ["sanitize", "escape", "html", "xss", "clean", "validator"],
-  },
+  // Date & Time, HTML parsing, and validation snippets have been removed —
+  // the corresponding work is done by dedicated nodes (lib.datetime.*,
+  // lib.html.*, lib.validate.*) so the JS sandbox can stay library-free.
 ];


### PR DESCRIPTION
The CodeNode (`nodetool.code.Code`, used by JS snippet nodes) exposes
`_` (lodash-es), `dayjs`, `cheerio`, `csvParse`, and `validator` as globals
inside the sandboxed `vm` context. In dev mode these load cleanly from
node_modules via tsx. In packaged Electron builds esbuild bundled them
into server.mjs, but the bundled copies could fail to initialise in the
utilityProcess environment — snippets referencing them then threw at
runtime while the same snippets worked in dev.

Move these packages to the EXTERNAL_PACKAGES list (and make them required)
so they're copied into the packaged `_modules/` directory and resolved via
standard Node resolution at runtime, matching dev mode behaviour.