### PR TITLE
feat(websocket): expose workflows, nodes, assets via read-only RPC

### DIFF
--- a/packages/protocol/src/api-schemas/nodes.ts
+++ b/packages/protocol/src/api-schemas/nodes.ts
@@ -23,6 +23,57 @@ export const dummyOutput = z.object({
   metadata: z.unknown().nullable()
 });
 
+// ── Node metadata ──────────────────────────────────────────────────
+// Mirrors `NodeMetadata` in api-types.ts. Inner shapes (Property,
+// OutputSlot, UnifiedModel, ModelPack) carry many nested `unknown`
+// fields, so we accept a passthrough record on the wire and trust the
+// registry to produce well-formed output.
+
+export const nodeMetadataSchema = z
+  .object({
+    node_type: z.string(),
+    title: z.string(),
+    description: z.string(),
+    namespace: z.string()
+  })
+  .passthrough();
+export type NodeMetadataSchema = z.infer<typeof nodeMetadataSchema>;
+
+// Slim summary returned when `fields=summary` (the default).
+export const nodeMetadataSummary = z.object({
+  node_type: z.string(),
+  title: z.string(),
+  description: z.string(),
+  namespace: z.string()
+});
+export type NodeMetadataSummary = z.infer<typeof nodeMetadataSummary>;
+
+// ── list (GET /api/nodes/metadata, no node_type) ─────────────────
+export const listInput = z.object({
+  namespace: z.string().optional(),
+  query: z.string().optional(),
+  fields: z.enum(["summary", "full"]).default("summary"),
+  limit: z.number().int().min(1).max(10000).optional()
+});
+export type ListInput = z.infer<typeof listInput>;
+
+// Output is a union of summary[] or full[] depending on `fields`.
+// Both shapes use the same `nodes` envelope so clients can switch on
+// the fields they care about.
+export const listOutput = z.object({
+  nodes: z.array(nodeMetadataSchema)
+});
+export type ListOutput = z.infer<typeof listOutput>;
+
+// ── get (GET /api/nodes/metadata?node_type=…) ────────────────────
+export const getInput = z.object({
+  node_type: z.string().min(1)
+});
+export type GetInput = z.infer<typeof getInput>;
+
+export const getOutput = nodeMetadataSchema;
+export type GetOutput = z.infer<typeof getOutput>;
+
 // ── Inferred types ─────────────────────────────────────────────────
 
 export type ReplicateStatusOutput = z.infer<typeof replicateStatusOutput>;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -341,7 +341,26 @@ export type UnifiedCommandType =
   | "end_input_stream"
   | "chat_message"
   | "inference"
-  | "stop";
+  | "stop"
+  | "list_workflows"
+  | "get_workflow"
+  | "list_assets"
+  | "get_asset"
+  | "list_nodes"
+  | "get_node";
+
+/**
+ * Read-only RPC commands that require a `request_id` and return a single
+ * `rpc_response` frame. Distinguished from streaming commands (run_job,
+ * chat_message, etc.) which fire-and-forget and stream results back.
+ */
+export type RpcCommandType =
+  | "list_workflows"
+  | "get_workflow"
+  | "list_assets"
+  | "get_asset"
+  | "list_nodes"
+  | "get_node";
 
 export interface WebSocketCommandEnvelope<
   C extends UnifiedCommandType = UnifiedCommandType,
@@ -349,6 +368,72 @@ export interface WebSocketCommandEnvelope<
 > {
   command: C;
   data: D;
+  /**
+   * Opaque client-generated id, echoed back in the `rpc_response` frame.
+   * REQUIRED for RPC commands (list_*, get_*); ignored for streaming
+   * commands (run_job, chat_message, …).
+   */
+  request_id?: string;
+}
+
+// ── RPC request payloads ──────────────────────────────────────────
+// Mirror the Zod input schemas in api-schemas/{workflows,assets,nodes}.ts.
+// Kept loose (Record<string, unknown>) so adding optional filters in the
+// underlying procedures doesn't require updating these envelopes.
+
+export interface ListWorkflowsRequest {
+  limit?: number;
+  run_mode?: string;
+  tag?: string;
+  cursor?: string;
+}
+
+export interface GetWorkflowRequest {
+  id: string;
+}
+
+export interface ListAssetsRequest {
+  parent_id?: string;
+  content_type?: string;
+  workflow_id?: string;
+  node_id?: string;
+  job_id?: string;
+  page_size?: number;
+}
+
+export interface GetAssetRequest {
+  id: string;
+}
+
+export interface ListNodesRequest {
+  namespace?: string;
+  query?: string;
+  fields?: "summary" | "full";
+  limit?: number;
+}
+
+export interface GetNodeRequest {
+  node_type: string;
+}
+
+export interface RpcErrorPayload {
+  code: string;
+  message: string;
+  apiCode?: string | null;
+  trpcCode?: string;
+}
+
+/**
+ * Single response frame for RPC commands. Either `result` or `error` is
+ * set; both are absent only for malformed requests where the server
+ * couldn't route the response (those use the legacy `{ error }` shape).
+ */
+export interface RpcResponseMessage {
+  type: "rpc_response";
+  request_id: string;
+  command: UnifiedCommandType;
+  result?: unknown;
+  error?: RpcErrorPayload;
 }
 
 export interface PingMessage {
@@ -394,6 +479,7 @@ export type WebSocketServerMessage =
   | PongMessage
   | SystemStatsMessage
   | ResourceChangeMessage
+  | RpcResponseMessage
   | Record<string, unknown>;
 
 // ---------------------------------------------------------------------------

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -13,6 +13,7 @@ import { randomUUID } from "node:crypto";
 import { Workflow } from "@nodetool-ai/models";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
 import type { NodeUpdate } from "@nodetool-ai/protocol";
+import type { HttpApiOptions } from "../http-api.js";
 
 const log = createLogger("nodetool.websocket.ws");
 
@@ -213,6 +214,8 @@ export interface WebSocketPluginOptions {
   getPythonBridgeReady: () => boolean;
   ensurePythonBridge: () => Promise<void>;
   toolClassMap: Map<string, new () => Tool>;
+  /** Forwarded to the runner for read-only RPC commands (list_workflows, …). */
+  apiOptions: HttpApiOptions;
 }
 
 async function resolveProvider(providerId: string, userId: string) {
@@ -327,7 +330,8 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
     pythonBridge,
     getPythonBridgeReady,
     ensurePythonBridge,
-    toolClassMap
+    toolClassMap,
+    apiOptions
   } = opts;
   const graphNodeTypeResolver = createGraphNodeTypeResolver(registry);
 
@@ -441,7 +445,10 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
       resolveTools,
       getNodeMetadata: (nodeType) => registry.getMetadata(nodeType),
       validateNode: registry.createNodeValidator(),
-      nodeRegistry: registry
+      nodeRegistry: registry,
+      pythonBridge,
+      getPythonBridgeReady,
+      apiOptions
     });
     log.info("WebSocket client connected");
     void runner.run(new WsAdapter(socket)).catch((error) => {

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -701,6 +701,7 @@ await app.register(fastifyTRPCPlugin, {
 await app.register(websocketPlugin, {
   registry,
   pythonBridge,
+  apiOptions,
   getPythonBridgeReady: () => pythonBridgeReady,
   ensurePythonBridge: async () => {
     if (pythonBridgeReady) return;

--- a/packages/websocket/src/trpc/routers/nodes.ts
+++ b/packages/websocket/src/trpc/routers/nodes.ts
@@ -1,7 +1,24 @@
 import { getSecret } from "@nodetool-ai/models";
 import { router, publicProcedure } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
+import { ApiErrorCode } from "../../error-codes.js";
+import { throwApiError } from "../error-formatter.js";
 import { z } from "zod";
+import {
+  listInput as nodesListInput,
+  listOutput as nodesListOutput,
+  getInput as nodesGetInput,
+  getOutput as nodesGetOutput
+} from "@nodetool-ai/protocol/api-schemas/nodes.js";
+import type { NodeMetadata } from "@nodetool-ai/node-sdk";
+
+type NodeMetaOut = {
+  node_type: string;
+  title: string;
+  description: string;
+  namespace: string;
+  [key: string]: unknown;
+};
 
 // ── Local schemas (mirrored in packages/protocol/src/api-schemas/nodes.ts) ──
 
@@ -25,6 +42,15 @@ const dummyOutput = z.object({
   data: z.unknown().nullable(),
   metadata: z.unknown().nullable()
 });
+
+function toSummary(n: NodeMetadata): NodeMetaOut {
+  return {
+    node_type: n.node_type,
+    title: n.title,
+    description: n.description,
+    namespace: n.namespace
+  };
+}
 
 export const nodesRouter = router({
   /**
@@ -60,5 +86,78 @@ export const nodesRouter = router({
     asset_id: null,
     data: null,
     metadata: null
-  }))
+  })),
+
+  /**
+   * List node metadata. Mirrors the legacy GET /api/nodes/metadata
+   * filtering: optional `namespace` prefix, comma-separated `query`
+   * full-text scoring over title/description/node_type/namespace, and
+   * `fields=summary` (default) vs `fields=full`.
+   *
+   * Lazy-loaded Python nodes only appear after the Python bridge has
+   * hydrated — same caveat as the REST endpoint, no regression.
+   */
+  list: protectedProcedure
+    .input(nodesListInput)
+    .output(nodesListOutput)
+    .query(({ ctx, input }) => {
+      let nodes: NodeMetadata[] = ctx.registry.listMetadata();
+      nodes.sort((a, b) => a.node_type.localeCompare(b.node_type));
+
+      if (input.namespace) {
+        const prefix = input.namespace;
+        nodes = nodes.filter((n) => n.namespace?.startsWith(prefix));
+      }
+
+      if (input.query) {
+        const terms = input.query
+          .split(",")
+          .map((t) => t.trim().toLowerCase())
+          .filter((t) => t.length > 0);
+        if (terms.length > 0) {
+          const scored = nodes.map((n) => {
+            const haystack =
+              `${n.title ?? ""} ${n.description ?? ""} ${n.node_type} ${n.namespace ?? ""}`.toLowerCase();
+            let score = 0;
+            for (const term of terms) if (haystack.includes(term)) score++;
+            return { node: n, score };
+          });
+          nodes = scored
+            .filter((s) => s.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .map((s) => s.node);
+        }
+      }
+
+      if (input.limit !== undefined) {
+        nodes = nodes.slice(0, input.limit);
+      }
+
+      const payload: NodeMetaOut[] =
+        input.fields === "full"
+          ? nodes.map((n) => n as unknown as NodeMetaOut)
+          : nodes.map(toSummary);
+      return { nodes: payload };
+    }),
+
+  /**
+   * Get a single node's full metadata by `node_type`. Throws NOT_FOUND
+   * if the registry doesn't know the type yet (e.g. Python node before
+   * bridge hydration).
+   */
+  get: protectedProcedure
+    .input(nodesGetInput)
+    .output(nodesGetOutput)
+    .query(({ ctx, input }) => {
+      const match = ctx.registry
+        .listMetadata()
+        .find((n) => n.node_type === input.node_type);
+      if (!match) {
+        throwApiError(
+          ApiErrorCode.NOT_FOUND,
+          `Node type not found: ${input.node_type}`
+        );
+      }
+      return match as unknown as NodeMetaOut;
+    })
 });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -54,10 +54,15 @@ import type { Chunk } from "@nodetool-ai/protocol";
 import type {
   UnifiedCommandType,
   WebSocketCommandEnvelope,
-  WebSocketMode
+  WebSocketMode,
+  RpcErrorPayload
 } from "@nodetool-ai/protocol";
 import { Tool } from "@nodetool-ai/agents";
 import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { PythonStdioBridge } from "@nodetool-ai/runtime";
+import { appRouter } from "./trpc/router.js";
+import { createCallerFactory } from "./trpc/index.js";
+import type { HttpApiOptions } from "./http-api.js";
 
 const log = createLogger("nodetool.websocket.runner");
 const DATA_URI_PATTERN = /data:([^;,]+)?;base64,[A-Za-z0-9+/=\r\n]+/gi;
@@ -740,6 +745,18 @@ export interface UnifiedWebSocketRunnerOptions {
    * toward `nodetool.*` core nodes and exposing a `find_model` tool.
    */
   nodeRegistry?: NodeRegistry;
+  /**
+   * Python stdio bridge. Required to serve the read-only RPC commands
+   * (list_workflows / get_workflow / list_assets / get_asset / list_nodes /
+   * get_node) which delegate to the existing tRPC routers; those routers
+   * accept the bridge in their context. Plain workflow execution and chat
+   * keep working without it.
+   */
+  pythonBridge?: PythonStdioBridge;
+  /** Whether the Python bridge has finished hydrating. Same wiring as the tRPC HTTP context. */
+  getPythonBridgeReady?: () => boolean;
+  /** API options forwarded into the tRPC context (metadata roots, registry, etc.). */
+  apiOptions?: HttpApiOptions;
 }
 
 export class UnifiedWebSocketRunner {
@@ -760,6 +777,9 @@ export class UnifiedWebSocketRunner {
   private getNodeMetadata?: UnifiedWebSocketRunnerOptions["getNodeMetadata"];
   private validateNode?: UnifiedWebSocketRunnerOptions["validateNode"];
   private nodeRegistry?: NodeRegistry;
+  private pythonBridge?: PythonStdioBridge;
+  private getPythonBridgeReady?: () => boolean;
+  private apiOptions?: HttpApiOptions;
   private configuredProvidersCache: Map<string, Record<string, BaseProvider>> =
     new Map();
 
@@ -907,6 +927,9 @@ export class UnifiedWebSocketRunner {
     this.getNodeMetadata = options.getNodeMetadata;
     this.validateNode = options.validateNode;
     this.nodeRegistry = options.nodeRegistry;
+    this.pythonBridge = options.pythonBridge;
+    this.getPythonBridgeReady = options.getPythonBridgeReady;
+    this.apiOptions = options.apiOptions;
     this.getSystemStats =
       options.getSystemStats ??
       (() => ({
@@ -4351,9 +4374,77 @@ export class UnifiedWebSocketRunner {
     }
   }
 
+  /**
+   * Build a tRPC caller bound to this connection's `userId`. Used to dispatch
+   * the read-only RPC commands (list_workflows, get_workflow, list_assets,
+   * get_asset, list_nodes, get_node) onto the existing tRPC routers — single
+   * source of truth, no logic duplication.
+   */
+  private getTrpcCaller() {
+    if (!this.nodeRegistry || !this.apiOptions || !this.pythonBridge) {
+      throw new Error(
+        "RPC commands require nodeRegistry, apiOptions, and pythonBridge"
+      );
+    }
+    const factory = createCallerFactory(appRouter);
+    return factory({
+      userId: this.userId,
+      registry: this.nodeRegistry,
+      apiOptions: this.apiOptions,
+      pythonBridge: this.pythonBridge,
+      getPythonBridgeReady: this.getPythonBridgeReady ?? (() => true)
+    });
+  }
+
+  /**
+   * Invoke a tRPC procedure and send back a single `rpc_response` frame
+   * correlating to `command.request_id`. Returns `null` so the receive loop
+   * skips the legacy auto-send (the frame has already been sent here).
+   *
+   * Errors thrown by the procedure are mapped to `rpc_response.error` using
+   * the `apiCode` cause attached by `throwApiError` in the tRPC layer.
+   */
+  private async runRpc(
+    command: WebSocketCommandEnvelope,
+    fn: () => Promise<unknown>
+  ): Promise<Record<string, unknown> | null> {
+    const requestId = command.request_id;
+    if (typeof requestId !== "string" || requestId.length === 0) {
+      return { error: "request_id is required for RPC commands" };
+    }
+    try {
+      const result = await fn();
+      await this.sendMessage({
+        type: "rpc_response",
+        request_id: requestId,
+        command: command.command,
+        result
+      });
+    } catch (err) {
+      const trpc = err as {
+        code?: string;
+        message?: string;
+        cause?: { apiCode?: string };
+      };
+      const error: RpcErrorPayload = {
+        code: trpc.cause?.apiCode ?? trpc.code ?? "INTERNAL_ERROR",
+        message: trpc.message ?? String(err),
+        apiCode: trpc.cause?.apiCode ?? null,
+        trpcCode: trpc.code
+      };
+      await this.sendMessage({
+        type: "rpc_response",
+        request_id: requestId,
+        command: command.command,
+        error
+      });
+    }
+    return null;
+  }
+
   async handleCommand(
     command: WebSocketCommandEnvelope
-  ): Promise<Record<string, unknown>> {
+  ): Promise<Record<string, unknown> | null> {
     const data = command.data ?? {};
     const jobId = typeof data.job_id === "string" ? data.job_id : undefined;
     const workflowId =
@@ -4515,6 +4606,42 @@ export class UnifiedWebSocketRunner {
           thread_id: threadId ?? null
         };
       }
+      case "list_workflows": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.workflows.list(data as Parameters<typeof caller.workflows.list>[0])
+        );
+      }
+      case "get_workflow": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.workflows.get({ id: String(data.id ?? "") })
+        );
+      }
+      case "list_assets": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.assets.list(data as Parameters<typeof caller.assets.list>[0])
+        );
+      }
+      case "get_asset": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.assets.get({ id: String(data.id ?? "") })
+        );
+      }
+      case "list_nodes": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.nodes.list(data as Parameters<typeof caller.nodes.list>[0])
+        );
+      }
+      case "get_node": {
+        const caller = this.getTrpcCaller();
+        return this.runRpc(command, () =>
+          caller.nodes.get({ node_type: String(data.node_type ?? "") })
+        );
+      }
       default:
         return { error: "Unknown command" };
     }
@@ -4636,7 +4763,9 @@ export class UnifiedWebSocketRunner {
         try {
           const command = data as unknown as WebSocketCommandEnvelope;
           const response = await this.handleCommand(command);
-          await this.sendMessage(response);
+          // RPC commands send their `rpc_response` frame inline (in runRpc)
+          // and return null so we don't send a stray legacy reply.
+          if (response) await this.sendMessage(response);
         } catch (err) {
           this.logError("invalid_command handling failed", err);
           await this.sendMessage({

--- a/packages/websocket/tests/rpc-readonly-commands.test.ts
+++ b/packages/websocket/tests/rpc-readonly-commands.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Integration tests for the read-only RPC commands exposed on the unified
+ * WebSocket: list_workflows, get_workflow, list_assets, get_asset,
+ * list_nodes, get_node.
+ *
+ * Drives the runner with a MockWebSocket and asserts that each request
+ * produces a single `rpc_response` frame correlated by `request_id`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { unpack } from "msgpackr";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+vi.mock("@nodetool-ai/models", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/models")>();
+  return {
+    ...actual,
+    Workflow: {
+      ...actual.Workflow,
+      get: vi.fn(),
+      find: vi.fn(),
+      paginate: vi.fn()
+    },
+    Asset: {
+      ...actual.Asset,
+      find: vi.fn(),
+      paginate: vi.fn()
+    }
+  };
+});
+
+vi.mock("@nodetool-ai/config", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/config")>();
+  return {
+    ...actual,
+    buildAssetUrl: vi.fn((filename: string) => `/api/storage/${filename}`)
+  };
+});
+
+import { Workflow, Asset } from "@nodetool-ai/models";
+
+class MockWebSocket implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  sentText: string[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+
+  async accept(): Promise<void> {
+    return;
+  }
+  async receive(): Promise<WebSocketReceiveFrame> {
+    const next = this.queue.shift();
+    if (!next) return { type: "websocket.disconnect" };
+    return next;
+  }
+  async sendBytes(data: Uint8Array): Promise<void> {
+    this.sentBytes.push(data);
+  }
+  async sendText(data: string): Promise<void> {
+    this.sentText.push(data);
+  }
+  async close(): Promise<void> {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const FOO_NODE = {
+  node_type: "foo.Bar",
+  title: "Bar",
+  description: "A node",
+  namespace: "foo",
+  properties: [],
+  outputs: [],
+  layout: "default",
+  recommended_models: [],
+  basic_fields: [],
+  required_settings: [],
+  is_dynamic: false,
+  is_streaming_output: false,
+  expose_as_tool: false,
+  supports_dynamic_outputs: false
+};
+
+function makeRunner(ws: MockWebSocket) {
+  const runner = new UnifiedWebSocketRunner({
+    resolveExecutor: () => ({
+      async process() {
+        return {};
+      }
+    }),
+    nodeRegistry: {
+      listMetadata: () => [FOO_NODE],
+      has: () => false,
+      resolve: () => ({ async process() { return {}; } }),
+      getMetadata: () => undefined,
+      createNodeValidator: () => () => undefined
+    } as never,
+    apiOptions: {
+      metadataRoots: [],
+      registry: {} as never,
+      storage: {}
+    } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => true
+  });
+  // Match the connect-time default in the production runner.
+  void runner.connect(ws);
+  return runner;
+}
+
+function decodeFrame(ws: MockWebSocket, idx: number): Record<string, unknown> {
+  if (ws.sentBytes[idx]) {
+    return unpack(ws.sentBytes[idx]) as Record<string, unknown>;
+  }
+  return JSON.parse(ws.sentText[idx]) as Record<string, unknown>;
+}
+
+function makeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wf-1",
+    user_id: "1",
+    name: "Test",
+    access: "private",
+    run_mode: "workflow",
+    tool_name: null,
+    package_name: null,
+    path: null,
+    tags: [],
+    description: "",
+    thumbnail: null,
+    thumbnail_url: null,
+    graph: { nodes: [], edges: [] },
+    settings: null,
+    workspace_id: null,
+    html_app: null,
+    created_at: "2026-04-17T00:00:00Z",
+    updated_at: "2026-04-17T00:00:00Z",
+    getEtag: () => "etag-1",
+    getGraph: () => ({ nodes: [], edges: [] }),
+    ...overrides
+  };
+}
+
+function makeAssetRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "a1",
+    user_id: "1",
+    parent_id: "1",
+    name: "x.png",
+    content_type: "image/png",
+    size: 1024,
+    metadata: null,
+    workflow_id: null,
+    node_id: null,
+    job_id: null,
+    created_at: "2026-04-17T00:00:00Z",
+    updated_at: "2026-04-17T00:00:00Z",
+    duration: null,
+    ...overrides
+  };
+}
+
+async function runOne(
+  ws: MockWebSocket,
+  runner: UnifiedWebSocketRunner,
+  frame: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  ws.queue.push({
+    type: "websocket.message",
+    text: JSON.stringify(frame)
+  });
+  ws.queue.push({ type: "websocket.disconnect" });
+  await runner.receiveMessages();
+  return decodeFrame(ws, 0);
+}
+
+describe("RPC read-only commands", () => {
+  let ws: MockWebSocket;
+  let runner: UnifiedWebSocketRunner;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ws = new MockWebSocket();
+    runner = makeRunner(ws);
+  });
+
+  afterEach(async () => {
+    await runner.disconnect();
+  });
+
+  describe("list_workflows", () => {
+    it("returns workflows envelope with echoed request_id", async () => {
+      (Workflow.paginate as ReturnType<typeof vi.fn>).mockResolvedValue([
+        [makeWorkflow({ id: "wf-1" })],
+        ""
+      ]);
+
+      const out = await runOne(ws, runner, {
+        command: "list_workflows",
+        request_id: "r-1",
+        data: { limit: 25 }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      expect(out.request_id).toBe("r-1");
+      expect(out.command).toBe("list_workflows");
+      const result = out.result as { workflows: Array<{ id: string }> };
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows[0]?.id).toBe("wf-1");
+    });
+  });
+
+  describe("get_workflow", () => {
+    it("returns the workflow when it exists", async () => {
+      (Workflow.get as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeWorkflow({ id: "wf-42", user_id: "1" })
+      );
+
+      const out = await runOne(ws, runner, {
+        command: "get_workflow",
+        request_id: "r-2",
+        data: { id: "wf-42" }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      expect(out.request_id).toBe("r-2");
+      const result = out.result as { id: string };
+      expect(result.id).toBe("wf-42");
+    });
+
+    it("returns rpc_response.error for a missing workflow", async () => {
+      (Workflow.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const out = await runOne(ws, runner, {
+        command: "get_workflow",
+        request_id: "r-3",
+        data: { id: "missing" }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      expect(out.result).toBeUndefined();
+      const error = out.error as Record<string, unknown>;
+      expect(error.trpcCode).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("list_assets", () => {
+    it("returns assets envelope", async () => {
+      (Asset.paginate as ReturnType<typeof vi.fn>).mockResolvedValue([
+        [makeAssetRow({ id: "a1" })],
+        ""
+      ]);
+
+      const out = await runOne(ws, runner, {
+        command: "list_assets",
+        request_id: "r-4",
+        data: { page_size: 50 }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      expect(out.request_id).toBe("r-4");
+      const result = out.result as { assets: Array<{ id: string }> };
+      expect(result.assets).toHaveLength(1);
+      expect(result.assets[0]?.id).toBe("a1");
+    });
+  });
+
+  describe("get_asset", () => {
+    it("returns rpc_response.error when the asset does not exist", async () => {
+      (Asset.find as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const out = await runOne(ws, runner, {
+        command: "get_asset",
+        request_id: "r-5",
+        data: { id: "missing" }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      const error = out.error as Record<string, unknown>;
+      expect(error.trpcCode).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("list_nodes", () => {
+    it("returns the registry's node metadata as a summary", async () => {
+      const out = await runOne(ws, runner, {
+        command: "list_nodes",
+        request_id: "r-6",
+        data: { fields: "summary" }
+      });
+
+      expect(out.type).toBe("rpc_response");
+      expect(out.request_id).toBe("r-6");
+      const result = out.result as {
+        nodes: Array<{ node_type: string; title: string }>;
+      };
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0]?.node_type).toBe("foo.Bar");
+    });
+  });
+
+  describe("get_node", () => {
+    it("returns full metadata for a known node_type", async () => {
+      const out = await runOne(ws, runner, {
+        command: "get_node",
+        request_id: "r-7",
+        data: { node_type: "foo.Bar" }
+      });
+
+      const result = out.result as {
+        node_type: string;
+        properties: unknown[];
+      };
+      expect(result.node_type).toBe("foo.Bar");
+      expect(Array.isArray(result.properties)).toBe(true);
+    });
+
+    it("returns rpc_response.error for an unknown node_type", async () => {
+      const out = await runOne(ws, runner, {
+        command: "get_node",
+        request_id: "r-8",
+        data: { node_type: "does.not.Exist" }
+      });
+
+      const error = out.error as Record<string, unknown>;
+      expect(error.trpcCode).toBe("NOT_FOUND");
+      expect(typeof error.message).toBe("string");
+      expect(error.message as string).toContain("does.not.Exist");
+    });
+  });
+
+  describe("envelope behavior", () => {
+    it("returns a legacy single-shot error when request_id is missing", async () => {
+      const out = await runOne(ws, runner, {
+        command: "list_workflows",
+        data: {}
+      });
+
+      // Note: legacy error shape (no `type: rpc_response`)
+      expect(out.type).toBeUndefined();
+      expect(out.error).toContain("request_id is required");
+    });
+
+    it("delivers rpc_response over text frames in text mode", async () => {
+      (Workflow.paginate as ReturnType<typeof vi.fn>).mockResolvedValue([
+        [],
+        ""
+      ]);
+
+      // Switch to text mode first, then send the RPC. Both frames produce
+      // responses, so we expect text frames in order.
+      ws.queue.push({
+        type: "websocket.message",
+        text: JSON.stringify({
+          command: "set_mode",
+          data: { mode: "text" }
+        })
+      });
+      ws.queue.push({
+        type: "websocket.message",
+        text: JSON.stringify({
+          command: "list_workflows",
+          request_id: "r-9",
+          data: {}
+        })
+      });
+      ws.queue.push({ type: "websocket.disconnect" });
+      await runner.receiveMessages();
+
+      // First frame is the set_mode ack (binary, queued before mode flipped).
+      // The second frame is the rpc_response which should arrive as text.
+      expect(ws.sentText.length).toBeGreaterThan(0);
+      const last = JSON.parse(
+        ws.sentText[ws.sentText.length - 1]
+      ) as Record<string, unknown>;
+      expect(last.type).toBe("rpc_response");
+      expect(last.request_id).toBe("r-9");
+    });
+  });
+});

--- a/packages/websocket/tests/trpc-nodes.test.ts
+++ b/packages/websocket/tests/trpc-nodes.test.ts
@@ -106,4 +106,133 @@ describe("nodes router", () => {
       await expect(caller.nodes.dummy()).rejects.toThrow();
     });
   });
+
+  describe("list (protected)", () => {
+    function makeRegistry(nodes: Array<Record<string, unknown>>) {
+      return {
+        listMetadata: () => nodes
+      } as never;
+    }
+
+    const FOO = {
+      node_type: "foo.bar.Alpha",
+      title: "Alpha",
+      description: "First alphabetical node",
+      namespace: "foo.bar",
+      properties: [],
+      outputs: [],
+      layout: "default",
+      recommended_models: [],
+      basic_fields: [],
+      required_settings: [],
+      is_dynamic: false,
+      is_streaming_output: false,
+      expose_as_tool: false,
+      supports_dynamic_outputs: false
+    };
+    const BAZ = {
+      ...FOO,
+      node_type: "baz.Beta",
+      title: "Beta",
+      description: "Second node",
+      namespace: "baz"
+    };
+
+    it("returns a slim summary by default", async () => {
+      const caller = createCaller(
+        makeCtx({ registry: makeRegistry([FOO, BAZ]) })
+      );
+      const result = await caller.nodes.list({ fields: "summary" });
+      expect(result.nodes).toHaveLength(2);
+      // Sorted alphabetically by node_type → "baz.Beta" before "foo.bar.Alpha"
+      expect(result.nodes[0].node_type).toBe("baz.Beta");
+      expect(result.nodes[1].node_type).toBe("foo.bar.Alpha");
+      // Summary mode strips heavy fields (properties/outputs)
+      expect(result.nodes[0]).not.toHaveProperty("properties");
+    });
+
+    it("returns full metadata when fields=full", async () => {
+      const caller = createCaller(
+        makeCtx({ registry: makeRegistry([FOO]) })
+      );
+      const result = await caller.nodes.list({ fields: "full" });
+      expect(result.nodes[0]).toMatchObject({
+        node_type: "foo.bar.Alpha",
+        properties: [],
+        outputs: []
+      });
+    });
+
+    it("filters by namespace prefix", async () => {
+      const caller = createCaller(
+        makeCtx({ registry: makeRegistry([FOO, BAZ]) })
+      );
+      const result = await caller.nodes.list({
+        namespace: "foo.",
+        fields: "summary"
+      });
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].node_type).toBe("foo.bar.Alpha");
+    });
+
+    it("scores and orders by query terms", async () => {
+      const caller = createCaller(
+        makeCtx({ registry: makeRegistry([FOO, BAZ]) })
+      );
+      const result = await caller.nodes.list({
+        query: "alphabetical",
+        fields: "summary"
+      });
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].node_type).toBe("foo.bar.Alpha");
+    });
+
+    it("throws UNAUTHORIZED for unauthenticated requests", async () => {
+      const caller = createCaller(
+        makeCtx({ userId: null, registry: makeRegistry([]) })
+      );
+      await expect(caller.nodes.list({ fields: "summary" })).rejects.toThrow();
+    });
+  });
+
+  describe("get (protected)", () => {
+    const NODE = {
+      node_type: "foo.Bar",
+      title: "Bar",
+      description: "A node",
+      namespace: "foo",
+      properties: [],
+      outputs: [],
+      layout: "default",
+      recommended_models: [],
+      basic_fields: [],
+      required_settings: [],
+      is_dynamic: false,
+      is_streaming_output: false,
+      expose_as_tool: false,
+      supports_dynamic_outputs: false
+    };
+    const registry = { listMetadata: () => [NODE] } as never;
+
+    it("returns full metadata for a known node_type", async () => {
+      const caller = createCaller(makeCtx({ registry }));
+      const result = await caller.nodes.get({ node_type: "foo.Bar" });
+      expect(result.node_type).toBe("foo.Bar");
+      expect(result.title).toBe("Bar");
+    });
+
+    it("throws NOT_FOUND for an unknown node_type", async () => {
+      const caller = createCaller(makeCtx({ registry }));
+      await expect(
+        caller.nodes.get({ node_type: "does.not.Exist" })
+      ).rejects.toThrow(/Node type not found/);
+    });
+
+    it("throws UNAUTHORIZED for unauthenticated requests", async () => {
+      const caller = createCaller(makeCtx({ userId: null, registry }));
+      await expect(
+        caller.nodes.get({ node_type: "foo.Bar" })
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -75,7 +75,7 @@ describe("UnifiedWebSocketRunner", () => {
       command: "set_mode",
       data: { mode: "text" }
     });
-    expect(res.message).toBe("Mode set to text");
+    expect(res?.message).toBe("Mode set to text");
     expect(runner.mode).toBe("text");
   });
 
@@ -84,14 +84,14 @@ describe("UnifiedWebSocketRunner", () => {
       command: "chat_message",
       data: { content: "hello" }
     });
-    expect(res.error).toContain("thread_id is required");
+    expect(res?.error).toContain("thread_id is required");
   });
 
   it("stop with empty data cancels in-progress generation", async () => {
     const res = await runner.handleCommand({ command: "stop", data: {} });
-    expect(res.message).toBe("Stop command processed");
-    expect(res.job_id).toBeNull();
-    expect(res.thread_id).toBeNull();
+    expect(res?.message).toBe("Stop command processed");
+    expect(res?.job_id).toBeNull();
+    expect(res?.thread_id).toBeNull();
   });
 
   it("replies pong for ping in receive loop", async () => {
@@ -184,13 +184,13 @@ describe("UnifiedWebSocketRunner", () => {
       command: "stream_input",
       data: { job_id: jobId, input: "stream_input", value: 7 }
     });
-    expect(streamed.message).toBe("Input item streamed");
+    expect(streamed?.message).toBe("Input item streamed");
 
     const ended = await runner.handleCommand({
       command: "end_input_stream",
       data: { job_id: jobId, input: "stream_input" }
     });
-    expect(ended.message).toBe("Input stream ended");
+    expect(ended?.message).toBe("Input stream ended");
 
     // Give the runner time to drain queue and complete.
     await new Promise((r) => setTimeout(r, 20));


### PR DESCRIPTION
## Summary

Adds read-only RPC over the unified WebSocket so clients on a single channel (mobile, embedded, automation) can list/get workflows, nodes, and assets without falling back to HTTP. The new commands reuse the existing tRPC routers via `createCallerFactory`, so validation, auth, and error handling stay single-source-of-truth.

- **Protocol** (`packages/protocol/src/messages.ts`): 6 new `UnifiedCommandType` values (`list_workflows`, `get_workflow`, `list_assets`, `get_asset`, `list_nodes`, `get_node`), optional `request_id` on `WebSocketCommandEnvelope`, and a new `RpcResponseMessage` type with `request_id` correlation.
- **tRPC** (`packages/websocket/src/trpc/routers/nodes.ts`): new `nodes.list` / `nodes.get` procedures backed by `NodeRegistry` (matches the legacy `/api/nodes/metadata` filtering: namespace prefix, comma-separated query scoring, summary vs. full).
- **Runner** (`packages/websocket/src/unified-websocket-runner.ts`): `getTrpcCaller` + `runRpc` helpers; six switch cases dispatch to the tRPC caller and emit a single `rpc_response` frame per request. Errors map cleanly through tRPC's `apiCode` cause shape.
- **Plugin / server**: thread `pythonBridge`, `getPythonBridgeReady`, and `apiOptions` through to the runner so the tRPC context is fully populated.

## API surface

```ts
// Request
{ command: "list_workflows", request_id: "r-1", data: { limit: 25 } }

// Response
{
  type: "rpc_response",
  request_id: "r-1",
  command: "list_workflows",
  result: { workflows: [...], next: null }
}

// Error response
{
  type: "rpc_response",
  request_id: "r-2",
  command: "get_workflow",
  error: {
    code: "WORKFLOW_NOT_FOUND",
    message: "Workflow not found",
    apiCode: "WORKFLOW_NOT_FOUND",
    trpcCode: "NOT_FOUND"
  }
}
```

Encoding follows the runner's existing mode (msgpack default, JSON text after `set_mode`). Missing `request_id` returns the legacy single-shot `{ error: ... }` shape (not a `rpc_response`), so non-RPC commands aren't affected.

## Out of scope

- No CRUD or write operations
- No removal of existing tRPC HTTP routes
- No frontend migration (web/mobile/electron continue using tRPC over HTTP; a future PR can add a `globalWebSocketManager.request()` helper)
- No auth model changes

## Test plan

- [x] `npm run build:packages` (all packages)
- [x] `npm test --workspace=packages/protocol` — 231/231 pass
- [x] `npm test --workspace=packages/websocket` — 599/599 pass (10 new RPC integration tests + extended `trpc-nodes` suite)
- [x] `npm run lint` (protocol + websocket)
- [x] `npm run typecheck --workspace=web` and `--workspace=electron`
- [ ] Smoke test: open a websocket, send `{ command: "list_workflows", request_id: "r1", data: {} }`, verify a single `rpc_response` frame returns

https://claude.ai/code/session_01BaZ5FopuuYqQ3gYn6SRgbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaZ5FopuuYqQ3gYn6SRgbU)_