### PR TITLE
feat: use S3/Supabase native signed URLs for asset get_url; remove domain support

### DIFF
--- a/packages/config/tests/paths.test.ts
+++ b/packages/config/tests/paths.test.ts
@@ -7,8 +7,6 @@ import {
   getPostgresDatabaseUrl,
   getDefaultVectorstoreDbPath,
   getDefaultAssetsPath,
-  getAssetDomain,
-  getTempDomain,
   buildAssetUrl
 } from "../src/paths.js";
 
@@ -182,109 +180,16 @@ describe("getDefaultAssetsPath", () => {
   });
 });
 
-describe("asset domain helpers", () => {
-  const saved: Record<string, string | undefined> = {};
-
-  afterEach(() => {
-    for (const [key, val] of Object.entries(saved)) {
-      if (val === undefined) delete process.env[key];
-      else process.env[key] = val;
-    }
-  });
-
-  function snapshot(): void {
-    saved.ASSET_DOMAIN = process.env.ASSET_DOMAIN;
-    saved.TEMP_DOMAIN = process.env.TEMP_DOMAIN;
-  }
-
-  it("getAssetDomain returns undefined when unset or empty", () => {
-    snapshot();
-    delete process.env.ASSET_DOMAIN;
-    expect(getAssetDomain()).toBeUndefined();
-    process.env.ASSET_DOMAIN = "   ";
-    expect(getAssetDomain()).toBeUndefined();
-  });
-
-  it("getAssetDomain returns trimmed value when set", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "  assets.nodetool.ai  ";
-    expect(getAssetDomain()).toBe("assets.nodetool.ai");
-  });
-
-  it("getTempDomain returns trimmed value when set", () => {
-    snapshot();
-    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
-    expect(getTempDomain()).toBe("temp.nodetool.ai");
-  });
-
-  it("buildAssetUrl falls back to /api/storage path when no domain set", () => {
-    snapshot();
-    delete process.env.ASSET_DOMAIN;
-    delete process.env.TEMP_DOMAIN;
+describe("buildAssetUrl", () => {
+  it("returns /api/storage/<key>", () => {
     expect(buildAssetUrl("abc.png")).toBe("/api/storage/abc.png");
     expect(buildAssetUrl("temp/uuid.png")).toBe("/api/storage/temp/uuid.png");
   });
 
-  it("buildAssetUrl strips leading slashes from the key", () => {
-    snapshot();
-    delete process.env.ASSET_DOMAIN;
-    delete process.env.TEMP_DOMAIN;
+  it("strips leading slashes from the key", () => {
     expect(buildAssetUrl("/abc.png")).toBe("/api/storage/abc.png");
     expect(buildAssetUrl("///temp/uuid.png")).toBe(
       "/api/storage/temp/uuid.png"
     );
-  });
-
-  it("buildAssetUrl uses ASSET_DOMAIN for permanent assets", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
-    delete process.env.TEMP_DOMAIN;
-    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
-  });
-
-  it("buildAssetUrl honours an explicit scheme on ASSET_DOMAIN", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "http://localhost:9000/cdn";
-    delete process.env.TEMP_DOMAIN;
-    expect(buildAssetUrl("abc.png")).toBe("http://localhost:9000/cdn/abc.png");
-  });
-
-  it("buildAssetUrl routes temp/ keys to TEMP_DOMAIN and drops the prefix", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
-    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
-    expect(buildAssetUrl("temp/uuid.png")).toBe(
-      "https://temp.nodetool.ai/uuid.png"
-    );
-    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
-  });
-
-  it("buildAssetUrl falls back to ASSET_DOMAIN for temp/ when TEMP_DOMAIN is unset", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "assets.nodetool.ai";
-    delete process.env.TEMP_DOMAIN;
-    // With no dedicated temp domain, the `temp/` prefix is preserved so the
-    // same bucket can host both kinds of content.
-    expect(buildAssetUrl("temp/uuid.png")).toBe(
-      "https://assets.nodetool.ai/temp/uuid.png"
-    );
-  });
-
-  it("buildAssetUrl uses TEMP_DOMAIN for temp/ even without ASSET_DOMAIN", () => {
-    snapshot();
-    delete process.env.ASSET_DOMAIN;
-    process.env.TEMP_DOMAIN = "temp.nodetool.ai";
-    expect(buildAssetUrl("temp/uuid.png")).toBe(
-      "https://temp.nodetool.ai/uuid.png"
-    );
-    // Permanent assets still fall back to the API path.
-    expect(buildAssetUrl("abc.png")).toBe("/api/storage/abc.png");
-  });
-
-  it("buildAssetUrl trims trailing slashes on the domain", () => {
-    snapshot();
-    process.env.ASSET_DOMAIN = "https://assets.nodetool.ai//";
-    delete process.env.TEMP_DOMAIN;
-    expect(buildAssetUrl("abc.png")).toBe("https://assets.nodetool.ai/abc.png");
   });
 });

--- a/packages/protocol/src/api-schemas/storage.ts
+++ b/packages/protocol/src/api-schemas/storage.ts
@@ -38,6 +38,19 @@ export const storageMetadataOutput = storageEntrySchema;
 export type StorageMetadataInput = z.infer<typeof storageMetadataInput>;
 export type StorageMetadataOutput = z.infer<typeof storageMetadataOutput>;
 
+// ── storage.signUrl ──────────────────────────────────────────────────────────
+
+export const signUrlInput = z.object({
+  key: z.string().min(1)
+});
+
+export const signUrlOutput = z.object({
+  url: z.string()
+});
+
+export type SignUrlInput = z.infer<typeof signUrlInput>;
+export type SignUrlOutput = z.infer<typeof signUrlOutput>;
+
 // ── storage.delete ───────────────────────────────────────────────────────────
 
 export const storageDeleteInput = z.object({

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1029.0",
+    "@aws-sdk/s3-request-presigner": "^3.1029.0",
     "@supabase/supabase-js": "^2.98.0"
   },
   "devDependencies": {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -19,6 +19,9 @@ export {
 } from "./supabase-storage-adapter.js";
 export { createStorageAdapter, type StorageConfig } from "./factory.js";
 
+// URL builder
+export { createAssetUrlBuilder } from "./url-builder.js";
+
 // Caches
 export { MemoryUriCache } from "./memory-uri-cache.js";
 export {

--- a/packages/storage/src/s3-storage.ts
+++ b/packages/storage/src/s3-storage.ts
@@ -23,7 +23,6 @@ export class S3Storage implements AbstractStorage {
   constructor(
     private readonly bucketName: string,
     private readonly endpointUrl?: string,
-    private readonly domain?: string,
     private readonly region: string = "us-east-1"
   ) {}
 
@@ -96,12 +95,6 @@ export class S3Storage implements AbstractStorage {
   }
 
   getUrl(key: string): string {
-    if (this.domain) {
-      if (this.domain.startsWith("http")) {
-        return `${this.domain}/${key}`;
-      }
-      return `https://${this.domain}/${key}`;
-    }
     return `https://${this.bucketName}.s3.${this.region}.amazonaws.com/${key}`;
   }
 }

--- a/packages/storage/src/url-builder.ts
+++ b/packages/storage/src/url-builder.ts
@@ -1,0 +1,59 @@
+/**
+ * Factory that returns a (key → signed URL) function for each storage backend.
+ *
+ * - file:     returns /api/storage/<key> — served by the local HTTP server,
+ *             no signing needed for local dev.
+ * - s3:       returns an AWS pre-signed GET URL valid for SIGNED_URL_TTL seconds.
+ * - supabase: returns a Supabase signed URL valid for SIGNED_URL_TTL seconds.
+ */
+
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { createClient } from "@supabase/supabase-js";
+import type { StorageConfig } from "./factory.js";
+
+/** 7 days — S3/Supabase maximum. */
+const SIGNED_URL_TTL = 604800;
+
+export function createAssetUrlBuilder(
+  config: StorageConfig
+): (key: string) => Promise<string> {
+  switch (config.kind) {
+    case "file": {
+      return async (key: string) =>
+        `/api/storage/${key.replace(/^\/+/, "")}`;
+    }
+
+    case "s3": {
+      const clientConfig: Record<string, unknown> = {
+        region: config.region ?? "us-east-1"
+      };
+      if (config.endpoint) {
+        clientConfig.endpoint = config.endpoint;
+        clientConfig.forcePathStyle = true;
+      }
+      const client = new S3Client(clientConfig);
+      const bucket = config.bucket;
+      return async (key: string) => {
+        const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+        return getSignedUrl(client, command, { expiresIn: SIGNED_URL_TTL });
+      };
+    }
+
+    case "supabase": {
+      const supabase = createClient(config.url, config.apiKey);
+      const bucket = config.bucket;
+      return async (key: string) => {
+        const { data, error } = await supabase.storage
+          .from(bucket)
+          .createSignedUrl(key, SIGNED_URL_TTL);
+        if (error || !data) {
+          throw new Error(
+            `Failed to create signed URL for "${key}": ${error?.message ?? "no data"}`
+          );
+        }
+        return data.signedUrl;
+      };
+    }
+  }
+}

--- a/packages/storage/tests/s3-storage.test.ts
+++ b/packages/storage/tests/s3-storage.test.ts
@@ -41,12 +41,7 @@ describe("S3Storage", () => {
 
   beforeEach(() => {
     mockSend.mockReset();
-    storage = new S3Storage(
-      "my-bucket",
-      "http://localhost:9000",
-      "cdn.example.com",
-      "us-west-2"
-    );
+    storage = new S3Storage("my-bucket", "http://localhost:9000", "us-west-2");
   });
 
   describe("upload", () => {
@@ -126,19 +121,8 @@ describe("S3Storage", () => {
   });
 
   describe("getUrl", () => {
-    it("uses domain when set", () => {
-      expect(storage.getUrl("path/to/file.txt")).toBe(
-        "https://cdn.example.com/path/to/file.txt"
-      );
-    });
-
-    it("preserves http prefix on domain", () => {
-      const s = new S3Storage("bucket", undefined, "http://localhost:9000");
-      expect(s.getUrl("file.txt")).toBe("http://localhost:9000/file.txt");
-    });
-
-    it("falls back to S3 URL when no domain", () => {
-      const s = new S3Storage("my-bucket", undefined, undefined, "eu-west-1");
+    it("returns S3 URL with bucket and region", () => {
+      const s = new S3Storage("my-bucket", undefined, "eu-west-1");
       expect(s.getUrl("file.txt")).toBe(
         "https://my-bucket.s3.eu-west-1.amazonaws.com/file.txt"
       );
@@ -151,12 +135,10 @@ describe("S3Storage", () => {
       );
     });
 
-    it("handles keys with special characters", () => {
-      expect(storage.getUrl("path/to/my file.txt")).toBe(
-        "https://cdn.example.com/path/to/my file.txt"
-      );
-      expect(storage.getUrl("a/b/c/d.txt")).toBe(
-        "https://cdn.example.com/a/b/c/d.txt"
+    it("handles nested keys", () => {
+      const s = new S3Storage("bucket", undefined, "us-east-1");
+      expect(s.getUrl("a/b/c/d.txt")).toBe(
+        "https://bucket.s3.us-east-1.amazonaws.com/a/b/c/d.txt"
       );
     });
   });
@@ -284,7 +266,6 @@ describe("S3Storage", () => {
 
   describe("SDK loading caching", () => {
     it("returns the same SDK module reference on repeated loads", async () => {
-      // Two separate S3Storage instances both load the SDK
       const s1 = new S3Storage("bucket-a");
       const s2 = new S3Storage("bucket-b");
 
@@ -292,8 +273,6 @@ describe("S3Storage", () => {
       await s1.upload("a.txt", Buffer.from("a"));
       await s2.upload("b.txt", Buffer.from("b"));
 
-      // The import() mock is called but the caching means S3Client is reused
-      // Both should work without error, proving the cached SDK is functional
       expect(mockSend).toHaveBeenCalledTimes(2);
     });
   });

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -8,7 +8,12 @@ import { gzipSync } from "node:zlib";
 import { mkdir, writeFile, stat, readFile } from "node:fs/promises";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import nodePath from "node:path";
-import { createLogger, buildAssetUrl } from "@nodetool-ai/config";
+import {
+  createLogger,
+  loadAssetStorageConfig,
+  type StorageConfig
+} from "@nodetool-ai/config";
+import { createAssetUrlBuilder } from "@nodetool-ai/storage";
 import { workflowToDsl } from "@nodetool-ai/dsl";
 import {
   Workflow,
@@ -1518,12 +1523,25 @@ interface AssetCreateBody {
   size?: number | null;
 }
 
-export function toAssetResponse(asset: Asset): JsonObject {
+// Lazily initialized URL builder based on the configured storage backend.
+let _httpStorageConfig: StorageConfig | null = null;
+let _httpUrlBuilder: ((key: string) => Promise<string>) | null = null;
+
+function getHttpUrlBuilder(): (key: string) => Promise<string> {
+  const config = loadAssetStorageConfig();
+  if (!_httpUrlBuilder || _httpStorageConfig?.kind !== config.kind) {
+    _httpStorageConfig = config;
+    _httpUrlBuilder = createAssetUrlBuilder(config);
+  }
+  return _httpUrlBuilder;
+}
+
+export async function toAssetResponse(asset: Asset): Promise<JsonObject> {
   const isFolder = asset.content_type === "folder";
   const fileName = isFolder
     ? null
     : getAssetFileName(asset.id, asset.content_type);
-  const getUrl = fileName ? buildAssetUrl(fileName) : null;
+  const getUrl = fileName ? await getHttpUrlBuilder()(fileName) : null;
 
   const hasThumbnail =
     asset.content_type.startsWith("image/") ||
@@ -1639,7 +1657,7 @@ export async function handleAssetsRoot(
       await writeFile(filePath, fileBuffer);
     }
 
-    return jsonResponse(toAssetResponse(asset));
+    return jsonResponse(await toAssetResponse(asset));
   }
 
   return errorResponse(405, "Method not allowed");

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -14,7 +14,11 @@ import nodePath from "node:path";
 import { Buffer } from "node:buffer";
 import { Asset } from "@nodetool-ai/models";
 import type { Asset as AssetModel } from "@nodetool-ai/models";
-import { buildAssetUrl } from "@nodetool-ai/config";
+import {
+  loadAssetStorageConfig,
+  type StorageConfig
+} from "@nodetool-ai/config";
+import { createAssetUrlBuilder } from "@nodetool-ai/storage";
 import {
   getAssetFileName,
   getAssetStoragePath
@@ -42,12 +46,26 @@ import {
   type AssetResponse
 } from "@nodetool-ai/protocol/api-schemas/assets.js";
 
-function toAssetResponse(asset: AssetModel): AssetResponse {
+// Lazily initialized URL builder based on the configured storage backend.
+let _storageConfig: StorageConfig | null = null;
+let _urlBuilder: ((key: string) => Promise<string>) | null = null;
+
+function getUrlBuilder(): (key: string) => Promise<string> {
+  const config = loadAssetStorageConfig();
+  // Recreate if the config kind changed (e.g. test env switching backends).
+  if (!_urlBuilder || _storageConfig?.kind !== config.kind) {
+    _storageConfig = config;
+    _urlBuilder = createAssetUrlBuilder(config);
+  }
+  return _urlBuilder;
+}
+
+async function toAssetResponse(asset: AssetModel): Promise<AssetResponse> {
   const isFolder = asset.content_type === "folder";
   const fileName = isFolder
     ? null
     : getAssetFileName(asset.id, asset.content_type);
-  const getUrl = fileName ? buildAssetUrl(fileName) : null;
+  const getUrl = fileName ? await getUrlBuilder()(fileName) : null;
 
   const hasThumbnail =
     asset.content_type.startsWith("image/") ||
@@ -142,7 +160,7 @@ export const assetsRouter = router({
         limit: input.page_size
       });
       return {
-        assets: assets.map((a) => toAssetResponse(a)),
+        assets: await Promise.all(assets.map((a) => toAssetResponse(a))),
         next: cursor || null
       };
     }),
@@ -274,7 +292,9 @@ export const assetsRouter = router({
     .output(recursiveOutput)
     .query(async ({ ctx, input }) => {
       const assets = await getAllAssetsRecursive(ctx.userId, input.id);
-      return { assets: assets.map((a) => toAssetResponse(a)) };
+      return {
+        assets: await Promise.all(assets.map((a) => toAssetResponse(a)))
+      };
     }),
 
   search: protectedProcedure
@@ -289,7 +309,7 @@ export const assetsRouter = router({
         a.name.toLowerCase().includes(lowerQuery)
       );
       return {
-        assets: matched.map((a) => toAssetResponse(a)),
+        assets: await Promise.all(matched.map((a) => toAssetResponse(a))),
         next_cursor: nextCursor || null,
         total_count: matched.length,
         is_global_search: input.workflow_id === undefined

--- a/packages/websocket/src/trpc/routers/storage.ts
+++ b/packages/websocket/src/trpc/routers/storage.ts
@@ -5,7 +5,11 @@
 import { stat, unlink, readdir } from "node:fs/promises";
 import path from "node:path";
 import { extname } from "node:path";
-import { getDefaultAssetsPath } from "@nodetool-ai/config";
+import {
+  getDefaultAssetsPath,
+  loadAssetStorageConfig
+} from "@nodetool-ai/config";
+import { createAssetUrlBuilder } from "@nodetool-ai/storage";
 
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
@@ -16,7 +20,9 @@ import {
   storageMetadataInput,
   storageMetadataOutput,
   storageDeleteInput,
-  storageDeleteOutput
+  storageDeleteOutput,
+  signUrlInput,
+  signUrlOutput
 } from "@nodetool-ai/protocol/api-schemas/storage.js";
 import { ApiErrorCode } from "@nodetool-ai/protocol/api-schemas/api-error-code.js";
 
@@ -69,6 +75,20 @@ function keyFromPath(rootDir: string, filePath: string): string {
   return path
     .relative(rootDir, filePath)
     .replace(/\\/g, "/");
+}
+
+// ── URL builder (lazy, cached per backend kind) ───────────────────────────────
+
+let _urlBuilder: ((key: string) => Promise<string>) | null = null;
+let _urlBuilderKind: string | null = null;
+
+function getUrlBuilder(): (key: string) => Promise<string> {
+  const config = loadAssetStorageConfig();
+  if (!_urlBuilder || _urlBuilderKind !== config.kind) {
+    _urlBuilderKind = config.kind;
+    _urlBuilder = createAssetUrlBuilder(config);
+  }
+  return _urlBuilder;
 }
 
 // ── Router ────────────────────────────────────────────────────────────────────
@@ -155,6 +175,18 @@ export const storageRouter = router({
       } catch {
         throwApiError(ApiErrorCode.NOT_FOUND, "Object not found");
       }
+    }),
+
+  signUrl: protectedProcedure
+    .input(signUrlInput)
+    .output(signUrlOutput)
+    .query(async ({ input }) => {
+      const validationError = validateStorageKey(input.key);
+      if (validationError) {
+        throwApiError(ApiErrorCode.INVALID_INPUT, validationError);
+      }
+      const url = await getUrlBuilder()(input.key);
+      return { url };
     }),
 
   delete: protectedProcedure

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -38,7 +38,7 @@ import {
   useImageAssets,
   useRevokeBlobUrls,
   useVideoSrc,
-  resolveAssetUri,
+  useSignedUrl,
   getMimeTypeFromUri
 } from "./output";
 import { TextRenderer } from "./output/TextRenderer";
@@ -391,6 +391,16 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
 
   const videoRef = useVideoSrc(type === "video" ? value : undefined);
 
+  // Extract the primary URI from the current value for signing.
+  // memory:// URIs are excluded — they're in-memory only and never stored.
+  const valueUri = useMemo(() => {
+    if (!value || typeof value !== "object") return undefined;
+    const v = value as Record<string, unknown>;
+    if (typeof v.uri === "string" && v.uri && !v.uri.startsWith("memory://")) return v.uri;
+    return undefined;
+  }, [value]);
+  const signedValueUrl = useSignedUrl(valueUri);
+
   const renderContent = useMemo(() => {
     switch (type) {
       case "plotly_config":
@@ -409,7 +419,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         } else {
           let imageSource: string | Uint8Array;
           if (value?.uri && value.uri !== "" && !value.uri.startsWith("memory://")) {
-            imageSource = resolveAssetUri(value.uri);
+            imageSource = signedValueUrl;
           } else if (value?.data instanceof Uint8Array) {
             imageSource = value.data;
           } else if (Array.isArray(value?.data)) {
@@ -426,8 +436,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         let audioSource: string | Uint8Array;
 
         if (value?.uri && value.uri !== "" && !value.uri.startsWith("memory://")) {
-          // Use URI if available (resolve asset:// to /api/storage/)
-          audioSource = resolveAssetUri(value.uri);
+          audioSource = signedValueUrl;
         } else if (Array.isArray(value?.data)) {
           // Convert array of bytes to Uint8Array
           audioSource = new Uint8Array(value.data);
@@ -462,7 +471,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
       case "html": {
         const uri =
           value?.uri && typeof value.uri === "string" && !value.uri.startsWith("memory://")
-            ? resolveAssetUri(value.uri)
+            ? signedValueUrl
             : "";
         if (uri) {
           return (
@@ -501,7 +510,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         const rawUri =
           value?.uri && typeof value.uri === "string" ? value.uri : "";
         const uriFromRef =
-          rawUri && !rawUri.startsWith("memory://") ? resolveAssetUri(rawUri) : "";
+          rawUri && !rawUri.startsWith("memory://") ? signedValueUrl : "";
         const uri = uriFromRef || documentDataPreview.url;
         const mimeType = uriFromRef ? getMimeTypeFromUri(uriFromRef) : undefined;
         const isPdf =
@@ -550,7 +559,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           return <JSONRenderer value={value} showActions={showTextActions} />;
         }
 
-        const url = resolveAssetUri(rawUri);
+        const url = signedValueUrl;
         const format =
           value && typeof value === "object" && typeof (value as Record<string, unknown>).format === "string"
             ? ((value as Record<string, unknown>).format as string)
@@ -940,6 +949,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
   }, [
     value,
     type,
+    signedValueUrl,
     documentDataPreview,
     onDoubleClickAsset,
     videoRef,

--- a/web/src/components/node/ResultPreviewStrip.tsx
+++ b/web/src/components/node/ResultPreviewStrip.tsx
@@ -3,7 +3,7 @@ import React, { memo, useMemo } from "react";
 import { Box } from "@mui/material";
 import { Caption, Tooltip } from "../ui_primitives";
 import { Visibility } from "@mui/icons-material";
-import { typeFor, resolveAssetUri } from "./output";
+import { typeFor, useSignedUrl } from "./output";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 
 interface ResultPreviewStripProps {
@@ -53,32 +53,23 @@ function getResultLabel(value: unknown): string {
 }
 
 /**
- * Extracts a thumbnail image URI from a result, if available.
+ * Extracts the raw asset URI from a result value (no URL resolution).
  */
-function getThumbnailUri(value: unknown): string | null {
+function getRawThumbnailUri(value: unknown): string | null {
   if (!value || typeof value !== "object") return null;
   const v = value as Record<string, unknown>;
 
-  // Direct image result
-  if (v.type === "image" && typeof v.uri === "string") {
-    return resolveAssetUri(v.uri);
+  if (v.type === "image" && typeof v.uri === "string") return v.uri;
+
+  if (v.output && typeof v.output === "object") {
+    const out = v.output as Record<string, unknown>;
+    if (out.type === "image" && typeof out.uri === "string") return out.uri;
   }
 
-  // Result with output that is an image
-  if (
-    v.output &&
-    typeof v.output === "object" &&
-    (v.output as Record<string, unknown>).type === "image"
-  ) {
-    const uri = (v.output as Record<string, unknown>).uri;
-    if (typeof uri === "string") return resolveAssetUri(uri);
-  }
-
-  // Array of images — use first
   if (Array.isArray(value) && value.length > 0) {
     const first = value[0];
     if (first && typeof first === "object" && first.type === "image" && typeof first.uri === "string") {
-      return resolveAssetUri(first.uri);
+      return first.uri;
     }
   }
 
@@ -106,7 +97,8 @@ const ResultPreviewStrip: React.FC<ResultPreviewStripProps> = ({
   }, [result]);
 
   const label = useMemo(() => getResultLabel(unwrapped), [unwrapped]);
-  const thumbnail = useMemo(() => getThumbnailUri(unwrapped), [unwrapped]);
+  const rawThumbnailUri = useMemo(() => getRawThumbnailUri(unwrapped), [unwrapped]);
+  const thumbnail = useSignedUrl(rawThumbnailUri);
 
   if (!label) return null;
 

--- a/web/src/components/node/output/AssetGrid.tsx
+++ b/web/src/components/node/output/AssetGrid.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import { AssetRef } from "../../../stores/ApiTypes";
 import PreviewImageGrid, { ImageSource } from "../PreviewImageGrid";
-import { resolveAssetUri } from "./hooks";
+import { trpc } from "../../../trpc/client";
 
 type Props = {
   values: AssetRef[];
@@ -11,26 +11,55 @@ type Props = {
 /**
  * Type guard to check if an AssetRef is an image type with data/uri
  */
-function isImageValue(item: AssetRef): item is AssetRef & { data?: Uint8Array; uri: string } {
+function isImageValue(item: AssetRef): item is AssetRef & { data?: Uint8Array; uri?: string } {
   return (item as { type?: string }).type === "image" &&
     ("uri" in item || "data" in item);
 }
 
-export const AssetGrid: React.FC<Props> = ({ values, onOpenIndex }) => {
-  // Memoize the expensive filter/map operations to avoid recalculating on every render
-  const images: ImageSource[] = React.useMemo(
-    () =>
-      values
-        .filter(isImageValue)
-        .map((item): ImageSource | undefined =>
-          item.uri
-            ? resolveAssetUri(item.uri)
-            : item.data
-        )
-        .filter((image): image is ImageSource => image !== undefined),
+function extractStorageKey(uri: string | undefined): string | null {
+  if (!uri) return null;
+  if (uri.startsWith("asset://")) return uri.slice("asset://".length);
+  if (uri.startsWith("/api/storage/")) return uri.slice("/api/storage/".length);
+  return null;
+}
+
+/**
+ * Fetches signed URLs for all URI-based image items in a single batch.
+ */
+function useSignedImageSources(
+  items: (AssetRef & { data?: Uint8Array; uri?: string })[]
+): ImageSource[] {
+  const uriItems = items.filter((item) => item.uri);
+  const staleTime = 6 * 24 * 60 * 60 * 1000;
+
+  const results = trpc.useQueries((t) =>
+    uriItems.map((item) =>
+      t.storage.signUrl(
+        { key: extractStorageKey(item.uri) ?? "" },
+        { enabled: Boolean(extractStorageKey(item.uri)), staleTime }
+      )
+    )
+  );
+
+  return items
+    .map((item): ImageSource | undefined => {
+      if (item.uri) {
+        const idx = uriItems.indexOf(item);
+        return results[idx]?.data?.url ?? item.uri;
+      }
+      return item.data;
+    })
+    .filter((img): img is ImageSource => img !== undefined);
+}
+
+const AssetGrid: React.FC<Props> = ({ values, onOpenIndex }) => {
+  const imageItems = React.useMemo(
+    () => values.filter(isImageValue),
     [values]
   );
+  const images = useSignedImageSources(imageItems);
   return <PreviewImageGrid images={images} onDoubleClick={onOpenIndex} />;
 };
 
+export { AssetGrid };
 export default memo(AssetGrid);

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Asset, AssetRef } from "../../../stores/ApiTypes";
 import { BASE_URL } from "../../../stores/BASE_URL";
+import { trpc } from "../../../trpc/client";
 
 /**
  * Base type for typed output values with a type discriminator
@@ -64,6 +65,18 @@ function toUint8Array(
   }
 
   return undefined;
+}
+
+/**
+ * Extracts the storage key from an asset URI.
+ * Handles asset:// and /api/storage/ schemes.
+ * Returns null for other schemes.
+ */
+function extractStorageKey(uri: string | null | undefined): string | null {
+  if (!uri) return null;
+  if (uri.startsWith("asset://")) return uri.slice("asset://".length);
+  if (uri.startsWith("/api/storage/")) return uri.slice("/api/storage/".length);
+  return null;
 }
 
 /**
@@ -142,10 +155,27 @@ export function getMimeTypeFromUri(
   }
 }
 
+/**
+ * Returns the signed URL for an asset URI.
+ * For cloud backends (S3/Supabase), returns a pre-signed URL.
+ * For the local file backend, returns the /api/storage/ URL.
+ * Falls back to resolveAssetUri() while the query is loading.
+ */
+export function useSignedUrl(uri: string | undefined | null): string {
+  const key = extractStorageKey(uri);
+  const { data } = trpc.storage.signUrl.useQuery(
+    { key: key ?? "" },
+    { enabled: Boolean(key), staleTime: 6 * 24 * 60 * 60 * 1000 }
+  );
+  return data?.url ?? resolveAssetUri(uri);
+}
+
 export function useVideoSrc(value: unknown) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const videoValue = value as VideoValue | null;
+  const signedUrl = useSignedUrl(videoValue?.uri);
+
   useEffect(() => {
-    const videoValue = value as VideoValue | null;
     if (videoValue?.type === "video" && videoRef.current) {
       const videoBytes = toUint8Array(videoValue.data);
       if (videoBytes && videoBytes.byteLength > 0) {
@@ -154,10 +184,10 @@ export function useVideoSrc(value: unknown) {
         videoRef.current.src = url;
         return () => URL.revokeObjectURL(url);
       } else if (videoValue.uri) {
-        videoRef.current.src = resolveAssetUri(videoValue.uri);
+        videoRef.current.src = signedUrl;
       }
     }
-  }, [value]);
+  }, [value, signedUrl]);
   return videoRef;
 }
 


### PR DESCRIPTION
- Add packages/storage/src/url-builder.ts: createAssetUrlBuilder() factory
  that returns (key → signed URL) per backend:
  • file: /api/storage/<key> — no signing needed for local dev
  • s3: AWS pre-signed GET URL via @aws-sdk/s3-request-presigner (7-day TTL)
  • supabase: Supabase createSignedUrl (7-day TTL)
- Add @aws-sdk/s3-request-presigner dependency to @nodetool-ai/storage
- Remove domain parameter from S3Storage; getUrl() now returns plain S3 URL
  (signed URLs are generated by createAssetUrlBuilder, not S3Storage)
- Make toAssetResponse() async in http-api.ts and trpc/routers/assets.ts;
  get_url is now produced by the url builder matching the configured backend
- Remove ASSET_DOMAIN / TEMP_DOMAIN domain tests from config/tests/paths.test.ts
  (domains are no longer used)

https://claude.ai/code/session_01NeVAcmMmEp1xgcaBBeGQjQ