### PR TITLE
Add Export as ComfyUI Workflow command to CommandMenu

### DIFF
--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -15,6 +15,7 @@ import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { useNodes } from "../../contexts/NodeContext";
+import { nodeToolGraphToComfyWorkflow } from "../../utils/comfyWorkflowConverter";
 import { create } from "zustand";
 import { shallow } from "zustand/shallow";
 import { isDevelopment } from "../../lib/env";
@@ -108,13 +109,15 @@ const WorkflowCommands = memo(function WorkflowCommands() {
     edges,
     currentWorkflow,
     workflowJSON,
-    autoLayout
+    autoLayout,
+    getWorkflow
   } = useNodes((state) => ({
     nodes: state.nodes,
     edges: state.edges,
     currentWorkflow: state.workflow,
     workflowJSON: state.workflowJSON,
-    autoLayout: state.autoLayout
+    autoLayout: state.autoLayout,
+    getWorkflow: state.getWorkflow
   }), shallow);
   const run = useWebsocketRunner((state) => state.run);
   const cancel = useWebsocketRunner((state) => state.cancel);
@@ -152,6 +155,18 @@ const WorkflowCommands = memo(function WorkflowCommands() {
       content: "Copied workflow JSON to Clipboard!"
     });
   }, [writeClipboard, workflowJSON, addNotification]);
+
+  const exportAsComfyWorkflow = useCallback(() => {
+    const workflow = getWorkflow();
+    const comfyWorkflow = nodeToolGraphToComfyWorkflow(workflow.graph ?? { nodes: [], edges: [] });
+    const blob = new Blob([JSON.stringify(comfyWorkflow, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.download = `${currentWorkflow.name}_comfy.json`;
+    link.href = url;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [getWorkflow, currentWorkflow.name]);
 
   const handleSave = useCallback(async () => {
     const workflow = getCurrentWorkflow();
@@ -207,6 +222,9 @@ const WorkflowCommands = memo(function WorkflowCommands() {
       </Command.Item>
       <Command.Item onSelect={() => executeAndClose(downloadWorkflow)}>
         <FileDownloadRoundedIcon /> Download Workflow as JSON
+      </Command.Item>
+      <Command.Item onSelect={() => executeAndClose(exportAsComfyWorkflow)}>
+        <FileDownloadRoundedIcon /> Export as ComfyUI Workflow
       </Command.Item>
       <Command.Item onSelect={() => executeAndClose(copyWorkflow)}>
         <ContentCopyRoundedIcon /> Copy Workflow as JSON


### PR DESCRIPTION
Wires the existing nodeToolGraphToComfyWorkflow converter into the
Command Menu so users can download the current workflow as a
ComfyUI-compatible JSON file (<name>_comfy.json) via the
"Export as ComfyUI Workflow" menu item, as documented in
docs/comfyui-integration.md.

https://claude.ai/code/session_01Sdb8YttzHEn1i1SYXWeGpj