### PR TITLE
Escape special regex characters in template variable keys

### DIFF
--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -233,8 +233,9 @@ export class TaskExecutor {
         for (const [key, value] of Object.entries(
           item as Record<string, unknown>
         )) {
+          const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           instructions = instructions.replace(
-            new RegExp(`\\{${key}\\}`, "g"),
+            new RegExp(`\\{${escapedKey}\\}`, "g"),
             String(value)
           );
         }

--- a/packages/base-nodes/src/nodes/text-extra.ts
+++ b/packages/base-nodes/src/nodes/text-extra.ts
@@ -2343,7 +2343,8 @@ export class FormatTextNode extends BaseNode {
     // Handle {variable} syntax (no filters)
     for (const [key, value] of Object.entries(props)) {
       const strValue = String(value ?? "");
-      const single = new RegExp(`(?<!\\{)\\{${key}\\}(?!\\})`, "g");
+      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const single = new RegExp(`(?<!\\{)\\{${escapedKey}\\}(?!\\})`, "g");
       result = result.replace(single, strValue);
     }
     return { output: result };
@@ -2378,9 +2379,10 @@ export class TemplateTextNode extends BaseNode {
 
     for (const [key, value] of Object.entries(props)) {
       const strValue = String(value ?? "");
-      const jinja = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, "g");
+      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const jinja = new RegExp(`\\{\\{\\s*${escapedKey}\\s*\\}\\}`, "g");
       result = result.replace(jinja, strValue);
-      const single = new RegExp(`(?<!\\{)\\{${key}\\}(?!\\})`, "g");
+      const single = new RegExp(`(?<!\\{)\\{${escapedKey}\\}(?!\\})`, "g");
       result = result.replace(single, strValue);
     }
     return { output: result };

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -1086,7 +1086,6 @@ const useGlobalChatStore = create<GlobalChatState>()(
           });
         } catch (error) {
           log.error("Failed to send stop signal:", error);
-          log.error("Failed to send stop signal:", error);
           set({
             error: "Failed to stop generation",
             status: "error",


### PR DESCRIPTION
## Summary
This PR fixes a bug where special regex characters in template variable keys could cause incorrect pattern matching or regex errors when performing string replacements in template nodes and task execution.

## Key Changes
- **FormatTextNode**: Added regex escaping for variable keys before constructing the replacement pattern
- **TemplateTextNode**: Added regex escaping for variable keys used in both Jinja-style (`{{ }}`) and single brace (`{ }`) patterns
- **TaskExecutor**: Added regex escaping for variable keys in instruction template replacement
- **GlobalChatStore**: Removed duplicate error log statement

## Implementation Details
All template variable key replacements now escape special regex characters (`.*+?^${}()|[\]\\`) using the standard pattern `key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` before constructing RegExp objects. This prevents keys containing characters like `.`, `*`, `+`, etc. from being interpreted as regex metacharacters, ensuring literal string matching for variable substitution.

https://claude.ai/code/session_01FXtdnxCdXJwhY9CnsVJuvS