### PR TITLE
Update AI models, providers, and deployment documentation

### DIFF
--- a/marketing/src/app/features.tsx
+++ b/marketing/src/app/features.tsx
@@ -86,7 +86,7 @@ export const features = [
   {
     name: "📁 Vector Storage & RAG",
     description:
-      "Built-in ChromaDB means your AI remembers everything. Create smart assistants that know your documents.",
+      "Built-in SQLite-vec embedded vector store. Create smart assistants that know your documents—no extra database to run.",
     icon: FolderIcon,
     href: "#",
     gif: "/vector-db.jpg",

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -58,7 +58,7 @@ export default function ComparisonSection({
           />
           <ComparisonCard
             competitor="LangChain"
-            sentence="LangChain is a Python framework for LLM apps. NodeTool is a visual, TypeScript-first platform with an async Node.js runtime and custom nodes in TS."
+            sentence="LangChain is a Python framework for LLM apps. NodeTool is a visual, TypeScript-first platform with an async Node.js runtime and custom nodes in TypeScript or Python."
             reducedMotion={reducedMotion}
             delay={0.1}
           />

--- a/marketing/src/components/DeploySection.tsx
+++ b/marketing/src/components/DeploySection.tsx
@@ -33,9 +33,10 @@ export default function DeploySection({
             </h2>
 
             <p className="text-lg text-slate-400 mb-8 leading-relaxed">
-              Same workflow runs locally or on serverless GPUs with no
-              rewrites. NodeTool provisions infrastructure, downloads models,
-              and configures containers automatically.
+              Same workflow runs locally or on a remote GPU with no rewrites.
+              NodeTool builds the container image and ships it to your provider
+              of choice—RunPod, Google Cloud Run, Fly.io, Railway, or your own
+              SSH host.
             </p>
 
             <div className="flex flex-col gap-6">
@@ -62,10 +63,11 @@ export default function DeploySection({
                   <Zap className="w-5 h-5 text-pink-400" />
                 </div>
                 <div>
-                  <h3 className="text-white font-semibold">Scale to Zero</h3>
+                  <h3 className="text-white font-semibold">Serverless-Ready</h3>
                   <p className="text-slate-400 text-sm mt-1 leading-relaxed">
-                    Pay only for active inference time. Endpoints automatically
-                    scale down when idle to save costs.
+                    Deploy to Google Cloud Run for native scale-to-zero, or to
+                    RunPod serverless endpoints—pay only when your workflow
+                    runs.
                   </p>
                 </div>
               </div>

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -140,7 +140,7 @@ export default function FeaturesSection({
             {
               title: "Multimodal",
               description:
-                "Process text, image, audio, and video in a single workflow. ChromaDB for RAG included.",
+                "Process text, image, audio, and video in a single workflow. Built-in SQLite-vec store for RAG.",
               icon: Layers,
               color: "text-orange-400",
               bg: "bg-orange-500/10",

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { motion } from "framer-motion";
-import { Cpu, Zap, Layers, Box, Sparkles, Cloud, Globe, Bot, ShieldCheck } from "lucide-react";
+import { Cpu, Zap, Layers, Box, Sparkles, Cloud, Bot, ShieldCheck } from "lucide-react";
 import {
     OpenAILogo,
     AnthropicLogo,
@@ -23,7 +23,7 @@ const localEngines = [
     { title: "Ollama", url: "https://ollama.com", LogoComponent: OllamaLogo, icon: Box, color: "text-purple-400", bg: "bg-purple-500/10", border: "border-purple-500/20" },
     { title: "llama.cpp", url: "https://github.com/ggml-org/llama.cpp", LogoComponent: LlamaCppLogo, icon: Zap, color: "text-yellow-400", bg: "bg-yellow-500/10", border: "border-yellow-500/20" },
     { title: "vLLM", url: "https://github.com/vllm-project/vllm", LogoComponent: null, icon: Layers, color: "text-cyan-400", bg: "bg-cyan-500/10", border: "border-cyan-500/20" },
-    { title: "Nunchaku", url: "https://github.com/nunchaku-tech/nunchaku", LogoComponent: null, icon: Sparkles, color: "text-pink-400", bg: "bg-pink-500/10", border: "border-pink-500/20" },
+    { title: "LM Studio", url: "https://lmstudio.ai", LogoComponent: null, icon: Box, color: "text-pink-400", bg: "bg-pink-500/10", border: "border-pink-500/20" },
 ];
 
 const cloudProviders = [
@@ -31,12 +31,13 @@ const cloudProviders = [
     { title: "Anthropic", url: "https://anthropic.com", LogoComponent: AnthropicLogo, icon: null, color: "text-amber-400", bg: "bg-amber-500/10", border: "border-amber-500/20" },
     { title: "Google", url: "https://ai.google.dev", LogoComponent: GeminiLogo, icon: null, color: "text-blue-400", bg: "bg-blue-500/10", border: "border-blue-500/20" },
     { title: "xAI", url: "https://x.ai", LogoComponent: null, icon: Bot, color: "text-indigo-400", bg: "bg-indigo-500/10", border: "border-indigo-500/20" },
+    { title: "Mistral", url: "https://mistral.ai", LogoComponent: null, icon: Sparkles, color: "text-orange-400", bg: "bg-orange-500/10", border: "border-orange-500/20" },
+    { title: "Groq", url: "https://groq.com", LogoComponent: null, icon: Zap, color: "text-rose-400", bg: "bg-rose-500/10", border: "border-rose-500/20" },
+    { title: "DeepSeek", url: "https://deepseek.com", LogoComponent: null, icon: Bot, color: "text-blue-400", bg: "bg-blue-500/10", border: "border-blue-500/20" },
+    { title: "Cerebras", url: "https://cerebras.ai", LogoComponent: null, icon: Zap, color: "text-amber-400", bg: "bg-amber-500/10", border: "border-amber-500/20" },
+    { title: "Together", url: "https://together.ai", LogoComponent: null, icon: Layers, color: "text-violet-400", bg: "bg-violet-500/10", border: "border-violet-500/20" },
     { title: "Kie.ai", url: "https://kie.ai", LogoComponent: null, icon: Sparkles, color: "text-sky-400", bg: "bg-sky-500/10", border: "border-sky-500/20" },
-    { title: "z.ai", url: "https://z.ai", LogoComponent: null, icon: Zap, color: "text-teal-400", bg: "bg-teal-500/10", border: "border-teal-500/20" },
-    { title: "Black Forest Labs", url: "https://blackforestlabs.ai", LogoComponent: null, icon: Sparkles, color: "text-pink-400", bg: "bg-pink-500/10", border: "border-pink-500/20" },
-    { title: "Alibaba", url: "https://www.alibabacloud.com", LogoComponent: null, icon: Globe, color: "text-orange-400", bg: "bg-orange-500/10", border: "border-orange-500/20" },
     { title: "MiniMax", url: "https://www.minimaxi.com", LogoComponent: null, icon: ShieldCheck, color: "text-red-400", bg: "bg-red-500/10", border: "border-red-500/20" },
-    { title: "Kling", url: "https://kling.kuaishou.com", LogoComponent: null, icon: Zap, color: "text-cyan-400", bg: "bg-cyan-500/10", border: "border-cyan-500/20" },
     { title: "Replicate", url: "https://replicate.com", LogoComponent: ReplicateLogo, icon: null, color: "text-purple-400", bg: "bg-purple-500/10", border: "border-purple-500/20" },
     { title: "Fal AI", url: "https://fal.ai", LogoComponent: null, icon: Layers, color: "text-teal-400", bg: "bg-teal-500/10", border: "border-teal-500/20" },
     { title: "OpenRouter", url: "https://openrouter.ai", LogoComponent: OpenRouterLogo, icon: null, color: "text-violet-400", bg: "bg-violet-500/10", border: "border-violet-500/20" },
@@ -44,24 +45,17 @@ const cloudProviders = [
 ];
 
 const frontierModels = [
-    { name: "GPT-5.4", color: "text-emerald-400" },
-    { name: "Claude 4.5 Opus", color: "text-amber-400" },
-    { name: "Claude 4.5 Sonnet", color: "text-amber-400" },
-    { name: "Gemini 3.0 Flash", color: "text-blue-400" },
-    { name: "Gemini 3.0 Pro", color: "text-blue-400" },
-    { name: "Kimi K 2.5", color: "text-orange-400" },
-    { name: "GLM 5.1", color: "text-red-400" },
-    { name: "MiniMax M2.7", color: "text-teal-400" },
-    { name: "FLUX.2 Pro", color: "text-pink-400" },
-    { name: "gpt-image-1.5", color: "text-emerald-400" },
+    { name: "Claude Opus 4.7", color: "text-amber-400" },
+    { name: "Claude Sonnet 4.6", color: "text-amber-400" },
+    { name: "Claude Haiku 4.5", color: "text-amber-400" },
+    { name: "Gemini 2.5 Pro", color: "text-blue-400" },
+    { name: "Gemini 2.5 Flash", color: "text-blue-400" },
     { name: "Qwen Image", color: "text-sky-400" },
-    { name: "Sora 2", color: "text-emerald-400" },
-    { name: "Veo 3", color: "text-blue-400" },
-    { name: "Seedance 2.0", color: "text-green-400" },
-    { name: "Kling 3.0", color: "text-cyan-400" },
-    { name: "Hailuo 2.3", color: "text-red-400" },
-    { name: "LTX 2", color: "text-orange-400" },
-    { name: "Qwen 3", color: "text-sky-400" },
+    { name: "Veo 3.1", color: "text-blue-400" },
+    { name: "Kling v2.1", color: "text-cyan-400" },
+    { name: "Hailuo 02", color: "text-red-400" },
+    { name: "Wan 2.2", color: "text-orange-400" },
+    { name: "FLUX", color: "text-pink-400" },
     { name: "Whisper", color: "text-emerald-400" },
     { name: "ElevenLabs", color: "text-violet-400" },
 ];

--- a/marketing/src/components/NodeMenuSection.tsx
+++ b/marketing/src/components/NodeMenuSection.tsx
@@ -53,7 +53,7 @@ export default function NodeMenuSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            1000+ ready-to-use components for AI models, data processing, and file operations.
+            Hundreds of ready-to-use components for AI models, data processing, and file operations—plus auto-generated nodes for every Replicate, Fal, and Kie.ai model.
           </motion.p>
         </div>
 

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -53,7 +53,7 @@ export default function VideoGenerationSection({
             className="text-lg text-slate-400 leading-relaxed"
           >
             Generate videos from text or images using state-of-the-art models.
-            Support for Seedance 2.0, OpenAI Sora, Google Veo, Kling 3.0, and local generation.
+            Support for Google Veo, Kling, Hailuo, Wan, and local open-weight generation.
           </motion.p>
 
           <motion.div
@@ -86,48 +86,48 @@ export default function VideoGenerationSection({
         >
           {[
             {
-              title: "Seedance 2.0",
-              description: "State-of-the-art video generation with exceptional motion quality",
+              title: "Wan 2.2",
+              description: "Open-weight video diffusion via Replicate—text-to-video and image-to-video.",
               icon: Film,
-              category: "Best-in-Class",
-              features: ["Text-to-video", "Image-to-video", "Superior motion"],
+              category: "Open Weights",
+              features: ["Text-to-video", "Image-to-video", "Open model"],
               color: "text-green-400",
               bg: "bg-green-500/10",
               border: "border-green-500/20",
             },
             {
-              title: "Kling 3.0",
-              description: "Latest Kling model with cinematic quality",
+              title: "Kling v2.1",
+              description: "Kuaishou's Kling 2.1—5s and 10s clips at up to 1080p from a starting image.",
               icon: Video,
               category: "Text & Image to Video",
-              features: ["Text-to-video", "Image-to-video", "Cinematic output"],
+              features: ["Image-to-video", "Up to 1080p", "Cinematic output"],
               color: "text-cyan-400",
               bg: "bg-cyan-500/10",
               border: "border-cyan-500/20",
             },
             {
-              title: "OpenAI Sora",
-              description: "Sora 2 & Sora 2 Pro models",
+              title: "Hailuo 02",
+              description: "MiniMax Hailuo 02—6s or 10s clips at 768p or 1080p with strong real-world physics.",
               icon: Video,
               category: "Text & Image to Video",
-              features: ["Text-to-video", "Image-to-video", "Auto-sizing"],
+              features: ["Text-to-video", "Image-to-video", "Real-world physics"],
               color: "text-emerald-400",
               bg: "bg-emerald-500/10",
               border: "border-emerald-500/20",
             },
             {
-              title: "Google Veo",
-              description: "Veo 2.0, 3.0, and 3.0 Fast",
+              title: "Google Veo 3.1",
+              description: "Latest Veo with image-to-video and high motion fidelity.",
               icon: ImageIcon,
               category: "Text & Image to Video",
-              features: ["Text-to-video", "Image-to-video", "Fast generation"],
+              features: ["Text-to-video", "Image-to-video", "High fidelity"],
               color: "text-teal-400",
               bg: "bg-teal-500/10",
               border: "border-teal-500/20",
             },
             {
               title: "HuggingFace",
-              description: "Via inference providers",
+              description: "Pull any compatible video model from the Hub via inference providers.",
               icon: Cloud,
               category: "Cloud Video Models",
               features: ["Text-to-video", "Multiple providers", "API access"],
@@ -137,10 +137,10 @@ export default function VideoGenerationSection({
             },
             {
               title: "Local Generation",
-              description: "Self-hosted video generation—run models entirely on your machine.",
+              description: "Run open-weight video models on your own GPU through the local HuggingFace bridge.",
               icon: Server,
               category: "Self-Hosted",
-              features: ["Wan 2.2 T2V", "No API costs", "Full privacy"],
+              features: ["Open-weight models", "No API costs", "Full privacy"],
               color: "text-blue-400",
               bg: "bg-blue-500/10",
               border: "border-blue-500/20",


### PR DESCRIPTION
## Summary
This PR updates the marketing website to reflect current AI model availability, adds new cloud providers, refines deployment documentation, and improves feature descriptions with more accurate technical details.

## Key Changes

**Model & Provider Updates:**
- Replaced "Nunchaku" with "LM Studio" in local engines
- Added 5 new cloud providers: Mistral, Groq, DeepSeek, Cerebras, and Together
- Removed outdated providers: z.ai, Black Forest Labs, Alibaba, and Kling
- Updated frontier models list with current versions (Claude Opus 4.7, Gemini 2.5, etc.)
- Replaced older video generation models (Seedance 2.0, Sora 2) with current ones (Wan 2.2, Hailuo 02)

**Video Generation Section:**
- Updated model descriptions to reflect current capabilities and availability
- Changed focus from "Seedance 2.0" and "Sora" to "Wan 2.2" and "Hailuo 02"
- Updated Kling reference from "3.0" to "v2.1" with accurate feature descriptions
- Clarified local generation uses "open-weight models" via HuggingFace bridge

**Deployment Documentation:**
- Clarified that NodeTool deploys to "remote GPU" providers (RunPod, Google Cloud Run, Fly.io, Railway, SSH hosts)
- Renamed "Scale to Zero" to "Serverless-Ready" with more specific provider examples
- Removed mention of automatic model provisioning in favor of container image shipping

**Feature Descriptions:**
- Changed vector storage from "ChromaDB" to "SQLite-vec embedded vector store" with emphasis on no external database requirement
- Updated comparison with LangChain to note support for "TypeScript or Python" custom nodes
- Updated node menu description from "1000+" to "Hundreds" with clarification about auto-generated nodes for Replicate, Fal, and Kie.ai models

**Removed Imports:**
- Removed unused `Globe` icon from lucide-react imports

https://claude.ai/code/session_01SNfDNihCrsHBQuL37Xz4g4