### PR TITLE
Add OpenTelemetry tracing for agents, workflows, and LLM calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,18 +258,74 @@ Most server-calling commands accept `--api-url <url>` (default: `http://localhos
 
 ### Observing Agent Execution
 
+NodeTool emits a hierarchy of OpenTelemetry spans that an analyzer agent can
+ingest to study and optimize prompts/agents/workflows:
+
+```
+workflow.run                       (kernel WorkflowRunner)
+  node.process                     (kernel NodeActor — one per node)
+    agent.execute                  (Agent.execute)
+      agent.plan                   (TaskPlanner / GraphPlanner)
+        llm.chat / llm.stream      (BaseProvider)
+      agent.step                   (StepExecutor)
+        llm.chat / llm.stream
+```
+
+Every `llm.chat` / `llm.stream` span carries `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`, and
+`gen_ai.usage.cost_credits`. Token counts also appear in the `llm_call`
+message events emitted by `BaseProvider`.
+
+#### Sinks
+
+Multiple sinks can run simultaneously (each gets its own span processor):
+
 ```bash
-# Debug logging (all LLM calls, planning details)
-NODETOOL_LOG_LEVEL=debug npm run dev:chat -- --agent
+# JSONL log file (analyzer-friendly — one span per line)
+NODETOOL_TRACE_FILE=/tmp/nodetool-trace.jsonl npm run dev:chat -- --agent
+npm run dev:chat -- --agent --trace-file /tmp/nodetool-trace.jsonl
 
-# OpenTelemetry tracing to console
-OTEL_TRACES_EXPORTER=console TRACELOOP_DISABLE_BATCH=true npm run dev:chat -- --agent
+# Stdout — pretty (human) or json (JSONL)
+NODETOOL_TRACE_STDOUT=pretty npm run dev:chat -- --agent
+npm run dev:chat -- --agent --trace-stdout pretty
+npm run dev:chat -- --agent --trace-stdout json
 
-# Traceloop cloud
+# OpenTelemetry — Traceloop cloud
 TRACELOOP_API_KEY=your-key npm run dev:chat -- --agent
 
-# Custom OTLP backend (Jaeger, Grafana)
+# OpenTelemetry — custom OTLP backend (Jaeger, Grafana, etc.)
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 npm run dev:chat -- --agent
+
+# Debug logging (all LLM calls, planning details)
+NODETOOL_LOG_LEVEL=debug npm run dev:chat -- --agent
+```
+
+The `--trace-file` and `--trace-stdout` flags also work on the `nodetool` CLI:
+
+```bash
+npm run dev:nodetool -- --trace-file trace.jsonl run workflow.ts
+npm run dev:nodetool -- --trace-stdout pretty workflows run <id>
+```
+
+#### JSONL trace schema
+
+Each line in the file is one span:
+
+```json
+{
+  "trace_id": "...", "span_id": "...", "parent_span_id": "...",
+  "name": "agent.plan", "kind": "INTERNAL",
+  "start_time_ms": 1700000000000, "end_time_ms": 1700000001234,
+  "duration_ms": 1234,
+  "status": { "code": "OK" },
+  "attributes": {
+    "agent.objective": "...", "agent.kind": "plan",
+    "agent.provider": "anthropic", "agent.model": "claude-sonnet-4-6",
+    "gen_ai.usage.input_tokens": 150, "gen_ai.usage.output_tokens": 80
+  },
+  "events": [],
+  "resource": { "service.name": "nodetool" }
+}
 ```
 
 See [packages/agents/CLAUDE.md](packages/agents/CLAUDE.md) for agent architecture, parallel execution, skills, and tuning.

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -209,25 +209,63 @@ export NODETOOL_LOG_FILE=/tmp/agents.log
 
 ### OpenTelemetry Tracing
 
-Every `generateMessagesTraced()` call creates an OpenTelemetry span with attributes: `llm.provider`, `llm.model`, `llm.request.message_count`, `llm.request.tools_count`, `llm.response.content`, `llm.response.tool_calls_count`.
+Span hierarchy (an analyzer agent can read this tree to optimize prompts):
+
+```
+workflow.run
+  node.process
+    agent.execute
+      agent.plan        (TaskPlanner.planMultiTask / GraphPlanner.plan)
+        llm.chat        (BaseProvider.generateMessageTraced)
+        llm.stream      (BaseProvider.generateMessagesTraced)
+      agent.step        (StepExecutor.execute)
+        llm.chat
+        llm.stream
+```
+
+Span attributes:
+
+- `agent.*`: `agent.kind` (execute/plan/step), `agent.objective`, `agent.provider`, `agent.model`, `agent.tools_count`, `agent.task` (for steps), `agent.plan.kind` (multi/single/graph)
+- `llm.*`: `llm.provider`, `llm.model`, `llm.request.message_count`, `llm.request.tools_count`, `llm.request.max_tokens`, `llm.request.stream`, `llm.response.content` (first 2000 chars), `llm.response.tool_calls_count`
+- `gen_ai.*` (OTel GenAI semconv): `gen_ai.system`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`, `gen_ai.usage.cost_credits`
+- `workflow.*` / `node.*`: `workflow.id`, `workflow.name`, `workflow.node_count`, `node.id`, `node.type`
+
+Sinks (simultaneous, each on its own SpanProcessor):
 
 ```bash
-# Console output (development)
+# JSONL trace file — one span per line, analyzer-friendly
+export NODETOOL_TRACE_FILE=/tmp/nodetool-trace.jsonl
+
+# Stdout — pretty (human) or json (JSONL)
+export NODETOOL_TRACE_STDOUT=pretty       # or "json"
+
+# OpenTelemetry — console (legacy)
 export OTEL_TRACES_EXPORTER=console
 export TRACELOOP_DISABLE_BATCH=true
 
-# Traceloop cloud
+# OpenTelemetry — Traceloop cloud
 export TRACELOOP_API_KEY=your-key
 
-# Custom OTLP backend (Jaeger, Grafana, etc.)
+# OpenTelemetry — custom OTLP backend (Jaeger, Grafana, etc.)
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+CLI flags pass these through:
+
+```bash
+nodetool-chat --agent --trace-file trace.jsonl
+nodetool-chat --agent --trace-stdout pretty
+nodetool --trace-file trace.jsonl run workflow.ts
 ```
 
 Telemetry must be initialized before use:
 
 ```typescript
 import { initTelemetry } from "@nodetool/runtime";
-await initTelemetry();
+await initTelemetry({
+  traceFile: "trace.jsonl",   // optional
+  stdout: "pretty",            // optional: "pretty" | "json" | false
+});
 ```
 
 The CLI calls `initTelemetry()` at startup automatically. The WebSocket server requires env vars to be set before starting.

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { createLogger } from "@nodetool/config";
 import type { BaseProvider } from "@nodetool/runtime";
+import { withAgentSpanGen } from "@nodetool/runtime";
 
 const log = createLogger("nodetool.agents.agent");
 import type { Message, ProcessingContext } from "@nodetool/runtime";
@@ -408,6 +409,22 @@ export class Agent extends BaseAgent {
   }
 
   async *execute(
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage> {
+    yield* withAgentSpanGen(
+      "execute",
+      {
+        objective: this.objective,
+        provider: this.provider.provider,
+        model: this.model,
+        toolsCount: this.tools.length,
+        extra: { "agent.name": this.name }
+      },
+      () => this._executeImpl(context)
+    );
+  }
+
+  private async *_executeImpl(
     context: ProcessingContext
   ): AsyncGenerator<ProcessingMessage> {
     log.info("Agent started", {

--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -11,6 +11,7 @@ import type {
   ProcessingContext,
   Message
 } from "@nodetool/runtime";
+import { withAgentSpanGen } from "@nodetool/runtime";
 import type { NodeRegistry } from "@nodetool/node-sdk";
 import { createLogger } from "@nodetool/config";
 import type {
@@ -105,6 +106,22 @@ export class GraphPlanner {
    * Returns null on repeated failure.
    */
   async *plan(
+    objective: string,
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage, GraphData | null> {
+    return yield* withAgentSpanGen(
+      "plan",
+      {
+        objective,
+        provider: this.provider.provider,
+        model: this.model,
+        extra: { "agent.plan.kind": "graph" }
+      },
+      () => this._planImpl(objective, context)
+    );
+  }
+
+  private async *_planImpl(
     objective: string,
     _context: ProcessingContext
   ): AsyncGenerator<ProcessingMessage, GraphData | null> {

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -18,6 +18,7 @@ import type {
   ToolCall,
   ProviderStreamItem
 } from "@nodetool/runtime";
+import { withAgentSpanGen } from "@nodetool/runtime";
 import { createLogger } from "@nodetool/config";
 import {
   TaskUpdateEvent,
@@ -844,6 +845,23 @@ export class StepExecutor {
    * Execute the step, yielding ProcessingMessages as progress updates.
    */
   async *execute(): AsyncGenerator<ProcessingMessage> {
+    yield* withAgentSpanGen(
+      "step",
+      {
+        provider: this.provider.provider,
+        model: this.model,
+        task: this.step.instructions,
+        toolsCount: this.tools.length,
+        extra: {
+          "agent.step.id": this.step.id,
+          "agent.task.id": this.task.id
+        }
+      },
+      () => this._executeImpl()
+    );
+  }
+
+  private async *_executeImpl(): AsyncGenerator<ProcessingMessage> {
     log.debug("Step started", {
       stepId: this.step.id,
       instructions: this.step.instructions.slice(0, 60)

--- a/packages/agents/src/task-planner.ts
+++ b/packages/agents/src/task-planner.ts
@@ -14,6 +14,7 @@ import type {
   Message,
   ToolCall
 } from "@nodetool/runtime";
+import { withAgentSpanGen } from "@nodetool/runtime";
 import { createLogger } from "@nodetool/config";
 import {
   TaskUpdateEvent,
@@ -174,6 +175,23 @@ export class TaskPlanner {
 
   async *plan(
     objective: string,
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage, Task | null> {
+    return yield* withAgentSpanGen(
+      "plan",
+      {
+        objective,
+        provider: this.provider.provider,
+        model: this.model,
+        toolsCount: this.tools.length,
+        extra: { "agent.plan.kind": "single" }
+      },
+      () => this._planImpl(objective, context)
+    );
+  }
+
+  private async *_planImpl(
+    objective: string,
     _context: ProcessingContext
   ): AsyncGenerator<ProcessingMessage, Task | null> {
     rejectAgenticProvider(this.provider, "TaskPlanner.plan");
@@ -278,6 +296,23 @@ export class TaskPlanner {
   // ---------------------------------------------------------------------------
 
   async *planMultiTask(
+    objective: string,
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage, TaskPlan | null> {
+    return yield* withAgentSpanGen(
+      "plan",
+      {
+        objective,
+        provider: this.provider.provider,
+        model: this.model,
+        toolsCount: this.tools.length,
+        extra: { "agent.plan.kind": "multi" }
+      },
+      () => this._planMultiTaskImpl(objective, context)
+    );
+  }
+
+  private async *_planMultiTaskImpl(
     objective: string,
     _context: ProcessingContext
   ): AsyncGenerator<ProcessingMessage, TaskPlan | null> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -88,6 +88,10 @@ program
     "--trace-stdout [format]",
     "Stream spans to stdout: 'pretty' (default, human-readable) or 'json' (JSONL)"
   )
+  .option(
+    "--no-trace-stdout",
+    "Disable stdout span output (overrides NODETOOL_TRACE_STDOUT)"
+  )
   .helpOption("-h, --help", "Show help")
   .version("0.1.0")
   .parse();
@@ -112,14 +116,23 @@ const opts = program.opts<{
 await initTelemetry({
   ...(opts.traceFile && { traceFile: opts.traceFile }),
   ...(opts.traceStdout !== undefined && {
-    stdout:
-      opts.traceStdout === "json"
-        ? "json"
-        : opts.traceStdout === false
-          ? false
-          : "pretty"
+    stdout: parseTraceStdout(opts.traceStdout)
   })
 });
+
+function parseTraceStdout(v: string | boolean): "pretty" | "json" | false {
+  if (v === false) return false;
+  if (v === true) return "pretty";
+  if (typeof v === "string") {
+    const lower = v.toLowerCase();
+    if (lower === "false" || lower === "0" || lower === "no") return false;
+    if (lower === "json") return "json";
+    if (lower === "pretty" || lower === "true" || lower === "1") return "pretty";
+  }
+  throw new Error(
+    `--trace-stdout must be 'pretty' or 'json' (got ${JSON.stringify(v)})`
+  );
+}
 
 // Initialize database
 try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,10 +47,6 @@ if (!process.env["NODETOOL_LOG_FILE"]) {
 }
 configureLogging();
 
-// Initialize OpenLLMetry before any LLM SDK calls are made.
-// No-op if TRACELOOP_API_KEY / OTEL_EXPORTER_OTLP_ENDPOINT is not set.
-await initTelemetry();
-
 program
   .name("nodetool-chat")
   .description(
@@ -84,6 +80,14 @@ program
     "--sandbox-image <image>",
     "Override the sandbox Docker image (default: nodetool/sandbox-agent:latest)"
   )
+  .option(
+    "--trace-file <path>",
+    "Append every LLM/agent/workflow span as JSONL to <path> (analyzer-friendly)"
+  )
+  .option(
+    "--trace-stdout [format]",
+    "Stream spans to stdout: 'pretty' (default, human-readable) or 'json' (JSONL)"
+  )
   .helpOption("-h, --help", "Show help")
   .version("0.1.0")
   .parse();
@@ -98,7 +102,24 @@ const opts = program.opts<{
   url?: string;
   sandbox?: boolean;
   sandboxImage?: string;
+  traceFile?: string;
+  traceStdout?: string | boolean;
 }>();
+
+// Initialize OpenLLMetry before any LLM SDK calls are made. Honors CLI flags
+// and env vars (TRACELOOP_API_KEY, OTEL_EXPORTER_OTLP_ENDPOINT,
+// NODETOOL_TRACE_FILE, NODETOOL_TRACE_STDOUT). No-op if nothing is configured.
+await initTelemetry({
+  ...(opts.traceFile && { traceFile: opts.traceFile }),
+  ...(opts.traceStdout !== undefined && {
+    stdout:
+      opts.traceStdout === "json"
+        ? "json"
+        : opts.traceStdout === false
+          ? false
+          : "pretty"
+  })
+});
 
 // Initialize database
 try {

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -32,7 +32,7 @@ import { registerElevenLabsNodes } from "@nodetool/elevenlabs-nodes";
 import { registerTransformersJsNodes } from "@nodetool/transformers-js-nodes";
 import { registerFalNodes } from "@nodetool/fal-nodes";
 import { registerReplicateNodes } from "@nodetool/replicate-nodes";
-import { ProcessingContext } from "@nodetool/runtime";
+import { ProcessingContext, initTelemetry } from "@nodetool/runtime";
 import { registerPackageCommands } from "./commands/package.js";
 import {
   registerDeployCommands,
@@ -110,7 +110,35 @@ function asJson(data: unknown): void {
 // info
 // ---------------------------------------------------------------------------
 
-program.name("nodetool").description("NodeTool CLI").version("0.1.0");
+program
+  .name("nodetool")
+  .description("NodeTool CLI")
+  .version("0.1.0")
+  .option(
+    "--trace-file <path>",
+    "Append every LLM/agent/workflow span as JSONL to <path>"
+  )
+  .option(
+    "--trace-stdout [format]",
+    "Stream spans to stdout: 'pretty' (default) or 'json' (JSONL)"
+  )
+  .hook("preAction", async (thisCommand) => {
+    const opts = thisCommand.opts<{
+      traceFile?: string;
+      traceStdout?: string | boolean;
+    }>();
+    await initTelemetry({
+      ...(opts.traceFile && { traceFile: opts.traceFile }),
+      ...(opts.traceStdout !== undefined && {
+        stdout:
+          opts.traceStdout === "json"
+            ? "json"
+            : opts.traceStdout === false
+              ? false
+              : "pretty"
+      })
+    });
+  });
 
 // ---------------------------------------------------------------------------
 // run — execute a TypeScript/JavaScript DSL workflow file

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -122,6 +122,10 @@ program
     "--trace-stdout [format]",
     "Stream spans to stdout: 'pretty' (default) or 'json' (JSONL)"
   )
+  .option(
+    "--no-trace-stdout",
+    "Disable stdout span output (overrides NODETOOL_TRACE_STDOUT)"
+  )
   .hook("preAction", async (thisCommand) => {
     const opts = thisCommand.opts<{
       traceFile?: string;
@@ -130,15 +134,24 @@ program
     await initTelemetry({
       ...(opts.traceFile && { traceFile: opts.traceFile }),
       ...(opts.traceStdout !== undefined && {
-        stdout:
-          opts.traceStdout === "json"
-            ? "json"
-            : opts.traceStdout === false
-              ? false
-              : "pretty"
+        stdout: parseTraceStdout(opts.traceStdout)
       })
     });
   });
+
+function parseTraceStdout(v: string | boolean): "pretty" | "json" | false {
+  if (v === false) return false;
+  if (v === true) return "pretty";
+  if (typeof v === "string") {
+    const lower = v.toLowerCase();
+    if (lower === "false" || lower === "0" || lower === "no") return false;
+    if (lower === "json") return "json";
+    if (lower === "pretty" || lower === "true" || lower === "1") return "pretty";
+  }
+  throw new Error(
+    `--trace-stdout must be 'pretty' or 'json' (got ${JSON.stringify(v)})`
+  );
+}
 
 // ---------------------------------------------------------------------------
 // run — execute a TypeScript/JavaScript DSL workflow file

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -19,6 +19,7 @@ import type { NodeDescriptor, ControlEvent } from "@nodetool/protocol";
 
 const log = createLogger("nodetool.kernel.actor");
 import type { ProcessingContext, NodeExecutor } from "@nodetool/runtime";
+import { withNodeSpan } from "@nodetool/runtime";
 import { NodeInbox } from "./inbox.js";
 import { NodeInputs, NodeOutputs } from "./io.js";
 
@@ -102,6 +103,13 @@ export class NodeActor {
    * Returns the last outputs produced.
    */
   async run(): Promise<ActorResult> {
+    return withNodeSpan(
+      { nodeId: this.node.id, nodeType: this.node.type },
+      () => this._runImpl()
+    );
+  }
+
+  private async _runImpl(): Promise<ActorResult> {
     let errorMessage: string | undefined;
     try {
       log.debug("Actor started", {

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -25,6 +25,7 @@ import { TypeMetadata } from "@nodetool/protocol";
 
 const log = createLogger("nodetool.kernel.runner");
 import type { ProcessingContext } from "@nodetool/runtime";
+import { withWorkflowSpan } from "@nodetool/runtime";
 import { isControlEdge, isDataEdge } from "@nodetool/protocol";
 import { Graph, GraphValidationError } from "./graph.js";
 import { rewriteBypassedNodes } from "./graph-utils.js";
@@ -238,6 +239,20 @@ export class WorkflowRunner {
    * Execute a workflow graph.
    */
   async run(
+    request: RunJobRequest,
+    graphData: { nodes: NodeDescriptor[]; edges: Edge[] }
+  ): Promise<RunResult> {
+    return withWorkflowSpan(
+      {
+        workflowId: request.workflow_id ?? undefined,
+        nodeCount: graphData.nodes.length,
+        extra: { "workflow.job_id": request.job_id }
+      },
+      () => this._runImpl(request, graphData)
+    );
+  }
+
+  private async _runImpl(
     request: RunJobRequest,
     graphData: { nodes: NodeDescriptor[]; edges: Edge[] }
   ): Promise<RunResult> {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -21,6 +21,26 @@ export {
   getTracer,
   type TelemetryOptions
 } from "./telemetry.js";
+export {
+  spanToRecord,
+  JsonlFileSpanExporter,
+  StdoutSpanExporter,
+  type TraceRecord,
+  type StdoutFormat
+} from "./trace-exporters.js";
+export {
+  withAgentSpan,
+  withAgentSpanGen,
+  withWorkflowSpan,
+  withNodeSpan,
+  withSpanGen,
+  setLastUsage,
+  consumeLastUsage,
+  peekLastUsage,
+  createUsageSlot,
+  type AgentSpanKind,
+  type LlmUsage
+} from "./tracing-helpers.js";
 export { packContext, type PackedContext } from "./context-packer.js";
 export {
   PythonStdioBridge,

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -23,6 +23,15 @@ import type {
 import { CostCalculator } from "./cost-calculator.js";
 import type { UsageInfo } from "./cost-calculator.js";
 import { getTracer } from "../telemetry.js";
+import {
+  withUsageCapture,
+  setLastUsage,
+  consumeLastUsage,
+  peekLastUsage,
+  createUsageSlot,
+  type LlmUsage
+} from "../tracing-helpers.js";
+import type { Span } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { createLogger, getAssetFilePath } from "@nodetool/config";
 
@@ -136,6 +145,12 @@ export abstract class BaseProvider {
   trackUsage(model: string, usage: UsageInfo): number {
     const cost = CostCalculator.calculate(model, usage, this.provider);
     this._cost += cost;
+    setLastUsage({
+      inputTokens: usage.inputTokens ?? 0,
+      outputTokens: usage.outputTokens ?? 0,
+      cachedInputTokens: usage.cachedTokens,
+      cost
+    });
     log.debug("Cost tracked", { model, cost, total: this._cost });
     return cost;
   }
@@ -263,14 +278,7 @@ export abstract class BaseProvider {
       return tracer.startActiveSpan(
         `llm.chat ${this.provider}/${args.model}`,
         async (span) => {
-          span.setAttributes({
-            "llm.provider": this.provider,
-            "llm.model": args.model,
-            "llm.request.message_count": args.messages.length,
-            "llm.request.tools_count": args.tools?.length ?? 0,
-            "llm.request.max_tokens": args.maxTokens ?? 0,
-            "llm.request.stream": false
-          });
+          this.applyLlmRequestAttributes(span, args, false);
           try {
             const result = await this.generateMessage(args);
             const content =
@@ -292,6 +300,7 @@ export abstract class BaseProvider {
             span.recordException(err as Error);
             throw err;
           } finally {
+            applyUsageAttributes(span, peekLastUsage());
             span.end();
           }
         }
@@ -300,8 +309,15 @@ export abstract class BaseProvider {
 
     let result: Message | undefined;
     let error: string | undefined;
+    let usage: LlmUsage | null = null;
     try {
-      result = await doCall();
+      // withUsageCapture creates a per-call AsyncLocalStorage slot so
+      // trackUsage() in the provider hands its numbers back to us.
+      result = await withUsageCapture(async () => {
+        const r = await doCall();
+        usage = consumeLastUsage();
+        return r;
+      });
       return result;
     } catch (err) {
       error = String(err);
@@ -323,14 +339,33 @@ export abstract class BaseProvider {
             name: tc.name,
             args: tc.args
           })) ?? null,
-        tokens_input: null,
-        tokens_output: null,
-        cost: null,
+        tokens_input: usage ? (usage as LlmUsage).inputTokens : null,
+        tokens_output: usage ? (usage as LlmUsage).outputTokens : null,
+        cost: usage ? ((usage as LlmUsage).cost ?? null) : null,
         duration_ms: Date.now() - startTime,
         error: error ?? null,
         timestamp: new Date(startTime).toISOString()
       });
     }
+  }
+
+  private applyLlmRequestAttributes(
+    span: Span,
+    args: { messages: unknown[]; model: string; tools?: unknown[]; maxTokens?: number; temperature?: number },
+    streaming: boolean
+  ): void {
+    span.setAttributes({
+      "llm.provider": this.provider,
+      "llm.model": args.model,
+      "gen_ai.system": this.provider,
+      "gen_ai.request.model": args.model,
+      "gen_ai.operation.name": streaming ? "chat.stream" : "chat",
+      "llm.request.message_count": args.messages.length,
+      "llm.request.tools_count": args.tools?.length ?? 0,
+      "llm.request.max_tokens": args.maxTokens ?? 0,
+      "llm.request.temperature": args.temperature ?? 0,
+      "llm.request.stream": streaming
+    });
   }
 
   /** Traced wrapper around generateMessages. Use this instead of calling generateMessages directly. */
@@ -346,7 +381,6 @@ export abstract class BaseProvider {
         : 0,
       hasOnToolCall: !!(args as Record<string, unknown>).onToolCall
     });
-    const tracer = getTracer();
 
     let fullResponse = "";
     const collectedToolCalls: Array<{
@@ -356,21 +390,30 @@ export abstract class BaseProvider {
     }> = [];
     let error: string | undefined;
 
-    try {
-      const source = tracer
-        ? this._tracedStream(args, tracer)
-        : this.generateMessages(args);
+    // Per-call usage slot survives across the generator's yields by wrapping
+    // each `next()` call in `runInSlot`.
+    const { runInSlot, getUsage } = createUsageSlot();
+    const tracer = getTracer();
+    const source = tracer
+      ? this._tracedStream(args, tracer)
+      : this.generateMessages(args);
 
-      for await (const item of source) {
-        // Accumulate text content from chunks
+    try {
+      while (true) {
+        const result = await runInSlot(() => source.next());
+        if (result.done) break;
+        const item = result.value;
         if ("type" in item && (item as { type: string }).type === "chunk") {
           const chunk = item as { content?: string };
           if (chunk.content) fullResponse += chunk.content;
         }
-        // Collect tool calls
         if ("id" in item && "name" in item && "args" in item) {
           const tc = item as { id: string; name: string; args: unknown };
-          collectedToolCalls.push({ id: tc.id, name: tc.name, args: tc.args });
+          collectedToolCalls.push({
+            id: tc.id,
+            name: tc.name,
+            args: tc.args
+          });
         }
         yield item;
       }
@@ -382,6 +425,7 @@ export abstract class BaseProvider {
       error = String(err);
       throw err;
     } finally {
+      const usage = getUsage();
       this.emitMessage({
         type: "llm_call",
         node_id: "",
@@ -393,9 +437,9 @@ export abstract class BaseProvider {
         })),
         response: fullResponse || null,
         tool_calls: collectedToolCalls.length > 0 ? collectedToolCalls : null,
-        tokens_input: null,
-        tokens_output: null,
-        cost: null,
+        tokens_input: usage?.inputTokens ?? null,
+        tokens_output: usage?.outputTokens ?? null,
+        cost: usage?.cost ?? null,
         duration_ms: Date.now() - startTime,
         error: error ?? null,
         timestamp: new Date(startTime).toISOString()
@@ -409,14 +453,7 @@ export abstract class BaseProvider {
     tracer: ReturnType<typeof getTracer> & object
   ): AsyncGenerator<ProviderStreamItem> {
     const span = tracer.startSpan(`llm.stream ${this.provider}/${args.model}`);
-    span.setAttributes({
-      "llm.provider": this.provider,
-      "llm.model": args.model,
-      "llm.request.message_count": args.messages.length,
-      "llm.request.tools_count": args.tools?.length ?? 0,
-      "llm.request.max_tokens": args.maxTokens ?? 0,
-      "llm.request.stream": true
-    });
+    this.applyLlmRequestAttributes(span, args, true);
     let chunkCount = 0;
     try {
       for await (const item of this.generateMessages(args)) {
@@ -430,6 +467,7 @@ export abstract class BaseProvider {
       span.recordException(err as Error);
       throw err;
     } finally {
+      applyUsageAttributes(span, peekLastUsage());
       span.end();
     }
   }
@@ -654,6 +692,20 @@ export abstract class BaseProvider {
 
     return uri;
   }
+}
+
+/** Attach gen_ai usage attributes to a span (no-op if usage is null). */
+function applyUsageAttributes(span: Span, usage: LlmUsage | null): void {
+  if (!usage) return;
+  span.setAttributes({
+    "gen_ai.usage.input_tokens": usage.inputTokens,
+    "gen_ai.usage.output_tokens": usage.outputTokens,
+    "gen_ai.usage.total_tokens": usage.inputTokens + usage.outputTokens,
+    ...(usage.cachedInputTokens !== undefined && {
+      "gen_ai.usage.cached_input_tokens": usage.cachedInputTokens
+    }),
+    ...(usage.cost !== undefined && { "gen_ai.usage.cost_credits": usage.cost })
+  });
 }
 
 const EXT_TO_MIME: Record<string, string> = {

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -362,9 +362,15 @@ export abstract class BaseProvider {
       "gen_ai.operation.name": streaming ? "chat.stream" : "chat",
       "llm.request.message_count": args.messages.length,
       "llm.request.tools_count": args.tools?.length ?? 0,
-      "llm.request.max_tokens": args.maxTokens ?? 0,
-      "llm.request.temperature": args.temperature ?? 0,
-      "llm.request.stream": streaming
+      "llm.request.stream": streaming,
+      // Only emit max_tokens / temperature when the caller actually set them —
+      // a literal 0 is a valid value and shouldn't be confused with "unset".
+      ...(args.maxTokens !== undefined && {
+        "llm.request.max_tokens": args.maxTokens
+      }),
+      ...(args.temperature !== undefined && {
+        "llm.request.temperature": args.temperature
+      })
     });
   }
 
@@ -397,11 +403,15 @@ export abstract class BaseProvider {
     const source = tracer
       ? this._tracedStream(args, tracer)
       : this.generateMessages(args);
+    let exhausted = false;
 
     try {
       while (true) {
         const result = await runInSlot(() => source.next());
-        if (result.done) break;
+        if (result.done) {
+          exhausted = true;
+          break;
+        }
         const item = result.value;
         if ("type" in item && (item as { type: string }).type === "chunk") {
           const chunk = item as { content?: string };
@@ -425,6 +435,14 @@ export abstract class BaseProvider {
       error = String(err);
       throw err;
     } finally {
+      // If the consumer cancelled early (broke out of for-await, threw, or
+      // called return()), give the underlying generator a chance to close
+      // so _tracedStream's finally runs and the LLM stream span ends.
+      if (!exhausted) {
+        await runInSlot(() =>
+          source.return?.(undefined as never) ?? Promise.resolve({ done: true, value: undefined } as IteratorResult<ProviderStreamItem>)
+        ).catch(() => {});
+      }
       const usage = getUsage();
       this.emitMessage({
         type: "llm_call",

--- a/packages/runtime/src/telemetry.ts
+++ b/packages/runtime/src/telemetry.ts
@@ -1,31 +1,53 @@
 /**
- * OpenTelemetry telemetry for LLM provider calls.
+ * OpenTelemetry telemetry for LLM provider calls, agent execution, and
+ * workflow runs.
  *
- * Uses manual spans in BaseProvider rather than auto-instrumentation, so it
- * works correctly with ESM (where module-level imports are hoisted before any
- * code runs, making monkey-patching unreliable).
+ * Multiple sinks can be active simultaneously — for example, log to a JSONL
+ * file *and* ship to Traceloop *and* pretty-print to stdout. Each sink gets
+ * its own span processor so they're independent.
  *
- * Configuration (via environment variables):
- *   TRACELOOP_API_KEY            — Traceloop cloud API key
- *   OTEL_EXPORTER_OTLP_ENDPOINT  — Any OTLP-compatible backend
- *   OTEL_SERVICE_NAME            — Service name tag (default: "nodetool")
- *   OTEL_TRACES_EXPORTER=console — Print spans to stdout
- *   TRACELOOP_DISABLE_BATCH=true — Flush spans immediately (dev mode)
+ * Configuration (env vars; CLI flags / programmatic options take precedence):
+ *
+ *   OpenTelemetry / OTLP:
+ *     TRACELOOP_API_KEY            — Traceloop cloud API key
+ *     OTEL_EXPORTER_OTLP_ENDPOINT  — Any OTLP-compatible backend
+ *     OTEL_SERVICE_NAME            — Service name tag (default: "nodetool")
+ *     OTEL_TRACES_EXPORTER=console — Print spans to stdout via OTel SDK
+ *     TRACELOOP_DISABLE_BATCH=true — Flush spans immediately (dev mode)
+ *
+ *   NodeTool sinks (analyzer-friendly):
+ *     NODETOOL_TRACE_FILE=path.jsonl     — append one JSON span per line
+ *     NODETOOL_TRACE_STDOUT=pretty|json  — write spans to stdout (human/JSONL)
+ *
+ * All NodeTool sinks emit the same {@link TraceRecord} shape (see
+ * trace-exporters.ts) so a downstream agent can ingest either one.
  */
 
 import type { Tracer } from "@opentelemetry/api";
 import { createLogger } from "@nodetool/config";
+import type { StdoutFormat } from "./trace-exporters.js";
 
 const log = createLogger("nodetool.runtime.telemetry");
 
 let _tracer: Tracer | null = null;
+let _initialized = false;
 
 export interface TelemetryOptions {
   /** Override the service name (defaults to OTEL_SERVICE_NAME or "nodetool"). */
   serviceName?: string;
-  /** Print spans to stdout. Also enabled via OTEL_TRACES_EXPORTER=console. */
+  /** Print spans to stdout via OTel SDK ConsoleSpanExporter (legacy). */
   console?: boolean;
-  /** Flush spans immediately instead of batching. */
+  /**
+   * Write spans to stdout in the given format. Same as setting
+   * `NODETOOL_TRACE_STDOUT`. Use this for the analyzer-friendly stdout sink.
+   */
+  stdout?: StdoutFormat | false;
+  /**
+   * Append spans as JSONL to this path. Same as `NODETOOL_TRACE_FILE`. Parent
+   * directories are created automatically.
+   */
+  traceFile?: string;
+  /** Flush OTLP spans immediately instead of batching. */
   disableBatch?: boolean;
   /** Suppress the initialization log. */
   silent?: boolean;
@@ -34,72 +56,108 @@ export interface TelemetryOptions {
 /**
  * Initialize OpenTelemetry instrumentation.
  *
- * Call once at startup before any LLM calls. Returns true if telemetry was
- * enabled, false if skipped (no configuration present).
+ * Idempotent: calling more than once is a no-op (returns the previous result).
+ * Returns true if at least one sink is active, false if telemetry was skipped.
  */
 export async function initTelemetry(
   options: TelemetryOptions = {}
 ): Promise<boolean> {
-  const apiKey = process.env["TRACELOOP_API_KEY"];
+  if (_initialized) return _tracer !== null;
+
+  const traceloopKey = process.env["TRACELOOP_API_KEY"];
   const otlpEndpoint = process.env["OTEL_EXPORTER_OTLP_ENDPOINT"];
   const consoleMode =
     options.console || process.env["OTEL_TRACES_EXPORTER"] === "console";
 
-  if (!apiKey && !otlpEndpoint && !consoleMode) {
+  const stdoutFormat: StdoutFormat | null = (() => {
+    if (options.stdout === false) return null;
+    if (options.stdout === "pretty" || options.stdout === "json") {
+      return options.stdout;
+    }
+    const env = process.env["NODETOOL_TRACE_STDOUT"];
+    if (env === "pretty" || env === "json") return env;
+    if (env === "1" || env === "true") return "pretty";
+    return null;
+  })();
+
+  const traceFilePath = options.traceFile ?? process.env["NODETOOL_TRACE_FILE"];
+
+  const hasOtlp = !!(traceloopKey || otlpEndpoint);
+  if (!hasOtlp && !consoleMode && !stdoutFormat && !traceFilePath) {
+    _initialized = true;
     return false;
   }
 
   const { NodeSDK } = await import("@opentelemetry/sdk-node");
   const { resourceFromAttributes } = await import("@opentelemetry/resources");
-  const { ATTR_SERVICE_NAME } =
-    await import("@opentelemetry/semantic-conventions");
+  const { ATTR_SERVICE_NAME } = await import(
+    "@opentelemetry/semantic-conventions"
+  );
   const otelApi = await import("@opentelemetry/api");
+  const { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } =
+    await import("@opentelemetry/sdk-trace-base");
 
   const serviceName =
     options.serviceName ?? process.env["OTEL_SERVICE_NAME"] ?? "nodetool";
 
   const disableBatch =
-    (options.disableBatch ??
-      process.env["TRACELOOP_DISABLE_BATCH"] === "true") ||
-    consoleMode;
+    options.disableBatch ?? process.env["TRACELOOP_DISABLE_BATCH"] === "true";
 
-  let exporter: unknown;
-  let destination: string;
+  const processors: unknown[] = [];
+  const destinations: string[] = [];
 
-  if (consoleMode) {
-    const { ConsoleSpanExporter } =
-      await import("@opentelemetry/sdk-trace-base");
-    exporter = new ConsoleSpanExporter();
-    destination = "console";
-  } else if (apiKey || otlpEndpoint) {
-    const { OTLPTraceExporter } =
-      await import("@opentelemetry/exporter-trace-otlp-proto");
+  if (hasOtlp) {
+    const { OTLPTraceExporter } = await import(
+      "@opentelemetry/exporter-trace-otlp-proto"
+    );
     const url = otlpEndpoint
       ? `${otlpEndpoint}/v1/traces`
       : "https://api.traceloop.com/v1/traces";
-    const headers: Record<string, string> = apiKey
-      ? { Authorization: `Bearer ${apiKey}` }
+    const headers: Record<string, string> = traceloopKey
+      ? { Authorization: `Bearer ${traceloopKey}` }
       : {};
-    exporter = new OTLPTraceExporter({ url, headers });
-    destination = apiKey ? "Traceloop" : otlpEndpoint!;
-  } else {
-    return false;
+    const exporter = new OTLPTraceExporter({ url, headers });
+    const Proc = disableBatch ? SimpleSpanProcessor : BatchSpanProcessor;
+    processors.push(new Proc(exporter));
+    destinations.push(traceloopKey ? "traceloop" : `otlp:${otlpEndpoint!}`);
   }
 
-  const { BatchSpanProcessor, SimpleSpanProcessor } =
-    await import("@opentelemetry/sdk-trace-base");
-  const SpanProcessor = disableBatch ? SimpleSpanProcessor : BatchSpanProcessor;
+  if (consoleMode) {
+    processors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+    destinations.push("otel-console");
+  }
+
+  if (stdoutFormat) {
+    const { StdoutSpanExporter } = await import("./trace-exporters.js");
+    processors.push(
+      new SimpleSpanProcessor(new StdoutSpanExporter(stdoutFormat))
+    );
+    destinations.push(`stdout:${stdoutFormat}`);
+  }
+
+  if (traceFilePath) {
+    const { JsonlFileSpanExporter } = await import("./trace-exporters.js");
+    // SimpleSpanProcessor — we want the file written eagerly so a crash
+    // doesn't lose recent spans, and disk I/O is cheap enough.
+    processors.push(
+      new SimpleSpanProcessor(new JsonlFileSpanExporter(traceFilePath))
+    );
+    destinations.push(`file:${traceFilePath}`);
+  }
 
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
-    spanProcessors: [new SpanProcessor(exporter as never)]
+    spanProcessors: processors as never
   });
 
   sdk.start();
   _tracer = otelApi.trace.getTracer("nodetool", "0.1.0");
+  _initialized = true;
 
   if (!options.silent) {
-    log.info(`OpenTelemetry initialized`, { destination });
+    log.info("OpenTelemetry initialized", {
+      destinations: destinations.join(", ")
+    });
   }
 
   return true;
@@ -108,4 +166,13 @@ export async function initTelemetry(
 /** Returns the active tracer, or null if telemetry is not initialized. */
 export function getTracer(): Tracer | null {
   return _tracer;
+}
+
+/**
+ * Reset the telemetry singleton. Test-only — production code should call
+ * `initTelemetry()` exactly once at startup.
+ */
+export function _resetTelemetryForTest(): void {
+  _tracer = null;
+  _initialized = false;
 }

--- a/packages/runtime/src/telemetry.ts
+++ b/packages/runtime/src/telemetry.ts
@@ -150,7 +150,11 @@ export async function initTelemetry(
     spanProcessors: processors as never
   });
 
-  sdk.start();
+  // sdk.start() is typed as void in current SDK versions, but historically
+  // returned a Promise — `await` is a no-op on non-thenable values, so this
+  // is safe across versions and avoids racing the first spans on any
+  // version that does init asynchronously.
+  await sdk.start();
   _tracer = otelApi.trace.getTracer("nodetool", "0.1.0");
   _initialized = true;
 

--- a/packages/runtime/src/trace-exporters.ts
+++ b/packages/runtime/src/trace-exporters.ts
@@ -1,0 +1,214 @@
+/**
+ * Custom OpenTelemetry span exporters for NodeTool.
+ *
+ * - {@link JsonlFileSpanExporter}  — appends one JSON line per span to a file
+ * - {@link StdoutSpanExporter}     — writes spans to stdout in `json` (JSONL)
+ *                                    or `pretty` (human-readable) format
+ *
+ * Both produce the same structured shape, so an analyzer agent reading either
+ * file or stdout output gets identical fields.
+ */
+
+import { createWriteStream, type WriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type {
+  ReadableSpan,
+  SpanExporter
+} from "@opentelemetry/sdk-trace-base";
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+
+/**
+ * Stable, analyzer-friendly JSON shape derived from a {@link ReadableSpan}.
+ *
+ * `start_time_ms` / `end_time_ms` are unix-epoch milliseconds; `duration_ms`
+ * is end−start. Timestamps are ms (not ns) because that's what every
+ * downstream consumer (logs, dashboards, LLMs) actually uses.
+ */
+export interface TraceRecord {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  name: string;
+  kind: string;
+  start_time_ms: number;
+  end_time_ms: number;
+  duration_ms: number;
+  status: { code: string; message?: string };
+  attributes: Record<string, unknown>;
+  events: Array<{
+    name: string;
+    time_ms: number;
+    attributes?: Record<string, unknown>;
+  }>;
+  resource: Record<string, unknown>;
+}
+
+const SPAN_KINDS = ["INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER"];
+const STATUS_CODES = ["UNSET", "OK", "ERROR"];
+
+function hrTimeToMs(hrTime: [number, number]): number {
+  return hrTime[0] * 1000 + hrTime[1] / 1_000_000;
+}
+
+export function spanToRecord(span: ReadableSpan): TraceRecord {
+  const ctx = span.spanContext();
+  const startMs = hrTimeToMs(span.startTime);
+  const endMs = hrTimeToMs(span.endTime);
+  return {
+    trace_id: ctx.traceId,
+    span_id: ctx.spanId,
+    parent_span_id: span.parentSpanContext?.spanId ?? null,
+    name: span.name,
+    kind: SPAN_KINDS[span.kind] ?? "INTERNAL",
+    start_time_ms: startMs,
+    end_time_ms: endMs,
+    duration_ms: endMs - startMs,
+    status: {
+      code: STATUS_CODES[span.status.code] ?? "UNSET",
+      ...(span.status.message ? { message: span.status.message } : {})
+    },
+    attributes: { ...span.attributes },
+    events: span.events.map((e) => ({
+      name: e.name,
+      time_ms: hrTimeToMs(e.time),
+      ...(e.attributes ? { attributes: { ...e.attributes } } : {})
+    })),
+    resource: { ...span.resource.attributes }
+  };
+}
+
+/**
+ * Append spans as JSONL to a file. Creates parent directories as needed.
+ *
+ * Spans are written as soon as `export()` is called (use a SimpleSpanProcessor
+ * for immediate flush, BatchSpanProcessor for buffered).
+ */
+export class JsonlFileSpanExporter implements SpanExporter {
+  private stream: WriteStream | null = null;
+  private streamReady: Promise<void>;
+
+  constructor(filePath: string) {
+    this.streamReady = (async () => {
+      await mkdir(dirname(filePath), { recursive: true });
+      this.stream = createWriteStream(filePath, { flags: "a" });
+    })();
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    void this.streamReady
+      .then(() => {
+        if (!this.stream) throw new Error("trace stream not initialized");
+        for (const span of spans) {
+          this.stream.write(JSON.stringify(spanToRecord(span)) + "\n");
+        }
+        resultCallback({ code: ExportResultCode.SUCCESS });
+      })
+      .catch((err) => {
+        resultCallback({ code: ExportResultCode.FAILED, error: err as Error });
+      });
+  }
+
+  async shutdown(): Promise<void> {
+    await this.streamReady;
+    await new Promise<void>((resolve) => {
+      if (!this.stream) return resolve();
+      this.stream.end(resolve);
+    });
+  }
+
+  async forceFlush(): Promise<void> {
+    // WriteStream auto-flushes on write; nothing to do.
+  }
+}
+
+export type StdoutFormat = "pretty" | "json";
+
+/**
+ * Write spans to stdout. `format: "json"` emits JSONL; `format: "pretty"`
+ * emits a human-readable single-line summary that's still grep-friendly.
+ */
+export class StdoutSpanExporter implements SpanExporter {
+  constructor(private readonly format: StdoutFormat = "pretty") {}
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    try {
+      for (const span of spans) {
+        const rec = spanToRecord(span);
+        if (this.format === "json") {
+          process.stdout.write(JSON.stringify(rec) + "\n");
+        } else {
+          process.stdout.write(formatPretty(rec) + "\n");
+        }
+      }
+      resultCallback({ code: ExportResultCode.SUCCESS });
+    } catch (err) {
+      resultCallback({ code: ExportResultCode.FAILED, error: err as Error });
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    // Nothing to clean up.
+  }
+
+  async forceFlush(): Promise<void> {
+    // stdout writes are synchronous-ish; nothing to do.
+  }
+}
+
+const COLOR = {
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  cyan: "\x1b[36m",
+  bold: "\x1b[1m",
+  reset: "\x1b[0m"
+};
+
+function colorize(s: string, color: keyof typeof COLOR): string {
+  return process.stdout.isTTY ? `${COLOR[color]}${s}${COLOR.reset}` : s;
+}
+
+function formatPretty(r: TraceRecord): string {
+  const dur = `${r.duration_ms.toFixed(1)}ms`;
+  const statusColor: keyof typeof COLOR =
+    r.status.code === "ERROR"
+      ? "red"
+      : r.status.code === "OK"
+        ? "green"
+        : "dim";
+  const tags: string[] = [];
+  // Surface the most useful attributes inline, in priority order.
+  const inlineKeys = [
+    "llm.provider",
+    "llm.model",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "agent.objective",
+    "node.type",
+    "node.id",
+    "workflow.id"
+  ];
+  for (const k of inlineKeys) {
+    const v = r.attributes[k];
+    if (v !== undefined && v !== null && v !== "") {
+      tags.push(`${colorize(k, "dim")}=${truncate(String(v), 60)}`);
+    }
+  }
+  const status =
+    r.status.code === "ERROR"
+      ? colorize(`[${r.status.code}${r.status.message ? `: ${r.status.message}` : ""}]`, statusColor)
+      : "";
+  return `${colorize(r.name, "cyan")} ${colorize(dur, "yellow")} ${tags.join(" ")} ${status}`.trimEnd();
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}

--- a/packages/runtime/src/trace-exporters.ts
+++ b/packages/runtime/src/trace-exporters.ts
@@ -47,8 +47,15 @@ export interface TraceRecord {
 const SPAN_KINDS = ["INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER"];
 const STATUS_CODES = ["UNSET", "OK", "ERROR"];
 
+/**
+ * Convert an OTel hrTime ([seconds, nanoseconds]) to integer unix-epoch ms.
+ *
+ * We round (rather than truncate) so a 0.6ms span doesn't read as 0ms, and
+ * we keep the schema integer-typed for downstream JSONL consumers that
+ * assume `start_time_ms`/`end_time_ms`/`duration_ms` are whole numbers.
+ */
 function hrTimeToMs(hrTime: [number, number]): number {
-  return hrTime[0] * 1000 + hrTime[1] / 1_000_000;
+  return Math.round(hrTime[0] * 1000 + hrTime[1] / 1_000_000);
 }
 
 export function spanToRecord(span: ReadableSpan): TraceRecord {
@@ -83,6 +90,10 @@ export function spanToRecord(span: ReadableSpan): TraceRecord {
  *
  * Spans are written as soon as `export()` is called (use a SimpleSpanProcessor
  * for immediate flush, BatchSpanProcessor for buffered).
+ *
+ * Honors stream backpressure: each batch awaits the underlying `write`
+ * callback (and a `drain` event when the stream reports it's full) before
+ * reporting SUCCESS, so high trace volume can't accumulate unbounded.
  */
 export class JsonlFileSpanExporter implements SpanExporter {
   private stream: WriteStream | null = null;
@@ -100,10 +111,10 @@ export class JsonlFileSpanExporter implements SpanExporter {
     resultCallback: (result: ExportResult) => void
   ): void {
     void this.streamReady
-      .then(() => {
+      .then(async () => {
         if (!this.stream) throw new Error("trace stream not initialized");
         for (const span of spans) {
-          this.stream.write(JSON.stringify(spanToRecord(span)) + "\n");
+          await writeLine(this.stream, JSON.stringify(spanToRecord(span)) + "\n");
         }
         resultCallback({ code: ExportResultCode.SUCCESS });
       })
@@ -123,6 +134,46 @@ export class JsonlFileSpanExporter implements SpanExporter {
   async forceFlush(): Promise<void> {
     // WriteStream auto-flushes on write; nothing to do.
   }
+}
+
+/**
+ * Write a single line to a WriteStream, respecting backpressure.
+ *
+ * Resolves once the write callback has fired AND the stream has drained
+ * (if `write()` returned false). Rejects on any stream error during the
+ * write — caller is responsible for re-attaching listeners afterwards.
+ */
+function writeLine(stream: WriteStream, line: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let written = false;
+    let drained = false;
+    let needsDrain = false;
+    const onError = (err: Error) => {
+      stream.off("drain", onDrain);
+      reject(err);
+    };
+    const onDrain = () => {
+      drained = true;
+      maybeDone();
+    };
+    const maybeDone = () => {
+      if (written && (!needsDrain || drained)) {
+        stream.off("error", onError);
+        stream.off("drain", onDrain);
+        resolve();
+      }
+    };
+    stream.once("error", onError);
+    const ok = stream.write(line, (err) => {
+      if (err) return onError(err);
+      written = true;
+      maybeDone();
+    });
+    if (!ok) {
+      needsDrain = true;
+      stream.once("drain", onDrain);
+    }
+  });
 }
 
 export type StdoutFormat = "pretty" | "json";

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -1,0 +1,274 @@
+/**
+ * Helpers for wrapping agent / workflow / node code in OpenTelemetry spans.
+ *
+ * All helpers degrade gracefully when telemetry is disabled (no tracer
+ * configured) — the wrapped function runs as if no span existed, with
+ * essentially zero overhead.
+ *
+ * # Span hierarchy
+ *
+ *   workflow.run                     ← `withWorkflowSpan`
+ *     node.process (per node)        ← `withNodeSpan`
+ *       llm.chat / llm.stream        ← BaseProvider (existing)
+ *
+ *   agent.execute                    ← `withAgentSpan({ kind: "execute" })`
+ *     agent.plan                     ← `withAgentSpan({ kind: "plan" })`
+ *     agent.step                     ← `withAgentSpan({ kind: "step" })`
+ *       llm.chat / llm.stream        ← BaseProvider (existing)
+ *
+ * Child spans nest automatically because OTel's `startActiveSpan` makes the
+ * span active in AsyncLocalStorage for the duration of the callback.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  SpanStatusCode,
+  context as otelContext,
+  trace as otelTrace,
+  type Span
+} from "@opentelemetry/api";
+import { getTracer } from "./telemetry.js";
+
+export type AgentSpanKind = "execute" | "plan" | "step";
+
+/** Token counts and computed cost for one LLM call. */
+export interface LlmUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+  /** In NodeTool credits (1 credit ≈ $0.01). */
+  cost?: number;
+}
+
+/**
+ * Per-call usage slot. Providers' `trackUsage` writes into the active slot
+ * via {@link setLastUsage}, and the traced wrapper reads it via
+ * {@link consumeLastUsage} so it can attach the numbers to its span and
+ * `llm_call` event.
+ *
+ * We use AsyncLocalStorage rather than an instance field so concurrent calls
+ * on the same provider instance don't clobber each other.
+ */
+const usageStore = new AsyncLocalStorage<{ usage: LlmUsage | null }>();
+
+/**
+ * Run `fn` inside a fresh usage slot. `consumeLastUsage()` afterwards returns
+ * whatever the deepest `setLastUsage()` call wrote.
+ */
+export function withUsageCapture<T>(fn: () => Promise<T>): Promise<T> {
+  return usageStore.run({ usage: null }, fn);
+}
+
+/** Provider hook: record token usage for the in-flight LLM call. */
+export function setLastUsage(usage: LlmUsage): void {
+  const slot = usageStore.getStore();
+  if (slot) slot.usage = usage;
+}
+
+/** Read and clear the most recent usage recorded in this async context. */
+export function consumeLastUsage(): LlmUsage | null {
+  const slot = usageStore.getStore();
+  if (!slot) return null;
+  const u = slot.usage;
+  slot.usage = null;
+  return u;
+}
+
+/** Read (without clearing) the most recent usage in this async context. */
+export function peekLastUsage(): LlmUsage | null {
+  return usageStore.getStore()?.usage ?? null;
+}
+
+/**
+ * Create a per-call usage slot that survives across async-generator yields.
+ *
+ * `AsyncLocalStorage.run()` only persists across awaits within its callback,
+ * so for streaming we explicitly wrap each `gen.next()` call in `runInSlot`.
+ * After the generator finishes, `getUsage()` returns whatever the deepest
+ * `setLastUsage()` call wrote.
+ */
+export function createUsageSlot(): {
+  runInSlot: <T>(fn: () => Promise<T>) => Promise<T>;
+  getUsage: () => LlmUsage | null;
+} {
+  const slot: { usage: LlmUsage | null } = { usage: null };
+  return {
+    runInSlot: <T>(fn: () => Promise<T>) => usageStore.run(slot, fn),
+    getUsage: () => slot.usage
+  };
+}
+
+/** Wrap a function in an OTel span; pass-through if telemetry is disabled. */
+async function withSpan<T>(
+  name: string,
+  attributes: Record<string, unknown>,
+  fn: (span: Span | null) => Promise<T>
+): Promise<T> {
+  const tracer = getTracer();
+  if (!tracer) return fn(null);
+  return tracer.startActiveSpan(name, async (span) => {
+    setAttributes(span, attributes);
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+      span.recordException(err as Error);
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Wrap an async generator in an OTel span. Each `next()` call runs in the
+ * span's context, so any spans created inside `genFactory` nest under it.
+ *
+ * Preserves the generator's `TReturn` so callers reading `.next().value`
+ * after `done` still get the underlying return value.
+ */
+export async function* withSpanGen<T, TReturn = void>(
+  name: string,
+  attributes: Record<string, unknown>,
+  genFactory: () => AsyncGenerator<T, TReturn>
+): AsyncGenerator<T, TReturn> {
+  const tracer = getTracer();
+  if (!tracer) {
+    return yield* genFactory();
+  }
+  const span = tracer.startSpan(name);
+  setAttributes(span, attributes);
+  const ctx = otelTrace.setSpan(otelContext.active(), span);
+  try {
+    const inner = otelContext.with(ctx, () => genFactory());
+    while (true) {
+      const result = await otelContext.with(ctx, () => inner.next());
+      if (result.done) {
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result.value;
+      }
+      yield result.value;
+    }
+  } catch (err) {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+    span.recordException(err as Error);
+    throw err;
+  } finally {
+    span.end();
+  }
+}
+
+function setAttributes(span: Span, attributes: Record<string, unknown>): void {
+  for (const [k, v] of Object.entries(attributes)) {
+    if (v !== undefined && v !== null) {
+      span.setAttribute(k, v as never);
+    }
+  }
+}
+
+/**
+ * Wrap an agent operation (execute / plan / step) in a span.
+ *
+ * @param kind        — which agent stage this is (becomes part of span name)
+ * @param attributes  — agent.* attributes (objective, model, provider, ...)
+ * @param fn          — the body of the agent stage
+ */
+export function withAgentSpan<T>(
+  kind: AgentSpanKind,
+  attributes: {
+    objective?: string;
+    provider?: string;
+    model?: string;
+    /** For `step`: which task / sub-objective is being executed. */
+    task?: string;
+    /** For `plan`: number of skills / tools available. */
+    toolsCount?: number;
+    /** Any additional attributes to attach. */
+    extra?: Record<string, unknown>;
+  },
+  fn: (span: Span | null) => Promise<T>
+): Promise<T> {
+  return withSpan(`agent.${kind}`, agentAttrs(kind, attributes), fn);
+}
+
+/** Wrap a workflow run (kernel WorkflowRunner) in a span. */
+export function withWorkflowSpan<T>(
+  attributes: {
+    workflowId?: string;
+    workflowName?: string;
+    nodeCount?: number;
+    extra?: Record<string, unknown>;
+  },
+  fn: (span: Span | null) => Promise<T>
+): Promise<T> {
+  const attrs: Record<string, unknown> = {};
+  if (attributes.workflowId !== undefined) {
+    attrs["workflow.id"] = attributes.workflowId;
+  }
+  if (attributes.workflowName !== undefined) {
+    attrs["workflow.name"] = attributes.workflowName;
+  }
+  if (attributes.nodeCount !== undefined) {
+    attrs["workflow.node_count"] = attributes.nodeCount;
+  }
+  if (attributes.extra) Object.assign(attrs, attributes.extra);
+  return withSpan("workflow.run", attrs, fn);
+}
+
+/** Async-generator variant of {@link withAgentSpan}. */
+export function withAgentSpanGen<T, TReturn = void>(
+  kind: AgentSpanKind,
+  attributes: Parameters<typeof withAgentSpan>[1],
+  genFactory: () => AsyncGenerator<T, TReturn>
+): AsyncGenerator<T, TReturn> {
+  return withSpanGen(`agent.${kind}`, agentAttrs(kind, attributes), genFactory);
+}
+
+function agentAttrs(
+  kind: AgentSpanKind,
+  attributes: Parameters<typeof withAgentSpan>[1]
+): Record<string, unknown> {
+  const attrs: Record<string, unknown> = { "agent.kind": kind };
+  if (attributes.objective !== undefined) {
+    attrs["agent.objective"] = truncate(attributes.objective, 1000);
+  }
+  if (attributes.provider !== undefined) {
+    attrs["agent.provider"] = attributes.provider;
+  }
+  if (attributes.model !== undefined) attrs["agent.model"] = attributes.model;
+  if (attributes.task !== undefined) {
+    attrs["agent.task"] = truncate(attributes.task, 1000);
+  }
+  if (attributes.toolsCount !== undefined) {
+    attrs["agent.tools_count"] = attributes.toolsCount;
+  }
+  if (attributes.extra) Object.assign(attrs, attributes.extra);
+  return attrs;
+}
+
+/** Wrap a single node execution (kernel Actor) in a span. */
+export function withNodeSpan<T>(
+  attributes: {
+    nodeId: string;
+    nodeType: string;
+    workflowId?: string;
+    extra?: Record<string, unknown>;
+  },
+  fn: (span: Span | null) => Promise<T>
+): Promise<T> {
+  const attrs: Record<string, unknown> = {
+    "node.id": attributes.nodeId,
+    "node.type": attributes.nodeType
+  };
+  if (attributes.workflowId !== undefined) {
+    attrs["workflow.id"] = attributes.workflowId;
+  }
+  if (attributes.extra) Object.assign(attrs, attributes.extra);
+  return withSpan("node.process", attrs, fn);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -127,7 +127,9 @@ async function withSpan<T>(
  * span's context, so any spans created inside `genFactory` nest under it.
  *
  * Preserves the generator's `TReturn` so callers reading `.next().value`
- * after `done` still get the underlying return value.
+ * after `done` still get the underlying return value. If the consumer
+ * cancels (breaks out of `for await`, calls `return()`, or throws), the
+ * inner generator's `return()` is invoked so its `finally` blocks run.
  */
 export async function* withSpanGen<T, TReturn = void>(
   name: string,
@@ -141,11 +143,13 @@ export async function* withSpanGen<T, TReturn = void>(
   const span = tracer.startSpan(name);
   setAttributes(span, attributes);
   const ctx = otelTrace.setSpan(otelContext.active(), span);
+  const inner = otelContext.with(ctx, () => genFactory());
+  let exhausted = false;
   try {
-    const inner = otelContext.with(ctx, () => genFactory());
     while (true) {
       const result = await otelContext.with(ctx, () => inner.next());
       if (result.done) {
+        exhausted = true;
         span.setStatus({ code: SpanStatusCode.OK });
         return result.value;
       }
@@ -156,6 +160,13 @@ export async function* withSpanGen<T, TReturn = void>(
     span.recordException(err as Error);
     throw err;
   } finally {
+    if (!exhausted) {
+      // Consumer cancelled early — give the inner generator a chance to
+      // run its own finally blocks (close streams, end child spans, etc).
+      await otelContext
+        .with(ctx, () => inner.return?.(undefined as never))
+        ?.catch(() => {});
+    }
     span.end();
   }
 }

--- a/packages/runtime/tests/telemetry-integration.test.ts
+++ b/packages/runtime/tests/telemetry-integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * End-to-end telemetry integration test.
+ *
+ * Wires up the real OTel SDK to write spans through the JSONL file exporter,
+ * then drives a fake provider through generateMessageTraced and asserts that
+ * the resulting trace file contains the expected span hierarchy and token
+ * usage attributes.
+ */
+
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  initTelemetry,
+  _resetTelemetryForTest
+} from "../src/telemetry.js";
+import { withAgentSpan } from "../src/tracing-helpers.js";
+import type { TraceRecord } from "../src/trace-exporters.js";
+import { BaseProvider } from "../src/providers/base-provider.js";
+import type {
+  Message,
+  ProviderId,
+  ProviderStreamItem
+} from "../src/providers/types.js";
+
+class TestProvider extends BaseProvider {
+  constructor() {
+    super("anthropic" as ProviderId);
+  }
+  async generateMessage(args: { messages: Message[]; model: string }): Promise<Message> {
+    this.trackUsage(args.model, { inputTokens: 100, outputTokens: 50 });
+    return { role: "assistant", content: "hello world" };
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    yield* [];
+  }
+}
+
+let traceDir: string;
+let traceFile: string;
+
+beforeAll(async () => {
+  traceDir = await mkdtemp(join(tmpdir(), "nodetool-trace-int-"));
+  traceFile = join(traceDir, "trace.jsonl");
+  _resetTelemetryForTest();
+  await initTelemetry({
+    traceFile,
+    silent: true
+  });
+});
+
+afterAll(async () => {
+  await rm(traceDir, { recursive: true, force: true });
+  _resetTelemetryForTest();
+});
+
+describe("telemetry integration", () => {
+  it("writes nested agent → llm.chat spans with token usage to JSONL", async () => {
+    const provider = new TestProvider();
+
+    await withAgentSpan(
+      "execute",
+      { objective: "test objective", provider: "anthropic", model: "claude-sonnet-4-6" },
+      async () => {
+        await provider.generateMessageTraced({
+          messages: [{ role: "user", content: "hi" }],
+          model: "claude-sonnet-4-6"
+        });
+      }
+    );
+
+    // Force flush — SimpleSpanProcessor writes synchronously, but the file
+    // stream is buffered.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const contents = await readFile(traceFile, "utf8");
+    const lines = contents
+      .trim()
+      .split("\n")
+      .filter((l) => l.length > 0);
+    const records = lines.map((l) => JSON.parse(l) as TraceRecord);
+
+    // We expect at least: one agent.execute span and one llm.chat span.
+    const agentSpan = records.find((r) => r.name === "agent.execute");
+    const llmSpan = records.find((r) => r.name.startsWith("llm.chat"));
+    expect(agentSpan).toBeDefined();
+    expect(llmSpan).toBeDefined();
+
+    // Hierarchy: llm.chat should be parented to agent.execute
+    expect(llmSpan?.parent_span_id).toBe(agentSpan?.span_id);
+
+    // Agent attributes
+    expect(agentSpan?.attributes["agent.objective"]).toBe("test objective");
+    expect(agentSpan?.attributes["agent.kind"]).toBe("execute");
+    expect(agentSpan?.attributes["agent.model"]).toBe("claude-sonnet-4-6");
+
+    // LLM usage attributes (gen_ai semconv)
+    expect(llmSpan?.attributes["gen_ai.usage.input_tokens"]).toBe(100);
+    expect(llmSpan?.attributes["gen_ai.usage.output_tokens"]).toBe(50);
+    expect(llmSpan?.attributes["gen_ai.usage.total_tokens"]).toBe(150);
+    expect(llmSpan?.attributes["llm.provider"]).toBe("anthropic");
+    expect(llmSpan?.attributes["llm.model"]).toBe("claude-sonnet-4-6");
+  });
+});

--- a/packages/runtime/tests/trace-exporters.test.ts
+++ b/packages/runtime/tests/trace-exporters.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for trace-exporters: JSONL file and stdout span exporters.
+ *
+ * We construct minimal `ReadableSpan`-shaped objects to drive the exporters
+ * directly; this covers the formatting code without requiring an actual SDK
+ * setup.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  spanToRecord,
+  JsonlFileSpanExporter,
+  StdoutSpanExporter,
+  type TraceRecord
+} from "../src/trace-exporters.js";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeSpan(overrides: Partial<{
+  name: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string;
+  startMs: number;
+  endMs: number;
+  attributes: Record<string, unknown>;
+  statusCode: number;
+  statusMessage: string;
+}> = {}) {
+  const startMs = overrides.startMs ?? 1_700_000_000_000;
+  const endMs = overrides.endMs ?? startMs + 250;
+  return {
+    name: overrides.name ?? "llm.chat anthropic/claude-sonnet-4-6",
+    kind: 0,
+    spanContext: () => ({
+      traceId: overrides.traceId ?? "a".repeat(32),
+      spanId: overrides.spanId ?? "b".repeat(16),
+      traceFlags: 1
+    }),
+    parentSpanContext: overrides.parentSpanId
+      ? { spanId: overrides.parentSpanId }
+      : undefined,
+    startTime: msToHrTime(startMs),
+    endTime: msToHrTime(endMs),
+    status: {
+      code: overrides.statusCode ?? 1,
+      message: overrides.statusMessage
+    },
+    attributes: overrides.attributes ?? {
+      "llm.provider": "anthropic",
+      "llm.model": "claude-sonnet-4-6",
+      "gen_ai.usage.input_tokens": 100,
+      "gen_ai.usage.output_tokens": 50
+    },
+    events: [],
+    resource: { attributes: { "service.name": "nodetool" } }
+  } as unknown as Parameters<typeof spanToRecord>[0];
+}
+
+function msToHrTime(ms: number): [number, number] {
+  const seconds = Math.floor(ms / 1000);
+  const nanos = Math.floor((ms - seconds * 1000) * 1_000_000);
+  return [seconds, nanos];
+}
+
+describe("spanToRecord", () => {
+  it("converts a span to a stable JSON record shape", () => {
+    const span = makeSpan({ startMs: 1000, endMs: 1500 });
+    const rec = spanToRecord(span);
+    expect(rec.name).toBe("llm.chat anthropic/claude-sonnet-4-6");
+    expect(rec.duration_ms).toBe(500);
+    expect(rec.start_time_ms).toBe(1000);
+    expect(rec.end_time_ms).toBe(1500);
+    expect(rec.status.code).toBe("OK");
+    expect(rec.attributes["llm.provider"]).toBe("anthropic");
+    expect(rec.parent_span_id).toBeNull();
+    expect(rec.trace_id).toHaveLength(32);
+  });
+
+  it("includes parent_span_id when present", () => {
+    const span = makeSpan({ parentSpanId: "c".repeat(16) });
+    const rec = spanToRecord(span);
+    expect(rec.parent_span_id).toBe("c".repeat(16));
+  });
+
+  it("maps status codes to readable strings", () => {
+    const errSpan = makeSpan({ statusCode: 2, statusMessage: "boom" });
+    const rec = spanToRecord(errSpan);
+    expect(rec.status.code).toBe("ERROR");
+    expect(rec.status.message).toBe("boom");
+  });
+});
+
+describe("JsonlFileSpanExporter", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "nodetool-trace-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("appends one JSON span per line", async () => {
+    const path = join(tmpDir, "trace.jsonl");
+    const exporter = new JsonlFileSpanExporter(path);
+    await new Promise<void>((resolve, reject) => {
+      exporter.export([makeSpan({ name: "first" }), makeSpan({ name: "second" })], (r) => {
+        if (r.code === 0) resolve();
+        else reject(r.error);
+      });
+    });
+    await exporter.shutdown();
+
+    const contents = await readFile(path, "utf8");
+    const lines = contents.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]) as TraceRecord;
+    expect(first.name).toBe("first");
+    expect(first.attributes["llm.provider"]).toBe("anthropic");
+  });
+
+  it("creates parent directories as needed", async () => {
+    const path = join(tmpDir, "nested", "deep", "trace.jsonl");
+    const exporter = new JsonlFileSpanExporter(path);
+    await new Promise<void>((resolve, reject) => {
+      exporter.export([makeSpan()], (r) => {
+        if (r.code === 0) resolve();
+        else reject(r.error);
+      });
+    });
+    await exporter.shutdown();
+
+    const contents = await readFile(path, "utf8");
+    expect(contents.trim().split("\n")).toHaveLength(1);
+  });
+});
+
+describe("StdoutSpanExporter", () => {
+  let stdoutChunks: string[];
+  let originalWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it("emits JSONL when format is 'json'", async () => {
+    const exporter = new StdoutSpanExporter("json");
+    await new Promise<void>((resolve, reject) => {
+      exporter.export([makeSpan({ name: "abc" })], (r) => {
+        if (r.code === 0) resolve();
+        else reject(r.error);
+      });
+    });
+    expect(stdoutChunks).toHaveLength(1);
+    const parsed = JSON.parse(stdoutChunks[0]) as TraceRecord;
+    expect(parsed.name).toBe("abc");
+  });
+
+  it("emits human-readable lines when format is 'pretty'", async () => {
+    const exporter = new StdoutSpanExporter("pretty");
+    await new Promise<void>((resolve, reject) => {
+      exporter.export([makeSpan({ name: "llm.chat openai/gpt-5" })], (r) => {
+        if (r.code === 0) resolve();
+        else reject(r.error);
+      });
+    });
+    expect(stdoutChunks).toHaveLength(1);
+    expect(stdoutChunks[0]).toContain("llm.chat openai/gpt-5");
+    expect(stdoutChunks[0]).toContain("ms");
+  });
+});

--- a/packages/runtime/tests/trace-exporters.test.ts
+++ b/packages/runtime/tests/trace-exporters.test.ts
@@ -90,6 +90,20 @@ describe("spanToRecord", () => {
     expect(rec.status.code).toBe("ERROR");
     expect(rec.status.message).toBe("boom");
   });
+
+  it("rounds sub-millisecond timestamps to integer milliseconds", () => {
+    // Construct a span whose endTime carries 600_000 ns (0.6ms) past the second.
+    const span = {
+      ...makeSpan(),
+      // raw hrTime: 1000s + 600µs → exactly 1_000_000.6 ms
+      startTime: [1000, 600_000] as [number, number],
+      endTime: [1000, 1_000_000] as [number, number]
+    };
+    const rec = spanToRecord(span as Parameters<typeof spanToRecord>[0]);
+    expect(Number.isInteger(rec.start_time_ms)).toBe(true);
+    expect(Number.isInteger(rec.end_time_ms)).toBe(true);
+    expect(Number.isInteger(rec.duration_ms)).toBe(true);
+  });
 });
 
 describe("JsonlFileSpanExporter", () => {

--- a/packages/runtime/tests/tracing-helpers.test.ts
+++ b/packages/runtime/tests/tracing-helpers.test.ts
@@ -86,6 +86,24 @@ describe("with*Span (no tracer configured)", () => {
     await wrapped.next();
     await expect(wrapped.next()).rejects.toThrow("boom");
   });
+
+  it("closes the inner generator's finally block on early consumer cancel", async () => {
+    let cleanup = false;
+    async function* gen(): AsyncGenerator<number> {
+      try {
+        yield 1;
+        yield 2;
+        yield 3;
+      } finally {
+        cleanup = true;
+      }
+    }
+    // Consume one value, then break out (mirrors `for await { break }`).
+    for await (const _v of withSpanGen("test", {}, () => gen())) {
+      break;
+    }
+    expect(cleanup).toBe(true);
+  });
 });
 
 describe("usage slot capture", () => {

--- a/packages/runtime/tests/tracing-helpers.test.ts
+++ b/packages/runtime/tests/tracing-helpers.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tracing-helper tests: verify pass-through behavior when telemetry is off,
+ * and async-generator-aware span wrapping.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  withAgentSpan,
+  withAgentSpanGen,
+  withWorkflowSpan,
+  withNodeSpan,
+  withSpanGen,
+  createUsageSlot,
+  setLastUsage,
+  consumeLastUsage,
+  peekLastUsage
+} from "../src/tracing-helpers.js";
+
+describe("with*Span (no tracer configured)", () => {
+  it("withAgentSpan calls the function with null span", async () => {
+    let received: unknown = "untouched";
+    const result = await withAgentSpan(
+      "execute",
+      { objective: "test" },
+      async (span) => {
+        received = span;
+        return 42;
+      }
+    );
+    expect(result).toBe(42);
+    expect(received).toBeNull();
+  });
+
+  it("withWorkflowSpan / withNodeSpan are pass-through when telemetry is off", async () => {
+    const wf = await withWorkflowSpan({ workflowId: "wf-1" }, async () => "wf");
+    const node = await withNodeSpan(
+      { nodeId: "n1", nodeType: "Constant" },
+      async () => "node"
+    );
+    expect(wf).toBe("wf");
+    expect(node).toBe("node");
+  });
+
+  it("withSpanGen yields all values and preserves TReturn", async () => {
+    async function* gen(): AsyncGenerator<number, string> {
+      yield 1;
+      yield 2;
+      yield 3;
+      return "done";
+    }
+    const yielded: number[] = [];
+    const wrapped = withSpanGen<number, string>("test", {}, () => gen());
+    let result = await wrapped.next();
+    while (!result.done) {
+      yielded.push(result.value);
+      result = await wrapped.next();
+    }
+    expect(yielded).toEqual([1, 2, 3]);
+    expect(result.value).toBe("done");
+  });
+
+  it("withAgentSpanGen forwards yields and TReturn", async () => {
+    async function* gen(): AsyncGenerator<string, number> {
+      yield "a";
+      return 99;
+    }
+    const wrapped = withAgentSpanGen<string, number>(
+      "plan",
+      { objective: "x" },
+      () => gen()
+    );
+    const first = await wrapped.next();
+    expect(first.done).toBe(false);
+    expect(first.value).toBe("a");
+    const second = await wrapped.next();
+    expect(second.done).toBe(true);
+    expect(second.value).toBe(99);
+  });
+
+  it("propagates errors through generator span", async () => {
+    async function* gen(): AsyncGenerator<number> {
+      yield 1;
+      throw new Error("boom");
+    }
+    const wrapped = withSpanGen("test", {}, () => gen());
+    await wrapped.next();
+    await expect(wrapped.next()).rejects.toThrow("boom");
+  });
+});
+
+describe("usage slot capture", () => {
+  it("createUsageSlot captures setLastUsage writes via runInSlot", async () => {
+    const { runInSlot, getUsage } = createUsageSlot();
+    expect(getUsage()).toBeNull();
+
+    await runInSlot(async () => {
+      setLastUsage({ inputTokens: 100, outputTokens: 50, cost: 0.5 });
+    });
+
+    const u = getUsage();
+    expect(u).not.toBeNull();
+    expect(u?.inputTokens).toBe(100);
+    expect(u?.outputTokens).toBe(50);
+    expect(u?.cost).toBe(0.5);
+  });
+
+  it("setLastUsage outside any slot is silently dropped", async () => {
+    setLastUsage({ inputTokens: 1, outputTokens: 1 });
+    expect(peekLastUsage()).toBeNull();
+    expect(consumeLastUsage()).toBeNull();
+  });
+
+  it("nested slots: each slot only sees writes inside its own scope", async () => {
+    const outer = createUsageSlot();
+    const inner = createUsageSlot();
+
+    await outer.runInSlot(async () => {
+      setLastUsage({ inputTokens: 10, outputTokens: 5 });
+      await inner.runInSlot(async () => {
+        setLastUsage({ inputTokens: 99, outputTokens: 99 });
+      });
+    });
+
+    expect(outer.getUsage()?.inputTokens).toBe(10);
+    expect(inner.getUsage()?.inputTokens).toBe(99);
+  });
+
+  it("concurrent slots don't interfere", async () => {
+    const a = createUsageSlot();
+    const b = createUsageSlot();
+
+    await Promise.all([
+      a.runInSlot(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        setLastUsage({ inputTokens: 1, outputTokens: 2 });
+      }),
+      b.runInSlot(async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        setLastUsage({ inputTokens: 100, outputTokens: 200 });
+      })
+    ]);
+
+    expect(a.getUsage()?.inputTokens).toBe(1);
+    expect(b.getUsage()?.inputTokens).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive OpenTelemetry instrumentation across the NodeTool runtime, enabling observability of agent execution, workflow runs, and LLM provider calls. It introduces new span exporters for analyzer-friendly output formats and integrates tracing helpers throughout the agent and kernel execution paths.

## Key Changes

### New Tracing Infrastructure
- **`tracing-helpers.ts`**: Core span wrapping utilities with graceful degradation when telemetry is disabled
  - `withAgentSpan()` / `withAgentSpanGen()` for agent operations (execute/plan/step)
  - `withWorkflowSpan()` for workflow runs
  - `withNodeSpan()` for individual node execution
  - `withSpanGen()` for async-generator-aware span wrapping
  - Usage slot capture via `AsyncLocalStorage` for token counts across concurrent LLM calls

- **`trace-exporters.ts`**: Custom OpenTelemetry span exporters
  - `JsonlFileSpanExporter`: Appends one JSON span per line to a file (analyzer-friendly)
  - `StdoutSpanExporter`: Writes spans to stdout in `pretty` (human-readable) or `json` (JSONL) format
  - `spanToRecord()`: Converts OTel spans to stable `TraceRecord` shape with millisecond timestamps

### Integration Points
- **`BaseProvider`**: Enhanced to capture token usage via `setLastUsage()` and attach `gen_ai.*` semantic convention attributes to LLM spans
- **`Agent` / `TaskPlanner` / `StepExecutor` / `GraphPlanner`**: Wrapped execution paths with `withAgentSpanGen()` to create agent.execute/plan/step spans
- **`WorkflowRunner` / `NodeActor`**: Wrapped with `withWorkflowSpan()` and `withNodeSpan()` to establish span hierarchy
- **`telemetry.ts`**: Extended to support multiple simultaneous sinks (JSONL file, stdout, OTLP) via independent span processors

### CLI & Configuration
- Added `--trace-file` and `--trace-stdout` flags to both `nodetool` and `nodetool-chat` CLIs
- Environment variables: `NODETOOL_TRACE_FILE`, `NODETOOL_TRACE_STDOUT`
- Telemetry initialization now deferred to first use (idempotent via `_initialized` flag)

### Span Hierarchy
```
workflow.run
  node.process (per node)
    agent.execute
      agent.plan
        llm.chat / llm.stream
      agent.step
        llm.chat / llm.stream
```

## Notable Implementation Details

- **Graceful degradation**: All span wrappers pass `null` to callbacks when telemetry is disabled, with zero overhead
- **Async-generator support**: `withSpanGen()` manually manages span context across generator yields since `AsyncLocalStorage.run()` doesn't persist across them
- **Token usage tracking**: Uses `AsyncLocalStorage` to avoid clobbering concurrent calls on the same provider instance; providers call `setLastUsage()` which is read back by traced wrappers
- **Semantic conventions**: Follows OpenTelemetry GenAI conventions (`gen_ai.usage.*`, `gen_ai.system`, etc.) alongside custom `agent.*` and `llm.*` attributes
- **Analyzer-friendly output**: `TraceRecord` uses millisecond timestamps and stable field names for downstream consumption by analyzer agents

## Tests

- `tracing-helpers.test.ts`: Verifies pass-through behavior, async-generator handling, and usage slot isolation
- `trace-exporters.test.ts`: Tests JSONL/stdout formatting and file creation
- `telemetry-integration.test.ts`: End-to-end test wiring real OTel SDK through JSONL exporter, verifying span hierarchy and token attributes

https://claude.ai/code/session_0134DVzr3yUCuEcg8s9KkfeK