### PR TITLE
Rebrand NodeTool as open creative AI workspace

### DIFF
--- a/marketing/src/app/creatives/layout.tsx
+++ b/marketing/src/app/creatives/layout.tsx
@@ -1,29 +1,29 @@
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
-  title: "NodeTool for Creative Professionals | AI-Powered Creative Workflows",
+  title: "NodeTool for working creatives | The open creative AI workspace",
   description:
-    "Build powerful creative pipelines with drag-and-drop simplicity. Generate images, process video, create audio—all in one visual workspace. Perfect for video creators, graphic designers, music producers, and photographers.",
+    "The open creative AI workspace, made for working artists, motion designers, and AI-native illustrators. Every major model from every major provider, called with your own keys, on one node-based canvas with masks, inpaint, outpaint, relight, upscale, and compositing built in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/creatives",
   },
   keywords: [
-    "AI for creatives",
-    "creative workflow automation",
-    "AI image generation",
-    "video processing",
-    "audio generation",
-    "visual workflow builder",
-    "creative professionals",
-    "AI tools for designers",
-    "AI video editing",
-    "AI music production",
+    "creative AI workspace",
+    "BYOK creative AI",
+    "ComfyUI alternative for creatives",
+    "Weavy alternative",
+    "AI canvas for artists",
+    "Flux workflow",
+    "Seedance workflow",
+    "ElevenLabs workflow",
+    "AI tools for motion designers",
+    "AI tools for illustrators",
   ],
   openGraph: {
-    title: "NodeTool for Creative Professionals | AI-Powered Creative Workflows",
+    title: "NodeTool for working creatives | The open creative AI workspace",
     description:
-      "Build powerful creative pipelines with drag-and-drop simplicity. Generate images, process video, create audio—all in one visual workspace.",
+      "Every model. Your keys. Your canvas. The open-source creative AI workspace for working artists, motion designers, and illustrators.",
     url: "https://nodetool.ai/creatives",
     siteName: "NodeTool",
     images: [
@@ -37,9 +37,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "NodeTool for Creative Professionals",
+    title: "NodeTool for working creatives",
     description:
-      "Build powerful creative pipelines with drag-and-drop simplicity. Generate images, process video, create audio—all in one visual workspace.",
+      "Every model. Your keys. Your canvas. The open creative AI workspace.",
     images: ["/preview.png"],
   },
 };

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -141,7 +141,7 @@ const creativeFeatures = [
   {
     title: "Audio Integration",
     description:
-      "Compose music with Suno, generate voice with ElevenLabs, and integrate audio seamlessly into workflows.",
+      "Compose music with Suno, generate voice with ElevenLabs, and wire audio straight into your canvas.",
     icon: Music,
     image: "/suno.png",
     features: ["Stem separation", "Music generation", "Voice generation"],
@@ -160,7 +160,7 @@ const workflowExamples = [
   {
     title: "Video Thumbnail Pipeline",
     description:
-      "Automatically create eye-catching thumbnails for your videos using AI-powered image generation.",
+      "Generate eye-catching thumbnails for your videos with one image-model node and a few editing nodes.",
     tags: ["Video", "Thumbnails", "YouTube"],
     gradient: "from-teal-500/20 to-purple-500/20",
   },
@@ -902,14 +902,14 @@ export default function CreativesPage() {
               viewport={{ once: true }}
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Ready to Transform Your <br />
+                Every model. Your keys. <br />
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-400 to-cyan-400">
-                  Creative Workflow?
+                  Your canvas.
                 </span>
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-                Download NodeTool for free and start building AI-powered
-                creative pipelines today.
+                Download NodeTool, plug in the providers you already pay for,
+                and start wiring your next piece on a canvas you actually own.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool/releases"

--- a/marketing/src/app/developers/layout.tsx
+++ b/marketing/src/app/developers/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata, Viewport } from "next";
 export const metadata: Metadata = {
   title: "NodeTool for Developers | Open-Source AI Workflow SDK & API",
   description:
-    "Build AI-powered applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production. Open-source, extensible, and developer-friendly.",
+    "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production. Open-source, extensible, and developer-friendly.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/developers",
@@ -21,12 +21,12 @@ export const metadata: Metadata = {
     "AI automation API",
     "self-hosted AI platform",
     "developer AI tools",
-    "AI orchestration framework",
+    "model-agnostic SDK",
   ],
   openGraph: {
     title: "NodeTool for Developers | Open-Source AI Workflow SDK & API",
     description:
-      "Build AI-powered applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production.",
+      "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production.",
     url: "https://nodetool.ai/developers",
     siteName: "NodeTool",
     images: [
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool for Developers",
     description:
-      "Build AI-powered applications with NodeTool's TypeScript SDK and REST API. Open-source and extensible.",
+      "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Open-source and extensible.",
     images: ["/preview.png"],
   },
 };

--- a/marketing/src/app/features.tsx
+++ b/marketing/src/app/features.tsx
@@ -74,9 +74,9 @@ export const features = [
     height: 400,
   },
   {
-    name: "🤖 AI Agent Orchestration",
+    name: "🤖 Agent Nodes",
     description:
-      "Build intelligent agents that coordinate multiple AI models. Chain reasoning, planning, and execution across complex multi-step workflows.",
+      "Drop in a planning agent that calls models and tools to finish a multi-step task. Used as a node, not a separate framework.",
     icon: PuzzlePieceIcon,
     href: "#",
     gif: "/agents.png",

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -16,26 +16,26 @@ const jetBrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "NodeTool: Node-Based Visual Builder for AI Workflows and LLM Agents",
+  title: "NodeTool — The open creative AI workspace",
   description:
-    "NodeTool is an open-source visual programming tool for building AI workflows. Run locally on macOS, Windows, or Linux. Connect LLMs, create RAG systems, build AI agents, and process multimodal content through a drag-and-drop node interface. Alternative to ComfyUI for general AI and n8n for AI-specific automation.",
+    "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas you run on your machine or in the browser. Pay providers directly. No credits, no markup, no vendor lock-in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
   },
   keywords: [
-    "AI workflow builder",
-    "node-based AI tool",
-    "visual programming AI",
-    "LLM agent builder",
-    "local AI development",
-    "RAG pipeline tool",
-    "multimodal AI",
+    "creative AI workspace",
+    "open source creative AI",
+    "BYOK AI canvas",
+    "AI workflow canvas",
     "ComfyUI alternative",
-    "n8n for AI",
-    "open source AI tool",
-    "local-first AI",
-    "AI orchestration",
+    "Weavy alternative",
+    "vendor-neutral AI tool",
+    "node-based AI canvas",
+    "Flux workflow",
+    "Seedance workflow",
+    "image video audio AI",
+    "model-agnostic AI",
   ],
   icons: {
     icon: [
@@ -47,15 +47,15 @@ export const metadata: Metadata = {
     other: [{ rel: "manifest", url: "/site.webmanifest" }],
   },
   openGraph: {
-    title: "NodeTool: Visual Builder for AI Workflows and LLM Agents",
+    title: "NodeTool — The open creative AI workspace",
     description:
-      "Open-source node-based tool for building AI workflows. Runs locally on macOS, Windows, Linux. Create LLM agents, RAG systems, and multimodal pipelines with drag-and-drop nodes.",
+      "Every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text on one surface. Open source. BYOK. Provider prices.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
       {
         url: "/preview.png",
-        alt: "NodeTool - Visual AI Workflow Builder",
+        alt: "NodeTool — the open creative AI workspace",
       },
     ],
     locale: "en_US",
@@ -63,9 +63,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "NodeTool: Visual AI Workflow Builder",
+    title: "NodeTool — The open creative AI workspace",
     description:
-      "Open-source node-based tool for AI development. Build LLM agents, RAG systems, and multimodal workflows locally on your machine.",
+      "Every model. Your keys. Your canvas. The open-source creative AI workspace, with BYOK to every major provider and provider-price billing.",
     images: ["/preview.png"],
   },
 };
@@ -92,9 +92,9 @@ export default function RootLayout({
               "@context": "https://schema.org",
               "@type": "SoftwareApplication",
               "name": "NodeTool",
-              "description": "NodeTool is a node-based visual programming tool for building AI workflows and applications. It allows developers to create LLM agents, RAG systems, and multimodal content pipelines by connecting nodes in a drag-and-drop interface. Runs locally on user's machine with support for cloud APIs.",
-              "applicationCategory": "DeveloperApplication",
-              "applicationSubCategory": "AI Development Tool",
+              "description": "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text on one surface, with masks, inpaint, outpaint, relight, upscale, and compositing built in. Runs as a desktop app on macOS, Windows, and Linux, or in the browser via NodeTool Cloud.",
+              "applicationCategory": "MultimediaApplication",
+              "applicationSubCategory": "Creative AI Workspace",
               "operatingSystem": "macOS, Windows, Linux",
               "offers": {
                 "@type": "Offer",
@@ -111,18 +111,16 @@ export default function RootLayout({
               },
               "screenshot": "https://nodetool.ai/preview.png",
               "featureList": [
-                "Node-based visual interface for AI workflow orchestration",
-                "Local execution engine running on macOS, Windows, and Linux",
-                "Support for local LLMs via Ollama, MLX, and GGML/GGUF formats",
-                "Integration with OpenAI, Anthropic, Replicate, and Hugging Face APIs",
-                "Multimodal processing: text, images, video, and audio",
-                "RAG (Retrieval-Augmented Generation) pipeline builder",
-                "Vector database integration for semantic search",
-                "AI agent framework with tool use and web browsing",
-                "Type-safe node connections",
-                "Real-time workflow execution with live output preview",
-                "Async Node.js runner extensible with custom nodes in TypeScript or Python",
-                "Open source, TypeScript end-to-end (frontend and backend)"
+                "Node-based creative canvas for image, video, audio, and text",
+                "BYOK to every major provider: FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, HuggingFace",
+                "Pay providers directly at provider prices, no credits, no markup",
+                "Editing tools built in: masks, inpaint, outpaint, relight, upscale, layers, compositing",
+                "Frontier models named by their real names: Flux, Seedance, Wan, Veo, Kling, Hailuo, Whisper, ElevenLabs, Suno",
+                "Local inference via MLX, Ollama, llama.cpp, vLLM, and LM Studio",
+                "Two editions on one open-source codebase: Studio (desktop) and Cloud (browser)",
+                "Streaming execution with live output as nodes finish",
+                "Workflows, files, and keys belong to you — runs on your machine or browser",
+                "AGPL-3.0 open source, self-host any time"
               ],
               "softwareRequirements": "Node.js 22+ (Python 3.11+ optional, for Python nodes)",
               "installUrl": "https://github.com/nodetool-ai/nodetool",
@@ -148,7 +146,7 @@ export default function RootLayout({
                 "https://github.com/nodetool-ai/nodetool",
                 "https://discord.gg/WmQTWZRcYE"
               ],
-              "description": "NodeTool is an open-source visual programming tool for AI development. It provides a node-based interface for building LLM agents, RAG systems, and multimodal AI workflows that run locally on user machines."
+              "description": "NodeTool builds the open creative AI workspace: a node-based canvas that connects every major model from every major provider with the user's own keys, available as a desktop app and as a browser-based managed edition."
             })
           }}
         />
@@ -166,7 +164,7 @@ export default function RootLayout({
                   "name": "What is NodeTool?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool is a node-based visual programming tool for building AI workflows and applications. It runs locally on macOS, Windows, and Linux, allowing developers to create LLM agents, RAG systems, and multimodal content pipelines by connecting nodes in a drag-and-drop interface."
+                    "text": "NodeTool is the open-source creative AI workspace. Every major model from every major provider — FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more — is called with your own keys and wired into one node-based canvas. Image, video, audio, and text live on the same surface, with editing tools like masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. Runs as a desktop app on macOS, Windows, and Linux, or in the browser via NodeTool Cloud."
                   }
                 },
                 {
@@ -174,39 +172,39 @@ export default function RootLayout({
                   "name": "How is NodeTool different from ComfyUI?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "ComfyUI focuses on image generation workflows with Stable Diffusion. NodeTool extends this node-based concept to general AI workflows including LLM agents, text processing, RAG systems, audio, and video generation."
+                    "text": "ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — every modality on one canvas, with the editing tools creatives actually use. NodeTool also supports a much wider model roster across providers and modalities, called with your own keys at provider prices."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "How is NodeTool different from n8n?",
+                  "name": "How is NodeTool different from Weavy or other closed SaaS canvases?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "n8n is a general workflow automation tool for business processes and API integrations. NodeTool is specialized for AI workloads with native support for model management, local LLMs, multimodal AI operations, and RAG pipelines."
+                    "text": "Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK. You bring your own API keys to every provider, pay providers directly at provider prices, and own your workflows and files. Cloud is just our managed hosting of the same open-source code you can run yourself."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "Does NodeTool require cloud services?",
+                  "name": "How does pricing work?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "No. NodeTool runs entirely on your local machine and can work with local LLMs via Ollama, MLX, or GGML/GGUF formats. Cloud APIs (OpenAI, Anthropic, etc.) are optional and can be used when needed."
+                    "text": "NodeTool Studio is free to download and use. NodeTool Cloud is a subscription for managed hosting. In both editions, you bring your own API keys to every provider and pay those providers directly at their list prices. NodeTool does not run model inference for you on its own servers, does not issue proprietary credits, and does not mark up model calls."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "What AI models does NodeTool support?",
+                  "name": "What models does NodeTool support?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool supports local LLMs via Ollama, MLX (Apple Silicon), and GGML/GGUF formats. It also integrates with cloud APIs including OpenAI, Anthropic Claude, Replicate, Hugging Face, and custom API endpoints."
+                    "text": "Frontier models including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Local inference is supported via MLX, Ollama, llama.cpp, vLLM, and LM Studio."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "Who should use NodeTool?",
+                  "name": "Who is NodeTool for?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool is for AI developers building LLM applications, creative professionals working with generative AI, data engineers creating RAG pipelines, researchers prototyping multimodal AI systems, and teams requiring local-first AI for privacy or compliance."
+                    "text": "Independent generative artists, motion designers, AI-native illustrators, technical art directors, ComfyUI power users frustrated with the UX, and small creative studios, brand teams, and post-production shops working with AI every day."
                   }
                 },
                 {
@@ -214,7 +212,7 @@ export default function RootLayout({
                   "name": "Is NodeTool open source?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. NodeTool is open source and TypeScript end-to-end. Workflows run in an async Node.js runner, and you can extend it with custom nodes written in TypeScript or Python. The source code is available on GitHub."
+                    "text": "Yes. Both Studio and Cloud share the same AGPL-3.0 codebase. There is no closed-source layer and no \"pro tier\" hiding the good features. You can self-host any time."
                   }
                 }
               ]

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -42,30 +42,30 @@ export default function BuildRunDeploy() {
       <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
-          title="Build Visually"
+          title="Wire your canvas"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="Drag, connect, and configure nodes to create powerful AI workflows. Every connection is type-safe."
+          description="Drag in models, edits, and assets. Connect them. Every model from every provider lives on the same canvas."
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Run Everything"
+          title="Render with your keys"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
-          description="Run LLM calls, image generation, data transforms, and more — locally. See results in real time."
+          description="Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate. Pay providers directly. Watch results stream in."
         >
           <RunVisual />
         </Card>
 
         <Card
           step="03"
-          title="Deploy Anywhere"
+          title="Ship the workflow"
           icon={<Globe className="h-6 w-6" />}
           accent="amber"
-          description="Export workflows to Docker, RunPod, Google Cloud Run, or your own servers."
+          description="Save it as a template, hand it to a teammate, or expose it as an API. Move between Studio on your machine and Cloud in the browser."
         >
           <DeployVisual />
         </Card>

--- a/marketing/src/components/CommunitySection.tsx
+++ b/marketing/src/components/CommunitySection.tsx
@@ -27,10 +27,10 @@ export default function CommunitySection({ stars }: { stars?: number | null }) {
               id="community-title"
               className="text-3xl md:text-4xl font-bold text-white mb-6"
             >
-              Build with the <span className="text-blue-400">community</span>
+              Made with <span className="text-blue-400">working creatives</span>
             </h2>
             <p className="text-lg text-slate-300 mb-10 leading-relaxed">
-              NodeTool is open-source under AGPL-3.0. Join the Discord, explore the GitHub repo, and share workflows with other builders.
+              NodeTool is AGPL-3.0 open source. Star the repo, jump into Discord, and trade workflows with other artists, motion designers, and studios using it for real work.
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -30,7 +30,7 @@ export default function ComparisonSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            How NodeTool differs
+            What NodeTool is, said honestly
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
@@ -39,26 +39,26 @@ export default function ComparisonSection({
             transition={{ duration: 0.5, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
-            We borrow ideas from a few categories of tools and specialize them for AI work.
+            Where we sit next to the tools you&apos;re already using.
           </motion.p>
         </header>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
             competitor="ComfyUI"
-            sentence="ComfyUI focuses on Stable Diffusion image generation. NodeTool covers the rest of the AI stack: LLMs, RAG, audio, and video."
+            sentence="ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with masks, inpaint, outpaint, relight, upscale, and compositing built in."
             reducedMotion={reducedMotion}
             delay={0}
           />
           <ComparisonCard
-            competitor="n8n"
-            sentence="n8n automates business processes and APIs. NodeTool is built for AI work, with model management and local LLMs included."
+            competitor="Weavy / closed canvases"
+            sentence="Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK — every provider, your keys, provider prices."
             reducedMotion={reducedMotion}
             delay={0.05}
           />
           <ComparisonCard
-            competitor="LangChain"
-            sentence="LangChain is a Python framework for LLM apps. NodeTool is a visual, TypeScript-first platform with an async Node.js runtime and custom nodes in TypeScript or Python."
+            competitor="A dozen browser tabs"
+            sentence="Midjourney, Runway, Photoshop, ElevenLabs, Suno — each in its own tab, none of them talking to each other. NodeTool wires them into one canvas you can run, share, and re-run."
             reducedMotion={reducedMotion}
             delay={0.1}
           />
@@ -99,16 +99,18 @@ export default function ComparisonSection({
                 Where NodeTool fits
               </div>
               <h3 className="text-2xl md:text-3xl font-semibold text-white mb-5 tracking-tight">
-                Prompt your workflows. Watch them render.
+                Every model. Your keys. Your canvas.
               </h3>
               <p className="text-slate-300 leading-relaxed mb-4 text-[1.025rem]">
-                Agents are first-class, not bolted on. Describe what you want and your
-                coding agent builds the graph. Run it autonomously, or as a fixed API.
+                Seedance is the best video model right now. It&apos;s available
+                on FAL, Replicate, and KIE at different price points. NodeTool
+                lets you pick the cheapest. When Veo 4 ships, you swap one node
+                and you&apos;re on it the same day.
               </p>
               <p className="text-slate-400 leading-relaxed text-[1.025rem]">
-                Image, video, audio, and text all live on one canvas. Results stream in
-                as nodes finish. Extend with custom nodes in TypeScript or Python. Local
-                by default.
+                That&apos;s what vendor neutrality actually buys you. No credit
+                markup, no curated roster, no roadmap risk if your favourite
+                tool gets acquired.
               </p>
             </div>
           </div>

--- a/marketing/src/components/EditionsCompareSection.tsx
+++ b/marketing/src/components/EditionsCompareSection.tsx
@@ -192,7 +192,7 @@ export default function EditionsCompareSection({
             transition={{ duration: 0.5, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
-            Same workflows, same nodes, same agent system. Pick the runtime that
+            Same workflows, same nodes, same providers. Pick the runtime that
             fits how you want to work — and switch any time. Both editions are
             AGPL-3.0 open source; Cloud is just our managed hosting of the same
             code you can run yourself.
@@ -205,9 +205,10 @@ export default function EditionsCompareSection({
             <EditionHeader kind="studio" highlighted={highlight === "studio"} />
             <div className="p-5 space-y-4">
               <p className="text-sm text-slate-300 leading-relaxed">
-                <strong className="text-white">Best for:</strong> privacy-first
-                builders, offline work, large local model collections, and
-                anyone with a capable GPU or Apple Silicon.
+                <strong className="text-white">Best for:</strong> artists with
+                a capable GPU or Apple Silicon, large local model collections,
+                offline work, and anyone who wants every byte on their own
+                disk.
               </p>
               <ul className="space-y-2.5">
                 {rows.map((r) => (
@@ -227,9 +228,10 @@ export default function EditionsCompareSection({
             <EditionHeader kind="cloud" highlighted={highlight === "cloud"} />
             <div className="p-5 space-y-4">
               <p className="text-sm text-slate-300 leading-relaxed">
-                <strong className="text-white">Best for:</strong> teams that
-                want to start in seconds, work from any device, and skip GPU
-                setup — while still using their own API keys for every provider.
+                <strong className="text-white">Best for:</strong> studios and
+                solo artists who want to start in seconds, work from any
+                device, and skip the GPU setup — while still bringing their
+                own keys to every provider.
               </p>
               <ul className="space-y-2.5">
                 {rows.map((r) => (

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -46,9 +46,9 @@ export default function FeaturesSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Why choose <br />
+            One canvas <br />
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-indigo-400">
-              NodeTool
+              for the whole craft
             </span>
           </motion.h2>
 
@@ -59,8 +59,9 @@ export default function FeaturesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            See your entire workflow on one canvas. Streaming execution shows
-            progress as it happens—no black-box mystery.
+            Image, video, audio, and text on a single node-based canvas — with
+            the editing tools you rely on: masks, inpaint, outpaint, relight,
+            upscale, layers, compositing.
           </motion.p>
         </div>
 
@@ -111,36 +112,36 @@ export default function FeaturesSection({
         >
           {[
             {
-              title: "Visual & Accessible",
+              title: "Editing tools, not just generation",
               description:
-                "Build AI workflows without coding. Drag-and-drop makes complex AI pipelines approachable for everyone.",
+                "Masks, inpaint, outpaint, relight, upscale, layers, compositing. The post tools you reach for, wired into the same canvas as the model calls.",
               icon: MousePointer2,
               color: "text-blue-400",
               bg: "bg-blue-500/10",
               border: "border-blue-500/20",
             },
             {
-              title: "Transparent & Debuggable",
+              title: "Watch every node render",
               description:
-                "See every step in real-time. Inspect outputs, understand what's happening, debug with confidence.",
+                "Outputs stream in as nodes finish. Inspect any frame, swap a model, re-run from that node down.",
               icon: Activity,
               color: "text-purple-400",
               bg: "bg-purple-500/10",
               border: "border-purple-500/20",
             },
             {
-              title: "Privacy-First",
+              title: "Your keys, provider prices",
               description:
-                "Run LLMs, Whisper, and diffusion models on your infrastructure. Opt into cloud only when you choose.",
+                "BYOK for FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and the rest. No credits, no markup, no curated roster.",
               icon: Database,
               color: "text-emerald-400",
               bg: "bg-emerald-500/10",
               border: "border-emerald-500/20",
             },
             {
-              title: "Multimodal",
+              title: "Image, video, audio, text",
               description:
-                "Process text, image, audio, and video in a single workflow. Built-in SQLite-vec store for RAG.",
+                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, Suno — every modality on one canvas, named by their real names.",
               icon: Layers,
               color: "text-orange-400",
               bg: "bg-orange-500/10",

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -92,9 +92,9 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.5 }}
                         className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
                     >
-                        Run Any Model,{" "}
+                        Every model.{" "}
                         <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 via-teal-400 to-blue-400">
-                            Anywhere
+                            Your keys.
                         </span>
                     </motion.h2>
 
@@ -105,7 +105,9 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.5, delay: 0.1 }}
                         className="text-lg text-slate-400 leading-relaxed"
                     >
-                        Access frontier models from leading cloud providers or run models locally with complete privacy.
+                        Frontier models from every major provider, called with
+                        the keys you already pay for. Switch the moment a better
+                        model ships. Run inference locally when you want to.
                     </motion.p>
                 </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Download, Play, Code2, ShieldCheck, Monitor } from "lucide-react";
+import { Download, Play, Code2, KeyRound, Layers } from "lucide-react";
 import { SmartDownloadButton } from "../app/SmartDownloadButton";
 
 export default function NodeToolHero() {
@@ -25,24 +25,24 @@ export default function NodeToolHero() {
             <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
             Open Source
             <span className="text-blue-500/60">•</span>
-            Local First
+            BYOK
           </span>
 
           <h1
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            Build AI Workflows.
+            The open creative
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              Run Them Locally.
+              AI workspace.
             </span>
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-400 md:text-lg">
-            Nodetool is a local-first AI workflow and agent builder. Connect
-            models and tools with visual nodes, run multimodal pipelines, and
-            deploy anywhere.
+            Every major model from every major provider, called with your own
+            keys, wired into one node-based canvas. Pay providers directly at
+            provider prices. Switch the moment a better model ships.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -55,24 +55,24 @@ export default function NodeToolHero() {
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-700 bg-slate-900/60 px-6 py-3.5 text-sm font-semibold text-slate-100 transition-all hover:border-slate-500 hover:bg-slate-800/60"
             >
               <Play className="h-4 w-4" />
-              See How It Works
+              See it in action
             </a>
           </div>
 
           <ul className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-medium text-slate-400">
             <li className="flex items-center gap-1.5">
+              <Layers className="h-3.5 w-3.5 text-fuchsia-400" />
+              Every model. Your keys. Your canvas.
+            </li>
+            <li className="text-slate-700">•</li>
+            <li className="flex items-center gap-1.5">
+              <KeyRound className="h-3.5 w-3.5 text-emerald-400" />
+              Pay providers directly
+            </li>
+            <li className="text-slate-700">•</li>
+            <li className="flex items-center gap-1.5">
               <Code2 className="h-3.5 w-3.5 text-blue-400" />
-              Open Source
-            </li>
-            <li className="text-slate-700">•</li>
-            <li className="flex items-center gap-1.5">
-              <ShieldCheck className="h-3.5 w-3.5 text-emerald-400" />
-              Privacy-First
-            </li>
-            <li className="text-slate-700">•</li>
-            <li className="flex items-center gap-1.5">
-              <Monitor className="h-3.5 w-3.5 text-slate-300" />
-              macOS · Windows · Linux
+              Open source, runs anywhere
             </li>
           </ul>
         </motion.div>
@@ -95,7 +95,7 @@ export default function NodeToolHero() {
           <div className="rounded-2xl border border-slate-700/60 bg-slate-900/80 p-1.5 shadow-2xl shadow-black/60 ring-1 ring-white/5 backdrop-blur">
             <img
               src="/screen_canvas.png"
-              alt="Nodetool workflow editor"
+              alt="NodeTool canvas: nodes for image, video, and text models wired together"
               className="block w-full rounded-xl"
               loading="eager"
             />

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -6,24 +6,24 @@ import { Shield, Cpu, Globe, Lock } from "lucide-react";
 
 const features = [
   {
-    title: "Local-First",
-    body: "All workflows, assets, and models can run on your machine for maximum privacy and control. Work offline once models are downloaded.",
-    icon: Cpu,
+    title: "BYOK, every provider",
+    body: "Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Keys stay on your disk in Studio, encrypted in Cloud. We never mark up model calls.",
+    icon: Lock,
   },
   {
-    title: "Always Open Source",
-    body: "Both editions — Studio (desktop) and Cloud (hosted) — share the same AGPL-3.0 codebase. No closed-source layer, no proprietary cloud-only features. Self-host any time.",
-    icon: Globe,
-  },
-  {
-    title: "Privacy by Design",
-    body: "Your data stays yours—process locally or use your API keys. No collection, no telemetry, opt-in cloud only.",
+    title: "Provider prices, no credits",
+    body: "No proprietary tokens. No minimum top-up. You pay providers what they charge. The same Seedance call that costs $0.18 on KIE costs $0.18 in NodeTool.",
     icon: Shield,
   },
   {
-    title: "BYOK Everywhere",
-    body: "Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more — in Studio (stored on disk) or Cloud (encrypted). You pay providers directly; we never mark up tokens.",
-    icon: Lock,
+    title: "Open source, always",
+    body: "Both editions — Studio (desktop) and Cloud (hosted) — share the same AGPL-3.0 codebase. No closed-source layer, no “pro tier” hiding the good features. Self-host any time.",
+    icon: Globe,
+  },
+  {
+    title: "Local inference when you want it",
+    body: "MLX, Ollama, llama.cpp, vLLM, LM Studio — fully supported. Runs offline once models are downloaded. Local is a feature, not a religion.",
+    icon: Cpu,
   },
 ];
 
@@ -47,8 +47,8 @@ export default function OwnershipSection({
             transition={{ duration: 0.5 }}
             className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Local-first or <br />
-            <span className="text-slate-300">cloud-augmented.</span>
+            Your keys. Your files. <br />
+            <span className="text-slate-300">Your roadmap.</span>
           </motion.h2>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
@@ -57,7 +57,10 @@ export default function OwnershipSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Your tools, your data—always under your control. Run everything locally for maximum privacy, or mix in cloud services for flexibility.
+            Creative tools shouldn&apos;t lock you into someone else&apos;s
+            pricing, model roster, or roadmap. NodeTool calls whatever models
+            you choose, charges you what the providers charge, and outlives
+            whoever built it.
           </motion.p>
         </div>
 

--- a/marketing/src/components/SeoHeroContent.tsx
+++ b/marketing/src/components/SeoHeroContent.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 /**
  * Server-rendered SEO content that appears above the fold.
- * This component is rendered on the server for search engine visibility.
- * It provides keyword-rich, semantic content optimized for LLM extraction and citations.
+ * Optimized for LLM extraction and citations on the canonical brand
+ * positioning: the open creative AI workspace.
  */
 export default function SeoHeroContent() {
   return (
@@ -11,12 +11,14 @@ export default function SeoHeroContent() {
       {/* Canonical Definition */}
       <section aria-labelledby="definition">
         <h1 id="definition" className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6">
-          NodeTool: Visual AI Workflow Builder for Local and Cloud AI Development
+          NodeTool: The Open Creative AI Workspace
         </h1>
         <p className="text-lg text-slate-300 mb-8 leading-relaxed">
-          NodeTool is a node-based visual programming tool for building AI workflows and applications. 
-          It runs locally on macOS, Windows, and Linux, allowing developers to create LLM agents, RAG systems, 
-          and multimodal content pipelines by connecting nodes in a drag-and-drop interface.
+          NodeTool is the open-source creative AI workspace — every major model
+          from every major provider, called with your own keys, wired into one
+          node-based canvas you run on your machine. Bring your own keys to FAL,
+          KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Pay providers
+          directly at provider prices. Switch the moment a better model ships.
         </p>
       </section>
 
@@ -26,10 +28,12 @@ export default function SeoHeroContent() {
           What Problem Does NodeTool Solve?
         </h2>
         <p className="text-slate-300 leading-relaxed">
-          Building AI workflows typically requires writing code to orchestrate multiple models, APIs, and data sources. 
-          NodeTool eliminates this friction by providing a visual canvas where developers can connect AI components 
-          without managing boilerplate code. It solves the data privacy concern of cloud-only solutions by running 
-          entirely on your local machine while still supporting cloud APIs when needed.
+          Creative pros working with AI are stuck choosing between ComfyUI&apos;s
+          engineer-first UX, closed SaaS canvases that lock you into a credit
+          system and a curated model roster, or a dozen browser tabs across
+          Midjourney, Runway, and Photoshop. NodeTool is the open alternative:
+          one canvas, every provider, your keys, no credit markup, no vendor
+          lock-in.
         </p>
       </section>
 
@@ -39,30 +43,26 @@ export default function SeoHeroContent() {
           Who Is NodeTool For?
         </h2>
         <ul className="space-y-2 text-slate-300">
-          <li>• AI developers building LLM applications and agents</li>
-          <li>• Creative professionals working with generative AI (images, video, audio)</li>
-          <li>• Data engineers creating RAG pipelines and vector database workflows</li>
-          <li>• Researchers prototyping multimodal AI systems</li>
-          <li>• Teams requiring local-first AI for privacy or compliance</li>
+          <li>• Independent generative artists and AI-native illustrators</li>
+          <li>• Motion designers and technical art directors</li>
+          <li>• ComfyUI power users who want better UX without losing control</li>
+          <li>• Weavy users looking for somewhere to go after the Figma acquisition</li>
+          <li>• Small studios, brand teams, and post-production shops working with AI every day</li>
         </ul>
       </section>
 
-      {/* How It Works */}
-      <section aria-labelledby="how-it-works" className="text-left max-w-2xl mx-auto mb-8">
-        <h2 id="how-it-works" className="text-xl font-semibold text-white mb-3">
-          How NodeTool Works
+      {/* The Proof Story */}
+      <section aria-labelledby="proof" className="text-left max-w-2xl mx-auto mb-8">
+        <h2 id="proof" className="text-xl font-semibold text-white mb-3">
+          What Vendor Neutrality Actually Buys You
         </h2>
-        <p className="text-slate-300 leading-relaxed mb-3">
-          NodeTool uses a node-based visual interface where each node represents an AI operation (LLM call, image generation, 
-          data transformation, etc.). Users connect nodes by dragging edges between them. The tool handles:
+        <p className="text-slate-300 leading-relaxed">
+          Seedance is the best video model right now. It&apos;s available on
+          FAL, Replicate, and KIE at different price points. NodeTool lets you
+          pick the cheapest. When Veo 4 ships, you swap one node and you&apos;re
+          on it the same day. The best model for the job changes every month —
+          your tool shouldn&apos;t slow that down.
         </p>
-        <ul className="space-y-2 text-slate-300">
-          <li>• Type-safe connections between nodes (preventing incompatible data flows)</li>
-          <li>• Local execution engine (async Node.js runner; custom nodes in TypeScript or Python)</li>
-          <li>• Real-time workflow execution with live preview of outputs</li>
-          <li>• Model management for local LLMs (MLX, GGML/GGUF formats)</li>
-          <li>• Integration with cloud APIs (OpenAI, Anthropic, Replicate, etc.)</li>
-        </ul>
       </section>
 
       {/* Key Differences */}
@@ -72,33 +72,37 @@ export default function SeoHeroContent() {
         </h2>
         <div className="space-y-3 text-slate-300">
           <div>
-            <strong className="text-white">vs ComfyUI:</strong> ComfyUI focuses on image generation workflows (Stable Diffusion). 
-            NodeTool extends this concept to general AI workflows including LLM agents, text processing, RAG, audio, and video.
+            <strong className="text-white">vs ComfyUI:</strong> ComfyUI is a
+            Stable Diffusion power tool with engineer-first UX. NodeTool is a
+            full creative workspace — image, video, audio, and text on one
+            canvas — with the editing tools you rely on: masks, inpaint,
+            outpaint, relight, upscale, layers, compositing.
           </div>
           <div>
-            <strong className="text-white">vs n8n:</strong> n8n is a general workflow automation tool. NodeTool is specialized 
-            for AI workloads with native support for model management, local LLMs, and multimodal AI operations.
+            <strong className="text-white">vs Weavy / closed SaaS canvases:</strong>{" "}
+            Closed canvases lock you into a credit system and a curated model
+            roster. NodeTool is open source and BYOK. You pay providers
+            directly. Your workflows, files, and keys belong to you.
           </div>
           <div>
-            <strong className="text-white">vs LangChain:</strong> LangChain is a code-first Python framework. NodeTool provides
-            a visual interface and runs workflows locally in an async Node.js runner. No coding required to build workflows,
-            and you can extend it with custom nodes in TypeScript or Python.
+            <strong className="text-white">vs Midjourney + Runway + Photoshop tabs:</strong>{" "}
+            Stop juggling tabs and exporting between tools. Wire every model and
+            every editor into one node-based canvas, then run it on your machine
+            or in the browser via NodeTool Cloud.
           </div>
         </div>
       </section>
 
-      {/* Key Capabilities */}
-      <section aria-labelledby="capabilities" className="text-left max-w-2xl mx-auto mb-8">
-        <h2 id="capabilities" className="text-xl font-semibold text-white mb-3">
-          Core Capabilities
+      {/* What it is not */}
+      <section aria-labelledby="not" className="text-left max-w-2xl mx-auto mb-8">
+        <h2 id="not" className="text-xl font-semibold text-white mb-3">
+          What NodeTool Is Not
         </h2>
         <ul className="space-y-2 text-slate-300">
-          <li>• <strong>Local-First Architecture:</strong> Runs on macOS, Windows, Linux without internet dependency</li>
-          <li>• <strong>Multi-Provider Support:</strong> OpenAI, Anthropic, Ollama, Replicate, Hugging Face, and custom models</li>
-          <li>• <strong>Multimodal Processing:</strong> Text, images, video, and audio in unified workflows</li>
-          <li>• <strong>RAG & Vector Databases:</strong> Built-in support for document indexing and semantic search</li>
-          <li>• <strong>AI Agent Framework:</strong> Build autonomous agents with tool use and web browsing</li>
-          <li>• <strong>Open Source:</strong> TypeScript end-to-end with an async Node.js runner; custom nodes in TypeScript or Python</li>
+          <li>• Not a model host. We don&apos;t run inference on our servers and resell it.</li>
+          <li>• Not a credit system. No proprietary tokens, no minimum top-up, no markup on model calls.</li>
+          <li>• Not a closed platform. Open source, runnable anywhere, no &quot;pro tier&quot; hiding the good features.</li>
+          <li>• Not local-only. Local inference is supported. It&apos;s not required.</li>
         </ul>
       </section>
 
@@ -106,10 +110,10 @@ export default function SeoHeroContent() {
       <section aria-labelledby="facts" className="mt-10 text-slate-400 border-t border-slate-800/50 pt-6">
         <h2 id="facts" className="sr-only">Quick Facts</h2>
         <dl className="space-y-2 text-sm">
-          <div><dt className="inline font-semibold">License:</dt> <dd className="inline">Open Source</dd></div>
-          <div><dt className="inline font-semibold">Platforms:</dt> <dd className="inline">macOS, Windows, Linux</dd></div>
-          <div><dt className="inline font-semibold">Architecture:</dt> <dd className="inline">Local-first with optional cloud APIs</dd></div>
-          <div><dt className="inline font-semibold">Category:</dt> <dd className="inline">AI Development Tool, Visual Programming</dd></div>
+          <div><dt className="inline font-semibold">License:</dt> <dd className="inline">Open Source (AGPL-3.0)</dd></div>
+          <div><dt className="inline font-semibold">Platforms:</dt> <dd className="inline">macOS, Windows, Linux desktop, plus NodeTool Cloud in the browser</dd></div>
+          <div><dt className="inline font-semibold">Pricing model:</dt> <dd className="inline">BYOK — pay providers directly at provider prices, no credits, no markup</dd></div>
+          <div><dt className="inline font-semibold">Category:</dt> <dd className="inline">The open creative AI workspace</dd></div>
         </dl>
       </section>
     </div>

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -23,7 +23,7 @@ export default function AgentBuildRunDeploy() {
             <div className="relative mx-auto max-w-6xl w-full z-10">
                 <div className="mb-12 text-center max-w-2xl mx-auto">
                     <h2 className="text-4xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white via-slate-200 to-slate-400 mb-4 tracking-tight">
-                        The Agentic Stack
+                        Plan. Act. Self-correct.
                     </h2>
                     <p className="text-slate-400 text-lg">
                         Design autonomous systems that plan, act, and self-correct. Then deploy them as reliable workers.

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -100,7 +100,7 @@ export default function AgentsGraphHero() {
                         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-teal-500/10 border border-teal-500/20 mb-6">
                             <Brain className="w-4 h-4 text-amber-400" />
                             <span className="text-sm font-medium text-amber-300">
-                                Agentic Workflows
+                                Agents on the canvas
                             </span>
                         </div>
 

--- a/marketing/src/components/business/BusinessUseCasesSection.tsx
+++ b/marketing/src/components/business/BusinessUseCasesSection.tsx
@@ -52,7 +52,7 @@ const useCases = [
   },
   {
     title: "Process Automation",
-    description: "Connect disparate systems and automate complex business workflows with AI-powered decision making.",
+    description: "Connect disparate systems and put AI in the loop where humans currently spend hours making routine decisions.",
     icon: Database,
     gradient: "from-amber-500/20 to-orange-500/20",
     examples: ["Data pipeline automation", "Cross-system integration", "Smart routing"],


### PR DESCRIPTION
## Summary
This PR rebrand NodeTool from a general-purpose AI workflow builder to a specialized open creative AI workspace. The messaging shifts focus from developers and LLM agents to working creatives (artists, motion designers, illustrators) and emphasizes vendor neutrality, BYOK (bring your own keys), and provider-direct pricing.

## Key Changes

**Messaging & Positioning**
- Updated hero headline from "Build AI Workflows. Run Them Locally." to "The open creative AI workspace"
- Reframed core value proposition: every major model from every major provider, called with your own keys, on one node-based canvas
- Changed tagline from "Local-first" to "BYOK" (bring your own keys)

**SEO & Metadata**
- Updated page titles, descriptions, and keywords across all pages to emphasize creative AI, BYOK, and vendor neutrality
- Changed primary keywords from "AI workflow builder", "LLM agents", "RAG systems" to "creative AI workspace", "BYOK AI canvas", "ComfyUI alternative"
- Updated schema.org structured data to reflect "MultimediaApplication" / "Creative AI Workspace" instead of "DeveloperApplication"

**Target Audience Shift**
- Reframed "Who is NodeTool for?" from developers and data engineers to independent artists, motion designers, illustrators, and post-production shops
- Updated comparisons: replaced n8n and LangChain comparisons with Weavy, closed SaaS canvases, and multi-tab workflows
- Repositioned ComfyUI comparison to emphasize full creative workspace (image, video, audio, text) with editing tools vs. Stable Diffusion-only focus

**Feature Messaging**
- Emphasized editing tools (masks, inpaint, outpaint, relight, upscale, layers, compositing) as first-class features
- Changed "How It Works" section to "What Vendor Neutrality Actually Buys You" with concrete example (Seedance pricing across providers)
- Replaced "Key Capabilities" with "What NodeTool Is Not" (not a model host, not a credit system, not closed, not local-only)

**Ownership & Pricing Section**
- Reordered features to lead with "BYOK, every provider" and "Provider prices, no credits"
- Updated copy to emphasize no markup, no proprietary tokens, no minimum top-up
- Changed section headline from "Local-first or cloud-augmented" to "Your keys. Your files. Your roadmap."

**Creatives Landing Page**
- Updated metadata and copy to target working creatives specifically
- Changed CTA from "Transform Your Creative Workflow" to "Every model. Your keys. Your canvas."

**Editions Comparison**
- Updated Studio description to emphasize "artists with a capable GPU" instead of "privacy-first builders"
- Simplified language around "same providers" instead of "same agent system"

## Implementation Details
- All changes are copy/messaging updates with no functional code changes
- Metadata updates include title tags, meta descriptions, Open Graph tags, Twitter cards, and JSON-LD schema
- Consistent messaging applied across marketing site, landing pages, and SEO content
- Maintained existing component structure while updating text content and emphasis

https://claude.ai/code/session_01NJEzPJucWDbL4Y37m47Lrr