### PR TITLE
feat(nodes): user-friendly fields on TextToImage / ImageToImage / TextToVideo / ImageToVideo

### DIFF
--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -111,6 +111,47 @@ function getModelConfig(props: Record<string, unknown>): {
   };
 }
 
+const IMAGE_ASPECT_RATIOS: Record<string, [number, number]> = {
+  "21:9": [21, 9],
+  "16:9": [16, 9],
+  "3:2": [3, 2],
+  "7:5": [7, 5],
+  "4:3": [4, 3],
+  "5:4": [5, 4],
+  "1:1": [1, 1],
+  "9:16": [9, 16],
+  "2:3": [2, 3],
+  "5:7": [5, 7],
+  "3:4": [3, 4],
+  "4:5": [4, 5]
+};
+
+const IMAGE_RESOLUTION_PX: Record<string, number> = {
+  "1K": 1024,
+  "2K": 2048,
+  "4K": 4096
+};
+
+function resolveImageSize(
+  resolution: string,
+  aspectRatio: string
+): { width: number; height: number } {
+  const base = IMAGE_RESOLUTION_PX[resolution] ?? 1024;
+  const [aw, ah] = IMAGE_ASPECT_RATIOS[aspectRatio] ?? [1, 1];
+  if (aw >= ah) {
+    const height = base;
+    const width = Math.round((height * aw) / ah);
+    return { width, height };
+  }
+  const width = base;
+  const height = Math.round((width * ah) / aw);
+  return { width, height };
+}
+
+const IMAGE_ASPECT_RATIO_VALUES = Object.keys(IMAGE_ASPECT_RATIOS);
+const IMAGE_RESOLUTION_VALUES = Object.keys(IMAGE_RESOLUTION_PX);
+const IMAGE_EDIT_STRENGTH_VALUES = [0.25, 0.5, 0.65, 0.75, 0.85, 1.0];
+
 function hasProviderSupport(
   context: ProcessingContext | undefined,
   providerId: string,
@@ -1085,7 +1126,12 @@ export class TextToImageNode extends BaseNode {
   static readonly metadataOutputTypes = {
     output: "image"
   };
-  static readonly basicFields = ["model", "prompt", "width", "height", "seed"];
+  static readonly basicFields = [
+    "model",
+    "prompt",
+    "aspect_ratio",
+    "resolution"
+  ];
   static readonly exposeAsTool = true;
   static readonly autoSaveAsset = true;
 
@@ -1121,61 +1167,24 @@ export class TextToImageNode extends BaseNode {
   declare negative_prompt: any;
 
   @prop({
-    type: "int",
-    default: 512,
-    title: "Width",
-    description: "Width of the generated image",
-    min: 64,
-    max: 2048
+    type: "str",
+    default: "1:1",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the generated image",
+    values: IMAGE_ASPECT_RATIO_VALUES,
+    json_schema_extra: { type: "media_aspect_ratio_image" }
   })
-  declare width: any;
+  declare aspect_ratio: any;
 
   @prop({
-    type: "int",
-    default: 512,
-    title: "Height",
-    description: "Height of the generated image",
-    min: 64,
-    max: 2048
+    type: "str",
+    default: "1K",
+    title: "Resolution",
+    description: "Output resolution (short edge in pixels)",
+    values: IMAGE_RESOLUTION_VALUES,
+    json_schema_extra: { type: "media_resolution_image" }
   })
-  declare height: any;
-
-  @prop({
-    type: "float",
-    default: 7.5,
-    title: "Guidance Scale",
-    description: "Classifier-free guidance scale (higher = closer to prompt)",
-    min: 0,
-    max: 30
-  })
-  declare guidance_scale: any;
-
-  @prop({
-    type: "int",
-    default: 30,
-    title: "Num Inference Steps",
-    description: "Number of denoising steps",
-    min: 1,
-    max: 100
-  })
-  declare num_inference_steps: any;
-
-  @prop({
-    type: "int",
-    default: -1,
-    title: "Seed",
-    description: "Random seed for reproducibility (-1 for random)",
-    min: -1
-  })
-  declare seed: any;
-
-  @prop({
-    type: "bool",
-    default: true,
-    title: "Safety Check",
-    description: "Enable safety checker to filter inappropriate content"
-  })
-  declare safety_check: any;
+  declare resolution: any;
 
   @prop({
     type: "int",
@@ -1189,8 +1198,9 @@ export class TextToImageNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const prompt = String(this.prompt ?? "");
-    const width = Number(this.width ?? 512);
-    const height = Number(this.height ?? 512);
+    const aspectRatio = String(this.aspect_ratio ?? "1:1");
+    const resolution = String(this.resolution ?? "1K");
+    const { width, height } = resolveImageSize(resolution, aspectRatio);
     const { providerId, modelId } = getModelConfig(this.serialize());
     if (!hasProviderSupport(context, providerId, modelId)) {
       throw new Error("No provider available for text-to-image generation.");
@@ -1203,11 +1213,9 @@ export class TextToImageNode extends BaseNode {
         prompt,
         width,
         height,
-        negative_prompt: this.negative_prompt,
-        guidance_scale: this.guidance_scale,
-        num_inference_steps: this.num_inference_steps,
-        seed: this.seed,
-        safety_check: this.safety_check
+        aspect_ratio: aspectRatio,
+        resolution,
+        negative_prompt: this.negative_prompt
       }
     })) as Uint8Array;
     const meta = await metadataFor(output);
@@ -1234,7 +1242,8 @@ export class ImageToImageNode extends BaseNode {
     "image",
     "prompt",
     "strength",
-    "seed"
+    "aspect_ratio",
+    "resolution"
   ];
   static readonly autoSaveAsset = true;
   static readonly exposeAsTool = true;
@@ -1286,63 +1295,34 @@ export class ImageToImageNode extends BaseNode {
 
   @prop({
     type: "float",
-    default: 0.8,
+    default: 0.65,
     title: "Strength",
     description:
-      "How much to transform the input image (0.0 = no change, 1.0 = maximum change)",
-    min: 0,
-    max: 1
+      "How much to transform the input image (subtle = minor edit, strong = major edit)",
+    values: IMAGE_EDIT_STRENGTH_VALUES,
+    json_schema_extra: { type: "media_strength" }
   })
   declare strength: any;
 
   @prop({
-    type: "float",
-    default: 7.5,
-    title: "Guidance Scale",
-    description: "Classifier-free guidance scale",
-    min: 0,
-    max: 30
+    type: "str",
+    default: "1:1",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the output image",
+    values: IMAGE_ASPECT_RATIO_VALUES,
+    json_schema_extra: { type: "media_aspect_ratio_image" }
   })
-  declare guidance_scale: any;
+  declare aspect_ratio: any;
 
   @prop({
-    type: "int",
-    default: 30,
-    title: "Num Inference Steps",
-    description: "Number of denoising steps",
-    min: 1,
-    max: 100
+    type: "str",
+    default: "1K",
+    title: "Resolution",
+    description: "Output resolution (short edge in pixels)",
+    values: IMAGE_RESOLUTION_VALUES,
+    json_schema_extra: { type: "media_resolution_image" }
   })
-  declare num_inference_steps: any;
-
-  @prop({
-    type: "int",
-    default: 512,
-    title: "Target Width",
-    description: "Target width of the output image",
-    min: 64,
-    max: 2048
-  })
-  declare target_width: any;
-
-  @prop({
-    type: "int",
-    default: 512,
-    title: "Target Height",
-    description: "Target height of the output image",
-    min: 64,
-    max: 2048
-  })
-  declare target_height: any;
-
-  @prop({
-    type: "int",
-    default: -1,
-    title: "Seed",
-    description: "Random seed for reproducibility (-1 for random)",
-    min: -1
-  })
-  declare seed: any;
+  declare resolution: any;
 
   @prop({
     type: "str",
@@ -1351,14 +1331,6 @@ export class ImageToImageNode extends BaseNode {
     description: "Scheduler to use (provider-specific)"
   })
   declare scheduler: any;
-
-  @prop({
-    type: "bool",
-    default: true,
-    title: "Safety Check",
-    description: "Enable safety checker"
-  })
-  declare safety_check: any;
 
   @prop({
     type: "int",
@@ -1376,6 +1348,9 @@ export class ImageToImageNode extends BaseNode {
     if (bytes.length === 0) {
       throw new Error("The input image is empty.");
     }
+    const aspectRatio = String(this.aspect_ratio ?? "1:1");
+    const resolution = String(this.resolution ?? "1K");
+    const { width, height } = resolveImageSize(resolution, aspectRatio);
     const { providerId, modelId } = getModelConfig(this.serialize());
     if (!hasProviderSupport(context, providerId, modelId)) {
       throw new Error("No provider available for image-to-image generation.");
@@ -1388,12 +1363,11 @@ export class ImageToImageNode extends BaseNode {
         image: bytes,
         prompt: String(this.prompt ?? ""),
         negative_prompt: this.negative_prompt,
-        target_width: this.target_width,
-        target_height: this.target_height,
-        guidance_scale: this.guidance_scale,
-        num_inference_steps: this.num_inference_steps,
+        target_width: width,
+        target_height: height,
+        aspect_ratio: aspectRatio,
+        resolution,
         strength: this.strength,
-        seed: this.seed,
         scheduler: this.scheduler
       }
     })) as Uint8Array;

--- a/packages/base-nodes/src/nodes/video.ts
+++ b/packages/base-nodes/src/nodes/video.ts
@@ -130,6 +130,17 @@ function canUseProvider(
   );
 }
 
+const VIDEO_ASPECT_RATIO_VALUES = [
+  "21:9",
+  "16:9",
+  "4:3",
+  "1:1",
+  "9:16",
+  "3:4"
+];
+const VIDEO_RESOLUTION_VALUES = ["1080p", "1440p", "4K"];
+const VIDEO_DURATION_VALUES = [2, 3, 4, 5, 6, 8];
+
 async function withTempFile(
   suffix: string,
   bytes: Uint8Array
@@ -188,7 +199,7 @@ export class TextToVideoNode extends BaseNode {
     "prompt",
     "aspect_ratio",
     "resolution",
-    "seed"
+    "duration"
   ];
   static readonly exposeAsTool = true;
 
@@ -224,61 +235,34 @@ export class TextToVideoNode extends BaseNode {
   declare negative_prompt: any;
 
   @prop({
-    type: "enum",
+    type: "str",
     default: "16:9",
     title: "Aspect Ratio",
     description: "Aspect ratio for the video",
-    values: ["16:9", "9:16", "1:1", "4:3", "3:4"]
+    values: VIDEO_ASPECT_RATIO_VALUES,
+    json_schema_extra: { type: "media_aspect_ratio_video" }
   })
   declare aspect_ratio: any;
 
   @prop({
-    type: "enum",
-    default: "720p",
+    type: "str",
+    default: "1080p",
     title: "Resolution",
     description: "Video resolution",
-    values: ["480p", "720p", "1080p"]
+    values: VIDEO_RESOLUTION_VALUES,
+    json_schema_extra: { type: "media_resolution_video" }
   })
   declare resolution: any;
 
   @prop({
     type: "int",
-    default: 60,
-    title: "Num Frames",
-    description: "Number of frames to generate (provider-specific)",
-    min: 1,
-    max: 300
+    default: 8,
+    title: "Duration",
+    description: "Video duration in seconds",
+    values: VIDEO_DURATION_VALUES,
+    json_schema_extra: { type: "media_duration" }
   })
-  declare num_frames: any;
-
-  @prop({
-    type: "float",
-    default: 7.5,
-    title: "Guidance Scale",
-    description: "Classifier-free guidance scale (higher = closer to prompt)",
-    min: 0,
-    max: 30
-  })
-  declare guidance_scale: any;
-
-  @prop({
-    type: "int",
-    default: 30,
-    title: "Num Inference Steps",
-    description: "Number of denoising steps",
-    min: 1,
-    max: 100
-  })
-  declare num_inference_steps: any;
-
-  @prop({
-    type: "int",
-    default: -1,
-    title: "Seed",
-    description: "Random seed for reproducibility (-1 for random)",
-    min: -1
-  })
-  declare seed: any;
+  declare duration: any;
 
   @prop({
     type: "int",
@@ -301,7 +285,7 @@ export class TextToVideoNode extends BaseNode {
         params: {
           prompt: text,
           negative_prompt: this.negative_prompt,
-          num_frames: this.num_frames,
+          duration_seconds: Number(this.duration ?? 0) || undefined,
           aspect_ratio: this.aspect_ratio,
           resolution: this.resolution
         }
@@ -327,7 +311,7 @@ export class ImageToVideoNode extends BaseNode {
     "prompt",
     "aspect_ratio",
     "resolution",
-    "seed"
+    "duration"
   ];
   static readonly exposeAsTool = true;
 
@@ -377,61 +361,34 @@ export class ImageToVideoNode extends BaseNode {
   declare negative_prompt: any;
 
   @prop({
-    type: "enum",
+    type: "str",
     default: "16:9",
     title: "Aspect Ratio",
     description: "Aspect ratio for the video",
-    values: ["16:9", "9:16", "1:1", "4:3", "3:4"]
+    values: VIDEO_ASPECT_RATIO_VALUES,
+    json_schema_extra: { type: "media_aspect_ratio_video" }
   })
   declare aspect_ratio: any;
 
   @prop({
-    type: "enum",
-    default: "720p",
+    type: "str",
+    default: "1080p",
     title: "Resolution",
     description: "Video resolution",
-    values: ["480p", "720p", "1080p"]
+    values: VIDEO_RESOLUTION_VALUES,
+    json_schema_extra: { type: "media_resolution_video" }
   })
   declare resolution: any;
 
   @prop({
     type: "int",
-    default: 60,
-    title: "Num Frames",
-    description: "Number of frames to generate (provider-specific)",
-    min: 1,
-    max: 300
+    default: 4,
+    title: "Duration",
+    description: "Video duration in seconds",
+    values: VIDEO_DURATION_VALUES,
+    json_schema_extra: { type: "media_duration" }
   })
-  declare num_frames: any;
-
-  @prop({
-    type: "float",
-    default: 7.5,
-    title: "Guidance Scale",
-    description: "Classifier-free guidance scale (higher = closer to prompt)",
-    min: 0,
-    max: 30
-  })
-  declare guidance_scale: any;
-
-  @prop({
-    type: "int",
-    default: 30,
-    title: "Num Inference Steps",
-    description: "Number of denoising steps",
-    min: 1,
-    max: 100
-  })
-  declare num_inference_steps: any;
-
-  @prop({
-    type: "int",
-    default: -1,
-    title: "Seed",
-    description: "Random seed for reproducibility (-1 for random)",
-    min: -1
-  })
-  declare seed: any;
+  declare duration: any;
 
   @prop({
     type: "int",
@@ -456,7 +413,7 @@ export class ImageToVideoNode extends BaseNode {
           image: img,
           prompt,
           negative_prompt: this.negative_prompt,
-          num_frames: this.num_frames,
+          duration_seconds: Number(this.duration ?? 0) || undefined,
           aspect_ratio: this.aspect_ratio,
           resolution: this.resolution
         }

--- a/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
+++ b/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
@@ -1331,8 +1331,8 @@ describe("image nodes — full coverage", () => {
     });
     expect(new TextToImageNode().serialize()).toMatchObject({
       prompt: "A cat holding a sign that says hello world",
-      width: 512,
-      height: 512
+      aspect_ratio: "1:1",
+      resolution: "1K"
     });
     expect(new ImageToImageNode().serialize()).toMatchObject({
       image: { type: "image", uri: "" },
@@ -1342,7 +1342,7 @@ describe("image nodes — full coverage", () => {
 
   it("TextToImageNode throws without provider", async () => {
     const _n = new TextToImageNode();
-    _n.assign({ prompt: "test-img", width: 256, height: 128 });
+    _n.assign({ prompt: "test-img", aspect_ratio: "1:1", resolution: "1K" });
     await expect(_n.process()).rejects.toThrow(
       "No provider available for text-to-image generation"
     );
@@ -1680,14 +1680,15 @@ describe("video nodes — full coverage", () => {
     expect(new TextToVideoNode().serialize()).toMatchObject({
       prompt: "A cat playing with a ball of yarn",
       aspect_ratio: "16:9",
-      resolution: "720p",
-      num_frames: 60
+      resolution: "1080p",
+      duration: 8
     });
     expect(new ImageToVideoNode().serialize()).toMatchObject({
       image: { type: "image", uri: "" },
       prompt: "",
       aspect_ratio: "16:9",
-      resolution: "720p"
+      resolution: "1080p",
+      duration: 4
     });
     expect(new LoadVideoFileNode().serialize()).toEqual({ path: "" });
     expect(new SaveVideoFileVideoNode().serialize()).toMatchObject({

--- a/packages/base-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/base-nodes/tests/regression-image-nodes.test.ts
@@ -353,26 +353,28 @@ describe("GetMetadataNode — output schema", () => {
 // ---------------------------------------------------------------------------
 
 describe("TextToImageNode — provider params", () => {
-  it("has guidance_scale, num_inference_steps, seed properties", () => {
+  it("has aspect_ratio and resolution properties", () => {
     const node = new TextToImageNode();
-    // These should be assignable without error
     node.assign({
-      guidance_scale: 7.5,
-      num_inference_steps: 30,
-      seed: 42
+      aspect_ratio: "16:9",
+      resolution: "2K"
     });
-    expect(node.guidance_scale).toBe(7.5);
-    expect(node.num_inference_steps).toBe(30);
-    expect(node.seed).toBe(42);
+    expect(node.aspect_ratio).toBe("16:9");
+    expect(node.resolution).toBe("2K");
   });
 
-  it("does not have a quality property in metadataOutputTypes or basicFields", () => {
-    expect(TextToImageNode.basicFields).not.toContain("quality");
-    expect(TextToImageNode.metadataOutputTypes).not.toHaveProperty("quality");
+  it("does not expose low-level sampler params", () => {
+    expect(TextToImageNode.basicFields).not.toContain("guidance_scale");
+    expect(TextToImageNode.basicFields).not.toContain("num_inference_steps");
+    expect(TextToImageNode.basicFields).not.toContain("seed");
+    expect(TextToImageNode.basicFields).not.toContain("safety_check");
+    expect(TextToImageNode.basicFields).not.toContain("width");
+    expect(TextToImageNode.basicFields).not.toContain("height");
   });
 
-  it("basicFields includes seed", () => {
-    expect(TextToImageNode.basicFields).toContain("seed");
+  it("basicFields surfaces aspect_ratio and resolution", () => {
+    expect(TextToImageNode.basicFields).toContain("aspect_ratio");
+    expect(TextToImageNode.basicFields).toContain("resolution");
   });
 });
 

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1441,6 +1441,8 @@ export class ProcessingContext {
           model: { id: req.model, name: req.model, provider: req.provider },
           width: params.width as number | undefined,
           height: params.height as number | undefined,
+          aspectRatio: params.aspect_ratio as string | undefined,
+          resolution: params.resolution as string | undefined,
           negativePrompt: params.negative_prompt as string | undefined,
           quality: params.quality as string | undefined
         });
@@ -1451,6 +1453,9 @@ export class ProcessingContext {
           negativePrompt: params.negative_prompt as string | undefined,
           targetWidth: params.target_width as number | undefined,
           targetHeight: params.target_height as number | undefined,
+          aspectRatio: params.aspect_ratio as string | undefined,
+          resolution: params.resolution as string | undefined,
+          strength: params.strength as number | undefined,
           quality: params.quality as string | undefined
         });
       case "text_to_video":
@@ -1459,6 +1464,7 @@ export class ProcessingContext {
           model: { id: req.model, name: req.model, provider: req.provider },
           negativePrompt: params.negative_prompt as string | undefined,
           numFrames: params.num_frames as number | undefined,
+          durationSeconds: params.duration_seconds as number | undefined,
           aspectRatio: params.aspect_ratio as string | undefined,
           resolution: params.resolution as string | undefined
         });
@@ -1468,6 +1474,7 @@ export class ProcessingContext {
           model: { id: req.model, name: req.model, provider: req.provider },
           negativePrompt: params.negative_prompt as string | undefined,
           numFrames: params.num_frames as number | undefined,
+          durationSeconds: params.duration_seconds as number | undefined,
           aspectRatio: params.aspect_ratio as string | undefined,
           resolution: params.resolution as string | undefined
         });

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -117,6 +117,8 @@ export interface TextToImageParams {
   negativePrompt?: string | null;
   width?: number;
   height?: number;
+  aspectRatio?: string | null;
+  resolution?: string | null;
   quality?: string | null;
   guidanceScale?: number | null;
   numInferenceSteps?: number | null;
@@ -131,6 +133,8 @@ export interface ImageToImageParams {
   negativePrompt?: string | null;
   targetWidth?: number | null;
   targetHeight?: number | null;
+  aspectRatio?: string | null;
+  resolution?: string | null;
   quality?: string | null;
   guidanceScale?: number | null;
   numInferenceSteps?: number | null;

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -51,6 +51,14 @@ import AudioListProperty from "../properties/AudioListProperty";
 import TextListProperty from "../properties/TextListProperty";
 import useMetadataStore from "../../stores/MetadataStore";
 import InferenceProviderModelSelect from "../properties/InferenceProviderModelSelect";
+import {
+  MediaAspectRatioImageProperty,
+  MediaAspectRatioVideoProperty,
+  MediaResolutionImageProperty,
+  MediaResolutionVideoProperty,
+  MediaDurationProperty,
+  MediaStrengthProperty
+} from "../properties/MediaPickerProperties";
 import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
 import { NodeData } from "../../stores/NodeData";
 import { useInputNodeAutoRun } from "../../hooks/nodes/useInputNodeAutoRun";
@@ -196,28 +204,62 @@ export function getComponentForProperty(
     values?: (string | number)[];
     enum?: (string | number)[];
   };
-  // If property has predefined values, treat it as an enum/select 
+
+  // Explicit `json_schema_extra.type` opts into a custom renderer regardless
+  // of base type or attached enum values (e.g. media_aspect_ratio_image
+  // wants the chip-style picker even though `values` is set).
+  if (property.json_schema_extra?.type) {
+    const overrideComponent = customComponentForType(
+      property.json_schema_extra.type as string
+    );
+    if (overrideComponent) {
+      return overrideComponent;
+    }
+  }
+
+  // If property has predefined values, treat it as an enum/select
   // regardless of base type (often comes as 'str' from dynamic schemas)
-  const hasValues = (property.type.values && property.type.values.length > 0) || 
+  const hasValues = (property.type.values && property.type.values.length > 0) ||
                     (property.type.type_args?.[0]?.values && property.type.type_args[0].values.length > 0) ||
                     (propertyWithExtras.values && propertyWithExtras.values.length > 0) ||
                     (propertyWithExtras.enum && propertyWithExtras.enum.length > 0);
-  
+
   if (hasValues) {
     return EnumProperty;
   }
 
   if (property.json_schema_extra?.type) {
     return componentForType(property.json_schema_extra.type as string);
-  } else {
-    switch (property.type.type) {
-      case "union":
-        return handleUnionType(property);
-      case "list":
-        return handleListType(property);
-      default:
-        return componentForType(property.type.type);
-    }
+  }
+
+  switch (property.type.type) {
+    case "union":
+      return handleUnionType(property);
+    case "list":
+      return handleListType(property);
+    default:
+      return componentForType(property.type.type);
+  }
+}
+
+function customComponentForType(
+  type: string
+): React.ComponentType<PropertyProps> | null {
+  switch (type) {
+    case "media_aspect_ratio_image":
+      return MediaAspectRatioImageProperty;
+    case "media_aspect_ratio_video":
+      return MediaAspectRatioVideoProperty;
+    case "media_resolution_image":
+      return MediaResolutionImageProperty;
+    case "media_resolution_video":
+      return MediaResolutionVideoProperty;
+    case "media_duration":
+      return MediaDurationProperty;
+    case "media_strength":
+      return MediaStrengthProperty;
+    default:
+      return null;
   }
 }
 

--- a/web/src/components/properties/MediaPickerProperties.tsx
+++ b/web/src/components/properties/MediaPickerProperties.tsx
@@ -1,0 +1,237 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useMemo, useRef, useState } from "react";
+import isEqual from "fast-deep-equal";
+import AspectRatioIcon from "@mui/icons-material/AspectRatio";
+import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import TuneIcon from "@mui/icons-material/Tune";
+import type { PropertyProps } from "../node/PropertyInput";
+import PropertyLabel from "../node/PropertyLabel";
+import MediaControlChip from "../chat/composer/MediaControlChip";
+import MediaAspectRatioMenu from "../chat/composer/MediaAspectRatioMenu";
+import MediaOptionMenu, {
+  type MediaOption
+} from "../chat/composer/MediaOptionMenu";
+import {
+  IMAGE_ASPECT_RATIOS,
+  VIDEO_ASPECT_RATIOS,
+  IMAGE_RESOLUTIONS,
+  VIDEO_RESOLUTIONS,
+  VIDEO_DURATIONS,
+  IMAGE_EDIT_STRENGTHS,
+  type AspectRatioOption
+} from "../../stores/MediaGenerationStore";
+
+interface AspectRatioBaseProps extends PropertyProps {
+  options: AspectRatioOption[];
+  defaultId: string;
+}
+
+const AspectRatioPicker: React.FC<AspectRatioBaseProps> = ({
+  property,
+  propertyIndex,
+  value,
+  onChange,
+  options,
+  defaultId
+}) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const id = `media-aspect-${property.name}-${propertyIndex}`;
+  const current = String(value ?? defaultId);
+  return (
+    <div className="media-aspect-ratio-property">
+      <PropertyLabel
+        name={property.name}
+        description={property.description}
+        id={id}
+      />
+      <MediaControlChip
+        ref={ref}
+        icon={<AspectRatioIcon fontSize="small" />}
+        label={current}
+        active={open}
+        onClick={() => setOpen(true)}
+        showChevron={false}
+      />
+      <MediaAspectRatioMenu
+        anchorEl={ref.current}
+        open={open}
+        onClose={() => setOpen(false)}
+        value={current}
+        options={options}
+        onChange={(v) => onChange(v)}
+      />
+    </div>
+  );
+};
+
+export const MediaAspectRatioImageProperty = memo<PropertyProps>(
+  (props) => (
+    <AspectRatioPicker
+      {...props}
+      options={IMAGE_ASPECT_RATIOS}
+      defaultId="1:1"
+    />
+  ),
+  isEqual
+);
+MediaAspectRatioImageProperty.displayName = "MediaAspectRatioImageProperty";
+
+export const MediaAspectRatioVideoProperty = memo<PropertyProps>(
+  (props) => (
+    <AspectRatioPicker
+      {...props}
+      options={VIDEO_ASPECT_RATIOS}
+      defaultId="16:9"
+    />
+  ),
+  isEqual
+);
+MediaAspectRatioVideoProperty.displayName = "MediaAspectRatioVideoProperty";
+
+interface OptionPickerProps<T extends string | number> extends PropertyProps {
+  options: MediaOption<T>[];
+  header?: string;
+  icon: React.ReactNode;
+  formatLabel?: (value: T) => string;
+  defaultValue: T;
+}
+
+function OptionPicker<T extends string | number>({
+  property,
+  propertyIndex,
+  value,
+  onChange,
+  options,
+  header,
+  icon,
+  formatLabel,
+  defaultValue
+}: OptionPickerProps<T>) {
+  const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null);
+  const id = `media-option-${property.name}-${propertyIndex}`;
+  const current = (value ?? defaultValue) as T;
+  const labelText = formatLabel
+    ? formatLabel(current)
+    : String(current);
+  return (
+    <div className="media-option-property">
+      <PropertyLabel
+        name={property.name}
+        description={property.description}
+        id={id}
+      />
+      <MediaControlChip
+        icon={icon}
+        label={labelText}
+        active={!!anchor}
+        onClick={(e) => setAnchor(e.currentTarget)}
+        showChevron={false}
+      />
+      <MediaOptionMenu<T>
+        anchorEl={anchor}
+        open={!!anchor}
+        onClose={() => setAnchor(null)}
+        header={header}
+        value={current}
+        options={options}
+        onChange={(v) => onChange(v as unknown)}
+      />
+    </div>
+  );
+}
+
+export const MediaResolutionImageProperty = memo<PropertyProps>((props) => {
+  const options = useMemo<MediaOption<string>[]>(
+    () =>
+      IMAGE_RESOLUTIONS.map((r) => ({
+        id: r,
+        label: r,
+        icon: <DisplaySettingsIcon fontSize="small" />
+      })),
+    []
+  );
+  return (
+    <OptionPicker<string>
+      {...props}
+      options={options}
+      header="Image Resolution"
+      icon={<DisplaySettingsIcon fontSize="small" />}
+      defaultValue="1K"
+    />
+  );
+}, isEqual);
+MediaResolutionImageProperty.displayName = "MediaResolutionImageProperty";
+
+export const MediaResolutionVideoProperty = memo<PropertyProps>((props) => {
+  const options = useMemo<MediaOption<string>[]>(
+    () =>
+      VIDEO_RESOLUTIONS.map((r) => ({
+        id: r,
+        label: r,
+        icon: <DisplaySettingsIcon fontSize="small" />
+      })),
+    []
+  );
+  return (
+    <OptionPicker<string>
+      {...props}
+      options={options}
+      header="Video Resolution"
+      icon={<DisplaySettingsIcon fontSize="small" />}
+      defaultValue="1080p"
+    />
+  );
+}, isEqual);
+MediaResolutionVideoProperty.displayName = "MediaResolutionVideoProperty";
+
+export const MediaDurationProperty = memo<PropertyProps>((props) => {
+  const options = useMemo<MediaOption<number>[]>(
+    () =>
+      VIDEO_DURATIONS.map((d) => ({
+        id: d,
+        label: `${d} Sec`,
+        icon: <AccessTimeIcon fontSize="small" />
+      })),
+    []
+  );
+  return (
+    <OptionPicker<number>
+      {...props}
+      options={options}
+      header="Duration"
+      icon={<AccessTimeIcon fontSize="small" />}
+      defaultValue={4}
+      formatLabel={(v) => `${v} Sec`}
+    />
+  );
+}, isEqual);
+MediaDurationProperty.displayName = "MediaDurationProperty";
+
+const strengthDescription = (s: number): string =>
+  s <= 0.35 ? "subtle" : s >= 0.85 ? "strong" : "balanced";
+
+export const MediaStrengthProperty = memo<PropertyProps>((props) => {
+  const options = useMemo<MediaOption<number>[]>(
+    () =>
+      IMAGE_EDIT_STRENGTHS.map((s) => ({
+        id: s,
+        label: s.toFixed(2),
+        description: strengthDescription(s),
+        icon: <TuneIcon fontSize="small" />
+      })),
+    []
+  );
+  return (
+    <OptionPicker<number>
+      {...props}
+      options={options}
+      header="Strength"
+      icon={<TuneIcon fontSize="small" />}
+      defaultValue={0.65}
+      formatLabel={(v) => `${(v as number).toFixed(2)} · ${strengthDescription(v as number)}`}
+    />
+  );
+}, isEqual);
+MediaStrengthProperty.displayName = "MediaStrengthProperty";


### PR DESCRIPTION
Replace low-level sampler params (num_inference_steps, guidance_scale,
seed, safety_check, width/height/target_width/target_height, num_frames)
with the same chip-style aspect-ratio / resolution / duration / strength
pickers used by the media chat composer.

- TextToImage / ImageToImage: aspect_ratio + resolution (chip pickers
  matching IMAGE_ASPECT_RATIOS / IMAGE_RESOLUTIONS); width/height now
  derived from these in process(). ImageToImage keeps strength but as a
  preset list (subtle / balanced / strong).
- TextToVideo / ImageToVideo: aspect_ratio + resolution + duration
  (chip pickers matching VIDEO_ASPECT_RATIOS / VIDEO_RESOLUTIONS /
  VIDEO_DURATIONS). num_frames replaced by duration in seconds.
- New MediaPickerProperties.tsx wraps MediaControlChip + MediaOptionMenu
  + MediaAspectRatioMenu so node properties render with the exact UI of
  the media chat composer.
- PropertyInput dispatcher: json_schema_extra.type now wins over the
  values-based EnumProperty fallback when it maps to a known custom
  component, so the new media_aspect_ratio_* / media_resolution_* /
  media_duration / media_strength types render as chips instead of a
  plain dropdown.
- Provider param plumbing: forward aspect_ratio/resolution to
  text_to_image/image_to_image and duration_seconds to text_to_video/
  image_to_video so providers that natively understand these (FAL,
  Gemini) can use them.

https://claude.ai/code/session_01A4qws63ndh2rV9z89t99WU