### PR TITLE
Rebrand marketing site to emphasize open-source, BYOK, and creative focus

### DIFF
--- a/marketing/src/app/agents/layout.tsx
+++ b/marketing/src/app/agents/layout.tsx
@@ -1,20 +1,18 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "AI Agents & Automation | NodeTool",
+  title: "Agents on the canvas | NodeTool",
   description:
-    "Build intelligent AI agents that reason, plan, and execute complex tasks. Create autonomous automation workflows with a visual drag-and-drop interface. Open-source, privacy-first, no code required.",
+    "Drop a planning agent into your canvas. It calls models and tools to finish a multi-step task — research, browse, write, generate — and hands the result back to the next node. Open source. BYOK. Runs on your machine or in the browser.",
   keywords: [
     "AI agents",
-    "automation",
-    "autonomous agents",
-    "workflow automation",
-    "LLM agents",
-    "ReAct agents",
-    "no-code AI",
-    "visual AI builder",
-    "AI automation",
-    "intelligent agents",
+    "creative AI workspace",
+    "planning agent",
+    "agent node",
+    "BYOK agents",
+    "open source agents",
+    "node-based agents",
+    "multi-step tasks",
   ],
 };
 

--- a/marketing/src/app/business/layout.tsx
+++ b/marketing/src/app/business/layout.tsx
@@ -1,23 +1,24 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "NodeTool for Business - Enterprise AI Automation Platform",
+  title: "NodeTool for Studios & Teams — The open creative AI workspace",
   description:
-    "Transform your business with AI automation. Build and deploy custom AI workflows without vendor lock-in. Reduce costs, enhance productivity, and maintain complete control over your data.",
+    "An open creative AI workspace for small studios, post-production shops, and agency teams. Every major model, your own keys, your workflows — no credit markup, no vendor lock-in, no acquisition risk.",
   keywords: [
-    "AI automation",
-    "enterprise AI",
-    "business automation",
-    "self-hosted AI",
-    "AI workflows",
-    "process automation",
-    "document intelligence",
-    "AI platform",
+    "creative AI workspace",
+    "studio AI tools",
+    "BYOK AI canvas",
+    "open source creative AI",
+    "ComfyUI alternative",
+    "Weavy alternative",
+    "vendor-neutral AI",
+    "agency AI workflows",
+    "post-production AI",
   ],
   openGraph: {
-    title: "NodeTool for Business - Enterprise AI Automation",
+    title: "NodeTool for Studios & Teams — The open creative AI workspace",
     description:
-      "Build and deploy custom AI workflows without vendor lock-in. Reduce costs by up to 80% while maintaining complete control over your data.",
+      "Every major model, your own keys, your workflows — wired into one node-based canvas. No credit markup, no vendor lock-in, no acquisition risk.",
     type: "website",
   },
 };

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -75,30 +75,30 @@ const creativePersonas: Array<{
   accent: PersonaAccent;
 }> = [
   {
-    title: "Video Creators",
+    title: "Motion designers",
     description:
-      "Automate editing workflows, generate B-roll, and create consistent visual styles across your content.",
+      "Wire Seedance, Veo, Kling, and Runway nodes for B-roll, transitions, and looks. Re-run the workflow when the brief changes.",
     icon: Video,
     accent: "rose",
   },
   {
-    title: "Graphic Designers",
+    title: "AI-native illustrators",
     description:
-      "Access Flux, Ideogram, and gpt-image-1.5. Generate variations and maintain brand consistency with world-class image models.",
+      "Mix Flux, Qwen Image, Ideogram, and gpt-image. Mask, inpaint, outpaint, relight, and upscale on the same canvas — no exporting between tools.",
     icon: Palette,
     accent: "emerald",
   },
   {
-    title: "Music Producers",
+    title: "Music & sound producers",
     description:
-      "Compose with Suno, generate speech with ElevenLabs, and experiment with audio processing in your pipeline.",
+      "Compose with Suno, voice with ElevenLabs, transcribe with Whisper. Wire audio straight into your visual workflows.",
     icon: Music,
     accent: "sky",
   },
   {
-    title: "Photographers",
+    title: "Photographers & retouchers",
     description:
-      "Batch process images, upscale photos, and apply consistent edits across your entire catalog.",
+      "Batch upscale, color-match, restyle. Wrap your repeatable retouching steps into a workflow you can re-run on the next shoot.",
     icon: Camera,
     accent: "amber",
   },
@@ -119,29 +119,29 @@ const creativeFeatures = [
     ],
   },
   {
-    title: "Image Generation",
+    title: "Image generation & editing",
     description:
-      "Run Flux, Qwen-Image, Nano-Banana or Z-Image. Generate, upscale, and transform images with professional-grade command.",
+      "Run Flux, Qwen-Image, Nano-Banana, Z-Image, gpt-image, and friends. Generate, mask, inpaint, outpaint, relight, and upscale — all on the canvas.",
     icon: Wand2,
     image: "/disaster_girl.mp4",
-    features: ["GPU acceleration", "Multi-model support", "Batch processing"],
+    features: ["Masks, inpaint, outpaint", "Multi-model support", "Batch processing"],
   },
   {
-    title: "Video Processing",
+    title: "Video pipelines",
     description:
-      "Create with cinematic video models like Seedance 2.0, Kling 3.0, Veo, Runway and Sora 2. Edit and build automated video pipelines.",
+      "Wire Seedance, Kling, Veo, Runway, and Sora alongside your edit nodes. Generate, transform, and stitch — without exporting between tools.",
     icon: Video,
     image: "/sora.mp4",
     features: [
-      "Frame-accurate editing",
+      "Frame-accurate edits",
       "Temporal smoothing",
       "Format transcoding",
     ],
   },
   {
-    title: "Audio Integration",
+    title: "Audio on the same surface",
     description:
-      "Compose music with Suno, generate voice with ElevenLabs, and wire audio straight into your canvas.",
+      "Compose with Suno, generate voice with ElevenLabs, transcribe with Whisper. Same canvas, same nodes, no extra tabs.",
     icon: Music,
     image: "/suno.png",
     features: ["Stem separation", "Music generation", "Voice generation"],
@@ -375,7 +375,7 @@ export default function CreativesPage() {
                 <div className="relative inline-flex items-center gap-2.5 px-6 py-2.5 rounded-full border border-rose-500/30 bg-gradient-to-r from-rose-500/[0.08] via-amber-500/[0.05] to-cyan-500/[0.08] mb-10 shadow-[0_0_40px_-10px_rgba(244,63,94,0.35)]">
                   <Sparkles className="w-4 h-4 text-rose-400" />
                   <span className="text-sm font-medium text-white tracking-wide">
-                    Built for Creative Professionals
+                    The open canvas for working creatives
                   </span>
                 </div>
 
@@ -391,8 +391,8 @@ export default function CreativesPage() {
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Drag-and-drop pipelines for every frontier model —
-                  Seedance 2.0, Kling 3.0, Runway, Luma, Suno, Flux, and more.
+                  Every model. Your keys. Your canvas. Wire Seedance, Kling, Veo, Runway,
+                  Luma, Suno, Flux, and more on one open-source surface — no credit markup, no vendor lock-in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -518,12 +518,13 @@ export default function CreativesPage() {
               <h2 className="text-4xl md:text-6xl font-bold tracking-tight text-white mb-6">
                 Built for{" "}
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 via-emerald-300 to-cyan-400">
-                  Every Creator
+                  working creatives
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-                Whether you&apos;re editing videos, designing graphics, producing music,
-                or processing photos, NodeTool adapts to your creative workflow.
+                Independent generative artists, motion designers, AI-native illustrators,
+                technical art directors, ComfyUI power users, and Weavy switchers — NodeTool
+                is the open canvas for your work.
               </p>
             </motion.div>
 
@@ -610,14 +611,15 @@ export default function CreativesPage() {
                 <Zap className="w-8 h-8 text-amber-400" />
               </div>
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Powerful Tools for <br />
+                One canvas for <br />
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400">
-                  Creative Work
+                  every modality
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-                Access the same elite models used by studios—Seedance 2.0, Kling 3.0, Luma, Suno,
-                Flux—all within a visual, intuitive interface.
+                The same models the studios use — Seedance, Kling, Luma, Suno, Flux —
+                wired into one node-based canvas, with masks, inpaint, outpaint,
+                relight, upscale, and compositing built in.
               </p>
             </motion.div>
 
@@ -698,14 +700,14 @@ export default function CreativesPage() {
               className="text-center mb-16"
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Creative Workflow{" "}
+                Workflow{" "}
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-emerald-400">
-                  Templates
+                  starting points
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-                Start with pre-built workflows designed for creative
-                professionals. Customize them to fit your unique process.
+                Real workflows for real creative work. Open one, swap models for the ones
+                you prefer, and make it yours.
               </p>
             </motion.div>
 
@@ -773,9 +775,9 @@ export default function CreativesPage() {
               className="text-center mb-16"
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Why Creatives{" "}
+                Why creatives{" "}
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-cyan-400">
-                  Choose NodeTool
+                  choose NodeTool
                 </span>
               </h2>
             </motion.div>
@@ -783,27 +785,27 @@ export default function CreativesPage() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {[
                 {
-                  title: "Your Data, Your Control",
+                  title: "Your work, your machine",
                   description:
-                    "Run everything locally. Your creative assets never leave your machine unless you choose to share them.",
+                    "Studio runs on your computer. Your prompts, files, and outputs stay on your disk unless you choose to share them.",
                   icon: Shield,
                   color: "text-emerald-400",
                   bgColor: "bg-emerald-500/10",
                   borderColor: "border-emerald-500/20",
                 },
                 {
-                  title: "No Subscription Required",
+                  title: "No credits. No markup.",
                   description:
-                    "NodeTool is free and open-source. Use your own API keys or run models completely offline.",
+                    "Studio is free and open source under AGPL-3.0. Bring your own keys to every provider and pay providers directly.",
                   icon: Sparkles,
                   color: "text-amber-400",
                   bgColor: "bg-amber-500/10",
                   borderColor: "border-amber-500/20",
                 },
                 {
-                  title: "All Leading Models",
+                  title: "Every model on one canvas",
                   description:
-                    "Access every top model in one place—Seedance 2.0, Kling 3.0, Luma, Runway, Suno, ElevenLabs, Flux, Ideogram, and more.",
+                    "Seedance, Kling, Veo, Runway, Luma, Suno, ElevenLabs, Flux, Ideogram, and more — switch the moment a better one ships.",
                   icon: Zap,
                   color: "text-amber-400",
                   bgColor: "bg-teal-500/10",
@@ -849,13 +851,12 @@ export default function CreativesPage() {
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
                 Join the{" "}
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 to-amber-400">
-                  Creative Community
+                  community
                 </span>
               </h2>
               <p className="text-lg text-slate-300 mb-10 max-w-2xl mx-auto leading-relaxed">
-                Connect with other creative professionals, share workflows, and
-                get help from the community. NodeTool is open-source under
-                AGPL-3.0.
+                Trade workflows, swap prompts, and ship work with other working
+                creatives. NodeTool is open source under AGPL-3.0 — built in the open.
               </p>
 
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/marketing/src/app/features.tsx
+++ b/marketing/src/app/features.tsx
@@ -19,11 +19,11 @@ export type Feature = {
 
 export const features = [
   {
-    name: "🔗 Snap Nodes Together",
+    name: "🔗 Snap nodes together",
     description: (
       <>
-        Drag any model into your canvas—LLMs, diffusion, agents, or custom code.
-        Connect with one click and watch your AI workflow come alive.
+        Drag any model into your canvas — image, video, audio, text, agents,
+        or custom code. Connect with one click and run.
       </>
     ),
     icon: CodeBracketIcon,
@@ -33,12 +33,12 @@ export const features = [
     height: 400,
   },
   {
-    name: "☁️ Access World-Class Models",
+    name: "☁️ Every model, your keys",
     description: (
       <>
-        One API for every top model. Generate video with Seedance 2.0, Kling 3.0, Luma & Runway,
-        music with Suno, and images with Flux & Ideogram via Kie.ai. Plus
-        support for local execution and major providers like OpenAI & Anthropic.
+        One canvas, every major provider. Video with Seedance, Kling, Veo, and
+        Runway; music with Suno; images with Flux and Ideogram via FAL or KIE;
+        plus OpenAI, Anthropic, Gemini — and local models via MLX, Ollama, and GGUF.
       </>
     ),
     icon: FolderIcon,
@@ -51,10 +51,9 @@ export const features = [
     name: "🚀 Deploy to RunPod",
     description: (
       <>
-        Ship AI workflows to RunPod with one command. Scale from local
-        development to production with GPU acceleration, auto-scaling, and
-        enterprise features. Support for CPU and GPU compute, multiple data
-        centers, and custom Docker images.
+        Ship workflows to RunPod with one command. GPU acceleration,
+        auto-scaling, multi-region, and custom Docker images — for when you need
+        a workflow to run on something bigger than your laptop.
       </>
     ),
     icon: CloudArrowUpIcon,
@@ -64,9 +63,9 @@ export const features = [
     height: 400,
   },
   {
-    name: "💬 Chat Interface",
+    name: "💬 Chat interface",
     description:
-      "Access and trigger AI workflows through a unified chat interface.",
+      "Trigger and re-run any workflow through a chat interface — same nodes, different surface.",
     icon: ChatBubbleBottomCenterTextIcon,
     href: "#",
     gif: "/chat.png",
@@ -74,7 +73,7 @@ export const features = [
     height: 400,
   },
   {
-    name: "🤖 Agent Nodes",
+    name: "🤖 Agent nodes",
     description:
       "Drop in a planning agent that calls models and tools to finish a multi-step task. Used as a node, not a separate framework.",
     icon: PuzzlePieceIcon,
@@ -84,9 +83,9 @@ export const features = [
     height: 400,
   },
   {
-    name: "📁 Vector Storage & RAG",
+    name: "📁 Vector store & RAG",
     description:
-      "Built-in SQLite-vec embedded vector store. Create smart assistants that know your documents—no extra database to run.",
+      "Built-in SQLite-vec embedded vector store. Build assistants that know your documents — no extra database to run.",
     icon: FolderIcon,
     href: "#",
     gif: "/vector-db.jpg",

--- a/marketing/src/components/UseCasesSection.tsx
+++ b/marketing/src/components/UseCasesSection.tsx
@@ -34,7 +34,7 @@ export default function UseCasesSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Use Cases
+            What people build
           </motion.h2>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
@@ -43,7 +43,7 @@ export default function UseCasesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            NodeTool supports multiple AI workflow categories. Connect nodes to build applications in these areas.
+            Image, video, audio, text, agents, RAG — all on the same canvas. Wire the models you want, switch when better ones ship.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -26,7 +26,7 @@ export default function AgentBuildRunDeploy() {
                         Plan. Act. Self-correct.
                     </h2>
                     <p className="text-slate-400 text-lg">
-                        Design autonomous systems that plan, act, and self-correct. Then deploy them as reliable workers.
+                        Design agents that plan a task, call the right tools, and self-correct as they go — then re-run them as a node in any workflow.
                     </p>
                 </div>
 
@@ -43,7 +43,7 @@ export default function AgentBuildRunDeploy() {
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-3 relative z-10">
                     <Card
                         title="Design"
-                        subtitle="Define objectives, choose execution mode (loop, plan, or multi-agent), and assign tools and skills visually."
+                        subtitle="Set the objective, pick a mode (loop, plan, or multi-agent), and wire in the tools and skills the agent should reach for."
                         step={1}
                         accentColor="blue"
                     >
@@ -52,7 +52,7 @@ export default function AgentBuildRunDeploy() {
 
                     <Card
                         title="Observe"
-                        subtitle="Stream reasoning traces, tool calls, and task progress in real-time. OpenTelemetry tracing built in."
+                        subtitle="Stream reasoning, tool calls, and task progress live. OpenTelemetry tracing built in so you can see exactly what the agent did."
                         step={2}
                         accentColor="purple"
                     >
@@ -60,8 +60,8 @@ export default function AgentBuildRunDeploy() {
                     </Card>
 
                     <Card
-                        title="Scale"
-                        subtitle="Run multi-agent teams with coordinator, autonomous, or hybrid strategies. Parallel DAG execution."
+                        title="Re-run"
+                        subtitle="Run a team of specialized agents in parallel via a shared task board, then re-run the whole thing as a node next time."
                         step={3}
                         accentColor="emerald"
                     >

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -110,8 +110,8 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Build agents that think, plan, and execute with the same visual
-            tools you use for any NodeTool workflow.
+            Agents are nodes. Use the same canvas you use for image, video, and text
+            workflows — just with a model that plans and acts.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -118,8 +118,8 @@ export default function AgentIntegrationsSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            NodeTool agents can connect to any service, API, or data source.
-            Built-in integrations make it easy to get started.
+            Agents can call any provider, browse the web, run code, query a vector
+            store, or hand off to another agent. Wire up what you need on the canvas.
           </motion.p>
         </div>
 
@@ -190,11 +190,11 @@ export default function AgentIntegrationsSection({
           className="mt-16 rounded-2xl border border-white/10 bg-gradient-to-r from-teal-900/20 via-slate-900/50 to-blue-900/20 p-8 md:p-12 text-center"
         >
           <h3 className="text-2xl md:text-3xl font-bold text-white mb-4">
-            Need a Custom Integration?
+            Need a tool that isn&apos;t here yet?
           </h3>
           <p className="text-slate-400 mb-6 max-w-2xl mx-auto">
-            NodeTool is fully extensible. Create custom nodes to connect to any
-            service, or use the TypeScript SDK to build integrations programmatically.
+            NodeTool is open source and extensible. Add your own node, plug in a proprietary
+            model, or drive the canvas from the TypeScript SDK — same code path as the built-ins.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
@@ -202,14 +202,14 @@ export default function AgentIntegrationsSection({
               className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-white/5 border border-white/10 text-slate-300 hover:bg-white/10 hover:text-white transition-all"
             >
               <Braces className="w-5 h-5" />
-              View Integration Docs
+              Read the docs
             </a>
             <a
               href="https://github.com/nodetool-ai/nodetool"
               className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-500 transition-all"
             >
               <Terminal className="w-5 h-5" />
-              Build Custom Nodes
+              Build a custom node
             </a>
           </div>
         </motion.div>

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -105,15 +105,16 @@ export default function AgentsGraphHero() {
                         </div>
 
                         <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-white mb-8">
-                            Build Autonomous <br />
+                            Agents are <br />
                             <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 via-fuchsia-400 to-rose-400">
-                                AI Agents Visually
+                                nodes on your canvas.
                             </span>
                         </h1>
 
                         <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
-                            Orchestrate multi-step reasoning loops. Connect LLMs to tools, databases, and APIs.
-                            Debug agent thoughts in real-time.
+                            Drop a planning agent into the canvas. It calls the right models and tools to
+                            finish a multi-step task — research, browse, write, generate — and hands the
+                            result to the next node. Watch the reasoning live.
                         </p>
 
                         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/marketing/src/components/agents/AgentsHero.tsx
+++ b/marketing/src/components/agents/AgentsHero.tsx
@@ -35,22 +35,22 @@ export default function AgentsHero() {
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-teal-500/10 border border-teal-500/20 mb-6">
               <Bot className="w-4 h-4 text-amber-400" />
               <span className="text-sm font-medium text-amber-300">
-                AI Agents & Automation
+                Agents on the canvas
               </span>
             </div>
 
             <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-white mb-8">
-              Build Intelligent
+              Drop a planning agent
               <br />
               <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 via-blue-400 to-cyan-400">
-                AI Agents
+                into your canvas.
               </span>
             </h1>
 
             <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
-              Create autonomous agents that reason, plan, and execute complex
-              tasks. Chain together AI models, tools, and APIs to automate
-              anything—all with a visual drag-and-drop interface.
+              Agents are nodes you wire into the same canvas as your image, video, and
+              text models. Give one an objective and it&apos;ll call the right models and
+              tools to finish the job — then hand the result to the next node.
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -59,13 +59,13 @@ export default function AgentsHero() {
                 className="px-8 py-4 rounded-xl font-semibold text-white bg-gradient-to-r from-teal-600 to-blue-600 hover:from-teal-500 hover:to-blue-500 transition-all shadow-lg shadow-teal-900/40 flex items-center gap-2"
               >
                 <Sparkles className="w-5 h-5" />
-                Get Started
+                Read the docs
               </a>
               <a
                 href="#use-cases"
                 className="px-8 py-4 rounded-xl font-semibold text-slate-300 bg-white/5 border border-white/10 hover:bg-white/10 transition-all flex items-center gap-2"
               >
-                See Use Cases
+                See examples
               </a>
             </div>
 
@@ -75,11 +75,11 @@ export default function AgentsHero() {
               </span>
               <span className="w-1 h-1 rounded-full bg-slate-700" />
               <span className="flex items-center gap-2">
-                <Zap className="w-4 h-4" /> No Code Required
+                <Zap className="w-4 h-4" /> BYOK to every provider
               </span>
               <span className="w-1 h-1 rounded-full bg-slate-700" />
               <span className="flex items-center gap-2">
-                <Workflow className="w-4 h-4" /> Visual Builder
+                <Workflow className="w-4 h-4" /> Visual canvas
               </span>
             </div>
           </motion.div>

--- a/marketing/src/components/business/BusinessFeaturesSection.tsx
+++ b/marketing/src/components/business/BusinessFeaturesSection.tsx
@@ -18,64 +18,64 @@ interface BusinessFeaturesSectionProps {
 
 const features = [
   {
-    title: "Cost Reduction",
-    description: "Slash AI costs by up to 80% by using your own infrastructure and avoiding expensive API subscriptions.",
+    title: "No credit markup",
+    description: "Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Pay providers directly at provider prices — no resold tokens, no minimum top-up.",
     icon: DollarSign,
     color: "text-emerald-400",
     bgColor: "bg-emerald-500/10",
     borderColor: "border-emerald-500/20",
   },
   {
-    title: "Data Privacy",
-    description: "Keep sensitive business data on-premise. Full control over your AI models and processing pipelines.",
+    title: "Your keys, your data",
+    description: "Workflows, files, and provider keys belong to you. Run Studio on your machine, run Cloud in the browser, or self-host the same open-source code.",
     icon: Lock,
     color: "text-blue-400",
     bgColor: "bg-blue-500/10",
     borderColor: "border-blue-500/20",
   },
   {
-    title: "Flexible Integration",
-    description: "Connect to existing tools and databases. REST APIs, webhooks, and custom connectors available.",
+    title: "One canvas, every modality",
+    description: "Image, video, audio, and text on the same surface. Masks, inpaint, outpaint, relight, upscale, layers, and compositing built in — no exporting between tools.",
     icon: Boxes,
     color: "text-amber-400",
     bgColor: "bg-teal-500/10",
     borderColor: "border-teal-500/20",
   },
   {
-    title: "Scalable Architecture",
-    description: "Start small and scale up. From single-machine deployment to distributed cloud infrastructure.",
+    title: "Scale on your terms",
+    description: "Start with one creative on a laptop. Add team members on Cloud, or run the same workflows on your own GPUs — same nodes either way.",
     icon: TrendingUp,
     color: "text-cyan-400",
     bgColor: "bg-cyan-500/10",
     borderColor: "border-cyan-500/20",
   },
   {
-    title: "Team Collaboration",
-    description: "Share workflows across teams. Version control, audit logs, and role-based access control.",
+    title: "Built to share",
+    description: "Hand off workflows between team members. Version them in git. Re-run them six months later when you need that look again.",
     icon: Users,
     color: "text-rose-400",
     bgColor: "bg-rose-500/10",
     borderColor: "border-rose-500/20",
   },
   {
-    title: "Developer Friendly",
-    description: "Open-source and extensible. Build custom nodes, integrate proprietary models, and automate with APIs.",
+    title: "Extensible by design",
+    description: "Open source under AGPL-3.0. Add your own nodes, wire in proprietary models, and drive the canvas from CLI or SDK when you need to.",
     icon: FileCode,
     color: "text-amber-400",
     bgColor: "bg-amber-500/10",
     borderColor: "border-amber-500/20",
   },
   {
-    title: "Hybrid Deployment",
-    description: "Deploy anywhere: on-premise, cloud, or hybrid. Compatible with AWS, Azure, GCP, and private clouds.",
+    title: "Run it anywhere",
+    description: "Studio on macOS, Windows, and Linux. Cloud in any browser. Self-host the runtime on your own boxes — same open-source codebase across all three.",
     icon: Cloud,
     color: "text-indigo-400",
     bgColor: "bg-indigo-500/10",
     borderColor: "border-indigo-500/20",
   },
   {
-    title: "Enterprise Performance",
-    description: "GPU acceleration, batch processing, and optimized inference. Handle high-volume workloads efficiently.",
+    title: "Use the best model for the job",
+    description: "Seedance, Flux, Veo, Kling, Hailuo, Whisper, ElevenLabs, Suno — switch the moment a better model ships, without rebuilding your workflow.",
     icon: Gauge,
     color: "text-pink-400",
     bgColor: "bg-pink-500/10",
@@ -96,10 +96,10 @@ export default function BusinessFeaturesSection({ reducedMotion }: BusinessFeatu
           className="text-center mb-16"
         >
           <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-            Enterprise-Grade AI Platform
+            One workspace. Every model. Your keys.
           </h2>
           <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-            Everything your business needs to build, deploy, and scale AI workflows with confidence.
+            Everything your team needs to build, share, and re-run creative AI workflows on a canvas you actually own.
           </p>
         </motion.div>
 

--- a/marketing/src/components/business/BusinessHero.tsx
+++ b/marketing/src/components/business/BusinessHero.tsx
@@ -15,20 +15,20 @@ export default function BusinessHero() {
       >
         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-emerald-500/10 to-blue-500/10 border border-white/10 mb-8">
           <BarChart3 className="w-4 h-4 text-emerald-400" />
-          <span className="text-sm font-medium text-slate-300">Enterprise AI Made Simple</span>
+          <span className="text-sm font-medium text-slate-300">For studios &amp; creative teams</span>
         </div>
 
         <h1 id="hero-title" className="text-5xl md:text-7xl font-bold tracking-tight mb-8">
-          <span className="text-white">Transform Your Business with</span>
+          <span className="text-white">The creative AI workspace</span>
           <br />
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 via-blue-400 to-amber-400">
-            AI Automation
+            your team actually owns.
           </span>
         </h1>
 
         <p className="text-xl md:text-2xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-          Build and deploy custom AI workflows without vendor lock-in. 
-          Reduce costs, enhance productivity, and maintain complete control over your data.
+          For small studios, post-production shops, and agency teams: every major model,
+          your own keys, your workflows. No credit markup, no vendor lock-in, no acquisition risk.
         </p>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">
@@ -37,7 +37,7 @@ export default function BusinessHero() {
             className="group inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-emerald-500 to-blue-600 text-white font-semibold hover:from-emerald-400 hover:to-blue-500 transition-all shadow-lg shadow-emerald-500/25 hover:shadow-emerald-500/40"
           >
             <Download className="w-5 h-5" />
-            Get Started Free
+            Download Studio
             <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
           </a>
           <a
@@ -45,22 +45,22 @@ export default function BusinessHero() {
             className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all"
           >
             <BarChart3 className="w-5 h-5" />
-            Calculate ROI
+            See the math
           </a>
         </div>
 
         <div className="flex items-center justify-center gap-8 text-sm text-slate-500">
           <span className="flex items-center gap-2">
             <Shield className="w-4 h-4" />
-            Enterprise Security
+            Your keys, your data
           </span>
           <span className="w-1 h-1 rounded-full bg-slate-700" />
           <span className="flex items-center gap-2">
             <Zap className="w-4 h-4" />
-            No Vendor Lock-in
+            No vendor lock-in
           </span>
           <span className="w-1 h-1 rounded-full bg-slate-700" />
-          <span>Self-Hosted or Cloud</span>
+          <span>Self-host or Cloud</span>
         </div>
       </motion.div>
 
@@ -77,11 +77,11 @@ export default function BusinessHero() {
             <div className="w-3 h-3 rounded-full bg-emerald-500/50" />
             <div className="w-3 h-3 rounded-full bg-amber-500/50" />
             <div className="w-3 h-3 rounded-full bg-rose-500/50" />
-            <span className="ml-4 text-xs text-slate-500 font-medium">Business Automation Workflow</span>
+            <span className="ml-4 text-xs text-slate-500 font-medium">Studio team workflow</span>
           </div>
           <Image
             src="/screen_canvas.png"
-            alt="Screenshot of NodeTool's visual workflow editor displaying a business automation workflow with interconnected nodes for AI processing, data transformation, and output generation"
+            alt="NodeTool canvas: a creative team workflow with image, video, and text nodes wired together"
             width={1400}
             height={800}
             className="w-full"

--- a/marketing/src/components/business/BusinessUseCasesSection.tsx
+++ b/marketing/src/components/business/BusinessUseCasesSection.tsx
@@ -16,46 +16,46 @@ interface BusinessUseCasesSectionProps {
 
 const useCases = [
   {
-    title: "Document Intelligence",
-    description: "Automate document processing, extraction, and analysis. Process invoices, contracts, and forms at scale.",
-    icon: FileText,
+    title: "Brand campaigns at speed",
+    description: "Generate on-brand visuals, social posts, and ad variants from a single workflow your team can re-run all season.",
+    icon: ImageIcon,
     gradient: "from-emerald-500/20 to-teal-500/20",
-    examples: ["Invoice processing", "Contract analysis", "Form extraction"],
+    examples: ["Ad creative variants", "Social post sets", "Brand-consistent imagery"],
   },
   {
-    title: "Customer Support Automation",
-    description: "Build intelligent chatbots and ticket routing systems. Reduce response times and support costs.",
+    title: "Video & post-production",
+    description: "Wire Seedance, Veo, Kling, and Runway alongside your existing edit tools. Generate B-roll, run upscales, and ship cuts faster.",
     icon: MessageSquare,
     gradient: "from-blue-500/20 to-cyan-500/20",
-    examples: ["24/7 chatbot support", "Ticket classification", "Knowledge base search"],
+    examples: ["B-roll generation", "Upscale & relight", "Frame-accurate edits"],
   },
   {
-    title: "Marketing & Content",
-    description: "Generate marketing materials, social media content, and personalized campaigns at scale.",
+    title: "Pitch & concept work",
+    description: "Move from rough idea to a presentable pitch deck of stills, motion, and voiceover in a single afternoon — without leaving the canvas.",
     icon: Mail,
     gradient: "from-teal-500/20 to-purple-500/20",
-    examples: ["Ad copy generation", "Image creation", "Email personalization"],
+    examples: ["Mood boards", "Animatics", "Voiceover with ElevenLabs"],
   },
   {
-    title: "Data Analysis & Insights",
-    description: "Transform raw data into actionable insights. Automated reporting, trend detection, and forecasting.",
+    title: "Asset libraries & batch work",
+    description: "Process hundreds of stills, generate variants, and tag everything — without juggling browser tabs across Midjourney, Runway, and Photoshop.",
     icon: BarChart3,
     gradient: "from-cyan-500/20 to-blue-500/20",
-    examples: ["Sales forecasting", "Anomaly detection", "Report generation"],
+    examples: ["Batch upscale", "Style transfer at scale", "Auto-tagging"],
   },
   {
-    title: "Quality Assurance",
-    description: "Automated visual inspection, defect detection, and quality control in manufacturing processes.",
-    icon: ImageIcon,
+    title: "Agent-driven research",
+    description: "Drop a planning agent into the canvas to research references, compile mood boards, and draft creative briefs from your prompts.",
+    icon: FileText,
     gradient: "from-rose-500/20 to-pink-500/20",
-    examples: ["Visual inspection", "Defect detection", "Product classification"],
+    examples: ["Reference research", "Brief drafting", "Mood board scraping"],
   },
   {
-    title: "Process Automation",
-    description: "Connect disparate systems and put AI in the loop where humans currently spend hours making routine decisions.",
+    title: "Custom team workflows",
+    description: "Wrap the steps your team does every week into a workflow they can re-run, share, and version — on a canvas, not a script.",
     icon: Database,
     gradient: "from-amber-500/20 to-orange-500/20",
-    examples: ["Data pipeline automation", "Cross-system integration", "Smart routing"],
+    examples: ["Repeatable team recipes", "Shared workflow library", "Workflow handoff"],
   },
 ];
 
@@ -70,10 +70,10 @@ export default function BusinessUseCasesSection({ reducedMotion }: BusinessUseCa
           className="text-center mb-16"
         >
           <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-            Real-World <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-blue-400">Business Applications</span>
+            Real workflows for <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-blue-400">creative teams</span>
           </h2>
           <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-            From small businesses to enterprise organizations, NodeTool powers AI automation across industries.
+            From small studios to agency creative teams, NodeTool runs the visual AI work your team already does — on a canvas you actually own.
           </p>
         </motion.div>
 

--- a/marketing/src/components/business/ROISection.tsx
+++ b/marketing/src/components/business/ROISection.tsx
@@ -10,31 +10,31 @@ interface ROISectionProps {
 const benefits = [
   {
     icon: TrendingDown,
-    title: "80% Cost Reduction",
-    description: "Save on API costs by running models on your own infrastructure",
-    metric: "$50k → $10k",
-    label: "Annual AI Costs",
+    title: "Pay providers, not middlemen",
+    description: "BYOK to every provider — pay them directly at provider prices. No resold credits, no markup.",
+    metric: "0% markup",
+    label: "On model calls",
   },
   {
     icon: Clock,
-    title: "10x Faster Development",
-    description: "Visual workflows reduce development time from weeks to days",
-    metric: "3 weeks → 2 days",
-    label: "Time to Deploy",
+    title: "Switch models in seconds",
+    description: "When a better model ships, swap one node and you're on it the same day.",
+    metric: "Same day",
+    label: "Time to swap providers",
   },
   {
     icon: Shield,
-    title: "Zero Data Leakage",
-    description: "Keep sensitive business data on your infrastructure",
-    metric: "100% Control",
-    label: "Data Ownership",
+    title: "Your workflows belong to you",
+    description: "Open source under AGPL-3.0. Workflows, files, and keys stay with you — self-host any time.",
+    metric: "100% yours",
+    label: "Workflows & data",
   },
   {
     icon: Zap,
-    title: "3x Productivity Gain",
-    description: "Automate repetitive tasks and free up your team",
-    metric: "30 hrs → 10 hrs",
-    label: "Weekly Manual Work",
+    title: "Re-run, don't rebuild",
+    description: "Wrap a complex creative process into a workflow your team can re-run for the next campaign in minutes.",
+    metric: "Hours → minutes",
+    label: "Per re-run",
   },
 ];
 
@@ -51,10 +51,10 @@ export default function ROISection({ reducedMotion }: ROISectionProps) {
           className="text-center mb-16"
         >
           <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-            Measurable <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-blue-400">Business Impact</span>
+            What <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-blue-400">vendor neutrality</span> actually buys you
           </h2>
           <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-            Real results from businesses that switched to NodeTool for their AI automation needs.
+            Open source, BYOK, and one canvas across providers — the math gets much friendlier when nobody&apos;s sitting between you and the model.
           </p>
         </motion.div>
 
@@ -92,16 +92,16 @@ export default function ROISection({ reducedMotion }: ROISectionProps) {
         >
           <div className="inline-block rounded-2xl border border-white/10 bg-gradient-to-br from-emerald-500/10 to-blue-500/10 backdrop-blur-xl p-8 md:p-12">
             <h3 className="text-2xl md:text-3xl font-bold text-white mb-4">
-              Calculate Your Potential ROI
+              Run the numbers on your own stack
             </h3>
             <p className="text-slate-300 mb-6 max-w-2xl">
-              Most businesses see positive ROI within 3 months. Self-hosting eliminates ongoing API costs and gives you full control.
+              Most teams see the math change the day they stop paying for resold tokens. Bring your own keys, run local models when it fits, and put the savings back into the work.
             </p>
             <a
               href="https://github.com/nodetool-ai/nodetool/releases"
               className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-emerald-500 to-blue-600 text-white font-semibold hover:from-emerald-400 hover:to-blue-500 transition-all shadow-lg shadow-emerald-500/25"
             >
-              Get Started Free
+              Download Studio
             </a>
           </div>
         </motion.div>

--- a/marketing/src/components/business/SecuritySection.tsx
+++ b/marketing/src/components/business/SecuritySection.tsx
@@ -10,41 +10,41 @@ interface SecuritySectionProps {
 const securityFeatures = [
   {
     icon: Shield,
-    title: "Data Sovereignty",
-    description: "Your data never leaves your infrastructure. Complete control over where and how data is processed.",
+    title: "Your data stays with you",
+    description: "Workflows, files, and provider keys live with you — on your machine, in your browser, or on hardware you control.",
   },
   {
     icon: Lock,
-    title: "End-to-End Encryption",
-    description: "All data in transit and at rest is encrypted. Support for custom encryption keys and HSM integration.",
+    title: "Encrypted in transit and at rest",
+    description: "Cloud storage is encrypted by default. Studio keeps everything on your disk and never phones home.",
   },
   {
     icon: Server,
-    title: "On-Premise Deployment",
-    description: "Deploy entirely on your infrastructure. No external dependencies or cloud services required.",
+    title: "Self-host the same code",
+    description: "Cloud is just our managed hosting of the open-source code. Run the same Docker images, CLI, and runtime on your own infrastructure.",
   },
   {
     icon: FileCheck,
-    title: "Audit Logs",
-    description: "Complete audit trail of all workflow executions, data access, and system changes.",
+    title: "Workflow history",
+    description: "Every workflow run, every node output, every prompt — captured so your team can re-run, audit, and version what shipped.",
   },
   {
     icon: Eye,
-    title: "Transparent & Open Source",
-    description: "Full source code access under AGPL-3.0. Audit every line of code for security compliance.",
+    title: "Open source, end to end",
+    description: "AGPL-3.0 on GitHub. No closed-source layer, no \"pro tier\" hiding the good features. Read the code, fork the code, ship the code.",
   },
   {
     icon: Key,
-    title: "Access Control",
-    description: "Role-based access control (RBAC), SSO integration, and fine-grained permissions management.",
+    title: "Your keys, your billing",
+    description: "BYOK for every provider. Use your own accounts, your own usage limits, and your own provider-side controls.",
   },
 ];
 
 const complianceLogos = [
-  { name: "SOC 2 Ready", color: "text-blue-400" },
-  { name: "GDPR Compliant", color: "text-emerald-400" },
-  { name: "HIPAA Compatible", color: "text-amber-400" },
-  { name: "ISO 27001 Ready", color: "text-cyan-400" },
+  { name: "Open source", color: "text-blue-400" },
+  { name: "BYOK", color: "text-emerald-400" },
+  { name: "Self-hostable", color: "text-amber-400" },
+  { name: "AGPL-3.0", color: "text-cyan-400" },
 ];
 
 export default function SecuritySection({ reducedMotion }: SecuritySectionProps) {
@@ -63,11 +63,11 @@ export default function SecuritySection({ reducedMotion }: SecuritySectionProps)
             <Shield className="w-8 h-8 text-blue-400" />
           </div>
           <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-            Enterprise Security <br />
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-amber-400">& Compliance</span>
+            Your keys. Your data. <br />
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-amber-400">Your call.</span>
           </h2>
           <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-            Built with security and compliance in mind from day one. Meet the strictest industry standards.
+            Open source, BYOK, and self-hostable — so your team controls where the work runs, where the keys live, and where the files end up.
           </p>
         </motion.div>
 
@@ -101,7 +101,7 @@ export default function SecuritySection({ reducedMotion }: SecuritySectionProps)
           className="text-center"
         >
           <div className="inline-block rounded-2xl border border-white/10 bg-slate-900/50 backdrop-blur-xl p-8 md:p-12">
-            <h3 className="text-xl font-semibold text-white mb-8">Compliance Ready</h3>
+            <h3 className="text-xl font-semibold text-white mb-8">Built on open ground</h3>
             <div className="flex flex-wrap items-center justify-center gap-8">
               {complianceLogos.map((compliance, index) => (
                 <motion.div
@@ -118,7 +118,7 @@ export default function SecuritySection({ reducedMotion }: SecuritySectionProps)
               ))}
             </div>
             <p className="mt-8 text-sm text-slate-400 max-w-2xl mx-auto">
-              Self-hosting gives you full control to meet your organization&apos;s specific compliance requirements.
+              Self-hosting puts the same open-source runtime on your hardware, so your team can meet whatever data and infrastructure rules your work needs to follow.
             </p>
           </div>
         </motion.div>

--- a/marketing/src/components/client/faqs.tsx
+++ b/marketing/src/components/client/faqs.tsx
@@ -5,11 +5,40 @@ import { MinusSmallIcon, PlusSmallIcon } from "@heroicons/react/24/outline";
 
 const faqs = [
   {
-    question: "What's the best thing about Switzerland?",
+    question: "What is NodeTool?",
     answer:
-      "I don't know, but the flag is a big plus. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas cupiditate laboriosam fugiat.",
+      "NodeTool is the open creative AI workspace. Every major model from every major provider — FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more — wired into one node-based canvas you run on your machine or in the browser.",
   },
-  // More questions...
+  {
+    question: "What does BYOK mean for me?",
+    answer:
+      "Bring your own keys. You connect your own provider accounts and pay providers directly at provider prices. NodeTool never marks up model calls and never issues proprietary credits.",
+  },
+  {
+    question: "Is NodeTool open source?",
+    answer:
+      "Yes. The full codebase is AGPL-3.0 on GitHub. Studio and Cloud share the same source — no closed-source layer, no \"pro\" tier hiding the good features. Self-host any time.",
+  },
+  {
+    question: "How is this different from ComfyUI?",
+    answer:
+      "ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with the editing tools creatives actually use: masks, inpaint, outpaint, relight, upscale, layers, compositing.",
+  },
+  {
+    question: "How is this different from Weavy and other closed canvases?",
+    answer:
+      "Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK. Your workflows, files, and keys belong to you. Switch providers the moment a better model ships.",
+  },
+  {
+    question: "Studio or Cloud — which should I use?",
+    answer:
+      "Studio is the desktop app: free, open source, runs on your machine, supports local models via MLX, Ollama, and GGUF. Cloud is the same workspace in the browser — zero setup, no GPU required, your keys still go to providers directly. Same workflows either way.",
+  },
+  {
+    question: "Which models are supported?",
+    answer:
+      "Frontier models including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno — called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Local inference via MLX, Ollama, llama.cpp, vLLM, and LM Studio.",
+  },
 ];
 
 export default function Faqs() {

--- a/marketing/src/components/developers/DeveloperCoreSection.tsx
+++ b/marketing/src/components/developers/DeveloperCoreSection.tsx
@@ -63,38 +63,38 @@ const dslExplanation = [
 const coreFeatures = [
   {
     icon: Box,
-    title: "Node-Based DSL",
-    description: "Declare graphs in code. Strict types, no vendor lock-in.",
+    title: "Node-based DSL",
+    description: "Declare graphs in code. Strict types, vendor-neutral.",
     color: "text-violet-400",
   },
   {
     icon: Layers,
-    title: "First-Class Agents",
-    description: "Planner, browser, search & tool-calling baked in.",
+    title: "Agents as nodes",
+    description: "Planner, browser, search, and tool-calling baked in.",
     color: "text-blue-400",
   },
   {
     icon: Network,
-    title: "Multi-Provider Models",
-    description: "OpenAI, Anthropic, Ollama, Hugging Face, and more.",
+    title: "Every major provider",
+    description: "FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Ollama, and more — your keys.",
     color: "text-emerald-400",
   },
   {
     icon: Database,
-    title: "RAG & Vector Stores",
-    description: "Native adapters for ChromaDB and semantic search.",
+    title: "RAG & vector stores",
+    description: "Built-in SQLite-vec, plus adapters for ChromaDB and friends.",
     color: "text-pink-400",
   },
   {
     icon: Zap,
-    title: "Actor-Based Execution",
+    title: "Actor-based execution",
     description: "One actor per node, streaming-first architecture.",
     color: "text-amber-400",
   },
   {
     icon: PackagePlus,
-    title: "Plugin SDK",
-    description: "Bring your own nodes with the extensible plugin system.",
+    title: "Custom nodes",
+    description: "Add your own nodes to the workspace with the SDK.",
     color: "text-cyan-400",
   },
 ];
@@ -123,7 +123,7 @@ export default function DeveloperCoreSection({
             className="inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-4 py-1.5 text-sm font-medium text-blue-300 ring-1 ring-inset ring-blue-500/20 mb-4"
           >
             <Code2 className="h-4 w-4" />
-            NodeTool Core Engine
+            NodeTool runtime
           </motion.span>
           <motion.h2
             id="core-title"
@@ -133,7 +133,7 @@ export default function DeveloperCoreSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Open-Source Runtime
+            Open source, end to end
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
@@ -142,9 +142,8 @@ export default function DeveloperCoreSection({
             transition={{ duration: 0.5, delay: 0.2 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
-            Workflows run in an async Node.js runtime. Use NodeTool as a library
-            in your own app, or standalone via the CLI to build, run, and ship AI
-            workflows.
+            Workflows run on an async Node.js runtime. Embed NodeTool as a library, drive it from
+            the CLI, or run the same code that powers Studio and Cloud on your own boxes.
           </motion.p>
           <motion.div
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}

--- a/marketing/src/components/developers/DeveloperFeaturesSection.tsx
+++ b/marketing/src/components/developers/DeveloperFeaturesSection.tsx
@@ -8,9 +8,9 @@ const sectionContainer = "mx-auto max-w-7xl px-6 lg:px-8";
 
 const features = [
   {
-    title: "Developer SDK",
+    title: "TypeScript SDK",
     description:
-      "Build and run workflows programmatically. Strict types, async streaming, and a fluent graph builder.",
+      "Build and run workflows from code. Strict types, async streaming, and a fluent graph builder.",
     icon: Code2,
     color: "text-violet-400",
     bgColor: "bg-violet-500/10",
@@ -39,9 +39,9 @@ const out = text.concat({ a: a.output, b: b.output });
 const wf = workflow(out);`,
   },
   {
-    title: "Custom Nodes",
+    title: "Custom nodes",
     description:
-      "Extend NodeTool with your own nodes. Decorate fields, implement process(), ship it.",
+      "Add your own nodes to the workspace. Decorate fields, implement process(), ship it.",
     icon: Blocks,
     color: "text-emerald-400",
     bgColor: "bg-emerald-500/10",
@@ -85,7 +85,7 @@ export default function DeveloperFeaturesSection({
             transition={{ duration: 0.5 }}
             className="inline-flex items-center gap-2 rounded-full bg-violet-500/10 px-4 py-1.5 text-sm font-medium text-violet-300 ring-1 ring-inset ring-violet-500/20 mb-4"
           >
-            Developer Experience
+            From the canvas to your code
           </motion.span>
           <motion.h2
             id="features-title"
@@ -95,7 +95,7 @@ export default function DeveloperFeaturesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Build with Powerful APIs
+            Drive the workspace from code
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
@@ -104,7 +104,7 @@ export default function DeveloperFeaturesSection({
             transition={{ duration: 0.5, delay: 0.2 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
-            Everything you need to integrate AI workflows into your applications
+            The same workflows you build on the canvas, callable from a TypeScript SDK and CLI.
           </motion.p>
         </div>
 

--- a/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
+++ b/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
@@ -85,7 +85,7 @@ export default function DeveloperIntegrationsSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Connect to Everything
+            Every model. Your keys.
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
@@ -94,7 +94,7 @@ export default function DeveloperIntegrationsSection({
             transition={{ duration: 0.5, delay: 0.2 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
-            340+ built-in nodes. Every major AI provider and model supported out of the box.
+            340+ built-in nodes spanning every major provider and modality. BYOK across the board.
           </motion.p>
         </div>
 
@@ -160,11 +160,11 @@ export default function DeveloperIntegrationsSection({
           className="mt-16 text-center rounded-2xl bg-gradient-to-br from-violet-900/20 to-teal-900/20 p-10 ring-1 ring-violet-500/20"
         >
           <h3 className="text-2xl font-bold text-white mb-4">
-            100% Open Source
+            100% open source
           </h3>
           <p className="text-slate-400 max-w-xl mx-auto mb-6">
-            NodeTool is MIT licensed. Fork it, modify it, host it yourself.
-            No vendor lock-in, no usage limits, complete control over your AI infrastructure.
+            NodeTool is AGPL-3.0. Fork it, audit it, self-host it. No vendor lock-in,
+            no usage limits — bring your own keys to every provider and pay providers directly.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <a

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -17,7 +17,7 @@ export default function DevelopersHero() {
         >
           <span className="inline-flex items-center gap-2 rounded-full bg-violet-500/10 px-4 py-1.5 text-sm font-medium text-violet-300 ring-1 ring-inset ring-violet-500/20">
             <Terminal className="h-4 w-4" />
-            Open-Source SDK & API
+            Open source SDK, CLI, and runtime
           </span>
         </motion.div>
 
@@ -29,9 +29,9 @@ export default function DevelopersHero() {
           transition={{ duration: 0.5, delay: 0.1 }}
           className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
         >
-          <span className="text-white">Build AI Apps with </span>
+          <span className="text-white">Extend the </span>
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-teal-400">
-            NodeTool
+            workspace.
           </span>
         </motion.h1>
 
@@ -42,9 +42,9 @@ export default function DevelopersHero() {
           transition={{ duration: 0.5, delay: 0.2 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
-          A visual workflow platform built on an async Node.js runtime. Use the
-          SDK and graph DSL to build, extend, and run AI workflows from code —
-          integrate any model and deploy anywhere.
+          NodeTool is a TypeScript-first workspace built on an async Node.js runtime. Add custom
+          nodes, drive the canvas from a CLI or SDK, and build the integrations your team needs —
+          all on the same open-source codebase.
         </motion.p>
 
         {/* Feature Pills */}


### PR DESCRIPTION
## Summary
Comprehensive rebrand of the marketing website to shift positioning from "enterprise AI automation platform" to "open creative AI workspace for studios and teams." The changes emphasize vendor neutrality (BYOK), open-source nature (AGPL-3.0), and creative-first use cases over generic business automation.

## Key Changes

**Messaging & Positioning**
- Reframed target audience from "businesses" to "creative professionals," "studios," "post-production shops," and "agency teams"
- Shifted value proposition from cost reduction and automation to creative control, vendor neutrality, and workflow ownership
- Updated hero sections across all pages (creatives, business, agents, developers) with new taglines emphasizing open-source and BYOK

**Creative Page Updates**
- Renamed personas from generic titles ("Video Creators") to role-specific ones ("Motion designers," "AI-native illustrators," "Photographers & retouchers")
- Updated persona descriptions to focus on specific tools and workflows (e.g., "Wire Seedance, Veo, Kling, and Runway nodes for B-roll")
- Reframed feature titles from capability-focused ("Image Generation") to workflow-focused ("Image generation & editing," "Video pipelines," "Audio on the same surface")
- Changed tagline from "Built for Creative Professionals" to "The open canvas for working creatives"

**Business Page Overhaul**
- Completely rewrote use cases from generic business automation (document intelligence, customer support) to creative workflows (brand campaigns, video production, pitch work, asset libraries)
- Updated ROI section to emphasize "pay providers, not middlemen," workflow reusability, and vendor switching flexibility
- Changed security messaging from compliance certifications (SOC 2, GDPR, HIPAA) to open-source, BYOK, and self-hosting capabilities
- Updated business features to highlight no credit markup, data ownership, and extensibility

**FAQ Expansion**
- Replaced placeholder FAQs with substantive Q&A covering NodeTool positioning, BYOK benefits, open-source nature, comparisons to ComfyUI and Weavy, and model support

**Metadata & SEO**
- Updated page titles and descriptions across business, agents, and creatives sections
- Revised keywords to focus on creative AI, BYOK, open-source, and vendor-neutral positioning
- Changed OpenGraph descriptions to emphasize workflow ownership and lack of vendor lock-in

**Tone & Language Adjustments**
- Shifted from formal enterprise language to conversational, creative-focused tone
- Emphasized "your keys," "your data," "your workflows" throughout
- Changed CTAs from "Get Started Free" to "Download Studio"
- Updated section headings to be more specific and action-oriented (e.g., "What people build" instead of "Use Cases")

## Notable Implementation Details
- Consistent emphasis on AGPL-3.0 open-source licensing and self-hosting capabilities
- Repeated messaging about BYOK (Bring Your Own Keys) across all sections
- Specific model names (Seedance, Kling, Veo, Flux, Suno, etc.) used throughout to demonstrate breadth of support
- Comparison positioning against ComfyUI (engineer-first) and Weavy (closed, credit-based) to clarify differentiation
- Distinction between Studio (desktop, free, open-source) and Cloud (browser-based) offerings

https://claude.ai/code/session_01AXV3azyadpd7WSeULGNAZ2