### PR TITLE
🎨 Palette: Add ARIA labels to node action buttons in ChainNodeCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2026-03-27 - Adding ARIA labels to CircularActionButton and DeleteButton with complex Tooltips
 **Learning:** Similar to `ToolbarIconButton` and `StateIconButton`, `CircularActionButton` and `DeleteButton` try to automatically extract an `aria-label` from their `tooltip` prop. If the `tooltip` prop receives a ReactNode, the `aria-label` becomes `undefined` or falls back to generic text, leaving the icon button inaccessible to screen readers or lacking specific context.
 **Action:** When using `CircularActionButton` or `DeleteButton` with a ReactNode tooltip, always explicitly provide the `ariaLabel` prop with a descriptive string. I've updated these components to explicitly support the `ariaLabel` prop.
+## 2025-02-12 - Added missing `aria-label`s to `IconButton` components
+**Learning:** Found that custom/complex components wrapped in MUI `IconButton` often drop context needed for screen readers if only icon nodes are provided as children, creating empty access labels for crucial UI actions.
+**Action:** When creating action buttons consisting strictly of an icon, ensure to explicitly pass an `aria-label` attribute on the bounding `IconButton` component to preserve accessibility.

--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -261,17 +261,17 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = ({
 
           {/* Actions */}
           <FlexRow gap={0.5} align="center">
-            <IconButton size="small" onClick={onMoveUp} disabled={index === 0}>
+            <IconButton aria-label="Move node up" size="small" onClick={onMoveUp} disabled={index === 0}>
               <ArrowUpwardIcon sx={{ fontSize: 18 }} />
             </IconButton>
-            <IconButton size="small" onClick={onMoveDown} disabled={index === totalNodes - 1}>
+            <IconButton aria-label="Move node down" size="small" onClick={onMoveDown} disabled={index === totalNodes - 1}>
               <ArrowDownwardIcon sx={{ fontSize: 18 }} />
             </IconButton>
             <Box sx={{ flex: 1 }} />
-            <IconButton size="small" onClick={onDuplicate}>
+            <IconButton aria-label="Duplicate node" size="small" onClick={onDuplicate}>
               <ContentCopyIcon sx={{ fontSize: 18 }} />
             </IconButton>
-            <IconButton size="small" onClick={onRemove} sx={{ color: theme.vars.palette.error.main }}>
+            <IconButton aria-label="Remove node" size="small" onClick={onRemove} sx={{ color: theme.vars.palette.error.main }}>
               <DeleteOutlineIcon sx={{ fontSize: 18 }} />
             </IconButton>
           </FlexRow>


### PR DESCRIPTION
💡 **What**: Added explicit `aria-label` attributes to the node action buttons (Move Up, Move Down, Duplicate, Remove) in `ChainNodeCard`.
🎯 **Why**: These `IconButton` elements previously only contained visual icons without accessible names, rendering them silent and unusable for screen reader users navigating the chain editor interface.
♿ **Accessibility**: Improves accessibility compliance by ensuring these critical actions have meaningful, descriptive labels when focused by assistive technologies.

---
*PR created automatically by Jules for task [9459046500504437923](https://jules.google.com/task/9459046500504437923) started by @georgi*