### PR TITLE
fix(web): correct BORDER_RADIUS import path in ThreadMessageList

### DIFF
--- a/web/src/components/node/ThreadMessageList.tsx
+++ b/web/src/components/node/ThreadMessageList.tsx
@@ -7,7 +7,7 @@ import { Message, ToolCall } from "../../stores/ApiTypes";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
 import ImageView from "./ImageView";
 import isEqual from "fast-deep-equal";
-import { BORDER_RADIUS } from "../../ui_primitives";
+import { BORDER_RADIUS } from "../ui_primitives";
 
 const styles = (theme: Theme) =>
   css({


### PR DESCRIPTION
The import used `../../ui_primitives` which resolves to `web/src/ui_primitives`
(non-existent), breaking the Docker production build (`vite build`). The
correct relative path from `web/src/components/node/` is `../ui_primitives`.

https://claude.ai/code/session_013xZypBJPqYGEg57Cf5PtM7