### PR TITLE
Add BM25 full-text search index for improved node ranking

### DIFF
--- a/web/src/utils/__tests__/bm25.test.ts
+++ b/web/src/utils/__tests__/bm25.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ */
+import { BM25Index, buildNodeBM25Index, tokenize } from "../bm25";
+import { NodeMetadata } from "../../stores/ApiTypes";
+
+const baseNode = (
+  overrides: Partial<NodeMetadata> & Pick<NodeMetadata, "node_type" | "title" | "namespace">
+): NodeMetadata =>
+  ({
+    description: "",
+    properties: [],
+    outputs: [],
+    layout: "default",
+    recommended_models: [],
+    basic_fields: [],
+    is_dynamic: false,
+    expose_as_tool: false,
+    supports_dynamic_outputs: false,
+    is_streaming_output: false,
+    required_settings: [],
+    ...overrides
+  }) as NodeMetadata;
+
+describe("bm25 tokenize", () => {
+  it("lowercases and splits on punctuation/whitespace", () => {
+    expect(tokenize("Hello, World! foo_bar.baz/qux")).toEqual([
+      "hello",
+      "world",
+      "foo",
+      "bar",
+      "baz",
+      "qux"
+    ]);
+  });
+
+  it("drops single-character tokens", () => {
+    expect(tokenize("a big DOG")).toEqual(["big", "dog"]);
+  });
+
+  it("handles empty input", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+});
+
+describe("BM25Index", () => {
+  it("ranks docs containing the term higher than those that don't", () => {
+    const index = new BM25Index([{ name: "text", weight: 1 }]);
+    index.index([
+      { id: "a", fields: { text: "alpha beta gamma" } },
+      { id: "b", fields: { text: "delta epsilon" } },
+      { id: "c", fields: { text: "alpha alpha beta" } }
+    ]);
+    const results = index.search("alpha");
+    expect(results.map((r) => r.id)).toEqual(["c", "a"]);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it("weights fields differently", () => {
+    const index = new BM25Index([
+      { name: "title", weight: 5 },
+      { name: "body", weight: 1 }
+    ]);
+    index.index([
+      { id: "title-match", fields: { title: "kittens", body: "" } },
+      { id: "body-match", fields: { title: "", body: "kittens" } }
+    ]);
+    const results = index.search("kittens");
+    expect(results[0].id).toBe("title-match");
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it("applies IDF: rare terms outweigh common ones", () => {
+    const index = new BM25Index([{ name: "text", weight: 1 }]);
+    index.index([
+      { id: "1", fields: { text: "common common common rare" } },
+      { id: "2", fields: { text: "common common common" } },
+      { id: "3", fields: { text: "common common" } },
+      { id: "4", fields: { text: "common" } }
+    ]);
+    const rareTopHit = index.search("rare")[0];
+    const commonTopHit = index.search("common")[0];
+    expect(rareTopHit.id).toBe("1");
+    // Rare term match should outscore the best "common" match.
+    expect(rareTopHit.score).toBeGreaterThan(commonTopHit.score);
+  });
+
+  it("returns empty for unknown terms or empty queries", () => {
+    const index = new BM25Index([{ name: "text", weight: 1 }]);
+    index.index([{ id: "a", fields: { text: "hello" } }]);
+    expect(index.search("zzz")).toEqual([]);
+    expect(index.search("")).toEqual([]);
+  });
+
+  it("respects the limit parameter", () => {
+    const index = new BM25Index([{ name: "text", weight: 1 }]);
+    index.index([
+      { id: "1", fields: { text: "foo" } },
+      { id: "2", fields: { text: "foo foo" } },
+      { id: "3", fields: { text: "foo foo foo" } }
+    ]);
+    expect(index.search("foo", 2)).toHaveLength(2);
+  });
+});
+
+describe("buildNodeBM25Index", () => {
+  const nodes: NodeMetadata[] = [
+    baseNode({
+      node_type: "math.add",
+      title: "Add",
+      namespace: "math",
+      description: "Adds two numbers together"
+    }),
+    baseNode({
+      node_type: "math.subtract",
+      title: "Subtract",
+      namespace: "math",
+      description: "Subtracts one number from another"
+    }),
+    baseNode({
+      node_type: "string.concat",
+      title: "Concatenate",
+      namespace: "string",
+      description: "Joins strings together"
+    })
+  ];
+
+  it("ranks title matches above description-only matches", () => {
+    const index = buildNodeBM25Index(nodes);
+    const results = index.search("add");
+    expect(results[0].id).toBe("math.add");
+  });
+
+  it("matches description tokens", () => {
+    const index = buildNodeBM25Index(nodes);
+    const results = index.search("strings");
+    expect(results.map((r) => r.id)).toContain("string.concat");
+  });
+
+  it("uses extra fields (tags, use_cases) when supplied", () => {
+    const extras = new Map<string, { tags: string; useCases: string }>();
+    extras.set("math.add", { tags: "arithmetic, sum", useCases: "" });
+    const index = buildNodeBM25Index(nodes, extras);
+    const results = index.search("arithmetic");
+    expect(results[0]?.id).toBe("math.add");
+  });
+});

--- a/web/src/utils/__tests__/bm25.test.ts
+++ b/web/src/utils/__tests__/bm25.test.ts
@@ -92,6 +92,19 @@ describe("BM25Index", () => {
     expect(index.search("")).toEqual([]);
   });
 
+  it("resets internal state when index() is called again", () => {
+    const index = new BM25Index([{ name: "text", weight: 1 }]);
+    index.index([
+      { id: "a", fields: { text: "alpha" } },
+      { id: "b", fields: { text: "beta" } }
+    ]);
+    // Re-index with a different doc set; old terms must not linger.
+    index.index([{ id: "c", fields: { text: "gamma" } }]);
+    expect(index.search("alpha")).toEqual([]);
+    expect(index.search("beta")).toEqual([]);
+    expect(index.search("gamma").map((r) => r.id)).toEqual(["c"]);
+  });
+
   it("respects the limit parameter", () => {
     const index = new BM25Index([{ name: "text", weight: 1 }]);
     index.index([
@@ -138,10 +151,61 @@ describe("buildNodeBM25Index", () => {
   });
 
   it("uses extra fields (tags, use_cases) when supplied", () => {
-    const extras = new Map<string, { tags: string; useCases: string }>();
-    extras.set("math.add", { tags: "arithmetic, sum", useCases: "" });
+    const extras = new Map<
+      string,
+      { description: string; tags: string; useCases: string }
+    >();
+    extras.set("math.add", {
+      description: "Adds two numbers together",
+      tags: "arithmetic, sum",
+      useCases: ""
+    });
     const index = buildNodeBM25Index(nodes, extras);
     const results = index.search("arithmetic");
     expect(results[0]?.id).toBe("math.add");
+  });
+
+  it("does not double-index tags/use-cases via the description field", () => {
+    // Real NodeMetadata.description is multi-line: line 1 = description,
+    // line 2 = tags, then a "Use cases:" section. The cleaned description
+    // (line 1 only) should be used for the description field; tags and
+    // use_cases must come exclusively from extraFields.
+    const node = baseNode({
+      node_type: "image.blur",
+      title: "Blur",
+      namespace: "image",
+      description:
+        "Applies a Gaussian blur to an image.\n" +
+        "filter, gaussian, smoothing\n" +
+        "Use cases:\n" +
+        "- Reduce noise in photos\n" +
+        "- Soften backgrounds"
+    });
+    const extras = new Map<
+      string,
+      { description: string; tags: string; useCases: string }
+    >();
+    extras.set("image.blur", {
+      description: "Applies a Gaussian blur to an image.",
+      tags: "filter, gaussian, smoothing",
+      useCases: "Reduce noise in photos\nSoften backgrounds"
+    });
+
+    const index = buildNodeBM25Index([node], extras);
+
+    // Tag terms still match (via the dedicated `tags` field) ...
+    expect(index.search("gaussian")[0]?.id).toBe("image.blur");
+    // ... and use-case terms still match (via the dedicated `use_cases` field).
+    expect(index.search("noise")[0]?.id).toBe("image.blur");
+    // The cleaned description must not contain the "Use cases:" label
+    // or tag tokens — verify by indexing without extras and confirming
+    // tag terms only match when extras are supplied.
+    const indexNoExtras = buildNodeBM25Index([node]);
+    // Without extras, the raw description leaks tags into description-only
+    // search. With extras, the dedicated tags field produces a higher score
+    // due to its higher weight (1.5 vs 0.8).
+    const withExtras = index.search("gaussian")[0]?.score ?? 0;
+    const withoutExtras = indexNoExtras.search("gaussian")[0]?.score ?? 0;
+    expect(withExtras).toBeGreaterThan(withoutExtras);
   });
 });

--- a/web/src/utils/bm25.ts
+++ b/web/src/utils/bm25.ts
@@ -1,0 +1,186 @@
+import { NodeMetadata } from "../stores/ApiTypes";
+
+/**
+ * BM25F-style multi-field index.
+ *
+ * Score for term t in doc d:
+ *   IDF(t) * Σ_field weight_f * tf_f(d,t)*(k1+1) / (tf_f(d,t) + k1*(1 - b + b*dl_f/avgdl_f))
+ *
+ * IDF uses the Lucene/BM25+ smoothed form:
+ *   log( (N - df + 0.5) / (df + 0.5) + 1 )
+ */
+
+export interface BM25Field {
+  name: string;
+  weight: number;
+}
+
+export interface BM25Doc {
+  id: string;
+  fields: Record<string, string>;
+}
+
+export interface BM25Result {
+  id: string;
+  score: number;
+}
+
+interface FieldStats {
+  avgLen: number;
+  docLens: Map<string, number>;
+}
+
+const TOKEN_SPLIT = /[\s.,;:!?\-_/(){}\[\]"'`<>@#$%^&*+=|\\~]+/;
+
+export function tokenize(text: string): string[] {
+  if (!text || typeof text !== "string") return [];
+  const out: string[] = [];
+  for (const part of text.toLowerCase().split(TOKEN_SPLIT)) {
+    if (part.length >= 2) out.push(part);
+  }
+  return out;
+}
+
+export class BM25Index {
+  private readonly fields: BM25Field[];
+  private readonly k1: number;
+  private readonly b: number;
+  private docCount = 0;
+  // field -> stats (avg length + per-doc length)
+  private fieldStats = new Map<string, FieldStats>();
+  // term -> field -> docId -> tf
+  private postings = new Map<string, Map<string, Map<string, number>>>();
+  // term -> document frequency (number of docs containing the term in any field)
+  private docFreq = new Map<string, number>();
+
+  constructor(fields: BM25Field[], k1 = 1.5, b = 0.75) {
+    this.fields = fields;
+    this.k1 = k1;
+    this.b = b;
+  }
+
+  index(docs: BM25Doc[]): void {
+    this.docCount = docs.length;
+    const fieldLenSums = new Map<string, number>();
+    for (const f of this.fields) {
+      this.fieldStats.set(f.name, { avgLen: 0, docLens: new Map() });
+      fieldLenSums.set(f.name, 0);
+    }
+
+    for (const doc of docs) {
+      const docTerms = new Set<string>();
+      for (const f of this.fields) {
+        const tokens = tokenize(doc.fields[f.name] ?? "");
+        const stats = this.fieldStats.get(f.name)!;
+        stats.docLens.set(doc.id, tokens.length);
+        fieldLenSums.set(
+          f.name,
+          (fieldLenSums.get(f.name) ?? 0) + tokens.length
+        );
+
+        const tfMap = new Map<string, number>();
+        for (const tok of tokens) tfMap.set(tok, (tfMap.get(tok) ?? 0) + 1);
+
+        for (const [tok, tf] of tfMap) {
+          let perField = this.postings.get(tok);
+          if (!perField) {
+            perField = new Map();
+            this.postings.set(tok, perField);
+          }
+          let perDoc = perField.get(f.name);
+          if (!perDoc) {
+            perDoc = new Map();
+            perField.set(f.name, perDoc);
+          }
+          perDoc.set(doc.id, tf);
+          docTerms.add(tok);
+        }
+      }
+      for (const tok of docTerms) {
+        this.docFreq.set(tok, (this.docFreq.get(tok) ?? 0) + 1);
+      }
+    }
+
+    for (const f of this.fields) {
+      const stats = this.fieldStats.get(f.name)!;
+      const sum = fieldLenSums.get(f.name) ?? 0;
+      stats.avgLen = this.docCount > 0 ? sum / this.docCount : 0;
+    }
+  }
+
+  /**
+   * Score every doc for the given query terms. Terms are lowercased and
+   * filtered to length >= 2; multi-word phrases should be tokenized first.
+   */
+  search(query: string, limit = 0): BM25Result[] {
+    const terms = tokenize(query);
+    if (terms.length === 0 || this.docCount === 0) return [];
+    const scores = new Map<string, number>();
+
+    for (const term of terms) {
+      const df = this.docFreq.get(term);
+      if (!df) continue;
+      const idf = Math.log((this.docCount - df + 0.5) / (df + 0.5) + 1);
+      const perField = this.postings.get(term);
+      if (!perField) continue;
+
+      for (const f of this.fields) {
+        const perDoc = perField.get(f.name);
+        if (!perDoc) continue;
+        const stats = this.fieldStats.get(f.name)!;
+        const avgLen = stats.avgLen || 1;
+        for (const [docId, tf] of perDoc) {
+          const dl = stats.docLens.get(docId) ?? 0;
+          const norm = 1 - this.b + this.b * (dl / avgLen);
+          const tfScore = (tf * (this.k1 + 1)) / (tf + this.k1 * norm);
+          scores.set(
+            docId,
+            (scores.get(docId) ?? 0) + idf * tfScore * f.weight
+          );
+        }
+      }
+    }
+
+    const sorted: BM25Result[] = [];
+    for (const [id, score] of scores) sorted.push({ id, score });
+    sorted.sort((a, b) => b.score - a.score);
+    return limit > 0 ? sorted.slice(0, limit) : sorted;
+  }
+}
+
+/**
+ * Build a BM25 index over node metadata. Field weights are tuned to mirror
+ * the existing prefix-tree weights: title is the strongest signal, then
+ * namespace/tags, then description.
+ */
+export function buildNodeBM25Index(
+  nodes: readonly NodeMetadata[],
+  extraFields?: ReadonlyMap<string, { tags: string; useCases: string }>
+): BM25Index {
+  const index = new BM25Index([
+    { name: "title", weight: 4.0 },
+    { name: "node_type", weight: 2.5 },
+    { name: "namespace", weight: 1.5 },
+    { name: "tags", weight: 1.5 },
+    { name: "description", weight: 0.8 },
+    { name: "use_cases", weight: 0.6 }
+  ]);
+
+  const docs: BM25Doc[] = nodes.map((node) => {
+    const extras = extraFields?.get(node.node_type);
+    return {
+      id: node.node_type,
+      fields: {
+        title: node.title ?? "",
+        node_type: node.node_type ?? "",
+        namespace: node.namespace ?? "",
+        tags: extras?.tags ?? "",
+        description: node.description ?? "",
+        use_cases: extras?.useCases ?? ""
+      }
+    };
+  });
+
+  index.index(docs);
+  return index;
+}

--- a/web/src/utils/bm25.ts
+++ b/web/src/utils/bm25.ts
@@ -60,7 +60,11 @@ export class BM25Index {
   }
 
   index(docs: BM25Doc[]): void {
+    // Reset prior state so the same instance can be re-indexed safely.
     this.docCount = docs.length;
+    this.fieldStats.clear();
+    this.postings.clear();
+    this.docFreq.clear();
     const fieldLenSums = new Map<string, number>();
     for (const f of this.fields) {
       this.fieldStats.set(f.name, { avgLen: 0, docLens: new Map() });
@@ -109,8 +113,9 @@ export class BM25Index {
   }
 
   /**
-   * Score every doc for the given query terms. Terms are lowercased and
-   * filtered to length >= 2; multi-word phrases should be tokenized first.
+   * Score every doc for the query. The query is tokenized internally with
+   * the same tokenizer used at index time (lowercased, split on punctuation,
+   * tokens shorter than 2 chars dropped).
    */
   search(query: string, limit = 0): BM25Result[] {
     const terms = tokenize(query);
@@ -148,14 +153,30 @@ export class BM25Index {
   }
 }
 
+export interface NodeBM25Extras {
+  /** Cleaned description (first line / body only — no tags or use-cases). */
+  description?: string;
+  /** Comma-joined tag list, parsed from line 2 of the raw description. */
+  tags?: string;
+  /** Use-cases section text, extracted from the raw description. */
+  useCases?: string;
+}
+
 /**
  * Build a BM25 index over node metadata. Field weights are tuned to mirror
  * the existing prefix-tree weights: title is the strongest signal, then
  * namespace/tags, then description.
+ *
+ * NodeMetadata.description in this codebase is multi-line: line 1 is the
+ * description, line 2 is a comma-separated tag list, and a "Use cases:"
+ * section may follow. To avoid double-counting tag/use-case terms (which
+ * are also indexed via dedicated fields), callers should pass cleaned
+ * `description` text in `extraFields` — typically from
+ * `formatNodeDocumentation(node.description)`.
  */
 export function buildNodeBM25Index(
   nodes: readonly NodeMetadata[],
-  extraFields?: ReadonlyMap<string, { tags: string; useCases: string }>
+  extraFields?: ReadonlyMap<string, NodeBM25Extras>
 ): BM25Index {
   const index = new BM25Index([
     { name: "title", weight: 4.0 },
@@ -168,6 +189,9 @@ export function buildNodeBM25Index(
 
   const docs: BM25Doc[] = nodes.map((node) => {
     const extras = extraFields?.get(node.node_type);
+    // Prefer the cleaned description from extras; fall back to the raw
+    // metadata only when no extras are supplied (e.g. unit tests).
+    const description = extras?.description ?? node.description ?? "";
     return {
       id: node.node_type,
       fields: {
@@ -175,7 +199,7 @@ export function buildNodeBM25Index(
         node_type: node.node_type ?? "",
         namespace: node.namespace ?? "",
         tags: extras?.tags ?? "",
-        description: node.description ?? "",
+        description,
         use_cases: extras?.useCases ?? ""
       }
     };

--- a/web/src/utils/bm25.ts
+++ b/web/src/utils/bm25.ts
@@ -30,7 +30,7 @@ interface FieldStats {
   docLens: Map<string, number>;
 }
 
-const TOKEN_SPLIT = /[\s.,;:!?\-_/(){}\[\]"'`<>@#$%^&*+=|\\~]+/;
+const TOKEN_SPLIT = /[\s.,;:!?\-_/(){}[\]"'`<>@#$%^&*+=|\\~]+/;
 
 export function tokenize(text: string): string[] {
   if (!text || typeof text !== "string") return [];

--- a/web/src/utils/nodeSearch.ts
+++ b/web/src/utils/nodeSearch.ts
@@ -106,16 +106,33 @@ let globalPrefixTreeNodesHash: string = "";
 let globalBM25Index: BM25Index | null = null;
 let globalBM25NodesHash: string = "";
 
+// Hash that detects changes to any indexed field, not just the node_type set.
+// Description length is included as a cheap proxy — full strings would bloat
+// the hash, but length changes catch most catalog edits in practice.
+function computeNodesHash(nodes: NodeMetadata[]): string {
+  const parts = nodes.map(
+    (n) =>
+      `${n.node_type}|${n.title ?? ""}|${n.namespace ?? ""}|${
+        (n.description ?? "").length
+      }`
+  );
+  parts.sort();
+  return parts.join(",");
+}
+
 function ensureBM25Index(nodes: NodeMetadata[]): BM25Index {
-  const nodesHash = nodes
-    .map((n) => n.node_type)
-    .sort()
-    .join(",");
+  const nodesHash = computeNodesHash(nodes);
   if (!globalBM25Index || globalBM25NodesHash !== nodesHash) {
-    const extras = new Map<string, { tags: string; useCases: string }>();
+    const extras = new Map<
+      string,
+      { description: string; tags: string; useCases: string }
+    >();
     for (const node of nodes) {
-      const { tags, useCases } = formatNodeDocumentation(node.description);
+      const { description, tags, useCases } = formatNodeDocumentation(
+        node.description
+      );
       extras.set(node.node_type, {
+        description,
         tags: tags.join(", "),
         useCases: useCases.raw
       });
@@ -131,11 +148,9 @@ function ensureBM25Index(nodes: NodeMetadata[]): BM25Index {
  * Uses a hash of node types to detect when re-indexing is needed
  */
 function ensurePrefixTree(nodes: NodeMetadata[]): PrefixTreeSearch {
-  // Create a hash of the nodes to detect changes
-  const nodesHash = nodes
-    .map((n) => n.node_type)
-    .sort()
-    .join(",");
+  // Hash includes title/namespace/description-length so the tree rebuilds
+  // when indexed fields change, not only when the node_type set changes.
+  const nodesHash = computeNodesHash(nodes);
 
   // Check if we need to rebuild the tree
   if (!globalPrefixTree || globalPrefixTreeNodesHash !== nodesHash) {

--- a/web/src/utils/nodeSearch.ts
+++ b/web/src/utils/nodeSearch.ts
@@ -10,6 +10,7 @@ import { PrefixTreeSearch, SearchField } from "./PrefixTreeSearch";
 import { getProviderKindForNamespace } from "./nodeProvider";
 import { rankNodeMetadata, searchTermsFromQuery } from "./nodeRanking";
 import { QUICK_ACTION_NODE_TYPES } from "../config/quickActionNodeTypes";
+import { BM25Index, buildNodeBM25Index } from "./bm25";
 
 /** Stop words to filter from multi-word queries */
 const QUERY_STOP_WORDS = new Set([
@@ -100,6 +101,30 @@ const addCandidateBoost = (
 // Cache is keyed by the metadata array to enable proper reuse
 let globalPrefixTree: PrefixTreeSearch | null = null;
 let globalPrefixTreeNodesHash: string = "";
+
+// Global BM25 index, cached alongside the prefix tree.
+let globalBM25Index: BM25Index | null = null;
+let globalBM25NodesHash: string = "";
+
+function ensureBM25Index(nodes: NodeMetadata[]): BM25Index {
+  const nodesHash = nodes
+    .map((n) => n.node_type)
+    .sort()
+    .join(",");
+  if (!globalBM25Index || globalBM25NodesHash !== nodesHash) {
+    const extras = new Map<string, { tags: string; useCases: string }>();
+    for (const node of nodes) {
+      const { tags, useCases } = formatNodeDocumentation(node.description);
+      extras.set(node.node_type, {
+        tags: tags.join(", "),
+        useCases: useCases.raw
+      });
+    }
+    globalBM25Index = buildNodeBM25Index(nodes, extras);
+    globalBM25NodesHash = nodesHash;
+  }
+  return globalBM25Index;
+}
 
 /**
  * Initialize or update the global prefix tree with node metadata
@@ -540,6 +565,33 @@ function collectFuseCandidateBoosts(
   return boosts;
 }
 
+/**
+ * BM25-based candidate boosts. Acts as the primary fuzzy/relevance signal
+ * for queries the prefix tree can't satisfy on its own — full-text term
+ * matches in title/namespace/tags/description with proper IDF weighting.
+ */
+const BM25_BOOST_SCALE = 1.5;
+const BM25_MIN_TERM_LENGTH = 2;
+
+function collectBM25CandidateBoosts(
+  nodes: NodeMetadata[],
+  terms: string[]
+): Map<string, number> {
+  const boosts = new Map<string, number>();
+  const normalizedTerms = terms
+    .map((t) => t.trim())
+    .filter((t) => t.length >= BM25_MIN_TERM_LENGTH);
+  if (normalizedTerms.length === 0 || nodes.length === 0) return boosts;
+
+  const index = ensureBM25Index(nodes);
+  for (const term of normalizedTerms) {
+    for (const result of index.search(term, 200)) {
+      addCandidateBoost(boosts, result.id, result.score * BM25_BOOST_SCALE);
+    }
+  }
+  return boosts;
+}
+
 const mergeCandidateBoosts = (
   target: Map<string, number>,
   source: Map<string, number>
@@ -567,6 +619,16 @@ export function rankSearchNodes(
     ? collectPrefixCandidateBoosts(nodes, expandedSearchTerms)
     : new Map<string, number>();
 
+  // Always merge BM25 scores when there's a query. BM25 catches fuzzy/term
+  // matches the prefix tree misses (e.g. queries that match description
+  // words mid-phrase) and provides principled IDF weighting.
+  if (term.trim()) {
+    mergeCandidateBoosts(
+      candidateBoosts,
+      collectBM25CandidateBoosts(nodes, expandedSearchTerms)
+    );
+  }
+
   let ranked = rankNodeMetadata(nodes, expandedSearchTerms, {
     boostedNodeTypes,
     candidateBoosts,
@@ -575,6 +637,8 @@ export function rankSearchNodes(
     recentNodeTypes
   });
 
+  // Fall back to Fuse only if BM25 + prefix didn't surface enough results
+  // (e.g. typo-tolerant fuzzy matches that BM25 won't catch).
   if (term.trim().length >= MIN_FUSE_QUERY_LENGTH && ranked.length < MIN_RESULTS_BEFORE_FUSE) {
     mergeCandidateBoosts(
       candidateBoosts,

--- a/web/src/utils/nodeSearch.ts
+++ b/web/src/utils/nodeSearch.ts
@@ -97,73 +97,88 @@ const addCandidateBoost = (
   boosts.set(nodeType, Math.max(boosts.get(nodeType) ?? 0, boost));
 };
 
-// Global prefix tree instance for fast prefix searches
-// Cache is keyed by the metadata array to enable proper reuse
+// Cached search indexes. Both the prefix tree and BM25 index are rebuilt
+// together when the metadata changes, so they share a single hash check.
 let globalPrefixTree: PrefixTreeSearch | null = null;
-let globalPrefixTreeNodesHash: string = "";
-
-// Global BM25 index, cached alongside the prefix tree.
 let globalBM25Index: BM25Index | null = null;
-let globalBM25NodesHash: string = "";
+let globalIndexesHash: string = "";
 
-// Hash that detects changes to any indexed field, not just the node_type set.
-// Description length is included as a cheap proxy — full strings would bloat
-// the hash, but length changes catch most catalog edits in practice.
+// WeakMap memo so we don't re-hash the metadata array on every keystroke
+// when the caller passes the same array reference (the common case).
+const HASH_CACHE = new WeakMap<readonly NodeMetadata[], string>();
+
+const PREFIX_TREE_FIELDS: SearchField[] = [
+  { field: "title", weight: 1.0 },
+  { field: "namespace", weight: 0.8 },
+  { field: "description", weight: 0.4 }
+];
+
+// Content hash over node_type/title/namespace/description-length. Order-
+// sensitive (filter results preserve catalog order, so omitting the sort is
+// safe). Memoized by array reference for ref-stable callers.
 function computeNodesHash(nodes: NodeMetadata[]): string {
+  const cached = HASH_CACHE.get(nodes);
+  if (cached !== undefined) return cached;
   const parts = nodes.map(
     (n) =>
       `${n.node_type}|${n.title ?? ""}|${n.namespace ?? ""}|${
         (n.description ?? "").length
       }`
   );
-  parts.sort();
-  return parts.join(",");
-}
-
-function ensureBM25Index(nodes: NodeMetadata[]): BM25Index {
-  const nodesHash = computeNodesHash(nodes);
-  if (!globalBM25Index || globalBM25NodesHash !== nodesHash) {
-    const extras = new Map<
-      string,
-      { description: string; tags: string; useCases: string }
-    >();
-    for (const node of nodes) {
-      const { description, tags, useCases } = formatNodeDocumentation(
-        node.description
-      );
-      extras.set(node.node_type, {
-        description,
-        tags: tags.join(", "),
-        useCases: useCases.raw
-      });
-    }
-    globalBM25Index = buildNodeBM25Index(nodes, extras);
-    globalBM25NodesHash = nodesHash;
-  }
-  return globalBM25Index;
+  const hash = parts.join(",");
+  HASH_CACHE.set(nodes, hash);
+  return hash;
 }
 
 /**
- * Initialize or update the global prefix tree with node metadata
- * Uses a hash of node types to detect when re-indexing is needed
+ * Build (or reuse) both the prefix tree and BM25 index for the given node
+ * set. Hashing and `formatNodeDocumentation` parsing happen once per
+ * rebuild — both indexes consume the same parsed extras.
  */
-function ensurePrefixTree(nodes: NodeMetadata[]): PrefixTreeSearch {
-  // Hash includes title/namespace/description-length so the tree rebuilds
-  // when indexed fields change, not only when the node_type set changes.
+function ensureIndexes(nodes: NodeMetadata[]): {
+  prefixTree: PrefixTreeSearch;
+  bm25: BM25Index;
+} {
   const nodesHash = computeNodesHash(nodes);
-
-  // Check if we need to rebuild the tree
-  if (!globalPrefixTree || globalPrefixTreeNodesHash !== nodesHash) {
-    const searchFields: SearchField[] = [
-      { field: "title", weight: 1.0 },
-      { field: "namespace", weight: 0.8 },
-      { field: "description", weight: 0.4 }
-    ];
-    globalPrefixTree = new PrefixTreeSearch(searchFields);
-    globalPrefixTree.indexNodes(nodes);
-    globalPrefixTreeNodesHash = nodesHash;
+  if (
+    globalPrefixTree &&
+    globalBM25Index &&
+    globalIndexesHash === nodesHash
+  ) {
+    return { prefixTree: globalPrefixTree, bm25: globalBM25Index };
   }
-  return globalPrefixTree;
+
+  const extras = new Map<
+    string,
+    { description: string; tags: string; useCases: string }
+  >();
+  for (const node of nodes) {
+    const { description, tags, useCases } = formatNodeDocumentation(
+      node.description
+    );
+    extras.set(node.node_type, {
+      description,
+      tags: tags.join(", "),
+      useCases: useCases.raw
+    });
+  }
+
+  const prefixTree = new PrefixTreeSearch(PREFIX_TREE_FIELDS);
+  prefixTree.indexNodes(nodes);
+  const bm25 = buildNodeBM25Index(nodes, extras);
+
+  globalPrefixTree = prefixTree;
+  globalBM25Index = bm25;
+  globalIndexesHash = nodesHash;
+  return { prefixTree, bm25 };
+}
+
+function ensureBM25Index(nodes: NodeMetadata[]): BM25Index {
+  return ensureIndexes(nodes).bm25;
+}
+
+function ensurePrefixTree(nodes: NodeMetadata[]): PrefixTreeSearch {
+  return ensureIndexes(nodes).prefixTree;
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements a BM25 full-text search index to improve node search relevance and ranking. The BM25 algorithm provides principled term frequency-inverse document frequency (TF-IDF) scoring across multiple fields, complementing the existing prefix-tree and fuzzy search approaches.

## Key Changes
- **New BM25 implementation** (`web/src/utils/bm25.ts`):
  - `BM25Index` class implementing BM25F multi-field scoring with configurable field weights
  - `tokenize()` function for consistent text preprocessing (lowercasing, punctuation splitting, minimum length filtering)
  - `buildNodeBM25Index()` helper to construct an index from node metadata with tuned field weights (title: 4.0, node_type: 2.5, namespace/tags: 1.5, description: 0.8, use_cases: 0.6)
  - Support for extra fields (tags, use cases) via optional parameter

- **Comprehensive test coverage** (`web/src/utils/__tests__/bm25.test.ts`):
  - Tokenization tests (lowercasing, punctuation handling, single-char filtering)
  - BM25 ranking tests (term frequency, field weighting, IDF weighting)
  - Integration tests with node metadata

- **Integration into search pipeline** (`web/src/utils/nodeSearch.ts`):
  - Global BM25 index caching with hash-based invalidation (mirrors existing prefix-tree pattern)
  - `collectBM25CandidateBoosts()` function to generate relevance scores for all query terms
  - BM25 scores merged into candidate boosts alongside prefix-tree results
  - Fuse fuzzy search now acts as fallback only when BM25 + prefix tree don't surface enough results

## Implementation Details
- BM25 uses Lucene/BM25+ smoothed IDF formula: `log((N - df + 0.5) / (df + 0.5) + 1)`
- Field weights tuned to mirror existing prefix-tree signal strength (title strongest, description weakest)
- Index caches globally and invalidates when node set changes (detected via sorted node_type hash)
- Extra metadata (tags, use cases) extracted from node descriptions and indexed as separate fields
- BM25 results scaled by 1.5x factor when merged into candidate boosts
- Minimum term length of 2 characters enforced to filter noise

https://claude.ai/code/session_01Gs1bFmuqPFyffPRYL7hJUQ