### PR TITLE
🎨 Palette: Add missing ARIA labels to scattered IconButtons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,6 @@
 ## 2024-06-25 - Using `LoadingSpinner` Primitive over Raw Material-UI
 **Learning:** Found instances of raw Material-UI `CircularProgress` usage in components like `CircularActionButton`, `DialogActionButtons`, `DownloadButton`, `RefreshButton`, `RunWorkflowButton`, and `StateIconButton`. This usage goes against `STRATEGY.md` standardizing UI primitives.
 **Action:** When working on UI components, use the explicit primitive `<LoadingSpinner inline />` over the raw `<CircularProgress>` to adhere to standardisation guidelines. Ensure proper test updates to reflect mock substitutions.
+## 2025-05-30 - Added missing aria-labels to scattered IconButtons
+**Learning:** Some custom UI interactions like NodeTestRow, DataframeRenderer, and ReplicateSchemaLoader were missing `aria-label` properties on their icon-only `IconButton` components, breaking accessibility for interactive elements, despite sometimes having `<Tooltip>` wrappers.
+**Action:** Always add an explicit `aria-label` matching the interactive intent whenever rendering an icon-only `<IconButton>`.

--- a/web/src/components/node/DynamicReplicateNode/ReplicateSchemaLoader.tsx
+++ b/web/src/components/node/DynamicReplicateNode/ReplicateSchemaLoader.tsx
@@ -152,6 +152,7 @@ export const ReplicateSchemaLoader: React.FC<ReplicateSchemaLoaderProps> = memo(
         <Tooltip title="Reload Schema" arrow delay={TOOLTIP_ENTER_DELAY}>
           <IconButton
             size="small"
+            aria-label="Reload Schema"
             disabled={loading}
             onClick={() => void handleLoad(true)}
             sx={{

--- a/web/src/components/node/output/DataframeRenderer.tsx
+++ b/web/src/components/node/output/DataframeRenderer.tsx
@@ -70,7 +70,7 @@ const DataframeRenderer: React.FC<DataframeRendererProps> = ({ dataframe }) => {
     <div css={styles(theme)} className="dataframe-renderer">
       <div className="dataframe-action-buttons">
         <Tooltip title="Open in Full View" placement="bottom">
-          <IconButton size="small" onClick={toggleExpand}>
+          <IconButton size="small" onClick={toggleExpand} aria-label="Open in Full View">
             <OpenInFullIcon />
           </IconButton>
         </Tooltip>

--- a/web/src/components/node_test/NodeTestRow.tsx
+++ b/web/src/components/node_test/NodeTestRow.tsx
@@ -70,6 +70,7 @@ function NodeTestRowInner({
       >
         <IconButton
           size="small"
+          aria-label="Run test"
           onClick={(e) => {
             e.stopPropagation();
             handleRun();
@@ -191,7 +192,7 @@ function NodeTestRowInner({
                   color={STATUS_COLORS[status]}
                 />
               )}
-              <IconButton size="small" onClick={handleClose}>
+              <IconButton size="small" onClick={handleClose} aria-label="Close dialog">
                 <CloseIcon fontSize="small" />
               </IconButton>
             </Box>


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to `IconButton` elements across `NodeTestRow`, `DataframeRenderer`, and `ReplicateSchemaLoader`.
🎯 Why: Icon-only buttons lacking `aria-label`s are not announced properly by screen readers, creating an inaccessible experience even when a visual tooltip is present.
♿ Accessibility: Improved keyboard navigation and screen reader support for key interface actions, including test runs and schema reloads.

---
*PR created automatically by Jules for task [8283715333696772199](https://jules.google.com/task/8283715333696772199) started by @georgi*