### PR TITLE
Fix: Prevent single-key callback when modifier released while key held

### DIFF
--- a/web/src/stores/KeyPressedStore.ts
+++ b/web/src/stores/KeyPressedStore.ts
@@ -207,10 +207,12 @@ const useKeyPressedStore = create<KeyPressedState>()((set, get) => ({
       const newKeyPressCount = { ...state.keyPressCount };
       let lastPressedKey = state.lastPressedKey;
 
+      let anyKeyPressed = false;
       Object.entries(keys).forEach(([key, isPressed]) => {
         const normalizedKey = key.toLowerCase();
 
         if (isPressed) {
+          anyKeyPressed = true;
           newPressedKeys.add(normalizedKey);
           lastPressedKey = normalizedKey;
           newKeyPressCount[normalizedKey] =
@@ -220,7 +222,13 @@ const useKeyPressedStore = create<KeyPressedState>()((set, get) => ({
         }
       });
 
-      executeComboCallbacks(newPressedKeys, event);
+      // Only fire combo callbacks on key-down transitions. Otherwise releasing
+      // a modifier while a non-modifier is still held (e.g. releasing Cmd
+      // while "1" is held after Cmd+1) would shrink pressedKeys to {"1"} and
+      // wrongly trigger the single-key "1" shortcut.
+      if (anyKeyPressed) {
+        executeComboCallbacks(newPressedKeys, event);
+      }
 
       return {
         pressedKeys: newPressedKeys,

--- a/web/src/stores/__tests__/KeyPressedStore.test.ts
+++ b/web/src/stores/__tests__/KeyPressedStore.test.ts
@@ -431,6 +431,59 @@ describe("KeyPressedStore", () => {
       unregisterComboCallback("delete");
     });
 
+    it("does not trigger single-key callback when modifier is released while key is held", () => {
+      const singleKeyCallback = jest.fn();
+      const comboCallback = jest.fn();
+      registerComboCallback("1", {
+        callback: singleKeyCallback,
+        preventDefault: false
+      });
+      registerComboCallback("1+meta", {
+        callback: comboCallback,
+        preventDefault: false
+      });
+
+      (document.body as HTMLElement).focus();
+      const { setKeysPressed } = useKeyPressedStore.getState();
+
+      // Press Cmd+1
+      const cmdDown = new KeyboardEvent("keydown", {
+        key: "Meta",
+        metaKey: true
+      });
+      const oneDown = new KeyboardEvent("keydown", {
+        key: "1",
+        metaKey: true
+      });
+      act(() => {
+        setKeysPressed({ meta: true }, cmdDown);
+        setKeysPressed(
+          { "1": true, shift: false, control: false, alt: false, meta: true },
+          oneDown
+        );
+      });
+
+      expect(comboCallback).toHaveBeenCalledTimes(1);
+      expect(singleKeyCallback).not.toHaveBeenCalled();
+
+      // Release Cmd while "1" is still held - must NOT fire single-key "1"
+      const cmdUp = new KeyboardEvent("keyup", {
+        key: "Meta",
+        metaKey: false
+      });
+      act(() => {
+        setKeysPressed(
+          { meta: false, shift: false, control: false, alt: false },
+          cmdUp
+        );
+      });
+
+      expect(singleKeyCallback).not.toHaveBeenCalled();
+
+      unregisterComboCallback("1");
+      unregisterComboCallback("1+meta");
+    });
+
     it("allows backspace callback when canvas is focused", () => {
       const callback = jest.fn();
       registerComboCallback("backspace", { callback, preventDefault: true });


### PR DESCRIPTION
## Summary
Fixed a bug where releasing a modifier key while another key is still held would incorrectly trigger the single-key callback for that key. For example, releasing Cmd while "1" is held after pressing Cmd+1 would fire both the Cmd+1 combo callback and the single "1" callback.

## Changes
- **KeyPressedStore.ts**: Modified `setKeysPressed` to only execute combo callbacks during key-down transitions (when `anyKeyPressed` is true), not during key-up transitions. This prevents the pressed keys set from shrinking and triggering unintended single-key shortcuts when modifiers are released.

- **KeyPressedStore.test.ts**: Added comprehensive test case "does not trigger single-key callback when modifier is released while key is held" that verifies:
  - Pressing Cmd+1 triggers only the combo callback
  - Releasing Cmd while "1" is still held does not trigger the single-key "1" callback

## Implementation Details
The fix works by tracking whether any key was actually pressed in the current event (`anyKeyPressed` flag) and only calling `executeComboCallbacks` when this flag is true. This ensures callbacks are only fired on key-down events, preventing the unintended triggering of single-key callbacks when modifiers are released while other keys remain held.

https://claude.ai/code/session_01DXwuMMCpyzjwsMgsBEoRBp