### PR TITLE
Add libsecret build module for keytar native dependency

### DIFF
--- a/electron/ai.nodetool.NodeTool.flatpak.yml
+++ b/electron/ai.nodetool.NodeTool.flatpak.yml
@@ -66,6 +66,28 @@ finish-args:
 
 # Build modules
 modules:
+  # libsecret: required by the `keytar` native module that our security package
+  # uses for system keychain access. The Freedesktop SDK 24.08 does not ship
+  # libsecret development files, so the keytar prebuild fallback (`node-gyp
+  # rebuild`) fails with `Package 'libsecret-1' not found`. Building libsecret
+  # here provides both the .pc file at build time and the runtime .so.
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dmanpage=false
+      - -Dvapi=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+      - -Dgcrypt=false
+      - -Dtpm2=disabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz
+        sha256: 163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20
+
   # Node.js runtime required to build the web frontend and electron app.
   # Installed as a build-time dependency only (cleanup removes it from the final app).
   - name: nodejs


### PR DESCRIPTION
## Summary
Added libsecret as a build module to the Flatpak manifest to resolve native module compilation failures for the keytar package used by the security layer.

## Changes
- Added libsecret 0.21.4 as a Meson-based build module in the Flatpak configuration
- Configured libsecret with minimal dependencies (disabled manpage, vapi, gtk_doc, introspection, gcrypt, and tpm2)
- Set up cleanup rules to remove development files from the final runtime image while preserving the required .so library

## Details
The Freedesktop SDK 24.08 does not include libsecret development files, causing the keytar native module's prebuild fallback (`node-gyp rebuild`) to fail with "Package 'libsecret-1' not found". By building libsecret as part of the Flatpak build process, we ensure both the .pc file is available at build time for keytar compilation and the runtime .so library is available in the final application image.

https://claude.ai/code/session_01TQGWJGQrib4S3sPSX7D6KK