### PR TITLE
fix(web): improve mobile rendering — safe areas, edge-to-edge dialogs, no flash

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,8 +4,14 @@
     <style>
       html,
       body,
-      #rooot {
+      #root {
         background-color: var(--palette-background-default, #181a1b);
+      }
+      html,
+      body {
+        /* Match doc bg under iOS dynamic toolbars; block rubber-band scroll. */
+        background-color: var(--palette-background-default, #181a1b);
+        overscroll-behavior-y: none;
       }
     </style>
     <meta charset="utf-8" />

--- a/web/src/components/MobileClassProvider.tsx
+++ b/web/src/components/MobileClassProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
@@ -9,21 +9,20 @@ interface MobileClassProviderProps {
 const MobileClassProvider: React.FC<MobileClassProviderProps> = ({ children }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isCoarsePointer = useMediaQuery('(pointer: coarse)');
 
-  useEffect(() => {
+  // useLayoutEffect: apply class pre-paint so first frame is mobile-styled.
+  useLayoutEffect(() => {
     const body = document.body;
-    
-    if (isMobile) {
-      body.classList.add('mobile');
-    } else {
-      body.classList.remove('mobile');
-    }
 
-    // Cleanup function to remove the class when component unmounts
+    body.classList.toggle('mobile', isMobile);
+    body.classList.toggle('coarse-pointer', isCoarsePointer);
+
     return () => {
       body.classList.remove('mobile');
+      body.classList.remove('coarse-pointer');
     };
-  }, [isMobile]);
+  }, [isMobile, isCoarsePointer]);
 
   return <>{children}</>;
 };

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -131,7 +131,8 @@ const styles = (theme: Theme) =>
       top: 0,
       left: 0,
       width: "100vw",
-      height: "100vh",
+      // dvh: avoid the gap iOS Safari leaves when the URL bar collapses.
+      height: "100dvh",
       padding: 0,
       backgroundColor: `rgba(${theme.vars.palette.background.defaultChannel} / 0.85)`
     },
@@ -554,6 +555,49 @@ const styles = (theme: Theme) =>
       ".button": {
         minWidth: "34px",
         minHeight: "34px"
+      }
+    },
+    // Phones: edge-to-edge — desktop layout leaves a 51px dead band on the left.
+    "@media (max-width: 599.95px)": {
+      ".modal-overlay": {
+        top: 0,
+        left: 0,
+        width: "100vw",
+        height: "100dvh",
+        maxHeight: "100dvh",
+        padding: 0,
+        alignItems: "stretch"
+      },
+      ".modal-content, .modal-content.fullscreen": {
+        width: "100vw",
+        maxWidth: "100vw",
+        height: "100dvh !important",
+        maxHeight: "100dvh",
+        margin: 0,
+        borderRadius: 0,
+        border: "none",
+        animation: "none"
+      },
+      ".resize-handle": {
+        display: "none"
+      },
+      ".language-select": {
+        display: "none"
+      },
+      ".modal-header": {
+        padding: "0.4em 0.6em",
+        minHeight: "2.6em"
+      },
+      ".description": {
+        display: "none"
+      },
+      ".toolbar-group": {
+        padding: "2px 4px"
+      },
+      ".button": {
+        minWidth: "32px",
+        minHeight: "32px",
+        padding: "4px"
       }
     }
   });

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -178,11 +178,14 @@
     max-width: 100% !important;
   }
 
-  /* Model Menu (LanguageModelSelect) Mobile Trims */
+  /* Model Menu fullscreen on mobile — match Settings dialog pattern. */
   .mobile .model-menu__dialog .MuiDialog-paper {
-    width: 98% !important;
-    max-width: 100% !important;
-    margin: 8px !important;
+    margin: 0 !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100dvh !important;
+    max-height: 100dvh !important;
+    border-radius: 0 !important;
   }
 
   /* Collapse complex 3-column grid → single column */
@@ -321,10 +324,13 @@
     display: none !important;
   }
 
-  /* Keep header fixed at the very top on mobile */
+  /* Header pinned to top; honour iOS safe-area so it clears the notch. */
   .mobile .app-header {
     position: fixed !important;
     top: 0 !important;
+    padding-top: env(safe-area-inset-top, 0px) !important;
+    padding-left: env(safe-area-inset-left, 0px) !important;
+    padding-right: env(safe-area-inset-right, 0px) !important;
     z-index: 1400 !important; /* Higher than panels */
   }
 
@@ -359,6 +365,12 @@
   /* Panel Right Mobile Styles - Hide entire right panel container on mobile */
   .mobile .panel-right,
   .mobile .panel-right .panel-container {
+    display: none !important;
+  }
+
+  /* Bottom trace panel is desktop-only; would overlap mobile bottom sheets. */
+  .mobile .panel-bottom-drawer,
+  .mobile .panel-bottom-drawer .MuiDrawer-paper {
     display: none !important;
   }
 
@@ -765,5 +777,46 @@
   .mobile .chat-composer .compose-message textarea {
     padding: 8px 10px 4px 6px;
     min-height: 36px;
+  }
+}
+
+/* Honour iOS safe-area bottom (home indicator) on bottom-anchored elements. */
+@media (max-width: 599.95px) {
+  .mobile .panel-bottom-drawer .MuiDrawer-paper,
+  .mobile .panel-bottom {
+    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+  }
+
+  .mobile .chat-input-section,
+  .mobile .global-chat-container .chat-input-section {
+    padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)) !important;
+  }
+
+  .mobile .mobile-bottom-sheet,
+  .mobile [data-mobile-bottom-sheet] {
+    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+  }
+
+  /* Inputs >=16px so iOS Safari doesn't auto-zoom on focus. */
+  .mobile input[type="text"],
+  .mobile input[type="search"],
+  .mobile input[type="number"],
+  .mobile input[type="email"],
+  .mobile input[type="url"],
+  .mobile input[type="tel"],
+  .mobile input[type="password"],
+  .mobile textarea,
+  .mobile select {
+    font-size: max(16px, 1em) !important;
+  }
+
+  .mobile .app-header .toolbar,
+  .mobile .tabs-container,
+  .mobile [data-mobile-scroll-x] {
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  .mobile .MuiDialog-root .MuiDialogActions-root {
+    padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)) !important;
   }
 }


### PR DESCRIPTION
- index.html: fix #root selector typo so pre-React bg applies; add iOS
  background fallback under dynamic toolbars and disable rubber-band
  overscroll on the document.
- MobileClassProvider: switch to useLayoutEffect so the .mobile class
  is applied before the first paint (fixes desktop->mobile style flash);
  also expose a .coarse-pointer body class for touch-vs-mouse styling.
- mobile.css: pad the fixed app-header for safe-area-inset-top so it
  clears the iOS notch / dynamic island; pad bottom-anchored elements
  (chat input, bottom sheet, dialog actions, panel-bottom) for the home
  indicator; bump form-field font-size to 16px to suppress iOS focus
  auto-zoom; hide the desktop trace PanelBottom on small screens (it
  overlapped the bottom-sheet primitives); make the model-menu dialog
  fullscreen to match the settings-dialog pattern.
- TextEditorModal: collapse the modal to edge-to-edge below 600px wide
  (the desktop top:72px / left:51px offset left a dead band), use 100dvh
  so the modal isn't clipped by mobile browser chrome, and trim the
  toolbar (hide language picker and bottom resize handle) to make room
  for the action buttons.

https://claude.ai/code/session_01FDscBuGv82QbmNCLzrXntQ