### PR TITLE
Grant contents: write to claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Required so Claude can push commits back to the branch (works around extraheader-override issue in claude-code-action that doesn't cover values from includeIf-included git configs used by actions/checkout)
       pull-requests: read
       issues: read
       id-token: write


### PR DESCRIPTION
Bumps the job-level contents permission from read to write so Claude can
push commits back to the branch from within the action. This avoids the
extraheader-override problem, where claude-code-action's unset step
doesn't cover extraheader values that live in includeIf-included git
config files (which actions/checkout@v4+ now uses).