### PR TITLE
fix: remove nodetool-dev export condition from decorator-using packages

### DIFF
--- a/packages/base-nodes/package.json
+++ b/packages/base-nodes/package.json
@@ -78,7 +78,6 @@
   },
   "exports": {
     ".": {
-      "nodetool-dev": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -24,7 +24,6 @@
   },
   "exports": {
     ".": {
-      "nodetool-dev": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
## Summary

- Removes the `nodetool-dev` export condition from `node-sdk` and `base-nodes` package exports
- Fixes `Decorators are not valid here` errors when running the dev server with `--conditions=nodetool-dev`

## Root Cause

`tsx` (used by the dev server) uses esbuild for TypeScript transformation. esbuild does not support TypeScript's legacy `experimentalDecorators` syntax. The `nodetool-dev` condition was redirecting imports to `./src/index.ts`, causing esbuild to fail on `@prop({...})` class-field decorators in these packages.

## Fix

Removing the `nodetool-dev` condition from `node-sdk` and `base-nodes` forces them to always load from `dist/` — which matches the documented behavior in CLAUDE.md: _"base-nodes, node-sdk use decorators and load from dist/. After changing these, run `npm run build:packages` before `npm run dev`."_

## Test plan

- [ ] Run `npm run dev:server` — no decorator errors on startup
- [ ] Verify node registry loads correctly (nodes from base-nodes are registered)
- [ ] Changes to `node-sdk`/`base-nodes` still require `npm run build:packages` before taking effect in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)