### PR TITLE
feat(web): add Cmd/Ctrl+, shortcut to open settings

### DIFF
--- a/web/src/config/shortcuts.ts
+++ b/web/src/config/shortcuts.ts
@@ -618,6 +618,16 @@ export const NODE_EDITOR_SHORTCUTS: Shortcut[] = [
     registerCombo: true
   },
 
+  // ---------- SETTINGS ------------------------------------------------------
+  {
+    title: "Open Settings",
+    slug: "openSettings",
+    keyCombo: ["Control", ","],
+    category: "editor",
+    description: "Open application settings",
+    registerCombo: true
+  },
+
   // ---------- FIND IN WORKFLOW ---------------------------------------------
   {
     title: "Find in Workflow",

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -21,6 +21,7 @@ import { useMenuHandler } from "./useIpcRenderer";
 import { useReactFlow } from "@xyflow/react";
 import { useNotificationStore } from "../stores/NotificationStore";
 import { useRightPanelStore } from "../stores/RightPanelStore";
+import { useSettingsStore } from "../stores/SettingsStore";
 import { NodeData } from "../stores/NodeData";
 import { Node } from "@xyflow/react";
 import { isMac } from "../utils/platform";
@@ -489,6 +490,9 @@ export const useNodeEditorShortcuts = (
       toggleInspector: { callback: handleInspectorToggle },
       toggleWorkflowSettings: { callback: handleWorkflowSettingsToggle },
       showKeyboardShortcuts: { callback: handleShowKeyboardShortcuts },
+      openSettings: {
+        callback: () => useSettingsStore.getState().setMenuOpen(true)
+      },
       saveWorkflow: { callback: handleSave },
       saveExample: { callback: handleSaveExample },
       newWorkflow: { callback: handleNewWorkflow },


### PR DESCRIPTION
Standard OS convention for opening application settings; the other
common shortcuts (Save, Find, Undo/Redo, Copy/Paste, Select All,
New/Close tab, Help) were already wired up.