### PR TITLE
Refactor node selection to use dedicated setSelectedNodes API

### DIFF
--- a/web/src/hooks/__tests__/useNodeFocus.test.ts
+++ b/web/src/hooks/__tests__/useNodeFocus.test.ts
@@ -13,7 +13,7 @@ describe("useNodeFocus", () => {
     { id: "node-3", position: { x: 300, y: 300 }, selected: false },
   ] as any;
 
-  const mockSetNodes = jest.fn();
+  const mockSetSelectedNodes = jest.fn();
 
   const mockFocusStore = {
     focusedNodeId: null as string | null,
@@ -34,9 +34,12 @@ describe("useNodeFocus", () => {
     mockFocusStore.focusHistory = [];
     (useNodes as jest.Mock).mockImplementation((selector) => {
       if (typeof selector === "function") {
-        return selector({ nodes: mockNodes, setNodes: mockSetNodes });
+        return selector({
+          nodes: mockNodes,
+          setSelectedNodes: mockSetSelectedNodes,
+        });
       }
-      return { nodes: mockNodes, setNodes: mockSetNodes };
+      return { nodes: mockNodes, setSelectedNodes: mockSetSelectedNodes };
     });
     (useNodeFocusStore as any).mockImplementation((selector: any) => {
       if (typeof selector === "function") {
@@ -147,12 +150,7 @@ describe("useNodeFocus", () => {
       result.current.selectFocused();
     });
 
-    expect(mockSetNodes).toHaveBeenCalledWith(
-      mockNodes.map((node: any) => ({
-        ...node,
-        selected: node.id === "node-2",
-      }))
-    );
+    expect(mockSetSelectedNodes).toHaveBeenCalledWith([mockNodes[1]]);
   });
 
   it("does not update nodes when no focused node", () => {
@@ -163,7 +161,7 @@ describe("useNodeFocus", () => {
       result.current.selectFocused();
     });
 
-    expect(mockSetNodes).not.toHaveBeenCalled();
+    expect(mockSetSelectedNodes).not.toHaveBeenCalled();
   });
 
   it("goes back in focus history", () => {

--- a/web/src/hooks/useNodeFocus.ts
+++ b/web/src/hooks/useNodeFocus.ts
@@ -39,7 +39,7 @@ interface UseNodeFocusReturn {
  */
 export const useNodeFocus = (): UseNodeFocusReturn => {
   const nodes = useNodes((state) => state.nodes);
-  const setNodes = useNodes((state) => state.setNodes);
+  const setSelectedNodes = useNodes((state) => state.setSelectedNodes);
 
   const focusedNodeId = useNodeFocusStore((state) => state.focusedNodeId);
   const isNavigationMode = useNodeFocusStore((state) => state.isNavigationMode);
@@ -85,14 +85,12 @@ export const useNodeFocus = (): UseNodeFocusReturn => {
 
   const selectFocused = useCallback(() => {
     if (focusedNodeId) {
-      setNodes(
-        nodes.map((node: Node<NodeData>) => ({
-          ...node,
-          selected: node.id === focusedNodeId
-        }))
+      const focusedNode = nodes.find(
+        (node: Node<NodeData>) => node.id === focusedNodeId
       );
+      setSelectedNodes(focusedNode ? [focusedNode] : []);
     }
-  }, [focusedNodeId, nodes, setNodes]);
+  }, [focusedNodeId, nodes, setSelectedNodes]);
 
   const goBack = useCallback(() => {
     if (focusHistory.length > 1) {

--- a/web/src/hooks/useWorkflowGraphUpdater.ts
+++ b/web/src/hooks/useWorkflowGraphUpdater.ts
@@ -69,13 +69,15 @@ export const useWorkflowGraphUpdater = () => {
         nodeStore.getState().setNodes(reactFlowNodes);
         nodeStore.getState().setEdges(reactFlowEdges);
 
-        layoutTimeout = setTimeout(() => {
-          nodeStore.getState().autoLayout();
+        // autoLayout runs async via setNodes which marks dirty; reset the flag
+        // *after* the layout pass so the cleared state isn't immediately undone.
+        layoutTimeout = setTimeout(async () => {
+          await nodeStore.getState().autoLayout();
+          nodeStore.getState().setWorkflowDirty(false);
         }, 100);
 
-        // Mark the workflow as clean since this is an update from the server
         nodeStore.getState().setWorkflowDirty(false);
-        
+
       } catch (error) {
         console.error("Error updating workflow graph:", error);
       }

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -482,13 +482,16 @@ export const createNodeStore = (
           setEdgeUpdateSuccessful: (value: boolean): void =>
             set({ edgeUpdateSuccessful: value }),
           onNodesChange: (changes: NodeChange<Node<NodeData>>[]): void => {
-            // Check if any dimension change is a user resize (has setAttributes set)
-            // This indicates the user intentionally resized the node via NodeResizeControl
+            // `resizing: true` is React Flow's signal for an active user resize
+            // via NodeResizer/NodeResizeControl. The `setAttributes` field is
+            // unreliable here because it also fires on initial measurement when
+            // a node has no explicit height, which would dirty every workflow
+            // on app start.
             const hasUserResize = changes.some(
               (change) =>
                 change.type === "dimensions" &&
-                "setAttributes" in change &&
-                change.setAttributes
+                "resizing" in change &&
+                change.resizing === true
             );
 
             // Treat as internal anything that React Flow emits without an explicit

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -491,14 +491,18 @@ export const createNodeStore = (
                 change.setAttributes
             );
 
-            // Check if changes are only internal React Flow updates (dimensions, positions from ResizeObserver, selection)
+            // Treat as internal anything that React Flow emits without an explicit
+            // user drag (`dragging: true`). Position changes with `dragging: false`
+            // are drag-end frames; with `dragging: undefined` they come from
+            // programmatic adjustments like extent constraints or initial measurement
+            // and must not mark the workflow dirty.
             const isOnlyInternalChanges =
               !hasUserResize &&
               changes.every(
                 (change) =>
                   change.type === "dimensions" ||
                   change.type === "select" ||
-                  (change.type === "position" && change.dragging === false)
+                  (change.type === "position" && change.dragging !== true)
               );
 
             // Filter out selection changes for group nodes that have selectable: false


### PR DESCRIPTION
## Summary
This PR refactors the node selection logic to use a dedicated `setSelectedNodes` API instead of mapping over all nodes and updating their `selected` property. This improves performance and provides a cleaner separation of concerns for node selection management.

## Key Changes

- **Updated `useNodeFocus` hook**: Changed from using `setNodes` to `setSelectedNodes` when selecting the focused node. The `selectFocused` function now finds the focused node and passes only that node to `setSelectedNodes` instead of mapping over all nodes.

- **Updated test mocks and assertions**: Renamed `mockSetNodes` to `mockSetSelectedNodes` throughout the test file and updated expectations to verify the new API is called with just the selected node array `[mockNodes[1]]` instead of the full mapped nodes array.

- **Improved `useWorkflowGraphUpdater` timing**: Made the `autoLayout` call properly async and moved the `setWorkflowDirty(false)` call into the timeout callback to ensure the dirty flag is cleared after the layout pass completes, preventing the cleared state from being immediately undone.

- **Refined dirty state detection in NodeStore**: Updated the logic for detecting internal-only changes to properly distinguish between user-initiated drags (`dragging: true`) and programmatic position updates (`dragging !== true`). Added clarifying comments explaining that position changes without explicit user drag should not mark the workflow as dirty.

## Implementation Details

The refactoring simplifies the `selectFocused` implementation from:
```typescript
setNodes(nodes.map((node) => ({ ...node, selected: node.id === focusedNodeId })))
```

To:
```typescript
const focusedNode = nodes.find((node) => node.id === focusedNodeId);
setSelectedNodes(focusedNode ? [focusedNode] : []);
```

This change reduces unnecessary node updates and makes the intent clearer by using a dedicated selection API.

https://claude.ai/code/session_01HK8ZsE6sKgW1rwQuoySKtc