### PR TITLE
Fix dollar sign handling in template replacements

### DIFF
--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -234,13 +234,15 @@ export class TaskExecutor {
           item as Record<string, unknown>
         )) {
           const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const strValue = String(value);
           instructions = instructions.replace(
             new RegExp(`\\{${escapedKey}\\}`, "g"),
-            String(value)
+            () => strValue
           );
         }
       } else {
-        instructions = instructions.replace(/\{item\}/g, String(item));
+        const strItem = String(item);
+        instructions = instructions.replace(/\{item\}/g, () => strItem);
       }
 
       const hash = this.shortHash(item);

--- a/packages/base-nodes/src/nodes/text-extra.ts
+++ b/packages/base-nodes/src/nodes/text-extra.ts
@@ -2345,7 +2345,7 @@ export class FormatTextNode extends BaseNode {
       const strValue = String(value ?? "");
       const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const single = new RegExp(`(?<!\\{)\\{${escapedKey}\\}(?!\\})`, "g");
-      result = result.replace(single, strValue);
+      result = result.replace(single, () => strValue);
     }
     return { output: result };
   }
@@ -2381,9 +2381,9 @@ export class TemplateTextNode extends BaseNode {
       const strValue = String(value ?? "");
       const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const jinja = new RegExp(`\\{\\{\\s*${escapedKey}\\s*\\}\\}`, "g");
-      result = result.replace(jinja, strValue);
+      result = result.replace(jinja, () => strValue);
       const single = new RegExp(`(?<!\\{)\\{${escapedKey}\\}(?!\\})`, "g");
-      result = result.replace(single, strValue);
+      result = result.replace(single, () => strValue);
     }
     return { output: result };
   }

--- a/packages/base-nodes/tests/regression-text-document.test.ts
+++ b/packages/base-nodes/tests/regression-text-document.test.ts
@@ -139,6 +139,16 @@ describe("text-extra regressions", () => {
       const result = await node.process();
       expect(result.output).toBe("HELLO");
     });
+
+    it("preserves $-sequences in dynamic property values", async () => {
+      const node = new FormatTextNode();
+      Object.assign(node, {
+        template: "price: {price}, code: {code}",
+        _dynamic_properties: { price: "$100", code: "a$&b$$c" }
+      });
+      const result = await node.process();
+      expect(result.output).toBe("price: $100, code: a$&b$$c");
+    });
   });
 
   // 4. HtmlToText


### PR DESCRIPTION
## Summary
Fixed a bug where dollar signs (`$`) and ampersands (`&`) in dynamic property values were being incorrectly interpreted as special replacement patterns in template strings. This affected text formatting and templating nodes across the codebase.

## Key Changes
- **FormatTextNode** (`text-extra.ts`): Changed `String.replace()` to use a callback function instead of a string replacement, preventing `$` sequences from being interpreted as backreferences
- **TemplateTextNode** (`text-extra.ts`): Applied the same fix to both Jinja-style (`{{ }}`) and single brace (`{}`) template replacements
- **TaskExecutor** (`task-executor.ts`): Updated template variable replacement logic to use callback functions for both dynamic properties and item placeholders
- **Test coverage**: Added regression test to verify that `$` sequences in property values are preserved correctly

## Implementation Details
The root cause was using string values directly in `String.replace()` calls. When the replacement string contains `$` characters, they are interpreted as special sequences (e.g., `$&` refers to the matched text). By switching to callback functions `() => strValue`, the replacement value is treated as a literal string, preserving all special characters exactly as provided.

This fix ensures that values like `"$100"` and `"a$&b$$c"` are inserted into templates without any unintended transformations.

https://claude.ai/code/session_01TJy5y25DWqn9RLaLt9ZAcB