### PR TITLE
🎨 Palette: Improve accessibility of SelectionControls and ZoomControls with grouping context

### DIFF
--- a/web/src/components/ui_primitives/SelectionControls.tsx
+++ b/web/src/components/ui_primitives/SelectionControls.tsx
@@ -153,6 +153,8 @@ export const SelectionControls = memo(
               nodrag && editorClassNames.nodrag,
               className
             )}
+            role="group"
+            aria-label="Selection controls"
             sx={{
               display: "flex",
               alignItems: "center",
@@ -198,6 +200,8 @@ export const SelectionControls = memo(
             nodrag && editorClassNames.nodrag,
             className
           )}
+          role="group"
+          aria-label="Selection controls"
           sx={{
             display: "flex",
             alignItems: "center",

--- a/web/src/components/ui_primitives/ZoomControls.tsx
+++ b/web/src/components/ui_primitives/ZoomControls.tsx
@@ -92,7 +92,7 @@ export const ZoomControls: React.FC<ZoomControlsProps> = memo(({
   const containerClassName = `nodrag zoom-controls${className ? ` ${className}` : ""}`;
 
   return (
-    <Box css={styles(theme)} className={containerClassName}>
+    <Box css={styles(theme)} className={containerClassName} role="group" aria-label="Zoom controls">
       <Tooltip title="Zoom out" placement={tooltipPlacement} enterDelay={TOOLTIP_ENTER_DELAY}>
         <span>
           <IconButton

--- a/web/src/components/ui_primitives/__tests__/SelectionControls.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/SelectionControls.test.tsx
@@ -171,4 +171,37 @@ describe("SelectionControls", () => {
     expect(screen.getByText("Select All").closest("button")).toBeDisabled();
     expect(screen.getByText("Clear").closest("button")).toBeDisabled();
   });
+
+  it("has group role and aria-label for accessibility (buttons variant)", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <SelectionControls
+          selectedCount={0}
+          totalCount={10}
+          onSelectAll={mockOnSelectAll}
+          onClear={mockOnClear}
+        />
+      </ThemeProvider>
+    );
+
+    const group = screen.getByRole("group");
+    expect(group).toHaveAttribute("aria-label", "Selection controls");
+  });
+
+  it("has group role and aria-label for accessibility (toggle variant)", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <SelectionControls
+          selectedCount={0}
+          totalCount={10}
+          onSelectAll={mockOnSelectAll}
+          onClear={mockOnClear}
+          variant="toggle"
+        />
+      </ThemeProvider>
+    );
+
+    const group = screen.getByRole("group");
+    expect(group).toHaveAttribute("aria-label", "Selection controls");
+  });
 });

--- a/web/src/components/ui_primitives/__tests__/ZoomControls.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ZoomControls.test.tsx
@@ -217,6 +217,17 @@ describe("ZoomControls", () => {
     expect(buttons[2]).toHaveAttribute("aria-label", "Reset zoom");
   });
 
+  it("has group role and aria-label for accessibility", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <ZoomControls zoom={1} onZoomChange={mockOnZoomChange} />
+      </ThemeProvider>
+    );
+
+    const group = screen.getByRole("group");
+    expect(group).toHaveAttribute("aria-label", "Zoom controls");
+  });
+
   it("applies custom className", () => {
     render(
       <ThemeProvider theme={mockTheme}>


### PR DESCRIPTION
### 💡 What
Added `role="group"` and `aria-label` attributes to the wrapper `<Box>` components in `ZoomControls.tsx` and `SelectionControls.tsx`. Also added unit tests to verify these attributes.

### 🎯 Why
When grouping related UI controls or icon buttons in a container, applying `role="group"` and an appropriate `aria-label` provides structural context for screen reader users navigating the group, significantly improving accessibility.

### ♿ Accessibility
- Added `role="group"` and `aria-label="Selection controls"` to the `SelectionControls` container.
- Added `role="group"` and `aria-label="Zoom controls"` to the `ZoomControls` container.
- These structural groupings help screen readers understand the relationship between the related buttons.

---
*PR created automatically by Jules for task [12841762811099062164](https://jules.google.com/task/12841762811099062164) started by @georgi*