### PR TITLE
fix(flatpak): adapt build commands to npm workspaces layout

### DIFF
--- a/electron/ai.nodetool.NodeTool.flatpak.yml
+++ b/electron/ai.nodetool.NodeTool.flatpak.yml
@@ -126,24 +126,33 @@ modules:
         npm_config_unsafe_perm: 'true'
         ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     build-commands:
-      # Install dependencies and build web frontend
-      - cd web && npm ci && npm run build
-      
-      # Build electron application
-      - cd electron && npm ci
-      - cd electron && npm run download-micromamba
-      - cd electron && npm run vite:build
-      - cd electron && npx tsc
-      
+      # Install all workspace dependencies from the monorepo root.
+      # web/ and electron/ are npm workspaces and have no individual
+      # package-lock.json — running `npm ci` in those subdirectories fails
+      # with "ci command can only install with an existing package-lock.json".
+      - npm ci
+
+      # Build the backend packages that web and electron depend on
+      # (protocol, websocket, etc.) before bundling the frontend.
+      - npm run build:packages
+
+      # Build web frontend
+      - npm run build --workspace=web
+
+      # Build electron renderer + main/preload bundles via vite
+      - npm run vite:build --workspace=electron
+
       # Create application directory
       - mkdir -p /app/nodetool
-      
-      # Copy built application
+
+      # Copy built application. Use the hoisted root node_modules — with npm
+      # workspaces most runtime dependencies live there, not in
+      # electron/node_modules.
       - cp -r electron/dist-electron /app/nodetool/
       - cp -r web/dist /app/nodetool/dist-web
       - cp -r electron/assets /app/nodetool/
       - cp -r electron/resources /app/nodetool/
-      - cp -r electron/node_modules /app/nodetool/node_modules
+      - cp -rL node_modules /app/nodetool/node_modules
       - cp electron/package.json /app/nodetool/
       
       # Install wrapper script


### PR DESCRIPTION
The flatpak build had been failing on main since the monorepo migration
(3ad605a) because it ran `cd web && npm ci` and `cd electron && npm ci`
against directories that no longer have their own package-lock.json —
both are npm workspaces of the repository root.

Run `npm ci` from the root, build the backend packages first, and use
workspace-scoped scripts for the per-package builds. Drop the obsolete
`download-micromamba` step (no such script exists anymore) and copy the
hoisted root node_modules into the runtime tree, dereferencing the
workspace symlinks so internal packages resolve under /app/nodetool.

https://claude.ai/code/session_01LuGmKKpQMznWbLww3KP7FT