### PR TITLE
Fix #2345: Your project is featured in Awesome MLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/nodetool-ai/nodetool?display_name=tag&sort=semver)](https://github.com/nodetool-ai/nodetool/releases/latest)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/WmQTWZRcYE)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE.txt)
+[![Awesome MLX](https://img.shields.io/badge/Awesome-MLX-blueviolet)](https://github.com/raullenchai/awesome-mlx)
 
 [![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey)](https://nodetool.ai)
 [![Platform: Windows](https://img.shields.io/badge/platform-Windows-blue)](https://nodetool.ai)


### PR DESCRIPTION
Closes #2345

Adds the Awesome MLX badge to `README.md` (line 8, alongside the existing shields.io badges) to reflect nodetool's listing in the [Awesome MLX](https://github.com/raullenchai/awesome-mlx) directory of 120+ MLX-based projects. The badge links directly to the awesome-mlx repository for visibility.

- `README.md`: inserted `[![Awesome MLX](https://img.shields.io/badge/Awesome-MLX-blueviolet)](https://github.com/raullenchai/awesome-mlx)` in the top badge block

Verified by rendering `README.md` locally to confirm the badge displays correctly and the link resolves to the expected awesome-mlx repository page.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*