### PR TITLE
Invalidate provider-dependent caches when secrets change

### DIFF
--- a/web/src/stores/SecretsStore.ts
+++ b/web/src/stores/SecretsStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { trpcClient } from "../trpc/client";
 import { createErrorMessage } from "../utils/errorHandling";
 import { SecretResponse } from "./ApiTypes";
+import { queryClient } from "../queryClient";
 
 interface SecretsStore {
   secrets: SecretResponse[];
@@ -12,6 +13,22 @@ interface SecretsStore {
   updateSecret: (key: string, value: string, description?: string) => Promise<void>;
   deleteSecret: (key: string) => Promise<void>;
 }
+
+// Provider availability is derived from configured secrets, and downstream
+// model lists are scoped to those providers. Whenever a secret is added,
+// changed, or removed, every cache that depends on the resulting provider
+// set must be refreshed so model dialogs reflect the new provider without
+// requiring a page reload.
+const invalidateProviderDependentCaches = (): void => {
+  queryClient.invalidateQueries({ queryKey: ["secrets"] });
+  queryClient.invalidateQueries({ queryKey: ["providers"] });
+  queryClient.invalidateQueries({ queryKey: ["language-models"] });
+  queryClient.invalidateQueries({ queryKey: ["embedding-models"] });
+  queryClient.invalidateQueries({ queryKey: ["image-models"] });
+  queryClient.invalidateQueries({ queryKey: ["tts-models"] });
+  queryClient.invalidateQueries({ queryKey: ["asr-models"] });
+  queryClient.invalidateQueries({ queryKey: ["video-models"] });
+};
 
 const useSecretsStore = create<SecretsStore>((set, get) => ({
   secrets: [],
@@ -60,6 +77,7 @@ const useSecretsStore = create<SecretsStore>((set, get) => ({
       });
       // Refresh secrets list
       await get().fetchSecrets();
+      invalidateProviderDependentCaches();
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
       set({
@@ -75,6 +93,7 @@ const useSecretsStore = create<SecretsStore>((set, get) => ({
       await trpcClient.settings.secrets.delete.mutate({ key });
       // Refresh secrets list
       await get().fetchSecrets();
+      invalidateProviderDependentCaches();
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
       set({

--- a/web/src/stores/__tests__/SecretsStore.test.ts
+++ b/web/src/stores/__tests__/SecretsStore.test.ts
@@ -16,6 +16,11 @@ jest.mock("../../trpc/client", () => ({
   }
 }));
 
+const invalidateQueries = jest.fn();
+jest.mock("../../queryClient", () => ({
+  queryClient: { invalidateQueries: (...args: unknown[]) => invalidateQueries(...args) }
+}));
+
 import { trpcClient } from "../../trpc/client";
 // Cast so we can read the Jest mock APIs on the nested procedures without
 // sprinkling `as any` in every test.
@@ -26,6 +31,7 @@ const deleteMutate = trpcClient.settings.secrets.delete.mutate as jest.Mock;
 describe("SecretsStore", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    invalidateQueries.mockReset();
     useSecretsStore.setState({
       secrets: [],
       isLoading: false,
@@ -166,6 +172,50 @@ describe("SecretsStore", () => {
 
       expect(result.current.error).toBeTruthy();
     });
+
+    it("should invalidate provider-dependent caches on success", async () => {
+      upsertMutate.mockResolvedValueOnce({
+        key: "OPENAI_API_KEY",
+        is_configured: true,
+        is_unreadable: false
+      });
+      listQuery.mockResolvedValueOnce({ secrets: [], next_key: null });
+
+      const { result } = renderHook(() => useSecretsStore());
+
+      await act(async () => {
+        await result.current.updateSecret("OPENAI_API_KEY", "new_value");
+      });
+
+      const invalidatedKeys = invalidateQueries.mock.calls.map((c) => c[0].queryKey[0]);
+      expect(invalidatedKeys).toEqual(
+        expect.arrayContaining([
+          "secrets",
+          "providers",
+          "language-models",
+          "image-models",
+          "tts-models",
+          "asr-models",
+          "video-models"
+        ])
+      );
+    });
+
+    it("should NOT invalidate caches when update fails", async () => {
+      upsertMutate.mockRejectedValueOnce(new Error("Failed"));
+
+      const { result } = renderHook(() => useSecretsStore());
+
+      await act(async () => {
+        try {
+          await result.current.updateSecret("OPENAI_API_KEY", "value");
+        } catch (_) {
+          // Error is expected
+        }
+      });
+
+      expect(invalidateQueries).not.toHaveBeenCalled();
+    });
   });
 
   describe("deleteSecret", () => {
@@ -212,6 +262,30 @@ describe("SecretsStore", () => {
       });
 
       expect(result.current.error).toBeTruthy();
+    });
+
+    it("should invalidate provider-dependent caches on success", async () => {
+      deleteMutate.mockResolvedValueOnce({ message: "Secret deleted" });
+      listQuery.mockResolvedValueOnce({ secrets: [], next_key: null });
+
+      const { result } = renderHook(() => useSecretsStore());
+
+      await act(async () => {
+        await result.current.deleteSecret("OPENAI_API_KEY");
+      });
+
+      const invalidatedKeys = invalidateQueries.mock.calls.map((c) => c[0].queryKey[0]);
+      expect(invalidatedKeys).toEqual(
+        expect.arrayContaining([
+          "secrets",
+          "providers",
+          "language-models",
+          "image-models",
+          "tts-models",
+          "asr-models",
+          "video-models"
+        ])
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
This PR ensures that when secrets are added, updated, or deleted, all provider-dependent caches are invalidated so that the UI reflects the new provider availability without requiring a page reload.

## Key Changes
- Added `invalidateProviderDependentCaches()` helper function that invalidates caches for secrets, providers, and all model types (language, embedding, image, TTS, ASR, video)
- Call cache invalidation after successful secret updates in `updateSecret()`
- Call cache invalidation after successful secret deletion in `deleteSecret()`
- Added comprehensive test coverage to verify cache invalidation occurs on success and does not occur on failure
- Mocked `queryClient` in tests to verify invalidation behavior

## Implementation Details
- Cache invalidation only occurs after successful mutations, preventing unnecessary cache clears on failed operations
- The invalidation strategy covers all downstream caches that depend on the provider set, ensuring model dialogs and provider lists stay in sync with the current secret configuration
- Tests verify that the correct set of cache keys are invalidated and that failures do not trigger invalidation

https://claude.ai/code/session_015maAtFziyuytRnbzf7hQ4b