### PR TITLE
fix(tests): add missing ui_primitives mocks and theme.spacing

### DIFF
--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -33,7 +33,12 @@ jest.mock("../components/ui_primitives", () => ({
         {children}
       </Tag>
     );
-  }
+  },
+  EditorButton: ({ children, onClick, className, ...props }: any) => (
+    <button onClick={onClick} className={className} {...props}>
+      {children}
+    </button>
+  )
 }));
 
 describe("ErrorBoundary", () => {

--- a/web/src/components/node/DynamicKieSchemaNode/__tests__/KieSchemaLoader.test.tsx
+++ b/web/src/components/node/DynamicKieSchemaNode/__tests__/KieSchemaLoader.test.tsx
@@ -8,7 +8,11 @@ const mockResolveKieSchemaClient = jest.fn();
 
 jest.mock("../../../ui_primitives", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  Caption: ({ children }: { children: React.ReactNode }) => <>{children}</>
+  Caption: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LoadingSpinner: () => <span data-testid="loading-spinner" />,
+  ToolbarIconButton: ({ children, onClick, disabled, ...props }: any) => (
+    <button onClick={onClick} disabled={disabled} {...props}>{children}</button>
+  )
 }));
 
 jest.mock("../../../../contexts/NodeContext", () => ({

--- a/web/src/components/node/__tests__/RerouteNode.performance.test.tsx
+++ b/web/src/components/node/__tests__/RerouteNode.performance.test.tsx
@@ -54,6 +54,7 @@ jest.mock('@mui/material/styles', () => {
   return {
     ...original,
     useTheme: () => ({
+      spacing: (factor: number) => `${factor * 8}px`,
       palette: {
         mode: 'dark',
         common: {


### PR DESCRIPTION
## Summary
- Add `EditorButton` to `ui_primitives` mock in `ErrorBoundary.test.tsx`
- Add `LoadingSpinner` and `ToolbarIconButton` to `ui_primitives` mock in `KieSchemaLoader.test.tsx`
- Add `spacing` function to `useTheme` mock in `RerouteNode.performance.test.tsx`

## Test plan
- [ ] `npm run test` passes with all 3 previously-failing suites now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)