### PR TITLE
feat: improve MediaChatComposer with clipboard paste, asset drops, batch image gen, and FAL progress

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -33,6 +33,7 @@ export {
   getDefaultDbPath,
   getDefaultVectorstoreDbPath,
   getDefaultAssetsPath,
+  getAssetFilePath,
   getAssetDomain,
   getTempDomain,
   buildAssetUrl

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -83,12 +83,24 @@ export function getTempDomain(): string | undefined {
 }
 
 /**
- * Build a public URL for an asset identified by its storage key.
+ * Return the absolute filesystem path for a storage key.
+ *
+ * Use this on the server side whenever you need to read an asset from disk.
+ * Never pass the result to a browser client — use `buildAssetUrl` for that.
+ */
+export function getAssetFilePath(key: string): string {
+  return join(getDefaultAssetsPath(), key.replace(/^\/+/, ""));
+}
+
+/**
+ * Build a **client-facing** URL for an asset identified by its storage key.
  *
  * The key is the storage-relative path (e.g. `abc.png` or `temp/uuid.png`).
- * When ASSET_DOMAIN / TEMP_DOMAIN are configured, returns an absolute URL
- * on the matching domain; otherwise returns the server-relative path
- * `/api/storage/<key>` so the HTTP API serves it directly.
+ * When ASSET_DOMAIN / TEMP_DOMAIN are configured, returns an absolute CDN URL.
+ * Otherwise returns `/api/storage/<key>` — a dev-mode path that the browser
+ * can reach via the Vite proxy or the local HTTP server.
+ *
+ * Do NOT use this for server-side file reads. Use `getAssetFilePath` instead.
  */
 export function buildAssetUrl(key: string): string {
   const normalized = key.replace(/^\/+/, "");

--- a/packages/fal-nodes/src/fal-base.ts
+++ b/packages/fal-nodes/src/fal-base.ts
@@ -37,12 +37,22 @@ function getClient(apiKey: string): FalClient {
 export async function falSubmit(
   apiKey: string,
   endpoint: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  onProgress?: (message: string) => void
 ): Promise<Record<string, unknown>> {
   const client = getClient(apiKey);
   const result = await client.subscribe(endpoint, {
     input: args,
-    logs: true
+    logs: true,
+    onQueueUpdate: onProgress
+      ? (update: { status: string; logs?: Array<{ message: string }> }) => {
+          if (update.status === "IN_PROGRESS") {
+            for (const entry of update.logs ?? []) {
+              onProgress(entry.message);
+            }
+          }
+        }
+      : undefined
   });
   return (result.data ?? result) as Record<string, unknown>;
 }

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -329,7 +329,10 @@ export class AnthropicProvider extends BaseProvider {
             base64 = parsed.base64;
             mediaType = part.image.mimeType ?? parsed.mime;
           } else if (uri) {
-            const response = await this._fetch(uri);
+            const resolvedUri = uri.startsWith("/")
+              ? `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`
+              : uri;
+            const response = await this._fetch(resolvedUri);
             if (!response.ok) {
               throw new Error(`Failed to fetch URI: ${response.status}`);
             }

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -329,17 +329,24 @@ export class AnthropicProvider extends BaseProvider {
             base64 = parsed.base64;
             mediaType = part.image.mimeType ?? parsed.mime;
           } else if (uri) {
-            const response = await this._fetch(this.resolveUri(uri));
-            if (!response.ok) {
-              throw new Error(`Failed to fetch URI: ${response.status}`);
+            const resolved = await this.resolveUri(uri);
+            if (resolved.startsWith("data:")) {
+              const parsed = parseDataUri(resolved);
+              base64 = parsed.base64;
+              mediaType = part.image.mimeType ?? parsed.mime;
+            } else {
+              const response = await this._fetch(resolved);
+              if (!response.ok) {
+                throw new Error(`Failed to fetch URI: ${response.status}`);
+              }
+              mediaType =
+                part.image.mimeType ??
+                response.headers.get("content-type") ??
+                "image/png";
+              base64 = Buffer.from(
+                new Uint8Array(await response.arrayBuffer())
+              ).toString("base64");
             }
-            mediaType =
-              part.image.mimeType ??
-              response.headers.get("content-type") ??
-              "image/png";
-            base64 = Buffer.from(
-              new Uint8Array(await response.arrayBuffer())
-            ).toString("base64");
           } else {
             throw new Error("Invalid image reference with no uri or data");
           }

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -329,10 +329,7 @@ export class AnthropicProvider extends BaseProvider {
             base64 = parsed.base64;
             mediaType = part.image.mimeType ?? parsed.mime;
           } else if (uri) {
-            const resolvedUri = uri.startsWith("/")
-              ? `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`
-              : uri;
-            const response = await this._fetch(resolvedUri);
+            const response = await this._fetch(this.resolveUri(uri));
             if (!response.ok) {
               throw new Error(`Failed to fetch URI: ${response.status}`);
             }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -506,4 +506,16 @@ export abstract class BaseProvider {
       args: this.parseToolCallArgs(args)
     };
   }
+
+  /**
+   * Resolve a potentially relative URI to an absolute URL.
+   * Relative paths (starting with "/") are resolved against the local server.
+   * This handles asset URIs like /api/storage/... stored by the frontend.
+   */
+  protected resolveUri(uri: string): string {
+    if (uri.startsWith("/")) {
+      return `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
+    }
+    return uri;
+  }
 }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -350,11 +350,47 @@ export abstract class BaseProvider {
     throw new Error(`${this.provider} does not support textToImage`);
   }
 
+  /**
+   * Generate multiple images from a text prompt.
+   *
+   * Default implementation calls textToImage() sequentially as a fallback.
+   * Providers that support native batch generation (e.g. FAL with num_images)
+   * should override this for efficiency.
+   */
+  async textToImages(
+    params: TextToImageParams,
+    numImages: number
+  ): Promise<Uint8Array[]> {
+    const results: Uint8Array[] = [];
+    for (let i = 0; i < numImages; i++) {
+      results.push(await this.textToImage(params));
+    }
+    return results;
+  }
+
   async imageToImage(
     _image: Uint8Array,
     _params: ImageToImageParams
   ): Promise<Uint8Array> {
     throw new Error(`${this.provider} does not support imageToImage`);
+  }
+
+  /**
+   * Generate multiple image-to-image results in one logical call.
+   *
+   * Default implementation calls imageToImage() sequentially as a fallback.
+   * Providers that support native batch generation should override this.
+   */
+  async imageToImages(
+    image: Uint8Array,
+    params: ImageToImageParams,
+    numImages: number
+  ): Promise<Uint8Array[]> {
+    const results: Uint8Array[] = [];
+    for (let i = 0; i < numImages; i++) {
+      results.push(await this.imageToImage(image, params));
+    }
+    return results;
   }
 
   async *textToSpeech(_args: {

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -21,7 +21,7 @@ import { CostCalculator } from "./cost-calculator.js";
 import type { UsageInfo } from "./cost-calculator.js";
 import { getTracer } from "../telemetry.js";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { createLogger, getDefaultAssetsPath } from "@nodetool/config";
+import { createLogger, getAssetFilePath } from "@nodetool/config";
 
 const log = createLogger("nodetool.runtime.provider");
 
@@ -533,13 +533,13 @@ export abstract class BaseProvider {
     // Legacy: old messages stored with browser-facing /api/storage/ path
     if (uri.startsWith("/api/storage/")) {
       const key = uri.slice("/api/storage/".length);
-      const filePath = `${getDefaultAssetsPath()}/${key}`;
       try {
-        const bytes = await readFile(filePath);
+        const bytes = await readFile(getAssetFilePath(key));
         const ext = key.split(".").pop()?.toLowerCase() ?? "";
         const mime = EXT_TO_MIME[ext] ?? "application/octet-stream";
         return `data:${mime};base64,${bytes.toString("base64")}`;
       } catch {
+        // Remote deployment: file not local, fall back to absolute HTTP
         return `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
       }
     }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -21,7 +21,7 @@ import { CostCalculator } from "./cost-calculator.js";
 import type { UsageInfo } from "./cost-calculator.js";
 import { getTracer } from "../telemetry.js";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { createLogger } from "@nodetool/config";
+import { createLogger, getDefaultAssetsPath } from "@nodetool/config";
 
 const log = createLogger("nodetool.runtime.provider");
 
@@ -508,13 +508,31 @@ export abstract class BaseProvider {
   }
 
   /**
-   * Resolve a potentially relative URI to an absolute URL.
-   * Relative paths (starting with "/") are resolved against the local server.
-   * This handles asset URIs like /api/storage/... stored by the frontend.
+   * Resolve a URI to a form that can be consumed by providers.
+   *
+   * - `/api/storage/<key>` → read the file from the local asset store and
+   *   return a `data:<mime>;base64,…` URI so no HTTP round-trip is needed.
+   * - Everything else → returned unchanged.
    */
-  protected resolveUri(uri: string): string {
-    if (uri.startsWith("/")) {
-      return `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
+  protected async resolveUri(uri: string): Promise<string> {
+    if (uri.startsWith("/api/storage/")) {
+      const key = uri.slice("/api/storage/".length);
+      const filePath = `${getDefaultAssetsPath()}/${key}`;
+      try {
+        const { readFile } = await import("node:fs/promises");
+        const bytes = await readFile(filePath);
+        const ext = key.split(".").pop()?.toLowerCase() ?? "";
+        const mime =
+          ({ jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png",
+             gif: "image/gif", webp: "image/webp", mp4: "video/mp4",
+             webm: "video/webm", mp3: "audio/mpeg", wav: "audio/wav",
+             pdf: "application/pdf" } as Record<string, string>)[ext] ??
+          "application/octet-stream";
+        return `data:${mime};base64,${bytes.toString("base64")}`;
+      } catch {
+        // Fall back to HTTP if the file can't be read (e.g. remote deployment)
+        return `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
+      }
     }
     return uri;
   }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -508,32 +508,50 @@ export abstract class BaseProvider {
   }
 
   /**
-   * Resolve a URI to a form that can be consumed by providers.
+   * Resolve a URI to a `data:` URI that providers can consume directly.
    *
-   * - `/api/storage/<key>` → read the file from the local asset store and
-   *   return a `data:<mime>;base64,…` URI so no HTTP round-trip is needed.
-   * - Everything else → returned unchanged.
+   * - `file://...`        → read from disk, return `data:<mime>;base64,…`
+   * - `/api/storage/<k>`  → read from getDefaultAssetsPath()/<k> (legacy fallback)
+   * - Everything else     → returned unchanged (http/https/data: pass through)
    */
   protected async resolveUri(uri: string): Promise<string> {
+    const { readFile } = await import("node:fs/promises");
+
+    if (uri.startsWith("file://")) {
+      try {
+        const { fileURLToPath } = await import("node:url");
+        const filePath = fileURLToPath(uri);
+        const bytes = await readFile(filePath);
+        const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+        const mime = EXT_TO_MIME[ext] ?? "application/octet-stream";
+        return `data:${mime};base64,${bytes.toString("base64")}`;
+      } catch {
+        return uri;
+      }
+    }
+
+    // Legacy: old messages stored with browser-facing /api/storage/ path
     if (uri.startsWith("/api/storage/")) {
       const key = uri.slice("/api/storage/".length);
       const filePath = `${getDefaultAssetsPath()}/${key}`;
       try {
-        const { readFile } = await import("node:fs/promises");
         const bytes = await readFile(filePath);
         const ext = key.split(".").pop()?.toLowerCase() ?? "";
-        const mime =
-          ({ jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png",
-             gif: "image/gif", webp: "image/webp", mp4: "video/mp4",
-             webm: "video/webm", mp3: "audio/mpeg", wav: "audio/wav",
-             pdf: "application/pdf" } as Record<string, string>)[ext] ??
-          "application/octet-stream";
+        const mime = EXT_TO_MIME[ext] ?? "application/octet-stream";
         return `data:${mime};base64,${bytes.toString("base64")}`;
       } catch {
-        // Fall back to HTTP if the file can't be read (e.g. remote deployment)
         return `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
       }
     }
+
     return uri;
   }
 }
+
+const EXT_TO_MIME: Record<string, string> = {
+  jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png",
+  gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
+  mp4: "video/mp4", webm: "video/webm",
+  mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg",
+  pdf: "application/pdf"
+};

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -24,10 +24,19 @@ const log = createLogger("nodetool.runtime.providers.fal");
 const FAL_MANIFEST_PKG = "@nodetool/fal-nodes";
 const FAL_MANIFEST_PATH = "fal-manifest.json";
 
+type FalQueueUpdate = {
+  status: string;
+  logs?: Array<{ message: string }>;
+};
+
 type FalClient = {
   subscribe(
     endpoint: string,
-    opts: { input: Record<string, unknown>; logs?: boolean }
+    opts: {
+      input: Record<string, unknown>;
+      logs?: boolean;
+      onQueueUpdate?: (update: FalQueueUpdate) => void;
+    }
   ): Promise<{ data?: Record<string, unknown> }>;
   storage: {
     upload(file: Blob): Promise<string>;
@@ -45,6 +54,37 @@ export class FalProvider extends BaseProvider {
   constructor(secrets: Record<string, unknown> = {}) {
     super("fal_ai");
     this.apiKey = (secrets["FAL_API_KEY"] as string) ?? "";
+  }
+
+  /** Build an onQueueUpdate callback that forwards progress via emitMessage. */
+  private makeQueueUpdateHandler(): (update: FalQueueUpdate) => void {
+    let tick = 0;
+    return (update) => {
+if (update.status === "IN_PROGRESS") {
+        tick++;
+        const logs = update.logs ?? [];
+        // Emit one message per log line; if no logs, emit a heartbeat tick
+        if (logs.length > 0) {
+          for (const entry of logs) {
+            this.emitMessage({
+              type: "node_progress",
+              node_id: "",
+              progress: tick,
+              total: 0,
+              chunk: entry.message
+            });
+          }
+        } else {
+          this.emitMessage({
+            type: "node_progress",
+            node_id: "",
+            progress: tick,
+            total: 0,
+            chunk: ""
+          });
+        }
+      }
+    };
   }
 
   private async getClient(): Promise<FalClient> {
@@ -94,7 +134,11 @@ export class FalProvider extends BaseProvider {
 
     const modelId = params.model.id;
     log.debug("FAL textToImage", { model: modelId });
-    const result = await client.subscribe(modelId, { input: args, logs: true });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
     const data = (result.data ?? result) as Record<string, unknown>;
     const imageUrl = extractImageUrl(data);
     return downloadBytes(imageUrl);
@@ -129,7 +173,11 @@ export class FalProvider extends BaseProvider {
 
     const modelId = params.model.id;
     log.debug("FAL imageToImage", { model: modelId });
-    const result = await client.subscribe(modelId, { input: args, logs: true });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
     const data = (result.data ?? result) as Record<string, unknown>;
     const imageUrl = extractImageUrl(data);
     return downloadBytes(imageUrl);
@@ -151,10 +199,93 @@ export class FalProvider extends BaseProvider {
 
     const modelId = params.model.id;
     log.debug("FAL textToVideo", { model: modelId });
-    const result = await client.subscribe(modelId, { input: args, logs: true });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
     const data = (result.data ?? result) as Record<string, unknown>;
     const videoUrl = extractVideoUrl(data);
     return downloadBytes(videoUrl);
+  }
+
+  override async imageToImages(
+    image: Uint8Array,
+    params: ImageToImageParams,
+    numImages: number
+  ): Promise<Uint8Array[]> {
+    if (numImages <= 1) {
+      return [await this.imageToImage(image, params)];
+    }
+    const client = await this.getClient();
+    const blob = new Blob([image], { type: "image/png" });
+    const uploadedUrl = await client.storage.upload(blob);
+
+    const args: Record<string, unknown> = {
+      prompt: params.prompt,
+      image_url: uploadedUrl,
+      output_format: "png",
+      num_images: numImages
+    };
+    if (params.negativePrompt) args.negative_prompt = params.negativePrompt;
+    if (params.guidanceScale != null)
+      args.guidance_scale = params.guidanceScale;
+    if (params.numInferenceSteps != null)
+      args.num_inference_steps = params.numInferenceSteps;
+    if (params.strength != null) args.strength = params.strength;
+    if (params.targetWidth && params.targetHeight) {
+      args.image_size = {
+        width: params.targetWidth,
+        height: params.targetHeight
+      };
+    }
+    if (params.seed != null && params.seed !== -1) args.seed = params.seed;
+
+    const modelId = params.model.id;
+    log.debug("FAL imageToImages", { model: modelId, numImages });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
+    const data = (result.data ?? result) as Record<string, unknown>;
+    const urls = extractImageUrls(data);
+    return Promise.all(urls.map(downloadBytes));
+  }
+
+  override async textToImages(
+    params: TextToImageParams,
+    numImages: number
+  ): Promise<Uint8Array[]> {
+    if (numImages <= 1) {
+      return [await this.textToImage(params)];
+    }
+    const client = await this.getClient();
+    const args: Record<string, unknown> = {
+      prompt: params.prompt,
+      output_format: "png",
+      num_images: numImages
+    };
+    if (params.negativePrompt) args.negative_prompt = params.negativePrompt;
+    if (params.guidanceScale != null)
+      args.guidance_scale = params.guidanceScale;
+    if (params.numInferenceSteps != null)
+      args.num_inference_steps = params.numInferenceSteps;
+    if (params.width && params.height) {
+      args.image_size = { width: params.width, height: params.height };
+    }
+    if (params.seed != null && params.seed !== -1) args.seed = params.seed;
+
+    const modelId = params.model.id;
+    log.debug("FAL textToImages", { model: modelId, numImages });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
+    const data = (result.data ?? result) as Record<string, unknown>;
+    const urls = extractImageUrls(data);
+    return Promise.all(urls.map(downloadBytes));
   }
 
   override async imageToVideo(
@@ -180,22 +311,30 @@ export class FalProvider extends BaseProvider {
 
     const modelId = params.model.id;
     log.debug("FAL imageToVideo", { model: modelId });
-    const result = await client.subscribe(modelId, { input: args, logs: true });
+    const result = await client.subscribe(modelId, {
+      input: args,
+      logs: true,
+      onQueueUpdate: this.makeQueueUpdateHandler()
+    });
     const data = (result.data ?? result) as Record<string, unknown>;
     const videoUrl = extractVideoUrl(data);
     return downloadBytes(videoUrl);
   }
 }
 
-function extractImageUrl(result: Record<string, unknown>): string {
+function extractImageUrls(result: Record<string, unknown>): string[] {
   const images = result.images as Array<Record<string, unknown>> | undefined;
   if (images && images.length > 0) {
-    const url = images[0].url as string | undefined;
-    if (url) return url;
+    const urls = images.map((img) => img.url as string).filter(Boolean);
+    if (urls.length > 0) return urls;
   }
   const image = result.image as Record<string, unknown> | undefined;
-  if (image?.url) return image.url as string;
+  if (image?.url) return [image.url as string];
   throw new Error(`Unexpected FAL image response: ${JSON.stringify(result)}`);
+}
+
+function extractImageUrl(result: Record<string, unknown>): string {
+  return extractImageUrls(result)[0];
 }
 
 function extractVideoUrl(result: Record<string, unknown>): string {

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -223,10 +223,7 @@ export class OllamaProvider extends BaseProvider {
       return Buffer.from(image.data).toString("base64");
     }
     if (image.uri) {
-      const resolvedUri = image.uri.startsWith("/")
-        ? `http://127.0.0.1:${process.env.PORT ?? 7777}${image.uri}`
-        : image.uri;
-      const response = await this._fetch(resolvedUri);
+      const response = await this._fetch(this.resolveUri(image.uri));
       if (!response.ok) {
         throw new Error(`Failed to fetch image URI: ${response.status}`);
       }

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -223,7 +223,11 @@ export class OllamaProvider extends BaseProvider {
       return Buffer.from(image.data).toString("base64");
     }
     if (image.uri) {
-      const response = await this._fetch(this.resolveUri(image.uri));
+      const resolved = await this.resolveUri(image.uri);
+      if (resolved.startsWith("data:")) {
+        return parseDataUri(resolved).base64;
+      }
+      const response = await this._fetch(resolved);
       if (!response.ok) {
         throw new Error(`Failed to fetch image URI: ${response.status}`);
       }

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -223,7 +223,10 @@ export class OllamaProvider extends BaseProvider {
       return Buffer.from(image.data).toString("base64");
     }
     if (image.uri) {
-      const response = await this._fetch(image.uri);
+      const resolvedUri = image.uri.startsWith("/")
+        ? `http://127.0.0.1:${process.env.PORT ?? 7777}${image.uri}`
+        : image.uri;
+      const response = await this._fetch(resolvedUri);
       if (!response.ok) {
         throw new Error(`Failed to fetch image URI: ${response.status}`);
       }

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -472,10 +472,11 @@ export class OpenAIProvider extends BaseProvider {
   }
 
   async uriToBase64(uri: string): Promise<string> {
-    if (uri.startsWith("data:")) {
-      return this.normalizeDataUri(uri);
+    const resolved = await this.resolveUri(uri);
+    if (resolved.startsWith("data:")) {
+      return this.normalizeDataUri(resolved);
     }
-    const response = await this._fetch(this.resolveUri(uri));
+    const response = await this._fetch(resolved);
     if (!response.ok) {
       throw new Error(`Failed to fetch URI: ${response.status}`);
     }

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -475,12 +475,7 @@ export class OpenAIProvider extends BaseProvider {
     if (uri.startsWith("data:")) {
       return this.normalizeDataUri(uri);
     }
-    // Resolve relative /api/ paths against the local server
-    if (uri.startsWith("/")) {
-      uri = `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
-    }
-
-    const response = await this._fetch(uri);
+    const response = await this._fetch(this.resolveUri(uri));
     if (!response.ok) {
       throw new Error(`Failed to fetch URI: ${response.status}`);
     }

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -475,6 +475,10 @@ export class OpenAIProvider extends BaseProvider {
     if (uri.startsWith("data:")) {
       return this.normalizeDataUri(uri);
     }
+    // Resolve relative /api/ paths against the local server
+    if (uri.startsWith("/")) {
+      uri = `http://127.0.0.1:${process.env.PORT ?? 7777}${uri}`;
+    }
 
     const response = await this._fetch(uri);
     if (!response.ok) {

--- a/packages/websocket/src/resolve-media-urls.ts
+++ b/packages/websocket/src/resolve-media-urls.ts
@@ -3,9 +3,14 @@
  *
  * Media refs store an `asset_id` in the database. Before sending to a
  * client, this module resolves each to a full URL via `buildAssetUrl`.
+ *
+ * For LLM providers use `resolveContentForProvider` instead, which maps
+ * asset_id directly to a file:// URI so no HTTP round-trip is needed.
  */
 
-import { buildAssetUrl } from "@nodetool/config";
+import { buildAssetUrl, getDefaultAssetsPath } from "@nodetool/config";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/png": "png",
@@ -46,6 +51,60 @@ function resolveRef(
   }
 
   return resolved;
+}
+
+/**
+ * Resolve a media ref for an LLM provider call.
+ * Maps asset_id directly to a file:// URI so providers read from disk,
+ * not via an HTTP round-trip to the local server.
+ */
+function resolveRefForProvider(
+  ref: Record<string, unknown>,
+  fallbackMime?: string
+): Record<string, unknown> {
+  const resolved = { ...ref };
+  const mime = (resolved.mimeType ?? resolved.mime_type ?? resolved.content_type ?? fallbackMime) as string | undefined;
+
+  if (typeof resolved.asset_id === "string" && resolved.asset_id && !resolved.uri) {
+    const ext = extFromMime(mime);
+    const filePath = join(getDefaultAssetsPath(), `${resolved.asset_id as string}.${ext}`);
+    resolved.uri = pathToFileURL(filePath).href;
+  }
+
+  return resolved;
+}
+
+/**
+ * Walk a message content array and resolve asset_id refs to file:// URIs
+ * suitable for LLM provider calls (reads directly from disk).
+ */
+export function resolveContentForProvider(
+  content: string | unknown[] | Record<string, unknown> | null
+): string | unknown[] | Record<string, unknown> | null {
+  if (!Array.isArray(content)) return content;
+
+  return content.map((block) => {
+    if (!block || typeof block !== "object") return block;
+    const b = block as Record<string, unknown>;
+
+    if (
+      (b.type === "image_url" || b.type === "image") &&
+      b.image &&
+      typeof b.image === "object"
+    ) {
+      return { ...b, image: resolveRefForProvider(b.image as Record<string, unknown>, "image/png") };
+    }
+
+    if (b.type === "video" && b.video && typeof b.video === "object") {
+      return { ...b, video: resolveRefForProvider(b.video as Record<string, unknown>, "video/mp4") };
+    }
+
+    if (b.type === "audio" && b.audio && typeof b.audio === "object") {
+      return { ...b, audio: resolveRefForProvider(b.audio as Record<string, unknown>, "audio/wav") };
+    }
+
+    return block;
+  });
 }
 
 /**

--- a/packages/websocket/src/resolve-media-urls.ts
+++ b/packages/websocket/src/resolve-media-urls.ts
@@ -8,8 +8,7 @@
  * asset_id directly to a file:// URI so no HTTP round-trip is needed.
  */
 
-import { buildAssetUrl, getDefaultAssetsPath } from "@nodetool/config";
-import { join } from "node:path";
+import { buildAssetUrl, getAssetFilePath } from "@nodetool/config";
 import { pathToFileURL } from "node:url";
 
 const MIME_TO_EXT: Record<string, string> = {
@@ -67,7 +66,7 @@ function resolveRefForProvider(
 
   if (typeof resolved.asset_id === "string" && resolved.asset_id && !resolved.uri) {
     const ext = extFromMime(mime);
-    const filePath = join(getDefaultAssetsPath(), `${resolved.asset_id as string}.${ext}`);
+    const filePath = getAssetFilePath(`${resolved.asset_id as string}.${ext}`);
     resolved.uri = pathToFileURL(filePath).href;
   }
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2690,13 +2690,13 @@ export class UnifiedWebSocketRunner {
       return;
     }
 
-    // Persist the user message first — mirrors handleChatMessage behaviour so
-    // the generation request is recorded in the thread history.
-    await this.saveMessageToDb(data);
-
     if (requestSeq !== undefined && requestSeq !== this.chatRequestSeq) return;
 
     const provider = await this.resolveProvider(providerId, userId);
+    // Wire up progress forwarding so provider.emitMessage() reaches the client.
+    provider.setMessageEmitter((msg) =>
+      void this.sendMessage(msg as Record<string, unknown>)
+    );
 
     // Store generated media as a proper Asset record and return the
     // asset ID.  The DB message stores only `asset_id` — URLs are
@@ -2762,11 +2762,11 @@ export class UnifiedWebSocketRunner {
           done: false
         });
 
+        if (requestSeq !== undefined && requestSeq !== this.chatRequestSeq)
+          return;
+        const imageBytesList = await provider.textToImages(params, variations);
         const imageContents: Array<Record<string, unknown>> = [];
-        for (let i = 0; i < variations; i++) {
-          if (requestSeq !== undefined && requestSeq !== this.chatRequestSeq)
-            return;
-          const bytes = await provider.textToImage(params);
+        for (const bytes of imageBytesList) {
           const assetId = await storeMediaAsset(bytes, "image/png", "png");
           imageContents.push({
             type: "image_url",
@@ -3114,14 +3114,15 @@ export class UnifiedWebSocketRunner {
             strength: strength ?? null,
             numInferenceSteps: numInferenceSteps ?? null
           };
+          if (requestSeq !== undefined && requestSeq !== this.chatRequestSeq)
+            return;
+          const imageBytesList = await provider.imageToImages(
+            sourceBytes,
+            params,
+            variations
+          );
           const imageContents: Array<Record<string, unknown>> = [];
-          for (let i = 0; i < variations; i++) {
-            if (
-              requestSeq !== undefined &&
-              requestSeq !== this.chatRequestSeq
-            )
-              return;
-            const bytes = await provider.imageToImage(sourceBytes, params);
+          for (const bytes of imageBytesList) {
             const assetId = await storeMediaAsset(bytes, "image/png", "png");
             imageContents.push({
               type: "image_url",

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -9,7 +9,7 @@ import {
   getDefaultAssetsPath,
   buildAssetUrl
 } from "@nodetool/config";
-import { resolveContentUrls } from "./resolve-media-urls.js";
+import { resolveContentUrls, resolveContentForProvider } from "./resolve-media-urls.js";
 import {
   Graph,
   WorkflowRunner,
@@ -1712,12 +1712,12 @@ export class UnifiedWebSocketRunner {
     if (!role || !["user", "assistant", "system", "tool"].includes(role)) {
       return null;
     }
+    const rawContent = Array.isArray(m.content)
+      ? (resolveContentForProvider(m.content as unknown[]) as MessageContent[])
+      : (m.content as string | null);
     return {
       role,
-      content:
-        (Array.isArray(m.content)
-          ? (m.content as MessageContent[])
-          : (m.content as string | null)) ?? "",
+      content: rawContent ?? "",
       toolCallId: typeof m.tool_call_id === "string" ? m.tool_call_id : null,
       toolCalls: Array.isArray(m.tool_calls)
         ? (m.tool_calls as Array<{

--- a/web/src/components/chat/composer/FilePreview.tsx
+++ b/web/src/components/chat/composer/FilePreview.tsx
@@ -6,7 +6,8 @@ import { DroppedFile } from "../types/chat.types";
 
 const isDisplayableImage = (uri: string) =>
   /^data:image\/(jpeg|jpg|png|gif|webp|svg\+xml|bmp);base64,/.test(uri) ||
-  /^https?:\/\//.test(uri);
+  /^https?:\/\//.test(uri) ||
+  uri.startsWith("/");
 
 interface FilePreviewProps {
   file: DroppedFile;

--- a/web/src/components/chat/composer/FilePreview.tsx
+++ b/web/src/components/chat/composer/FilePreview.tsx
@@ -4,8 +4,9 @@ import { ResponsiveImage } from "../../ui_primitives/ResponsiveImage";
 import { CloseButton } from "../../ui_primitives/CloseButton";
 import { DroppedFile } from "../types/chat.types";
 
-const isValidImageDataUri = (uri: string) =>
-  /^data:image\/(jpeg|jpg|png|gif|webp);base64,/.test(uri);
+const isDisplayableImage = (uri: string) =>
+  /^data:image\/(jpeg|jpg|png|gif|webp|svg\+xml|bmp);base64,/.test(uri) ||
+  /^https?:\/\//.test(uri);
 
 interface FilePreviewProps {
   file: DroppedFile;
@@ -14,7 +15,7 @@ interface FilePreviewProps {
 
 export const FilePreview: React.FC<FilePreviewProps> = ({ file, onRemove }) => (
   <div className="file-preview">
-    {file.type.startsWith("image/") && isValidImageDataUri(file.dataUri) ? (
+    {file.type.startsWith("image/") && isDisplayableImage(file.dataUri) ? (
       <ResponsiveImage
         src={file.dataUri}
         alt={file.name}

--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -141,5 +141,19 @@ export const createMediaComposerStyles = (theme: Theme) =>
       display: "flex",
       flexWrap: "wrap",
       gap: 6
+    },
+
+    ".file-preview": {
+      position: "relative",
+      maxWidth: 48,
+      maxHeight: 48,
+      flexShrink: 0,
+
+      img: {
+        width: 48,
+        height: 48,
+        objectFit: "cover",
+        borderRadius: 4
+      }
     }
   });

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -430,6 +430,27 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     agentMode
   ]);
 
+  // Handle paste events — extract images from clipboard
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const imageFiles: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.kind === "file" && item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          if (file) imageFiles.push(file);
+        }
+      }
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        addFiles(imageFiles);
+      }
+    },
+    [addFiles]
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter") {
@@ -721,6 +742,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder={placeholder}
           rows={1}
           spellCheck={false}
@@ -777,6 +799,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 active={languageModelOpen}
                 onClick={() => setLanguageModelOpen(true)}
                 showChevron={false}
+                truncate
               />
               <LanguageModelMenuDialog
                 open={languageModelOpen}
@@ -800,6 +823,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 active={imageModelOpen}
                 onClick={() => setImageModelOpen(true)}
                 showChevron={false}
+                truncate
               />
               <ImageModelMenuDialog
                 open={imageModelOpen}
@@ -869,6 +893,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 label={videoParams.model?.name || "Select Video Model"}
                 active={videoModelOpen}
                 onClick={() => setVideoModelOpen(true)}
+                truncate
                 showChevron={false}
               />
               <VideoModelMenuDialog
@@ -944,6 +969,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 icon={<AutoFixHighIcon fontSize="small" />}
                 label={imageEditParams.model?.name || "Select Edit Model"}
                 active={imageModelOpen}
+                truncate
                 onClick={() => setImageModelOpen(true)}
                 showChevron={false}
               />
@@ -1054,6 +1080,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 active={videoModelOpen}
                 onClick={() => setVideoModelOpen(true)}
                 showChevron={false}
+                truncate
               />
               <VideoModelMenuDialog
                 open={videoModelOpen}
@@ -1143,6 +1170,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 active={ttsModelOpen}
                 onClick={() => setTtsModelOpen(true)}
                 showChevron={false}
+                truncate
               />
               <TTSModelMenuDialog
                 open={ttsModelOpen}

--- a/web/src/components/chat/composer/MediaControlChip.tsx
+++ b/web/src/components/chat/composer/MediaControlChip.tsx
@@ -28,9 +28,11 @@ interface MediaControlChipProps {
   className?: string;
   /** Show as emphasized / primary. */
   emphasis?: "default" | "primary";
+  /** Allow this chip to shrink and truncate its label. */
+  truncate?: boolean;
 }
 
-const createStyles = (theme: Theme, size: "sm" | "md", emphasis: "default" | "primary", active: boolean) =>
+const createStyles = (theme: Theme, size: "sm" | "md", emphasis: "default" | "primary", active: boolean, truncate: boolean) =>
   css({
     display: "inline-flex",
     alignItems: "center",
@@ -53,7 +55,10 @@ const createStyles = (theme: Theme, size: "sm" | "md", emphasis: "default" | "pr
     transition:
       "background-color 160ms ease, border-color 160ms ease, color 160ms ease",
     whiteSpace: "nowrap",
-    flexShrink: 0,
+    flexShrink: truncate ? 1 : 0,
+    minWidth: truncate ? 0 : undefined,
+    maxWidth: truncate ? 200 : undefined,
+    overflow: truncate ? "hidden" : undefined,
     "&:hover:not(:disabled)": {
       backgroundColor: "rgba(255,255,255,0.10)"
     },
@@ -96,7 +101,8 @@ const MediaControlChip = memo(
         disabled = false,
         size = "md",
         className,
-        emphasis = "default"
+        emphasis = "default",
+        truncate = false
       },
       ref
     ) => {
@@ -106,7 +112,7 @@ const MediaControlChip = memo(
           ref={ref}
           type="button"
           className={`media-control-chip${className ? ` ${className}` : ""}${active ? " active" : ""}`}
-          css={createStyles(theme, size, emphasis, active)}
+          css={createStyles(theme, size, emphasis, active, truncate)}
           onClick={onClick}
           disabled={disabled}
           aria-pressed={active || undefined}
@@ -117,7 +123,15 @@ const MediaControlChip = memo(
               component="span"
               size="small"
               weight={500}
-              sx={{ color: "inherit", lineHeight: 1 }}
+              sx={{
+                color: "inherit",
+                lineHeight: 1,
+                ...(truncate && {
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap"
+                })
+              }}
             >
               {label}
             </Text>

--- a/web/src/components/chat/hooks/useDragAndDrop.ts
+++ b/web/src/components/chat/hooks/useDragAndDrop.ts
@@ -12,6 +12,35 @@ import log from "loglevel";
 // Generate a unique ID for each file
 const generateFileId = () => `file_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
+/**
+ * Fetch an asset URL and return a data: URI.
+ * Handles relative paths (proxied via Vite in dev) and absolute URLs.
+ * Falls back to the original URL string if fetch fails.
+ */
+async function assetUrlToDataUri(url: string, mimeType: string): Promise<string> {
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) return url;
+    const buf = await resp.arrayBuffer();
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+    return `data:${mimeType};base64,${base64}`;
+  } catch {
+    return url;
+  }
+}
+
+async function assetToDroppedFile(asset: Asset): Promise<DroppedFile> {
+  const url = asset.get_url ?? "";
+  const mimeType = asset.content_type || "application/octet-stream";
+  const dataUri = url ? await assetUrlToDataUri(url, mimeType) : url;
+  return {
+    id: generateFileId(),
+    dataUri,
+    type: mimeType,
+    name: asset.name
+  };
+}
+
 export const useDragAndDrop = (
   onFilesDropped: (files: File[]) => void,
   onAssetsDropped?: (files: DroppedFile[]) => void
@@ -33,81 +62,64 @@ export const useDragAndDrop = (
       e.preventDefault();
       setIsDragging(false);
 
-      // Use unified deserialization
       const dragData = deserializeDragData(e.dataTransfer);
 
       if (dragData && onAssetsDropped) {
-        try {
-          const droppedFiles: DroppedFile[] = [];
-          
-          // Handle multiple assets
-          if (dragData.type === "assets-multiple") {
-            const selectedIds = dragData.payload as string[];
-            const { filteredAssets, globalSearchResults } = useAssetGridStore.getState();
-            // Combine sources to find assets. 
-            // Note: filteredAssets might be only the current folder view.
-            // If we are in global search, use globalSearchResults.
-            // We can also try to find in selectedAssets if the store keeps them populated.
-            const potentialAssets = [...filteredAssets, ...globalSearchResults, ...(useAssetGridStore.getState().selectedAssets || [])];
-            
-            const foundAssets = potentialAssets.filter(a => selectedIds.includes(a.id));
-            // Deduplicate by ID
-            const uniqueAssets = Array.from(new Map(foundAssets.map(item => [item.id, item])).values());
-            
-            uniqueAssets.forEach(asset => {
+        void (async () => {
+          try {
+            const droppedFiles: DroppedFile[] = [];
+
+            // Handle multiple assets
+            if (dragData.type === "assets-multiple") {
+              const selectedIds = dragData.payload as string[];
+              const { filteredAssets, globalSearchResults } = useAssetGridStore.getState();
+              const potentialAssets = [...filteredAssets, ...globalSearchResults, ...(useAssetGridStore.getState().selectedAssets || [])];
+              const foundAssets = potentialAssets.filter(a => selectedIds.includes(a.id));
+              const uniqueAssets = Array.from(new Map(foundAssets.map(item => [item.id, item])).values());
+              const resolved = await Promise.all(uniqueAssets.filter(a => a.get_url).map(assetToDroppedFile));
+              droppedFiles.push(...resolved);
+            }
+
+            // Handle single asset
+            if (droppedFiles.length === 0 && dragData.type === "asset") {
+              const asset = dragData.payload as Asset;
               if (asset.get_url) {
-                droppedFiles.push({
-                  id: generateFileId(),
-                  dataUri: asset.get_url,
-                  type: asset.content_type || "application/octet-stream",
-                  name: asset.name
-                });
+                droppedFiles.push(await assetToDroppedFile(asset));
               }
-            });
-          }
-
-          // Handle single asset (direct asset drop or fallback from assets-multiple)
-          if (droppedFiles.length === 0 && dragData.type === "asset") {
-            const asset = dragData.payload as Asset;
-            if (asset.get_url) {
-              droppedFiles.push({
-                id: generateFileId(),
-                dataUri: asset.get_url,
-                type: asset.content_type || "application/octet-stream",
-                name: asset.name
-              });
             }
-          }
 
-          // Fallback: if assets-multiple lookup failed, try the legacy "asset" key directly
-          // This handles the case where asset IDs couldn't be found in stores
-          if (droppedFiles.length === 0 && dragData.type === "assets-multiple") {
-            const assetJson = e.dataTransfer.getData("asset");
-            if (assetJson) {
-              try {
-                const asset: Asset = JSON.parse(assetJson);
-                if (asset.get_url) {
-                  droppedFiles.push({
-                    id: generateFileId(),
-                    dataUri: asset.get_url,
-                    type: asset.content_type || "application/octet-stream",
-                    name: asset.name
-                  });
+            // Fallback: legacy "asset" key when assets-multiple store lookup fails
+            if (droppedFiles.length === 0 && dragData.type === "assets-multiple") {
+              const assetJson = e.dataTransfer.getData("asset");
+              if (assetJson) {
+                try {
+                  const asset: Asset = JSON.parse(assetJson);
+                  if (asset.get_url) {
+                    droppedFiles.push(await assetToDroppedFile(asset));
+                  }
+                } catch {
+                  // Ignore parse errors
                 }
-              } catch {
-                // Ignore parse errors
               }
             }
+
+            if (droppedFiles.length > 0) {
+              onAssetsDropped(droppedFiles);
+              return;
+            }
+          } catch (err) {
+            log.error("Failed to process dropped asset", err);
           }
 
-          if (droppedFiles.length > 0) {
-            onAssetsDropped(droppedFiles);
-            return;
+          // Fall through to external files if asset processing yielded nothing
+          if (hasExternalFiles(e.dataTransfer)) {
+            const files = extractFiles(e.dataTransfer);
+            if (files.length > 0) {
+              onFilesDropped(files);
+            }
           }
-
-        } catch (err) {
-          log.error("Failed to process dropped asset", err);
-        }
+        })();
+        return;
       }
 
       // Handle external files

--- a/web/src/components/chat/hooks/useDragAndDrop.ts
+++ b/web/src/components/chat/hooks/useDragAndDrop.ts
@@ -58,68 +58,57 @@ export const useDragAndDrop = (
   }, []);
 
   const handleDrop = useCallback(
-    (e: React.DragEvent) => {
+    async (e: React.DragEvent) => {
       e.preventDefault();
       setIsDragging(false);
 
       const dragData = deserializeDragData(e.dataTransfer);
 
       if (dragData && onAssetsDropped) {
-        void (async () => {
-          try {
-            const droppedFiles: DroppedFile[] = [];
+        try {
+          const droppedFiles: DroppedFile[] = [];
 
-            // Handle multiple assets
-            if (dragData.type === "assets-multiple") {
-              const selectedIds = dragData.payload as string[];
-              const { filteredAssets, globalSearchResults } = useAssetGridStore.getState();
-              const potentialAssets = [...filteredAssets, ...globalSearchResults, ...(useAssetGridStore.getState().selectedAssets || [])];
-              const foundAssets = potentialAssets.filter(a => selectedIds.includes(a.id));
-              const uniqueAssets = Array.from(new Map(foundAssets.map(item => [item.id, item])).values());
-              const resolved = await Promise.all(uniqueAssets.filter(a => a.get_url).map(assetToDroppedFile));
-              droppedFiles.push(...resolved);
+          // Handle multiple assets
+          if (dragData.type === "assets-multiple") {
+            const selectedIds = dragData.payload as string[];
+            const { filteredAssets, globalSearchResults } = useAssetGridStore.getState();
+            const potentialAssets = [...filteredAssets, ...globalSearchResults, ...(useAssetGridStore.getState().selectedAssets || [])];
+            const foundAssets = potentialAssets.filter(a => selectedIds.includes(a.id));
+            const uniqueAssets = Array.from(new Map(foundAssets.map(item => [item.id, item])).values());
+            const resolved = await Promise.all(uniqueAssets.filter(a => a.get_url).map(assetToDroppedFile));
+            droppedFiles.push(...resolved);
+          }
+
+          // Handle single asset
+          if (droppedFiles.length === 0 && dragData.type === "asset") {
+            const asset = dragData.payload as Asset;
+            if (asset.get_url) {
+              droppedFiles.push(await assetToDroppedFile(asset));
             }
+          }
 
-            // Handle single asset
-            if (droppedFiles.length === 0 && dragData.type === "asset") {
-              const asset = dragData.payload as Asset;
-              if (asset.get_url) {
-                droppedFiles.push(await assetToDroppedFile(asset));
-              }
-            }
-
-            // Fallback: legacy "asset" key when assets-multiple store lookup fails
-            if (droppedFiles.length === 0 && dragData.type === "assets-multiple") {
-              const assetJson = e.dataTransfer.getData("asset");
-              if (assetJson) {
-                try {
-                  const asset: Asset = JSON.parse(assetJson);
-                  if (asset.get_url) {
-                    droppedFiles.push(await assetToDroppedFile(asset));
-                  }
-                } catch {
-                  // Ignore parse errors
+          // Fallback: legacy "asset" key when assets-multiple store lookup fails
+          if (droppedFiles.length === 0 && dragData.type === "assets-multiple") {
+            const assetJson = e.dataTransfer.getData("asset");
+            if (assetJson) {
+              try {
+                const asset: Asset = JSON.parse(assetJson);
+                if (asset.get_url) {
+                  droppedFiles.push(await assetToDroppedFile(asset));
                 }
+              } catch {
+                // Ignore parse errors
               }
             }
-
-            if (droppedFiles.length > 0) {
-              onAssetsDropped(droppedFiles);
-              return;
-            }
-          } catch (err) {
-            log.error("Failed to process dropped asset", err);
           }
 
-          // Fall through to external files if asset processing yielded nothing
-          if (hasExternalFiles(e.dataTransfer)) {
-            const files = extractFiles(e.dataTransfer);
-            if (files.length > 0) {
-              onFilesDropped(files);
-            }
+          if (droppedFiles.length > 0) {
+            onAssetsDropped(droppedFiles);
+            return;
           }
-        })();
-        return;
+        } catch (err) {
+          log.error("Failed to process dropped asset", err);
+        }
       }
 
       // Handle external files

--- a/web/src/components/chat/hooks/useDragAndDrop.ts
+++ b/web/src/components/chat/hooks/useDragAndDrop.ts
@@ -21,9 +21,15 @@ async function assetUrlToDataUri(url: string, mimeType: string): Promise<string>
   try {
     const resp = await fetch(url);
     if (!resp.ok) return url;
-    const buf = await resp.arrayBuffer();
-    const base64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
-    return `data:${mimeType};base64,${base64}`;
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    // Use FileReader to safely encode arbitrary-size buffers (btoa + spread fails for large files)
+    return await new Promise<string>((resolve) => {
+      const blob = new Blob([buf], { type: mimeType });
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => resolve(url);
+      reader.readAsDataURL(blob);
+    });
   } catch {
     return url;
   }

--- a/web/src/components/chat/hooks/useFileHandling.ts
+++ b/web/src/components/chat/hooks/useFileHandling.ts
@@ -6,6 +6,28 @@ import { useNotificationStore } from "../../../stores/NotificationStore";
 // Generate a unique ID for each file
 const generateFileId = () => `file_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
+/** Infer MIME type from file extension when the browser doesn't provide one */
+function resolveFileType(file: File): string {
+  if (file.type) return file.type;
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  const mimeMap: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp",
+    svg: "image/svg+xml",
+    bmp: "image/bmp",
+    mp4: "video/mp4",
+    webm: "video/webm",
+    mp3: "audio/mpeg",
+    wav: "audio/wav",
+    ogg: "audio/ogg",
+    pdf: "application/pdf"
+  };
+  return ext ? (mimeMap[ext] ?? "application/octet-stream") : "application/octet-stream";
+}
+
 export const useFileHandling = () => {
   const [droppedFiles, setDroppedFiles] = useState<DroppedFile[]>([]);
   const addNotification = useNotificationStore((state) => state.addNotification);
@@ -54,13 +76,14 @@ export const useFileHandling = () => {
   const addFiles = useCallback(
     (files: File[]) => {
       const filePromises = files.map((file) => {
+        const mimeType = resolveFileType(file);
         return new Promise<DroppedFile>((resolve, reject) => {
           const reader = new FileReader();
           reader.onload = () => {
             resolve({
               id: generateFileId(),
               dataUri: reader.result as string,
-              type: file.type,
+              type: mimeType,
               name: file.name
             });
           };

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -917,11 +917,17 @@ const applyNodeProgress = (
       );
   }
 
+  // Keep the existing statusMessage for heartbeat ticks (empty chunk, total=0)
+  // so the "Generating image…" label set from the chunk metadata stays visible.
+  const statusMessage =
+    progress.chunk
+      ? progress.chunk
+      : state.statusMessage;
   return {
     update: {
       status: "loading",
       progress: { current: progress.progress, total: progress.total },
-      statusMessage: null
+      statusMessage
     }
   };
 };


### PR DESCRIPTION
## Summary

- **Clipboard paste**: Images pasted from system clipboard are now added to the composer
- **JPG drop fix**: Infer MIME type from file extension when browser omits it (fixes `.jpg` drops)
- **File preview fix**: X-button now anchors to top-right of preview thumbnail via `position: relative`
- **Model chip truncation**: Long model names truncate with ellipsis instead of breaking layout
- **Batch image generation**: New `textToImages`/`imageToImages` methods on `BaseProvider` with sequential fallback; `FalProvider` overrides with native `num_images` in a single API call
- **FAL progress forwarding**: `onQueueUpdate` wired to emit `node_progress` messages; heartbeat ticks keep the spinner active when FAL returns no log lines
- **Duplicate prompt fix**: Removed redundant `saveMessageToDb` call from `handleMediaGenerationMessage`

## Test plan

- [ ] Paste an image from clipboard into the chat composer — preview should appear
- [ ] Drag and drop a `.jpg` file — should show as image preview, not generic file icon
- [ ] Select a model with a long name — chip should truncate with ellipsis, not break layout
- [ ] Generate multiple image variations — all images should appear in the response
- [ ] Generate an image with a FAL model — progress spinner should animate during generation
- [ ] Send a text-to-image request — prompt should appear only once in chat history

🤖 Generated with [Claude Code](https://claude.com/claude-code)