### PR TITLE
Fix falsy value handling and improve type safety across codebase

### DIFF
--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -52,12 +52,7 @@ const mainExternalModules = [
 export default defineConfig({
   base: "./",
   optimizeDeps: {
-    include: [
-      "superjson",
-      "@trpc/client",
-      "@trpc/react-query",
-      "@trpc/server"
-    ]
+    include: ["superjson", "@trpc/client", "@trpc/react-query"]
   },
   plugins: [
     react(),

--- a/mobile/src/trpc/client.ts
+++ b/mobile/src/trpc/client.ts
@@ -15,9 +15,12 @@ import { getApiHost } from '../services/apiHost';
 import { useAuthStore } from '../stores/AuthStore';
 
 /**
- * Build a tRPC client using the current API host and session token.
- * Calling this is cheap — each returned client uses the live host/token values
- * at request time through the `url` and `headers` factories.
+ * Build a tRPC client bound to the current API host.
+ *
+ * The host URL is captured at client-creation time (httpBatchLink resolves
+ * `url` once when the link is built), so callers must recreate the client
+ * whenever `getApiHost()` changes — the auth token, by contrast, is read
+ * per-request via the async `headers` factory.
  */
 export function createMobileTRPCClient() {
   return createTRPCClient<AppRouter>({

--- a/packages/protocol/src/api-schemas/mcp-config.ts
+++ b/packages/protocol/src/api-schemas/mcp-config.ts
@@ -32,14 +32,22 @@ export const installInput = z.object({
 export type InstallInput = z.infer<typeof installInput>;
 
 // Each result element has either success=true+configPath OR success=false+error.
-// We use a discriminated union so the client gets narrowing.
-export const installResult = z.object({
-  target: mcpTarget,
-  label: z.string(),
-  success: z.boolean(),
-  configPath: z.string().optional(),
-  error: z.string().optional()
-});
+// Modeled as a real discriminated union so clients get exhaustive narrowing
+// on `result.success` (true → configPath, false → error).
+export const installResult = z.discriminatedUnion("success", [
+  z.object({
+    target: mcpTarget,
+    label: z.string(),
+    success: z.literal(true),
+    configPath: z.string()
+  }),
+  z.object({
+    target: mcpTarget,
+    label: z.string(),
+    success: z.literal(false),
+    error: z.string()
+  })
+]);
 export type InstallResult = z.infer<typeof installResult>;
 
 export const installOutput = z.object({

--- a/packages/runtime/src/providers/provider-registry.ts
+++ b/packages/runtime/src/providers/provider-registry.ts
@@ -59,11 +59,13 @@ export async function getProvider(
     throw new Error(`No provider registered for "${providerId}"`);
   }
 
-  // Re-resolve any undefined/empty values via secret resolver (DB → env)
-  // or direct env var lookup as final fallback
+  // Re-resolve any unset values via secret resolver (DB → env) or direct env
+  // var lookup as final fallback. Only treat empty string / null / undefined
+  // as "needs resolution" so that valid falsy defaults (`0`, `false`) on
+  // numeric/boolean kwargs are preserved.
   const kwargs = { ...registration.kwargs };
   for (const [key, value] of Object.entries(kwargs)) {
-    if (!value) {
+    if (value === "" || value == null) {
       if (_secretResolver) {
         const resolved = await _secretResolver(key, userId);
         if (resolved) {
@@ -123,14 +125,19 @@ export async function isProviderConfigured(
   }
 
   // A kwarg is "required at runtime" when the registration declares the key
-  // with a falsy value — registerProvider() uses empty strings to mark
-  // credentials that must be resolved from the DB or environment. Non-empty
-  // registration values are defaults the constructor can use directly.
-  // Keys starting with "_" are treated as runtime injections (e.g. `_bridge`,
-  // `_id` for Python providers) and excluded from the required-credentials
-  // check since they can't be resolved via secret resolver or env vars.
+  // with an empty-string / null / undefined value — registerProvider() uses
+  // empty strings to mark credentials that must be resolved from the DB or
+  // environment. Non-empty registration values (including valid falsy
+  // defaults like `0` or `false`) are defaults the constructor can use
+  // directly. Keys starting with "_" are runtime injections (e.g.
+  // `_bridge`, `_id` for Python providers) and excluded from the
+  // required-credentials check since they can't be resolved via secret
+  // resolver or env vars.
   const required = Object.entries(reg.kwargs)
-    .filter(([key, value]) => !value && !key.startsWith("_"))
+    .filter(
+      ([key, value]) =>
+        (value === "" || value == null) && !key.startsWith("_")
+    )
     .map(([key]) => key);
 
   if (required.length === 0) {

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -64,7 +64,7 @@
     },
     "./trpc": {
       "nodetool-dev": "./src/trpc/router.ts",
-      "types": "./src/trpc/router.ts",
+      "types": "./dist/trpc/router.d.ts",
       "import": "./dist/trpc/router.js",
       "default": "./dist/trpc/router.js"
     }

--- a/packages/websocket/src/routes/files.ts
+++ b/packages/websocket/src/routes/files.ts
@@ -12,7 +12,9 @@ interface RouteOptions {
 }
 
 const filesRoutes: FastifyPluginAsync<RouteOptions> = async (app, _opts) => {
-  app.get("/api/files/download", async (req, reply) => {
+  // Register all methods so unsupported verbs reach the handler and get the
+  // explicit 405 response instead of Fastify's default 404.
+  app.all("/api/files/download", async (req, reply) => {
     await bridge(req, reply, (request) => handleFileRequest(request));
   });
 };

--- a/packages/websocket/src/routes/storage.ts
+++ b/packages/websocket/src/routes/storage.ts
@@ -15,15 +15,9 @@ const storageRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
   const { apiOptions } = opts;
   const storageHandler = createStorageHandler(apiOptions.storage);
 
-  app.head("/api/storage/*", async (req, reply) => {
-    await bridge(req, reply, (request) => storageHandler(request));
-  });
-
-  app.get("/api/storage/*", async (req, reply) => {
-    await bridge(req, reply, (request) => storageHandler(request));
-  });
-
-  app.put("/api/storage/*", async (req, reply) => {
+  // Register all methods so unsupported verbs (DELETE, POST, …) reach the
+  // handler and get a proper 405 instead of Fastify's default 404.
+  app.all("/api/storage/*", async (req, reply) => {
     await bridge(req, reply, (request) => storageHandler(request));
   });
 };

--- a/packages/websocket/src/trpc/routers/settings.ts
+++ b/packages/websocket/src/trpc/routers/settings.ts
@@ -146,6 +146,11 @@ export const settingsRouter = router({
   list: protectedProcedure.output(listOutput).query(async ({ ctx }) => {
     const userSettings = await Setting.listForUser(ctx.userId);
     const settingsMap = new Map(userSettings.map((s) => [s.key, s.value]));
+
+    // Fetch all secrets once and build a lookup map to avoid N+1 queries.
+    const [userSecrets] = await Secret.listForUser(ctx.userId, 1000);
+    const secretsMap = new Map(userSecrets.map((s) => [s.key, s]));
+
     const result: SettingWithValue[] = [];
 
     // Non-secret settings: read from DB then env.
@@ -166,7 +171,7 @@ export const settingsRouter = router({
     // Secrets: "****" if configured (DB or env), null otherwise.
     for (const def of getRegisteredSettings()) {
       if (!def.isSecret) continue;
-      const secret = await Secret.find(ctx.userId, def.envVar);
+      const hasSecret = secretsMap.has(def.envVar);
       const hasEnvVar = Boolean(process.env[def.envVar]);
       result.push({
         package_name: def.packageName,
@@ -174,7 +179,7 @@ export const settingsRouter = router({
         group: def.group,
         description: def.description,
         enum: null,
-        value: secret || hasEnvVar ? "****" : null,
+        value: hasSecret || hasEnvVar ? "****" : null,
         is_secret: true
       });
     }

--- a/packages/websocket/src/trpc/routers/workspace.ts
+++ b/packages/websocket/src/trpc/routers/workspace.ts
@@ -9,9 +9,9 @@
  * `NODETOOL_ENV=production` env var.
  */
 
-import { stat, readdir } from "node:fs/promises";
-import { existsSync, accessSync, constants } from "node:fs";
-import { resolve, join, isAbsolute } from "node:path";
+import { stat, readdir, access } from "node:fs/promises";
+import { existsSync, constants } from "node:fs";
+import { resolve, relative, join, isAbsolute } from "node:path";
 import { Workspace } from "@nodetool/models";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
@@ -125,7 +125,7 @@ export const workspaceRouter = router({
         throwApiError(ApiErrorCode.INVALID_INPUT, "Cannot access path");
       }
       try {
-        accessSync(input.path, constants.W_OK);
+        await access(input.path, constants.W_OK);
       } catch {
         throwApiError(ApiErrorCode.INVALID_INPUT, "Path is not writable");
       }
@@ -209,8 +209,11 @@ export const workspaceRouter = router({
       const workspacePath = resolve(workspace.path);
       const resolvedPath = resolve(join(workspacePath, queryPath));
 
-      // Path traversal check
-      if (!resolvedPath.startsWith(workspacePath)) {
+      // Path traversal check — boundary-safe: a sibling like `/tmp/ws-evil`
+      // would pass a naive `startsWith("/tmp/ws")`, so use `path.relative`
+      // and require the result to be empty or a non-`..` relative path.
+      const rel = relative(workspacePath, resolvedPath);
+      if (rel.startsWith("..") || isAbsolute(rel)) {
         throwApiError(ApiErrorCode.FORBIDDEN, "Path traversal not allowed");
       }
 

--- a/packages/websocket/tests/trpc-integration.test.ts
+++ b/packages/websocket/tests/trpc-integration.test.ts
@@ -70,7 +70,7 @@ describe("tRPC /trpc/settings.list over Fastify", () => {
     // Mock model reads to produce a deterministic (empty-DB) response so the
     // snapshot is the registry defaults with env/DB values resolved.
     vi.spyOn(Setting, "listForUser").mockResolvedValue([]);
-    vi.spyOn(Secret, "find").mockResolvedValue(null);
+    vi.spyOn(Secret, "listForUser").mockResolvedValue([[], ""]);
 
     const app = buildTestApp();
     await app.ready();

--- a/packages/websocket/tests/trpc-settings.test.ts
+++ b/packages/websocket/tests/trpc-settings.test.ts
@@ -107,7 +107,9 @@ describe("settings router", () => {
   describe("list", () => {
     it("returns an array of settings under `settings`", async () => {
       (Setting.listForUser as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      (Secret.find as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (Secret.listForUser as ReturnType<typeof vi.fn>).mockResolvedValue([
+        []
+      ]);
 
       const caller = createCaller(makeCtx());
       const result = await caller.settings.list();

--- a/packages/websocket/tests/trpc-workspace.test.ts
+++ b/packages/websocket/tests/trpc-workspace.test.ts
@@ -28,21 +28,21 @@ vi.mock("node:fs/promises", async (orig) => {
   return {
     ...actual,
     stat: vi.fn(),
-    readdir: vi.fn()
+    readdir: vi.fn(),
+    access: vi.fn()
   };
 });
 vi.mock("node:fs", async (orig) => {
   const actual = await orig<typeof import("node:fs")>();
   return {
     ...actual,
-    existsSync: vi.fn(),
-    accessSync: vi.fn()
+    existsSync: vi.fn()
   };
 });
 
 import { Workspace } from "@nodetool/models";
-import { stat, readdir } from "node:fs/promises";
-import { existsSync, accessSync } from "node:fs";
+import { stat, readdir, access } from "node:fs/promises";
+import { existsSync } from "node:fs";
 
 const createCaller = createCallerFactory(appRouter);
 
@@ -189,7 +189,7 @@ describe("workspace router", () => {
       (stat as ReturnType<typeof vi.fn>).mockResolvedValue({
         isDirectory: () => true
       });
-      (accessSync as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      (access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
       const ws = makeWorkspace({
         id: "new-ws",
         name: "New",
@@ -216,7 +216,7 @@ describe("workspace router", () => {
       (stat as ReturnType<typeof vi.fn>).mockResolvedValue({
         isDirectory: () => true
       });
-      (accessSync as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      (access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
       (Workspace.create as ReturnType<typeof vi.fn>).mockResolvedValue(
         makeWorkspace({ is_default: true })
       );
@@ -261,9 +261,9 @@ describe("workspace router", () => {
       (stat as ReturnType<typeof vi.fn>).mockResolvedValue({
         isDirectory: () => true
       });
-      (accessSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error("EACCES");
-      });
+      (access as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("EACCES")
+      );
       const caller = createCaller(makeCtx());
       await expect(
         caller.workspace.create({ name: "x", path: "/read/only" })


### PR DESCRIPTION
## Summary
This PR addresses several correctness and type safety issues across the codebase, primarily focusing on proper handling of falsy values (like `0` and `false`) in provider configuration, improving discriminated union types, fixing async/sync API mismatches, and preventing path traversal vulnerabilities.

## Key Changes

### Provider Registry & Configuration
- **Fixed falsy value handling in provider kwargs**: Changed condition from `!value` to `value === "" || value == null` to preserve valid falsy defaults like `0` and `false` on numeric/boolean parameters, while still treating empty strings, null, and undefined as "needs resolution"
- Updated comments to clarify the distinction between unset values and valid falsy defaults
- Applied the same fix to the `isProviderConfigured` function's required credentials check

### Type Safety Improvements
- **Converted `installResult` to a proper discriminated union**: Changed from optional fields to a real Zod discriminated union on the `success` field, enabling exhaustive type narrowing for clients (true → `configPath` required, false → `error` required)

### Async/Sync API Corrections
- **Workspace router**: Replaced synchronous `accessSync()` with async `access()` from `node:fs/promises` for consistency with async context
- Updated test mocks to use `mockResolvedValue` and `mockRejectedValue` instead of `mockReturnValue` and `mockImplementation`
- Updated imports to reflect the API changes

### Path Traversal Security
- **Improved path traversal check**: Replaced naive `startsWith()` check with `path.relative()` to prevent boundary confusion (e.g., `/tmp/ws-evil` bypassing `/tmp/ws` check)
- Added validation that relative path doesn't start with `..` or is absolute

### Performance & Correctness
- **Settings router**: Optimized secret lookup from N+1 queries to single batch fetch using `Secret.listForUser()` with a lookup map
- Updated test mocks to match the new batch API

### HTTP Route Handling
- **Storage and files routes**: Changed from registering specific HTTP methods (GET, HEAD, PUT) to `app.all()` to ensure unsupported verbs reach the handler for proper 405 responses instead of Fastify's default 404

### Build Configuration
- **Electron vite config**: Removed `@trpc/server` from optimizeDeps (likely unused or causing issues)
- **Package.json exports**: Fixed `./trpc` export types path from source to compiled output (`./dist/trpc/router.d.ts`)

### Test Updates
- Updated settings and integration tests to use `Secret.listForUser()` instead of `Secret.find()`
- Updated mobile tRPC client documentation to clarify that the host URL is captured at client-creation time

https://claude.ai/code/session_01XjF8uCiiE3Xsi9NoRJiYoX