### PR TITLE
ci: standardize all Claude and build workflows on Node 22

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,9 +27,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,9 +26,20 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: windows-latest
-            node_version: "25.7.0"
-          - os: ubuntu-latest
-            node_version: "25.2.1"
-          - os: macos-latest
-            node_version: "24.12.0"
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -47,7 +41,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: "22"
+          cache: "npm"
 
       - name: Sync package versions to release tag
         if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.version != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: mobile/package-lock.json
 


### PR DESCRIPTION
Aligns every workflow with the CI test environment defined in
test.yml/quality-checks.yml: Node 22 + npm ci with
ELECTRON_SKIP_BINARY_DOWNLOAD=1 (matching CLAUDE.md's hard
requirement that Electron 35 embeds Node 22).

- claude.yml, claude-code-review.yml: add Node 22 setup +
  workspace install (previously ran with the action's default Node)
- test.yml mobile job: bump from Node 20 to Node 22
- release.yaml: collapse the per-OS Node 24/25 matrix to a single
  Node 22 (with npm cache) so the published builds match the runtime
  embedded by Electron

https://claude.ai/code/session_01EwsHtQcX26gSrfa2EZ9shu