### PR TITLE
Make timeline package browser-compatible by removing Node.js crypto dependency

### DIFF
--- a/packages/timeline/src/defaults.ts
+++ b/packages/timeline/src/defaults.ts
@@ -12,7 +12,6 @@
  * deps: drizzle, better-sqlite3) into this types-only package.
  */
 
-import { randomUUID } from "node:crypto";
 import type {
   TimelineSequence,
   TimelineTrack,
@@ -27,9 +26,13 @@ import type {
  * Mirrors `createTimeOrderedUuid` from `@nodetool-ai/models`.
  * Returns a UUID v4 with hyphens stripped, matching the format used by
  * all other model IDs in the system.
+ *
+ * Uses the Web Crypto API (`globalThis.crypto.randomUUID`) which is
+ * available in Node 19+ and all modern browsers, so this module stays
+ * usable in browser builds.
  */
 export function createTimeOrderedUuid(): string {
-  return randomUUID().replace(/-/g, "");
+  return globalThis.crypto.randomUUID().replace(/-/g, "");
 }
 
 function nowIso(): string {

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -4,7 +4,9 @@
 
 export * from "./types.js";
 export * from "./defaults.js";
-export * from "./dependencyHash.js";
+// `dependencyHash` is intentionally NOT re-exported: it depends on
+// `node:crypto`, which breaks browser bundles. Server consumers should
+// import it directly from "@nodetool-ai/timeline/dependencyHash".
 export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./snap.js";


### PR DESCRIPTION
## Summary
This PR makes the `@nodetool-ai/timeline` package usable in browser environments by removing its dependency on Node.js-specific crypto APIs.

## Key Changes
- **Replaced Node.js `randomUUID` with Web Crypto API**: Changed `createTimeOrderedUuid()` in `defaults.ts` to use `globalThis.crypto.randomUUID()` instead of importing from `node:crypto`. This API is available in Node 19+ and all modern browsers.
- **Removed `dependencyHash` from main exports**: Stopped re-exporting `dependencyHash.js` from the main `index.ts` since it still depends on `node:crypto`. Added a comment directing server-side consumers to import it directly when needed.
- **Updated JSDoc**: Enhanced the documentation for `createTimeOrderedUuid()` to clarify that it now uses the Web Crypto API and explain the browser compatibility benefits.

## Implementation Details
The Web Crypto API's `randomUUID()` method is a standard, cross-platform alternative that works in both Node.js (19+) and browsers, making it ideal for a types-only package that should remain usable across environments. The `dependencyHash` module is intentionally excluded from the main export to prevent transitive Node.js dependencies from breaking browser builds, while still allowing server-side consumers to access it via direct import.

https://claude.ai/code/session_01RpdotM8Pad1QMuYs7fdKf6