### PR TITLE
Add libsecret system dependency for keytar on Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install system libraries for keytar (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Configure node-gyp Python path
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Added installation of the `libsecret-1-dev` system library in the release workflow for Linux builds to support the keytar native module compilation.

## Key Changes
- Added a new workflow step that installs `libsecret-1-dev` on Ubuntu runners before node-gyp configuration
- This step only runs on `ubuntu-latest` to avoid unnecessary installation on other platforms

## Implementation Details
The `libsecret-1-dev` library is a required system dependency for building keytar (a native Node.js module for secure credential storage) on Linux systems. Without this library, the native module compilation would fail during the release build process. The installation is performed early in the workflow, right after Python setup and before node-gyp configuration.

https://claude.ai/code/session_01PyREMPd3nBp1QVALkvLXZe