### PR TITLE
Wire imported clip inspector to TimelineEditor

### DIFF
--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useTheme } from "@mui/material/styles";
 import { css } from "@emotion/react";
 
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
@@ -29,9 +28,48 @@ const BLEND_MODES = ["normal", "screen", "multiply", "add", "overlay"] as const;
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
+/**
+ * Numeric field with local draft state — only commits on blur or Enter.
+ * Avoids patching the store on every keystroke.
+ */
+const NumericField: React.FC<{
+  label: string;
+  value: number | undefined;
+  onCommit: (raw: string) => void;
+}> = ({ label, value, onCommit }) => {
+  const initial = value ?? "";
+  const [draft, setDraft] = useState<string>(String(initial));
+
+  // Re-sync when the underlying value changes (e.g. clip selection swap).
+  useEffect(() => {
+    setDraft(value == null ? "" : String(value));
+  }, [value]);
+
+  const commit = () => {
+    if (draft === String(value ?? "")) return;
+    onCommit(draft);
+  };
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (e.key === "Enter") {
+      (e.target as HTMLInputElement).blur();
+    }
+  };
+
+  return (
+    <FormField label={label}>
+      <NodeTextField
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+      />
+    </FormField>
+  );
+};
+
 export const TimelineInspector: React.FC = memo(() => {
   const navigate = useNavigate();
-  const theme = useTheme();
   const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
   const clipId = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
   const selectedCount = selectedClipIds.size;
@@ -54,12 +92,6 @@ export const TimelineInspector: React.FC = memo(() => {
   const isAudio = clip?.mediaType === "audio";
   const isOverlay = track?.type === "overlay";
 
-  const renderField = useCallback((label: string, value: number | undefined, onCommit: (value: string) => void) => (
-    <FormField label={label}>
-      <NodeTextField size="small" value={value ?? ""} onChange={(e) => onCommit(e.target.value)} />
-    </FormField>
-  ), []);
-
   if (selectedCount === 0) {
     return <EmptyState variant="empty" size="small" title="Inspector" description="Select a clip to inspect" />;
   }
@@ -67,8 +99,8 @@ export const TimelineInspector: React.FC = memo(() => {
   if (selectedCount > 1) {
     return (
       <Panel sx={{ width: "100%", p: 1 }}>
-        <Text weight="medium">{selectedCount} clips selected</Text>
-        <FlexRow sx={{ gap: theme.spacing(1), mt: 1 }}>
+        <Text weight={500}>{selectedCount} clips selected</Text>
+        <FlexRow gap={1} sx={{ mt: 1 }}>
           <EditorButton onClick={() => deleteSelected(selectedClipIds)}>Delete</EditorButton>
           <EditorButton disabled>Lock</EditorButton>
           <EditorButton disabled>Mute</EditorButton>
@@ -92,11 +124,11 @@ export const TimelineInspector: React.FC = memo(() => {
 
         <CollapsibleSection title="Timing" defaultOpen>
           <FlexColumn css={sectionContentStyles} gap={1}>
-            {renderField("Start (ms)", clip.startMs, (v) => onPatchNumber("startMs", v, 0, Number.MAX_SAFE_INTEGER))}
-            {renderField("Duration (ms)", clip.durationMs, (v) => onPatchNumber("durationMs", v, 1, Number.MAX_SAFE_INTEGER))}
-            {renderField("In point (ms)", clip.inPointMs ?? 0, (v) => onPatchNumber("inPointMs", v, 0, Number.MAX_SAFE_INTEGER))}
-            {renderField("Out point (ms)", clip.outPointMs ?? clip.durationMs, (v) => onPatchNumber("outPointMs", v, 1, Number.MAX_SAFE_INTEGER))}
-            {renderField("Speed", clip.speedMultiplier ?? 1, (v) => onPatchNumber("speedMultiplier", v, 0.1, 8))}
+            <NumericField label="Start (ms)" value={clip.startMs} onCommit={(v) => onPatchNumber("startMs", v, 0, Number.MAX_SAFE_INTEGER)} />
+            <NumericField label="Duration (ms)" value={clip.durationMs} onCommit={(v) => onPatchNumber("durationMs", v, 1, Number.MAX_SAFE_INTEGER)} />
+            <NumericField label="In point (ms)" value={clip.inPointMs ?? 0} onCommit={(v) => onPatchNumber("inPointMs", v, 0, Number.MAX_SAFE_INTEGER)} />
+            <NumericField label="Out point (ms)" value={clip.outPointMs ?? clip.durationMs} onCommit={(v) => onPatchNumber("outPointMs", v, 1, Number.MAX_SAFE_INTEGER)} />
+            <NumericField label="Speed" value={clip.speedMultiplier ?? 1} onCommit={(v) => onPatchNumber("speedMultiplier", v, 0.1, 8)} />
           </FlexColumn>
         </CollapsibleSection>
 
@@ -116,9 +148,9 @@ export const TimelineInspector: React.FC = memo(() => {
             )}
             {isAudio && (
               <>
-                {renderField("Volume (dB)", clip.volumeDb ?? 0, (v) => onPatchNumber("volumeDb", v, -60, 12))}
-                {renderField("Fade in (ms)", clip.fadeInMs ?? 0, (v) => onPatchNumber("fadeInMs", v, 0, Math.floor(clip.durationMs / 2)))}
-                {renderField("Fade out (ms)", clip.fadeOutMs ?? 0, (v) => onPatchNumber("fadeOutMs", v, 0, Math.floor(clip.durationMs / 2)))}
+                <NumericField label="Volume (dB)" value={clip.volumeDb ?? 0} onCommit={(v) => onPatchNumber("volumeDb", v, -60, 12)} />
+                <NumericField label="Fade in (ms)" value={clip.fadeInMs ?? 0} onCommit={(v) => onPatchNumber("fadeInMs", v, 0, Math.floor(clip.durationMs / 2))} />
+                <NumericField label="Fade out (ms)" value={clip.fadeOutMs ?? 0} onCommit={(v) => onPatchNumber("fadeOutMs", v, 0, Math.floor(clip.durationMs / 2))} />
               </>
             )}
           </FlexColumn>

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -1,0 +1,141 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import { css } from "@emotion/react";
+
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  CollapsibleSection,
+  EditorButton,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  FormField,
+  NodeSelect,
+  NodeSlider,
+  NodeTextField,
+  NodeMenuItem,
+  Panel,
+  Text,
+  Toast
+} from "../../ui_primitives";
+
+const containerStyles = css({ width: "100%", padding: 8, overflow: "auto" });
+const sectionContentStyles = css({ padding: 8 });
+
+const BLEND_MODES = ["normal", "screen", "multiply", "add", "overlay"] as const;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export const TimelineInspector: React.FC = memo(() => {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
+  const clipId = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
+  const selectedCount = selectedClipIds.size;
+
+  const clip = useTimelineStore((s) => (clipId ? s.clips.find((c) => c.id === clipId) : null));
+  const track = useTimelineStore((s) => (clip ? s.tracks.find((t) => t.id === clip.trackId) : null));
+  const deleteSelected = useTimelineStore((s) => s.deleteSelected);
+  const setClipLocked = useTimelineStore((s) => s.setClipLocked);
+  const patchClip = useTimelineStore((s) => s.patchClip);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const onPatchNumber = useCallback((field: string, raw: string, min?: number, max?: number) => {
+    if (!clipId) return;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return;
+    const value = min != null && max != null ? clamp(parsed, min, max) : parsed;
+    patchClip(clipId, { [field]: value });
+  }, [clipId, patchClip]);
+
+  const isAudio = clip?.mediaType === "audio";
+  const isOverlay = track?.type === "overlay";
+
+  const renderField = useCallback((label: string, value: number | undefined, onCommit: (value: string) => void) => (
+    <FormField label={label}>
+      <NodeTextField size="small" value={value ?? ""} onChange={(e) => onCommit(e.target.value)} />
+    </FormField>
+  ), []);
+
+  if (selectedCount === 0) {
+    return <EmptyState variant="empty" size="small" title="Inspector" description="Select a clip to inspect" />;
+  }
+
+  if (selectedCount > 1) {
+    return (
+      <Panel sx={{ width: "100%", p: 1 }}>
+        <Text weight="medium">{selectedCount} clips selected</Text>
+        <FlexRow sx={{ gap: theme.spacing(1), mt: 1 }}>
+          <EditorButton onClick={() => deleteSelected(selectedClipIds)}>Delete</EditorButton>
+          <EditorButton disabled>Lock</EditorButton>
+          <EditorButton disabled>Mute</EditorButton>
+        </FlexRow>
+      </Panel>
+    );
+  }
+
+  if (!clip) return null;
+
+  return (
+    <Panel css={containerStyles}>
+      <FlexColumn gap={1}>
+        <CollapsibleSection title="Media" defaultOpen>
+          <FlexColumn css={sectionContentStyles} gap={1}>
+            <Text size="small">Name: {clip.name}</Text>
+            <Text size="small">Type: {clip.mediaType}</Text>
+            <Text size="small">Asset: {clip.currentAssetId ?? "—"}</Text>
+          </FlexColumn>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Timing" defaultOpen>
+          <FlexColumn css={sectionContentStyles} gap={1}>
+            {renderField("Start (ms)", clip.startMs, (v) => onPatchNumber("startMs", v, 0, Number.MAX_SAFE_INTEGER))}
+            {renderField("Duration (ms)", clip.durationMs, (v) => onPatchNumber("durationMs", v, 1, Number.MAX_SAFE_INTEGER))}
+            {renderField("In point (ms)", clip.inPointMs ?? 0, (v) => onPatchNumber("inPointMs", v, 0, Number.MAX_SAFE_INTEGER))}
+            {renderField("Out point (ms)", clip.outPointMs ?? clip.durationMs, (v) => onPatchNumber("outPointMs", v, 1, Number.MAX_SAFE_INTEGER))}
+            {renderField("Speed", clip.speedMultiplier ?? 1, (v) => onPatchNumber("speedMultiplier", v, 0.1, 8))}
+          </FlexColumn>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Render" defaultOpen>
+          <FlexColumn css={sectionContentStyles} gap={1}>
+            {!isAudio && (
+              <FormField label="Opacity">
+                <NodeSlider min={0} max={1} step={0.01} value={clip.opacity ?? 1} onChange={(_e, value) => patchClip(clip.id, { opacity: Array.isArray(value) ? value[0] : value })} />
+              </FormField>
+            )}
+            {isOverlay && !isAudio && (
+              <FormField label="Blend mode">
+                <NodeSelect value={clip.blendMode ?? "normal"} onChange={(e) => patchClip(clip.id, { blendMode: e.target.value as (typeof BLEND_MODES)[number] })}>
+                  {BLEND_MODES.map((mode) => <NodeMenuItem key={mode} value={mode}>{mode}</NodeMenuItem>)}
+                </NodeSelect>
+              </FormField>
+            )}
+            {isAudio && (
+              <>
+                {renderField("Volume (dB)", clip.volumeDb ?? 0, (v) => onPatchNumber("volumeDb", v, -60, 12))}
+                {renderField("Fade in (ms)", clip.fadeInMs ?? 0, (v) => onPatchNumber("fadeInMs", v, 0, Math.floor(clip.durationMs / 2)))}
+                {renderField("Fade out (ms)", clip.fadeOutMs ?? 0, (v) => onPatchNumber("fadeOutMs", v, 0, Math.floor(clip.durationMs / 2)))}
+              </>
+            )}
+          </FlexColumn>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Actions" defaultOpen>
+          <FlexColumn css={sectionContentStyles} gap={1}>
+            <EditorButton onClick={() => setToast("Replace media picker coming soon")}>Replace Media</EditorButton>
+            <EditorButton onClick={() => navigate("/assets")}>Reveal in Library</EditorButton>
+            <EditorButton onClick={() => setToast("Convert to Generated Clip will be wired in NOD-306")}>Convert to Generated Clip</EditorButton>
+            <EditorButton onClick={() => setClipLocked(clip.id, !clip.locked)}>{clip.locked ? "Unlock" : "Lock"}</EditorButton>
+          </FlexColumn>
+        </CollapsibleSection>
+      </FlexColumn>
+      <Toast open={toast !== null} message={toast ?? ""} onClose={() => setToast(null)} severity="info" />
+    </Panel>
+  );
+});
+
+TimelineInspector.displayName = "TimelineInspector";

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -21,6 +21,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import {
+  EmptyState,
   FlexColumn,
   FlexRow,
   LoadingSpinner
@@ -130,7 +131,6 @@ const PreviewRegion: React.FC<{ isLoading: boolean; sequence?: { fps?: number; w
 
 const InspectorRegion: React.FC = () => {
   const theme = useTheme();
-
 
   return (
     <FlexColumn

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -23,7 +23,6 @@ import type { Theme } from "@mui/material/styles";
 import {
   FlexColumn,
   FlexRow,
-  EmptyState,
   LoadingSpinner
 } from "../ui_primitives";
 
@@ -32,9 +31,8 @@ import { BottomStatusBar } from "./BottomStatusBar";
 import { useTimeline } from "../../hooks/useTimelineSequence";
 import { TracksRegion } from "./Tracks/TracksRegion";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
-import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { PreviewArea } from "./preview/PreviewArea";
-import { ClipActions } from "./Inspector/ClipActions";
+import { TimelineInspector } from "./Inspector/TimelineInspector";
 import { ActivityIndicator } from "./ActivityIndicator";
 import { StructuralDriftDialog } from "./Inspector/StructuralDriftDialog";
 import {
@@ -133,16 +131,6 @@ const PreviewRegion: React.FC<{ isLoading: boolean; sequence?: { fps?: number; w
 const InspectorRegion: React.FC = () => {
   const theme = useTheme();
 
-  const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
-  const selectedId =
-    selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
-
-  // Get durationMs for the offset default so duplicates are placed right after
-  const clipDurationMs = useTimelineStore((s) =>
-    selectedId
-      ? (s.clips.find((c) => c.id === selectedId)?.durationMs ?? 0)
-      : 0
-  );
 
   return (
     <FlexColumn
@@ -150,16 +138,7 @@ const InspectorRegion: React.FC = () => {
       fullHeight
       sx={{ flex: "1 1 45%" }}
     >
-      {selectedId ? (
-        <ClipActions clipId={selectedId} duplicateOffsetMs={clipDurationMs} />
-      ) : (
-        <EmptyState
-          variant="empty"
-          size="small"
-          title="Inspector"
-          description="Select a clip to inspect"
-        />
-      )}
+      <TimelineInspector />
     </FlexColumn>
   );
 };


### PR DESCRIPTION
### Motivation
- Expose imported-clip asset, timing, and render properties in the right-hand inspector using existing inspector primitives and editing patterns.
- Provide immediate, store-backed updates for clip fields (timing, speed, opacity, blend mode, audio volume/fades) and reuse UI primitives rather than raw MUI.
- Support single-clip detailed editing and a minimal multi-select inspector for basic bulk actions.

### Description
- Added a new `TimelineInspector` component (`web/src/components/timeline/Inspector/TimelineInspector.tsx`) that composes `Panel`, `CollapsibleSection`, `FormField`, `NodeTextField`, `NodeSlider`, `NodeSelect`/`NodeMenuItem`, and other primitives from `ui_primitives` to match the inspector patterns.
- Wired `TimelineInspector` into `TimelineEditor` (replaced the previous per-clip `ClipActions` placeholder in the inspector region) so the inspector renders timeline clip editing UI for the selected clip.
- Implemented immediate updates via `TimelineStore.patchClip` for numeric and select fields with clamping for ranges (e.g. `opacity ∈ [0,1]`, `speedMultiplier ∈ [0.1,8]`, `volumeDb ∈ [-60,12]`, fades `≥ 0` and `≤ durationMs/2`).
- Conditional section visibility and controls: audio-only fields (volume/fades), overlay track blend mode, and video/image opacity are shown appropriately; multi-select shows a count with bulk `Delete` action and placeholders for `Lock`/`Mute`; `Replace Media` and `Convert to Generated Clip` are currently toast stubs.

### Testing
- Ran `cd web && npm run typecheck` which reports missing type-definition packages in this environment (errors for `@testing-library/jest-dom` / `jest`), so full typecheck could not be completed here.
- Ran `cd web && npm run lint` which failed in this environment because `oxlint` is not available, so lint could not be validated here.
- Ran `cd web && npm test -- --runInBand` which failed due to `jest` not being available in the execution environment, so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb40bec90832da3adba45be830c13)