### PR TITLE
Add Supabase/PostgreSQL support to the Drizzle models package

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,39 @@ nodetool run workflow.ts
 nodetool run workflow.ts --json
 ```
 
+## Database Migrations
+
+### `nodetool db migrate`
+
+Applies NodeTool migrations to a PostgreSQL/Supabase database. For Supabase, use the **direct connection URL** from Settings → Database (port `5432`), not the transaction pooler URL.
+
+**Options:**
+
+- `--direct-url <url>` — Supabase/PostgreSQL direct connection URL.
+- `--database-url <url>` — connection URL; defaults to `DIRECT_URL` or `DATABASE_URL`.
+- `--target <version>` — stop after a specific migration version.
+- `--dry-run` — show pending migrations without applying them.
+- `--skip-checksums` — skip checksum validation.
+- `--json` — output as JSON.
+
+**Examples:**
+
+```bash
+DIRECT_URL="postgresql://postgres:[password]@db.[project].supabase.co:5432/postgres" \
+  nodetool db migrate
+
+nodetool db status --direct-url "$DIRECT_URL"
+nodetool db migrate --direct-url "$DIRECT_URL" --dry-run
+```
+
+Other migration commands:
+
+```bash
+nodetool db status   --direct-url "$DIRECT_URL"
+nodetool db baseline --direct-url "$DIRECT_URL"   # for existing DBs
+nodetool db rollback --direct-url "$DIRECT_URL" --steps 1
+```
+
 ## Chat
 
 ### `nodetool chat`

--- a/package-lock.json
+++ b/package-lock.json
@@ -34917,7 +34917,8 @@
         "marked-terminal": "^7.1.0",
         "react": "^19.0.0",
         "superjson": "^2.2.2",
-        "ws": "^8.18.3"
+        "ws": "^8.18.3",
+        "postgres": "^3.4.7"
       },
       "bin": {
         "nodetool": "dist/nodetool.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "latest",
@@ -29568,6 +29568,19 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "license": "MIT",
@@ -34729,7 +34742,7 @@
     },
     "packages/agents": {
       "name": "@nodetool-ai/agents",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
@@ -34754,7 +34767,7 @@
     },
     "packages/auth": {
       "name": "@nodetool-ai/auth",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.98.0",
@@ -34774,7 +34787,7 @@
     },
     "packages/base-nodes": {
       "name": "@nodetool-ai/base-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -34854,7 +34867,7 @@
     },
     "packages/chat": {
       "name": "@nodetool-ai/chat",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -34868,7 +34881,7 @@
     },
     "packages/cli": {
       "name": "@nodetool-ai/cli",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.0.0",
@@ -34936,7 +34949,7 @@
     },
     "packages/code-runners": {
       "name": "@nodetool-ai/code-runners",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -34964,7 +34977,7 @@
     },
     "packages/config": {
       "name": "@nodetool-ai/config",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.0"
@@ -34976,7 +34989,7 @@
     },
     "packages/deploy": {
       "name": "@nodetool-ai/deploy",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -35001,7 +35014,7 @@
     },
     "packages/dsl": {
       "name": "@nodetool-ai/dsl",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/base-nodes": "*",
@@ -35021,7 +35034,7 @@
     },
     "packages/elevenlabs-nodes": {
       "name": "@nodetool-ai/elevenlabs-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.0.0",
@@ -35049,7 +35062,7 @@
     },
     "packages/fal-nodes": {
       "name": "@nodetool-ai/fal-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@fal-ai/client": "^1.9.4",
@@ -35064,7 +35077,7 @@
     },
     "packages/huggingface": {
       "name": "@nodetool-ai/huggingface",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@huggingface/hub": "^2.11.0",
@@ -35078,7 +35091,7 @@
     },
     "packages/kernel": {
       "name": "@nodetool-ai/kernel",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -35117,7 +35130,7 @@
     },
     "packages/kie-nodes": {
       "name": "@nodetool-ai/kie-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -35130,14 +35143,15 @@
     },
     "packages/models": {
       "name": "@nodetool-ai/models",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/security": "*",
         "better-sqlite3": "^12.8.0",
-        "drizzle-orm": "^0.45.2"
+        "drizzle-orm": "^0.45.2",
+        "postgres": "^3.4.7"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -35148,7 +35162,7 @@
     },
     "packages/node-sdk": {
       "name": "@nodetool-ai/node-sdk",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -35163,7 +35177,7 @@
     },
     "packages/protocol": {
       "name": "@nodetool-ai/protocol",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.0.0"
@@ -35186,7 +35200,7 @@
     },
     "packages/replicate-nodes": {
       "name": "@nodetool-ai/replicate-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -35200,7 +35214,7 @@
     },
     "packages/runtime": {
       "name": "@nodetool-ai/runtime",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@aki-io/aki-io": "^1.0.1",
@@ -35231,7 +35245,7 @@
     },
     "packages/sandbox": {
       "name": "@nodetool-ai/sandbox",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -35247,7 +35261,7 @@
     },
     "packages/sandbox-agent": {
       "name": "@nodetool-ai/sandbox-agent",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^9.0.0",
@@ -35265,7 +35279,7 @@
     },
     "packages/sandbox-tools": {
       "name": "@nodetool-ai/sandbox-tools",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -35281,7 +35295,7 @@
     },
     "packages/security": {
       "name": "@nodetool-ai/security",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1029.0",
@@ -35295,7 +35309,7 @@
     },
     "packages/storage": {
       "name": "@nodetool-ai/storage",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -35309,7 +35323,7 @@
     },
     "packages/transformers-js-nodes": {
       "name": "@nodetool-ai/transformers-js-nodes",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.7.6",
@@ -35326,7 +35340,7 @@
     },
     "packages/transformers-js-provider": {
       "name": "@nodetool-ai/transformers-js-provider",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -35342,7 +35356,7 @@
     },
     "packages/vectorstore": {
       "name": "@nodetool-ai/vectorstore",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -35359,7 +35373,7 @@
     },
     "packages/websocket": {
       "name": "@nodetool-ai/websocket",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "latest",
@@ -35404,7 +35418,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.7.0-rc.21",
+      "version": "0.7.0-rc.23",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.13.5",

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -13,7 +13,7 @@ The `packages/` directory contains the TypeScript backend — a set of npm works
 | `@nodetool-ai/security` | Secret storage and encryption |
 | `@nodetool-ai/auth` | Authentication middleware and utilities |
 | `@nodetool-ai/storage` | File storage adapters (local, S3) |
-| `@nodetool-ai/models` | SQLite data models via Drizzle ORM (Workflow, Job, Asset, Secret) |
+| `@nodetool-ai/models` | Data models via Drizzle ORM — SQLite (local/Electron) and PostgreSQL/Supabase (cloud) |
 | `@nodetool-ai/node-sdk` | BaseNode class, NodeRegistry, node authoring API, type system |
 | `@nodetool-ai/runtime` | ProcessingContext, LLM providers (Anthropic, OpenAI, Gemini, Ollama, etc.), message queue |
 | `@nodetool-ai/kernel` | Workflow graph model, NodeInbox, ActorRuntime, WorkflowRunner |

--- a/packages/agents/src/team/db-task-board.ts
+++ b/packages/agents/src/team/db-task-board.ts
@@ -19,7 +19,9 @@ import type {
 
 export type BoardEventHandler = (event: TeamEvent) => void;
 
-function rowToTask(row: typeof teamTasks.$inferSelect): BoardTask {
+type TeamTaskRow = typeof teamTasks.$inferSelect;
+
+function rowToTask(row: TeamTaskRow): BoardTask {
   return {
     id: row.id,
     title: row.title,
@@ -339,7 +341,9 @@ export class DbTaskBoard implements ITaskBoard {
       .all();
 
     if (rows.length === 0) return false;
-    return rows.every((r) => r.status === "done" || r.status === "failed");
+    return rows.every(
+      (r: TeamTaskRow) => r.status === "done" || r.status === "failed"
+    );
   }
 
   detectDeadlock(): string[] | null {
@@ -365,7 +369,7 @@ export class DbTaskBoard implements ITaskBoard {
 
     if (stuck.length > 0 && active.length === 0) {
       const claimable = rows.filter(
-        (r) => r.status === "open" && this.dependenciesMet(r.id)
+        (r: TeamTaskRow) => r.status === "open" && this.dependenciesMet(r.id)
       );
       if (claimable.length === 0) return stuck;
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,8 @@
     "marked": "^12.0.0",
     "marked-terminal": "^7.1.0",
     "react": "^19.0.0",
-    "superjson": "^2.2.2"
+    "superjson": "^2.2.2",
+    "postgres": "^3.4.7"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,0 +1,258 @@
+import type { Command } from "commander";
+import {
+  MigrationRunner,
+  PostgresJsMigrationAdapter,
+  type MigrationStatus
+} from "@nodetool-ai/models";
+
+interface DatabaseUrlOptions {
+  databaseUrl?: string;
+  directUrl?: string;
+}
+
+interface JsonOption {
+  json?: boolean;
+}
+
+interface MigrateOptions extends DatabaseUrlOptions, JsonOption {
+  target?: string;
+  dryRun?: boolean;
+  skipChecksums?: boolean;
+}
+
+interface BaselineOptions extends DatabaseUrlOptions, JsonOption {
+  force?: boolean;
+}
+
+interface RollbackOptions extends DatabaseUrlOptions, JsonOption {
+  steps?: string;
+}
+
+function resolveDatabaseUrl(opts: DatabaseUrlOptions): string {
+  const url =
+    opts.directUrl ??
+    opts.databaseUrl ??
+    process.env["DIRECT_URL"] ??
+    process.env["DATABASE_URL"];
+
+  if (!url) {
+    throw new Error(
+      "No PostgreSQL connection URL provided. Pass --direct-url/--database-url, " +
+        "or set DIRECT_URL or DATABASE_URL to your Supabase direct connection URL."
+    );
+  }
+
+  return url;
+}
+
+function maskDatabaseUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+    return parsed.toString();
+  } catch {
+    return "(provided)";
+  }
+}
+
+async function withPostgresMigrationRunner<T>(
+  databaseUrl: string,
+  fn: (runner: MigrationRunner) => Promise<T>
+): Promise<T> {
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    idle_timeout: 5,
+    connect_timeout: 30
+  });
+  const adapter = new PostgresJsMigrationAdapter(sql);
+
+  try {
+    return await fn(new MigrationRunner(adapter));
+  } finally {
+    try {
+      await adapter.release();
+    } finally {
+      await sql.end();
+    }
+  }
+}
+
+function printStatus(status: MigrationStatus, databaseUrl: string): void {
+  console.log(`Database: ${maskDatabaseUrl(databaseUrl)}`);
+  console.log(`State: ${status.state}`);
+  console.log(`Current version: ${status.currentVersion ?? "(none)"}`);
+  console.log(`Applied migrations: ${status.applied.length}`);
+  console.log(`Pending migrations: ${status.pending.length}`);
+
+  if (status.pending.length > 0) {
+    console.log("\nPending:");
+    for (const migration of status.pending) {
+      console.log(`  ${migration.version}  ${migration.name}`);
+    }
+  }
+}
+
+function printMigrationList(versions: string[], dryRun: boolean): void {
+  if (versions.length === 0) {
+    console.log("No pending migrations.");
+    return;
+  }
+
+  console.log(
+    dryRun
+      ? `Would apply ${versions.length} migration(s):`
+      : `Applied ${versions.length} migration(s):`
+  );
+  for (const version of versions) {
+    console.log(`  ${version}`);
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runCliAction(action: () => Promise<void>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    console.error(getErrorMessage(error));
+    process.exit(1);
+  }
+}
+
+function addDatabaseUrlOptions(command: Command): Command {
+  return command
+    .option(
+      "--direct-url <url>",
+      "Supabase/PostgreSQL direct connection URL for migrations (preferred)"
+    )
+    .option(
+      "--database-url <url>",
+      "Supabase/PostgreSQL connection URL (defaults to DIRECT_URL or DATABASE_URL)"
+    );
+}
+
+export function registerDbCommands(program: Command): void {
+  const db = program
+    .command("db")
+    .description("Database migration commands for PostgreSQL/Supabase");
+
+  addDatabaseUrlOptions(
+    db
+      .command("status")
+      .description("Show PostgreSQL/Supabase migration status")
+      .option("--json", "Output as JSON")
+  ).action(async (opts: DatabaseUrlOptions & JsonOption) => {
+    await runCliAction(async () => {
+      const databaseUrl = resolveDatabaseUrl(opts);
+      const status = await withPostgresMigrationRunner(databaseUrl, (runner) =>
+        runner.status()
+      );
+
+      if (opts.json) {
+        console.log(JSON.stringify(status, null, 2));
+        return;
+      }
+
+      printStatus(status, databaseUrl);
+    });
+  });
+
+  addDatabaseUrlOptions(
+    db
+      .command("migrate")
+      .description("Apply pending PostgreSQL/Supabase migrations")
+      .option("--target <version>", "Stop after applying this migration version")
+      .option("--dry-run", "Print pending migrations without applying them")
+      .option("--skip-checksums", "Skip checksum validation")
+      .option("--json", "Output as JSON")
+  ).action(async (opts: MigrateOptions) => {
+    await runCliAction(async () => {
+      const databaseUrl = resolveDatabaseUrl(opts);
+      const versions = await withPostgresMigrationRunner(databaseUrl, (runner) =>
+        runner.migrate({
+          ...(opts.target ? { target: opts.target } : {}),
+          dryRun: opts.dryRun ?? false,
+          validateChecksums: !(opts.skipChecksums ?? false)
+        })
+      );
+
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            {
+              dryRun: opts.dryRun ?? false,
+              migrations: versions
+            },
+            null,
+            2
+          )
+        );
+        return;
+      }
+
+      printMigrationList(versions, opts.dryRun ?? false);
+    });
+  });
+
+  addDatabaseUrlOptions(
+    db
+      .command("baseline")
+      .description("Mark existing PostgreSQL/Supabase tables as migrated")
+      .option("--force", "Clear and recreate migration tracking records")
+      .option("--json", "Output as JSON")
+  ).action(async (opts: BaselineOptions) => {
+    await runCliAction(async () => {
+      const databaseUrl = resolveDatabaseUrl(opts);
+      const baselined = await withPostgresMigrationRunner(databaseUrl, (runner) =>
+        runner.baseline(opts.force ?? false)
+      );
+
+      if (opts.json) {
+        console.log(JSON.stringify({ baselined }, null, 2));
+        return;
+      }
+
+      console.log(`Baselined ${baselined} migration(s).`);
+    });
+  });
+
+  addDatabaseUrlOptions(
+    db
+      .command("rollback")
+      .description("Roll back PostgreSQL/Supabase migrations")
+      .option("--steps <n>", "Number of migrations to roll back", "1")
+      .option("--json", "Output as JSON")
+  ).action(async (opts: RollbackOptions) => {
+    await runCliAction(async () => {
+      const steps = Number.parseInt(opts.steps ?? "1", 10);
+      if (!Number.isInteger(steps) || steps < 1) {
+        throw new Error("--steps must be a positive integer");
+      }
+
+      const databaseUrl = resolveDatabaseUrl(opts);
+      const rolledBack = await withPostgresMigrationRunner(databaseUrl, (runner) =>
+        runner.rollback(steps)
+      );
+
+      if (opts.json) {
+        console.log(JSON.stringify({ rolledBack }, null, 2));
+        return;
+      }
+
+      if (rolledBack.length === 0) {
+        console.log("No migrations to roll back.");
+        return;
+      }
+
+      console.log(`Rolled back ${rolledBack.length} migration(s):`);
+      for (const version of rolledBack) {
+        console.log(`  ${version}`);
+      }
+    });
+  });
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -41,6 +41,7 @@ import {
 import { registerHfCommands } from "./commands/models-hf.js";
 import { registerRecommendedCommand } from "./commands/models-recommended.js";
 import { registerAgentCommands } from "./commands/agent.js";
+import { registerDbCommands } from "./commands/db.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -1372,6 +1373,7 @@ registerPackageCommands(program);
 registerDeployCommands(program);
 registerListGcpOptions(program);
 registerAgentCommands(program);
+registerDbCommands(program);
 
 // ---------------------------------------------------------------------------
 

--- a/packages/models/AGENTS.md
+++ b/packages/models/AGENTS.md
@@ -1,0 +1,137 @@
+# @nodetool-ai/models — Agent Guidelines
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) | [Root CLAUDE.md](../../CLAUDE.md)
+
+This package is the persistence layer. It owns all database tables, schema definitions, migrations, and the `DBModel` base class.
+
+## Dialect Support
+
+The package supports two database backends. The active dialect is set at startup and cannot change at runtime:
+
+| Dialect | Init function | Schema path | Driver |
+|---------|--------------|-------------|--------|
+| SQLite | `initDb(path)` | `src/schema/` | `better-sqlite3` |
+| PostgreSQL | `await initPostgresDb(url)` | `src/schema-pg/` | `postgres` (postgres.js) |
+
+Use `getDbType()` → `"sqlite" | "postgres"` to branch on dialect if unavoidable.
+
+## Adding a Column
+
+1. Add the column to **both** schema files:
+   - `src/schema/<table>.ts` — `sqliteTable`, e.g. `text("my_col")`
+   - `src/schema-pg/<table>.ts` — `pgTable`, same column name and semantics
+
+2. Update `TABLE_COLUMNS` in `src/db.ts` (the additive-migration map) so SQLite users get the column automatically without a migration file.
+
+3. Add a `declare my_col: ...` field to the model class.
+
+4. Update the constructor to set a default: `this.my_col ??= null;`
+
+5. If needed, add a migration entry in `src/migrations/versions.ts`.
+
+## Adding a New Model
+
+1. Create `src/schema/<name>.ts` (SQLite) and `src/schema-pg/<name>.ts` (PostgreSQL).
+2. Export both from their respective `index.ts` barrel files.
+3. Add the table to `TABLE_COLUMNS` in `src/db.ts`.
+4. Add the `CREATE TABLE IF NOT EXISTS` and index SQL to `getCreateSchemaSql()` in `src/db.ts`.
+5. Create `src/<model-name>.ts` extending `DBModel`. Set `static override table = <sqliteTable>`.
+6. Export the new model from `src/index.ts`.
+
+## Writing Query Methods
+
+All query methods must be `async`. Use Drizzle's promise-based API — it works on both dialects:
+
+```typescript
+// Fetch one row
+const [row] = await db.select().from(myTable).where(eq(myTable.id, id)).limit(1);
+return row ? new MyModel(row as Record<string, unknown>) : null;
+
+// Fetch many rows
+const rows = await db.select().from(myTable).where(eq(myTable.user_id, userId));
+return rows.map((r: Record<string, unknown>) => new MyModel(r));
+
+// Insert / upsert — handled by DBModel.save() via onConflictDoUpdate
+// Delete — handled by DBModel.delete()
+```
+
+Never use `.get()`, `.run()`, or `.all()` — those are synchronous SQLite-only methods.
+
+### Returning pattern for CAS
+
+When you need to know if an `UPDATE` matched a row (e.g. optimistic locking), use `.returning()`:
+
+```typescript
+const updated = await db
+  .update(myTable)
+  .set({ version: newVersion })
+  .where(and(eq(myTable.id, id), eq(myTable.version, expected)))
+  .returning({ id: myTable.id });
+
+if (updated.length === 0) return false; // row was already modified
+```
+
+## JSON Columns
+
+Both schemas use a `jsonText<T>()` custom column that stores JSON as plain `TEXT`. Do **not** use `json()` or `jsonb()` — they behave differently across dialects and complicate cross-backend data sharing.
+
+```typescript
+// SQLite schema:
+import { jsonText } from "./helpers.js";
+graph: jsonText<WorkflowGraph>()("graph").notNull()
+
+// PostgreSQL schema (same helper, pg-core version):
+import { jsonText } from "./helpers.js";
+graph: jsonText<WorkflowGraph>()("graph").notNull()
+```
+
+## Boolean Columns
+
+SQLite schema uses `integer("col", { mode: "boolean" })` — TypeScript type is `boolean`, comparisons use `true`/`false`.
+
+PostgreSQL schema uses plain `integer("col")` — TypeScript type is `number | null`, comparisons use `0`/`1` or filter in application code.
+
+If your query filters on a boolean-like column, pick the right literal for the schema you're querying against.
+
+## Migrations
+
+Migrations live in `src/migrations/versions.ts` as an ordered list of `MigrationDef` objects. Each migration has a `version` integer, `description`, and `up` SQL string (plus optional `down`).
+
+The `MigrationRunner` applies pending migrations in order and records them in `_migration_history`. It works on both dialects via the `MigrationDBAdapter` interface:
+
+- `SQLiteMigrationAdapter` — uses `better-sqlite3` synchronous API
+- `PostgresMigrationAdapter` — uses `pg` (node-postgres) pool
+- `PostgresJsMigrationAdapter` — uses `postgres.js` reserved connection (preferred for Supabase)
+
+### drizzle-kit
+
+Use `drizzle-kit` to introspect schema changes and auto-generate migration SQL:
+
+```bash
+# Generate migration SQL from schema changes
+DATABASE_URL=postgres://... npx drizzle-kit generate --config packages/models/drizzle.pg.config.ts
+
+# Push schema directly (dev/staging only — never production without review)
+DATABASE_URL=postgres://... npx drizzle-kit push --config packages/models/drizzle.pg.config.ts
+```
+
+The generated SQL in `src/drizzle-migrations-pg/` should be reviewed and then added as a `MigrationDef` entry in `versions.ts` for auditability.
+
+## Tests
+
+Tests live in `tests/`. All tests use `initTestDb()` which creates an in-memory SQLite database. No PostgreSQL instance is required.
+
+```bash
+npm run test --workspace=packages/models
+npm run test:watch --workspace=packages/models
+```
+
+When writing tests for new models, call `initTestDb()` in `beforeEach` to reset state between tests.
+
+## Rules
+
+- All public query methods must be `async`.
+- Annotate `.map()` callbacks explicitly: `(r: Record<string, unknown>) => new Model(r)` — `getDb()` returns `any`, so TypeScript cannot infer row types.
+- Never import from `dist/`. Use `@nodetool-ai/models` for cross-package imports.
+- Keep `src/schema/` (SQLite) and `src/schema-pg/` (PostgreSQL) in sync — columns, names, and types must match.
+- `TABLE_COLUMNS` in `db.ts` must stay in sync with `src/schema/` to support additive SQLite migrations.

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -55,6 +55,19 @@ For Supabase, both URLs are on the project's *Settings → Database* page.
 | `DATABASE_URL` | PostgreSQL connection string (Supabase pooler or direct) |
 | `NODETOOL_DB_PATH` | SQLite file path (defaults to `~/.nodetool/nodetool.db`) |
 
+## Running Supabase Migrations
+
+Use the CLI with your Supabase **direct connection URL** (port `5432`):
+
+```bash
+DIRECT_URL="postgresql://postgres:[password]@db.[project].supabase.co:5432/postgres" \
+  nodetool db migrate
+
+nodetool db status --direct-url "$DIRECT_URL"
+```
+
+Use the pooler URL (port `6543`, transaction mode) only for the running app, not migration runs.
+
 ## Schema Generation (drizzle-kit)
 
 ```bash
@@ -85,9 +98,13 @@ await initPostgresDb(process.env.DIRECT_URL!); // use direct URL for migrations
 
 const sql = postgres(process.env.DIRECT_URL!);
 const adapter = new PostgresJsMigrationAdapter(sql);
-const runner = new MigrationRunner(adapter);
-await runner.migrate();
-await sql.end();
+try {
+  const runner = new MigrationRunner(adapter);
+  await runner.migrate();
+} finally {
+  await adapter.release();
+  await sql.end();
+}
 ```
 
 For SQLite, the `SQLiteMigrationAdapter` accepts a `better-sqlite3` `Database` instance.

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -1,0 +1,152 @@
+# @nodetool-ai/models
+
+Data models for NodeTool, backed by [Drizzle ORM](https://orm.drizzle.team/).
+
+Supports both **SQLite** (local / Electron) and **PostgreSQL / Supabase** (cloud).
+
+## Models
+
+| Model | Table | Description |
+|-------|-------|-------------|
+| `Workflow` | `nodetool_workflows` | DAG-based workflow definitions |
+| `Job` | `nodetool_jobs` | Workflow execution state |
+| `Asset` | `nodetool_assets` | User-uploaded files |
+| `Message` | `nodetool_messages` | Chat messages |
+| `Thread` | `nodetool_threads` | Chat threads |
+| `Secret` | `nodetool_secrets` | Encrypted user secrets |
+| `OAuthCredential` | `nodetool_oauth_credentials` | Encrypted OAuth tokens |
+| `Workspace` | `nodetool_workspaces` | File-system workspace directories |
+| `WorkflowVersion` | `nodetool_workflow_versions` | Versioned workflow snapshots |
+| `Prediction` | `nodetool_predictions` | LLM/AI call records |
+| `RunNodeState` | `run_node_state` | Per-node execution state for a run |
+| `RunEvent` | `run_events` | Append-only execution event log |
+| `RunLease` | `run_leases` | Worker lease records |
+| `Setting` | `nodetool_settings` | Per-user key/value settings |
+| `TeamTask` | `nodetool_team_tasks` | Multi-agent task coordination |
+
+## Quick Start
+
+### SQLite (default)
+
+```typescript
+import { initDb } from "@nodetool-ai/models";
+
+initDb("/path/to/nodetool.db");
+```
+
+SQLite creates all tables on first use and applies additive column migrations automatically (no external migration tool needed for local development).
+
+### PostgreSQL / Supabase
+
+```typescript
+import { initPostgresDb } from "@nodetool-ai/models";
+
+await initPostgresDb(process.env.DATABASE_URL!);
+```
+
+`DATABASE_URL` should be the **connection pooler URL** (port 6543, transaction mode) for the application. For migration runs, use the **direct URL** (port 5432).
+
+For Supabase, both URLs are on the project's *Settings → Database* page.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string (Supabase pooler or direct) |
+| `NODETOOL_DB_PATH` | SQLite file path (defaults to `~/.nodetool/nodetool.db`) |
+
+## Schema Generation (drizzle-kit)
+
+```bash
+# SQLite – generate or push schema changes
+npx drizzle-kit generate --config packages/models/drizzle.config.ts
+npx drizzle-kit push    --config packages/models/drizzle.config.ts
+
+# PostgreSQL / Supabase
+DATABASE_URL=postgres://... npx drizzle-kit generate --config packages/models/drizzle.pg.config.ts
+DATABASE_URL=postgres://... npx drizzle-kit push    --config packages/models/drizzle.pg.config.ts
+
+# Supabase Studio (schema browser)
+DATABASE_URL=postgres://... npx drizzle-kit studio  --config packages/models/drizzle.pg.config.ts
+```
+
+## Programmatic Migrations
+
+The migration system works on both dialects and is used by the server at startup:
+
+```typescript
+import {
+  initPostgresDb, getDb, getDbType,
+  MigrationRunner, PostgresJsMigrationAdapter
+} from "@nodetool-ai/models";
+import postgres from "postgres";
+
+await initPostgresDb(process.env.DIRECT_URL!); // use direct URL for migrations
+
+const sql = postgres(process.env.DIRECT_URL!);
+const adapter = new PostgresJsMigrationAdapter(sql);
+const runner = new MigrationRunner(adapter);
+await runner.migrate();
+await sql.end();
+```
+
+For SQLite, the `SQLiteMigrationAdapter` accepts a `better-sqlite3` `Database` instance.
+
+## Dialects
+
+```typescript
+import { getDbType } from "@nodetool-ai/models";
+
+getDbType(); // "sqlite" | "postgres"
+```
+
+### Schema files
+
+| Path | Dialect |
+|------|---------|
+| `src/schema/` | SQLite (`sqliteTable` from `drizzle-orm/sqlite-core`) |
+| `src/schema-pg/` | PostgreSQL (`pgTable` from `drizzle-orm/pg-core`) |
+
+Both schema sets use a `jsonText<T>()` custom column type that stores JSON as `TEXT` (not `JSONB`) for cross-dialect compatibility.
+
+## Architecture
+
+### `DBModel`
+
+Base class for all models. Provides:
+
+- `static get<T>(id)` — fetch by primary key
+- `static create<T>(data)` — insert and return new instance
+- `save()` — upsert (insert or replace)
+- `delete()` — remove row
+- `beforeSave()` — lifecycle hook (override to set `updated_at`, etc.)
+- `ModelObserver` — subscribe to create/update/delete events
+
+All query methods are `async` and work transparently with both SQLite and PostgreSQL.
+
+### CAS (Compare-and-Swap)
+
+`Job.acquireWithCas(workerId, expectedVersion)` uses `.returning()` to atomically claim a job only if `version` matches — no dialect-specific `.changes` property needed.
+
+### Transactions
+
+```typescript
+const db = getDb();
+await db.transaction(async (tx) => {
+  // works on both SQLite and PostgreSQL
+});
+```
+
+## Testing
+
+```bash
+npm run test --workspace=packages/models
+```
+
+Tests use an in-memory SQLite database (`initTestDb()`). No PostgreSQL instance is required to run the test suite.
+
+```typescript
+import { initTestDb } from "@nodetool-ai/models";
+
+beforeEach(() => initTestDb());
+```

--- a/packages/models/drizzle.pg.config.ts
+++ b/packages/models/drizzle.pg.config.ts
@@ -1,0 +1,35 @@
+/**
+ * Drizzle Kit configuration for PostgreSQL / Supabase.
+ *
+ * Used by `drizzle-kit` commands when targeting a PostgreSQL database:
+ *
+ *   npx drizzle-kit generate --config drizzle.pg.config.ts
+ *   npx drizzle-kit push    --config drizzle.pg.config.ts
+ *   npx drizzle-kit studio  --config drizzle.pg.config.ts
+ *
+ * Set the DATABASE_URL environment variable to your Supabase / Postgres
+ * connection string before running these commands. For Supabase use the
+ * direct connection URL (port 5432), not the pooler (port 6543).
+ *
+ * Example:
+ *   DATABASE_URL="postgresql://postgres:[password]@db.[project].supabase.co:5432/postgres"
+ */
+
+import { defineConfig } from "drizzle-kit";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL environment variable is required for PostgreSQL migrations.\n" +
+      "Set it to your Supabase direct connection URL:\n" +
+      "  postgresql://postgres:[password]@db.[project].supabase.co:5432/postgres"
+  );
+}
+
+export default defineConfig({
+  schema: "./src/schema-pg",
+  out: "./src/drizzle-migrations-pg",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL
+  }
+});

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -28,7 +28,8 @@
     "@nodetool-ai/protocol": "*",
     "@nodetool-ai/security": "*",
     "better-sqlite3": "^12.8.0",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.7"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -117,15 +117,14 @@ export class Asset extends DBModel {
       conditions.push(eq(assets.job_id, jobId));
     }
 
-    const rows = db
+    const rows = await db
       .select()
       .from(assets)
       .where(and(...conditions))
       .orderBy(desc(assets.created_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Asset(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Asset(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
@@ -168,19 +167,18 @@ export class Asset extends DBModel {
       conditions.push(like(assets.content_type, `${sanitizedType}%`));
     }
 
-    const rows = db
+    const rows = await db
       .select()
       .from(assets)
       .where(and(...conditions))
       .limit(limit)
-      .all();
 
-    const items = rows.map((r) => new Asset(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Asset(r as Record<string, unknown>));
     const cursor = "";
 
     const pathInfo = await Asset.getAssetPathInfo(
       userId,
-      items.map((a) => a.id)
+      items.map((a: Record<string, unknown>) => a.id)
     );
 
     const folderPaths: Array<Record<string, string>> = [];

--- a/packages/models/src/base-model.ts
+++ b/packages/models/src/base-model.ts
@@ -1,17 +1,14 @@
 /**
  * DBModel – base class for database-backed models.
  *
- * Rewritten to use Drizzle ORM as the query layer.
- * Each concrete model class provides a static `table` pointing to its
- * Drizzle table definition. The base class supplies common CRUD,
- * observer notifications, and etag computation.
+ * Uses Drizzle ORM as the query layer. Supports both SQLite (better-sqlite3)
+ * and PostgreSQL (postgres.js) via async methods that work on both dialects.
  */
 
 import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
 import { eq } from "drizzle-orm";
-import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
 import { getDb } from "./db.js";
 
 const log = createLogger("nodetool.models");
@@ -53,10 +50,6 @@ export class ModelObserver {
   static notify(instance: DBModel, event: ModelChangeEvent): void {
     const className = instance.constructor.name;
 
-    // Intentional: catch and log observer errors to prevent one failing observer
-    // from blocking notifications to remaining observers.
-
-    // Class-specific observers
     for (const cb of ModelObserver.observers.get(className) ?? []) {
       try {
         cb(instance, event);
@@ -67,7 +60,6 @@ export class ModelObserver {
       }
     }
 
-    // Global observers
     for (const cb of ModelObserver.observers.get(null) ?? []) {
       try {
         cb(instance, event);
@@ -86,12 +78,10 @@ export class ModelObserver {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/** Create a time-ordered UUID (v4 for simplicity; Python uses uuid1). */
 export function createTimeOrderedUuid(): string {
   return randomUUID().replace(/-/g, "");
 }
 
-/** Compute an MD5 etag from a plain object. */
 export function computeEtag(data: Record<string, unknown>): string {
   const raw = JSON.stringify(data, Object.keys(data).sort());
   return createHash("md5").update(raw).digest("hex");
@@ -99,40 +89,27 @@ export function computeEtag(data: Record<string, unknown>): string {
 
 // ── DBModel Base ─────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle tables have deeply nested generics; `any` is required for the base-class pattern.
-export type DrizzleTable = SQLiteTableWithColumns<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle table type varies by dialect; any is required for the base-class pattern.
+export type DrizzleTable = any;
 
-/**
- * Helper to get column object from table by name.
- * Needed because Drizzle tables store columns as properties keyed by column name.
- * Returns the Drizzle column object for use with query builders (eq, etc.).
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle column type varies per table; callers pass result to eq() which accepts any column.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getTableColumn(table: DrizzleTable, colName: string): any {
   return (table as Record<string, unknown>)[colName];
 }
 
-/**
- * Get column names from a Drizzle table.
- */
 function getColumnNames(table: DrizzleTable): string[] {
-  // Drizzle stores column config under Symbol.for("drizzle:Columns")
   const cols = (table as unknown as Record<symbol, Record<string, unknown>>)[
     Symbol.for("drizzle:Columns")
   ];
   if (cols) return Object.keys(cols);
-  // Fallback: iterate own enumerable string keys that look like columns
   return Object.keys(table).filter((k) => !k.startsWith("_"));
 }
 
 export abstract class DBModel {
-  /** Subclass must set this to its Drizzle table definition. */
   static table: DrizzleTable;
 
-  /** Primary key column name. Override for non-'id' PKs (e.g. RunLease uses 'run_id'). */
   static primaryKey = "id";
 
-  // Allow dynamic property access for column data — DBModel instances store column values as properties.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 
@@ -142,7 +119,7 @@ export abstract class DBModel {
 
   // ── CRUD ─────────────────────────────────────────────────────────
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `this: any` enables static polymorphism across subclasses.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async create<T extends DBModel>(
     this: any,
     data: Record<string, unknown>
@@ -153,7 +130,7 @@ export abstract class DBModel {
     return instance;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `this: any` enables static polymorphism across subclasses.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async get<T extends DBModel>(
     this: any,
     key: string | number
@@ -161,12 +138,12 @@ export abstract class DBModel {
     const db = getDb();
     const table = this.table as DrizzleTable;
     const pkCol = getTableColumn(table, this.primaryKey);
-    const row = db.select().from(table).where(eq(pkCol, key)).get();
+    const rows = await db.select().from(table).where(eq(pkCol, key)).limit(1);
+    const row = rows[0];
     if (!row) return null;
     return new this(row as Record<string, unknown>) as T;
   }
 
-  /** Hook called before save. Subclasses may override. */
   beforeSave(): void {}
 
   async save(): Promise<this> {
@@ -177,13 +154,13 @@ export abstract class DBModel {
     const row = this.toRow();
     const pkCol = getTableColumn(table, ctor.primaryKey);
 
-    db.insert(table)
+    await db
+      .insert(table)
       .values(row)
       .onConflictDoUpdate({
         target: pkCol,
         set: row
-      })
-      .run();
+      });
 
     ModelObserver.notify(this, ModelChangeEvent.UPDATED);
     return this;
@@ -194,7 +171,7 @@ export abstract class DBModel {
     const db = getDb();
     const table = ctor.table;
     const pkCol = getTableColumn(table, ctor.primaryKey);
-    db.delete(table).where(eq(pkCol, this.partitionValue())).run();
+    await db.delete(table).where(eq(pkCol, this.partitionValue()));
     ModelObserver.notify(this, ModelChangeEvent.DELETED);
   }
 
@@ -205,29 +182,28 @@ export abstract class DBModel {
   }
 
   async reload(): Promise<this> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- constructor must be callable with `new` for dynamic instantiation.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ctor = this.constructor as any;
     const db = getDb();
     const table = (ctor as typeof DBModel).table;
     const pkCol = getTableColumn(table, (ctor as typeof DBModel).primaryKey);
-    const row = db
+    const rows = await db
       .select()
       .from(table)
       .where(eq(pkCol, this.partitionValue()))
-      .get();
+      .limit(1);
+    const row = rows[0];
     if (!row) throw new Error(`Item not found: ${this.partitionValue()}`);
     const fresh = new ctor(row as Record<string, unknown>);
     Object.assign(this, fresh);
     return this;
   }
 
-  /** Get the primary key value for this instance. */
   partitionValue(): string | number {
     const ctor = this.constructor as typeof DBModel;
     return this[ctor.primaryKey];
   }
 
-  /** Serialize to a plain row object for Drizzle. */
   toRow(): Record<string, unknown> {
     const ctor = this.constructor as typeof DBModel;
     const columnNames = getColumnNames(ctor.table);
@@ -245,7 +221,6 @@ export abstract class DBModel {
     return row;
   }
 
-  /** Compute an ETag for this instance. */
   getEtag(): string {
     return computeEtag(this.toRow());
   }

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -18,6 +18,8 @@ export type DbDialect = "sqlite" | "postgres";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- union of BetterSQLite3Database and PostgresJsDatabase
 let _db: any = null;
 let _sqlite: Database.Database | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js Sql instance
+let _pgClient: any = null;
 let _dbType: DbDialect = "sqlite";
 
 /**
@@ -25,7 +27,12 @@ let _dbType: DbDialect = "sqlite";
  * Configures WAL mode, busy timeout, and synchronous mode.
  */
 export function initDb(dbPath: string): BetterSQLite3Database<typeof schema> {
-  if (_db) return _db as BetterSQLite3Database<typeof schema>;
+  if (_db && _dbType === "sqlite") return _db as BetterSQLite3Database<typeof schema>;
+  if (_db && _dbType === "postgres") {
+    throw new Error(
+      "A PostgreSQL connection is already active. Call closeDb() before switching to SQLite."
+    );
+  }
   const sqlite = new Database(dbPath);
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("busy_timeout = 30000");
@@ -44,13 +51,18 @@ export function initDb(dbPath: string): BetterSQLite3Database<typeof schema> {
 /**
  * Initialize a PostgreSQL database connection.
  * Accepts a connection string (e.g. Supabase DATABASE_URL or DIRECT_URL).
- * Runs all pending migrations automatically.
  *
  * For Supabase, use the connection pooler URL (port 6543, transaction mode)
  * for the application, and the direct URL (port 5432) for migrations.
+ * Migrations must be run separately via MigrationRunner + PostgresJsMigrationAdapter.
  */
 export async function initPostgresDb(connectionString: string): Promise<void> {
   if (_db && _dbType === "postgres") return;
+  if (_db && _dbType === "sqlite") {
+    throw new Error(
+      "A SQLite connection is already active. Call closeDb() before switching to PostgreSQL."
+    );
+  }
 
   // Dynamic import so that the `postgres` package is only loaded when needed,
   // keeping the SQLite-only path free of the extra dependency at runtime.
@@ -63,6 +75,7 @@ export async function initPostgresDb(connectionString: string): Promise<void> {
     connect_timeout: 10
   });
 
+  _pgClient = client;
   _db = drizzlePg(client, { schema: pgSchema });
   _dbType = "postgres";
 }
@@ -125,8 +138,9 @@ export function getRawDb(): Database.Database {
 
 /**
  * Close the database connection and reset state.
+ * For PostgreSQL, returns a Promise that resolves once the connection pool is drained.
  */
-export function closeDb(): void {
+export async function closeDb(): Promise<void> {
   if (_sqlite) {
     try {
       _sqlite.close();
@@ -134,6 +148,14 @@ export function closeDb(): void {
       /* ignore */
     }
     _sqlite = null;
+  }
+  if (_pgClient) {
+    try {
+      await _pgClient.end();
+    } catch {
+      /* ignore */
+    }
+    _pgClient = null;
   }
   _db = null;
   _dbType = "sqlite";

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1,50 +1,77 @@
 /**
  * Database connection manager for Drizzle ORM.
  *
- * Replaces SQLiteAdapterFactory + setGlobalAdapterResolver() with a
- * single module-level connection.
+ * Supports both SQLite (via better-sqlite3) and PostgreSQL (via postgres.js).
+ * Use initDb() for SQLite and initPostgresDb() for Supabase/PostgreSQL.
  */
 
 import Database from "better-sqlite3";
 import {
-  drizzle,
+  drizzle as drizzleSqlite,
   type BetterSQLite3Database
 } from "drizzle-orm/better-sqlite3";
 import * as schema from "./schema/index.js";
+import * as pgSchema from "./schema-pg/index.js";
 
-let _db: BetterSQLite3Database<typeof schema> | null = null;
+export type DbDialect = "sqlite" | "postgres";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- union of BetterSQLite3Database and PostgresJsDatabase
+let _db: any = null;
 let _sqlite: Database.Database | null = null;
+let _dbType: DbDialect = "sqlite";
 
 /**
- * Initialize the database connection with a file path.
+ * Initialize a SQLite database connection with a file path.
  * Configures WAL mode, busy timeout, and synchronous mode.
  */
 export function initDb(dbPath: string): BetterSQLite3Database<typeof schema> {
-  if (_db) return _db;
+  if (_db) return _db as BetterSQLite3Database<typeof schema>;
   const sqlite = new Database(dbPath);
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("busy_timeout = 30000");
   sqlite.pragma("synchronous = NORMAL");
   _sqlite = sqlite;
-  _db = drizzle(sqlite, { schema });
+  _db = drizzleSqlite(sqlite, { schema });
+  _dbType = "sqlite";
 
   sqlite.exec(getCreateTableStatementsSql());
-
-  // Add any columns that exist in the schema but are missing from existing tables.
-  // This preserves the old sqlite-adapter's additive migration behavior for upgrades.
   addMissingColumns(sqlite);
-
   sqlite.exec(getCreateIndexStatementsSql());
 
-  return _db;
+  return _db as BetterSQLite3Database<typeof schema>;
 }
 
 /**
- * Initialize an in-memory database for testing.
+ * Initialize a PostgreSQL database connection.
+ * Accepts a connection string (e.g. Supabase DATABASE_URL or DIRECT_URL).
+ * Runs all pending migrations automatically.
+ *
+ * For Supabase, use the connection pooler URL (port 6543, transaction mode)
+ * for the application, and the direct URL (port 5432) for migrations.
+ */
+export async function initPostgresDb(connectionString: string): Promise<void> {
+  if (_db && _dbType === "postgres") return;
+
+  // Dynamic import so that the `postgres` package is only loaded when needed,
+  // keeping the SQLite-only path free of the extra dependency at runtime.
+  const { default: postgres } = await import("postgres");
+  const { drizzle: drizzlePg } = await import("drizzle-orm/postgres-js");
+
+  const client = postgres(connectionString, {
+    max: 10,
+    idle_timeout: 20,
+    connect_timeout: 10
+  });
+
+  _db = drizzlePg(client, { schema: pgSchema });
+  _dbType = "postgres";
+}
+
+/**
+ * Initialize an in-memory SQLite database for testing.
  * Creates all tables from the Drizzle schema.
  */
 export function initTestDb(): BetterSQLite3Database<typeof schema> {
-  // Close existing connection if any
   if (_sqlite) {
     try {
       _sqlite.close();
@@ -54,33 +81,44 @@ export function initTestDb(): BetterSQLite3Database<typeof schema> {
   }
   const sqlite = new Database(":memory:");
   _sqlite = sqlite;
-  _db = drizzle(sqlite, { schema });
+  _db = drizzleSqlite(sqlite, { schema });
+  _dbType = "sqlite";
 
   sqlite.exec(getCreateTableStatementsSql());
   sqlite.exec(getCreateIndexStatementsSql());
 
-  return _db;
+  return _db as BetterSQLite3Database<typeof schema>;
 }
 
 /**
  * Get the current database instance.
+ * Returns `any` so callers work transparently with both SQLite and PostgreSQL.
  * Throws if not initialized.
  */
-export function getDb(): BetterSQLite3Database<typeof schema> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getDb(): any {
   if (!_db)
     throw new Error(
-      "Database not initialized."
+      "Database not initialized. Call initDb() or initPostgresDb() first."
     );
   return _db;
 }
 
 /**
+ * Get the current database dialect.
+ */
+export function getDbType(): DbDialect {
+  return _dbType;
+}
+
+/**
  * Get the underlying better-sqlite3 Database instance for raw queries.
+ * Only available when using SQLite.
  */
 export function getRawDb(): Database.Database {
   if (!_sqlite)
     throw new Error(
-      "Database not initialized."
+      "SQLite database not initialized. Raw access is only available for SQLite."
     );
   return _sqlite;
 }
@@ -98,11 +136,11 @@ export function closeDb(): void {
     _sqlite = null;
   }
   _db = null;
+  _dbType = "sqlite";
 }
 
 /**
- * Expected columns per table, used for additive migration on existing DBs.
- * Each entry maps column name → SQLite column type string (used in ALTER TABLE ADD COLUMN).
+ * Expected columns per table, used for additive migration on existing SQLite DBs.
  */
 const TABLE_COLUMNS: Record<string, Record<string, string>> = {
   nodetool_workflows: {
@@ -340,12 +378,6 @@ const TABLE_COLUMNS: Record<string, Record<string, string>> = {
   }
 };
 
-/**
- * For each table that already exists, add any columns defined in the schema
- * but missing from the on-disk table.  This replicates the old
- * `SQLiteAdapter.createTable()` behaviour that ran
- * `ALTER TABLE … ADD COLUMN` for every new column.
- */
 function addMissingColumns(sqlite: Database.Database): void {
   for (const [tableName, expectedCols] of Object.entries(TABLE_COLUMNS)) {
     const existingCols = new Set(
@@ -364,10 +396,6 @@ function addMissingColumns(sqlite: Database.Database): void {
   }
 }
 
-/**
- * Generate CREATE TABLE SQL for all schema tables.
- * Used by initTestDb to set up in-memory databases.
- */
 function getCreateSchemaSql(): string {
   return `
     CREATE TABLE IF NOT EXISTS "nodetool_workflows" (

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -6,9 +6,18 @@
  */
 
 // ── Database Connection ─────────────────────────────────────────────
-export { initDb, initTestDb, getDb, getRawDb, closeDb } from "./db.js";
+export {
+  initDb,
+  initPostgresDb,
+  initTestDb,
+  getDb,
+  getDbType,
+  getRawDb,
+  closeDb
+} from "./db.js";
+export type { DbDialect } from "./db.js";
 
-// ── Drizzle Schema (for consumers needing raw queries) ──────────────
+// ── Drizzle Schema (SQLite — default) ──────────────────────────────
 export {
   workflows,
   jobs,
@@ -26,6 +35,9 @@ export {
   teamTasks,
   appSettings
 } from "./schema/index.js";
+
+// ── Drizzle Schema (PostgreSQL) ─────────────────────────────────────
+export * as pgSchema from "./schema-pg/index.js";
 
 // ── Base Model ───────────────────────────────────────────────────────
 export {
@@ -107,6 +119,7 @@ export {
   detectDatabaseState,
   SQLiteMigrationAdapter,
   PostgresMigrationAdapter,
+  PostgresJsMigrationAdapter,
   migrations,
   MigrationRunner
 } from "./migrations/index.js";

--- a/packages/models/src/job.ts
+++ b/packages/models/src/job.ts
@@ -204,7 +204,7 @@ export class Job extends DBModel {
       const now = new Date().toISOString();
       const newVersion = expectedVersion + 1;
       // Atomic CAS: only update if the database row still has the expected version.
-      const result = db
+      const updated = await db
         .update(jobs)
         .set({
           worker_id: workerId,
@@ -213,8 +213,8 @@ export class Job extends DBModel {
           updated_at: now
         })
         .where(and(eq(jobs.id, this.id), eq(jobs.version, expectedVersion)))
-        .run();
-      if (result.changes === 0) return false;
+        .returning({ id: jobs.id });
+      if (updated.length === 0) return false;
       // Sync in-memory state
       this.worker_id = workerId;
       this.heartbeat_at = now;
@@ -251,15 +251,14 @@ export class Job extends DBModel {
     if (status) conditions.push(eq(jobs.status, status));
     if (workflowId) conditions.push(eq(jobs.workflow_id, workflowId));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(jobs)
       .where(and(...conditions))
       .orderBy(desc(jobs.updated_at))
-      .limit(limit + 1)
-      .all();
+      .limit(limit + 1);
 
-    const items = rows.map((r) => new Job(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Job(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";

--- a/packages/models/src/message.ts
+++ b/packages/models/src/message.ts
@@ -86,15 +86,14 @@ export class Message extends DBModel {
   ): Promise<[Message[], string]> {
     const { limit = 50, reverse = false } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(messages)
       .where(eq(messages.thread_id, threadId))
       .orderBy(reverse ? desc(messages.created_at) : asc(messages.created_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Message(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Message(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";

--- a/packages/models/src/migrations/db-adapter.ts
+++ b/packages/models/src/migrations/db-adapter.ts
@@ -256,3 +256,150 @@ export class PostgresMigrationAdapter implements MigrationDBAdapter {
     }
   }
 }
+
+// ── postgres.js Implementation ───────────────────────────────────────
+
+/**
+ * Migration adapter for the `postgres` (postgres.js) package.
+ * Works with Supabase, Neon, or any standard PostgreSQL database.
+ *
+ * This is the recommended adapter when using `initPostgresDb()` since
+ * both the Drizzle ORM connection and the migration system use postgres.js.
+ *
+ * SQL uses `?` placeholders which are converted to `$1, $2, ...`
+ * for PostgreSQL compatibility with the SQLite-style migration SQL.
+ *
+ * Usage:
+ * ```typescript
+ * import postgres from 'postgres';
+ * import { PostgresJsMigrationAdapter, MigrationRunner } from '@nodetool-ai/models';
+ *
+ * const sql = postgres(process.env.DATABASE_URL);
+ * const adapter = new PostgresJsMigrationAdapter(sql);
+ * await adapter.begin();
+ * try {
+ *   const runner = new MigrationRunner(adapter);
+ *   await runner.migrate();
+ * } finally {
+ *   await adapter.release();
+ * }
+ * ```
+ */
+export class PostgresJsMigrationAdapter implements MigrationDBAdapter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private sql: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private reserved: any = null;
+  private lastRowCount = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(sql: any) {
+    this.sql = sql;
+  }
+
+  get dbType(): string {
+    return "postgres";
+  }
+
+  /** Convert `?` placeholders to PostgreSQL `$1, $2, ...` style. */
+  private pgSql(sql: string): string {
+    let idx = 0;
+    return sql.replace(/\?/g, () => `$${++idx}`);
+  }
+
+  /** Acquire a reserved connection for the migration session. */
+  async begin(): Promise<void> {
+    if (!this.reserved) {
+      this.reserved = await this.sql.reserve();
+      await this.reserved.unsafe("BEGIN");
+    }
+  }
+
+  private async getConn(): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    if (!this.reserved) {
+      await this.begin();
+    }
+    return this.reserved;
+  }
+
+  async execute(sql: string, params?: SqlParams): Promise<void> {
+    const conn = await this.getConn();
+    const result = await conn.unsafe(this.pgSql(sql), params ?? []);
+    this.lastRowCount = result.count ?? 0;
+  }
+
+  async fetchone(sql: string, params?: SqlParams): Promise<Row | null> {
+    const conn = await this.getConn();
+    const rows = await conn.unsafe(this.pgSql(sql), params ?? []);
+    return rows[0] ?? null;
+  }
+
+  async fetchall(sql: string, params?: SqlParams): Promise<Row[]> {
+    const conn = await this.getConn();
+    return conn.unsafe(this.pgSql(sql), params ?? []);
+  }
+
+  async commit(): Promise<void> {
+    if (this.reserved) {
+      await this.reserved.unsafe("COMMIT");
+      await this.reserved.unsafe("BEGIN");
+    }
+  }
+
+  async rollback(): Promise<void> {
+    if (this.reserved) {
+      await this.reserved.unsafe("ROLLBACK");
+      await this.reserved.unsafe("BEGIN");
+    }
+  }
+
+  async tableExists(tableName: string): Promise<boolean> {
+    const row = await this.fetchone(
+      "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = ?) AS exists",
+      [tableName]
+    );
+    return row?.exists === true;
+  }
+
+  async columnExists(tableName: string, columnName: string): Promise<boolean> {
+    const row = await this.fetchone(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = ? AND column_name = ?
+      ) AS exists`,
+      [tableName, columnName]
+    );
+    return row?.exists === true;
+  }
+
+  async getColumns(tableName: string): Promise<string[]> {
+    const rows = await this.fetchall(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = ?
+       ORDER BY ordinal_position`,
+      [tableName]
+    );
+    return rows.map((r) => r.column_name);
+  }
+
+  async indexExists(indexName: string): Promise<boolean> {
+    const row = await this.fetchone(
+      "SELECT EXISTS (SELECT FROM pg_indexes WHERE schemaname = 'public' AND indexname = ?) AS exists",
+      [indexName]
+    );
+    return row?.exists === true;
+  }
+
+  getRowcount(): number {
+    return this.lastRowCount;
+  }
+
+  /** Release the reserved connection back to the pool. */
+  async release(): Promise<void> {
+    if (this.reserved) {
+      this.reserved.release();
+      this.reserved = null;
+    }
+  }
+}

--- a/packages/models/src/migrations/db-adapter.ts
+++ b/packages/models/src/migrations/db-adapter.ts
@@ -251,6 +251,11 @@ export class PostgresMigrationAdapter implements MigrationDBAdapter {
    */
   async release(): Promise<void> {
     if (this.client) {
+      try {
+        await this.client.query("ROLLBACK");
+      } catch {
+        // Ignore rollback errors during cleanup.
+      }
       this.client.release();
       this.client = null;
     }
@@ -398,6 +403,11 @@ export class PostgresJsMigrationAdapter implements MigrationDBAdapter {
   /** Release the reserved connection back to the pool. */
   async release(): Promise<void> {
     if (this.reserved) {
+      try {
+        await this.reserved.unsafe("ROLLBACK");
+      } catch {
+        // Ignore rollback errors during cleanup.
+      }
       this.reserved.release();
       this.reserved = null;
     }

--- a/packages/models/src/migrations/index.ts
+++ b/packages/models/src/migrations/index.ts
@@ -25,7 +25,8 @@ export {
 export type { MigrationDBAdapter, SqlParams, Row } from "./db-adapter.js";
 export {
   SQLiteMigrationAdapter,
-  PostgresMigrationAdapter
+  PostgresMigrationAdapter,
+  PostgresJsMigrationAdapter
 } from "./db-adapter.js";
 
 export type { MigrationDef } from "./versions.js";

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -1081,5 +1081,282 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_settings_user_id");
       await db.execute("DROP TABLE IF EXISTS nodetool_settings");
     }
+  },
+
+  // ── Ensure schema columns match current Drizzle models ─────────────
+  {
+    version: "20260430_000000",
+    name: "add_current_schema_missing_columns",
+    createsTables: [],
+    modifiesTables: [
+      "nodetool_workflows",
+      "nodetool_jobs",
+      "nodetool_messages",
+      "nodetool_threads",
+      "nodetool_assets",
+      "nodetool_secrets",
+      "nodetool_workspaces",
+      "nodetool_workflow_versions",
+      "nodetool_oauth_credentials",
+      "run_node_state",
+      "nodetool_predictions",
+      "run_events",
+      "run_leases",
+      "nodetool_team_tasks",
+      "nodetool_settings"
+    ],
+    async up(db) {
+      const tableColumns: Record<string, Record<string, string>> = {
+        nodetool_workflows: {
+          id: "TEXT",
+          user_id: "TEXT",
+          name: "TEXT",
+          tool_name: "TEXT",
+          description: "TEXT",
+          tags: "TEXT",
+          thumbnail: "TEXT",
+          thumbnail_url: "TEXT",
+          graph: "TEXT",
+          settings: "TEXT",
+          package_name: "TEXT",
+          path: "TEXT",
+          run_mode: "TEXT",
+          workspace_id: "TEXT",
+          html_app: "TEXT",
+          receive_clipboard: "INTEGER",
+          access: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_jobs: {
+          id: "TEXT",
+          user_id: "TEXT",
+          job_type: "TEXT",
+          workflow_id: "TEXT",
+          status: "TEXT",
+          name: "TEXT",
+          graph: "TEXT",
+          params: "TEXT",
+          worker_id: "TEXT",
+          heartbeat_at: "TEXT",
+          started_at: "TEXT",
+          finished_at: "TEXT",
+          completed_at: "TEXT",
+          failed_at: "TEXT",
+          error: "TEXT",
+          error_message: "TEXT",
+          cost: "REAL",
+          logs: "TEXT",
+          retry_count: "INTEGER",
+          max_retries: "INTEGER",
+          version: "INTEGER",
+          suspended_node_id: "TEXT",
+          suspension_reason: "TEXT",
+          suspension_state_json: "TEXT",
+          suspension_metadata_json: "TEXT",
+          execution_strategy: "TEXT",
+          execution_id: "TEXT",
+          metadata_json: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_messages: {
+          id: "TEXT",
+          user_id: "TEXT",
+          thread_id: "TEXT",
+          role: "TEXT",
+          name: "TEXT",
+          content: "TEXT",
+          tool_calls: "TEXT",
+          tool_call_id: "TEXT",
+          input_files: "TEXT",
+          output_files: "TEXT",
+          provider: "TEXT",
+          model: "TEXT",
+          cost: "REAL",
+          workflow_id: "TEXT",
+          graph: "TEXT",
+          tools: "TEXT",
+          collections: "TEXT",
+          agent_mode: "INTEGER",
+          help_mode: "INTEGER",
+          agent_execution_id: "TEXT",
+          execution_event_type: "TEXT",
+          workflow_target: "TEXT",
+          media_generation: "TEXT",
+          created_at: "TEXT"
+        },
+        nodetool_threads: {
+          id: "TEXT",
+          user_id: "TEXT",
+          title: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_assets: {
+          id: "TEXT",
+          user_id: "TEXT",
+          parent_id: "TEXT",
+          file_id: "TEXT",
+          name: "TEXT",
+          content_type: "TEXT",
+          size: "REAL",
+          duration: "REAL",
+          metadata: "TEXT",
+          workflow_id: "TEXT",
+          node_id: "TEXT",
+          job_id: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_secrets: {
+          id: "TEXT",
+          user_id: "TEXT",
+          key: "TEXT",
+          encrypted_value: "TEXT",
+          description: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_workspaces: {
+          id: "TEXT",
+          user_id: "TEXT",
+          name: "TEXT",
+          path: "TEXT",
+          is_default: "INTEGER",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_workflow_versions: {
+          id: "TEXT",
+          workflow_id: "TEXT",
+          user_id: "TEXT",
+          name: "TEXT",
+          description: "TEXT",
+          graph: "TEXT",
+          version: "INTEGER",
+          save_type: "TEXT",
+          autosave_metadata: "TEXT",
+          created_at: "TEXT"
+        },
+        nodetool_oauth_credentials: {
+          id: "TEXT",
+          user_id: "TEXT",
+          provider: "TEXT",
+          account_id: "TEXT",
+          encrypted_access_token: "TEXT",
+          encrypted_refresh_token: "TEXT",
+          username: "TEXT",
+          token_type: "TEXT",
+          scope: "TEXT",
+          received_at: "TEXT",
+          expires_at: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        run_node_state: {
+          id: "TEXT",
+          run_id: "TEXT",
+          node_id: "TEXT",
+          status: "TEXT",
+          attempt: "INTEGER",
+          scheduled_at: "TEXT",
+          started_at: "TEXT",
+          completed_at: "TEXT",
+          failed_at: "TEXT",
+          suspended_at: "TEXT",
+          updated_at: "TEXT",
+          last_error: "TEXT",
+          retryable: "INTEGER",
+          suspension_reason: "TEXT",
+          resume_state_json: "TEXT",
+          outputs_json: "TEXT"
+        },
+        nodetool_predictions: {
+          id: "TEXT",
+          user_id: "TEXT",
+          node_id: "TEXT",
+          provider: "TEXT",
+          model: "TEXT",
+          workflow_id: "TEXT",
+          error: "TEXT",
+          logs: "TEXT",
+          status: "TEXT",
+          cost: "REAL",
+          input_tokens: "INTEGER",
+          output_tokens: "INTEGER",
+          total_tokens: "INTEGER",
+          cached_tokens: "INTEGER",
+          reasoning_tokens: "INTEGER",
+          created_at: "TEXT",
+          started_at: "TEXT",
+          completed_at: "TEXT",
+          duration: "REAL",
+          hardware: "TEXT",
+          input_size: "INTEGER",
+          output_size: "INTEGER",
+          parameters: "TEXT",
+          metadata: "TEXT"
+        },
+        run_events: {
+          id: "TEXT",
+          run_id: "TEXT",
+          seq: "INTEGER",
+          event_type: "TEXT",
+          event_time: "TEXT",
+          node_id: "TEXT",
+          payload: "TEXT"
+        },
+        run_leases: {
+          run_id: "TEXT",
+          worker_id: "TEXT",
+          acquired_at: "TEXT",
+          expires_at: "TEXT"
+        },
+        nodetool_team_tasks: {
+          id: "TEXT",
+          team_id: "TEXT",
+          title: "TEXT",
+          description: "TEXT",
+          status: "TEXT",
+          created_by: "TEXT",
+          claimed_by: "TEXT",
+          depends_on: "TEXT",
+          required_skills: "TEXT",
+          priority: "INTEGER",
+          artifacts: "TEXT",
+          parent_task_id: "TEXT",
+          result: "TEXT",
+          failure_reason: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        },
+        nodetool_settings: {
+          id: "TEXT",
+          user_id: "TEXT",
+          key: "TEXT",
+          value: "TEXT",
+          description: "TEXT",
+          created_at: "TEXT",
+          updated_at: "TEXT"
+        }
+      };
+
+      for (const [tableName, columns] of Object.entries(tableColumns)) {
+        if (!(await db.tableExists(tableName))) {
+          continue;
+        }
+        for (const [columnName, columnType] of Object.entries(columns)) {
+          if (!(await db.columnExists(tableName, columnName))) {
+            await db.execute(
+              `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnType}`
+            );
+          }
+        }
+      }
+    },
+    async down() {
+      // no-op: dropping columns is unsafe across dialects and versions
+    }
   }
 ];

--- a/packages/models/src/oauth-credential.ts
+++ b/packages/models/src/oauth-credential.ts
@@ -114,7 +114,7 @@ export class OAuthCredential extends DBModel {
     accountId: string
   ): Promise<OAuthCredential | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(oauthCredentials)
       .where(
@@ -124,8 +124,7 @@ export class OAuthCredential extends DBModel {
           eq(oauthCredentials.account_id, accountId)
         )
       )
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new OAuthCredential(row as Record<string, unknown>) : null;
   }
 
@@ -135,7 +134,7 @@ export class OAuthCredential extends DBModel {
     provider: string
   ): Promise<OAuthCredential[]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(oauthCredentials)
       .where(
@@ -144,9 +143,8 @@ export class OAuthCredential extends DBModel {
           eq(oauthCredentials.provider, provider)
         )
       )
-      .orderBy(desc(oauthCredentials.updated_at))
-      .all();
-    return rows.map((r) => new OAuthCredential(r as Record<string, unknown>));
+      .orderBy(desc(oauthCredentials.updated_at));
+    return rows.map((r: Record<string, unknown>) => new OAuthCredential(r as Record<string, unknown>));
   }
 
   /** Create a new credential with encrypted tokens. */

--- a/packages/models/src/prediction.ts
+++ b/packages/models/src/prediction.ts
@@ -118,15 +118,14 @@ export class Prediction extends DBModel {
     if (provider) conditions.push(eq(predictions.provider, provider));
     if (model) conditions.push(eq(predictions.model, model));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(predictions)
       .where(and(...conditions))
       .orderBy(desc(predictions.created_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Prediction(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Prediction(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
@@ -143,12 +142,11 @@ export class Prediction extends DBModel {
       conditions.push(eq(predictions.provider, opts.provider));
     if (opts?.model) conditions.push(eq(predictions.model, opts.model));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(predictions)
       .where(and(...conditions))
       .limit(10000)
-      .all();
 
     let total_cost = 0;
     let total_input_tokens = 0;
@@ -178,12 +176,11 @@ export class Prediction extends DBModel {
     userId: string
   ): Promise<ProviderAggregateResult[]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(predictions)
       .where(eq(predictions.user_id, userId))
       .limit(10000)
-      .all();
 
     const groups = new Map<string, ProviderAggregateResult>();
     for (const p of rows) {
@@ -219,12 +216,11 @@ export class Prediction extends DBModel {
     if (opts?.provider)
       conditions.push(eq(predictions.provider, opts.provider));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(predictions)
       .where(and(...conditions))
       .limit(10000)
-      .all();
 
     const groups = new Map<string, ModelAggregateResult>();
     for (const p of rows) {

--- a/packages/models/src/run-event.ts
+++ b/packages/models/src/run-event.ts
@@ -53,13 +53,12 @@ export class RunEvent extends DBModel {
   /** Get the next sequence number for a run. */
   static async getNextSeq(runId: string): Promise<number> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select({ seq: runEvents.seq })
       .from(runEvents)
       .where(eq(runEvents.run_id, runId))
       .orderBy(desc(runEvents.seq))
       .limit(1)
-      .all();
 
     if (rows.length === 0) return 0;
     return rows[0].seq + 1;
@@ -105,15 +104,14 @@ export class RunEvent extends DBModel {
       conditions.push(eq(runEvents.event_type, eventType));
     if (nodeId !== undefined) conditions.push(eq(runEvents.node_id, nodeId));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(runEvents)
       .where(and(...conditions))
       .orderBy(asc(runEvents.seq))
       .limit(limit)
-      .all();
 
-    return rows.map((r) => new RunEvent(r as Record<string, unknown>));
+    return rows.map((r: Record<string, unknown>) => new RunEvent(r as Record<string, unknown>));
   }
 
   /** Deserialize a RunEvent from a plain object (e.g. from JSON). */
@@ -140,13 +138,12 @@ export class RunEvent extends DBModel {
       conditions.push(eq(runEvents.event_type, opts.eventType));
     if (opts.nodeId) conditions.push(eq(runEvents.node_id, opts.nodeId));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(runEvents)
       .where(and(...conditions))
       .orderBy(desc(runEvents.seq))
       .limit(1)
-      .all();
 
     return rows.length > 0
       ? new RunEvent(rows[0] as Record<string, unknown>)

--- a/packages/models/src/run-lease.ts
+++ b/packages/models/src/run-lease.ts
@@ -36,27 +36,25 @@ export class RunLease extends DBModel {
     const expiresIso = expires.toISOString();
 
     const db = getDb();
-    // Use a transaction with BEGIN IMMEDIATE to get an exclusive lock,
-    // preventing two workers from acquiring the same lease concurrently.
-    return db.transaction((tx: any) => {
-      const existing = tx
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return db.transaction(async (tx: any) => {
+      const [existing] = await tx
         .select()
         .from(runLeases)
         .where(eq(runLeases.run_id, runId))
-        .limit(1)
-        .get();
+        .limit(1);
 
       if (existing) {
         if (new Date(existing.expires_at) < now) {
           // Expired lease -- reclaim it
-          tx.update(runLeases)
+          await tx
+            .update(runLeases)
             .set({
               worker_id: workerId,
               acquired_at: nowIso,
               expires_at: expiresIso
             })
-            .where(eq(runLeases.run_id, runId))
-            .run();
+            .where(eq(runLeases.run_id, runId));
           return new RunLease({
             ...existing,
             worker_id: workerId,
@@ -69,14 +67,12 @@ export class RunLease extends DBModel {
       }
 
       // No existing lease -- create one
-      tx.insert(runLeases)
-        .values({
-          run_id: runId,
-          worker_id: workerId,
-          acquired_at: nowIso,
-          expires_at: expiresIso
-        })
-        .run();
+      await tx.insert(runLeases).values({
+        run_id: runId,
+        worker_id: workerId,
+        acquired_at: nowIso,
+        expires_at: expiresIso
+      });
 
       return new RunLease({
         run_id: runId,
@@ -99,12 +95,10 @@ export class RunLease extends DBModel {
     await this.delete();
   }
 
-  /** Check if this lease has expired. */
   isExpired(): boolean {
     return new Date(this.expires_at) < new Date();
   }
 
-  /** Check if this lease is held by a specific worker (and not expired). */
   isHeldBy(workerId: string): boolean {
     return this.worker_id === workerId && !this.isExpired();
   }
@@ -113,11 +107,10 @@ export class RunLease extends DBModel {
   static async cleanupExpired(): Promise<number> {
     const now = new Date().toISOString();
     const db = getDb();
-    const expired = db
+    const expired = await db
       .select()
       .from(runLeases)
-      .where(lt(runLeases.expires_at, now))
-      .all();
+      .where(lt(runLeases.expires_at, now));
 
     for (const row of expired) {
       const lease = new RunLease(row as Record<string, unknown>);

--- a/packages/models/src/run-node-state.ts
+++ b/packages/models/src/run-node-state.ts
@@ -79,14 +79,13 @@ export class RunNodeState extends DBModel {
     nodeId: string
   ): Promise<RunNodeState | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(runNodeState)
       .where(
         and(eq(runNodeState.run_id, runId), eq(runNodeState.node_id, nodeId))
       )
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new RunNodeState(row as Record<string, unknown>) : null;
   }
 
@@ -109,7 +108,7 @@ export class RunNodeState extends DBModel {
   /** Get all incomplete (scheduled or running) nodes for a run. */
   static async getIncompleteNodes(runId: string): Promise<RunNodeState[]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(runNodeState)
       .where(
@@ -118,15 +117,14 @@ export class RunNodeState extends DBModel {
           inArray(runNodeState.status, ["scheduled", "running"])
         )
       )
-      .limit(10000)
-      .all();
-    return rows.map((r) => new RunNodeState(r as Record<string, unknown>));
+      .limit(10000);
+    return rows.map((r: Record<string, unknown>) => new RunNodeState(r as Record<string, unknown>));
   }
 
   /** Get all suspended nodes for a run. */
   static async getSuspendedNodes(runId: string): Promise<RunNodeState[]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(runNodeState)
       .where(
@@ -135,9 +133,8 @@ export class RunNodeState extends DBModel {
           eq(runNodeState.status, "suspended")
         )
       )
-      .limit(10000)
-      .all();
-    return rows.map((r) => new RunNodeState(r as Record<string, unknown>));
+      .limit(10000);
+    return rows.map((r: Record<string, unknown>) => new RunNodeState(r as Record<string, unknown>));
   }
 
   // ── State transitions ─────────────────────────────────────────────

--- a/packages/models/src/schema-pg/assets.ts
+++ b/packages/models/src/schema-pg/assets.ts
@@ -1,0 +1,27 @@
+import { pgTable, text, real, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const assets = pgTable(
+  "nodetool_assets",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    parent_id: text("parent_id"),
+    file_id: text("file_id"),
+    name: text("name").notNull().default(""),
+    content_type: text("content_type")
+      .notNull()
+      .default("application/octet-stream"),
+    size: real("size"),
+    duration: real("duration"),
+    metadata: jsonText<Record<string, unknown>>()("metadata"),
+    workflow_id: text("workflow_id"),
+    node_id: text("node_id"),
+    job_id: text("job_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_assets_user_parent").on(table.user_id, table.parent_id)
+  ]
+);

--- a/packages/models/src/schema-pg/helpers.ts
+++ b/packages/models/src/schema-pg/helpers.ts
@@ -1,0 +1,19 @@
+import { customType } from "drizzle-orm/pg-core";
+
+/**
+ * Custom Drizzle column type that stores JSON as TEXT in PostgreSQL.
+ * Uses TEXT (not JSONB) to match the SQLite schema exactly, making cross-dialect
+ * data migration straightforward. Handles serialization/deserialization automatically.
+ */
+export const jsonText = <T>() =>
+  customType<{ data: T; driverData: string }>({
+    dataType() {
+      return "text";
+    },
+    toDriver(value: T): string {
+      return JSON.stringify(value);
+    },
+    fromDriver(value: string): T {
+      return JSON.parse(value) as T;
+    }
+  });

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -1,0 +1,15 @@
+export { workflows } from "./workflows.js";
+export { jobs } from "./jobs.js";
+export { messages } from "./messages.js";
+export { threads } from "./threads.js";
+export { assets } from "./assets.js";
+export { secrets } from "./secrets.js";
+export { workspaces } from "./workspaces.js";
+export { workflowVersions } from "./workflow-versions.js";
+export { oauthCredentials } from "./oauth-credentials.js";
+export { runNodeState } from "./run-node-state.js";
+export { predictions } from "./predictions.js";
+export { runEvents } from "./run-events.js";
+export { runLeases } from "./run-leases.js";
+export { teamTasks } from "./team-tasks.js";
+export { appSettings } from "./settings.js";

--- a/packages/models/src/schema-pg/jobs.ts
+++ b/packages/models/src/schema-pg/jobs.ts
@@ -1,0 +1,49 @@
+import { pgTable, text, integer, real, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const jobs = pgTable(
+  "nodetool_jobs",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    job_type: text("job_type").notNull().default(""),
+    workflow_id: text("workflow_id").notNull(),
+    status: text("status").notNull().default("scheduled"),
+    name: text("name").default(""),
+    graph: jsonText<Record<string, unknown>>()("graph"),
+    params: jsonText<Record<string, unknown>>()("params"),
+    worker_id: text("worker_id"),
+    heartbeat_at: text("heartbeat_at"),
+    started_at: text("started_at"),
+    finished_at: text("finished_at"),
+    completed_at: text("completed_at"),
+    failed_at: text("failed_at"),
+    error: text("error"),
+    error_message: text("error_message"),
+    cost: real("cost"),
+    logs: jsonText<Record<string, unknown>[]>()("logs"),
+    retry_count: integer("retry_count").notNull().default(0),
+    max_retries: integer("max_retries").notNull().default(3),
+    version: integer("version").notNull().default(0),
+    suspended_node_id: text("suspended_node_id"),
+    suspension_reason: text("suspension_reason"),
+    suspension_state_json: jsonText<Record<string, unknown>>()(
+      "suspension_state_json"
+    ),
+    suspension_metadata_json: jsonText<Record<string, unknown>>()(
+      "suspension_metadata_json"
+    ),
+    execution_strategy: text("execution_strategy"),
+    execution_id: text("execution_id"),
+    metadata_json: jsonText<Record<string, unknown>>()("metadata_json"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_jobs_status").on(table.status),
+    index("idx_jobs_updated_at").on(table.updated_at),
+    index("idx_jobs_worker_id").on(table.worker_id),
+    index("idx_jobs_heartbeat_at").on(table.heartbeat_at),
+    index("idx_jobs_recovery").on(table.status, table.heartbeat_at)
+  ]
+);

--- a/packages/models/src/schema-pg/messages.ts
+++ b/packages/models/src/schema-pg/messages.ts
@@ -1,0 +1,35 @@
+import { pgTable, text, integer, real, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const messages = pgTable(
+  "nodetool_messages",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    thread_id: text("thread_id").notNull(),
+    role: text("role").notNull().default("user"),
+    name: text("name"),
+    content: jsonText<string | Record<string, unknown> | unknown[]>()(
+      "content"
+    ),
+    tool_calls: jsonText<unknown[]>()("tool_calls"),
+    tool_call_id: text("tool_call_id"),
+    input_files: jsonText<unknown[]>()("input_files"),
+    output_files: jsonText<unknown[]>()("output_files"),
+    provider: text("provider"),
+    model: text("model"),
+    cost: real("cost"),
+    workflow_id: text("workflow_id"),
+    graph: jsonText<Record<string, unknown>>()("graph"),
+    tools: jsonText<string[]>()("tools"),
+    collections: jsonText<string[]>()("collections"),
+    agent_mode: integer("agent_mode"),
+    help_mode: integer("help_mode"),
+    agent_execution_id: text("agent_execution_id"),
+    execution_event_type: text("execution_event_type"),
+    workflow_target: text("workflow_target"),
+    media_generation: jsonText<Record<string, unknown>>()("media_generation"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [index("idx_messages_thread_id").on(table.thread_id)]
+);

--- a/packages/models/src/schema-pg/oauth-credentials.ts
+++ b/packages/models/src/schema-pg/oauth-credentials.ts
@@ -1,0 +1,29 @@
+import { pgTable, text, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const oauthCredentials = pgTable(
+  "nodetool_oauth_credentials",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    provider: text("provider").notNull(),
+    account_id: text("account_id").notNull(),
+    encrypted_access_token: text("encrypted_access_token").notNull(),
+    encrypted_refresh_token: text("encrypted_refresh_token"),
+    username: text("username"),
+    token_type: text("token_type").notNull().default("Bearer"),
+    scope: text("scope"),
+    received_at: text("received_at").notNull(),
+    expires_at: text("expires_at"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_oauth_user_id").on(table.user_id),
+    index("idx_oauth_user_provider").on(table.user_id, table.provider),
+    uniqueIndex("idx_oauth_user_provider_account").on(
+      table.user_id,
+      table.provider,
+      table.account_id
+    )
+  ]
+);

--- a/packages/models/src/schema-pg/predictions.ts
+++ b/packages/models/src/schema-pg/predictions.ts
@@ -1,0 +1,38 @@
+import { pgTable, text, integer, real, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const predictions = pgTable(
+  "nodetool_predictions",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    node_id: text("node_id").notNull().default(""),
+    provider: text("provider").notNull().default(""),
+    model: text("model").notNull().default(""),
+    workflow_id: text("workflow_id"),
+    error: text("error"),
+    logs: text("logs"),
+    status: text("status").notNull().default("pending"),
+    cost: real("cost"),
+    input_tokens: integer("input_tokens"),
+    output_tokens: integer("output_tokens"),
+    total_tokens: integer("total_tokens"),
+    cached_tokens: integer("cached_tokens"),
+    reasoning_tokens: integer("reasoning_tokens"),
+    created_at: text("created_at"),
+    started_at: text("started_at"),
+    completed_at: text("completed_at"),
+    duration: real("duration"),
+    hardware: text("hardware"),
+    input_size: integer("input_size"),
+    output_size: integer("output_size"),
+    parameters: jsonText<Record<string, unknown>>()("parameters"),
+    metadata: jsonText<Record<string, unknown>>()("metadata")
+  },
+  (table) => [
+    index("idx_predictions_user_id").on(table.user_id),
+    index("idx_predictions_user_provider").on(table.user_id, table.provider),
+    index("idx_prediction_created_at").on(table.created_at),
+    index("idx_prediction_user_model").on(table.user_id, table.model)
+  ]
+);

--- a/packages/models/src/schema-pg/run-events.ts
+++ b/packages/models/src/schema-pg/run-events.ts
@@ -1,0 +1,20 @@
+import { pgTable, text, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const runEvents = pgTable(
+  "run_events",
+  {
+    id: text("id").primaryKey(),
+    run_id: text("run_id").notNull(),
+    seq: integer("seq").notNull(),
+    event_type: text("event_type").notNull(),
+    event_time: text("event_time").notNull(),
+    node_id: text("node_id"),
+    payload: jsonText<Record<string, unknown>>()("payload")
+  },
+  (table) => [
+    uniqueIndex("idx_run_events_run_seq").on(table.run_id, table.seq),
+    index("idx_run_events_run_node").on(table.run_id, table.node_id),
+    index("idx_run_events_run_type").on(table.run_id, table.event_type)
+  ]
+);

--- a/packages/models/src/schema-pg/run-leases.ts
+++ b/packages/models/src/schema-pg/run-leases.ts
@@ -1,0 +1,12 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+
+export const runLeases = pgTable(
+  "run_leases",
+  {
+    run_id: text("run_id").primaryKey(),
+    worker_id: text("worker_id").notNull(),
+    acquired_at: text("acquired_at").notNull(),
+    expires_at: text("expires_at").notNull()
+  },
+  (table) => [index("idx_run_leases_expires").on(table.expires_at)]
+);

--- a/packages/models/src/schema-pg/run-node-state.ts
+++ b/packages/models/src/schema-pg/run-node-state.ts
@@ -1,0 +1,28 @@
+import { pgTable, text, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const runNodeState = pgTable(
+  "run_node_state",
+  {
+    id: text("id").primaryKey(),
+    run_id: text("run_id").notNull(),
+    node_id: text("node_id").notNull(),
+    status: text("status").notNull().default("idle"),
+    attempt: integer("attempt").notNull().default(1),
+    scheduled_at: text("scheduled_at"),
+    started_at: text("started_at"),
+    completed_at: text("completed_at"),
+    failed_at: text("failed_at"),
+    suspended_at: text("suspended_at"),
+    updated_at: text("updated_at").notNull(),
+    last_error: text("last_error"),
+    retryable: integer("retryable").notNull().default(0),
+    suspension_reason: text("suspension_reason"),
+    resume_state_json: jsonText<Record<string, unknown>>()("resume_state_json"),
+    outputs_json: jsonText<Record<string, unknown>>()("outputs_json")
+  },
+  (table) => [
+    index("idx_run_node_state_run_status").on(table.run_id, table.status),
+    uniqueIndex("idx_run_node_state_run_node").on(table.run_id, table.node_id)
+  ]
+);

--- a/packages/models/src/schema-pg/secrets.ts
+++ b/packages/models/src/schema-pg/secrets.ts
@@ -1,0 +1,18 @@
+import { pgTable, text, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const secrets = pgTable(
+  "nodetool_secrets",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    key: text("key").notNull(),
+    encrypted_value: text("encrypted_value").notNull(),
+    description: text("description").default(""),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    uniqueIndex("idx_secrets_user_key").on(table.user_id, table.key),
+    index("idx_secrets_user_id").on(table.user_id)
+  ]
+);

--- a/packages/models/src/schema-pg/settings.ts
+++ b/packages/models/src/schema-pg/settings.ts
@@ -1,0 +1,18 @@
+import { pgTable, text, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const appSettings = pgTable(
+  "nodetool_settings",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    description: text("description").default(""),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    uniqueIndex("idx_settings_user_key").on(table.user_id, table.key),
+    index("idx_settings_user_id").on(table.user_id)
+  ]
+);

--- a/packages/models/src/schema-pg/team-tasks.ts
+++ b/packages/models/src/schema-pg/team-tasks.ts
@@ -1,0 +1,30 @@
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const teamTasks = pgTable(
+  "nodetool_team_tasks",
+  {
+    id: text("id").primaryKey(),
+    team_id: text("team_id").notNull(),
+    title: text("title").notNull(),
+    description: text("description").notNull().default(""),
+    status: text("status").notNull().default("open"),
+    created_by: text("created_by").notNull(),
+    claimed_by: text("claimed_by"),
+    depends_on: jsonText<string[]>()("depends_on").notNull(),
+    required_skills: jsonText<string[]>()("required_skills").notNull(),
+    priority: integer("priority").notNull().default(5),
+    artifacts: jsonText<unknown[]>()("artifacts").notNull(),
+    parent_task_id: text("parent_task_id"),
+    result: jsonText<unknown>()("result"),
+    failure_reason: text("failure_reason"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_team_tasks_team_id").on(table.team_id),
+    index("idx_team_tasks_status").on(table.status),
+    index("idx_team_tasks_team_status").on(table.team_id, table.status),
+    index("idx_team_tasks_parent").on(table.parent_task_id)
+  ]
+);

--- a/packages/models/src/schema-pg/threads.ts
+++ b/packages/models/src/schema-pg/threads.ts
@@ -1,0 +1,13 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+
+export const threads = pgTable(
+  "nodetool_threads",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    title: text("title").notNull().default(""),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [index("idx_threads_user_id").on(table.user_id)]
+);

--- a/packages/models/src/schema-pg/workflow-versions.ts
+++ b/packages/models/src/schema-pg/workflow-versions.ts
@@ -1,0 +1,30 @@
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const workflowVersions = pgTable(
+  "nodetool_workflow_versions",
+  {
+    id: text("id").primaryKey(),
+    workflow_id: text("workflow_id").notNull(),
+    user_id: text("user_id").notNull(),
+    name: text("name"),
+    description: text("description"),
+    graph: jsonText<{
+      nodes: Record<string, unknown>[];
+      edges: Record<string, unknown>[];
+    }>()("graph").notNull(),
+    version: integer("version").notNull().default(1),
+    save_type: text("save_type").notNull().default("manual"),
+    autosave_metadata: jsonText<Record<string, unknown>>()("autosave_metadata"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [
+    index("idx_wv_workflow_id").on(table.workflow_id),
+    index("idx_wv_user_id").on(table.user_id),
+    index("idx_nodetool_workflow_versions_workflow_id_save_type_created_at").on(
+      table.workflow_id,
+      table.save_type,
+      table.created_at
+    )
+  ]
+);

--- a/packages/models/src/schema-pg/workflows.ts
+++ b/packages/models/src/schema-pg/workflows.ts
@@ -1,0 +1,34 @@
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+export const workflows = pgTable(
+  "nodetool_workflows",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    name: text("name").notNull().default(""),
+    tool_name: text("tool_name"),
+    description: text("description").default(""),
+    tags: jsonText<string[]>()("tags"),
+    thumbnail: text("thumbnail"),
+    thumbnail_url: text("thumbnail_url"),
+    graph: jsonText<{
+      nodes: Record<string, unknown>[];
+      edges: Record<string, unknown>[];
+    }>()("graph").notNull(),
+    settings: jsonText<Record<string, unknown>>()("settings"),
+    package_name: text("package_name"),
+    path: text("path"),
+    run_mode: text("run_mode"),
+    workspace_id: text("workspace_id"),
+    html_app: text("html_app"),
+    receive_clipboard: integer("receive_clipboard"),
+    access: text("access").notNull().default("private"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_workflows_user_id").on(table.user_id),
+    index("idx_workflows_access").on(table.access)
+  ]
+);

--- a/packages/models/src/schema-pg/workspaces.ts
+++ b/packages/models/src/schema-pg/workspaces.ts
@@ -1,0 +1,15 @@
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+
+export const workspaces = pgTable(
+  "nodetool_workspaces",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    name: text("name").notNull().default(""),
+    path: text("path").notNull().default(""),
+    is_default: integer("is_default").default(0),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [index("idx_workspaces_user_id").on(table.user_id)]
+);

--- a/packages/models/src/secret.ts
+++ b/packages/models/src/secret.ts
@@ -46,12 +46,11 @@ export class Secret extends DBModel {
   /** Find a secret by user_id and key. */
   static async find(userId: string, key: string): Promise<Secret | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(secrets)
       .where(and(eq(secrets.user_id, userId), eq(secrets.key, key)))
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new Secret(row as Record<string, unknown>) : null;
   }
 
@@ -136,14 +135,13 @@ export class Secret extends DBModel {
     limit = 100
   ): Promise<[Secret[], string]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(secrets)
       .where(eq(secrets.user_id, userId))
-      .limit(limit + 1)
-      .all();
+      .limit(limit + 1);
 
-    const items = rows.map((r) => new Secret(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Secret(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
@@ -153,8 +151,8 @@ export class Secret extends DBModel {
   /** List all secrets across all users (admin only). */
   static async listAll(limit = 1000): Promise<Secret[]> {
     const db = getDb();
-    const rows = db.select().from(secrets).limit(limit).all();
-    return rows.map((r) => new Secret(r as Record<string, unknown>));
+    const rows = await db.select().from(secrets).limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Secret(r as Record<string, unknown>));
   }
 
   /** Get the decrypted plaintext value. */

--- a/packages/models/src/setting.ts
+++ b/packages/models/src/setting.ts
@@ -37,12 +37,11 @@ export class Setting extends DBModel {
   /** Find a setting by user_id and key. */
   static async find(userId: string, key: string): Promise<Setting | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(appSettings)
       .where(and(eq(appSettings.user_id, userId), eq(appSettings.key, key)))
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new Setting(row as Record<string, unknown>) : null;
   }
 
@@ -90,12 +89,11 @@ export class Setting extends DBModel {
   /** List all settings for a user. */
   static async listForUser(userId: string): Promise<Setting[]> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(appSettings)
-      .where(eq(appSettings.user_id, userId))
-      .all();
-    return rows.map((r) => new Setting(r as Record<string, unknown>));
+      .where(eq(appSettings.user_id, userId));
+    return rows.map((r: Record<string, unknown>) => new Setting(r as Record<string, unknown>));
   }
 
   /** Get the plaintext value. */

--- a/packages/models/src/thread.ts
+++ b/packages/models/src/thread.ts
@@ -46,15 +46,14 @@ export class Thread extends DBModel {
   ): Promise<[Thread[], string]> {
     const { limit = 50, reverse = true } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(threads)
       .where(eq(threads.user_id, userId))
       .orderBy(reverse ? desc(threads.updated_at) : asc(threads.updated_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Thread(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Thread(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";

--- a/packages/models/src/workflow-version.ts
+++ b/packages/models/src/workflow-version.ts
@@ -42,14 +42,13 @@ export class WorkflowVersion extends DBModel {
   ): Promise<WorkflowVersion[]> {
     const { limit = 100 } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(workflowVersions)
       .where(eq(workflowVersions.workflow_id, workflowId))
       .orderBy(desc(workflowVersions.version))
-      .limit(limit)
-      .all();
-    return rows.map((r) => new WorkflowVersion(r as Record<string, unknown>));
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new WorkflowVersion(r as Record<string, unknown>));
   }
 
   /** Get a specific version by workflow_id + version number. */
@@ -58,7 +57,7 @@ export class WorkflowVersion extends DBModel {
     version: number
   ): Promise<WorkflowVersion | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(workflowVersions)
       .where(
@@ -67,8 +66,7 @@ export class WorkflowVersion extends DBModel {
           eq(workflowVersions.version, version)
         )
       )
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new WorkflowVersion(row as Record<string, unknown>) : null;
   }
 

--- a/packages/models/src/workflow.ts
+++ b/packages/models/src/workflow.ts
@@ -127,15 +127,14 @@ export class Workflow extends DBModel {
     if (access) conditions.push(eq(workflows.access, access));
     if (runMode) conditions.push(eq(workflows.run_mode, runMode));
 
-    const rows = db
+    const rows = await db
       .select()
       .from(workflows)
       .where(and(...conditions))
       .orderBy(desc(workflows.updated_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Workflow(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Workflow(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
@@ -148,15 +147,14 @@ export class Workflow extends DBModel {
   ): Promise<[Workflow[], string]> {
     const { limit = 50 } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(workflows)
       .where(eq(workflows.access, "public"))
       .orderBy(desc(workflows.updated_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Workflow(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Workflow(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
@@ -170,21 +168,20 @@ export class Workflow extends DBModel {
   ): Promise<[Workflow[], string]> {
     const { limit = 50 } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(workflows)
       .where(and(eq(workflows.user_id, userId), eq(workflows.run_mode, "tool")))
       .orderBy(desc(workflows.updated_at))
       .limit(limit + 1)
-      .all();
 
-    const items = rows.map((r) => new Workflow(r as Record<string, unknown>));
+    const items: Workflow[] = rows.map((r: Record<string, unknown>) => new Workflow(r as Record<string, unknown>));
     if (items.length <= limit) {
-      const tools = items.filter((w) => w.hasToolName());
+      const tools = items.filter((w: Workflow) => w.hasToolName());
       return [tools, ""];
     }
     items.pop();
-    const tools = items.filter((w) => w.hasToolName());
+    const tools = items.filter((w: Workflow) => w.hasToolName());
     const cursor = items[items.length - 1]?.id ?? "";
     return [tools, cursor];
   }
@@ -221,7 +218,7 @@ export class Workflow extends DBModel {
     toolName: string
   ): Promise<Workflow | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(workflows)
       .where(
@@ -231,8 +228,7 @@ export class Workflow extends DBModel {
           eq(workflows.run_mode, "tool")
         )
       )
-      .limit(1)
-      .get();
+      .limit(1);
     return row ? new Workflow(row as Record<string, unknown>) : null;
   }
 }

--- a/packages/models/src/workspace.ts
+++ b/packages/models/src/workspace.ts
@@ -26,7 +26,7 @@ export class Workspace extends DBModel {
     super(data);
     const now = new Date().toISOString();
     this.id ??= createTimeOrderedUuid();
-    // Drizzle handles boolean<->integer conversion, but handle raw DB reads too
+    // Handle raw integer booleans from legacy data
     if (typeof this.is_default === "number") {
       this.is_default = (this.is_default as unknown as number) !== 0;
     }
@@ -39,7 +39,6 @@ export class Workspace extends DBModel {
     this.updated_at = new Date().toISOString();
   }
 
-  /** Check if the workspace path exists and is writable. */
   isAccessible(): boolean {
     if (!existsSync(this.path)) return false;
     try {
@@ -50,78 +49,64 @@ export class Workspace extends DBModel {
     }
   }
 
-  /** Find a workspace by user_id and workspace id. */
   static async find(
     userId: string,
     workspaceId: string
   ): Promise<Workspace | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(workspaces)
-      .where(
-        and(eq(workspaces.user_id, userId), eq(workspaces.id, workspaceId))
-      )
-      .limit(1)
-      .get();
+      .where(and(eq(workspaces.user_id, userId), eq(workspaces.id, workspaceId)))
+      .limit(1);
     return row ? new Workspace(row as Record<string, unknown>) : null;
   }
 
-  /** Paginate workspaces for a user. */
   static async paginate(
     userId: string,
     opts: { limit?: number; startKey?: string } = {}
   ): Promise<[Workspace[], string]> {
     const { limit = 50 } = opts;
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(workspaces)
       .where(eq(workspaces.user_id, userId))
-      .limit(limit + 1)
-      .all();
+      .limit(limit + 1);
 
-    const items = rows.map((r) => new Workspace(r as Record<string, unknown>));
+    const items = rows.map((r: Record<string, unknown>) => new Workspace(r as Record<string, unknown>));
     if (items.length <= limit) return [items, ""];
     items.pop();
     const cursor = items[items.length - 1]?.id ?? "";
     return [items, cursor];
   }
 
-  /** Get the default workspace for a user. */
   static async getDefault(userId: string): Promise<Workspace | null> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select()
       .from(workspaces)
-      .where(
-        and(eq(workspaces.user_id, userId), eq(workspaces.is_default, true))
-      )
-      .limit(1)
-      .get();
+      .where(and(eq(workspaces.user_id, userId), eq(workspaces.is_default, true)))
+      .limit(1);
     return row ? new Workspace(row as Record<string, unknown>) : null;
   }
 
-  /** Check if any workflows are linked to a workspace. */
   static async hasLinkedWorkflows(workspaceId: string): Promise<boolean> {
     const db = getDb();
-    const row = db
+    const [row] = await db
       .select({ id: workflows.id })
       .from(workflows)
       .where(eq(workflows.workspace_id, workspaceId))
-      .limit(1)
-      .get();
+      .limit(1);
     return row != null;
   }
 
-  /** Unset is_default on all workspaces for a user. */
   static async unsetOtherDefaults(userId: string): Promise<void> {
     const db = getDb();
-    const rows = db
+    const rows = await db
       .select()
       .from(workspaces)
-      .where(eq(workspaces.user_id, userId))
-      .all();
+      .where(eq(workspaces.user_id, userId));
     for (const row of rows) {
       const ws = new Workspace(row as Record<string, unknown>);
       if (ws.is_default) {

--- a/packages/models/tests/db.test.ts
+++ b/packages/models/tests/db.test.ts
@@ -8,12 +8,12 @@ import { closeDb, getDb, getRawDb, initDb, initTestDb } from "../src/db.js";
 describe("db", () => {
   let tempDir: string | null = null;
 
-  beforeEach(() => {
-    closeDb();
+  beforeEach(async () => {
+    await closeDb();
   });
 
-  afterEach(() => {
-    closeDb();
+  afterEach(async () => {
+    await closeDb();
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
       tempDir = null;
@@ -21,8 +21,8 @@ describe("db", () => {
   });
 
   it("throws when database accessors are used before initialization", () => {
-    expect(() => getDb()).toThrow(/Database not initialized/);
-    expect(() => getRawDb()).toThrow(/Database not initialized/);
+    expect(() => getDb()).toThrow(/not initialized/i);
+    expect(() => getRawDb()).toThrow(/not initialized/i);
   });
 
   it("initializes a file-backed database and exposes the raw connection", () => {
@@ -83,15 +83,15 @@ describe("db", () => {
     expect(jobCols).toContain("suspension_metadata_json");
   });
 
-  it("closeDb resets both the drizzle and raw database handles", () => {
+  it("closeDb resets both the drizzle and raw database handles", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "nodetool-models-db-"));
     const dbPath = join(tempDir, "close.sqlite");
 
     initDb(dbPath);
-    closeDb();
+    await closeDb();
 
-    expect(() => getDb()).toThrow(/Database not initialized/);
-    expect(() => getRawDb()).toThrow(/Database not initialized/);
+    expect(() => getDb()).toThrow(/not initialized/i);
+    expect(() => getRawDb()).toThrow(/not initialized/i);
   });
 
   it("swallows close errors when replacing an existing test database", () => {
@@ -111,7 +111,7 @@ describe("db", () => {
     }
   });
 
-  it("swallows close errors when shutting down the active connection", () => {
+  it("swallows close errors when shutting down the active connection", async () => {
     initTestDb();
     const rawDb = getRawDb();
     const originalClose = rawDb.close.bind(rawDb);
@@ -120,9 +120,9 @@ describe("db", () => {
     };
 
     try {
-      expect(() => closeDb()).not.toThrow();
-      expect(() => getDb()).toThrow(/Database not initialized/);
-      expect(() => getRawDb()).toThrow(/Database not initialized/);
+      await expect(closeDb()).resolves.toBeUndefined();
+      expect(() => getDb()).toThrow(/not initialized/i);
+      expect(() => getRawDb()).toThrow(/not initialized/i);
     } finally {
       (rawDb as Database.Database & { close: () => void }).close =
         originalClose;

--- a/packages/websocket/src/routes/health.ts
+++ b/packages/websocket/src/routes/health.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
-import { getRawDb } from "@nodetool-ai/models";
+import { sql } from "drizzle-orm";
+import { getDb, getDbType, getRawDb } from "@nodetool-ai/models";
 
 const serverStartTime = Date.now();
 
@@ -13,9 +14,13 @@ const healthRoute: FastifyPluginAsync = async (app) => {
     let dbStatus: "ok" | "error" = "ok";
 
     try {
-      const raw = getRawDb();
-      // Fast integrity check — just verifies the connection is alive
-      raw.pragma("quick_check(1)");
+      if (getDbType() === "postgres") {
+        await getDb().execute(sql`select 1`);
+      } else {
+        const raw = getRawDb();
+        // Fast integrity check — just verifies the connection is alive
+        raw.pragma("quick_check(1)");
+      }
     } catch {
       dbStatus = "error";
     }

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -29,7 +29,7 @@ import {
   PythonStdioBridge
 } from "@nodetool-ai/runtime";
 import { initMasterKey } from "@nodetool-ai/security";
-import { initDb, getSecret } from "@nodetool-ai/models";
+import { initDb, initPostgresDb, getSecret } from "@nodetool-ai/models";
 import {
   Tool,
   GoogleSearchTool,
@@ -187,11 +187,32 @@ async function notifyPythonBridgeResourceChanges(
 // Database setup
 // ---------------------------------------------------------------------------
 
-const dbPath = getDefaultDbPath();
+function maskDatabaseUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+    return parsed.toString();
+  } catch {
+    return "(provided)";
+  }
+}
+
 try {
-  mkdirSync(dirname(dbPath), { recursive: true });
-  initDb(dbPath);
-  log.info(`Database ready [${startupMs()}]`, { path: dbPath });
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl) {
+    await initPostgresDb(databaseUrl);
+    log.info(`PostgreSQL database ready [${startupMs()}]`, {
+      url: maskDatabaseUrl(databaseUrl)
+    });
+  } else {
+    const dbPath = getDefaultDbPath();
+    mkdirSync(dirname(dbPath), { recursive: true });
+    initDb(dbPath);
+    log.info(`SQLite database ready [${startupMs()}]`, { path: dbPath });
+  }
+
   // Initialize master key from keychain before any secret access.
   // This must happen before setSecretResolver so that getMasterKey() (sync)
   // returns the keychain key rather than auto-generating a new one.


### PR DESCRIPTION
- Add `postgres` (postgres.js) dependency for PG driver
- Add `initPostgresDb(connectionString)` in db.ts for lazy PG init;
  `getDbType()` returns current dialect ("sqlite" | "postgres")
- Rewrite base-model.ts to use async Drizzle query patterns that work
  with both SQLite and PostgreSQL (replaces sync .get()/.run()/.all())
- Convert all model query methods to async (asset, job, message,
  oauth-credential, prediction, run-event, run-lease, run-node-state,
  secret, setting, thread, workflow, workflow-version, workspace)
- Add PostgreSQL schema in src/schema-pg/ (17 files) mirroring SQLite
  schema using pgTable from drizzle-orm/pg-core; uses custom jsonText()
  helper to store JSON as TEXT for cross-dialect compatibility
- Add PostgresJsMigrationAdapter for running raw SQL migrations against
  Supabase/PG via sql.reserve() + conn.unsafe()
- Add drizzle.pg.config.ts for drizzle-kit schema generation against PG
- Export initPostgresDb, getDbType, DbDialect, pgSchema, and
  PostgresJsMigrationAdapter from package index

https://claude.ai/code/session_01LnMKcZZTDonreP7SiqAcKx