### PR TITLE
Migrate toolbars, dialogs, and inline spinners to UI primitives

### DIFF
--- a/web/src/components/hugging_face/model_list/ModelListItemActions.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListItemActions.tsx
@@ -1,7 +1,13 @@
 import React, { memo, useCallback } from "react";
-import { Button, Chip, CircularProgress, Box } from "@mui/material";
+import { Box } from "@mui/material";
 import { Check } from "@mui/icons-material";
-import { DeleteButton, Tooltip } from "../../ui_primitives";
+import {
+  Chip,
+  DeleteButton,
+  EditorButton,
+  LoadingSpinner,
+  Tooltip
+} from "../../ui_primitives";
 import DownloadIcon from "@mui/icons-material/Download";
 
 import {
@@ -76,19 +82,19 @@ export const ModelListItemActions: React.FC<ModelListItemActionsProps> = ({
             fontSize: "0.75rem"
           }}
         >
-          <CircularProgress size={12} thickness={5} />
+          <LoadingSpinner inline size={12} thickness={5} color="inherit" />
           Checking cache...
         </Box>
       )}
       {onDownload && !downloaded && !isCheckingCache && (
-        <Button
+        <EditorButton
           className="model-download-button"
           onClick={onDownload}
           variant="outlined"
+          startIcon={<DownloadIcon sx={{ fontSize: "1.25em" }} />}
         >
-          <DownloadIcon sx={{ marginRight: "0.5em", fontSize: "1.25em" }} />
           Download
-        </Button>
+        </EditorButton>
       )}
       {downloaded && (
         <Tooltip

--- a/web/src/components/hugging_face/model_list/ModelTypeSidebar.tsx
+++ b/web/src/components/hugging_face/model_list/ModelTypeSidebar.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback } from "react";
 import {
-  Chip,
-  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText
 } from "@mui/material";
-import { Tooltip } from "../../ui_primitives";
+import { Chip, ToolbarIconButton } from "../../ui_primitives";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { IconForType } from "../../../config/data_types";
 import { prettifyModelType } from "../../../utils/modelFormatting";
@@ -64,25 +62,22 @@ const ModelTypeSidebar: React.FC = () => {
               }}
               secondaryAction={
                 href ? (
-                  <Tooltip title="View on Hugging Face">
-                    <IconButton
-                      edge="end"
-                      component="a"
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      size="small"
-                      onClick={handleLinkClick}
-                      aria-label={`View ${prettifyModelType(type)} models on Hugging Face`}
-                      sx={{
-                        color: isSelected ? theme.vars.palette.text.primary : "inherit",
-                        opacity: 0.7,
-                        "&:hover": { opacity: 1 }
-                      }}
-                    >
-                      <OpenInNewIcon fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
+                  <ToolbarIconButton
+                    icon={<OpenInNewIcon fontSize="small" />}
+                    tooltip="View on Hugging Face"
+                    edge="end"
+                    component="a"
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={handleLinkClick}
+                    ariaLabel={`View ${prettifyModelType(type)} models on Hugging Face`}
+                    sx={{
+                      color: isSelected ? theme.vars.palette.text.primary : "inherit",
+                      opacity: 0.7,
+                      "&:hover": { opacity: 1 }
+                    }}
+                  />
                 ) : undefined
               }
             >

--- a/web/src/components/node/image_editor/ImageEditor.tsx
+++ b/web/src/components/node/image_editor/ImageEditor.tsx
@@ -8,14 +8,13 @@ import React, {
 } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { CircularProgress } from "@mui/material";
 
 // Icons
 import SaveIcon from "@mui/icons-material/Save";
 import DownloadIcon from "@mui/icons-material/Download";
 
 // UI Primitives
-import { CloseButton, Tooltip, Text } from "../../ui_primitives";
+import { CloseButton, LoadingSpinner, Tooltip, Text } from "../../ui_primitives";
 
 import { useCombo } from "../../../stores/KeyPressedStore";
 import ImageEditorToolbar from "./ImageEditorToolbar";
@@ -571,7 +570,7 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
                             disabled={isSaving}
                         >
                             {isSaving ? (
-                                <CircularProgress size={16} color="inherit" />
+                                <LoadingSpinner inline size={16} color="inherit" />
                             ) : (
                                 <SaveIcon fontSize="small" />
                             )}

--- a/web/src/components/node/image_editor/ImageEditorModal.tsx
+++ b/web/src/components/node/image_editor/ImageEditorModal.tsx
@@ -9,14 +9,13 @@ import React, {
 import ReactDOM from "react-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { CircularProgress } from "@mui/material";
 
 // Icons
 import SaveIcon from "@mui/icons-material/Save";
 import DownloadIcon from "@mui/icons-material/Download";
 
 // UI Primitives
-import { CloseButton, Tooltip, Text } from "../../ui_primitives";
+import { CloseButton, LoadingSpinner, Tooltip, Text } from "../../ui_primitives";
 
 import { useCombo } from "../../../stores/KeyPressedStore";
 import ImageEditorToolbar from "./ImageEditorToolbar";
@@ -573,7 +572,7 @@ const ImageEditorModal: React.FC<ImageEditorModalProps> = ({
                 disabled={isSaving}
               >
                 {isSaving ? (
-                  <CircularProgress size={16} color="inherit" />
+                  <LoadingSpinner inline size={16} color="inherit" />
                 ) : (
                   <SaveIcon fontSize="small" />
                 )}

--- a/web/src/components/node/image_editor/ImageEditorToolbar.tsx
+++ b/web/src/components/node/image_editor/ImageEditorToolbar.tsx
@@ -4,12 +4,11 @@ import React, { memo, useCallback } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import {
-  IconButton,
   Slider,
   Checkbox,
   FormControlLabel
 } from "@mui/material";
-import { Tooltip, Text, Caption } from "../../ui_primitives";
+import { Text, Caption, ToolbarIconButton } from "../../ui_primitives";
 
 // Icons
 import PanToolIcon from "@mui/icons-material/PanTool";
@@ -313,106 +312,96 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">Tools</Text>
           <div className="tools-grid">
-            <Tooltip title="Select / Pan (V)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "select" ? "active" : ""}`}
-                onClick={handleSelectTool("select")}
-                size="small"
-                aria-label="Select or Pan tool"
-              >
-                <PanToolIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Crop (C)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "crop" ? "active" : ""}`}
-                onClick={handleSelectTool("crop")}
-                size="small"
-                aria-label="Crop tool"
-              >
-                <CropIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Draw / Paint (B)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "draw" ? "active" : ""}`}
-                onClick={handleSelectTool("draw")}
-                size="small"
-                aria-label="Draw or Paint tool"
-              >
-                <BrushIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Erase (E)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "erase" ? "active" : ""}`}
-                onClick={handleSelectTool("erase")}
-                size="small"
-                aria-label="Erase tool"
-              >
-                <AutoFixHighIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Fill (G)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "fill" ? "active" : ""}`}
-                onClick={handleSelectTool("fill")}
-                size="small"
-                aria-label="Fill tool"
-              >
-                <FormatColorFillIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Text (T)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "text" ? "active" : ""}`}
-                onClick={handleSelectTool("text")}
-                size="small"
-                aria-label="Text tool"
-              >
-                <TextFieldsIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Rectangle (R)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "rectangle" ? "active" : ""}`}
-                onClick={handleSelectTool("rectangle")}
-                size="small"
-                aria-label="Rectangle tool"
-              >
-                <RectangleOutlinedIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Ellipse (O)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "ellipse" ? "active" : ""}`}
-                onClick={handleSelectTool("ellipse")}
-                size="small"
-                aria-label="Ellipse tool"
-              >
-                <CircleOutlinedIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Line (L)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "line" ? "active" : ""}`}
-                onClick={handleSelectTool("line")}
-                size="small"
-                aria-label="Line tool"
-              >
-                <RemoveIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Arrow (A)" placement="top">
-              <IconButton
-                className={`tool-button ${tool === "arrow" ? "active" : ""}`}
-                onClick={handleSelectTool("arrow")}
-                size="small"
-                aria-label="Arrow tool"
-              >
-                <ArrowRightAltIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+              icon={<PanToolIcon fontSize="small" />}
+              tooltip="Select / Pan (V)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "select"}
+              onClick={handleSelectTool("select")}
+              ariaLabel="Select or Pan tool"
+            />
+            <ToolbarIconButton
+              icon={<CropIcon fontSize="small" />}
+              tooltip="Crop (C)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "crop"}
+              onClick={handleSelectTool("crop")}
+              ariaLabel="Crop tool"
+            />
+            <ToolbarIconButton
+              icon={<BrushIcon fontSize="small" />}
+              tooltip="Draw / Paint (B)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "draw"}
+              onClick={handleSelectTool("draw")}
+              ariaLabel="Draw or Paint tool"
+            />
+            <ToolbarIconButton
+              icon={<AutoFixHighIcon fontSize="small" />}
+              tooltip="Erase (E)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "erase"}
+              onClick={handleSelectTool("erase")}
+              ariaLabel="Erase tool"
+            />
+            <ToolbarIconButton
+              icon={<FormatColorFillIcon fontSize="small" />}
+              tooltip="Fill (G)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "fill"}
+              onClick={handleSelectTool("fill")}
+              ariaLabel="Fill tool"
+            />
+            <ToolbarIconButton
+              icon={<TextFieldsIcon fontSize="small" />}
+              tooltip="Text (T)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "text"}
+              onClick={handleSelectTool("text")}
+              ariaLabel="Text tool"
+            />
+            <ToolbarIconButton
+              icon={<RectangleOutlinedIcon fontSize="small" />}
+              tooltip="Rectangle (R)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "rectangle"}
+              onClick={handleSelectTool("rectangle")}
+              ariaLabel="Rectangle tool"
+            />
+            <ToolbarIconButton
+              icon={<CircleOutlinedIcon fontSize="small" />}
+              tooltip="Ellipse (O)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "ellipse"}
+              onClick={handleSelectTool("ellipse")}
+              ariaLabel="Ellipse tool"
+            />
+            <ToolbarIconButton
+              icon={<RemoveIcon fontSize="small" />}
+              tooltip="Line (L)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "line"}
+              onClick={handleSelectTool("line")}
+              ariaLabel="Line tool"
+            />
+            <ToolbarIconButton
+              icon={<ArrowRightAltIcon fontSize="small" />}
+              tooltip="Arrow (A)"
+              tooltipPlacement="top"
+              className="tool-button"
+              active={tool === "arrow"}
+              onClick={handleSelectTool("arrow")}
+              ariaLabel="Arrow tool"
+            />
           </div>
         </div>
 
@@ -670,46 +659,34 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">Transform</Text>
           <div className="actions-row">
-            <Tooltip title="Rotate 90° CCW">
-              <IconButton
-                className="action-button"
-                onClick={handleRotateCCW}
-                size="small"
-                aria-label="Rotate 90 degrees counter-clockwise"
-              >
-                <Rotate90DegreesCcwIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Rotate 90° CW">
-              <IconButton
-                className="action-button"
-                onClick={handleRotateCW}
-                size="small"
-                aria-label="Rotate 90 degrees clockwise"
-              >
-                <Rotate90DegreesCwIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Flip Horizontal">
-              <IconButton
-                className="action-button"
-                onClick={handleFlipH}
-                size="small"
-                aria-label="Flip image horizontally"
-              >
-                <FlipIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Flip Vertical">
-              <IconButton
-                className="action-button"
-                onClick={handleFlipV}
-                size="small"
-                aria-label="Flip image vertically"
-              >
-                <FlipIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+              icon={<Rotate90DegreesCcwIcon fontSize="small" />}
+              tooltip="Rotate 90° CCW"
+              className="action-button"
+              onClick={handleRotateCCW}
+              ariaLabel="Rotate 90 degrees counter-clockwise"
+            />
+            <ToolbarIconButton
+              icon={<Rotate90DegreesCwIcon fontSize="small" />}
+              tooltip="Rotate 90° CW"
+              className="action-button"
+              onClick={handleRotateCW}
+              ariaLabel="Rotate 90 degrees clockwise"
+            />
+            <ToolbarIconButton
+              icon={<FlipIcon fontSize="small" />}
+              tooltip="Flip Horizontal"
+              className="action-button"
+              onClick={handleFlipH}
+              ariaLabel="Flip image horizontally"
+            />
+            <ToolbarIconButton
+              icon={<FlipIcon fontSize="small" />}
+              tooltip="Flip Vertical"
+              className="action-button"
+              onClick={handleFlipV}
+              ariaLabel="Flip image vertically"
+            />
           </div>
         </div>
 
@@ -770,33 +747,28 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">View</Text>
           <div className="zoom-controls">
-            <IconButton
+            <ToolbarIconButton
+              icon={<ZoomOutIcon fontSize="small" />}
+              tooltip="Zoom out"
               className="action-button"
               onClick={handleZoomOut}
-              size="small"
-              aria-label="Zoom out"
-            >
-              <ZoomOutIcon fontSize="small" />
-            </IconButton>
+              ariaLabel="Zoom out"
+            />
             <span className="zoom-value">{Math.round(zoom * 100)}%</span>
-            <IconButton
+            <ToolbarIconButton
+              icon={<ZoomInIcon fontSize="small" />}
+              tooltip="Zoom in"
               className="action-button"
               onClick={handleZoomIn}
-              size="small"
-              aria-label="Zoom in"
-            >
-              <ZoomInIcon fontSize="small" />
-            </IconButton>
-            <Tooltip title="Reset Zoom">
-              <IconButton
-                className="action-button"
-                onClick={handleZoomReset}
-                size="small"
-                aria-label="Reset zoom to 100%"
-              >
-                <RestartAltIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
+              ariaLabel="Zoom in"
+            />
+            <ToolbarIconButton
+              icon={<RestartAltIcon fontSize="small" />}
+              tooltip="Reset Zoom"
+              className="action-button"
+              onClick={handleZoomReset}
+              ariaLabel="Reset zoom to 100%"
+            />
           </div>
         </div>
 
@@ -804,42 +776,29 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">History</Text>
           <div className="actions-row">
-            <Tooltip title="Undo (Ctrl+Z)">
-              <span>
-                <IconButton
-                  className="action-button"
-                  onClick={onUndo}
-                  disabled={!canUndo}
-                  size="small"
-                  aria-label="Undo last action"
-                >
-                  <UndoIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title="Redo (Ctrl+Y)">
-              <span>
-                <IconButton
-                  className="action-button"
-                  onClick={onRedo}
-                  disabled={!canRedo}
-                  size="small"
-                  aria-label="Redo last action"
-                >
-                  <RedoIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title="Reset to Original">
-              <IconButton
-                className="action-button"
-                onClick={handleReset}
-                size="small"
-                aria-label="Reset image to original"
-              >
-                <RestartAltIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+              icon={<UndoIcon fontSize="small" />}
+              tooltip="Undo (Ctrl+Z)"
+              className="action-button"
+              onClick={onUndo}
+              disabled={!canUndo}
+              ariaLabel="Undo last action"
+            />
+            <ToolbarIconButton
+              icon={<RedoIcon fontSize="small" />}
+              tooltip="Redo (Ctrl+Y)"
+              className="action-button"
+              onClick={onRedo}
+              disabled={!canRedo}
+              ariaLabel="Redo last action"
+            />
+            <ToolbarIconButton
+              icon={<RestartAltIcon fontSize="small" />}
+              tooltip="Reset to Original"
+              className="action-button"
+              onClick={handleReset}
+              ariaLabel="Reset image to original"
+            />
           </div>
         </div>
       </div>

--- a/web/src/components/panels/LogPanel.tsx
+++ b/web/src/components/panels/LogPanel.tsx
@@ -7,11 +7,10 @@ import {
   InputLabel,
   MenuItem,
   OutlinedInput,
-  IconButton,
   Select,
   SelectChangeEvent
 } from "@mui/material";
-import { Tooltip, Chip } from "../ui_primitives";
+import { Chip, ToolbarIconButton } from "../ui_primitives";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { useTheme } from "@mui/material/styles";
@@ -191,19 +190,18 @@ const LogPanel: React.FC = memo(function LogPanel() {
       <PanelHeadline
         title="Logs"
         actions={
-          <Tooltip title={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}>
-            <IconButton
-              size="small"
-              onClick={handleFullscreenToggle}
-              aria-label="Toggle fullscreen"
-            >
-              {isFullscreen ? (
+          <ToolbarIconButton
+            icon={
+              isFullscreen ? (
                 <FullscreenExitIcon fontSize="small" />
               ) : (
                 <FullscreenIcon fontSize="small" />
-              )}
-            </IconButton>
-          </Tooltip>
+              )
+            }
+            tooltip={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
+            onClick={handleFullscreenToggle}
+            ariaLabel="Toggle fullscreen"
+          />
         }
       />
       <Box className="filters">

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -2,8 +2,8 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Drawer, IconButton } from "@mui/material";
-import { CloseButton, Tooltip } from "../ui_primitives";
+import { Drawer } from "@mui/material";
+import { CloseButton, ToolbarIconButton, Tooltip } from "../ui_primitives";
 import { useResizeBottomPanel } from "../../hooks/handlers/useResizeBottomPanel";
 import { useBottomPanelStore } from "../../stores/BottomPanelStore";
 import { memo, useCallback } from "react";
@@ -166,15 +166,14 @@ const PanelBottom: React.FC = () => {
           {isVisible && (
             <div className="panel-header">
               <div className="left">
-                <Tooltip title="Trace (Ctrl+Shift+T)" delay={TOOLTIP_ENTER_DELAY}>
-                  <IconButton
-                    size="small"
-                    onClick={handleTraceToggle}
-                    sx={{ color: activeView === "trace" ? "primary.main" : "text.secondary" }}
-                  >
-                    <TimelineIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                <ToolbarIconButton
+                  icon={<TimelineIcon fontSize="small" />}
+                  tooltip="Trace (Ctrl+Shift+T)"
+                  delay={TOOLTIP_ENTER_DELAY}
+                  onClick={handleTraceToggle}
+                  active={activeView === "trace"}
+                  variant={activeView === "trace" ? "primary" : "default"}
+                />
               </div>
               <Tooltip
                 title={

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Box, IconButton, useMediaQuery } from "@mui/material";
+import { Box, useMediaQuery } from "@mui/material";
 import Inspector from "../Inspector";
 import { useResizeRightPanel } from "../../hooks/handlers/useResizeRightPanel";
 import { useRightPanelStore, type RightPanelView } from "../../stores/RightPanelStore";
@@ -30,7 +30,7 @@ import { VersionHistoryPanel } from "../version";
 import ContextMenus from "../context_menus/ContextMenus";
 import WorkflowForm from "../workflows/WorkflowForm";
 import AgentPanel from "./AgentPanel";
-import { MobileBottomSheet, Tooltip } from "../ui_primitives";
+import { MobileBottomSheet, ToolbarIconButton } from "../ui_primitives";
 
 // Icons for mobile tab rail
 import CenterFocusWeakIcon from "@mui/icons-material/CenterFocusWeak";
@@ -252,30 +252,32 @@ const MobilePanelRight: React.FC<MobilePanelRightProps> = ({
     label: string,
     icon: React.ReactNode
   ) => (
-    <Tooltip title={label} placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-      <IconButton
-        className={`tab-button ${activeView === view ? "active" : ""}`}
-        onClick={() => setView(view)}
-        aria-label={label}
-        tabIndex={-1}
-      >
-        {icon}
-      </IconButton>
-    </Tooltip>
+    <ToolbarIconButton
+      icon={icon}
+      tooltip={label}
+      tooltipPlacement="bottom"
+      delay={TOOLTIP_ENTER_DELAY}
+      className="tab-button"
+      active={activeView === view}
+      onClick={() => setView(view)}
+      ariaLabel={label}
+      tabIndex={-1}
+    />
   );
 
   return (
     <>
-      <IconButton
-        className={`panel-right-mobile-launcher ${isVisible ? "active" : ""}`}
+      <ToolbarIconButton
+        icon={<TuneIcon />}
+        tooltip={isVisible ? "Close panel" : "Open inspector panel"}
+        className="panel-right-mobile-launcher"
+        active={isVisible}
         css={mobileLauncherStyles(theme)}
         onClick={isVisible ? onClose : onOpen}
-        aria-label={isVisible ? "Close panel" : "Open inspector panel"}
+        ariaLabel={isVisible ? "Close panel" : "Open inspector panel"}
         aria-expanded={isVisible}
         tabIndex={-1}
-      >
-        <TuneIcon />
-      </IconButton>
+      />
 
       <MobileBottomSheet
         open={isVisible}

--- a/web/src/components/panels/VerticalToolbar.tsx
+++ b/web/src/components/panels/VerticalToolbar.tsx
@@ -1,10 +1,8 @@
 import { memo } from "react";
-import { IconButton, SxProps } from "@mui/material";
-import { Tooltip, Divider } from "../ui_primitives";
-import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
+import { SxProps } from "@mui/material";
+import { Divider, ToolbarIconButton } from "../ui_primitives";
 import { getShortcutTooltip } from "../../config/shortcuts";
 
-// Memoized styles to prevent object creation on each render
 const spacerStyle = { flexGrow: 1 } as const;
 const dividerSx: SxProps = { my: 1, mx: "6px", borderColor: "rgba(255, 255, 255, 0.15)" };
 
@@ -46,129 +44,74 @@ function VerticalToolbar({
     activeView,
     panelVisible
 }: VerticalToolbarProps) {
+    const isActive = (view: VerticalToolbarProps["activeView"]) =>
+        activeView === view && panelVisible;
+
     return (
         <div className="vertical-toolbar">
-            {/* Workflow Tools Section */}
-            {/* Inspector Button */}
-            <Tooltip
-                title={getShortcutTooltip("toggleInspector")}
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleInspectorToggle}
-                    aria-label="Toggle Inspector panel (I)"
-                    className={
-                        activeView === "inspector" && panelVisible
-                            ? "inspector active"
-                            : "inspector"
-                    }
-                >
-                    <CenterFocusWeakIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<CenterFocusWeakIcon />}
+                tooltip={getShortcutTooltip("toggleInspector")}
+                tooltipPlacement="left-start"
+                onClick={handleInspectorToggle}
+                ariaLabel="Toggle Inspector panel (I)"
+                className="inspector"
+                active={isActive("inspector")}
+            />
 
-            {/* Assistant Button */}
-            <Tooltip
-                title={getShortcutTooltip("toggleOperator")}
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleAssistantToggle}
-                    aria-label="Toggle Operator panel (O)"
-                    className={
-                        activeView === "assistant" && panelVisible
-                            ? "assistant active"
-                            : "assistant"
-                    }
-                >
-                    <SvgFileIcon
-                        iconName="assistant"
-                        svgProp={{ width: 18, height: 18 }}
-                    />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<SvgFileIcon iconName="assistant" svgProp={{ width: 18, height: 18 }} />}
+                tooltip={getShortcutTooltip("toggleOperator")}
+                tooltipPlacement="left-start"
+                onClick={handleAssistantToggle}
+                ariaLabel="Toggle Operator panel (O)"
+                className="assistant"
+                active={isActive("assistant")}
+            />
 
-            {/* Agent Button */}
-            <Tooltip
-                title="Agent"
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleAgentToggle}
-                    aria-label="Toggle Agent panel"
-                    className={
-                        activeView === "agent" && panelVisible
-                            ? "agent active"
-                            : "agent"
-                    }
-                >
-                    <SmartToyIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<SmartToyIcon />}
+                tooltip="Agent"
+                tooltipPlacement="left-start"
+                onClick={handleAgentToggle}
+                ariaLabel="Toggle Agent panel"
+                className="agent"
+                active={isActive("agent")}
+            />
 
-            {/* Workspace Button */}
-            <Tooltip
-                title="Workspace"
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleWorkspaceToggle}
-                    aria-label="Toggle Workspace panel"
-                    className={
-                        activeView === "workspace" && panelVisible
-                            ? "workspace active"
-                            : "workspace"
-                    }
-                >
-                    <FolderIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<FolderIcon />}
+                tooltip="Workspace"
+                tooltipPlacement="left-start"
+                onClick={handleWorkspaceToggle}
+                ariaLabel="Toggle Workspace panel"
+                className="workspace"
+                active={isActive("workspace")}
+            />
 
-            {/* Versions Button */}
-            <Tooltip
-                title="Version History"
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleVersionsToggle}
-                    aria-label="Toggle Version History panel"
-                    className={
-                        activeView === "versions" && panelVisible
-                            ? "versions active"
-                            : "versions"
-                    }
-                >
-                    <HistoryIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<HistoryIcon />}
+                tooltip="Version History"
+                tooltipPlacement="left-start"
+                onClick={handleVersionsToggle}
+                ariaLabel="Toggle Version History panel"
+                className="versions"
+                active={isActive("versions")}
+            />
 
-            {/* Workflow Settings Button */}
-            <Tooltip
-                title={getShortcutTooltip("toggleWorkflowSettings")}
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleWorkflowToggle}
-                    aria-label="Toggle Workflow Settings panel (W)"
-                    className={
-                        activeView === "workflow" && panelVisible
-                            ? "workflow active"
-                            : "workflow"
-                    }
-                >
-                    <SettingsIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<SettingsIcon />}
+                tooltip={getShortcutTooltip("toggleWorkflowSettings")}
+                tooltipPlacement="left-start"
+                onClick={handleWorkflowToggle}
+                ariaLabel="Toggle Workflow Settings panel (W)"
+                className="workflow"
+                active={isActive("workflow")}
+            />
 
-            {/* Workflow Assets Button */}
-            <Tooltip
-                title={
+            <ToolbarIconButton
+                icon={<FolderSpecialIcon />}
+                tooltip={
                     <div className="tooltip-span">
                         <div className="tooltip-title">Workflow Assets</div>
                         <div className="tooltip-key">
@@ -176,32 +119,20 @@ function VerticalToolbar({
                         </div>
                     </div>
                 }
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleWorkflowAssetsToggle}
-                    aria-label="Toggle Workflow Assets panel (3)"
-                    className={
-                        activeView === "workflowAssets" && panelVisible
-                            ? "workflowAssets active"
-                            : "workflowAssets"
-                    }
-                >
-                    <FolderSpecialIcon />
-                </IconButton>
-            </Tooltip>
+                tooltipPlacement="left-start"
+                onClick={handleWorkflowAssetsToggle}
+                ariaLabel="Toggle Workflow Assets panel (3)"
+                className="workflowAssets"
+                active={isActive("workflowAssets")}
+            />
 
-            {/* Spacer to push runtime section to bottom */}
             <div style={spacerStyle} />
 
-            {/* Divider between workflow tools and runtime section */}
             <Divider sx={dividerSx} />
 
-            {/* Runtime Section - Logs and Jobs */}
-            {/* Logs Button */}
-            <Tooltip
-                title={
+            <ToolbarIconButton
+                icon={<ArticleIcon />}
+                tooltip={
                     <div className="tooltip-span">
                         <div className="tooltip-title">Logs</div>
                         <div className="tooltip-key">
@@ -209,39 +140,25 @@ function VerticalToolbar({
                         </div>
                     </div>
                 }
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleLogsToggle}
-                    aria-label="Toggle Logs panel (L)"
-                    className={
-                        activeView === "logs" && panelVisible ? "logs active" : "logs"
-                    }
-                >
-                    <ArticleIcon />
-                </IconButton>
-            </Tooltip>
+                tooltipPlacement="left-start"
+                onClick={handleLogsToggle}
+                ariaLabel="Toggle Logs panel (L)"
+                className="logs"
+                active={isActive("logs")}
+            />
 
-            {/* Jobs Button */}
-            <Tooltip
-                title="Jobs"
-                placement="left-start"
-                delay={TOOLTIP_ENTER_DELAY}
-            >
-                <IconButton
-                    onClick={handleJobsToggle}
-                    aria-label="Toggle Jobs panel"
-                    className={
-                        activeView === "jobs" && panelVisible ? "jobs active" : "jobs"
-                    }
-                >
-                    <WorkHistoryIcon />
-                </IconButton>
-            </Tooltip>
+            <ToolbarIconButton
+                icon={<WorkHistoryIcon />}
+                tooltip="Jobs"
+                tooltipPlacement="left-start"
+                onClick={handleJobsToggle}
+                ariaLabel="Toggle Jobs panel"
+                className="jobs"
+                active={isActive("jobs")}
+            />
         </div>
     );
-};
+}
 
 VerticalToolbar.displayName = "VerticalToolbar";
 

--- a/web/src/components/panels/WorkflowAssistantChat.tsx
+++ b/web/src/components/panels/WorkflowAssistantChat.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, { useCallback, useEffect, useState, useMemo, memo } from "react";
-import { IconButton, Button, Popover } from "@mui/material";
-import { Tooltip } from "../ui_primitives";
+import { Button, Popover } from "@mui/material";
+import { ToolbarIconButton } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import ListIcon from "@mui/icons-material/List";
 import AddIcon from "@mui/icons-material/Add";
@@ -530,11 +530,11 @@ const WorkflowAssistantChat: React.FC = () => {
         }}
       >
         <NewChatButton onNewThread={handleNewChat} />
-        <Tooltip title="Chat History">
-          <IconButton onClick={handleOpenThreadList} size="small">
-            <ListIcon />
-          </IconButton>
-        </Tooltip>
+        <ToolbarIconButton
+          icon={<ListIcon />}
+          tooltip="Chat History"
+          onClick={handleOpenThreadList}
+        />
 
         <Popover
           open={isThreadListOpen}

--- a/web/src/components/ui_primitives/LoadingSpinner.tsx
+++ b/web/src/components/ui_primitives/LoadingSpinner.tsx
@@ -49,12 +49,18 @@ export type LoadingVariant = "circular" | "dots";
 export interface LoadingSpinnerProps {
   /** Loading variant */
   variant?: LoadingVariant;
-  /** Size of the spinner */
-  size?: "small" | "medium" | "large";
+  /** Size of the spinner. Preset strings map to fixed pixel sizes; a number
+   * overrides the preset (useful for inline spinners inside buttons, e.g. 16). */
+  size?: "small" | "medium" | "large" | number;
   /** Optional loading text */
   text?: string;
   /** Color override */
   color?: "primary" | "secondary" | "inherit";
+  /** Render just the spinner without the centered wrapper/role, for use inside
+   * buttons, chips, or other inline contexts. */
+  inline?: boolean;
+  /** CircularProgress stroke thickness (defaults to MUI default). */
+  thickness?: number;
   /** Custom class name */
   className?: string;
 }
@@ -64,11 +70,21 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   size = "medium",
   text,
   color = "primary",
+  inline = false,
+  thickness,
   className
 }) => {
   const theme = useTheme();
 
-  const circularSize = size === "small" ? 20 : size === "large" ? 48 : 32;
+  const circularSize =
+    typeof size === "number"
+      ? size
+      : size === "small"
+        ? 20
+        : size === "large"
+          ? 48
+          : 32;
+  const sizePreset = typeof size === "number" ? "small" : size;
 
   const renderContent = () => {
     switch (variant) {
@@ -82,13 +98,23 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
         );
       case "circular":
       default:
-        return <CircularProgress size={circularSize} color={color} />;
+        return (
+          <CircularProgress
+            size={circularSize}
+            color={color}
+            thickness={thickness}
+          />
+        );
     }
   };
 
+  if (inline) {
+    return renderContent();
+  }
+
   return (
     <Box
-      css={styles(theme, variant, size)}
+      css={styles(theme, variant, sizePreset)}
       className={`loading-spinner ${className || ""}`}
       role="status"
       aria-live="polite"

--- a/web/src/components/ui_primitives/ToolbarIconButton.tsx
+++ b/web/src/components/ui_primitives/ToolbarIconButton.tsx
@@ -92,6 +92,16 @@ export interface ToolbarIconButtonProps
    * Explicit aria-label for accessibility (required when tooltip is not a string)
    */
   ariaLabel?: string;
+  /**
+   * Render as an anchor element. When provided, `href`, `target`, and `rel` are forwarded.
+   */
+  component?: React.ElementType;
+  /** Link href (requires `component="a"`) */
+  href?: string;
+  /** Anchor target attribute */
+  target?: string;
+  /** Anchor rel attribute */
+  rel?: string;
 }
 
 /**

--- a/web/src/components/workspaces/WorkspacesManager.tsx
+++ b/web/src/components/workspaces/WorkspacesManager.tsx
@@ -10,16 +10,10 @@ import {
   ListItem,
   ListItemText,
   ListItemSecondaryAction,
-  IconButton,
-  Button,
-  TextField,
-  CircularProgress,
-  Chip,
   FormControlLabel,
   Checkbox
 } from "@mui/material";
 import React, { useCallback, useState, useEffect, memo } from "react";
-import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import AddIcon from "@mui/icons-material/Add";
@@ -36,7 +30,17 @@ import { useNotificationStore } from "../../stores/NotificationStore";
 import FileBrowserDialog from "../dialogs/FileBrowserDialog";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import PanelHeadline from "../ui/PanelHeadline";
-import { Dialog, Text, Tooltip, FlexRow } from "../ui_primitives";
+import {
+  Chip,
+  CloseButton,
+  Dialog,
+  EditorButton,
+  FlexRow,
+  LoadingSpinner,
+  Text,
+  TextInput,
+  ToolbarIconButton
+} from "../ui_primitives";
 
 const styles = (theme: Theme) =>
   css({
@@ -476,15 +480,11 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
           <PanelHeadline
             title="Workspaces Manager"
             actions={
-              <Tooltip title="Close">
-                <IconButton
-                  aria-label="close"
-                  onClick={onClose}
-                  className="close-button"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </Tooltip>
+              <CloseButton
+                onClick={onClose}
+                tooltip="Close"
+                className="close-button"
+              />
             }
           />
         </DialogTitle>
@@ -496,7 +496,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                 align="center"
                 sx={{ py: 4 }}
               >
-                <CircularProgress size={30} />
+                <LoadingSpinner size={30} />
               </FlexRow>
             ) : error ? (
               <Box className="empty-state">
@@ -506,12 +506,12 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                 <Text size="small" color="secondary" sx={{ mb: 2 }}>
                   Check your connection and try again
                 </Text>
-                <Button
+                <EditorButton
                   variant="outlined"
                   onClick={handleRetry}
                 >
                   Retry
-                </Button>
+                </EditorButton>
               </Box>
             ) : workspaces && workspaces.length > 0 ? (
               <List className="workspace-list">
@@ -519,7 +519,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                   <ListItem key={workspace.id} className="workspace-item">
                     {editingId === workspace.id ? (
                       <div className="edit-form">
-                        <TextField
+                        <TextInput
                           size="small"
                           value={editName}
                           onChange={handleEditNameChange}
@@ -535,16 +535,17 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                             }
                           }}
                         />
-                        <IconButton
-                          size="small"
+                        <ToolbarIconButton
+                          icon={<CheckIcon />}
+                          tooltip="Save changes"
                           onClick={createUpdateHandler(workspace.id)}
-                          color="primary"
-                        >
-                          <CheckIcon />
-                        </IconButton>
-                        <IconButton size="small" onClick={handleCancelEdit}>
-                          <CancelIcon />
-                        </IconButton>
+                          variant="primary"
+                        />
+                        <ToolbarIconButton
+                          icon={<CancelIcon />}
+                          tooltip="Cancel"
+                          onClick={handleCancelEdit}
+                        />
                       </div>
                     ) : (
                       <>
@@ -581,48 +582,39 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                           />
                         </div>
                         <ListItemSecondaryAction>
-                          <Tooltip
-                            title={
+                          <ToolbarIconButton
+                            icon={
+                              workspace.is_default ? (
+                                <StarIcon fontSize="small" />
+                              ) : (
+                                <StarBorderIcon fontSize="small" />
+                              )
+                            }
+                            tooltip={
                               workspace.is_default
                                 ? "Default workspace"
                                 : "Set as default"
                             }
-                          >
-                            <IconButton
-                              size="small"
-                              onClick={createToggleDefaultHandler(workspace)}
-                              sx={{
-                                color: workspace.is_default
-                                  ? "warning.main"
-                                  : "text.secondary",
-                                "&:hover": {
-                                  color: "warning.main"
-                                }
-                              }}
-                            >
-                              {workspace.is_default ? (
-                                <StarIcon fontSize="small" />
-                              ) : (
-                                <StarBorderIcon fontSize="small" />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Edit">
-                            <IconButton
-                              size="small"
-                              onClick={createStartEditHandler(workspace)}
-                            >
-                              <EditIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Delete">
-                            <IconButton
-                              size="small"
-                              onClick={createDeleteWorkspaceHandler(workspace.id)}
-                            >
-                              <DeleteIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
+                            onClick={createToggleDefaultHandler(workspace)}
+                            sx={{
+                              color: workspace.is_default
+                                ? "warning.main"
+                                : "text.secondary",
+                              "&:hover": {
+                                color: "warning.main"
+                              }
+                            }}
+                          />
+                          <ToolbarIconButton
+                            icon={<EditIcon fontSize="small" />}
+                            tooltip="Edit"
+                            onClick={createStartEditHandler(workspace)}
+                          />
+                          <ToolbarIconButton
+                            icon={<DeleteIcon fontSize="small" />}
+                            tooltip="Delete"
+                            onClick={createDeleteWorkspaceHandler(workspace.id)}
+                          />
                         </ListItemSecondaryAction>
                       </>
                     )}
@@ -643,7 +635,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
             <div className="add-workspace-section">
               {isAdding ? (
                 <div className="add-form">
-                  <TextField
+                  <TextInput
                     size="small"
                     label="Name"
                     value={newName}
@@ -653,7 +645,7 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                     autoFocus
                   />
                   <div className="form-row">
-                    <TextField
+                    <TextInput
                       size="small"
                       label="Path"
                       value={newPath}
@@ -661,13 +653,13 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                       placeholder="/path/to/folder"
                       fullWidth
                     />
-                    <Button
+                    <EditorButton
                       className="browse-button"
                       variant="outlined"
                       onClick={handleBrowse}
                     >
                       Browse
-                    </Button>
+                    </EditorButton>
                   </div>
                   <FormControlLabel
                     control={
@@ -684,29 +676,29 @@ const WorkspacesManager: React.FC<WorkspacesManagerProps> = ({
                     gap={1}
                     sx={{ mt: 1 }}
                   >
-                    <Button
+                    <EditorButton
                       onClick={handleCancelAdd}
                       color="inherit"
                     >
                       Cancel
-                    </Button>
-                    <Button
+                    </EditorButton>
+                    <EditorButton
                       variant="contained"
                       onClick={handleCreate}
                       disabled={createMutation.isPending}
                     >
                       {createMutation.isPending ? "Adding..." : "Add Workspace"}
-                    </Button>
+                    </EditorButton>
                   </FlexRow>
                 </div>
               ) : (
-                <Button
+                <EditorButton
                   startIcon={<AddIcon />}
                   onClick={handleAddWorkspace}
                   fullWidth
                 >
                   Add Workspace
-                </Button>
+                </EditorButton>
               )}
             </div>
           </div>


### PR DESCRIPTION
Replaces raw MUI imports (IconButton, Button, Chip, TextField, Tooltip,
CircularProgress) with their ui_primitives equivalents across the image
editor toolbar, panel toolbars, workspaces manager, and hugging_face
model list. Extends LoadingSpinner with inline/custom-size support for
in-button spinners and adds anchor-link props to ToolbarIconButton so it
can replace `<IconButton component="a" href="...">` patterns.

https://claude.ai/code/session_016ks8rRBAnjeauCxzbmcQLT