### PR TITLE
Add Moonshot AI (Kimi) provider support

### DIFF
--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -16,6 +16,7 @@ import {
   GeminiProvider,
   MistralProvider,
   GroqProvider,
+  MoonshotProvider,
   ClaudeAgentProvider,
   BaseProvider as BaseProviderClass
 } from "@nodetool/runtime";
@@ -30,6 +31,7 @@ export const KNOWN_PROVIDERS = [
   "gemini",
   "mistral",
   "groq",
+  "moonshot",
   "claude_agent"
 ] as const;
 export type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
@@ -42,6 +44,7 @@ export const DEFAULT_MODELS: Record<string, string> = {
   gemini: "gemini-2.0-flash",
   mistral: "mistral-large-latest",
   groq: "llama-3.3-70b-versatile",
+  moonshot: "kimi-k2-turbo-preview",
   claude_agent: "claude-opus-4-6"
 };
 
@@ -78,6 +81,10 @@ export async function createProvider(
       return new GroqProvider({
         GROQ_API_KEY: await resolveKey("GROQ_API_KEY")
       });
+    case "moonshot":
+      return new MoonshotProvider({
+        MOONSHOT_API_KEY: await resolveKey("MOONSHOT_API_KEY")
+      });
     case "claude_agent":
       return new ClaudeAgentProvider();
     default:
@@ -95,6 +102,7 @@ export function availableProviders(): string[] {
   if (process.env["GEMINI_API_KEY"]) available.push("gemini");
   if (process.env["MISTRAL_API_KEY"]) available.push("mistral");
   if (process.env["GROQ_API_KEY"]) available.push("groq");
+  if (process.env["MOONSHOT_API_KEY"]) available.push("moonshot");
   available.push("ollama"); // always available (local)
   return available;
 }

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -58,6 +58,12 @@ vi.mock("@nodetool/runtime", () => {
         void cfg;
       }
     },
+    MoonshotProvider: class extends FakeProvider {
+      constructor(cfg: Record<string, unknown>) {
+        super("moonshot");
+        void cfg;
+      }
+    },
     BaseProvider: FakeProvider
   };
 });
@@ -76,6 +82,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "");
     vi.stubEnv("MISTRAL_API_KEY", "");
     vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
     const { availableProviders } = await import("../src/providers.js");
     expect(availableProviders()).toEqual(["ollama"]);
   });
@@ -86,6 +93,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "");
     vi.stubEnv("MISTRAL_API_KEY", "");
     vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
     const { availableProviders } = await import("../src/providers.js");
     const providers = availableProviders();
     expect(providers).toContain("anthropic");
@@ -98,6 +106,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "");
     vi.stubEnv("MISTRAL_API_KEY", "");
     vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
     const { availableProviders } = await import("../src/providers.js");
     const providers = availableProviders();
     expect(providers).toContain("openai");
@@ -109,6 +118,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "c");
     vi.stubEnv("MISTRAL_API_KEY", "d");
     vi.stubEnv("GROQ_API_KEY", "e");
+    vi.stubEnv("MOONSHOT_API_KEY", "f");
     const { availableProviders } = await import("../src/providers.js");
     const providers = availableProviders();
     expect(providers).toContain("anthropic");
@@ -116,6 +126,7 @@ describe("availableProviders", () => {
     expect(providers).toContain("gemini");
     expect(providers).toContain("mistral");
     expect(providers).toContain("groq");
+    expect(providers).toContain("moonshot");
     expect(providers).toContain("ollama");
   });
 
@@ -125,6 +136,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "");
     vi.stubEnv("MISTRAL_API_KEY", "");
     vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
     const { availableProviders } = await import("../src/providers.js");
     const providers = availableProviders();
     expect(providers[providers.length - 1]).toBe("ollama");
@@ -136,6 +148,7 @@ describe("availableProviders", () => {
     vi.stubEnv("GEMINI_API_KEY", "test-gemini");
     vi.stubEnv("MISTRAL_API_KEY", "");
     vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
     const { availableProviders } = await import("../src/providers.js");
     expect(availableProviders()).toEqual(["anthropic", "gemini", "ollama"]);
   });
@@ -153,7 +166,8 @@ describe("KNOWN_PROVIDERS", () => {
       "ollama",
       "gemini",
       "mistral",
-      "groq"
+      "groq",
+      "moonshot"
     ];
     for (const p of expected) {
       expect(KNOWN_PROVIDERS).toContain(p);
@@ -235,6 +249,13 @@ describe("createProvider", () => {
     const { createProvider } = await import("../src/providers.js");
     const provider = await createProvider("groq");
     expect((provider as unknown as { id: string }).id).toBe("groq");
+  });
+
+  it("creates a MoonshotProvider for 'moonshot'", async () => {
+    vi.stubEnv("MOONSHOT_API_KEY", "test-moonshot");
+    const { createProvider } = await import("../src/providers.js");
+    const provider = await createProvider("moonshot");
+    expect((provider as unknown as { id: string }).id).toBe("moonshot");
   });
 
   it("falls back to OllamaProvider for an unknown provider id", async () => {

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -15,6 +15,7 @@ import { OpenAIProvider } from "./openai-provider.js";
 import { OllamaProvider } from "./ollama-provider.js";
 import { GroqProvider } from "./groq-provider.js";
 import { MistralProvider } from "./mistral-provider.js";
+import { MoonshotProvider } from "./moonshot-provider.js";
 import { OpenRouterProvider } from "./openrouter-provider.js";
 import { TogetherProvider } from "./together-provider.js";
 import { CerebrasProvider } from "./cerebras-provider.js";
@@ -44,6 +45,7 @@ export { OpenAIProvider };
 export { OllamaProvider };
 export { GroqProvider };
 export { MistralProvider };
+export { MoonshotProvider };
 export { OpenRouterProvider };
 export { TogetherProvider };
 export { CerebrasProvider };
@@ -129,6 +131,9 @@ registerBuiltinProvider("groq", GroqProvider, {
 });
 registerBuiltinProvider("mistral", MistralProvider, {
   MISTRAL_API_KEY: process.env["MISTRAL_API_KEY"]
+});
+registerBuiltinProvider("moonshot", MoonshotProvider, {
+  MOONSHOT_API_KEY: process.env["MOONSHOT_API_KEY"]
 });
 registerBuiltinProvider("replicate", ReplicateProvider, {
   REPLICATE_API_TOKEN: process.env["REPLICATE_API_TOKEN"]

--- a/packages/runtime/src/providers/moonshot-provider.ts
+++ b/packages/runtime/src/providers/moonshot-provider.ts
@@ -1,0 +1,69 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicProvider } from "./anthropic-provider.js";
+import type { LanguageModel } from "./types.js";
+
+const MOONSHOT_BASE_URL = "https://api.kimi.com/coding";
+
+interface MoonshotProviderOptions {
+  client?: Anthropic;
+  clientFactory?: (apiKey: string) => Anthropic;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Moonshot AI (Kimi) provider. Uses the Anthropic SDK against Moonshot's
+ * Claude-compatible endpoint exposed to Kimi coding plan subscribers at
+ * https://api.kimi.com/coding.
+ */
+export class MoonshotProvider extends AnthropicProvider {
+  static override requiredSecrets(): string[] {
+    return ["MOONSHOT_API_KEY"];
+  }
+
+  constructor(
+    secrets: { MOONSHOT_API_KEY?: string },
+    options: MoonshotProviderOptions = {}
+  ) {
+    const apiKey = secrets.MOONSHOT_API_KEY;
+    if (!apiKey || !apiKey.trim()) {
+      throw new Error("MOONSHOT_API_KEY is not configured");
+    }
+
+    super(
+      { ANTHROPIC_API_KEY: apiKey },
+      {
+        client: options.client,
+        clientFactory:
+          options.clientFactory ??
+          ((key) =>
+            new Anthropic({
+              apiKey: key,
+              baseURL: MOONSHOT_BASE_URL
+            })),
+        fetchFn: options.fetchFn
+      }
+    );
+
+    (this as { provider: string }).provider = "moonshot";
+  }
+
+  override getContainerEnv(): Record<string, string> {
+    return {
+      MOONSHOT_API_KEY: this.apiKey,
+      ANTHROPIC_BASE_URL: MOONSHOT_BASE_URL
+    };
+  }
+
+  override async hasToolSupport(_model: string): Promise<boolean> {
+    return true;
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const knownModels = [
+      "kimi-k2-turbo-preview",
+      "kimi-k2-0905-preview",
+      "kimi-k2-0711-preview"
+    ];
+    return knownModels.map((id) => ({ id, name: id, provider: "moonshot" }));
+  }
+}

--- a/packages/runtime/tests/providers/moonshot-provider.test.ts
+++ b/packages/runtime/tests/providers/moonshot-provider.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { MoonshotProvider } from "../../src/providers/moonshot-provider.js";
+
+describe("MoonshotProvider", () => {
+  it("reports required secrets and container env", () => {
+    const provider = new MoonshotProvider(
+      { MOONSHOT_API_KEY: "k" },
+      { client: {} as any }
+    );
+
+    expect(MoonshotProvider.requiredSecrets()).toEqual(["MOONSHOT_API_KEY"]);
+    expect(provider.getContainerEnv()).toEqual({
+      MOONSHOT_API_KEY: "k",
+      ANTHROPIC_BASE_URL: "https://api.kimi.com/coding"
+    });
+    expect((provider as unknown as { provider: string }).provider).toBe(
+      "moonshot"
+    );
+  });
+
+  it("throws when MOONSHOT_API_KEY is missing", () => {
+    expect(() => new MoonshotProvider({}, { client: {} as any })).toThrow(
+      "MOONSHOT_API_KEY is not configured"
+    );
+  });
+
+  it("uses custom clientFactory with Kimi baseURL", () => {
+    const clientFactory = vi.fn().mockReturnValue({ messages: { create: vi.fn() } });
+    const provider = new MoonshotProvider(
+      { MOONSHOT_API_KEY: "kimi-key" },
+      { clientFactory }
+    );
+
+    // Force lazy client creation
+    provider.getClient();
+    expect(clientFactory).toHaveBeenCalledWith("kimi-key");
+  });
+
+  it("reports tool support for kimi models", async () => {
+    const provider = new MoonshotProvider(
+      { MOONSHOT_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(await provider.hasToolSupport("kimi-k2-turbo-preview")).toBe(true);
+  });
+
+  it("returns known Kimi models", async () => {
+    const provider = new MoonshotProvider(
+      { MOONSHOT_API_KEY: "k" },
+      { client: {} as any }
+    );
+    const models = await provider.getAvailableLanguageModels();
+    expect(models.length).toBeGreaterThan(0);
+    for (const model of models) {
+      expect(model.provider).toBe("moonshot");
+      expect(model.id).toMatch(/^kimi-/);
+    }
+  });
+
+  it("generates messages through the underlying Anthropic client", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "hello from kimi" }]
+    });
+
+    const provider = new MoonshotProvider(
+      { MOONSHOT_API_KEY: "k" },
+      {
+        client: {
+          messages: { create }
+        } as any
+      }
+    );
+
+    await expect(
+      provider.generateMessage({
+        model: "kimi-k2-turbo-preview",
+        messages: [{ role: "user", content: "hi" }]
+      })
+    ).resolves.toEqual({
+      role: "assistant",
+      content: "hello from kimi",
+      toolCalls: []
+    });
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -254,6 +254,11 @@ sec(
   "Mistral API key for accessing Mistral AI models"
 );
 sec(
+  "MOONSHOT_API_KEY",
+  "Moonshot",
+  "Moonshot (Kimi) API key for accessing Kimi models via the Claude-compatible endpoint"
+);
+sec(
   "MINIMAX_API_KEY",
   "MiniMax",
   "MiniMax API key for accessing MiniMax AI models"

--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -36,7 +36,8 @@ const SETTING_LINKS: Record<string, string> = {
   ELEVENLABS_API_KEY: "https://elevenlabs.io/subscription",
   FAL_API_KEY: "https://fal.ai/dashboard/keys",
   SERPAPI_API_KEY: "https://serpapi.com/manage-api-key",
-  DATA_FOR_SEO_LOGIN: "https://app.dataforseo.com/api-dashboard"
+  DATA_FOR_SEO_LOGIN: "https://app.dataforseo.com/api-dashboard",
+  MOONSHOT_API_KEY: "https://platform.moonshot.ai/console/api-keys"
 };
 
 const SETTING_BUTTON_TITLES: Record<string, string> = {
@@ -51,7 +52,8 @@ const SETTING_BUTTON_TITLES: Record<string, string> = {
   ELEVENLABS_API_KEY: "Get ElevenLabs API Key",
   FAL_API_KEY: "Get Fal API Key",
   SERPAPI_API_KEY: "Get SerpAPI API Key",
-  DATA_FOR_SEO_LOGIN: "Get DataForSEO Credentials"
+  DATA_FOR_SEO_LOGIN: "Get DataForSEO Credentials",
+  MOONSHOT_API_KEY: "Get Moonshot API Key"
 };
 
 const SETTING_TOOLTIPS: Record<string, string> = {
@@ -66,7 +68,8 @@ const SETTING_TOOLTIPS: Record<string, string> = {
   ELEVENLABS_API_KEY: "Go to ElevenLabs subscription page",
   FAL_API_KEY: "Go to Fal.ai dashboard",
   SERPAPI_API_KEY: "Go to SerpAPI key management page",
-  DATA_FOR_SEO_LOGIN: "Go to DataForSEO dashboard"
+  DATA_FOR_SEO_LOGIN: "Go to DataForSEO dashboard",
+  MOONSHOT_API_KEY: "Go to Moonshot (Kimi) platform API keys page"
 };
 
 interface SettingItemProps {

--- a/web/src/stores/ModelMenuStore.ts
+++ b/web/src/stores/ModelMenuStore.ts
@@ -63,6 +63,7 @@ export const requiredSecretForProvider = (provider?: string): string | null => {
   if (p.includes("replicate")) {return "REPLICATE_API_TOKEN";}
   if (p.includes("fal")) {return "FAL_API_KEY";}
   if (p.includes("aime")) {return "AIME_API_KEY";}
+  if (p.includes("moonshot") || p.includes("kimi")) {return "MOONSHOT_API_KEY";}
   return null;
 };
 
@@ -71,6 +72,7 @@ export const ALL_PROVIDERS = [
   "anthropic",
   "claude_agent",
   "gemini",
+  "moonshot",
   "replicate",
   "ollama",
   "llama_cpp",

--- a/web/src/stores/__tests__/ModelMenuStore.test.ts
+++ b/web/src/stores/__tests__/ModelMenuStore.test.ts
@@ -43,6 +43,12 @@ describe("ModelMenuStore", () => {
       expect(requiredSecretForProvider("aime")).toBe("AIME_API_KEY");
     });
 
+    it("returns MOONSHOT_API_KEY for Moonshot/Kimi provider", () => {
+      expect(requiredSecretForProvider("moonshot")).toBe("MOONSHOT_API_KEY");
+      expect(requiredSecretForProvider("Moonshot")).toBe("MOONSHOT_API_KEY");
+      expect(requiredSecretForProvider("kimi")).toBe("MOONSHOT_API_KEY");
+    });
+
     it("returns null for providers without required secrets", () => {
       expect(requiredSecretForProvider("ollama")).toBeNull();
       expect(requiredSecretForProvider("local")).toBeNull();

--- a/web/src/utils/__tests__/providerDisplay.test.ts
+++ b/web/src/utils/__tests__/providerDisplay.test.ts
@@ -126,6 +126,12 @@ describe("providerDisplay", () => {
       expect(formatGenericProviderName("zai")).toBe("Z.AI");
     });
 
+    it("should handle special case for Moonshot (Kimi)", () => {
+      expect(formatGenericProviderName("moonshot")).toBe("Moonshot AI");
+      expect(formatGenericProviderName("Moonshot")).toBe("Moonshot AI");
+      expect(formatGenericProviderName("kimi")).toBe("Moonshot AI");
+    });
+
     it("should add spaces before capitals", () => {
       expect(formatGenericProviderName("OpenAI")).toBe("Open Ai");
       expect(formatGenericProviderName("BlackForestLabs")).toBe("Black Forest Labs");
@@ -181,6 +187,8 @@ describe("providerDisplay", () => {
       expect(getProviderUrl("zai")).toBe("https://z.ai");
       expect(getProviderUrl("zai-org")).toBe("https://z.ai");
       expect(getProviderUrl("Z.AI")).toBe("https://z.ai");
+      expect(getProviderUrl("moonshot")).toBe("https://platform.moonshot.ai");
+      expect(getProviderUrl("kimi")).toBe("https://platform.moonshot.ai");
     });
 
     it("should return null for unknown providers", () => {

--- a/web/src/utils/providerDisplay.ts
+++ b/web/src/utils/providerDisplay.ts
@@ -121,6 +121,7 @@ export const formatGenericProviderName = (provider?: string): string => {
   if (providerLower === "google") {return "Gemini";}
   if (providerLower === "fal_ai" || providerLower === "fal-ai" || providerLower === "falai") {return "FAL AI";}
   if (providerLower === "zai-org" || providerLower === "zai_org" || providerLower === "zai") {return "Z.AI";}
+  if (providerLower === "moonshot" || providerLower === "kimi") {return "Moonshot AI";}
   const withSpaces = insertSpacesBeforeCapitals(
     provider.replace(/_/g, " ").replace(/-/g, " ")
   );
@@ -203,6 +204,8 @@ export const getProviderUrl = (provider?: string): string | null => {
   if (providerLower.includes("fal")) {return "https://fal.ai";}
   if (providerLower.includes("replicate")) {return "https://replicate.com";}
   if (providerLower.includes("aime")) {return "https://www.aime.info/en/";}
+  if (providerLower.includes("moonshot") || providerLower.includes("kimi"))
+    {return "https://platform.moonshot.ai";}
   if (providerLower === "zai" || providerLower === "zai-org" || providerLower === "zai_org" || providerLower === "z.ai")
     {return "https://z.ai";}
   // Unknown


### PR DESCRIPTION
## Summary
This PR adds support for Moonshot AI (Kimi) as a language model provider. Moonshot AI provides a Claude-compatible API endpoint that allows users to access Kimi models through the Anthropic SDK.

## Key Changes

- **New MoonshotProvider class** (`packages/runtime/src/providers/moonshot-provider.ts`):
  - Extends `AnthropicProvider` to leverage existing Anthropic SDK integration
  - Configures the Anthropic client to use Moonshot's Claude-compatible endpoint at `https://api.kimi.com/coding`
  - Requires `MOONSHOT_API_KEY` environment variable
  - Supports three Kimi models: `kimi-k2-turbo-preview`, `kimi-k2-0905-preview`, `kimi-k2-0711-preview`
  - Reports full tool support for all Kimi models

- **Provider registration and integration**:
  - Registered in `packages/runtime/src/providers/index.ts`
  - Added to CLI provider factory in `packages/cli/src/providers.ts` with default model `kimi-k2-turbo-preview`
  - Added to `KNOWN_PROVIDERS` list and availability detection logic

- **UI/UX updates**:
  - Added Moonshot API key configuration links and tooltips in `web/src/components/menus/RemoteSettingsMenu.tsx`
  - Added provider display formatting for "moonshot" and "kimi" aliases in `web/src/utils/providerDisplay.ts`
  - Added provider URL mapping to Moonshot platform in `web/src/utils/providerDisplay.ts`
  - Updated `ModelMenuStore.ts` to recognize Moonshot/Kimi provider and return correct secret key

- **Settings and documentation**:
  - Added `MOONSHOT_API_KEY` to settings registry in `packages/websocket/src/settings-registry.ts`

- **Comprehensive test coverage**:
  - Added full test suite in `packages/runtime/tests/providers/moonshot-provider.test.ts` covering:
    - Required secrets and container environment configuration
    - Error handling for missing API key
    - Client factory initialization
    - Tool support reporting
    - Available models listing
    - Message generation through the Anthropic client
  - Updated CLI provider tests to include Moonshot in availability and creation tests

## Implementation Details

The `MoonshotProvider` leverages the existing `AnthropicProvider` implementation by:
- Passing the Moonshot API key as the Anthropic API key
- Configuring a custom client factory that sets the base URL to Moonshot's endpoint
- Overriding `getContainerEnv()` to expose the correct environment variables
- Providing a hardcoded list of known Kimi models since Moonshot doesn't expose a models API

This approach minimizes code duplication while maintaining full compatibility with the Anthropic SDK's message generation interface.

https://claude.ai/code/session_01CsxHcvWUspfHNaRiDQmZn3