### PR TITLE
agents: organize tools into single canonical built-in list

### DIFF
--- a/packages/agents/src/agent-executor.ts
+++ b/packages/agents/src/agent-executor.ts
@@ -16,71 +16,15 @@ import type {
 } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { Tool } from "./tools/base-tool.js";
+import {
+  FinishTool,
+  jsonSchemaForOutputType
+} from "./tools/finish-task-tool.js";
 
 const DEFAULT_MAX_ITERATIONS = 10;
 
-const METADATA_SCHEMA: Record<string, unknown> = {
-  type: "object",
-  properties: {
-    title: { type: "string" },
-    description: { type: "string" },
-    sources: { type: "array", items: { type: "string" } }
-  },
-  required: ["title", "description"],
-  additionalProperties: true
-};
-
-export function jsonSchemaForOutputType(type: string): Record<string, unknown> {
-  const schemas: Record<string, Record<string, unknown>> = {
-    json: { type: "object", description: "JSON object" },
-    list: { type: "array", description: "Array of values" },
-    string: { type: "string", description: "Text string" },
-    number: { type: "number", description: "Numeric value" },
-    boolean: { type: "boolean", description: "Boolean value" },
-    markdown: { type: "string", description: "Markdown formatted text" },
-    html: { type: "string", description: "HTML markup" },
-    csv: { type: "string", description: "CSV formatted data" },
-    yaml: { type: "string", description: "YAML formatted data" }
-  };
-  return (
-    schemas[type] ?? {
-      type: "string",
-      description: `Output of type ${type}`
-    }
-  );
-}
-
-export class FinishTool extends Tool {
-  readonly name = "finish_task";
-  readonly description =
-    "Finish the task by providing the final result value and metadata.";
-  readonly inputSchema: Record<string, unknown>;
-
-  constructor(
-    outputType: string,
-    outputSchema: Record<string, unknown> | null
-  ) {
-    super();
-    const resultSchema = outputSchema ?? jsonSchemaForOutputType(outputType);
-
-    this.inputSchema = {
-      type: "object",
-      properties: {
-        result: resultSchema,
-        metadata: METADATA_SCHEMA
-      },
-      required: ["result", "metadata"],
-      additionalProperties: false
-    };
-  }
-
-  async process(
-    _context: ProcessingContext,
-    params: Record<string, unknown>
-  ): Promise<unknown> {
-    return params;
-  }
-}
+// Re-export for backwards compatibility — these were defined here originally.
+export { FinishTool, jsonSchemaForOutputType };
 
 export interface AgentExecutorOptions {
   provider: BaseProvider;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -124,7 +124,8 @@ export {
 export {
   BUILTIN_TOOL_CLASSES,
   getBuiltinTools,
-  registerBuiltinTools
+  registerBuiltinTools,
+  resetBuiltinToolsRegistration
 } from "./tools/builtin-tools.js";
 
 export {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8,6 +8,10 @@ export type { Step, Task, TaskPlan, AgentMode, SubAgentConfig } from "./types.js
 // Tools
 export { Tool } from "./tools/base-tool.js";
 export { FinishStepTool } from "./tools/finish-step-tool.js";
+export {
+  FinishTool,
+  jsonSchemaForOutputType
+} from "./tools/finish-task-tool.js";
 export { CalculatorTool } from "./tools/calculator-tool.js";
 export {
   StatisticsTool,
@@ -117,6 +121,11 @@ export {
   listTools,
   getAllTools
 } from "./tools/tool-registry.js";
+export {
+  BUILTIN_TOOL_CLASSES,
+  getBuiltinTools,
+  registerBuiltinTools
+} from "./tools/builtin-tools.js";
 
 export {
   WorkspaceReadTool,
@@ -198,11 +207,7 @@ export { wrapGeneratorsParallel } from "./utils/wrap-generators-parallel.js";
 // Core execution
 export { StepExecutor } from "./step-executor.js";
 export type { StepExecutorOptions } from "./step-executor.js";
-export {
-  AgentExecutor,
-  FinishTool,
-  jsonSchemaForOutputType
-} from "./agent-executor.js";
+export { AgentExecutor } from "./agent-executor.js";
 export type { AgentExecutorOptions } from "./agent-executor.js";
 
 // Agents

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -129,19 +129,32 @@ export function getBuiltinTools(): Tool[] {
   return BUILTIN_TOOL_CLASSES.map((Cls) => new Cls());
 }
 
+let registeredNames: string[] | null = null;
+
 /**
  * Register all built-in tools in the global tool registry, so that
  * `resolveTool(name)` returns a usable instance for any built-in by name.
  *
- * Idempotent: repeated calls re-register the same instances. Returns the
- * map of registered names for diagnostics.
+ * Truly idempotent: only the first call instantiates and registers; later
+ * calls return the cached list of names without touching the registry.
+ * Returns the array of registered tool names.
  */
 export function registerBuiltinTools(): string[] {
+  if (registeredNames) return registeredNames;
   const names: string[] = [];
   for (const Cls of BUILTIN_TOOL_CLASSES) {
     const instance = new Cls();
     registerTool(instance);
     names.push(instance.name);
   }
+  registeredNames = names;
   return names;
+}
+
+/**
+ * Reset the one-time registration guard. Test-only — production code
+ * should never call this.
+ */
+export function resetBuiltinToolsRegistration(): void {
+  registeredNames = null;
 }

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -1,0 +1,147 @@
+/**
+ * Canonical list of built-in agent tool classes.
+ *
+ * "Built-in" = constructable with `new ToolClass()` (no required args), and
+ * not tied to a specific NodeRegistry, sandbox, workspace, or vector
+ * collection. These are the tools the WebSocket server exposes by name —
+ * any tool listed here can be selected from the chat / agent frontends and
+ * resolved via `resolveTool(name)` without additional context.
+ *
+ * Tools that need constructor args (workspace path, vector collection,
+ * NodeRegistry, ProcessingContext, sandbox client, …) are NOT included
+ * here; they are wired up by their owning subsystem (e.g. base-nodes,
+ * sandbox-tools, mcp-tools).
+ */
+
+import type { Tool } from "./base-tool.js";
+import { registerTool } from "./tool-registry.js";
+
+import { CalculatorTool } from "./calculator-tool.js";
+import { RunCodeTool } from "./code-tools.js";
+import { MiniJSAgentTool } from "./js-code-tool.js";
+import { BrowserTool, ScreenshotTool } from "./browser-tools.js";
+import { DownloadFileTool, HttpRequestTool } from "./http-tools.js";
+import {
+  OpenAIWebSearchTool,
+  OpenAIImageGenerationTool,
+  OpenAITextToSpeechTool
+} from "./openai-tools.js";
+import {
+  GoogleGroundedSearchTool,
+  GoogleImageGenerationTool
+} from "./google-tools.js";
+import {
+  DataForSEOSearchTool,
+  DataForSEONewsTool,
+  DataForSEOImagesTool
+} from "./dataseo-tools.js";
+import {
+  GoogleSearchTool,
+  GoogleNewsTool,
+  GoogleImagesTool
+} from "./search-tools.js";
+import {
+  SearchEmailTool,
+  ArchiveEmailTool,
+  AddLabelToEmailTool
+} from "./email-tools.js";
+import {
+  StatisticsTool,
+  GeometryTool,
+  TrigonometryTool,
+  ConversionTool
+} from "./math-tools.js";
+import {
+  ExtractPDFTextTool,
+  ExtractPDFTablesTool,
+  ConvertPDFToMarkdownTool,
+  ConvertMarkdownToPDFTool,
+  ConvertDocumentTool
+} from "./pdf-tools.js";
+import {
+  ReadFileTool,
+  WriteFileTool,
+  ListDirectoryTool
+} from "./filesystem-tools.js";
+import {
+  EditFileTool,
+  GlobTool,
+  GrepTool
+} from "./claude-code-tools.js";
+
+export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
+  // Search
+  GoogleSearchTool,
+  GoogleNewsTool,
+  GoogleImagesTool,
+  GoogleGroundedSearchTool,
+  OpenAIWebSearchTool,
+  DataForSEOSearchTool,
+  DataForSEONewsTool,
+  DataForSEOImagesTool,
+
+  // Generation
+  GoogleImageGenerationTool,
+  OpenAIImageGenerationTool,
+  OpenAITextToSpeechTool,
+
+  // Web
+  BrowserTool,
+  ScreenshotTool,
+  DownloadFileTool,
+  HttpRequestTool,
+
+  // Filesystem (workspace-relative)
+  ReadFileTool,
+  WriteFileTool,
+  ListDirectoryTool,
+  EditFileTool,
+  GlobTool,
+  GrepTool,
+
+  // Email
+  SearchEmailTool,
+  ArchiveEmailTool,
+  AddLabelToEmailTool,
+
+  // Compute
+  CalculatorTool,
+  RunCodeTool,
+  MiniJSAgentTool,
+  StatisticsTool,
+  GeometryTool,
+  TrigonometryTool,
+  ConversionTool,
+
+  // Documents
+  ExtractPDFTextTool,
+  ExtractPDFTablesTool,
+  ConvertPDFToMarkdownTool,
+  ConvertMarkdownToPDFTool,
+  ConvertDocumentTool
+];
+
+/**
+ * Return one fresh instance per built-in tool class.
+ * Useful when constructing a tool list for an agent.
+ */
+export function getBuiltinTools(): Tool[] {
+  return BUILTIN_TOOL_CLASSES.map((Cls) => new Cls());
+}
+
+/**
+ * Register all built-in tools in the global tool registry, so that
+ * `resolveTool(name)` returns a usable instance for any built-in by name.
+ *
+ * Idempotent: repeated calls re-register the same instances. Returns the
+ * map of registered names for diagnostics.
+ */
+export function registerBuiltinTools(): string[] {
+  const names: string[] = [];
+  for (const Cls of BUILTIN_TOOL_CLASSES) {
+    const instance = new Cls();
+    registerTool(instance);
+    names.push(instance.name);
+  }
+  return names;
+}

--- a/packages/agents/src/tools/finish-task-tool.ts
+++ b/packages/agents/src/tools/finish-task-tool.ts
@@ -1,0 +1,72 @@
+/**
+ * FinishTool — terminal tool emitted by AgentExecutor's value-based loop.
+ *
+ * The agent calls `finish_task` exactly once with `result` (typed by
+ * outputType / outputSchema) and `metadata` (title, description, sources).
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+
+const METADATA_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    description: { type: "string" },
+    sources: { type: "array", items: { type: "string" } }
+  },
+  required: ["title", "description"],
+  additionalProperties: true
+};
+
+export function jsonSchemaForOutputType(type: string): Record<string, unknown> {
+  const schemas: Record<string, Record<string, unknown>> = {
+    json: { type: "object", description: "JSON object" },
+    list: { type: "array", description: "Array of values" },
+    string: { type: "string", description: "Text string" },
+    number: { type: "number", description: "Numeric value" },
+    boolean: { type: "boolean", description: "Boolean value" },
+    markdown: { type: "string", description: "Markdown formatted text" },
+    html: { type: "string", description: "HTML markup" },
+    csv: { type: "string", description: "CSV formatted data" },
+    yaml: { type: "string", description: "YAML formatted data" }
+  };
+  return (
+    schemas[type] ?? {
+      type: "string",
+      description: `Output of type ${type}`
+    }
+  );
+}
+
+export class FinishTool extends Tool {
+  readonly name = "finish_task";
+  readonly description =
+    "Finish the task by providing the final result value and metadata.";
+  readonly inputSchema: Record<string, unknown>;
+
+  constructor(
+    outputType: string,
+    outputSchema: Record<string, unknown> | null
+  ) {
+    super();
+    const resultSchema = outputSchema ?? jsonSchemaForOutputType(outputType);
+
+    this.inputSchema = {
+      type: "object",
+      properties: {
+        result: resultSchema,
+        metadata: METADATA_SCHEMA
+      },
+      required: ["result", "metadata"],
+      additionalProperties: false
+    };
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    return params;
+  }
+}

--- a/packages/agents/tests/builtin-tools-integration.test.ts
+++ b/packages/agents/tests/builtin-tools-integration.test.ts
@@ -13,22 +13,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   BUILTIN_TOOL_CLASSES,
   getBuiltinTools,
-  registerBuiltinTools
+  registerBuiltinTools,
+  resetBuiltinToolsRegistration
 } from "../src/tools/builtin-tools.js";
 import { resolveTool, listTools } from "../src/tools/tool-registry.js";
 import { SimpleAgent } from "../src/simple-agent.js";
 import { CalculatorTool } from "../src/tools/calculator-tool.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 
-// Tool IDs hardcoded in chat / agent frontends. These MUST resolve to
-// real built-in tool instances. If a frontend adds a new ID, add it here.
+// Tool IDs hardcoded in chat / agent frontends. Every ID here MUST
+// resolve to a real built-in tool instance — if a frontend adds a new
+// one, add it here. (Dynamic browser_*/sandbox_* IDs come from
+// base-nodes / sandbox-tools and are intentionally excluded; MCP tools
+// require a NodeRegistry and are also excluded.)
 //
 // Sources:
 //   web/src/components/chat/composer/ToolsSelector.tsx
-//   web/src/components/properties/ToolsListProperty.tsx (subset — the
-//     dynamic browser_*/sandbox_* IDs come from base-nodes / sandbox-tools)
-//   mobile/src/components/chat/ChatOptionsBar.tsx (subset — same)
-const FRONTEND_TOOL_IDS = [
+//   web/src/components/properties/ToolsListProperty.tsx
+//   mobile/src/components/chat/ChatOptionsBar.tsx
+const WEB_AND_MOBILE_TOOL_IDS = [
   "google_search",
   "google_image_generation",
   "openai_image_generation",
@@ -38,6 +41,40 @@ const FRONTEND_TOOL_IDS = [
   "write_file",
   "list_directory"
 ];
+
+// CLI defaults from packages/cli/src/settings.ts (DEFAULT_SETTINGS.enabledTools)
+// and the `autoEnable` calls in packages/cli/src/index.ts. The CLI feeds
+// these names directly into its toolMap, which is now keyed by canonical
+// tool name — so each entry here MUST resolve.
+const CLI_DEFAULT_TOOL_IDS = [
+  "read_file",
+  "write_file",
+  "edit_file",
+  "list_directory",
+  "glob",
+  "grep",
+  "download_file",
+  "http_request",
+  "browser",
+  "take_screenshot",
+  "run_code",
+  "calculate",
+  // autoEnable groups
+  "google_search",
+  "google_news",
+  "google_images",
+  "openai_web_search",
+  "openai_image_generation",
+  "openai_text_to_speech",
+  "dataforseo_search",
+  "dataforseo_news",
+  "search_email",
+  "archive_email"
+];
+
+const FRONTEND_TOOL_IDS = Array.from(
+  new Set([...WEB_AND_MOBILE_TOOL_IDS, ...CLI_DEFAULT_TOOL_IDS])
+);
 
 // ---------------------------------------------------------------------------
 // Mock provider — minimal shape needed by SimpleAgent / StepExecutor
@@ -138,8 +175,6 @@ describe("BUILTIN_TOOL_CLASSES", () => {
 
 describe("registerBuiltinTools()", () => {
   beforeEach(() => {
-    // Re-register on every test so order/state from sibling tests doesn't
-    // affect us. registerBuiltinTools() is idempotent.
     registerBuiltinTools();
   });
 
@@ -158,6 +193,17 @@ describe("registerBuiltinTools()", () => {
       expect(tool, `${id} did not resolve — frontend selectors will break`).not.toBeNull();
       expect(tool!.name).toBe(id);
     }
+  });
+
+  it("is idempotent — repeated calls return the same name list without re-registering", () => {
+    resetBuiltinToolsRegistration();
+    const first = registerBuiltinTools();
+    // Second call must short-circuit and return the same array reference.
+    const second = registerBuiltinTools();
+    expect(second).toBe(first);
+    expect(first.length).toBe(BUILTIN_TOOL_CLASSES.length);
+    // Re-register after reset.
+    registerBuiltinTools();
   });
 });
 

--- a/packages/agents/tests/builtin-tools-integration.test.ts
+++ b/packages/agents/tests/builtin-tools-integration.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Integration tests verifying that the canonical built-in tool list
+ * (`BUILTIN_TOOL_CLASSES`) instantiates cleanly, registers via the global
+ * tool registry, and round-trips through a SimpleAgent driven by a fake
+ * provider that calls one of the registered tools.
+ *
+ * These tests double as the executable contract used by the chat / agent
+ * frontends — every tool ID that the frontend lets a user select must
+ * resolve here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  BUILTIN_TOOL_CLASSES,
+  getBuiltinTools,
+  registerBuiltinTools
+} from "../src/tools/builtin-tools.js";
+import { resolveTool, listTools } from "../src/tools/tool-registry.js";
+import { SimpleAgent } from "../src/simple-agent.js";
+import { CalculatorTool } from "../src/tools/calculator-tool.js";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+
+// Tool IDs hardcoded in chat / agent frontends. These MUST resolve to
+// real built-in tool instances. If a frontend adds a new ID, add it here.
+//
+// Sources:
+//   web/src/components/chat/composer/ToolsSelector.tsx
+//   web/src/components/properties/ToolsListProperty.tsx (subset — the
+//     dynamic browser_*/sandbox_* IDs come from base-nodes / sandbox-tools)
+//   mobile/src/components/chat/ChatOptionsBar.tsx (subset — same)
+const FRONTEND_TOOL_IDS = [
+  "google_search",
+  "google_image_generation",
+  "openai_image_generation",
+  "openai_text_to_speech",
+  "browser",
+  "read_file",
+  "write_file",
+  "list_directory"
+];
+
+// ---------------------------------------------------------------------------
+// Mock provider — minimal shape needed by SimpleAgent / StepExecutor
+// ---------------------------------------------------------------------------
+
+function createMockProvider(
+  responseSequence: Array<
+    Array<
+      | { type: "chunk"; content: string; done?: boolean }
+      | { id: string; name: string; args: Record<string, unknown> }
+    >
+  >
+) {
+  let callIndex = 0;
+  const provider: any = {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    generateMessages: async function* () {
+      const items = responseSequence[callIndex] ?? [];
+      callIndex++;
+      for (const item of items) yield item;
+    },
+    async *generateMessagesTraced(...args: any[]) {
+      yield* (this as any).generateMessages(...args);
+    },
+    async generateMessageTraced(...args: any[]) {
+      return (this as any).generateMessage(...args);
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getAvailableImageModels: vi.fn().mockResolvedValue([]),
+    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
+    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
+    getAvailableASRModels: vi.fn().mockResolvedValue([]),
+    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    textToImage: vi.fn(),
+    imageToImage: vi.fn(),
+    textToSpeech: vi.fn(),
+    automaticSpeechRecognition: vi.fn(),
+    textToVideo: vi.fn(),
+    imageToVideo: vi.fn(),
+    generateEmbedding: vi.fn(),
+    isContextLengthError: () => false
+  };
+  return provider;
+}
+
+function createMockContext() {
+  const store = new Map<string, unknown>();
+  return {
+    storeStepResult: vi.fn(async (k: string, v: unknown) => {
+      store.set(k, v);
+      return k;
+    }),
+    loadStepResult: vi.fn(async (k: string) => store.get(k)),
+    set: vi.fn((k: string, v: unknown) => {
+      store.set(k, v);
+    }),
+    get: vi.fn((k: string) => store.get(k))
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+
+describe("BUILTIN_TOOL_CLASSES", () => {
+  it("instantiates every class without arguments", () => {
+    for (const Cls of BUILTIN_TOOL_CLASSES) {
+      expect(() => new Cls()).not.toThrow();
+    }
+  });
+
+  it("each tool exposes a non-empty name, description, and schema", () => {
+    const tools = getBuiltinTools();
+    for (const tool of tools) {
+      expect(tool.name, `class missing name`).toBeTruthy();
+      expect(typeof tool.name).toBe("string");
+      expect(tool.description, `${tool.name} missing description`).toBeTruthy();
+      expect(tool.inputSchema, `${tool.name} missing inputSchema`).toBeTruthy();
+    }
+  });
+
+  it("tool names are unique across the built-in catalog", () => {
+    const names = getBuiltinTools().map((t) => t.name);
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    expect(dupes).toEqual([]);
+  });
+
+  it("toProviderTool() round-trips name/description/schema", () => {
+    for (const tool of getBuiltinTools()) {
+      const pt = tool.toProviderTool();
+      expect(pt.name).toBe(tool.name);
+      expect(pt.description).toBe(tool.description);
+      expect(pt.inputSchema).toBe(tool.inputSchema);
+    }
+  });
+});
+
+describe("registerBuiltinTools()", () => {
+  beforeEach(() => {
+    // Re-register on every test so order/state from sibling tests doesn't
+    // affect us. registerBuiltinTools() is idempotent.
+    registerBuiltinTools();
+  });
+
+  it("registers every built-in name in the global registry", () => {
+    const registered = new Set(listTools());
+    for (const tool of getBuiltinTools()) {
+      expect(registered.has(tool.name), `${tool.name} not registered`).toBe(
+        true
+      );
+    }
+  });
+
+  it("resolves frontend-referenced tool IDs", () => {
+    for (const id of FRONTEND_TOOL_IDS) {
+      const tool = resolveTool(id);
+      expect(tool, `${id} did not resolve — frontend selectors will break`).not.toBeNull();
+      expect(tool!.name).toBe(id);
+    }
+  });
+});
+
+describe("Agent end-to-end with fake provider + real tools", () => {
+  beforeEach(() => {
+    registerBuiltinTools();
+  });
+
+  it("runs a SimpleAgent that invokes the real CalculatorTool", async () => {
+    // The fake provider yields two LLM turns:
+    //   1. a `calculate` tool call,
+    //   2. a `finish_step` with the final result.
+    const provider = createMockProvider([
+      [
+        { type: "chunk", content: "computing..." },
+        {
+          id: "tc_calc",
+          name: "calculate",
+          args: { expression: "2 + 3 * 4" }
+        }
+      ],
+      [
+        { type: "chunk", content: "done" },
+        {
+          id: "tc_finish",
+          name: "finish_step",
+          args: { result: { answer: 14 } }
+        }
+      ]
+    ]);
+
+    const agent = new SimpleAgent({
+      name: "calc-agent",
+      objective: "Compute 2 + 3 * 4 using the calculate tool",
+      provider,
+      model: "fake-model",
+      tools: [new CalculatorTool()],
+      outputSchema: {
+        type: "object",
+        properties: { answer: { type: "number" } },
+        required: ["answer"]
+      }
+    });
+
+    const context = createMockContext();
+    const messages: ProcessingMessage[] = [];
+    for await (const msg of agent.execute(context)) {
+      messages.push(msg);
+    }
+
+    expect(agent.getResults()).toEqual({ answer: 14 });
+
+    // The real calculator must have run — its tool_call_update should be
+    // in the message stream.
+    const calcCalls = messages.filter(
+      (m) => m.type === "tool_call_update" && (m as any).name === "calculate"
+    );
+    expect(calcCalls.length).toBeGreaterThan(0);
+  });
+
+  it("runs a SimpleAgent that resolves a tool by name from the registry", async () => {
+    const calc = resolveTool("calculate");
+    expect(calc).not.toBeNull();
+
+    const provider = createMockProvider([
+      [
+        {
+          id: "tc_1",
+          name: "calculate",
+          args: { expression: "10 / 2" }
+        }
+      ],
+      [
+        {
+          id: "tc_2",
+          name: "finish_step",
+          args: { result: { value: 5 } }
+        }
+      ]
+    ]);
+
+    const agent = new SimpleAgent({
+      name: "registry-agent",
+      objective: "Halve 10",
+      provider,
+      model: "fake-model",
+      tools: [calc!],
+      outputSchema: {
+        type: "object",
+        properties: { value: { type: "number" } }
+      }
+    });
+
+    const context = createMockContext();
+    for await (const _ of agent.execute(context)) {
+      // drain
+    }
+
+    expect(agent.getResults()).toEqual({ value: 5 });
+  });
+});

--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -24,20 +24,9 @@ import { useExecutionState } from "./useExecutionState.js";
 import type { Message, ToolCall } from "@nodetool-ai/runtime";
 import { ProcessingContext } from "@nodetool-ai/runtime";
 import { processChat } from "@nodetool-ai/chat";
-import { MultiModeAgent } from "@nodetool-ai/agents";
 import {
-  ReadFileTool, WriteFileTool, ListDirectoryTool,
-  EditFileTool, GlobTool, GrepTool,
-  DownloadFileTool, HttpRequestTool,
-  GoogleSearchTool, GoogleNewsTool, GoogleImagesTool,
-  BrowserTool, ScreenshotTool,
-  RunCodeTool,
-  CalculatorTool,
-  ExtractPDFTextTool, ConvertPDFToMarkdownTool, ConvertDocumentTool,
-  StatisticsTool, GeometryTool, ConversionTool,
-  OpenAIWebSearchTool, OpenAIImageGenerationTool, OpenAITextToSpeechTool,
-  DataForSEOSearchTool, DataForSEONewsTool,
-  SearchEmailTool, ArchiveEmailTool,
+  MultiModeAgent,
+  getBuiltinTools,
   getAllMcpTools,
 } from "@nodetool-ai/agents";
 import { createProvider, DEFAULT_MODELS, KNOWN_PROVIDERS, WebSocketProvider } from "./providers.js";
@@ -352,47 +341,15 @@ export function App({
     }
   }, []);
 
-  // Create tools from enabled list
+  // Create tools from enabled list. The toolMap is keyed by canonical
+  // tool `name` (matching what `BUILTIN_TOOL_CLASSES` exposes), so the
+  // names users put in their settings.json `enabledTools` are the same
+  // IDs the LLM sees and the same IDs other frontends use.
   function buildTools() {
-    const toolMap: Record<string, unknown> = {
-      // Filesystem
-      read_file: new ReadFileTool(),
-      write_file: new WriteFileTool(),
-      edit_file: new EditFileTool(),
-      list_directory: new ListDirectoryTool(),
-      glob: new GlobTool(),
-      grep: new GrepTool(),
-      // HTTP
-      download_file: new DownloadFileTool(),
-      http_request: new HttpRequestTool(),
-      // Search (SERPAPI)
-      google_search: new GoogleSearchTool(),
-      google_news: new GoogleNewsTool(),
-      google_images: new GoogleImagesTool(),
-      // Browser
-      browser: new BrowserTool(),
-      screenshot: new ScreenshotTool(),
-      // Code & math
-      run_code: new RunCodeTool(),
-      calculator: new CalculatorTool(),
-      statistics: new StatisticsTool(),
-      geometry: new GeometryTool(),
-      conversion: new ConversionTool(),
-      // PDF & documents
-      extract_pdf_text: new ExtractPDFTextTool(),
-      convert_pdf_to_markdown: new ConvertPDFToMarkdownTool(),
-      convert_document: new ConvertDocumentTool(),
-      // OpenAI tools
-      openai_web_search: new OpenAIWebSearchTool(),
-      openai_image_generation: new OpenAIImageGenerationTool(),
-      openai_text_to_speech: new OpenAITextToSpeechTool(),
-      // DataForSEO
-      dataseo_search: new DataForSEOSearchTool(),
-      dataseo_news: new DataForSEONewsTool(),
-      // Email (IMAP)
-      search_email: new SearchEmailTool(),
-      archive_email: new ArchiveEmailTool(),
-    };
+    const toolMap: Record<string, import("@nodetool-ai/agents").Tool> = {};
+    for (const tool of getBuiltinTools()) {
+      toolMap[tool.name] = tool;
+    }
     // NodeTool MCP tools (workflows, nodes, jobs, assets, models).
     // When a NodeRegistry is in process, this swaps the REST node-search
     // tools for the local biased versions (and adds `find_model`) so any
@@ -416,18 +373,18 @@ export function App({
           "grep",
           "run_code",
           "browser",
-          "screenshot",
+          "take_screenshot",
           "google_search",
           "google_news",
           "google_images",
-          "dataseo_search",
-          "dataseo_news"
+          "dataforseo_search",
+          "dataforseo_news"
         ])
       : null;
 
     const enabled = enabledTools
       .filter(name => name in toolMap && !(hostToolsToExclude?.has(name)))
-      .map(name => toolMap[name] as import("@nodetool-ai/agents").Tool);
+      .map(name => toolMap[name]);
     return extraTools && extraTools.length > 0
       ? [...enabled, ...extraTools]
       : enabled;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -190,7 +190,7 @@ await Promise.all([
     "openai_image_generation",
     "openai_text_to_speech"
   ]),
-  autoEnable("DATA_FOR_SEO_LOGIN", ["dataseo_search", "dataseo_news"]),
+  autoEnable("DATA_FOR_SEO_LOGIN", ["dataforseo_search", "dataforseo_news"]),
   autoEnable("IMAP_USERNAME", ["search_email", "archive_email"])
 ]);
 

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -32,9 +32,9 @@ export const DEFAULT_SETTINGS: ChatSettings = {
     "download_file",
     "http_request",
     "browser",
-    "screenshot",
+    "take_screenshot",
     "run_code",
-    "calculator",
+    "calculate",
     // NodeTool MCP tools
     "list_workflows",
     "get_workflow",

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -35,31 +35,7 @@ import {
 } from "@nodetool-ai/runtime";
 import { initMasterKey } from "@nodetool-ai/security";
 import { initDb, initPostgresDb, runSeeds } from "@nodetool-ai/models";
-import {
-  Tool,
-  GoogleSearchTool,
-  GoogleNewsTool,
-  GoogleImagesTool,
-  GoogleGroundedSearchTool,
-  GoogleImageGenerationTool,
-  OpenAIWebSearchTool,
-  OpenAIImageGenerationTool,
-  OpenAITextToSpeechTool,
-  BrowserTool,
-  ScreenshotTool,
-  HttpRequestTool,
-  CalculatorTool,
-  RunCodeTool,
-  StatisticsTool,
-  GeometryTool,
-  ConversionTool,
-  SearchEmailTool,
-  ArchiveEmailTool,
-  AddLabelToEmailTool,
-  DataForSEOSearchTool,
-  DataForSEONewsTool,
-  DataForSEOImagesTool
-} from "@nodetool-ai/agents";
+import { Tool, BUILTIN_TOOL_CLASSES } from "@nodetool-ai/agents";
 import { registerPythonProviders } from "./models-api.js";
 import type { HttpApiOptions } from "./http-api.js";
 import { handleMcpHttpRequest } from "./mcp-server.js";
@@ -428,40 +404,15 @@ pythonBridge.on("exit", (code: number) => {
 });
 
 // ---------------------------------------------------------------------------
-// Tool registry
+// Tool registry — sourced from @nodetool-ai/agents BUILTIN_TOOL_CLASSES
 // ---------------------------------------------------------------------------
-
-const builtinToolClasses: (new () => Tool)[] = [
-  GoogleSearchTool,
-  GoogleNewsTool,
-  GoogleImagesTool,
-  GoogleGroundedSearchTool,
-  GoogleImageGenerationTool,
-  OpenAIWebSearchTool,
-  OpenAIImageGenerationTool,
-  OpenAITextToSpeechTool,
-  BrowserTool,
-  ScreenshotTool,
-  HttpRequestTool,
-  CalculatorTool,
-  RunCodeTool,
-  StatisticsTool,
-  GeometryTool,
-  ConversionTool,
-  SearchEmailTool,
-  ArchiveEmailTool,
-  AddLabelToEmailTool,
-  DataForSEOSearchTool,
-  DataForSEONewsTool,
-  DataForSEOImagesTool
-];
 
 // Lazy tool class map — defers instantiation until first access.
 let _toolClassMap: Map<string, new () => Tool> | null = null;
 function getToolClassMap(): Map<string, new () => Tool> {
   if (!_toolClassMap) {
     _toolClassMap = new Map();
-    for (const cls of builtinToolClasses) {
+    for (const cls of BUILTIN_TOOL_CLASSES) {
       const instance = new cls();
       _toolClassMap.set(instance.name, cls);
     }

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -3810,8 +3810,14 @@ export class UnifiedWebSocketRunner {
       BrowserTool,
       GoogleSearchTool,
       getAllMcpTools,
-      resolveTool
+      resolveTool,
+      registerBuiltinTools
     } = await import("@nodetool-ai/agents");
+
+    // Ensure the global tool registry is populated with all built-in tools,
+    // so `resolveTool(name)` works for any builtin selected by the client.
+    // Idempotent — only the first call does real work.
+    registerBuiltinTools();
 
     let selectedTools: Tool[] = [];
     const rawToolNames = Array.isArray(data.tools)

--- a/packages/websocket/tests/chat-agent-parity.test.ts
+++ b/packages/websocket/tests/chat-agent-parity.test.ts
@@ -629,7 +629,8 @@ vi.mock("@nodetool-ai/agents", () => {
       name = "google_search";
     },
     getAllMcpTools: () => [],
-    resolveTool: () => null
+    resolveTool: () => null,
+    registerBuiltinTools: () => []
   };
 });
 


### PR DESCRIPTION
Consolidates how built-in agent tools are organized and exposed:

* Move FinishTool out of agent-executor.ts into tools/finish-task-tool.ts
  alongside FinishStepTool and FinishGraphTool. Re-export from the old
  location for backwards compatibility.
* Add BUILTIN_TOOL_CLASSES, getBuiltinTools(), and registerBuiltinTools()
  in tools/builtin-tools.ts as the single source of truth for tools
  selectable from chat/agent frontends. Replaces the duplicated list
  inside packages/websocket/src/server.ts and adds previously missing
  tools (read_file, write_file, list_directory, edit_file, glob, grep,
  pdf tools, http_request, mini-js, etc.) so frontend tool selectors
  for them now actually resolve.
* Wire registerBuiltinTools() into UnifiedWebSocketRunner so the
  global tool-registry is populated on first agent execution; this
  fixes resolveTool(name) which previously returned null for every
  built-in (the registry had no production registrations).
* Add packages/agents/tests/builtin-tools-integration.test.ts: drives
  a SimpleAgent with a fake provider invoking the real CalculatorTool,
  asserts that every frontend-referenced tool ID resolves, and that
  every BUILTIN_TOOL_CLASSES entry instantiates with name/description/
  inputSchema set. (8 tests; full agents suite: 1004 passed.)

https://claude.ai/code/session_01VGesEYt3AfKXkrLcYpS5Mp