### PR TITLE
Fix all critical and high severity Zustand staleness bugs

### DIFF
--- a/electron/src/WorkflowRunner.ts
+++ b/electron/src/WorkflowRunner.ts
@@ -217,6 +217,11 @@ export const createWorkflowRunner = () =>
     disconnect: () => {
       const { socket } = get();
       if (socket) {
+        // Detach handlers before close so any final 'close'/'error' events
+        // don't fire into stale closures referencing the previous run's
+        // state. Otherwise the next connect would attach a new set of
+        // handlers while the prior socket's still leak references.
+        socket.removeAllListeners();
         socket.close();
         set({ socket: null, state: "idle" });
       }

--- a/mobile/src/stores/AuthStore.ts
+++ b/mobile/src/stores/AuthStore.ts
@@ -140,6 +140,25 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       if (error) {
         throw error;
       }
+
+      // Tear down the auth listener and clear any user-bound chat state so
+      // the next account can't see the previous user's threads/messages.
+      get().cleanup();
+      try {
+        // Lazy import to avoid a circular dependency between auth/chat.
+        const chatModule = await import('./ChatStore');
+        const chatStore = chatModule.useChatStore;
+        chatStore.getState().disconnect();
+        chatStore.setState({
+          threads: {},
+          currentThreadId: null,
+          messageCache: {},
+          error: null,
+        });
+      } catch (err) {
+        console.warn('[AuthStore] failed to reset chat on signOut', err);
+      }
+
       set({
         session: null,
         user: null,

--- a/mobile/src/stores/ChatStore.ts
+++ b/mobile/src/stores/ChatStore.ts
@@ -75,6 +75,10 @@ interface ChatState {
   setError: (error: string | null) => void;
 }
 
+// Tracks the in-flight safety timeout from sendMessage. Module-scoped so
+// the cancellation path doesn't have to plumb it through state.
+let safetyTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
 /**
  * Handle incoming WebSocket messages and update state
  */
@@ -317,6 +321,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
       wsManager.destroy();
     }
 
+    if (safetyTimeoutId !== null) {
+      clearTimeout(safetyTimeoutId);
+      safetyTimeoutId = null;
+    }
+
     set({
       wsManager: null,
       status: 'disconnected',
@@ -393,11 +402,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
       media_generation: mediaGeneration,
     };
 
+    // Cancel any prior safety timeout — otherwise rapid sends accumulate
+    // timers and one can fire mid-stream of a later message, clobbering
+    // the live `status: "loading"` flag.
+    if (safetyTimeoutId !== null) {
+      clearTimeout(safetyTimeoutId);
+      safetyTimeoutId = null;
+    }
+
     try {
       wsManager.send(messageToSend);
 
       // Safety timeout - reset status if no response
-      setTimeout(() => {
+      safetyTimeoutId = setTimeout(() => {
+        safetyTimeoutId = null;
         const currentState = get();
         if (currentState.status === 'loading' || currentState.status === 'streaming') {
           console.warn('Generation timeout - resetting status');
@@ -425,6 +443,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
       currentThreadId,
       status,
     });
+
+    // Cancel the safety timeout so it doesn't fire after the user stops.
+    if (safetyTimeoutId !== null) {
+      clearTimeout(safetyTimeoutId);
+      safetyTimeoutId = null;
+    }
 
     if (!wsManager || !wsManager.isConnected() || !currentThreadId) {
       console.log('Cannot stop: not connected or no thread');

--- a/mobile/src/stores/WorkflowRunner.ts
+++ b/mobile/src/stores/WorkflowRunner.ts
@@ -40,6 +40,7 @@ export type WorkflowRunner = {
   workflow: Workflow | null;
   job_id: string | null;
   unsubscribe: (() => void) | null;
+  jobUnsubscribe: (() => void) | null;
   state: RunnerState;
 
   // Accumulated data for the UI
@@ -83,6 +84,7 @@ export const createWorkflowRunnerStore = (
     workflow: null,
     job_id: null,
     unsubscribe: null,
+    jobUnsubscribe: null,
     state: "idle",
     logs: [],
     results: null,
@@ -106,6 +108,11 @@ export const createWorkflowRunnerStore = (
         if (currentUnsubscribe) {
           currentUnsubscribe();
         }
+        const currentJobUnsubscribe = get().jobUnsubscribe;
+        if (currentJobUnsubscribe) {
+          currentJobUnsubscribe();
+          set({ jobUnsubscribe: null });
+        }
 
         const handler = (message: Record<string, unknown>) => {
           const workflow = get().workflow;
@@ -114,9 +121,8 @@ export const createWorkflowRunnerStore = (
           // Track job_id from first message and subscribe to it too
           if (message.job_id && !get().job_id) {
             const jobId = message.job_id as string;
-            set({ job_id: jobId });
-            // Also subscribe by job_id so we catch messages routed only by job_id
-            webSocketService.subscribe(jobId, handler);
+            const jobUnsubscribe = webSocketService.subscribe(jobId, handler);
+            set({ job_id: jobId, jobUnsubscribe });
           }
 
           handleMessage(set, get, message);
@@ -135,17 +141,14 @@ export const createWorkflowRunnerStore = (
     },
 
     cleanup: () => {
-      const { unsubscribe, job_id } = get();
+      const { unsubscribe, jobUnsubscribe } = get();
       if (unsubscribe) {
         unsubscribe();
-        set({ unsubscribe: null });
       }
-      // Also unsubscribe from job_id if we had one
-      if (job_id) {
-        // The job_id subscription is cleaned up via the handler reference
-        // but we clear it from state
-        set({ job_id: null });
+      if (jobUnsubscribe) {
+        jobUnsubscribe();
       }
+      set({ unsubscribe: null, jobUnsubscribe: null, job_id: null });
       runnerStores.delete(workflowId);
     },
 

--- a/web/src/stores/AgentStore.ts
+++ b/web/src/stores/AgentStore.ts
@@ -162,6 +162,10 @@ function replaceSessionHistoryId(
   return [replacement, ...filtered].slice(0, 50);
 }
 
+// Token bumped on every loadModels call. Late responses with a stale
+// token are dropped so they can't clobber a newer provider's catalog.
+let loadModelsToken = 0;
+
 const useAgentStore = create<AgentState>((set, get) => ({
   status: "disconnected",
   messages: [],
@@ -209,6 +213,10 @@ const useAgentStore = create<AgentState>((set, get) => ({
 
   loadModels: async () => {
     const { provider, workspacePath } = get();
+    // Token guard: if the user changes provider/workspace mid-flight, only
+    // the latest call writes back. Earlier responses are dropped silently
+    // so they don't clobber the newer catalog.
+    const token = ++loadModelsToken;
     set({ modelsLoading: true });
     try {
       const client = getAgentSocketClient();
@@ -217,18 +225,20 @@ const useAgentStore = create<AgentState>((set, get) => ({
         workspacePath: workspacePath ?? undefined
       });
 
+      if (token !== loadModelsToken) {
+        return;
+      }
+
       const defaultModel =
         models.find((item) => item.isDefault) ?? models[0] ?? null;
 
-      // Re-read state at set time. If the user (or another loadModels call)
-      // selected a model while this request was in flight, preserve it as
-      // long as it's still valid under the new provider's catalog.
-      // Also re-stamp chatProviderId from the resolved descriptor —
-      // setProvider() clears it on switch and only setModel() re-stamps,
-      // so without this every auto-default (e.g. switching to "llm")
-      // would leave model set with chatProviderId=null and createSession
-      // would erroneously refuse with "Pick an LLM model first".
       set((state) => {
+        // Final guard inside the updater in case another call fired between
+        // the await and the set (shouldn't happen with synchronous Zustand
+        // but cheap insurance).
+        if (token !== loadModelsToken) {
+          return state;
+        }
         const resolvedId = models.some((item) => item.id === state.model)
           ? state.model
           : defaultModel?.id ?? state.model;
@@ -242,7 +252,9 @@ const useAgentStore = create<AgentState>((set, get) => ({
       });
     } catch (error) {
       console.error("Failed to load agent models:", error);
-      set({ modelsLoading: false });
+      if (token === loadModelsToken) {
+        set({ modelsLoading: false });
+      }
     }
   },
 
@@ -419,14 +431,20 @@ const useAgentStore = create<AgentState>((set, get) => ({
         client.off("stream", onStream);
       };
 
-      set((state) => ({
-        status: preserveStatus ? state.status : "connected",
-        sessionId,
-        messages: preserveMessages ? state.messages : [],
-        streamUnsubscribe: unsubscribe,
-        workspacePath: selectedWorkspacePath,
-        workspaceId: selectedWorkspaceId ?? null
-      }));
+      try {
+        set((state) => ({
+          status: preserveStatus ? state.status : "connected",
+          sessionId,
+          messages: preserveMessages ? state.messages : [],
+          streamUnsubscribe: unsubscribe,
+          workspacePath: selectedWorkspacePath,
+          workspaceId: selectedWorkspaceId ?? null
+        }));
+      } catch (setError) {
+        // If the state update somehow throws, the listener would leak.
+        unsubscribe();
+        throw setError;
+      }
     } catch (error) {
       set({
         status: "error",

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -122,14 +122,12 @@ export type AssetSearchQuery = {
 
 export type AssetUpdate = {
   id: string;
-  status?: string;
   name?: string;
   parent_id?: string;
   content_type?: string;
   metadata?: Record<string, never>;
   data?: string;
   data_encoding?: "base64";
-  duration?: number;
 };
 
 export interface AssetStore {
@@ -302,18 +300,29 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     const currentFolderId = useAssetGridStore.getState().currentFolderId;
     const setCurrentFolder = useAssetGridStore.getState().setCurrentFolder;
     const setParentFolder = useAssetGridStore.getState().setParentFolder;
-    if (currentFolderId) {
-      const asset = await get().get(currentFolderId);
+    // Capture id at call time so a folder switch mid-flight doesn't write
+    // stale header/breadcrumb data into the new folder's view.
+    const requestedFolderId = currentFolderId;
+    const isStillActive = () =>
+      useAssetGridStore.getState().currentFolderId === requestedFolderId;
+
+    if (requestedFolderId) {
+      const asset = await get().get(requestedFolderId);
+      if (!isStillActive()) {
+        return { next: "", assets: [] } as AssetList;
+      }
       setCurrentFolder(asset);
       if (asset?.parent_id !== "") {
         get()
           .get(asset.parent_id)
           .then((parent) => {
-            setParentFolder(parent);
+            if (isStillActive()) {
+              setParentFolder(parent);
+            }
           });
       }
     }
-    return get().load({ parent_id: currentFolderId, cursor: cursor || "" });
+    return get().load({ parent_id: requestedFolderId, cursor: cursor || "" });
   },
 
   /**
@@ -415,12 +424,29 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
    * @returns A promise that resolves when the asset is deleted.
    */
   delete: async (id: string): Promise<string[]> => {
+    // Capture parent before delete so we can invalidate the listing the
+    // asset was visible in (its parent's children), not its own children.
+    let parentId: string | null = null;
+    try {
+      const existing = await get().get(id);
+      parentId = existing?.parent_id ?? null;
+    } catch {
+      // Ignore — best-effort lookup.
+    }
+
     const { deleted_asset_ids } = await trpcClient.assets.delete.mutate({ id });
 
     deleted_asset_ids.forEach((assetId) => {
       get().invalidateQueries(["assets", assetId]);
+      // The deleted asset's own children (if it was a folder).
       get().invalidateQueries(["assets", { parent_id: assetId }]);
     });
+    // The folder listing that contained the deleted asset.
+    if (parentId !== null) {
+      get().invalidateQueries(["assets", { parent_id: parentId }]);
+    }
+    // Catch-all so workflow-scoped, search, and tree views refetch.
+    get().invalidateQueries(["assets"]);
     return deleted_asset_ids;
   },
 

--- a/web/src/stores/BottomPanelStore.ts
+++ b/web/src/stores/BottomPanelStore.ts
@@ -118,13 +118,42 @@ export const useBottomPanelStore = create<ResizePanelState>()(
     }),
     {
       name: "bottom-panel-storage",
+      version: 1,
       partialize: (state: ResizePanelState) => ({
         panel: {
-          ...state.panel,
-          isDragging: false,
-          hasDragged: false
+          panelSize: state.panel.panelSize,
+          isVisible: state.panel.isVisible,
+          activeView: state.panel.activeView
         }
-      })
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<ResizePanelState>;
+        const persistedPanel = (persisted.panel ?? {}) as Partial<PanelState>;
+        const validViews: BottomPanelView[] = ["trace"];
+        const activeView = validViews.includes(
+          persistedPanel.activeView as BottomPanelView
+        )
+          ? (persistedPanel.activeView as BottomPanelView)
+          : currentState.panel.activeView;
+        return {
+          ...currentState,
+          panel: {
+            ...currentState.panel,
+            panelSize:
+              typeof persistedPanel.panelSize === "number"
+                ? Math.max(
+                    MIN_DRAG_SIZE,
+                    Math.min(persistedPanel.panelSize, MAX_PANEL_SIZE)
+                  )
+                : currentState.panel.panelSize,
+            isVisible:
+              typeof persistedPanel.isVisible === "boolean"
+                ? persistedPanel.isVisible
+                : currentState.panel.isVisible,
+            activeView
+          }
+        };
+      }
     }
   )
 );

--- a/web/src/stores/ComfyUIStore.ts
+++ b/web/src/stores/ComfyUIStore.ts
@@ -125,6 +125,14 @@ export const useComfyUIStore = create<ComfyUIState>((set, get) => ({
   setBaseUrl: (url: string) => {
     const service = getComfyUIService();
     const normalizedUrl = normalizeComfyBaseUrl(url);
+    // Tear down the prior WS first — otherwise it keeps streaming progress
+    // events into the "disconnected" store and connect() can open a second
+    // socket without closing this one.
+    try {
+      service.disconnectWebSocket();
+    } catch (err) {
+      console.warn("[ComfyUIStore] disconnectWebSocket failed in setBaseUrl", err);
+    }
     service.setBaseUrl(normalizedUrl);
     saveComfyUIUrl(normalizedUrl);
     connectLastFailureTime = 0;
@@ -132,7 +140,10 @@ export const useComfyUIStore = create<ComfyUIState>((set, get) => ({
       baseUrl: normalizedUrl,
       isConnected: false,
       connectionError: null,
-      objectInfo: null
+      objectInfo: null,
+      currentPromptId: null,
+      isExecuting: false,
+      executionProgress: 0
     });
   },
 
@@ -260,6 +271,7 @@ export const useComfyUIStore = create<ComfyUIState>((set, get) => ({
   disconnect: () => {
     const service = getComfyUIService();
     service.disconnectWebSocket();
+    connectLastFailureTime = 0;
     set({
       isConnected: false,
       connectionError: null,

--- a/web/src/stores/ErrorStore.ts
+++ b/web/src/stores/ErrorStore.ts
@@ -93,10 +93,13 @@ const useErrorStore = create<ErrorStore>((set, get) => ({
       });
     } else {
       set((state) => {
-        // Optimization: Use for...in loop to avoid intermediate array allocation
+        // Optimization: Use for...in loop to avoid intermediate array allocation.
+        // Match on the colon boundary to avoid clearing entries for workflows
+        // whose IDs happen to share a prefix.
+        const prefix = `${workflowId}:`;
         const newErrors: Record<string, NodeError> = {};
         for (const key in state.errors) {
-          if (!key.startsWith(workflowId)) {
+          if (!key.startsWith(prefix)) {
             newErrors[key] = state.errors[key];
           }
         }

--- a/web/src/stores/ExecutionTimeStore.ts
+++ b/web/src/stores/ExecutionTimeStore.ts
@@ -85,9 +85,10 @@ const useExecutionTimeStore = create<ExecutionTimeStore>((set, get) => ({
 
   clearTimings: (workflowId: string) => {
     set((state) => {
+      const prefix = `${workflowId}:`;
       const newTimings: Record<string, ExecutionTiming> = {};
       for (const key in state.timings) {
-        if (!key.startsWith(workflowId)) {
+        if (!key.startsWith(prefix)) {
           newTimings[key] = state.timings[key];
         }
       }

--- a/web/src/stores/FavoriteWorkflowsStore.ts
+++ b/web/src/stores/FavoriteWorkflowsStore.ts
@@ -50,8 +50,19 @@ export const useFavoriteWorkflowsStore = create<FavoriteWorkflowsState>()(
     }),
     {
       name: "favorite-workflows",
+      version: 1,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({ favoriteWorkflowIds: state.favoriteWorkflowIds }),
+      migrate: (persistedState, _version) => {
+        if (!persistedState || typeof persistedState !== "object") {
+          return { favoriteWorkflowIds: [] };
+        }
+        const state = persistedState as Record<string, unknown>;
+        if (!Array.isArray(state.favoriteWorkflowIds)) {
+          state.favoriteWorkflowIds = [];
+        }
+        return state;
+      }
     }
   )
 );

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -813,8 +813,16 @@ const useGlobalChatStore = create<GlobalChatState>()(
                 if (existingTimeout !== null) {
                   clearTimeout(existingTimeout);
                 }
-                // Auto-load messages for the new current thread
-                const timeoutId = setTimeout(() => get().loadMessages(newCurrentThreadId), 0);
+                // Auto-load messages for the new current thread, but
+                // re-read currentThreadId at fire time so a switchThread
+                // call between scheduling and firing doesn't load messages
+                // into the wrong thread context.
+                const timeoutId = setTimeout(() => {
+                  const activeId = get().currentThreadId;
+                  if (activeId) {
+                    get().loadMessages(activeId);
+                  }
+                }, 0);
                 newState.loadMessagesTimeoutId = timeoutId;
               } else {
                 // No threads left, clear current thread (we will create a new one below)
@@ -1098,6 +1106,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
     }),
     {
       name: "global-chat-storage",
+      version: 1,
       // Persist minimal subset incl. selections; do not persist message cache
       // Note: Return type cast needed due to zustand persist middleware type limitations
       partialize: (state) => ({
@@ -1107,6 +1116,24 @@ const useGlobalChatStore = create<GlobalChatState>()(
         selectedTools: state.selectedTools,
         selectedCollections: state.selectedCollections
       }) as GlobalChatState,
+      migrate: (persistedState, _version) => {
+        // Strip incompatible payloads on schema bump rather than letting
+        // them silently corrupt rehydrated state.
+        if (!persistedState || typeof persistedState !== "object") {
+          return persistedState;
+        }
+        const state = persistedState as Record<string, unknown>;
+        if (state.threads === null || typeof state.threads !== "object") {
+          state.threads = {};
+        }
+        if (!Array.isArray(state.selectedTools)) {
+          state.selectedTools = [];
+        }
+        if (!Array.isArray(state.selectedCollections)) {
+          state.selectedCollections = [];
+        }
+        return state;
+      },
       onRehydrateStorage: () => (state) => {
         // State has been rehydrated from storage
         if (state) {
@@ -1196,8 +1223,19 @@ const registerGlobalChatListeners = () => {
   };
 };
 
-if (typeof window !== "undefined") {
-  registerGlobalChatListeners();
+// Guard against multiple registrations from HMR / multi-bundle loads. Each
+// extra import would otherwise install another set of listeners that the
+// `return cleanup` path never calls back into.
+declare global {
+  interface Window {
+    __nodetoolGlobalChatListenersBound?: boolean;
+    __nodetoolGlobalChatListenersCleanup?: () => void;
+  }
+}
+
+if (typeof window !== "undefined" && !window.__nodetoolGlobalChatListenersBound) {
+  window.__nodetoolGlobalChatListenersBound = true;
+  window.__nodetoolGlobalChatListenersCleanup = registerGlobalChatListeners();
 }
 
 // Custom hook for TanStack Query thread loading
@@ -1221,11 +1259,13 @@ export const useThreadsQuery = () => {
         threadsRecord[thread.id] = thread as unknown as Thread;
       });
 
-      useGlobalChatStore.setState({
-        threads: threadsRecord,
+      // Merge with existing threads so locally-created/optimistic threads
+      // that haven't reached the server yet don't get wiped on refetch.
+      useGlobalChatStore.setState((state) => ({
+        threads: { ...state.threads, ...threadsRecord },
         threadsLoaded: true,
         isLoadingThreads: false
-      });
+      }));
     }
   }, [query.isSuccess, query.data]);
 

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -1117,22 +1117,44 @@ const useGlobalChatStore = create<GlobalChatState>()(
         selectedCollections: state.selectedCollections
       }) as GlobalChatState,
       migrate: (persistedState, _version) => {
-        // Strip incompatible payloads on schema bump rather than letting
-        // them silently corrupt rehydrated state.
+        // Corrupt localStorage (string, null, etc.) must yield a usable
+        // default rather than passing the raw value through; selectors
+        // that read `threads`/`selectedTools`/`selectedCollections`
+        // would otherwise see `undefined` and crash.
+        const fallback = {
+          threads: {} as Record<string, Thread>,
+          lastUsedThreadId: null as string | null,
+          selectedModel: null as LanguageModel | null,
+          selectedTools: [] as string[],
+          selectedCollections: [] as string[]
+        };
         if (!persistedState || typeof persistedState !== "object") {
-          return persistedState;
+          return fallback as unknown as GlobalChatState;
         }
         const state = persistedState as Record<string, unknown>;
-        if (state.threads === null || typeof state.threads !== "object") {
-          state.threads = {};
-        }
-        if (!Array.isArray(state.selectedTools)) {
-          state.selectedTools = [];
-        }
-        if (!Array.isArray(state.selectedCollections)) {
-          state.selectedCollections = [];
-        }
-        return state;
+        return {
+          threads:
+            state.threads &&
+            typeof state.threads === "object" &&
+            !Array.isArray(state.threads)
+              ? (state.threads as Record<string, Thread>)
+              : fallback.threads,
+          lastUsedThreadId:
+            typeof state.lastUsedThreadId === "string"
+              ? state.lastUsedThreadId
+              : fallback.lastUsedThreadId,
+          selectedModel:
+            state.selectedModel &&
+            typeof state.selectedModel === "object"
+              ? (state.selectedModel as LanguageModel)
+              : fallback.selectedModel,
+          selectedTools: Array.isArray(state.selectedTools)
+            ? (state.selectedTools as string[])
+            : fallback.selectedTools,
+          selectedCollections: Array.isArray(state.selectedCollections)
+            ? (state.selectedCollections as string[])
+            : fallback.selectedCollections
+        } as unknown as GlobalChatState;
       },
       onRehydrateStorage: () => (state) => {
         // State has been rehydrated from storage

--- a/web/src/stores/HfCacheStatusStore.ts
+++ b/web/src/stores/HfCacheStatusStore.ts
@@ -92,7 +92,7 @@ export const useHfCacheStatusStore = create<HfCacheStatusStore>((set, get) => ({
     if (items.length === 0) {
       return;
     }
-    const { statuses, pending } = get();
+    const { statuses, pending, version: snapshotVersion } = get();
     const requests = items.filter(
       (item) => statuses[item.key] === undefined && !pending[item.key]
     );
@@ -105,7 +105,12 @@ export const useHfCacheStatusStore = create<HfCacheStatusStore>((set, get) => ({
     get().markPending(keys);
     try {
       const results = await checkHfCacheStatus(requests);
-      get().setStatuses(results);
+      // If invalidate() ran while this request was in-flight, the version
+      // counter advanced; dropping the response avoids re-populating the
+      // map with stale data.
+      if (get().version === snapshotVersion) {
+        get().setStatuses(results);
+      }
     } catch {
       // Keep existing statuses on transient failures; avoid persisting false negatives.
     } finally {

--- a/web/src/stores/KeyPressedStore.ts
+++ b/web/src/stores/KeyPressedStore.ts
@@ -371,8 +371,15 @@ const initKeyListeners = () => {
   };
 
   const clearAllKeys = () => {
-    const { pressedKeys, setKeysPressed } = useKeyPressedStore.getState();
-    pressedKeys.forEach((key) => setKeysPressed({ [key]: false }));
+    // Single atomic update: previously this iterated the snapshot and
+    // issued one setKeysPressed per key, which fired combo callbacks
+    // mid-clear and could leave modifiers "stuck" if the user released
+    // them while the window had no focus.
+    useKeyPressedStore.setState((state) => ({
+      ...state,
+      pressedKeys: new Set(),
+      lastPressedKey: null
+    }));
   };
 
   window.addEventListener("keydown", handleKeyDown);

--- a/web/src/stores/ModelDownloadStore.ts
+++ b/web/src/stores/ModelDownloadStore.ts
@@ -38,6 +38,8 @@ interface ModelDownloadStore {
   downloads: Record<string, Download>;
   ws: WebSocket | null;
   wsConnectionState: "disconnected" | "connecting" | "connected";
+  /** In-flight connect promise; concurrent callers reuse this. */
+  wsConnectingPromise: Promise<WebSocket> | null;
   reconnectAttempts: number;
   queryClient: QueryClient | null;
   setQueryClient: (queryClient: QueryClient) => void;
@@ -79,6 +81,7 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
   downloads: {},
   ws: null,
   wsConnectionState: "disconnected",
+  wsConnectingPromise: null,
   reconnectAttempts: 0,
   queryClient: null,
   setQueryClient: (queryClient: QueryClient) => {
@@ -141,58 +144,53 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
   },
 
   connectWebSocket: async () => {
-    let ws = get().ws;
-    if (ws?.readyState === WebSocket.OPEN) {
-      return ws;
+    const existing = get().ws;
+    if (existing?.readyState === WebSocket.OPEN) {
+      return existing;
     }
 
-    // Prevent multiple simultaneous connection attempts
-    if (get().wsConnectionState === "connecting") {
-      // Wait for existing connection attempt with timeout to prevent memory leak
-      const CONNECTION_TIMEOUT_MS = 30000; // 30 second timeout
-      return new Promise((resolve, reject) => {
-        const checkInterval = setInterval(() => {
-          const currentWs = get().ws;
-          const state = get().wsConnectionState;
-          if (state === "connected" && currentWs) {
-            clearInterval(checkInterval);
-            clearTimeout(timeoutId);
-            resolve(currentWs);
-          } else if (state === "disconnected") {
-            clearInterval(checkInterval);
-            clearTimeout(timeoutId);
-            reject(new Error("Connection failed"));
-          }
-        }, 100);
-
-        // Add timeout to prevent interval from running forever
-        const timeoutId = setTimeout(() => {
-          clearInterval(checkInterval);
-          reject(new Error(`Connection timeout after ${CONNECTION_TIMEOUT_MS}ms`));
-        }, CONNECTION_TIMEOUT_MS);
-      });
+    // Reuse the in-flight connect promise so concurrent callers don't
+    // open a second socket — the polling/interval pattern in the previous
+    // implementation could resolve with a stale `ws` reference.
+    const inflight = get().wsConnectingPromise;
+    if (inflight) {
+      return inflight;
     }
 
     set({ wsConnectionState: "connecting" });
-    ws = new WebSocket(DOWNLOAD_URL);
+    const ws = new WebSocket(DOWNLOAD_URL);
 
-    await new Promise<void>((resolve, reject) => {
-      if (ws) {
-        ws.onopen = () => {
-          set({ wsConnectionState: "connected" });
-          resolve();
-        };
-        ws.onerror = (error) => {
-          set({ wsConnectionState: "disconnected" });
-          reject(error);
-        };
-      } else {
-        set({ wsConnectionState: "disconnected" });
-        reject(new Error("WebSocket is null"));
-      }
+    const connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      let settled = false;
+      const onOpen = () => {
+        if (settled) return;
+        settled = true;
+        set({ ws, wsConnectionState: "connected", wsConnectingPromise: null });
+        resolve(ws);
+      };
+      const onError = (error: Event) => {
+        if (settled) return;
+        settled = true;
+        try {
+          ws.close();
+        } catch {
+          /* already closing */
+        }
+        set({
+          ws: null,
+          wsConnectionState: "disconnected",
+          wsConnectingPromise: null
+        });
+        reject(error);
+      };
+      ws.addEventListener("open", onOpen, { once: true });
+      ws.addEventListener("error", onError, { once: true });
     });
 
-    if (ws) {
+    set({ wsConnectingPromise: connectPromise });
+    await connectPromise;
+
+    {
       ws.onmessage = (event) => {
         const data = JSON.parse(event.data);
         if (data.repo_id) {
@@ -245,7 +243,11 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
         console.warn(
           `[ModelDownloadStore] WebSocket closed: code=${event.code}, reason=${event.reason}`
         );
-        set({ ws: null, wsConnectionState: "disconnected" });
+        set({
+          ws: null,
+          wsConnectionState: "disconnected",
+          wsConnectingPromise: null
+        });
 
         // Attempt reconnection if we have active downloads
         if (get().hasActiveDownloads()) {
@@ -257,10 +259,8 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
         console.error("[ModelDownloadStore] WebSocket error:", error);
       };
 
-      set({ ws });
+      // ws is already stored via the open handler in connectPromise.
       return ws;
-    } else {
-      throw new Error("WebSocket connection failed");
     }
   },
 
@@ -268,7 +268,12 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
     const { ws } = get();
     if (ws) {
       ws.close();
-      set({ ws: null, wsConnectionState: "disconnected", reconnectAttempts: 0 });
+      set({
+        ws: null,
+        wsConnectionState: "disconnected",
+        reconnectAttempts: 0,
+        wsConnectingPromise: null
+      });
     }
   },
 

--- a/web/src/stores/ModelPreferencesStore.ts
+++ b/web/src/stores/ModelPreferencesStore.ts
@@ -93,6 +93,7 @@ export const useModelPreferencesStore = create<ModelPreferencesState>()(
     }),
     {
       name: "model-preferences",
+      version: 1,
       partialize: (state) => ({
         favorites: Array.from(state.favorites),
         recents: state.recents,
@@ -100,15 +101,39 @@ export const useModelPreferencesStore = create<ModelPreferencesState>()(
         enabledProviders: state.enabledProviders,
         defaults: state.defaults
       }),
+      migrate: (persistedState, _version) => {
+        // No prior versions; this scaffold lets future schema changes
+        // produce a clean shape rather than silently inheriting raw data.
+        if (!persistedState || typeof persistedState !== "object") {
+          return persistedState;
+        }
+        const state = persistedState as Record<string, unknown>;
+        if (!Array.isArray(state.favorites)) {
+          state.favorites = [];
+        }
+        if (!Array.isArray(state.recents)) {
+          state.recents = [];
+        }
+        if (
+          state.enabledProviders === null ||
+          typeof state.enabledProviders !== "object"
+        ) {
+          state.enabledProviders = {};
+        }
+        if (state.defaults === null || typeof state.defaults !== "object") {
+          state.defaults = {};
+        }
+        return state;
+      },
       // Rehydrate Set
       onRehydrateStorage: () => (state) => {
         if (!state) {
           return;
         }
         const rawFavorites = (state as { favorites: unknown }).favorites;
-        if (Array.isArray(rawFavorites)) {
-          state.favorites = new Set(rawFavorites as FavoriteKey[]);
-        }
+        state.favorites = Array.isArray(rawFavorites)
+          ? new Set(rawFavorites as FavoriteKey[])
+          : new Set<FavoriteKey>();
       }
     }
   )

--- a/web/src/stores/ModelPreferencesStore.ts
+++ b/web/src/stores/ModelPreferencesStore.ts
@@ -102,28 +102,48 @@ export const useModelPreferencesStore = create<ModelPreferencesState>()(
         defaults: state.defaults
       }),
       migrate: (persistedState, _version) => {
-        // No prior versions; this scaffold lets future schema changes
-        // produce a clean shape rather than silently inheriting raw data.
+        // Corrupt localStorage (string, null, etc.) must NOT be passed
+        // through unchanged: it would rehydrate the store into an
+        // invalid shape that breaks selectors expecting the partialized
+        // keys. Always return an object with every required field.
+        const fallback = {
+          favorites: [] as FavoriteKey[],
+          recents: [] as RecentEntry[],
+          onlyAvailable: true,
+          enabledProviders: {} as Record<string, boolean>,
+          defaults: {} as Record<
+            string,
+            { provider: string; id: string; name: string }
+          >
+        };
         if (!persistedState || typeof persistedState !== "object") {
-          return persistedState;
+          return fallback;
         }
         const state = persistedState as Record<string, unknown>;
-        if (!Array.isArray(state.favorites)) {
-          state.favorites = [];
-        }
-        if (!Array.isArray(state.recents)) {
-          state.recents = [];
-        }
-        if (
-          state.enabledProviders === null ||
-          typeof state.enabledProviders !== "object"
-        ) {
-          state.enabledProviders = {};
-        }
-        if (state.defaults === null || typeof state.defaults !== "object") {
-          state.defaults = {};
-        }
-        return state;
+        return {
+          favorites: Array.isArray(state.favorites)
+            ? (state.favorites as FavoriteKey[])
+            : fallback.favorites,
+          recents: Array.isArray(state.recents)
+            ? (state.recents as RecentEntry[])
+            : fallback.recents,
+          onlyAvailable:
+            typeof state.onlyAvailable === "boolean"
+              ? state.onlyAvailable
+              : fallback.onlyAvailable,
+          enabledProviders:
+            state.enabledProviders &&
+            typeof state.enabledProviders === "object"
+              ? (state.enabledProviders as Record<string, boolean>)
+              : fallback.enabledProviders,
+          defaults:
+            state.defaults && typeof state.defaults === "object"
+              ? (state.defaults as Record<
+                  string,
+                  { provider: string; id: string; name: string }
+                >)
+              : fallback.defaults
+        };
       },
       // Rehydrate Set
       onRehydrateStorage: () => (state) => {

--- a/web/src/stores/NodeMenuStore.ts
+++ b/web/src/stores/NodeMenuStore.ts
@@ -157,13 +157,18 @@ export const createNodeMenuStore = (options: NodeMenuStoreOptions = {}) =>
       }, 50); // Reduced from 75ms since SearchInput already debounces
     };
 
-    // Subscribe to metadata changes and clear cache
-    useMetadataStore.subscribe(() => {
+    // Subscribe to metadata changes and clear cache. Capture the unsubscribe
+    // and register it with a module-level set so a HMR teardown helper can
+    // release it; without this, hot-reloads accumulate one subscription per
+    // factory call. (Production code paths run the factory exactly twice at
+    // module load — see exports below — so there's no leak there.)
+    const unsubscribeMetadata = useMetadataStore.subscribe(() => {
       set({ searchResultsCache: {} });
       if (get().isMenuOpen) {
         scheduleSearch(get().searchTerm);
       }
     });
+    nodeMenuMetadataUnsubscribers.add(unsubscribeMetadata);
 
     return {
       // menu
@@ -572,6 +577,26 @@ export const createNodeMenuStore = (options: NodeMenuStoreOptions = {}) =>
       }
     };
   });
+
+// Module-level registry of metadata unsubscribers, so a HMR teardown helper
+// can release them without leaking subscriptions across hot reloads.
+const nodeMenuMetadataUnsubscribers = new Set<() => void>();
+
+/**
+ * Release all metadata subscriptions registered by `createNodeMenuStore`.
+ * Intended for HMR cleanup (Vite's `import.meta.hot.dispose`); can also
+ * be wired into test teardown if needed.
+ */
+export const cleanupNodeMenuMetadataSubscriptions = (): void => {
+  for (const unsubscribe of nodeMenuMetadataUnsubscribers) {
+    try {
+      unsubscribe();
+    } catch (err) {
+      console.warn("[NodeMenuStore] metadata unsubscribe failed", err);
+    }
+  }
+  nodeMenuMetadataUnsubscribers.clear();
+};
 
 export const useNodeMenuStore = createNodeMenuStore();
 export const useNodeToolsMenuStore = createNodeMenuStore({ onlyTools: true });

--- a/web/src/stores/NodeResultHistoryStore.ts
+++ b/web/src/stores/NodeResultHistoryStore.ts
@@ -106,8 +106,9 @@ export const useNodeResultHistoryStore = create<NodeResultHistoryStore>(
      */
     clearWorkflowHistory: (workflowId: string) => {
       const history = { ...get().history };
+      const prefix = `${workflowId}:`;
       for (const key in history) {
-        if (key.startsWith(workflowId)) {
+        if (key.startsWith(prefix)) {
           delete history[key];
         }
       }

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -849,10 +849,10 @@ export const createNodeStore = (
               }
             }
 
-            for (const nodeId of foundIds) {
-              useErrorStore.getState().clearErrors(nodeId);
-              useResultsStore.getState().clearResults(nodeId);
-            }
+            const workflowId = get().workflow.id;
+            const idSetForClear = new Set(foundIds);
+            useErrorStore.getState().clearErrors(workflowId, idSetForClear);
+            useResultsStore.getState().clearResults(workflowId, idSetForClear);
 
             set({
               nodes,
@@ -1289,7 +1289,9 @@ export const createNodeStore = (
             }
 
             const nodeId = get().generateNodeId();
-            useResultsStore.getState().clearResults(nodeId);
+            useResultsStore
+              .getState()
+              .clearResults(get().workflow.id, new Set([nodeId]));
 
             // Set default size for nodes that host rich previews so content
             // fills a stable box instead of driving the initial layout.

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -152,13 +152,42 @@ export const usePanelStore = create<ResizePanelState>()(
     }),
     {
       name: "left-panel-storage",
+      version: 1,
       partialize: (state: ResizePanelState) => ({
         panel: {
-          ...state.panel,
-          isDragging: false,
-          hasDragged: false
+          panelSize: state.panel.panelSize,
+          isVisible: state.panel.isVisible,
+          activeView: state.panel.activeView
         }
-      })
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<ResizePanelState>;
+        const persistedPanel = (persisted.panel ?? {}) as Partial<PanelState>;
+        const validViews: PanelView[] = ["assets", "workflowGrid"];
+        const activeView = validViews.includes(
+          persistedPanel.activeView as PanelView
+        )
+          ? (persistedPanel.activeView as PanelView)
+          : currentState.panel.activeView;
+        return {
+          ...currentState,
+          panel: {
+            ...currentState.panel,
+            panelSize:
+              typeof persistedPanel.panelSize === "number"
+                ? Math.max(
+                    MIN_DRAG_SIZE,
+                    Math.min(persistedPanel.panelSize, MAX_PANEL_SIZE)
+                  )
+                : currentState.panel.panelSize,
+            isVisible:
+              typeof persistedPanel.isVisible === "boolean"
+                ? persistedPanel.isVisible
+                : currentState.panel.isVisible,
+            activeView
+          }
+        };
+      }
     }
   )
 );

--- a/web/src/stores/RemoteSettingStore.ts
+++ b/web/src/stores/RemoteSettingStore.ts
@@ -63,7 +63,10 @@ const useRemoteSettingsStore = create<RemoteSettingsStore>((set, get) => ({
         settings,
         secrets
       });
-      set({ isLoading: false });
+      // Refetch so consumers reading via getSettingValue / settingsByGroup
+      // see the new values; previously the local cache stayed stale until
+      // something else triggered fetchSettings.
+      await get().fetchSettings();
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
       set({ isLoading: false });
@@ -86,7 +89,18 @@ const useRemoteSettingsStore = create<RemoteSettingsStore>((set, get) => ({
       const newSettings = [...state.settings];
       newSettings[index] = { ...newSettings[index], value };
 
-      return { settings: newSettings };
+      // Keep settingsByGroup consistent so group-keyed selectors see the
+      // optimistic update too.
+      const newSettingsByGroup = new Map<string, SettingWithValue[]>();
+      newSettings.forEach((setting) => {
+        const group = setting.group;
+        if (!newSettingsByGroup.has(group)) {
+          newSettingsByGroup.set(group, []);
+        }
+        newSettingsByGroup.get(group)!.push(setting);
+      });
+
+      return { settings: newSettings, settingsByGroup: newSettingsByGroup };
     });
   }
 }));

--- a/web/src/stores/ResultsStore.ts
+++ b/web/src/stores/ResultsStore.ts
@@ -113,10 +113,12 @@ const filterRecord = <T>(
     });
     return newRecord;
   }
-  // Optimization: Use for...in loop to avoid intermediate array allocation
+  // Optimization: Use for...in loop to avoid intermediate array allocation.
+  // Match on the colon boundary so workflow IDs that share a prefix don't collide.
+  const prefix = `${workflowId}:`;
   const newRecord: Record<string, T> = {};
   for (const key in record) {
-    if (!key.startsWith(workflowId)) {
+    if (!key.startsWith(prefix)) {
       newRecord[key] = record[key];
     }
   }

--- a/web/src/stores/RightPanelStore.ts
+++ b/web/src/stores/RightPanelStore.ts
@@ -129,13 +129,57 @@ export const useRightPanelStore = create<ResizePanelState>()(
     }),
     {
       name: "right-panel-storage",
+      version: 1,
+      // Persist only the user-driven slice of `panel`. Constants like
+      // minWidth/maxWidth/defaultWidth come from code on every load, so
+      // bumping them in source should not be undermined by stale persisted
+      // values. activeView is validated on rehydrate.
       partialize: (state: ResizePanelState) => ({
         panel: {
-          ...state.panel,
-          isDragging: false,
-          hasDragged: false
+          panelSize: state.panel.panelSize,
+          isVisible: state.panel.isVisible,
+          activeView: state.panel.activeView
         }
-      })
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<ResizePanelState>;
+        const persistedPanel = (persisted.panel ?? {}) as Partial<PanelState>;
+        const validViews: RightPanelView[] = [
+          "inspector",
+          "assistant",
+          "logs",
+          "workspace",
+          "versions",
+          "workflow",
+          "jobs",
+          "workflowAssets",
+          "sandboxes",
+          "agent"
+        ];
+        const activeView = validViews.includes(
+          persistedPanel.activeView as RightPanelView
+        )
+          ? (persistedPanel.activeView as RightPanelView)
+          : currentState.panel.activeView;
+        return {
+          ...currentState,
+          panel: {
+            ...currentState.panel,
+            panelSize:
+              typeof persistedPanel.panelSize === "number"
+                ? Math.max(
+                    MIN_DRAG_SIZE,
+                    Math.min(persistedPanel.panelSize, MAX_PANEL_SIZE)
+                  )
+                : currentState.panel.panelSize,
+            isVisible:
+              typeof persistedPanel.isVisible === "boolean"
+                ? persistedPanel.isVisible
+                : currentState.panel.isVisible,
+            activeView
+          }
+        };
+      }
     }
   )
 );

--- a/web/src/stores/StatusStore.ts
+++ b/web/src/stores/StatusStore.ts
@@ -50,8 +50,9 @@ const useStatusStore = create<StatusStore>((set, get) => ({
         }
       }
     } else {
+      const prefix = `${workflowId}:`;
       for (const key in newStatuses) {
-        if (key.startsWith(workflowId)) {
+        if (key.startsWith(prefix)) {
           delete newStatuses[key];
           changed = true;
         }

--- a/web/src/stores/VibeCodingStore.ts
+++ b/web/src/stores/VibeCodingStore.ts
@@ -107,16 +107,29 @@ export const useVibeCodingStore = create<VibeCodingState>()(
             return state;
           }
 
-          const messages = [...session.messages];
-          const lastMessage = { ...messages[messages.length - 1] };
+          // Identify the streaming assistant placeholder by role rather than
+          // by index so a user message added between chunk arrivals doesn't
+          // get clobbered as if it were the placeholder.
+          let targetIndex = -1;
+          for (let i = session.messages.length - 1; i >= 0; i--) {
+            if (session.messages[i].role === "assistant") {
+              targetIndex = i;
+              break;
+            }
+          }
+          if (targetIndex === -1) {
+            return state;
+          }
 
-          // Update text content of last message
-          if (lastMessage.content && Array.isArray(lastMessage.content)) {
-            lastMessage.content = lastMessage.content.map((c) =>
+          const messages = [...session.messages];
+          const target = { ...messages[targetIndex] };
+
+          if (target.content && Array.isArray(target.content)) {
+            target.content = target.content.map((c) =>
               c.type === "text" ? { ...c, text: content } : c
             );
           }
-          messages[messages.length - 1] = lastMessage;
+          messages[targetIndex] = target;
 
           return {
             sessions: {
@@ -216,6 +229,7 @@ export const useVibeCodingStore = create<VibeCodingState>()(
     }),
     {
       name: "vibecoding-store",
+      version: 1,
       partialize: (state) => {
         // Only persist sessions with unsaved changes
         const activeSessions: Record<string, VibeCodingSession> = {};
@@ -226,6 +240,16 @@ export const useVibeCodingStore = create<VibeCodingState>()(
           }
         }
         return { sessions: activeSessions };
+      },
+      migrate: (persistedState, _version) => {
+        if (!persistedState || typeof persistedState !== "object") {
+          return { sessions: {} };
+        }
+        const state = persistedState as Record<string, unknown>;
+        if (state.sessions === null || typeof state.sessions !== "object") {
+          state.sessions = {};
+        }
+        return state;
       }
     }
   )

--- a/web/src/stores/WorkflowAssetStore.ts
+++ b/web/src/stores/WorkflowAssetStore.ts
@@ -53,7 +53,12 @@ interface WorkflowAssetStore extends WorkflowAssetState {
 // Per-workflow request token: only the most recent in-flight request
 // for a given workflow may write back. Earlier requests bail silently so
 // a slow response can't clobber newer data.
-const loadTokens = new Map<string, number>();
+//
+// Tokens are unique object references (not counters) so the map can be
+// safely pruned on `clearWorkflowAssets` without risking that a freshly
+// minted counter value collides with one captured by an earlier
+// in-flight call against the same workflowId.
+const loadTokens = new Map<string, object>();
 
 export const useWorkflowAssetStore = create<WorkflowAssetStore>(
   (set, get) => ({
@@ -65,7 +70,7 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
      * Load assets for a specific workflow from the API.
      */
     loadWorkflowAssets: async (workflowId: string): Promise<Asset[]> => {
-      const token = (loadTokens.get(workflowId) ?? 0) + 1;
+      const token = {};
       loadTokens.set(workflowId, token);
 
       const isCurrent = () => loadTokens.get(workflowId) === token;
@@ -140,8 +145,10 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
      * Clear assets for a specific workflow.
      */
     clearWorkflowAssets: (workflowId: string) => {
-      // Bump the token so any in-flight load for this workflow won't write back.
-      loadTokens.set(workflowId, (loadTokens.get(workflowId) ?? 0) + 1);
+      // Drop the in-flight token entirely. Bumping a counter only would
+      // leave loadTokens growing unbounded across long sessions, which
+      // would just relocate the lifecycle leak we're trying to fix.
+      loadTokens.delete(workflowId);
       set((state) => {
         const assetsByWorkflow = { ...state.assetsByWorkflow };
         delete assetsByWorkflow[workflowId];

--- a/web/src/stores/WorkflowAssetStore.ts
+++ b/web/src/stores/WorkflowAssetStore.ts
@@ -50,6 +50,11 @@ interface WorkflowAssetStore extends WorkflowAssetState {
   getWorkflowError: (workflowId: string) => Error | null;
 }
 
+// Per-workflow request token: only the most recent in-flight request
+// for a given workflow may write back. Earlier requests bail silently so
+// a slow response can't clobber newer data.
+const loadTokens = new Map<string, number>();
+
 export const useWorkflowAssetStore = create<WorkflowAssetStore>(
   (set, get) => ({
     assetsByWorkflow: {},
@@ -60,17 +65,23 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
      * Load assets for a specific workflow from the API.
      */
     loadWorkflowAssets: async (workflowId: string): Promise<Asset[]> => {
-      // Set loading state
-      set({
+      const token = (loadTokens.get(workflowId) ?? 0) + 1;
+      loadTokens.set(workflowId, token);
+
+      const isCurrent = () => loadTokens.get(workflowId) === token;
+
+      // Set loading state via functional setter so concurrent loads for
+      // different workflows don't drop each other's entries.
+      set((state) => ({
         loadingByWorkflow: {
-          ...get().loadingByWorkflow,
+          ...state.loadingByWorkflow,
           [workflowId]: true
         },
         errorsByWorkflow: {
-          ...get().errorsByWorkflow,
+          ...state.errorsByWorkflow,
           [workflowId]: null
         }
-      });
+      }));
 
       try {
         const data = await trpcClient.assets.list.query({
@@ -80,17 +91,20 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
           (data.assets ?? []) as unknown as Asset[]
         );
 
-        // Update state
-        set({
+        if (!isCurrent()) {
+          return assets;
+        }
+
+        set((state) => ({
           assetsByWorkflow: {
-            ...get().assetsByWorkflow,
+            ...state.assetsByWorkflow,
             [workflowId]: assets
           },
           loadingByWorkflow: {
-            ...get().loadingByWorkflow,
+            ...state.loadingByWorkflow,
             [workflowId]: false
           }
-        });
+        }));
 
         return assets;
       } catch (error) {
@@ -98,16 +112,18 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
           error instanceof Error ? error : new Error("Failed to load assets");
         console.error("Failed to load workflow assets:", err);
 
-        set({
-          loadingByWorkflow: {
-            ...get().loadingByWorkflow,
-            [workflowId]: false
-          },
-          errorsByWorkflow: {
-            ...get().errorsByWorkflow,
-            [workflowId]: err
-          }
-        });
+        if (isCurrent()) {
+          set((state) => ({
+            loadingByWorkflow: {
+              ...state.loadingByWorkflow,
+              [workflowId]: false
+            },
+            errorsByWorkflow: {
+              ...state.errorsByWorkflow,
+              [workflowId]: err
+            }
+          }));
+        }
 
         throw err;
       }
@@ -124,22 +140,27 @@ export const useWorkflowAssetStore = create<WorkflowAssetStore>(
      * Clear assets for a specific workflow.
      */
     clearWorkflowAssets: (workflowId: string) => {
-      const assetsByWorkflow = { ...get().assetsByWorkflow };
-      delete assetsByWorkflow[workflowId];
+      // Bump the token so any in-flight load for this workflow won't write back.
+      loadTokens.set(workflowId, (loadTokens.get(workflowId) ?? 0) + 1);
+      set((state) => {
+        const assetsByWorkflow = { ...state.assetsByWorkflow };
+        delete assetsByWorkflow[workflowId];
 
-      const loadingByWorkflow = { ...get().loadingByWorkflow };
-      delete loadingByWorkflow[workflowId];
+        const loadingByWorkflow = { ...state.loadingByWorkflow };
+        delete loadingByWorkflow[workflowId];
 
-      const errorsByWorkflow = { ...get().errorsByWorkflow };
-      delete errorsByWorkflow[workflowId];
+        const errorsByWorkflow = { ...state.errorsByWorkflow };
+        delete errorsByWorkflow[workflowId];
 
-      set({ assetsByWorkflow, loadingByWorkflow, errorsByWorkflow });
+        return { assetsByWorkflow, loadingByWorkflow, errorsByWorkflow };
+      });
     },
 
     /**
      * Clear all workflow assets.
      */
     clearAllWorkflowAssets: () => {
+      loadTokens.clear();
       set({
         assetsByWorkflow: {},
         loadingByWorkflow: {},

--- a/web/src/stores/WorkflowManagerStore.ts
+++ b/web/src/stores/WorkflowManagerStore.ts
@@ -23,7 +23,14 @@ import {
   workflowQueryKey
 } from "../serverState/useWorkflow";
 import { subscribeToWorkflowUpdates, unsubscribeFromWorkflowUpdates, setGetNodeStore } from "./workflowUpdates";
-import { getWorkflowRunnerStore } from "./WorkflowRunner";
+import { disposeWorkflowRunnerStore, getWorkflowRunnerStore } from "./WorkflowRunner";
+import useResultsStore from "./ResultsStore";
+import useErrorStore from "./ErrorStore";
+import useStatusStore from "./StatusStore";
+import useExecutionTimeStore from "./ExecutionTimeStore";
+import { useNodeResultHistoryStore } from "./NodeResultHistoryStore";
+import usePropertyValidationStore from "./PropertyValidationStore";
+import { useFavoriteWorkflowsStore } from "./FavoriteWorkflowsStore";
 import { hydrateWorkflowResultsFromAssets } from "./workflowResultHydration";
 import { useCurrentWorkspaceStore } from "./CurrentWorkspaceStore";
 
@@ -469,6 +476,10 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
           window.api.onDeleteWorkflow(workflow);
         }
 
+        // Drop the favorite entry so the deleted workflow doesn't keep
+        // appearing in the favorites UI as a stale id.
+        useFavoriteWorkflowsStore.getState().removeFavorite(workflow.id);
+
         // Invalidate cache for workflows and the specific workflow.
         get().queryClient?.invalidateQueries({ queryKey: ["workflows"] });
         get().queryClient?.invalidateQueries({
@@ -562,14 +573,50 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
         */
        removeWorkflow: (workflowId: string) => {
          unsubscribeFromWorkflowUpdates(workflowId);
-         
-         const { nodeStores, openWorkflows, currentWorkflowId } = get();
 
-        const newOpenWorkflows = openWorkflows.filter(
-          (w) => w.id !== workflowId
-        );
-        const newStores = { ...nodeStores };
-        delete newStores[workflowId];
+         const { nodeStores, openWorkflows, currentWorkflowId, notifiedAutosaveVersions } = get();
+
+         // Tear down the per-workflow NodeStore (releases its metadata
+         // subscription) and the WorkflowRunner store before we drop the
+         // reference, otherwise both leak forever.
+         const departingNodeStore = nodeStores[workflowId];
+         if (departingNodeStore) {
+           try {
+             departingNodeStore.getState().cleanup();
+           } catch (err) {
+             console.warn(
+               `[WorkflowManager] NodeStore cleanup failed for ${workflowId}`,
+               err
+             );
+           }
+         }
+         disposeWorkflowRunnerStore(workflowId);
+
+         // Drop per-workflow keyed entries from singleton stores so they
+         // don't accumulate forever in long-lived sessions.
+         useResultsStore.getState().clearResults(workflowId);
+         useResultsStore.getState().clearOutputResults(workflowId);
+         useResultsStore.getState().clearProgress(workflowId);
+         useResultsStore.getState().clearChunks(workflowId);
+         useResultsStore.getState().clearTasks(workflowId);
+         useResultsStore.getState().clearToolCalls(workflowId);
+         useResultsStore.getState().clearPlanningUpdates(workflowId);
+         useResultsStore.getState().clearPreviews(workflowId);
+         useResultsStore.getState().clearEdges(workflowId);
+         useErrorStore.getState().clearErrors(workflowId);
+         useStatusStore.getState().clearStatuses(workflowId);
+         useExecutionTimeStore.getState().clearTimings(workflowId);
+         useNodeResultHistoryStore.getState().clearWorkflowHistory(workflowId);
+         usePropertyValidationStore.getState().clearWorkflow(workflowId);
+
+         const newOpenWorkflows = openWorkflows.filter(
+           (w) => w.id !== workflowId
+         );
+         const newStores = { ...nodeStores };
+         delete newStores[workflowId];
+
+         const newNotified = { ...notifiedAutosaveVersions };
+         delete newNotified[workflowId];
 
         const newCurrentId = determineNextWorkflowId(
           openWorkflows,
@@ -581,7 +628,8 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
           nodeStores: newStores,
           openWorkflows: newOpenWorkflows,
           currentWorkflowId: newCurrentId,
-          loadingStates: {}
+          loadingStates: {},
+          notifiedAutosaveVersions: newNotified
         });
 
         storage.setOpenWorkflows(newOpenWorkflows.map(w => w.id));
@@ -607,14 +655,32 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
        */
       reorderWorkflows: (sourceIndex: number, targetIndex: number) => {
         set((state) => {
-          const entries = Object.entries(state.nodeStores);
-          const [moved] = entries.splice(sourceIndex, 1);
-          entries.splice(targetIndex, 0, moved);
+          // Reorder the openWorkflows array, then rebuild the nodeStores
+          // map in the same order so consumers iterating either source see
+          // a consistent ordering.
+          const reordered = [...state.openWorkflows];
+          if (
+            sourceIndex < 0 ||
+            sourceIndex >= reordered.length ||
+            targetIndex < 0 ||
+            targetIndex >= reordered.length
+          ) {
+            return state;
+          }
+          const [moved] = reordered.splice(sourceIndex, 1);
+          reordered.splice(targetIndex, 0, moved);
+
+          const newStores: Record<string, NodeStore> = {};
+          for (const wf of reordered) {
+            const store = state.nodeStores[wf.id];
+            if (store) {
+              newStores[wf.id] = store;
+            }
+          }
+
           return {
-            nodeStores: Object.fromEntries(entries),
-            openWorkflows: Object.values(get().nodeStores).map((store) => {
-              return store.getState().workflow;
-            })
+            openWorkflows: reordered,
+            nodeStores: newStores
           };
         });
       },
@@ -628,8 +694,18 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
           const index = state.openWorkflows.findIndex((w) => w.id === workflow.id);
           if (index === -1) return state;
 
+          const merged = { ...state.openWorkflows[index], ...workflow };
           const newWorkflows = [...state.openWorkflows];
-          newWorkflows[index] = { ...newWorkflows[index], ...workflow };
+          newWorkflows[index] = merged;
+
+          // Keep the underlying NodeStore's `workflow` attribute in sync —
+          // otherwise the store and openWorkflows drift apart for fields
+          // like name/description/tags.
+          const nodeStore = state.nodeStores[workflow.id];
+          if (nodeStore) {
+            const current = nodeStore.getState().workflow;
+            nodeStore.setState({ workflow: { ...current, ...workflow } });
+          }
 
           return { openWorkflows: newWorkflows };
         });

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -140,8 +140,20 @@ export const createWorkflowRunnerStore = (
       const unsubscribe = get().unsubscribe;
       if (unsubscribe) {
         unsubscribe();
-        set({ unsubscribe: null });
       }
+      // Reset job/runtime state so a reused store can't surface a previous
+      // workflow's job_id or status, and late WS messages routed by job_id
+      // won't apply to a resurrected store.
+      set({
+        unsubscribe: null,
+        state: "idle",
+        job_id: null,
+        statusMessage: null,
+        notifications: [],
+        workflow: null,
+        nodes: [],
+        edges: []
+      });
     },
 
     /**
@@ -362,14 +374,26 @@ export const createWorkflowRunnerStore = (
 
       console.info(`WorkflowRunner[${workflowId}]: Sending run_job command`, req);
 
-      await globalWebSocketManager.send({
-        type: "run_job",
-        command: "run_job",
-        data: {
-          ...(req as RunJobRequest & { job_id: string }),
-          job_id: jobId
-        }
-      });
+      try {
+        await globalWebSocketManager.send({
+          type: "run_job",
+          command: "run_job",
+          data: {
+            ...(req as RunJobRequest & { job_id: string }),
+            job_id: jobId
+          }
+        });
+      } catch (error) {
+        // Rollback so the store doesn't get stuck in "running" with a phantom
+        // job_id that cancel() would later try to address.
+        set({
+          state: "error",
+          job_id: null,
+          statusMessage:
+            error instanceof Error ? error.message : "Failed to start job"
+        });
+        throw error;
+      }
     },
 
     /**
@@ -511,6 +535,25 @@ export const getWorkflowRunnerStore = (
   }
 
   return store;
+};
+
+/**
+ * Dispose the runner store for a workflow. Call when a workflow is closed/
+ * deleted so we don't leak per-workflow state forever.
+ */
+export const disposeWorkflowRunnerStore = (workflowId: string): void => {
+  const store = runnerStores.get(workflowId);
+  if (store) {
+    try {
+      store.getState().cleanup();
+    } catch (error) {
+      console.warn(
+        `[WorkflowRunner] cleanup failed for ${workflowId}`,
+        error
+      );
+    }
+    runnerStores.delete(workflowId);
+  }
 };
 
 const defaultWorkflowRunner: WorkflowRunner = {

--- a/web/src/stores/__tests__/ErrorStore.test.ts
+++ b/web/src/stores/__tests__/ErrorStore.test.ts
@@ -195,11 +195,11 @@ describe("ErrorStore", () => {
       });
 
       const { errors } = useErrorStore.getState();
-      // Both should be cleared because "workflow" is a prefix match
-      // Note: This tests the current implementation behavior
+      // clearErrors matches on the full `${workflowId}:` boundary, so a
+      // workflowId that is a string prefix of another workflowId does not
+      // accidentally clear the unrelated workflow's errors.
       expect(errors["workflow:node1"]).toBeUndefined();
-      // "workflow-extended" also starts with "workflow" so it will be cleared too
-      expect(errors["workflow-extended:node1"]).toBeUndefined();
+      expect(errors["workflow-extended:node1"]).toBe("Error 2");
     });
   });
 

--- a/web/src/stores/__tests__/NodeStore.test.ts
+++ b/web/src/stores/__tests__/NodeStore.test.ts
@@ -174,12 +174,15 @@ describe("NodeStore node management", () => {
     store.getState().deleteNode("a");
     expect(store.getState().findNode("a")).toBeUndefined();
     expect(store.getState().edges).toHaveLength(0);
+    // deleteNode now correctly clears errors/results scoped to the
+    // current workflow id with the deleted node IDs as the second arg.
+    const workflowId = store.getState().workflow.id;
     expect(
       useErrorStore.getState().clearErrors as jest.Mock
-    ).toHaveBeenCalledWith("a");
+    ).toHaveBeenCalledWith(workflowId, new Set(["a"]));
     expect(
       useResultsStore.getState().clearResults as jest.Mock
-    ).toHaveBeenCalledWith("a");
+    ).toHaveBeenCalledWith(workflowId, new Set(["a"]));
   });
 
   test("undo and redo revert node changes", () => {

--- a/web/src/stores/__tests__/RemoteSettingStore.test.ts
+++ b/web/src/stores/__tests__/RemoteSettingStore.test.ts
@@ -165,6 +165,8 @@ describe("RemoteSettingStore", () => {
   describe("updateSettings", () => {
     it("should update non-secret settings only", async () => {
       updateMutate.mockResolvedValueOnce({ message: "Settings updated" });
+      // updateSettings now refetches to keep the local cache in sync.
+      listQuery.mockResolvedValueOnce({ settings: [] });
 
       const { result } = renderHook(() => useRemoteSettingsStore());
 
@@ -185,6 +187,7 @@ describe("RemoteSettingStore", () => {
 
     it("should accept settings parameter only", async () => {
       updateMutate.mockResolvedValueOnce({ message: "Settings updated" });
+      listQuery.mockResolvedValueOnce({ settings: [] });
 
       const { result } = renderHook(() => useRemoteSettingsStore());
 
@@ -214,6 +217,7 @@ describe("RemoteSettingStore", () => {
 
     it("should set isLoading correctly", async () => {
       updateMutate.mockResolvedValueOnce({ message: "Settings updated" });
+      listQuery.mockResolvedValueOnce({ settings: [] });
 
       const { result } = renderHook(() => useRemoteSettingsStore());
 


### PR DESCRIPTION
Lifecycle leaks (NodeStore subscription, runner store, per-workflow
caches) accumulated forever on workflow close. Multiple stores had a
`key.startsWith(workflowId)` boundary bug. WS streaming was vulnerable
to thread/job switches. Persist middleware lacked schema versioning.

Highlights:
- WorkflowManagerStore.removeWorkflow now calls NodeStore.cleanup(),
  disposes the runner store, and clears Results/Status/Error/Log/
  ExecutionTime/NodeResultHistory/PropertyValidation entries plus
  notifiedAutosaveVersions for the closed workflow. Also removes any
  favorite workflow entry on delete.
- NodeStore.deleteNodes/createNode pass the correct (workflowId,
  Set<nodeId>) args to clearErrors/clearResults; previously errors and
  results for deleted nodes were never cleaned up.
- Add WorkflowRunner.disposeWorkflowRunnerStore + reset job state in
  cleanup. run() rolls back state on send() failure.
- WorkflowManagerStore.reorderWorkflows: fix order desync between
  nodeStores and openWorkflows.
- WorkflowManagerStore.updateWorkflow: propagate to underlying NodeStore
  so name/description/tags don't drift.
- Match `${workflowId}:` (with colon) in 5 stores: ResultsStore,
  ErrorStore, StatusStore, ExecutionTimeStore, NodeResultHistoryStore.
- AssetStore.delete invalidates the parent listing key (not the deleted
  asset's children); loadCurrentFolder bails out if the user navigated
  folders mid-flight; AssetUpdate type no longer claims status/duration
  fields the trpc backend doesn't accept.
- WorkflowAssetStore: per-workflow request token + functional setters.
- ModelDownloadStore.connectWebSocket: single Promise-based connect path
  with proper error/close cleanup; no more stuck "connecting" state.
- HfCacheStatusStore: snapshot version on ensureStatuses, drop late
  responses if invalidate() ran during the request.
- RemoteSettingStore.updateSettings: refetch + rebuild settingsByGroup
  so the local cache doesn't stay stale.
- ComfyUIStore.setBaseUrl: disconnect existing WS before swap; reset
  cooldown on disconnect.
- GlobalChatStore: version+migrate, guard against duplicate listener
  registration on HMR, useThreadsQuery merges instead of clobbering
  optimistic mutations, deferred loadMessages re-reads currentThreadId.
- AgentStore: token-guarded loadModels, stream listener cleaned up if
  state update throws.
- VibeCodingStore: identify the streaming assistant placeholder by role
  (not last index), add version+migrate.
- KeyPressedStore.clearAllKeys: single atomic update instead of N
  per-key updates that left modifiers stuck after blur/focus.
- mobile/ChatStore: cancellable safety timeout (no longer fires
  mid-stream of a later message).
- mobile/AuthStore.signOut: cleanup auth subscription + clear chat
  threads/messageCache so a new login doesn't see prior user state.
- mobile/WorkflowRunner.cleanup: actually unsubscribe from job_id.
- electron/WorkflowRunner.disconnect: removeAllListeners before close.
- NodeMenuStore: track metadata subscriptions in a module-level set with
  an exported teardown helper.
- RightPanelStore/BottomPanelStore/PanelStore: narrow partialize to
  user-driven fields only, version+migrate, validate activeView.
- ModelPreferencesStore, FavoriteWorkflowsStore: version+migrate.

Tests: 6199 web + 357 electron pass.