### PR TITLE
Add HuggingFace Hub search and model management CLI commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6103,359 +6103,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@inquirer/checkbox": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
-      "integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/checkbox/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/checkbox/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
-      "integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "external-editor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
-      "integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
-      "integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/number": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
-      "integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/password/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/password/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
-      "integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^2.5.0",
-        "@inquirer/confirm": "^3.2.0",
-        "@inquirer/editor": "^2.2.0",
-        "@inquirer/expand": "^2.3.0",
-        "@inquirer/input": "^2.3.0",
-        "@inquirer/number": "^1.1.0",
-        "@inquirer/password": "^2.2.0",
-        "@inquirer/rawlist": "^2.3.0",
-        "@inquirer/search": "^1.1.0",
-        "@inquirer/select": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
-      "integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/search": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
-      "integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
-      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/select/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/select/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -15728,15 +15375,6 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/natural": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@types/natural/-/natural-5.1.5.tgz",
@@ -16059,12 +15697,6 @@
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -18654,12 +18286,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "license": "MIT"
-    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -18933,15 +18559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -23074,44 +22691,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -31872,15 +31451,6 @@
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
-    "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -32775,15 +32345,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -39713,18 +39274,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/yoga-layout": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
@@ -39972,7 +39521,6 @@
       "name": "@nodetool/cli",
       "version": "0.1.0",
       "dependencies": {
-        "@inquirer/prompts": "^5.0.0",
         "@nodetool/agents": "*",
         "@nodetool/base-nodes": "*",
         "@nodetool/chat": "*",
@@ -39981,6 +39529,7 @@
         "@nodetool/dsl": "*",
         "@nodetool/elevenlabs-nodes": "*",
         "@nodetool/fal-nodes": "*",
+        "@nodetool/huggingface": "*",
         "@nodetool/kernel": "*",
         "@nodetool/models": "*",
         "@nodetool/node-sdk": "*",
@@ -39990,7 +39539,6 @@
         "@nodetool/sandbox": "*",
         "@nodetool/sandbox-tools": "*",
         "@nodetool/security": "*",
-        "@nodetool/storage": "*",
         "@nodetool/vectorstore": "*",
         "@nodetool/websocket": "*",
         "@trpc/client": "^11.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
     "@nodetool/config": "*",
     "@nodetool/agents": "*",
     "@nodetool/deploy": "*",
+    "@nodetool/huggingface": "*",
     "@nodetool/vectorstore": "*",
     "@nodetool/websocket": "*",
     "@trpc/client": "^11.0.0",

--- a/packages/cli/src/commands/models-hf.ts
+++ b/packages/cli/src/commands/models-hf.ts
@@ -1,0 +1,302 @@
+/**
+ * `nodetool models hf-*` and `download-hf` commands.
+ *
+ * These operate locally against the HuggingFace cache / Hub HTTP API — they
+ * do not require a running nodetool server.
+ */
+
+import type { Command } from "commander";
+
+import {
+  DownloadManager,
+  GENERIC_HF_TYPES,
+  SUPPORTED_MODEL_TYPES,
+  listAllHfModels,
+  readCachedHfModels,
+  searchHfHub,
+  type DownloadUpdate
+} from "@nodetool/huggingface";
+
+import { asJson, printTable } from "./deploy-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(n: number | null | undefined): string {
+  if (!n || n <= 0) return "-";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = n;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value.toFixed(1)} ${units[i]}`;
+}
+
+function parseLimit(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const parsed = Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`Invalid --limit value: ${String(raw)}`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+function collectOption(value: string, previous: string[] | undefined): string[] {
+  return previous ? [...previous, value] : [value];
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerHfCommands(models: Command): void {
+  registerHfTypes(models);
+  registerListHf(models);
+  registerListHfAll(models);
+  registerHfCache(models);
+  registerDownloadHf(models);
+}
+
+// ---------------------------------------------------------------------------
+// hf-types
+// ---------------------------------------------------------------------------
+
+function registerHfTypes(models: Command): void {
+  models
+    .command("hf-types")
+    .description("Print the list of nodetool HF model types")
+    .option("--json", "Output as JSON")
+    .action((opts: { json?: boolean }) => {
+      const types = [...SUPPORTED_MODEL_TYPES];
+      const generic = [...GENERIC_HF_TYPES];
+      if (opts.json) {
+        asJson({ types, generic });
+        return;
+      }
+      for (const t of types) {
+        const marker = GENERIC_HF_TYPES.has(t) ? "  (requires --task)" : "";
+        console.log(`${t}${marker}`);
+      }
+      if (generic.length > 0) {
+        console.log();
+        console.log("Generic types (require --task):");
+        for (const t of generic) console.log(`  ${t}`);
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// list-hf
+// ---------------------------------------------------------------------------
+
+function registerListHf(models: Command): void {
+  models
+    .command("list-hf <model_type>")
+    .description(
+      "Search the HuggingFace Hub for models matching a nodetool model type"
+    )
+    .option("--task <task>", "HF pipeline tag (required for generic types)")
+    .option("--limit <n>", "Cap the number of results")
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        modelType: string,
+        opts: { task?: string; limit?: string; json?: boolean }
+      ) => {
+        try {
+          const limit = parseLimit(opts.limit);
+          const results = await searchHfHub({
+            modelType,
+            task: opts.task,
+            limit
+          });
+          if (opts.json) {
+            asJson(results);
+            return;
+          }
+          printTable(
+            results.map((m) => ({
+              repo_id: m.id,
+              pipeline: m.pipeline_tag ?? "-",
+              library: m.library_name ?? "-",
+              downloads: m.downloads ?? 0,
+              likes: m.likes ?? 0
+            }))
+          );
+        } catch (e) {
+          console.error(String(e instanceof Error ? e.message : e));
+          process.exit(1);
+        }
+      }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// list-hf-all
+// ---------------------------------------------------------------------------
+
+function registerListHfAll(models: Command): void {
+  models
+    .command("list-hf-all")
+    .description(
+      "List HuggingFace models across every nodetool HF model type"
+    )
+    .option("--limit <n>", "Cap the total number of results")
+    .option(
+      "--repo-only",
+      "Keep only repo-level entries (drop file-level entries)"
+    )
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: { limit?: string; repoOnly?: boolean; json?: boolean }) => {
+        try {
+          const limit = parseLimit(opts.limit);
+          const results = await listAllHfModels({
+            limit,
+            repoOnly: Boolean(opts.repoOnly)
+          });
+          if (opts.json) {
+            asJson(results);
+            return;
+          }
+          printTable(
+            results.map((m) => ({
+              repo_id: m.id,
+              model_type: m.model_type ?? "-",
+              pipeline: m.pipeline_tag ?? "-",
+              downloads: m.downloads ?? 0
+            }))
+          );
+        } catch (e) {
+          console.error(String(e instanceof Error ? e.message : e));
+          process.exit(1);
+        }
+      }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hf-cache
+// ---------------------------------------------------------------------------
+
+function registerHfCache(models: Command): void {
+  models
+    .command("hf-cache")
+    .description("List HuggingFace cache entries on the local machine")
+    .option("--downloaded-only", "Only show repos fully downloaded to disk")
+    .option("--limit <n>", "Cap the number of results")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        downloadedOnly?: boolean;
+        limit?: string;
+        json?: boolean;
+      }) => {
+        try {
+          let rows = await readCachedHfModels();
+          if (opts.downloadedOnly) rows = rows.filter((r) => r.downloaded);
+          const limit = parseLimit(opts.limit);
+          if (limit) rows = rows.slice(0, limit);
+
+          if (opts.json) {
+            asJson(rows);
+            return;
+          }
+          printTable(
+            rows.map((r) => ({
+              repo_id: r.repo_id ?? r.id,
+              path: r.path ?? "-",
+              type: r.type ?? "-",
+              downloaded: r.downloaded ? "yes" : "no",
+              size: formatBytes(r.size_on_disk),
+              pipeline: r.pipeline_tag ?? "-"
+            }))
+          );
+        } catch (e) {
+          console.error(String(e instanceof Error ? e.message : e));
+          process.exit(1);
+        }
+      }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// download-hf
+// ---------------------------------------------------------------------------
+
+function registerDownloadHf(models: Command): void {
+  models
+    .command("download-hf")
+    .description(
+      "Download a HuggingFace repository (or a single file) into the local cache"
+    )
+    .requiredOption("--repo-id <id>", "HuggingFace repo id (owner/name)")
+    .option("--cache-dir <dir>", "Override cache directory")
+    .option("--file-path <path>", "Download a single file from the repo")
+    .option(
+      "-a, --allow-patterns <pattern>",
+      "Only download files matching this glob (repeatable)",
+      collectOption
+    )
+    .option(
+      "-i, --ignore-patterns <pattern>",
+      "Skip files matching this glob (repeatable)",
+      collectOption
+    )
+    .action(
+      async (opts: {
+        repoId: string;
+        cacheDir?: string;
+        filePath?: string;
+        allowPatterns?: string[];
+        ignorePatterns?: string[];
+      }) => {
+        const mgr = new DownloadManager();
+        let lastLine = "";
+        let errorMessage: string | null = null;
+        const render = (u: DownloadUpdate) => {
+          if (u.status === "error") {
+            errorMessage = u.error ?? "download failed";
+          }
+          const pct =
+            u.total_bytes > 0
+              ? Math.floor((u.downloaded_bytes / u.total_bytes) * 100)
+              : 0;
+          const line = `[${u.status}] ${u.repo_id} ${u.downloaded_files}/${u.total_files} files  ${formatBytes(u.downloaded_bytes)}/${formatBytes(u.total_bytes)}  ${pct}%`;
+          if (line !== lastLine) {
+            process.stderr.write(`\r${line.padEnd(100)}`);
+            lastLine = line;
+          }
+          if (
+            u.status === "completed" ||
+            u.status === "error" ||
+            u.status === "cancelled"
+          ) {
+            process.stderr.write("\n");
+          }
+        };
+
+        try {
+          await mgr.startDownload(opts.repoId, {
+            path: opts.filePath ?? null,
+            allowPatterns: opts.allowPatterns ?? null,
+            ignorePatterns: opts.ignorePatterns ?? null,
+            cacheDir: opts.cacheDir ?? null,
+            onProgress: render
+          });
+          if (errorMessage) {
+            console.error(errorMessage);
+            process.exit(1);
+          }
+          console.log(`Downloaded '${opts.repoId}'`);
+        } catch (e) {
+          console.error(String(e instanceof Error ? e.message : e));
+          process.exit(1);
+        }
+      }
+    );
+}

--- a/packages/cli/src/commands/models-recommended.ts
+++ b/packages/cli/src/commands/models-recommended.ts
@@ -1,0 +1,194 @@
+/**
+ * `nodetool models recommended` — enhanced filtering over the curated list.
+ *
+ * By default reads `RECOMMENDED_MODELS` locally (no server needed). Pass
+ * `--check-servers` to defer to the tRPC endpoint, which also probes local
+ * server reachability (ollama, llama_cpp).
+ */
+
+import type { Command } from "commander";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@nodetool/websocket/trpc";
+import {
+  RECOMMENDED_MODELS,
+  type RecommendedUnifiedModel
+} from "@nodetool/runtime";
+import type { UnifiedModel } from "@nodetool/protocol";
+
+import { asJson, printTable } from "./deploy-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Category filters
+// ---------------------------------------------------------------------------
+
+type Modality = RecommendedUnifiedModel["modality"];
+type Task = NonNullable<RecommendedUnifiedModel["task"]>;
+
+interface CategoryFilter {
+  modality?: Modality;
+  task?: Task;
+}
+
+const CATEGORY_FILTERS: Record<string, CategoryFilter> = {
+  all: {},
+  image: { modality: "image" },
+  "image-text-to-image": { modality: "image", task: "text_to_image" },
+  "image-image-to-image": { modality: "image", task: "image_to_image" },
+  language: { modality: "language" },
+  "language-text-generation": {
+    modality: "language",
+    task: "text_generation"
+  },
+  "language-embedding": { modality: "language", task: "embedding" },
+  asr: { modality: "asr" },
+  tts: { modality: "tts" },
+  "video-text-to-video": { modality: "video", task: "text_to_video" },
+  "video-image-to-video": { modality: "video", task: "image_to_video" }
+};
+
+const VALID_CATEGORIES = Object.keys(CATEGORY_FILTERS);
+const VALID_SYSTEMS = ["darwin", "linux", "windows"] as const;
+type SupportedSystem = (typeof VALID_SYSTEMS)[number];
+
+function filterByCategory(
+  rows: RecommendedUnifiedModel[],
+  category: string
+): RecommendedUnifiedModel[] {
+  const filter = CATEGORY_FILTERS[category];
+  if (!filter) return rows;
+  return rows.filter((m) => {
+    if (filter.modality && m.modality !== filter.modality) return false;
+    if (filter.task && m.task !== filter.task) return false;
+    return true;
+  });
+}
+
+function filterBySystem(
+  rows: RecommendedUnifiedModel[],
+  system: SupportedSystem
+): RecommendedUnifiedModel[] {
+  return rows.filter(
+    (m) => !m.supported_systems || m.supported_systems.includes(system)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row rendering
+// ---------------------------------------------------------------------------
+
+function modelRow(m: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: m["id"],
+    name: m["name"],
+    provider: m["provider"] ?? "",
+    type: m["type"] ?? "",
+    repo_id: m["repo_id"] ?? ""
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+function parseLimit(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const parsed = Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`Invalid --limit value: ${String(raw)}`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+export function registerRecommendedCommand(models: Command): void {
+  models
+    .command("recommended")
+    .description("List recommended models")
+    .option(
+      "--api-url <url>",
+      "API base URL (only used with --check-servers)",
+      process.env["NODETOOL_API_URL"] ?? "http://localhost:7777"
+    )
+    .option(
+      "--category <category>",
+      `Filter by category: ${VALID_CATEGORIES.join(", ")}`,
+      "all"
+    )
+    .option(
+      "--system <system>",
+      `Filter to a platform: ${VALID_SYSTEMS.join(", ")}`
+    )
+    .option("--limit <n>", "Cap the number of results")
+    .option(
+      "--check-servers",
+      "Check availability on local servers via the API (requires --api-url)"
+    )
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        apiUrl: string;
+        category: string;
+        system?: string;
+        limit?: string;
+        checkServers?: boolean;
+        json?: boolean;
+      }) => {
+        if (!(opts.category in CATEGORY_FILTERS)) {
+          console.error(
+            `Invalid --category '${opts.category}'. Valid values: ${VALID_CATEGORIES.join(", ")}`
+          );
+          process.exit(1);
+        }
+
+        if (
+          opts.system !== undefined &&
+          !VALID_SYSTEMS.includes(opts.system as SupportedSystem)
+        ) {
+          console.error(
+            `Invalid --system '${opts.system}'. Valid values: ${VALID_SYSTEMS.join(", ")}`
+          );
+          process.exit(1);
+        }
+
+        const limit = parseLimit(opts.limit);
+
+        try {
+          let rows: RecommendedUnifiedModel[];
+          if (opts.checkServers) {
+            const client = createTRPCClient<AppRouter>({
+              links: [
+                httpBatchLink({
+                  url: `${opts.apiUrl}/trpc`,
+                  transformer: superjson
+                })
+              ]
+            });
+            const remote = (await client.models.recommended.query({
+              check_servers: true
+            })) as unknown as UnifiedModel[];
+            rows = remote as RecommendedUnifiedModel[];
+          } else {
+            rows = [...RECOMMENDED_MODELS];
+          }
+
+          rows = filterByCategory(rows, opts.category);
+          if (opts.system) {
+            rows = filterBySystem(rows, opts.system as SupportedSystem);
+          }
+          if (limit) rows = rows.slice(0, limit);
+
+          if (opts.json) {
+            asJson(rows);
+            return;
+          }
+          printTable(
+            (rows as unknown as Record<string, unknown>[]).map(modelRow)
+          );
+        } catch (e) {
+          console.error(String(e instanceof Error ? e.message : e));
+          process.exit(1);
+        }
+      }
+    );
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -36,6 +36,8 @@ import {
   registerDeployCommands,
   registerListGcpOptions
 } from "./commands/deploy.js";
+import { registerHfCommands } from "./commands/models-hf.js";
+import { registerRecommendedCommand } from "./commands/models-recommended.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -739,33 +741,8 @@ models
     }
   });
 
-models
-  .command("recommended")
-  .description("List recommended models")
-  .option(
-    "--api-url <url>",
-    "API base URL",
-    process.env["NODETOOL_API_URL"] ?? "http://localhost:7777"
-  )
-  .option("--check-servers", "Check availability on local servers")
-  .option("--json", "Output as JSON")
-  .action(async (opts) => {
-    try {
-      const client = createApiClient(opts.apiUrl);
-      const data = await client.models.recommended.query({
-        check_servers: Boolean(opts.checkServers)
-      });
-      const rows = data as unknown as Record<string, unknown>[];
-      if (opts.json) {
-        asJson(rows);
-        return;
-      }
-      printTable(rows.map(modelRow));
-    } catch (e) {
-      console.error(String(e));
-      process.exit(1);
-    }
-  });
+registerRecommendedCommand(models);
+registerHfCommands(models);
 
 models
   .command("ollama")

--- a/packages/cli/tests/models-hf.test.ts
+++ b/packages/cli/tests/models-hf.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for `nodetool models hf-*` and `recommended` commands.
+ *
+ * Mocks @nodetool/huggingface + @nodetool/runtime so we don't hit the
+ * network or the local HF cache.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const searchHfHub = vi.fn();
+const listAllHfModels = vi.fn();
+const readCachedHfModels = vi.fn();
+const startDownload = vi.fn();
+
+class FakeDownloadManager {
+  startDownload = startDownload;
+}
+
+vi.mock("@nodetool/huggingface", () => ({
+  searchHfHub,
+  listAllHfModels,
+  readCachedHfModels,
+  DownloadManager: FakeDownloadManager,
+  SUPPORTED_MODEL_TYPES: ["qwen2", "llama", "hf.text_to_image"] as const,
+  GENERIC_HF_TYPES: new Set([
+    "hf.text_to_image",
+    "hf.image_to_image",
+    "hf.model",
+    "hf.model_generic"
+  ])
+}));
+
+vi.mock("@nodetool/runtime", () => ({
+  RECOMMENDED_MODELS: [
+    {
+      id: "gpt-4o-mini",
+      type: "language_model",
+      name: "GPT-4o mini",
+      repo_id: null,
+      path: null,
+      downloaded: false,
+      modality: "language",
+      task: "text_generation",
+      provider: "openai"
+    },
+    {
+      id: "claude-3-5-sonnet-latest",
+      type: "language_model",
+      name: "Claude 3.5 Sonnet",
+      repo_id: null,
+      path: null,
+      downloaded: false,
+      modality: "language",
+      task: "text_generation",
+      provider: "anthropic"
+    },
+    {
+      id: "text-embedding-3-small",
+      type: "embedding_model",
+      name: "Text Embedding 3 Small",
+      repo_id: null,
+      path: null,
+      downloaded: false,
+      modality: "language",
+      task: "embedding",
+      provider: "openai"
+    },
+    {
+      id: "whisper-1",
+      type: "asr_model",
+      name: "Whisper",
+      repo_id: null,
+      path: null,
+      downloaded: false,
+      modality: "asr",
+      provider: "openai"
+    }
+  ]
+}));
+
+vi.mock("@trpc/client", () => ({
+  createTRPCClient: vi.fn(),
+  httpBatchLink: vi.fn()
+}));
+vi.mock("superjson", () => ({ default: {} }));
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+async function captureOutput(
+  fn: () => Promise<void> | void
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  let stdout = "";
+  let stderr = "";
+  let exitCode: number | null = null;
+  const origLog = console.log;
+  const origErr = console.error;
+  const origExit = process.exit;
+  console.log = (...args: unknown[]) => {
+    stdout += args.map(String).join(" ") + "\n";
+  };
+  console.error = (...args: unknown[]) => {
+    stderr += args.map(String).join(" ") + "\n";
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__EXIT__${code ?? 0}`);
+  }) as typeof process.exit;
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith("__EXIT__")) throw e;
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { stdout, stderr, exitCode };
+}
+
+async function buildProgram(): Promise<Command> {
+  const { registerHfCommands } = await import("../src/commands/models-hf.js");
+  const { registerRecommendedCommand } = await import(
+    "../src/commands/models-recommended.js"
+  );
+  const program = new Command();
+  program.exitOverride();
+  const models = program.command("models");
+  registerHfCommands(models);
+  registerRecommendedCommand(models);
+  return program;
+}
+
+beforeEach(() => {
+  searchHfHub.mockReset();
+  listAllHfModels.mockReset();
+  readCachedHfModels.mockReset();
+  startDownload.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── hf-types ──────────────────────────────────────────────────────────────
+
+describe("models hf-types", () => {
+  it("prints the list of types", async () => {
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "models", "hf-types"])
+    );
+    expect(stdout).toContain("qwen2");
+    expect(stdout).toContain("llama");
+    expect(stdout).toContain("hf.text_to_image");
+  });
+
+  it("emits valid JSON with --json", async () => {
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "models", "hf-types", "--json"])
+    );
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed).toHaveProperty("types");
+    expect(parsed).toHaveProperty("generic");
+    expect(Array.isArray(parsed.types)).toBe(true);
+  });
+});
+
+// ─── list-hf ───────────────────────────────────────────────────────────────
+
+describe("models list-hf", () => {
+  it("forwards --task and --limit to searchHfHub", async () => {
+    searchHfHub.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "list-hf",
+        "hf.text_to_image",
+        "--task",
+        "text-to-image",
+        "--limit",
+        "7"
+      ])
+    );
+    expect(searchHfHub).toHaveBeenCalledWith({
+      modelType: "hf.text_to_image",
+      task: "text-to-image",
+      limit: 7
+    });
+  });
+
+  it("exits(1) when searchHfHub throws", async () => {
+    searchHfHub.mockRejectedValueOnce(new Error("Unknown model type 'foo'"));
+    const program = await buildProgram();
+    const { exitCode, stderr } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "models", "list-hf", "foo"])
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown");
+  });
+});
+
+// ─── list-hf-all ───────────────────────────────────────────────────────────
+
+describe("models list-hf-all", () => {
+  it("forwards --repo-only and --limit", async () => {
+    listAllHfModels.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "list-hf-all",
+        "--repo-only",
+        "--limit",
+        "3"
+      ])
+    );
+    expect(listAllHfModels).toHaveBeenCalledWith({
+      limit: 3,
+      repoOnly: true
+    });
+  });
+});
+
+// ─── hf-cache ──────────────────────────────────────────────────────────────
+
+describe("models hf-cache", () => {
+  it("filters --downloaded-only", async () => {
+    readCachedHfModels.mockResolvedValueOnce([
+      { id: "a/repo", type: "hf.flux", downloaded: true, size_on_disk: 1024 },
+      { id: "b/repo", type: "hf.flux", downloaded: false, size_on_disk: 0 }
+    ]);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "hf-cache",
+        "--downloaded-only",
+        "--json"
+      ])
+    );
+    const parsed = JSON.parse(stdout.trim()) as Array<{ id: string }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.id).toBe("a/repo");
+  });
+});
+
+// ─── download-hf ───────────────────────────────────────────────────────────
+
+describe("models download-hf", () => {
+  it("invokes DownloadManager.startDownload", async () => {
+    startDownload.mockResolvedValueOnce(undefined);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "download-hf",
+        "--repo-id",
+        "foo/bar"
+      ])
+    );
+    expect(startDownload).toHaveBeenCalledTimes(1);
+    const [repoId, opts] = startDownload.mock.calls[0]!;
+    expect(repoId).toBe("foo/bar");
+    expect(opts).toMatchObject({
+      path: null,
+      allowPatterns: null,
+      ignorePatterns: null,
+      cacheDir: null
+    });
+  });
+
+  it("collects repeated --allow-patterns / --ignore-patterns", async () => {
+    startDownload.mockResolvedValueOnce(undefined);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "download-hf",
+        "--repo-id",
+        "foo/bar",
+        "-a",
+        "*.safetensors",
+        "-a",
+        "*.json",
+        "-i",
+        "*.bin"
+      ])
+    );
+    const [, opts] = startDownload.mock.calls[0]!;
+    expect(opts.allowPatterns).toEqual(["*.safetensors", "*.json"]);
+    expect(opts.ignorePatterns).toEqual(["*.bin"]);
+  });
+});
+
+// ─── recommended ───────────────────────────────────────────────────────────
+
+describe("models recommended", () => {
+  it("filters by --category and caps with --limit", async () => {
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "recommended",
+        "--category",
+        "language-text-generation",
+        "--limit",
+        "1",
+        "--json"
+      ])
+    );
+    const rows = JSON.parse(stdout.trim()) as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe("gpt-4o-mini");
+  });
+
+  it("exits(1) on unknown --category", async () => {
+    const program = await buildProgram();
+    const { exitCode, stderr } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "recommended",
+        "--category",
+        "bogus"
+      ])
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid --category");
+  });
+
+  it("filters language → 3 rows from the fixture", async () => {
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "models",
+        "recommended",
+        "--category",
+        "language",
+        "--json"
+      ])
+    );
+    const rows = JSON.parse(stdout.trim()) as unknown[];
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/packages/huggingface/src/hf-hub-search.ts
+++ b/packages/huggingface/src/hf-hub-search.ts
@@ -1,0 +1,282 @@
+/**
+ * HuggingFace Hub model search.
+ *
+ * Queries https://huggingface.co/api/models to discover repos matching a
+ * nodetool model type. Translation between nodetool's hf.* types and HF Hub
+ * query parameters lives in `HF_HUB_QUERY_CONFIG` below, with fallbacks for
+ * GENERIC_HF_TYPES (require a --task) and llama.cpp-style model types
+ * enumerated in SUPPORTED_MODEL_TYPES.
+ */
+
+import { resolveHfToken } from "./hf-auth.js";
+import {
+  GENERIC_HF_TYPES,
+  HF_SEARCH_TYPE_CONFIG,
+  SUPPORTED_MODEL_TYPES
+} from "./hf-models.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single repo entry returned by the HF Hub API. */
+export interface HfHubModel {
+  id: string;
+  pipeline_tag?: string | null;
+  tags?: string[];
+  downloads?: number;
+  likes?: number;
+  gated?: boolean | "auto" | "manual" | null;
+  private?: boolean;
+  library_name?: string | null;
+  created_at?: string;
+  last_modified?: string;
+  /** Echoed from the nodetool side; not from HF API. */
+  model_type?: string | null;
+  /** Alias for id, for UnifiedModel compatibility. */
+  repo_id?: string;
+}
+
+export interface SearchHfHubOptions {
+  /** Nodetool HF model type (must map to a known query or be a GENERIC type with --task). */
+  modelType: string;
+  /** Optional HF Hub task filter (e.g. "text-to-speech"). Required for GENERIC_HF_TYPES. */
+  task?: string;
+  /** Cap on number of results (default: no cap). */
+  limit?: number;
+  /** HF Hub token; default: resolveHfToken(undefined). */
+  token?: string | null;
+}
+
+export interface ListAllHfModelsOptions {
+  limit?: number;
+  token?: string | null;
+  /** If true, drop file-level entries and keep only repo-level entries. */
+  repoOnly?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Query translation
+// ---------------------------------------------------------------------------
+
+interface HfHubQueryParams {
+  filter?: string[];
+  search?: string;
+  pipeline_tag?: string;
+  library?: string;
+}
+
+/**
+ * Direct nodetool-type → HF Hub API query mapping.
+ *
+ * Only populated for types where the translation differs from
+ * `HF_SEARCH_TYPE_CONFIG`. For hf.* types without an entry here, we derive
+ * params from HF_SEARCH_TYPE_CONFIG at runtime.
+ */
+const HF_HUB_QUERY_CONFIG: Record<string, HfHubQueryParams> = {
+  // llama.cpp GGUF types in SUPPORTED_MODEL_TYPES: filter to GGUF library.
+  qwen2: { search: "qwen2", library: "gguf" },
+  qwen3: { search: "qwen3", library: "gguf" },
+  qwen_2_5_vl: { search: "qwen2.5-vl", library: "gguf" },
+  qwen_3_vl: { search: "qwen3-vl", library: "gguf" },
+  mistral3: { search: "mistral", library: "gguf" },
+  gpt_oss: { search: "gpt-oss", library: "gguf" },
+  llama: { search: "llama", library: "gguf" },
+  gemma2: { search: "gemma-2", library: "gguf" },
+  gemma3: { search: "gemma-3", library: "gguf" },
+  gemma3n: { search: "gemma-3n", library: "gguf" },
+  phi3: { search: "phi-3", library: "gguf" },
+  phi4: { search: "phi-4", library: "gguf" }
+};
+
+/** Build HF Hub API query params from HF_SEARCH_TYPE_CONFIG for hf.* types. */
+function deriveFromSearchConfig(
+  modelType: string
+): HfHubQueryParams | null {
+  const cfg = HF_SEARCH_TYPE_CONFIG[modelType];
+  if (!cfg) return null;
+  const out: HfHubQueryParams = {};
+
+  const pipelineTags = cfg["pipeline_tag"];
+  if (Array.isArray(pipelineTags) && pipelineTags.length > 0) {
+    out.pipeline_tag = pipelineTags[0]!;
+  }
+
+  const tagFilters = cfg["tag"];
+  if (Array.isArray(tagFilters) && tagFilters.length > 0) {
+    // Strip "*" wildcards — HF Hub API takes literal tags.
+    const concrete = tagFilters
+      .map((t) => t.replace(/\*/g, "").trim())
+      .filter((t) => t.length > 0);
+    if (concrete.length > 0) out.filter = concrete;
+  }
+
+  const repoPatterns = cfg["repo_pattern"];
+  if (Array.isArray(repoPatterns) && !out.search) {
+    const first = repoPatterns.find(
+      (p) => !p.startsWith("*") && !p.endsWith("*") && !p.includes("*")
+    );
+    if (first) out.search = first;
+    else {
+      // Take the first pattern, stripping wildcards.
+      const cleaned = repoPatterns[0]?.replace(/\*/g, "").trim();
+      if (cleaned) out.search = cleaned;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function buildQueryParams(
+  modelType: string,
+  task?: string
+): HfHubQueryParams {
+  const normalized = modelType.toLowerCase();
+
+  if (GENERIC_HF_TYPES.has(normalized)) {
+    if (!task) {
+      throw new Error(
+        `Model type '${modelType}' requires --task (e.g. 'text-to-image').`
+      );
+    }
+    return { pipeline_tag: task.replace(/_/g, "-") };
+  }
+
+  if (task) {
+    return { pipeline_tag: task.replace(/_/g, "-") };
+  }
+
+  const direct = HF_HUB_QUERY_CONFIG[normalized];
+  if (direct) return direct;
+
+  const derived = deriveFromSearchConfig(normalized);
+  if (derived) return derived;
+
+  throw new Error(
+    `Unknown model type '${modelType}'. Run 'nodetool models hf-types' to list supported types.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+const HF_API_BASE = "https://huggingface.co/api/models";
+
+interface RawHfHubModel {
+  id?: string;
+  modelId?: string;
+  pipeline_tag?: string | null;
+  tags?: string[];
+  downloads?: number;
+  likes?: number;
+  gated?: boolean | "auto" | "manual" | null;
+  private?: boolean;
+  library_name?: string | null;
+  createdAt?: string;
+  lastModified?: string;
+}
+
+function buildSearchUrl(params: HfHubQueryParams, limit?: number): string {
+  const search = new URLSearchParams();
+  if (params.pipeline_tag) search.set("pipeline_tag", params.pipeline_tag);
+  if (params.library) search.set("library", params.library);
+  if (params.search) search.set("search", params.search);
+  if (params.filter) {
+    for (const f of params.filter) search.append("filter", f);
+  }
+  if (limit && limit > 0) search.set("limit", String(limit));
+  search.set("full", "false");
+  return `${HF_API_BASE}?${search.toString()}`;
+}
+
+function normalizeRaw(raw: RawHfHubModel, modelType: string): HfHubModel {
+  const id = raw.id ?? raw.modelId ?? "";
+  return {
+    id,
+    pipeline_tag: raw.pipeline_tag ?? null,
+    tags: raw.tags ?? [],
+    downloads: raw.downloads ?? 0,
+    likes: raw.likes ?? 0,
+    gated: raw.gated ?? null,
+    private: raw.private ?? false,
+    library_name: raw.library_name ?? null,
+    created_at: raw.createdAt,
+    last_modified: raw.lastModified,
+    model_type: modelType,
+    repo_id: id
+  };
+}
+
+/**
+ * Search the HuggingFace Hub for models matching a nodetool model type.
+ */
+export async function searchHfHub(
+  options: SearchHfHubOptions
+): Promise<HfHubModel[]> {
+  const params = buildQueryParams(options.modelType, options.task);
+  const url = buildSearchUrl(params, options.limit);
+
+  const token =
+    options.token !== undefined
+      ? options.token
+      : await resolveHfToken(undefined);
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (token) headers["authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `HF Hub search failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`
+    );
+  }
+  const raw = (await res.json()) as RawHfHubModel[];
+  return raw.map((r) => normalizeRaw(r, options.modelType));
+}
+
+/**
+ * Iterate SUPPORTED_MODEL_TYPES, search each, aggregate, dedupe by id, limit.
+ * Skips types that require a task when none is given.
+ */
+export async function listAllHfModels(
+  options: ListAllHfModelsOptions = {}
+): Promise<HfHubModel[]> {
+  const { limit, token, repoOnly } = options;
+
+  // Use a per-type cap when an overall limit is set so we don't pull way more
+  // than needed up-front. Still dedupe + final-cap later.
+  const perTypeLimit = limit ? Math.max(limit, 50) : undefined;
+
+  const seen = new Set<string>();
+  const aggregated: HfHubModel[] = [];
+
+  for (const modelType of SUPPORTED_MODEL_TYPES) {
+    if (GENERIC_HF_TYPES.has(modelType.toLowerCase())) continue;
+    try {
+      const results = await searchHfHub({
+        modelType,
+        limit: perTypeLimit,
+        token
+      });
+      for (const m of results) {
+        if (!m.id || seen.has(m.id)) continue;
+        seen.add(m.id);
+        aggregated.push(m);
+        if (limit && aggregated.length >= limit) break;
+      }
+      if (limit && aggregated.length >= limit) break;
+    } catch (err) {
+      // One type failing shouldn't tank the whole list. Log + continue.
+      console.error(
+        `listAllHfModels: ${modelType} failed — ${String(err)}`
+      );
+    }
+  }
+
+  let out = aggregated;
+  if (repoOnly) {
+    out = out.filter((m) => m.id.split("/").length <= 2);
+  }
+  return out;
+}

--- a/packages/huggingface/src/index.ts
+++ b/packages/huggingface/src/index.ts
@@ -8,6 +8,9 @@ export { HfFastCache, getDefaultHfCacheDir } from "./hf-cache.js";
 export type { UnifiedModel } from "./hf-models.js";
 export {
   RepoPackagingHint,
+  SUPPORTED_MODEL_TYPES,
+  GENERIC_HF_TYPES,
+  HF_SEARCH_TYPE_CONFIG,
   readCachedHfModels,
   searchCachedHfModels,
   getModelsByHfType,
@@ -15,6 +18,13 @@ export {
   getLlamaCppModelsFromCache,
   detectRepoPackaging
 } from "./hf-models.js";
+
+export type {
+  HfHubModel,
+  SearchHfHubOptions,
+  ListAllHfModelsOptions
+} from "./hf-hub-search.js";
+export { searchHfHub, listAllHfModels } from "./hf-hub-search.js";
 
 export type { DetectionResult } from "./safetensors-inspector.js";
 export { detectModel } from "./safetensors-inspector.js";

--- a/packages/huggingface/tests/hf-hub-search.test.ts
+++ b/packages/huggingface/tests/hf-hub-search.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  searchHfHub,
+  listAllHfModels,
+  SUPPORTED_MODEL_TYPES
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockResponse {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  body: unknown;
+}
+
+function fetchMockOnce(response: MockResponse) {
+  const fn = vi.fn(async () => ({
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    statusText: response.statusText ?? "OK",
+    json: async () => response.body,
+    text: async () =>
+      typeof response.body === "string"
+        ? response.body
+        : JSON.stringify(response.body)
+  }));
+  (globalThis as { fetch: unknown }).fetch = fn as unknown;
+  return fn;
+}
+
+const SAMPLE_MODEL = {
+  id: "owner/my-model",
+  pipeline_tag: "text-to-image",
+  tags: ["diffusers"],
+  downloads: 100,
+  likes: 5,
+  library_name: "diffusers"
+};
+
+// ---------------------------------------------------------------------------
+// Env shim so resolveHfToken doesn't read ~/.cache/huggingface/token
+// ---------------------------------------------------------------------------
+
+let savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  "HF_TOKEN",
+  "HF_API_TOKEN",
+  "HUGGING_FACE_HUB_TOKEN",
+  "HF_HOME",
+  "HF_TOKEN_PATH",
+  "HF_HUB_DISABLE_IMPLICIT_TOKEN"
+];
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1";
+  process.env["HF_HOME"] = "/tmp/hf-hub-search-test-no-token";
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// searchHfHub
+// ---------------------------------------------------------------------------
+
+describe("searchHfHub", () => {
+  it("calls the HF API with params derived from the model type", async () => {
+    const fn = fetchMockOnce({ body: [SAMPLE_MODEL] });
+    const results = await searchHfHub({ modelType: "hf.flux", limit: 5 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    const url = String(fn.mock.calls[0]![0]);
+    expect(url).toMatch(/^https:\/\/huggingface\.co\/api\/models\?/);
+    expect(url).toContain("limit=5");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe("owner/my-model");
+    expect(results[0]!.model_type).toBe("hf.flux");
+    expect(results[0]!.repo_id).toBe("owner/my-model");
+  });
+
+  it("uses library=gguf for SUPPORTED_MODEL_TYPES entries", async () => {
+    const fn = fetchMockOnce({ body: [] });
+    await searchHfHub({ modelType: "qwen2" });
+    const url = String(fn.mock.calls[0]![0]);
+    expect(url).toContain("library=gguf");
+    expect(url).toMatch(/search=qwen2/);
+  });
+
+  it("throws for GENERIC types without --task", async () => {
+    await expect(
+      searchHfHub({ modelType: "hf.text_to_image" })
+    ).rejects.toThrow(/requires --task/);
+  });
+
+  it("passes --task through as pipeline_tag (normalizing underscores)", async () => {
+    const fn = fetchMockOnce({ body: [] });
+    await searchHfHub({
+      modelType: "hf.text_to_image",
+      task: "text_to_image"
+    });
+    const url = String(fn.mock.calls[0]![0]);
+    expect(url).toContain("pipeline_tag=text-to-image");
+  });
+
+  it("throws on unknown model types", async () => {
+    await expect(
+      searchHfHub({ modelType: "not_a_real_type" })
+    ).rejects.toThrow(/Unknown model type/);
+  });
+
+  it("throws on non-200 HTTP responses", async () => {
+    fetchMockOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      body: "boom"
+    });
+    await expect(searchHfHub({ modelType: "hf.flux" })).rejects.toThrow(
+      /HF Hub search failed/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAllHfModels
+// ---------------------------------------------------------------------------
+
+describe("listAllHfModels", () => {
+  it("iterates non-generic types, caps at limit, dedupes by id", async () => {
+    let call = 0;
+    const fn = vi.fn(async () => {
+      call += 1;
+      const body = [
+        { id: `owner/model-${call}-a` },
+        { id: `owner/shared` }, // duplicate across calls — dedup
+        { id: `owner/model-${call}-b` }
+      ];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => body,
+        text: async () => JSON.stringify(body)
+      };
+    });
+    (globalThis as { fetch: unknown }).fetch = fn as unknown;
+
+    const results = await listAllHfModels({ limit: 5 });
+    expect(results.length).toBeLessThanOrEqual(5);
+    const ids = results.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // Should have hit at least one of the non-generic supported types.
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("skips a type on failure and continues with the rest", async () => {
+    let call = 0;
+    const fn = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: async () => ({}),
+          text: async () => "boom"
+        };
+      }
+      const body = [{ id: `owner/ok-${call}` }];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => body,
+        text: async () => JSON.stringify(body)
+      };
+    });
+    (globalThis as { fetch: unknown }).fetch = fn as unknown;
+    const logErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const results = await listAllHfModels({ limit: 3 });
+    // first type throws, later ones succeed
+    expect(results.length).toBeGreaterThan(0);
+    expect(logErr).toHaveBeenCalled();
+  });
+});
+
+describe("constants", () => {
+  it("re-exports SUPPORTED_MODEL_TYPES from the package index", () => {
+    expect(Array.isArray(SUPPORTED_MODEL_TYPES)).toBe(true);
+    expect(SUPPORTED_MODEL_TYPES.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -48,3 +48,5 @@ export type {
   ComfyProgressEvent,
   ComfyExecutionHandle
 } from "./comfy-executor.js";
+export { RECOMMENDED_MODELS } from "./recommended-models.js";
+export type { RecommendedUnifiedModel } from "./recommended-models.js";

--- a/packages/runtime/src/recommended-models.ts
+++ b/packages/runtime/src/recommended-models.ts
@@ -1,0 +1,123 @@
+/**
+ * Curated list of recommended models surfaced by the models API and CLI.
+ *
+ * Kept here (outside the websocket package) so CLI/tooling can import the
+ * list without pulling in a Fastify server.
+ */
+
+import type { UnifiedModel } from "@nodetool/protocol";
+import type { ProviderId } from "./providers/index.js";
+
+export interface RecommendedUnifiedModel extends UnifiedModel {
+  modality: "language" | "image" | "tts" | "asr" | "video";
+  task?:
+    | "text_generation"
+    | "embedding"
+    | "text_to_image"
+    | "image_to_image"
+    | "text_to_video"
+    | "image_to_video";
+  provider?: ProviderId;
+  /** Optional list of platforms this entry is valid on. Undefined = all. */
+  supported_systems?: Array<"darwin" | "linux" | "windows">;
+}
+
+export const RECOMMENDED_MODELS: RecommendedUnifiedModel[] = [
+  {
+    id: "gpt-4o-mini",
+    type: "language_model",
+    name: "GPT-4o mini",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "language",
+    task: "text_generation",
+    provider: "openai"
+  },
+  {
+    id: "claude-3-5-sonnet-latest",
+    type: "language_model",
+    name: "Claude 3.5 Sonnet",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "language",
+    task: "text_generation",
+    provider: "anthropic"
+  },
+  {
+    id: "text-embedding-3-small",
+    type: "embedding_model",
+    name: "Text Embedding 3 Small",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "language",
+    task: "embedding",
+    provider: "openai"
+  },
+  {
+    id: "gpt-image-1",
+    type: "image_model",
+    name: "GPT Image 1",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "image",
+    task: "text_to_image",
+    provider: "openai"
+  },
+  {
+    id: "gpt-image-1",
+    type: "image_model",
+    name: "GPT Image 1",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "image",
+    task: "image_to_image",
+    provider: "openai"
+  },
+  {
+    id: "whisper-1",
+    type: "asr_model",
+    name: "Whisper",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "asr",
+    provider: "openai"
+  },
+  {
+    id: "tts-1",
+    type: "tts_model",
+    name: "TTS 1",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "tts",
+    provider: "openai"
+  },
+  {
+    id: "sora-2",
+    type: "video_model",
+    name: "Sora 2",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "video",
+    task: "text_to_video",
+    provider: "openai"
+  },
+  {
+    id: "sora-2",
+    type: "video_model",
+    name: "Sora 2",
+    repo_id: null,
+    path: null,
+    downloaded: false,
+    modality: "video",
+    task: "image_to_video",
+    provider: "openai"
+  }
+];

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -7,11 +7,13 @@ import {
   isProviderConfigured,
   listRegisteredProviderIds,
   providerCapabilities,
+  RECOMMENDED_MODELS,
   type ASRModel,
   type EmbeddingModel,
   type ImageModel,
   type LanguageModel,
   type ProviderId,
+  type RecommendedUnifiedModel,
   type TTSModel,
   type VideoModel
 } from "@nodetool/runtime";
@@ -28,18 +30,6 @@ import {
 import type { UnifiedModel } from "@nodetool/protocol";
 
 export type { UnifiedModel };
-
-interface RecommendedUnifiedModel extends UnifiedModel {
-  modality: "language" | "image" | "tts" | "asr" | "video";
-  task?:
-    | "text_generation"
-    | "embedding"
-    | "text_to_image"
-    | "image_to_image"
-    | "text_to_video"
-    | "image_to_video";
-  provider?: ProviderId;
-}
 
 interface RepoPath {
   repo_id: string;
@@ -89,106 +79,6 @@ const LLAMA_CPP_MODEL_TYPES = new Set([
   "llama_cpp",
   "hf.gguf"
 ]);
-
-const RECOMMENDED_MODELS: RecommendedUnifiedModel[] = [
-  {
-    id: "gpt-4o-mini",
-    type: "language_model",
-    name: "GPT-4o mini",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "language",
-    task: "text_generation",
-    provider: "openai"
-  },
-  {
-    id: "claude-3-5-sonnet-latest",
-    type: "language_model",
-    name: "Claude 3.5 Sonnet",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "language",
-    task: "text_generation",
-    provider: "anthropic"
-  },
-  {
-    id: "text-embedding-3-small",
-    type: "embedding_model",
-    name: "Text Embedding 3 Small",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "language",
-    task: "embedding",
-    provider: "openai"
-  },
-  {
-    id: "gpt-image-1",
-    type: "image_model",
-    name: "GPT Image 1",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "image",
-    task: "text_to_image",
-    provider: "openai"
-  },
-  {
-    id: "gpt-image-1",
-    type: "image_model",
-    name: "GPT Image 1",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "image",
-    task: "image_to_image",
-    provider: "openai"
-  },
-  {
-    id: "whisper-1",
-    type: "asr_model",
-    name: "Whisper",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "asr",
-    provider: "openai"
-  },
-  {
-    id: "tts-1",
-    type: "tts_model",
-    name: "TTS 1",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "tts",
-    provider: "openai"
-  },
-  {
-    id: "sora-2",
-    type: "video_model",
-    name: "Sora 2",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "video",
-    task: "text_to_video",
-    provider: "openai"
-  },
-  {
-    id: "sora-2",
-    type: "video_model",
-    name: "Sora 2",
-    repo_id: null,
-    path: null,
-    downloaded: false,
-    modality: "video",
-    task: "image_to_video",
-    provider: "openai"
-  }
-];
 
 function jsonResponse(data: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(data), {


### PR DESCRIPTION
## Summary
This PR adds comprehensive CLI commands for discovering, listing, and managing HuggingFace models, along with an enhanced recommended models command. The implementation includes HuggingFace Hub API integration, local cache inspection, and model download capabilities.

## Key Changes

### New CLI Commands
- **`models hf-types`** — Lists all supported HuggingFace model types with indicators for generic types requiring `--task`
- **`models list-hf <model_type>`** — Searches the HuggingFace Hub for models matching a nodetool model type, with optional task filtering
- **`models list-hf-all`** — Aggregates models across all supported HF types with deduplication and limiting
- **`models hf-cache`** — Inspects the local HuggingFace cache with filtering by download status
- **`models download-hf`** — Downloads HuggingFace repositories or individual files with pattern-based filtering
- **`models recommended`** — Enhanced filtering of curated recommended models by category, platform, and availability

### New Modules
- **`packages/huggingface/src/hf-hub-search.ts`** — HuggingFace Hub API client with:
  - Query parameter translation from nodetool model types to HF Hub filters
  - Support for both specific types (qwen2, llama, etc.) and generic types (hf.text_to_image, etc.)
  - Aggregation across multiple model types with deduplication
  - Graceful error handling with per-type fallback

- **`packages/cli/src/commands/models-hf.ts`** — CLI command implementations with:
  - Byte formatting utilities for download progress
  - Option collection for repeated patterns (allow/ignore)
  - Streaming download progress rendering
  - JSON and table output formats

- **`packages/cli/src/commands/models-recommended.ts`** — Recommended models command with:
  - Category-based filtering (language, image, asr, tts, video with task variants)
  - Platform filtering (darwin, linux, windows)
  - Optional server availability checking via tRPC
  - Fallback to local RECOMMENDED_MODELS list

- **`packages/runtime/src/recommended-models.ts`** — Extracted curated model list:
  - Moved from websocket package to enable CLI-only usage without server dependency
  - Extended with modality, task, provider, and platform support metadata

### Testing
- Comprehensive test suite (`packages/cli/tests/models-hf.test.ts`) with:
  - Mocked HuggingFace and runtime modules
  - Output capture for stdout/stderr/exit codes
  - Tests for all command variants and error cases
  - Parameter forwarding and filtering validation

- HuggingFace Hub search tests (`packages/huggingface/tests/hf-hub-search.test.ts`) with:
  - API parameter derivation validation
  - Error handling and HTTP failure scenarios
  - Deduplication and limiting behavior

### Exports and Integration
- Exported `SUPPORTED_MODEL_TYPES`, `GENERIC_HF_TYPES`, and `HF_SEARCH_TYPE_CONFIG` from `@nodetool/huggingface`
- Exported `RECOMMENDED_MODELS` and `RecommendedUnifiedModel` from `@nodetool/runtime`
- Registered new commands in main CLI entry point
- Added `@nodetool/huggingface` dependency to CLI package

## Notable Implementation Details
- Generic HF types (hf.text_to_image, etc.) require explicit `--task` parameter; specific types (qwen2, llama) have predefined queries
- Download progress uses carriage return (`\r`) for in-place terminal updates
- Model search gracefully skips types that fail and continues with others
- Recommended models support both local filtering and remote server availability checking via tRPC
- All commands support `--json` output for scripting and integration

https://claude.ai/code/session_01GU1Z2CUV8yhR22eKRkMsuG