### PR TITLE
Add one-time keychain explanation dialog on first launch

### DIFF
--- a/electron/src/__tests__/keychainPrompt.test.ts
+++ b/electron/src/__tests__/keychainPrompt.test.ts
@@ -1,0 +1,161 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import yaml from "js-yaml";
+
+let tempDir: string;
+const originalPlatform = process.platform;
+const originalEnv = { ...process.env };
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "keychain-prompt-test-"));
+  jest.spyOn(os, "homedir").mockReturnValue(tempDir);
+  setPlatform("darwin");
+  // Don't treat tests as CI for this module under test — we gate explicitly.
+  delete process.env.CI;
+  delete process.env.NODE_ENV;
+  delete process.env.SECRETS_MASTER_KEY;
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  (os.homedir as jest.Mock).mockRestore();
+  setPlatform(originalPlatform as NodeJS.Platform);
+  process.env = { ...originalEnv };
+});
+
+function readPersistedSettings(): Record<string, unknown> {
+  const settingsPath = path.join(
+    tempDir,
+    ".config",
+    "nodetool",
+    "settings.yaml",
+  );
+  if (!fs.existsSync(settingsPath)) {
+    return {};
+  }
+  return (yaml.load(fs.readFileSync(settingsPath, "utf8")) as Record<string, unknown>) ?? {};
+}
+
+describe("showKeychainExplanationIfNeeded", () => {
+  test("shows dialog on macOS and records acknowledgement on first launch", async () => {
+    const { dialog } = await import("electron");
+    (dialog.showMessageBox as jest.Mock).mockResolvedValueOnce({ response: 0 });
+
+    const {
+      showKeychainExplanationIfNeeded,
+      KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY,
+    } = await import("../keychainPrompt");
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+    const [options] = (dialog.showMessageBox as jest.Mock).mock.calls[0];
+    expect(options.buttons).toEqual(["Continue"]);
+    expect(options.title).toMatch(/keychain/i);
+
+    const persisted = readPersistedSettings();
+    expect(persisted[KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY]).toBe(true);
+  });
+
+  test("does not show dialog when already acknowledged", async () => {
+    const settingsDir = path.join(tempDir, ".config", "nodetool");
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, "settings.yaml"),
+      yaml.dump({ keychainExplanationAcknowledged: true }),
+      "utf8",
+    );
+
+    const { dialog } = await import("electron");
+    const { showKeychainExplanationIfNeeded } = await import(
+      "../keychainPrompt"
+    );
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  test("does not show dialog on Windows", async () => {
+    setPlatform("win32");
+
+    const { dialog } = await import("electron");
+    const { showKeychainExplanationIfNeeded } = await import(
+      "../keychainPrompt"
+    );
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    // Should also not write anything to settings on Windows.
+    expect(readPersistedSettings()).toEqual({});
+  });
+
+  test("skips dialog when SECRETS_MASTER_KEY env is set", async () => {
+    process.env.SECRETS_MASTER_KEY = "base64-thing";
+
+    const { dialog } = await import("electron");
+    const { showKeychainExplanationIfNeeded } = await import(
+      "../keychainPrompt"
+    );
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    expect(readPersistedSettings()).toEqual({});
+  });
+
+  test("skips dialog in CI / test environments", async () => {
+    process.env.CI = "true";
+
+    const { dialog } = await import("electron");
+    const { showKeychainExplanationIfNeeded } = await import(
+      "../keychainPrompt"
+    );
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    expect(readPersistedSettings()).toEqual({});
+  });
+
+  test("shows Linux-specific wording on linux", async () => {
+    setPlatform("linux");
+
+    const { dialog } = await import("electron");
+    (dialog.showMessageBox as jest.Mock).mockResolvedValueOnce({ response: 0 });
+
+    const { showKeychainExplanationIfNeeded } = await import(
+      "../keychainPrompt"
+    );
+
+    await showKeychainExplanationIfNeeded();
+
+    expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+    const [options] = (dialog.showMessageBox as jest.Mock).mock.calls[0];
+    expect(options.detail).toMatch(/gnome-keyring|kwallet|secret service/i);
+  });
+
+  test("still records acknowledgement if dialog itself throws", async () => {
+    const { dialog } = await import("electron");
+    (dialog.showMessageBox as jest.Mock).mockRejectedValueOnce(
+      new Error("ipc boom"),
+    );
+
+    const {
+      showKeychainExplanationIfNeeded,
+      KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY,
+    } = await import("../keychainPrompt");
+
+    await expect(showKeychainExplanationIfNeeded()).resolves.toBeUndefined();
+
+    const persisted = readPersistedSettings();
+    expect(persisted[KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY]).toBe(true);
+  });
+});

--- a/electron/src/keychainPrompt.ts
+++ b/electron/src/keychainPrompt.ts
@@ -1,0 +1,112 @@
+import { dialog } from "electron";
+import { logMessage } from "./logger";
+import { readSettingsAsync, updateSetting } from "./settings";
+
+/**
+ * Settings key recording whether the user has seen the one-time
+ * explanation that the OS keychain is about to be accessed.
+ */
+export const KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY =
+  "keychainExplanationAcknowledged";
+
+/** Platform-specific wording for the keychain prompt explanation. */
+function getKeychainExplanation(): { title: string; detail: string } {
+  if (process.platform === "darwin") {
+    return {
+      title: "Keychain Access",
+      detail:
+        "NodeTool uses your macOS Keychain to store an encryption key for your API credentials. " +
+        "macOS will now ask for permission to store or access an item named 'secrets_master_key'. " +
+        "This keeps the API keys you add in Settings encrypted at rest on this machine.",
+    };
+  }
+  // Linux / BSD: libsecret (gnome-keyring, kwallet) may prompt to unlock.
+  return {
+    title: "Keychain Access",
+    detail:
+      "NodeTool uses your system's secret service (e.g. gnome-keyring, kwallet) to store " +
+      "an encryption key for your API credentials. You may be prompted to unlock your keyring. " +
+      "This keeps the API keys you add in Settings encrypted at rest on this machine.",
+  };
+}
+
+/**
+ * Shows a one-time informational dialog before the backend accesses the
+ * system keychain. Persists acknowledgement so the dialog only appears on
+ * first launch.
+ *
+ * No-op on:
+ * - Windows (Credential Manager does not prompt the user)
+ * - Environments with SECRETS_MASTER_KEY set (keytar is never touched)
+ * - Subsequent launches (setting already recorded)
+ * - CI / test runs (NODE_ENV=test or CI=true)
+ */
+export async function showKeychainExplanationIfNeeded(): Promise<void> {
+  // Windows Credential Manager does not surface a permission prompt, so the
+  // explanation would be pointless friction there.
+  if (process.platform === "win32") {
+    return;
+  }
+
+  // If the user has configured an env-provided master key, keytar is never
+  // consulted by the backend. Skip the dialog entirely.
+  if (process.env.SECRETS_MASTER_KEY) {
+    logMessage(
+      "SECRETS_MASTER_KEY is set; skipping keychain explanation dialog"
+    );
+    return;
+  }
+
+  // Don't interrupt automated runs.
+  if (process.env.NODE_ENV === "test" || process.env.CI) {
+    return;
+  }
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = await readSettingsAsync();
+  } catch (error) {
+    logMessage(
+      `Failed to read settings while checking keychain acknowledgement: ${error}`,
+      "warn"
+    );
+    // If we can't read settings, don't block startup — the OS prompt will
+    // still appear, just without our explanation.
+    return;
+  }
+
+  if (settings[KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY] === true) {
+    return;
+  }
+
+  const { title, detail } = getKeychainExplanation();
+
+  logMessage("Showing one-time keychain explanation dialog");
+  try {
+    await dialog.showMessageBox({
+      type: "info",
+      title,
+      message: "NodeTool needs access to your system keychain",
+      detail,
+      buttons: ["Continue"],
+      defaultId: 0,
+    });
+  } catch (error) {
+    logMessage(
+      `Failed to show keychain explanation dialog: ${error}`,
+      "warn"
+    );
+    // Fall through and still record acknowledgement — retrying on every
+    // startup would be more annoying than losing a single informational prompt.
+  }
+
+  try {
+    updateSetting(KEYCHAIN_EXPLANATION_ACKNOWLEDGED_KEY, true);
+    logMessage("Recorded keychain explanation acknowledgement");
+  } catch (error) {
+    logMessage(
+      `Failed to persist keychain acknowledgement: ${error}`,
+      "warn"
+    );
+  }
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -40,6 +40,7 @@ import { logMessage, closeLogStream } from "./logger";
 import { initializeBackendServer, stopServer, serverState } from "./server";
 import { verifyApplicationPaths, isCondaEnvironmentInstalled } from "./python";
 import { emitBootMessage, emitShowPackageManager } from "./events";
+import { showKeychainExplanationIfNeeded } from "./keychainPrompt";
 import { createTray, cleanupTrayEvents } from "./tray";
 import { createWorkflowWindow } from "./workflowWindow";
 import { initializeIpcHandlers } from "./ipc";
@@ -282,6 +283,8 @@ async function initialize(): Promise<void> {
 
     if (isDevMode) {
       logMessage("Skipping environment installation and package update checks");
+      // Explain the upcoming keychain prompt before the backend touches keytar.
+      await showKeychainExplanationIfNeeded();
       logMessage("Starting backend server");
       await initializeBackendServer();
       logMessage("initializeBackendServer() completed");
@@ -301,6 +304,9 @@ async function initialize(): Promise<void> {
           "Users can install it via the package manager.",
         );
       }
+
+      // Explain the upcoming keychain prompt before the backend touches keytar.
+      await showKeychainExplanationIfNeeded();
 
       // Start the backend server regardless of Python availability
       logMessage("Starting backend server");


### PR DESCRIPTION
## Summary
Adds a one-time informational dialog that explains to users why NodeTool needs access to their system keychain before the backend attempts to access it. The dialog is shown only on first launch and persists the acknowledgement in settings to avoid repeated prompts.

## Key Changes
- **New module `keychainPrompt.ts`**: Implements `showKeychainExplanationIfNeeded()` function that:
  - Shows a platform-specific explanation dialog (macOS Keychain vs. Linux secret services)
  - Persists acknowledgement in settings to display only once
  - Skips the dialog on Windows (Credential Manager doesn't prompt users)
  - Skips the dialog when `SECRETS_MASTER_KEY` environment variable is set (keytar not used)
  - Skips the dialog in CI/test environments
  - Gracefully handles errors without blocking application startup

- **Comprehensive test suite `keychainPrompt.test.ts`**: Tests all scenarios including:
  - Dialog display and acknowledgement persistence on macOS
  - Skipping on subsequent launches
  - Platform-specific behavior (Windows, Linux)
  - Environment variable handling
  - Error resilience
  - Platform-specific wording variations

- **Integration in `main.ts`**: Calls `showKeychainExplanationIfNeeded()` during initialization before the backend server starts, ensuring the explanation appears before any keychain access occurs

## Implementation Details
- Uses existing settings infrastructure (`readSettingsAsync`, `updateSetting`) for persistence
- Logs all operations for debugging
- Continues gracefully if settings cannot be read or written
- Records acknowledgement even if the dialog itself fails to display
- Platform detection uses `process.platform` to provide appropriate messaging

https://claude.ai/code/session_01SoasqQaR75b7kadD2XYvcL