### PR TITLE
agents: unify memory across all agent types

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -136,11 +136,19 @@ context.memory.getValue(memoryKeys.task("research"));
 | `input:<key>` | `memoryKeys.input(key)` | Caller-supplied inputs and edge inputs |
 | `shared:<key>` | `memoryKeys.shared(key)` | Cross-agent communication, tool-published facts |
 
-**Propagation rule**: `StepExecutor.buildUserMessage()` injects a Markdown block of every relevant memory entry (`task_result + step_result + input`) into the user message of every step. Downstream tasks discover upstream results without explicit edges or prompt assembly.
+**Access pattern — progressive disclosure via tool calls**: memory contents are NOT auto-injected into prompts. The agent uses three auto-attached tools:
 
-**Multi-agent teams** mirror `TaskBoard` `task_completed` events into `context.memory`, so sub-agents see each other's work through the same channel.
+| Tool | Purpose |
+|---|---|
+| `memory_list` | Discover available entries (metadata only — keys, titles, kinds, byte sizes) |
+| `memory_read` | Fetch full values for specific keys |
+| `memory_write` | Publish a value under `shared:<key>` for other agents to discover |
 
-For the full API, propagation flow, examples, and troubleshooting, see [Agent Memory System](agent-memory.md).
+The default execution system prompt explains these tools; the user message names only the **specific** upstream keys the planner declared as required for the step. Values are pulled on demand.
+
+**Multi-agent teams** mirror `TaskBoard` `task_completed` events into `context.memory`, so sub-agents see each other's work through `memory_list`.
+
+For the full API, tool schemas, propagation flow, examples, and troubleshooting, see [Agent Memory System](agent-memory.md).
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -111,6 +111,39 @@ Steps can use three modes for batch processing:
 
 ---
 
+## Memory
+
+Every `ProcessingContext` carries an **`AgentMemory`** at `context.memory` — the single namespaced store for results shared between steps, tasks, sub-agents, and tools. There are no parallel result maps; all executors write and read through the same API.
+
+```ts
+import { memoryKeys } from "@nodetool-ai/runtime";
+
+context.memory.set({
+  key: memoryKeys.task("research"),
+  kind: "task_result",
+  value: { findings: ["alpha", "beta"] },
+  source: "research",
+  title: "Research findings"
+});
+
+context.memory.getValue(memoryKeys.task("research"));
+```
+
+| Namespace | Helper | Used For |
+|---|---|---|
+| `step:<id>` | `memoryKeys.step(id)` | Per-step results |
+| `task:<id>` | `memoryKeys.task(id)` | Per-task results |
+| `input:<key>` | `memoryKeys.input(key)` | Caller-supplied inputs and edge inputs |
+| `shared:<key>` | `memoryKeys.shared(key)` | Cross-agent communication, tool-published facts |
+
+**Propagation rule**: `StepExecutor.buildUserMessage()` injects a Markdown block of every relevant memory entry (`task_result + step_result + input`) into the user message of every step. Downstream tasks discover upstream results without explicit edges or prompt assembly.
+
+**Multi-agent teams** mirror `TaskBoard` `task_completed` events into `context.memory`, so sub-agents see each other's work through the same channel.
+
+For the full API, propagation flow, examples, and troubleshooting, see [Agent Memory System](agent-memory.md).
+
+---
+
 ## Tool System
 
 Every tool extends a single base class:
@@ -395,6 +428,7 @@ su claude -s /bin/bash -c "CLAUDE_OAUTH_TOKEN=1 npx vitest run packages/runtime/
 
 ## Related Pages
 
+- [Agent Memory System](agent-memory.md) — Unified memory across all agent types: API, propagation, examples
 - [Global Chat & Agents](global-chat-agents.md) — Using agents in the chat interface
 - [Agent CLI](agent-cli.md) — Running agents from the command line
 - [Agent Configuration Schema](agent-config-schema.md) — YAML configuration reference

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -1,0 +1,515 @@
+---
+layout: page
+title: "Agent Memory System"
+permalink: /agent-memory
+description: "Unified, structured memory shared by every agent, task, and step in NodeTool — design, API, and propagation rules."
+---
+
+**Navigation**: [Root AGENTS.md](../AGENTS.md) | [Agent System](AGENTS.md) → **Agent Memory**
+
+The **agent memory system** is the single source of truth for everything that flows between agents, tasks, steps, sub-agents, and tools during a workflow run. One `AgentMemory` instance lives on every `ProcessingContext` as `context.memory`. All executors read from it and write to it through a single namespaced API.
+
+This page is the comprehensive reference. For a quick orientation, jump to [Quick Reference](#quick-reference) or [Examples](#examples).
+
+---
+
+## Why This Exists
+
+Earlier versions of the agent system kept results in three uncoordinated stores:
+
+| Store | Owner | Used For |
+|---|---|---|
+| `ProcessingContext._variables` | Runtime | Step results (`storeStepResult`), inputs |
+| `ParallelTaskExecutor.taskResults` | Plan-mode executor (private map) | Task-level results in plan mode |
+| `TaskBoard.task.result` | TeamExecutor | Task-level results in multi-agent mode |
+
+The three drifted out of sync. Worse, each agent type had its own way to deliver upstream results to the LLM:
+
+- `StepExecutor` injected dependency results into the *user message*, but only iterated `step.dependsOn` (intra-task) — task-level dependencies were invisible at this layer.
+- `ParallelTaskExecutor` built an "enhanced system prompt" that **replaced** the default execution prompt — discarding the `finish_step` discipline and breaking result capture.
+- `TeamExecutor` re-rendered prompts from `TaskBoard.task.result` and passed nothing through `context`.
+
+The fix is one store, one API, one rendering.
+
+---
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────┐
+                    │     ProcessingContext.memory     │
+                    │                                  │
+                    │  Map<string, MemoryEntry>        │
+                    │                                  │
+                    │  step:<id>   step_result         │
+                    │  task:<id>   task_result         │
+                    │  input:<key> input               │
+                    │  shared:<k>  shared              │
+                    └────────────┬─────────────────────┘
+                                 │
+       ┌─────────────────────────┼─────────────────────────┐
+       │                         │                         │
+       ▼                         ▼                         ▼
+  StepExecutor           ParallelTaskExecutor        TeamExecutor
+  (writes step:,         (reads task: deps,         (subscribes to
+   task: on              writes task: results)       TaskBoard, mirrors
+   finish-task steps)                                completed tasks)
+```
+
+Every executor writes results into `context.memory`. Every step gets a Markdown snapshot of relevant memory entries injected into its user message via `AgentMemory.formatForPrompt()`. Downstream tasks discover upstream results without any side channel.
+
+---
+
+## Key Namespaces
+
+| Namespace | Helper | Written By | Used For |
+|---|---|---|---|
+| `step:<id>` | `memoryKeys.step(id)` | `StepExecutor`, `TaskExecutor` (process mode) | Per-step results |
+| `task:<id>` | `memoryKeys.task(id)` | `StepExecutor` (finish-task steps), `ParallelTaskExecutor`, `TeamExecutor` | Per-task results |
+| `input:<key>` | `memoryKeys.input(key)` | `TaskExecutor`, `ParallelTaskExecutor`, `AgentStepExecutor` | Caller-supplied inputs and edge inputs |
+| `shared:<key>` | `memoryKeys.shared(key)` | Tools, custom code | Cross-agent communication, scratch space |
+
+Always use the helper functions when constructing keys — they prevent typos and make grep-able call sites.
+
+```ts
+import { memoryKeys } from "@nodetool-ai/runtime";
+
+context.memory.has(memoryKeys.task("research_phase"));
+context.memory.getValue(memoryKeys.step("step_1"));
+```
+
+---
+
+## Memory Entry Shape
+
+```ts
+export interface MemoryEntry {
+  /** Globally unique key (use memoryKeys.*). */
+  key: string;
+  /** Categorization for filtering and prompt rendering. */
+  kind: "task_result" | "step_result" | "input" | "shared";
+  /** Stored value (any JSON-serializable structure). */
+  value: unknown;
+  /** Optional ID of the producer (task / step / agent / tool). */
+  source?: string;
+  /** Optional human-readable title used as the prompt heading. */
+  title?: string;
+  /** Optional brief description rendered alongside the title. */
+  description?: string;
+  /** Wall-clock ms when the entry was first written. */
+  createdAt: number;
+}
+```
+
+`title` and `description` flow through to prompt rendering, so set them when you want the LLM to see a friendly label rather than a UUID.
+
+---
+
+## API Reference
+
+The full class lives in `packages/runtime/src/agent-memory.ts` and is re-exported from `@nodetool-ai/runtime`.
+
+### Writing
+
+```ts
+context.memory.set({
+  key: memoryKeys.task("research"),
+  kind: "task_result",
+  value: { findings: ["alpha", "beta"] },
+  source: "research",
+  title: "Research findings",
+  description: "Top three sources from the web search step."
+});
+```
+
+`set` returns the persisted `MemoryEntry`. Repeated writes for the same key overwrite the value but preserve the original `createdAt`.
+
+### Reading
+
+```ts
+// Full entry (kind, source, title, ...)
+const entry = context.memory.get(memoryKeys.task("research"));
+
+// Just the value (no metadata)
+const findings = context.memory.getValue<{ findings: string[] }>(
+  memoryKeys.task("research")
+);
+
+// Existence check
+context.memory.has(memoryKeys.task("research"));
+
+// Snapshot (insertion order)
+context.memory.snapshot();
+```
+
+### Listing & Filtering
+
+```ts
+// All entries (no filter)
+context.memory.list();
+
+// Single kind
+context.memory.list({ kind: "task_result" });
+
+// Multiple kinds
+context.memory.list({ kind: ["task_result", "input"] });
+
+// Specific keys
+context.memory.list({ keys: ["task:research", "task:report"] });
+
+// Prefix match
+context.memory.list({ keyPrefix: "step:" });
+
+// By producer
+context.memory.list({ sources: ["research", "summary"] });
+```
+
+### Prompt Rendering
+
+```ts
+const block = context.memory.formatForPrompt({
+  kind: ["task_result", "step_result", "input"]
+});
+```
+
+`formatForPrompt` returns a Markdown block ready to inject into a user/system prompt. It sorts entries by `createdAt` ascending and renders each as:
+
+```markdown
+## [task_result] Research findings (task:research)
+Top three sources from the web search step.
+```
+{
+  "findings": ["alpha", "beta"]
+}
+```
+```
+
+When no entries match the filter, it returns an empty string. The default user-message injection in `StepExecutor.buildUserMessage` filters by `task_result | step_result | input`.
+
+### Subscriptions
+
+```ts
+const unsubscribe = context.memory.subscribe((entry) => {
+  console.log(`memory write: ${entry.key} (${entry.kind})`);
+});
+// later...
+unsubscribe();
+```
+
+Subscribers fire synchronously on every `set`. `TeamExecutor` uses this to mirror `TaskBoard` task completions into shared memory, and tests use it to capture write order.
+
+### Clearing
+
+```ts
+context.memory.clear();                          // wipe everything
+context.memory.clear({ kind: "step_result" });   // selective
+context.memory.clear({ keyPrefix: "input:" });   // by prefix
+```
+
+---
+
+## How Each Agent Type Uses Memory
+
+### StepExecutor (`packages/agents/src/step-executor.ts`)
+
+The execution engine for a single step. On completion, it writes:
+
+| Trigger | Key | Kind |
+|---|---|---|
+| Always | `step:<step.id>` | `step_result` |
+| Last step of a task (finish-task) | `task:<task.id>` | `task_result` |
+| Step exhausted iterations | `step:<step.id>` (with `{ error }`) | `step_result` |
+
+Before each LLM call, `buildUserMessage()` renders the full memory snapshot of `task_result + step_result + input` into the user message. This guarantees the LLM sees **every** prior result, not just declared `dependsOn` IDs — protection against under-specified plans.
+
+`buildSystemPrompt()` always uses the default execution prompt (with output-schema and `finish_step` directives). A caller-supplied `systemPrompt` is layered as a *preamble*, never replacing the defaults. This is the key fix for plan-mode reliability — earlier versions allowed the parent's prompt to clobber the execution discipline.
+
+### TaskExecutor (`packages/agents/src/task-executor.ts`)
+
+Walks the step DAG of a single task. On startup it seeds caller inputs:
+
+```ts
+for (const [key, value] of Object.entries(this.inputs)) {
+  this.context.memory.set({
+    key: memoryKeys.input(key),
+    kind: "input",
+    value,
+    title: key
+  });
+}
+```
+
+In **process mode** (fan-out over a discover step's list), it reads the discover result via `memoryKeys.step(discoverStepId)` and writes the aggregated array back under `memoryKeys.step(processStepId)` after collecting per-item results.
+
+### ParallelTaskExecutor (`packages/agents/src/parallel-task-executor.ts`)
+
+Runs a `TaskPlan` of multiple tasks as a DAG. It owns no private result map — everything lives in `context.memory`.
+
+| Operation | Memory Action |
+|---|---|
+| Startup: seed inputs | `set` each as `input:<key>` |
+| Schedule task | (no memory access — purely structural via `task.completed`) |
+| After task executor completes | If no `is_task_result` was emitted, fall back to `step:<lastStepId>` |
+| Idempotent task write | `set` `task:<task.id>` only if not already present (StepExecutor already wrote it for finish-task steps) |
+| Read final result | `getFinalResult()` returns `getValue(task:<lastTaskId>)` |
+| Read all results | `getAllResults()` lists all `task_result` entries |
+| Read specific task | `getTaskResult(id)` |
+
+Downstream tasks discover upstream task results through `StepExecutor.buildUserMessage` — no special prompt assembly needed in this layer.
+
+### TeamExecutor (`packages/agents/src/team/team-executor.ts`)
+
+Multi-agent mode using a shared `TaskBoard` + `MessageBus`. On startup, `execute()` subscribes to board events:
+
+```ts
+this.board.onEvent((event) => {
+  if (event.type !== "task_completed") return;
+  const task = this.board.get(event.taskId);
+  if (!task) return;
+  this.context.memory.set({
+    key: memoryKeys.task(task.id),
+    kind: "task_result",
+    value: task.result,
+    source: task.id,
+    title: task.title,
+    description: task.description
+  });
+});
+```
+
+Every time an agent completes a task on the board, the result is mirrored into shared memory. Other agents see it in their next `runAgentWorkCycle()`, which now injects:
+
+```ts
+const memoryBlock = this.context.memory.formatForPrompt({
+  kind: ["task_result", "shared", "input"]
+});
+```
+
+This makes the team's execution loop equivalent to plan mode from the LLM's perspective: every teammate's completed work is visible.
+
+### AgentStepExecutor (`packages/agents/src/agent-step-executor.ts`)
+
+The bridge between the kernel's workflow runner and the agent system. When a workflow node of type `nodetool.agents.AgentStep` runs, this adapter wraps `StepExecutor`. It also surfaces upstream **edge** inputs into memory:
+
+```ts
+for (const [key, value] of Object.entries(inputs)) {
+  if (value === undefined || value === null) continue;
+  context.memory.set({
+    key: memoryKeys.input(`${this.node.id}.${key}`),
+    kind: "input",
+    value,
+    source: this.node.id,
+    title: `${this.node.id}.${key}`
+  });
+}
+```
+
+The result is written under `step:<node.id>` by `StepExecutor`, so subsequent agent steps in the same workflow graph see prior nodes' outputs through memory automatically.
+
+### MultiModeAgent (`packages/agents/src/multi-mode-agent.ts`)
+
+The top-level dispatcher (`loop` / `plan` / `multi-agent` modes). Memory itself is mode-independent: each mode delegates to the executor above, which all use `context.memory`.
+
+---
+
+## Propagation Flow
+
+This is the canonical end-to-end flow for a multi-task plan:
+
+```
+1. Caller: agent.execute(context)
+2. ParallelTaskExecutor.execute()
+   ├─ Seed inputs:  context.memory.set({ kind: "input", ... })
+   └─ For each executable task:
+      └─ TaskExecutor.executeTasks()
+         └─ For each step:
+            └─ StepExecutor.execute()
+               ├─ buildUserMessage() →
+               │     prompt includes formatForPrompt({
+               │       kind: ["task_result", "step_result", "input"]
+               │     })
+               ├─ LLM streams → tool calls
+               ├─ finish_step received → storeCompletionResult()
+               │     ├─ context.memory.set({ key: "step:<id>", ... })
+               │     └─ if useFinishTask:
+               │         context.memory.set({ key: "task:<id>", ... })
+               └─ yield step_result
+3. ParallelTaskExecutor: ensure task: entry exists (idempotent)
+4. Mark task.completed = true → unblocks downstream tasks
+5. Next iteration: downstream tasks now executable, see all prior
+   memory entries via buildUserMessage
+```
+
+The same flow applies to `TeamExecutor` with the board-event subscription standing in for the explicit task-result write.
+
+---
+
+## Examples
+
+### Inspect memory at the end of an agent run
+
+```ts
+import { Agent } from "@nodetool-ai/agents";
+import { memoryKeys } from "@nodetool-ai/runtime";
+
+const agent = new Agent({ /* ... */ });
+for await (const _msg of agent.execute(context)) { /* drain */ }
+
+console.log("Final result:", agent.getResults());
+console.log("All task results:", context.memory.list({ kind: "task_result" }));
+console.log(
+  "Specific task:",
+  context.memory.getValue(memoryKeys.task("research_phase"))
+);
+```
+
+### Tool that publishes to shared memory
+
+```ts
+import { Tool } from "@nodetool-ai/agents";
+import { memoryKeys } from "@nodetool-ai/runtime";
+
+class PublishFactTool extends Tool {
+  readonly name = "publish_fact";
+  readonly description = "Publish a fact into shared agent memory.";
+  readonly inputSchema = {
+    type: "object",
+    properties: {
+      key: { type: "string" },
+      value: { type: "string" }
+    },
+    required: ["key", "value"]
+  };
+
+  async process(context, params) {
+    context.memory.set({
+      key: memoryKeys.shared(String(params.key)),
+      kind: "shared",
+      value: params.value,
+      source: this.name,
+      title: `Fact: ${params.key}`
+    });
+    return { ok: true };
+  }
+}
+```
+
+Subsequent steps will see the fact in their user-message memory block automatically — no edges, no plumbing.
+
+### Subscribe in a host application (UI sidebar)
+
+```ts
+const unsubscribe = context.memory.subscribe((entry) => {
+  ui.appendMemoryEntry(entry); // render the new entry in a side panel
+});
+// ...
+unsubscribe();
+```
+
+### Pre-populate memory before running
+
+Useful for tests or for restoring state from a checkpoint:
+
+```ts
+context.memory.set({
+  key: memoryKeys.task("prior_research"),
+  kind: "task_result",
+  value: cachedFindings,
+  source: "prior_research",
+  title: "Cached prior research"
+});
+
+const agent = new MultiModeAgent({
+  name: "follow-up",
+  objective: "Build on the prior research findings.",
+  /* ... */,
+  mode: "plan"
+});
+// First step's user message will include the pre-populated entry.
+```
+
+---
+
+## Quick Reference
+
+```ts
+import { AgentMemory, memoryKeys, type MemoryEntry } from "@nodetool-ai/runtime";
+
+// Already mounted on every ProcessingContext
+context.memory; // AgentMemory
+
+// Write
+context.memory.set({
+  key: memoryKeys.task("t1"),
+  kind: "task_result",
+  value: result,
+  source: "t1",
+  title: "Task One"
+});
+
+// Read
+context.memory.get(memoryKeys.task("t1"));        // MemoryEntry | undefined
+context.memory.getValue(memoryKeys.task("t1"));   // unknown | undefined
+context.memory.has(memoryKeys.task("t1"));        // boolean
+
+// List / filter
+context.memory.list({ kind: "task_result" });
+context.memory.list({ keyPrefix: "step:" });
+context.memory.list({ sources: ["research"] });
+
+// Render for prompts
+context.memory.formatForPrompt({ kind: ["task_result", "input"] });
+
+// Subscribe
+const off = context.memory.subscribe((entry) => { /* ... */ });
+
+// Clear
+context.memory.clear({ kind: "step_result" });
+```
+
+---
+
+## Design Decisions
+
+**Why a single map and not a relational store?**
+Agent runs are short-lived and the data is small (typically tens of entries). A `Map` plus structured rendering covers every observed use case without the operational cost of a database. Persistent storage belongs in the asset / vector layer, not in working memory.
+
+**Why namespaced string keys instead of typed IDs?**
+The LLM has to read the keys back from the prompt block (e.g. "the result of task `task:research_phase` was ..."). Strings round-trip cleanly through prompts and logs without serialization games.
+
+**Why include all upstream memory in every step's user message, instead of just `dependsOn`?**
+Planners drop edges. Tools surface results the planner never knew about. Sub-agents complete tasks the planner didn't anticipate. Including the full snapshot is the smallest reliable contract — tokens are cheap, missed propagation is expensive. If you ever need to scope visibility per task, the filter API supports it without architectural changes.
+
+**Why isn't memory shared across `context.copy()`?**
+Copies are designed for isolated sub-runs. If a sub-run should inherit memory, the caller can `set` entries from the parent before kicking it off, or pass the same context. Default isolation is the safer choice.
+
+**Why does `customPrompt` no longer replace the default execution prompt?**
+Replacing it stripped the `finish_step` discipline and broke result capture in plan mode. The fix layers any caller preamble before the default prompt rather than replacing it. The execution contract (output schema, completion protocol, conclusion-stage rules) is now non-bypassable.
+
+---
+
+## Troubleshooting
+
+**Symptom:** A downstream task's prompt contains an empty memory block.
+- Check the planner output: did the upstream step have an `outputSchema`? Without one, `StepExecutor` runs in unstructured mode and accepts plain text content as the result. If your mock or model only emits a `finish_step` tool call (no text fallback), the step never completes and never writes to memory.
+- Verify the step actually completed: look for `task_update` events with `event: StepCompleted`, and inspect `context.memory.snapshot()`.
+
+**Symptom:** Task result key is missing after the step yielded `step_result` with `is_task_result: true`.
+- `StepExecutor` only writes `task:<id>` for steps where `useFinishTask === true`. That flag is set by `TaskExecutor.isFinishStep()` for the last step in the task (or the explicit `finalStepId` option). Steps in the middle of a task only write `step:<id>`.
+- For belt-and-suspenders, `ParallelTaskExecutor` also performs an idempotent task-result write after each task, falling back to the last step's value.
+
+**Symptom:** Cross-agent results not visible in `TeamExecutor` agents.
+- Verify the board emitted `task_completed` events. The mirror subscription only fires on that event type — tasks that fail or stay `working` won't be mirrored.
+- Check that `context.memory.has(memoryKeys.task(taskId))` is true after the relevant teammate completes its work.
+
+**Symptom:** Tests pass but memory entries seem stale across test runs.
+- A new `AgentMemory` instance is constructed for every `ProcessingContext`. If you reuse a context across tests, call `context.memory.clear()` between them.
+
+---
+
+## Related
+
+- [Agent System](AGENTS.md) — overall architecture
+- `packages/runtime/src/agent-memory.ts` — implementation
+- `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation tests
+- `packages/runtime/tests/agent-memory.test.ts` — `AgentMemory` unit tests

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -2,12 +2,16 @@
 layout: page
 title: "Agent Memory System"
 permalink: /agent-memory
-description: "Unified, structured memory shared by every agent, task, and step in NodeTool — design, API, and propagation rules."
+description: "Unified, structured memory shared by every agent, task, and step in NodeTool — accessed via tool calls with progressive disclosure."
 ---
 
 **Navigation**: [Root AGENTS.md](../AGENTS.md) | [Agent System](AGENTS.md) → **Agent Memory**
 
-The **agent memory system** is the single source of truth for everything that flows between agents, tasks, steps, sub-agents, and tools during a workflow run. One `AgentMemory` instance lives on every `ProcessingContext` as `context.memory`. All executors read from it and write to it through a single namespaced API.
+The **agent memory system** is the single source of truth for everything that flows between agents, tasks, steps, sub-agents, and tools during a workflow run. One `AgentMemory` instance lives on every `ProcessingContext` as `context.memory`. All executors read from and write to it through a single namespaced API, and every agent accesses it through three auto-attached tools:
+
+- `memory_list` — discover what's available (metadata only)
+- `memory_read` — fetch full values for specific keys
+- `memory_write` — publish a value under the `shared:` namespace
 
 This page is the comprehensive reference. For a quick orientation, jump to [Quick Reference](#quick-reference) or [Examples](#examples).
 
@@ -15,21 +19,13 @@ This page is the comprehensive reference. For a quick orientation, jump to [Quic
 
 ## Why This Exists
 
-Earlier versions of the agent system kept results in three uncoordinated stores:
+Earlier versions of the agent system kept results in three uncoordinated stores (`context._variables`, `ParallelTaskExecutor.taskResults`, `TaskBoard.task.result`) and had each agent type deliver upstream results to the LLM differently. Plan mode replaced the default execution prompt with a "dependency context" block that stripped the `finish_step` discipline, so downstream tasks routinely lost results.
 
-| Store | Owner | Used For |
-|---|---|---|
-| `ProcessingContext._variables` | Runtime | Step results (`storeStepResult`), inputs |
-| `ParallelTaskExecutor.taskResults` | Plan-mode executor (private map) | Task-level results in plan mode |
-| `TaskBoard.task.result` | TeamExecutor | Task-level results in multi-agent mode |
+The fix is one store, one API, and one access pattern — **progressive disclosure via tool calls**:
 
-The three drifted out of sync. Worse, each agent type had its own way to deliver upstream results to the LLM:
-
-- `StepExecutor` injected dependency results into the *user message*, but only iterated `step.dependsOn` (intra-task) — task-level dependencies were invisible at this layer.
-- `ParallelTaskExecutor` built an "enhanced system prompt" that **replaced** the default execution prompt — discarding the `finish_step` discipline and breaking result capture.
-- `TeamExecutor` re-rendered prompts from `TaskBoard.task.result` and passed nothing through `context`.
-
-The fix is one store, one API, one rendering.
+- **Auto-injection is wasteful**: dumping all upstream results into every prompt bloats context with data the step rarely needs.
+- **Tool-mediated access is selective**: the agent sees a tiny "what's available" hint in the system prompt and pulls only the values it actually needs.
+- **Specific declared dependencies still get a nudge**: if the planner declared `task.dependsOn` or `step.dependsOn`, those exact memory keys appear in the user message as a hint — but the values are not included.
 
 ---
 
@@ -51,12 +47,16 @@ The fix is one store, one API, one rendering.
        │                         │                         │
        ▼                         ▼                         ▼
   StepExecutor           ParallelTaskExecutor        TeamExecutor
-  (writes step:,         (reads task: deps,         (subscribes to
-   task: on              writes task: results)       TaskBoard, mirrors
-   finish-task steps)                                completed tasks)
+  (writes step:,         (passes task.dependsOn      (subscribes to
+   task: on              IDs as upstream key          TaskBoard, mirrors
+   finish-task steps;    hints to TaskExecutor)       completed tasks;
+   auto-attaches                                      adds memory tools
+   memory_list /                                      to shared toolset)
+   memory_read /
+   memory_write tools)
 ```
 
-Every executor writes results into `context.memory`. Every step gets a Markdown snapshot of relevant memory entries injected into its user message via `AgentMemory.formatForPrompt()`. Downstream tasks discover upstream results without any side channel.
+Every executor writes results into `context.memory`. Every step has the three memory tools available automatically, and the system prompt instructs the model when to use them.
 
 ---
 
@@ -67,7 +67,7 @@ Every executor writes results into `context.memory`. Every step gets a Markdown 
 | `step:<id>` | `memoryKeys.step(id)` | `StepExecutor`, `TaskExecutor` (process mode) | Per-step results |
 | `task:<id>` | `memoryKeys.task(id)` | `StepExecutor` (finish-task steps), `ParallelTaskExecutor`, `TeamExecutor` | Per-task results |
 | `input:<key>` | `memoryKeys.input(key)` | `TaskExecutor`, `ParallelTaskExecutor`, `AgentStepExecutor` | Caller-supplied inputs and edge inputs |
-| `shared:<key>` | `memoryKeys.shared(key)` | Tools, custom code | Cross-agent communication, scratch space |
+| `shared:<key>` | `memoryKeys.shared(key)` | `memory_write` tool | Cross-agent communication, scratch space |
 
 Always use the helper functions when constructing keys — they prevent typos and make grep-able call sites.
 
@@ -86,28 +86,113 @@ context.memory.getValue(memoryKeys.step("step_1"));
 export interface MemoryEntry {
   /** Globally unique key (use memoryKeys.*). */
   key: string;
-  /** Categorization for filtering and prompt rendering. */
+  /** Categorization for filtering and rendering. */
   kind: "task_result" | "step_result" | "input" | "shared";
   /** Stored value (any JSON-serializable structure). */
   value: unknown;
   /** Optional ID of the producer (task / step / agent / tool). */
   source?: string;
-  /** Optional human-readable title used as the prompt heading. */
+  /** Optional human-readable title shown in `memory_list`. */
   title?: string;
-  /** Optional brief description rendered alongside the title. */
+  /** Optional brief description. */
   description?: string;
   /** Wall-clock ms when the entry was first written. */
   createdAt: number;
 }
 ```
 
-`title` and `description` flow through to prompt rendering, so set them when you want the LLM to see a friendly label rather than a UUID.
+`title` and `description` flow through to `memory_list` output, so set them when you want the LLM to see a friendly label rather than a UUID.
 
 ---
 
-## API Reference
+## Memory Tools (the LLM-facing API)
 
-The full class lives in `packages/runtime/src/agent-memory.ts` and is re-exported from `@nodetool-ai/runtime`.
+Three tools are auto-attached to every `StepExecutor` and to `TeamExecutor`'s shared tool list. Their schemas are documented at the top of every default execution system prompt so the model knows when to call them.
+
+### `memory_list`
+
+Discover available entries without paying for their values.
+
+```jsonc
+// args
+{
+  "kind": ["task_result", "shared"],   // optional filter
+  "key_prefix": "task:",                // optional filter
+  "sources": ["research", "summary"]    // optional filter
+}
+
+// result
+{
+  "total": 4,
+  "returned": 4,
+  "truncated": false,
+  "entries": [
+    {
+      "key": "task:research",
+      "kind": "task_result",
+      "title": "Research findings",
+      "description": "Top three sources from the web search step.",
+      "source": "research",
+      "valueBytes": 142,
+      "createdAt": "2026-05-07T14:00:01.234Z"
+    }
+    // ...
+  ]
+}
+```
+
+`valueBytes` is the size of the JSON-serialized value — useful for the model to budget reads. The result is hard-capped at 200 entries; older entries are truncated and reported via `truncated: true`.
+
+### `memory_read`
+
+Fetch full values for one or more keys.
+
+```jsonc
+// args
+{ "keys": ["task:research", "step:summary"] }
+
+// result
+{
+  "entries": {
+    "task:research": {
+      "key": "task:research",
+      "kind": "task_result",
+      "value": { "findings": ["alpha", "beta"] },
+      "source": "research",
+      "title": "Research findings",
+      "createdAt": 1700000000000
+    }
+  },
+  "missing": ["step:summary"]
+}
+```
+
+Missing keys are reported in `missing` so the model can decide whether to retry, list again, or proceed without them.
+
+### `memory_write`
+
+Publish a value under the `shared:` namespace so other agents and steps can discover it via `memory_list`.
+
+```jsonc
+// args
+{
+  "key": "top_source",                 // suffix; stored as "shared:top_source"
+  "value": "https://example.com",
+  "title": "Top source URL",
+  "description": "Picked by the researcher agent."
+}
+
+// result
+{ "ok": true, "key": "shared:top_source", "kind": "shared", "createdAt": "..." }
+```
+
+Writes are restricted to the `shared:` namespace to prevent agents from spoofing step / task / input results.
+
+---
+
+## Direct API Reference
+
+The `AgentMemory` class lives in `packages/runtime/src/agent-memory.ts` and is re-exported from `@nodetool-ai/runtime`. Tools and executors use this API directly; agents reach it only through the three memory tools above.
 
 ### Writing
 
@@ -127,64 +212,22 @@ context.memory.set({
 ### Reading
 
 ```ts
-// Full entry (kind, source, title, ...)
-const entry = context.memory.get(memoryKeys.task("research"));
-
-// Just the value (no metadata)
-const findings = context.memory.getValue<{ findings: string[] }>(
-  memoryKeys.task("research")
-);
-
-// Existence check
-context.memory.has(memoryKeys.task("research"));
-
-// Snapshot (insertion order)
-context.memory.snapshot();
+context.memory.get(memoryKeys.task("research"));        // MemoryEntry | undefined
+context.memory.getValue<T>(memoryKeys.task("research")); // T | undefined
+context.memory.has(memoryKeys.task("research"));        // boolean
+context.memory.snapshot();                              // MemoryEntry[]
 ```
 
 ### Listing & Filtering
 
 ```ts
-// All entries (no filter)
-context.memory.list();
-
-// Single kind
+context.memory.list();                                    // all
 context.memory.list({ kind: "task_result" });
-
-// Multiple kinds
 context.memory.list({ kind: ["task_result", "input"] });
-
-// Specific keys
 context.memory.list({ keys: ["task:research", "task:report"] });
-
-// Prefix match
 context.memory.list({ keyPrefix: "step:" });
-
-// By producer
-context.memory.list({ sources: ["research", "summary"] });
+context.memory.list({ sources: ["research"] });
 ```
-
-### Prompt Rendering
-
-```ts
-const block = context.memory.formatForPrompt({
-  kind: ["task_result", "step_result", "input"]
-});
-```
-
-`formatForPrompt` returns a Markdown block ready to inject into a user/system prompt. It sorts entries by `createdAt` ascending and renders each as:
-
-```markdown
-## [task_result] Research findings (task:research)
-Top three sources from the web search step.
-```
-{
-  "findings": ["alpha", "beta"]
-}
-```
-```
-
-When no entries match the filter, it returns an empty string. The default user-message injection in `StepExecutor.buildUserMessage` filters by `task_result | step_result | input`.
 
 ### Subscriptions
 
@@ -196,7 +239,7 @@ const unsubscribe = context.memory.subscribe((entry) => {
 unsubscribe();
 ```
 
-Subscribers fire synchronously on every `set`. `TeamExecutor` uses this to mirror `TaskBoard` task completions into shared memory, and tests use it to capture write order.
+`TeamExecutor` uses this to mirror `TaskBoard` task completions into shared memory. UIs can use it to render a live memory side panel.
 
 ### Clearing
 
@@ -212,7 +255,9 @@ context.memory.clear({ keyPrefix: "input:" });   // by prefix
 
 ### StepExecutor (`packages/agents/src/step-executor.ts`)
 
-The execution engine for a single step. On completion, it writes:
+The execution engine for a single step.
+
+**Writes**:
 
 | Trigger | Key | Kind |
 |---|---|---|
@@ -220,9 +265,17 @@ The execution engine for a single step. On completion, it writes:
 | Last step of a task (finish-task) | `task:<task.id>` | `task_result` |
 | Step exhausted iterations | `step:<step.id>` (with `{ error }`) | `step_result` |
 
-Before each LLM call, `buildUserMessage()` renders the full memory snapshot of `task_result + step_result + input` into the user message. This guarantees the LLM sees **every** prior result, not just declared `dependsOn` IDs — protection against under-specified plans.
+**LLM access**:
 
-`buildSystemPrompt()` always uses the default execution prompt (with output-schema and `finish_step` directives). A caller-supplied `systemPrompt` is layered as a *preamble*, never replacing the defaults. This is the key fix for plan-mode reliability — earlier versions allowed the parent's prompt to clobber the execution discipline.
+- The default execution system prompts (`DEFAULT_EXECUTION_SYSTEM_PROMPT`, `DEFAULT_FINISH_TASK_SYSTEM_PROMPT`, `DEFAULT_UNSTRUCTURED_SYSTEM_PROMPT`) include a `## Memory Tools (progressive disclosure)` section that explains how to use the tools.
+- The user message includes only **specific declared upstream keys** as a hint:
+  - `step:<id>` for every entry of the step's `dependsOn` (intra-task deps).
+  - any key supplied via `StepExecutorOptions.upstreamMemoryKeys` (typically `task:<id>` from the parent task's `dependsOn`).
+- Values are not included; the agent calls `memory_read` to fetch them.
+
+**Tool attachment**: `getMemoryTools()` is auto-pushed into the step's tool list at construction time, alongside any caller-supplied tools and (when the step has a schema) `finish_step`. The conclusion stage strips everything except `finish_step`.
+
+**Custom prompts are preambles, not replacements**: A caller-supplied `systemPrompt` is layered before the default execution prompt, so the contract — including the memory-tool documentation and `finish_step` discipline — is non-bypassable.
 
 ### TaskExecutor (`packages/agents/src/task-executor.ts`)
 
@@ -241,6 +294,8 @@ for (const [key, value] of Object.entries(this.inputs)) {
 
 In **process mode** (fan-out over a discover step's list), it reads the discover result via `memoryKeys.step(discoverStepId)` and writes the aggregated array back under `memoryKeys.step(processStepId)` after collecting per-item results.
 
+`TaskExecutor` accepts an optional `upstreamMemoryKeys` array (e.g. `task:<id>` keys from the parent plan). It forwards this verbatim to every `StepExecutor` it creates.
+
 ### ParallelTaskExecutor (`packages/agents/src/parallel-task-executor.ts`)
 
 Runs a `TaskPlan` of multiple tasks as a DAG. It owns no private result map — everything lives in `context.memory`.
@@ -248,14 +303,14 @@ Runs a `TaskPlan` of multiple tasks as a DAG. It owns no private result map — 
 | Operation | Memory Action |
 |---|---|
 | Startup: seed inputs | `set` each as `input:<key>` |
-| Schedule task | (no memory access — purely structural via `task.completed`) |
+| For each task: derive upstream keys | `task.dependsOn.map(memoryKeys.task)` → forwarded as `upstreamMemoryKeys` to `TaskExecutor` |
 | After task executor completes | If no `is_task_result` was emitted, fall back to `step:<lastStepId>` |
-| Idempotent task write | `set` `task:<task.id>` only if not already present (StepExecutor already wrote it for finish-task steps) |
+| Idempotent task write | `set` `task:<task.id>` only if not already present |
 | Read final result | `getFinalResult()` returns `getValue(task:<lastTaskId>)` |
 | Read all results | `getAllResults()` lists all `task_result` entries |
 | Read specific task | `getTaskResult(id)` |
 
-Downstream tasks discover upstream task results through `StepExecutor.buildUserMessage` — no special prompt assembly needed in this layer.
+Downstream tasks see their declared upstream task keys as hints in the step user message and pull values via `memory_read` when needed.
 
 ### TeamExecutor (`packages/agents/src/team/team-executor.ts`)
 
@@ -277,15 +332,7 @@ this.board.onEvent((event) => {
 });
 ```
 
-Every time an agent completes a task on the board, the result is mirrored into shared memory. Other agents see it in their next `runAgentWorkCycle()`, which now injects:
-
-```ts
-const memoryBlock = this.context.memory.formatForPrompt({
-  kind: ["task_result", "shared", "input"]
-});
-```
-
-This makes the team's execution loop equivalent to plan mode from the LLM's perspective: every teammate's completed work is visible.
+Each agent's tool set includes the memory tools alongside the team tools and any caller-supplied shared tools. The team system prompt has a `## Shared Memory (progressive disclosure)` section instructing teammates to use `memory_list` / `memory_read` to discover and fetch each other's results.
 
 ### AgentStepExecutor (`packages/agents/src/agent-step-executor.ts`)
 
@@ -304,7 +351,7 @@ for (const [key, value] of Object.entries(inputs)) {
 }
 ```
 
-The result is written under `step:<node.id>` by `StepExecutor`, so subsequent agent steps in the same workflow graph see prior nodes' outputs through memory automatically.
+The result is written under `step:<node.id>` by `StepExecutor`, so subsequent agent steps in the same workflow graph discover prior nodes' outputs through `memory_list`.
 
 ### MultiModeAgent (`packages/agents/src/multi-mode-agent.ts`)
 
@@ -324,11 +371,16 @@ This is the canonical end-to-end flow for a multi-task plan:
       └─ TaskExecutor.executeTasks()
          └─ For each step:
             └─ StepExecutor.execute()
-               ├─ buildUserMessage() →
-               │     prompt includes formatForPrompt({
-               │       kind: ["task_result", "step_result", "input"]
-               │     })
-               ├─ LLM streams → tool calls
+               ├─ buildSystemPrompt() → default execution prompt
+               │     (includes "Memory Tools" section)
+               ├─ buildUserMessage() → instructions
+               │     + "Required upstream memory" hint listing
+               │       declared dependency keys (no values)
+               ├─ LLM streams → may emit:
+               │     - memory_list  → returns metadata
+               │     - memory_read  → returns values for chosen keys
+               │     - memory_write → publishes shared facts
+               │     - other tools / finish_step
                ├─ finish_step received → storeCompletionResult()
                │     ├─ context.memory.set({ key: "step:<id>", ... })
                │     └─ if useFinishTask:
@@ -336,8 +388,9 @@ This is the canonical end-to-end flow for a multi-task plan:
                └─ yield step_result
 3. ParallelTaskExecutor: ensure task: entry exists (idempotent)
 4. Mark task.completed = true → unblocks downstream tasks
-5. Next iteration: downstream tasks now executable, see all prior
-   memory entries via buildUserMessage
+5. Next iteration: downstream tasks now executable. Their step user
+   messages name the upstream task keys; agents call memory_read when
+   they actually need the values.
 ```
 
 The same flow applies to `TeamExecutor` with the board-event subscription standing in for the explicit task-result write.
@@ -363,48 +416,35 @@ console.log(
 );
 ```
 
-### Tool that publishes to shared memory
+### What the LLM sees (system prompt extract)
 
-```ts
-import { Tool } from "@nodetool-ai/agents";
-import { memoryKeys } from "@nodetool-ai/runtime";
+The default execution system prompt includes:
 
-class PublishFactTool extends Tool {
-  readonly name = "publish_fact";
-  readonly description = "Publish a fact into shared agent memory.";
-  readonly inputSchema = {
-    type: "object",
-    properties: {
-      key: { type: "string" },
-      value: { type: "string" }
-    },
-    required: ["key", "value"]
-  };
-
-  async process(context, params) {
-    context.memory.set({
-      key: memoryKeys.shared(String(params.key)),
-      kind: "shared",
-      value: params.value,
-      source: this.name,
-      title: `Fact: ${params.key}`
-    });
-    return { ok: true };
-  }
-}
+```markdown
+## Memory Tools (progressive disclosure)
+- Shared agent memory holds results from prior steps and tasks, original
+  inputs, and facts published by other agents.
+- Memory contents are NOT auto-included in your prompt. If you need upstream
+  context, discover it on demand:
+  1. Call `memory_list` to see what's available (returns metadata only —
+     keys, titles, kinds, byte sizes).
+  2. Call `memory_read` with the specific keys you actually need; it returns
+     full values.
+  3. Call `memory_write` to publish a value under `shared:<key>` so other
+     agents can find it via `memory_list`.
+- Pull only what you need — don't fetch every entry by reflex.
 ```
 
-Subsequent steps will see the fact in their user-message memory block automatically — no edges, no plumbing.
+And the user message for a step that depends on `task:research_phase` looks like:
 
-### Subscribe in a host application (UI sidebar)
+```markdown
+Write a report from the upstream findings.
 
-```ts
-const unsubscribe = context.memory.subscribe((entry) => {
-  ui.appendMemoryEntry(entry); // render the new entry in a side panel
-});
-// ...
-unsubscribe();
+# Required upstream memory (call `memory_read` with these keys):
+- task:research_phase — Research findings
 ```
+
+The model then chooses whether to call `memory_read` or proceed.
 
 ### Pre-populate memory before running
 
@@ -416,7 +456,8 @@ context.memory.set({
   kind: "task_result",
   value: cachedFindings,
   source: "prior_research",
-  title: "Cached prior research"
+  title: "Cached prior research",
+  description: "Findings from a previous run; reuse instead of re-researching."
 });
 
 const agent = new MultiModeAgent({
@@ -425,7 +466,31 @@ const agent = new MultiModeAgent({
   /* ... */,
   mode: "plan"
 });
-// First step's user message will include the pre-populated entry.
+// The agent's first memory_list call will surface this entry.
+```
+
+### Tool that publishes to shared memory directly (without an LLM round-trip)
+
+For deterministic publish-from-code use cases, write to the API directly:
+
+```ts
+context.memory.set({
+  key: memoryKeys.shared("top_source"),
+  kind: "shared",
+  value: "https://example.com/article",
+  source: "data_pipeline",
+  title: "Top source URL"
+});
+```
+
+Subsequent agents will see this via `memory_list` and can fetch it via `memory_read`.
+
+### Subscribe in a host application (UI sidebar)
+
+```ts
+const unsubscribe = context.memory.subscribe((entry) => {
+  ui.appendMemoryEntry(entry); // render the new entry in a side panel
+});
 ```
 
 ---
@@ -457,9 +522,6 @@ context.memory.list({ kind: "task_result" });
 context.memory.list({ keyPrefix: "step:" });
 context.memory.list({ sources: ["research"] });
 
-// Render for prompts
-context.memory.formatForPrompt({ kind: ["task_result", "input"] });
-
 // Subscribe
 const off = context.memory.subscribe((entry) => { /* ... */ });
 
@@ -467,49 +529,72 @@ const off = context.memory.subscribe((entry) => { /* ... */ });
 context.memory.clear({ kind: "step_result" });
 ```
 
+LLM-facing tools (auto-attached to every step):
+
+| Tool | Purpose | Returns |
+|---|---|---|
+| `memory_list` | Discover entries (metadata only) | `{ total, returned, entries: [...] }` |
+| `memory_read` | Fetch full values for specific keys | `{ entries: { ... }, missing: [...] }` |
+| `memory_write` | Publish under `shared:<key>` | `{ ok, key, kind, createdAt }` |
+
 ---
 
 ## Design Decisions
 
+**Why progressive disclosure and not auto-injection?**
+Auto-injecting every memory entry into every prompt is wasteful. Most steps need one or two specific upstream values; dumping all of them costs tokens and pollutes attention. Progressive disclosure mirrors how a human researcher works: scan the index, fetch the specific document, ignore the rest.
+
+**Why expose memory through tools instead of a dedicated channel?**
+Models in 2026 are excellent tool callers — and tools come with rich JSON schemas that make discovery, filtering, and parameter validation trivial. Adding bespoke prompt syntax for memory access would be reinventing function calling. Tools also give us first-class observability: every memory access shows up as a `tool_call_update` in the message stream.
+
+**Why is `memory_write` restricted to `shared:`?**
+Step results, task results, and inputs are owned by the executors. Letting an agent overwrite a `task:<id>` entry would let it spoof the result of work it didn't actually do, breaking the audit trail. Agents publish under `shared:` and the executor namespaces stay tamper-proof.
+
+**Why does the user message still mention specific upstream keys?**
+A pure tool-only design would force the agent to call `memory_list` even when the planner already declared the dependency. That's an unnecessary round trip for a known-relevant key. The user message names exactly the keys the planner pinned (`step.dependsOn` plus parent-task `dependsOn`), so the agent can go straight to `memory_read` for declared deps and use `memory_list` only when it needs to discover beyond them.
+
 **Why a single map and not a relational store?**
-Agent runs are short-lived and the data is small (typically tens of entries). A `Map` plus structured rendering covers every observed use case without the operational cost of a database. Persistent storage belongs in the asset / vector layer, not in working memory.
+Agent runs are short-lived and the data is small (typically tens of entries). A `Map` plus structured rendering covers every observed use case without the operational cost of a database. Persistent storage belongs in the asset / vector layer.
 
 **Why namespaced string keys instead of typed IDs?**
-The LLM has to read the keys back from the prompt block (e.g. "the result of task `task:research_phase` was ..."). Strings round-trip cleanly through prompts and logs without serialization games.
-
-**Why include all upstream memory in every step's user message, instead of just `dependsOn`?**
-Planners drop edges. Tools surface results the planner never knew about. Sub-agents complete tasks the planner didn't anticipate. Including the full snapshot is the smallest reliable contract — tokens are cheap, missed propagation is expensive. If you ever need to scope visibility per task, the filter API supports it without architectural changes.
+The LLM has to read keys back from the tool result and pass them to `memory_read`. Strings round-trip cleanly through prompts and logs without serialization games.
 
 **Why isn't memory shared across `context.copy()`?**
-Copies are designed for isolated sub-runs. If a sub-run should inherit memory, the caller can `set` entries from the parent before kicking it off, or pass the same context. Default isolation is the safer choice.
+Copies are designed for isolated sub-runs. If a sub-run should inherit memory, the caller can `set` entries from the parent before kicking it off. Default isolation is the safer choice.
 
 **Why does `customPrompt` no longer replace the default execution prompt?**
-Replacing it stripped the `finish_step` discipline and broke result capture in plan mode. The fix layers any caller preamble before the default prompt rather than replacing it. The execution contract (output schema, completion protocol, conclusion-stage rules) is now non-bypassable.
+Replacing it stripped the memory-tool documentation and the `finish_step` discipline. The fix layers any caller preamble before the default prompt rather than replacing it. The execution contract (memory tools, output schema, completion protocol, conclusion-stage rules) is now non-bypassable.
 
 ---
 
 ## Troubleshooting
 
-**Symptom:** A downstream task's prompt contains an empty memory block.
-- Check the planner output: did the upstream step have an `outputSchema`? Without one, `StepExecutor` runs in unstructured mode and accepts plain text content as the result. If your mock or model only emits a `finish_step` tool call (no text fallback), the step never completes and never writes to memory.
-- Verify the step actually completed: look for `task_update` events with `event: StepCompleted`, and inspect `context.memory.snapshot()`.
+**Symptom:** A downstream task's prompt shows the upstream key hint but the agent never calls `memory_read`.
+- The model may have decided it doesn't need the value. If you know it should, make the user instructions more explicit ("read the upstream findings via memory_read before writing").
+- Check the conclusion stage: if the step is at >90% token budget, only `finish_step` is allowed and `memory_read` is filtered out.
 
 **Symptom:** Task result key is missing after the step yielded `step_result` with `is_task_result: true`.
 - `StepExecutor` only writes `task:<id>` for steps where `useFinishTask === true`. That flag is set by `TaskExecutor.isFinishStep()` for the last step in the task (or the explicit `finalStepId` option). Steps in the middle of a task only write `step:<id>`.
-- For belt-and-suspenders, `ParallelTaskExecutor` also performs an idempotent task-result write after each task, falling back to the last step's value.
+- For belt-and-suspenders, `ParallelTaskExecutor` performs an idempotent task-result write after each task, falling back to the last step's value.
 
 **Symptom:** Cross-agent results not visible in `TeamExecutor` agents.
 - Verify the board emitted `task_completed` events. The mirror subscription only fires on that event type — tasks that fail or stay `working` won't be mirrored.
 - Check that `context.memory.has(memoryKeys.task(taskId))` is true after the relevant teammate completes its work.
+- Confirm the agent's tool list includes the memory tools: `getMemoryTools()` is automatically added to every team iteration.
 
 **Symptom:** Tests pass but memory entries seem stale across test runs.
 - A new `AgentMemory` instance is constructed for every `ProcessingContext`. If you reuse a context across tests, call `context.memory.clear()` between them.
+
+**Symptom:** Agent calls `memory_list` and gets `truncated: true`.
+- The list response is hard-capped at 200 entries. If you need more, narrow the filter (`kind`, `key_prefix`, or `sources`) — or accept that for very long runs, only the most recent 200 are visible at once.
 
 ---
 
 ## Related
 
 - [Agent System](AGENTS.md) — overall architecture
-- `packages/runtime/src/agent-memory.ts` — implementation
-- `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation tests
+- `packages/runtime/src/agent-memory.ts` — `AgentMemory` implementation
+- `packages/agents/src/tools/memory-tools.ts` — `memory_list` / `memory_read` / `memory_write`
+- `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation tests including the tool round-trip
+- `packages/agents/tests/memory-tools.test.ts` — unit tests for the memory tools
 - `packages/runtime/tests/agent-memory.test.ts` — `AgentMemory` unit tests

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -1,5 +1,49 @@
 # Agents Package
 
+## Agent Memory (`@nodetool-ai/runtime` → `context.memory`)
+
+Every `ProcessingContext` carries an `AgentMemory` instance at `context.memory`. It is the **single source of truth** for everything shared between steps, tasks, sub-agents, and tools. Do not introduce a parallel result map in any executor — read and write through `context.memory`.
+
+### Key namespaces
+
+```ts
+import { memoryKeys } from "@nodetool-ai/runtime";
+
+memoryKeys.step("step_1");         // "step:step_1"  — step result
+memoryKeys.task("research_phase"); // "task:research_phase"  — task result
+memoryKeys.input("customer");      // "input:customer"  — caller-supplied input
+memoryKeys.shared("note");         // "shared:note"  — cross-agent scratch
+```
+
+### Who writes what
+
+| Writer | Trigger | Key | Kind |
+|---|---|---|---|
+| `StepExecutor` | Step completion | `step:<step.id>` | `step_result` |
+| `StepExecutor` | Last step of a task (finish-task) | `task:<task.id>` | `task_result` |
+| `TaskExecutor` | Startup / process-mode aggregation | `input:<key>` / `step:<step.id>` | `input` / `step_result` |
+| `ParallelTaskExecutor` | After a task completes (idempotent) | `task:<task.id>` | `task_result` |
+| `TeamExecutor` | `TaskBoard.task_completed` event | `task:<task.id>` | `task_result` |
+| `AgentStepExecutor` | Workflow edge inputs | `input:<nodeId>.<key>` | `input` |
+
+### How LLMs see memory
+
+`StepExecutor.buildUserMessage()` injects a Markdown snapshot of `task_result + step_result + input` entries into every step's user message via `formatForPrompt()`. Downstream tasks see upstream results without explicit dependency edges. `TeamExecutor.runAgentWorkCycle()` injects a similar block (`task_result + shared + input`) so teammates discover each other's work.
+
+### Custom prompts are preambles, not replacements
+
+`StepExecutor.buildSystemPrompt()` always uses the default execution prompt (output schema, `finish_step` discipline, conclusion-stage rules). A caller-supplied `systemPrompt` is layered as a preamble *before* the default — it cannot override the execution contract. Earlier versions allowed this and broke result capture in plan mode.
+
+### Tests
+
+- `packages/runtime/tests/agent-memory.test.ts` — unit tests for `AgentMemory`
+- `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation through `MultiModeAgent` plan mode
+- `packages/agents/tests/_helpers/mock-context.ts` — shared mock context with a real `AgentMemory` for executor tests
+
+When asserting memory writes in tests, prefer `context.memory.has(memoryKeys.task("..."))` and `context.memory.subscribe(...)` over spies on `set` / `storeStepResult`.
+
+For the full API reference, propagation flow, design decisions, and troubleshooting, see [docs/agent-memory.md](../../docs/agent-memory.md).
+
 ## JavaScript Sandbox (`src/js-sandbox.ts`)
 
 User-authored JS from `MiniJSAgentTool` and `nodetool.code.Code` runs in a

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -4,6 +4,18 @@
 
 Every `ProcessingContext` carries an `AgentMemory` instance at `context.memory`. It is the **single source of truth** for everything shared between steps, tasks, sub-agents, and tools. Do not introduce a parallel result map in any executor — read and write through `context.memory`.
 
+### Access pattern: progressive disclosure via tools
+
+Memory contents are NOT auto-injected into prompts. Agents access memory through three tools that are auto-attached to every step (and to every team iteration):
+
+| Tool | Purpose |
+|---|---|
+| `memory_list` | Discover available entries (metadata only — keys, titles, kinds, byte sizes) |
+| `memory_read` | Fetch full values for specific keys |
+| `memory_write` | Publish a value under `shared:<key>` |
+
+The default execution system prompt documents these tools. The user message names only **specific** upstream keys the planner pinned (`step.dependsOn` plus parent-task `dependsOn` via `upstreamMemoryKeys`) — values are pulled on demand.
+
 ### Key namespaces
 
 ```ts
@@ -25,24 +37,28 @@ memoryKeys.shared("note");         // "shared:note"  — cross-agent scratch
 | `ParallelTaskExecutor` | After a task completes (idempotent) | `task:<task.id>` | `task_result` |
 | `TeamExecutor` | `TaskBoard.task_completed` event | `task:<task.id>` | `task_result` |
 | `AgentStepExecutor` | Workflow edge inputs | `input:<nodeId>.<key>` | `input` |
+| `memory_write` tool | Agent / sub-agent publish | `shared:<key>` | `shared` |
 
-### How LLMs see memory
-
-`StepExecutor.buildUserMessage()` injects a Markdown snapshot of `task_result + step_result + input` entries into every step's user message via `formatForPrompt()`. Downstream tasks see upstream results without explicit dependency edges. `TeamExecutor.runAgentWorkCycle()` injects a similar block (`task_result + shared + input`) so teammates discover each other's work.
+`memory_write` is restricted to the `shared:` namespace so agents can't spoof step / task / input results. Internal executors write directly through `context.memory.set` for their owned namespaces.
 
 ### Custom prompts are preambles, not replacements
 
-`StepExecutor.buildSystemPrompt()` always uses the default execution prompt (output schema, `finish_step` discipline, conclusion-stage rules). A caller-supplied `systemPrompt` is layered as a preamble *before* the default — it cannot override the execution contract. Earlier versions allowed this and broke result capture in plan mode.
+`StepExecutor.buildSystemPrompt()` always uses the default execution prompt (memory tools docs, output schema, `finish_step` discipline, conclusion-stage rules). A caller-supplied `systemPrompt` is layered as a preamble *before* the default — it cannot override the execution contract. Earlier versions allowed this and broke result capture in plan mode.
+
+### Threading task-level deps through executors
+
+`ParallelTaskExecutor` derives `task.dependsOn.map(memoryKeys.task)` and forwards it as `upstreamMemoryKeys` to `TaskExecutor`, which forwards it verbatim to every `StepExecutor`. The step's user message renders these as `- task:<id>` hints next to the intra-task `step:<id>` deps. The agent calls `memory_read` when it needs the values.
 
 ### Tests
 
 - `packages/runtime/tests/agent-memory.test.ts` — unit tests for `AgentMemory`
-- `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation through `MultiModeAgent` plan mode
+- `packages/agents/tests/memory-tools.test.ts` — unit tests for `memory_list` / `memory_read` / `memory_write`
+- `packages/agents/tests/memory-propagation.test.ts` — end-to-end through `MultiModeAgent` plan mode, including a fake-provider round trip that drives `memory_list` → `memory_read` → `finish_step`
 - `packages/agents/tests/_helpers/mock-context.ts` — shared mock context with a real `AgentMemory` for executor tests
 
 When asserting memory writes in tests, prefer `context.memory.has(memoryKeys.task("..."))` and `context.memory.subscribe(...)` over spies on `set` / `storeStepResult`.
 
-For the full API reference, propagation flow, design decisions, and troubleshooting, see [docs/agent-memory.md](../../docs/agent-memory.md).
+For the full API reference, tool schemas, propagation flow, design decisions, and troubleshooting, see [docs/agent-memory.md](../../docs/agent-memory.md).
 
 ## JavaScript Sandbox (`src/js-sandbox.ts`)
 

--- a/packages/agents/src/agent-step-executor.ts
+++ b/packages/agents/src/agent-step-executor.ts
@@ -92,10 +92,11 @@ export class AgentStepExecutor implements NodeExecutor {
       steps: [step]
     };
 
-    // Surface upstream edge inputs through shared agent memory so the step
-    // sees them via the standard memory-rendered prompt block. The legacy
-    // `Upstream Results` preamble is preserved for clients that read the
-    // raw step instructions.
+    // Persist upstream edge inputs into shared agent memory for cross-step
+    // discoverability and tool-based access (for example via memory tools /
+    // progressive disclosure). This method does not render memory into the
+    // current step prompt automatically; direct visibility for this step still
+    // comes from the legacy `Upstream Results` preamble added below.
     if (context) {
       for (const [key, value] of Object.entries(inputs)) {
         if (value === undefined || value === null) continue;

--- a/packages/agents/src/agent-step-executor.ts
+++ b/packages/agents/src/agent-step-executor.ts
@@ -10,6 +10,7 @@
 
 import type { NodeExecutor } from "@nodetool-ai/runtime";
 import type { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import { memoryKeys } from "@nodetool-ai/runtime";
 import type {
   NodeDescriptor,
   ProcessingMessage,
@@ -91,7 +92,22 @@ export class AgentStepExecutor implements NodeExecutor {
       steps: [step]
     };
 
-    // Prepend upstream results to step instructions
+    // Surface upstream edge inputs through shared agent memory so the step
+    // sees them via the standard memory-rendered prompt block. The legacy
+    // `Upstream Results` preamble is preserved for clients that read the
+    // raw step instructions.
+    if (context) {
+      for (const [key, value] of Object.entries(inputs)) {
+        if (value === undefined || value === null) continue;
+        context.memory.set({
+          key: memoryKeys.input(`${this.node.id}.${key}`),
+          kind: "input",
+          value,
+          source: this.node.id,
+          title: `${this.node.id}.${key}`
+        });
+      }
+    }
     const upstreamContext = formatUpstreamContext(inputs);
     if (upstreamContext) {
       step.instructions = upstreamContext + step.instructions;
@@ -125,11 +141,6 @@ export class AgentStepExecutor implements NodeExecutor {
       if (msg.type === "step_result") {
         result = (msg as StepResult).result;
       }
-    }
-
-    // Also store in context for backwards compat with code reading from context
-    if (context) {
-      context.set(this.node.id, result);
     }
 
     // Use "output" as the handle name so downstream nodes can connect via .output

--- a/packages/agents/src/agent-step-executor.ts
+++ b/packages/agents/src/agent-step-executor.ts
@@ -92,11 +92,11 @@ export class AgentStepExecutor implements NodeExecutor {
       steps: [step]
     };
 
-    // Persist upstream edge inputs into shared agent memory for cross-step
-    // discoverability and tool-based access (for example via memory tools /
-    // progressive disclosure). This method does not render memory into the
-    // current step prompt automatically; direct visibility for this step still
-    // comes from the legacy `Upstream Results` preamble added below.
+    // Persist upstream edge inputs into shared agent memory so other agents
+    // and downstream steps can discover them via `memory_list` and fetch them
+    // via `memory_read` (progressive disclosure). The current step does NOT
+    // see these entries in its prompt automatically — direct visibility for
+    // this step comes from the `Upstream Results` preamble appended below.
     if (context) {
       for (const [key, value] of Object.entries(inputs)) {
         if (value === undefined || value === null) continue;

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -15,6 +15,7 @@
 
 import type { BaseProvider } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { memoryKeys } from "@nodetool-ai/runtime";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ProcessingMessage,
@@ -61,9 +62,6 @@ export class ParallelTaskExecutor {
   private readonly maxStepIterations: number;
   private readonly maxTokenLimit: number;
 
-  /** Results collected per task ID. */
-  private readonly taskResults = new Map<string, unknown>();
-
   constructor(opts: ParallelTaskExecutorOptions) {
     this.provider = opts.provider;
     this.model = opts.model;
@@ -83,9 +81,14 @@ export class ParallelTaskExecutor {
    * Independent tasks run concurrently as separate sub-agents.
    */
   async *execute(): AsyncGenerator<ProcessingMessage> {
-    // Seed inputs into context
+    // Seed inputs into shared agent memory so every task and step sees them.
     for (const [key, value] of Object.entries(this.inputs)) {
-      this.context.set(key, value);
+      this.context.memory.set({
+        key: memoryKeys.input(key),
+        kind: "input",
+        value,
+        title: key
+      });
     }
 
     const totalTasks = this.taskPlan.tasks.length;
@@ -186,21 +189,19 @@ export class ParallelTaskExecutor {
       } as TaskUpdate["task"]
     } satisfies TaskUpdate;
 
-    // Build context with dependency results
-    const depContext = this.buildDependencyContext(task);
-
-    // Build enhanced system prompt with dependency information
-    const enhancedPrompt = this.buildTaskSystemPrompt(task, depContext);
-
-    // Create TaskExecutor for this task's steps
+    // Create TaskExecutor for this task's steps. Dependency results are
+    // discovered through `context.memory` — we don't need to build a custom
+    // system prompt here, since `StepExecutor` injects the full memory
+    // snapshot into every step's user message. The user-supplied
+    // `systemPrompt` is forwarded as a preamble.
     const executor = new TaskExecutor({
       provider: this.provider,
       model: this.model,
       context: this.context,
       tools: [...this.tools],
       task,
-      systemPrompt: enhancedPrompt,
-      inputs: { ...this.inputs, ...depContext },
+      systemPrompt: this.systemPrompt,
+      inputs: this.inputs,
       maxSteps: task.steps.length + 5, // Allow some slack
       maxStepIterations: this.maxStepIterations,
       maxTokenLimit: this.maxTokenLimit,
@@ -219,20 +220,31 @@ export class ParallelTaskExecutor {
       yield item;
     }
 
-    // Store task result in shared context and mark complete
-    if (taskResult !== null && taskResult !== undefined) {
-      this.taskResults.set(task.id, taskResult);
-      this.context.set(task.id, taskResult);
-    } else {
-      // Use last step result as task result
+    // Resolve the task result. StepExecutor already wrote a `task:<id>` entry
+    // for finish-task steps; if not, fall back to the last step's result.
+    if (taskResult === null || taskResult === undefined) {
       const lastStep = task.steps[task.steps.length - 1];
       if (lastStep) {
-        const lastResult = this.context.get(lastStep.id);
+        const lastResult = this.context.memory.getValue(
+          memoryKeys.step(lastStep.id)
+        );
         if (lastResult !== undefined) {
-          this.taskResults.set(task.id, lastResult);
-          this.context.set(task.id, lastResult);
           taskResult = lastResult;
         }
+      }
+    }
+
+    if (taskResult !== null && taskResult !== undefined) {
+      // Idempotent: only write if StepExecutor didn't already persist it.
+      if (!this.context.memory.has(memoryKeys.task(task.id))) {
+        this.context.memory.set({
+          key: memoryKeys.task(task.id),
+          kind: "task_result",
+          value: taskResult,
+          source: task.id,
+          title: task.title,
+          description: task.description
+        });
       }
     }
 
@@ -252,50 +264,6 @@ export class ParallelTaskExecutor {
       taskId: task.id,
       title: task.title
     });
-  }
-
-  /**
-   * Build a map of dependency results for a task.
-   */
-  private buildDependencyContext(
-    task: Task
-  ): Record<string, unknown> {
-    const depContext: Record<string, unknown> = {};
-    for (const depId of task.dependsOn ?? []) {
-      const result = this.taskResults.get(depId);
-      if (result !== undefined) {
-        depContext[depId] = result;
-      }
-    }
-    return depContext;
-  }
-
-  /**
-   * Build system prompt enhanced with dependency results.
-   */
-  private buildTaskSystemPrompt(
-    task: Task,
-    depContext: Record<string, unknown>
-  ): string | undefined {
-    const parts: string[] = [];
-    if (this.systemPrompt) {
-      parts.push(this.systemPrompt);
-    }
-
-    if (Object.keys(depContext).length > 0) {
-      parts.push("\n# Results from prerequisite tasks:");
-      for (const [depId, result] of Object.entries(depContext)) {
-        const depTask = this.taskPlan.tasks.find((t) => t.id === depId);
-        const depTitle = depTask?.title ?? depId;
-        const resultStr =
-          typeof result === "string"
-            ? result
-            : JSON.stringify(result, null, 2);
-        parts.push(`\n## ${depTitle} (${depId}):\n${resultStr}`);
-      }
-    }
-
-    return parts.length > 0 ? parts.join("\n") : undefined;
   }
 
   /**
@@ -326,20 +294,17 @@ export class ParallelTaskExecutor {
     );
   }
 
-  /**
-   * Get the result of a specific task.
-   */
+  /** Get the result of a specific task from shared memory. */
   getTaskResult(taskId: string): unknown {
-    return this.taskResults.get(taskId);
+    return this.context.memory.getValue(memoryKeys.task(taskId));
   }
 
-  /**
-   * Get all task results.
-   */
+  /** Get all task results recorded in shared memory. */
   getAllResults(): Record<string, unknown> {
     const results: Record<string, unknown> = {};
-    for (const [id, result] of this.taskResults) {
-      results[id] = result;
+    for (const entry of this.context.memory.list({ kind: "task_result" })) {
+      const id = entry.source ?? entry.key.replace(/^task:/, "");
+      results[id] = entry.value;
     }
     return results;
   }
@@ -350,7 +315,7 @@ export class ParallelTaskExecutor {
   getFinalResult(): unknown {
     if (this.taskPlan.tasks.length === 0) return null;
     const lastTask = this.taskPlan.tasks[this.taskPlan.tasks.length - 1];
-    return this.taskResults.get(lastTask.id) ?? null;
+    return this.context.memory.getValue(memoryKeys.task(lastTask.id)) ?? null;
   }
 }
 

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -189,11 +189,14 @@ export class ParallelTaskExecutor {
       } as TaskUpdate["task"]
     } satisfies TaskUpdate;
 
-    // Create TaskExecutor for this task's steps. Dependency results are
-    // discovered through `context.memory` — we don't need to build a custom
-    // system prompt here, since `StepExecutor` injects the full memory
-    // snapshot into every step's user message. The user-supplied
-    // `systemPrompt` is forwarded as a preamble.
+    // Create TaskExecutor for this task's steps. Each step discovers
+    // upstream context on demand via the `memory_list` / `memory_read` tools
+    // (progressive disclosure). The task's declared `dependsOn` IDs are
+    // forwarded as `upstreamMemoryKeys` so every step's user message names
+    // them explicitly without dumping their values.
+    const upstreamMemoryKeys = (task.dependsOn ?? []).map((id) =>
+      memoryKeys.task(id)
+    );
     const executor = new TaskExecutor({
       provider: this.provider,
       model: this.model,
@@ -205,7 +208,8 @@ export class ParallelTaskExecutor {
       maxSteps: task.steps.length + 5, // Allow some slack
       maxStepIterations: this.maxStepIterations,
       maxTokenLimit: this.maxTokenLimit,
-      parallelExecution: true // Enable parallel step execution within each task
+      parallelExecution: true, // Enable parallel step execution within each task
+      upstreamMemoryKeys
     });
 
     let taskResult: unknown = null;

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -33,10 +33,7 @@ import type { Step, Task } from "./types.js";
 import type { Tool } from "./tools/base-tool.js";
 import { ControlNodeTool } from "./tools/control-tool.js";
 import { FinishStepTool } from "./tools/finish-step-tool.js";
-import {
-  MEMORY_TOOL_NAMES,
-  getMemoryTools
-} from "./tools/memory-tools.js";
+import { getMemoryTools } from "./tools/memory-tools.js";
 import { extractJSON } from "./utils/json-parser.js";
 import { DEFAULT_TOKEN_LIMIT, MAX_TOOL_RESULT_CHARS } from "./constants.js";
 import { rejectAgenticProvider } from "./reject-agentic-provider.js";

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -33,6 +33,10 @@ import type { Step, Task } from "./types.js";
 import type { Tool } from "./tools/base-tool.js";
 import { ControlNodeTool } from "./tools/control-tool.js";
 import { FinishStepTool } from "./tools/finish-step-tool.js";
+import {
+  MEMORY_TOOL_NAMES,
+  getMemoryTools
+} from "./tools/memory-tools.js";
 import { extractJSON } from "./utils/json-parser.js";
 import { DEFAULT_TOKEN_LIMIT, MAX_TOOL_RESULT_CHARS } from "./constants.js";
 import { rejectAgenticProvider } from "./reject-agentic-provider.js";
@@ -66,6 +70,14 @@ const PROMPT_TOOL_USE = `# Tool Use
 - Use tools only when they materially improve correctness or are required.
 - Avoid exploratory or repeated tool calls that are unlikely to change the outcome.
 - Before each tool call, emit a one-sentence rationale describing what you're doing and why.
+
+## Memory Tools (progressive disclosure)
+- Shared agent memory holds results from prior steps and tasks, original inputs, and facts published by other agents.
+- Memory contents are NOT auto-included in your prompt. If you need upstream context, discover it on demand:
+  1. Call \`memory_list\` to see what's available (returns metadata only — keys, titles, kinds, byte sizes).
+  2. Call \`memory_read\` with the specific keys you actually need; it returns full values.
+  3. Call \`memory_write\` to publish a value under \`shared:<key>\` so other agents can find it via \`memory_list\`.
+- Pull only what you need — don't fetch every entry by reflex.
 
 ## File Tools
 - Use \`read_file\` to read files. Do not use \`run_code\` with cat/head/tail.
@@ -305,6 +317,15 @@ export interface StepExecutorOptions {
   maxIterations?: number;
   useFinishTask?: boolean;
   threadId?: string;
+  /**
+   * Additional memory keys to surface in the user message as required
+   * upstream context for this step. Typically `task:<id>` keys derived from
+   * the parent task's `dependsOn` (set by ParallelTaskExecutor / TaskExecutor).
+   *
+   * The step's own `step.dependsOn` IDs are added automatically as
+   * `step:<id>` keys — callers should not duplicate them here.
+   */
+  upstreamMemoryKeys?: string[];
 }
 
 export class StepExecutor {
@@ -335,6 +356,7 @@ export class StepExecutor {
     event: import("@nodetool-ai/protocol").ControlEvent;
   }> = [];
   private threadId?: string;
+  private upstreamMemoryKeys: string[];
 
   constructor(opts: StepExecutorOptions) {
     this.task = opts.task;
@@ -347,9 +369,19 @@ export class StepExecutor {
     this.maxIterations = opts.maxIterations ?? DEFAULT_MAX_ITERATIONS;
     this.useFinishTask = opts.useFinishTask ?? false;
     this.threadId = opts.threadId;
+    this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
 
     // Load and sanitize the output schema
     this.resultSchema = this.loadResultSchema();
+
+    // Auto-attach memory tools so the step can list / read / write
+    // shared agent memory on demand. Skip any caller-supplied duplicates.
+    const existingNames = new Set(this.tools.map((t) => t.name));
+    for (const memoryTool of getMemoryTools()) {
+      if (!existingNames.has(memoryTool.name)) {
+        this.tools.push(memoryTool);
+      }
+    }
 
     // Setup finish_step tool if we have a schema
     if (this.resultSchema) {
@@ -933,28 +965,48 @@ export class StepExecutor {
   }
 
   /**
-   * Build the initial user message with instructions and a structured
-   * snapshot of {@link ProcessingContext.memory}.
+   * Build the initial user message.
    *
-   * Every step receives the full memory snapshot of prior task / step / input
-   * entries — not only its declared `dependsOn` IDs. This guarantees that
-   * upstream results from any agent or task are discoverable, even when the
-   * planner forgets to wire an explicit dependency edge.
+   * Memory contents are NOT auto-included — callers fetch on demand via the
+   * `memory_list` / `memory_read` tools (progressive disclosure; tool usage
+   * is documented in the default system prompt).
+   *
+   * The only memory information the user message carries is a short list of
+   * **specific** upstream keys the planner declared as relevant to this step:
+   *
+   *   - `step:<id>` for every entry of `step.dependsOn` (intra-task deps).
+   *   - any caller-supplied {@link StepExecutorOptions.upstreamMemoryKeys}
+   *     (typically `task:<id>` entries from the parent task's `dependsOn`).
+   *
+   * Only keys that actually exist in `context.memory` are listed. The LLM
+   * is expected to call `memory_read` with whichever subset it needs.
    */
   private buildUserMessage(): string {
     const parts: string[] = [this.step.instructions];
 
-    const memoryBlock = this.context.memory.formatForPrompt({
-      kind: ["task_result", "step_result", "input"]
-    });
-    if (memoryBlock) {
-      parts.push("");
-      parts.push(memoryBlock);
+    const declared = [
+      ...this.step.dependsOn.map((id) => memoryKeys.step(id)),
+      ...this.upstreamMemoryKeys
+    ];
+    const seen = new Set<string>();
+    const hints: { key: string; title?: string }[] = [];
+    for (const key of declared) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const entry = this.context.memory.get(key);
+      if (!entry) continue;
+      hints.push({ key: entry.key, title: entry.title });
     }
 
-    parts.push(
-      "\nPerform this step using the instructions above. Use any matching memory entries as upstream context."
-    );
+    if (hints.length > 0) {
+      parts.push("");
+      parts.push(
+        "# Required upstream memory (call `memory_read` with these keys):"
+      );
+      for (const hint of hints) {
+        parts.push(`- ${hint.key}${hint.title ? ` — ${hint.title}` : ""}`);
+      }
+    }
 
     return parts.join("\n");
   }

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -18,7 +18,7 @@ import type {
   ToolCall,
   ProviderStreamItem
 } from "@nodetool-ai/runtime";
-import { withAgentSpanGen } from "@nodetool-ai/runtime";
+import { memoryKeys, withAgentSpanGen } from "@nodetool-ai/runtime";
 import { createLogger } from "@nodetool-ai/config";
 import {
   TaskUpdateEvent,
@@ -391,28 +391,32 @@ export class StepExecutor {
 
   /**
    * Build the system prompt for this step using templates.
+   *
+   * The default execution prompts encode the contract every step relies on
+   * (output discipline, finish_step protocol, conclusion stage). They must
+   * always be present. A caller-supplied `userPrompt` is added as a preamble
+   * — never as a replacement — so domain context can be layered in without
+   * losing the execution discipline.
    */
-  private buildSystemPrompt(customPrompt?: string): string {
+  private buildSystemPrompt(userPrompt?: string): string {
     let basePrompt: string;
     const templateContext: Record<string, string> = {};
 
     if (this.resultSchema) {
       const schemaJson = JSON.stringify(this.resultSchema, null, 2);
       templateContext["output_schema_json"] = schemaJson;
-
-      if (this.useFinishTask) {
-        basePrompt = customPrompt ?? DEFAULT_FINISH_TASK_SYSTEM_PROMPT;
-        templateContext["step_content"] = this.step.instructions;
-      } else {
-        basePrompt = customPrompt ?? DEFAULT_EXECUTION_SYSTEM_PROMPT;
-        templateContext["step_content"] = this.step.instructions;
-      }
+      basePrompt = this.useFinishTask
+        ? DEFAULT_FINISH_TASK_SYSTEM_PROMPT
+        : DEFAULT_EXECUTION_SYSTEM_PROMPT;
     } else {
-      basePrompt = customPrompt ?? DEFAULT_UNSTRUCTURED_SYSTEM_PROMPT;
-      templateContext["step_content"] = this.step.instructions;
+      basePrompt = DEFAULT_UNSTRUCTURED_SYSTEM_PROMPT;
     }
+    templateContext["step_content"] = this.step.instructions;
 
     let prompt = renderTemplate(basePrompt, templateContext);
+    if (userPrompt && userPrompt.trim().length > 0) {
+      prompt = `${userPrompt.trim()}\n\n---\n\n${prompt}`;
+    }
     prompt += `\n\nToday's date is ${new Date().toISOString().slice(0, 10)}`;
     return prompt;
   }
@@ -467,15 +471,30 @@ export class StepExecutor {
 
   /**
    * Persist the final result and mark the step as completed.
+   *
+   * Writes a `step_result` entry to {@link ProcessingContext.memory} under
+   * `step:<id>`. For finish-task steps it additionally writes the same value
+   * as a `task_result` under `task:<id>` so downstream tasks can discover it
+   * via memory.
    */
-  private async storeCompletionResult(
-    normalizedResult: unknown
-  ): Promise<void> {
+  private storeCompletionResult(normalizedResult: unknown): void {
     this.step.completed = true;
     this.step.endTime = Date.now();
-    await this.context.storeStepResult(this.step.id, normalizedResult);
+    this.context.memory.set({
+      key: memoryKeys.step(this.step.id),
+      kind: "step_result",
+      value: normalizedResult,
+      source: this.step.id,
+      title: this.step.instructions.slice(0, 80)
+    });
     if (this.useFinishTask) {
-      await this.context.storeStepResult(this.task.id, normalizedResult);
+      this.context.memory.set({
+        key: memoryKeys.task(this.task.id),
+        kind: "task_result",
+        value: normalizedResult,
+        source: this.task.id,
+        title: this.task.title
+      });
     }
     this.result = normalizedResult;
   }
@@ -914,24 +933,27 @@ export class StepExecutor {
   }
 
   /**
-   * Build the initial user message with instructions and dependency results.
+   * Build the initial user message with instructions and a structured
+   * snapshot of {@link ProcessingContext.memory}.
+   *
+   * Every step receives the full memory snapshot of prior task / step / input
+   * entries — not only its declared `dependsOn` IDs. This guarantees that
+   * upstream results from any agent or task are discoverable, even when the
+   * planner forgets to wire an explicit dependency edge.
    */
-  private async buildUserMessage(): Promise<string> {
+  private buildUserMessage(): string {
     const parts: string[] = [this.step.instructions];
 
-    if (this.step.dependsOn.length > 0) {
-      for (const depId of this.step.dependsOn) {
-        const depResult = await this.context.loadStepResult(depId);
-        if (depResult !== undefined && depResult !== null) {
-          parts.push(
-            `**Result from Task ${depId}:**\n${JSON.stringify(depResult, null, 2)}\n`
-          );
-        }
-      }
+    const memoryBlock = this.context.memory.formatForPrompt({
+      kind: ["task_result", "step_result", "input"]
+    });
+    if (memoryBlock) {
+      parts.push("");
+      parts.push(memoryBlock);
     }
 
     parts.push(
-      "Please perform the step based on the provided context, instructions, and upstream task results."
+      "\nPerform this step using the instructions above. Use any matching memory entries as upstream context."
     );
 
     return parts.join("\n");
@@ -968,7 +990,7 @@ export class StepExecutor {
     this.history.push({ role: "system" as const, content: this.systemPrompt });
 
     // Build user message with instructions and dependency results
-    const userContent = await this.buildUserMessage();
+    const userContent = this.buildUserMessage();
     this.history.push({ role: "user" as const, content: userContent });
 
     // Yield task update: step started
@@ -1119,7 +1141,7 @@ export class StepExecutor {
                 content: '{"status": "completed"}'
               });
 
-              await this.storeCompletionResult(normalizedResult);
+              this.storeCompletionResult(normalizedResult);
               log.debug("Step completed", { stepId: this.step.id });
 
               yield {
@@ -1277,7 +1299,7 @@ export class StepExecutor {
           normalizedResult !== null &&
           normalizedResult !== undefined
         ) {
-          await this.storeCompletionResult(normalizedResult);
+          this.storeCompletionResult(normalizedResult);
 
           yield {
             type: "task_update",
@@ -1308,7 +1330,13 @@ export class StepExecutor {
         error: `Step failed: exceeded ${this.maxIterations} iterations without completion`
       };
       this.result = errorResult;
-      await this.context.storeStepResult(this.step.id, errorResult);
+      this.context.memory.set({
+        key: memoryKeys.step(this.step.id),
+        kind: "step_result",
+        value: errorResult,
+        source: this.step.id,
+        title: `Failed: ${this.step.instructions.slice(0, 60)}`
+      });
 
       yield {
         type: "task_update",

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -16,6 +16,7 @@
 import { createHash } from "node:crypto";
 import type { BaseProvider } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { memoryKeys } from "@nodetool-ai/runtime";
 import { createLogger } from "@nodetool-ai/config";
 import type { ProcessingMessage, Chunk, StepResult } from "@nodetool-ai/protocol";
 
@@ -81,9 +82,14 @@ export class TaskExecutor {
    * Supports both sequential and parallel execution modes.
    */
   async *executeTasks(): AsyncGenerator<ProcessingMessage> {
-    // Seed inputs into context
+    // Seed inputs into shared memory so every step sees them.
     for (const [key, value] of Object.entries(this.inputs)) {
-      this.context.set(key, value);
+      this.context.memory.set({
+        key: memoryKeys.input(key),
+        kind: "input",
+        value,
+        title: key
+      });
     }
 
     // Auto-detect finish step (last step) like Python does
@@ -196,13 +202,21 @@ export class TaskExecutor {
       return;
     }
 
-    let discoverResult = this.context.get(discoverStepId);
+    let discoverResult = this.context.memory.getValue(
+      memoryKeys.step(discoverStepId)
+    );
     if (discoverResult === undefined || discoverResult === null) {
       log.warn("Discover step result is null/undefined, skipping fan-out", {
         stepId: step.id
       });
       step.completed = true;
-      this.context.set(step.id, []);
+      this.context.memory.set({
+        key: memoryKeys.step(step.id),
+        kind: "step_result",
+        value: [],
+        source: step.id,
+        title: step.instructions.slice(0, 60)
+      });
       step.endTime = Date.now();
       return;
     }
@@ -294,8 +308,14 @@ export class TaskExecutor {
       }
     }
 
-    // Store aggregated results and mark complete
-    this.context.set(step.id, results);
+    // Store aggregated results and mark complete.
+    this.context.memory.set({
+      key: memoryKeys.step(step.id),
+      kind: "step_result",
+      value: results,
+      source: step.id,
+      title: step.instructions.slice(0, 60)
+    });
     step.completed = true;
     step.endTime = Date.now();
 

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -90,10 +90,14 @@ export class TaskExecutor {
    * Supports both sequential and parallel execution modes.
    */
   async *executeTasks(): AsyncGenerator<ProcessingMessage> {
-    // Seed inputs into shared memory so every step sees them.
+    // Seed inputs into shared memory so every step sees them. Skip keys that
+    // were already seeded by an upstream caller (e.g. ParallelTaskExecutor) to
+    // avoid redundant writes and extra subscriber notifications.
     for (const [key, value] of Object.entries(this.inputs)) {
+      const fullKey = memoryKeys.input(key);
+      if (this.context.memory.has(fullKey)) continue;
       this.context.memory.set({
-        key: memoryKeys.input(key),
+        key: fullKey,
         kind: "input",
         value,
         title: key

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -44,6 +44,12 @@ export interface TaskExecutorOptions {
   finalStepId?: string;
   /** Execute independent steps in parallel (default: false). */
   parallelExecution?: boolean;
+  /**
+   * Memory keys (typically `task:<id>` from the parent plan's task-level
+   * dependencies) to surface in every step's user message as required
+   * upstream context. Forwarded to {@link StepExecutor.upstreamMemoryKeys}.
+   */
+  upstreamMemoryKeys?: string[];
 }
 
 export class TaskExecutor {
@@ -59,6 +65,7 @@ export class TaskExecutor {
   private maxTokenLimit: number;
   private finalStepId: string | undefined;
   private parallelExecution: boolean;
+  private upstreamMemoryKeys: string[];
   private _finishStepId: string | undefined;
 
   constructor(opts: TaskExecutorOptions) {
@@ -75,6 +82,7 @@ export class TaskExecutor {
     this.maxTokenLimit = opts.maxTokenLimit ?? DEFAULT_TOKEN_LIMIT;
     this.finalStepId = opts.finalStepId;
     this.parallelExecution = opts.parallelExecution ?? false;
+    this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
   }
 
   /**
@@ -149,7 +157,8 @@ export class TaskExecutor {
           systemPrompt: this.systemPrompt,
           maxTokenLimit: this.maxTokenLimit,
           maxIterations: this.maxStepIterations,
-          useFinishTask: this.isFinishStep(step)
+          useFinishTask: this.isFinishStep(step),
+          upstreamMemoryKeys: this.upstreamMemoryKeys
         });
         return executor.execute();
       });
@@ -282,7 +291,8 @@ export class TaskExecutor {
         systemPrompt: this.systemPrompt,
         maxTokenLimit: this.maxTokenLimit,
         maxIterations: this.maxStepIterations,
-        useFinishTask: false
+        useFinishTask: false,
+        upstreamMemoryKeys: this.upstreamMemoryKeys
       });
       return executor.execute();
     });

--- a/packages/agents/src/team/team-executor.ts
+++ b/packages/agents/src/team/team-executor.ts
@@ -17,6 +17,7 @@ import type {
 } from "@nodetool-ai/runtime";
 import { memoryKeys } from "@nodetool-ai/runtime";
 import { Tool } from "../tools/base-tool.js";
+import { getMemoryTools } from "../tools/memory-tools.js";
 import { MessageBus } from "./message-bus.js";
 import { TaskBoard } from "./task-board.js";
 import { createTeamTools } from "./team-tools.js";
@@ -301,15 +302,6 @@ export class TeamExecutor {
         (t.status === "claimed" || t.status === "working")
     );
 
-    // Inject shared agent memory so teammates can read each other's results.
-    const memoryBlock = this.context.memory.formatForPrompt({
-      kind: ["task_result", "shared", "input"]
-    });
-    if (memoryBlock) {
-      promptParts.push(memoryBlock);
-      promptParts.push("");
-    }
-
     if (myTasks.length > 0) {
       promptParts.push("**Your current tasks:**");
       for (const t of myTasks) {
@@ -357,14 +349,26 @@ export class TeamExecutor {
     this.totalIterations++;
     agent.iterations++;
 
-    // Build tool list: team tools + shared tools + agent-specific tools
+    // Build tool list: team tools + shared tools + memory tools.
+    // Memory tools provide progressive-disclosure access to results
+    // produced by other teammates (mirrored from the TaskBoard) and any
+    // facts published via `memory_write`.
     const teamTools = createTeamTools(
       agent.identity,
       this.config.agents,
       this.bus,
       this.board
     );
-    const allTools: Tool[] = [...teamTools, ...this.sharedTools];
+    const memoryTools = getMemoryTools().filter((mt) => {
+      const sharedNames = new Set(this.sharedTools.map((t) => t.name));
+      const teamNames = new Set(teamTools.map((t) => t.name));
+      return !sharedNames.has(mt.name) && !teamNames.has(mt.name);
+    });
+    const allTools: Tool[] = [
+      ...teamTools,
+      ...this.sharedTools,
+      ...memoryTools
+    ];
     const providerTools: ProviderTool[] = allTools.map((t) =>
       t.toProviderTool()
     );
@@ -560,6 +564,14 @@ export class TeamExecutor {
       "- Use `list_tasks` to see the board, `claim_task` to take work, `complete_task` when done.",
       "- Use `send_message` to coordinate with specific teammates, or `broadcast` for the whole team.",
       "- Use `create_task` to add new work items, `decompose_task` to break complex tasks apart.",
+      "",
+      "## Shared Memory (progressive disclosure)",
+      "- Completed teammate task results are mirrored into shared agent memory.",
+      "- Memory contents are NOT auto-included in your prompts. Pull on demand:",
+      "  1. `memory_list` — see what's available (metadata only).",
+      "  2. `memory_read` — fetch full values for specific keys.",
+      "  3. `memory_write` — publish a value under `shared:<key>` for others.",
+      "- Pull only what you need — don't fetch every entry by reflex.",
       "",
       strategyInstructions,
       "",

--- a/packages/agents/src/team/team-executor.ts
+++ b/packages/agents/src/team/team-executor.ts
@@ -120,6 +120,14 @@ export class TeamExecutor {
           })
         : null;
 
+    try {
+      yield* this.executeInner();
+    } finally {
+      unsubscribeBoard?.();
+    }
+  }
+
+  private async *executeInner(): AsyncGenerator<TeamEvent> {
     // Initialize agents
     for (const identity of this.config.agents) {
       const provider = await this.context.getProvider(identity.provider);
@@ -197,8 +205,6 @@ export class TeamExecutor {
     };
     this.events.push(completeEvent);
     yield completeEvent;
-
-    unsubscribeBoard?.();
   }
 
   // ─── Strategy Phases ───

--- a/packages/agents/src/team/team-executor.ts
+++ b/packages/agents/src/team/team-executor.ts
@@ -359,9 +359,9 @@ export class TeamExecutor {
       this.bus,
       this.board
     );
+    const sharedNames = new Set(this.sharedTools.map((t) => t.name));
+    const teamNames = new Set(teamTools.map((t) => t.name));
     const memoryTools = getMemoryTools().filter((mt) => {
-      const sharedNames = new Set(this.sharedTools.map((t) => t.name));
-      const teamNames = new Set(teamTools.map((t) => t.name));
       return !sharedNames.has(mt.name) && !teamNames.has(mt.name);
     });
     const allTools: Tool[] = [

--- a/packages/agents/src/team/team-executor.ts
+++ b/packages/agents/src/team/team-executor.ts
@@ -15,6 +15,7 @@ import type {
   Message,
   ProviderTool
 } from "@nodetool-ai/runtime";
+import { memoryKeys } from "@nodetool-ai/runtime";
 import { Tool } from "../tools/base-tool.js";
 import { MessageBus } from "./message-bus.js";
 import { TaskBoard } from "./task-board.js";
@@ -98,6 +99,26 @@ export class TeamExecutor {
    * Main execution loop. Yields TeamEvents as the team works.
    */
   async *execute(): AsyncGenerator<TeamEvent> {
+    // Mirror task-board completions into shared agent memory so every
+    // teammate (and any downstream agent on the same context) sees task
+    // results through the unified `context.memory` API.
+    const unsubscribeBoard =
+      typeof (this.board as TaskBoard).onEvent === "function"
+        ? (this.board as TaskBoard).onEvent((event) => {
+            if (event.type !== "task_completed") return;
+            const task = this.board.get(event.taskId);
+            if (!task) return;
+            this.context.memory.set({
+              key: memoryKeys.task(task.id),
+              kind: "task_result",
+              value: task.result,
+              source: task.id,
+              title: task.title,
+              description: task.description
+            });
+          })
+        : null;
+
     // Initialize agents
     for (const identity of this.config.agents) {
       const provider = await this.context.getProvider(identity.provider);
@@ -175,6 +196,8 @@ export class TeamExecutor {
     };
     this.events.push(completeEvent);
     yield completeEvent;
+
+    unsubscribeBoard?.();
   }
 
   // ─── Strategy Phases ───
@@ -277,6 +300,15 @@ export class TeamExecutor {
         t.claimedBy === agent.identity.id &&
         (t.status === "claimed" || t.status === "working")
     );
+
+    // Inject shared agent memory so teammates can read each other's results.
+    const memoryBlock = this.context.memory.formatForPrompt({
+      kind: ["task_result", "shared", "input"]
+    });
+    if (memoryBlock) {
+      promptParts.push(memoryBlock);
+      promptParts.push("");
+    }
 
     if (myTasks.length > 0) {
       promptParts.push("**Your current tasks:**");

--- a/packages/agents/src/tools/memory-tools.ts
+++ b/packages/agents/src/tools/memory-tools.ts
@@ -1,0 +1,299 @@
+/**
+ * Memory tools — progressive disclosure access to the shared agent memory.
+ *
+ * Earlier versions auto-injected every memory entry into every step's user
+ * message. That worked but was wasteful: large upstream results bloated every
+ * downstream prompt even when the step only needed one specific entry.
+ *
+ * The 2026 pattern is **progressive disclosure**: the model receives a tiny
+ * "what's available" hint up front and pulls full values on demand:
+ *
+ *   1. `memory_list` — returns metadata for all entries (key, kind, title,
+ *      description, source, byte size). No values. Cheap to call.
+ *   2. `memory_read` — returns full values for a list of keys.
+ *   3. `memory_write` — publishes a value to the `shared:` namespace so other
+ *      agents and steps can discover it via `memory_list`.
+ *
+ * These three tools are auto-attached to every {@link StepExecutor} and to
+ * {@link TeamExecutor}'s shared tool list. Authors of custom executors should
+ * call `getMemoryTools()` and append the result to their tool array.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { MemoryEntry, MemoryKind } from "@nodetool-ai/runtime";
+import { memoryKeys } from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+
+/** Maximum bytes of `description` returned per entry from memory_list. */
+const MAX_DESCRIPTION_CHARS = 240;
+
+/** Hard upper bound on entries returned in a single memory_list call. */
+const MAX_LIST_ENTRIES = 200;
+
+interface MemoryListEntry {
+  key: string;
+  kind: MemoryKind;
+  title?: string;
+  description?: string;
+  source?: string;
+  /** Approximate size of the value when JSON-serialized (in characters). */
+  valueBytes: number;
+  /** ISO timestamp when the entry was first written. */
+  createdAt: string;
+}
+
+function describeEntry(entry: MemoryEntry): MemoryListEntry {
+  const serialized =
+    typeof entry.value === "string"
+      ? entry.value
+      : (() => {
+          try {
+            return JSON.stringify(entry.value);
+          } catch {
+            return String(entry.value);
+          }
+        })();
+  return {
+    key: entry.key,
+    kind: entry.kind,
+    title: entry.title,
+    description:
+      entry.description && entry.description.length > MAX_DESCRIPTION_CHARS
+        ? entry.description.slice(0, MAX_DESCRIPTION_CHARS) + "…"
+        : entry.description,
+    source: entry.source,
+    valueBytes: serialized.length,
+    createdAt: new Date(entry.createdAt).toISOString()
+  };
+}
+
+/**
+ * `memory_list` — discover what's in shared agent memory. Returns metadata
+ * only (no values). Filter by kind, key prefix, or producer source.
+ */
+export class MemoryListTool extends Tool {
+  readonly name = "memory_list";
+  readonly description =
+    "List entries in shared agent memory (results from prior steps and tasks, " +
+    "inputs, and shared facts published by other agents). Returns metadata " +
+    "only — call `memory_read` to fetch full values. Use this when you need " +
+    "context from upstream work but don't yet know which entry holds it.";
+
+  readonly inputSchema: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      kind: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["task_result", "step_result", "input", "shared"]
+        },
+        description:
+          "Optional filter — restrict results to the listed kinds. Omit to list everything."
+      },
+      key_prefix: {
+        type: "string",
+        description:
+          "Optional filter — only entries whose key starts with this prefix (e.g. \"task:\")."
+      },
+      sources: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Optional filter — only entries produced by one of these source IDs."
+      }
+    },
+    additionalProperties: false
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const kindFilter = Array.isArray(params.kind)
+      ? (params.kind as MemoryKind[])
+      : undefined;
+    const keyPrefix =
+      typeof params.key_prefix === "string"
+        ? (params.key_prefix as string)
+        : undefined;
+    const sources = Array.isArray(params.sources)
+      ? (params.sources as string[])
+      : undefined;
+
+    const entries = context.memory.list({
+      kind: kindFilter,
+      keyPrefix,
+      sources
+    });
+    const truncated = entries.length > MAX_LIST_ENTRIES;
+    const sliced = truncated ? entries.slice(0, MAX_LIST_ENTRIES) : entries;
+    return {
+      total: entries.length,
+      returned: sliced.length,
+      truncated,
+      entries: sliced.map(describeEntry)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const parts: string[] = [];
+    if (Array.isArray(params.kind))
+      parts.push(`kinds=${(params.kind as string[]).join(",")}`);
+    if (params.key_prefix) parts.push(`prefix=${params.key_prefix}`);
+    if (Array.isArray(params.sources))
+      parts.push(`sources=${(params.sources as string[]).join(",")}`);
+    return parts.length > 0
+      ? `Listing memory (${parts.join(" ")})`
+      : "Listing memory";
+  }
+}
+
+/**
+ * `memory_read` — fetch full values for one or more memory keys.
+ *
+ * The response maps each requested key to its full entry. Missing keys are
+ * reported in `missing` so the agent can decide whether to retry or proceed.
+ */
+export class MemoryReadTool extends Tool {
+  readonly name = "memory_read";
+  readonly description =
+    "Read full values from shared agent memory by key. Use the keys returned " +
+    "by `memory_list`. Returns each requested entry with its value, kind, " +
+    "title, and source. Missing keys are reported in `missing`.";
+
+  readonly inputSchema: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      keys: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        description:
+          "Memory keys to read (e.g. [\"task:research\", \"step:summary\"])."
+      }
+    },
+    required: ["keys"],
+    additionalProperties: false
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const keys = Array.isArray(params.keys)
+      ? (params.keys as unknown[]).map(String)
+      : [];
+
+    const found: Record<string, MemoryEntry> = {};
+    const missing: string[] = [];
+    for (const key of keys) {
+      const entry = context.memory.get(key);
+      if (entry) {
+        found[key] = entry;
+      } else {
+        missing.push(key);
+      }
+    }
+
+    return { entries: found, missing };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const keys = Array.isArray(params.keys)
+      ? (params.keys as unknown[]).map(String)
+      : [];
+    if (keys.length === 0) return "Reading memory";
+    if (keys.length === 1) return `Reading memory: ${keys[0]}`;
+    return `Reading memory: ${keys.length} entries`;
+  }
+}
+
+/**
+ * `memory_write` — publish a value to the `shared:` namespace so other agents
+ * and steps can discover it via `memory_list`.
+ *
+ * Writes are restricted to `shared:` keys to prevent agents from spoofing
+ * step / task / input results. The `key` argument is the suffix after
+ * `shared:` and is passed through `memoryKeys.shared()`.
+ */
+export class MemoryWriteTool extends Tool {
+  readonly name = "memory_write";
+  readonly description =
+    "Publish a value to shared agent memory under the `shared:` namespace. " +
+    "Other agents and downstream steps can discover it via `memory_list` and " +
+    "fetch it via `memory_read`. Use this to broadcast facts, intermediate " +
+    "findings, or coordination signals to the rest of the team.";
+
+  readonly inputSchema: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      key: {
+        type: "string",
+        minLength: 1,
+        description:
+          "Suffix for the memory key. Stored as `shared:<key>`. Use a short, " +
+          "descriptive identifier (e.g. \"top_sources\")."
+      },
+      value: {
+        description:
+          "The value to publish. Any JSON-serializable structure or string."
+      },
+      title: {
+        type: "string",
+        description:
+          "Optional human-readable title shown when the entry is listed."
+      },
+      description: {
+        type: "string",
+        description: "Optional brief description shown alongside the title."
+      }
+    },
+    required: ["key", "value"],
+    additionalProperties: false
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const suffix = String(params.key);
+    const fullKey = memoryKeys.shared(suffix);
+    const entry = context.memory.set({
+      key: fullKey,
+      kind: "shared",
+      value: params.value,
+      title: typeof params.title === "string" ? params.title : suffix,
+      description:
+        typeof params.description === "string" ? params.description : undefined,
+      source: "memory_write"
+    });
+    return {
+      ok: true,
+      key: entry.key,
+      kind: entry.kind,
+      createdAt: new Date(entry.createdAt).toISOString()
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const key = typeof params.key === "string" ? params.key : "(no key)";
+    return `Publishing to memory: shared:${key}`;
+  }
+}
+
+/**
+ * Returns fresh instances of the three memory tools. Call this once per
+ * executor — every executor needs its own instances so they don't share
+ * mutable state (none currently exists, but this future-proofs).
+ */
+export function getMemoryTools(): Tool[] {
+  return [new MemoryListTool(), new MemoryReadTool(), new MemoryWriteTool()];
+}
+
+/** Names of the auto-attached memory tools. Useful for filtering / detection. */
+export const MEMORY_TOOL_NAMES = [
+  "memory_list",
+  "memory_read",
+  "memory_write"
+] as const;

--- a/packages/agents/src/tools/memory-tools.ts
+++ b/packages/agents/src/tools/memory-tools.ts
@@ -168,7 +168,6 @@ export class MemoryReadTool extends Tool {
       keys: {
         type: "array",
         items: { type: "string" },
-        minItems: 1,
         description:
           "Memory keys to read (e.g. [\"task:research\", \"step:summary\"])."
       }

--- a/packages/agents/tests/_helpers/mock-context.ts
+++ b/packages/agents/tests/_helpers/mock-context.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared mock ProcessingContext for unit tests.
+ *
+ * Backs `set/get/storeStepResult/loadStepResult` with an in-memory Map and
+ * mounts a real {@link AgentMemory} so executor code that goes through
+ * `context.memory` works against the production class — not a stub.
+ */
+
+import { vi } from "vitest";
+import { AgentMemory } from "@nodetool-ai/runtime";
+
+export function createMockContext() {
+  const variables = new Map<string, unknown>();
+  return {
+    memory: new AgentMemory(),
+    workspaceDir: null,
+    storeStepResult: vi.fn(async (key: string, value: unknown) => {
+      variables.set(key, value);
+      return key;
+    }),
+    loadStepResult: vi.fn(async (key: string) => {
+      return variables.get(key);
+    }),
+    set: vi.fn((key: string, value: unknown) => {
+      variables.set(key, value);
+    }),
+    get: vi.fn((key: string) => {
+      return variables.get(key);
+    }),
+    sandboxToAsset: vi.fn(async (uri: string) => ({ uri: `asset://${uri}` })),
+    emit: vi.fn(),
+    postMessage: vi.fn(),
+    post_message: vi.fn(),
+    _store: variables
+  } as any;
+}

--- a/packages/agents/tests/agent-executor.test.ts
+++ b/packages/agents/tests/agent-executor.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/agent-executor.js";
 import type { ToolCall } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 function createMockProvider(toolCallArgs?: Record<string, unknown>) {
   const args = toolCallArgs ?? {
@@ -50,15 +51,6 @@ function createMockProvider(toolCallArgs?: Record<string, unknown>) {
     trackUsage: vi.fn(),
     getTotalCost: vi.fn().mockReturnValue(0),
     resetCost: vi.fn()
-  } as any;
-}
-
-function createMockContext() {
-  return {
-    storeStepResult: vi.fn(),
-    loadStepResult: vi.fn(),
-    set: vi.fn(),
-    get: vi.fn()
   } as any;
 }
 

--- a/packages/agents/tests/agent.test.ts
+++ b/packages/agents/tests/agent.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Agent, loadSkillsFromDirectory } from "../src/agent.js";
 import { parseFrontmatter } from "../src/agent.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 // ---------------------------------------------------------------------------
 // Mock helpers (same pattern as agents.test.ts)
@@ -91,26 +92,6 @@ function planCalls(
     { id: "tc_finish", name: "finish_plan", args: { title: plan.title } }
   ]);
   return calls;
-}
-
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    }),
-    loadStepResult: vi.fn(async (key: string) => {
-      return store.get(key);
-    }),
-    set: vi.fn((key: string, value: unknown) => {
-      store.set(key, value);
-    }),
-    get: vi.fn((key: string) => {
-      return store.get(key);
-    }),
-    _store: store
-  } as any;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agents/tests/agents.test.ts
+++ b/packages/agents/tests/agents.test.ts
@@ -4,6 +4,7 @@ import { TaskPlanner } from "../src/task-planner.js";
 import { TaskExecutor } from "../src/task-executor.js";
 import type { Step, Task } from "../src/types.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -55,29 +56,6 @@ function createMockProvider(
     imageToVideo: vi.fn(),
     generateEmbedding: vi.fn(),
     isContextLengthError: () => false
-  } as any;
-}
-
-/**
- * Minimal mock ProcessingContext.
- */
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    }),
-    loadStepResult: vi.fn(async (key: string) => {
-      return store.get(key);
-    }),
-    set: vi.fn((key: string, value: unknown) => {
-      store.set(key, value);
-    }),
-    get: vi.fn((key: string) => {
-      return store.get(key);
-    }),
-    _store: store
   } as any;
 }
 
@@ -715,10 +693,10 @@ describe("TaskExecutor", () => {
     expect(stepB.completed).toBe(true);
 
     // step_a result should be stored before step_b runs
-    expect(context.storeStepResult).toHaveBeenCalledWith("step_a", {
+    expect(context.memory.getValue("step:step_a")).toEqual({
       data: "from_a"
     });
-    expect(context.storeStepResult).toHaveBeenCalledWith("step_b", {
+    expect(context.memory.getValue("step:step_b")).toEqual({
       result: "from_b"
     });
 
@@ -932,8 +910,6 @@ describe("TaskExecutor", () => {
 
     // Step should complete because "user_input" is in inputs
     expect(stepA.completed).toBe(true);
-    expect(context.storeStepResult).toHaveBeenCalledWith("step_a", {
-      v: "done"
-    });
+    expect(context.memory.getValue("step:step_a")).toEqual({ v: "done" });
   });
 });

--- a/packages/agents/tests/builtin-tools-integration.test.ts
+++ b/packages/agents/tests/builtin-tools-integration.test.ts
@@ -20,6 +20,7 @@ import { resolveTool, listTools } from "../src/tools/tool-registry.js";
 import { SimpleAgent } from "../src/simple-agent.js";
 import { CalculatorTool } from "../src/tools/calculator-tool.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 // Tool IDs hardcoded in chat / agent frontends. Every ID here MUST
 // resolve to a real built-in tool instance — if a frontend adds a new
@@ -121,21 +122,6 @@ function createMockProvider(
     isContextLengthError: () => false
   };
   return provider;
-}
-
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (k: string, v: unknown) => {
-      store.set(k, v);
-      return k;
-    }),
-    loadStepResult: vi.fn(async (k: string) => store.get(k)),
-    set: vi.fn((k: string, v: unknown) => {
-      store.set(k, v);
-    }),
-    get: vi.fn((k: string) => store.get(k))
-  } as any;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agents/tests/e2e/agent-e2e.test.ts
+++ b/packages/agents/tests/e2e/agent-e2e.test.ts
@@ -17,6 +17,7 @@ import { TaskPlanner } from "../../src/task-planner.js";
 import { TaskExecutor } from "../../src/task-executor.js";
 import { StepExecutor } from "../../src/step-executor.js";
 import {
+  AgentMemory,
   ScriptedProvider,
   planScript,
   stepScript,
@@ -34,6 +35,8 @@ import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
 function makeContext() {
   const store = new Map<string, unknown>();
   return {
+    memory: new AgentMemory(),
+    workspaceDir: null,
     storeStepResult: async (key: string, value: unknown) => {
       store.set(key, value);
       return key;
@@ -303,8 +306,8 @@ describe("TaskExecutor E2E", () => {
     expect(results[0].result).toEqual({ value: 10 });
     expect(results[1].result).toEqual({ result: 20 });
 
-    // step_1 result should be available for step_2 to load
-    const stored = await context.loadStepResult("step_1");
+    // step_1 result should be available for step_2 to load via shared memory
+    const stored = context.memory.getValue("step:step_1");
     expect(stored).toEqual({ value: 10 });
   });
 

--- a/packages/agents/tests/memory-propagation.test.ts
+++ b/packages/agents/tests/memory-propagation.test.ts
@@ -1,20 +1,24 @@
 /**
- * End-to-end tests for the unified agent memory system.
+ * End-to-end tests for the unified agent memory system with progressive
+ * disclosure.
  *
  * Drives `MultiModeAgent` in plan mode and `TaskExecutor` directly with a
  * scriptable mock provider, then verifies that:
  *
  *   1. Every step / task / input is written to `context.memory` under a
  *      canonical namespaced key.
- *   2. Downstream tasks see upstream task results in their step's user
- *      message (no replacement of the default execution prompt).
- *   3. Final task results survive even when only one task in a multi-task
- *      plan emits an `is_task_result` step result.
+ *   2. Memory contents are NOT auto-injected into prompts; the agent
+ *      discovers them via `memory_list` / `memory_read` tools.
+ *   3. Downstream tasks see only specific upstream key hints (the planner's
+ *      declared `dependsOn` IDs), not full values.
+ *   4. The progressive-disclosure round trip (`memory_list` → `memory_read`
+ *      → `finish_step`) works end-to-end with a fake provider.
  */
 
 import { describe, expect, it, vi } from "vitest";
 import { MultiModeAgent } from "../src/multi-mode-agent.js";
 import { TaskExecutor } from "../src/task-executor.js";
+import { StepExecutor } from "../src/step-executor.js";
 import { ParallelTaskExecutor } from "../src/parallel-task-executor.js";
 import { memoryKeys } from "@nodetool-ai/runtime";
 import type { Task, TaskPlan } from "../src/types.js";
@@ -181,11 +185,15 @@ describe("Agent memory propagation", () => {
 
     expect(context.memory.getValue(memoryKeys.input("customer"))).toBe("Acme");
     expect(context.memory.getValue(memoryKeys.input("region"))).toBe("EU");
-    // Inputs should also surface in the user message of the first step.
+    // Inputs are NOT auto-injected into the user message — the agent must
+    // discover them via memory_list / memory_read (progressive disclosure).
     const userMsg = provider.calls[0].userContent;
-    expect(userMsg).toContain("# Memory");
-    expect(userMsg).toContain("Acme");
-    expect(userMsg).toContain("EU");
+    expect(userMsg).not.toContain("Acme");
+    expect(userMsg).not.toContain("EU");
+    // The system prompt always advertises the memory tools.
+    const sysPrompt = provider.calls[0].systemPrompt;
+    expect(sysPrompt).toContain("memory_list");
+    expect(sysPrompt).toContain("memory_read");
   });
 
   it("makes upstream task results visible in downstream task prompts (plan mode)", async () => {
@@ -258,17 +266,25 @@ describe("Agent memory propagation", () => {
     expect(plan.tasks[0].completed).toBe(true);
     expect(plan.tasks[1].completed).toBe(true);
 
-    // First call (research) must NOT see the not-yet-existing task result.
+    // First call (research) has no upstream task → no memory hint.
     const firstUserMsg = provider.calls[0].userContent;
     expect(firstUserMsg).not.toContain("task:task_research");
+    expect(firstUserMsg).not.toContain("Required upstream memory");
 
-    // Second call (report) MUST see the upstream task result rendered into
-    // the user message — proving downstream agents discover memory entries.
+    // Second call (report) names the upstream task as a memory hint —
+    // values are NOT included; the agent fetches via memory_read.
     const secondUserMsg = provider.calls[1].userContent;
-    expect(secondUserMsg).toContain("# Memory");
-    expect(secondUserMsg).toContain("task:task_research");
-    expect(secondUserMsg).toContain("alpha");
-    expect(secondUserMsg).toContain("beta");
+    expect(secondUserMsg).toContain(
+      "# Required upstream memory (call `memory_read` with these keys):"
+    );
+    expect(secondUserMsg).toContain("- task:task_research");
+    expect(secondUserMsg).not.toContain("alpha");
+    expect(secondUserMsg).not.toContain("beta");
+
+    // The actual value is in shared memory and reachable via the tool.
+    expect(
+      context.memory.getValue(memoryKeys.task("task_research"))
+    ).toEqual({ findings: ["alpha", "beta"] });
   });
 
   it("preserves the default execution discipline (finish_step instructions) when a custom user prompt is provided", async () => {
@@ -378,5 +394,163 @@ describe("Agent memory propagation", () => {
     });
     // The agent's `results` is set from the captured step_result.
     expect(agent.getResults()).toEqual({ greeting: "Hello" });
+  });
+
+  it("agent discovers and reads memory via memory_list → memory_read → finish_step", async () => {
+    // Pre-populate memory with two upstream task results — neither auto-
+    // injected. The agent must list, read the relevant one, and finish.
+    const context = createMockContext();
+    context.memory.set({
+      key: memoryKeys.task("upstream_a"),
+      kind: "task_result",
+      value: { findings: ["alpha", "beta"] },
+      source: "upstream_a",
+      title: "Upstream A findings"
+    });
+    context.memory.set({
+      key: memoryKeys.task("upstream_b"),
+      kind: "task_result",
+      value: { unrelated: "ignore me" },
+      source: "upstream_b",
+      title: "Upstream B"
+    });
+
+    // Scripted provider: turn 1 → memory_list, turn 2 → memory_read, turn 3 → finish_step.
+    const provider = createRecordingProvider([
+      // Turn 1: list memory
+      [
+        {
+          id: "tc_list",
+          name: "memory_list",
+          args: { kind: ["task_result"] }
+        }
+      ],
+      // Turn 2: read just the relevant entry
+      [
+        {
+          id: "tc_read",
+          name: "memory_read",
+          args: { keys: ["task:upstream_a"] }
+        }
+      ],
+      // Turn 3: finish_step using the value the agent fetched
+      [finishStep("tc_finish", { summary: "alpha, beta" })]
+    ]);
+
+    const task: Task = {
+      id: "task_synth",
+      title: "Synthesize",
+      steps: [
+        {
+          id: "step_synth",
+          instructions: "Summarize the upstream findings.",
+          completed: false,
+          dependsOn: [],
+          outputSchema: JSON.stringify({
+            type: "object",
+            properties: { summary: { type: "string" } },
+            required: ["summary"]
+          }),
+          logs: []
+        }
+      ]
+    };
+
+    const executor = new StepExecutor({
+      task,
+      step: task.steps[0],
+      context,
+      provider,
+      model: "test"
+    });
+
+    for await (const _ of executor.execute()) {
+      /* drain */
+    }
+
+    // The first user message must NOT contain the values, only the
+    // instructions + system prompt mentions of the memory tools.
+    const firstUser = provider.calls[0].userContent;
+    expect(firstUser).not.toContain("alpha");
+    expect(firstUser).not.toContain("beta");
+
+    // System prompt advertises the tools.
+    const sys = provider.calls[0].systemPrompt;
+    expect(sys).toContain("memory_list");
+    expect(sys).toContain("memory_read");
+
+    // After the agent fetched via memory_read, the conversation history
+    // (turn 3) must include the value as a tool result.
+    const turn3 = provider.calls[2].fullMessages;
+    const toolMessages = turn3.filter((m) => m.role === "tool");
+    const hasReadResult = toolMessages.some(
+      (m) =>
+        typeof m.content === "string" &&
+        m.content.includes("alpha") &&
+        m.content.includes("beta")
+    );
+    expect(hasReadResult).toBe(true);
+
+    // Final result captured.
+    expect(executor.getResult()).toEqual({ summary: "alpha, beta" });
+  });
+
+  it("memory_write publishes shared facts that subsequent steps see in memory_list", async () => {
+    const context = createMockContext();
+
+    // Step 1 publishes a fact via memory_write, then finishes.
+    const provider = createRecordingProvider([
+      [
+        {
+          id: "tc_write",
+          name: "memory_write",
+          args: {
+            key: "top_source",
+            value: "https://example.com/article",
+            title: "Top source URL"
+          }
+        }
+      ],
+      [finishStep("tc_finish", { ok: true })]
+    ]);
+
+    const task: Task = {
+      id: "task_publisher",
+      title: "Publisher",
+      steps: [
+        {
+          id: "step_publisher",
+          instructions: "Publish the top source to shared memory.",
+          completed: false,
+          dependsOn: [],
+          outputSchema: JSON.stringify({
+            type: "object",
+            properties: { ok: { type: "boolean" } },
+            required: ["ok"]
+          }),
+          logs: []
+        }
+      ]
+    };
+
+    const executor = new StepExecutor({
+      task,
+      step: task.steps[0],
+      context,
+      provider,
+      model: "test"
+    });
+
+    for await (const _ of executor.execute()) {
+      /* drain */
+    }
+
+    // The shared entry is in memory under shared:<suffix>.
+    const sharedKey = memoryKeys.shared("top_source");
+    expect(context.memory.has(sharedKey)).toBe(true);
+    const entry = context.memory.get(sharedKey);
+    expect(entry?.kind).toBe("shared");
+    expect(entry?.value).toBe("https://example.com/article");
+    expect(entry?.title).toBe("Top source URL");
   });
 });

--- a/packages/agents/tests/memory-propagation.test.ts
+++ b/packages/agents/tests/memory-propagation.test.ts
@@ -1,0 +1,382 @@
+/**
+ * End-to-end tests for the unified agent memory system.
+ *
+ * Drives `MultiModeAgent` in plan mode and `TaskExecutor` directly with a
+ * scriptable mock provider, then verifies that:
+ *
+ *   1. Every step / task / input is written to `context.memory` under a
+ *      canonical namespaced key.
+ *   2. Downstream tasks see upstream task results in their step's user
+ *      message (no replacement of the default execution prompt).
+ *   3. Final task results survive even when only one task in a multi-task
+ *      plan emits an `is_task_result` step result.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { MultiModeAgent } from "../src/multi-mode-agent.js";
+import { TaskExecutor } from "../src/task-executor.js";
+import { ParallelTaskExecutor } from "../src/parallel-task-executor.js";
+import { memoryKeys } from "@nodetool-ai/runtime";
+import type { Task, TaskPlan } from "../src/types.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+// ---------------------------------------------------------------------------
+// Mock provider that records the messages it sees on every call.
+// ---------------------------------------------------------------------------
+
+interface RecordedCall {
+  systemPrompt: string;
+  userContent: string;
+  fullMessages: Array<{ role: string; content: unknown }>;
+}
+
+function createRecordingProvider(
+  scripted: Record<
+    string,
+    | { type: "chunk"; content: string; done?: boolean }
+    | { id: string; name: string; args: Record<string, unknown> }
+  >[][]
+) {
+  const calls: RecordedCall[] = [];
+  let callIndex = 0;
+  return {
+    provider: "mock",
+    calls,
+    hasToolSupport: async () => true,
+    generateMessages: async function* (args: any) {
+      const messages = (args?.messages ?? []) as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const sys = messages.find((m) => m.role === "system");
+      const user = messages.find((m) => m.role === "user");
+      calls.push({
+        systemPrompt: typeof sys?.content === "string" ? sys.content : "",
+        userContent: typeof user?.content === "string" ? user.content : "",
+        fullMessages: messages
+      });
+
+      const items = scripted[callIndex] ?? [];
+      callIndex++;
+      for (const item of items) {
+        yield item;
+      }
+    },
+    async *generateMessagesTraced(...args: any[]) {
+      yield* (this as any).generateMessages(...args);
+    },
+    async generateMessageTraced(...args: any[]) {
+      return (this as any).generateMessage(...args);
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getAvailableImageModels: vi.fn().mockResolvedValue([]),
+    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
+    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
+    getAvailableASRModels: vi.fn().mockResolvedValue([]),
+    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    textToImage: vi.fn(),
+    imageToImage: vi.fn(),
+    textToSpeech: vi.fn(),
+    automaticSpeechRecognition: vi.fn(),
+    textToVideo: vi.fn(),
+    imageToVideo: vi.fn(),
+    generateEmbedding: vi.fn(),
+    isContextLengthError: () => false
+  } as any;
+}
+
+const finishStep = (id: string, result: unknown) => ({
+  id,
+  name: "finish_step",
+  args: { result }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Agent memory propagation", () => {
+  it("writes step and task results to memory under canonical keys", async () => {
+    const provider = createRecordingProvider([
+      [finishStep("tc1", { value: 42 })]
+    ]);
+    const context = createMockContext();
+
+    const task: Task = {
+      id: "task_alpha",
+      title: "Alpha",
+      steps: [
+        {
+          id: "step_alpha",
+          instructions: "Compute alpha.",
+          completed: false,
+          dependsOn: [],
+          outputSchema: JSON.stringify({
+            type: "object",
+            properties: { value: { type: "number" } }
+          }),
+          logs: []
+        }
+      ]
+    };
+
+    const executor = new TaskExecutor({
+      provider,
+      model: "test",
+      context,
+      tools: [],
+      task
+    });
+
+    for await (const _ of executor.executeTasks()) {
+      /* drain */
+    }
+
+    expect(context.memory.has(memoryKeys.step("step_alpha"))).toBe(true);
+    expect(context.memory.getValue(memoryKeys.step("step_alpha"))).toEqual({
+      value: 42
+    });
+    // Last step is the finish step → also stored as task_result.
+    expect(context.memory.has(memoryKeys.task("task_alpha"))).toBe(true);
+    expect(context.memory.getValue(memoryKeys.task("task_alpha"))).toEqual({
+      value: 42
+    });
+  });
+
+  it("seeds inputs as input: memory entries", async () => {
+    const provider = createRecordingProvider([
+      [finishStep("tc1", { value: 1 })]
+    ]);
+    const context = createMockContext();
+
+    const task: Task = {
+      id: "t1",
+      title: "T",
+      steps: [
+        {
+          id: "s1",
+          instructions: "Do",
+          completed: false,
+          dependsOn: [],
+          outputSchema: JSON.stringify({ type: "object", properties: {} }),
+          logs: []
+        }
+      ]
+    };
+
+    const executor = new TaskExecutor({
+      provider,
+      model: "test",
+      context,
+      tools: [],
+      task,
+      inputs: { customer: "Acme", region: "EU" }
+    });
+
+    for await (const _ of executor.executeTasks()) {
+      /* drain */
+    }
+
+    expect(context.memory.getValue(memoryKeys.input("customer"))).toBe("Acme");
+    expect(context.memory.getValue(memoryKeys.input("region"))).toBe("EU");
+    // Inputs should also surface in the user message of the first step.
+    const userMsg = provider.calls[0].userContent;
+    expect(userMsg).toContain("# Memory");
+    expect(userMsg).toContain("Acme");
+    expect(userMsg).toContain("EU");
+  });
+
+  it("makes upstream task results visible in downstream task prompts (plan mode)", async () => {
+    const provider = createRecordingProvider([
+      // task_research → step_research
+      [finishStep("tc_a", { findings: ["alpha", "beta"] })],
+      // task_report → step_report (depends on task_research)
+      [finishStep("tc_b", { report: "summary" })]
+    ]);
+    const context = createMockContext();
+
+    const plan: TaskPlan = {
+      title: "Research and report",
+      tasks: [
+        {
+          id: "task_research",
+          title: "Research",
+          dependsOn: [],
+          completed: false,
+          steps: [
+            {
+              id: "step_research",
+              instructions: "Gather findings.",
+              completed: false,
+              dependsOn: [],
+              outputSchema: JSON.stringify({
+                type: "object",
+                properties: {
+                  findings: { type: "array", items: { type: "string" } }
+                }
+              }),
+              logs: []
+            }
+          ]
+        },
+        {
+          id: "task_report",
+          title: "Report",
+          dependsOn: ["task_research"],
+          completed: false,
+          steps: [
+            {
+              id: "step_report",
+              instructions: "Write report from upstream findings.",
+              completed: false,
+              dependsOn: [],
+              outputSchema: JSON.stringify({
+                type: "object",
+                properties: { report: { type: "string" } }
+              }),
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const executor = new ParallelTaskExecutor({
+      provider,
+      model: "test",
+      context,
+      tools: [],
+      taskPlan: plan
+    });
+
+    for await (const _ of executor.execute()) {
+      /* drain */
+    }
+
+    expect(plan.tasks[0].completed).toBe(true);
+    expect(plan.tasks[1].completed).toBe(true);
+
+    // First call (research) must NOT see the not-yet-existing task result.
+    const firstUserMsg = provider.calls[0].userContent;
+    expect(firstUserMsg).not.toContain("task:task_research");
+
+    // Second call (report) MUST see the upstream task result rendered into
+    // the user message — proving downstream agents discover memory entries.
+    const secondUserMsg = provider.calls[1].userContent;
+    expect(secondUserMsg).toContain("# Memory");
+    expect(secondUserMsg).toContain("task:task_research");
+    expect(secondUserMsg).toContain("alpha");
+    expect(secondUserMsg).toContain("beta");
+  });
+
+  it("preserves the default execution discipline (finish_step instructions) when a custom user prompt is provided", async () => {
+    const provider = createRecordingProvider([
+      [finishStep("tc_a", { findings: [] })]
+    ]);
+    const context = createMockContext();
+
+    const plan: TaskPlan = {
+      title: "Plan",
+      tasks: [
+        {
+          id: "t1",
+          title: "T",
+          dependsOn: [],
+          completed: false,
+          steps: [
+            {
+              id: "s1",
+              instructions: "Do work.",
+              completed: false,
+              dependsOn: [],
+              outputSchema: JSON.stringify({
+                type: "object",
+                properties: {
+                  findings: { type: "array", items: { type: "string" } }
+                }
+              }),
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const userPrompt = "DOMAIN_PREAMBLE_MARKER: company data is confidential.";
+    const executor = new ParallelTaskExecutor({
+      provider,
+      model: "test",
+      context,
+      tools: [],
+      taskPlan: plan,
+      systemPrompt: userPrompt
+    });
+
+    for await (const _ of executor.execute()) {
+      /* drain */
+    }
+
+    // The final system prompt must contain BOTH the user preamble AND the
+    // default execution discipline (output schema, finish_step protocol).
+    const sys = provider.calls[0].systemPrompt;
+    expect(sys).toContain("DOMAIN_PREAMBLE_MARKER");
+    expect(sys).toContain("CALL `finish_step`");
+    expect(sys).toContain("Output Schema");
+  });
+
+  it("plan mode emits a final task_result discoverable by callers", async () => {
+    // Two-task plan via MultiModeAgent driven by the planner tool sequence.
+    const provider = createRecordingProvider([
+      // Planner: add_task #1
+      [
+        {
+          id: "tc_add_1",
+          name: "add_task",
+          args: {
+            id: "task_one",
+            title: "Task One",
+            depends_on: [],
+            steps: [
+              {
+                id: "task_one_s1",
+                instructions: "Do A",
+                depends_on: [],
+                output_schema: JSON.stringify({
+                  type: "object",
+                  properties: { greeting: { type: "string" } },
+                  required: ["greeting"]
+                })
+              }
+            ]
+          }
+        }
+      ],
+      // Planner: finish_plan
+      [{ id: "tc_finish_plan", name: "finish_plan", args: { title: "P" } }],
+      // Step task_one_s1
+      [finishStep("tc_step", { greeting: "Hello" })]
+    ]);
+    const context = createMockContext();
+
+    const agent = new MultiModeAgent({
+      name: "test-plan-mode",
+      objective: "Greet the user",
+      provider,
+      model: "test",
+      mode: "plan"
+    });
+
+    for await (const _ of agent.execute(context)) {
+      /* drain */
+    }
+
+    // The task result must be in shared memory under the canonical key.
+    expect(context.memory.getValue(memoryKeys.task("task_one"))).toEqual({
+      greeting: "Hello"
+    });
+    // The agent's `results` is set from the captured step_result.
+    expect(agent.getResults()).toEqual({ greeting: "Hello" });
+  });
+});

--- a/packages/agents/tests/memory-tools.test.ts
+++ b/packages/agents/tests/memory-tools.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the memory tools (memory_list / memory_read / memory_write).
+ *
+ * These are the progressive-disclosure interface that agents use to access
+ * shared agent memory without paying the token cost of an auto-injected
+ * snapshot.
+ */
+
+import { describe, expect, it } from "vitest";
+import { memoryKeys } from "@nodetool-ai/runtime";
+import {
+  MemoryListTool,
+  MemoryReadTool,
+  MemoryWriteTool,
+  MEMORY_TOOL_NAMES,
+  getMemoryTools
+} from "../src/tools/memory-tools.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+function seed(context: ReturnType<typeof createMockContext>): void {
+  context.memory.set({
+    key: memoryKeys.task("research"),
+    kind: "task_result",
+    value: { findings: ["alpha", "beta"] },
+    source: "research",
+    title: "Research findings",
+    description: "Top sources from a web search step."
+  });
+  context.memory.set({
+    key: memoryKeys.step("step_1"),
+    kind: "step_result",
+    value: "intermediate text",
+    source: "step_1",
+    title: "Intermediate"
+  });
+  context.memory.set({
+    key: memoryKeys.input("customer"),
+    kind: "input",
+    value: "Acme",
+    title: "customer"
+  });
+  context.memory.set({
+    key: memoryKeys.shared("note"),
+    kind: "shared",
+    value: "user-published note",
+    source: "memory_write",
+    title: "note"
+  });
+}
+
+describe("getMemoryTools", () => {
+  it("returns three fresh tool instances with the canonical names", () => {
+    const tools = getMemoryTools();
+    expect(tools.map((t) => t.name)).toEqual([...MEMORY_TOOL_NAMES]);
+  });
+});
+
+describe("MemoryListTool", () => {
+  it("returns metadata for every entry without values", async () => {
+    const tool = new MemoryListTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, {})) as {
+      total: number;
+      returned: number;
+      truncated: boolean;
+      entries: Array<{
+        key: string;
+        kind: string;
+        title?: string;
+        description?: string;
+        source?: string;
+        valueBytes: number;
+        createdAt: string;
+      }>;
+    };
+
+    expect(result.total).toBe(4);
+    expect(result.returned).toBe(4);
+    expect(result.truncated).toBe(false);
+
+    const keys = result.entries.map((e) => e.key).sort();
+    expect(keys).toEqual([
+      "input:customer",
+      "shared:note",
+      "step:step_1",
+      "task:research"
+    ]);
+
+    // No `value` field in entries — values must be fetched via memory_read.
+    for (const e of result.entries) {
+      expect(e).not.toHaveProperty("value");
+      expect(typeof e.valueBytes).toBe("number");
+      expect(typeof e.createdAt).toBe("string");
+    }
+  });
+
+  it("filters by kind", async () => {
+    const tool = new MemoryListTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, {
+      kind: ["task_result"]
+    })) as { entries: Array<{ key: string }> };
+    expect(result.entries.map((e) => e.key)).toEqual(["task:research"]);
+  });
+
+  it("filters by key_prefix", async () => {
+    const tool = new MemoryListTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, {
+      key_prefix: "input:"
+    })) as { entries: Array<{ key: string }> };
+    expect(result.entries.map((e) => e.key)).toEqual(["input:customer"]);
+  });
+
+  it("filters by sources", async () => {
+    const tool = new MemoryListTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, {
+      sources: ["research"]
+    })) as { entries: Array<{ key: string }> };
+    expect(result.entries.map((e) => e.key)).toEqual(["task:research"]);
+  });
+
+  it("returns empty list when memory is empty", async () => {
+    const tool = new MemoryListTool();
+    const context = createMockContext();
+
+    const result = (await tool.process(context, {})) as {
+      total: number;
+      returned: number;
+      entries: unknown[];
+    };
+    expect(result.total).toBe(0);
+    expect(result.entries).toEqual([]);
+  });
+});
+
+describe("MemoryReadTool", () => {
+  it("returns full values for requested keys, with missing keys reported", async () => {
+    const tool = new MemoryReadTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, {
+      keys: ["task:research", "step:step_1", "task:does_not_exist"]
+    })) as {
+      entries: Record<string, { value: unknown; kind: string }>;
+      missing: string[];
+    };
+
+    expect(Object.keys(result.entries).sort()).toEqual([
+      "step:step_1",
+      "task:research"
+    ]);
+    expect(result.entries["task:research"].value).toEqual({
+      findings: ["alpha", "beta"]
+    });
+    expect(result.entries["task:research"].kind).toBe("task_result");
+    expect(result.entries["step:step_1"].value).toBe("intermediate text");
+    expect(result.missing).toEqual(["task:does_not_exist"]);
+  });
+
+  it("treats an empty keys array as a no-op", async () => {
+    const tool = new MemoryReadTool();
+    const context = createMockContext();
+    seed(context);
+
+    const result = (await tool.process(context, { keys: [] })) as {
+      entries: Record<string, unknown>;
+      missing: string[];
+    };
+    expect(result.entries).toEqual({});
+    expect(result.missing).toEqual([]);
+  });
+});
+
+describe("MemoryWriteTool", () => {
+  it("publishes a value under the shared: namespace", async () => {
+    const tool = new MemoryWriteTool();
+    const context = createMockContext();
+
+    const result = (await tool.process(context, {
+      key: "top_source",
+      value: "https://example.com",
+      title: "Top source URL",
+      description: "Picked by the researcher agent."
+    })) as { ok: boolean; key: string; kind: string };
+
+    expect(result.ok).toBe(true);
+    expect(result.key).toBe("shared:top_source");
+    expect(result.kind).toBe("shared");
+
+    const entry = context.memory.get("shared:top_source");
+    expect(entry?.value).toBe("https://example.com");
+    expect(entry?.title).toBe("Top source URL");
+    expect(entry?.description).toBe("Picked by the researcher agent.");
+    expect(entry?.source).toBe("memory_write");
+  });
+
+  it("only writes under shared: even when caller specifies a different prefix", async () => {
+    const tool = new MemoryWriteTool();
+    const context = createMockContext();
+
+    // The schema doesn't let the agent pick a kind, and the suffix is
+    // always passed through memoryKeys.shared. Even a colon-suffixed key
+    // gets its prefix overwritten.
+    const result = (await tool.process(context, {
+      key: "task:bogus",
+      value: 42
+    })) as { key: string };
+    expect(result.key).toBe("shared:task:bogus");
+    expect(context.memory.has("task:bogus")).toBe(false);
+    expect(context.memory.has("shared:task:bogus")).toBe(true);
+  });
+});

--- a/packages/agents/tests/multi-mode-agent.test.ts
+++ b/packages/agents/tests/multi-mode-agent.test.ts
@@ -3,6 +3,7 @@ import { MultiModeAgent } from "../src/multi-mode-agent.js";
 import { SubAgentPlanner } from "../src/sub-agent-planner.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import type { AgentMode, SubAgentConfig, Task } from "../src/types.js";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -100,26 +101,6 @@ function createTracedMockProvider(
     imageToVideo: vi.fn(),
     generateEmbedding: vi.fn(),
     isContextLengthError: () => false
-  } as any;
-}
-
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    }),
-    loadStepResult: vi.fn(async (key: string) => {
-      return store.get(key);
-    }),
-    set: vi.fn((key: string, value: unknown) => {
-      store.set(key, value);
-    }),
-    get: vi.fn((key: string) => {
-      return store.get(key);
-    }),
-    _store: store
   } as any;
 }
 

--- a/packages/agents/tests/parallel-task-executor.test.ts
+++ b/packages/agents/tests/parallel-task-executor.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { ParallelTaskExecutor } from "../src/parallel-task-executor.js";
 import type { TaskPlan } from "../src/types.js";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
+import { memoryKeys } from "@nodetool-ai/runtime";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 function createMockProvider(delayMs = 0) {
   return {
@@ -51,26 +53,6 @@ function createMockProvider(delayMs = 0) {
     generateEmbedding: vi.fn(),
     isContextLengthError: () => false
   } as ReturnType<typeof createMockProvider>;
-}
-
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    }),
-    loadStepResult: vi.fn(async (key: string) => {
-      return store.get(key);
-    }),
-    set: vi.fn((key: string, value: unknown) => {
-      store.set(key, value);
-    }),
-    get: vi.fn((key: string) => {
-      return store.get(key);
-    }),
-    _store: store
-  } as ReturnType<typeof createMockContext>;
 }
 
 describe("ParallelTaskExecutor", () => {
@@ -231,12 +213,10 @@ describe("ParallelTaskExecutor", () => {
 
     const completionOrder: string[] = [];
     const context = createMockContext();
-    const origSet = context.set;
-    context.set = vi.fn((key: string, value: unknown) => {
-      if (key.startsWith("task_")) {
-        completionOrder.push(key);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "task_result" && entry.source) {
+        completionOrder.push(entry.source);
       }
-      origSet(key, value);
     });
 
     const executor = new ParallelTaskExecutor({
@@ -386,7 +366,8 @@ describe("ParallelTaskExecutor", () => {
       // consume
     }
 
-    expect(context.set).toHaveBeenCalledWith("myKey", "myValue");
+    expect(context.memory.has(memoryKeys.input("myKey"))).toBe(true);
+    expect(context.memory.getValue(memoryKeys.input("myKey"))).toBe("myValue");
   });
 
   it("executes a diamond dependency pattern (fan-out + fan-in)", async () => {
@@ -474,12 +455,10 @@ describe("ParallelTaskExecutor", () => {
 
     const completionOrder: string[] = [];
     const context = createMockContext();
-    const origSet = context.set;
-    context.set = vi.fn((key: string, value: unknown) => {
-      if (key.startsWith("task_")) {
-        completionOrder.push(key);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "task_result" && entry.source) {
+        completionOrder.push(entry.source);
       }
-      origSet(key, value);
     });
 
     const executor = new ParallelTaskExecutor({

--- a/packages/agents/tests/plan-builder-tools.test.ts
+++ b/packages/agents/tests/plan-builder-tools.test.ts
@@ -1,18 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   PlanBuilder,
   AddTaskTool,
   RemoveTaskTool,
   FinishPlanTool
 } from "../src/tools/plan-builder-tools.js";
-
-function createMockContext() {
-  return {
-    set: vi.fn(),
-    get: vi.fn(),
-    storeStepResult: vi.fn()
-  } as any;
-}
+import { createMockContext } from "./_helpers/mock-context.js";
 
 describe("PlanBuilder.addTask", () => {
   it("accepts a valid first task", () => {

--- a/packages/agents/tests/simple-agent.test.ts
+++ b/packages/agents/tests/simple-agent.test.ts
@@ -7,8 +7,9 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { SimpleAgent } from "../src/simple-agent.js";
-import type { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import type { BaseProvider } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 function createMockProvider(finishResult?: Record<string, unknown>) {
   const result = finishResult ?? { answer: "42" };
@@ -69,15 +70,6 @@ function createMockProvider(finishResult?: Record<string, unknown>) {
     getTotalCost: vi.fn().mockReturnValue(0),
     resetCost: vi.fn()
   } as unknown as BaseProvider;
-}
-
-function createMockContext() {
-  return {
-    storeStepResult: vi.fn(),
-    loadStepResult: vi.fn(),
-    set: vi.fn(),
-    get: vi.fn()
-  } as unknown as ProcessingContext;
 }
 
 describe("SimpleAgent constructor", () => {

--- a/packages/agents/tests/step-executor.test.ts
+++ b/packages/agents/tests/step-executor.test.ts
@@ -3,6 +3,7 @@ import { StepExecutor } from "../src/step-executor.js";
 import type { Step, Task } from "../src/types.js";
 import type { ProcessingMessage, TaskUpdate } from "@nodetool-ai/protocol";
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import { AgentMemory } from "@nodetool-ai/runtime";
 import type { Tool } from "../src/tools/base-tool.js";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -73,13 +74,15 @@ function createMockProvider(toolCallArgs?: Record<string, unknown>): BaseProvide
 }
 
 /**
- * Minimal mock context with storeStepResult and loadStepResult.
+ * Minimal mock context with a real AgentMemory.
  */
 function createMockContext(
   overrides: Record<string, unknown> = {}
 ): ProcessingContext {
   const store = new Map<string, unknown>();
   return asProcessingContext({
+    memory: new AgentMemory(),
+    workspaceDir: null,
     storeStepResult: vi.fn(async (key: string, value: unknown) => {
       store.set(key, value);
       return key;
@@ -89,6 +92,7 @@ function createMockContext(
     }),
     set: vi.fn(),
     get: vi.fn(),
+    sandboxToAsset: vi.fn(async (uri: string) => ({ uri: `asset://${uri}` })),
     _store: store,
     ...overrides
   });
@@ -141,9 +145,8 @@ describe("StepExecutor", () => {
     expect(step.completed).toBe(true);
 
     // Result should be stored
-    expect(context.storeStepResult).toHaveBeenCalledWith("step_1", {
-      answer: "42"
-    });
+    const stored = context.memory.getValue("step:step_1");
+    expect(stored).toEqual({ answer: "42" });
     expect(executor.getResult()).toEqual({ answer: "42" });
   });
 
@@ -594,8 +597,14 @@ describe("StepExecutor", () => {
 
     const provider = createMockProvider({ result: { v: "ok" } });
     const context = createMockContext();
-    // Pre-store a dependency result
-    await context.storeStepResult("dep_step", { previous: "data" });
+    // Pre-populate the dependency in shared memory
+    context.memory.set({
+      key: "step:dep_step",
+      kind: "step_result",
+      value: { previous: "data" },
+      source: "dep_step",
+      title: "dep_step"
+    });
 
     const executor = new StepExecutor({
       task,
@@ -611,8 +620,9 @@ describe("StepExecutor", () => {
     }
 
     expect(step.completed).toBe(true);
-    // Verify loadStepResult was called for the dependency
-    expect(context.loadStepResult).toHaveBeenCalledWith("dep_step");
+    // The new memory write for this step should exist alongside the dep entry.
+    expect(context.memory.has("step:step_with_deps")).toBe(true);
+    expect(context.memory.has("step:dep_step")).toBe(true);
   });
 
   it("uses full args when finish_step has no result key", async () => {

--- a/packages/agents/tests/task-executor.test.ts
+++ b/packages/agents/tests/task-executor.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { TaskExecutor } from "../src/task-executor.js";
 import type { Step, Task } from "../src/types.js";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { memoryKeys } from "@nodetool-ai/runtime";
+import { createMockContext } from "./_helpers/mock-context.js";
 
 /**
  * Creates a mock provider that returns a finish_step tool call for each step.
@@ -44,22 +46,6 @@ function createMockProvider(delayMs = 0) {
     imageToVideo: vi.fn(),
     generateEmbedding: vi.fn(),
     isContextLengthError: () => false
-  } as any;
-}
-
-function createMockContext() {
-  const store = new Map<string, unknown>();
-  return {
-    storeStepResult: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    }),
-    loadStepResult: vi.fn(async (key: string) => {
-      return store.get(key);
-    }),
-    set: vi.fn(),
-    get: vi.fn(),
-    _store: store
   } as any;
 }
 
@@ -118,11 +104,10 @@ describe("TaskExecutor", () => {
     } as any;
 
     const context = createMockContext();
-    // Track step completion order via storeStepResult
-    const origStore = context.storeStepResult;
-    context.storeStepResult = vi.fn(async (key: string, value: unknown) => {
-      completionOrder.push(key);
-      return origStore(key, value);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "step_result" && entry.source) {
+        completionOrder.push(entry.source);
+      }
     });
 
     const executor = new TaskExecutor({
@@ -140,8 +125,9 @@ describe("TaskExecutor", () => {
     expect(s1.completed).toBe(true);
     expect(s2.completed).toBe(true);
     // s1 must complete before s2
-    const stepIds = completionOrder.filter((id) => id.startsWith("s"));
-    expect(stepIds.indexOf("s1")).toBeLessThan(stepIds.indexOf("s2"));
+    expect(completionOrder.indexOf("s1")).toBeLessThan(
+      completionOrder.indexOf("s2")
+    );
   });
 
   it("defers finish step until other steps complete", async () => {
@@ -153,10 +139,10 @@ describe("TaskExecutor", () => {
 
     const completionOrder: string[] = [];
     const context = createMockContext();
-    const origStore = context.storeStepResult;
-    context.storeStepResult = vi.fn(async (key: string, value: unknown) => {
-      completionOrder.push(key);
-      return origStore(key, value);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "step_result" && entry.source) {
+        completionOrder.push(entry.source);
+      }
     });
 
     const executor = new TaskExecutor({
@@ -175,9 +161,7 @@ describe("TaskExecutor", () => {
     expect(s2.completed).toBe(true);
     expect(s3.completed).toBe(true);
     // s3 (finish step) must be last step stored
-    // Note: finish step also stores task-level result, so filter to step ids
-    const stepIds = completionOrder.filter((id) => id.startsWith("s"));
-    expect(stepIds[stepIds.length - 1]).toBe("s3");
+    expect(completionOrder[completionOrder.length - 1]).toBe("s3");
   });
 
   it("defers finish step even when it has no explicit dependencies", async () => {
@@ -189,10 +173,10 @@ describe("TaskExecutor", () => {
 
     const completionOrder: string[] = [];
     const context = createMockContext();
-    const origStore = context.storeStepResult;
-    context.storeStepResult = vi.fn(async (key: string, value: unknown) => {
-      completionOrder.push(key);
-      return origStore(key, value);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "step_result" && entry.source) {
+        completionOrder.push(entry.source);
+      }
     });
 
     const executor = new TaskExecutor({
@@ -209,8 +193,7 @@ describe("TaskExecutor", () => {
 
     expect(s3.completed).toBe(true);
     // s3 must be last due to finish step deferral
-    const stepIds = completionOrder.filter((id) => id.startsWith("s"));
-    expect(stepIds[stepIds.length - 1]).toBe("s3");
+    expect(completionOrder[completionOrder.length - 1]).toBe("s3");
   });
 
   it("executes independent steps in parallel when parallelExecution=true", async () => {
@@ -307,7 +290,8 @@ describe("TaskExecutor", () => {
       // consume
     }
 
-    expect(context.set).toHaveBeenCalledWith("myKey", "myValue");
+    expect(context.memory.has(memoryKeys.input("myKey"))).toBe(true);
+    expect(context.memory.getValue(memoryKeys.input("myKey"))).toBe("myValue");
   });
 
   it("respects maxSteps limit", async () => {
@@ -364,10 +348,10 @@ describe("TaskExecutor", () => {
 
     const completionOrder: string[] = [];
     const context = createMockContext();
-    const origStore = context.storeStepResult;
-    context.storeStepResult = vi.fn(async (key: string, value: unknown) => {
-      completionOrder.push(key);
-      return origStore(key, value);
+    context.memory.subscribe((entry: { kind: string; source?: string }) => {
+      if (entry.kind === "step_result" && entry.source) {
+        completionOrder.push(entry.source);
+      }
     });
 
     // Set s1 as the final step (not the default last step s2)
@@ -385,8 +369,7 @@ describe("TaskExecutor", () => {
     }
 
     // s1 is the designated finish step, should be deferred until s2 completes
-    const stepIds = completionOrder.filter((id) => id.startsWith("s"));
-    expect(stepIds[0]).toBe("s2");
-    expect(stepIds[1]).toBe("s1");
+    expect(completionOrder[0]).toBe("s2");
+    expect(completionOrder[1]).toBe("s1");
   });
 });

--- a/packages/agents/tests/task-planner.test.ts
+++ b/packages/agents/tests/task-planner.test.ts
@@ -1,15 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { CreatePlanTool } from "../src/tools/create-plan-tool.js";
 import { CreateTaskPlanTool } from "../src/tools/create-task-tool.js";
 import type { Step, Task, TaskPlan } from "../src/types.js";
-
-function createMockContext() {
-  return {
-    set: vi.fn(),
-    get: vi.fn(),
-    storeStepResult: vi.fn()
-  } as any;
-}
+import { createMockContext } from "./_helpers/mock-context.js";
 
 // ---------------------------------------------------------------------------
 // CreateTaskPlanTool (single-task planning)

--- a/packages/runtime/src/agent-memory.ts
+++ b/packages/runtime/src/agent-memory.ts
@@ -1,0 +1,205 @@
+/**
+ * AgentMemory — unified, structured key/value store for agent results.
+ *
+ * One memory instance lives on every {@link ProcessingContext}. It is the
+ * single source of truth for everything that flows between agents, tasks and
+ * steps:
+ *
+ *   - **inputs** seeded by the caller
+ *   - **step_result** entries written by {@link StepExecutor}
+ *   - **task_result** entries written by {@link StepExecutor} for finish-task
+ *     steps and by {@link ParallelTaskExecutor} / {@link TeamExecutor} when
+ *     a task completes
+ *   - **shared** entries written by tools or by the user for cross-agent
+ *     communication
+ *
+ * Keys use namespaced prefixes (`step:`, `task:`, `input:`, `shared:`) so the
+ * different kinds never collide. The {@link AgentMemory.formatForPrompt}
+ * helper renders selected entries as a Markdown block ready to inject into a
+ * user/system prompt — the canonical way agents discover prior results.
+ *
+ * Design goals (2026 agent patterns):
+ *
+ *   - **Single store, single API**: no parallel maps in executors.
+ *   - **Discoverable**: every step/task/sub-agent can list and read all
+ *     prior results via the same calls.
+ *   - **Structured**: entries carry kind, source, title and description so
+ *     prompts render consistently.
+ *   - **Reactive**: subscribers can react to writes (used by TeamExecutor to
+ *     mirror task-board completions into shared memory).
+ */
+
+export type MemoryKind = "task_result" | "step_result" | "input" | "shared";
+
+export interface MemoryEntry {
+  /** Globally unique key. Use {@link memoryKeys} for canonical namespacing. */
+  key: string;
+  /** Categorization used for filtering and prompt rendering. */
+  kind: MemoryKind;
+  /** Stored value (any JSON-serializable structure). */
+  value: unknown;
+  /** Optional ID of the producer (task / step / agent / tool). */
+  source?: string;
+  /** Optional human-readable title used as the heading in prompt rendering. */
+  title?: string;
+  /** Optional brief description rendered alongside the title. */
+  description?: string;
+  /** Wall-clock ms when the entry was first written. */
+  createdAt: number;
+}
+
+export interface MemoryFilter {
+  /** One or more kinds to include. Omit to include all kinds. */
+  kind?: MemoryKind | MemoryKind[];
+  /** Only include entries whose key is in this list. */
+  keys?: string[];
+  /** Only include entries whose key starts with this prefix. */
+  keyPrefix?: string;
+  /** Only include entries whose source matches one of these IDs. */
+  sources?: string[];
+}
+
+export type MemoryListener = (entry: MemoryEntry) => void;
+
+/**
+ * Canonical key builders. Every namespace has its own helper so callers
+ * never invent free-form keys that drift between writers and readers.
+ */
+export const memoryKeys = {
+  step: (id: string): string => `step:${id}`,
+  task: (id: string): string => `task:${id}`,
+  input: (key: string): string => `input:${key}`,
+  shared: (key: string): string => `shared:${key}`
+} as const;
+
+export class AgentMemory {
+  private readonly entries = new Map<string, MemoryEntry>();
+  private readonly listeners = new Set<MemoryListener>();
+
+  /**
+   * Write an entry. If a value already exists for {@link MemoryEntry.key} it
+   * is overwritten. The original `createdAt` is preserved unless the caller
+   * supplies a new one.
+   */
+  set(input: Omit<MemoryEntry, "createdAt"> & { createdAt?: number }): MemoryEntry {
+    const existing = this.entries.get(input.key);
+    const entry: MemoryEntry = {
+      key: input.key,
+      kind: input.kind,
+      value: input.value,
+      source: input.source,
+      title: input.title,
+      description: input.description,
+      createdAt: input.createdAt ?? existing?.createdAt ?? Date.now()
+    };
+    this.entries.set(entry.key, entry);
+    for (const listener of this.listeners) {
+      listener(entry);
+    }
+    return entry;
+  }
+
+  /** Get the full entry, or undefined if no such key. */
+  get(key: string): MemoryEntry | undefined {
+    return this.entries.get(key);
+  }
+
+  /** Get just the stored value, or undefined if no such key. */
+  getValue<T = unknown>(key: string): T | undefined {
+    return this.entries.get(key)?.value as T | undefined;
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  delete(key: string): boolean {
+    return this.entries.delete(key);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** List entries matching an optional filter, in insertion order. */
+  list(filter?: MemoryFilter): MemoryEntry[] {
+    if (!filter) return [...this.entries.values()];
+
+    const kindArr =
+      filter.kind === undefined
+        ? null
+        : Array.isArray(filter.kind)
+          ? filter.kind
+          : [filter.kind];
+    const keysSet = filter.keys ? new Set(filter.keys) : null;
+    const sourcesSet = filter.sources ? new Set(filter.sources) : null;
+
+    const out: MemoryEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (kindArr && !kindArr.includes(entry.kind)) continue;
+      if (keysSet && !keysSet.has(entry.key)) continue;
+      if (filter.keyPrefix && !entry.key.startsWith(filter.keyPrefix)) continue;
+      if (sourcesSet && (!entry.source || !sourcesSet.has(entry.source))) continue;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * Render selected entries as a Markdown block suitable for injection into
+   * a user/system prompt. Returns an empty string when no entries match.
+   *
+   * Each entry is rendered as:
+   *
+   *     ## [kind] title (key)
+   *     description (if any)
+   *     ```
+   *     value (JSON-serialized for non-strings)
+   *     ```
+   */
+  formatForPrompt(filter?: MemoryFilter): string {
+    const entries = this.list(filter);
+    if (entries.length === 0) return "";
+    const sorted = [...entries].sort((a, b) => a.createdAt - b.createdAt);
+
+    const lines: string[] = ["# Memory (results from prior steps and tasks)"];
+    for (const entry of sorted) {
+      const heading = entry.title ?? entry.key;
+      lines.push("");
+      lines.push(`## [${entry.kind}] ${heading} (${entry.key})`);
+      if (entry.description) lines.push(entry.description);
+      const valueStr =
+        typeof entry.value === "string"
+          ? entry.value
+          : JSON.stringify(entry.value, null, 2);
+      lines.push("```");
+      lines.push(valueStr);
+      lines.push("```");
+    }
+    return lines.join("\n");
+  }
+
+  /** Remove all entries (or those matching a filter). */
+  clear(filter?: MemoryFilter): void {
+    if (!filter) {
+      this.entries.clear();
+      return;
+    }
+    for (const key of this.list(filter).map((e) => e.key)) {
+      this.entries.delete(key);
+    }
+  }
+
+  /** Subscribe to writes. Returns an unsubscribe function. */
+  subscribe(listener: MemoryListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Snapshot all entries (insertion order). */
+  snapshot(): MemoryEntry[] {
+    return [...this.entries.values()];
+  }
+}

--- a/packages/runtime/src/agent-memory.ts
+++ b/packages/runtime/src/agent-memory.ts
@@ -94,7 +94,14 @@ export class AgentMemory {
     };
     this.entries.set(entry.key, entry);
     for (const listener of this.listeners) {
-      listener(entry);
+      try {
+        listener(entry);
+      } catch (error) {
+        console.error("AgentMemory listener failed", {
+          key: entry.key,
+          error
+        });
+      }
     }
     return entry;
   }

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -11,6 +11,7 @@
  */
 
 import type { AssetRef, ProcessingMessage } from "@nodetool-ai/protocol";
+import { AgentMemory } from "./agent-memory.js";
 import { randomUUID } from "node:crypto";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import {
@@ -481,6 +482,12 @@ export class ProcessingContext {
 
   /** Storage adapter (optional, for asset handling). */
   readonly storage: StorageAdapter | null;
+  /**
+   * Unified, structured agent memory. The single source of truth for results
+   * shared between agents, tasks, steps and tools. Keys use the namespaces
+   * `step:`, `task:`, `input:`, `shared:` (see {@link memoryKeys}).
+   */
+  readonly memory: AgentMemory = new AgentMemory();
   /** Variables shared across node execution. */
   private _variables: Record<string, unknown>;
   /** Optional async secret resolver. */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,14 @@ export {
   type S3Client,
   type StorageAdapter
 } from "./context.js";
+export {
+  AgentMemory,
+  memoryKeys,
+  type MemoryEntry,
+  type MemoryFilter,
+  type MemoryKind,
+  type MemoryListener
+} from "./agent-memory.js";
 
 export * from "./providers/index.js";
 export {

--- a/packages/runtime/tests/agent-memory.test.ts
+++ b/packages/runtime/tests/agent-memory.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentMemory, memoryKeys } from "../src/agent-memory.js";
+
+describe("AgentMemory", () => {
+  it("stores and retrieves entries by key", () => {
+    const m = new AgentMemory();
+    m.set({
+      key: memoryKeys.task("t1"),
+      kind: "task_result",
+      value: { foo: "bar" },
+      source: "t1",
+      title: "Task One"
+    });
+
+    const entry = m.get("task:t1");
+    expect(entry?.value).toEqual({ foo: "bar" });
+    expect(entry?.kind).toBe("task_result");
+    expect(m.getValue("task:t1")).toEqual({ foo: "bar" });
+    expect(m.has("task:t1")).toBe(true);
+    expect(m.size()).toBe(1);
+  });
+
+  it("filters list() by kind, keys, prefix, and source", () => {
+    const m = new AgentMemory();
+    m.set({ key: "step:s1", kind: "step_result", value: 1, source: "s1" });
+    m.set({ key: "step:s2", kind: "step_result", value: 2, source: "s2" });
+    m.set({ key: "task:t1", kind: "task_result", value: 3, source: "t1" });
+    m.set({ key: "input:foo", kind: "input", value: 4, source: "input" });
+
+    expect(m.list({ kind: "step_result" })).toHaveLength(2);
+    expect(m.list({ kind: ["task_result", "input"] })).toHaveLength(2);
+    expect(m.list({ keys: ["step:s1", "task:t1"] })).toHaveLength(2);
+    expect(m.list({ keyPrefix: "step:" })).toHaveLength(2);
+    expect(m.list({ sources: ["s1"] })).toHaveLength(1);
+  });
+
+  it("preserves the original createdAt on overwrite", () => {
+    const m = new AgentMemory();
+    m.set({
+      key: "step:s1",
+      kind: "step_result",
+      value: 1,
+      createdAt: 100
+    });
+    m.set({ key: "step:s1", kind: "step_result", value: 2 });
+    expect(m.get("step:s1")?.value).toBe(2);
+    expect(m.get("step:s1")?.createdAt).toBe(100);
+  });
+
+  it("notifies subscribers on writes", () => {
+    const m = new AgentMemory();
+    const listener = vi.fn();
+    const unsubscribe = m.subscribe(listener);
+    m.set({ key: "step:s1", kind: "step_result", value: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].key).toBe("step:s1");
+
+    unsubscribe();
+    m.set({ key: "step:s2", kind: "step_result", value: 2 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders entries as a Markdown prompt block", () => {
+    const m = new AgentMemory();
+    m.set({
+      key: "task:research",
+      kind: "task_result",
+      value: { findings: ["a", "b"] },
+      source: "research",
+      title: "Research findings",
+      createdAt: 1
+    });
+    m.set({
+      key: "task:summary",
+      kind: "task_result",
+      value: "A short summary string.",
+      source: "summary",
+      title: "Summary",
+      createdAt: 2
+    });
+
+    const block = m.formatForPrompt({ kind: "task_result" });
+    expect(block).toContain("# Memory");
+    expect(block).toContain("## [task_result] Research findings (task:research)");
+    expect(block).toContain("findings");
+    expect(block).toContain("## [task_result] Summary (task:summary)");
+    expect(block).toContain("A short summary string.");
+  });
+
+  it("returns empty string when no entries match formatForPrompt filter", () => {
+    const m = new AgentMemory();
+    m.set({ key: "step:s1", kind: "step_result", value: 1 });
+    expect(m.formatForPrompt({ kind: "task_result" })).toBe("");
+  });
+
+  it("clears entries by filter or completely", () => {
+    const m = new AgentMemory();
+    m.set({ key: "step:s1", kind: "step_result", value: 1 });
+    m.set({ key: "task:t1", kind: "task_result", value: 2 });
+    m.clear({ kind: "step_result" });
+    expect(m.has("step:s1")).toBe(false);
+    expect(m.has("task:t1")).toBe(true);
+    m.clear();
+    expect(m.size()).toBe(0);
+  });
+
+  it("orders formatForPrompt by createdAt ascending", () => {
+    const m = new AgentMemory();
+    m.set({
+      key: "step:b",
+      kind: "step_result",
+      value: "second",
+      createdAt: 200,
+      title: "B"
+    });
+    m.set({
+      key: "step:a",
+      kind: "step_result",
+      value: "first",
+      createdAt: 100,
+      title: "A"
+    });
+    const block = m.formatForPrompt();
+    const aIdx = block.indexOf("## [step_result] A");
+    const bIdx = block.indexOf("## [step_result] B");
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+});


### PR DESCRIPTION
Plan mode in MultiModeAgent had unreliable memory propagation: results
from upstream tasks did not consistently reach downstream tasks and
sub-agents. Three concurrent stores (`context._variables`,
`ParallelTaskExecutor.taskResults`, `TaskBoard.task.result`) drifted out
of sync, and the user-supplied system prompt replaced the default
execution discipline (output schema, finish_step protocol), breaking
result capture.

Introduce `AgentMemory` on `ProcessingContext.memory` as the single
namespaced store for `step:`, `task:`, `input:`, and `shared:` entries.
Every step / task / sub-agent now writes results into `context.memory`
and discovers prior results through `formatForPrompt`, which is injected
into each step's user message. The team task board mirrors completed
tasks into memory through a subscription, so cross-agent visibility uses
the same channel as plan mode.

Stop letting `customPrompt` replace the default execution prompt in
StepExecutor — it is now layered as a preamble, preserving finish_step
discipline for every call. ParallelTaskExecutor drops its private
`taskResults` map and reads dependencies from memory.

https://claude.ai/code/session_01STit9was64oGZct6BVyRyp