### PR TITLE
Add asset drag-and-drop to timeline tracks (NOD-304)

### DIFF
--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -1,0 +1,48 @@
+# Timeline Component
+
+The timeline editor (`/timeline/:sequenceId`) is a generation-aware media
+sequencing surface. Tracks hold imported or AI-generated clips; each clip
+remembers how it was made and can be re-generated, versioned, and exported.
+
+## Asset Drag-and-Drop
+
+### From AssetExplorer → TrackLane (supported)
+
+Drag any image, video, or audio asset from the `AssetExplorer` panel and drop
+it onto a compatible track lane:
+
+| Asset type | Valid track types |
+|-----------|-------------------|
+| `image/*` | `video`, `overlay` |
+| `video/*` | `video`, `overlay` |
+| `audio/*` | `audio` |
+
+A clip is created at the drop position with:
+- `sourceType = "imported"` and `status = "generated"` (the asset *is* its output).
+- `durationMs` derived from `asset.duration` (× 1 000 to convert seconds → ms),
+  falling back to 4 000 ms for assets without duration metadata.
+- `currentAssetId` pointing to the dragged asset.
+
+Dropping onto an incompatible track (e.g. audio onto a video lane) shows a
+brief warning banner and does **not** create a clip.
+
+### From OS file system → Timeline (out of scope)
+
+Dragging a file directly from the operating system's file explorer into the
+timeline is **not** supported. The recommended workflow is:
+
+1. Drop the file onto the `Dropzone` in the `AssetExplorer` panel.
+   The file is uploaded and appears as a new asset in your library.
+2. Once the upload completes, drag the resulting asset from `AssetExplorer`
+   onto the desired track lane in the timeline.
+
+This keeps the upload and clip-creation paths separate, ensures assets are
+persisted in the database before being referenced by a clip, and avoids
+partial-upload states in the timeline document.
+
+## Persistence
+
+Every `TimelineStore` mutation (clip add, move, trim, split, delete) is
+observed by the autosave hook, which PATCHes the sequence document via the
+timeline REST API (NOD-299). Changes survive a page refresh. Concurrent
+edits from another tab are out of scope (last-write-wins via `updated_at`).

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -24,7 +24,7 @@ import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { Clip } from "./Clip";
 import { WarningBanner } from "../../ui_primitives";
-import { deserializeDragData, DRAG_DATA_MIME } from "../../../lib/dragdrop";
+import { deserializeDragData } from "../../../lib/dragdrop";
 import type { Asset } from "../../../stores/ApiTypes";
 import {
   assetMediaType,
@@ -145,25 +145,29 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     };
   }, []);
 
-  const showWarning = useCallback((message: string) => {
+  const showWarning = useCallback((message: string, isReject = false) => {
     setDropWarning(message);
+    setIsDragReject(isReject);
     if (warningTimerRef.current !== null) {
       clearTimeout(warningTimerRef.current);
     }
     warningTimerRef.current = setTimeout(() => {
       setDropWarning(null);
+      setIsDragReject(false);
       warningTimerRef.current = null;
     }, WARNING_DISMISS_MS);
   }, []);
 
-  /** Returns true if the dataTransfer looks like an internal asset drag. */
+  /**
+   * Returns true if the dataTransfer looks like an asset drag (single or multi).
+   * The legacy "asset" key is only set by single-asset drags; "selectedAssetIds"
+   * is set by multi-asset drags. We intentionally do NOT check DRAG_DATA_MIME
+   * alone because that MIME type is shared with create-node and other drag types.
+   */
   const isAssetDrag = useCallback((e: React.DragEvent): boolean => {
-    // Check for both the unified MIME type and the legacy "asset" key.
-    // useAssetActions sets both for backward compatibility: serializeDragData
-    // writes DRAG_DATA_MIME, and a separate line writes the legacy "asset" key.
     return (
-      e.dataTransfer.types.includes(DRAG_DATA_MIME) ||
-      e.dataTransfer.types.includes("asset")
+      e.dataTransfer.types.includes("asset") ||
+      e.dataTransfer.types.includes("selectedAssetIds")
     );
   }, []);
 
@@ -208,6 +212,12 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         return;
       }
 
+      // Multi-asset drags are not supported for clip creation — guide the user.
+      if (dragData.type === "assets-multiple") {
+        showWarning("Drop one asset at a time onto a track.", true);
+        return;
+      }
+
       // Resolve asset: only single-asset drags are supported for clip creation
       let asset: Asset | null = null;
       if (dragData.type === "asset") {
@@ -228,10 +238,9 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         const expected =
           mediaType === "audio" ? "an audio" : "a video or overlay";
         showWarning(
-          `Cannot drop ${mediaType} asset onto this ${track.type} track — use ${expected} track.`
+          `Cannot drop ${mediaType} asset onto this ${track.type} track — use ${expected} track.`,
+          true
         );
-        setIsDragReject(true);
-        setTimeout(() => setIsDragReject(false), WARNING_DISMISS_MS);
         return;
       }
 

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -11,9 +11,10 @@
  *   - Click on empty space → clear selection
  *   - Rubber-band selection (pointer drag on empty space)
  *   - Drop target for clips dragged from other tracks
+ *   - Drop target for assets dragged from AssetExplorer (NOD-304)
  */
 
-import React, { memo, useCallback, useRef } from "react";
+import React, { memo, useCallback, useRef, useState, useEffect } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -22,10 +23,19 @@ import type { TimelineTrack } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { Clip } from "./Clip";
+import { WarningBanner } from "../../ui_primitives";
+import { deserializeDragData, DRAG_DATA_MIME } from "../../../lib/dragdrop";
+import type { Asset } from "../../../stores/ApiTypes";
+import {
+  assetMediaType,
+  isCompatibleWithTrack
+} from "../dnd/assetToClipAdapter";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const DEFAULT_TRACK_HEIGHT_PX = 64;
+/** Duration (ms) the mismatch warning banner remains visible. */
+const WARNING_DISMISS_MS = 3000;
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
@@ -33,7 +43,9 @@ const laneStyles = (
   theme: Theme,
   heightPx: number,
   visible: boolean,
-  isRubberBanding: boolean
+  isRubberBanding: boolean,
+  isDragOver: boolean,
+  isDragReject: boolean
 ) =>
   css({
     position: "relative",
@@ -43,7 +55,17 @@ const laneStyles = (
     backgroundColor: visible
       ? theme.vars.palette.background.default
       : theme.vars.palette.action.disabledBackground,
-    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    borderBottom: `1px solid ${isDragReject
+      ? theme.vars.palette.error.main
+      : isDragOver
+        ? theme.vars.palette.primary.main
+        : theme.vars.palette.divider}`,
+    outline: isDragOver
+      ? `2px solid ${theme.vars.palette.primary.main}`
+      : isDragReject
+        ? `2px solid ${theme.vars.palette.error.main}`
+        : "none",
+    outlineOffset: "-2px",
     overflow: "hidden",
     cursor: isRubberBanding ? "crosshair" : "default",
     // Subtle alternating stripe
@@ -92,8 +114,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   );
 
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
+  const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
   const clearSelection = useTimelineUIStore((s) => s.clearSelection);
   const setSelection = useTimelineUIStore((s) => s.setSelection);
+  const addImportedClip = useTimelineStore((s) => s.addImportedClip);
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
 
@@ -103,6 +127,126 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const rbStartRef = useRef({ x: 0, y: 0 });
   const [rubberBand, setRubberBand] = React.useState<RubberBandRect | null>(
     null
+  );
+
+  // ── Asset drop state ────────────────────────────────────────────────────
+
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [isDragReject, setIsDragReject] = useState(false);
+  const [dropWarning, setDropWarning] = useState<string | null>(null);
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending warning timer on unmount
+  useEffect(() => {
+    return () => {
+      if (warningTimerRef.current !== null) {
+        clearTimeout(warningTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showWarning = useCallback((message: string) => {
+    setDropWarning(message);
+    if (warningTimerRef.current !== null) {
+      clearTimeout(warningTimerRef.current);
+    }
+    warningTimerRef.current = setTimeout(() => {
+      setDropWarning(null);
+      warningTimerRef.current = null;
+    }, WARNING_DISMISS_MS);
+  }, []);
+
+  /** Returns true if the dataTransfer looks like an internal asset drag. */
+  const isAssetDrag = useCallback((e: React.DragEvent): boolean => {
+    return (
+      e.dataTransfer.types.includes(DRAG_DATA_MIME) ||
+      e.dataTransfer.types.includes("asset")
+    );
+  }, []);
+
+  const handleAssetDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!isAssetDrag(e)) {
+        return;
+      }
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+      setIsDragOver(true);
+    },
+    [isAssetDrag]
+  );
+
+  const handleAssetDragLeave = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      // Only clear when leaving the lane itself (not a child element)
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        setIsDragOver(false);
+        setIsDragReject(false);
+      }
+    },
+    []
+  );
+
+  const handleAssetDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      setIsDragOver(false);
+      setIsDragReject(false);
+
+      if (!isAssetDrag(e)) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const dragData = deserializeDragData(e.dataTransfer);
+      if (!dragData) {
+        return;
+      }
+
+      // Resolve asset: only single-asset drags are supported for clip creation
+      let asset: Asset | null = null;
+      if (dragData.type === "asset") {
+        asset = dragData.payload as Asset;
+      }
+
+      if (!asset) {
+        return;
+      }
+
+      const mediaType = assetMediaType(asset.content_type);
+      if (!mediaType) {
+        showWarning(`Cannot import "${asset.name}": unsupported media type.`);
+        return;
+      }
+
+      if (!isCompatibleWithTrack(mediaType, track.type)) {
+        const expected =
+          mediaType === "audio" ? "an audio" : "a video or overlay";
+        showWarning(
+          `Cannot drop ${mediaType} asset onto this ${track.type} track — use ${expected} track.`
+        );
+        setIsDragReject(true);
+        setTimeout(() => setIsDragReject(false), WARNING_DISMISS_MS);
+        return;
+      }
+
+      // Compute start time from drop position + scroll offset
+      const rect = e.currentTarget.getBoundingClientRect();
+      const dropX = e.clientX - rect.left;
+      const startMs = Math.max(0, Math.round((dropX + scrollLeftPx) * msPerPx));
+
+      addImportedClip(asset, track.id, startMs);
+    },
+    [
+      isAssetDrag,
+      track.type,
+      track.id,
+      scrollLeftPx,
+      msPerPx,
+      addImportedClip,
+      showWarning
+    ]
   );
 
   const handleLanePointerDown = useCallback(
@@ -174,11 +318,14 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   return (
     <div
-      css={laneStyles(theme, heightPx, track.visible, rubberBand !== null)}
+      css={laneStyles(theme, heightPx, track.visible, rubberBand !== null, isDragOver, isDragReject)}
       data-testid={`track-lane-${track.id}`}
       onPointerDown={handleLanePointerDown}
       onPointerMove={handleLanePointerMove}
       onPointerUp={handleLanePointerUp}
+      onDragOver={handleAssetDragOver}
+      onDragLeave={handleAssetDragLeave}
+      onDrop={handleAssetDrop}
       role="listbox"
       aria-label={`Track: ${track.name}`}
       aria-multiselectable="true"
@@ -199,6 +346,27 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
           }}
           aria-hidden="true"
         />
+      )}
+
+      {/* Mismatch / error warning banner (auto-dismissed) */}
+      {dropWarning && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: 4,
+            left: 4,
+            right: 4,
+            zIndex: 30,
+            pointerEvents: "none"
+          }}
+          aria-live="polite"
+        >
+          <WarningBanner
+            message={dropWarning}
+            variant="warning"
+            compact
+          />
+        </div>
       )}
     </div>
   );

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -158,6 +158,9 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   /** Returns true if the dataTransfer looks like an internal asset drag. */
   const isAssetDrag = useCallback((e: React.DragEvent): boolean => {
+    // Check for both the unified MIME type and the legacy "asset" key.
+    // useAssetActions sets both for backward compatibility: serializeDragData
+    // writes DRAG_DATA_MIME, and a separate line writes the legacy "asset" key.
     return (
       e.dataTransfer.types.includes(DRAG_DATA_MIME) ||
       e.dataTransfer.types.includes("asset")
@@ -178,8 +181,9 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   const handleAssetDragLeave = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
-      // Only clear when leaving the lane itself (not a child element)
-      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      // Only clear when leaving the lane itself (not a child element).
+      // relatedTarget is null or an Element, both of which are Nodes.
+      if (!(e.relatedTarget instanceof Node) || !e.currentTarget.contains(e.relatedTarget)) {
         setIsDragOver(false);
         setIsDragReject(false);
       }

--- a/web/src/components/timeline/dnd/__tests__/assetToClipAdapter.test.ts
+++ b/web/src/components/timeline/dnd/__tests__/assetToClipAdapter.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for assetToClipAdapter.
+ *
+ * Tests the pure conversion functions without any React or store dependencies.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  assetMediaType,
+  isCompatibleWithTrack,
+  assetToClip
+} from "../assetToClipAdapter";
+import type { Asset } from "../../../../stores/ApiTypes";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeAsset(overrides: Partial<Asset> = {}): Asset {
+  return {
+    id: "asset-1",
+    user_id: "user-1",
+    parent_id: "root",
+    name: "test-asset.jpg",
+    content_type: "image/jpeg",
+    workflow_id: null,
+    created_at: "2024-01-01T00:00:00Z",
+    get_url: "https://cdn.example.com/test.jpg",
+    thumb_url: "https://cdn.example.com/thumb.jpg",
+    ...overrides
+  };
+}
+
+// ── assetMediaType ─────────────────────────────────────────────────────────
+
+describe("assetMediaType", () => {
+  it("returns 'image' for image/* content types", () => {
+    expect(assetMediaType("image/jpeg")).toBe("image");
+    expect(assetMediaType("image/png")).toBe("image");
+    expect(assetMediaType("image/webp")).toBe("image");
+  });
+
+  it("returns 'video' for video/* content types", () => {
+    expect(assetMediaType("video/mp4")).toBe("video");
+    expect(assetMediaType("video/webm")).toBe("video");
+  });
+
+  it("returns 'audio' for audio/* content types", () => {
+    expect(assetMediaType("audio/mpeg")).toBe("audio");
+    expect(assetMediaType("audio/wav")).toBe("audio");
+  });
+
+  it("returns null for unsupported content types", () => {
+    expect(assetMediaType("application/pdf")).toBeNull();
+    expect(assetMediaType("text/plain")).toBeNull();
+    expect(assetMediaType("folder")).toBeNull();
+  });
+
+  it("returns null for empty or null values", () => {
+    expect(assetMediaType(undefined)).toBeNull();
+    expect(assetMediaType(null)).toBeNull();
+    expect(assetMediaType("")).toBeNull();
+  });
+});
+
+// ── isCompatibleWithTrack ──────────────────────────────────────────────────
+
+describe("isCompatibleWithTrack", () => {
+  it("accepts image onto video track", () => {
+    expect(isCompatibleWithTrack("image", "video")).toBe(true);
+  });
+
+  it("accepts image onto overlay track", () => {
+    expect(isCompatibleWithTrack("image", "overlay")).toBe(true);
+  });
+
+  it("rejects image onto audio track", () => {
+    expect(isCompatibleWithTrack("image", "audio")).toBe(false);
+  });
+
+  it("accepts video onto video track", () => {
+    expect(isCompatibleWithTrack("video", "video")).toBe(true);
+  });
+
+  it("accepts video onto overlay track", () => {
+    expect(isCompatibleWithTrack("video", "overlay")).toBe(true);
+  });
+
+  it("rejects video onto audio track", () => {
+    expect(isCompatibleWithTrack("video", "audio")).toBe(false);
+  });
+
+  it("accepts audio onto audio track", () => {
+    expect(isCompatibleWithTrack("audio", "audio")).toBe(true);
+  });
+
+  it("rejects audio onto video track", () => {
+    expect(isCompatibleWithTrack("audio", "video")).toBe(false);
+  });
+
+  it("rejects audio onto overlay track", () => {
+    expect(isCompatibleWithTrack("audio", "overlay")).toBe(false);
+  });
+});
+
+// ── assetToClip ────────────────────────────────────────────────────────────
+
+describe("assetToClip", () => {
+  it("creates an image clip with default 4 s duration", () => {
+    const asset = makeAsset({ content_type: "image/jpeg" });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.mediaType).toBe("image");
+    expect(clip.durationMs).toBe(4000);
+    expect(clip.currentAssetId).toBe("asset-1");
+    expect(clip.sourceType).toBe("imported");
+    expect(clip.status).toBe("generated");
+    expect(clip.trackId).toBe("track-1");
+    expect(clip.startMs).toBe(0);
+    expect(clip.versions).toEqual([]);
+  });
+
+  it("creates a video clip with duration from asset.duration", () => {
+    const asset = makeAsset({ content_type: "video/mp4", duration: 12.5 });
+    const clip = assetToClip(asset, "track-1", 1000);
+
+    expect(clip.mediaType).toBe("video");
+    expect(clip.durationMs).toBe(12500);
+    expect(clip.startMs).toBe(1000);
+  });
+
+  it("falls back to 4 s when video has no duration", () => {
+    const asset = makeAsset({ content_type: "video/mp4", duration: null });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.durationMs).toBe(4000);
+  });
+
+  it("creates an audio clip with duration from asset.duration", () => {
+    const asset = makeAsset({ content_type: "audio/mpeg", duration: 60 });
+    const clip = assetToClip(asset, "track-2", 500);
+
+    expect(clip.mediaType).toBe("audio");
+    expect(clip.durationMs).toBe(60000);
+  });
+
+  it("uses asset name as clip name", () => {
+    const asset = makeAsset({ name: "my-video.mp4", content_type: "video/mp4" });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.name).toBe("my-video.mp4");
+  });
+
+  it("sets thumbnailAssetId from video asset metadata.thumbnails", () => {
+    const asset = makeAsset({
+      content_type: "video/mp4",
+      metadata: { thumbnails: ["thumb-asset-id-1", "thumb-asset-id-2"] }
+    });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.thumbnailAssetId).toBe("thumb-asset-id-1");
+  });
+
+  it("does not set thumbnailAssetId when metadata has no thumbnails", () => {
+    const asset = makeAsset({
+      content_type: "video/mp4",
+      metadata: {}
+    });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.thumbnailAssetId).toBeUndefined();
+  });
+
+  it("does not set thumbnailAssetId for image clips", () => {
+    const asset = makeAsset({ content_type: "image/png" });
+    const clip = assetToClip(asset, "track-1", 0);
+
+    expect(clip.thumbnailAssetId).toBeUndefined();
+  });
+
+  it("throws for unsupported content types", () => {
+    const asset = makeAsset({ content_type: "application/pdf" });
+
+    expect(() => assetToClip(asset, "track-1", 0)).toThrow();
+  });
+
+  it("generates a unique ID for each clip", () => {
+    const asset = makeAsset({ content_type: "image/jpeg" });
+    const clip1 = assetToClip(asset, "track-1", 0);
+    const clip2 = assetToClip(asset, "track-1", 0);
+
+    expect(clip1.id).not.toBe(clip2.id);
+  });
+});

--- a/web/src/components/timeline/dnd/assetToClipAdapter.ts
+++ b/web/src/components/timeline/dnd/assetToClipAdapter.ts
@@ -1,0 +1,108 @@
+/**
+ * assetToClipAdapter
+ *
+ * Pure function that converts a dragged Asset into a new TimelineClip.
+ * No React dependencies — safe to import from stores or non-UI modules.
+ *
+ * Mapping rules (from NOD-304):
+ *   image/* → mediaType "image", durationMs 4000, currentAssetId = asset.id
+ *   video/* → mediaType "video", durationMs = asset.duration * 1000 ?? 4000,
+ *              thumbnailAssetId from asset.metadata.thumbnails[0] if present
+ *   audio/* → mediaType "audio", durationMs = asset.duration * 1000 ?? 4000
+ *
+ * All imported clips get:
+ *   sourceType = "imported"
+ *   status     = "generated"  (the asset IS its output)
+ *   versions   = []
+ */
+
+import type { Asset } from "../../../stores/ApiTypes";
+import { makeClip } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+const DEFAULT_DURATION_MS = 4000;
+
+/**
+ * Derive the timeline mediaType from an asset's content_type.
+ * Returns null if the content type is not image, video, or audio.
+ */
+export function assetMediaType(
+  contentType: string | undefined | null
+): "image" | "video" | "audio" | null {
+  if (!contentType) {
+    return null;
+  }
+  if (contentType.startsWith("image/")) {
+    return "image";
+  }
+  if (contentType.startsWith("video/")) {
+    return "video";
+  }
+  if (contentType.startsWith("audio/")) {
+    return "audio";
+  }
+  return null;
+}
+
+/**
+ * Return true if the given mediaType is compatible with the given track type.
+ *
+ *   image / video  → track.type "video" or "overlay"
+ *   audio          → track.type "audio"
+ */
+export function isCompatibleWithTrack(
+  mediaType: "image" | "video" | "audio",
+  trackType: "video" | "audio" | "overlay" | "subtitle"
+): boolean {
+  if (mediaType === "audio") {
+    return trackType === "audio";
+  }
+  // image and video are accepted on video and overlay tracks
+  return trackType === "video" || trackType === "overlay";
+}
+
+/**
+ * Convert an Asset to a TimelineClip positioned at the given
+ * (trackId, startMs).
+ *
+ * Throws if the asset content_type is not image/*, video/*, or audio/*.
+ */
+export function assetToClip(
+  asset: Asset,
+  trackId: string,
+  startMs: number
+): TimelineClip {
+  const mediaType = assetMediaType(asset.content_type);
+  if (!mediaType) {
+    throw new Error(
+      `assetToClip: unsupported content_type "${asset.content_type}"`
+    );
+  }
+
+  const durationMs =
+    asset.duration != null ? Math.round(asset.duration * 1000) : DEFAULT_DURATION_MS;
+
+  // Thumbnail: for video assets check metadata.thumbnails array
+  let thumbnailAssetId: string | undefined;
+  if (mediaType === "video") {
+    const thumbnails = (
+      asset.metadata as { thumbnails?: string[] } | null
+    )?.thumbnails;
+    if (thumbnails && thumbnails.length > 0) {
+      thumbnailAssetId = thumbnails[0];
+    }
+  }
+
+  return makeClip({
+    trackId,
+    name: asset.name,
+    startMs,
+    durationMs,
+    mediaType,
+    sourceType: "imported",
+    status: "generated",
+    currentAssetId: asset.id,
+    ...(thumbnailAssetId ? { thumbnailAssetId } : {}),
+    versions: []
+  });
+}

--- a/web/src/components/timeline/dnd/assetToClipAdapter.ts
+++ b/web/src/components/timeline/dnd/assetToClipAdapter.ts
@@ -1,21 +1,3 @@
-/**
- * assetToClipAdapter
- *
- * Pure function that converts a dragged Asset into a new TimelineClip.
- * No React dependencies — safe to import from stores or non-UI modules.
- *
- * Mapping rules (from NOD-304):
- *   image/* → mediaType "image", durationMs 4000, currentAssetId = asset.id
- *   video/* → mediaType "video", durationMs = asset.duration * 1000 ?? 4000,
- *              thumbnailAssetId from asset.metadata.thumbnails[0] if present
- *   audio/* → mediaType "audio", durationMs = asset.duration * 1000 ?? 4000
- *
- * All imported clips get:
- *   sourceType = "imported"
- *   status     = "generated"  (the asset IS its output)
- *   versions   = []
- */
-
 import type { Asset } from "../../../stores/ApiTypes";
 import { makeClip } from "@nodetool-ai/timeline";
 import type { TimelineClip } from "@nodetool-ai/timeline";
@@ -62,8 +44,7 @@ export function isCompatibleWithTrack(
 }
 
 /**
- * Convert an Asset to a TimelineClip positioned at the given
- * (trackId, startMs).
+ * Convert an Asset to a TimelineClip positioned at the given (trackId, startMs).
  *
  * Throws if the asset content_type is not image/*, video/*, or audio/*.
  */
@@ -80,7 +61,9 @@ export function assetToClip(
   }
 
   const durationMs =
-    asset.duration != null ? Math.round(asset.duration * 1000) : DEFAULT_DURATION_MS;
+    asset.duration !== null && asset.duration !== undefined
+      ? Math.round(asset.duration * 1000)
+      : DEFAULT_DURATION_MS;
 
   // Thumbnail: for video assets check metadata.thumbnails array
   let thumbnailAssetId: string | undefined;

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -40,6 +40,8 @@ import type {
   TimelineMarker
 } from "@nodetool-ai/timeline";
 import { trpcClient } from "../../trpc/client";
+import type { Asset } from "../ApiTypes";
+import { assetToClip } from "../../components/timeline/dnd/assetToClipAdapter";
 
 // ── Snap threshold ─────────────────────────────────────────────────────────
 
@@ -133,6 +135,13 @@ export interface TimelineStoreState {
 
   /** Add a pre-built clip object directly (used by NOD-304 import). */
   addClip: (clip: TimelineClip) => void;
+
+  /**
+   * Create an imported clip from an Asset and insert it into the store.
+   * The clip geometry is derived from the asset's content type and duration.
+   * Use this action to add clips created by asset drag-and-drop.
+   */
+  addImportedClip: (asset: Asset, trackId: string, startMs: number) => void;
 
   /** Update an arbitrary subset of fields on a clip. */
   patchClip: (clipId: string, patch: Partial<TimelineClip>) => void;
@@ -478,6 +487,11 @@ export const createTimelineStore = (
           set((state) => ({
             clips: [...state.clips, clip]
           })),
+
+        addImportedClip: (asset, trackId, startMs) => {
+          const clip = assetToClip(asset, trackId, startMs);
+          set((state) => ({ clips: [...state.clips, clip] }));
+        },
 
         patchClip: (clipId, patch) =>
           set((state) => ({

--- a/web/src/stores/timeline/__tests__/TimelineStore.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.test.ts
@@ -602,3 +602,89 @@ describe("TimelineStore — replaceClipOutput", () => {
     expect(updated.lastGeneratedHash).toBe("old-hash");
   });
 });
+
+describe("TimelineStore — addImportedClip", () => {
+  it("creates an image clip from an image asset", () => {
+    const store = mkStore();
+    const track = makeTrack({ type: "video" });
+    store.setState({ tracks: [track] });
+
+    const asset = {
+      id: "img-asset-1",
+      user_id: "u1",
+      parent_id: "root",
+      name: "photo.jpg",
+      content_type: "image/jpeg",
+      workflow_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+      get_url: "https://cdn.example.com/photo.jpg",
+      thumb_url: null,
+      duration: null
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.getState().addImportedClip(asset as any, track.id, 2000);
+
+    const clips = store.getState().clips;
+    expect(clips).toHaveLength(1);
+    expect(clips[0].mediaType).toBe("image");
+    expect(clips[0].sourceType).toBe("imported");
+    expect(clips[0].status).toBe("generated");
+    expect(clips[0].currentAssetId).toBe("img-asset-1");
+    expect(clips[0].durationMs).toBe(4000);
+    expect(clips[0].startMs).toBe(2000);
+    expect(clips[0].trackId).toBe(track.id);
+  });
+
+  it("creates a video clip with duration from the asset", () => {
+    const store = mkStore();
+    const track = makeTrack({ type: "video" });
+    store.setState({ tracks: [track] });
+
+    const asset = {
+      id: "vid-asset-1",
+      user_id: "u1",
+      parent_id: "root",
+      name: "clip.mp4",
+      content_type: "video/mp4",
+      workflow_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+      get_url: "https://cdn.example.com/clip.mp4",
+      thumb_url: null,
+      duration: 10 // seconds
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.getState().addImportedClip(asset as any, track.id, 0);
+
+    const clips = store.getState().clips;
+    expect(clips[0].mediaType).toBe("video");
+    expect(clips[0].durationMs).toBe(10000);
+  });
+
+  it("creates an audio clip on an audio track", () => {
+    const store = mkStore();
+    const track = makeTrack({ type: "audio" });
+    store.setState({ tracks: [track] });
+
+    const asset = {
+      id: "audio-asset-1",
+      user_id: "u1",
+      parent_id: "root",
+      name: "track.mp3",
+      content_type: "audio/mpeg",
+      workflow_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+      get_url: "https://cdn.example.com/track.mp3",
+      thumb_url: null,
+      duration: 120
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.getState().addImportedClip(asset as any, track.id, 0);
+
+    const clips = store.getState().clips;
+    expect(clips[0].mediaType).toBe("audio");
+    expect(clips[0].durationMs).toBe(120000);
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.test.ts
@@ -18,6 +18,23 @@ import {
   mockWorkflowsGet,
   mockWorkflowsCreate
 } from "../../../__mocks__/trpcClientMock";
+import type { Asset } from "../../ApiTypes";
+
+/** Minimal valid Asset fixture for addImportedClip tests. */
+function makeAsset(overrides: Partial<Asset> = {}): Asset {
+  return {
+    id: "asset-1",
+    user_id: "u1",
+    parent_id: "root",
+    name: "test.jpg",
+    content_type: "image/jpeg",
+    workflow_id: null,
+    created_at: "2024-01-01T00:00:00Z",
+    get_url: "https://cdn.example.com/test.jpg",
+    thumb_url: null,
+    ...overrides
+  };
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -609,21 +626,9 @@ describe("TimelineStore — addImportedClip", () => {
     const track = makeTrack({ type: "video" });
     store.setState({ tracks: [track] });
 
-    const asset = {
-      id: "img-asset-1",
-      user_id: "u1",
-      parent_id: "root",
-      name: "photo.jpg",
-      content_type: "image/jpeg",
-      workflow_id: null,
-      created_at: "2024-01-01T00:00:00Z",
-      get_url: "https://cdn.example.com/photo.jpg",
-      thumb_url: null,
-      duration: null
-    };
+    const asset = makeAsset({ id: "img-asset-1", name: "photo.jpg", content_type: "image/jpeg", duration: null });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    store.getState().addImportedClip(asset as any, track.id, 2000);
+    store.getState().addImportedClip(asset, track.id, 2000);
 
     const clips = store.getState().clips;
     expect(clips).toHaveLength(1);
@@ -641,21 +646,9 @@ describe("TimelineStore — addImportedClip", () => {
     const track = makeTrack({ type: "video" });
     store.setState({ tracks: [track] });
 
-    const asset = {
-      id: "vid-asset-1",
-      user_id: "u1",
-      parent_id: "root",
-      name: "clip.mp4",
-      content_type: "video/mp4",
-      workflow_id: null,
-      created_at: "2024-01-01T00:00:00Z",
-      get_url: "https://cdn.example.com/clip.mp4",
-      thumb_url: null,
-      duration: 10 // seconds
-    };
+    const asset = makeAsset({ id: "vid-asset-1", name: "clip.mp4", content_type: "video/mp4", duration: 10 });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    store.getState().addImportedClip(asset as any, track.id, 0);
+    store.getState().addImportedClip(asset, track.id, 0);
 
     const clips = store.getState().clips;
     expect(clips[0].mediaType).toBe("video");
@@ -667,21 +660,9 @@ describe("TimelineStore — addImportedClip", () => {
     const track = makeTrack({ type: "audio" });
     store.setState({ tracks: [track] });
 
-    const asset = {
-      id: "audio-asset-1",
-      user_id: "u1",
-      parent_id: "root",
-      name: "track.mp3",
-      content_type: "audio/mpeg",
-      workflow_id: null,
-      created_at: "2024-01-01T00:00:00Z",
-      get_url: "https://cdn.example.com/track.mp3",
-      thumb_url: null,
-      duration: 120
-    };
+    const asset = makeAsset({ id: "audio-asset-1", name: "track.mp3", content_type: "audio/mpeg", duration: 120 });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    store.getState().addImportedClip(asset as any, track.id, 0);
+    store.getState().addImportedClip(asset, track.id, 0);
 
     const clips = store.getState().clips;
     expect(clips[0].mediaType).toBe("audio");


### PR DESCRIPTION
## Summary

Implement drag-and-drop support for importing assets from the AssetExplorer into timeline tracks. Users can now drag image, video, or audio assets and drop them onto compatible track lanes to create clips at the drop position.

## Key Changes

- **New adapter module** (`assetToClipAdapter.ts`): Pure conversion functions to transform assets into timeline clips
  - `assetMediaType()`: Derives media type from content_type
  - `isCompatibleWithTrack()`: Validates asset-to-track compatibility rules
  - `assetToClip()`: Converts an asset to a TimelineClip with appropriate duration and metadata

- **TrackLane drag-and-drop handlers**: Added full drag-and-drop lifecycle
  - `onDragOver`: Validates asset drag and shows visual feedback (border/outline)
  - `onDragLeave`: Clears drag state when leaving the lane
  - `onDrop`: Resolves asset, validates compatibility, computes drop position, and creates clip
  - Visual feedback: border and outline color changes based on drag state (valid/invalid)
  - Auto-dismissing warning banner for incompatible drops (3s timeout)

- **TimelineStore action** (`addImportedClip`): New action to create and insert imported clips
  - Delegates to `assetToClip()` for conversion logic
  - Adds the resulting clip to the store

- **Compatibility rules**:
  - Image/video assets → video or overlay tracks
  - Audio assets → audio tracks only
  - Multi-asset drags rejected with user guidance

- **Clip properties**:
  - `sourceType = "imported"` and `status = "generated"` (asset is its output)
  - Duration from `asset.duration` (converted to ms), fallback to 4s for assets without duration
  - Thumbnail asset ID extracted from video metadata if available
  - Start position computed from drop X coordinate + scroll offset

- **Comprehensive test coverage**:
  - Unit tests for adapter functions (media type detection, compatibility, clip creation)
  - Integration tests for `addImportedClip` action
  - Tests cover image, video, audio clips and edge cases (missing duration, thumbnails, etc.)

- **Documentation**: Added README explaining asset drag-and-drop workflow and persistence model

## Implementation Details

- Drag detection uses both legacy "asset" key (single-asset) and "selectedAssetIds" key (multi-asset) to distinguish asset drags from other drag types
- `relatedTarget` check in `onDragLeave` prevents clearing state when dragging over child elements
- Drop position calculation accounts for horizontal scroll offset to place clips at correct timeline position
- Warning banner uses `aria-live="polite"` for accessibility

https://claude.ai/code/session_01KsLpN7zt1nY2qW3eLZoTYk