### PR TITLE
Add external navigation links to header and footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -4,6 +4,9 @@
       <div class="footer-section">
         <h3 class="footer-title">NodeTool</h3>
         <p class="footer-desc">{{ site.description }}</p>
+        <p class="footer-marketing-link">
+          <a href="https://nodetool.ai" rel="noopener">← Back to nodetool.ai</a>
+        </p>
       </div>
 
       <div class="footer-section">

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -16,6 +16,7 @@
       </button>
 
       <ul class="nav-list">
+        <li><a href="https://nodetool.ai" class="nav-item nav-item-external" rel="noopener">nodetool.ai</a></li>
         <li><a href="{{ '/' | relative_url }}" class="nav-item {% if page.url == '/' %}active{% endif %}">Home</a></li>
         <li><a href="{{ '/getting-started' | relative_url }}" class="nav-item {% if page.url contains '/getting-started' %}active{% endif %}">Getting Started</a></li>
         <li><a href="{{ '/cookbook' | relative_url }}" class="nav-item {% if page.url contains '/cookbook' %}active{% endif %}">Cookbook</a></li>

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -659,6 +659,16 @@ blockquote {
   border-color: rgba(59, 130, 246, 0.4);
 }
 
+.nav-item-external {
+  color: var(--color-accent-cyan, #67e8f9);
+  border-color: rgba(103, 232, 249, 0.3);
+}
+
+.nav-item-external:hover {
+  background-color: rgba(103, 232, 249, 0.1);
+  color: var(--color-accent-cyan, #67e8f9);
+}
+
 /* Remove old underline effect */
 .nav-item::before {
   display: none;
@@ -1360,6 +1370,23 @@ blockquote {
   color: var(--color-text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
+}
+
+.footer-marketing-link {
+  margin-top: var(--spacing-md);
+  font-size: 0.95rem;
+}
+
+.footer-marketing-link a {
+  color: var(--color-accent-cyan);
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.footer-marketing-link a:hover {
+  opacity: 0.8;
+  text-decoration: underline;
 }
 
 .footer-heading {


### PR DESCRIPTION
## Summary
This PR adds navigation links to the external nodetool.ai website in both the header and footer of the documentation site, along with corresponding styling for external navigation items.

## Key Changes
- **Header Navigation**: Added a new external link to `nodetool.ai` at the beginning of the navigation list with a distinct visual style using the `.nav-item-external` class
- **Footer Marketing Link**: Added a "Back to nodetool.ai" link in the footer's main section to improve navigation between the documentation and main website
- **Styling for External Links**: 
  - Created `.nav-item-external` class with cyan accent color (`#67e8f9`) and custom hover state
  - Created `.footer-marketing-link` class with appropriate spacing, font sizing, and hover effects (opacity transition and underline)
  - External links use `rel="noopener"` for security best practices

## Implementation Details
- External navigation items use a cyan color scheme (`var(--color-accent-cyan)`) to visually distinguish them from internal documentation links
- Hover states provide visual feedback with background color changes for header links and opacity/underline changes for footer links
- All external links include `rel="noopener"` attribute to prevent potential security vulnerabilities
- Styling follows existing design patterns and uses CSS variables for consistency with the design system

https://claude.ai/code/session_01TPVQTNSBcvb2hx2kLFEPzc