### PR TITLE
Fix chain editor: workflow run, media upload, and namespace display

### DIFF
--- a/mobile/src/components/graph_editor/ChainNodeCard.tsx
+++ b/mobile/src/components/graph_editor/ChainNodeCard.tsx
@@ -344,6 +344,14 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = ({
           >
             {node.metadata.title}
           </Text>
+          {node.expanded && (
+            <Text
+              style={[styles.namespace, { color: nsColor }]}
+              numberOfLines={1}
+            >
+              {formatNamespace(node.metadata.namespace)}
+            </Text>
+          )}
         </View>
 
         {/* Running indicator with time */}
@@ -608,6 +616,10 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: "700",
+  },
+  namespace: {
+    fontSize: 11,
+    fontWeight: "600",
   },
 expandedContent: {
     paddingHorizontal: 14,

--- a/mobile/src/components/graph_editor/FloatingToolbar.tsx
+++ b/mobile/src/components/graph_editor/FloatingToolbar.tsx
@@ -3,7 +3,14 @@
  * Mirrors the web's FloatingToolBar with mobile-appropriate actions.
  */
 
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   View,
   TouchableOpacity,
@@ -15,7 +22,8 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../hooks/useTheme";
 import { useGraphEditorStore } from "../../stores/GraphEditorStore";
-import { useWorkflowRunner } from "../../stores/WorkflowRunner";
+import { getWorkflowRunnerStore } from "../../stores/WorkflowRunner";
+import type { RunnerState } from "../../stores/WorkflowRunner";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface FloatingToolbarProps {
@@ -32,16 +40,40 @@ export const FloatingToolbar: React.FC<FloatingToolbarProps> = memo(
     const chain = useGraphEditorStore((s) => s.chain);
     const saveWorkflow = useGraphEditorStore((s) => s.saveWorkflow);
     const showNodePicker = useGraphEditorStore((s) => s.showNodePicker);
+    const storeWorkflowId = useGraphEditorStore((s) => s.workflowId);
 
-    // Workflow runner state (only when we have a workflowId)
-    const runnerStore = workflowId
-      ? useWorkflowRunner(workflowId)
-      : null;
-    const runState = runnerStore?.((s) => s.state) ?? "idle";
-    const run = runnerStore?.((s) => s.run);
-    const cancel = runnerStore?.((s) => s.cancel);
-    const resume = runnerStore?.((s) => s.resume);
-    const statusMessage = runnerStore?.((s) => s.statusMessage);
+    // Use store workflowId (updated after save) with prop as fallback
+    const effectiveWorkflowId = storeWorkflowId || workflowId;
+
+    // Subscribe to runner store state without conditional hooks
+    const [runState, setRunState] = useState<RunnerState>("idle");
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+      if (!effectiveWorkflowId) {
+        setRunState("idle");
+        setStatusMessage(null);
+        return;
+      }
+      const store = getWorkflowRunnerStore(effectiveWorkflowId);
+      const update = () => {
+        const s = store.getState();
+        setRunState(s.state);
+        setStatusMessage(s.statusMessage);
+      };
+      update();
+      return store.subscribe(update);
+    }, [effectiveWorkflowId]);
+
+    const cancel = useMemo(() => {
+      if (!effectiveWorkflowId) return undefined;
+      return getWorkflowRunnerStore(effectiveWorkflowId).getState().cancel;
+    }, [effectiveWorkflowId]);
+
+    const resume = useMemo(() => {
+      if (!effectiveWorkflowId) return undefined;
+      return getWorkflowRunnerStore(effectiveWorkflowId).getState().resume;
+    }, [effectiveWorkflowId]);
 
     const isRunning = runState === "running" || runState === "connecting";
     const isPaused = runState === "paused" || runState === "suspended";
@@ -97,7 +129,6 @@ export const FloatingToolbar: React.FC<FloatingToolbarProps> = memo(
     }, [saveWorkflow]);
 
     const handleRun = useCallback(async () => {
-      if (!run) return;
       try {
         // Save first to ensure we have a persisted workflow with current edits
         const saved = await saveWorkflow();
@@ -105,11 +136,14 @@ export const FloatingToolbar: React.FC<FloatingToolbarProps> = memo(
           console.error("Cannot run: workflow save failed");
           return;
         }
-        await run({}, saved);
+        // Get runner store using the saved workflow's ID
+        // (handles new workflows that didn't have an ID before save)
+        const runner = getWorkflowRunnerStore(saved.id);
+        await runner.getState().run({}, saved);
       } catch (err) {
         console.error("Failed to run workflow:", err);
       }
-    }, [run, saveWorkflow]);
+    }, [saveWorkflow]);
 
     const handleStop = useCallback(() => {
       cancel?.();

--- a/mobile/src/components/graph_editor/PropertyField.tsx
+++ b/mobile/src/components/graph_editor/PropertyField.tsx
@@ -23,6 +23,7 @@ import * as DocumentPicker from "expo-document-picker";
 import { useTheme } from "../../hooks/useTheme";
 import { useModelsForType } from "../../hooks/useModelsByProvider";
 import { ModelSelectModal } from "./ModelSelectModal";
+import { apiService } from "../../services/api";
 import type { Property } from "../../types/ApiTypes";
 
 // ── Shared types ────────────────────────────────────────────────────
@@ -410,6 +411,7 @@ const ImageWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ prop, value, onChange, colors }) => {
   const uri = extractUri(value);
+  const [uploading, setUploading] = useState(false);
 
   const pickImage = useCallback(async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -417,7 +419,29 @@ const ImageWidget: React.FC<{
       quality: 0.8,
     });
     if (!result.canceled && result.assets[0]) {
-      onChange({ type: "image", uri: result.assets[0].uri });
+      const picked = result.assets[0];
+      const fileName = picked.fileName ?? `image_${Date.now()}.jpg`;
+      const mimeType = picked.mimeType ?? "image/jpeg";
+      setUploading(true);
+      try {
+        const asset = await apiService.uploadAsset({
+          uri: picked.uri,
+          name: fileName,
+          contentType: mimeType,
+          parentId: "",
+        });
+        const ext = fileName.includes(".")
+          ? fileName.slice(fileName.lastIndexOf("."))
+          : ".jpg";
+        const storageUri = `${apiService.getApiHost()}/api/storage/${asset.id}${ext}`;
+        onChange({ type: "image", uri: storageUri, asset_id: asset.id });
+      } catch (err) {
+        console.error("Failed to upload image:", err);
+        // Fall back to local URI so the preview still works
+        onChange({ type: "image", uri: picked.uri });
+      } finally {
+        setUploading(false);
+      }
     }
   }, [onChange]);
 
@@ -475,6 +499,7 @@ const AudioWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ prop, value, onChange, colors }) => {
   const uri = extractUri(value);
+  const [uploading, setUploading] = useState(false);
 
   const pickAudio = useCallback(async () => {
     const result = await DocumentPicker.getDocumentAsync({
@@ -482,7 +507,28 @@ const AudioWidget: React.FC<{
       copyToCacheDirectory: true,
     });
     if (!result.canceled && result.assets?.[0]) {
-      onChange({ type: "audio", uri: result.assets[0].uri });
+      const picked = result.assets[0];
+      const fileName = picked.name ?? `audio_${Date.now()}.wav`;
+      const mimeType = picked.mimeType ?? "audio/wav";
+      setUploading(true);
+      try {
+        const asset = await apiService.uploadAsset({
+          uri: picked.uri,
+          name: fileName,
+          contentType: mimeType,
+          parentId: "",
+        });
+        const ext = fileName.includes(".")
+          ? fileName.slice(fileName.lastIndexOf("."))
+          : ".wav";
+        const storageUri = `${apiService.getApiHost()}/api/storage/${asset.id}${ext}`;
+        onChange({ type: "audio", uri: storageUri, asset_id: asset.id });
+      } catch (err) {
+        console.error("Failed to upload audio:", err);
+        onChange({ type: "audio", uri: picked.uri });
+      } finally {
+        setUploading(false);
+      }
     }
   }, [onChange]);
 
@@ -527,6 +573,7 @@ const VideoWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ prop, value, onChange, colors }) => {
   const uri = extractUri(value);
+  const [uploading, setUploading] = useState(false);
 
   const pickVideo = useCallback(async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -534,7 +581,28 @@ const VideoWidget: React.FC<{
       quality: 0.8,
     });
     if (!result.canceled && result.assets[0]) {
-      onChange({ type: "video", uri: result.assets[0].uri });
+      const picked = result.assets[0];
+      const fileName = picked.fileName ?? `video_${Date.now()}.mp4`;
+      const mimeType = picked.mimeType ?? "video/mp4";
+      setUploading(true);
+      try {
+        const asset = await apiService.uploadAsset({
+          uri: picked.uri,
+          name: fileName,
+          contentType: mimeType,
+          parentId: "",
+        });
+        const ext = fileName.includes(".")
+          ? fileName.slice(fileName.lastIndexOf("."))
+          : ".mp4";
+        const storageUri = `${apiService.getApiHost()}/api/storage/${asset.id}${ext}`;
+        onChange({ type: "video", uri: storageUri, asset_id: asset.id });
+      } catch (err) {
+        console.error("Failed to upload video:", err);
+        onChange({ type: "video", uri: picked.uri });
+      } finally {
+        setUploading(false);
+      }
     }
   }, [onChange]);
 
@@ -1595,8 +1663,25 @@ const AssetRefWidget: React.FC<{
       copyToCacheDirectory: true,
     });
     if (!result.canceled && result.assets?.[0]) {
-      const asset = result.assets[0];
-      onChange({ type: typeLabel, uri: asset.uri, name: asset.name });
+      const picked = result.assets[0];
+      const fileName = picked.name ?? `file_${Date.now()}`;
+      const mimeType = picked.mimeType ?? "application/octet-stream";
+      try {
+        const uploaded = await apiService.uploadAsset({
+          uri: picked.uri,
+          name: fileName,
+          contentType: mimeType,
+          parentId: "",
+        });
+        const ext = fileName.includes(".")
+          ? fileName.slice(fileName.lastIndexOf("."))
+          : "";
+        const storageUri = `${apiService.getApiHost()}/api/storage/${uploaded.id}${ext}`;
+        onChange({ type: typeLabel, uri: storageUri, asset_id: uploaded.id, name: fileName });
+      } catch (err) {
+        console.error("Failed to upload document:", err);
+        onChange({ type: typeLabel, uri: picked.uri, name: fileName });
+      }
     }
   }, [onChange, typeLabel]);
 

--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -180,9 +180,11 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = ({
 
         <FlexColumn gap={0.25} sx={{ flex: 1, minWidth: 0 }}>
           <Text size="small" weight={700} truncate>{node.metadata.title}</Text>
-          <Text size="tiny" weight={600} sx={{ color: nsColor }}>
-            {formatNs(node.metadata.namespace)}
-          </Text>
+          {node.expanded && (
+            <Text size="tiny" weight={600} sx={{ color: nsColor }}>
+              {formatNs(node.metadata.namespace)}
+            </Text>
+          )}
         </FlexColumn>
 
         {/* Status indicator */}


### PR DESCRIPTION
- Fix run workflow button doing nothing for new workflows by reading workflowId from store and using getWorkflowRunnerStore directly
- Fix conditional hook call crash by replacing useWorkflowRunner with manual store subscription
- Upload media files (image/video/audio/document) to server before storing references, fixing ENOENT errors from local file:// URIs
- Show node namespace in chain editor header when expanded (web+mobile)