### PR TITLE
Add sandbox infrastructure for isolated agent execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "packages/kie-nodes",
         "packages/sandbox",
         "packages/sandbox-agent",
+        "packages/sandbox-tools",
         "web",
         "electron"
       ],
@@ -10680,6 +10681,10 @@
     },
     "node_modules/@nodetool/sandbox-agent": {
       "resolved": "packages/sandbox-agent",
+      "link": true
+    },
+    "node_modules/@nodetool/sandbox-tools": {
+      "resolved": "packages/sandbox-tools",
       "link": true
     },
     "node_modules/@nodetool/security": {
@@ -39320,6 +39325,8 @@
         "@nodetool/protocol": "*",
         "@nodetool/replicate-nodes": "*",
         "@nodetool/runtime": "*",
+        "@nodetool/sandbox": "*",
+        "@nodetool/sandbox-tools": "*",
         "@nodetool/security": "*",
         "@nodetool/websocket": "*",
         "@trpc/client": "^11.0.0",
@@ -39678,6 +39685,21 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsx": "^4.19.2",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      }
+    },
+    "packages/sandbox-tools": {
+      "name": "@nodetool/sandbox-tools",
+      "version": "0.1.0",
+      "dependencies": {
+        "@nodetool/agents": "*",
+        "@nodetool/runtime": "*",
+        "@nodetool/sandbox": "*",
+        "zod": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39672,6 +39672,7 @@
         "@fastify/multipart": "^9.0.0",
         "@nodetool/sandbox": "*",
         "fastify": "^5.1.0",
+        "playwright": "^1.49.0",
         "zod": "^4.0.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "packages/elevenlabs-nodes",
         "packages/kie-codegen",
         "packages/kie-nodes",
+        "packages/sandbox",
+        "packages/sandbox-agent",
         "web",
         "electron"
       ],
@@ -61,7 +63,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.7.0-rc.7",
+      "version": "0.7.0-rc.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "latest",
@@ -5083,6 +5085,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-10.1.0.tgz",
@@ -5102,6 +5110,22 @@
         "fastify-plugin": "^5.0.0",
         "mnemonist": "0.40.0"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -5171,6 +5195,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
+      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {
@@ -10625,6 +10672,14 @@
     },
     "node_modules/@nodetool/runtime": {
       "resolved": "packages/runtime",
+      "link": true
+    },
+    "node_modules/@nodetool/sandbox": {
+      "resolved": "packages/sandbox",
+      "link": true
+    },
+    "node_modules/@nodetool/sandbox-agent": {
+      "resolved": "packages/sandbox-agent",
       "link": true
     },
     "node_modules/@nodetool/security": {
@@ -39595,6 +39650,37 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.101"
       }
     },
+    "packages/sandbox": {
+      "name": "@nodetool/sandbox",
+      "version": "0.1.0",
+      "dependencies": {
+        "@nodetool/config": "*",
+        "dockerode": "^4.0.4",
+        "zod": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/dockerode": "^3.3.34",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      }
+    },
+    "packages/sandbox-agent": {
+      "name": "@nodetool/sandbox-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "@fastify/multipart": "^9.0.0",
+        "@nodetool/sandbox": "*",
+        "fastify": "^5.1.0",
+        "zod": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      }
+    },
     "packages/security": {
       "name": "@nodetool/security",
       "version": "0.1.0",
@@ -39680,7 +39766,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.7.0-rc.7",
+      "version": "0.7.0-rc.8",
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "packages/elevenlabs-nodes",
     "packages/kie-codegen",
     "packages/kie-nodes",
+    "packages/sandbox",
+    "packages/sandbox-agent",
     "web",
     "electron"
   ],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "packages/kie-nodes",
     "packages/sandbox",
     "packages/sandbox-agent",
+    "packages/sandbox-tools",
     "web",
     "electron"
   ],

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -37,6 +37,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./tool": {
+      "nodetool-dev": "./src/tools/base-tool.ts",
+      "types": "./dist/tools/base-tool.d.ts",
+      "import": "./dist/tools/base-tool.js",
+      "default": "./dist/tools/base-tool.js"
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,8 @@
     "@nodetool/chat": "*",
     "@nodetool/protocol": "*",
     "@nodetool/runtime": "*",
+    "@nodetool/sandbox": "*",
+    "@nodetool/sandbox-tools": "*",
     "@nodetool/security": "*",
     "chalk": "^5.3.0",
     "ws": "^8.18.3",

--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -66,6 +66,11 @@ interface AppProps {
   enabledTools: string[];
   workspaceDir: string;
   wsUrl?: string;
+  /**
+   * Pre-built tools appended to the tool list returned from buildTools().
+   * Used by --sandbox to inject the 37 sandbox-tools adapter instances.
+   */
+  extraTools?: import("@nodetool/agents").Tool[];
 }
 
 // ---------------------------------------------------------------------------
@@ -210,6 +215,7 @@ export function App({
   enabledTools,
   workspaceDir,
   wsUrl,
+  extraTools,
 }: AppProps) {
   const { exit } = useApp();
 
@@ -371,9 +377,12 @@ export function App({
     for (const tool of getAllMcpTools()) {
       toolMap[tool.name] = tool;
     }
-    return enabledTools
+    const enabled = enabledTools
       .filter(name => name in toolMap)
       .map(name => toolMap[name] as import("@nodetool/agents").Tool);
+    return extraTools && extraTools.length > 0
+      ? [...enabled, ...extraTools]
+      : enabled;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -377,8 +377,30 @@ export function App({
     for (const tool of getAllMcpTools()) {
       toolMap[tool.name] = tool;
     }
+    // When sandbox tools are present, exclude host tools that have sandbox
+    // equivalents so the agent is forced to execute inside the sandbox.
+    const sandboxMode = extraTools && extraTools.length > 0;
+    const hostToolsToExclude = sandboxMode
+      ? new Set([
+          "read_file",
+          "write_file",
+          "edit_file",
+          "list_directory",
+          "glob",
+          "grep",
+          "run_code",
+          "browser",
+          "screenshot",
+          "google_search",
+          "google_news",
+          "google_images",
+          "dataseo_search",
+          "dataseo_news"
+        ])
+      : null;
+
     const enabled = enabledTools
-      .filter(name => name in toolMap)
+      .filter(name => name in toolMap && !(hostToolsToExclude?.has(name)))
       .map(name => toolMap[name] as import("@nodetool/agents").Tool);
     return extraTools && extraTools.length > 0
       ? [...enabled, ...extraTools]
@@ -542,8 +564,8 @@ export function App({
           await addMessage("assistant", taskResults.join("\n\n---\n\n"));
         }
 
-      } else if (wsClientRef.current) {
-        // --- Regular chat via WebSocket ---
+      } else if (wsClientRef.current && !extraTools?.length) {
+        // --- Regular chat via WebSocket (server handles everything) ---
         const wsClient = wsClientRef.current;
         let assistantContent = "";
         const toolSchemas = tools.map(t => t.toProviderTool());
@@ -569,6 +591,45 @@ export function App({
             break;
           }
         }
+        if (assistantContent) {
+          await addMessage("assistant", assistantContent);
+        }
+
+      } else if (wsClientRef.current && extraTools?.length) {
+        // --- Regular chat via WebSocket inference + local sandbox tool execution ---
+        const prov = new WebSocketProvider(wsClientRef.current, modelRef.current, providerRef.current);
+        let assistantContent = "";
+        const updatedHistory = [...chatHistoryRef.current];
+
+        await processChat({
+          userInput: trimmed,
+          messages: updatedHistory,
+          model: modelRef.current,
+          provider: prov,
+          context: ctx,
+          tools,
+          signal: abortController.signal,
+          callbacks: {
+            onChunk: (text) => {
+              if (abortRef.current) throw new Error("aborted");
+              assistantContent += text;
+              setStreamContent(assistantContent);
+              setStreamLabel("streaming");
+            },
+            onToolCall: (tc: ToolCall) => {
+              setStreamLabel(`tool: ${tc.name}`);
+            },
+            onToolResult: (tc: ToolCall, result: unknown) => {
+              const preview = typeof result === "string"
+                ? result
+                : JSON.stringify(result).slice(0, 100);
+              addMessage("tool", preview, { toolName: tc.name, toolArgs: tc.args });
+            },
+          },
+        });
+
+        setChatHistory(updatedHistory);
+
         if (assistantContent) {
           await addMessage("assistant", assistantContent);
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,14 @@ import { loadSettings } from "./settings.js";
 import { runStdinMode } from "./stdin.js";
 import { initDb, getSecret } from "@nodetool/models";
 import { getDefaultDbPath, configureLogging } from "@nodetool/config";
+import {
+  DockerSandboxProvider,
+  SessionStore,
+  type Sandbox
+} from "@nodetool/sandbox";
+import { createSandboxTools } from "@nodetool/sandbox-tools";
+import { randomUUID } from "node:crypto";
+import type { Tool } from "@nodetool/agents";
 
 // Configure logging: in interactive mode, suppress non-error logs to a file
 // so they don't interfere with the Ink TUI. Env vars can still override.
@@ -61,6 +69,14 @@ program
     "-u, --url <url>",
     "NodeTool server WebSocket URL (e.g. ws://localhost:7777/ws)"
   )
+  .option(
+    "--sandbox",
+    "Provision an isolated Docker sandbox and expose its tools (file, shell, browser, desktop, search, messaging) to the agent"
+  )
+  .option(
+    "--sandbox-image <image>",
+    "Override the sandbox Docker image (default: nodetool/sandbox-agent:latest)"
+  )
   .helpOption("-h, --help", "Show help")
   .version("0.1.0")
   .parse();
@@ -72,6 +88,8 @@ const opts = program.opts<{
   workspace?: string;
   tools?: string;
   url?: string;
+  sandbox?: boolean;
+  sandboxImage?: string;
 }>();
 
 // Initialize database
@@ -130,15 +148,64 @@ await Promise.all([
   autoEnable("IMAP_USERNAME", ["search_email", "archive_email"])
 ]);
 
+// --- Sandbox provisioning (optional) ---------------------------------------
+//
+// When `--sandbox` is set we bring up a DockerSandbox for this CLI process,
+// wrap its ToolClient with the agent adapter, and pass the resulting Tool
+// array into the App as `extraTools`. The sandbox is released on exit.
+
+let sandboxStore: SessionStore | null = null;
+let sandboxHandle: Sandbox | null = null;
+let sandboxExtraTools: Tool[] | undefined;
+
+if (opts.sandbox) {
+  const provider_ = new DockerSandboxProvider(
+    opts.sandboxImage ? { defaultImage: opts.sandboxImage } : {}
+  );
+  sandboxStore = new SessionStore({ provider: provider_ });
+  const sessionId = `cli-${randomUUID().slice(0, 8)}`;
+  try {
+    sandboxHandle = await sandboxStore.acquire(sessionId, {
+      workspaceDir: workspace
+    });
+    sandboxExtraTools = createSandboxTools(sandboxHandle.client);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Failed to provision sandbox: ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exit(1);
+  }
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      if (sandboxStore) await sandboxStore.close();
+    } catch {
+      // ignore
+    }
+  };
+  process.on("SIGINT", () => void cleanup().finally(() => process.exit(130)));
+  process.on("SIGTERM", () => void cleanup().finally(() => process.exit(143)));
+  process.on("exit", () => {
+    // Best-effort synchronous cleanup; `release` is async so we just
+    // kick it off and trust Docker to reap containers on daemon shutdown.
+    if (sandboxHandle) void sandboxHandle.release();
+  });
+}
+
 // Stdin mode: activated when stdin is piped (not a TTY)
 if (!process.stdin.isTTY) {
-  await runStdinMode({
-    provider,
-    model,
-    workspaceDir: workspace,
-    agentMode,
-    wsUrl: opts.url
-  });
+  try {
+    await runStdinMode({
+      provider,
+      model,
+      workspaceDir: workspace,
+      agentMode,
+      wsUrl: opts.url
+    });
+  } finally {
+    if (sandboxStore) await sandboxStore.close();
+  }
   process.exit(0);
 }
 
@@ -149,10 +216,12 @@ const { waitUntilExit } = render(
     initialAgentMode: agentMode,
     enabledTools,
     workspaceDir: workspace,
-    wsUrl: opts.url
+    wsUrl: opts.url,
+    extraTools: sandboxExtraTools
   }),
   { exitOnCtrlC: false }
 );
 
 await waitUntilExit();
+if (sandboxStore) await sandboxStore.close();
 process.exit(0);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -201,7 +201,8 @@ if (!process.stdin.isTTY) {
       model,
       workspaceDir: workspace,
       agentMode,
-      wsUrl: opts.url
+      wsUrl: opts.url,
+      extraTools: sandboxExtraTools
     });
   } finally {
     if (sandboxStore) await sandboxStore.close();

--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -276,8 +276,8 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
       if (taskResult !== null) {
         process.stdout.write(taskResult);
       }
-    } else if (wsClient) {
-      // --- Regular chat via WebSocket ---
+    } else if (wsClient && !opts.extraTools?.length) {
+      // --- Regular chat via WebSocket (server handles everything) ---
       for await (const event of wsClient.chat(
         trimmed,
         threadId,
@@ -311,6 +311,27 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
           break;
         }
       }
+    } else if (wsClient && opts.extraTools?.length) {
+      // --- Regular chat via WebSocket inference + local sandbox tool execution ---
+      const prov = new WebSocketProvider(wsClient, opts.model, opts.provider);
+      await processChat({
+        userInput: trimmed,
+        messages: chatHistory,
+        model: opts.model,
+        provider: prov,
+        context: new ProcessingContext({
+          jobId: crypto.randomUUID(),
+          userId: "1",
+          workspaceDir: opts.workspaceDir,
+          secretResolver: getSecret
+        }),
+        tools: opts.extraTools,
+        callbacks: {
+          onChunk: (text) => {
+            process.stdout.write(text);
+          }
+        }
+      });
     } else {
       // --- Regular chat via direct provider ---
       await processChat({

--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -23,6 +23,7 @@ import type { Message } from "@nodetool/runtime";
 import { ProcessingContext } from "@nodetool/runtime";
 import { processChat } from "@nodetool/chat";
 import { Agent } from "@nodetool/agents";
+import type { Tool } from "@nodetool/agents/tool";
 import { createProvider, WebSocketProvider } from "./providers.js";
 import { WebSocketChatClient, type JobEvent } from "./websocket-client.js";
 import { getSecret } from "@nodetool/models";
@@ -33,6 +34,8 @@ export interface StdinModeOptions {
   workspaceDir: string;
   agentMode?: boolean;
   wsUrl?: string;
+  /** Pre-built tools (e.g. from --sandbox) appended to the Agent's tool list. */
+  extraTools?: Tool[];
 }
 
 interface SlashCommand {
@@ -233,7 +236,7 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
         objective: trimmed,
         provider: prov,
         model: opts.model,
-        tools: [],
+        tools: opts.extraTools ?? [],
         outputFormat: "markdown",
         maxStepIterations: 20
       });
@@ -321,7 +324,7 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
           workspaceDir: opts.workspaceDir,
           secretResolver: getSecret
         }),
-        tools: [],
+        tools: opts.extraTools ?? [],
         callbacks: {
           onChunk: (text) => {
             process.stdout.write(text);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -59,6 +59,12 @@
       "path": "../runtime"
     },
     {
+      "path": "../sandbox"
+    },
+    {
+      "path": "../sandbox-tools"
+    },
+    {
       "path": "../security"
     }
   ]

--- a/packages/sandbox-agent/docker/Dockerfile
+++ b/packages/sandbox-agent/docker/Dockerfile
@@ -19,10 +19,13 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl wget git sudo tmux \
       python3 python3-pip python3-venv \
-      xvfb fluxbox x11vnc websockify \
+      xvfb fluxbox x11vnc websockify novnc \
       xdotool scrot imagemagick tesseract-ocr \
       ffmpeg pandoc weasyprint \
       chromium fonts-liberation fonts-noto-color-emoji \
+      libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+      libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+      libgbm1 libpango-1.0-0 libcairo2 libasound2 \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
@@ -83,6 +86,13 @@ RUN set -eux; \
 
 COPY packages/sandbox-agent/docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+# Install Playwright's own Chromium build under a shared dir so the ubuntu
+# user can launch it. The distro chromium is left in place for apps that
+# shell out to `chromium` directly.
+RUN npx --yes playwright@1.49.0 install chromium \
+    && chown -R ubuntu:ubuntu /opt/pw-browsers
 
 USER ubuntu
 WORKDIR /home/ubuntu

--- a/packages/sandbox-agent/docker/Dockerfile
+++ b/packages/sandbox-agent/docker/Dockerfile
@@ -1,0 +1,91 @@
+# ------------------------------------------------------------------------------
+# nodetool/sandbox-agent — isolated agent computer
+#
+# Ubuntu 22.04 + Node 24 + Chromium + Xvfb/fluxbox + x11vnc + websockify.
+# The in-container tool server (@nodetool/sandbox-agent) listens on :7788
+# and exposes file/shell/browser/desktop tools over HTTP.
+# ------------------------------------------------------------------------------
+
+FROM node:24-bookworm-slim AS base
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DISPLAY=:99 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    NODETOOL_TOOL_PORT=7788 \
+    NODETOOL_VNC_PORT=6080
+
+# System packages. One big apt install to minimize layers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl wget git sudo tmux \
+      python3 python3-pip python3-venv \
+      xvfb fluxbox x11vnc websockify \
+      xdotool scrot imagemagick tesseract-ocr \
+      ffmpeg pandoc weasyprint \
+      chromium fonts-liberation fonts-noto-color-emoji \
+      build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user for the agent's workload. Passwordless sudo is NOT granted;
+# sudo-gated tools should fail unless the operator explicitly enables it.
+RUN useradd -m -s /bin/bash -u 1000 ubuntu \
+    && mkdir -p /workspace \
+    && chown ubuntu:ubuntu /workspace
+
+# -----------------------------------------------------------------------------
+# Build stage: compile @nodetool/sandbox-agent and its deps.
+# -----------------------------------------------------------------------------
+FROM base AS build
+WORKDIR /build
+# The build context should be the repo root (docker build -f packages/sandbox-agent/docker/Dockerfile .)
+COPY package.json package-lock.json ./
+COPY tsconfig.build.json ./
+COPY scripts/ ./scripts/
+COPY packages/config ./packages/config
+COPY packages/sandbox ./packages/sandbox
+COPY packages/sandbox-agent ./packages/sandbox-agent
+
+# Install workspace deps (scoped to what sandbox-agent needs).
+RUN npm install --workspaces=false --include-workspace-root=true \
+    && npm install -w @nodetool/config -w @nodetool/sandbox -w @nodetool/sandbox-agent
+
+RUN npx tsc --build \
+      packages/config \
+      packages/sandbox \
+      packages/sandbox-agent
+
+# -----------------------------------------------------------------------------
+# Runtime stage.
+# -----------------------------------------------------------------------------
+FROM base AS runtime
+WORKDIR /opt/sandbox-agent
+
+# Copy built JS and production node_modules for the agent.
+COPY --from=build /build/packages/config/dist ./node_modules/@nodetool/config/dist
+COPY --from=build /build/packages/config/package.json ./node_modules/@nodetool/config/package.json
+COPY --from=build /build/packages/sandbox/dist ./node_modules/@nodetool/sandbox/dist
+COPY --from=build /build/packages/sandbox/package.json ./node_modules/@nodetool/sandbox/package.json
+COPY --from=build /build/packages/sandbox-agent/dist ./dist
+COPY --from=build /build/packages/sandbox-agent/package.json ./package.json
+COPY --from=build /build/node_modules ./vendor_modules
+
+# Merge vendor modules (fastify, zod, etc.) into local node_modules, skipping
+# the @nodetool/* packages we've already laid down.
+RUN set -eux; \
+    for d in vendor_modules/*; do \
+      name=$(basename "$d"); \
+      case "$name" in \
+        @nodetool) cp -rn "$d"/* ./node_modules/@nodetool/ 2>/dev/null || true ;; \
+        *) cp -rn "$d" ./node_modules/ 2>/dev/null || true ;; \
+      esac; \
+    done; \
+    rm -rf vendor_modules
+
+COPY packages/sandbox-agent/docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER ubuntu
+WORKDIR /home/ubuntu
+
+EXPOSE 7788 6080
+ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/sandbox-agent/docker/Dockerfile
+++ b/packages/sandbox-agent/docker/Dockerfile
@@ -1,7 +1,8 @@
 # ------------------------------------------------------------------------------
 # nodetool/sandbox-agent — isolated agent computer
 #
-# Ubuntu 22.04 + Node 24 + Chromium + Xvfb/fluxbox + x11vnc + websockify.
+# Debian Bookworm (via node:24-bookworm-slim) + Node 24 + Chromium +
+# Xvfb/fluxbox + x11vnc + websockify.
 # The in-container tool server (@nodetool/sandbox-agent) listens on :7788
 # and exposes file/shell/browser/desktop tools over HTTP.
 # ------------------------------------------------------------------------------

--- a/packages/sandbox-agent/docker/Dockerfile
+++ b/packages/sandbox-agent/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Non-root user for the agent's workload. Passwordless sudo is NOT granted;
 # sudo-gated tools should fail unless the operator explicitly enables it.
-RUN useradd -m -s /bin/bash -u 1000 ubuntu \
+RUN userdel node 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 ubuntu \
     && mkdir -p /workspace \
     && chown ubuntu:ubuntu /workspace
 
@@ -43,6 +44,7 @@ FROM base AS build
 WORKDIR /build
 # The build context should be the repo root (docker build -f packages/sandbox-agent/docker/Dockerfile .)
 COPY package.json package-lock.json ./
+COPY tsconfig.base.json ./
 COPY tsconfig.build.json ./
 COPY scripts/ ./scripts/
 COPY packages/config ./packages/config

--- a/packages/sandbox-agent/docker/entrypoint.sh
+++ b/packages/sandbox-agent/docker/entrypoint.sh
@@ -1,21 +1,47 @@
 #!/usr/bin/env bash
 # Container entrypoint for nodetool/sandbox-agent.
 #
-# Phase 1: only starts the Node tool server.
-# Phase 2 will start Xvfb + fluxbox + x11vnc + websockify before the tool
-# server. The commented block below is kept as a reference for that upgrade.
+# Starts the X11 desktop stack (Xvfb + fluxbox + x11vnc + websockify) and
+# the Node tool server. The desktop stack is required for:
+#   - browser_* tools (Chromium renders against :99)
+#   - desktop_* tools (xdotool/scrot act on :99)
+#   - live viewing via noVNC over websockify
+#
+# Disable the desktop stack by setting NODETOOL_HEADLESS=1 — the tool server
+# will still start, and browser tools will launch headless Chromium on demand.
 set -euo pipefail
 
 TOOL_PORT="${NODETOOL_TOOL_PORT:-7788}"
-# VNC_PORT="${NODETOOL_VNC_PORT:-6080}"
+VNC_WS_PORT="${NODETOOL_VNC_PORT:-6080}"
+VNC_DISPLAY="${NODETOOL_VNC_DISPLAY:-:99}"
+VNC_GEOMETRY="${NODETOOL_VNC_GEOMETRY:-1280x900x24}"
 
-# --- Phase 2 (desktop stack) — enable when browser/desktop tools ship. -------
-# Xvfb :99 -screen 0 1440x900x24 -nolisten tcp &
-# sleep 0.5
-# fluxbox >/dev/null 2>&1 &
-# x11vnc -display :99 -forever -nopw -quiet -shared -rfbport 5900 &
-# websockify --web=/usr/share/novnc "${VNC_PORT}" localhost:5900 &
-# -----------------------------------------------------------------------------
+if [[ "${NODETOOL_HEADLESS:-0}" != "1" ]]; then
+  # Start a virtual X server.
+  Xvfb "${VNC_DISPLAY}" -screen 0 "${VNC_GEOMETRY}" -nolisten tcp &
+  XVFB_PID=$!
+
+  # Give Xvfb a moment to create the socket. We don't block forever — if it
+  # fails to start, the downstream commands below will surface the error.
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if [[ -S "/tmp/.X11-unix/X${VNC_DISPLAY#:}" ]]; then break; fi
+    sleep 0.1
+  done
+
+  export DISPLAY="${VNC_DISPLAY}"
+
+  # Minimal window manager so apps get decorations + focus.
+  fluxbox >/dev/null 2>&1 &
+
+  # VNC over x11vnc; no password, bound to localhost. The published host
+  # port (random ephemeral) is the real access control.
+  x11vnc -display "${VNC_DISPLAY}" -forever -nopw -quiet -shared \
+    -localhost -rfbport 5900 >/dev/null 2>&1 &
+
+  # Expose VNC over WebSocket for browser-based noVNC viewers.
+  websockify --web=/usr/share/novnc "${VNC_WS_PORT}" localhost:5900 \
+    >/dev/null 2>&1 &
+fi
 
 cd /opt/sandbox-agent
 exec node dist/entry.js

--- a/packages/sandbox-agent/docker/entrypoint.sh
+++ b/packages/sandbox-agent/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Container entrypoint for nodetool/sandbox-agent.
+#
+# Phase 1: only starts the Node tool server.
+# Phase 2 will start Xvfb + fluxbox + x11vnc + websockify before the tool
+# server. The commented block below is kept as a reference for that upgrade.
+set -euo pipefail
+
+TOOL_PORT="${NODETOOL_TOOL_PORT:-7788}"
+# VNC_PORT="${NODETOOL_VNC_PORT:-6080}"
+
+# --- Phase 2 (desktop stack) — enable when browser/desktop tools ship. -------
+# Xvfb :99 -screen 0 1440x900x24 -nolisten tcp &
+# sleep 0.5
+# fluxbox >/dev/null 2>&1 &
+# x11vnc -display :99 -forever -nopw -quiet -shared -rfbport 5900 &
+# websockify --web=/usr/share/novnc "${VNC_PORT}" localhost:5900 &
+# -----------------------------------------------------------------------------
+
+cd /opt/sandbox-agent
+exec node dist/entry.js

--- a/packages/sandbox-agent/package.json
+++ b/packages/sandbox-agent/package.json
@@ -18,6 +18,7 @@
     "@fastify/multipart": "^9.0.0",
     "@nodetool/sandbox": "*",
     "fastify": "^5.1.0",
+    "playwright": "^1.49.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/sandbox-agent/package.json
+++ b/packages/sandbox-agent/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@nodetool/sandbox-agent",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "In-container tool server: Fastify HTTP service exposing file, shell, browser, and desktop tools to the host sandbox. Ships baked into the sandbox Docker image.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node ../../scripts/build-typescript-workspace.mjs",
+    "start": "node dist/entry.js",
+    "dev": "tsx src/entry.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fastify/multipart": "^9.0.0",
+    "@nodetool/sandbox": "*",
+    "fastify": "^5.1.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.2"
+  },
+  "exports": {
+    ".": {
+      "nodetool-dev": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/sandbox-agent/src/entry.ts
+++ b/packages/sandbox-agent/src/entry.ts
@@ -1,0 +1,39 @@
+/**
+ * Container entrypoint: start the Fastify tool server.
+ *
+ * Port is read from NODETOOL_TOOL_PORT (injected by the host provider).
+ * Bound to 0.0.0.0 since the container is the isolation boundary; the
+ * published port is already bound to 127.0.0.1 on the host.
+ */
+
+import { buildServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const port = parseInt(process.env.NODETOOL_TOOL_PORT ?? "7788", 10);
+  const workspace = process.env.NODETOOL_WORKSPACE ?? "/workspace";
+  const app = buildServer({ workspace });
+
+  try {
+    await app.listen({ host: "0.0.0.0", port });
+    // eslint-disable-next-line no-console
+    console.log(`[sandbox-agent] listening on :${port}`);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[sandbox-agent] failed to start:", err);
+    process.exit(1);
+  }
+
+  const shutdown = async (signal: string): Promise<void> => {
+    // eslint-disable-next-line no-console
+    console.log(`[sandbox-agent] received ${signal}, shutting down`);
+    try {
+      await app.close();
+    } finally {
+      process.exit(0);
+    }
+  };
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+}
+
+void main();

--- a/packages/sandbox-agent/src/event-bus.ts
+++ b/packages/sandbox-agent/src/event-bus.ts
@@ -1,0 +1,54 @@
+/**
+ * In-process event bus that backs the /events SSE endpoint and the
+ * message_notify_user / message_ask_user tools.
+ *
+ * Events are:
+ *   - broadcast to every active SSE subscriber immediately
+ *   - kept in a bounded ring buffer so late subscribers can replay
+ *     recent events (useful when a client reconnects mid-task)
+ *
+ * The bus is a module-level singleton — each container runs exactly one
+ * agent session, so there's no multi-tenancy concern.
+ */
+
+import { randomBytes } from "node:crypto";
+import type { SandboxEvent } from "@nodetool/sandbox/schemas";
+
+const MAX_RING = 500;
+
+type Subscriber = (event: SandboxEvent) => void;
+
+const ring: SandboxEvent[] = [];
+const subscribers = new Set<Subscriber>();
+
+export function newEventId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export function publish(event: SandboxEvent): void {
+  ring.push(event);
+  if (ring.length > MAX_RING) ring.splice(0, ring.length - MAX_RING);
+  for (const sub of subscribers) {
+    try {
+      sub(event);
+    } catch {
+      // A broken subscriber must not take down siblings.
+    }
+  }
+}
+
+export function subscribe(sub: Subscriber): () => void {
+  subscribers.add(sub);
+  return () => {
+    subscribers.delete(sub);
+  };
+}
+
+export function replay(): SandboxEvent[] {
+  return ring.slice();
+}
+
+export function _resetForTests(): void {
+  ring.length = 0;
+  subscribers.clear();
+}

--- a/packages/sandbox-agent/src/index.ts
+++ b/packages/sandbox-agent/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @nodetool/sandbox-agent — in-container tool server.
+ *
+ * This package is baked into the sandbox Docker image and started by the
+ * container entrypoint. Not intended for direct use from host code; the
+ * host side uses @nodetool/sandbox which talks to this over HTTP.
+ */
+
+export { buildServer, SANDBOX_AGENT_VERSION } from "./server.js";
+export type { BuildServerOptions } from "./server.js";

--- a/packages/sandbox-agent/src/port-map.ts
+++ b/packages/sandbox-agent/src/port-map.ts
@@ -1,0 +1,25 @@
+/**
+ * In-container registry of container_port → public URL.
+ *
+ * Populated by the host immediately after container startup via
+ * POST /internal/set-port-map. The `expose_port` tool reads from this
+ * registry to answer the agent's URL lookup.
+ */
+
+let portMap: Record<string, string> = {};
+
+export function setPortMap(next: Record<string, string>): void {
+  portMap = { ...next };
+}
+
+export function getPublicUrl(containerPort: number): string | null {
+  return portMap[String(containerPort)] ?? null;
+}
+
+export function knownContainerPorts(): number[] {
+  return Object.keys(portMap).map((s) => parseInt(s, 10));
+}
+
+export function _resetForTests(): void {
+  portMap = {};
+}

--- a/packages/sandbox-agent/src/server.ts
+++ b/packages/sandbox-agent/src/server.ts
@@ -17,7 +17,26 @@ import {
   ShellViewInput,
   ShellWaitInput,
   ShellWriteToProcessInput,
-  ShellKillProcessInput
+  ShellKillProcessInput,
+  BrowserViewInput,
+  BrowserNavigateInput,
+  BrowserRestartInput,
+  BrowserClickInput,
+  BrowserInputTextInput,
+  BrowserMoveMouseInput,
+  BrowserPressKeyInput,
+  BrowserSelectOptionInput,
+  BrowserScrollInput,
+  BrowserConsoleExecInput,
+  BrowserConsoleViewInput,
+  ScreenCaptureInput,
+  ScreenFindInput,
+  MouseMoveInput,
+  MouseClickInput,
+  MouseDragInput,
+  MouseScrollInput,
+  KeyPressInput,
+  KeyTypeInput
 } from "@nodetool/sandbox/schemas";
 import {
   fileRead,
@@ -33,6 +52,30 @@ import {
   shellWriteToProcess,
   shellKillProcess
 } from "./tools/shell.js";
+import {
+  browserView,
+  browserNavigate,
+  browserRestart,
+  browserClick,
+  browserInput,
+  browserMoveMouse,
+  browserPressKey,
+  browserSelectOption,
+  browserScroll,
+  browserConsoleExec,
+  browserConsoleView
+} from "./tools/browser.js";
+import {
+  screenCapture,
+  screenFind,
+  mouseMove,
+  mouseClick,
+  mouseDrag,
+  mouseScroll,
+  keyPress,
+  keyType,
+  cursorPosition
+} from "./tools/desktop.js";
 
 export const SANDBOX_AGENT_VERSION = "0.1.0";
 
@@ -42,7 +85,7 @@ export interface BuildServerOptions {
 }
 
 export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
-  const app = Fastify({ logger: false });
+  const app = Fastify({ logger: false, bodyLimit: 32 * 1024 * 1024 });
   const startedAt = options.startedAt ?? Date.now();
   const workspace = options.workspace ?? "/workspace";
 
@@ -53,17 +96,43 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
     workspace
   }));
 
+  // --- File tools --------------------------------------------------------
   route(app, "/file/read", FileReadInput, fileRead);
   route(app, "/file/write", FileWriteInput, fileWrite);
   route(app, "/file/str-replace", FileStrReplaceInput, fileStrReplace);
   route(app, "/file/find-in-content", FileFindInContentInput, fileFindInContent);
   route(app, "/file/find-by-name", FileFindByNameInput, fileFindByName);
 
+  // --- Shell tools -------------------------------------------------------
   route(app, "/shell/exec", ShellExecInput, shellExec);
   route(app, "/shell/view", ShellViewInput, shellView);
   route(app, "/shell/wait", ShellWaitInput, shellWait);
   route(app, "/shell/write", ShellWriteToProcessInput, shellWriteToProcess);
   route(app, "/shell/kill", ShellKillProcessInput, shellKillProcess);
+
+  // --- Browser tools -----------------------------------------------------
+  route(app, "/browser/view", BrowserViewInput, browserView);
+  route(app, "/browser/navigate", BrowserNavigateInput, browserNavigate);
+  route(app, "/browser/restart", BrowserRestartInput, browserRestart);
+  route(app, "/browser/click", BrowserClickInput, browserClick);
+  route(app, "/browser/input", BrowserInputTextInput, browserInput);
+  route(app, "/browser/move-mouse", BrowserMoveMouseInput, browserMoveMouse);
+  route(app, "/browser/press-key", BrowserPressKeyInput, browserPressKey);
+  route(app, "/browser/select-option", BrowserSelectOptionInput, browserSelectOption);
+  route(app, "/browser/scroll", BrowserScrollInput, browserScroll);
+  route(app, "/browser/console-exec", BrowserConsoleExecInput, browserConsoleExec);
+  route(app, "/browser/console-view", BrowserConsoleViewInput, browserConsoleView);
+
+  // --- Desktop tools -----------------------------------------------------
+  route(app, "/desktop/capture", ScreenCaptureInput, screenCapture);
+  route(app, "/desktop/find", ScreenFindInput, screenFind);
+  route(app, "/desktop/mouse/move", MouseMoveInput, mouseMove);
+  route(app, "/desktop/mouse/click", MouseClickInput, mouseClick);
+  route(app, "/desktop/mouse/drag", MouseDragInput, mouseDrag);
+  route(app, "/desktop/mouse/scroll", MouseScrollInput, mouseScroll);
+  route(app, "/desktop/key/press", KeyPressInput, keyPress);
+  route(app, "/desktop/key/type", KeyTypeInput, keyType);
+  app.get("/desktop/cursor-position", async () => cursorPosition());
 
   app.setErrorHandler((err: unknown, _req, reply) => {
     const status =

--- a/packages/sandbox-agent/src/server.ts
+++ b/packages/sandbox-agent/src/server.ts
@@ -40,7 +40,8 @@ import {
   InfoSearchWebInput,
   MessageNotifyUserInput,
   MessageAskUserInput,
-  IdleInput
+  IdleInput,
+  ExposePortInput
 } from "@nodetool/sandbox/schemas";
 import {
   fileRead,
@@ -86,7 +87,9 @@ import {
   messageAskUser,
   idle
 } from "./tools/message.js";
+import { exposePort } from "./tools/deploy.js";
 import { replay, subscribe } from "./event-bus.js";
+import { setPortMap } from "./port-map.js";
 
 export const SANDBOX_AGENT_VERSION = "0.1.0";
 
@@ -152,6 +155,20 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
   route(app, "/message/notify", MessageNotifyUserInput, messageNotifyUser);
   route(app, "/message/ask", MessageAskUserInput, messageAskUser);
   route(app, "/idle", IdleInput, idle);
+
+  // --- Deploy ------------------------------------------------------------
+  route(app, "/deploy/expose-port", ExposePortInput, exposePort);
+
+  // Internal control plane (host → server). Not an agent-facing tool.
+  app.post("/internal/set-port-map", async (req, reply) => {
+    const body = req.body as { map?: Record<string, string> } | undefined;
+    if (!body || typeof body.map !== "object" || body.map === null) {
+      reply.status(400).send({ error: "missing map" });
+      return;
+    }
+    setPortMap(body.map);
+    reply.send({ ok: true });
+  });
 
   // --- Event stream (SSE) ------------------------------------------------
   app.get("/events", async (req, reply) => {

--- a/packages/sandbox-agent/src/server.ts
+++ b/packages/sandbox-agent/src/server.ts
@@ -1,0 +1,109 @@
+/**
+ * In-container Fastify server exposing sandbox tools on NODETOOL_TOOL_PORT.
+ *
+ * Every route is validated against the shared Zod schemas in
+ * @nodetool/sandbox/schemas, so host and container agree on shapes by
+ * construction.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  FileReadInput,
+  FileWriteInput,
+  FileStrReplaceInput,
+  FileFindInContentInput,
+  FileFindByNameInput,
+  ShellExecInput,
+  ShellViewInput,
+  ShellWaitInput,
+  ShellWriteToProcessInput,
+  ShellKillProcessInput
+} from "@nodetool/sandbox/schemas";
+import {
+  fileRead,
+  fileWrite,
+  fileStrReplace,
+  fileFindInContent,
+  fileFindByName
+} from "./tools/file.js";
+import {
+  shellExec,
+  shellView,
+  shellWait,
+  shellWriteToProcess,
+  shellKillProcess
+} from "./tools/shell.js";
+
+export const SANDBOX_AGENT_VERSION = "0.1.0";
+
+export interface BuildServerOptions {
+  workspace?: string;
+  startedAt?: number;
+}
+
+export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
+  const app = Fastify({ logger: false });
+  const startedAt = options.startedAt ?? Date.now();
+  const workspace = options.workspace ?? "/workspace";
+
+  app.get("/health", async () => ({
+    ok: true as const,
+    version: SANDBOX_AGENT_VERSION,
+    uptime_seconds: (Date.now() - startedAt) / 1000,
+    workspace
+  }));
+
+  route(app, "/file/read", FileReadInput, fileRead);
+  route(app, "/file/write", FileWriteInput, fileWrite);
+  route(app, "/file/str-replace", FileStrReplaceInput, fileStrReplace);
+  route(app, "/file/find-in-content", FileFindInContentInput, fileFindInContent);
+  route(app, "/file/find-by-name", FileFindByNameInput, fileFindByName);
+
+  route(app, "/shell/exec", ShellExecInput, shellExec);
+  route(app, "/shell/view", ShellViewInput, shellView);
+  route(app, "/shell/wait", ShellWaitInput, shellWait);
+  route(app, "/shell/write", ShellWriteToProcessInput, shellWriteToProcess);
+  route(app, "/shell/kill", ShellKillProcessInput, shellKillProcess);
+
+  app.setErrorHandler((err: unknown, _req, reply) => {
+    const status =
+      err !== null &&
+      typeof err === "object" &&
+      "statusCode" in err &&
+      typeof (err as { statusCode?: unknown }).statusCode === "number"
+        ? (err as { statusCode: number }).statusCode
+        : 500;
+    const message =
+      err !== null &&
+      typeof err === "object" &&
+      "message" in err &&
+      typeof (err as { message?: unknown }).message === "string"
+        ? (err as { message: string }).message
+        : "internal error";
+    reply.status(status).send({ error: message });
+  });
+
+  return app;
+}
+
+import type { ZodType } from "zod";
+
+function route<TIn, TOut>(
+  app: FastifyInstance,
+  path: string,
+  schema: ZodType<TIn>,
+  handler: (input: TIn) => Promise<TOut>
+): void {
+  app.post(path, async (req, reply) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.status(400).send({
+        error: "invalid input",
+        issues: parsed.error.issues
+      });
+      return;
+    }
+    const result = await handler(parsed.data);
+    reply.send(result);
+  });
+}

--- a/packages/sandbox-agent/src/server.ts
+++ b/packages/sandbox-agent/src/server.ts
@@ -36,7 +36,11 @@ import {
   MouseDragInput,
   MouseScrollInput,
   KeyPressInput,
-  KeyTypeInput
+  KeyTypeInput,
+  InfoSearchWebInput,
+  MessageNotifyUserInput,
+  MessageAskUserInput,
+  IdleInput
 } from "@nodetool/sandbox/schemas";
 import {
   fileRead,
@@ -76,6 +80,13 @@ import {
   keyType,
   cursorPosition
 } from "./tools/desktop.js";
+import { infoSearchWeb } from "./tools/search.js";
+import {
+  messageNotifyUser,
+  messageAskUser,
+  idle
+} from "./tools/message.js";
+import { replay, subscribe } from "./event-bus.js";
 
 export const SANDBOX_AGENT_VERSION = "0.1.0";
 
@@ -133,6 +144,50 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
   route(app, "/desktop/key/press", KeyPressInput, keyPress);
   route(app, "/desktop/key/type", KeyTypeInput, keyType);
   app.get("/desktop/cursor-position", async () => cursorPosition());
+
+  // --- Search ------------------------------------------------------------
+  route(app, "/search/web", InfoSearchWebInput, infoSearchWeb);
+
+  // --- Messaging ---------------------------------------------------------
+  route(app, "/message/notify", MessageNotifyUserInput, messageNotifyUser);
+  route(app, "/message/ask", MessageAskUserInput, messageAskUser);
+  route(app, "/idle", IdleInput, idle);
+
+  // --- Event stream (SSE) ------------------------------------------------
+  app.get("/events", async (req, reply) => {
+    reply.raw.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      "x-accel-buffering": "no"
+    });
+
+    // Replay buffered events so reconnecting clients catch up.
+    for (const ev of replay()) {
+      reply.raw.write(`data: ${JSON.stringify(ev)}\n\n`);
+    }
+
+    const unsubscribe = subscribe((ev) => {
+      reply.raw.write(`data: ${JSON.stringify(ev)}\n\n`);
+    });
+
+    // Heartbeat comments keep intermediaries from closing the pipe.
+    const heartbeat = setInterval(() => {
+      reply.raw.write(": heartbeat\n\n");
+    }, 15_000);
+
+    const close = (): void => {
+      clearInterval(heartbeat);
+      unsubscribe();
+      try {
+        reply.raw.end();
+      } catch {
+        // ignore
+      }
+    };
+    req.raw.on("close", close);
+    req.raw.on("error", close);
+  });
 
   app.setErrorHandler((err: unknown, _req, reply) => {
     const status =

--- a/packages/sandbox-agent/src/tools/browser.ts
+++ b/packages/sandbox-agent/src/tools/browser.ts
@@ -1,0 +1,328 @@
+/**
+ * Browser tools — Playwright-driven Chromium with element-index + coordinate
+ * addressing.
+ *
+ * A single Browser/Context/Page is kept alive for the lifetime of the
+ * container; the agent shares one session across calls so cookies and auth
+ * persist. `browser_restart` tears down and re-creates the page.
+ *
+ * Element indexing: on each browser_view, a JS expression runs in the page
+ * that selects all interactive elements (button, link, input, select,
+ * textarea, [role="button"], [onclick], [tabindex]) and assigns a numeric
+ * data-nt-idx attribute. The assignment is deterministic within a view call
+ * but IS rebuilt each time the DOM changes, so callers should always call
+ * browser_view before relying on an index.
+ *
+ * Console capture: page.on("console") pushes into an in-memory ring buffer
+ * so browser_console_view can return recent messages.
+ */
+
+import type {
+  Browser,
+  BrowserContext,
+  ConsoleMessage,
+  Page
+} from "playwright";
+import type {
+  BrowserViewInput,
+  BrowserViewOutput,
+  BrowserNavigateInput,
+  BrowserNavigateOutput,
+  BrowserRestartInput,
+  BrowserRestartOutput,
+  BrowserClickInput,
+  BrowserClickOutput,
+  BrowserInputTextInput,
+  BrowserInputTextOutput,
+  BrowserMoveMouseInput,
+  BrowserMoveMouseOutput,
+  BrowserPressKeyInput,
+  BrowserPressKeyOutput,
+  BrowserSelectOptionInput,
+  BrowserSelectOptionOutput,
+  BrowserScrollInput,
+  BrowserScrollOutput,
+  BrowserConsoleExecInput,
+  BrowserConsoleExecOutput,
+  BrowserConsoleViewInput,
+  BrowserConsoleViewOutput,
+  BrowserElement,
+  BrowserConsoleMessage
+} from "@nodetool/sandbox/schemas";
+
+const CONSOLE_BUFFER_MAX = 500;
+
+interface BrowserState {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  consoleMessages: BrowserConsoleMessage[];
+}
+
+let state: BrowserState | null = null;
+
+/** Injectable for tests: replace the Playwright launcher. */
+export interface PlaywrightAdapter {
+  launch(): Promise<Browser>;
+}
+
+let adapter: PlaywrightAdapter | null = null;
+
+/** Test hook — override the Playwright launcher. */
+export function setPlaywrightAdapter(a: PlaywrightAdapter | null): void {
+  adapter = a;
+}
+
+async function ensureState(): Promise<BrowserState> {
+  if (state) return state;
+
+  let browser: Browser;
+  if (adapter) {
+    browser = await adapter.launch();
+  } else {
+    const { chromium } = await import("playwright");
+    browser = await chromium.launch({
+      headless: process.env.NODETOOL_BROWSER_HEADLESS === "true",
+      args: [
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-gpu",
+        "--window-size=1280,900"
+      ]
+    });
+  }
+
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 900 }
+  });
+  const page = await context.newPage();
+
+  const consoleMessages: BrowserConsoleMessage[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    consoleMessages.push({
+      type: msg.type(),
+      text: msg.text(),
+      timestamp: Date.now()
+    });
+    if (consoleMessages.length > CONSOLE_BUFFER_MAX) {
+      consoleMessages.splice(0, consoleMessages.length - CONSOLE_BUFFER_MAX);
+    }
+  });
+
+  state = { browser, context, page, consoleMessages };
+  return state;
+}
+
+export async function browserView(
+  input: BrowserViewInput
+): Promise<BrowserViewOutput> {
+  const s = await ensureState();
+  const { page } = s;
+
+  // Index interactive elements and pull their geometry.
+  const elements = (await page.evaluate(() => {
+    const SELECTOR =
+      "a, button, input, select, textarea, [role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='menuitem'], [role='tab'], [onclick], [tabindex]";
+    const nodes = Array.from(document.querySelectorAll(SELECTOR));
+    return nodes.flatMap((el, i) => {
+      const he = el as HTMLElement;
+      const rect = he.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return [];
+      const style = window.getComputedStyle(he);
+      if (style.visibility === "hidden" || style.display === "none") return [];
+      he.setAttribute("data-nt-idx", String(i));
+      const attrs: Record<string, string> = {};
+      for (const a of Array.from(he.attributes)) {
+        if (a.name.startsWith("data-nt-")) continue;
+        attrs[a.name] = a.value;
+      }
+      return [
+        {
+          index: i,
+          tag: he.tagName.toLowerCase(),
+          role: he.getAttribute("role"),
+          text: (he.innerText || he.getAttribute("value") || "").slice(0, 200),
+          attributes: attrs,
+          bbox: {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height
+          }
+        }
+      ];
+    });
+  })) as BrowserElement[];
+
+  const viewport = page.viewportSize() ?? { width: 1280, height: 900 };
+  const url = page.url();
+  const title = await page.title();
+
+  const want =
+    input.include_screenshot === undefined ? true : input.include_screenshot;
+  let screenshot: string | null = null;
+  if (want) {
+    const buf = await page.screenshot({ type: "png", fullPage: false });
+    screenshot = buf.toString("base64");
+  }
+
+  return {
+    url,
+    title,
+    viewport,
+    elements,
+    screenshot_png_b64: screenshot
+  };
+}
+
+export async function browserNavigate(
+  input: BrowserNavigateInput
+): Promise<BrowserNavigateOutput> {
+  const s = await ensureState();
+  const waitUntil = input.wait_until ?? "load";
+  const res = await s.page.goto(input.url, { waitUntil });
+  return {
+    url: s.page.url(),
+    title: await s.page.title(),
+    status: res?.status() ?? null
+  };
+}
+
+export async function browserRestart(
+  input: BrowserRestartInput
+): Promise<BrowserRestartOutput> {
+  if (state) {
+    try {
+      await state.browser.close();
+    } catch {
+      // ignore
+    }
+    state = null;
+  }
+  const s = await ensureState();
+  if (input.url) {
+    await s.page.goto(input.url, { waitUntil: "load" });
+  }
+  return { url: s.page.url() };
+}
+
+export async function browserClick(
+  input: BrowserClickInput
+): Promise<BrowserClickOutput> {
+  const s = await ensureState();
+  if (input.index !== undefined) {
+    await s.page.click(`[data-nt-idx="${input.index}"]`);
+  } else {
+    await s.page.mouse.click(input.coordinate_x!, input.coordinate_y!);
+  }
+  return { clicked: true };
+}
+
+export async function browserInput(
+  input: BrowserInputTextInput
+): Promise<BrowserInputTextOutput> {
+  const s = await ensureState();
+  if (input.index !== undefined) {
+    const sel = `[data-nt-idx="${input.index}"]`;
+    await s.page.fill(sel, input.text);
+    if (input.press_enter) {
+      await s.page.press(sel, "Enter");
+    }
+  } else {
+    await s.page.mouse.click(input.coordinate_x!, input.coordinate_y!);
+    await s.page.keyboard.type(input.text);
+    if (input.press_enter) {
+      await s.page.keyboard.press("Enter");
+    }
+  }
+  return { typed: true };
+}
+
+export async function browserMoveMouse(
+  input: BrowserMoveMouseInput
+): Promise<BrowserMoveMouseOutput> {
+  const s = await ensureState();
+  await s.page.mouse.move(input.coordinate_x, input.coordinate_y);
+  return { moved: true };
+}
+
+export async function browserPressKey(
+  input: BrowserPressKeyInput
+): Promise<BrowserPressKeyOutput> {
+  const s = await ensureState();
+  await s.page.keyboard.press(input.key);
+  return { pressed: true };
+}
+
+export async function browserSelectOption(
+  input: BrowserSelectOptionInput
+): Promise<BrowserSelectOptionOutput> {
+  const s = await ensureState();
+  const sel = `[data-nt-idx="${input.index}"]`;
+  const selected = await s.page.selectOption(sel, input.option);
+  return { selected };
+}
+
+export async function browserScroll(
+  input: BrowserScrollInput
+): Promise<BrowserScrollOutput> {
+  const s = await ensureState();
+  const scrollY = (await s.page.evaluate(
+    (args: { top: boolean; bottom: boolean; pixels: number | null }) => {
+      if (args.top) {
+        window.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+      } else if (args.bottom) {
+        window.scrollTo({
+          top: document.documentElement.scrollHeight,
+          behavior: "instant" as ScrollBehavior
+        });
+      } else if (args.pixels !== null) {
+        window.scrollBy({
+          top: args.pixels,
+          behavior: "instant" as ScrollBehavior
+        });
+      }
+      return window.scrollY;
+    },
+    {
+      top: input.to_top === true,
+      bottom: input.to_bottom === true,
+      pixels: input.pixels ?? null
+    }
+  )) as number;
+  return { scroll_y: scrollY };
+}
+
+export async function browserConsoleExec(
+  input: BrowserConsoleExecInput
+): Promise<BrowserConsoleExecOutput> {
+  const s = await ensureState();
+  const result = await s.page.evaluate(
+    (code: string) =>
+      // eslint-disable-next-line no-new-func
+      new Function(`return (async () => { return (${code}); })()`)(),
+    input.javascript
+  );
+  return { result_json: JSON.stringify(result ?? null) };
+}
+
+export async function browserConsoleView(
+  input: BrowserConsoleViewInput
+): Promise<BrowserConsoleViewOutput> {
+  const s = await ensureState();
+  const max = input.max_lines ?? 100;
+  const messages = s.consoleMessages.slice(-max);
+  return { messages };
+}
+
+/** Test hook — tear down the browser singleton. */
+export async function _shutdownForTests(): Promise<void> {
+  if (state) {
+    try {
+      await state.browser.close();
+    } catch {
+      // ignore
+    }
+    state = null;
+  }
+}

--- a/packages/sandbox-agent/src/tools/deploy.ts
+++ b/packages/sandbox-agent/src/tools/deploy.ts
@@ -1,0 +1,35 @@
+/**
+ * Deploy tools — `expose_port` returns the published host URL for one of
+ * the pre-allocated user-service container ports.
+ *
+ * The host publishes ports at container-create time (see
+ * DockerSandboxProvider.userServicePorts) and then POSTs the resolved
+ * map to /internal/set-port-map. `expose_port` is a read-only lookup
+ * against that registry; the agent's service has to actually be
+ * listening on the requested container port.
+ */
+
+import type {
+  ExposePortInput,
+  ExposePortOutput
+} from "@nodetool/sandbox/schemas";
+import { getPublicUrl, knownContainerPorts } from "../port-map.js";
+
+export async function exposePort(
+  input: ExposePortInput
+): Promise<ExposePortOutput> {
+  const url = getPublicUrl(input.port);
+  if (!url) {
+    const known = knownContainerPorts().join(", ") || "(none)";
+    throw new Error(
+      `container port ${input.port} is not in the exposed pool. Available: ${known}`
+    );
+  }
+  const scheme = input.scheme ?? "http";
+  const rewritten = url.replace(/^https?:/, `${scheme}:`);
+  return {
+    container_port: input.port,
+    public_url: rewritten,
+    expires_at: null
+  };
+}

--- a/packages/sandbox-agent/src/tools/desktop.ts
+++ b/packages/sandbox-agent/src/tools/desktop.ts
@@ -70,7 +70,7 @@ export async function screenCapture(
           width: input.region.width,
           height: input.region.height
         }
-      : await readPngDimensions(buf);
+      : await readImageDimensions(buf, format);
     return { image_b64: b64, format, width, height };
   } finally {
     await fs.unlink(tmpFile).catch(() => {});
@@ -255,6 +255,52 @@ async function readPngDimensions(
     width: buf.readUInt32BE(16),
     height: buf.readUInt32BE(20)
   };
+}
+
+function readJpegDimensions(buf: Buffer): { width: number; height: number } {
+  if (buf.length < 2 || buf[0] !== 0xff || buf[1] !== 0xd8) {
+    return { width: 0, height: 0 };
+  }
+  let offset = 2;
+  while (offset < buf.length - 1) {
+    if (buf[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buf[offset + 1];
+    if (marker === 0xd8) {
+      offset += 2;
+      continue;
+    }
+    if (marker === 0xd9) break;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+      offset += 2;
+      continue;
+    }
+    if (buf.length < offset + 4) break;
+    const length = buf.readUInt16BE(offset + 2);
+    if (
+      (marker === 0xc0 || marker === 0xc1 || marker === 0xc2) &&
+      buf.length >= offset + 10
+    ) {
+      return {
+        height: buf.readUInt16BE(offset + 5),
+        width: buf.readUInt16BE(offset + 7)
+      };
+    }
+    offset += 2 + length;
+  }
+  return { width: 0, height: 0 };
+}
+
+async function readImageDimensions(
+  buf: Buffer,
+  format: string
+): Promise<{ width: number; height: number }> {
+  if (format === "jpeg") {
+    return readJpegDimensions(buf);
+  }
+  return readPngDimensions(buf);
 }
 
 /** @internal exported for tests */

--- a/packages/sandbox-agent/src/tools/desktop.ts
+++ b/packages/sandbox-agent/src/tools/desktop.ts
@@ -1,0 +1,331 @@
+/**
+ * Desktop (X11) tools — thin wrappers over xdotool and scrot.
+ *
+ * Coordinates are screen pixels against $DISPLAY (":99" by default, set by
+ * entrypoint.sh). Screenshots are returned as base64-encoded image data.
+ * `screen_find` uses tesseract OCR to locate text on screen; template image
+ * matching is deferred to a later phase.
+ *
+ * These tools intentionally have NO in-memory state — every call is a
+ * fresh subprocess.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import type {
+  ScreenCaptureInput,
+  ScreenCaptureOutput,
+  ScreenFindInput,
+  ScreenFindOutput,
+  ScreenMatch,
+  MouseMoveInput,
+  MouseMoveOutput,
+  MouseClickInput,
+  MouseClickOutput,
+  MouseDragInput,
+  MouseDragOutput,
+  MouseScrollInput,
+  MouseScrollOutput,
+  KeyPressInput,
+  KeyPressOutput,
+  KeyTypeInput,
+  KeyTypeOutput,
+  CursorPositionOutput
+} from "@nodetool/sandbox/schemas";
+
+const XDOTOOL_BUTTON: Record<string, string> = {
+  left: "1",
+  middle: "2",
+  right: "3"
+};
+
+export async function screenCapture(
+  input: ScreenCaptureInput
+): Promise<ScreenCaptureOutput> {
+  const format = input.format ?? "png";
+  const ext = format === "jpeg" ? "jpg" : "png";
+  const tmpFile = join(
+    tmpdir(),
+    `nt-capture-${randomBytes(6).toString("hex")}.${ext}`
+  );
+
+  const args: string[] = ["-o"];
+  if (input.region) {
+    args.push("-a", `${input.region.x},${input.region.y},${input.region.width},${input.region.height}`);
+  }
+  if (format === "jpeg") {
+    args.push("-q", "90");
+  }
+  args.push(tmpFile);
+
+  try {
+    await runCapture("scrot", args);
+    const buf = await fs.readFile(tmpFile);
+    const b64 = buf.toString("base64");
+    const { width, height } = input.region
+      ? {
+          width: input.region.width,
+          height: input.region.height
+        }
+      : await readPngDimensions(buf);
+    return { image_b64: b64, format, width, height };
+  } finally {
+    await fs.unlink(tmpFile).catch(() => {});
+  }
+}
+
+export async function screenFind(
+  input: ScreenFindInput
+): Promise<ScreenFindOutput> {
+  // Capture screen (or region), run tesseract with TSV output, filter by query.
+  const tmpImg = join(
+    tmpdir(),
+    `nt-find-${randomBytes(6).toString("hex")}.png`
+  );
+  const scrotArgs: string[] = ["-o"];
+  let regionOffset = { x: 0, y: 0 };
+  if (input.region) {
+    scrotArgs.push(
+      "-a",
+      `${input.region.x},${input.region.y},${input.region.width},${input.region.height}`
+    );
+    regionOffset = { x: input.region.x, y: input.region.y };
+  }
+  scrotArgs.push(tmpImg);
+
+  try {
+    await runCapture("scrot", scrotArgs);
+    const tsv = (
+      await runCapture("tesseract", [tmpImg, "stdout", "tsv"])
+    ).toString("utf-8");
+    const matches = parseTesseractTsv(tsv, input.query, regionOffset);
+    return { matches };
+  } finally {
+    await fs.unlink(tmpImg).catch(() => {});
+  }
+}
+
+export async function mouseMove(input: MouseMoveInput): Promise<MouseMoveOutput> {
+  if (input.duration_ms && input.duration_ms > 0) {
+    // xdotool has no native tween, so step in ~10ms increments.
+    const steps = Math.max(2, Math.round(input.duration_ms / 10));
+    const cur = await getCursor();
+    for (let i = 1; i <= steps; i++) {
+      const x = Math.round(cur.x + ((input.x - cur.x) * i) / steps);
+      const y = Math.round(cur.y + ((input.y - cur.y) * i) / steps);
+      await runCapture("xdotool", ["mousemove", String(x), String(y)]);
+      await sleep(Math.round(input.duration_ms / steps));
+    }
+  } else {
+    await runCapture("xdotool", [
+      "mousemove",
+      String(input.x),
+      String(input.y)
+    ]);
+  }
+  return { moved: true };
+}
+
+export async function mouseClick(
+  input: MouseClickInput
+): Promise<MouseClickOutput> {
+  const button = XDOTOOL_BUTTON[input.button ?? "left"] ?? "1";
+  const count = input.count ?? 1;
+  await runCapture("xdotool", [
+    "mousemove",
+    String(input.x),
+    String(input.y),
+    "click",
+    "--repeat",
+    String(count),
+    button
+  ]);
+  return { clicked: true };
+}
+
+export async function mouseDrag(input: MouseDragInput): Promise<MouseDragOutput> {
+  const button = XDOTOOL_BUTTON[input.button ?? "left"] ?? "1";
+  await runCapture("xdotool", [
+    "mousemove",
+    String(input.from_x),
+    String(input.from_y),
+    "mousedown",
+    button
+  ]);
+  if (input.duration_ms && input.duration_ms > 0) {
+    const steps = Math.max(2, Math.round(input.duration_ms / 10));
+    for (let i = 1; i <= steps; i++) {
+      const x = Math.round(input.from_x + ((input.to_x - input.from_x) * i) / steps);
+      const y = Math.round(input.from_y + ((input.to_y - input.from_y) * i) / steps);
+      await runCapture("xdotool", ["mousemove", String(x), String(y)]);
+      await sleep(Math.round(input.duration_ms / steps));
+    }
+  } else {
+    await runCapture("xdotool", [
+      "mousemove",
+      String(input.to_x),
+      String(input.to_y)
+    ]);
+  }
+  await runCapture("xdotool", ["mouseup", button]);
+  return { dragged: true };
+}
+
+export async function mouseScroll(
+  input: MouseScrollInput
+): Promise<MouseScrollOutput> {
+  // xdotool: button 4 scroll up, 5 down, 6 left, 7 right; each click = 1 step.
+  await runCapture("xdotool", [
+    "mousemove",
+    String(input.x),
+    String(input.y)
+  ]);
+  const steps = Math.min(50, Math.abs(input.dy));
+  const vButton = input.dy < 0 ? "4" : "5";
+  if (steps > 0) {
+    await runCapture("xdotool", [
+      "click",
+      "--repeat",
+      String(steps),
+      vButton
+    ]);
+  }
+  if (input.dx !== undefined && input.dx !== 0) {
+    const hSteps = Math.min(50, Math.abs(input.dx));
+    const hButton = input.dx < 0 ? "6" : "7";
+    await runCapture("xdotool", [
+      "click",
+      "--repeat",
+      String(hSteps),
+      hButton
+    ]);
+  }
+  return { scrolled: true };
+}
+
+export async function keyPress(input: KeyPressInput): Promise<KeyPressOutput> {
+  await runCapture("xdotool", ["key", "--", input.keys]);
+  return { pressed: true };
+}
+
+export async function keyType(input: KeyTypeInput): Promise<KeyTypeOutput> {
+  const args = ["type"];
+  if (input.delay_ms !== undefined) {
+    args.push("--delay", String(input.delay_ms));
+  }
+  args.push("--", input.text);
+  await runCapture("xdotool", args);
+  return { typed: true };
+}
+
+export async function cursorPosition(): Promise<CursorPositionOutput> {
+  return getCursor();
+}
+
+// ---- internals -------------------------------------------------------------
+
+async function getCursor(): Promise<{ x: number; y: number }> {
+  const out = (await runCapture("xdotool", ["getmouselocation"]))
+    .toString("utf-8")
+    .trim();
+  // Format: "x:NNN y:NNN screen:0 window:0"
+  const match = /x:(-?\d+)\s+y:(-?\d+)/.exec(out);
+  if (!match) throw new Error(`unable to parse cursor position: ${out}`);
+  return { x: parseInt(match[1], 10), y: parseInt(match[2], 10) };
+}
+
+async function readPngDimensions(
+  buf: Buffer
+): Promise<{ width: number; height: number }> {
+  // PNG signature is 8 bytes, then an IHDR chunk at offset 8:
+  //   4B length, 4B "IHDR", 4B width, 4B height, ...
+  if (
+    buf.length < 24 ||
+    buf[0] !== 0x89 ||
+    buf[1] !== 0x50 ||
+    buf[2] !== 0x4e ||
+    buf[3] !== 0x47
+  ) {
+    return { width: 0, height: 0 };
+  }
+  return {
+    width: buf.readUInt32BE(16),
+    height: buf.readUInt32BE(20)
+  };
+}
+
+/** @internal exported for tests */
+export function parseTesseractTsv(
+  tsv: string,
+  query: string,
+  offset: { x: number; y: number }
+): ScreenMatch[] {
+  const lines = tsv.split("\n");
+  if (lines.length < 2) return [];
+  const header = lines[0].split("\t");
+  const col = (name: string) => header.indexOf(name);
+  const idx = {
+    left: col("left"),
+    top: col("top"),
+    width: col("width"),
+    height: col("height"),
+    conf: col("conf"),
+    text: col("text")
+  };
+  if (Object.values(idx).some((v) => v < 0)) return [];
+
+  const needle = query.toLowerCase();
+  const matches: ScreenMatch[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const parts = lines[i].split("\t");
+    if (parts.length <= idx.text) continue;
+    const text = parts[idx.text];
+    if (!text || !text.toLowerCase().includes(needle)) continue;
+    const rawConf = parseFloat(parts[idx.conf]);
+    const confidence = Number.isFinite(rawConf) ? Math.max(0, rawConf) / 100 : 0;
+    const left = parseInt(parts[idx.left], 10);
+    const top = parseInt(parts[idx.top], 10);
+    const width = parseInt(parts[idx.width], 10);
+    const height = parseInt(parts[idx.height], 10);
+    if ([left, top, width, height].some((n) => !Number.isFinite(n))) continue;
+    matches.push({
+      text,
+      confidence,
+      x: offset.x + left,
+      y: offset.y + top,
+      width,
+      height
+    });
+  }
+  return matches;
+}
+
+function runCapture(cmd: string, args: string[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, DISPLAY: process.env.DISPLAY ?? ":99" }
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout?.on("data", (c: Buffer) => out.push(c));
+    child.stderr?.on("data", (c: Buffer) => err.push(c));
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      if (code === 0) resolve(Buffer.concat(out));
+      else
+        reject(
+          new Error(
+            Buffer.concat(err).toString("utf-8").trim() || `${cmd} exit ${code}`
+          )
+        );
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/sandbox-agent/src/tools/file.ts
+++ b/packages/sandbox-agent/src/tools/file.ts
@@ -1,0 +1,220 @@
+/**
+ * File tools — direct fs operations inside the sandbox container.
+ *
+ * Paths are passed through as-is; the container's filesystem IS the sandbox
+ * boundary, so there's no chroot logic here. The server runs as an
+ * unprivileged user; `sudo` is allowed only when the caller requests it AND
+ * passwordless sudo is configured in the image for whitelisted commands.
+ */
+
+import { promises as fs } from "node:fs";
+import { dirname } from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  type FileReadInput,
+  type FileReadOutput,
+  type FileWriteInput,
+  type FileWriteOutput,
+  type FileStrReplaceInput,
+  type FileStrReplaceOutput,
+  type FileFindInContentInput,
+  type FileFindInContentOutput,
+  type FileFindByNameInput,
+  type FileFindByNameOutput,
+  type FileMatch
+} from "@nodetool/sandbox/schemas";
+
+const MAX_READ_BYTES = 10 * 1024 * 1024;
+
+export async function fileRead(input: FileReadInput): Promise<FileReadOutput> {
+  const raw = await readMaybeSudo(input.file, input.sudo ?? false);
+  const text = raw.toString("utf-8");
+  const lines = text.split("\n");
+  const total = lines.length;
+
+  const start = input.start_line ?? 0;
+  const end = input.end_line ?? total;
+  const slice = lines.slice(start, end).join("\n");
+
+  return {
+    content: slice,
+    total_lines: total,
+    truncated: raw.byteLength >= MAX_READ_BYTES
+  };
+}
+
+export async function fileWrite(
+  input: FileWriteInput
+): Promise<FileWriteOutput> {
+  let content = input.content;
+  if (input.leading_newline && !content.startsWith("\n")) content = "\n" + content;
+  if (input.trailing_newline && !content.endsWith("\n")) content = content + "\n";
+
+  await fs.mkdir(dirname(input.file), { recursive: true });
+
+  if (input.sudo) {
+    await writeSudo(input.file, content, input.append ?? false);
+  } else if (input.append) {
+    await fs.appendFile(input.file, content, "utf-8");
+  } else {
+    await fs.writeFile(input.file, content, "utf-8");
+  }
+
+  return {
+    bytes_written: Buffer.byteLength(content, "utf-8"),
+    file: input.file
+  };
+}
+
+export async function fileStrReplace(
+  input: FileStrReplaceInput
+): Promise<FileStrReplaceOutput> {
+  const raw = await readMaybeSudo(input.file, input.sudo ?? false);
+  const text = raw.toString("utf-8");
+  const parts = text.split(input.old_str);
+  const replacements = parts.length - 1;
+  if (replacements === 0) {
+    throw new Error(`old_str not found in ${input.file}`);
+  }
+  const next = parts.join(input.new_str);
+  if (input.sudo) {
+    await writeSudo(input.file, next, false);
+  } else {
+    await fs.writeFile(input.file, next, "utf-8");
+  }
+  return { replacements, file: input.file };
+}
+
+export async function fileFindInContent(
+  input: FileFindInContentInput
+): Promise<FileFindInContentOutput> {
+  const raw = await readMaybeSudo(input.file, input.sudo ?? false);
+  const text = raw.toString("utf-8");
+  const lines = text.split("\n");
+  const re = new RegExp(input.regex);
+  const matches: FileMatch[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = re.exec(lines[i]);
+    if (m) {
+      matches.push({
+        line_number: i + 1,
+        line: lines[i],
+        match: m[0]
+      });
+    }
+  }
+  return { matches };
+}
+
+export async function fileFindByName(
+  input: FileFindByNameInput
+): Promise<FileFindByNameOutput> {
+  // Use `find` with -name to keep globs simple and behavior predictable.
+  // We pass the glob as-is; shell quoting is handled by spawn's argv form.
+  const paths = await runFind(input.path, input.glob);
+  return { paths };
+}
+
+// ---- internals -------------------------------------------------------------
+
+async function readMaybeSudo(file: string, sudo: boolean): Promise<Buffer> {
+  if (!sudo) {
+    const stat = await fs.stat(file);
+    if (stat.size > MAX_READ_BYTES) {
+      const fd = await fs.open(file, "r");
+      try {
+        const buf = Buffer.alloc(MAX_READ_BYTES);
+        await fd.read(buf, 0, MAX_READ_BYTES, 0);
+        return buf;
+      } finally {
+        await fd.close();
+      }
+    }
+    return fs.readFile(file);
+  }
+  return runCapture("sudo", ["-n", "cat", file]);
+}
+
+async function writeSudo(
+  file: string,
+  content: string,
+  append: boolean
+): Promise<void> {
+  const cmd = append
+    ? ["sudo", "-n", "tee", "-a", file]
+    : ["sudo", "-n", "tee", file];
+  await runWithStdin(cmd[0], cmd.slice(1), content);
+}
+
+function runCapture(cmd: string, args: string[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout?.on("data", (c: Buffer) => out.push(c));
+    child.stderr?.on("data", (c: Buffer) => err.push(c));
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      if (code === 0) resolve(Buffer.concat(out));
+      else
+        reject(
+          new Error(
+            Buffer.concat(err).toString("utf-8").trim() || `${cmd} exit ${code}`
+          )
+        );
+    });
+  });
+}
+
+function runWithStdin(
+  cmd: string,
+  args: string[],
+  stdin: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(cmd, args, {
+      stdio: ["pipe", "ignore", "pipe"]
+    });
+    const err: Buffer[] = [];
+    child.stderr?.on("data", (c: Buffer) => err.push(c));
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(
+            Buffer.concat(err).toString("utf-8").trim() || `${cmd} exit ${code}`
+          )
+        );
+    });
+    child.stdin?.end(stdin, "utf-8");
+  });
+}
+
+function runFind(root: string, glob: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn("find", [root, "-name", glob], {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout?.on("data", (c: Buffer) => out.push(c));
+    child.stderr?.on("data", (c: Buffer) => err.push(c));
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      if (code !== 0 && code !== 1) {
+        reject(
+          new Error(
+            Buffer.concat(err).toString("utf-8").trim() || `find exit ${code}`
+          )
+        );
+        return;
+      }
+      const text = Buffer.concat(out).toString("utf-8");
+      const paths = text.split("\n").map((s) => s.trim()).filter(Boolean);
+      resolve(paths);
+    });
+  });
+}

--- a/packages/sandbox-agent/src/tools/file.ts
+++ b/packages/sandbox-agent/src/tools/file.ts
@@ -32,9 +32,11 @@ export async function fileRead(input: FileReadInput): Promise<FileReadOutput> {
   const lines = text.split("\n");
   const total = lines.length;
 
-  const start = input.start_line ?? 0;
-  const end = input.end_line ?? total;
-  const slice = lines.slice(start, end).join("\n");
+  const requestedStartLine = input.start_line ?? 1;
+  const requestedEndLine = input.end_line ?? total;
+  const startIdx = Math.max(0, requestedStartLine - 1);
+  const endIdx = Math.min(total, requestedEndLine);
+  const slice = lines.slice(startIdx, endIdx).join("\n");
 
   return {
     content: slice,
@@ -195,7 +197,7 @@ function runWithStdin(
 
 function runFind(root: string, glob: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    const child: ChildProcess = spawn("find", [root, "-name", glob], {
+    const child: ChildProcess = spawn("find", ["--", root, "-name", glob], {
       stdio: ["ignore", "pipe", "pipe"]
     });
     const out: Buffer[] = [];

--- a/packages/sandbox-agent/src/tools/file.ts
+++ b/packages/sandbox-agent/src/tools/file.ts
@@ -93,7 +93,14 @@ export async function fileFindInContent(
   const raw = await readMaybeSudo(input.file, input.sudo ?? false);
   const text = raw.toString("utf-8");
   const lines = text.split("\n");
-  const re = new RegExp(input.regex);
+  let re: RegExp;
+  try {
+    re = new RegExp(input.regex);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid regex for fileFindInContent: ${message}`);
+  }
   const matches: FileMatch[] = [];
   for (let i = 0; i < lines.length; i++) {
     const m = re.exec(lines[i]);

--- a/packages/sandbox-agent/src/tools/message.ts
+++ b/packages/sandbox-agent/src/tools/message.ts
@@ -1,0 +1,62 @@
+/**
+ * Messaging tools — emit SandboxEvents onto the event bus.
+ *
+ * Manus splits "notify" (non-blocking) from "ask" (blocking question).
+ * We keep that split even though both map to the same push-an-event
+ * operation here; the *agent's* loop is what chooses to wait for a
+ * user reply before the next step after an `ask`.
+ *
+ * `idle` is a sentinel event the agent emits to signal it has finished
+ * the current objective (Manus convention, explicitly documented in the
+ * leaked system prompt).
+ */
+
+import type {
+  MessageNotifyUserInput,
+  MessageNotifyUserOutput,
+  MessageAskUserInput,
+  MessageAskUserOutput,
+  IdleInput,
+  IdleOutput
+} from "@nodetool/sandbox/schemas";
+import { newEventId, publish } from "../event-bus.js";
+
+export async function messageNotifyUser(
+  input: MessageNotifyUserInput
+): Promise<MessageNotifyUserOutput> {
+  const id = newEventId();
+  publish({
+    id,
+    type: "notify",
+    timestamp: Date.now(),
+    text: input.text,
+    attachments: input.attachments
+  });
+  return { event_id: id };
+}
+
+export async function messageAskUser(
+  input: MessageAskUserInput
+): Promise<MessageAskUserOutput> {
+  const id = newEventId();
+  publish({
+    id,
+    type: "ask",
+    timestamp: Date.now(),
+    text: input.text,
+    attachments: input.attachments,
+    suggest_user_takeover: input.suggest_user_takeover
+  });
+  return { event_id: id };
+}
+
+export async function idle(input: IdleInput): Promise<IdleOutput> {
+  const id = newEventId();
+  publish({
+    id,
+    type: "idle",
+    timestamp: Date.now(),
+    text: input.reason
+  });
+  return { event_id: id };
+}

--- a/packages/sandbox-agent/src/tools/search.ts
+++ b/packages/sandbox-agent/src/tools/search.ts
@@ -1,0 +1,259 @@
+/**
+ * Search tool — web search over a configurable provider.
+ *
+ * Provider is selected via NODETOOL_SEARCH_PROVIDER env var. Each provider
+ * reads its own API key from env:
+ *   - tavily  : TAVILY_API_KEY
+ *   - brave   : BRAVE_API_KEY
+ *   - serper  : SERPER_API_KEY
+ *
+ * All providers normalize to the shared SearchResult shape.
+ */
+
+import type {
+  InfoSearchWebInput,
+  InfoSearchWebOutput,
+  SearchResult,
+  SearchDateRange
+} from "@nodetool/sandbox/schemas";
+
+export type SearchProvider = "tavily" | "brave" | "serper" | "mock";
+
+export interface SearchProviderFn {
+  (query: string, opts: {
+    count: number;
+    dateRange: SearchDateRange;
+  }): Promise<SearchResult[]>;
+}
+
+interface Env {
+  provider: SearchProvider;
+  tavilyKey?: string;
+  braveKey?: string;
+  serperKey?: string;
+}
+
+function readEnv(): Env {
+  const rawProvider = (process.env.NODETOOL_SEARCH_PROVIDER ?? "").toLowerCase();
+  const provider: SearchProvider =
+    rawProvider === "brave" ||
+    rawProvider === "serper" ||
+    rawProvider === "tavily" ||
+    rawProvider === "mock"
+      ? rawProvider
+      : "tavily";
+  return {
+    provider,
+    tavilyKey: process.env.TAVILY_API_KEY,
+    braveKey: process.env.BRAVE_API_KEY,
+    serperKey: process.env.SERPER_API_KEY
+  };
+}
+
+/** Test hook: injected fetch + provider override. */
+export interface SearchOverride {
+  fetch?: typeof fetch;
+  provider?: SearchProvider;
+  providers?: Partial<Record<SearchProvider, SearchProviderFn>>;
+}
+
+let override: SearchOverride | null = null;
+export function setSearchOverride(o: SearchOverride | null): void {
+  override = o;
+}
+
+export async function infoSearchWeb(
+  input: InfoSearchWebInput
+): Promise<InfoSearchWebOutput> {
+  const env = readEnv();
+  const provider = override?.provider ?? env.provider;
+  const count = input.count ?? 10;
+  const dateRange = input.date_range ?? "any";
+  const f = override?.fetch ?? globalThis.fetch;
+
+  const custom = override?.providers?.[provider];
+  let results: SearchResult[];
+  if (custom) {
+    results = await custom(input.query, { count, dateRange });
+  } else {
+    switch (provider) {
+      case "tavily":
+        results = await tavilySearch(f, env.tavilyKey, input.query, count, dateRange);
+        break;
+      case "brave":
+        results = await braveSearch(f, env.braveKey, input.query, count, dateRange);
+        break;
+      case "serper":
+        results = await serperSearch(f, env.serperKey, input.query, count, dateRange);
+        break;
+      case "mock":
+        results = [];
+        break;
+    }
+  }
+
+  return { provider, query: input.query, results };
+}
+
+// ---- provider implementations --------------------------------------------
+
+async function tavilySearch(
+  f: typeof fetch,
+  key: string | undefined,
+  query: string,
+  count: number,
+  dateRange: SearchDateRange
+): Promise<SearchResult[]> {
+  if (!key) throw new Error("TAVILY_API_KEY not set");
+  const body: Record<string, unknown> = {
+    api_key: key,
+    query,
+    max_results: count,
+    include_answer: false,
+    search_depth: "basic"
+  };
+  if (dateRange !== "any") {
+    body.days = dateRangeToDays(dateRange);
+  }
+  const res = await f("https://api.tavily.com/search", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`tavily ${res.status}: ${await res.text()}`);
+  const data = (await res.json()) as {
+    results?: Array<{
+      title?: string;
+      url?: string;
+      content?: string;
+      published_date?: string;
+    }>;
+  };
+  return (data.results ?? []).map((r) => ({
+    title: r.title ?? "",
+    url: r.url ?? "",
+    snippet: r.content ?? "",
+    published_at: r.published_date ?? null
+  }));
+}
+
+async function braveSearch(
+  f: typeof fetch,
+  key: string | undefined,
+  query: string,
+  count: number,
+  dateRange: SearchDateRange
+): Promise<SearchResult[]> {
+  if (!key) throw new Error("BRAVE_API_KEY not set");
+  const url = new URL("https://api.search.brave.com/res/v1/web/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(count));
+  if (dateRange !== "any") {
+    url.searchParams.set("freshness", braveFreshness(dateRange));
+  }
+  const res = await f(url.toString(), {
+    headers: {
+      accept: "application/json",
+      "X-Subscription-Token": key
+    }
+  });
+  if (!res.ok) throw new Error(`brave ${res.status}: ${await res.text()}`);
+  const data = (await res.json()) as {
+    web?: {
+      results?: Array<{
+        title?: string;
+        url?: string;
+        description?: string;
+        page_age?: string;
+      }>;
+    };
+  };
+  return (data.web?.results ?? []).map((r) => ({
+    title: r.title ?? "",
+    url: r.url ?? "",
+    snippet: r.description ?? "",
+    published_at: r.page_age ?? null
+  }));
+}
+
+async function serperSearch(
+  f: typeof fetch,
+  key: string | undefined,
+  query: string,
+  count: number,
+  dateRange: SearchDateRange
+): Promise<SearchResult[]> {
+  if (!key) throw new Error("SERPER_API_KEY not set");
+  const body: Record<string, unknown> = { q: query, num: count };
+  if (dateRange !== "any") {
+    body.tbs = serperTbs(dateRange);
+  }
+  const res = await f("https://google.serper.dev/search", {
+    method: "POST",
+    headers: {
+      "X-API-KEY": key,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`serper ${res.status}: ${await res.text()}`);
+  const data = (await res.json()) as {
+    organic?: Array<{
+      title?: string;
+      link?: string;
+      snippet?: string;
+      date?: string;
+    }>;
+  };
+  return (data.organic ?? []).map((r) => ({
+    title: r.title ?? "",
+    url: r.link ?? "",
+    snippet: r.snippet ?? "",
+    published_at: r.date ?? null
+  }));
+}
+
+function dateRangeToDays(d: SearchDateRange): number {
+  switch (d) {
+    case "past_day":
+      return 1;
+    case "past_week":
+      return 7;
+    case "past_month":
+      return 30;
+    case "past_year":
+      return 365;
+    default:
+      return 0;
+  }
+}
+
+function braveFreshness(d: SearchDateRange): string {
+  switch (d) {
+    case "past_day":
+      return "pd";
+    case "past_week":
+      return "pw";
+    case "past_month":
+      return "pm";
+    case "past_year":
+      return "py";
+    default:
+      return "";
+  }
+}
+
+function serperTbs(d: SearchDateRange): string {
+  switch (d) {
+    case "past_day":
+      return "qdr:d";
+    case "past_week":
+      return "qdr:w";
+    case "past_month":
+      return "qdr:m";
+    case "past_year":
+      return "qdr:y";
+    default:
+      return "";
+  }
+}

--- a/packages/sandbox-agent/src/tools/shell.ts
+++ b/packages/sandbox-agent/src/tools/shell.ts
@@ -1,0 +1,234 @@
+/**
+ * Shell tools — named tmux sessions.
+ *
+ * Each session is a tmux detached session with a single window and pane.
+ * Commands are appended with a sentinel to detect completion and capture
+ * the exit code from the pane output.
+ *
+ * Session state is kept in-process. If the tool server restarts, tmux
+ * sessions survive on the host side (tmux server lives in the container)
+ * but the sentinel-tracking state is lost; callers should create fresh
+ * session ids after a server restart.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+  type ShellExecInput,
+  type ShellExecOutput,
+  type ShellViewInput,
+  type ShellViewOutput,
+  type ShellWaitInput,
+  type ShellWaitOutput,
+  type ShellWriteToProcessInput,
+  type ShellWriteToProcessOutput,
+  type ShellKillProcessInput,
+  type ShellKillProcessOutput
+} from "@nodetool/sandbox/schemas";
+
+interface SessionState {
+  tmuxName: string;
+  workDir: string;
+  marker: string | null;
+  lastExitCode: number | null;
+}
+
+const sessions = new Map<string, SessionState>();
+
+const DONE_PREFIX = "__NODETOOL_DONE_";
+
+function tmuxNameFor(id: string): string {
+  // tmux session names can't contain ':' or '.'. Sanitize.
+  return `nt-${id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
+export async function shellExec(input: ShellExecInput): Promise<ShellExecOutput> {
+  const existing = sessions.get(input.id);
+  const workDir = input.exec_dir ?? existing?.workDir ?? "/home/ubuntu";
+
+  if (!existing) {
+    const tmuxName = tmuxNameFor(input.id);
+    // -d detach, -s session name, -c workdir
+    await runTmux(["new-session", "-d", "-s", tmuxName, "-c", workDir]);
+    sessions.set(input.id, {
+      tmuxName,
+      workDir,
+      marker: null,
+      lastExitCode: null
+    });
+  } else if (input.exec_dir && input.exec_dir !== existing.workDir) {
+    // Change directory in the existing session before running the new command.
+    await sendKeys(existing.tmuxName, `cd ${shellQuote(input.exec_dir)}`);
+    existing.workDir = input.exec_dir;
+  }
+
+  const state = sessions.get(input.id)!;
+  const marker = randomBytes(6).toString("hex");
+  state.marker = marker;
+  state.lastExitCode = null;
+
+  const wrapped = `${input.command}; __NT_EC=$?; echo ${DONE_PREFIX}${marker}__:$__NT_EC`;
+  await sendKeys(state.tmuxName, wrapped);
+
+  return { id: input.id, started: true };
+}
+
+export async function shellView(input: ShellViewInput): Promise<ShellViewOutput> {
+  const state = sessions.get(input.id);
+  if (!state) {
+    throw new Error(`shell session not found: ${input.id}`);
+  }
+  const output = await capturePane(state.tmuxName);
+  const { running, exitCode } = parseCompletion(output, state.marker);
+  if (!running && exitCode !== null) state.lastExitCode = exitCode;
+  return {
+    id: input.id,
+    output,
+    running,
+    exit_code: running ? null : state.lastExitCode
+  };
+}
+
+export async function shellWait(input: ShellWaitInput): Promise<ShellWaitOutput> {
+  const state = sessions.get(input.id);
+  if (!state) {
+    throw new Error(`shell session not found: ${input.id}`);
+  }
+  const deadline = Date.now() + (input.seconds ?? 60) * 1000;
+  let output = "";
+  while (Date.now() < deadline) {
+    output = await capturePane(state.tmuxName);
+    const { running, exitCode } = parseCompletion(output, state.marker);
+    if (!running) {
+      state.lastExitCode = exitCode;
+      return {
+        id: input.id,
+        output,
+        running: false,
+        exit_code: exitCode,
+        timed_out: false
+      };
+    }
+    await sleep(500);
+  }
+  return {
+    id: input.id,
+    output,
+    running: true,
+    exit_code: null,
+    timed_out: true
+  };
+}
+
+export async function shellWriteToProcess(
+  input: ShellWriteToProcessInput
+): Promise<ShellWriteToProcessOutput> {
+  const state = sessions.get(input.id);
+  if (!state) {
+    throw new Error(`shell session not found: ${input.id}`);
+  }
+  if (input.press_enter) {
+    await sendKeys(state.tmuxName, input.input);
+  } else {
+    // send-keys without Enter: pass -l (literal) and omit the Enter key.
+    await runTmux([
+      "send-keys",
+      "-t",
+      `${state.tmuxName}:0.0`,
+      "-l",
+      input.input
+    ]);
+  }
+  return {
+    id: input.id,
+    bytes_written: Buffer.byteLength(input.input, "utf-8")
+  };
+}
+
+export async function shellKillProcess(
+  input: ShellKillProcessInput
+): Promise<ShellKillProcessOutput> {
+  const state = sessions.get(input.id);
+  if (!state) {
+    return { id: input.id, killed: false };
+  }
+  try {
+    await runTmux(["kill-session", "-t", state.tmuxName]);
+  } catch {
+    // ignore — session may already be gone
+  }
+  sessions.delete(input.id);
+  return { id: input.id, killed: true };
+}
+
+/** Test-only: clear in-process session registry. */
+export function _resetSessionsForTests(): void {
+  sessions.clear();
+}
+
+// ---- internals -------------------------------------------------------------
+
+async function sendKeys(tmuxName: string, line: string): Promise<void> {
+  // send-keys with Enter: two invocations, first literal text then Enter.
+  await runTmux(["send-keys", "-t", `${tmuxName}:0.0`, "-l", line]);
+  await runTmux(["send-keys", "-t", `${tmuxName}:0.0`, "Enter"]);
+}
+
+async function capturePane(tmuxName: string): Promise<string> {
+  // -p print to stdout, -J join wrapped lines, -S -3000 capture scrollback.
+  const buf = await runCapture("tmux", [
+    "capture-pane",
+    "-t",
+    `${tmuxName}:0.0`,
+    "-p",
+    "-J",
+    "-S",
+    "-3000"
+  ]);
+  return buf.toString("utf-8");
+}
+
+function parseCompletion(
+  output: string,
+  marker: string | null
+): { running: boolean; exitCode: number | null } {
+  if (!marker) return { running: false, exitCode: null };
+  const re = new RegExp(`${DONE_PREFIX}${marker}__:(-?\\d+)`);
+  const m = re.exec(output);
+  if (!m) return { running: true, exitCode: null };
+  return { running: false, exitCode: parseInt(m[1], 10) };
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+async function runTmux(args: string[]): Promise<void> {
+  await runCapture("tmux", args);
+}
+
+function runCapture(cmd: string, args: string[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout?.on("data", (c: Buffer) => out.push(c));
+    child.stderr?.on("data", (c: Buffer) => err.push(c));
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      if (code === 0) resolve(Buffer.concat(out));
+      else
+        reject(
+          new Error(
+            Buffer.concat(err).toString("utf-8").trim() || `${cmd} exit ${code}`
+          )
+        );
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/sandbox-agent/tests/browser.test.ts
+++ b/packages/sandbox-agent/tests/browser.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Browser tool unit tests.
+ *
+ * The tests install a fake PlaywrightAdapter that returns a scripted Browser
+ * / Context / Page — this keeps the test suite off Chromium (which isn't
+ * available in CI by default) while still exercising the full route handling
+ * and DOM-shaping logic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  browserView,
+  browserNavigate,
+  browserClick,
+  browserInput,
+  browserConsoleView,
+  setPlaywrightAdapter,
+  _shutdownForTests
+} from "../src/tools/browser.js";
+
+interface RecordedCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeFakeBrowser(): {
+  calls: RecordedCall[];
+  adapter: { launch: () => Promise<unknown> };
+  emitConsole: (msg: { type(): string; text(): string }) => void;
+  setViewState: (state: {
+    url: string;
+    title: string;
+    elements: unknown[];
+  }) => void;
+} {
+  const calls: RecordedCall[] = [];
+  let onConsole: ((msg: { type(): string; text(): string }) => void) | null = null;
+  const viewState = {
+    url: "about:blank",
+    title: "",
+    elements: [] as unknown[]
+  };
+
+  const page = {
+    url: () => viewState.url,
+    title: async () => viewState.title,
+    viewportSize: () => ({ width: 1280, height: 900 }),
+    evaluate: async (_fn: unknown, _arg?: unknown) => viewState.elements,
+    screenshot: async () => Buffer.from("fake-png"),
+    goto: async (url: string) => {
+      calls.push({ method: "goto", args: [url] });
+      viewState.url = url;
+      viewState.title = `title of ${url}`;
+      return { status: () => 200 };
+    },
+    click: async (selector: string) => {
+      calls.push({ method: "click", args: [selector] });
+    },
+    fill: async (selector: string, text: string) => {
+      calls.push({ method: "fill", args: [selector, text] });
+    },
+    press: async (selector: string, key: string) => {
+      calls.push({ method: "press", args: [selector, key] });
+    },
+    selectOption: async (selector: string, option: string) => {
+      calls.push({ method: "selectOption", args: [selector, option] });
+      return [option];
+    },
+    mouse: {
+      move: async (x: number, y: number) =>
+        calls.push({ method: "mouse.move", args: [x, y] }),
+      click: async (x: number, y: number) =>
+        calls.push({ method: "mouse.click", args: [x, y] })
+    },
+    keyboard: {
+      type: async (text: string) =>
+        calls.push({ method: "keyboard.type", args: [text] }),
+      press: async (key: string) =>
+        calls.push({ method: "keyboard.press", args: [key] })
+    },
+    on: (event: string, handler: (msg: unknown) => void) => {
+      if (event === "console") {
+        onConsole = handler as (m: { type(): string; text(): string }) => void;
+      }
+    }
+  };
+
+  const context = {
+    newPage: async () => page
+  };
+
+  const browser = {
+    newContext: async () => context,
+    close: async () => {
+      calls.push({ method: "browser.close", args: [] });
+    }
+  };
+
+  return {
+    calls,
+    adapter: {
+      launch: async () => browser
+    },
+    emitConsole: (msg) => {
+      if (onConsole) onConsole(msg);
+    },
+    setViewState: (s) => {
+      viewState.url = s.url;
+      viewState.title = s.title;
+      viewState.elements = s.elements;
+    }
+  };
+}
+
+let harness: ReturnType<typeof makeFakeBrowser>;
+
+beforeEach(async () => {
+  harness = makeFakeBrowser();
+  setPlaywrightAdapter(harness.adapter as never);
+});
+
+afterEach(async () => {
+  await _shutdownForTests();
+  setPlaywrightAdapter(null);
+});
+
+describe("browserNavigate", () => {
+  it("navigates and returns status + title", async () => {
+    const out = await browserNavigate({ url: "https://example.com" });
+    expect(out.url).toBe("https://example.com");
+    expect(out.title).toBe("title of https://example.com");
+    expect(out.status).toBe(200);
+    expect(harness.calls[0]).toEqual({
+      method: "goto",
+      args: ["https://example.com"]
+    });
+  });
+});
+
+describe("browserView", () => {
+  it("returns elements and a screenshot by default", async () => {
+    harness.setViewState({
+      url: "https://example.com",
+      title: "Example",
+      elements: [
+        {
+          index: 0,
+          tag: "button",
+          role: null,
+          text: "Submit",
+          attributes: {},
+          bbox: { x: 0, y: 0, width: 10, height: 10 }
+        }
+      ]
+    });
+    const out = await browserView({});
+    expect(out.url).toBe("https://example.com");
+    expect(out.title).toBe("Example");
+    expect(out.elements).toHaveLength(1);
+    expect(out.screenshot_png_b64).toBe(
+      Buffer.from("fake-png").toString("base64")
+    );
+  });
+
+  it("omits screenshot when include_screenshot=false", async () => {
+    const out = await browserView({ include_screenshot: false });
+    expect(out.screenshot_png_b64).toBeNull();
+  });
+});
+
+describe("browserClick", () => {
+  it("clicks by index using the data-nt-idx selector", async () => {
+    await browserClick({ index: 5 });
+    expect(harness.calls.pop()).toEqual({
+      method: "click",
+      args: ['[data-nt-idx="5"]']
+    });
+  });
+
+  it("clicks by coordinates using mouse.click", async () => {
+    await browserClick({ coordinate_x: 42, coordinate_y: 99 });
+    expect(harness.calls.pop()).toEqual({
+      method: "mouse.click",
+      args: [42, 99]
+    });
+  });
+});
+
+describe("browserInput", () => {
+  it("fills the indexed element and optionally presses Enter", async () => {
+    await browserInput({ index: 2, text: "hi", press_enter: true });
+    expect(harness.calls).toContainEqual({
+      method: "fill",
+      args: ['[data-nt-idx="2"]', "hi"]
+    });
+    expect(harness.calls).toContainEqual({
+      method: "press",
+      args: ['[data-nt-idx="2"]', "Enter"]
+    });
+  });
+
+  it("types into coord target after clicking", async () => {
+    await browserInput({
+      text: "hello",
+      coordinate_x: 50,
+      coordinate_y: 50
+    });
+    expect(harness.calls).toContainEqual({
+      method: "mouse.click",
+      args: [50, 50]
+    });
+    expect(harness.calls).toContainEqual({
+      method: "keyboard.type",
+      args: ["hello"]
+    });
+  });
+});
+
+describe("browserConsoleView", () => {
+  it("captures console messages and returns the latest N", async () => {
+    // Force state creation so the console listener is wired up.
+    await browserNavigate({ url: "https://x.test" });
+    harness.emitConsole({ type: () => "log", text: () => "hello" });
+    harness.emitConsole({ type: () => "warn", text: () => "warn!" });
+    const out = await browserConsoleView({ max_lines: 10 });
+    expect(out.messages.map((m) => m.text)).toEqual(["hello", "warn!"]);
+    expect(out.messages[0].type).toBe("log");
+  });
+});

--- a/packages/sandbox-agent/tests/deploy.test.ts
+++ b/packages/sandbox-agent/tests/deploy.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { exposePort } from "../src/tools/deploy.js";
+import { setPortMap, _resetForTests } from "../src/port-map.js";
+
+beforeEach(() => {
+  _resetForTests();
+});
+
+describe("exposePort", () => {
+  it("returns the mapped public URL when the container port is registered", async () => {
+    setPortMap({
+      "8080": "http://127.0.0.1:34567"
+    });
+    const out = await exposePort({ port: 8080 });
+    expect(out).toMatchObject({
+      container_port: 8080,
+      public_url: "http://127.0.0.1:34567",
+      expires_at: null
+    });
+  });
+
+  it("rewrites the scheme when requested", async () => {
+    setPortMap({ "3000": "http://host:12345" });
+    const out = await exposePort({ port: 3000, scheme: "https" });
+    expect(out.public_url).toBe("https://host:12345");
+  });
+
+  it("lists known ports in the error when the requested port is unmapped", async () => {
+    setPortMap({ "3000": "http://host:1", "8080": "http://host:2" });
+    await expect(exposePort({ port: 9999 })).rejects.toThrow(/3000.*8080/);
+  });
+
+  it("error is descriptive when no ports are registered", async () => {
+    await expect(exposePort({ port: 8080 })).rejects.toThrow(/Available: \(none\)/);
+  });
+});

--- a/packages/sandbox-agent/tests/desktop.test.ts
+++ b/packages/sandbox-agent/tests/desktop.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Desktop tool tests.
+ *
+ * - parseTesseractTsv is pure and always tested.
+ * - Runtime tests are gated on xdotool + scrot being installed AND a real
+ *   X display being available (either a running Xvfb or host X11). In most
+ *   CI environments the runtime tests are skipped.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { parseTesseractTsv } from "../src/tools/desktop.js";
+
+const xdotoolAvailable =
+  spawnSync("xdotool", ["--version"], { stdio: "ignore" }).status === 0;
+const scrotAvailable =
+  spawnSync("scrot", ["--version"], { stdio: "ignore" }).status === 0;
+const displayAvailable = !!process.env.DISPLAY;
+
+const runtimeOk = xdotoolAvailable && scrotAvailable && displayAvailable;
+const describeRuntime = runtimeOk ? describe : describe.skip;
+
+describe("parseTesseractTsv", () => {
+  const header =
+    "level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext";
+
+  it("filters matches by query (case-insensitive) and returns offset coords", () => {
+    const tsv =
+      `${header}\n` +
+      `5\t1\t1\t1\t1\t1\t10\t20\t30\t8\t95\tHello\n` +
+      `5\t1\t1\t1\t1\t2\t50\t20\t40\t8\t90\tWorld\n`;
+    const matches = parseTesseractTsv(tsv, "hello", { x: 100, y: 200 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      text: "Hello",
+      x: 110,
+      y: 220,
+      width: 30,
+      height: 8
+    });
+    expect(matches[0].confidence).toBeCloseTo(0.95);
+  });
+
+  it("returns empty array for empty TSV", () => {
+    expect(parseTesseractTsv("", "x", { x: 0, y: 0 })).toEqual([]);
+  });
+
+  it("returns empty array when no rows match", () => {
+    const tsv = `${header}\n5\t1\t1\t1\t1\t1\t0\t0\t1\t1\t95\tonly\n`;
+    expect(parseTesseractTsv(tsv, "missing", { x: 0, y: 0 })).toEqual([]);
+  });
+
+  it("normalizes negative tesseract confidence to 0", () => {
+    const tsv =
+      `${header}\n` + `5\t1\t1\t1\t1\t1\t0\t0\t5\t5\t-1\tBlurry\n`;
+    const matches = parseTesseractTsv(tsv, "blurry", { x: 0, y: 0 });
+    expect(matches[0].confidence).toBe(0);
+  });
+});
+
+describeRuntime("xdotool/scrot runtime (requires DISPLAY + tools)", () => {
+  it("smoke: cursorPosition returns plausible coords", async () => {
+    const { cursorPosition } = await import("../src/tools/desktop.js");
+    const pos = await cursorPosition();
+    expect(Number.isFinite(pos.x)).toBe(true);
+    expect(Number.isFinite(pos.y)).toBe(true);
+  });
+});

--- a/packages/sandbox-agent/tests/file.test.ts
+++ b/packages/sandbox-agent/tests/file.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  fileRead,
+  fileWrite,
+  fileStrReplace,
+  fileFindInContent,
+  fileFindByName
+} from "../src/tools/file.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(join(tmpdir(), "nt-sandbox-file-"));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("fileWrite / fileRead", () => {
+  it("writes then reads back content", async () => {
+    const f = join(root, "a.txt");
+    const w = await fileWrite({ file: f, content: "hello\nworld" });
+    expect(w.bytes_written).toBe(11);
+    expect(w.file).toBe(f);
+
+    const r = await fileRead({ file: f });
+    expect(r.content).toBe("hello\nworld");
+    expect(r.total_lines).toBe(2);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("appends when append=true", async () => {
+    const f = join(root, "a.txt");
+    await fileWrite({ file: f, content: "hello" });
+    await fileWrite({ file: f, content: "-world", append: true });
+    const r = await fileRead({ file: f });
+    expect(r.content).toBe("hello-world");
+  });
+
+  it("applies leading_newline and trailing_newline", async () => {
+    const f = join(root, "a.txt");
+    await fileWrite({
+      file: f,
+      content: "mid",
+      leading_newline: true,
+      trailing_newline: true
+    });
+    const r = await fileRead({ file: f });
+    expect(r.content).toBe("\nmid\n");
+  });
+
+  it("creates parent directories", async () => {
+    const f = join(root, "deep", "nest", "a.txt");
+    await fileWrite({ file: f, content: "x" });
+    const r = await fileRead({ file: f });
+    expect(r.content).toBe("x");
+  });
+
+  it("supports start_line/end_line slicing", async () => {
+    const f = join(root, "lines.txt");
+    await fileWrite({ file: f, content: "a\nb\nc\nd\ne" });
+    const r = await fileRead({ file: f, start_line: 1, end_line: 4 });
+    expect(r.content).toBe("b\nc\nd");
+    expect(r.total_lines).toBe(5);
+  });
+});
+
+describe("fileStrReplace", () => {
+  it("replaces all occurrences", async () => {
+    const f = join(root, "a.txt");
+    await fileWrite({ file: f, content: "foo bar foo baz" });
+    const out = await fileStrReplace({
+      file: f,
+      old_str: "foo",
+      new_str: "qux"
+    });
+    expect(out.replacements).toBe(2);
+    const r = await fileRead({ file: f });
+    expect(r.content).toBe("qux bar qux baz");
+  });
+
+  it("throws when old_str is missing", async () => {
+    const f = join(root, "a.txt");
+    await fileWrite({ file: f, content: "nothing here" });
+    await expect(
+      fileStrReplace({ file: f, old_str: "missing", new_str: "x" })
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("fileFindInContent", () => {
+  it("returns matching lines with line numbers", async () => {
+    const f = join(root, "a.txt");
+    await fileWrite({
+      file: f,
+      content: "alpha\nbravo 42\ncharlie\ndelta 7"
+    });
+    const out = await fileFindInContent({ file: f, regex: "\\d+" });
+    expect(out.matches).toHaveLength(2);
+    expect(out.matches[0]).toMatchObject({
+      line_number: 2,
+      match: "42"
+    });
+    expect(out.matches[1]).toMatchObject({
+      line_number: 4,
+      match: "7"
+    });
+  });
+});
+
+describe("fileFindByName", () => {
+  it("finds files by glob", async () => {
+    await fileWrite({ file: join(root, "a.txt"), content: "1" });
+    await fileWrite({ file: join(root, "b.txt"), content: "2" });
+    await fileWrite({ file: join(root, "c.md"), content: "3" });
+    const out = await fileFindByName({ path: root, glob: "*.txt" });
+    expect(out.paths.sort()).toEqual(
+      [join(root, "a.txt"), join(root, "b.txt")].sort()
+    );
+  });
+
+  it("returns empty array when nothing matches", async () => {
+    const out = await fileFindByName({ path: root, glob: "*.nothing" });
+    expect(out.paths).toEqual([]);
+  });
+});

--- a/packages/sandbox-agent/tests/file.test.ts
+++ b/packages/sandbox-agent/tests/file.test.ts
@@ -63,7 +63,7 @@ describe("fileWrite / fileRead", () => {
   it("supports start_line/end_line slicing", async () => {
     const f = join(root, "lines.txt");
     await fileWrite({ file: f, content: "a\nb\nc\nd\ne" });
-    const r = await fileRead({ file: f, start_line: 1, end_line: 4 });
+    const r = await fileRead({ file: f, start_line: 2, end_line: 4 });
     expect(r.content).toBe("b\nc\nd");
     expect(r.total_lines).toBe(5);
   });

--- a/packages/sandbox-agent/tests/messaging-events.test.ts
+++ b/packages/sandbox-agent/tests/messaging-events.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildServer } from "../src/server.js";
+import { _resetForTests } from "../src/event-bus.js";
+
+beforeEach(() => {
+  _resetForTests();
+});
+
+describe("messaging + /events SSE", () => {
+  it("notify_user publishes an event observable via /events", async () => {
+    const app = buildServer();
+    try {
+      const published = await app.inject({
+        method: "POST",
+        url: "/message/notify",
+        payload: { text: "progress update" }
+      });
+      expect(published.statusCode).toBe(200);
+      const { event_id: id } = published.json();
+
+      // After publishing, /events should replay the buffered event.
+      // Use a timeout: inject holds the SSE connection open, so we read
+      // the prefix using a real listen() + fetch.
+      await app.listen({ host: "127.0.0.1", port: 0 });
+      const port = (app.server.address() as { port: number }).port;
+      const controller = new AbortController();
+      const res = await fetch(`http://127.0.0.1:${port}/events`, {
+        headers: { accept: "text/event-stream" },
+        signal: controller.signal
+      });
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let chunk = "";
+      // Read until we see a full SSE frame.
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunk += decoder.decode(value, { stream: true });
+        if (chunk.includes("\n\n")) break;
+      }
+      controller.abort();
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+
+      const frame = chunk.split("\n\n")[0];
+      expect(frame).toContain("progress update");
+      expect(frame).toContain(id);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("ask_user propagates suggest_user_takeover", async () => {
+    const app = buildServer();
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/message/ask",
+        payload: {
+          text: "Solve the captcha",
+          suggest_user_takeover: true
+        }
+      });
+      expect(res.statusCode).toBe(200);
+      await app.listen({ host: "127.0.0.1", port: 0 });
+      const port = (app.server.address() as { port: number }).port;
+      const controller = new AbortController();
+      const es = await fetch(`http://127.0.0.1:${port}/events`, {
+        signal: controller.signal
+      });
+      const reader = es.body!.getReader();
+      const decoder = new TextDecoder();
+      let chunk = "";
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunk += decoder.decode(value, { stream: true });
+        if (chunk.includes("\n\n")) break;
+      }
+      controller.abort();
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+      expect(chunk).toContain('"type":"ask"');
+      expect(chunk).toContain('"suggest_user_takeover":true');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("idle emits an idle event", async () => {
+    const app = buildServer();
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/idle",
+        payload: { reason: "objective complete" }
+      });
+      expect(res.statusCode).toBe(200);
+      const { event_id } = res.json();
+      expect(typeof event_id).toBe("string");
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/sandbox-agent/tests/search.test.ts
+++ b/packages/sandbox-agent/tests/search.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { infoSearchWeb, setSearchOverride } from "../src/tools/search.js";
+
+afterEach(() => {
+  setSearchOverride(null);
+});
+
+function mockFetch(
+  responder: (url: string, init?: RequestInit) => Response
+): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve(responder(String(input), init))) as typeof fetch;
+}
+
+describe("infoSearchWeb", () => {
+  it("normalizes tavily results into SearchResult shape", async () => {
+    setSearchOverride({
+      provider: "tavily",
+      fetch: mockFetch(() =>
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "T1",
+                url: "https://u1",
+                content: "snippet 1",
+                published_date: "2025-10-01"
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+    });
+    process.env.TAVILY_API_KEY = "xxx";
+    const out = await infoSearchWeb({ query: "q" });
+    expect(out.provider).toBe("tavily");
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]).toMatchObject({
+      title: "T1",
+      url: "https://u1",
+      snippet: "snippet 1",
+      published_at: "2025-10-01"
+    });
+  });
+
+  it("maps brave results", async () => {
+    setSearchOverride({
+      provider: "brave",
+      fetch: mockFetch((url) => {
+        expect(url).toContain("search.brave.com");
+        return new Response(
+          JSON.stringify({
+            web: {
+              results: [
+                {
+                  title: "B1",
+                  url: "https://b1",
+                  description: "b-snippet",
+                  page_age: "2025-11-01"
+                }
+              ]
+            }
+          }),
+          { status: 200 }
+        );
+      })
+    });
+    process.env.BRAVE_API_KEY = "yyy";
+    const out = await infoSearchWeb({ query: "q", count: 5 });
+    expect(out.results[0].url).toBe("https://b1");
+  });
+
+  it("uses an injected provider function when supplied", async () => {
+    setSearchOverride({
+      provider: "tavily",
+      providers: {
+        tavily: async (q, opts) => [
+          {
+            title: q.toUpperCase(),
+            url: `https://x/${opts.count}`,
+            snippet: opts.dateRange,
+            published_at: null
+          }
+        ]
+      }
+    });
+    const out = await infoSearchWeb({
+      query: "hi",
+      count: 3,
+      date_range: "past_day"
+    });
+    expect(out.results[0]).toMatchObject({
+      title: "HI",
+      url: "https://x/3",
+      snippet: "past_day"
+    });
+  });
+
+  it("returns empty results for the mock provider", async () => {
+    setSearchOverride({ provider: "mock" });
+    const out = await infoSearchWeb({ query: "q" });
+    expect(out.results).toEqual([]);
+    expect(out.provider).toBe("mock");
+  });
+
+  it("throws when tavily key is missing", async () => {
+    delete process.env.TAVILY_API_KEY;
+    setSearchOverride({ provider: "tavily" });
+    await expect(infoSearchWeb({ query: "q" })).rejects.toThrow(
+      /TAVILY_API_KEY/
+    );
+  });
+});

--- a/packages/sandbox-agent/tests/server.test.ts
+++ b/packages/sandbox-agent/tests/server.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildServer, SANDBOX_AGENT_VERSION } from "../src/server.js";
+
+describe("buildServer / health", () => {
+  it("responds on /health with ok", async () => {
+    const app = buildServer({ workspace: "/workspace" });
+    try {
+      const res = await app.inject({ method: "GET", url: "/health" });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.ok).toBe(true);
+      expect(body.version).toBe(SANDBOX_AGENT_VERSION);
+      expect(body.workspace).toBe("/workspace");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("returns 400 with issues when a route receives invalid input", async () => {
+    const app = buildServer();
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/file/read",
+        payload: { file: "" }
+      });
+      expect(res.statusCode).toBe(400);
+      const body = res.json();
+      expect(body.error).toBe("invalid input");
+      expect(Array.isArray(body.issues)).toBe(true);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/sandbox-agent/tests/server.test.ts
+++ b/packages/sandbox-agent/tests/server.test.ts
@@ -32,4 +32,32 @@ describe("buildServer / health", () => {
       await app.close();
     }
   });
+
+  it("rejects browser_click without index or full coords", async () => {
+    const app = buildServer();
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/browser/click",
+        payload: { coordinate_x: 10 }
+      });
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("rejects mouse_drag missing required coords", async () => {
+    const app = buildServer();
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/desktop/mouse/drag",
+        payload: { from_x: 0, from_y: 0 }
+      });
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/packages/sandbox-agent/tests/shell.test.ts
+++ b/packages/sandbox-agent/tests/shell.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  shellExec,
+  shellView,
+  shellWait,
+  shellKillProcess,
+  _resetSessionsForTests
+} from "../src/tools/shell.js";
+
+const tmuxAvailable = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
+const describeTmux = tmuxAvailable ? describe : describe.skip;
+
+beforeEach(() => {
+  _resetSessionsForTests();
+});
+
+afterAll(() => {
+  if (tmuxAvailable) {
+    // Best-effort: kill any leftover sessions we created.
+    spawnSync("tmux", ["kill-server"], { stdio: "ignore" });
+  }
+});
+
+describeTmux("shell tools (tmux required)", () => {
+  it("runs a command and captures its exit code", async () => {
+    const exec = await shellExec({ id: "t1", command: "echo hi" });
+    expect(exec.started).toBe(true);
+
+    const waited = await shellWait({ id: "t1", seconds: 10 });
+    expect(waited.running).toBe(false);
+    expect(waited.exit_code).toBe(0);
+    expect(waited.output).toMatch(/hi/);
+    expect(waited.timed_out).toBe(false);
+
+    await shellKillProcess({ id: "t1" });
+  });
+
+  it("propagates non-zero exit codes", async () => {
+    await shellExec({ id: "t2", command: "false" });
+    const waited = await shellWait({ id: "t2", seconds: 10 });
+    expect(waited.exit_code).toBe(1);
+    await shellKillProcess({ id: "t2" });
+  });
+
+  it("reports running=true while a command is in-flight", async () => {
+    await shellExec({ id: "t3", command: "sleep 2" });
+    const view = await shellView({ id: "t3" });
+    expect(view.running).toBe(true);
+    expect(view.exit_code).toBeNull();
+    const waited = await shellWait({ id: "t3", seconds: 5 });
+    expect(waited.running).toBe(false);
+    expect(waited.exit_code).toBe(0);
+    await shellKillProcess({ id: "t3" });
+  });
+
+  it("reuses a named session across commands", async () => {
+    await shellExec({ id: "t4", command: "A=42; echo one" });
+    await shellWait({ id: "t4", seconds: 5 });
+    await shellExec({ id: "t4", command: "echo two-$A" });
+    const waited = await shellWait({ id: "t4", seconds: 5 });
+    expect(waited.output).toMatch(/two-42/);
+    await shellKillProcess({ id: "t4" });
+  });
+
+  it("reports timed_out when the command runs past the deadline", async () => {
+    await shellExec({ id: "t5", command: "sleep 5" });
+    const waited = await shellWait({ id: "t5", seconds: 1 });
+    expect(waited.timed_out).toBe(true);
+    expect(waited.running).toBe(true);
+    await shellKillProcess({ id: "t5" });
+  });
+
+  it("throws on view/wait of an unknown session", async () => {
+    await expect(shellView({ id: "nope" })).rejects.toThrow();
+  });
+
+  it("idempotent kill returns killed=false for unknown sessions", async () => {
+    const out = await shellKillProcess({ id: "never-existed" });
+    expect(out.killed).toBe(false);
+  });
+});

--- a/packages/sandbox-agent/tsconfig.json
+++ b/packages/sandbox-agent/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [{ "path": "../sandbox" }]
+}

--- a/packages/sandbox-agent/vitest.config.ts
+++ b/packages/sandbox-agent/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: {
+    timeout: 30_000,
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/packages/sandbox-tools/package.json
+++ b/packages/sandbox-tools/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@nodetool/sandbox-tools",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Agent tool adapter: exposes a sandbox's ToolClient as a set of @nodetool/agents Tool instances",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node ../../scripts/build-typescript-workspace.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nodetool/agents": "*",
+    "@nodetool/runtime": "*",
+    "@nodetool/sandbox": "*",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.2"
+  },
+  "exports": {
+    ".": {
+      "nodetool-dev": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/sandbox-tools/src/SandboxTool.ts
+++ b/packages/sandbox-tools/src/SandboxTool.ts
@@ -1,0 +1,99 @@
+/**
+ * SandboxTool — bridges a sandbox ToolClient method into an
+ * @nodetool/agents Tool.
+ *
+ * Each instance wraps exactly one sandbox tool; the manifest in
+ * `./manifest.ts` instantiates one SandboxTool per sandbox surface
+ * method. Input validation is delegated to the ToolClient (which
+ * re-validates against the shared Zod schema), so the Tool's
+ * `inputSchema` field here is purely for the LLM provider — we convert
+ * the Zod schema via `z.toJSONSchema()`.
+ */
+
+import { z } from "zod";
+import { Tool } from "@nodetool/agents/tool";
+import type { ProcessingContext } from "@nodetool/runtime";
+import type { ToolClient } from "@nodetool/sandbox";
+
+export interface SandboxToolDefinition<TIn, TOut> {
+  /** Tool name as exposed to the LLM. */
+  name: string;
+  /** Human-readable description shown to the LLM. */
+  description: string;
+  /** Input schema used for BOTH the JSON-schema (LLM) and runtime validation. */
+  inputSchema: z.ZodType<TIn>;
+  /** Invoke the ToolClient. */
+  invoke: (client: ToolClient, input: TIn) => Promise<TOut>;
+  /** Optional status-line formatter. */
+  renderStatus?: (input: TIn) => string;
+}
+
+export class SandboxTool<TIn = unknown, TOut = unknown> extends Tool {
+  public readonly name: string;
+  public readonly description: string;
+  public readonly inputSchema: Record<string, unknown>;
+
+  private readonly client: ToolClient;
+  private readonly def: SandboxToolDefinition<TIn, TOut>;
+
+  constructor(client: ToolClient, def: SandboxToolDefinition<TIn, TOut>) {
+    super();
+    this.client = client;
+    this.def = def;
+    this.name = def.name;
+    this.description = def.description;
+    this.inputSchema = toJsonSchema(def.inputSchema);
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const parsed = this.def.inputSchema.safeParse(params);
+    if (!parsed.success) {
+      return {
+        error: "invalid input",
+        issues: parsed.error.issues
+      };
+    }
+    try {
+      return await this.def.invoke(this.client, parsed.data);
+    } catch (err: unknown) {
+      const message =
+        err !== null && typeof err === "object" && "message" in err
+          ? String((err as { message: unknown }).message)
+          : String(err);
+      return { error: message };
+    }
+  }
+
+  override userMessage(params: Record<string, unknown>): string {
+    if (this.def.renderStatus) {
+      try {
+        const parsed = this.def.inputSchema.safeParse(params);
+        if (parsed.success) return this.def.renderStatus(parsed.data);
+      } catch {
+        // fall through
+      }
+    }
+    return `Running ${this.name}`;
+  }
+}
+
+/**
+ * Convert a Zod schema into a plain JSON-schema object suitable for
+ * passing to an LLM provider. Normalizes the output by stripping Zod's
+ * `$schema` key (providers don't consume it) and ensuring `type` is
+ * present — some providers refuse an untyped object.
+ */
+export function toJsonSchema(
+  schema: z.ZodType<unknown>
+): Record<string, unknown> {
+  const raw = z.toJSONSchema(schema, { target: "draft-7" }) as Record<
+    string,
+    unknown
+  >;
+  const { $schema: _s, ...rest } = raw;
+  if (!("type" in rest)) rest.type = "object";
+  return rest;
+}

--- a/packages/sandbox-tools/src/index.ts
+++ b/packages/sandbox-tools/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @nodetool/sandbox-tools — adapter that exposes a sandbox's ToolClient
+ * as a set of @nodetool/agents Tool instances.
+ *
+ * Usage:
+ *
+ *   const provider = new DockerSandboxProvider();
+ *   const store = new SessionStore({ provider });
+ *   const sandbox = await store.acquire("chat-123");
+ *
+ *   const agent = new Agent({
+ *     name: "researcher",
+ *     objective: "...",
+ *     provider, model,
+ *     tools: createSandboxTools(sandbox.client)
+ *   });
+ *
+ *   // ...
+ *   await sandbox.release();
+ */
+
+export { SandboxTool, toJsonSchema } from "./SandboxTool.js";
+export type { SandboxToolDefinition } from "./SandboxTool.js";
+export {
+  createSandboxTools,
+  listSandboxToolNames
+} from "./manifest.js";
+export type { CreateSandboxToolsOptions } from "./manifest.js";

--- a/packages/sandbox-tools/src/manifest.ts
+++ b/packages/sandbox-tools/src/manifest.ts
@@ -1,0 +1,375 @@
+/**
+ * Manifest of every sandbox tool exposed to agents.
+ *
+ * Adding a new sandbox tool here is a three-field change: name,
+ * description, and the ToolClient method to invoke. The input schema is
+ * imported directly from the shared @nodetool/sandbox/schemas.
+ */
+
+import type { ToolClient } from "@nodetool/sandbox";
+import {
+  FileReadInput,
+  FileWriteInput,
+  FileStrReplaceInput,
+  FileFindInContentInput,
+  FileFindByNameInput,
+  ShellExecInput,
+  ShellViewInput,
+  ShellWaitInput,
+  ShellWriteToProcessInput,
+  ShellKillProcessInput,
+  BrowserViewInput,
+  BrowserNavigateInput,
+  BrowserRestartInput,
+  BrowserClickInput,
+  BrowserInputTextInput,
+  BrowserMoveMouseInput,
+  BrowserPressKeyInput,
+  BrowserSelectOptionInput,
+  BrowserScrollInput,
+  BrowserConsoleExecInput,
+  BrowserConsoleViewInput,
+  ScreenCaptureInput,
+  ScreenFindInput,
+  MouseMoveInput,
+  MouseClickInput,
+  MouseDragInput,
+  MouseScrollInput,
+  KeyPressInput,
+  KeyTypeInput,
+  InfoSearchWebInput,
+  MessageNotifyUserInput,
+  MessageAskUserInput,
+  IdleInput,
+  ExposePortInput
+} from "@nodetool/sandbox/schemas";
+import type { SandboxToolDefinition } from "./SandboxTool.js";
+import { SandboxTool } from "./SandboxTool.js";
+
+// Registry of every tool. Not typed as `SandboxToolDefinition<any, any>[]`
+// to keep each entry's generics precise; we erase to `unknown` at the
+// factory boundary.
+function defs(): SandboxToolDefinition<unknown, unknown>[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const all: SandboxToolDefinition<any, any>[] = [
+    // --- File -----------------------------------------------------------
+    {
+      name: "file_read",
+      description:
+        "Read a file from the sandbox filesystem. Returns the full content and a truncation flag.",
+      inputSchema: FileReadInput,
+      invoke: (c, i) => c.fileRead(i),
+      renderStatus: (i) => `Reading ${i.file}`
+    },
+    {
+      name: "file_write",
+      description:
+        "Write (or append to) a file in the sandbox filesystem. Creates parent directories.",
+      inputSchema: FileWriteInput,
+      invoke: (c, i) => c.fileWrite(i),
+      renderStatus: (i) => `Writing ${i.file}`
+    },
+    {
+      name: "file_str_replace",
+      description:
+        "Replace every occurrence of old_str with new_str inside a file. Errors if old_str is absent.",
+      inputSchema: FileStrReplaceInput,
+      invoke: (c, i) => c.fileStrReplace(i),
+      renderStatus: (i) => `Patching ${i.file}`
+    },
+    {
+      name: "file_find_in_content",
+      description:
+        "Search for a regex pattern inside a file. Returns the matching lines with line numbers.",
+      inputSchema: FileFindInContentInput,
+      invoke: (c, i) => c.fileFindInContent(i),
+      renderStatus: (i) => `Searching ${i.file}`
+    },
+    {
+      name: "file_find_by_name",
+      description:
+        "Find files whose name matches a glob under a root directory.",
+      inputSchema: FileFindByNameInput,
+      invoke: (c, i) => c.fileFindByName(i),
+      renderStatus: (i) => `Finding ${i.glob} in ${i.path}`
+    },
+
+    // --- Shell ----------------------------------------------------------
+    {
+      name: "shell_exec",
+      description:
+        "Run a shell command in a persistent named tmux session. Use the same id to run multiple commands in the same session.",
+      inputSchema: ShellExecInput,
+      invoke: (c, i) => c.shellExec(i),
+      renderStatus: (i) =>
+        `Running \`${i.command.slice(0, 60)}${i.command.length > 60 ? "…" : ""}\``
+    },
+    {
+      name: "shell_view",
+      description:
+        "Read the current output buffer of a shell session without blocking.",
+      inputSchema: ShellViewInput,
+      invoke: (c, i) => c.shellView(i),
+      renderStatus: (i) => `Viewing session ${i.id}`
+    },
+    {
+      name: "shell_wait",
+      description:
+        "Wait for a shell session's current command to finish, up to `seconds`.",
+      inputSchema: ShellWaitInput,
+      invoke: (c, i) => c.shellWait(i),
+      renderStatus: (i) => `Waiting on ${i.id}`
+    },
+    {
+      name: "shell_write_to_process",
+      description:
+        "Write to the stdin of a running shell process. Use press_enter=true to submit a line.",
+      inputSchema: ShellWriteToProcessInput,
+      invoke: (c, i) => c.shellWriteToProcess(i),
+      renderStatus: (i) => `Writing to ${i.id}`
+    },
+    {
+      name: "shell_kill_process",
+      description:
+        "Terminate a shell session and release its resources.",
+      inputSchema: ShellKillProcessInput,
+      invoke: (c, i) => c.shellKillProcess(i),
+      renderStatus: (i) => `Killing ${i.id}`
+    },
+
+    // --- Browser --------------------------------------------------------
+    {
+      name: "browser_view",
+      description:
+        "Return the current page's URL, title, an indexed list of interactive elements, and a screenshot.",
+      inputSchema: BrowserViewInput,
+      invoke: (c, i) => c.browserView(i),
+      renderStatus: () => "Inspecting the page"
+    },
+    {
+      name: "browser_navigate",
+      description: "Navigate the browser to a URL and wait for load.",
+      inputSchema: BrowserNavigateInput,
+      invoke: (c, i) => c.browserNavigate(i),
+      renderStatus: (i) => `Navigating to ${i.url}`
+    },
+    {
+      name: "browser_restart",
+      description:
+        "Close and re-open the browser. Optionally navigate to a starting URL.",
+      inputSchema: BrowserRestartInput,
+      invoke: (c, i) => c.browserRestart(i),
+      renderStatus: () => "Restarting the browser"
+    },
+    {
+      name: "browser_click",
+      description:
+        "Click an element. Address by the index returned from browser_view or by viewport coordinates.",
+      inputSchema: BrowserClickInput,
+      invoke: (c, i) => c.browserClick(i),
+      renderStatus: (i) =>
+        i.index !== undefined
+          ? `Clicking element ${i.index}`
+          : `Clicking (${i.coordinate_x}, ${i.coordinate_y})`
+    },
+    {
+      name: "browser_input",
+      description:
+        "Type text into a form field. Address by element index or viewport coordinates. Optionally press Enter after typing.",
+      inputSchema: BrowserInputTextInput,
+      invoke: (c, i) => c.browserInput(i),
+      renderStatus: () => "Typing into the page"
+    },
+    {
+      name: "browser_move_mouse",
+      description: "Move the browser's virtual mouse to viewport coordinates.",
+      inputSchema: BrowserMoveMouseInput,
+      invoke: (c, i) => c.browserMoveMouse(i),
+      renderStatus: (i) =>
+        `Moving mouse to (${i.coordinate_x}, ${i.coordinate_y})`
+    },
+    {
+      name: "browser_press_key",
+      description:
+        "Press a keyboard key or chord in the browser (e.g. 'Enter', 'Control+a').",
+      inputSchema: BrowserPressKeyInput,
+      invoke: (c, i) => c.browserPressKey(i),
+      renderStatus: (i) => `Pressing ${i.key}`
+    },
+    {
+      name: "browser_select_option",
+      description:
+        "Select an option value from a <select> element by its element index.",
+      inputSchema: BrowserSelectOptionInput,
+      invoke: (c, i) => c.browserSelectOption(i),
+      renderStatus: (i) => `Selecting ${i.option}`
+    },
+    {
+      name: "browser_scroll",
+      description:
+        "Scroll the browser viewport. Use to_top, to_bottom, or pixels for a relative scroll.",
+      inputSchema: BrowserScrollInput,
+      invoke: (c, i) => c.browserScroll(i),
+      renderStatus: () => "Scrolling"
+    },
+    {
+      name: "browser_console_exec",
+      description:
+        "Evaluate a JavaScript expression in the page and return the JSON-serialized result.",
+      inputSchema: BrowserConsoleExecInput,
+      invoke: (c, i) => c.browserConsoleExec(i),
+      renderStatus: () => "Running JS in the page"
+    },
+    {
+      name: "browser_console_view",
+      description:
+        "Return recent console messages from the page (log, warn, error).",
+      inputSchema: BrowserConsoleViewInput,
+      invoke: (c, i) => c.browserConsoleView(i),
+      renderStatus: () => "Reading console"
+    },
+
+    // --- Desktop --------------------------------------------------------
+    {
+      name: "screen_capture",
+      description:
+        "Capture the sandbox desktop as a base64-encoded PNG or JPEG. Optionally restricts to a region.",
+      inputSchema: ScreenCaptureInput,
+      invoke: (c, i) => c.screenCapture(i),
+      renderStatus: () => "Capturing screen"
+    },
+    {
+      name: "screen_find",
+      description:
+        "Locate text on the desktop via OCR. Returns bounding boxes and OCR confidence.",
+      inputSchema: ScreenFindInput,
+      invoke: (c, i) => c.screenFind(i),
+      renderStatus: (i) => `Looking for "${i.query}"`
+    },
+    {
+      name: "mouse_move",
+      description:
+        "Move the real desktop mouse cursor to screen coordinates. Optional tween duration in ms.",
+      inputSchema: MouseMoveInput,
+      invoke: (c, i) => c.mouseMove(i),
+      renderStatus: (i) => `Moving cursor to (${i.x}, ${i.y})`
+    },
+    {
+      name: "mouse_click",
+      description:
+        "Move the desktop mouse to coordinates and click. Optional button and click count.",
+      inputSchema: MouseClickInput,
+      invoke: (c, i) => c.mouseClick(i),
+      renderStatus: (i) => `Clicking (${i.x}, ${i.y})`
+    },
+    {
+      name: "mouse_drag",
+      description: "Press-and-hold, move, and release the desktop mouse.",
+      inputSchema: MouseDragInput,
+      invoke: (c, i) => c.mouseDrag(i),
+      renderStatus: (i) =>
+        `Dragging (${i.from_x}, ${i.from_y}) → (${i.to_x}, ${i.to_y})`
+    },
+    {
+      name: "mouse_scroll",
+      description: "Scroll the desktop mouse wheel at a given position.",
+      inputSchema: MouseScrollInput,
+      invoke: (c, i) => c.mouseScroll(i),
+      renderStatus: () => "Scrolling desktop"
+    },
+    {
+      name: "key_press",
+      description:
+        "Press a key or chord on the desktop keyboard (xdotool syntax, e.g. 'ctrl+c').",
+      inputSchema: KeyPressInput,
+      invoke: (c, i) => c.keyPress(i),
+      renderStatus: (i) => `Pressing ${i.keys}`
+    },
+    {
+      name: "key_type",
+      description: "Type a literal string via the desktop keyboard.",
+      inputSchema: KeyTypeInput,
+      invoke: (c, i) => c.keyType(i),
+      renderStatus: () => "Typing on keyboard"
+    },
+
+    // --- Search ---------------------------------------------------------
+    {
+      name: "info_search_web",
+      description:
+        "Search the web via the configured provider (Tavily / Brave / Serper). Returns ranked results.",
+      inputSchema: InfoSearchWebInput,
+      invoke: (c, i) => c.infoSearchWeb(i),
+      renderStatus: (i) => `Searching: ${i.query}`
+    },
+
+    // --- Messaging ------------------------------------------------------
+    {
+      name: "message_notify_user",
+      description:
+        "Send a non-blocking status update to the user. Optionally attach files from the workspace.",
+      inputSchema: MessageNotifyUserInput,
+      invoke: (c, i) => c.messageNotifyUser(i),
+      renderStatus: () => "Notifying user"
+    },
+    {
+      name: "message_ask_user",
+      description:
+        "Ask the user a question and wait for their reply. Set suggest_user_takeover to hand off control (captchas, logins).",
+      inputSchema: MessageAskUserInput,
+      invoke: (c, i) => c.messageAskUser(i),
+      renderStatus: () => "Asking user"
+    },
+    {
+      name: "idle",
+      description:
+        "Signal that the current objective is complete. Call this exactly once when done.",
+      inputSchema: IdleInput,
+      invoke: (c, i) => c.idle(i),
+      renderStatus: () => "Finishing"
+    },
+
+    // --- Deploy ---------------------------------------------------------
+    {
+      name: "expose_port",
+      description:
+        "Return the public host URL for a service the agent is running on a known sandbox container port (3000, 5000, 8000, 8080).",
+      inputSchema: ExposePortInput,
+      invoke: (c, i) => c.exposePort(i),
+      renderStatus: (i) => `Exposing port ${i.port}`
+    }
+  ];
+  return all as SandboxToolDefinition<unknown, unknown>[];
+}
+
+export interface CreateSandboxToolsOptions {
+  /** Only include tools whose name appears in the list. */
+  include?: string[];
+  /** Exclude tools whose name appears in the list. */
+  exclude?: string[];
+}
+
+/**
+ * Build the full array of agent-facing sandbox tools for a given
+ * ToolClient. Callers can filter by include/exclude to constrain the
+ * tool surface exposed to an agent.
+ */
+export function createSandboxTools(
+  client: ToolClient,
+  options: CreateSandboxToolsOptions = {}
+): SandboxTool[] {
+  const include = options.include ? new Set(options.include) : null;
+  const exclude = options.exclude ? new Set(options.exclude) : null;
+  const out: SandboxTool[] = [];
+  for (const def of defs()) {
+    if (include && !include.has(def.name)) continue;
+    if (exclude && exclude.has(def.name)) continue;
+    out.push(new SandboxTool(client, def));
+  }
+  return out;
+}
+
+/** All tool names defined by the manifest, in a stable order. */
+export function listSandboxToolNames(): string[] {
+  return defs().map((d) => d.name);
+}

--- a/packages/sandbox-tools/tests/SandboxTool.test.ts
+++ b/packages/sandbox-tools/tests/SandboxTool.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { SandboxTool, toJsonSchema } from "../src/SandboxTool.js";
+import { ToolClient } from "@nodetool/sandbox";
+import type { ProcessingContext } from "@nodetool/runtime";
+
+const makeFetch = (
+  responder: (url: string, init?: RequestInit) => Response
+): typeof fetch =>
+  ((input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve(responder(String(input), init))) as typeof fetch;
+
+function makeClient(
+  responder: (url: string, init?: RequestInit) => Response
+): ToolClient {
+  return new ToolClient({
+    baseUrl: "http://sbx",
+    fetch: makeFetch(responder)
+  });
+}
+
+const DummyCtx = {} as ProcessingContext;
+
+describe("toJsonSchema", () => {
+  it("produces a JSON schema with type=object for object schemas", () => {
+    const s = toJsonSchema(z.object({ x: z.string() }));
+    expect(s.type).toBe("object");
+    expect(s.properties).toBeDefined();
+  });
+
+  it("strips the $schema key", () => {
+    const s = toJsonSchema(z.object({ x: z.string() }));
+    expect("$schema" in s).toBe(false);
+  });
+
+  it("preserves required arrays", () => {
+    const s = toJsonSchema(
+      z.object({ required: z.string(), optional: z.string().optional() })
+    );
+    expect(s.required).toEqual(["required"]);
+  });
+});
+
+describe("SandboxTool", () => {
+  const schema = z.object({ q: z.string().min(1) });
+
+  function makeTool(
+    invoke: (client: ToolClient, input: { q: string }) => Promise<unknown>
+  ): SandboxTool<{ q: string }, unknown> {
+    const client = makeClient(
+      () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+    return new SandboxTool(client, {
+      name: "t",
+      description: "d",
+      inputSchema: schema,
+      invoke
+    });
+  }
+
+  it("rejects invalid input by returning an error object", async () => {
+    const tool = makeTool(async () => ({ ok: true }));
+    const out = (await tool.process(DummyCtx, { q: "" })) as { error?: string };
+    expect(out.error).toBe("invalid input");
+  });
+
+  it("passes validated input through to invoke", async () => {
+    let captured: unknown = null;
+    const tool = makeTool(async (_c, i) => {
+      captured = i;
+      return { ok: true };
+    });
+    const out = await tool.process(DummyCtx, { q: "hello" });
+    expect(captured).toEqual({ q: "hello" });
+    expect(out).toEqual({ ok: true });
+  });
+
+  it("wraps invoke failures as an error object instead of throwing", async () => {
+    const tool = makeTool(async () => {
+      throw new Error("boom");
+    });
+    const out = (await tool.process(DummyCtx, { q: "hi" })) as {
+      error?: string;
+    };
+    expect(out.error).toBe("boom");
+  });
+
+  it("generates a well-formed JSON schema from the Zod schema", () => {
+    const tool = makeTool(async () => ({}));
+    expect(tool.inputSchema.type).toBe("object");
+    const props = tool.inputSchema.properties as Record<string, unknown>;
+    expect(props.q).toBeDefined();
+  });
+
+  it("uses renderStatus when provided", () => {
+    const client = makeClient(
+      () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+    const tool = new SandboxTool(client, {
+      name: "t",
+      description: "d",
+      inputSchema: schema,
+      invoke: async () => ({}),
+      renderStatus: (i) => `Searching ${i.q}`
+    });
+    expect(tool.userMessage({ q: "alpha" })).toBe("Searching alpha");
+  });
+
+  it("falls back to default userMessage on invalid input", () => {
+    const client = makeClient(
+      () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+    const tool = new SandboxTool(client, {
+      name: "custom_name",
+      description: "d",
+      inputSchema: schema,
+      invoke: async () => ({}),
+      renderStatus: (i) => `go ${i.q}`
+    });
+    expect(tool.userMessage({})).toBe("Running custom_name");
+  });
+});

--- a/packages/sandbox-tools/tests/manifest.test.ts
+++ b/packages/sandbox-tools/tests/manifest.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { ToolClient } from "@nodetool/sandbox";
+import {
+  createSandboxTools,
+  listSandboxToolNames
+} from "../src/manifest.js";
+
+function fakeClient(): ToolClient {
+  const fakeFetch: typeof fetch = ((
+    _input: RequestInfo | URL,
+    _init?: RequestInit
+  ) =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    )) as typeof fetch;
+  return new ToolClient({ baseUrl: "http://sbx", fetch: fakeFetch });
+}
+
+describe("createSandboxTools", () => {
+  it("produces a tool per manifest entry", () => {
+    const tools = createSandboxTools(fakeClient());
+    expect(tools.length).toBe(listSandboxToolNames().length);
+    expect(tools.length).toBeGreaterThanOrEqual(30);
+    for (const tool of tools) {
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.inputSchema.type).toBe("object");
+    }
+  });
+
+  it("names are unique", () => {
+    const names = createSandboxTools(fakeClient()).map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("filters by include list", () => {
+    const tools = createSandboxTools(fakeClient(), {
+      include: ["file_read", "shell_exec"]
+    });
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "file_read",
+      "shell_exec"
+    ]);
+  });
+
+  it("filters by exclude list", () => {
+    const all = createSandboxTools(fakeClient());
+    const filtered = createSandboxTools(fakeClient(), {
+      exclude: ["browser_view"]
+    });
+    expect(filtered.length).toBe(all.length - 1);
+    expect(filtered.some((t) => t.name === "browser_view")).toBe(false);
+  });
+
+  it("covers the major tool groups", () => {
+    const names = listSandboxToolNames();
+    expect(names).toContain("file_read");
+    expect(names).toContain("shell_exec");
+    expect(names).toContain("browser_navigate");
+    expect(names).toContain("screen_capture");
+    expect(names).toContain("info_search_web");
+    expect(names).toContain("message_notify_user");
+    expect(names).toContain("idle");
+    expect(names).toContain("expose_port");
+  });
+
+  it("includes exactly one idle tool and one info_search_web tool", () => {
+    const names = listSandboxToolNames();
+    expect(names.filter((n) => n === "idle")).toHaveLength(1);
+    expect(names.filter((n) => n === "info_search_web")).toHaveLength(1);
+  });
+});

--- a/packages/sandbox-tools/tsconfig.json
+++ b/packages/sandbox-tools/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../sandbox" },
+    { "path": "../agents" },
+    { "path": "../runtime" }
+  ]
+}

--- a/packages/sandbox-tools/vitest.config.ts
+++ b/packages/sandbox-tools/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: {
+    timeout: 30_000,
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@nodetool/sandbox",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Host-side sandbox provisioning: Docker-backed isolated Linux computers for agents, with shell, file, browser, and desktop tools",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node ../../scripts/build-typescript-workspace.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nodetool/config": "*",
+    "dockerode": "^4.0.4",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/dockerode": "^3.3.34",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.2"
+  },
+  "exports": {
+    ".": {
+      "nodetool-dev": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./schemas": {
+      "nodetool-dev": "./src/schemas/index.ts",
+      "types": "./dist/schemas/index.d.ts",
+      "import": "./dist/schemas/index.js",
+      "default": "./dist/schemas/index.js"
+    }
+  }
+}

--- a/packages/sandbox/src/DockerSandbox.ts
+++ b/packages/sandbox/src/DockerSandbox.ts
@@ -27,6 +27,11 @@ import { ToolClient } from "./ToolClient.js";
 export const DEFAULT_SANDBOX_IMAGE = "nodetool/sandbox-agent:latest";
 export const TOOL_SERVER_PORT = 7788;
 export const VNC_WS_PORT = 6080;
+/** User-service ports pre-published at container create time. Each is
+ *  bound to an ephemeral host port and reachable via `expose_port`.
+ *  Covers the common dev-server defaults: Next.js (3000), Flask (5000),
+ *  Django (8000), generic (8080). */
+export const USER_SERVICE_PORTS = [3000, 5000, 8000, 8080] as const;
 
 export interface DockerSandboxProviderOptions {
   /** Host IP bound for published ports. Default: 127.0.0.1. */
@@ -37,6 +42,9 @@ export interface DockerSandboxProviderOptions {
   readyTimeoutSeconds?: number;
   /** Pull image if absent locally. Default: true. */
   autoPull?: boolean;
+  /** Container ports to publish for user services (agent-hosted dev
+   *  servers, generated sites). Defaults to USER_SERVICE_PORTS. */
+  userServicePorts?: readonly number[];
 }
 
 export class DockerSandbox implements Sandbox {
@@ -88,6 +96,7 @@ export class DockerSandboxProvider implements SandboxProvider {
   private readonly defaultImage: string;
   private readonly readyTimeoutSeconds: number;
   private readonly autoPull: boolean;
+  private readonly userServicePorts: readonly number[];
 
   constructor(options: DockerSandboxProviderOptions = {}) {
     this.docker = new Dockerode();
@@ -95,6 +104,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     this.defaultImage = options.defaultImage ?? DEFAULT_SANDBOX_IMAGE;
     this.readyTimeoutSeconds = options.readyTimeoutSeconds ?? 30;
     this.autoPull = options.autoPull ?? true;
+    this.userServicePorts = options.userServicePorts ?? USER_SERVICE_PORTS;
   }
 
   async acquire(options: SandboxOptions): Promise<Sandbox> {
@@ -112,11 +122,29 @@ export class DockerSandboxProvider implements SandboxProvider {
       `NODETOOL_SESSION_ID=${options.sessionId}`,
       `NODETOOL_TOOL_PORT=${TOOL_SERVER_PORT}`,
       `NODETOOL_VNC_PORT=${VNC_WS_PORT}`,
+      `NODETOOL_USER_SERVICE_PORTS=${this.userServicePorts.join(",")}`,
       ...Object.entries(options.env ?? {}).map(([k, v]) => `${k}=${v}`)
     ];
 
     const toolPortKey = `${TOOL_SERVER_PORT}/tcp`;
     const vncPortKey = `${VNC_WS_PORT}/tcp`;
+
+    const exposedPorts: Record<string, Record<string, never>> = {
+      [toolPortKey]: {},
+      [vncPortKey]: {}
+    };
+    const portBindings: Record<
+      string,
+      Array<{ HostIp: string; HostPort: string }>
+    > = {
+      [toolPortKey]: [{ HostIp: this.hostIp, HostPort: "" }],
+      [vncPortKey]: [{ HostIp: this.hostIp, HostPort: "" }]
+    };
+    for (const p of this.userServicePorts) {
+      const key = `${p}/tcp`;
+      exposedPorts[key] = {};
+      portBindings[key] = [{ HostIp: this.hostIp, HostPort: "" }];
+    }
 
     const container = await this.docker.createContainer({
       name: containerName,
@@ -125,19 +153,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       WorkingDir: "/home/ubuntu",
       OpenStdin: false,
       Tty: false,
-      ExposedPorts: {
-        [toolPortKey]: {},
-        [vncPortKey]: {}
-      },
+      ExposedPorts: exposedPorts,
       HostConfig: {
         Binds: binds.length > 0 ? binds : undefined,
         Memory: parseMemLimit(options.memLimit ?? "2g"),
         NanoCpus: options.nanoCpus ?? 2_000_000_000,
         SecurityOpt: ["no-new-privileges"],
-        PortBindings: {
-          [toolPortKey]: [{ HostIp: this.hostIp, HostPort: "" }],
-          [vncPortKey]: [{ HostIp: this.hostIp, HostPort: "" }]
-        }
+        PortBindings: portBindings
       }
     });
 
@@ -152,6 +174,18 @@ export class DockerSandboxProvider implements SandboxProvider {
       const vncUrl =
         vncPort !== null ? `ws://${this.hostIp}:${vncPort}` : undefined;
 
+      // Resolve user-service host ports so the in-container expose_port
+      // tool can map container_port → public URL.
+      const userServiceMap: Record<string, string> = {};
+      for (const p of this.userServicePorts) {
+        const host = await waitForHostPort(container, `${p}/tcp`).catch(
+          () => null
+        );
+        if (host !== null) {
+          userServiceMap[String(p)] = `http://${this.hostIp}:${host}`;
+        }
+      }
+
       const ready = await waitForTcp(
         this.hostIp,
         toolPort,
@@ -164,6 +198,18 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       const client = new ToolClient({ baseUrl: toolUrl });
+
+      // Publish the resolved map to the in-container server so the
+      // expose_port tool can answer with real public URLs.
+      if (Object.keys(userServiceMap).length > 0) {
+        await fetch(`${toolUrl}/internal/set-port-map`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ map: userServiceMap })
+        }).catch(() => {
+          // best-effort; expose_port will simply return an empty URL
+        });
+      }
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const limit = options.timeoutSeconds ?? 3600;

--- a/packages/sandbox/src/DockerSandbox.ts
+++ b/packages/sandbox/src/DockerSandbox.ts
@@ -159,6 +159,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         Memory: parseMemLimit(options.memLimit ?? "2g"),
         NanoCpus: options.nanoCpus ?? 2_000_000_000,
         SecurityOpt: ["no-new-privileges"],
+        CapDrop: ["ALL"],
         PortBindings: portBindings
       }
     });

--- a/packages/sandbox/src/DockerSandbox.ts
+++ b/packages/sandbox/src/DockerSandbox.ts
@@ -112,7 +112,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     const image = options.image ?? this.defaultImage;
     await this.ensureImage(image);
 
-    const containerName = `nodetool-sandbox-${options.sessionId}`;
+    const containerName = `nodetool-sandbox-${options.sessionId.replace(/[^a-zA-Z0-9_.-]/g, "-")}`;
     const binds: string[] = [];
     if (options.workspaceDir) {
       binds.push(`${options.workspaceDir}:/workspace:rw`);

--- a/packages/sandbox/src/DockerSandbox.ts
+++ b/packages/sandbox/src/DockerSandbox.ts
@@ -1,0 +1,286 @@
+/**
+ * DockerSandbox — Dockerode-backed SandboxProvider.
+ *
+ * Each acquire() starts a long-running container from the sandbox image,
+ * publishes the in-container tool server port (7788) to an ephemeral host
+ * port, waits for readiness, and returns a Sandbox handle with a connected
+ * ToolClient.
+ *
+ * Security posture (defaults):
+ *   - no-new-privileges, all capabilities dropped
+ *   - read-only rootfs disabled (agents need /tmp, /home/ubuntu writable);
+ *     will revisit once agents settle on a workspace pattern
+ *   - memory and CPU capped
+ *   - network enabled (agents need internet to research)
+ */
+
+import { createConnection, type Socket as NetSocket } from "node:net";
+import Dockerode from "dockerode";
+import type {
+  Sandbox,
+  SandboxOptions,
+  SandboxProvider,
+  SandboxEndpoint
+} from "./SandboxProvider.js";
+import { ToolClient } from "./ToolClient.js";
+
+export const DEFAULT_SANDBOX_IMAGE = "nodetool/sandbox-agent:latest";
+export const TOOL_SERVER_PORT = 7788;
+export const VNC_WS_PORT = 6080;
+
+export interface DockerSandboxProviderOptions {
+  /** Host IP bound for published ports. Default: 127.0.0.1. */
+  hostIp?: string;
+  /** Docker image name used when SandboxOptions.image is omitted. */
+  defaultImage?: string;
+  /** Max seconds to wait for the in-container tool server. Default: 30. */
+  readyTimeoutSeconds?: number;
+  /** Pull image if absent locally. Default: true. */
+  autoPull?: boolean;
+}
+
+export class DockerSandbox implements Sandbox {
+  public readonly sessionId: string;
+  public readonly endpoint: SandboxEndpoint;
+  public readonly client: ToolClient;
+
+  private readonly container: Dockerode.Container;
+  private released = false;
+  private readonly timeoutHandle: ReturnType<typeof setTimeout> | null;
+
+  constructor(args: {
+    sessionId: string;
+    endpoint: SandboxEndpoint;
+    client: ToolClient;
+    container: Dockerode.Container;
+    timeoutHandle: ReturnType<typeof setTimeout> | null;
+  }) {
+    this.sessionId = args.sessionId;
+    this.endpoint = args.endpoint;
+    this.client = args.client;
+    this.container = args.container;
+    this.timeoutHandle = args.timeoutHandle;
+  }
+
+  async release(): Promise<void> {
+    if (this.released) return;
+    this.released = true;
+    if (this.timeoutHandle !== null) clearTimeout(this.timeoutHandle);
+    try {
+      await this.container.remove({ force: true });
+    } catch {
+      // best-effort; container may already be gone
+    }
+  }
+
+  async pause(): Promise<void> {
+    await this.container.pause();
+  }
+
+  async resume(): Promise<void> {
+    await this.container.unpause();
+  }
+}
+
+export class DockerSandboxProvider implements SandboxProvider {
+  private readonly docker: Dockerode;
+  private readonly hostIp: string;
+  private readonly defaultImage: string;
+  private readonly readyTimeoutSeconds: number;
+  private readonly autoPull: boolean;
+
+  constructor(options: DockerSandboxProviderOptions = {}) {
+    this.docker = new Dockerode();
+    this.hostIp = options.hostIp ?? "127.0.0.1";
+    this.defaultImage = options.defaultImage ?? DEFAULT_SANDBOX_IMAGE;
+    this.readyTimeoutSeconds = options.readyTimeoutSeconds ?? 30;
+    this.autoPull = options.autoPull ?? true;
+  }
+
+  async acquire(options: SandboxOptions): Promise<Sandbox> {
+    await this.pingDocker();
+    const image = options.image ?? this.defaultImage;
+    await this.ensureImage(image);
+
+    const containerName = `nodetool-sandbox-${options.sessionId}`;
+    const binds: string[] = [];
+    if (options.workspaceDir) {
+      binds.push(`${options.workspaceDir}:/workspace:rw`);
+    }
+
+    const env: string[] = [
+      `NODETOOL_SESSION_ID=${options.sessionId}`,
+      `NODETOOL_TOOL_PORT=${TOOL_SERVER_PORT}`,
+      `NODETOOL_VNC_PORT=${VNC_WS_PORT}`,
+      ...Object.entries(options.env ?? {}).map(([k, v]) => `${k}=${v}`)
+    ];
+
+    const toolPortKey = `${TOOL_SERVER_PORT}/tcp`;
+    const vncPortKey = `${VNC_WS_PORT}/tcp`;
+
+    const container = await this.docker.createContainer({
+      name: containerName,
+      Image: image,
+      Env: env,
+      WorkingDir: "/home/ubuntu",
+      OpenStdin: false,
+      Tty: false,
+      ExposedPorts: {
+        [toolPortKey]: {},
+        [vncPortKey]: {}
+      },
+      HostConfig: {
+        Binds: binds.length > 0 ? binds : undefined,
+        Memory: parseMemLimit(options.memLimit ?? "2g"),
+        NanoCpus: options.nanoCpus ?? 2_000_000_000,
+        SecurityOpt: ["no-new-privileges"],
+        PortBindings: {
+          [toolPortKey]: [{ HostIp: this.hostIp, HostPort: "" }],
+          [vncPortKey]: [{ HostIp: this.hostIp, HostPort: "" }]
+        }
+      }
+    });
+
+    try {
+      await container.start();
+      const toolPort = await waitForHostPort(container, toolPortKey);
+      const vncPort = await waitForHostPort(container, vncPortKey).catch(
+        () => null
+      );
+
+      const toolUrl = `http://${this.hostIp}:${toolPort}`;
+      const vncUrl =
+        vncPort !== null ? `ws://${this.hostIp}:${vncPort}` : undefined;
+
+      const ready = await waitForTcp(
+        this.hostIp,
+        toolPort,
+        this.readyTimeoutSeconds
+      );
+      if (!ready) {
+        throw new Error(
+          `sandbox tool server did not become ready on ${toolUrl}`
+        );
+      }
+
+      const client = new ToolClient({ baseUrl: toolUrl });
+
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      const limit = options.timeoutSeconds ?? 3600;
+      if (limit > 0) {
+        timeoutHandle = setTimeout(() => {
+          container.remove({ force: true }).catch(() => {});
+        }, limit * 1000);
+      }
+
+      return new DockerSandbox({
+        sessionId: options.sessionId,
+        endpoint: { toolUrl, vncUrl },
+        client,
+        container,
+        timeoutHandle
+      });
+    } catch (err) {
+      await container.remove({ force: true }).catch(() => {});
+      throw err;
+    }
+  }
+
+  private async pingDocker(): Promise<void> {
+    try {
+      await this.docker.ping();
+    } catch (err) {
+      throw new Error(
+        `Docker daemon is not available. Start Docker and try again. (${String(err)})`
+      );
+    }
+  }
+
+  private async ensureImage(image: string): Promise<void> {
+    try {
+      await this.docker.getImage(image).inspect();
+      return;
+    } catch {
+      if (!this.autoPull) {
+        throw new Error(`sandbox image not found locally: ${image}`);
+      }
+    }
+    const pullStream = await this.docker.pull(image);
+    await new Promise<void>((resolve, reject) => {
+      this.docker.modem.followProgress(pullStream, (err: Error | null) =>
+        err ? reject(err) : resolve()
+      );
+    });
+  }
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+export function parseMemLimit(mem: string): number {
+  const match = mem.match(/^(\d+)([kmgt]?)b?$/i);
+  if (!match) return 2 * 1024 * 1024 * 1024;
+  const num = parseInt(match[1], 10);
+  const unit = (match[2] || "").toLowerCase();
+  switch (unit) {
+    case "k":
+      return num * 1024;
+    case "m":
+      return num * 1024 * 1024;
+    case "g":
+      return num * 1024 * 1024 * 1024;
+    case "t":
+      return num * 1024 * 1024 * 1024 * 1024;
+    default:
+      return num;
+  }
+}
+
+async function waitForHostPort(
+  container: Dockerode.Container,
+  portKey: string,
+  timeoutMs = 20_000
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const info = await container.inspect();
+    if (info.State?.Status === "exited") {
+      throw new Error("container exited before ports were published");
+    }
+    const bindings = info.NetworkSettings?.Ports?.[portKey];
+    if (Array.isArray(bindings) && bindings[0]?.HostPort) {
+      return parseInt(bindings[0].HostPort, 10);
+    }
+    await sleep(150);
+  }
+  throw new Error(`timed out waiting for host port for ${portKey}`);
+}
+
+async function waitForTcp(
+  host: string,
+  port: number,
+  timeoutSeconds: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    if (await tcpProbe(host, port, 1000)) return true;
+    await sleep(200);
+  }
+  return false;
+}
+
+function tcpProbe(host: string, port: number, timeoutMs = 1000): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const sock: NetSocket = createConnection({ host, port, timeout: timeoutMs });
+    const done = (ok: boolean) => {
+      sock.destroy();
+      resolve(ok);
+    };
+    sock.once("connect", () => done(true));
+    sock.once("timeout", () => done(false));
+    sock.once("error", () => done(false));
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/sandbox/src/SandboxProvider.ts
+++ b/packages/sandbox/src/SandboxProvider.ts
@@ -1,0 +1,57 @@
+/**
+ * SandboxProvider — abstract contract for isolated computer environments.
+ *
+ * A sandbox is a long-lived, network-reachable environment the agent drives
+ * via a tool client. Implementations may be Docker (current), gVisor,
+ * Firecracker, or a managed sandbox API (E2B, Daytona, Modal).
+ *
+ * Lifecycle:
+ *   acquire() → sandbox running and reachable
+ *   client()  → ToolClient for calling tools inside it
+ *   release() → stopped and removed; workspace may persist via TTL
+ *
+ * Pause/resume are optional optimizations for warm pools.
+ */
+
+import type { ToolClient } from "./ToolClient.js";
+
+export interface SandboxOptions {
+  /** Stable identifier used for workspace volume and container name. */
+  sessionId: string;
+  /** Host directory bind-mounted at /workspace inside the sandbox. */
+  workspaceDir?: string;
+  /** Max lifetime in seconds; 0 = no limit. Default: 3600. */
+  timeoutSeconds?: number;
+  /** Docker memory limit (e.g. "2g"). */
+  memLimit?: string;
+  /** Nano CPUs (1e9 = 1 CPU). */
+  nanoCpus?: number;
+  /** Override default sandbox image. */
+  image?: string;
+  /** Extra env vars injected into the container. */
+  env?: Record<string, string>;
+}
+
+export interface SandboxEndpoint {
+  /** http://host:port URL of the in-container tool server. */
+  toolUrl: string;
+  /** ws://host:port URL of the VNC viewer (if desktop enabled). */
+  vncUrl?: string;
+}
+
+export interface Sandbox {
+  readonly sessionId: string;
+  readonly endpoint: SandboxEndpoint;
+  readonly client: ToolClient;
+  /** Stop and delete the sandbox. */
+  release(): Promise<void>;
+  /** Pause execution; memory retained. Optional. */
+  pause?(): Promise<void>;
+  /** Resume from paused state. Optional. */
+  resume?(): Promise<void>;
+}
+
+export interface SandboxProvider {
+  /** Create and start a fresh sandbox. Resolves when tool server is reachable. */
+  acquire(options: SandboxOptions): Promise<Sandbox>;
+}

--- a/packages/sandbox/src/ToolClient.ts
+++ b/packages/sandbox/src/ToolClient.ts
@@ -70,6 +70,15 @@ import {
   KeyTypeInput,
   KeyTypeOutput,
   CursorPositionOutput,
+  InfoSearchWebInput,
+  InfoSearchWebOutput,
+  MessageNotifyUserInput,
+  MessageNotifyUserOutput,
+  MessageAskUserInput,
+  MessageAskUserOutput,
+  IdleInput,
+  IdleOutput,
+  SandboxEvent,
   HealthOutput
 } from "./schemas/index.js";
 
@@ -367,6 +376,99 @@ export class ToolClient {
     return this.get("/desktop/cursor-position", CursorPositionOutput);
   }
 
+  // --- Search ------------------------------------------------------------
+
+  async infoSearchWeb(
+    input: InfoSearchWebInput
+  ): Promise<InfoSearchWebOutput> {
+    return this.post(
+      "/search/web",
+      input,
+      InfoSearchWebInput,
+      InfoSearchWebOutput
+    );
+  }
+
+  // --- Messaging ---------------------------------------------------------
+
+  async messageNotifyUser(
+    input: MessageNotifyUserInput
+  ): Promise<MessageNotifyUserOutput> {
+    return this.post(
+      "/message/notify",
+      input,
+      MessageNotifyUserInput,
+      MessageNotifyUserOutput
+    );
+  }
+
+  async messageAskUser(
+    input: MessageAskUserInput
+  ): Promise<MessageAskUserOutput> {
+    return this.post(
+      "/message/ask",
+      input,
+      MessageAskUserInput,
+      MessageAskUserOutput
+    );
+  }
+
+  async idle(input: IdleInput = {}): Promise<IdleOutput> {
+    return this.post("/idle", input, IdleInput, IdleOutput);
+  }
+
+  /**
+   * Consume the server-sent event stream from /events.
+   *
+   * Yields each SandboxEvent as it's pushed by the sandbox. Cancel by
+   * passing an AbortSignal; the async iterator will return cleanly on
+   * abort. If the server closes the stream, the iterator returns.
+   */
+  async *events(options?: { signal?: AbortSignal }): AsyncGenerator<
+    SandboxEvent,
+    void
+  > {
+    const res = await this.fetchImpl(`${this.baseUrl}/events`, {
+      method: "GET",
+      headers: { accept: "text/event-stream" },
+      signal: options?.signal
+    });
+    if (!res.ok || !res.body) {
+      throw new ToolInvocationError(
+        res.status,
+        null,
+        `failed to open event stream: ${res.status}`
+      );
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        buffer += decoder.decode(value, { stream: true });
+        // SSE frames are separated by a blank line.
+        let idx = buffer.indexOf("\n\n");
+        while (idx !== -1) {
+          const frame = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+          const event = parseSseFrame(frame);
+          if (event) yield event;
+          idx = buffer.indexOf("\n\n");
+        }
+      }
+    } finally {
+      try {
+        reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
   // --- Internals ---------------------------------------------------------
 
   private async get<TOut>(
@@ -429,5 +531,24 @@ export class ToolClient {
       throw new ToolInvocationError(res.status, body, msg);
     }
     return outSchema.parse(body);
+  }
+}
+
+function parseSseFrame(frame: string): SandboxEvent | null {
+  // Per SSE spec: lines prefixed with "data:" are concatenated (newline-
+  // joined); we only use the data field.
+  const dataLines: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+  if (dataLines.length === 0) return null;
+  const raw = dataLines.join("\n");
+  try {
+    const parsed = SandboxEvent.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
   }
 }

--- a/packages/sandbox/src/ToolClient.ts
+++ b/packages/sandbox/src/ToolClient.ts
@@ -1,0 +1,217 @@
+/**
+ * ToolClient — typed HTTP client for the in-container tool server.
+ *
+ * Each method corresponds to a Fastify route on the sandbox-agent server.
+ * Requests are validated on both sides against the shared Zod schemas in
+ * @nodetool/sandbox/schemas.
+ *
+ * The client has no session state; a fresh client can be created against
+ * an existing sandbox endpoint URL.
+ */
+
+import type { z } from "zod";
+import {
+  FileReadInput,
+  FileReadOutput,
+  FileWriteInput,
+  FileWriteOutput,
+  FileStrReplaceInput,
+  FileStrReplaceOutput,
+  FileFindInContentInput,
+  FileFindInContentOutput,
+  FileFindByNameInput,
+  FileFindByNameOutput,
+  ShellExecInput,
+  ShellExecOutput,
+  ShellViewInput,
+  ShellViewOutput,
+  ShellWaitInput,
+  ShellWaitOutput,
+  ShellWriteToProcessInput,
+  ShellWriteToProcessOutput,
+  ShellKillProcessInput,
+  ShellKillProcessOutput,
+  HealthOutput
+} from "./schemas/index.js";
+
+export class ToolInvocationError extends Error {
+  public readonly status: number;
+  public readonly body: unknown;
+
+  constructor(status: number, body: unknown, message: string) {
+    super(message);
+    this.name = "ToolInvocationError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export interface ToolClientOptions {
+  /** Base URL of the in-container tool server, e.g. http://127.0.0.1:32768 */
+  baseUrl: string;
+  /** Fetch implementation; defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
+  /** Per-request timeout in ms. Default: 60_000. */
+  timeoutMs?: number;
+}
+
+export class ToolClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: ToolClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.timeoutMs = options.timeoutMs ?? 60_000;
+  }
+
+  // --- Health ------------------------------------------------------------
+
+  async health(): Promise<HealthOutput> {
+    return this.get("/health", HealthOutput);
+  }
+
+  // --- File tools --------------------------------------------------------
+
+  async fileRead(input: FileReadInput): Promise<FileReadOutput> {
+    return this.post("/file/read", input, FileReadInput, FileReadOutput);
+  }
+
+  async fileWrite(input: FileWriteInput): Promise<FileWriteOutput> {
+    return this.post("/file/write", input, FileWriteInput, FileWriteOutput);
+  }
+
+  async fileStrReplace(
+    input: FileStrReplaceInput
+  ): Promise<FileStrReplaceOutput> {
+    return this.post(
+      "/file/str-replace",
+      input,
+      FileStrReplaceInput,
+      FileStrReplaceOutput
+    );
+  }
+
+  async fileFindInContent(
+    input: FileFindInContentInput
+  ): Promise<FileFindInContentOutput> {
+    return this.post(
+      "/file/find-in-content",
+      input,
+      FileFindInContentInput,
+      FileFindInContentOutput
+    );
+  }
+
+  async fileFindByName(
+    input: FileFindByNameInput
+  ): Promise<FileFindByNameOutput> {
+    return this.post(
+      "/file/find-by-name",
+      input,
+      FileFindByNameInput,
+      FileFindByNameOutput
+    );
+  }
+
+  // --- Shell tools -------------------------------------------------------
+
+  async shellExec(input: ShellExecInput): Promise<ShellExecOutput> {
+    return this.post("/shell/exec", input, ShellExecInput, ShellExecOutput);
+  }
+
+  async shellView(input: ShellViewInput): Promise<ShellViewOutput> {
+    return this.post("/shell/view", input, ShellViewInput, ShellViewOutput);
+  }
+
+  async shellWait(input: ShellWaitInput): Promise<ShellWaitOutput> {
+    return this.post("/shell/wait", input, ShellWaitInput, ShellWaitOutput);
+  }
+
+  async shellWriteToProcess(
+    input: ShellWriteToProcessInput
+  ): Promise<ShellWriteToProcessOutput> {
+    return this.post(
+      "/shell/write",
+      input,
+      ShellWriteToProcessInput,
+      ShellWriteToProcessOutput
+    );
+  }
+
+  async shellKillProcess(
+    input: ShellKillProcessInput
+  ): Promise<ShellKillProcessOutput> {
+    return this.post(
+      "/shell/kill",
+      input,
+      ShellKillProcessInput,
+      ShellKillProcessOutput
+    );
+  }
+
+  // --- Internals ---------------------------------------------------------
+
+  private async get<TOut>(
+    path: string,
+    outSchema: z.ZodType<TOut>
+  ): Promise<TOut> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "GET",
+        signal: controller.signal
+      });
+      return this.parseResponse(res, outSchema);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async post<TIn, TOut>(
+    path: string,
+    input: TIn,
+    inSchema: z.ZodType<TIn>,
+    outSchema: z.ZodType<TOut>
+  ): Promise<TOut> {
+    const validated = inSchema.parse(input);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validated),
+        signal: controller.signal
+      });
+      return this.parseResponse(res, outSchema);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async parseResponse<TOut>(
+    res: Response,
+    outSchema: z.ZodType<TOut>
+  ): Promise<TOut> {
+    const text = await res.text();
+    let body: unknown = null;
+    if (text.length > 0) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    if (!res.ok) {
+      const msg =
+        body && typeof body === "object" && "error" in body
+          ? String((body as { error: unknown }).error)
+          : `sandbox tool ${res.status}`;
+      throw new ToolInvocationError(res.status, body, msg);
+    }
+    return outSchema.parse(body);
+  }
+}

--- a/packages/sandbox/src/ToolClient.ts
+++ b/packages/sandbox/src/ToolClient.ts
@@ -31,6 +31,45 @@ import {
   ShellWriteToProcessOutput,
   ShellKillProcessInput,
   ShellKillProcessOutput,
+  BrowserViewInput,
+  BrowserViewOutput,
+  BrowserNavigateInput,
+  BrowserNavigateOutput,
+  BrowserRestartInput,
+  BrowserRestartOutput,
+  BrowserClickInput,
+  BrowserClickOutput,
+  BrowserInputTextInput,
+  BrowserInputTextOutput,
+  BrowserMoveMouseInput,
+  BrowserMoveMouseOutput,
+  BrowserPressKeyInput,
+  BrowserPressKeyOutput,
+  BrowserSelectOptionInput,
+  BrowserSelectOptionOutput,
+  BrowserScrollInput,
+  BrowserScrollOutput,
+  BrowserConsoleExecInput,
+  BrowserConsoleExecOutput,
+  BrowserConsoleViewInput,
+  BrowserConsoleViewOutput,
+  ScreenCaptureInput,
+  ScreenCaptureOutput,
+  ScreenFindInput,
+  ScreenFindOutput,
+  MouseMoveInput,
+  MouseMoveOutput,
+  MouseClickInput,
+  MouseClickOutput,
+  MouseDragInput,
+  MouseDragOutput,
+  MouseScrollInput,
+  MouseScrollOutput,
+  KeyPressInput,
+  KeyPressOutput,
+  KeyTypeInput,
+  KeyTypeOutput,
+  CursorPositionOutput,
   HealthOutput
 } from "./schemas/index.js";
 
@@ -149,6 +188,183 @@ export class ToolClient {
       ShellKillProcessInput,
       ShellKillProcessOutput
     );
+  }
+
+  // --- Browser tools -----------------------------------------------------
+
+  async browserView(input: BrowserViewInput = {}): Promise<BrowserViewOutput> {
+    return this.post("/browser/view", input, BrowserViewInput, BrowserViewOutput);
+  }
+
+  async browserNavigate(
+    input: BrowserNavigateInput
+  ): Promise<BrowserNavigateOutput> {
+    return this.post(
+      "/browser/navigate",
+      input,
+      BrowserNavigateInput,
+      BrowserNavigateOutput
+    );
+  }
+
+  async browserRestart(
+    input: BrowserRestartInput = {}
+  ): Promise<BrowserRestartOutput> {
+    return this.post(
+      "/browser/restart",
+      input,
+      BrowserRestartInput,
+      BrowserRestartOutput
+    );
+  }
+
+  async browserClick(input: BrowserClickInput): Promise<BrowserClickOutput> {
+    return this.post(
+      "/browser/click",
+      input,
+      BrowserClickInput,
+      BrowserClickOutput
+    );
+  }
+
+  async browserInput(
+    input: BrowserInputTextInput
+  ): Promise<BrowserInputTextOutput> {
+    return this.post(
+      "/browser/input",
+      input,
+      BrowserInputTextInput,
+      BrowserInputTextOutput
+    );
+  }
+
+  async browserMoveMouse(
+    input: BrowserMoveMouseInput
+  ): Promise<BrowserMoveMouseOutput> {
+    return this.post(
+      "/browser/move-mouse",
+      input,
+      BrowserMoveMouseInput,
+      BrowserMoveMouseOutput
+    );
+  }
+
+  async browserPressKey(
+    input: BrowserPressKeyInput
+  ): Promise<BrowserPressKeyOutput> {
+    return this.post(
+      "/browser/press-key",
+      input,
+      BrowserPressKeyInput,
+      BrowserPressKeyOutput
+    );
+  }
+
+  async browserSelectOption(
+    input: BrowserSelectOptionInput
+  ): Promise<BrowserSelectOptionOutput> {
+    return this.post(
+      "/browser/select-option",
+      input,
+      BrowserSelectOptionInput,
+      BrowserSelectOptionOutput
+    );
+  }
+
+  async browserScroll(input: BrowserScrollInput): Promise<BrowserScrollOutput> {
+    return this.post(
+      "/browser/scroll",
+      input,
+      BrowserScrollInput,
+      BrowserScrollOutput
+    );
+  }
+
+  async browserConsoleExec(
+    input: BrowserConsoleExecInput
+  ): Promise<BrowserConsoleExecOutput> {
+    return this.post(
+      "/browser/console-exec",
+      input,
+      BrowserConsoleExecInput,
+      BrowserConsoleExecOutput
+    );
+  }
+
+  async browserConsoleView(
+    input: BrowserConsoleViewInput = {}
+  ): Promise<BrowserConsoleViewOutput> {
+    return this.post(
+      "/browser/console-view",
+      input,
+      BrowserConsoleViewInput,
+      BrowserConsoleViewOutput
+    );
+  }
+
+  // --- Desktop tools -----------------------------------------------------
+
+  async screenCapture(
+    input: ScreenCaptureInput = {}
+  ): Promise<ScreenCaptureOutput> {
+    return this.post(
+      "/desktop/capture",
+      input,
+      ScreenCaptureInput,
+      ScreenCaptureOutput
+    );
+  }
+
+  async screenFind(input: ScreenFindInput): Promise<ScreenFindOutput> {
+    return this.post("/desktop/find", input, ScreenFindInput, ScreenFindOutput);
+  }
+
+  async mouseMove(input: MouseMoveInput): Promise<MouseMoveOutput> {
+    return this.post(
+      "/desktop/mouse/move",
+      input,
+      MouseMoveInput,
+      MouseMoveOutput
+    );
+  }
+
+  async mouseClick(input: MouseClickInput): Promise<MouseClickOutput> {
+    return this.post(
+      "/desktop/mouse/click",
+      input,
+      MouseClickInput,
+      MouseClickOutput
+    );
+  }
+
+  async mouseDrag(input: MouseDragInput): Promise<MouseDragOutput> {
+    return this.post(
+      "/desktop/mouse/drag",
+      input,
+      MouseDragInput,
+      MouseDragOutput
+    );
+  }
+
+  async mouseScroll(input: MouseScrollInput): Promise<MouseScrollOutput> {
+    return this.post(
+      "/desktop/mouse/scroll",
+      input,
+      MouseScrollInput,
+      MouseScrollOutput
+    );
+  }
+
+  async keyPress(input: KeyPressInput): Promise<KeyPressOutput> {
+    return this.post("/desktop/key/press", input, KeyPressInput, KeyPressOutput);
+  }
+
+  async keyType(input: KeyTypeInput): Promise<KeyTypeOutput> {
+    return this.post("/desktop/key/type", input, KeyTypeInput, KeyTypeOutput);
+  }
+
+  async cursorPosition(): Promise<CursorPositionOutput> {
+    return this.get("/desktop/cursor-position", CursorPositionOutput);
   }
 
   // --- Internals ---------------------------------------------------------

--- a/packages/sandbox/src/ToolClient.ts
+++ b/packages/sandbox/src/ToolClient.ts
@@ -78,6 +78,8 @@ import {
   MessageAskUserOutput,
   IdleInput,
   IdleOutput,
+  ExposePortInput,
+  ExposePortOutput,
   SandboxEvent,
   HealthOutput
 } from "./schemas/index.js";
@@ -415,6 +417,17 @@ export class ToolClient {
 
   async idle(input: IdleInput = {}): Promise<IdleOutput> {
     return this.post("/idle", input, IdleInput, IdleOutput);
+  }
+
+  // --- Deploy ------------------------------------------------------------
+
+  async exposePort(input: ExposePortInput): Promise<ExposePortOutput> {
+    return this.post(
+      "/deploy/expose-port",
+      input,
+      ExposePortInput,
+      ExposePortOutput
+    );
   }
 
   /**

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -25,4 +25,7 @@ export {
 export { ToolClient, ToolInvocationError } from "./ToolClient.js";
 export type { ToolClientOptions } from "./ToolClient.js";
 
+export { SessionStore } from "./session/index.js";
+export type { SessionStoreOptions } from "./session/index.js";
+
 export * from "./schemas/index.js";

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @nodetool/sandbox — Host-side sandbox provisioning.
+ *
+ * Provides isolated Linux environments for agents to drive. Current backend
+ * is Docker; future backends (gVisor, Firecracker, E2B, Daytona) implement
+ * the same `SandboxProvider` interface.
+ */
+
+export type {
+  Sandbox,
+  SandboxProvider,
+  SandboxOptions,
+  SandboxEndpoint
+} from "./SandboxProvider.js";
+
+export {
+  DockerSandbox,
+  DockerSandboxProvider,
+  DEFAULT_SANDBOX_IMAGE,
+  TOOL_SERVER_PORT,
+  VNC_WS_PORT,
+  parseMemLimit
+} from "./DockerSandbox.js";
+
+export { ToolClient, ToolInvocationError } from "./ToolClient.js";
+export type { ToolClientOptions } from "./ToolClient.js";
+
+export * from "./schemas/index.js";

--- a/packages/sandbox/src/schemas/browser.ts
+++ b/packages/sandbox/src/schemas/browser.ts
@@ -1,0 +1,181 @@
+import { z } from "zod";
+
+/**
+ * Browser tool schemas.
+ *
+ * The browser exposes TWO addressing modes for every action that hits an
+ * element:
+ *   - index: numeric id from the element index (produced by browser_view),
+ *     cheapest and most reliable for known web apps
+ *   - coordinate_x/y: viewport coordinates, required for arbitrary GUI-like
+ *     interactions (canvas, custom widgets, drag handles)
+ *
+ * At least one must be provided; index wins if both are set.
+ */
+
+const ElementRef = z
+  .object({
+    index: z.number().int().nonnegative().optional(),
+    coordinate_x: z.number().int().optional(),
+    coordinate_y: z.number().int().optional()
+  })
+  .refine(
+    (v) =>
+      v.index !== undefined ||
+      (v.coordinate_x !== undefined && v.coordinate_y !== undefined),
+    { message: "provide either index or (coordinate_x, coordinate_y)" }
+  );
+
+export const BrowserViewInput = z.object({
+  include_screenshot: z.boolean().optional()
+});
+export type BrowserViewInput = z.infer<typeof BrowserViewInput>;
+
+export const BrowserElement = z.object({
+  index: z.number().int().nonnegative(),
+  tag: z.string(),
+  role: z.string().nullable(),
+  text: z.string(),
+  attributes: z.record(z.string(), z.string()),
+  bbox: z.object({
+    x: z.number(),
+    y: z.number(),
+    width: z.number(),
+    height: z.number()
+  })
+});
+export type BrowserElement = z.infer<typeof BrowserElement>;
+
+export const BrowserViewOutput = z.object({
+  url: z.string(),
+  title: z.string(),
+  viewport: z.object({ width: z.number(), height: z.number() }),
+  elements: z.array(BrowserElement),
+  screenshot_png_b64: z.string().nullable()
+});
+export type BrowserViewOutput = z.infer<typeof BrowserViewOutput>;
+
+export const BrowserNavigateInput = z.object({
+  url: z.string().min(1),
+  wait_until: z.enum(["load", "domcontentloaded", "networkidle"]).optional()
+});
+export type BrowserNavigateInput = z.infer<typeof BrowserNavigateInput>;
+
+export const BrowserNavigateOutput = z.object({
+  url: z.string(),
+  title: z.string(),
+  status: z.number().int().nullable()
+});
+export type BrowserNavigateOutput = z.infer<typeof BrowserNavigateOutput>;
+
+export const BrowserRestartInput = z.object({
+  url: z.string().optional()
+});
+export type BrowserRestartInput = z.infer<typeof BrowserRestartInput>;
+
+export const BrowserRestartOutput = z.object({
+  url: z.string()
+});
+export type BrowserRestartOutput = z.infer<typeof BrowserRestartOutput>;
+
+export const BrowserClickInput = ElementRef;
+export type BrowserClickInput = z.infer<typeof BrowserClickInput>;
+
+export const BrowserClickOutput = z.object({
+  clicked: z.literal(true)
+});
+export type BrowserClickOutput = z.infer<typeof BrowserClickOutput>;
+
+export const BrowserInputTextInput = z
+  .object({
+    text: z.string(),
+    press_enter: z.boolean().optional(),
+    index: z.number().int().nonnegative().optional(),
+    coordinate_x: z.number().int().optional(),
+    coordinate_y: z.number().int().optional()
+  })
+  .refine(
+    (v) =>
+      v.index !== undefined ||
+      (v.coordinate_x !== undefined && v.coordinate_y !== undefined),
+    { message: "provide either index or (coordinate_x, coordinate_y)" }
+  );
+export type BrowserInputTextInput = z.infer<typeof BrowserInputTextInput>;
+
+export const BrowserInputTextOutput = z.object({
+  typed: z.literal(true)
+});
+export type BrowserInputTextOutput = z.infer<typeof BrowserInputTextOutput>;
+
+export const BrowserMoveMouseInput = z.object({
+  coordinate_x: z.number().int(),
+  coordinate_y: z.number().int()
+});
+export type BrowserMoveMouseInput = z.infer<typeof BrowserMoveMouseInput>;
+
+export const BrowserMoveMouseOutput = z.object({
+  moved: z.literal(true)
+});
+export type BrowserMoveMouseOutput = z.infer<typeof BrowserMoveMouseOutput>;
+
+export const BrowserPressKeyInput = z.object({
+  key: z.string().min(1)
+});
+export type BrowserPressKeyInput = z.infer<typeof BrowserPressKeyInput>;
+
+export const BrowserPressKeyOutput = z.object({
+  pressed: z.literal(true)
+});
+export type BrowserPressKeyOutput = z.infer<typeof BrowserPressKeyOutput>;
+
+export const BrowserSelectOptionInput = z.object({
+  index: z.number().int().nonnegative(),
+  option: z.string()
+});
+export type BrowserSelectOptionInput = z.infer<typeof BrowserSelectOptionInput>;
+
+export const BrowserSelectOptionOutput = z.object({
+  selected: z.array(z.string())
+});
+export type BrowserSelectOptionOutput = z.infer<
+  typeof BrowserSelectOptionOutput
+>;
+
+export const BrowserScrollInput = z.object({
+  to_top: z.boolean().optional(),
+  to_bottom: z.boolean().optional(),
+  pixels: z.number().int().optional()
+});
+export type BrowserScrollInput = z.infer<typeof BrowserScrollInput>;
+
+export const BrowserScrollOutput = z.object({
+  scroll_y: z.number()
+});
+export type BrowserScrollOutput = z.infer<typeof BrowserScrollOutput>;
+
+export const BrowserConsoleExecInput = z.object({
+  javascript: z.string().min(1)
+});
+export type BrowserConsoleExecInput = z.infer<typeof BrowserConsoleExecInput>;
+
+export const BrowserConsoleExecOutput = z.object({
+  result_json: z.string()
+});
+export type BrowserConsoleExecOutput = z.infer<typeof BrowserConsoleExecOutput>;
+
+export const BrowserConsoleViewInput = z.object({
+  max_lines: z.number().int().positive().optional()
+});
+export type BrowserConsoleViewInput = z.infer<typeof BrowserConsoleViewInput>;
+
+export const BrowserConsoleMessage = z.object({
+  type: z.string(),
+  text: z.string(),
+  timestamp: z.number()
+});
+export type BrowserConsoleMessage = z.infer<typeof BrowserConsoleMessage>;
+
+export const BrowserConsoleViewOutput = z.object({
+  messages: z.array(BrowserConsoleMessage)
+});
+export type BrowserConsoleViewOutput = z.infer<typeof BrowserConsoleViewOutput>;

--- a/packages/sandbox/src/schemas/deploy.ts
+++ b/packages/sandbox/src/schemas/deploy.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * Deploy tools — let the agent surface a locally-running service (dev
+ * server, API, generated static site) to the user via a published host URL.
+ *
+ * The DockerSandbox publishes a known pool of "user-service" container
+ * ports at container-create time (3000, 8000, 8080 by default). The
+ * `expose_port` tool is a lookup that returns the published URL for one
+ * of those ports; the agent's own service must actually be listening on
+ * the chosen container port for the URL to respond.
+ */
+
+export const ExposePortInput = z.object({
+  port: z.number().int().positive().max(65535),
+  scheme: z.enum(["http", "https"]).optional()
+});
+export type ExposePortInput = z.infer<typeof ExposePortInput>;
+
+export const ExposePortOutput = z.object({
+  container_port: z.number().int().positive(),
+  public_url: z.string(),
+  expires_at: z.number().nullable()
+});
+export type ExposePortOutput = z.infer<typeof ExposePortOutput>;

--- a/packages/sandbox/src/schemas/desktop.ts
+++ b/packages/sandbox/src/schemas/desktop.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+
+/**
+ * Desktop (X11) tool schemas — CUA-style computer control.
+ *
+ * Coordinates are screen pixels. Keys use xdotool syntax (e.g. "Return",
+ * "ctrl+c", "alt+Tab"). Screenshots are returned as base64 PNG.
+ */
+
+export const ScreenCaptureInput = z.object({
+  region: z
+    .object({
+      x: z.number().int().nonnegative(),
+      y: z.number().int().nonnegative(),
+      width: z.number().int().positive(),
+      height: z.number().int().positive()
+    })
+    .optional(),
+  format: z.enum(["png", "jpeg"]).optional()
+});
+export type ScreenCaptureInput = z.infer<typeof ScreenCaptureInput>;
+
+export const ScreenCaptureOutput = z.object({
+  image_b64: z.string(),
+  format: z.enum(["png", "jpeg"]),
+  width: z.number().int().positive(),
+  height: z.number().int().positive()
+});
+export type ScreenCaptureOutput = z.infer<typeof ScreenCaptureOutput>;
+
+export const ScreenFindInput = z.object({
+  query: z.string().min(1),
+  region: z
+    .object({
+      x: z.number().int().nonnegative(),
+      y: z.number().int().nonnegative(),
+      width: z.number().int().positive(),
+      height: z.number().int().positive()
+    })
+    .optional()
+});
+export type ScreenFindInput = z.infer<typeof ScreenFindInput>;
+
+export const ScreenMatch = z.object({
+  text: z.string(),
+  confidence: z.number().min(0).max(1),
+  x: z.number().int(),
+  y: z.number().int(),
+  width: z.number().int(),
+  height: z.number().int()
+});
+export type ScreenMatch = z.infer<typeof ScreenMatch>;
+
+export const ScreenFindOutput = z.object({
+  matches: z.array(ScreenMatch)
+});
+export type ScreenFindOutput = z.infer<typeof ScreenFindOutput>;
+
+export const MouseMoveInput = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  duration_ms: z.number().int().nonnegative().optional()
+});
+export type MouseMoveInput = z.infer<typeof MouseMoveInput>;
+
+export const MouseMoveOutput = z.object({
+  moved: z.literal(true)
+});
+export type MouseMoveOutput = z.infer<typeof MouseMoveOutput>;
+
+export const MouseButton = z.enum(["left", "middle", "right"]);
+export type MouseButton = z.infer<typeof MouseButton>;
+
+export const MouseClickInput = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  button: MouseButton.optional(),
+  count: z.number().int().positive().optional()
+});
+export type MouseClickInput = z.infer<typeof MouseClickInput>;
+
+export const MouseClickOutput = z.object({
+  clicked: z.literal(true)
+});
+export type MouseClickOutput = z.infer<typeof MouseClickOutput>;
+
+export const MouseDragInput = z.object({
+  from_x: z.number().int(),
+  from_y: z.number().int(),
+  to_x: z.number().int(),
+  to_y: z.number().int(),
+  duration_ms: z.number().int().nonnegative().optional(),
+  button: MouseButton.optional()
+});
+export type MouseDragInput = z.infer<typeof MouseDragInput>;
+
+export const MouseDragOutput = z.object({
+  dragged: z.literal(true)
+});
+export type MouseDragOutput = z.infer<typeof MouseDragOutput>;
+
+export const MouseScrollInput = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  dy: z.number().int(),
+  dx: z.number().int().optional()
+});
+export type MouseScrollInput = z.infer<typeof MouseScrollInput>;
+
+export const MouseScrollOutput = z.object({
+  scrolled: z.literal(true)
+});
+export type MouseScrollOutput = z.infer<typeof MouseScrollOutput>;
+
+export const KeyPressInput = z.object({
+  keys: z.string().min(1)
+});
+export type KeyPressInput = z.infer<typeof KeyPressInput>;
+
+export const KeyPressOutput = z.object({
+  pressed: z.literal(true)
+});
+export type KeyPressOutput = z.infer<typeof KeyPressOutput>;
+
+export const KeyTypeInput = z.object({
+  text: z.string(),
+  delay_ms: z.number().int().nonnegative().optional()
+});
+export type KeyTypeInput = z.infer<typeof KeyTypeInput>;
+
+export const KeyTypeOutput = z.object({
+  typed: z.literal(true)
+});
+export type KeyTypeOutput = z.infer<typeof KeyTypeOutput>;
+
+export const CursorPositionInput = z.object({}).optional();
+export type CursorPositionInput = z.infer<typeof CursorPositionInput>;
+
+export const CursorPositionOutput = z.object({
+  x: z.number().int(),
+  y: z.number().int()
+});
+export type CursorPositionOutput = z.infer<typeof CursorPositionOutput>;

--- a/packages/sandbox/src/schemas/file.ts
+++ b/packages/sandbox/src/schemas/file.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 
 export const FileReadInput = z.object({
   file: z.string().min(1),
-  start_line: z.number().int().nonnegative().optional(),
-  end_line: z.number().int().nonnegative().optional(),
+  start_line: z.number().int().positive().optional(),
+  end_line: z.number().int().positive().optional(),
   sudo: z.boolean().optional()
 });
 export type FileReadInput = z.infer<typeof FileReadInput>;

--- a/packages/sandbox/src/schemas/file.ts
+++ b/packages/sandbox/src/schemas/file.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+export const FileReadInput = z.object({
+  file: z.string().min(1),
+  start_line: z.number().int().nonnegative().optional(),
+  end_line: z.number().int().nonnegative().optional(),
+  sudo: z.boolean().optional()
+});
+export type FileReadInput = z.infer<typeof FileReadInput>;
+
+export const FileReadOutput = z.object({
+  content: z.string(),
+  total_lines: z.number().int().nonnegative(),
+  truncated: z.boolean()
+});
+export type FileReadOutput = z.infer<typeof FileReadOutput>;
+
+export const FileWriteInput = z.object({
+  file: z.string().min(1),
+  content: z.string(),
+  append: z.boolean().optional(),
+  leading_newline: z.boolean().optional(),
+  trailing_newline: z.boolean().optional(),
+  sudo: z.boolean().optional()
+});
+export type FileWriteInput = z.infer<typeof FileWriteInput>;
+
+export const FileWriteOutput = z.object({
+  bytes_written: z.number().int().nonnegative(),
+  file: z.string()
+});
+export type FileWriteOutput = z.infer<typeof FileWriteOutput>;
+
+export const FileStrReplaceInput = z.object({
+  file: z.string().min(1),
+  old_str: z.string(),
+  new_str: z.string(),
+  sudo: z.boolean().optional()
+});
+export type FileStrReplaceInput = z.infer<typeof FileStrReplaceInput>;
+
+export const FileStrReplaceOutput = z.object({
+  replacements: z.number().int().nonnegative(),
+  file: z.string()
+});
+export type FileStrReplaceOutput = z.infer<typeof FileStrReplaceOutput>;
+
+export const FileFindInContentInput = z.object({
+  file: z.string().min(1),
+  regex: z.string().min(1),
+  sudo: z.boolean().optional()
+});
+export type FileFindInContentInput = z.infer<typeof FileFindInContentInput>;
+
+export const FileMatch = z.object({
+  line_number: z.number().int().positive(),
+  line: z.string(),
+  match: z.string()
+});
+export type FileMatch = z.infer<typeof FileMatch>;
+
+export const FileFindInContentOutput = z.object({
+  matches: z.array(FileMatch)
+});
+export type FileFindInContentOutput = z.infer<typeof FileFindInContentOutput>;
+
+export const FileFindByNameInput = z.object({
+  path: z.string().min(1),
+  glob: z.string().min(1)
+});
+export type FileFindByNameInput = z.infer<typeof FileFindByNameInput>;
+
+export const FileFindByNameOutput = z.object({
+  paths: z.array(z.string())
+});
+export type FileFindByNameOutput = z.infer<typeof FileFindByNameOutput>;

--- a/packages/sandbox/src/schemas/health.ts
+++ b/packages/sandbox/src/schemas/health.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const HealthOutput = z.object({
+  ok: z.literal(true),
+  version: z.string(),
+  uptime_seconds: z.number().nonnegative(),
+  workspace: z.string()
+});
+export type HealthOutput = z.infer<typeof HealthOutput>;

--- a/packages/sandbox/src/schemas/index.ts
+++ b/packages/sandbox/src/schemas/index.ts
@@ -11,4 +11,6 @@
 
 export * from "./file.js";
 export * from "./shell.js";
+export * from "./browser.js";
+export * from "./desktop.js";
 export * from "./health.js";

--- a/packages/sandbox/src/schemas/index.ts
+++ b/packages/sandbox/src/schemas/index.ts
@@ -15,4 +15,5 @@ export * from "./browser.js";
 export * from "./desktop.js";
 export * from "./search.js";
 export * from "./message.js";
+export * from "./deploy.js";
 export * from "./health.js";

--- a/packages/sandbox/src/schemas/index.ts
+++ b/packages/sandbox/src/schemas/index.ts
@@ -13,4 +13,6 @@ export * from "./file.js";
 export * from "./shell.js";
 export * from "./browser.js";
 export * from "./desktop.js";
+export * from "./search.js";
+export * from "./message.js";
 export * from "./health.js";

--- a/packages/sandbox/src/schemas/index.ts
+++ b/packages/sandbox/src/schemas/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared Zod schemas for the sandbox tool surface.
+ *
+ * Imported by:
+ *   - host (@nodetool/sandbox) — to validate client requests and describe
+ *     tools to LLMs
+ *   - in-container (@nodetool/sandbox-agent) — to validate Fastify routes
+ *
+ * Single source of truth means no schema drift between host and container.
+ */
+
+export * from "./file.js";
+export * from "./shell.js";
+export * from "./health.js";

--- a/packages/sandbox/src/schemas/message.ts
+++ b/packages/sandbox/src/schemas/message.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+/**
+ * Messaging tools — how the agent talks BACK to the user.
+ *
+ * `notify` is non-blocking (the agent keeps working); `ask` stores a
+ * pending question that a subsequent user reply can satisfy. Both can
+ * carry attachments (paths inside the sandbox workspace).
+ *
+ * The events are streamed to the host over the /events SSE endpoint,
+ * where the host relays them to the user-facing UI.
+ */
+
+export const Attachment = z.object({
+  path: z.string().min(1),
+  mime: z.string().optional(),
+  caption: z.string().optional()
+});
+export type Attachment = z.infer<typeof Attachment>;
+
+export const MessageNotifyUserInput = z.object({
+  text: z.string(),
+  attachments: z.array(Attachment).optional()
+});
+export type MessageNotifyUserInput = z.infer<typeof MessageNotifyUserInput>;
+
+export const MessageNotifyUserOutput = z.object({
+  event_id: z.string()
+});
+export type MessageNotifyUserOutput = z.infer<typeof MessageNotifyUserOutput>;
+
+export const MessageAskUserInput = z.object({
+  text: z.string(),
+  attachments: z.array(Attachment).optional(),
+  suggest_user_takeover: z.boolean().optional()
+});
+export type MessageAskUserInput = z.infer<typeof MessageAskUserInput>;
+
+export const MessageAskUserOutput = z.object({
+  event_id: z.string()
+});
+export type MessageAskUserOutput = z.infer<typeof MessageAskUserOutput>;
+
+/**
+ * Server-sent event payload pushed over /events. The host's ToolClient
+ * exposes this as an async iterator.
+ */
+export const SandboxEventType = z.enum([
+  "notify",
+  "ask",
+  "log",
+  "idle"
+]);
+export type SandboxEventType = z.infer<typeof SandboxEventType>;
+
+export const SandboxEvent = z.object({
+  id: z.string(),
+  type: SandboxEventType,
+  timestamp: z.number(),
+  text: z.string().optional(),
+  attachments: z.array(Attachment).optional(),
+  suggest_user_takeover: z.boolean().optional()
+});
+export type SandboxEvent = z.infer<typeof SandboxEvent>;
+
+export const IdleInput = z.object({
+  reason: z.string().optional()
+});
+export type IdleInput = z.infer<typeof IdleInput>;
+
+export const IdleOutput = z.object({
+  event_id: z.string()
+});
+export type IdleOutput = z.infer<typeof IdleOutput>;

--- a/packages/sandbox/src/schemas/search.ts
+++ b/packages/sandbox/src/schemas/search.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * Search tool — web search abstracted behind a provider. The actual
+ * HTTP call to Brave/Tavily/Serper is made inside the container, using
+ * env-configured API keys injected by the host at container-create time.
+ */
+
+export const SearchDateRange = z.enum([
+  "any",
+  "past_day",
+  "past_week",
+  "past_month",
+  "past_year"
+]);
+export type SearchDateRange = z.infer<typeof SearchDateRange>;
+
+export const InfoSearchWebInput = z.object({
+  query: z.string().min(1),
+  date_range: SearchDateRange.optional(),
+  count: z.number().int().positive().max(20).optional()
+});
+export type InfoSearchWebInput = z.infer<typeof InfoSearchWebInput>;
+
+export const SearchResult = z.object({
+  title: z.string(),
+  url: z.string(),
+  snippet: z.string(),
+  published_at: z.string().nullable()
+});
+export type SearchResult = z.infer<typeof SearchResult>;
+
+export const InfoSearchWebOutput = z.object({
+  provider: z.string(),
+  query: z.string(),
+  results: z.array(SearchResult)
+});
+export type InfoSearchWebOutput = z.infer<typeof InfoSearchWebOutput>;

--- a/packages/sandbox/src/schemas/shell.ts
+++ b/packages/sandbox/src/schemas/shell.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const ShellExecInput = z.object({
+  id: z.string().min(1),
+  exec_dir: z.string().optional(),
+  command: z.string().min(1)
+});
+export type ShellExecInput = z.infer<typeof ShellExecInput>;
+
+export const ShellExecOutput = z.object({
+  id: z.string(),
+  started: z.boolean()
+});
+export type ShellExecOutput = z.infer<typeof ShellExecOutput>;
+
+export const ShellViewInput = z.object({
+  id: z.string().min(1)
+});
+export type ShellViewInput = z.infer<typeof ShellViewInput>;
+
+export const ShellViewOutput = z.object({
+  id: z.string(),
+  output: z.string(),
+  running: z.boolean(),
+  exit_code: z.number().int().nullable()
+});
+export type ShellViewOutput = z.infer<typeof ShellViewOutput>;
+
+export const ShellWaitInput = z.object({
+  id: z.string().min(1),
+  seconds: z.number().positive().optional()
+});
+export type ShellWaitInput = z.infer<typeof ShellWaitInput>;
+
+export const ShellWaitOutput = z.object({
+  id: z.string(),
+  output: z.string(),
+  running: z.boolean(),
+  exit_code: z.number().int().nullable(),
+  timed_out: z.boolean()
+});
+export type ShellWaitOutput = z.infer<typeof ShellWaitOutput>;
+
+export const ShellWriteToProcessInput = z.object({
+  id: z.string().min(1),
+  input: z.string(),
+  press_enter: z.boolean()
+});
+export type ShellWriteToProcessInput = z.infer<typeof ShellWriteToProcessInput>;
+
+export const ShellWriteToProcessOutput = z.object({
+  id: z.string(),
+  bytes_written: z.number().int().nonnegative()
+});
+export type ShellWriteToProcessOutput = z.infer<
+  typeof ShellWriteToProcessOutput
+>;
+
+export const ShellKillProcessInput = z.object({
+  id: z.string().min(1)
+});
+export type ShellKillProcessInput = z.infer<typeof ShellKillProcessInput>;
+
+export const ShellKillProcessOutput = z.object({
+  id: z.string(),
+  killed: z.boolean()
+});
+export type ShellKillProcessOutput = z.infer<typeof ShellKillProcessOutput>;

--- a/packages/sandbox/src/session/SessionStore.ts
+++ b/packages/sandbox/src/session/SessionStore.ts
@@ -116,7 +116,11 @@ export class SessionStore {
     const warm = hasPerCallOptions ? undefined : this.warmPool.shift();
     let sandbox: Sandbox;
     if (warm) {
-      sandbox = warm;
+      // Warm sandboxes keep their generated id internally. Wrap so the
+      // caller sees the requested sessionId (SandboxProvider contract).
+      const wrapper = Object.create(warm);
+      wrapper.sessionId = sessionId;
+      sandbox = wrapper as Sandbox;
       // Trigger async refill without blocking the caller.
       void this.refillWarmPool();
     } else {

--- a/packages/sandbox/src/session/SessionStore.ts
+++ b/packages/sandbox/src/session/SessionStore.ts
@@ -1,0 +1,232 @@
+/**
+ * SessionStore — lifecycle manager for Sandbox instances on the host.
+ *
+ * Responsibilities:
+ *   - acquire(sessionId)  look up an existing session or allocate a new one
+ *   - touch(sessionId)    mark activity; resets the idle timer
+ *   - release(sessionId)  stop and remove a session
+ *   - TTL sweeper         removes sessions idle past `idleTtlSeconds`
+ *   - warm pool           keeps N pre-started sandboxes ready so acquire()
+ *                         is near-instant for the common fresh-session case
+ *
+ * Pause/resume: if a sandbox has been idle longer than `idlePauseSeconds`
+ * but not yet past the TTL, it's docker-paused to reclaim RAM. The next
+ * touch() auto-resumes it.
+ *
+ * Warm pool: a separate queue of pre-acquired sandboxes with generated
+ * ("warm-XXXX") session ids. When acquire() is called without matching an
+ * existing session, the store takes from the warm pool (renaming the id)
+ * and asynchronously tops the pool back up to target size.
+ */
+
+import type {
+  Sandbox,
+  SandboxOptions,
+  SandboxProvider
+} from "../SandboxProvider.js";
+
+export interface SessionStoreOptions {
+  provider: SandboxProvider;
+  /** Max idle seconds before a session is released. Default: 3600. */
+  idleTtlSeconds?: number;
+  /** Idle seconds before a running session is paused. 0 = never. */
+  idlePauseSeconds?: number;
+  /** Number of warm sandboxes to keep ready. Default: 0. */
+  warmPoolSize?: number;
+  /** Base acquire options applied to every new session. */
+  defaults?: Partial<SandboxOptions>;
+  /** Sweeper cadence in ms. Default: 5000. */
+  sweepIntervalMs?: number;
+}
+
+interface SessionRecord {
+  sandbox: Sandbox;
+  sessionId: string;
+  lastTouch: number;
+  paused: boolean;
+}
+
+export class SessionStore {
+  private readonly provider: SandboxProvider;
+  private readonly idleTtlMs: number;
+  private readonly idlePauseMs: number;
+  private readonly warmPoolSize: number;
+  private readonly defaults: Partial<SandboxOptions>;
+  private readonly sweepIntervalMs: number;
+
+  private readonly records = new Map<string, SessionRecord>();
+  private readonly warmPool: Sandbox[] = [];
+  private closed = false;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private warming = false;
+
+  constructor(options: SessionStoreOptions) {
+    this.provider = options.provider;
+    this.idleTtlMs = (options.idleTtlSeconds ?? 3600) * 1000;
+    this.idlePauseMs = (options.idlePauseSeconds ?? 0) * 1000;
+    this.warmPoolSize = options.warmPoolSize ?? 0;
+    this.defaults = options.defaults ?? {};
+    this.sweepIntervalMs = options.sweepIntervalMs ?? 5000;
+
+    this.sweepTimer = setInterval(() => {
+      void this.sweep();
+    }, this.sweepIntervalMs);
+    // Don't keep the event loop alive just for the sweeper.
+    this.sweepTimer.unref?.();
+
+    if (this.warmPoolSize > 0) {
+      void this.refillWarmPool();
+    }
+  }
+
+  /**
+   * Return an existing sandbox for the id, or allocate a new one. New
+   * sandboxes may come from the warm pool for near-zero latency.
+   */
+  async acquire(
+    sessionId: string,
+    options: Partial<SandboxOptions> = {}
+  ): Promise<Sandbox> {
+    if (this.closed) throw new Error("SessionStore is closed");
+
+    const existing = this.records.get(sessionId);
+    if (existing) {
+      existing.lastTouch = Date.now();
+      if (existing.paused) {
+        await existing.sandbox.resume?.();
+        existing.paused = false;
+      }
+      return existing.sandbox;
+    }
+
+    const warm = this.warmPool.shift();
+    let sandbox: Sandbox;
+    if (warm) {
+      sandbox = warm;
+      // Trigger async refill without blocking the caller.
+      void this.refillWarmPool();
+    } else {
+      sandbox = await this.provider.acquire({
+        ...this.defaults,
+        ...options,
+        sessionId
+      });
+    }
+
+    this.records.set(sessionId, {
+      sandbox,
+      sessionId,
+      lastTouch: Date.now(),
+      paused: false
+    });
+    return sandbox;
+  }
+
+  /** Mark activity on a session without fetching the sandbox handle. */
+  touch(sessionId: string): void {
+    const rec = this.records.get(sessionId);
+    if (rec) rec.lastTouch = Date.now();
+  }
+
+  /** Get an existing session handle without allocating. */
+  get(sessionId: string): Sandbox | undefined {
+    return this.records.get(sessionId)?.sandbox;
+  }
+
+  has(sessionId: string): boolean {
+    return this.records.has(sessionId);
+  }
+
+  size(): number {
+    return this.records.size;
+  }
+
+  warmCount(): number {
+    return this.warmPool.length;
+  }
+
+  /** Stop and remove a session. */
+  async release(sessionId: string): Promise<void> {
+    const rec = this.records.get(sessionId);
+    if (!rec) return;
+    this.records.delete(sessionId);
+    await rec.sandbox.release();
+  }
+
+  /** Stop all sessions, drain the warm pool, and cancel the sweeper. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.sweepTimer) clearInterval(this.sweepTimer);
+    const all = [
+      ...Array.from(this.records.values()).map((r) => r.sandbox.release()),
+      ...this.warmPool.splice(0).map((s) => s.release())
+    ];
+    this.records.clear();
+    await Promise.allSettled(all);
+  }
+
+  /** @internal — exported for tests. */
+  async _sweepForTests(): Promise<void> {
+    await this.sweep();
+  }
+
+  private async sweep(): Promise<void> {
+    if (this.closed) return;
+    const now = Date.now();
+    const pauseOps: Array<Promise<void>> = [];
+    const releaseIds: string[] = [];
+    for (const [id, rec] of this.records) {
+      const idle = now - rec.lastTouch;
+      if (idle >= this.idleTtlMs) {
+        releaseIds.push(id);
+        continue;
+      }
+      if (
+        !rec.paused &&
+        this.idlePauseMs > 0 &&
+        idle >= this.idlePauseMs &&
+        rec.sandbox.pause
+      ) {
+        pauseOps.push(
+          rec.sandbox
+            .pause()
+            .then(() => {
+              rec.paused = true;
+            })
+            .catch(() => {
+              // best-effort; leave record unpaused
+            })
+        );
+      }
+    }
+    await Promise.allSettled(pauseOps);
+    for (const id of releaseIds) {
+      await this.release(id).catch(() => {});
+    }
+  }
+
+  private async refillWarmPool(): Promise<void> {
+    if (this.closed || this.warming) return;
+    if (this.warmPool.length >= this.warmPoolSize) return;
+    this.warming = true;
+    try {
+      while (!this.closed && this.warmPool.length < this.warmPoolSize) {
+        const id = `warm-${Math.random().toString(36).slice(2, 10)}`;
+        try {
+          const sandbox = await this.provider.acquire({
+            ...this.defaults,
+            sessionId: id
+          });
+          this.warmPool.push(sandbox);
+        } catch {
+          // Back off briefly if the provider is failing — don't spin.
+          await new Promise((r) => setTimeout(r, 1000));
+          break;
+        }
+      }
+    } finally {
+      this.warming = false;
+    }
+  }
+}

--- a/packages/sandbox/src/session/SessionStore.ts
+++ b/packages/sandbox/src/session/SessionStore.ts
@@ -10,15 +10,23 @@
  *                         is near-instant for the common fresh-session case
  *
  * Pause/resume: if a sandbox has been idle longer than `idlePauseSeconds`
- * but not yet past the TTL, it's docker-paused to reclaim RAM. The next
- * touch() auto-resumes it.
+ * but not yet past the TTL, it's docker-paused to reclaim RAM by the
+ * sweeper. A paused sandbox is auto-resumed on the next `acquire()` for
+ * that session id (not on `touch()` — touch only resets the timer).
  *
  * Warm pool: a separate queue of pre-acquired sandboxes with generated
- * ("warm-XXXX") session ids. When acquire() is called without matching an
- * existing session, the store takes from the warm pool (renaming the id)
- * and asynchronously tops the pool back up to target size.
+ * session ids. When `acquire()` is called for a fresh id AND no per-call
+ * options are supplied, the store takes from the warm pool and registers
+ * the sandbox under the caller's id (the sandbox's own `sessionId`
+ * property is NOT renamed; it keeps its warm-* generated id). The pool
+ * is bypassed when `acquire(id, options)` is given a non-empty `options`
+ * object, since the warm sandbox was created only with `defaults` and
+ * per-call settings like `workspaceDir`, `env`, or `memLimit` cannot be
+ * retrofitted onto an already-running container. The pool is
+ * asynchronously topped up after each take.
  */
 
+import { randomBytes } from "node:crypto";
 import type {
   Sandbox,
   SandboxOptions,
@@ -81,7 +89,9 @@ export class SessionStore {
 
   /**
    * Return an existing sandbox for the id, or allocate a new one. New
-   * sandboxes may come from the warm pool for near-zero latency.
+   * sandboxes may come from the warm pool for near-zero latency when the
+   * caller doesn't request per-call options — see the class doc-comment
+   * for why per-call options bypass the warm pool.
    */
   async acquire(
     sessionId: string,
@@ -99,7 +109,11 @@ export class SessionStore {
       return existing.sandbox;
     }
 
-    const warm = this.warmPool.shift();
+    // Warm-pool sandboxes were created with only `defaults`; we can't
+    // retrofit per-call `workspaceDir` / `env` / `memLimit` / `image`
+    // onto an already-running container. Bypass the pool in that case.
+    const hasPerCallOptions = Object.keys(options).length > 0;
+    const warm = hasPerCallOptions ? undefined : this.warmPool.shift();
     let sandbox: Sandbox;
     if (warm) {
       sandbox = warm;
@@ -212,7 +226,7 @@ export class SessionStore {
     this.warming = true;
     try {
       while (!this.closed && this.warmPool.length < this.warmPoolSize) {
-        const id = `warm-${Math.random().toString(36).slice(2, 10)}`;
+        const id = `warm-${randomBytes(6).toString("hex")}`;
         try {
           const sandbox = await this.provider.acquire({
             ...this.defaults,

--- a/packages/sandbox/src/session/index.ts
+++ b/packages/sandbox/src/session/index.ts
@@ -1,0 +1,2 @@
+export { SessionStore } from "./SessionStore.js";
+export type { SessionStoreOptions } from "./SessionStore.js";

--- a/packages/sandbox/tests/DockerSandbox.test.ts
+++ b/packages/sandbox/tests/DockerSandbox.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMemLimit,
+  DEFAULT_SANDBOX_IMAGE,
+  TOOL_SERVER_PORT,
+  VNC_WS_PORT
+} from "../src/DockerSandbox.js";
+
+describe("parseMemLimit", () => {
+  it("parses megabytes", () => {
+    expect(parseMemLimit("512m")).toBe(512 * 1024 * 1024);
+  });
+
+  it("parses gigabytes", () => {
+    expect(parseMemLimit("2g")).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it("parses kilobytes", () => {
+    expect(parseMemLimit("1024k")).toBe(1024 * 1024);
+  });
+
+  it("falls back to 2GiB for garbage input", () => {
+    expect(parseMemLimit("oops")).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it("accepts an uppercase M", () => {
+    expect(parseMemLimit("256M")).toBe(256 * 1024 * 1024);
+  });
+
+  it("accepts a bare byte count", () => {
+    expect(parseMemLimit("1024")).toBe(1024);
+  });
+});
+
+describe("DockerSandbox constants", () => {
+  it("exposes the expected default image tag", () => {
+    expect(DEFAULT_SANDBOX_IMAGE).toBe("nodetool/sandbox-agent:latest");
+  });
+
+  it("uses port 7788 for the tool server", () => {
+    expect(TOOL_SERVER_PORT).toBe(7788);
+  });
+
+  it("uses port 6080 for the VNC websocket", () => {
+    expect(VNC_WS_PORT).toBe(6080);
+  });
+});

--- a/packages/sandbox/tests/SessionStore.test.ts
+++ b/packages/sandbox/tests/SessionStore.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { SessionStore } from "../src/session/SessionStore.js";
+import type {
+  Sandbox,
+  SandboxProvider,
+  SandboxOptions
+} from "../src/SandboxProvider.js";
+import { ToolClient } from "../src/ToolClient.js";
+
+function makeFakeSandbox(sessionId: string): Sandbox & {
+  released: boolean;
+  paused: boolean;
+  resumed: boolean;
+} {
+  const state = { released: false, paused: false, resumed: false };
+  const sb: Sandbox & typeof state = {
+    sessionId,
+    endpoint: { toolUrl: "http://fake" },
+    client: new ToolClient({ baseUrl: "http://fake" }),
+    async release() {
+      state.released = true;
+    },
+    async pause() {
+      state.paused = true;
+    },
+    async resume() {
+      state.paused = false;
+      state.resumed = true;
+    },
+    ...state
+  };
+  // Proxy state so the sandbox object reflects live flags even after the
+  // test function reads .released etc.
+  Object.defineProperty(sb, "released", { get: () => state.released });
+  Object.defineProperty(sb, "paused", { get: () => state.paused });
+  Object.defineProperty(sb, "resumed", { get: () => state.resumed });
+  return sb;
+}
+
+function makeProvider(): {
+  provider: SandboxProvider;
+  created: Array<{ sessionId: string; sandbox: ReturnType<typeof makeFakeSandbox> }>;
+} {
+  const created: Array<{ sessionId: string; sandbox: ReturnType<typeof makeFakeSandbox> }> = [];
+  const provider: SandboxProvider = {
+    async acquire(options: SandboxOptions) {
+      const sandbox = makeFakeSandbox(options.sessionId);
+      created.push({ sessionId: options.sessionId, sandbox });
+      return sandbox;
+    }
+  };
+  return { provider, created };
+}
+
+describe("SessionStore", () => {
+  it("acquires a fresh sandbox for a new session id", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({ provider, sweepIntervalMs: 60_000 });
+    try {
+      const sb = await store.acquire("s1");
+      expect(sb.sessionId).toBe("s1");
+      expect(created).toHaveLength(1);
+      expect(store.size()).toBe(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("returns the same sandbox on subsequent acquires with the same id", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({ provider, sweepIntervalMs: 60_000 });
+    try {
+      const a = await store.acquire("s1");
+      const b = await store.acquire("s1");
+      expect(a).toBe(b);
+      expect(created).toHaveLength(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("auto-resumes a paused sandbox on re-acquire", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      idlePauseSeconds: 0.001,
+      idleTtlSeconds: 3600
+    });
+    try {
+      await store.acquire("s1");
+      await new Promise((r) => setTimeout(r, 10));
+      await store._sweepForTests();
+      expect(created[0].sandbox.paused).toBe(true);
+      await store.acquire("s1");
+      expect(created[0].sandbox.resumed).toBe(true);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("releases idle sandboxes past the TTL on sweep", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      idleTtlSeconds: 0.001
+    });
+    try {
+      await store.acquire("s1");
+      await new Promise((r) => setTimeout(r, 10));
+      await store._sweepForTests();
+      expect(created[0].sandbox.released).toBe(true);
+      expect(store.has("s1")).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("touches reset the idle timer", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      idleTtlSeconds: 0.05
+    });
+    try {
+      await store.acquire("s1");
+      for (let i = 0; i < 6; i++) {
+        await new Promise((r) => setTimeout(r, 10));
+        store.touch("s1");
+      }
+      await store._sweepForTests();
+      expect(created[0].sandbox.released).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("keeps a warm pool topped up and uses a pre-warmed sandbox on first acquire", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      warmPoolSize: 2
+    });
+    try {
+      // Wait for the warm pool to fill in the background.
+      for (let i = 0; i < 50 && store.warmCount() < 2; i++) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(store.warmCount()).toBe(2);
+      const warmIds = created.map((c) => c.sessionId);
+      expect(warmIds.every((id) => id.startsWith("warm-"))).toBe(true);
+
+      const sb = await store.acquire("real-1");
+      expect(sb.sessionId).toMatch(/^warm-/);
+      expect(store.warmCount()).toBeGreaterThanOrEqual(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("close() releases every active and warm sandbox", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      warmPoolSize: 1
+    });
+    await store.acquire("s1");
+    for (let i = 0; i < 50 && store.warmCount() < 1; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await store.close();
+    expect(created.every((c) => c.sandbox.released)).toBe(true);
+  });
+});

--- a/packages/sandbox/tests/SessionStore.test.ts
+++ b/packages/sandbox/tests/SessionStore.test.ts
@@ -154,7 +154,7 @@ describe("SessionStore", () => {
       expect(warmIds.every((id) => id.startsWith("warm-"))).toBe(true);
 
       const sb = await store.acquire("real-1");
-      expect(sb.sessionId).toMatch(/^warm-/);
+      expect(sb.sessionId).toBe("real-1");
       expect(store.warmCount()).toBeGreaterThanOrEqual(1);
     } finally {
       await store.close();

--- a/packages/sandbox/tests/SessionStore.test.ts
+++ b/packages/sandbox/tests/SessionStore.test.ts
@@ -161,6 +161,33 @@ describe("SessionStore", () => {
     }
   });
 
+  it("bypasses the warm pool when per-call options are provided", async () => {
+    const { provider, created } = makeProvider();
+    const store = new SessionStore({
+      provider,
+      sweepIntervalMs: 60_000,
+      warmPoolSize: 1
+    });
+    try {
+      for (let i = 0; i < 50 && store.warmCount() < 1; i++) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(store.warmCount()).toBe(1);
+
+      // Per-call options must NOT be silently dropped by taking a warm
+      // sandbox that was created with defaults.
+      const sb = await store.acquire("with-opts", {
+        workspaceDir: "/mnt/work"
+      });
+      expect(sb.sessionId).toBe("with-opts");
+      expect(store.warmCount()).toBe(1);
+      // The last created record is the with-opts sandbox, provisioned fresh.
+      expect(created[created.length - 1].sessionId).toBe("with-opts");
+    } finally {
+      await store.close();
+    }
+  });
+
   it("close() releases every active and warm sandbox", async () => {
     const { provider, created } = makeProvider();
     const store = new SessionStore({

--- a/packages/sandbox/tests/ToolClient.test.ts
+++ b/packages/sandbox/tests/ToolClient.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { ToolClient, ToolInvocationError } from "../src/ToolClient.js";
+
+function makeFetch(
+  responder: (input: RequestInfo | URL, init?: RequestInit) => Response
+): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve(responder(input, init))) as typeof fetch;
+}
+
+describe("ToolClient", () => {
+  it("calls /health with GET and parses the response", async () => {
+    const client = new ToolClient({
+      baseUrl: "http://sbx:7788",
+      fetch: makeFetch((url, init) => {
+        expect(String(url)).toBe("http://sbx:7788/health");
+        expect((init?.method ?? "GET").toUpperCase()).toBe("GET");
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            version: "0.1.0",
+            uptime_seconds: 12.5,
+            workspace: "/workspace"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      })
+    });
+    const health = await client.health();
+    expect(health.ok).toBe(true);
+    expect(health.version).toBe("0.1.0");
+  });
+
+  it("validates input and sends JSON body for file.read", async () => {
+    let captured: { url: string; body: unknown } | null = null;
+    const client = new ToolClient({
+      baseUrl: "http://sbx:7788",
+      fetch: makeFetch((url, init) => {
+        captured = { url: String(url), body: JSON.parse(init!.body as string) };
+        return new Response(
+          JSON.stringify({ content: "hi", total_lines: 1, truncated: false }),
+          { status: 200 }
+        );
+      })
+    });
+    const out = await client.fileRead({ file: "/tmp/x" });
+    expect(captured).not.toBeNull();
+    expect(captured!.url).toBe("http://sbx:7788/file/read");
+    expect(captured!.body).toEqual({ file: "/tmp/x" });
+    expect(out.content).toBe("hi");
+  });
+
+  it("throws ToolInvocationError on non-2xx responses", async () => {
+    const client = new ToolClient({
+      baseUrl: "http://sbx:7788",
+      fetch: makeFetch(
+        () =>
+          new Response(JSON.stringify({ error: "boom" }), { status: 500 })
+      )
+    });
+    await expect(client.fileRead({ file: "/tmp/x" })).rejects.toBeInstanceOf(
+      ToolInvocationError
+    );
+  });
+
+  it("strips a trailing slash from baseUrl", async () => {
+    let capturedUrl = "";
+    const client = new ToolClient({
+      baseUrl: "http://sbx:7788/",
+      fetch: makeFetch((url) => {
+        capturedUrl = String(url);
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            version: "0.1.0",
+            uptime_seconds: 0,
+            workspace: "/workspace"
+          }),
+          { status: 200 }
+        );
+      })
+    });
+    await client.health();
+    expect(capturedUrl).toBe("http://sbx:7788/health");
+  });
+
+  it("raises a zod error when response body is malformed", async () => {
+    const client = new ToolClient({
+      baseUrl: "http://sbx:7788",
+      fetch: makeFetch(
+        () => new Response(JSON.stringify({ wrong: true }), { status: 200 })
+      )
+    });
+    await expect(client.fileRead({ file: "/tmp/x" })).rejects.toThrow();
+  });
+});

--- a/packages/sandbox/tests/browser-schemas.test.ts
+++ b/packages/sandbox/tests/browser-schemas.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  BrowserViewInput,
+  BrowserNavigateInput,
+  BrowserClickInput,
+  BrowserInputTextInput,
+  BrowserScrollInput,
+  BrowserSelectOptionInput,
+  BrowserConsoleExecInput
+} from "../src/schemas/index.js";
+
+describe("browser schemas", () => {
+  it("defaults browser_view to empty object input", () => {
+    const parsed = BrowserViewInput.parse({});
+    expect(parsed.include_screenshot).toBeUndefined();
+  });
+
+  it("requires url on browser_navigate", () => {
+    expect(() => BrowserNavigateInput.parse({})).toThrow();
+  });
+
+  it("rejects an unknown wait_until value", () => {
+    expect(() =>
+      BrowserNavigateInput.parse({ url: "https://x", wait_until: "oops" })
+    ).toThrow();
+  });
+
+  it("accepts index-only browser_click", () => {
+    const parsed = BrowserClickInput.parse({ index: 3 });
+    expect(parsed.index).toBe(3);
+  });
+
+  it("accepts coord-only browser_click", () => {
+    const parsed = BrowserClickInput.parse({
+      coordinate_x: 100,
+      coordinate_y: 200
+    });
+    expect(parsed.coordinate_x).toBe(100);
+  });
+
+  it("rejects browser_click with neither index nor full coords", () => {
+    expect(() => BrowserClickInput.parse({ coordinate_x: 100 })).toThrow();
+    expect(() => BrowserClickInput.parse({})).toThrow();
+  });
+
+  it("requires either index or full coords on browser_input", () => {
+    const ok = BrowserInputTextInput.parse({
+      text: "hi",
+      coordinate_x: 10,
+      coordinate_y: 20
+    });
+    expect(ok.text).toBe("hi");
+    expect(() =>
+      BrowserInputTextInput.parse({ text: "hi" })
+    ).toThrow();
+  });
+
+  it("accepts to_top / to_bottom / pixels on browser_scroll", () => {
+    expect(BrowserScrollInput.parse({ to_top: true }).to_top).toBe(true);
+    expect(BrowserScrollInput.parse({ pixels: 500 }).pixels).toBe(500);
+  });
+
+  it("requires non-empty javascript on console_exec", () => {
+    expect(() => BrowserConsoleExecInput.parse({ javascript: "" })).toThrow();
+  });
+
+  it("requires option on browser_select_option", () => {
+    expect(() => BrowserSelectOptionInput.parse({ index: 0 })).toThrow();
+  });
+});

--- a/packages/sandbox/tests/desktop-schemas.test.ts
+++ b/packages/sandbox/tests/desktop-schemas.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  ScreenCaptureInput,
+  ScreenFindInput,
+  MouseMoveInput,
+  MouseClickInput,
+  MouseDragInput,
+  MouseScrollInput,
+  KeyPressInput,
+  KeyTypeInput
+} from "../src/schemas/index.js";
+
+describe("desktop schemas", () => {
+  it("accepts screen_capture with no args", () => {
+    const parsed = ScreenCaptureInput.parse({});
+    expect(parsed.format).toBeUndefined();
+  });
+
+  it("rejects screen_capture with zero-size region", () => {
+    expect(() =>
+      ScreenCaptureInput.parse({
+        region: { x: 0, y: 0, width: 0, height: 100 }
+      })
+    ).toThrow();
+  });
+
+  it("requires non-empty query on screen_find", () => {
+    expect(() => ScreenFindInput.parse({ query: "" })).toThrow();
+  });
+
+  it("accepts mouse_move with integer coords", () => {
+    const parsed = MouseMoveInput.parse({ x: 500, y: 400 });
+    expect(parsed.x).toBe(500);
+  });
+
+  it("rejects mouse_click with count <= 0", () => {
+    expect(() =>
+      MouseClickInput.parse({ x: 0, y: 0, count: 0 })
+    ).toThrow();
+  });
+
+  it("accepts mouse_drag with all required coords", () => {
+    const parsed = MouseDragInput.parse({
+      from_x: 0,
+      from_y: 0,
+      to_x: 100,
+      to_y: 100,
+      button: "left"
+    });
+    expect(parsed.button).toBe("left");
+  });
+
+  it("rejects mouse_click with unknown button", () => {
+    expect(() =>
+      MouseClickInput.parse({ x: 0, y: 0, button: "scroll" })
+    ).toThrow();
+  });
+
+  it("requires mouse_scroll dy", () => {
+    expect(() => MouseScrollInput.parse({ x: 0, y: 0 })).toThrow();
+  });
+
+  it("requires non-empty keys on key_press", () => {
+    expect(() => KeyPressInput.parse({ keys: "" })).toThrow();
+  });
+
+  it("accepts empty text on key_type", () => {
+    const parsed = KeyTypeInput.parse({ text: "" });
+    expect(parsed.text).toBe("");
+  });
+});

--- a/packages/sandbox/tests/schemas.test.ts
+++ b/packages/sandbox/tests/schemas.test.ts
@@ -19,7 +19,7 @@ describe("schemas / file", () => {
   it("accepts line ranges", () => {
     const parsed = FileReadInput.parse({
       file: "/tmp/x.txt",
-      start_line: 0,
+      start_line: 1,
       end_line: 10
     });
     expect(parsed.end_line).toBe(10);

--- a/packages/sandbox/tests/schemas.test.ts
+++ b/packages/sandbox/tests/schemas.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  FileReadInput,
+  FileWriteInput,
+  ShellExecInput,
+  ShellWaitInput
+} from "../src/schemas/index.js";
+
+describe("schemas / file", () => {
+  it("accepts a minimal file_read input", () => {
+    const parsed = FileReadInput.parse({ file: "/tmp/x.txt" });
+    expect(parsed.file).toBe("/tmp/x.txt");
+  });
+
+  it("rejects empty file paths", () => {
+    expect(() => FileReadInput.parse({ file: "" })).toThrow();
+  });
+
+  it("accepts line ranges", () => {
+    const parsed = FileReadInput.parse({
+      file: "/tmp/x.txt",
+      start_line: 0,
+      end_line: 10
+    });
+    expect(parsed.end_line).toBe(10);
+  });
+
+  it("rejects negative line numbers", () => {
+    expect(() =>
+      FileReadInput.parse({ file: "/tmp/x.txt", start_line: -1 })
+    ).toThrow();
+  });
+
+  it("accepts a file_write with append and sudo", () => {
+    const parsed = FileWriteInput.parse({
+      file: "/etc/hosts",
+      content: "127.0.0.1 x",
+      append: true,
+      sudo: true
+    });
+    expect(parsed.append).toBe(true);
+    expect(parsed.sudo).toBe(true);
+  });
+});
+
+describe("schemas / shell", () => {
+  it("accepts a minimal shell_exec input", () => {
+    const parsed = ShellExecInput.parse({ id: "s1", command: "ls" });
+    expect(parsed.id).toBe("s1");
+  });
+
+  it("rejects empty session ids", () => {
+    expect(() => ShellExecInput.parse({ id: "", command: "ls" })).toThrow();
+  });
+
+  it("rejects empty commands", () => {
+    expect(() => ShellExecInput.parse({ id: "s1", command: "" })).toThrow();
+  });
+
+  it("rejects non-positive wait seconds", () => {
+    expect(() =>
+      ShellWaitInput.parse({ id: "s1", seconds: 0 })
+    ).toThrow();
+  });
+});

--- a/packages/sandbox/tests/search-message-schemas.test.ts
+++ b/packages/sandbox/tests/search-message-schemas.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  InfoSearchWebInput,
+  SearchResult,
+  MessageNotifyUserInput,
+  MessageAskUserInput,
+  SandboxEvent,
+  IdleInput
+} from "../src/schemas/index.js";
+
+describe("search + messaging schemas", () => {
+  it("requires a non-empty query", () => {
+    expect(() => InfoSearchWebInput.parse({ query: "" })).toThrow();
+  });
+
+  it("caps count at 20", () => {
+    expect(() => InfoSearchWebInput.parse({ query: "x", count: 21 })).toThrow();
+    expect(() => InfoSearchWebInput.parse({ query: "x", count: 20 })).not.toThrow();
+  });
+
+  it("accepts known date_range values", () => {
+    const parsed = InfoSearchWebInput.parse({
+      query: "x",
+      date_range: "past_week"
+    });
+    expect(parsed.date_range).toBe("past_week");
+  });
+
+  it("rejects unknown date_range", () => {
+    expect(() =>
+      InfoSearchWebInput.parse({ query: "x", date_range: "past_era" })
+    ).toThrow();
+  });
+
+  it("normalizes a missing published_at to null", () => {
+    const r = SearchResult.parse({
+      title: "t",
+      url: "u",
+      snippet: "s",
+      published_at: null
+    });
+    expect(r.published_at).toBeNull();
+  });
+
+  it("accepts attachments on notify_user", () => {
+    const parsed = MessageNotifyUserInput.parse({
+      text: "done",
+      attachments: [{ path: "/workspace/report.pdf", mime: "application/pdf" }]
+    });
+    expect(parsed.attachments?.[0].path).toBe("/workspace/report.pdf");
+  });
+
+  it("accepts suggest_user_takeover on ask_user", () => {
+    const parsed = MessageAskUserInput.parse({
+      text: "solve captcha please",
+      suggest_user_takeover: true
+    });
+    expect(parsed.suggest_user_takeover).toBe(true);
+  });
+
+  it("validates a well-formed SandboxEvent", () => {
+    const ev = SandboxEvent.parse({
+      id: "abc",
+      type: "notify",
+      timestamp: Date.now(),
+      text: "hi"
+    });
+    expect(ev.type).toBe("notify");
+  });
+
+  it("allows an empty idle input", () => {
+    expect(IdleInput.parse({}).reason).toBeUndefined();
+  });
+});

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [{ "path": "../config" }]
+}

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: {
+    timeout: 30_000,
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -26,6 +26,8 @@
     { "path": "packages/deploy" },
     { "path": "packages/chat" },
     { "path": "packages/websocket" },
-    { "path": "packages/cli" }
+    { "path": "packages/cli" },
+    { "path": "packages/sandbox" },
+    { "path": "packages/sandbox-agent" }
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -28,6 +28,7 @@
     { "path": "packages/websocket" },
     { "path": "packages/cli" },
     { "path": "packages/sandbox" },
-    { "path": "packages/sandbox-agent" }
+    { "path": "packages/sandbox-agent" },
+    { "path": "packages/sandbox-tools" }
   ]
 }


### PR DESCRIPTION
## Summary

This PR introduces a complete sandbox infrastructure for running agents in isolated Docker containers. It includes host-side provisioning (Docker-backed sandbox provider), an in-container tool server exposing file/shell/browser/desktop tools, and an adapter layer to expose sandbox tools as agent-compatible Tool instances.

## Key Changes

### New Packages

- **`@nodetool/sandbox`**: Host-side sandbox provisioning
  - `ToolClient`: Typed HTTP client for the in-container tool server with request/response validation against shared Zod schemas
  - `DockerSandbox`: Dockerode-backed SandboxProvider that acquires containers, publishes ports, waits for readiness
  - `SessionStore`: Lifecycle manager for sandbox instances with TTL sweeping, pause/resume, and warm pool support
  - Comprehensive Zod schemas for all tool inputs/outputs (file, shell, browser, desktop, search, messaging, deploy)

- **`@nodetool/sandbox-agent`**: In-container Fastify tool server
  - `server.ts`: Fastify HTTP service exposing all sandbox tools on port 7788
  - Tool implementations:
    - `file.ts`: File read/write/search operations with optional sudo support
    - `shell.ts`: Named tmux sessions for command execution with exit code tracking
    - `browser.ts`: Playwright-driven Chromium with element indexing and console capture
    - `desktop.ts`: X11 tools (xdotool, scrot) for screen capture, OCR-based text finding, mouse/keyboard control
    - `search.ts`: Web search abstraction supporting Tavily, Brave, Serper providers
    - `message.ts`: Event bus for agent-to-user notifications and questions
    - `deploy.ts`: Port exposure for user-hosted services
  - `event-bus.ts`: In-process event bus backing SSE /events endpoint
  - `port-map.ts`: Registry of container port → public URL mappings
  - Docker image definition with Ubuntu 22.04, Node 24, Chromium, Xvfb/fluxbox, x11vnc, websockify
  - Container entrypoint managing X11 desktop stack and tool server startup

- **`@nodetool/sandbox-tools`**: Agent tool adapter
  - `SandboxTool`: Bridges ToolClient methods into @nodetool/agents Tool instances
  - `manifest.ts`: Registry of all 37 sandbox tools with names, descriptions, input schemas, and invocation logic
  - `createSandboxTools()`: Factory function to instantiate tools for a given ToolClient

### Integration

- Updated `@nodetool/cli` to support `--sandbox` flag for agent execution in isolated containers
- Modified `app.tsx` to accept pre-built tools (sandbox tools) alongside standard tools
- Updated workspace configuration to include new packages in build and TypeScript references

### Testing

- Comprehensive test suites for all major components:
  - Schema validation tests (file, shell, browser, desktop, search, messaging)
  - Tool implementation tests (file operations, shell sessions, browser interactions, desktop capture)
  - Client/server integration tests
  - SessionStore lifecycle tests
  - Manifest and tool adapter tests

## Notable Implementation Details

- **Shared Zod schemas**: Single source of truth for request/response validation across host and container
- **Element indexing**: Browser tool assigns numeric indices to interactive elements for reliable addressing
- **Console capture**: Browser maintains ring buffer of console messages for inspection
- **Stateless desktop tools**: No in-memory state; each call is a fresh subprocess for isolation
- **Session persistence**: Shell sessions survive server restarts via tmux; file/browser state is per-request
- **Security defaults**: Containers run with no-new-privileges, dropped capabilities, memory/CPU limits
- **Warm pool**: SessionStore pre-allocates sandboxes for near-instant acquire() in common case
- **Pause/resume**: Idle containers are paused to reclaim RAM before TTL expiration

https://claude.ai/code/session_017HwmJ6CHvyyR6bieF3BPcz