### PR TITLE
Simplify example workflow docs and agent YAML configs

### DIFF
--- a/docs/examples/agents/code-assistant.yaml
+++ b/docs/examples/agents/code-assistant.yaml
@@ -1,26 +1,23 @@
-# Code Assistant Agent Configuration
-# This agent helps with coding tasks, debugging, and code review
-
 name: code-assistant
 description: AI coding assistant for development tasks
 
 system_prompt: |
   You are an expert software engineer and coding assistant.
-  
+
   Your capabilities:
   - Write clean, efficient, and well-documented code
   - Debug issues and suggest fixes
   - Explain complex code concepts clearly
   - Follow best practices and coding standards
   - Provide code reviews with constructive feedback
-  
+
   Your workflow:
   1. Understand the coding task or problem
   2. Break down complex tasks into manageable steps
   3. Write or modify code incrementally
   4. Test and verify solutions
   5. Document code and explain decisions
-  
+
   Guidelines:
   - Prioritize code quality, readability, and maintainability
   - Consider edge cases and error handling
@@ -31,26 +28,24 @@ system_prompt: |
 model:
   provider: anthropic
   id: claude-3-5-sonnet-20241022
-  name: Claude 3.5 Sonnet
 
 planning_agent:
   enabled: true
   model:
     provider: openai
     id: gpt-4o-mini
-    name: GPT-4o Mini
 
 tools:
   - write_file
   - read_file
   - list_directory
-  - execute_code    # Execute code in sandboxed environment
-  - terminal        # Run terminal commands
-  - grep            # Search in files
+  - execute_code
+  - terminal
+  - grep
 
 max_tokens: 8192
-context_window: 200000  # Claude has large context window
-temperature: 0.3        # Lower temperature for more focused code
+context_window: 200000
+temperature: 0.3
 max_iterations: 15
 
 workspace:

--- a/docs/examples/agents/content-creator.yaml
+++ b/docs/examples/agents/content-creator.yaml
@@ -1,26 +1,23 @@
-# Content Creator Agent Configuration
-# This agent creates written content, blog posts, and marketing materials
-
 name: content-creator
 description: Creative writing agent for content generation
 
 system_prompt: |
   You are a professional content creator and copywriter.
-  
+
   Your expertise includes:
   - Blog posts and articles
   - Marketing copy and ad content
   - Social media posts
   - Technical documentation
   - Creative storytelling
-  
+
   Your workflow:
   1. Understand the content goals and target audience
   2. Research relevant topics and trends
   3. Create outlines and structure
   4. Write engaging, high-quality content
   5. Refine and polish the final output
-  
+
   Guidelines:
   - Match tone and style to the intended audience
   - Ensure content is engaging and valuable
@@ -31,14 +28,12 @@ system_prompt: |
 model:
   provider: google
   id: gemini-2.0-flash-exp
-  name: Gemini 2.0 Flash
 
 planning_agent:
   enabled: true
   model:
     provider: openai
     id: gpt-4o-mini
-    name: GPT-4o Mini
 
 tools:
   - google_search
@@ -48,7 +43,7 @@ tools:
 
 max_tokens: 8192
 context_window: 32768
-temperature: 0.9     # Higher creativity for content generation
+temperature: 0.9
 max_iterations: 8
 
 workspace:

--- a/docs/examples/agents/minimal.yaml
+++ b/docs/examples/agents/minimal.yaml
@@ -1,12 +1,9 @@
-# Minimal Agent Configuration
-# Simple agent with minimal required fields
-
 name: minimal-agent
 description: Basic agent configuration example
 
 system_prompt: |
   You are a helpful AI assistant.
-  
+
   Answer questions clearly and concisely.
   Use available tools when needed to accomplish tasks.
 

--- a/docs/examples/agents/research-agent.yaml
+++ b/docs/examples/agents/research-agent.yaml
@@ -1,20 +1,16 @@
-# Research Agent Configuration
-# This agent conducts web research and synthesizes findings
-
 name: research-assistant
 description: Autonomous research agent for gathering and synthesizing information
 
-# System prompt that defines agent behavior
 system_prompt: |
   You are a research assistant specializing in thorough, accurate information gathering.
-  
+
   Your workflow:
   1. Break down research objectives into specific queries
   2. Use search tools to find relevant sources
   3. Extract and verify information from credible sources
   4. Organize findings systematically in the workspace
   5. Synthesize results into a comprehensive, well-structured report
-  
+
   Guidelines:
   - Prioritize authoritative and recent sources
   - Cross-reference information across multiple sources
@@ -22,36 +18,28 @@ system_prompt: |
   - Note any conflicting information or uncertainties
   - Structure findings logically and coherently
 
-# Model configuration
 model:
-  provider: openai  # Options: openai, anthropic, google, ollama, etc.
-  id: gpt-4o        # Model identifier
-  name: GPT-4o      # Display name (optional)
+  provider: openai
+  id: gpt-4o
 
-# Planning agent configuration
-# The planning agent breaks down tasks and coordinates execution
 planning_agent:
-  enabled: true  # Always true for agent command
+  enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini  # Planning can use a faster/cheaper model
-    name: GPT-4o Mini
+    id: gpt-4o-mini
 
-# Available tools for the agent
 tools:
-  - google_search   # Web search capability
-  - browser         # Browse and extract web page content
-  - write_file      # Save research findings
-  - read_file       # Read previously saved files
-  - list_directory  # List workspace files
+  - google_search
+  - browser
+  - write_file
+  - read_file
+  - list_directory
 
-# Execution parameters
-max_tokens: 8192          # Maximum response length
-context_window: 8192      # Context window size
-temperature: 0.7          # Response randomness (0.0 - 1.0)
-max_iterations: 10        # Maximum planning/execution cycles
+max_tokens: 8192
+context_window: 8192
+temperature: 0.7
+max_iterations: 10
 
-# Workspace configuration
 workspace:
-  path: ~/.nodetool-workspaces/research  # Agent workspace directory
-  auto_create: true                      # Create workspace if it doesn't exist
+  path: ~/.nodetool-workspaces/research
+  auto_create: true

--- a/docs/workflows/categorize-mails.md
+++ b/docs/workflows/categorize-mails.md
@@ -5,19 +5,14 @@ title: "Categorize Mails"
 
 ## Overview
 
-Automatically categorize and organize emails using AI
+Classifies emails into predefined categories (Newsletter, Work, Family, Friends) using an LLM and applies matching Gmail labels.
 
-This workflow classifies emails into predefined categories (e.g., Newsletter, Work, Family, Friends) using a large language model and applies the matching Gmail labels.
+## Workflow Steps
 
-## Workflow Steps:
-
-2. **Gmail Search** - Fetches up to 10 recent emails using the specified filters (e.g., date, subject, sender).
-
-2. **Template** - Formats each email into a structured prompt including subject, sender, and a truncated body snippet.
-
-3. **Classifier** - Uses an LLM to classify the email into one or more of the categories: newsletter, work, family, friends.
-
-4. **Add Label** - Applies the determined label(s) to each email message in Gmail.
+1. **Gmail Search** - Fetches up to 10 recent emails using the specified filters (date, subject, sender).
+2. **Template** - Formats each email into a structured prompt with subject, sender, and body snippet.
+3. **Classifier** - Uses an LLM to classify the email into one or more categories.
+4. **Add Label** - Applies the determined label(s) to each email in Gmail.
 
 ## Tags
 
@@ -36,14 +31,3 @@ graph TD
   gmailsearch_b776a8 --> addlabel_663354
   gmailsearch_b776a8 --> template_29a39f
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/chat-with-docs.md
+++ b/docs/workflows/chat-with-docs.md
@@ -5,9 +5,7 @@ title: "Chat with Docs"
 
 ## Overview
 
-A document retrieval and question-answering system that uses vector search and local LLMs to answer questions based on your document collection.
-
-
+Document retrieval and question-answering using vector search and local LLMs.
 
 ## Tags
 
@@ -26,14 +24,3 @@ graph TD
   query_2cff53 --> formattext_9
   formattext_9 --> agent_d83380
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/color-boost-video.md
+++ b/docs/workflows/color-boost-video.md
@@ -5,21 +5,12 @@ title: "Color Boost Video"
 
 ## Overview
 
+Extracts frames from a video, amplifies color intensity, and reassembles them into a modified video.
 
-
-🎨 **Color Boost Video**
-
-This workflow processes a short segment of a video by extracting individual frames, enhancing their color intensity, and reassembling them into a modified video. Specifically:
-
-1.	**Video Input: **A video is loaded.
-
-2.	**Frame Iteration: **Only frames 0 to 2 are extracted.
-
-3.	**Color Enhancement: **Each frame’s color is amplified using a factor of 3.0 with Pillow’s Enhance module.
-
-4.	**Reassembly: **Enhanced frames are recompiled into a new video stream.
-
-5.	**Preview: **The resulting video is displayed in a preview window.
+1. **Video Input** - A video is loaded.
+2. **Frame Iteration** - Frames 0 to 2 are extracted.
+3. **Color Enhancement** - Each frame's color is amplified 3x using Pillow's Enhance module.
+4. **Reassembly** - Enhanced frames are recompiled into a new video stream.
 
 ## Tags
 
@@ -40,14 +31,3 @@ graph TD
   frameiterator_abb8ee --> frametovideo_4ca887
   frameiterator_abb8ee --> frametovideo_4ca887
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/creative-story-ideas.md
+++ b/docs/workflows/creative-story-ideas.md
@@ -3,32 +3,19 @@ layout: page
 title: "Creative Story Ideas"
 ---
 
-## What You'll Create
-
-Generate story ideas quickly using AI. This simple workflow demonstrates core NodeTool concepts: inputs, templates, and AI generation. Good for writers, game designers, and content creators who need creative inspiration.
-
-**Time to complete:** 5 minutes  
-**Difficulty:** Beginner
-
----
-
 ## Overview
 
-A beginner-friendly template showing how to combine inputs with an AI agent to generate creative story ideas.
+A beginner-friendly template for combining inputs with an AI agent to generate creative story ideas.
 
 **How it works:**
 1. **Set inputs** - Define genre, character type, and setting
 2. **Format template** - Combine inputs into a prompt
 3. **Generate ideas** - AI produces multiple story concepts
-4. **View results** - Preview and use the generated ideas
 
 **Key concepts:**
 - Connect nodes to create workflows
 - Use templates with {{VARIABLES}} for dynamic prompts
 - AI agents process inputs and generate results
-- Preview nodes show outputs at each stage
-
----
 
 ## Tags
 
@@ -60,20 +47,13 @@ graph TD
    - **Setting**: "Space station", "Medieval castle", "Future city", etc.
 3. Press <kbd>Ctrl/⌘ + Enter</kbd> or click Run
 4. View the generated ideas in the Preview node
-5. Copy ideas you like to use in your writing
 
 **Tips:**
 - Run multiple times to get different ideas
 - Try unusual combinations for unique results
-- Adjust inputs to refine the style of ideas you get
-
----
 
 ## Next Steps
 
-Try these related workflows:
 - [Movie Posters](movie-posters.md) - Generate images from ideas
 - [Image Enhance](image-enhance.md) - Chain image transformations
 - [Story to Video](story-to-video-generator.md) - Create video from stories
-
-Browse all [workflows](/workflows/) for more examples.

--- a/docs/workflows/data-generator.md
+++ b/docs/workflows/data-generator.md
@@ -5,15 +5,7 @@ title: "Data Generator"
 
 ## Overview
 
-Generate structured data using AI agents
-
-**Data Generator**
-
-- Generate synthetic data
-
-- Use prompt to describe the data
-
-- Add columns to specify the shape of data
+Generate synthetic structured data using an AI agent. Describe the data with a prompt and add columns to specify its shape.
 
 ## Tags
 
@@ -25,14 +17,3 @@ agents
 graph TD
   datagenerator_2ed27b["DataGenerator"]
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/data-visualization-pipeline.md
+++ b/docs/workflows/data-visualization-pipeline.md
@@ -5,17 +5,7 @@ title: "Data Visualization Pipeline"
 
 ## Overview
 
-Transform natural language descriptions into data visualizations with AI-powered data and chart generation. This workflow demonstrates how to create customized charts from text prompts without manual data preparation.
-
-**Historical GDP Data Visualization Workflow**
-
-This workflow pulls historical GDP data from an HTTP source.
-
-The file is converted to a Dataframe and then passed to the Chart Generator node.
-
-The Chart Generator configures the data into a line chart format.
-
-The model is instructed to create a line chart showing GDP trends over the century.
+Fetches historical GDP data from an HTTP source, converts it to a DataFrame, and generates a line chart showing trends over the century.
 
 ## Tags
 
@@ -33,14 +23,3 @@ graph TD
   importcsv_bbf878 --> filter_fdbb90
   filter_fdbb90 --> chartgenerator_d6a24f
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/fetch-papers.md
+++ b/docs/workflows/fetch-papers.md
@@ -5,23 +5,7 @@ title: "Fetch Papers"
 
 ## Overview
 
-This workflow automatically fetches and downloads research papers from the Awesome Transformers GitHub repository. It extracts paper links from the README.md file, filters for actual papers, and downloads them to a specified folder. Ideal for researchers and AI enthusiasts who want to stay updated with the latest transformer model papers.
-
-This workflow automatically fetches and downloads research papers from the Awesome Transformers GitHub repository. The process follows these steps:
-
-1. **Fetch the README.md** from the GitHub repository
-
-2. **Extract all links** with their titles from the markdown
-
-3. **Convert the extracted links** to a DataFrame for processing
-
-4. **Filter the DataFrame** to keep only entries with title 'Paper'
-
-5. **Extract the URL column** from the filtered DataFrame
-
-6. **Preview the URLs** before downloading
-
-7. **Download all papers** to the specified folder
+Fetches and downloads research papers from the Awesome Transformers GitHub repository. Extracts paper links from the README, filters for actual papers, and downloads them to a specified folder.
 
 ## Tags
 
@@ -43,14 +27,3 @@ graph TD
   extractcolumn_25 --> downloadfiles_21698c
   getrequest_422102 --> extractlinks_32
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/flashcard-generator.md
+++ b/docs/workflows/flashcard-generator.md
@@ -5,9 +5,7 @@ title: "Flashcard Generator"
 
 ## Overview
 
-Generate study flashcards using AI and store them persistently in a database. Enter any topic and get instant flashcards that are saved for future review.
-
-
+Generate study flashcards using AI and store them in a database. Enter any topic and get instant flashcards saved for future review.
 
 ## Tags
 
@@ -32,14 +30,3 @@ graph TD
   createtable_create --> insert_insert
   createtable_create --> query_query_
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/image-enhance.md
+++ b/docs/workflows/image-enhance.md
@@ -3,18 +3,9 @@ layout: page
 title: "Image Enhance"
 ---
 
-## What You'll Create
-
-Enhance your images with AI-powered sharpening and contrast adjustments. Good for photographers, designers, and content creators who want to improve visual quality quickly.
-
-**Time to complete:** 3 minutes  
-**Difficulty:** Beginner
-
----
-
 ## Overview
 
-A simple image enhancement pipeline using sharpening for crisp details and auto-contrast for better exposure balance.
+A simple image enhancement pipeline: sharpen for crisp details, then auto-contrast for better exposure balance.
 
 **The Pipeline:**
 1. **Image Input** - Your photo or artwork
@@ -22,35 +13,7 @@ A simple image enhancement pipeline using sharpening for crisp details and auto-
 3. **Auto Contrast** - Optimize brightness and contrast
 4. **Image Output** - Your enhanced result
 
----
-
-## The Enhancement Process
-
-**Input:** Load any image - portraits, landscapes, product photos, digital art.
-
-**Sharpen:** Sharpens edges and fine details. Good for:
-- Product photography
-- Portraits
-- Landscape photos
-- Screenshots
-
-**Auto Contrast:** Automatically adjusts contrast for better visual impact. Good for:
-- Underexposed photos
-- Backlit images
-- Flat-looking images
-
-**Output:** Your enhanced image, ready to save or share.
-
----
-
-## Advanced Options
-
-For more enhancement capabilities, explore these nodes:
-- **Replicate.Image.Process** - More image processing options
-- **Replicate.Image.Upscale** - AI upscaling for quality improvements
-- **Nodetool.Image.Transform** - Additional color and brightness controls
-
----
+For more options: **Replicate.Image.Upscale** for AI upscaling, **Nodetool.Image.Transform** for color and brightness controls.
 
 ## Tags
 
@@ -72,28 +35,16 @@ graph TD
 ## How to Use
 
 1. Open NodeTool and find "Image Enhance" in Templates
-2. Load your image:
-   - Click the Image Input node
-   - Upload a photo (JPG, PNG, WebP)
-3. Adjust settings (optional):
-   - Click Sharpen node to control sharpness intensity
-   - Auto Contrast works automatically
+2. Click the Image Input node and upload a photo (JPG, PNG, WebP)
+3. Optionally click Sharpen to adjust intensity
 4. Press <kbd>Ctrl/⌘ + Enter</kbd> or click Run
-5. View the enhanced result
-6. Save or export the image
 
 **Tips:**
-- Try different sharpness levels - more isn't always better
-- Works well with batches - process multiple images
-- Chain with other workflows for more effects
-
----
+- More sharpness isn't always better
+- Works well on batches
 
 ## Next Steps
 
-Related workflows:
 - [Movie Posters](movie-posters.md) - Combine enhancement with AI generation
 - [Color Boost Video](color-boost-video.md) - Apply similar enhancements to video
 - [Story to Video](story-to-video-generator.md) - Create multimedia projects
-
-Browse all [workflows](/workflows/) for more examples.

--- a/docs/workflows/image-to-audio-story.md
+++ b/docs/workflows/image-to-audio-story.md
@@ -3,72 +3,20 @@ layout: page
 title: "Image To Audio Story"
 ---
 
-## What You'll Create
-
-Transform images into narrated stories using AI vision and text-to-speech. Good for content creators, educators, and storytellers who want to add audio descriptions to images.
-
-**Time to complete:** 5 minutes  
-**Difficulty:** Intermediate
-
----
-
 ## Overview
 
-Turn visual content into narrated stories by combining vision AI with language generation and speech synthesis.
+Transforms images into narrated stories by combining vision AI with language generation and speech synthesis.
 
 **How it works:**
 1. **Image Input** - Your photo, artwork, or any visual
-2. **AI Vision + Story Generation** - AI analyzes the image and writes a story
-3. **Text Output** - Generated description or narrative
-4. **Text-to-Speech** - Converts text to spoken audio
-5. **Audio Output** - Narration you can save or share
-
----
-
-## The Process
-
-### Vision Analysis
-AI analyzes your image to understand:
-- Visual elements and composition
-- Emotions and mood
-- Themes and symbolism
-- Story potential
-
-### Story Generation
-AI writes a narrative inspired by the image. Can create:
-- Descriptive captions
-- Emotional narratives
-- Poetic descriptions
-- Character backstories
-
-### Audio Narration
-Text-to-speech converts the story to audio with:
-- Natural intonation
-- Multiple voice options
-- Adjustable speed
-
----
-
-## Customization Ideas
+2. **AI Vision + Story** - AI analyzes the image and writes a narrative
+3. **Text-to-Speech** - Converts the story to spoken audio
+4. **Audio Output** - Narration you can save or share
 
 **Prompt examples:**
 - "Describe this image as if you're a museum curator"
 - "Write a short poem inspired by this artwork"
 - "Create a brief backstory for this scene"
-- "Explain what you see in simple, accessible language"
-
-**Vision models:**
-- OpenAI: GPT-4o (vision + text generation)
-- Anthropic: Claude 3 (Opus, Sonnet, Haiku)
-- Local: LLaVA, Qwen-VL via Ollama
-- Google: Gemini Pro Vision
-
-**TTS options:**
-- OpenAI TTS (multiple voices)
-- ElevenLabs (customizable)
-- Local TTS (Coqui, Bark)
-
----
 
 ## Tags
 
@@ -88,26 +36,13 @@ graph TD
 ## How to Use
 
 1. Open NodeTool and find "Image to Audio Story" template
-2. Load your image (artwork, photos, or any visual content)
-3. Customize the AI prompt in the Agent node:
-   - Default: "Create a story inspired by this image"
-   - Or try: "Write like a museum curator", "Create a children's story"
+2. Load your image
+3. Customize the AI prompt in the Agent node (default: "Create a story inspired by this image")
 4. Choose your voice in the TextToSpeech node
 5. Press <kbd>Ctrl/⌘ + Enter</kbd> to run
-6. View the written story and hear the narration
-7. Export audio or copy text as needed
-
-**Tips:**
-- Try the same image with different prompts for varied results
-- Use multiple images to create series or episodes
-- Combine with video workflows for multimedia content
-
----
 
 ## Related Workflows
 
 - [Story to Video Generator](story-to-video-generator.md) - Turn stories into videos
 - [Movie Posters](movie-posters.md) - Create visual content
 - [Creative Story Ideas](creative-story-ideas.md) - Generate story concepts
-
-Browse all [workflows](/workflows/) for more examples.

--- a/docs/workflows/index-pdfs.md
+++ b/docs/workflows/index-pdfs.md
@@ -5,9 +5,7 @@ title: "Index PDFs"
 
 ## Overview
 
-Workflow to index PDFs in a folder into a Chroma collection
-
-
+Index PDFs from a folder into a Chroma collection for vector search.
 
 ## Tags
 
@@ -32,14 +30,3 @@ graph TD
   listfiles_8eb41c --> pathtostring_7fdb62
   pathtostring_7fdb62 --> sentencesplitter_be7780
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/meeting-transcript-summarizer.md
+++ b/docs/workflows/meeting-transcript-summarizer.md
@@ -5,19 +5,12 @@ title: "Meeting Transcript Summarizer"
 
 ## Overview
 
-Automatically transcribe a meeting recording and generate concise notes.
+Transcribes a meeting recording with OpenAI Whisper, then condenses the transcript into concise notes.
 
-📄 **Meeting Transcript Summarizer**
-
-This workflow converts a meeting recording into concise notes.
-
-1.	**Audio Input: **Load a meeting recording.
-
-2.	**Transcription: **Speech is transcribed with OpenAI Whisper.
-
-3.	**Summarization: **The transcript is condensed into key points.
-
-4.	**Output: **A text node displays the final summary.
+1. **Audio Input** - Load a meeting recording.
+2. **Transcription** - Speech is transcribed with Whisper.
+3. **Summarization** - Transcript is condensed into key points.
+4. **Output** - A text node displays the final summary.
 
 ## Tags
 
@@ -35,14 +28,3 @@ graph TD
   audio_1 --> automaticspeechrecognition_a2e093
   summarizer_3 --> summary_4
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/movie-posters.md
+++ b/docs/workflows/movie-posters.md
@@ -3,58 +3,16 @@ layout: page
 title: "Movie Posters"
 ---
 
-## What You'll Create
-
-Generate movie poster concepts with AI. This workflow chains multiple AI models to go from idea to visual design, demonstrating how to build multi-stage creative pipelines.
-
-**Time to complete:** 5 minutes  
-**Difficulty:** Intermediate
-
----
-
 ## Overview
 
-An AI-powered poster generator that plans a visual strategy, then creates image variations.
+An AI-powered poster generator: a strategy agent plans the visual concept, then an image model renders poster variations.
 
 **How it works:**
 1. **Input** - Movie title, genre, and target audience
 2. **Strategy Agent** - Creates a marketing approach and visual concept
-3. **Prompt Generator** - Converts strategy into detailed image prompts
-4. **Image Generator** - Creates poster variations using Stable Diffusion/Flux
-5. **Preview** - Shows both the strategy and resulting posters
-
----
-
-## The Creative Pipeline
-
-### Inputs
-Three input nodes define your movie:
-- **Title**: Your movie name
-- **Genre**: Action, Horror, Romance, etc.
-- **Audience**: Who will watch it
-
-### Strategy Planning
-First AI agent analyzes inputs and creates a marketing strategy and visual direction.
-
-### Prompt Generation
-Second AI converts strategy into specific image prompts, generating multiple variations for different approaches.
-
-### Image Creation
-Stable Diffusion or Flux renders 512×768px posters. Multiple images generated simultaneously.
-
-### Preview & Results
-Top preview shows the creative strategy. Bottom gallery displays all generated posters.
-
----
-
-## Key Concepts
-
-- **Multi-stage workflows**: Chain AI models for complex results
-- **Variation generation**: Create multiple concepts to choose from
-- **Streaming results**: Watch posters appear as they generate
-- **Reusable template**: Save and use for any project
-
----
+3. **Prompt Generator** - Converts strategy into image prompts for multiple variations
+4. **Image Generator** - Renders 512×768px posters with Stable Diffusion/Flux
+5. **Preview** - Shows the strategy and all generated posters
 
 ## Tags
 
@@ -91,22 +49,14 @@ graph TD
    - **Genre**: "Sci-Fi Thriller" (choose any genre)
    - **Primary Audience**: "Adults 25-40 who love space mysteries"
 3. Press <kbd>Ctrl/⌘ + Enter</kbd> or click Run
-4. View the AI strategy in the top preview
-5. Watch posters generate in the bottom preview
-6. Run again with different inputs for new styles
+4. View the AI strategy in the top preview, posters in the bottom gallery
 
 **Tips:**
 - Try different genres for the same title to see how styles change
 - Be specific about audience to get more targeted designs
-- Run multiple times to build a portfolio of concepts
-
----
 
 ## Next Steps
 
-Try these related workflows:
 - [Image Enhance](image-enhance.md) - Enhance your poster designs
 - [Creative Story Ideas](creative-story-ideas.md) - Generate movie concepts
 - [Story to Video](story-to-video-generator.md) - Create video trailers
-
-Browse all [workflows](/workflows/) for more examples.

--- a/docs/workflows/realtime-agent.md
+++ b/docs/workflows/realtime-agent.md
@@ -5,9 +5,7 @@ title: "Realtime Agent"
 
 ## Overview
 
-
-
-
+Stream audio to OpenAI's Realtime API for low-latency voice interaction.
 
 ## Tags
 
@@ -21,14 +19,3 @@ graph TD
   realtimeagent_a2a7cb["RealtimeAgent"]
   audio_4d19aa --> realtimeagent_a2a7cb
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/story-to-video-generator.md
+++ b/docs/workflows/story-to-video-generator.md
@@ -5,7 +5,7 @@ title: "Story to Video Generator"
 
 ## Overview
 
-Transform story ideas into AI-generated videos. An agent crafts detailed visual prompts optimized for video generation, then creates the video using Gemini Veo.
+Transform story ideas into AI-generated videos. An agent crafts detailed visual prompts optimized for video generation, then Gemini Veo renders the video.
 
 ## How It Works
 
@@ -13,7 +13,6 @@ Transform story ideas into AI-generated videos. An agent crafts detailed visual 
 2. **FormatText** - Injects theme into the prompt template
 3. **AI Agent** - Crafts a video prompt with camera movements, lighting, and composition details
 4. **TextToVideo** - Gemini Veo generates your video
-5. **Preview** - View the crafted prompt and final video
 
 ## Example Story Themes
 
@@ -29,22 +28,17 @@ Transform story ideas into AI-generated videos. An agent crafts detailed visual 
 - "New York City street at night in the rain, neon reflections"
 - "Drone shot rising over Tokyo at golden hour"
 
-## Tips for Best Results
+## Tips
 
-✅ Be specific - Include setting, lighting, time of day  
-✅ Add motion - Describe camera movements or actions  
-✅ Set the mood - Mention atmosphere (peaceful, dramatic, mysterious)  
-✅ Keep it visual - Focus on what can be seen  
-
-❌ Avoid vague descriptions  
-❌ Don't include dialogue or sound effects  
-❌ Keep themes focused on a single scene
+- Be specific: include setting, lighting, time of day
+- Describe camera movements or subject motion
+- Keep themes focused on a single scene; omit dialogue and sound effects
 
 ## Configuration Options
 
 - **Aspect Ratio**: 16:9 (widescreen), 9:16 (vertical), 1:1 (square)
 - **Resolution**: 720p (faster), 1080p (higher quality)
-- **Seed**: Set to same number for consistent results, -1 for random
+- **Seed**: fixed number for consistent results, -1 for random
 
 ## Tags
 
@@ -65,14 +59,3 @@ graph TD
   agent_prompt --> texttovideo_video_
   texttovideo_video_ --> generated_video_video_
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/summarize-paper.md
+++ b/docs/workflows/summarize-paper.md
@@ -5,31 +5,17 @@ title: "Summarize Paper"
 
 ## Overview
 
+Downloads a PDF from a URL, extracts text from selected pages, and generates a concise summary.
 
+- Change the URL in the String Input node to process a different PDF.
+- Adjust Start Page / End Page to select which pages to summarize.
+- Modify Max Tokens in Summarizer for longer or shorter summaries.
 
-This workflow takes a PDF document from a given URL, extracts text, and generates a concise summary.
-
----
-
-### 🔹 Steps
-
-String Input → Provides the PDF URL (example: arXiv paper).  GET Document → Downloads the PDF from the given URL.  Extract Text → Reads the PDF pages (here: pages 0–4).  Summarizer → Uses the gemma3:1b model to produce a summary of the extracted text (max 200 tokens).
-
----
-
-### 🔹 Usage
-
-Change the URL in the String Input node to process a different PDF.  Adjust Start Page / End Page to select which pages to summarize.  Modify Max Tokens in Summarizer for longer or shorter summaries.
-
----
-
-### 🔹 Example
-
-Summarizing “Attention is All You Need” (arXiv:1706.03762) to get a clear, concise overview of the Transformer architecture.
+**Example:** Summarizing "Attention is All You Need" (arXiv:1706.03762) with gemma3:1b, max 200 tokens.
 
 ## Tags
 
-audio, start
+start
 
 ## Workflow Diagram
 
@@ -43,14 +29,3 @@ graph TD
   extracttext_4 --> summarizer_6
   url_f78b00 --> getrequestdocument_5
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/summarize-rss.md
+++ b/docs/workflows/summarize-rss.md
@@ -5,13 +5,11 @@ title: "Summarize RSS"
 
 ## Overview
 
-
-
-
+Fetches an RSS feed, collects all entries, and generates a summary.
 
 ## Tags
 
-N/A
+rss, llm
 
 ## Workflow Diagram
 
@@ -23,14 +21,3 @@ graph TD
   fetchrssfeed_3fd0dc --> collect_98cc0c
   collect_98cc0c --> summarizer_065961
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.

--- a/docs/workflows/transcribe-audio.md
+++ b/docs/workflows/transcribe-audio.md
@@ -5,22 +5,16 @@ title: "Transcribe Audio"
 
 ## Overview
 
-Convert speech to text using Whisper model with word-level timestamps
-
 Convert speech to text using the Whisper model with word-level timestamps.
 
 1. **Audio Input** - Record your voice or upload an audio file
-
-2. **Automatic Speech Recognition** - Processes the audio through Whisper model to generate transcription
-
+2. **Automatic Speech Recognition** - Processes audio through Whisper
 3. **String Output** - Displays the transcribed text
 
-## How to Use:
+## How to Use
 
-- Record your voice using the audio input
-
-- Hit the run button
-
+- Record your voice or upload a file using the audio input
+- Click Run
 - Read the transcription in the output
 
 ## Tags
@@ -37,14 +31,3 @@ graph TD
   audio_7 --> automaticspeechrecognition_c51917
   automaticspeechrecognition_c51917 --> transciption_8
 {% endmermaid %}
-
-## How to Use
-
-1. Open NodeTool and create a new workflow
-2. Import this workflow from the examples gallery or build it manually following the diagram above
-3. Configure the input nodes with your data
-4. Run the workflow to see results
-
-## Related Workflows
-
-Browse other [workflow examples](/cookbook.md) to discover more capabilities.


### PR DESCRIPTION
Removed boilerplate from all 22 files:
- Agent YAMLs: stripped comment headers and per-field annotations that restate the field name; removed redundant `name:` display fields in model config
- Workflow markdown: cut the identical 4-line "How to Use" + generic "Related Workflows" block that appeared on ~12 pages; removed "What You'll Create" sections that duplicated adjacent Overview sections; fixed empty Overview sections (realtime-agent, summarize-rss, color-boost-video); fixed step numbering bug in categorize-mails; cleaned up tab-indented and emoji-prefixed steps; collapsed duplicate paragraphs in fetch-papers and transcribe-audio

https://claude.ai/code/session_01SaqAKXi78F8P15SDA9E2ZX