### PR TITLE
Fix Blob creation from Uint8Array in AudioPlayer and ImageView

### DIFF
--- a/marketing/src/components/client/AudioPlayer.tsx
+++ b/marketing/src/components/client/AudioPlayer.tsx
@@ -218,7 +218,7 @@ const AudioPlayer: React.FC<WaveSurferProps> = (incomingProps) => {
 
   useEffect(() => {
     if (source instanceof Uint8Array) {
-      const blob = new Blob([source], { type: mimeType });
+      const blob = new Blob([new Uint8Array(source)], { type: mimeType });
       const url = URL.createObjectURL(blob);
       setAudioUrl(url);
       return () => URL.revokeObjectURL(url);

--- a/marketing/src/components/client/ImageView.tsx
+++ b/marketing/src/components/client/ImageView.tsx
@@ -11,7 +11,7 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
     if (!source) return undefined;
     if (typeof source === "string") return source;
 
-    return URL.createObjectURL(new Blob([source], { type: "image/png" }));
+    return URL.createObjectURL(new Blob([new Uint8Array(source)], { type: "image/png" }));
   }, [source]);
 
   if (!imageUrl) {


### PR DESCRIPTION
## Summary
Fixed potential issues with Blob creation by explicitly wrapping Uint8Array sources in a new Uint8Array instance before passing to the Blob constructor.

## Key Changes
- **AudioPlayer.tsx**: Wrapped `source` parameter in `new Uint8Array(source)` when creating Blob for audio data
- **ImageView.tsx**: Wrapped `source` parameter in `new Uint8Array(source)` when creating Blob for image data

## Implementation Details
The changes ensure that Uint8Array data is properly copied before being passed to the Blob constructor. This prevents potential issues where:
- The original Uint8Array buffer might be detached or modified
- The Blob constructor receives a fresh copy of the data, ensuring data integrity
- The blob URL remains valid even if the source buffer is garbage collected or reused

This is a defensive programming practice that makes the code more robust when handling binary data from various sources.

https://claude.ai/code/session_015REGWVHPVtTBZGkAgU752c