### PR TITLE
fix(web): make app header space-efficient on mobile, fullscreen Settings

### DIFF
--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -4,7 +4,8 @@ import React, { memo, useId } from "react";
 import {
   Tabs,
   Tab,
-  Box
+  Box,
+  useMediaQuery
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import SettingsIcon from "@mui/icons-material/Settings";
@@ -327,6 +328,7 @@ function SettingsMenu({ buttonText = "" }: SettingsMenuProps) {
   void secrets;
 
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   return (
     <div className="settings">
@@ -347,11 +349,20 @@ function SettingsMenu({ buttonText = "" }: SettingsMenuProps) {
         open={isMenuOpen}
         onClose={handleClose}
         fullWidth
+        fullScreen={isMobile}
         maxWidth="lg"
+        className={`settings-dialog${isMobile ? " settings-dialog--mobile" : ""}`}
         sx={{
           "& .MuiPaper-root": {
-            height: "85vh",
-            overflow: "hidden"
+            height: isMobile ? "100dvh" : "85vh",
+            maxHeight: isMobile ? "100dvh" : undefined,
+            overflow: "hidden",
+            ...(isMobile && {
+              margin: 0,
+              borderRadius: 0,
+              maxWidth: "100vw",
+              width: "100vw"
+            })
           },
           "& .dialog-content": {
             padding: 0,
@@ -384,20 +395,22 @@ function SettingsMenu({ buttonText = "" }: SettingsMenuProps) {
             </div>
 
             <div className="settings-container">
-              <SettingsSidebar
-                key={`sidebar-${settingsTab}`}
-                activeSection={activeSection}
-                sections={
-                  settingsTab === 0
-                    ? generalSidebarSections
-                    : settingsTab === 1
-                      ? apiKeysSidebarSections
-                      : settingsTab === 2
-                        ? getAboutSidebarSections()
-                        : []
-                }
-                onSectionClick={scrollToSection}
-              />
+              {!isMobile && (
+                <SettingsSidebar
+                  key={`sidebar-${settingsTab}`}
+                  activeSection={activeSection}
+                  sections={
+                    settingsTab === 0
+                      ? generalSidebarSections
+                      : settingsTab === 1
+                        ? apiKeysSidebarSections
+                        : settingsTab === 2
+                          ? getAboutSidebarSections()
+                          : []
+                  }
+                  onSectionClick={scrollToSection}
+                />
+              )}
 
               <div className="settings-content" ref={settingsContentRef}>
                 {/* Tab 0: General */}

--- a/web/src/components/panels/AppHeader.tsx
+++ b/web/src/components/panels/AppHeader.tsx
@@ -3,7 +3,8 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import React, { memo, useCallback, useMemo } from "react";
-import { Toolbar, Box, Button } from "@mui/material";
+import { Toolbar, Box, Button, useMediaQuery } from "@mui/material";
+import AutoAwesomeMosaicIcon from "@mui/icons-material/AutoAwesomeMosaic";
 import { useLocation, useNavigate } from "react-router-dom";
 import { TOOLTIP_ENTER_DELAY, HEADER_HEIGHT } from "../../config/constants";
 import RightSideButtons from "./RightSideButtons";
@@ -255,9 +256,16 @@ const TemplatesButton = memo(function TemplatesButton({
         size="small"
         sx={{
           height: "1.75em",
+          minWidth: "auto",
           borderRadius: "var(--rounded-md)",
           color: "var(--palette-text-default)",
           border: "1px solid transparent",
+          gap: "6px",
+          "& .templates-icon": {
+            width: "16px",
+            height: "16px",
+            fontSize: "16px"
+          },
           "&:hover": {
             backgroundColor: "var(--palette-action-hover)",
             color: "var(--palette-text-primary)",
@@ -274,7 +282,9 @@ const TemplatesButton = memo(function TemplatesButton({
         onClick={handleClick}
         tabIndex={-1}
         aria-current={isActive ? "page" : undefined}
+        aria-label="Templates"
       >
+        <AutoAwesomeMosaicIcon className="templates-icon" />
         <span className="nav-button-text">Templates</span>
       </Button>
     </Tooltip>
@@ -305,6 +315,7 @@ const AppHeader: React.FC = memo(function AppHeader() {
   const path = useLocation().pathname;
   const headerStyles = useMemo(() => styles(theme), [theme]);
   const navigate = useNavigate();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const handleLogoClick = useCallback(() => {
     navigate("/dashboard");
@@ -331,7 +342,7 @@ const AppHeader: React.FC = memo(function AppHeader() {
           <Box sx={{ flexGrow: 1 }} />
         </FlexRow>
         <div className="buttons-right">
-          {workspacesEnabled && <HeaderWorkspaceSelector />}
+          {workspacesEnabled && !isMobile && <HeaderWorkspaceSelector />}
           <TemplatesButton isActive={path.startsWith("/templates")} />
           <RightSideButtons />
         </div>

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -125,6 +125,59 @@
   .mobile .models-manager-dialog .model-list-item .show-in-explorer-button {
     display: none !important;
   }
+  /* Settings Dialog Mobile - fullscreen, edge-to-edge, no sidebar */
+  .mobile .settings-dialog .MuiPaper-root {
+    margin: 0 !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100dvh !important;
+    max-height: 100dvh !important;
+    border-radius: 0 !important;
+  }
+
+  .mobile .settings-dialog .top {
+    padding: 0.6em 0.75em !important;
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 10 !important;
+    background-color: var(--palette-background-paper) !important;
+  }
+
+  .mobile .settings-dialog .settings-tabs {
+    margin-bottom: 0.5em !important;
+  }
+
+  .mobile .settings-dialog .settings-tabs .MuiTab-root {
+    min-width: auto !important;
+    min-height: 44px !important;
+    padding: 6px 12px !important;
+    font-size: 0.85rem !important;
+    flex: 1 !important;
+  }
+
+  .mobile .settings-dialog .sticky-header {
+    padding: 0 0.5em !important;
+  }
+
+  .mobile .settings-dialog .settings-content {
+    padding: 0 0.75em 1.5em !important;
+  }
+
+  .mobile .settings-dialog .settings-section {
+    padding: 0.5em 0.75em 0.75em !important;
+    margin: 1em 0 !important;
+  }
+
+  /* Stack settings item label and control instead of side-by-side */
+  .mobile .settings-dialog .settings-item .MuiInputBase-root {
+    max-width: 100% !important;
+    width: 100% !important;
+  }
+
+  .mobile .settings-dialog .settings-item .MuiFormControl-root .MuiInputBase-root {
+    max-width: 100% !important;
+  }
+
   /* Model Menu (LanguageModelSelect) Mobile Trims */
   .mobile .model-menu__dialog .MuiDialog-paper {
     width: 98% !important;
@@ -227,7 +280,45 @@
 
   /* Adjust logo spacing on mobile */
   .mobile .app-header .logo-container {
-    margin-right: 12px !important;
+    margin-right: 6px !important;
+  }
+
+  /* Tighten toolbar padding on mobile */
+  .mobile .app-header .toolbar {
+    padding: 0 4px 0 6px !important;
+  }
+
+  /* Compact mode pills on mobile to free up space */
+  .mobile .app-header .mode-pills {
+    height: 1.5em !important;
+  }
+
+  .mobile .app-header .mode-pill {
+    padding: 4px 8px !important;
+    font-size: 11px !important;
+    letter-spacing: 0.01em !important;
+  }
+
+  /* Compact buttons-right gap and margins on mobile */
+  .mobile .app-header .buttons-right {
+    gap: 2px !important;
+    margin-left: 4px !important;
+  }
+
+  /* Templates button: icon-only square on mobile */
+  .mobile .app-header .templates-button {
+    padding: 4px 6px !important;
+    min-width: 32px !important;
+  }
+
+  /* Hide Help button on mobile to save space (still accessible via shortcut) */
+  .mobile .app-header .help-button {
+    display: none !important;
+  }
+
+  /* Hide notification badge button on mobile to save space */
+  .mobile .app-header .notification-button {
+    display: none !important;
   }
 
   /* Keep header fixed at the very top on mobile */


### PR DESCRIPTION
- Add icon to Templates button so it remains visible when text is
  hidden on mobile (previously rendered an empty button)
- Hide workspace selector on mobile to free header space
- Compact mode pills (Editor/Chat/App) padding and font on mobile
- Compact buttons-right gap and Templates button on mobile
- Hide Help and Notification buttons on mobile (low-priority on small
  screens) so Templates and Settings remain visible
- Settings dialog: render fullscreen on mobile, hide the sidebar
  (categories already accessible via tabs + section headers), expand
  inputs to full width, make tabs touch-friendly (44px min height)

https://claude.ai/code/session_018BmtnmGoebDhhjQPbFmcq6