### PR TITLE
ci: set model to Claude Opus 4.6 on all Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--model claude-opus-4-6'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,7 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-6'
 

--- a/.github/workflows/dead-code-cleanup.yaml
+++ b/.github/workflows/dead-code-cleanup.yaml
@@ -53,6 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Dead Code Cleanup

--- a/.github/workflows/dependency-cleanup.yaml
+++ b/.github/workflows/dependency-cleanup.yaml
@@ -53,6 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Dependency Cleanup

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -44,6 +44,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,WebFetch,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # NodeTool Assistant

--- a/.github/workflows/performance-optimization.yaml
+++ b/.github/workflows/performance-optimization.yaml
@@ -53,6 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Performance Optimization

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -74,6 +74,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Fix Broken Quality Checks

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -63,6 +63,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Security Audit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -69,6 +69,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Improve Test Coverage

--- a/.github/workflows/type-safety.yaml
+++ b/.github/workflows/type-safety.yaml
@@ -71,6 +71,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
           prompt: |
             # Improve Type Safety


### PR DESCRIPTION
Pin all Claude Code action workflows to claude-opus-4-6 via --model
in claude_args, making the model explicit and consistent across the
scheduled automation and interactive assistant workflows.