### PR TITLE
Consolidate query invalidation logic for resource changes

### DIFF
--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -16,6 +16,10 @@ import useRemoteSettingsStore, {
   type SettingWithValue
 } from "../../stores/RemoteSettingStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  MODEL_QUERY_KEYS,
+  PROVIDER_QUERY_KEYS
+} from "../../stores/resourceChangeHandler";
 import { useTheme } from "@mui/material/styles";
 import { getSharedSettingsStyles } from "./sharedSettingsStyles";
 import ExternalLink from "../common/ExternalLink";
@@ -312,8 +316,20 @@ const RemoteSettings = () => {
   const updateSettingsMutation = useMutation({
     mutationFn: (args: { settings: Record<string, string>; secrets: Record<string, string> }) =>
       updateSettings(args.settings, args.secrets),
-    onSuccess: () => {
+    onSuccess: (_data, args) => {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
+      // Saving secrets through the remote-settings panel must propagate the
+      // same way SecretsMenu does — provider availability and per-modality
+      // model lists derive from configured secrets.
+      if (args.secrets && Object.keys(args.secrets).length > 0) {
+        queryClient.invalidateQueries({ queryKey: ["secrets"] });
+        for (const key of PROVIDER_QUERY_KEYS) {
+          queryClient.invalidateQueries({ queryKey: [key] });
+        }
+        for (const key of MODEL_QUERY_KEYS) {
+          queryClient.invalidateQueries({ queryKey: [key] });
+        }
+      }
     }
   });
 

--- a/web/src/components/menus/SecretsMenu.tsx
+++ b/web/src/components/menus/SecretsMenu.tsx
@@ -8,6 +8,10 @@ import LockIcon from "@mui/icons-material/Lock";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import useSecretsStore from "../../stores/SecretsStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  MODEL_QUERY_KEYS,
+  PROVIDER_QUERY_KEYS
+} from "../../stores/resourceChangeHandler";
 import { useState, useCallback, useMemo, memo } from "react";
 import type React from "react";
 import { useTheme } from "@mui/material/styles";
@@ -99,6 +103,18 @@ const SecretsMenu = memo(({ searchTerm: externalSearchTerm }: SecretsMenuProps) 
     return { configured, unconfigured };
   }, [safeSecrets, searchTerm]);
 
+  // Provider availability and the per-modality model lists are derived from
+  // configured secrets, so any secret change invalidates the full set.
+  const invalidateSecretDependents = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["secrets"] });
+    for (const key of PROVIDER_QUERY_KEYS) {
+      queryClient.invalidateQueries({ queryKey: [key] });
+    }
+    for (const key of MODEL_QUERY_KEYS) {
+      queryClient.invalidateQueries({ queryKey: [key] });
+    }
+  }, [queryClient]);
+
   const updateMutation = useMutation({
     mutationFn: () => {
       if (!editingSecret) {
@@ -107,16 +123,7 @@ const SecretsMenu = memo(({ searchTerm: externalSearchTerm }: SecretsMenuProps) 
       return updateSecret(editingSecret.key, formData.value);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["secrets"] });
-      // Invalidate providers cache when secrets change, as provider availability
-      // depends on having the required secrets configured
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-      // Also invalidate all model queries that depend on providers
-      queryClient.invalidateQueries({ queryKey: ["language-models"] });
-      queryClient.invalidateQueries({ queryKey: ["image-models"] });
-      queryClient.invalidateQueries({ queryKey: ["tts-models"] });
-      queryClient.invalidateQueries({ queryKey: ["asr-models"] });
-      queryClient.invalidateQueries({ queryKey: ["video-models"] });
+      invalidateSecretDependents();
       addNotification({
         type: "success",
         content: "Secret updated successfully",
@@ -136,16 +143,7 @@ const SecretsMenu = memo(({ searchTerm: externalSearchTerm }: SecretsMenuProps) 
   const deleteMutation = useMutation({
     mutationFn: (key: string) => deleteSecret(key),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["secrets"] });
-      // Invalidate providers cache when secrets change, as provider availability
-      // depends on having the required secrets configured
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-      // Also invalidate all model queries that depend on providers
-      queryClient.invalidateQueries({ queryKey: ["language-models"] });
-      queryClient.invalidateQueries({ queryKey: ["image-models"] });
-      queryClient.invalidateQueries({ queryKey: ["tts-models"] });
-      queryClient.invalidateQueries({ queryKey: ["asr-models"] });
-      queryClient.invalidateQueries({ queryKey: ["video-models"] });
+      invalidateSecretDependents();
       addNotification({
         type: "success",
         content: "Secret deleted successfully",

--- a/web/src/components/workflows/WorkflowList.tsx
+++ b/web/src/components/workflows/WorkflowList.tsx
@@ -255,6 +255,15 @@ const WorkflowList = () => {
             )
           };
         });
+        // The optimistic write only updates the list query. Detail consumers
+        // (`["workflow", id]`) and the workflow tools picker also surface the
+        // name and must be refetched. The backend resource_change broadcast
+        // will normally cover this, but invalidating here keeps the UI
+        // consistent even if the broadcast is missed.
+        queryClient.invalidateQueries({
+          queryKey: ["workflow", workflow.id]
+        });
+        queryClient.invalidateQueries({ queryKey: ["workflow-tools"] });
         // Also update the workflow manager if this workflow is open (updates tabs)
         const openWorkflow = getWorkflow(workflow.id);
         if (openWorkflow) {

--- a/web/src/serverState/useAssets.ts
+++ b/web/src/serverState/useAssets.ts
@@ -222,31 +222,37 @@ export const useAssets = (_initialFolderId: string | null = null) => {
     });
   }, [filterAssets, processedAssets, assetSearchTerm, sizeFilter, typeFilter]);
 
+  // AssetStore.{createFolder,delete,update} already invalidates the
+  // ["assets", { parent_id }] queries it touches; these mutations only need
+  // to refresh the folder tree and the workflow-filtered list.
+  const invalidateAssetSiblings = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ["assets", { parent_id: currentFolderId }]
+    });
+    if (workflowFilter) {
+      queryClient.invalidateQueries({
+        queryKey: ["assets", { workflow_id: workflowFilter }]
+      });
+    }
+    queryClient.invalidateQueries({ queryKey: ["folderTree"] });
+  }, [queryClient, currentFolderId, workflowFilter]);
+
   // Create folder mutation
   const createFolderMutation = useMutation({
     mutationFn: (name: string) => createFolder(currentFolderId, name),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["assets", currentFolderId] });
-      queryClient.invalidateQueries({ queryKey: ["folderTree"] });
-    }
+    onSuccess: invalidateAssetSiblings
   });
 
   // Delete asset mutation
   const deleteAssetMutation = useMutation({
     mutationFn: (assetId: string) => deleteAsset(assetId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["assets", currentFolderId] });
-      queryClient.invalidateQueries({ queryKey: ["folderTree"] });
-    }
+    onSuccess: invalidateAssetSiblings
   });
 
   // Update asset mutation
   const updateAssetMutation = useMutation({
     mutationFn: (updateData: AssetUpdate) => update(updateData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["assets", currentFolderId] });
-      queryClient.invalidateQueries({ queryKey: ["folderTree"] });
-    }
+    onSuccess: invalidateAssetSiblings
   });
 
   // Navigate to folder

--- a/web/src/stores/CollectionStore.ts
+++ b/web/src/stores/CollectionStore.ts
@@ -3,6 +3,7 @@ import { devtools } from "zustand/middleware";
 import { restFetch } from "../lib/rest-fetch";
 import { CollectionList as CollectionListType } from "./ApiTypes";
 import { trpcClient } from "../trpc/client";
+import { queryClient } from "../queryClient";
 
 interface IndexResponseData {
   path: string;
@@ -96,6 +97,9 @@ export const useCollectionStore = create<CollectionStore>()(
       deleteCollection: async (collectionName: string) => {
         await trpcClient.collections.delete.mutate({ name: collectionName });
         await get().fetchCollections();
+        // Collections are not DBModels and don't broadcast resource_change,
+        // so React Query consumers (CollectionProperty) need an explicit kick.
+        queryClient.invalidateQueries({ queryKey: ["collections"] });
       },
 
       confirmDelete: async () => {
@@ -188,6 +192,8 @@ export const useCollectionStore = create<CollectionStore>()(
         }
 
         await get().fetchCollections();
+        // Indexing changes the collection's document count; refresh consumers.
+        queryClient.invalidateQueries({ queryKey: ["collections"] });
         set({ indexProgress: null, indexErrors: errors });
       }
     }),

--- a/web/src/stores/ModelDownloadStore.ts
+++ b/web/src/stores/ModelDownloadStore.ts
@@ -3,6 +3,7 @@ import { DOWNLOAD_URL } from "./BASE_URL";
 import { QueryClient } from "@tanstack/react-query";
 import { trpc } from "../lib/trpc";
 import { useHfCacheStatusStore } from "./HfCacheStatusStore";
+import { MODEL_QUERY_KEYS } from "./resourceChangeHandler";
 
 interface SpeedDataPoint {
   bytes: number;
@@ -209,11 +210,18 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
           });
           if (data.status === "completed") {
             const queryClient = get().queryClient;
-            queryClient?.invalidateQueries({ queryKey: ["allModels"] });
-            queryClient?.invalidateQueries({ queryKey: ["image-models"] });
-            // TJS picker queries by `["tjs-models", modelType]` and
-            // `["tjs-recommended", modelType]` — invalidate both so newly
-            // cached repos flip from "Download" to "Downloaded" immediately.
+            // A finished download can produce any modality (LLM GGUF, TTS,
+            // diffusion, embedding, …), so invalidate every per-modality
+            // picker query plus the aggregated lists. The HuggingFace and
+            // Ollama listings also derive from on-disk state and must
+            // refresh so newly cached repos flip from "Download" to
+            // "Downloaded" immediately.
+            for (const key of MODEL_QUERY_KEYS) {
+              queryClient?.invalidateQueries({ queryKey: [key] });
+            }
+            queryClient?.invalidateQueries({ queryKey: ["huggingFaceModels"] });
+            queryClient?.invalidateQueries({ queryKey: ["hf-models"] });
+            queryClient?.invalidateQueries({ queryKey: ["ollamaModels"] });
             queryClient?.invalidateQueries({ queryKey: ["tjs-models"] });
             queryClient?.invalidateQueries({ queryKey: ["tjs-recommended"] });
             useHfCacheStatusStore.getState().invalidate([id]);

--- a/web/src/stores/__tests__/resourceChangeHandler.test.ts
+++ b/web/src/stores/__tests__/resourceChangeHandler.test.ts
@@ -13,6 +13,10 @@ jest.mock("../../queryClient", () => ({
   }
 }));
 
+// `predicate` invalidations need access to the query cache. Provide a stub
+// invalidator the test can inspect; for keyed calls we keep the existing
+// `queryKey`-shape assertions.
+
 jest.mock("../../serverState/useMetadata", () => ({
   loadMetadata: jest.fn()
 }));
@@ -259,6 +263,52 @@ describe("handleResourceChange", () => {
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["allModels"]
     });
+  });
+
+  it("invalidates settings on setting update", () => {
+    const update: ResourceChangeUpdate = {
+      type: "resource_change",
+      event: "updated",
+      resource_type: "setting",
+      resource: { id: "OPENAI_API_KEY" }
+    };
+
+    handleResourceChange(update);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["settings"]
+    });
+  });
+
+  it("invalidates workflow version queries on workflowversion change", () => {
+    const update: ResourceChangeUpdate = {
+      type: "resource_change",
+      event: "created",
+      resource_type: "workflowversion",
+      resource: { id: "version-xyz" }
+    };
+
+    handleResourceChange(update);
+
+    // The version's id is not the workflow id, so the handler invalidates
+    // every `["workflow", *, "versions"]` query via predicate.
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        predicate: expect.any(Function)
+      })
+    );
+    const predicateCall = (
+      queryClient.invalidateQueries as jest.Mock
+    ).mock.calls.find((call) => typeof call[0]?.predicate === "function");
+    expect(predicateCall).toBeTruthy();
+    const predicate = predicateCall![0].predicate as (q: {
+      queryKey: readonly unknown[];
+    }) => boolean;
+    expect(
+      predicate({ queryKey: ["workflow", "abc", "versions"] })
+    ).toBe(true);
+    expect(predicate({ queryKey: ["workflow", "abc"] })).toBe(false);
+    expect(predicate({ queryKey: ["workflows"] })).toBe(false);
   });
 
   it("includes additional resource properties in the update", () => {

--- a/web/src/stores/resourceChangeHandler.ts
+++ b/web/src/stores/resourceChangeHandler.ts
@@ -15,6 +15,10 @@ import { loadMetadata } from "../serverState/useMetadata";
  * Mapping of resource types to their TanStack Query cache keys.
  * When a resource change event is received, all associated query keys
  * will be invalidated to trigger refetch.
+ *
+ * `resource_type` matches the lowercased model class name emitted by the
+ * backend ModelObserver (see packages/websocket/src/unified-websocket-runner.ts
+ * `onModelChange`).
  */
 const RESOURCE_TYPE_TO_QUERY_KEYS: Record<string, string[]> = {
   workflow: ["workflows", "templates"],
@@ -24,12 +28,12 @@ const RESOURCE_TYPE_TO_QUERY_KEYS: Record<string, string[]> = {
   collection: ["collections"],
   workspace: ["workspaces"],
   secret: ["secrets"],
-  metadata: ["metadata"]
-  // Add more mappings as needed
+  metadata: ["metadata"],
+  setting: ["settings"]
 };
 
-const PROVIDER_QUERY_KEYS = ["providers"] as const;
-const MODEL_QUERY_KEYS = [
+export const PROVIDER_QUERY_KEYS = ["providers"] as const;
+export const MODEL_QUERY_KEYS = [
   "models",
   "language-models",
   "embedding-models",
@@ -77,6 +81,17 @@ export function handleResourceChange(update: ResourceChangeUpdate): void {
   if (resource_type === "model") {
     console.info("[ResourceChange] Invalidating model queries");
     invalidateQueryKeys(MODEL_QUERY_KEYS);
+    return;
+  }
+
+  // WorkflowVersion changes carry the version's id, not the workflow id, so
+  // invalidate every workflow version query and let consumers refetch.
+  if (resource_type === "workflowversion") {
+    console.info("[ResourceChange] Invalidating workflow version queries");
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[0] === "workflow" && query.queryKey[2] === "versions"
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary
This PR refactors query cache invalidation across the application to be more consistent and maintainable. It centralizes the definition of query keys that depend on secrets/settings/resources and ensures invalidation logic is coordinated through the resource change handler and reused across components.

## Key Changes

- **Resource Change Handler Enhancements**
  - Added support for `setting` resource type invalidation
  - Added special handling for `workflowversion` changes using predicate-based invalidation (since version IDs don't map to workflow IDs)
  - Exported `PROVIDER_QUERY_KEYS` and `MODEL_QUERY_KEYS` constants for reuse across components
  - Improved documentation of resource type mappings and backend integration

- **SecretsMenu Refactoring**
  - Extracted repeated invalidation logic into `invalidateSecretDependents()` callback
  - Consolidated invalidation of secrets, providers, and all model query types (language, image, TTS, ASR, video)
  - Applied to both update and delete mutations for consistency

- **RemoteSettingsMenu Enhancement**
  - Added conditional invalidation of provider and model queries when secrets are updated through the settings panel
  - Ensures secret changes propagate the same way as SecretsMenu

- **Asset Management Cleanup**
  - Extracted asset invalidation logic into `invalidateAssetSiblings()` callback
  - Simplified mutation success handlers by reusing the callback
  - Fixed query key format to use object-based parameters consistently

- **Model Download Store Update**
  - Refactored to use `MODEL_QUERY_KEYS` constant instead of hardcoded keys
  - Added invalidation for HuggingFace and Ollama model listings
  - Improved comments explaining why multiple query types must be invalidated

- **Workflow List Optimization**
  - Added explicit invalidation of workflow detail and tools queries after optimistic updates
  - Ensures UI consistency even if resource change broadcasts are missed

- **Collection Store Fix**
  - Added explicit query invalidation for collection operations (delete, index)
  - Collections don't broadcast resource_change events, so manual invalidation is required

## Implementation Details

- Query key constants are now centralized in `resourceChangeHandler.ts` and exported for use throughout the application
- Invalidation callbacks are created with `useCallback` to maintain referential stability
- Predicate-based invalidation is used for workflowversion queries where the resource ID doesn't directly map to a query key
- Comments explain the rationale for invalidating multiple related query types (e.g., why model queries depend on secrets)

https://claude.ai/code/session_01Xuvm7RtoYJF8rhVqJpWNrG