### PR TITLE
Improve native module rebuild discovery for Electron packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Sync package versions to release tag

--- a/electron/scripts/after-pack.cjs
+++ b/electron/scripts/after-pack.cjs
@@ -49,6 +49,41 @@ async function promoteBackendNodeModules(context) {
   }
 }
 
+// Walk the staged node_modules and collect names of packages that contain a
+// binding.gyp (i.e. need a node-gyp rebuild against Electron's ABI).
+// @electron/rebuild's default discovery walks `dependencies` listed in
+// buildPath/package.json, but the backend bundle's package.json only
+// declares `{ "type": "module" }` with no deps, so without an explicit
+// list the rebuild would silently skip everything and leave the workspace's
+// system-Node ABI binaries in place.
+function findNativeModuleNames(nodeModulesPath) {
+  const names = [];
+  if (!fs.existsSync(nodeModulesPath)) return names;
+
+  const hasBindingGyp = (pkgPath) =>
+    fs.existsSync(path.join(pkgPath, "binding.gyp"));
+
+  for (const entry of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    if (entry.name.startsWith("@")) {
+      const scopeDir = path.join(nodeModulesPath, entry.name);
+      for (const sub of fs.readdirSync(scopeDir, { withFileTypes: true })) {
+        if (!sub.isDirectory()) continue;
+        const pkgPath = path.join(scopeDir, sub.name);
+        if (hasBindingGyp(pkgPath)) {
+          names.push(`${entry.name}/${sub.name}`);
+        }
+      }
+      continue;
+    }
+    const pkgPath = path.join(nodeModulesPath, entry.name);
+    if (hasBindingGyp(pkgPath)) {
+      names.push(entry.name);
+    }
+  }
+  return names;
+}
+
 async function rebuildNativeModulesForElectron(context) {
   const { rebuild } = require("@electron/rebuild");
   const resourcesDir = resolveResourcesDir(context);
@@ -58,13 +93,26 @@ async function rebuildNativeModulesForElectron(context) {
     ?? require("electron/package.json").version;
   const arch = typeof context.arch === "string" ? context.arch : ["ia32","x64","armv7l","arm64","universal"][context.arch] ?? "x64";
 
-  console.info(`Rebuilding native backend modules for Electron ${electronVersion} (${arch})...`);
+  const runtimeNodeModulesPath = path.join(backendDir, "node_modules");
+  const onlyModules = findNativeModuleNames(runtimeNodeModulesPath);
+
+  if (onlyModules.length === 0) {
+    throw new Error(
+      `No native modules found to rebuild in ${runtimeNodeModulesPath}. ` +
+      `Expected at least better-sqlite3. Did bundle-backend.mjs stage modules correctly?`
+    );
+  }
+
+  console.info(
+    `Rebuilding ${onlyModules.length} native backend module(s) for Electron ${electronVersion} (${arch}): ${onlyModules.join(", ")}`
+  );
 
   await rebuild({
     buildPath: backendDir,
     electronVersion,
     arch,
     force: true,
+    onlyModules,
   });
 
   console.info("Native backend module rebuild complete.");
@@ -82,3 +130,4 @@ module.exports = async function afterPack(context) {
 
 module.exports.promoteBackendNodeModules = promoteBackendNodeModules;
 module.exports.resolveResourcesDir = resolveResourcesDir;
+module.exports.findNativeModuleNames = findNativeModuleNames;

--- a/electron/src/__tests__/afterPack.test.ts
+++ b/electron/src/__tests__/afterPack.test.ts
@@ -3,9 +3,10 @@ import * as os from "os";
 import * as path from "path";
 
 // Use require for CJS module to avoid ESM interop issues across Node versions
- 
+
 const afterPack = require("../../scripts/after-pack.cjs") as {
   promoteBackendNodeModules: (context: Record<string, unknown>) => Promise<void>;
+  findNativeModuleNames: (nodeModulesPath: string) => string[];
 };
 
 describe("promoteBackendNodeModules", () => {
@@ -53,5 +54,53 @@ describe("promoteBackendNodeModules", () => {
       "utf8"
     );
     expect(packageJson).toContain('"name":"openai"');
+  });
+});
+
+describe("findNativeModuleNames", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "nodetool-find-native-")
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("detects top-level and scoped packages that ship a binding.gyp", async () => {
+    const makePkg = async (relPath: string, withBindingGyp: boolean) => {
+      const pkgDir = path.join(tempDir, relPath);
+      await fs.promises.mkdir(pkgDir, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(pkgDir, "package.json"),
+        `{"name":"${relPath.replace(/\\/g, "/")}"}\n`
+      );
+      if (withBindingGyp) {
+        await fs.promises.writeFile(path.join(pkgDir, "binding.gyp"), "{}\n");
+      }
+    };
+
+    await makePkg("better-sqlite3", true);
+    await makePkg("bufferutil", true);
+    await makePkg("openai", false);
+    await makePkg(path.join("@napi-rs", "canvas"), true);
+    await makePkg(path.join("@aws-sdk", "client-s3"), false);
+
+    const names = afterPack.findNativeModuleNames(tempDir);
+    expect(names).toEqual(
+      expect.arrayContaining(["better-sqlite3", "bufferutil", "@napi-rs/canvas"])
+    );
+    expect(names).not.toContain("openai");
+    expect(names).not.toContain("@aws-sdk/client-s3");
+  });
+
+  it("returns an empty list when node_modules does not exist", () => {
+    const names = afterPack.findNativeModuleNames(
+      path.join(tempDir, "does-not-exist")
+    );
+    expect(names).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
This PR improves the native module rebuild process during Electron packaging by explicitly discovering and rebuilding only the native modules that are actually present, rather than relying on implicit dependency resolution.

## Key Changes
- **Added `findNativeModuleNames()` function**: Walks the staged `node_modules` directory to discover packages containing `binding.gyp` files (indicating native modules requiring node-gyp rebuild). Handles both top-level and scoped packages (e.g., `@napi-rs/canvas`).
- **Enhanced native module rebuild logic**: 
  - Now explicitly passes discovered native module names to `@electron/rebuild` via the `onlyModules` parameter
  - Adds validation to ensure at least one native module is found (fails fast if the backend bundle wasn't staged correctly)
  - Improves logging to show which modules are being rebuilt
- **Added comprehensive test coverage**: New test suite for `findNativeModuleNames()` covering scoped packages, top-level packages, and edge cases
- **Updated Node.js version**: Bumped CI Node.js version from 22 to 24

## Implementation Details
The `findNativeModuleNames()` function:
- Returns an empty array if `node_modules` doesn't exist (graceful handling)
- Recursively checks scoped packages (directories starting with `@`)
- Skips hidden directories and non-directory entries
- Collects package names in the format expected by `@electron/rebuild`

This approach solves the issue where `@electron/rebuild`'s default discovery would silently skip all modules because the backend bundle's `package.json` declares no dependencies, leaving stale system-Node ABI binaries in place.

https://claude.ai/code/session_01FLYYiC3SNZmWvezQqfo345