### PR TITLE
Replace raw MUI components with ui primitives

### DIFF
--- a/web/src/ErrorBoundary.tsx
+++ b/web/src/ErrorBoundary.tsx
@@ -3,8 +3,8 @@ import { css } from "@emotion/react";
 
 import React, { useState } from "react";
 import { useRouteError } from "react-router-dom";
-import { Typography, Box, Button, ThemeProvider } from "@mui/material";
-import { CopyButton } from "./components/ui_primitives";
+import { Box, Button, ThemeProvider } from "@mui/material";
+import { CopyButton, Text } from "./components/ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
@@ -198,11 +198,11 @@ const ErrorBoundary: React.FC = () => {
       <Box css={errorBoundaryStyles(theme)}>
         <Box className="hero">
           <img src="/logo192.png" alt="NodeTool Logo" className="logo" />
-          <Typography className="heading">Something went wrong</Typography>
-          <Typography className="subtext">
+          <Text className="heading">Something went wrong</Text>
+          <Text className="subtext">
             An unexpected error occurred. You can try reloading the page. If
             this keeps happening, please reach out so we can fix it.
-          </Typography>
+          </Text>
         </Box>
 
         <Box className="actions">
@@ -250,9 +250,9 @@ const ErrorBoundary: React.FC = () => {
 
           {showDetails && (
             <>
-              <Typography className="error-summary">
+              <Text className="error-summary">
                 {errorMessage}
-              </Typography>
+              </Text>
               <Box className="stack-wrapper">
                 <CopyButton
                   value={stackTrace}
@@ -260,9 +260,9 @@ const ErrorBoundary: React.FC = () => {
                   buttonSize="medium"
                   sx={{ position: "absolute", top: 6, right: 6, zIndex: 1 }}
                 />
-                <Typography component="pre" className="error-stack-trace">
+                <Text component="pre" className="error-stack-trace">
                   {stackTrace}
-                </Typography>
+                </Text>
               </Box>
             </>
           )}

--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -21,11 +21,19 @@ jest.mock("@mui/material", () => ({
   )
 }));
 
-// Mock CopyButton primitive
+// Mock ui_primitives used by ErrorBoundary
 jest.mock("../components/ui_primitives", () => ({
   CopyButton: ({ value }: { value: string }) => (
     <button data-testid="copy-button">Copy: {String(value).substring(0, 20)}</button>
-  )
+  ),
+  Text: ({ children, className, component, ...props }: any) => {
+    const Tag = component || "p";
+    return (
+      <Tag className={className} {...props}>
+        {children}
+      </Tag>
+    );
+  }
 }));
 
 describe("ErrorBoundary", () => {

--- a/web/src/components/assistants/WorkflowGenerator.tsx
+++ b/web/src/components/assistants/WorkflowGenerator.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, memo } from "react";
-import { Box, Paper, InputAdornment } from "@mui/material";
+import { Box, InputAdornment } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 import { client } from "../../stores/ApiClient";
 import { graphNodeToReactFlowNode } from "../../stores/graphNodeToReactFlowNode";
@@ -7,7 +7,7 @@ import { graphEdgeToReactFlowEdge } from "../../stores/graphEdgeToReactFlowEdge"
 import { useNodes } from "../../contexts/NodeContext";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { createErrorMessage } from "../../utils/errorHandling";
-import { NodeTextField, ToolbarIconButton } from "../ui_primitives";
+import { Card, NodeTextField, ToolbarIconButton } from "../ui_primitives";
 import type { Graph } from "../../stores/ApiTypes";
 import log from "loglevel";
 import { shallow } from "zustand/shallow";
@@ -88,12 +88,12 @@ const WorkflowGenerator: React.FC = memo(() => {
         zIndex: 1000
       }}
     >
-      <Paper
+      <Card
+        variant="elevated"
         elevation={3}
+        padding="normal"
         sx={{
           borderRadius: 3,
-          padding: 2,
-          backgroundColor: "background.paper",
           backdropFilter: "blur(16px)",
           boxShadow: "0 4px 24px -1px rgba(0, 0, 0, 0.2)"
         }}
@@ -128,7 +128,7 @@ const WorkflowGenerator: React.FC = memo(() => {
             }}
           />
         </form>
-      </Paper>
+      </Card>
     </Box>
   );
 });

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -3,8 +3,8 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import React, { useState, useCallback, useMemo, useEffect } from "react";
-import { Box, CircularProgress, Button } from "@mui/material";
-import { Text } from "../../ui_primitives";
+import { Box, Button } from "@mui/material";
+import { LoadingSpinner, Text } from "../../ui_primitives";
 import SearchOffIcon from "@mui/icons-material/SearchOff";
 import DownloadIcon from "@mui/icons-material/Download";
 import { VariableSizeList as VirtualList } from "react-window";
@@ -281,10 +281,7 @@ const ModelListIndex: React.FC = () => {
           textAlign: "center"
         }}
       >
-        <CircularProgress />
-        <Text size="big" sx={{ mt: 2 }}>
-          Loading models
-        </Text>
+        <LoadingSpinner size="medium" text="Loading models" />
       </Box>
     );
   }
@@ -365,10 +362,9 @@ const ModelListIndex: React.FC = () => {
 
         <Box className="content">
           {isFetching && (
-            <CircularProgress
-              size={20}
-              sx={{ position: "absolute", top: "1em", right: "1em", zIndex: 1 }}
-            />
+            <Box sx={{ position: "absolute", top: "1em", right: "1em", zIndex: 1 }}>
+              <LoadingSpinner size="small" />
+            </Box>
           )}
           {modelSearchTerm && selectedModelType === "All" && (
             <Text size="normal" weight={600} sx={{ mb: 2 }}>

--- a/web/src/components/node/TaskView.tsx
+++ b/web/src/components/node/TaskView.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Paper, List } from "@mui/material";
-import { Text } from "../ui_primitives";
+import { List } from "@mui/material";
+import { Text, Card } from "../ui_primitives";
 import { Task } from "../../stores/ApiTypes";
 import StepView from "./StepView";
 
@@ -34,7 +34,7 @@ const TaskView: React.FC<TaskViewProps> = ({ task }) => {
   const theme = useTheme();
   return (
     <div css={styles(theme)} className="noscroll">
-      <Paper className="task-container" elevation={1}>
+      <Card className="task-container" variant="elevated" elevation={1}>
         <Text size="normal" weight={600} className="task-title">
           Task: {task.title}
         </Text>
@@ -52,7 +52,7 @@ const TaskView: React.FC<TaskViewProps> = ({ task }) => {
             </List>
           </>
         )}
-      </Paper>
+      </Card>
     </div>
   );
 };

--- a/web/src/components/node/output/PlotlyRenderer.tsx
+++ b/web/src/components/node/output/PlotlyRenderer.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React, { Suspense, lazy, memo } from "react";
-import { Box, CircularProgress } from "@mui/material";
+import { Box } from "@mui/material";
+import { LoadingSpinner } from "../../ui_primitives";
 import type { PlotlyConfig } from "../../../stores/ApiTypes";
 import type { Data, Layout, Config, Frame } from "plotly.js";
 
@@ -25,7 +26,7 @@ const PlotlyRenderer: React.FC<PlotlyRendererProps> = ({ config }) => {
           bgcolor: "action.hover",
           borderRadius: 1
         }}>
-          <CircularProgress size={24} />
+          <LoadingSpinner size="small" />
         </Box>
       }>
         <PlotlyPlot

--- a/web/src/components/node_editor/Alert.tsx
+++ b/web/src/components/node_editor/Alert.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, { useEffect, useState, useRef, createRef, memo, useCallback } from "react";
-import { AlertColor, Alert as MUIAlert } from "@mui/material";
-import { EditorButton } from "../ui_primitives";
+import type { AlertColor } from "@mui/material";
+import { AlertBanner, EditorButton } from "../ui_primitives";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import {
@@ -120,7 +120,7 @@ const NotificationItem = memo(function NotificationItem({
       onExited={onExited}
     >
       <li ref={nodeRef} style={{ position: "relative" }}>
-        <MUIAlert
+        <AlertBanner
           severity={mapTypeToSeverity(notification.type)}
           onClose={handleClose}
           action={
@@ -136,7 +136,7 @@ const NotificationItem = memo(function NotificationItem({
           }
         >
           {notification.content}
-        </MUIAlert>
+        </AlertBanner>
         {(notification.dismissable || notification.type === "error") && (
           <CopyButton
             value={notification.content}


### PR DESCRIPTION
Migrate confirmed raw MUI imports outside ui_primitives/editor_ui to
primitives per STRATEGY.md:

- TaskView, WorkflowGenerator: Paper -> Card (elevated)
- node_editor/Alert: MUIAlert -> AlertBanner
- ErrorBoundary: Typography -> Text (Button kept; custom CSS conflicts)
- PlotlyRenderer, ModelListIndex: CircularProgress -> LoadingSpinner

Also updates ErrorBoundary.test mock to stub the Text primitive.

https://claude.ai/code/session_01WzunDsxLsurKGMjtQZMo5t