### PR TITLE
Manage optional agent runtimes separately

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,7 +127,7 @@ jobs:
         run: npm run build --workspace=web
 
       - name: Create Web Build Archive
-        if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'ubuntu-latest'
         shell: bash
         id: create_archive
         run: |
@@ -240,7 +240,7 @@ jobs:
           echo "Moved signed exe to ${APP_EXE}"
 
       - name: Build NSIS installer from prepackaged app (Windows)
-        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest'
         shell: bash -l {0}
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
@@ -251,7 +251,7 @@ jobs:
           npx electron-builder --config electron-builder.json --win --x64 --prepackaged dist/win-unpacked --publish never
 
       - name: Locate built Windows installer
-        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest'
         shell: bash -l {0}
         run: |
           set -euo pipefail
@@ -360,7 +360,7 @@ jobs:
           NODE
 
       - name: Upload Windows assets to GitHub Release (signed)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/') && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
@@ -522,6 +522,15 @@ jobs:
             electron/dist/latest-linux.yml
 
       # ── Workflow artifacts (downloadable from the Actions run page) ────
+      - name: Upload web build artifact
+        if: matrix.os == 'ubuntu-latest' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nodetool-web
+          retention-days: 7
+          if-no-files-found: ignore
+          path: nodetool-web-*.zip
+
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:24-slim
+# syntax=docker/dockerfile:1
 
-# System deps for native modules.
-# libsecret is required by keytar on Linux. The entrypoint below also provides a
-# Docker-friendly SECRETS_MASTER_KEY fallback so headless containers do not need
-# a desktop keychain/DBus session.
+FROM node:24-slim AS deps
+
+# Native build dependencies are only needed while installing/building packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-venv python3-pip \
-    build-essential curl ca-certificates \
-    libsecret-1-0 libsecret-1-dev \
+    build-essential pkg-config \
+    ca-certificates \
+    libsecret-1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy package files first for better layer caching
+# Copy package manifests first for better dependency-layer caching.
 COPY package.json package-lock.json ./
 COPY packages/protocol/package.json packages/protocol/
 COPY packages/config/package.json packages/config/
@@ -33,6 +33,8 @@ COPY packages/replicate-nodes/package.json packages/replicate-nodes/
 COPY packages/elevenlabs-nodes/package.json packages/elevenlabs-nodes/
 COPY packages/kie-codegen/package.json packages/kie-codegen/
 COPY packages/kie-nodes/package.json packages/kie-nodes/
+COPY packages/transformers-js-nodes/package.json packages/transformers-js-nodes/
+COPY packages/transformers-js-provider/package.json packages/transformers-js-provider/
 COPY packages/agents/package.json packages/agents/
 COPY packages/base-nodes/package.json packages/base-nodes/
 COPY packages/dsl/package.json packages/dsl/
@@ -40,12 +42,20 @@ COPY packages/chat/package.json packages/chat/
 COPY packages/websocket/package.json packages/websocket/
 COPY packages/cli/package.json packages/cli/
 COPY packages/deploy/package.json packages/deploy/
+COPY packages/sandbox/package.json packages/sandbox/
+COPY packages/sandbox-agent/package.json packages/sandbox-agent/
+COPY packages/sandbox-tools/package.json packages/sandbox-tools/
 COPY web/package.json web/
 
-# Install deps
-RUN npm ci 2>/dev/null || npm install
+RUN npm ci
 
-# Copy source and build backend packages
+FROM deps AS prod-deps
+RUN rm -rf node_modules \
+    && npm ci --omit=dev --workspace=@nodetool-ai/websocket --include-workspace-root=false \
+    && npm cache clean --force
+
+FROM deps AS build
+
 COPY packages/ packages/
 COPY scripts/ scripts/
 COPY tsconfig*.json ./
@@ -53,18 +63,51 @@ COPY turbo.json ./
 
 RUN npm run build:packages
 
-# Copy web source and build the frontend
 COPY web/ web/
+ARG WEB_BUILD_NODE_OPTIONS=--max-old-space-size=4096
+RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" npm run build
 
-RUN cd web && npm run build
+# Assemble a minimal runtime filesystem with compiled packages and web assets.
+RUN mkdir -p /runtime/packages /runtime/web \
+    && cp package.json package-lock.json /runtime/ \
+    && for pkg in packages/*; do \
+         if [ -d "$pkg/dist" ]; then \
+           mkdir -p "/runtime/$pkg"; \
+           cp "$pkg/package.json" "/runtime/$pkg/package.json"; \
+           cp -a "$pkg/dist" "/runtime/$pkg/dist"; \
+         fi; \
+       done \
+    && cp web/package.json /runtime/web/package.json \
+    && cp -a web/dist /runtime/web/dist
 
-# Tell the server to serve the built web app from the root path
-ENV STATIC_FOLDER=/app/web/dist
+FROM node:24-slim AS runtime
 
-# In Docker/headless Linux there is usually no system keychain. If neither a
-# master key nor AWS Secrets Manager is configured, persist a generated 32-byte
-# base64 key next to the SQLite database so encrypted secrets survive restarts
-# when /workspace is mounted as a volume. For production, pass
+ENV NODE_ENV=production \
+    NODETOOL_ENV=production \
+    HOST=0.0.0.0 \
+    STATIC_FOLDER=/app/web/dist \
+    DB_PATH=/workspace/nodetool.db \
+    CHROMA_PATH=/workspace/chroma \
+    ASSET_BUCKET=/workspace/assets \
+    HF_HOME=/workspace/hf-cache
+
+# Runtime-only OS packages. Key management is provided through
+# SECRETS_MASTER_KEY, not a system keychain inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /workspace \
+    && chown node:node /workspace
+
+WORKDIR /app
+
+COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=node:node /app/packages ./packages
+COPY --from=build --chown=node:node /runtime/ ./
+
+# If neither a master key nor AWS Secrets Manager is configured, persist a
+# generated 32-byte base64 key next to the SQLite database so encrypted secrets
+# survive restarts when /workspace is mounted as a volume. For production, pass
 # -e SECRETS_MASTER_KEY=$(openssl rand -base64 32) or configure AWS.
 RUN printf '%s\n' \
     '#!/bin/sh' \
@@ -82,11 +125,12 @@ RUN printf '%s\n' \
     > /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/local/bin/docker-entrypoint.sh
 
+USER node
+
 EXPOSE 7777
 
-# Health check supports both TLS and plain HTTP
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
-    CMD curl -fsk https://localhost:7777/health 2>/dev/null || curl -f http://localhost:7777/health 2>/dev/null || exit 1
+    CMD curl -f http://localhost:7777/health || exit 1
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "packages/websocket/dist/server.js"]

--- a/electron/pages/PackageManager.tsx
+++ b/electron/pages/PackageManager.tsx
@@ -431,7 +431,7 @@ const PackageManager: React.FC = () => {
         {activeTab === "runtimes" ? (
           <div className="runtimes-section">
             <p className="runtimes-description">
-              Runtimes are system tools required by certain nodes. Install them to enable video processing, code execution, document conversion, and more.
+              Runtimes and optional Node.js modules enable extra features such as video processing, code execution, Claude/Codex agents, Transformers.js, and TensorFlow.js nodes.
             </p>
             {error && (
               <div className="error-banner">

--- a/electron/scripts/bundle-backend.mjs
+++ b/electron/scripts/bundle-backend.mjs
@@ -73,10 +73,6 @@ const EXTERNAL_PACKAGES = [
   "@llamaindex/liteparse",
   "@hyzyla/pdfium",
   "tesseract.js",
-  // Lazy-loaded SDK that fails on Windows when resolved from inside the
-  // ASAR at module init. Keeping it external preserves the lazy semantics.
-  "@anthropic-ai/claude-agent-sdk",
-
   // Emscripten package with a package-relative .wasm asset. Keeping it external
   // preserves import.meta.url so emscripten-module.wasm resolves next to the
   // package's own JS instead of next to backend/server.mjs.

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -222,6 +222,9 @@ const getDefaultAssetsPath = (): string => {
   return getSystemDataPath("assets");
 };
 
+const getOptionalNodeModulesPath = (): string =>
+  path.join(app.getPath("userData"), "optional-node", "node_modules");
+
 const getProcessEnv = (): ProcessEnv => {
   const condaPath: string = getCondaEnvPath();
 
@@ -309,6 +312,7 @@ const getProcessEnv = (): ProcessEnv => {
     PYTHONNOUSERSITE: "1",
     UV_CACHE_DIR: uvCacheDir,
     XDG_CACHE_HOME: xdgCacheHome,
+    NODETOOL_OPTIONAL_NODE_MODULES: getOptionalNodeModulesPath(),
     PATH:
       process.platform === "win32"
         ? pathSegmentsWin.filter(Boolean).join(path.delimiter)
@@ -333,6 +337,7 @@ export {
   getProcessEnv,
   getSystemDataPath,
   getDefaultAssetsPath,
+  getOptionalNodeModulesPath,
   _resetCondaEnvCache,
   PID_FILE_PATH,
   PID_DIRECTORY,

--- a/electron/src/packageManager.ts
+++ b/electron/src/packageManager.ts
@@ -1,8 +1,14 @@
 import { spawn } from "child_process";
 import { app } from "electron";
 import { logMessage } from "./logger";
-import { getProcessEnv, getPythonPath, getCondaEnvPath } from "./config";
+import {
+  getOptionalNodeModulesPath,
+  getProcessEnv,
+  getPythonPath,
+  getCondaEnvPath,
+} from "./config";
 import * as path from "path";
+import * as fsp from "fs/promises";
 
 /** Extract the message from an unknown catch-clause error. */
 function errorMsg(error: unknown): string {
@@ -1155,13 +1161,15 @@ import type { RuntimePackageId, RuntimePackageStatus } from "./types.d";
 export const RUNTIME_PACKAGE_IDS: readonly RuntimePackageId[] = [
   "python", "nodejs", "bash", "ruby", "lua",
   "ffmpeg", "pandoc", "pdftotext", "yt-dlp",
+  "claude-agent-sdk", "codex-sdk", "transformers-js", "tensorflow-js",
 ] as const;
 
 /**
  * Maps each runtime to the conda package specs needed to provide it,
  * and the binary name used to verify installation.
  */
-const RUNTIME_DEFINITIONS: Record<RuntimePackageId, {
+type CondaRuntimeDefinition = {
+  type: "conda";
   name: string;
   description: string;
   condaPackages: string[];
@@ -1169,38 +1177,56 @@ const RUNTIME_DEFINITIONS: Record<RuntimePackageId, {
   verifyBinary: string;
   /** Windows subdirectory under conda env where the binary lives (default: root for .exe) */
   windowsBinSubdir?: string;
-}> = {
+};
+
+type NpmRuntimeDefinition = {
+  type: "npm";
+  name: string;
+  description: string;
+  npmPackages: string[];
+  packageNames: string[];
+};
+
+type RuntimeDefinition = CondaRuntimeDefinition | NpmRuntimeDefinition;
+
+const RUNTIME_DEFINITIONS: Record<RuntimePackageId, RuntimeDefinition> = {
   python: {
+    type: "conda",
     name: "Python",
     description: "Python interpreter and uv package manager. Required for AI and data processing nodes.",
     condaPackages: ["python=3.11", "uv"],
     verifyBinary: "python",
   },
   nodejs: {
+    type: "conda",
     name: "Node.js",
     description: "JavaScript runtime for Node.js-based nodes.",
     condaPackages: ["nodejs>=24"],
     verifyBinary: "node",
   },
   bash: {
+    type: "conda",
     name: "Bash",
     description: "Bash shell for script execution nodes.",
     condaPackages: ["bash"],
     verifyBinary: "bash",
   },
   ruby: {
+    type: "conda",
     name: "Ruby",
     description: "Ruby interpreter for Ruby-based nodes.",
     condaPackages: ["ruby"],
     verifyBinary: "ruby",
   },
   lua: {
+    type: "conda",
     name: "Lua",
     description: "Lua interpreter for Lua-based nodes.",
     condaPackages: ["lua"],
     verifyBinary: "lua",
   },
   ffmpeg: {
+    type: "conda",
     name: "FFmpeg & Codecs",
     description: "Audio/video processing toolkit. Required for video nodes and the FFmpeg Agent.",
     condaPackages: [
@@ -1212,27 +1238,154 @@ const RUNTIME_DEFINITIONS: Record<RuntimePackageId, {
     windowsBinSubdir: "Library\\bin",
   },
   pandoc: {
+    type: "conda",
     name: "Pandoc",
     description: "Universal document converter for text and file format conversion.",
     condaPackages: ["pandoc"],
     verifyBinary: "pandoc",
   },
   pdftotext: {
+    type: "conda",
     name: "PDF Tools (Poppler)",
     description: "PDF text extraction using pdftotext from poppler. Required for PDF-to-text conversion.",
     condaPackages: ["poppler"],
     verifyBinary: "pdftotext",
   },
   "yt-dlp": {
+    type: "conda",
     name: "yt-dlp",
     description: "Video/audio downloader from YouTube and other sites.",
     condaPackages: ["yt-dlp"],
     verifyBinary: "yt-dlp",
   },
+  "claude-agent-sdk": {
+    type: "npm",
+    name: "Claude Agent SDK",
+    description: "Optional Claude Code agent integration for the local NodeTool backend.",
+    npmPackages: ["@anthropic-ai/claude-agent-sdk@latest"],
+    packageNames: ["@anthropic-ai/claude-agent-sdk"],
+  },
+  "codex-sdk": {
+    type: "npm",
+    name: "OpenAI Codex SDK",
+    description: "Optional OpenAI Codex agent integration for the local NodeTool backend.",
+    npmPackages: ["@openai/codex-sdk@^0.118.0"],
+    packageNames: ["@openai/codex-sdk"],
+  },
+  "transformers-js": {
+    type: "npm",
+    name: "Transformers.js",
+    description: "Optional Hugging Face Transformers.js runtime for local JavaScript AI nodes.",
+    npmPackages: ["@huggingface/transformers@^3.7.6", "kokoro-js@^1.2.1"],
+    packageNames: ["@huggingface/transformers", "kokoro-js"],
+  },
+  "tensorflow-js": {
+    type: "npm",
+    name: "TensorFlow.js Models",
+    description: "Optional TensorFlow.js model packages for image classification, object detection, and Q&A nodes.",
+    npmPackages: [
+      "@tensorflow/tfjs@^4.22.0",
+      "@tensorflow-models/mobilenet@^2.1.1",
+      "@tensorflow-models/coco-ssd@^2.2.3",
+      "@tensorflow-models/qna@^1.0.2",
+    ],
+    packageNames: [
+      "@tensorflow/tfjs",
+      "@tensorflow-models/mobilenet",
+      "@tensorflow-models/coco-ssd",
+      "@tensorflow-models/qna",
+    ],
+  },
 };
 
 // Track which runtime packages are currently being installed
 const runtimeInstalling = new Set<RuntimePackageId>();
+
+function getOptionalNodeRuntimeRoot(): string {
+  return path.dirname(getOptionalNodeModulesPath());
+}
+
+function getNpmPath(): string {
+  const condaPath = getCondaEnvPath();
+  return process.platform === "win32"
+    ? path.join(condaPath, "npm.cmd")
+    : path.join(condaPath, "bin", "npm");
+}
+
+async function ensureOptionalNodePackageRoot(): Promise<void> {
+  const root = getOptionalNodeRuntimeRoot();
+  await fsp.mkdir(root, { recursive: true });
+  const packageJsonPath = path.join(root, "package.json");
+  try {
+    await fsp.access(packageJsonPath);
+  } catch {
+    await fsp.writeFile(
+      packageJsonPath,
+      JSON.stringify({ private: true, type: "module" }, null, 2),
+      "utf8"
+    );
+  }
+}
+
+async function isOptionalNodePackageInstalled(packageName: string): Promise<boolean> {
+  return fileExists(path.join(getOptionalNodeModulesPath(), ...packageName.split("/"), "package.json"));
+}
+
+async function runNpmCommand(args: string[]): Promise<string> {
+  let npmPath = getNpmPath();
+  if (!(await fileExists(npmPath))) {
+    const message = "Node.js/npm runtime not found — installing Node.js first...";
+    logMessage(message);
+    emitServerLog(message);
+    const result = await installRuntimePackage("nodejs");
+    if (!result.success) {
+      throw new Error(result.message);
+    }
+    npmPath = getNpmPath();
+  }
+
+  await ensureOptionalNodePackageRoot();
+  const root = getOptionalNodeRuntimeRoot();
+  const cacheDir = path.join(app.getPath("userData"), "npm-cache");
+  await fsp.mkdir(cacheDir, { recursive: true });
+
+  const command = [npmPath, ...args, "--prefix", root, "--cache", cacheDir];
+  return new Promise((resolve, reject) => {
+    logMessage(`Running npm command: ${command.join(" ")}`);
+    const child = spawn(command[0], command.slice(1), {
+      env: getProcessEnv(),
+      stdio: "pipe",
+      windowsHide: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (data: Buffer) => {
+      const output = data.toString();
+      stdout += output;
+      for (const line of output.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)) {
+        logMessage(line);
+        emitServerLog(line);
+      }
+    });
+    child.stderr?.on("data", (data: Buffer) => {
+      const output = data.toString();
+      stderr += output;
+      for (const line of output.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)) {
+        logMessage(line, "warn");
+        emitServerLog(line);
+      }
+    });
+    child.on("exit", (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`npm failed with code ${code}: ${stderr}`));
+      }
+    });
+    child.on("error", (error) => reject(error));
+  });
+}
 
 /**
  * Check if a runtime binary exists in the conda environment.
@@ -1267,12 +1420,19 @@ export async function getRuntimePackageStatuses(): Promise<RuntimePackageStatus[
   const condaEnvPath = getCondaEnvPath();
   const envExists = await isCondaEnvPresent(condaEnvPath);
 
-  const entries = Object.entries(RUNTIME_DEFINITIONS) as [RuntimePackageId, typeof RUNTIME_DEFINITIONS[RuntimePackageId]][];
+  const entries = Object.entries(RUNTIME_DEFINITIONS) as [RuntimePackageId, RuntimeDefinition][];
 
   const checks = entries.map(async ([id, def]) => {
     let installed = false;
-    if (envExists) {
-      installed = await checkRuntimeBinary(condaEnvPath, def.verifyBinary, def.windowsBinSubdir);
+    if (def.type === "conda") {
+      if (envExists) {
+        installed = await checkRuntimeBinary(condaEnvPath, def.verifyBinary, def.windowsBinSubdir);
+      }
+    } else {
+      const packageChecks = await Promise.all(
+        def.packageNames.map((packageName) => isOptionalNodePackageInstalled(packageName))
+      );
+      installed = packageChecks.every(Boolean);
     }
     return {
       id,
@@ -1324,9 +1484,18 @@ export async function installRuntimePackage(
       setCondaInstallLocation(installLocation);
     }
 
-    // Auto-init conda env if not present (prompts user for folder)
     emitBootMessage(`Installing ${def.name}...`);
     logMessage(`Installing runtime: ${packageId}`);
+
+    if (def.type === "npm") {
+      await runNpmCommand(["install", ...def.npmPackages]);
+      return {
+        success: true,
+        message: `${def.name} installed successfully. Restart the backend if it was already running.`,
+      };
+    }
+
+    // Auto-init conda env if not present (prompts user for folder)
     const condaEnvPath = await ensureCondaEnvironment(installLocation);
 
     // Determine packages to install
@@ -1364,11 +1533,19 @@ export async function uninstallRuntimePackage(
   }
 
   try {
-    const { removeCondaPackageBySpec } = await import("./installer");
-    const condaEnvPath = getCondaEnvPath();
-
     logMessage(`Uninstalling runtime: ${packageId}`);
     emitBootMessage(`Removing ${def.name}...`);
+
+    if (def.type === "npm") {
+      await runNpmCommand(["uninstall", ...def.packageNames]);
+      return {
+        success: true,
+        message: `${def.name} removed successfully. Restart the backend if it was already running.`,
+      };
+    }
+
+    const { removeCondaPackageBySpec } = await import("./installer");
+    const condaEnvPath = getCondaEnvPath();
 
     await removeCondaPackageBySpec(condaEnvPath, def.condaPackages, `Removing ${def.name}`);
 

--- a/electron/src/server.ts
+++ b/electron/src/server.ts
@@ -2,6 +2,7 @@ import { dialog, shell, app } from "electron";
 import { logMessage } from "./logger";
 import {
   getLlamaServerPath,
+  getOptionalNodeModulesPath,
   getPythonPath,
   getProcessEnv,
   PID_FILE_PATH,
@@ -392,7 +393,9 @@ async function startServer(): Promise<void> {
   // backend/node_modules directory so Node.js can resolve externalized
   // ESM packages with standard package resolution.
   const backendNodeModules = path.join(path.dirname(backendEntryPoint), "node_modules");
-  logMessage(`Backend NODE_PATH: ${backendNodeModules}`);
+  const optionalNodeModules = getOptionalNodeModulesPath();
+  const backendNodePath = [backendNodeModules, optionalNodeModules].join(path.delimiter);
+  logMessage(`Backend NODE_PATH: ${backendNodePath}`);
 
   // Python path may not exist if the Python runtime hasn't been installed yet.
   // The backend will start without Python support in that case.
@@ -433,7 +436,8 @@ async function startServer(): Promise<void> {
     LLAMA_CPP_URL: serverState.llamaPort ? `http://127.0.0.1:${serverState.llamaPort}` : "",
     NODE_ENV: isDevMode() ? "development" : "production",
     NODE_OPTIONS: nodeOptionsParts.filter(Boolean).join(" "),
-    NODE_PATH: backendNodeModules,
+    NODE_PATH: backendNodePath,
+    NODETOOL_OPTIONAL_NODE_MODULES: optionalNodeModules,
   };
   const watchdogOpts: import("./watchdog").WatchdogOptions = isDevMode()
     ? {

--- a/electron/src/types.d.ts
+++ b/electron/src/types.d.ts
@@ -929,7 +929,11 @@ export type RuntimePackageId =
   | "ffmpeg"
   | "pandoc"
   | "pdftotext"
-  | "yt-dlp";
+  | "yt-dlp"
+  | "claude-agent-sdk"
+  | "codex-sdk"
+  | "transformers-js"
+  | "tensorflow-js";
 
 export interface RuntimePackageStatus {
   id: RuntimePackageId;

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,12 +43,12 @@
         "electron"
       ],
       "dependencies": {
-        "@openai/codex-sdk": "^0.118.0",
         "keytar": "^7.9.0",
         "msgpackr": "^1.11.9"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@openai/codex-sdk": "^0.118.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.1.2",
@@ -11152,6 +11152,7 @@
     },
     "node_modules/@openai/codex": {
       "version": "0.118.0",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -11174,6 +11175,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -11191,6 +11193,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -11208,6 +11211,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -11225,6 +11229,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -11236,6 +11241,7 @@
     },
     "node_modules/@openai/codex-sdk": {
       "version": "0.118.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/codex": "0.118.0"
@@ -11252,6 +11258,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -11269,6 +11276,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -35193,13 +35201,11 @@
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.101",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
-      },
-      "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.101"
       }
     },
     "packages/sandbox": {
@@ -35335,7 +35341,6 @@
       "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "latest",
         "@fastify/cors": "^10.0.2",
         "@fastify/static": "^9.1.1",
         "@fastify/websocket": "^11.0.1",
@@ -35361,7 +35366,6 @@
         "@nodetool-ai/transformers-js-nodes": "*",
         "@nodetool-ai/transformers-js-provider": "*",
         "@nodetool-ai/vectorstore": "*",
-        "@openai/codex-sdk": "^0.118.0",
         "@opencode-ai/sdk": "^1.3.15",
         "@trpc/server": "^11.0.0",
         "fastify": "^5.8.5",
@@ -35370,6 +35374,8 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "latest",
+        "@openai/codex-sdk": "^0.118.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -120,10 +120,10 @@
     "tsx": "^4.0.0",
     "turbo": "^2.9.6",
     "typescript-eslint": "^8.56.1",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "@openai/codex-sdk": "^0.118.0"
   },
   "dependencies": {
-    "@openai/codex-sdk": "^0.118.0",
     "keytar": "^7.9.0",
     "msgpackr": "^1.11.9"
   },

--- a/packages/base-nodes/src/nodes/lib-tensorflow.ts
+++ b/packages/base-nodes/src/nodes/lib-tensorflow.ts
@@ -14,6 +14,7 @@
  *   - COCO-SSD object detection
  *   - BERT QnA (extractive question answering)
  */
+import { importOptionalModule } from "@nodetool-ai/config";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import sharp from "sharp";
@@ -130,7 +131,9 @@ function cacheLazy<T>(
 const tfStore: { current: Promise<any> | null } = { current: null };
 async function loadTf(): Promise<any> {
   return cacheLazy(tfStore, async () => {
-    const tf = await import("@tensorflow/tfjs");
+    const tf = await importOptionalModule<typeof import("@tensorflow/tfjs")>(
+      "@tensorflow/tfjs"
+    );
     try {
       await (tf as any).setBackend("cpu");
       await (tf as any).ready();
@@ -158,7 +161,9 @@ async function loadMobileNet(version: 1 | 2 = 2): Promise<any> {
   }
   return cacheLazy(store, async () => {
     await loadTf();
-    const mobilenet = await import("@tensorflow-models/mobilenet");
+    const mobilenet = await importOptionalModule<
+      typeof import("@tensorflow-models/mobilenet")
+    >("@tensorflow-models/mobilenet");
     return mobilenet.load({ version, alpha: 1.0 });
   });
 }
@@ -270,7 +275,9 @@ const cocoSsdStore: { current: Promise<any> | null } = { current: null };
 async function loadCocoSsd(): Promise<any> {
   return cacheLazy(cocoSsdStore, async () => {
     await loadTf();
-    const cocoSsd = await import("@tensorflow-models/coco-ssd");
+    const cocoSsd = await importOptionalModule<
+      typeof import("@tensorflow-models/coco-ssd")
+    >("@tensorflow-models/coco-ssd");
     return cocoSsd.load({ base: "mobilenet_v2" });
   });
 }
@@ -343,7 +350,9 @@ const qnaStore: { current: Promise<any> | null } = { current: null };
 async function loadQna(): Promise<any> {
   return cacheLazy(qnaStore, async () => {
     await loadTf();
-    const qna = await import("@tensorflow-models/qna");
+    const qna = await importOptionalModule<typeof import("@tensorflow-models/qna")>(
+      "@tensorflow-models/qna"
+    );
     return qna.load();
   });
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -28,6 +28,8 @@ export {
   type DiagnosticResult
 } from "./diagnostics.js";
 
+export { importOptionalModule } from "./optional-modules.js";
+
 export {
   getNodetoolDataDir,
   getDefaultDbPath,

--- a/packages/config/src/optional-modules.ts
+++ b/packages/config/src/optional-modules.ts
@@ -1,0 +1,28 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Import an optional dependency from the normal module graph, or from a
+ * user-managed node_modules directory pointed to by NODETOOL_OPTIONAL_NODE_MODULES.
+ */
+export async function importOptionalModule<T>(packageName: string): Promise<T> {
+  try {
+    return (await import(packageName)) as T;
+  } catch (error) {
+    const optionalNodeModules = process.env["NODETOOL_OPTIONAL_NODE_MODULES"];
+    if (!optionalNodeModules) {
+      throw error;
+    }
+
+    try {
+      const requireFromOptional = createRequire(
+        join(optionalNodeModules, "..", "package.json")
+      );
+      const resolved = requireFromOptional.resolve(packageName);
+      return (await import(pathToFileURL(resolved).href)) as T;
+    } catch {
+      throw error;
+    }
+  }
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -28,10 +28,8 @@
     "sharp": "^0.34.5",
     "ws": "^8.19.0"
   },
-  "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.101"
-  },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.101",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "typescript": "^5.7.2",

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -19,7 +19,7 @@
  */
 
 import { BaseProvider } from "./base-provider.js";
-import { createLogger } from "@nodetool-ai/config";
+import { createLogger, importOptionalModule } from "@nodetool-ai/config";
 import type { Chunk } from "@nodetool-ai/protocol";
 import type {
   LanguageModel,
@@ -520,7 +520,9 @@ export class ClaudeAgentProvider extends BaseProvider {
     // the SDK at startup.
     let sdk: typeof SdkType;
     try {
-      sdk = await import("@anthropic-ai/claude-agent-sdk");
+      sdk = await importOptionalModule<typeof import("@anthropic-ai/claude-agent-sdk")>(
+        "@anthropic-ai/claude-agent-sdk"
+      );
     } catch (err) {
       throw classifyClaudeAgentError(err);
     }

--- a/packages/transformers-js-nodes/src/transformers-base.ts
+++ b/packages/transformers-js-nodes/src/transformers-base.ts
@@ -4,7 +4,10 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { tmpdir } from "node:os";
 import { join as joinPath } from "node:path";
-import { getDefaultTransformersJsCacheDir } from "@nodetool-ai/config";
+import {
+  getDefaultTransformersJsCacheDir,
+  importOptionalModule
+} from "@nodetool-ai/config";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 const execFileP = promisify(execFile);
@@ -86,8 +89,9 @@ export async function loadTransformers(): Promise<TransformersModule> {
       let mod: TransformersModule;
       try {
         // Use a variable so bundlers don't try to resolve at build time.
-        const moduleName = "@huggingface/transformers";
-        mod = (await import(moduleName)) as TransformersModule;
+        mod = await importOptionalModule<TransformersModule>(
+          "@huggingface/transformers"
+        );
       } catch (err) {
         throw new Error(
           "The '@huggingface/transformers' package is required to run " +

--- a/packages/transformers-js-nodes/src/tts-shared.ts
+++ b/packages/transformers-js-nodes/src/tts-shared.ts
@@ -1,5 +1,6 @@
-import { KokoroTTS } from "kokoro-js";
+import { importOptionalModule } from "@nodetool-ai/config";
 import { loadTransformers } from "./transformers-base.js";
+import type { KokoroTTS } from "kokoro-js";
 
 /** Voices supported by kokoro-js v1.2.1 (English only). */
 export const KOKORO_VOICES = [
@@ -43,6 +44,9 @@ export async function getKokoro(
   if (!pending) {
     pending = (async () => {
       await loadTransformers();
+      const { KokoroTTS } = await importOptionalModule<typeof import("kokoro-js")>(
+        "kokoro-js"
+      );
       const opts: Record<string, unknown> = {};
       if (dtype) opts.dtype = dtype;
       if (device) opts.device = device;

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -19,7 +19,6 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "latest",
     "@fastify/cors": "^10.0.2",
     "@fastify/static": "^9.1.1",
     "@fastify/websocket": "^11.0.1",
@@ -45,7 +44,6 @@
     "@nodetool-ai/security": "*",
     "@nodetool-ai/vectorstore": "*",
     "@mariozechner/pi-coding-agent": "^0.67.4",
-    "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.3.15",
     "fastify": "^5.8.5",
     "@trpc/server": "^11.0.0",
@@ -54,6 +52,8 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "@openai/codex-sdk": "^0.118.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"

--- a/packages/websocket/src/agent/agent-runtime.ts
+++ b/packages/websocket/src/agent/agent-runtime.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createLogger } from "@nodetool-ai/config";
+import { createLogger, importOptionalModule } from "@nodetool-ai/config";
 // `@anthropic-ai/claude-agent-sdk` is an optionalDependencies package that
 // isn't always resolvable inside the packaged Electron ASAR (notably on
 // Windows). Importing it statically would crash the backend at startup
@@ -256,7 +256,9 @@ class ClaudeAgentSession implements AgentQuerySession {
         ? Object.keys(uiToolSchemas).map((n) => `mcp__nodetool-ui__${n}`)
         : [];
 
-      const { query } = await import("@anthropic-ai/claude-agent-sdk");
+      const { query } = await importOptionalModule<typeof import("@anthropic-ai/claude-agent-sdk")>(
+        "@anthropic-ai/claude-agent-sdk"
+      );
       const queryHandle = query({
         prompt: message,
         options: {
@@ -402,7 +404,9 @@ class ClaudeSdkProvider implements AgentSdkProvider {
     _userId: string,
   ): Promise<AgentSessionInfoEntry[]> {
     try {
-      const { listSessions } = await import("@anthropic-ai/claude-agent-sdk");
+      const { listSessions } = await importOptionalModule<typeof import("@anthropic-ai/claude-agent-sdk")>(
+        "@anthropic-ai/claude-agent-sdk"
+      );
       const sdkSessions: SDKSessionInfo[] = await listSessions({
         dir: options.dir,
         limit: options.limit ?? 50,

--- a/packages/websocket/src/agent/codex-agent.ts
+++ b/packages/websocket/src/agent/codex-agent.ts
@@ -1,7 +1,8 @@
 /**
  * Codex SDK agent integration.
  *
- * Uses the official @openai/codex-sdk to manage threads and stream events.
+ * Uses the official @openai/codex-sdk to manage threads and stream events when
+ * the optional package is installed.
  */
 
 import { randomUUID } from "node:crypto";
@@ -12,12 +13,12 @@ import {
   existsSync,
 } from "node:fs";
 import { join } from "node:path";
-import { createLogger } from "@nodetool-ai/config";
-import {
-  Codex,
-  type ThreadEvent,
-  type ThreadItem,
-  type ThreadOptions,
+import { createLogger, importOptionalModule } from "@nodetool-ai/config";
+import type {
+  Codex as CodexClient,
+  ThreadEvent,
+  ThreadItem,
+  ThreadOptions,
 } from "@openai/codex-sdk";
 import type { AgentTransport } from "./transport.js";
 import type {
@@ -30,13 +31,16 @@ const log = createLogger("nodetool.websocket.agent.codex");
 const NODETOOL_MCP_BEGIN = "# BEGIN NODETOOL MCP";
 const NODETOOL_MCP_END = "# END NODETOOL MCP";
 
-let codexInstance: Codex | null = null;
+let codexInstance: CodexClient | null = null;
 
-function getCodex(): Codex {
+async function getCodex(): Promise<CodexClient> {
   if (!codexInstance) {
+    const { Codex } = await importOptionalModule<typeof import("@openai/codex-sdk")>(
+      "@openai/codex-sdk"
+    );
     codexInstance = new Codex();
   }
-  return codexInstance;
+  return codexInstance as CodexClient;
 }
 
 export async function listCodexModels(): Promise<AgentModelDescriptor[]> {
@@ -139,8 +143,8 @@ export class CodexQuerySession {
     }
   }
 
-  private getThread(): ReturnType<Codex["startThread"]> {
-    const codex = getCodex();
+  private async getThread(): Promise<ReturnType<CodexClient["startThread"]>> {
+    const codex = await getCodex();
     const threadOptions: ThreadOptions = {
       model: this.model,
       workingDirectory: this.workspacePath,
@@ -200,7 +204,7 @@ export class CodexQuerySession {
 
     try {
       await this.ensureMcpConfig(mcpServerUrl ?? null);
-      const thread = this.getThread();
+      const thread = await this.getThread();
       const prompt = this.buildPrompt(message, manifest);
       const { events } = await thread.runStreamed(prompt, {
         signal: this.abortController.signal,


### PR DESCRIPTION
## Summary
- Convert Dockerfile to a cleaner multi-stage runtime image and keep only production websocket deps in the final image
- Move Claude Agent SDK and Codex SDK out of production runtime deps so Docker excludes agent runtimes
- Add Electron Package Manager support for optional npm runtimes, installed into a user-data node_modules directory
- Add optional module resolution via NODETOOL_OPTIONAL_NODE_MODULES for Claude/Codex and existing optional Transformers/TensorFlow loaders

## Validation
- npm run build --workspace=packages/config
- npm run lint --workspace=packages/websocket
- npm run lint --workspace=packages/runtime
- npm run lint --workspace=packages/base-nodes
- npm run lint --workspace=packages/transformers-js-nodes
- npm run typecheck --workspace=electron
- npm test --workspace=electron -- packageManager
