### PR TITLE
feat(runtime): add DeepSeek and xAI (Grok) providers

### DIFF
--- a/packages/runtime/src/providers/deepseek-provider.ts
+++ b/packages/runtime/src/providers/deepseek-provider.ts
@@ -1,0 +1,92 @@
+import OpenAI from "openai";
+import { OpenAIProvider } from "./openai-provider.js";
+import type { LanguageModel } from "./types.js";
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
+
+interface DeepSeekProviderOptions {
+  client?: OpenAI;
+  clientFactory?: (apiKey: string) => OpenAI;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * DeepSeek provider. Uses the OpenAI SDK against DeepSeek's
+ * OpenAI-compatible endpoint at https://api.deepseek.com/v1.
+ * Covers DeepSeek-V3 chat and DeepSeek-R1 reasoning models.
+ */
+export class DeepSeekProvider extends OpenAIProvider {
+  static override requiredSecrets(): string[] {
+    return ["DEEPSEEK_API_KEY"];
+  }
+
+  private _deepseekFetch: typeof fetch;
+
+  constructor(
+    secrets: { DEEPSEEK_API_KEY?: string },
+    options: DeepSeekProviderOptions = {}
+  ) {
+    const apiKey = secrets.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      throw new Error("DEEPSEEK_API_KEY is required");
+    }
+
+    const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+
+    super(
+      { OPENAI_API_KEY: apiKey },
+      {
+        client: options.client,
+        clientFactory:
+          options.clientFactory ??
+          ((key) =>
+            new OpenAI({
+              apiKey: key,
+              baseURL: DEEPSEEK_BASE_URL
+            })),
+        fetchFn
+      }
+    );
+
+    (this as { provider: string }).provider = "deepseek";
+    this._deepseekFetch = fetchFn;
+  }
+
+  override getContainerEnv(): Record<string, string> {
+    return { DEEPSEEK_API_KEY: this.apiKey };
+  }
+
+  override async hasToolSupport(_model: string): Promise<boolean> {
+    return true;
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const response = await this._deepseekFetch(
+      `${DEEPSEEK_BASE_URL}/models`,
+      {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`
+        }
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string; name?: string }>;
+    };
+    const rows = payload.data ?? [];
+    return rows
+      .filter(
+        (row): row is { id: string; name?: string } =>
+          typeof row.id === "string" && row.id.length > 0
+      )
+      .map((row) => ({
+        id: row.id,
+        name: row.name ?? row.id,
+        provider: "deepseek"
+      }));
+  }
+}

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -20,6 +20,8 @@ import { MoonshotProvider } from "./moonshot-provider.js";
 import { OpenRouterProvider } from "./openrouter-provider.js";
 import { TogetherProvider } from "./together-provider.js";
 import { CerebrasProvider } from "./cerebras-provider.js";
+import { DeepSeekProvider } from "./deepseek-provider.js";
+import { XAIProvider } from "./xai-provider.js";
 import { LMStudioProvider } from "./lmstudio-provider.js";
 import { VLLMProvider } from "./vllm-provider.js";
 import { HuggingFaceProvider } from "./huggingface-provider.js";
@@ -54,6 +56,8 @@ export { MoonshotProvider };
 export { OpenRouterProvider };
 export { TogetherProvider };
 export { CerebrasProvider };
+export { DeepSeekProvider };
+export { XAIProvider };
 export { LMStudioProvider };
 export { VLLMProvider };
 export { HuggingFaceProvider };
@@ -175,6 +179,12 @@ registerBuiltinProvider("together", TogetherProvider, {
 });
 registerBuiltinProvider("cerebras", CerebrasProvider, {
   CEREBRAS_API_KEY: process.env["CEREBRAS_API_KEY"]
+});
+registerBuiltinProvider("deepseek", DeepSeekProvider, {
+  DEEPSEEK_API_KEY: process.env["DEEPSEEK_API_KEY"]
+});
+registerBuiltinProvider("xai", XAIProvider, {
+  XAI_API_KEY: process.env["XAI_API_KEY"]
 });
 
 // Local-only providers — require local servers/CLIs, skip in production

--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -1,0 +1,88 @@
+import OpenAI from "openai";
+import { OpenAIProvider } from "./openai-provider.js";
+import type { LanguageModel } from "./types.js";
+
+const XAI_BASE_URL = "https://api.x.ai/v1";
+
+interface XAIProviderOptions {
+  client?: OpenAI;
+  clientFactory?: (apiKey: string) => OpenAI;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * xAI (Grok) provider. Uses the OpenAI SDK against xAI's
+ * OpenAI-compatible endpoint at https://api.x.ai/v1.
+ */
+export class XAIProvider extends OpenAIProvider {
+  static override requiredSecrets(): string[] {
+    return ["XAI_API_KEY"];
+  }
+
+  private _xaiFetch: typeof fetch;
+
+  constructor(
+    secrets: { XAI_API_KEY?: string },
+    options: XAIProviderOptions = {}
+  ) {
+    const apiKey = secrets.XAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("XAI_API_KEY is required");
+    }
+
+    const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+
+    super(
+      { OPENAI_API_KEY: apiKey },
+      {
+        client: options.client,
+        clientFactory:
+          options.clientFactory ??
+          ((key) =>
+            new OpenAI({
+              apiKey: key,
+              baseURL: XAI_BASE_URL
+            })),
+        fetchFn
+      }
+    );
+
+    (this as { provider: string }).provider = "xai";
+    this._xaiFetch = fetchFn;
+  }
+
+  override getContainerEnv(): Record<string, string> {
+    return { XAI_API_KEY: this.apiKey };
+  }
+
+  override async hasToolSupport(_model: string): Promise<boolean> {
+    return true;
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const response = await this._xaiFetch(`${XAI_BASE_URL}/models`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string; name?: string }>;
+    };
+    const rows = payload.data ?? [];
+    return rows
+      .filter(
+        (row): row is { id: string; name?: string } =>
+          typeof row.id === "string" && row.id.length > 0
+      )
+      .map((row) => ({
+        id: row.id,
+        name: row.name ?? row.id,
+        provider: "xai"
+      }));
+  }
+}

--- a/packages/runtime/tests/providers/deepseek-provider.test.ts
+++ b/packages/runtime/tests/providers/deepseek-provider.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from "vitest";
+import { DeepSeekProvider } from "../../src/providers/deepseek-provider.js";
+import type { Message } from "../../src/providers/types.js";
+
+function makeAsyncIterable(items: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) {
+        yield item;
+      }
+    },
+    async close() {
+      return;
+    }
+  };
+}
+
+describe("DeepSeekProvider", () => {
+  it("throws if DEEPSEEK_API_KEY is missing", () => {
+    expect(() => new DeepSeekProvider({})).toThrow(
+      "DEEPSEEK_API_KEY is required"
+    );
+  });
+
+  it("reports provider id as deepseek", () => {
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(provider.provider).toBe("deepseek");
+  });
+
+  it("returns required secrets", () => {
+    expect(DeepSeekProvider.requiredSecrets()).toEqual(["DEEPSEEK_API_KEY"]);
+  });
+
+  it("returns container env with DEEPSEEK_API_KEY", () => {
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "test-key" },
+      { client: {} as any }
+    );
+    expect(provider.getContainerEnv()).toEqual({
+      DEEPSEEK_API_KEY: "test-key"
+    });
+  });
+
+  it("has tool support for all models", async () => {
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(await provider.hasToolSupport("deepseek-chat")).toBe(true);
+  });
+
+  it("fetches available language models", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "deepseek-chat", name: "DeepSeek V3" },
+          { id: "deepseek-reasoner" }
+        ]
+      })
+    });
+
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const models = await provider.getAvailableLanguageModels();
+    expect(models).toEqual([
+      {
+        id: "deepseek-chat",
+        name: "DeepSeek V3",
+        provider: "deepseek"
+      },
+      {
+        id: "deepseek-reasoner",
+        name: "deepseek-reasoner",
+        provider: "deepseek"
+      }
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.deepseek.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer k" }
+      })
+    );
+  });
+
+  it("returns empty list when model fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const models = await provider.getAvailableLanguageModels();
+    expect(models).toEqual([]);
+  });
+
+  it("generates non-streaming message via inherited OpenAI logic", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: "deepseek response",
+            tool_calls: null
+          }
+        }
+      ]
+    });
+
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      {
+        client: {
+          chat: { completions: { create } }
+        } as any
+      }
+    );
+
+    const messages: Message[] = [{ role: "user", content: "hello" }];
+    const result = await provider.generateMessage({
+      messages,
+      model: "deepseek-chat"
+    });
+
+    expect(result.role).toBe("assistant");
+    expect(result.content).toBe("deepseek response");
+  });
+
+  it("streams messages via inherited OpenAI logic", async () => {
+    const chunks = [
+      {
+        choices: [{ delta: { content: "hello" }, finish_reason: null }]
+      },
+      {
+        choices: [{ delta: { content: "" }, finish_reason: "stop" }]
+      }
+    ];
+
+    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+
+    const provider = new DeepSeekProvider(
+      { DEEPSEEK_API_KEY: "k" },
+      {
+        client: {
+          chat: { completions: { create } }
+        } as any
+      }
+    );
+
+    const messages: Message[] = [{ role: "user", content: "hi" }];
+    const items: unknown[] = [];
+    for await (const item of provider.generateMessages({
+      messages,
+      model: "deepseek-chat"
+    })) {
+      items.push(item);
+    }
+
+    expect(items.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from "vitest";
+import { XAIProvider } from "../../src/providers/xai-provider.js";
+import type { Message } from "../../src/providers/types.js";
+
+function makeAsyncIterable(items: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) {
+        yield item;
+      }
+    },
+    async close() {
+      return;
+    }
+  };
+}
+
+describe("XAIProvider", () => {
+  it("throws if XAI_API_KEY is missing", () => {
+    expect(() => new XAIProvider({})).toThrow("XAI_API_KEY is required");
+  });
+
+  it("reports provider id as xai", () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(provider.provider).toBe("xai");
+  });
+
+  it("returns required secrets", () => {
+    expect(XAIProvider.requiredSecrets()).toEqual(["XAI_API_KEY"]);
+  });
+
+  it("returns container env with XAI_API_KEY", () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "test-key" },
+      { client: {} as any }
+    );
+    expect(provider.getContainerEnv()).toEqual({
+      XAI_API_KEY: "test-key"
+    });
+  });
+
+  it("has tool support for all models", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(await provider.hasToolSupport("grok-4")).toBe(true);
+  });
+
+  it("fetches available language models", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "grok-4", name: "Grok 4" },
+          { id: "grok-3-mini" }
+        ]
+      })
+    });
+
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const models = await provider.getAvailableLanguageModels();
+    expect(models).toEqual([
+      { id: "grok-4", name: "Grok 4", provider: "xai" },
+      { id: "grok-3-mini", name: "grok-3-mini", provider: "xai" }
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.x.ai/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer k" }
+      })
+    );
+  });
+
+  it("returns empty list when model fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const models = await provider.getAvailableLanguageModels();
+    expect(models).toEqual([]);
+  });
+
+  it("generates non-streaming message via inherited OpenAI logic", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: "grok response",
+            tool_calls: null
+          }
+        }
+      ]
+    });
+
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      {
+        client: {
+          chat: { completions: { create } }
+        } as any
+      }
+    );
+
+    const messages: Message[] = [{ role: "user", content: "hello" }];
+    const result = await provider.generateMessage({
+      messages,
+      model: "grok-4"
+    });
+
+    expect(result.role).toBe("assistant");
+    expect(result.content).toBe("grok response");
+  });
+
+  it("streams messages via inherited OpenAI logic", async () => {
+    const chunks = [
+      {
+        choices: [{ delta: { content: "hi" }, finish_reason: null }]
+      },
+      {
+        choices: [{ delta: { content: "" }, finish_reason: "stop" }]
+      }
+    ];
+
+    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      {
+        client: {
+          chat: { completions: { create } }
+        } as any
+      }
+    );
+
+    const messages: Message[] = [{ role: "user", content: "hi" }];
+    const items: unknown[] = [];
+    for await (const item of provider.generateMessages({
+      messages,
+      model: "grok-4"
+    })) {
+      items.push(item);
+    }
+
+    expect(items.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -239,6 +239,16 @@ sec(
   "Together AI API key for accessing open-source LLMs through Together's inference API"
 );
 sec(
+  "DEEPSEEK_API_KEY",
+  "DeepSeek",
+  "DeepSeek API key for accessing DeepSeek-V3 chat and DeepSeek-R1 reasoning models"
+);
+sec(
+  "XAI_API_KEY",
+  "xAI",
+  "xAI API key for accessing Grok models via xAI's OpenAI-compatible API"
+);
+sec(
   "GROQ_API_KEY",
   "Groq",
   "Groq API key for accessing ultra-fast LLM inference on Groq's LPU hardware"


### PR DESCRIPTION
Both expose OpenAI-compatible APIs, so they extend OpenAIProvider and
configure the SDK with their own base URLs:

- DeepSeek: https://api.deepseek.com/v1 (DeepSeek-V3, DeepSeek-R1)
- xAI:     https://api.x.ai/v1 (Grok models)

Registers each in the provider registry and adds DEEPSEEK_API_KEY /
XAI_API_KEY entries to the websocket settings registry so they show up
in the secrets UI. Tool support is enabled for all models on both.

https://claude.ai/code/session_013FEXmF71fx6pd7mGQkMDmB