### PR TITLE
Add configurable asset domain support for CDN integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.6.3-rc.47",
+      "version": "0.7.0-rc.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -12916,23 +12916,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mailparser": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.6.tgz",
@@ -13256,13 +13239,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/validator": {
-      "version": "13.15.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
-      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {
@@ -16982,12 +16958,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/csv-parse": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
-      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
       "license": "MIT"
     },
     "node_modules/d": {
@@ -26626,12 +26596,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -35371,15 +35335,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/validator": {
-      "version": "13.15.26",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
-      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -36452,20 +36407,13 @@
         "@nodetool/protocol": "*",
         "@nodetool/runtime": "*",
         "@types/mailparser": "^3.4.6",
-        "cheerio": "^1.2.0",
-        "csv-parse": "^6.2.1",
-        "dayjs": "^1.11.20",
         "imapflow": "^1.2.12",
         "js-tiktoken": "^1.0.18",
-        "lodash-es": "^4.18.1",
         "mailparser": "^3.9.3",
-        "pdfjs-dist": "^5.5.207",
-        "validator": "^13.15.26"
+        "pdfjs-dist": "^5.5.207"
       },
       "devDependencies": {
-        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.0.0",
-        "@types/validator": "^13.15.10",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       }
@@ -36972,7 +36920,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.6.3-rc.47",
+      "version": "0.7.0-rc.1",
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/react": "^11.14.0",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -32,5 +32,8 @@ export {
   getNodetoolDataDir,
   getDefaultDbPath,
   getDefaultVectorstoreDbPath,
-  getDefaultAssetsPath
+  getDefaultAssetsPath,
+  getAssetDomain,
+  getTempDomain,
+  buildAssetUrl
 } from "./paths.js";

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -56,3 +56,58 @@ export function getDefaultAssetsPath(): string {
     join(getNodetoolDataDir(), "assets")
   );
 }
+
+/**
+ * Public domain for permanent assets (set via ASSET_DOMAIN env var).
+ *
+ * When set, asset URLs are built as `https://<domain>/<key>` instead of
+ * `/api/storage/<key>`. Accepts bare hostnames (`assets.nodetool.ai`) or
+ * full origins (`https://assets.nodetool.ai`). Returns `undefined` when not
+ * configured.
+ */
+export function getAssetDomain(): string | undefined {
+  const value = process.env["ASSET_DOMAIN"];
+  return value && value.trim() !== "" ? value.trim() : undefined;
+}
+
+/**
+ * Public domain for temporary assets (set via TEMP_DOMAIN env var).
+ *
+ * Applied to keys with the `temp/` prefix. Accepts bare hostnames or full
+ * origins. Returns `undefined` when not configured, in which case temp URLs
+ * fall back to `ASSET_DOMAIN` (if set) or the `/api/storage/` path.
+ */
+export function getTempDomain(): string | undefined {
+  const value = process.env["TEMP_DOMAIN"];
+  return value && value.trim() !== "" ? value.trim() : undefined;
+}
+
+/**
+ * Build a public URL for an asset identified by its storage key.
+ *
+ * The key is the storage-relative path (e.g. `abc.png` or `temp/uuid.png`).
+ * When ASSET_DOMAIN / TEMP_DOMAIN are configured, returns an absolute URL
+ * on the matching domain; otherwise returns the server-relative path
+ * `/api/storage/<key>` so the HTTP API serves it directly.
+ */
+export function buildAssetUrl(key: string): string {
+  const normalized = key.replace(/^\/+/, "");
+  const isTemp = normalized.startsWith("temp/");
+  const domain = isTemp
+    ? (getTempDomain() ?? getAssetDomain())
+    : getAssetDomain();
+
+  if (!domain) {
+    return `/api/storage/${normalized}`;
+  }
+
+  const origin = /^https?:\/\//i.test(domain) ? domain : `https://${domain}`;
+  const trimmedOrigin = origin.replace(/\/+$/, "");
+  // When serving from a dedicated temp domain, the `temp/` prefix is
+  // redundant — the domain itself identifies the bucket.
+  const path =
+    isTemp && getTempDomain() !== undefined
+      ? normalized.slice("temp/".length)
+      : normalized;
+  return `${trimmedOrigin}/${path}`;
+}

--- a/packages/config/tests/paths.test.ts
+++ b/packages/config/tests/paths.test.ts
@@ -5,7 +5,10 @@ import {
   getNodetoolDataDir,
   getDefaultDbPath,
   getDefaultVectorstoreDbPath,
-  getDefaultAssetsPath
+  getDefaultAssetsPath,
+  getAssetDomain,
+  getTempDomain,
+  buildAssetUrl
 } from "../src/paths.js";
 
 describe("getNodetoolDataDir", () => {
@@ -126,5 +129,112 @@ describe("getDefaultAssetsPath", () => {
     delete process.env.ASSET_FOLDER;
     delete process.env.STORAGE_PATH;
     expect(getDefaultAssetsPath()).toBe(join(getNodetoolDataDir(), "assets"));
+  });
+});
+
+describe("asset domain helpers", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(saved)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  function snapshot(): void {
+    saved.ASSET_DOMAIN = process.env.ASSET_DOMAIN;
+    saved.TEMP_DOMAIN = process.env.TEMP_DOMAIN;
+  }
+
+  it("getAssetDomain returns undefined when unset or empty", () => {
+    snapshot();
+    delete process.env.ASSET_DOMAIN;
+    expect(getAssetDomain()).toBeUndefined();
+    process.env.ASSET_DOMAIN = "   ";
+    expect(getAssetDomain()).toBeUndefined();
+  });
+
+  it("getAssetDomain returns trimmed value when set", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "  assets.nodetool.ai  ";
+    expect(getAssetDomain()).toBe("assets.nodetool.ai");
+  });
+
+  it("getTempDomain returns trimmed value when set", () => {
+    snapshot();
+    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
+    expect(getTempDomain()).toBe("temp.nodetool.ai");
+  });
+
+  it("buildAssetUrl falls back to /api/storage path when no domain set", () => {
+    snapshot();
+    delete process.env.ASSET_DOMAIN;
+    delete process.env.TEMP_DOMAIN;
+    expect(buildAssetUrl("abc.png")).toBe("/api/storage/abc.png");
+    expect(buildAssetUrl("temp/uuid.png")).toBe("/api/storage/temp/uuid.png");
+  });
+
+  it("buildAssetUrl strips leading slashes from the key", () => {
+    snapshot();
+    delete process.env.ASSET_DOMAIN;
+    delete process.env.TEMP_DOMAIN;
+    expect(buildAssetUrl("/abc.png")).toBe("/api/storage/abc.png");
+    expect(buildAssetUrl("///temp/uuid.png")).toBe(
+      "/api/storage/temp/uuid.png"
+    );
+  });
+
+  it("buildAssetUrl uses ASSET_DOMAIN for permanent assets", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
+    delete process.env.TEMP_DOMAIN;
+    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
+  });
+
+  it("buildAssetUrl honours an explicit scheme on ASSET_DOMAIN", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "http://localhost:9000/cdn";
+    delete process.env.TEMP_DOMAIN;
+    expect(buildAssetUrl("abc.png")).toBe("http://localhost:9000/cdn/abc.png");
+  });
+
+  it("buildAssetUrl routes temp/ keys to TEMP_DOMAIN and drops the prefix", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
+    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
+    expect(buildAssetUrl("temp/uuid.png")).toBe(
+      "https://temp.nodetool.ai/uuid.png"
+    );
+    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
+  });
+
+  it("buildAssetUrl falls back to ASSET_DOMAIN for temp/ when TEMP_DOMAIN is unset", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
+    delete process.env.TEMP_DOMAIN;
+    // With no dedicated temp domain, the `temp/` prefix is preserved so the
+    // same bucket can host both kinds of content.
+    expect(buildAssetUrl("temp/uuid.png")).toBe(
+      "https://assets.nodetool.ai/temp/uuid.png"
+    );
+  });
+
+  it("buildAssetUrl uses TEMP_DOMAIN for temp/ even without ASSET_DOMAIN", () => {
+    snapshot();
+    delete process.env.ASSET_DOMAIN;
+    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
+    expect(buildAssetUrl("temp/uuid.png")).toBe(
+      "https://temp.nodetool.ai/uuid.png"
+    );
+    // Permanent assets still fall back to the API path.
+    expect(buildAssetUrl("abc.png")).toBe("/api/storage/abc.png");
+  });
+
+  it("buildAssetUrl trims trailing slashes on the domain", () => {
+    snapshot();
+    process.env.ASSET_DOMAIN = "https://assets.nodetool.ai//";
+    delete process.env.TEMP_DOMAIN;
+    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
   });
 });

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -8,7 +8,11 @@ import { gzipSync } from "node:zlib";
 import { mkdir, writeFile, stat, readFile } from "node:fs/promises";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import nodePath from "node:path";
-import { createLogger, getDefaultAssetsPath } from "@nodetool/config";
+import {
+  createLogger,
+  getDefaultAssetsPath,
+  buildAssetUrl
+} from "@nodetool/config";
 import { workflowToDsl } from "@nodetool/dsl";
 import {
   Workflow,
@@ -1712,7 +1716,7 @@ function toAssetResponse(asset: Asset): JsonObject {
   const fileName = isFolder
     ? null
     : getAssetFileName(asset.id, asset.content_type);
-  const getUrl = fileName ? `/api/storage/${fileName}` : null;
+  const getUrl = fileName ? buildAssetUrl(fileName) : null;
 
   const hasThumbnail =
     asset.content_type.startsWith("image/") ||

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4,7 +4,11 @@ import { pathToFileURL } from "node:url";
 import { getSecret } from "@nodetool/security";
 import { getSetting } from "./settings-api.js";
 import { pack, unpack } from "msgpackr";
-import { createLogger, getDefaultAssetsPath } from "@nodetool/config";
+import {
+  createLogger,
+  getDefaultAssetsPath,
+  buildAssetUrl
+} from "@nodetool/config";
 import {
   Graph,
   WorkflowRunner,
@@ -388,10 +392,12 @@ function createRuntimeContext(opts: {
     secretResolver: getSecret,
     storage,
     tempUrlResolver: (fileUri: string) => {
-      // Convert file:///path/to/storage/temp/uuid.png → /api/storage/temp/uuid.png
+      // Convert file:///path/to/storage/temp/uuid.png → public asset URL.
+      // When ASSET_DOMAIN / TEMP_DOMAIN are configured the result uses those
+      // domains; otherwise it falls back to /api/storage/temp/uuid.png.
       const prefix = pathToFileURL(storagePath).toString();
       if (fileUri.startsWith(prefix)) {
-        return `/api/storage/${fileUri.slice(prefix.length + 1)}`;
+        return buildAssetUrl(fileUri.slice(prefix.length + 1));
       }
       return fileUri;
     }

--- a/packages/websocket/tests/http-api-assets.test.ts
+++ b/packages/websocket/tests/http-api-assets.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { initTestDb, Asset } from "@nodetool/models";
 import { handleApiRequest } from "../src/http-api.js";
 
@@ -446,5 +446,69 @@ describe("HTTP API: assets", () => {
       assets: Array<Record<string, unknown>>;
     };
     expect(data.assets.length).toBe(2);
+  });
+});
+
+describe("HTTP API: assets — get_url and thumb_url", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(saved)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  function snapshotDomains(): void {
+    saved.ASSET_DOMAIN = process.env.ASSET_DOMAIN;
+    saved.TEMP_DOMAIN = process.env.TEMP_DOMAIN;
+  }
+
+  async function createAsset(contentType: string): Promise<Record<string, unknown>> {
+    const res = await handleApiRequest(
+      makeRequest("/api/assets", {
+        method: "POST",
+        body: {
+          name: "file",
+          content_type: contentType,
+          parent_id: "user-1"
+        }
+      })
+    );
+    return (await jsonBody(res)) as Record<string, unknown>;
+  }
+
+  it("returns /api/storage path when ASSET_DOMAIN is not configured", async () => {
+    snapshotDomains();
+    delete process.env.ASSET_DOMAIN;
+    delete process.env.TEMP_DOMAIN;
+
+    const asset = await createAsset("image/png");
+    expect(asset.get_url).toBe(`/api/storage/${asset.id}.png`);
+    expect(asset.thumb_url).toMatch(
+      new RegExp(`^/api/assets/${asset.id}/thumbnail\\?t=\\d+$`)
+    );
+  });
+
+  it("returns absolute URL on ASSET_DOMAIN when configured", async () => {
+    snapshotDomains();
+    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
+    delete process.env.TEMP_DOMAIN;
+
+    const asset = await createAsset("image/jpeg");
+    expect(asset.get_url).toBe(`https://assets.nodetool.ai/${asset.id}.jpg`);
+  });
+
+  it("returns null get_url for folders regardless of ASSET_DOMAIN", async () => {
+    snapshotDomains();
+    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
+
+    const folder = await createAsset("folder");
+    expect(folder.get_url).toBeNull();
+    expect(folder.thumb_url).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for configuring custom domains for serving assets via CDN, allowing asset URLs to be built as absolute URLs on configured domains instead of relative `/api/storage/` paths.

## Key Changes
- **New path helpers** (`packages/config/src/paths.ts`):
  - `getAssetDomain()`: Returns the configured `ASSET_DOMAIN` environment variable for permanent assets
  - `getTempDomain()`: Returns the configured `TEMP_DOMAIN` environment variable for temporary assets
  - `buildAssetUrl(key)`: Constructs asset URLs using configured domains or falls back to `/api/storage/` paths
  
- **URL building logic**:
  - Supports bare hostnames (`assets.nodetool.ai`) and full origins (`https://assets.nodetool.ai`)
  - Routes keys with `temp/` prefix to `TEMP_DOMAIN` when configured, dropping the prefix
  - Falls back to `ASSET_DOMAIN` for temp assets if `TEMP_DOMAIN` is not set
  - Normalizes leading/trailing slashes in domains and keys
  
- **Integration points**:
  - Updated `http-api.ts` to use `buildAssetUrl()` when generating asset response URLs
  - Updated `unified-websocket-runner.ts` to use `buildAssetUrl()` for temp file URL resolution
  - Exported new functions from `@nodetool/config` package

- **Comprehensive test coverage**:
  - Added 11 test cases in `packages/config/tests/paths.test.ts` covering domain configuration, URL building, and fallback behavior
  - Added 3 integration tests in `packages/websocket/tests/http-api-assets.test.ts` verifying asset response URLs with and without domain configuration

## Implementation Details
- Environment variables are trimmed and treated as undefined when empty
- Domains without explicit schemes default to `https://`
- When both `ASSET_DOMAIN` and `TEMP_DOMAIN` are configured, temp assets use the dedicated temp domain with the `temp/` prefix stripped
- Backward compatible: when no domains are configured, URLs default to the existing `/api/storage/` paths

https://claude.ai/code/session_01YJ7skLRrxh8atZZJgubT6z