### PR TITLE
feat(kernel,node-sdk): pre-flight graph validation for required fields and models

### DIFF
--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -24,10 +24,19 @@ import { isControlEdge, isDataEdge, TypeMetadata } from "@nodetool/protocol";
 // Graph errors
 // ---------------------------------------------------------------------------
 
+export interface GraphValidationIssue {
+  nodeId?: string;
+  nodeType?: string;
+  property?: string;
+  message: string;
+}
+
 export class GraphValidationError extends Error {
-  constructor(message: string) {
+  readonly issues: GraphValidationIssue[];
+  constructor(message: string, issues: GraphValidationIssue[] = []) {
     super(message);
     this.name = "GraphValidationError";
+    this.issues = issues;
   }
 }
 

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -5,6 +5,7 @@
 export {
   Graph,
   GraphValidationError,
+  type GraphValidationIssue,
   type GraphFromDictOptions,
   type GraphLoadOptions,
   type NodeTypeResolver,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -16,7 +16,9 @@ export {
   WorkflowRunner,
   type RunJobRequest,
   type WorkflowRunnerOptions,
-  type RunResult
+  type RunResult,
+  type NodeValidationIssue,
+  type NodeValidator
 } from "./runner.js";
 export { Channel, ChannelManager, type ChannelStats } from "./channel.js";
 export { NodeInputs, NodeOutputs, type NodeOutputsOptions } from "./io.js";

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -26,10 +26,37 @@ import { TypeMetadata } from "@nodetool/protocol";
 const log = createLogger("nodetool.kernel.runner");
 import type { ProcessingContext } from "@nodetool/runtime";
 import { isControlEdge, isDataEdge } from "@nodetool/protocol";
-import { Graph } from "./graph.js";
+import { Graph, GraphValidationError } from "./graph.js";
 import { rewriteBypassedNodes } from "./graph-utils.js";
 import { NodeInbox } from "./inbox.js";
 import { NodeActor, type NodeExecutor } from "./actor.js";
+
+// ---------------------------------------------------------------------------
+// Node-level validation hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue reported by a node validator. Mirrors the shape of
+ * `@nodetool/node-sdk`'s `NodePropertyValidationIssue`, redeclared here to
+ * avoid a circular dependency (node-sdk depends on kernel).
+ */
+export interface NodeValidationIssue {
+  nodeId?: string;
+  nodeType?: string;
+  property: string;
+  message: string;
+}
+
+/**
+ * Function used by WorkflowRunner to validate each node before execution.
+ * `connectedHandles` lists the targetHandles on the node that have an
+ * incoming data edge — those properties are produced at runtime and the
+ * validator must not flag them as missing.
+ */
+export type NodeValidator = (
+  node: NodeDescriptor,
+  connectedHandles: ReadonlySet<string>
+) => NodeValidationIssue[] | undefined | null;
 
 // ---------------------------------------------------------------------------
 // Runner options
@@ -61,6 +88,16 @@ export interface WorkflowRunnerOptions {
 
   /** Optional execution context passed to each node executor call. */
   executionContext?: ProcessingContext;
+
+  /**
+   * Optional pre-flight validator invoked once per node after structural
+   * graph validation succeeds. Returning a non-empty list of issues aborts
+   * the run with a `GraphValidationError` before any actor is spawned.
+   *
+   * `NodeRegistry.createNodeValidator()` from `@nodetool/node-sdk` produces
+   * a callback compatible with this signature.
+   */
+  validateNode?: NodeValidator;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,6 +266,10 @@ export class WorkflowRunner {
       // Validate
       this._graph.validate();
 
+      // Pre-flight node validation: catch missing required fields and
+      // unset model selections before spawning any actors.
+      this._validateNodes();
+
       // Emit job_update: running
       this._emit({
         type: "job_update",
@@ -350,6 +391,56 @@ export class WorkflowRunner {
         nodes: [...this._graph.nodes],
         edges: validEdges
       });
+    }
+  }
+
+  /**
+   * Run the optional `validateNode` callback for every node in the graph,
+   * passing the set of property handles that have an incoming data edge.
+   * Aggregates issues across nodes and throws a single GraphValidationError.
+   */
+  private _validateNodes(): void {
+    const validator = this._options.validateNode;
+    if (!validator) return;
+
+    // Build map: nodeId -> set of targetHandles with an incoming data edge.
+    const connectedByNode = new Map<string, Set<string>>();
+    for (const edge of this._graph.edges) {
+      if (!isDataEdge(edge)) continue;
+      let handles = connectedByNode.get(edge.target);
+      if (!handles) {
+        handles = new Set();
+        connectedByNode.set(edge.target, handles);
+      }
+      handles.add(edge.targetHandle);
+    }
+
+    const issues: NodeValidationIssue[] = [];
+    for (const node of this._graph.nodes) {
+      const handles = connectedByNode.get(node.id) ?? new Set<string>();
+      const nodeIssues = validator(node, handles);
+      if (nodeIssues && nodeIssues.length > 0) {
+        for (const issue of nodeIssues) {
+          issues.push({
+            nodeId: issue.nodeId ?? node.id,
+            nodeType: issue.nodeType ?? node.type,
+            property: issue.property,
+            message: issue.message
+          });
+        }
+      }
+    }
+
+    if (issues.length > 0) {
+      const lines = issues.map((issue) => {
+        const where = ` on node "${issue.nodeId}"${
+          issue.nodeType ? ` (${issue.nodeType})` : ""
+        }`;
+        return `  - ${issue.message}${where}`;
+      });
+      throw new GraphValidationError(
+        `Graph validation failed with ${issues.length} issue(s):\n${lines.join("\n")}`
+      );
     }
   }
 

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -328,12 +328,24 @@ export class WorkflowRunner {
       log.error("Workflow failed", { jobId: request.job_id, error: message });
       // Drain active edges on error for front-end cleanup
       this._drainActiveEdges();
+      const validationIssues =
+        err instanceof GraphValidationError && err.issues.length > 0
+          ? err.issues
+              .filter((i): i is typeof i & { nodeId: string } => !!i.nodeId)
+              .map((i) => ({
+                node_id: i.nodeId,
+                node_type: i.nodeType ?? null,
+                property: i.property ?? "",
+                message: i.message
+              }))
+          : null;
       this._emit({
         type: "job_update",
         status: "failed",
         job_id: request.job_id,
         workflow_id: request.workflow_id ?? null,
-        error: message
+        error: message,
+        validation_issues: validationIssues
       });
       return {
         outputs: Object.fromEntries(this._outputs),
@@ -439,7 +451,13 @@ export class WorkflowRunner {
         return `  - ${issue.message}${where}`;
       });
       throw new GraphValidationError(
-        `Graph validation failed with ${issues.length} issue(s):\n${lines.join("\n")}`
+        `Graph validation failed with ${issues.length} issue(s):\n${lines.join("\n")}`,
+        issues.map((issue) => ({
+          nodeId: issue.nodeId,
+          nodeType: issue.nodeType,
+          property: issue.property,
+          message: issue.message
+        }))
       );
     }
   }

--- a/packages/kernel/tests/runner-node-validation.test.ts
+++ b/packages/kernel/tests/runner-node-validation.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Runner-level pre-flight node validation.
+ *
+ * Exercises WorkflowRunnerOptions.validateNode — the hook that catches
+ * missing required fields and unset model selections before any actor
+ * is spawned.
+ */
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner, type NodeValidator } from "../src/runner.js";
+import type { NodeDescriptor, Edge } from "@nodetool/protocol";
+import type { NodeExecutor } from "../src/actor.js";
+
+function passthrough(): NodeExecutor {
+  return {
+    async process(inputs) {
+      return { value: inputs.in };
+    }
+  };
+}
+
+function makeRunner(validator?: NodeValidator): WorkflowRunner {
+  return new WorkflowRunner("test-job", {
+    resolveExecutor: () => passthrough(),
+    validateNode: validator
+  });
+}
+
+describe("WorkflowRunner – pre-flight node validation", () => {
+  it("fails the run with collected validation issues", async () => {
+    const validator: NodeValidator = (node) => {
+      if (node.type === "test.NeedsModel") {
+        return [
+          {
+            property: "model",
+            message: 'Property "model" requires a language_model'
+          }
+        ];
+      }
+      return [];
+    };
+    const runner = makeRunner(validator);
+
+    const nodes: NodeDescriptor[] = [
+      { id: "n1", type: "test.NeedsModel", name: "model_in", properties: {} }
+    ];
+    const result = await runner.run(
+      { job_id: "j1" },
+      { nodes, edges: [] }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/Graph validation failed/);
+    expect(result.error).toMatch(/test\.NeedsModel/);
+    expect(result.error).toMatch(/model/);
+  });
+
+  it("passes connectedHandles to the validator and skips connected properties", async () => {
+    const seen: { id: string; handles: string[] }[] = [];
+    const validator: NodeValidator = (node, connected) => {
+      seen.push({ id: node.id, handles: [...connected] });
+      return [];
+    };
+    const runner = makeRunner(validator);
+
+    const nodes: NodeDescriptor[] = [
+      { id: "src", type: "test.Source", name: "src", properties: {} },
+      { id: "dst", type: "test.Dest", properties: {} }
+    ];
+    const edges: Edge[] = [
+      { source: "src", sourceHandle: "out", target: "dst", targetHandle: "in" }
+    ];
+
+    await runner.run({ job_id: "j2" }, { nodes, edges });
+
+    const dst = seen.find((s) => s.id === "dst")!;
+    expect(dst.handles).toEqual(["in"]);
+    const src = seen.find((s) => s.id === "src")!;
+    expect(src.handles).toEqual([]);
+  });
+
+  it("skips validation entirely when no validateNode option is provided", async () => {
+    const runner = new WorkflowRunner("test-job", {
+      resolveExecutor: () => passthrough()
+    });
+    const result = await runner.run(
+      { job_id: "j3" },
+      {
+        nodes: [{ id: "n1", type: "test.Anything", properties: {} }],
+        edges: []
+      }
+    );
+    expect(result.status).toBe("completed");
+  });
+
+  it("aggregates issues across multiple nodes", async () => {
+    const validator: NodeValidator = (node) => [
+      {
+        property: "x",
+        message: `${node.id} missing x`
+      }
+    ];
+    const runner = makeRunner(validator);
+
+    const result = await runner.run(
+      { job_id: "j4" },
+      {
+        nodes: [
+          { id: "a", type: "t.A", properties: {} },
+          { id: "b", type: "t.B", properties: {} }
+        ],
+        edges: []
+      }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/2 issue/);
+    expect(result.error).toMatch(/a missing x/);
+    expect(result.error).toMatch(/b missing x/);
+  });
+
+  it("ignores control edges when computing connected handles", async () => {
+    const seen: { id: string; handles: string[] }[] = [];
+    const validator: NodeValidator = (node, connected) => {
+      seen.push({ id: node.id, handles: [...connected] });
+      return [];
+    };
+    const runner = makeRunner(validator);
+
+    const nodes: NodeDescriptor[] = [
+      { id: "ctl", type: "test.Controller", properties: {} },
+      { id: "tgt", type: "test.Target", properties: {} }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "ctl",
+        sourceHandle: "trigger",
+        target: "tgt",
+        targetHandle: "__control__",
+        edge_type: "control"
+      }
+    ];
+
+    await runner.run({ job_id: "j5" }, { nodes, edges });
+
+    const tgt = seen.find((s) => s.id === "tgt")!;
+    // Control edges must not be treated as data inputs for validation.
+    expect(tgt.handles).toEqual([]);
+  });
+});

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -6,9 +6,24 @@ import type {
   StreamingOutputs
 } from "@nodetool/runtime";
 import { getDeclaredPropertiesForClass } from "./decorators.js";
+import {
+  validateNodeProperties,
+  type NodePropertyValidationIssue
+} from "./validation.js";
 
 export interface DeclaredOutputTypes {
   [name: string]: string;
+}
+
+export interface NodeValidationOptions {
+  /**
+   * Set of property names that are connected to incoming data edges. These
+   * properties are produced at runtime by upstream nodes, so their current
+   * value should not be flagged as missing.
+   */
+  connectedHandles?: ReadonlySet<string> | ReadonlyArray<string>;
+  /** Node id to attach to issues. Defaults to the node's __node_id. */
+  nodeId?: string;
 }
 
 export type NodeClass = {
@@ -39,6 +54,10 @@ export type NodeClass = {
   }>;
   getDeclaredOutputs(): Record<string, string>;
   toDescriptor(id?: string): NodeDescriptor;
+  validateProperties(
+    properties: Record<string, unknown>,
+    options?: NodeValidationOptions
+  ): NodePropertyValidationIssue[];
 };
 
 // ---------------------------------------------------------------------------
@@ -105,6 +124,32 @@ export abstract class BaseNode {
 
   static getDeclaredOutputs(): Record<string, string> {
     return { ...(this.outputTypes ?? {}) };
+  }
+
+  /**
+   * Validate a property bag against this node's declared @prop metadata.
+   *
+   * Flags two classes of problem:
+   *   - Properties declared `required: true` whose value is missing/empty.
+   *   - Properties whose type ends in `_model` whose value carries the
+   *     "empty" provider sentinel or an empty model id.
+   *
+   * Properties listed in `options.connectedHandles` are ignored — those
+   * receive their value from an upstream node at runtime.
+   *
+   * Subclasses may override this to add custom rules. Most nodes won't
+   * need to: declarative `@prop` metadata is enough.
+   */
+  static validateProperties(
+    properties: Record<string, unknown>,
+    options: NodeValidationOptions = {}
+  ): NodePropertyValidationIssue[] {
+    const cls = this as unknown as typeof BaseNode;
+    return validateNodeProperties(cls.getDeclaredProperties(), properties, {
+      connectedHandles: options.connectedHandles,
+      nodeId: options.nodeId,
+      nodeType: cls.nodeType
+    });
   }
 
   assign(properties: Record<string, unknown>): void {
@@ -179,6 +224,23 @@ export abstract class BaseNode {
   async initialize(): Promise<void> {}
   async preProcess(): Promise<void> {}
   async finalize(): Promise<void> {}
+
+  /**
+   * Validate the current property values on this instance.
+   *
+   * Default implementation defers to the class's static validateProperties
+   * over the result of `serialize()`. Subclasses can override to add
+   * runtime-only rules (for example, mutually-exclusive fields).
+   */
+  validate(
+    options: NodeValidationOptions = {}
+  ): NodePropertyValidationIssue[] {
+    const ctor = this.constructor as typeof BaseNode;
+    return ctor.validateProperties(this.serialize(), {
+      connectedHandles: options.connectedHandles,
+      nodeId: options.nodeId ?? (this.__node_id || undefined)
+    });
+  }
 
   abstract process(
     context?: ProcessingContext

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -3,6 +3,7 @@ export * from "./registry.js";
 export * from "./metadata.js";
 export * from "./node-metadata.js";
 export * from "./decorators.js";
+export * from "./validation.js";
 export * from "./nodes/test-nodes.js";
 export * from "./package-registry-client.js";
 export * from "./docs/index.js";

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -8,6 +8,7 @@ import type {
 } from "./metadata.js";
 import { loadPythonPackageMetadata } from "./metadata.js";
 import { getNodeMetadata } from "./node-metadata.js";
+import type { NodePropertyValidationIssue } from "./validation.js";
 
 export interface NodeRegistryOptions {
   metadataByType?: Map<string, NodeMetadata>;
@@ -59,6 +60,40 @@ export class NodeRegistry {
       );
     }
     this._classes.set(nodeClass.nodeType, nodeClass);
+  }
+
+  /**
+   * Validate a node descriptor against its registered class's @prop schema.
+   *
+   * Returns an empty array when:
+   *   - the class is not registered (the runner will surface that elsewhere), or
+   *   - all required/model fields are populated.
+   */
+  validateNode(
+    descriptor: NodeDescriptor,
+    connectedHandles?: ReadonlySet<string> | ReadonlyArray<string>
+  ): NodePropertyValidationIssue[] {
+    const NodeClass = this._classes.get(descriptor.type);
+    if (!NodeClass) return [];
+    const properties =
+      (descriptor.properties as Record<string, unknown> | undefined) ?? {};
+    return NodeClass.validateProperties(properties, {
+      connectedHandles,
+      nodeId: descriptor.id
+    });
+  }
+
+  /**
+   * Create a validator function compatible with WorkflowRunnerOptions.validateNode.
+   * Bound to this registry, so the runner can call it without holding a
+   * reference to the registry itself.
+   */
+  createNodeValidator(): (
+    descriptor: NodeDescriptor,
+    connectedHandles: ReadonlySet<string>
+  ) => NodePropertyValidationIssue[] {
+    return (descriptor, connectedHandles) =>
+      this.validateNode(descriptor, connectedHandles);
   }
 
   resolve(descriptor: NodeDescriptor): NodeExecutor {

--- a/packages/node-sdk/src/validation.ts
+++ b/packages/node-sdk/src/validation.ts
@@ -1,0 +1,145 @@
+/**
+ * Node-level validation.
+ *
+ * Validates that a node descriptor has all of its required properties set
+ * before a workflow is executed. Properties supplied via incoming edges are
+ * skipped (the value will be produced at runtime by an upstream node).
+ *
+ * Two checks are run for each declared property:
+ *
+ *   1. `required: true` — the value must be present and non-empty.
+ *   2. Model fields (`type` ending in `_model`) — if the value carries a
+ *      `provider`, it must not be the sentinel `"empty"` and `id` must be
+ *      a non-empty string. This catches the very common "user forgot to
+ *      pick a model" case for LLM/agent nodes.
+ *
+ * The validator works against the @prop metadata on a node class, so any
+ * node that uses `@prop({ required: true, ... })` or a model-typed field
+ * gets validation for free with no per-node code.
+ */
+import type { DeclaredPropertyMetadata } from "./decorators.js";
+
+/** A single validation issue tied to a node property. */
+export interface NodePropertyValidationIssue {
+  /** Node id, when known. */
+  nodeId?: string;
+  /** Node type, when known. */
+  nodeType?: string;
+  /** Property name that failed validation. */
+  property: string;
+  /** Human-readable message describing the failure. */
+  message: string;
+}
+
+export interface ValidateNodePropertiesOptions {
+  /**
+   * Set of property names that are connected to incoming data edges. These
+   * properties are produced at runtime, so their default value (often empty)
+   * should not be flagged as missing.
+   */
+  connectedHandles?: ReadonlySet<string> | ReadonlyArray<string>;
+  /** Node id to attach to issues. */
+  nodeId?: string;
+  /** Node type to attach to issues. */
+  nodeType?: string;
+}
+
+const MODEL_TYPE_SUFFIX = "_model";
+const EMPTY_PROVIDER = "empty";
+
+function isModelType(typeStr: string | undefined): boolean {
+  if (!typeStr) return false;
+  return typeStr.endsWith(MODEL_TYPE_SUFFIX);
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+function isUnsetModel(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  // Only treat the value as a "model object" when it carries a provider key —
+  // this guards against false positives on opaque values flowing through.
+  if (!("provider" in v) && !("id" in v)) return false;
+  const provider = v.provider;
+  const id = v.id;
+  if (typeof provider === "string" && provider === EMPTY_PROVIDER) return true;
+  if (provider == null) return true;
+  if (typeof id === "string" && id.length === 0) return true;
+  if (id == null) return true;
+  return false;
+}
+
+function toSet(
+  handles: ReadonlySet<string> | ReadonlyArray<string> | undefined
+): ReadonlySet<string> {
+  if (!handles) return new Set();
+  if (handles instanceof Set) return handles;
+  return new Set(handles as ReadonlyArray<string>);
+}
+
+/**
+ * Validate property values against declared @prop metadata.
+ *
+ * Properties whose name appears in `connectedHandles` are skipped because
+ * they will receive a value from an upstream node at runtime.
+ */
+export function validateNodeProperties(
+  declared: ReadonlyArray<DeclaredPropertyMetadata>,
+  properties: Record<string, unknown>,
+  options: ValidateNodePropertiesOptions = {}
+): NodePropertyValidationIssue[] {
+  const connected = toSet(options.connectedHandles);
+  const issues: NodePropertyValidationIssue[] = [];
+
+  for (const { name, options: meta } of declared) {
+    if (connected.has(name)) continue;
+    const value = properties[name];
+    const typeStr = meta.type;
+
+    if (meta.required && isEmptyValue(value)) {
+      issues.push({
+        nodeId: options.nodeId,
+        nodeType: options.nodeType,
+        property: name,
+        message: `Required property "${name}" is not set`
+      });
+      continue;
+    }
+
+    if (isModelType(typeStr) && isUnsetModel(value)) {
+      issues.push({
+        nodeId: options.nodeId,
+        nodeType: options.nodeType,
+        property: name,
+        message: `Property "${name}" requires a ${typeStr} to be selected (provider and model id)`
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Format a list of validation issues into a single human-readable message.
+ * Used by GraphValidationError when validation fails.
+ */
+export function formatValidationIssues(
+  issues: ReadonlyArray<NodePropertyValidationIssue>
+): string {
+  if (issues.length === 0) return "";
+  const lines = issues.map((issue) => {
+    const where = issue.nodeId
+      ? ` on node "${issue.nodeId}"${issue.nodeType ? ` (${issue.nodeType})` : ""}`
+      : issue.nodeType
+        ? ` on ${issue.nodeType}`
+        : "";
+    return `  - ${issue.message}${where}`;
+  });
+  return `Graph validation failed with ${issues.length} issue(s):\n${lines.join("\n")}`;
+}

--- a/packages/node-sdk/src/validation.ts
+++ b/packages/node-sdk/src/validation.ts
@@ -63,15 +63,14 @@ function isUnsetModel(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   if (typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
-  // Only treat the value as a "model object" when it carries a provider key —
-  // this guards against false positives on opaque values flowing through.
-  if (!("provider" in v) && !("id" in v)) return false;
   const provider = v.provider;
   const id = v.id;
-  if (typeof provider === "string" && provider === EMPTY_PROVIDER) return true;
+  // A bare placeholder like `{ type: "language_model" }` (no provider, no id)
+  // is exactly the unselected default we want to flag.
   if (provider == null) return true;
-  if (typeof id === "string" && id.length === 0) return true;
+  if (typeof provider === "string" && provider === EMPTY_PROVIDER) return true;
   if (id == null) return true;
+  if (typeof id === "string" && id.length === 0) return true;
   return false;
 }
 

--- a/packages/node-sdk/tests/registry-validation.test.ts
+++ b/packages/node-sdk/tests/registry-validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { BaseNode } from "../src/base-node.js";
+import { prop } from "../src/decorators.js";
+import { NodeRegistry } from "../src/registry.js";
+
+class NeedsModelNode extends BaseNode {
+  static readonly nodeType = "test.NeedsModel";
+  static readonly title = "Needs Model";
+  static readonly description = "LLM-style node with a language_model field";
+
+  @prop({
+    type: "language_model",
+    default: {
+      type: "language_model",
+      provider: "empty",
+      id: "",
+      name: "",
+      path: null,
+      supported_tasks: []
+    }
+  })
+  declare model: unknown;
+
+  @prop({ type: "str", default: "", required: true })
+  declare prompt: string;
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+}
+
+function makeRegistry(): NodeRegistry {
+  const registry = new NodeRegistry();
+  registry.register(NeedsModelNode);
+  return registry;
+}
+
+describe("NodeRegistry.validateNode", () => {
+  it("returns issues for a descriptor missing required fields", () => {
+    const registry = makeRegistry();
+    const issues = registry.validateNode({
+      id: "n1",
+      type: "test.NeedsModel",
+      properties: {}
+    });
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.some((i) => i.property === "prompt")).toBe(true);
+    expect(issues.some((i) => i.property === "model")).toBe(true);
+    expect(issues[0].nodeId).toBe("n1");
+  });
+
+  it("skips connected properties", () => {
+    const registry = makeRegistry();
+    const issues = registry.validateNode(
+      { id: "n1", type: "test.NeedsModel", properties: {} },
+      new Set(["prompt", "model"])
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("returns an empty list for unregistered node types", () => {
+    const registry = makeRegistry();
+    const issues = registry.validateNode({
+      id: "x",
+      type: "unknown.Type",
+      properties: {}
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it("createNodeValidator returns a function bound to the registry", () => {
+    const registry = makeRegistry();
+    const validate = registry.createNodeValidator();
+    const issues = validate(
+      { id: "n2", type: "test.NeedsModel", properties: {} },
+      new Set()
+    );
+    expect(issues.some((i) => i.property === "prompt")).toBe(true);
+  });
+});

--- a/packages/node-sdk/tests/validation.test.ts
+++ b/packages/node-sdk/tests/validation.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { BaseNode, type NodeValidationOptions } from "../src/base-node.js";
+import { prop } from "../src/decorators.js";
+import {
+  validateNodeProperties,
+  formatValidationIssues
+} from "../src/validation.js";
+
+const EMPTY_LANGUAGE_MODEL = {
+  type: "language_model",
+  provider: "empty",
+  id: "",
+  name: "",
+  path: null,
+  supported_tasks: []
+};
+
+class RequiredFieldNode extends BaseNode {
+  static readonly nodeType = "test.RequiredField";
+  static readonly title = "Required Field";
+  static readonly description = "Has a required text field";
+
+  @prop({ type: "str", default: "", required: true })
+  declare text: string;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { value: this.text };
+  }
+}
+
+class ModelFieldNode extends BaseNode {
+  static readonly nodeType = "test.ModelField";
+  static readonly title = "Model Field";
+  static readonly description = "Has a language_model field";
+
+  @prop({
+    type: "language_model",
+    default: EMPTY_LANGUAGE_MODEL,
+    title: "Model"
+  })
+  declare model: unknown;
+
+  @prop({ type: "str", default: "" })
+  declare prompt: string;
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+}
+
+class CustomValidationNode extends BaseNode {
+  static readonly nodeType = "test.CustomValidation";
+  static readonly title = "Custom";
+  static readonly description = "Custom validate() override";
+
+  @prop({ type: "int", default: 0 })
+  declare min: number;
+
+  @prop({ type: "int", default: 0 })
+  declare max: number;
+
+  static validateProperties(
+    properties: Record<string, unknown>,
+    options: NodeValidationOptions = {}
+  ) {
+    const issues = super.validateProperties(properties, options);
+    const min = Number(properties.min ?? 0);
+    const max = Number(properties.max ?? 0);
+    if (min > max) {
+      issues.push({
+        nodeId: options.nodeId,
+        nodeType: this.nodeType,
+        property: "min",
+        message: `min (${min}) must be <= max (${max})`
+      });
+    }
+    return issues;
+  }
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+}
+
+describe("validateNodeProperties — required fields", () => {
+  it("flags an unset required string", () => {
+    const issues = RequiredFieldNode.validateProperties({ text: "" });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].property).toBe("text");
+    expect(issues[0].message).toMatch(/Required property "text"/);
+  });
+
+  it("passes when the required field is set", () => {
+    const issues = RequiredFieldNode.validateProperties({ text: "hello" });
+    expect(issues).toHaveLength(0);
+  });
+
+  it("treats null and undefined as missing", () => {
+    expect(
+      RequiredFieldNode.validateProperties({ text: null })
+    ).toHaveLength(1);
+    expect(
+      RequiredFieldNode.validateProperties({ text: undefined })
+    ).toHaveLength(1);
+  });
+
+  it("skips required fields supplied via incoming edge", () => {
+    const issues = RequiredFieldNode.validateProperties(
+      { text: "" },
+      { connectedHandles: new Set(["text"]) }
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("attaches nodeId and nodeType to issues", () => {
+    const issues = RequiredFieldNode.validateProperties(
+      { text: "" },
+      { nodeId: "n1" }
+    );
+    expect(issues[0].nodeId).toBe("n1");
+    expect(issues[0].nodeType).toBe("test.RequiredField");
+  });
+});
+
+describe("validateNodeProperties — *_model fields", () => {
+  it("flags the empty language_model default", () => {
+    const issues = ModelFieldNode.validateProperties({
+      model: EMPTY_LANGUAGE_MODEL,
+      prompt: ""
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].property).toBe("model");
+    expect(issues[0].message).toMatch(/language_model/);
+  });
+
+  it("flags a model with non-empty provider but missing id", () => {
+    const issues = ModelFieldNode.validateProperties({
+      model: { type: "language_model", provider: "openai", id: "", name: "" },
+      prompt: ""
+    });
+    expect(issues).toHaveLength(1);
+  });
+
+  it("passes for a fully populated model", () => {
+    const issues = ModelFieldNode.validateProperties({
+      model: {
+        type: "language_model",
+        provider: "openai",
+        id: "gpt-5.4",
+        name: "GPT 5.4"
+      },
+      prompt: ""
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it("skips model validation when the field is connected to an edge", () => {
+    const issues = ModelFieldNode.validateProperties(
+      { model: EMPTY_LANGUAGE_MODEL, prompt: "" },
+      { connectedHandles: new Set(["model"]) }
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("instance.validate() proxies to the static validator", () => {
+    const node = new ModelFieldNode();
+    const issues = node.validate();
+    expect(issues.some((i) => i.property === "model")).toBe(true);
+  });
+});
+
+describe("validateNodeProperties — subclass overrides", () => {
+  it("subclasses can layer custom rules over the default validator", () => {
+    const issues = CustomValidationNode.validateProperties({
+      min: 10,
+      max: 1
+    });
+    expect(issues.some((i) => i.property === "min")).toBe(true);
+  });
+
+  it("custom rule does not fire when constraints are satisfied", () => {
+    const issues = CustomValidationNode.validateProperties({
+      min: 1,
+      max: 10
+    });
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("validateNodeProperties — direct call with declared metadata", () => {
+  it("works with hand-constructed metadata", () => {
+    const issues = validateNodeProperties(
+      [{ name: "x", options: { type: "str", required: true, default: "" } }],
+      { x: "" },
+      { nodeId: "n1", nodeType: "test.X" }
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].nodeId).toBe("n1");
+  });
+});
+
+describe("formatValidationIssues", () => {
+  it("formats issues as a readable multi-line message", () => {
+    const out = formatValidationIssues([
+      {
+        nodeId: "a",
+        nodeType: "test.A",
+        property: "x",
+        message: "Required property \"x\" is not set"
+      }
+    ]);
+    expect(out).toMatch(/1 issue/);
+    expect(out).toMatch(/test\.A/);
+    expect(out).toMatch(/x/);
+  });
+
+  it("returns an empty string for no issues", () => {
+    expect(formatValidationIssues([])).toBe("");
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -111,6 +111,20 @@ export interface JobUpdate {
   traceback?: string | null;
   run_state?: RunStateInfo | null;
   duration?: number | null;
+  /**
+   * Per-property issues from pre-flight graph validation. Present when
+   * `status === "failed"` and the failure was caused by a validation error
+   * (not a runtime exception). Frontend uses this to highlight specific
+   * fields on the offending nodes instead of showing a node-level banner.
+   */
+  validation_issues?: ValidationIssue[] | null;
+}
+
+export interface ValidationIssue {
+  node_id: string;
+  node_type?: string | null;
+  property: string;
+  message: string;
 }
 
 export interface NodeUpdate {

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -341,7 +341,8 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
       resolveNodeType: graphNodeTypeResolver,
       resolveProvider,
       resolveTools,
-      getNodeMetadata: (nodeType) => registry.getMetadata(nodeType)
+      getNodeMetadata: (nodeType) => registry.getMetadata(nodeType),
+      validateNode: registry.createNodeValidator()
     });
     log.info("WebSocket client connected");
     void runner.run(new WsAdapter(socket)).catch((error) => {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -14,7 +14,8 @@ import {
   Graph,
   WorkflowRunner,
   type NodeExecutor,
-  type NodeTypeResolver
+  type NodeTypeResolver,
+  type NodeValidator
 } from "@nodetool/kernel";
 import {
   Asset,
@@ -716,6 +717,13 @@ export interface UnifiedWebSocketRunnerOptions {
   }) => Promise<void>;
   /** Resolve node metadata by type — used for auto_save_asset detection. */
   getNodeMetadata?: (nodeType: string) => NodeMetadata | undefined;
+  /**
+   * Optional pre-flight per-node validator. Forwarded to WorkflowRunner so
+   * missing required fields and unset model selections abort the run before
+   * any actor is spawned. `NodeRegistry.createNodeValidator()` from
+   * `@nodetool/node-sdk` produces a compatible callback.
+   */
+  validateNode?: NodeValidator;
 }
 
 export class UnifiedWebSocketRunner {
@@ -734,6 +742,7 @@ export class UnifiedWebSocketRunner {
   private workspaceResolver?: UnifiedWebSocketRunnerOptions["workspaceResolver"];
   private beforeRunJob?: UnifiedWebSocketRunnerOptions["beforeRunJob"];
   private getNodeMetadata?: UnifiedWebSocketRunnerOptions["getNodeMetadata"];
+  private validateNode?: UnifiedWebSocketRunnerOptions["validateNode"];
 
   private sendLock: Promise<void> = Promise.resolve();
   private activeJobs = new Map<string, ActiveJob>();
@@ -877,6 +886,7 @@ export class UnifiedWebSocketRunner {
     this.workspaceResolver = options.workspaceResolver;
     this.beforeRunJob = options.beforeRunJob;
     this.getNodeMetadata = options.getNodeMetadata;
+    this.validateNode = options.validateNode;
     this.getSystemStats =
       options.getSystemStats ??
       (() => ({
@@ -1196,7 +1206,8 @@ export class UnifiedWebSocketRunner {
         this.resolveExecutor(
           node as { id: string; type: string; [key: string]: unknown }
         ),
-      executionContext: context
+      executionContext: context,
+      validateNode: this.validateNode
     });
 
     const active: ActiveJob = {
@@ -3515,7 +3526,8 @@ export class UnifiedWebSocketRunner {
           this.resolveExecutor(
             node as { id: string; type: string; [key: string]: unknown }
           ),
-        executionContext: context
+        executionContext: context,
+        validateNode: this.validateNode
       });
 
       const active: ActiveJob = {

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -13,6 +13,8 @@ import isEqual from "fast-deep-equal";
 import { isConnectableCached } from "../node_menu/typeFilterUtils";
 import HandleTooltip from "../HandleTooltip";
 import { NodeData } from "../../stores/NodeData";
+import usePropertyValidationStore from "../../stores/PropertyValidationStore";
+import { Tooltip } from "../ui_primitives/Tooltip";
 
 export type PropertyFieldProps = {
   id: string;
@@ -65,6 +67,11 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
     shallow
   );
   const openContextMenu = useContextMenuStore((state) => state.openContextMenu);
+  const validationError = usePropertyValidationStore((state) =>
+    data.workflow_id
+      ? state.errors[`${data.workflow_id}:${id}:${property.name}` as const]
+      : undefined
+  );
   const classConnectable = useMemo(() => {
     // Control edges can connect to any node's control handle
     if (connectType?.type === "control") {
@@ -116,8 +123,12 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
     [id, openContextMenu, property.description, property.name, property.type]
   );
 
-  return (
-    <div className={`node-property ${Slugify(property.type.type)}`}>
+  const fieldClass = `node-property ${Slugify(property.type.type)}${
+    validationError ? " has-validation-error" : ""
+  }`;
+
+  const inner = (
+    <div className={fieldClass}>
       {showHandle && (
         <div className="handle-popup" style={handlePopupStyle}>
           <HandleTooltip
@@ -168,6 +179,13 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
         </div>
       )}
     </div>
+  );
+
+  if (!validationError) return inner;
+  return (
+    <Tooltip title={validationError} placement="top" arrow enterDelay={250}>
+      {inner}
+    </Tooltip>
   );
 };
 

--- a/web/src/stores/PropertyValidationStore.ts
+++ b/web/src/stores/PropertyValidationStore.ts
@@ -1,0 +1,74 @@
+import { create } from "zustand";
+import { shallow } from "zustand/shallow";
+
+type Key = `${string}:${string}:${string}`;
+
+const key = (workflowId: string, nodeId: string, property: string): Key =>
+  `${workflowId}:${nodeId}:${property}` as Key;
+
+const nodePrefix = (workflowId: string, nodeId: string) =>
+  `${workflowId}:${nodeId}:`;
+
+type PropertyValidationStore = {
+  errors: Record<Key, string>;
+  setIssues: (
+    workflowId: string,
+    issues: ReadonlyArray<{
+      node_id: string;
+      property: string;
+      message: string;
+    }>
+  ) => void;
+  clearWorkflow: (workflowId: string) => void;
+  clearNode: (workflowId: string, nodeId: string) => void;
+  getError: (
+    workflowId: string,
+    nodeId: string,
+    property: string
+  ) => string | undefined;
+};
+
+const usePropertyValidationStore = create<PropertyValidationStore>(
+  (set, get) => ({
+    errors: {},
+    setIssues: (workflowId, issues) => {
+      set((state) => {
+        const next: Record<Key, string> = {};
+        const prefix = `${workflowId}:`;
+        for (const k in state.errors) {
+          if (!k.startsWith(prefix)) next[k as Key] = state.errors[k as Key];
+        }
+        for (const issue of issues) {
+          if (!issue.node_id || !issue.property) continue;
+          next[key(workflowId, issue.node_id, issue.property)] = issue.message;
+        }
+        return { errors: next };
+      });
+    },
+    clearWorkflow: (workflowId) => {
+      set((state) => {
+        const next: Record<Key, string> = {};
+        const prefix = `${workflowId}:`;
+        for (const k in state.errors) {
+          if (!k.startsWith(prefix)) next[k as Key] = state.errors[k as Key];
+        }
+        return { errors: next };
+      });
+    },
+    clearNode: (workflowId, nodeId) => {
+      set((state) => {
+        const next: Record<Key, string> = {};
+        const prefix = nodePrefix(workflowId, nodeId);
+        for (const k in state.errors) {
+          if (!k.startsWith(prefix)) next[k as Key] = state.errors[k as Key];
+        }
+        return { errors: next };
+      });
+    },
+    getError: (workflowId, nodeId, property) =>
+      get().errors[key(workflowId, nodeId, property)]
+  })
+);
+
+export { shallow };
+export default usePropertyValidationStore;

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -20,6 +20,7 @@ import useResultsStore from "./ResultsStore";
 import useStatusStore from "./StatusStore";
 import useLogsStore from "./LogStore";
 import useErrorStore, { normalizeNodeError } from "./ErrorStore";
+import usePropertyValidationStore from "./PropertyValidationStore";
 import type { WorkflowRunnerStore } from "./WorkflowRunner";
 import { Notification } from "./ApiTypes";
 import { useNotificationStore } from "./NotificationStore";
@@ -383,6 +384,9 @@ export const handleUpdate = (
       if (currentState !== "error") {
         newState = "running";
       }
+      // A new run starts: clear any prior pre-flight validation highlights
+      // so stale red outlines don't linger after the user fixes them.
+      usePropertyValidationStore.getState().clearWorkflow(workflow.id);
     } else if (job.status === "suspended") {
       newState = "suspended";
     } else if (job.status === "paused") {
@@ -450,19 +454,43 @@ export const handleUpdate = (
         clearTimings(workflow.id);
         break;
       case "failed":
-      case "timed_out":
-        runner.addNotification({
-          type: "error",
-          alert: true,
-          content: `Job ${job.status}${job.error ? ` ${job.error}` : ""}`,
-          timeout: NOTIFICATION_TIMEOUT_JOB_COMPLETED
-        });
+      case "timed_out": {
+        const validationIssues = (
+          job as JobUpdate & {
+            validation_issues?: Array<{
+              node_id: string;
+              property: string;
+              message: string;
+            }> | null;
+          }
+        ).validation_issues;
+        if (validationIssues && validationIssues.length > 0) {
+          usePropertyValidationStore
+            .getState()
+            .setIssues(workflow.id, validationIssues);
+          const noun =
+            validationIssues.length === 1 ? "field" : "fields";
+          runner.addNotification({
+            type: "error",
+            alert: true,
+            content: `Fix ${validationIssues.length} highlighted ${noun} before running.`,
+            timeout: NOTIFICATION_TIMEOUT_JOB_COMPLETED
+          });
+        } else {
+          runner.addNotification({
+            type: "error",
+            alert: true,
+            content: `Job ${job.status}${job.error ? ` ${job.error}` : ""}`,
+            timeout: NOTIFICATION_TIMEOUT_JOB_COMPLETED
+          });
+        }
         clearStatuses(workflow.id);
         clearEdges(workflow.id);
         clearProgress(workflow.id);
         clearOutputResults(workflow.id);
         clearTimings(workflow.id);
         break;
+      }
       case "queued":
         runnerStore.setState({
           statusMessage: "Worker is booting (may take a 15 seconds)..."

--- a/web/src/styles/properties.css
+++ b/web/src/styles/properties.css
@@ -20,6 +20,60 @@
   margin-bottom: 0;
 }
 
+/* Pre-flight validation: a property value is missing or invalid for the
+   declared type. Goal is to draw the eye without overwhelming the node:
+   a thin left accent bar, red label, and a focus-style ring on the input.
+   Hover the row to see the exact message via Tooltip. */
+.node-property.has-validation-error {
+  position: relative;
+  border-radius: 4px;
+  background:
+    linear-gradient(
+      to right,
+      rgba(244, 67, 54, 0.06) 0%,
+      rgba(244, 67, 54, 0) 60%
+    );
+  transition: background-color 200ms ease-out;
+}
+.node-property.has-validation-error::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  border-radius: 2px;
+  background-color: var(--palette-error-main, #f44336);
+  box-shadow: 0 0 6px rgba(244, 67, 54, 0.55);
+}
+.node-property.has-validation-error .property-label {
+  color: var(--palette-error-light, #ef9a9a);
+  font-weight: 500;
+}
+.node-property.has-validation-error .property-label::after {
+  content: " ⚠";
+  color: var(--palette-error-main, #f44336);
+  font-size: 0.85em;
+  margin-left: 2px;
+}
+/* Subtle ring on the actual input control inside the row.
+   Targets common MUI/native form controls so the affected widget — not the
+   surrounding row — looks "selected" by validation. */
+.node-property.has-validation-error :is(
+    .MuiInputBase-root,
+    .MuiOutlinedInput-root,
+    .MuiSelect-select,
+    input,
+    textarea,
+    select
+  ) {
+  border-color: var(--palette-error-main, #f44336) !important;
+  box-shadow: 0 0 0 1px rgba(244, 67, 54, 0.45) inset;
+}
+.node-property.has-validation-error .MuiOutlinedInput-notchedOutline {
+  border-color: var(--palette-error-main, #f44336) !important;
+}
+
 .node-property .react-flow__handle {
   margin-top: 2px;
 }


### PR DESCRIPTION
Adds declarative graph validation that runs before WorkflowRunner spawns
any actor. Catches the two most common configuration mistakes early:

  1. @prop({ required: true }) fields that are unset.
  2. *_model fields (language_model, image_model, etc.) where the user
     hasn't picked a provider/model — i.e. the "empty" sentinel default.

Properties connected to an incoming data edge are skipped, since their
value is produced at runtime.

Layered design so validation is opt-in and pluggable:

  - node-sdk: validateNodeProperties() + BaseNode.validateProperties()/
    BaseNode.validate(). Subclasses override either to add custom rules.
  - node-sdk: NodeRegistry.validateNode() and createNodeValidator().
  - kernel: WorkflowRunnerOptions.validateNode hook; collected issues
    abort the run with a single GraphValidationError.

The kernel has no dependency on node-sdk (would be circular); the
runner's NodeValidator type is structurally compatible with what
NodeRegistry.createNodeValidator() returns.