### PR TITLE
fix(types): resolve typecheck errors across web and mobile

### DIFF
--- a/mobile/src/components/outputs/OutputRenderer.tsx
+++ b/mobile/src/components/outputs/OutputRenderer.tsx
@@ -35,7 +35,11 @@ interface DataframeColumn {
 }
 
 type OutputRendererProps = {
-  value: unknown;
+  // OutputRenderer accepts arbitrary runtime values from the backend
+  // and dispatches on a discriminated `type` field. The shape is
+  // dynamic and well-defended at runtime, so `any` is appropriate here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
 };
 
 /**
@@ -740,7 +744,7 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
  */
 function renderJSON(
   value: unknown,
-  codeTheme: Record<string, React.CSSProperties>,
+  codeTheme: Record<string, unknown>,
   colors: ThemeColors,
   mode: string,
   monoFont: string

--- a/mobile/src/services/WebSocketManager.ts
+++ b/mobile/src/services/WebSocketManager.ts
@@ -15,10 +15,7 @@ import {
   WebSocketMessageData 
 } from '../types/chat';
 
-interface WebSocketMessage {
-  type: string;
-  [key: string]: unknown;
-}
+type WebSocketMessage = { type: string };
 
 interface WebSocketCallbacks {
   onStateChange?: (state: ConnectionState, previousState: ConnectionState) => void;
@@ -146,7 +143,7 @@ export class WebSocketManager {
     }
   }
 
-  public send(message: WebSocketMessage): void {
+  public send<T extends WebSocketMessage>(message: T): void {
     if (!this.isConnected()) {
       if (
         this.config.reconnect &&
@@ -221,7 +218,7 @@ export class WebSocketManager {
       }
 
       console.log('[WS Receive]', data);
-      this.callbacks.onMessage?.(data);
+      this.callbacks.onMessage?.(data as WebSocketMessageData);
     } catch (error) {
       console.error('Failed to process message:', error);
       this.callbacks.onError?.(error as Error);

--- a/web/src/components/context_menus/InputContextMenu.tsx
+++ b/web/src/components/context_menus/InputContextMenu.tsx
@@ -160,7 +160,7 @@ const InputContextMenu: React.FC = () => {
       menuPosition: state.menuPosition,
       closeContextMenu: state.closeContextMenu,
       payload: state.payload
-    }), shallow);
+    }));
   const openNodeMenu = useNodeMenuStore((state) => state.openNodeMenu);
 
   // "collect" handle: allow connecting T -> list[T] and multiple connections
@@ -209,7 +209,7 @@ const InputContextMenu: React.FC = () => {
     setFilterType: state.setFilterType,
     setConnectableType: state.setTypeMetadata,
     setTargetHandle: state.setTargetHandle
-  }), shallow);
+  }));
 
   const collectElementDatatypeLabel = collectElementType
     ? labelForType(collectElementType.type || "").replaceAll(" ", "")

--- a/web/src/components/context_menus/OutputContextMenu.tsx
+++ b/web/src/components/context_menus/OutputContextMenu.tsx
@@ -39,7 +39,7 @@ const OutputContextMenu: React.FC = () => {
     closeContextMenu: state.closeContextMenu,
     type: state.type,
     handleId: state.handleId
-  }), shallow);
+  }));
   const openNodeMenu = useNodeMenuStore((state) => state.openNodeMenu);
   // Combine multiple useNodes subscriptions into a single selector with shallow equality
   // to reduce unnecessary re-renders when other parts of the node state change
@@ -68,7 +68,7 @@ const OutputContextMenu: React.FC = () => {
     setNodeId: state.setNodeId,
     setFilterType: state.setFilterType,
     setConnectableType: state.setTypeMetadata
-  }), shallow);
+  }));
 
   type HandleType = "value" | "image" | "df" | "values";
   const getTargetHandle = useCallback(

--- a/web/src/components/context_menus/PropertyContextMenu.tsx
+++ b/web/src/components/context_menus/PropertyContextMenu.tsx
@@ -37,7 +37,7 @@ const PropertyContextMenuComponent: React.FC = () => {
     nodeId: state.nodeId,
     handleId: state.handleId,
     isDynamicProperty: state.isDynamicProperty
-  }), shallow);
+  }));
   const { findNode, updateNodeData, updateNodeProperties } = useNodes(
     (state) => ({
       findNode: state.findNode,

--- a/web/src/hooks/useDebouncedCallback.ts
+++ b/web/src/hooks/useDebouncedCallback.ts
@@ -1,14 +1,14 @@
 import { useEffect, useMemo, useRef } from "react";
 
-type DebouncedCallback<T extends (...args: unknown[]) => unknown> = {
-  (...args: Parameters<T>): void;
+type DebouncedCallback<TArgs extends unknown[]> = {
+  (...args: TArgs): void;
   cancel: () => void;
 };
 
-export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
-  fn: T,
+export function useDebouncedCallback<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => unknown,
   delay: number
-): DebouncedCallback<T> {
+): DebouncedCallback<TArgs> {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fnRef = useRef(fn);
   fnRef.current = fn;
@@ -28,7 +28,7 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
         timerRef.current = null;
       }
     };
-    const debounced = (...args: Parameters<T>) => {
+    const debounced = (...args: TArgs) => {
       cancel();
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
@@ -36,6 +36,6 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
       }, delay);
     };
     debounced.cancel = cancel;
-    return debounced as DebouncedCallback<T>;
+    return debounced as DebouncedCallback<TArgs>;
   }, [delay]);
 }


### PR DESCRIPTION
- web: drop stale `shallow` arg from `useContextMenuStore` /
  `useConnectableNodesStore` calls; both hooks now accept only a
  selector after the recent refactor.
- web: parameterize `useDebouncedCallback` over its arg tuple so
  callers can pass functions with concrete (e.g. `string`) parameters.
- mobile: relax `WebSocketMessage` to a generic-bound `{ type: string }`
  so typed message variants (`ChatMessageRequest`, `{ type: 'stop' }`)
  are accepted without requiring an index signature.
- mobile: cast decoded msgpack payload to `WebSocketMessageData` at
  the callback boundary.
- mobile: type `OutputRenderer`'s `value` as `any` (with a comment) to
  match the dynamic, runtime-validated shape it dispatches on; widen
  `renderJSON`'s `codeTheme` to `Record<string, unknown>` to match
  `react-syntax-highlighter` style imports.