### PR TITLE
Fix Packages Test CI failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install system libraries for keytar
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-0
+
       - name: Install all workspace dependencies
         run: npm install
         env:

--- a/packages/runtime/tests/providers/fal-provider.test.ts
+++ b/packages/runtime/tests/providers/fal-provider.test.ts
@@ -109,18 +109,21 @@ describe("FalProvider", () => {
     const result = await p.textToImage(params);
     expect(result).toBeInstanceOf(Uint8Array);
 
-    expect(subscribeMock).toHaveBeenCalledWith("fal-ai/flux/dev", {
-      input: expect.objectContaining({
-        prompt: "a cat",
-        negative_prompt: "blurry",
-        guidance_scale: 7.5,
-        num_inference_steps: 30,
-        image_size: { width: 1024, height: 768 },
-        seed: 42,
-        output_format: "png"
-      }),
-      logs: true
-    });
+    expect(subscribeMock).toHaveBeenCalledWith(
+      "fal-ai/flux/dev",
+      expect.objectContaining({
+        input: expect.objectContaining({
+          prompt: "a cat",
+          negative_prompt: "blurry",
+          guidance_scale: 7.5,
+          num_inference_steps: 30,
+          image_size: { width: 1024, height: 768 },
+          seed: 42,
+          output_format: "png"
+        }),
+        logs: true
+      })
+    );
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
Two issues caused the Packages Test job to fail:

1. keytar's native module requires libsecret-1-0 on Linux, but the CI
   runner didn't have it installed. After commit a9701ab made keytar a
   static top-level import in @nodetool/security, any transitive loader
   of the module (including the CLI run-dsl tests that import
   @nodetool/dsl → @nodetool/runtime) crashed at import time with
   "libsecret-1.so.0: cannot open shared object file". Install
   libsecret-1-0 via apt before running the packages test suite.

2. fal-provider's textToImage now passes an onQueueUpdate callback to
   client.subscribe (added in 7079c98 for FAL progress forwarding), but
   the test still used toHaveBeenCalledWith with a strict object literal
   so the extra key caused an assertion mismatch. Wrap the expected
   second argument with expect.objectContaining.