### PR TITLE
Optimize mobile navigation header and add persona quick links

### DIFF
--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -454,6 +454,27 @@ export default function Home() {
                 </a>
               </div>
             </div>
+            {/* Mobile-only persona links — surfaced so /creatives and /developers are reachable without opening the menu */}
+            <div className="md:hidden flex items-center justify-center gap-2 pt-1.5 pb-0.5">
+              <a
+                href="/agents"
+                className="px-3 py-1 text-xs font-medium rounded-full lift text-slate-300 bg-slate-900/40 ring-1 ring-white/5 border border-slate-800/50 hover:text-blue-200 hover:bg-slate-800/60"
+              >
+                Agents
+              </a>
+              <a
+                href="/creatives"
+                className="px-3 py-1 text-xs font-medium rounded-full lift text-slate-300 bg-slate-900/40 ring-1 ring-white/5 border border-slate-800/50 hover:text-blue-200 hover:bg-slate-800/60"
+              >
+                Creatives
+              </a>
+              <a
+                href="/developers"
+                className="px-3 py-1 text-xs font-medium rounded-full lift text-slate-300 bg-slate-900/40 ring-1 ring-white/5 border border-slate-800/50 hover:text-blue-200 hover:bg-slate-800/60"
+              >
+                Developers
+              </a>
+            </div>
           </div>
         </nav>
         {/* Mobile menu */}

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -365,10 +365,10 @@ export default function Home() {
           className="fixed top-0 left-0 right-0 z-50 border-b border-slate-800/60 bg-glass supports-[backdrop-filter]:bg-glass shadow-[0_1px_0_0_rgba(59,130,246,0.08)]"
           aria-label="Primary"
         >
-          <div className={`${sectionContainer} py-4 sm:py-4 lg:py-2`}>
-            <div className="relative flex items-center justify-center gap-6 w-full min-h-[56px] sm:min-h-[64px]">
+          <div className={`${sectionContainer} py-2 sm:py-4 lg:py-2`}>
+            <div className="relative flex items-center justify-center gap-6 w-full min-h-[44px] sm:min-h-[64px]">
               {/* Logo: absolutely left */}
-              <div className="absolute left-0 flex items-center h-12 sm:h-10">
+              <div className="absolute left-0 flex items-center h-9 sm:h-10">
                 <a href="/" className={`group flex items-center gap-2 rounded`}>
                   <Image
                     src="/logo_small.png"
@@ -377,9 +377,9 @@ export default function Home() {
                     height={48}
                     priority
                     sizes="180px"
-                    className="brightness-0 invert transition-all duration-300 group-hover:brightness-100 group-hover:invert-0"
+                    className="h-8 w-8 sm:h-12 sm:w-12 brightness-0 invert transition-all duration-300 group-hover:brightness-100 group-hover:invert-0"
                   />
-                  <span className="text-xl font-bold tracking-widest text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-orange-300">
+                  <span className="text-base sm:text-xl font-bold tracking-widest text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-orange-300">
                     nodetool
                   </span>
                 </a>
@@ -409,11 +409,11 @@ export default function Home() {
                 {/* Mobile menu button */}
                 <button
                   type="button"
-                  className="md:hidden rounded-md p-2 text-slate-300 hover:bg-slate-800/60 transition-colors"
+                  className="md:hidden rounded-md p-1.5 text-slate-300 hover:bg-slate-800/60 transition-colors"
                   onClick={() => setMobileMenuOpen(true)}
                   aria-label="Open menu"
                 >
-                  <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+                  <Bars3Icon className="h-5 w-5" aria-hidden="true" />
                 </button>
                 <a
                   href="https://github.com/nodetool-ai/nodetool"
@@ -440,7 +440,7 @@ export default function Home() {
                   href="https://github.com/nodetool-ai/nodetool"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="sm:hidden rounded-lg p-1.5 transition-all duration-200 hover:bg-slate-800/60"
+                  className="sm:hidden rounded-lg p-1 transition-all duration-200 hover:bg-slate-800/60"
                   aria-label="NodeTool on GitHub"
                 >
                   <Image
@@ -448,6 +448,7 @@ export default function Home() {
                     alt=""
                     width={24}
                     height={24}
+                    className="h-5 w-5"
                     role="presentation"
                   />
                 </a>


### PR DESCRIPTION
## Summary
This PR refines the navigation header for better mobile responsiveness and adds quick access links to key personas (Agents, Creatives, Developers) on mobile devices.

## Key Changes
- **Header spacing optimization**: Reduced vertical padding on mobile (`py-2`) while maintaining desktop spacing (`lg:py-2`)
- **Logo sizing adjustments**: 
  - Reduced logo container height from `h-12` to `h-9` on mobile
  - Added explicit image dimensions (`h-8 w-8 sm:h-12 sm:w-12`) for better scaling
  - Adjusted brand text size from `text-xl` to responsive `text-base sm:text-xl`
- **Mobile menu button refinement**: Reduced padding from `p-2` to `p-1.5` and icon size from `h-6 w-6` to `h-5 w-5`
- **GitHub icon sizing**: Added explicit dimensions (`h-5 w-5`) to mobile GitHub link icon
- **New mobile persona navigation**: Added a mobile-only section below the header with quick links to `/agents`, `/creatives`, and `/developers` personas, styled with small pill-shaped buttons

## Implementation Details
- Mobile persona links are hidden on medium screens and above (`md:hidden`)
- Persona buttons use consistent styling with slate backgrounds, subtle rings, and hover states
- All spacing and sizing changes maintain visual hierarchy while improving mobile usability

https://claude.ai/code/session_01GvVWTk5jU5qGYsTVxEtaWK