### PR TITLE
fix(web): prefix relative /api/ asset URLs with BASE_URL for production

### DIFF
--- a/web/src/components/assets/AssetItem.tsx
+++ b/web/src/components/assets/AssetItem.tsx
@@ -17,6 +17,7 @@ import { useSettingsStore } from "../../stores/SettingsStore";
 import { useAssetActions } from "./useAssetActions";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import { resolveApiUrl } from "../../stores/BASE_URL";
 
 
 const styles = (theme: Theme) =>
@@ -447,14 +448,14 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
                 <div
                   className="image"
                   style={{
-                    backgroundImage: `url(${asset.thumb_url || asset.get_url})`
+                    backgroundImage: `url(${resolveApiUrl(asset.thumb_url || asset.get_url)})`
                   }}
                   aria-label={asset.id}
                 />
                 <div
                   className="image-aspect-ratio"
                   style={{
-                    backgroundImage: `url(${asset.thumb_url || asset.get_url})`
+                    backgroundImage: `url(${resolveApiUrl(asset.thumb_url || asset.get_url)})`
                   }}
                   aria-label={asset.id}
                 />
@@ -495,7 +496,7 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
               <div
                 className="image"
                 style={{
-                  backgroundImage: `url(${asset.thumb_url || asset.get_url})`
+                  backgroundImage: `url(${resolveApiUrl(asset.thumb_url || asset.get_url)})`
                 }}
                 aria-label={asset.id}
               />
@@ -524,7 +525,7 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
               <div
                 className="image"
                 style={{
-                  backgroundImage: `url(${asset.get_url})`
+                  backgroundImage: `url(${resolveApiUrl(asset.get_url)})`
                 }}
                 aria-label={asset.id}
               />

--- a/web/src/components/assets/AssetListView.tsx
+++ b/web/src/components/assets/AssetListView.tsx
@@ -15,6 +15,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { ExpandCollapseButton, EmptyState, Text } from "../ui_primitives";
 import { useSettingsStore } from "../../stores/SettingsStore";
+import { resolveApiUrl } from "../../stores/BASE_URL";
 
 interface AssetListViewProps {
   assets: Asset[];
@@ -432,7 +433,7 @@ const AssetListView: React.FC<AssetListViewProps> = memo(({
           <div
             className="asset-item-thumbnail"
             style={{
-              backgroundImage: `url(${asset.thumb_url || asset.get_url})`
+              backgroundImage: `url(${resolveApiUrl(asset.thumb_url || asset.get_url)})`
             }}
             title={`${asset.content_type} thumbnail`}
           />

--- a/web/src/components/assets/GlobalSearchResults.tsx
+++ b/web/src/components/assets/GlobalSearchResults.tsx
@@ -23,6 +23,7 @@ import {
   createAssetDragImage
 } from "../../lib/dragdrop";
 import { useDragDropStore } from "../../lib/dragdrop/store";
+import { resolveApiUrl } from "../../stores/BASE_URL";
 
 interface GlobalSearchResultsProps {
   results: AssetWithPath[];
@@ -453,8 +454,7 @@ const GlobalSearchResults: React.FC<GlobalSearchResultsProps> = ({
                   <div
                     className="global-search-result-thumbnail result-item-thumbnail"
                     style={{
-                      backgroundImage: `url(${asset.thumb_url || asset.get_url
-                        })`
+                      backgroundImage: `url(${resolveApiUrl(asset.thumb_url || asset.get_url)})`
                     }}
                     title={`${asset.content_type} thumbnail`}
                     data-testid="global-search-result-thumbnail"

--- a/web/src/components/context_menus/AssetInfoPanel.tsx
+++ b/web/src/components/context_menus/AssetInfoPanel.tsx
@@ -10,6 +10,7 @@ import { formatFileSize } from "../../utils/formatUtils";
 import { secondsToHMS } from "../../utils/formatDateAndTime";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import { resolveApiUrl } from "../../stores/BASE_URL";
 
 const styles = (theme: Theme) =>
   css({
@@ -94,7 +95,7 @@ const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({ asset }) => {
   }, [asset.workflow_id, getWorkflow]);
 
   const isImage = asset.content_type?.startsWith("image/");
-  const thumbSrc = asset.thumb_url || (isImage ? asset.get_url : null);
+  const thumbSrc = resolveApiUrl(asset.thumb_url || (isImage ? asset.get_url : null));
   const metadata = asset.metadata as Record<string, unknown> | null | undefined;
 
   return (

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -82,10 +82,9 @@ export function resolveAssetUri(uri: string | undefined | null): string {
     return `${BASE_URL}/api/storage/${assetId}`;
   }
 
-  // Handle /api/storage/ relative URLs — prefix with BASE_URL for Electron
-  if (uri.startsWith("/api/storage/")) {
-    const resolved = `${BASE_URL}${uri}`;
-    return resolved;
+  // Handle relative /api/ URLs — prefix with BASE_URL for production/Electron
+  if (uri.startsWith("/api/")) {
+    return `${BASE_URL}${uri}`;
   }
 
   return uri;

--- a/web/src/stores/BASE_URL.ts
+++ b/web/src/stores/BASE_URL.ts
@@ -36,3 +36,13 @@ export const DOWNLOAD_URL = getWebSocketUrl("/ws/download");
 
 /** WebSocket URL for the Claude/Codex/OpenCode agent endpoint. */
 export const AGENT_WS_URL = getWebSocketUrl("/ws/agent");
+
+/**
+ * Prefix a relative /api/* path with BASE_URL so it resolves to the correct
+ * API server in production (where the React app and API are on different origins).
+ */
+export function resolveApiUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  if (url.startsWith("/api/")) return `${BASE_URL}${url}`;
+  return url;
+}


### PR DESCRIPTION
## Summary

- Asset `thumb_url` and `get_url` values returned by the server are relative `/api/` paths (e.g. `/api/assets/<id>/thumbnail`, `/api/storage/<key>`)
- In production, the React app is served from `app.nodetool.ai` which does not proxy `/api/*` to the API server, so these URLs resolve to the wrong origin
- Added `resolveApiUrl()` helper in `BASE_URL.ts` that prepends `VITE_API_URL` (via `BASE_URL`) to any relative `/api/` path
- Applied it to all `thumb_url`/`get_url` usages in `AssetItem`, `AssetListView`, `AssetInfoPanel`, `GlobalSearchResults`
- Generalized `resolveAssetUri()` in `hooks.ts` to cover all `/api/` paths, not just `/api/storage/`

## Test plan

- [ ] Set `VITE_API_URL=https://your-api-server.com` and verify asset thumbnails load from the correct domain
- [ ] Verify local dev still works (empty `VITE_API_URL` → relative URLs proxied by Vite)
- [ ] Check asset grid, list view, info panel, and global search all show thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)