### PR TITLE
Include kie-nodes and codegen packages in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,3 @@ docs
 .env
 cert.pem
 key.pem
-packages/fal-codegen
-packages/replicate-codegen
-packages/kie-codegen
-packages/kie-nodes

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,13 @@ COPY packages/kernel/package.json packages/kernel/
 COPY packages/node-sdk/package.json packages/node-sdk/
 COPY packages/models/package.json packages/models/
 COPY packages/code-runners/package.json packages/code-runners/
+COPY packages/fal-codegen/package.json packages/fal-codegen/
 COPY packages/fal-nodes/package.json packages/fal-nodes/
+COPY packages/replicate-codegen/package.json packages/replicate-codegen/
 COPY packages/replicate-nodes/package.json packages/replicate-nodes/
 COPY packages/elevenlabs-nodes/package.json packages/elevenlabs-nodes/
+COPY packages/kie-codegen/package.json packages/kie-codegen/
+COPY packages/kie-nodes/package.json packages/kie-nodes/
 COPY packages/agents/package.json packages/agents/
 COPY packages/base-nodes/package.json packages/base-nodes/
 COPY packages/dsl/package.json packages/dsl/


### PR DESCRIPTION
The Docker build failed because tsconfig.build.json references
packages/fal-codegen, packages/replicate-codegen, packages/kie-codegen,
and packages/kie-nodes, but these were all excluded via .dockerignore.
Additionally, packages/kie-nodes is a runtime dependency of base-nodes
and websocket, so it is required inside the image.

Remove the exclusions from .dockerignore and add the missing COPY
statements so the tsc project references resolve during
npm run build:packages.

https://claude.ai/code/session_01XsFzEw1xE7sFdhMXohzo9A