### PR TITLE
Gate workspace features behind Electron/non-production flag

### DIFF
--- a/web/src/components/panels/AgentPanel.tsx
+++ b/web/src/components/panels/AgentPanel.tsx
@@ -41,11 +41,14 @@ import {
 } from "../ui_primitives";
 
 import { useQuery } from "@tanstack/react-query";
-import { isLocalhost } from "../../lib/env";
+import { isLocalhost, isProduction } from "../../lib/env";
+import { getIsElectronDetails } from "../../utils/browser";
 import { trpcClient } from "../../trpc/client";
 import { useSettingsStore } from "../../stores/SettingsStore";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { getAgentSocketClient } from "../../lib/agent/AgentSocketClient";
+
+const workspacesEnabled = getIsElectronDetails().isElectron || !isProduction;
 
 const containerStyles = (_theme: Theme) =>
   css({
@@ -283,7 +286,8 @@ const AgentPanel: React.FC = () => {
   );
   const { data: workspaces } = useQuery({
     queryKey: ["workspaces"],
-    queryFn: fetchWorkspaces
+    queryFn: fetchWorkspaces,
+    enabled: workspacesEnabled
   });
 
   const { data: mcpStatus } = useQuery({

--- a/web/src/components/panels/AppHeader.tsx
+++ b/web/src/components/panels/AppHeader.tsx
@@ -13,6 +13,10 @@ import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { FlexRow, Tooltip } from "../ui_primitives";
 import WorkspaceSelect from "../workspaces/WorkspaceSelect";
 import { useCurrentWorkspace } from "../../hooks/useCurrentWorkspace";
+import { isProduction } from "../../lib/env";
+import { getIsElectronDetails } from "../../utils/browser";
+
+const workspacesEnabled = getIsElectronDetails().isElectron || !isProduction;
 
 const styles = (theme: Theme) =>
   css({
@@ -327,7 +331,7 @@ const AppHeader: React.FC = memo(function AppHeader() {
           <Box sx={{ flexGrow: 1 }} />
         </FlexRow>
         <div className="buttons-right">
-          <HeaderWorkspaceSelector />
+          {workspacesEnabled && <HeaderWorkspaceSelector />}
           <TemplatesButton isActive={path.startsWith("/templates")} />
           <RightSideButtons />
         </div>

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -31,6 +31,10 @@ import ContextMenus from "../context_menus/ContextMenus";
 import WorkflowForm from "../workflows/WorkflowForm";
 import AgentPanel from "./AgentPanel";
 import { MobileBottomSheet, ToolbarIconButton } from "../ui_primitives";
+import { isProduction } from "../../lib/env";
+import { getIsElectronDetails } from "../../utils/browser";
+
+const workspacesEnabled = getIsElectronDetails().isElectron || !isProduction;
 
 // Icons for mobile tab rail
 import CenterFocusWeakIcon from "@mui/icons-material/CenterFocusWeak";
@@ -293,7 +297,8 @@ const MobilePanelRight: React.FC<MobilePanelRightProps> = ({
               <SvgFileIcon iconName="assistant" svgProp={{ width: 18, height: 18 }} />
             )}
             {renderTabButton("agent", "Agent", <SmartToyIcon />)}
-            {renderTabButton("workspace", "Workspace", <FolderIcon />)}
+            {workspacesEnabled &&
+              renderTabButton("workspace", "Workspace", <FolderIcon />)}
             {renderTabButton("workflow", "Settings", <SettingsIcon />)}
             {renderTabButton("workflowAssets", "Assets", <FolderSpecialIcon />)}
             {renderTabButton("versions", "Versions", <HistoryIcon />)}
@@ -335,6 +340,14 @@ const PanelRight: React.FC = () => {
   const activeView = useRightPanelStore((state) => state.panel.activeView);
   const setActiveView = useRightPanelStore((state) => state.setActiveView);
   const setVisibility = useRightPanelStore((state) => state.setVisibility);
+
+  // If a previous session persisted "workspace" but workspaces are disabled
+  // (production web), fall back to a safe default view.
+  useEffect(() => {
+    if (!workspacesEnabled && activeView === "workspace") {
+      setActiveView("inspector");
+    }
+  }, [activeView, setActiveView]);
 
   const activeNodeStore = useWorkflowManager((state) =>
     state.currentWorkflowId
@@ -579,7 +592,7 @@ const PanelRight: React.FC = () => {
             <PanelHeadline title="Jobs" />
             <JobsPanel />
           </Box>
-        ) : activeView === "workspace" ? (
+        ) : activeView === "workspace" && workspacesEnabled ? (
           <Box
             className="workspace-panel"
             sx={{

--- a/web/src/components/panels/VerticalToolbar.tsx
+++ b/web/src/components/panels/VerticalToolbar.tsx
@@ -2,6 +2,10 @@ import { memo } from "react";
 import { SxProps } from "@mui/material";
 import { Divider, ToolbarIconButton } from "../ui_primitives";
 import { getShortcutTooltip } from "../../config/shortcuts";
+import { isProduction } from "../../lib/env";
+import { getIsElectronDetails } from "../../utils/browser";
+
+const workspacesEnabled = getIsElectronDetails().isElectron || !isProduction;
 
 const spacerStyle = { flexGrow: 1 } as const;
 const dividerSx: SxProps = { my: 1, mx: "6px", borderColor: "rgba(255, 255, 255, 0.15)" };
@@ -79,15 +83,17 @@ function VerticalToolbar({
                 active={isActive("agent")}
             />
 
-            <ToolbarIconButton
-                icon={<FolderIcon />}
-                tooltip="Workspace"
-                tooltipPlacement="left-start"
-                onClick={handleWorkspaceToggle}
-                ariaLabel="Toggle Workspace panel"
-                className="workspace"
-                active={isActive("workspace")}
-            />
+            {workspacesEnabled && (
+                <ToolbarIconButton
+                    icon={<FolderIcon />}
+                    tooltip="Workspace"
+                    tooltipPlacement="left-start"
+                    onClick={handleWorkspaceToggle}
+                    ariaLabel="Toggle Workspace panel"
+                    className="workspace"
+                    active={isActive("workspace")}
+                />
+            )}
 
             <ToolbarIconButton
                 icon={<HistoryIcon />}

--- a/web/src/components/workflows/WorkflowForm.tsx
+++ b/web/src/components/workflows/WorkflowForm.tsx
@@ -9,6 +9,10 @@ import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import WorkspaceSelect from "../workspaces/WorkspaceSelect";
 import PanelHeadline from "../ui/PanelHeadline";
+import { isProduction } from "../../lib/env";
+import { getIsElectronDetails } from "../../utils/browser";
+
+const workspacesEnabled = getIsElectronDetails().isElectron || !isProduction;
 
 const DEFAULT_TAG_SUGGESTIONS = [
   "image",
@@ -321,14 +325,18 @@ const WorkflowForm = ({ workflow, onClose, availableTags = [] }: WorkflowFormPro
       <div className="settings-section">
         <Text className="section-title">Advanced</Text>
         <Caption sx={{ display: "block", mb: 2 }}>
-          Advanced configuration for workspaces and API/tool usage
+          {workspacesEnabled
+            ? "Advanced configuration for workspaces and API/tool usage"
+            : "Advanced configuration for API/tool usage"}
         </Caption>
 
-        <WorkspaceSelect
-          value={localWorkflow.workspace_id ?? undefined}
-          onChange={handleWorkspaceChange}
-          helperText="Associate a workspace folder with this workflow for agent access"
-        />
+        {workspacesEnabled && (
+          <WorkspaceSelect
+            value={localWorkflow.workspace_id ?? undefined}
+            onChange={handleWorkspaceChange}
+            helperText="Associate a workspace folder with this workflow for agent access"
+          />
+        )}
 
         <TextInput
           label="Tool Name"


### PR DESCRIPTION
## Summary
This PR conditionally disables workspace functionality in production web environments while keeping it enabled for Electron and non-production builds. A new feature flag `workspacesEnabled` is introduced across multiple components to control the visibility and functionality of workspace-related UI elements and API calls.

## Key Changes
- Added `workspacesEnabled` constant computed as `getIsElectronDetails().isElectron || !isProduction` in 5 components
- **VerticalToolbar**: Conditionally render workspace toolbar button
- **WorkflowForm**: Conditionally render workspace select input and update advanced settings description
- **PanelRight**: 
  - Conditionally render workspace tab in mobile view
  - Add fallback logic to redirect from "workspace" view to "inspector" when workspaces are disabled
  - Guard workspace panel rendering with feature flag
- **AgentPanel**: Disable workspace query when `workspacesEnabled` is false
- **AppHeader**: Conditionally render header workspace selector

## Implementation Details
- The feature flag is consistently defined as `getIsElectronDetails().isElectron || !isProduction` across all modified files
- A `useEffect` hook in `PanelRight` ensures users are redirected from a persisted "workspace" view to "inspector" if workspaces become disabled (e.g., when loading a production web build after using Electron)
- The workspace query in `AgentPanel` uses the `enabled` option to prevent unnecessary API calls when workspaces are disabled
- All workspace UI elements are wrapped in conditional rendering rather than being completely removed, maintaining cleaner code structure

https://claude.ai/code/session_01P1XKwzwFChbK5upVy4tZG3