### PR TITLE
feat(timeline): per-layer transform, border-radius, GPU effects

### DIFF
--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -93,6 +93,60 @@ export interface TimelineClip {
   fadeInMs?: number;
   /** Duration of the fade-out effect in milliseconds. */
   fadeOutMs?: number;
+  /** 2D placement on the preview canvas. Default: identity (centered, contain-fit). */
+  transform?: ClipTransform;
+  /** Rounded-corner radius in source pixels. 0 = sharp corners. */
+  borderRadius?: number;
+  /** GPU effects applied to this clip in order. */
+  effects?: ClipEffect[];
+}
+
+/**
+ * 2D transform applied per clip in the GPU compositor.
+ * - `position` is in canvas pixels relative to the canvas center.
+ * - `scale` multiplies the contain-fit base scale (1 = fit, 2 = 2x).
+ * - `rotation` is in radians.
+ * - `anchor` is the rotation/scale pivot in normalized [0,1] coords (0.5 = center).
+ */
+export interface ClipTransform {
+  position: { x: number; y: number };
+  scale: { x: number; y: number };
+  rotation: number;
+  anchor: { x: number; y: number };
+}
+
+export type ClipEffect = ClipColorEffect | ClipBlurEffect;
+
+export interface ClipColorEffect {
+  id: string;
+  type: "color";
+  enabled: boolean;
+  /** -1..1, default 0 */
+  brightness?: number;
+  /** 0..4, default 1 */
+  contrast?: number;
+  /** 0..4, default 1 */
+  saturation?: number;
+  /** degrees -180..180, default 0 */
+  hue?: number;
+  /** -1..1 (cool→warm), default 0 */
+  temperature?: number;
+  /** -1..1 (green→magenta), default 0 */
+  tint?: number;
+  /** -1..1, default 0 */
+  shadows?: number;
+  /** -1..1, default 0 */
+  highlights?: number;
+}
+
+export interface ClipBlurEffect {
+  id: string;
+  type: "blur";
+  enabled: boolean;
+  /** Blur radius in source pixels (0..20 typical). */
+  radius: number;
+  /** Optional Gaussian sigma. Defaults to radius / 3. */
+  sigma?: number;
 }
 
 export interface ClipVersion {

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -91,6 +91,9 @@ interface ActiveVideoSlot {
   blendMode: CompositorBlendMode;
   opacity: number;
   assetUrl: string;
+  transform?: TimelineClip["transform"];
+  borderRadius?: number;
+  effects?: TimelineClip["effects"];
 }
 
 interface ActiveImageLayer {
@@ -100,6 +103,9 @@ interface ActiveImageLayer {
   opacity: number;
   assetUrl: string;
   status: TimelineClip["status"];
+  transform?: TimelineClip["transform"];
+  borderRadius?: number;
+  effects?: TimelineClip["effects"];
 }
 
 function isClipActive(clip: TimelineClip, currentTimeMs: number): boolean {
@@ -318,7 +324,10 @@ export const PreviewCompositor: React.FC = memo(() => {
           blendMode: resolveBlendMode(clip.blendMode),
           opacity: clip.opacity ?? 1,
           assetUrl: url ?? "",
-          status: clip.status
+          status: clip.status,
+          transform: clip.transform,
+          borderRadius: clip.borderRadius,
+          effects: clip.effects
         });
         if (!url) {
           placeholders.push({
@@ -338,7 +347,10 @@ export const PreviewCompositor: React.FC = memo(() => {
             trackIndex: track.index,
             blendMode: resolveBlendMode(clip.blendMode),
             opacity: clip.opacity ?? 1,
-            assetUrl: url
+            assetUrl: url,
+            transform: clip.transform,
+            borderRadius: clip.borderRadius,
+            effects: clip.effects
           });
         } else if (!url) {
           placeholders.push({
@@ -472,7 +484,10 @@ export const PreviewCompositor: React.FC = memo(() => {
         source: el,
         opacity: slot.opacity,
         blendMode: slot.blendMode,
-        zIndex: slot.trackIndex
+        zIndex: slot.trackIndex,
+        transform: slot.transform,
+        borderRadius: slot.borderRadius,
+        effects: slot.effects
       });
     });
 
@@ -485,7 +500,10 @@ export const PreviewCompositor: React.FC = memo(() => {
         source: img,
         opacity: layer.opacity,
         blendMode: layer.blendMode,
-        zIndex: layer.trackIndex
+        zIndex: layer.trackIndex,
+        transform: layer.transform,
+        borderRadius: layer.borderRadius,
+        effects: layer.effects
       });
     }
 

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -1,4 +1,10 @@
-import { compositeShader } from "./shaders";
+import { WebGPUEffectsProcessor } from "./effectsProcessor";
+import { borderRadiusShader, transformShader } from "./shaders";
+import {
+  IDENTITY_TRANSFORM,
+  buildTransformMatrix,
+  containBaseScale
+} from "./transform";
 import type {
   CompositeLayer,
   CompositeSource,
@@ -6,7 +12,8 @@ import type {
   CompositorInitResult
 } from "./types";
 
-const UNIFORM_BUFFER_SIZE = 16; // 4 x f32 (scaleX, scaleY, opacity, pad)
+const TRANSFORM_UNIFORM_BYTES = 96;
+const BORDER_RADIUS_UNIFORM_BYTES = 96;
 
 const BLEND_MODES: CompositorBlendMode[] = [
   "normal",
@@ -16,10 +23,6 @@ const BLEND_MODES: CompositorBlendMode[] = [
   "overlay"
 ];
 
-/**
- * Maps each TimelineClip blend mode to a WebGPU fixed-function blend state.
- * `overlay` has no fixed-function equivalent — fall back to normal alpha.
- */
 function blendStateFor(mode: CompositorBlendMode): GPUBlendState {
   switch (mode) {
     case "add":
@@ -63,23 +66,16 @@ function blendStateFor(mode: CompositorBlendMode): GPUBlendState {
   }
 }
 
-interface LayerTexture {
+interface SourceTexture {
   texture: GPUTexture;
   width: number;
   height: number;
   source: CompositeSource;
-  /** Last frame number we copied for this source. Re-used to skip needless uploads. */
   lastUploadKey: string;
 }
 
-/**
- * Returns a key that changes when the source has produced a new pixel state.
- * For video this uses the underlying mediaTime when available; for images,
- * src + naturalWidth+Height suffices.
- */
 function uploadKey(source: CompositeSource): string {
   if (source instanceof HTMLVideoElement) {
-    // currentTime alone is enough to discriminate frames during playback.
     return `v:${source.currentTime}:${source.videoWidth}x${source.videoHeight}`;
   }
   if (source instanceof HTMLImageElement) {
@@ -107,6 +103,11 @@ function sourceDimensions(source: CompositeSource): {
   return { width: source.width, height: source.height };
 }
 
+interface PipelinePair {
+  plain: GPURenderPipeline;
+  rounded: GPURenderPipeline;
+}
+
 export class WebGPUCompositor {
   private device: GPUDevice | null = null;
   private context: GPUCanvasContext | null = null;
@@ -115,20 +116,20 @@ export class WebGPUCompositor {
   private uniformLayout: GPUBindGroupLayout | null = null;
   private textureLayout: GPUBindGroupLayout | null = null;
   private sampler: GPUSampler | null = null;
-  private pipelines = new Map<CompositorBlendMode, GPURenderPipeline>();
+  private pipelines = new Map<CompositorBlendMode, PipelinePair>();
 
   private canvasWidth = 0;
   private canvasHeight = 0;
 
-  private layerTextures = new Map<string, LayerTexture>();
+  private sourceTextures = new Map<string, SourceTexture>();
   private uniformBuffers: GPUBuffer[] = [];
   private layers: CompositeLayer[] = [];
+  private effects: WebGPUEffectsProcessor | null = null;
 
   async init(canvas: HTMLCanvasElement): Promise<CompositorInitResult> {
     if (typeof navigator === "undefined" || !navigator.gpu) {
       return { ok: false, reason: "WebGPU not supported in this browser" };
     }
-
     const adapter = await navigator.gpu.requestAdapter({
       powerPreference: "high-performance"
     });
@@ -187,28 +188,46 @@ export class WebGPUCompositor {
       addressModeV: "clamp-to-edge"
     });
 
-    const shaderModule = device.createShaderModule({
-      label: "preview-composite",
-      code: compositeShader
+    const transformModule = device.createShaderModule({
+      label: "preview-transform",
+      code: transformShader
+    });
+    const borderRadiusModule = device.createShaderModule({
+      label: "preview-border-radius",
+      code: borderRadiusShader
     });
     const pipelineLayout = device.createPipelineLayout({
       bindGroupLayouts: [this.uniformLayout, this.textureLayout]
     });
 
     for (const mode of BLEND_MODES) {
-      const pipeline = device.createRenderPipeline({
+      const blend = blendStateFor(mode);
+      const plain = device.createRenderPipeline({
         label: `preview-pipeline-${mode}`,
         layout: pipelineLayout,
-        vertex: { module: shaderModule, entryPoint: "vs" },
+        vertex: { module: transformModule, entryPoint: "vs" },
         fragment: {
-          module: shaderModule,
+          module: transformModule,
           entryPoint: "fs",
-          targets: [{ format: this.canvasFormat, blend: blendStateFor(mode) }]
+          targets: [{ format: this.canvasFormat, blend }]
         },
         primitive: { topology: "triangle-list" }
       });
-      this.pipelines.set(mode, pipeline);
+      const rounded = device.createRenderPipeline({
+        label: `preview-pipeline-rounded-${mode}`,
+        layout: pipelineLayout,
+        vertex: { module: borderRadiusModule, entryPoint: "vs" },
+        fragment: {
+          module: borderRadiusModule,
+          entryPoint: "fs",
+          targets: [{ format: this.canvasFormat, blend }]
+        },
+        primitive: { topology: "triangle-list" }
+      });
+      this.pipelines.set(mode, { plain, rounded });
     }
+
+    this.effects = new WebGPUEffectsProcessor(device);
 
     return { ok: true };
   }
@@ -220,32 +239,31 @@ export class WebGPUCompositor {
 
   setLayers(layers: CompositeLayer[]): void {
     this.layers = [...layers].sort((a, b) => a.zIndex - b.zIndex);
-    this.pruneStaleTextures();
+    this.pruneStale();
   }
 
-  private pruneStaleTextures(): void {
+  private pruneStale(): void {
     const liveIds = new Set(this.layers.map((l) => l.id));
-    for (const [id, entry] of this.layerTextures) {
+    for (const [id, entry] of this.sourceTextures) {
       if (!liveIds.has(id)) {
         entry.texture.destroy();
-        this.layerTextures.delete(id);
+        this.sourceTextures.delete(id);
       }
     }
+    this.effects?.retainOnly(liveIds);
   }
 
   /**
-   * Allocates / reuses a GPU texture for the layer's source and copies the
-   * current source pixels into it. Returns null if the source isn't ready
-   * yet (e.g. video has no decoded frame).
+   * Allocates / reuses a source GPU texture for the layer and copies its
+   * current pixels into it. Returns null if the source isn't ready yet.
    */
-  private uploadLayer(layer: CompositeLayer): LayerTexture | null {
+  private uploadSource(layer: CompositeLayer): SourceTexture | null {
     if (!this.device) return null;
-
     const { width, height } = sourceDimensions(layer.source);
     if (width === 0 || height === 0) return null;
 
     const key = uploadKey(layer.source);
-    let entry = this.layerTextures.get(layer.id);
+    let entry = this.sourceTextures.get(layer.id);
 
     if (
       !entry ||
@@ -255,16 +273,17 @@ export class WebGPUCompositor {
     ) {
       entry?.texture.destroy();
       const texture = this.device.createTexture({
-        label: `preview-layer-${layer.id}`,
+        label: `preview-source-${layer.id}`,
         size: { width, height },
         format: "rgba8unorm",
         usage:
           GPUTextureUsage.TEXTURE_BINDING |
           GPUTextureUsage.COPY_DST |
+          GPUTextureUsage.COPY_SRC |
           GPUTextureUsage.RENDER_ATTACHMENT
       });
       entry = { texture, width, height, source: layer.source, lastUploadKey: "" };
-      this.layerTextures.set(layer.id, entry);
+      this.sourceTextures.set(layer.id, entry);
     }
 
     if (entry.lastUploadKey !== key) {
@@ -278,41 +297,20 @@ export class WebGPUCompositor {
     return entry;
   }
 
-  private getUniformBuffer(index: number): GPUBuffer {
+  private getUniformBuffer(index: number, size: number): GPUBuffer {
     if (!this.device) {
       throw new Error("Compositor not initialized");
     }
     let buffer = this.uniformBuffers[index];
     if (!buffer) {
       buffer = this.device.createBuffer({
-        label: `preview-uniforms-${index}`,
-        size: UNIFORM_BUFFER_SIZE,
+        label: `preview-layer-uniforms-${index}`,
+        size: Math.max(size, TRANSFORM_UNIFORM_BYTES),
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
       });
       this.uniformBuffers[index] = buffer;
     }
     return buffer;
-  }
-
-  /** Compute object-fit:contain scale factors in clip space. */
-  private containScale(
-    layerWidth: number,
-    layerHeight: number
-  ): { scaleX: number; scaleY: number } {
-    if (
-      this.canvasWidth === 0 ||
-      this.canvasHeight === 0 ||
-      layerWidth === 0 ||
-      layerHeight === 0
-    ) {
-      return { scaleX: 1, scaleY: 1 };
-    }
-    const canvasAspect = this.canvasWidth / this.canvasHeight;
-    const layerAspect = layerWidth / layerHeight;
-    if (layerAspect > canvasAspect) {
-      return { scaleX: 1, scaleY: canvasAspect / layerAspect };
-    }
-    return { scaleX: layerAspect / canvasAspect, scaleY: 1 };
   }
 
   render(): void {
@@ -342,12 +340,52 @@ export class WebGPUCompositor {
 
     let drawn = 0;
     for (const layer of this.layers) {
-      const entry = this.uploadLayer(layer);
-      if (!entry) continue;
+      const src = this.uploadSource(layer);
+      if (!src) continue;
 
-      const { scaleX, scaleY } = this.containScale(entry.width, entry.height);
-      const uniformBuffer = this.getUniformBuffer(drawn);
-      const data = new Float32Array([scaleX, scaleY, layer.opacity, 0]);
+      // Run effects pre-pass if any. Effects uses its own command encoder
+      // and submits before we record this draw — so the result is ready.
+      const effectsList = layer.effects ?? [];
+      const processedTexture =
+        effectsList.length > 0 && this.effects
+          ? this.effects.process(layer.id, src.texture, src.width, src.height, effectsList)
+          : src.texture;
+
+      const transform = layer.transform ?? IDENTITY_TRANSFORM;
+      const base = containBaseScale(
+        src.width,
+        src.height,
+        this.canvasWidth,
+        this.canvasHeight
+      );
+      const matrix = buildTransformMatrix(
+        transform,
+        base,
+        this.canvasWidth,
+        this.canvasHeight
+      );
+
+      const radiusPx = layer.borderRadius ?? 0;
+      const radiusNormalized =
+        radiusPx > 0 && src.width > 0 && src.height > 0
+          ? Math.min(0.5, radiusPx / Math.min(src.width, src.height))
+          : 0;
+      const useRadius = radiusNormalized > 0.001;
+      const aspect = src.height === 0 ? 1 : src.width / src.height;
+
+      const uniformBuffer = this.getUniformBuffer(
+        drawn,
+        useRadius ? BORDER_RADIUS_UNIFORM_BYTES : TRANSFORM_UNIFORM_BYTES
+      );
+      // Both pipelines use 96-byte buffers but the tail layout differs.
+      const data = new Float32Array(24);
+      data.set(matrix, 0);
+      data[16] = layer.opacity;
+      if (useRadius) {
+        data[17] = radiusNormalized;
+        data[18] = aspect;
+        data[19] = 0.01; // smoothness — small, anti-alias band
+      }
       this.device.queue.writeBuffer(uniformBuffer, 0, data.buffer, 0, data.byteLength);
 
       const uniformBindGroup = this.device.createBindGroup({
@@ -358,13 +396,14 @@ export class WebGPUCompositor {
         layout: this.textureLayout,
         entries: [
           { binding: 0, resource: this.sampler },
-          { binding: 1, resource: entry.texture.createView() }
+          { binding: 1, resource: processedTexture.createView() }
         ]
       });
 
-      const pipeline =
+      const pair =
         this.pipelines.get(layer.blendMode) ?? this.pipelines.get("normal");
-      if (!pipeline) continue;
+      if (!pair) continue;
+      const pipeline = useRadius ? pair.rounded : pair.plain;
 
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, uniformBindGroup);
@@ -378,15 +417,17 @@ export class WebGPUCompositor {
   }
 
   dispose(): void {
-    for (const entry of this.layerTextures.values()) {
+    for (const entry of this.sourceTextures.values()) {
       entry.texture.destroy();
     }
-    this.layerTextures.clear();
+    this.sourceTextures.clear();
     for (const buffer of this.uniformBuffers) {
       buffer.destroy();
     }
     this.uniformBuffers = [];
     this.pipelines.clear();
+    this.effects?.dispose();
+    this.effects = null;
     this.sampler = null;
     this.uniformLayout = null;
     this.textureLayout = null;

--- a/web/src/components/timeline/preview/gpu/effectsProcessor.ts
+++ b/web/src/components/timeline/preview/gpu/effectsProcessor.ts
@@ -1,0 +1,334 @@
+import type { ClipEffect, ClipColorEffect } from "@nodetool-ai/timeline";
+import { blurComputeShader, effectsComputeShader } from "./shaders";
+
+interface AggregatedColor {
+  brightness: number;
+  contrast: number;
+  saturation: number;
+  hue: number;
+  temperature: number;
+  tint: number;
+  shadows: number;
+  highlights: number;
+}
+
+const NEUTRAL_COLOR: AggregatedColor = {
+  brightness: 0,
+  contrast: 1,
+  saturation: 1,
+  hue: 0,
+  temperature: 0,
+  tint: 0,
+  shadows: 0,
+  highlights: 0
+};
+
+const COLOR_UNIFORM_BYTES = 32;
+const BLUR_UNIFORM_BYTES = 16;
+const DIMS_UNIFORM_BYTES = 16;
+
+interface IntermediatePool {
+  width: number;
+  height: number;
+  textures: [GPUTexture, GPUTexture];
+  dimsBuffer: GPUBuffer;
+  /** Currently holds the latest pixel state (input to next pass). */
+  currentIndex: 0 | 1;
+}
+
+/**
+ * GPU pre-pass for per-clip color grading and Gaussian blur. Caller passes
+ * a source GPU texture + ClipEffect[] and gets back a texture (either the
+ * original if no effects apply, or a processed intermediate). Intermediate
+ * textures are pooled by layer id + source dimensions so we don't reallocate
+ * every frame.
+ */
+export class WebGPUEffectsProcessor {
+  private device: GPUDevice;
+
+  private effectsPipeline: GPUComputePipeline;
+  private blurPipeline: GPUComputePipeline;
+  private bindGroupLayout: GPUBindGroupLayout;
+
+  private colorBuffer: GPUBuffer;
+  private blurBuffer: GPUBuffer;
+
+  private pools = new Map<string, IntermediatePool>();
+
+  constructor(device: GPUDevice) {
+    this.device = device;
+
+    this.bindGroupLayout = device.createBindGroupLayout({
+      label: "preview-effects-layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          texture: { sampleType: "float" }
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.COMPUTE,
+          storageTexture: { access: "write-only", format: "rgba8unorm" }
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: "uniform" }
+        },
+        {
+          binding: 3,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: "uniform" }
+        }
+      ]
+    });
+    const layout = device.createPipelineLayout({
+      bindGroupLayouts: [this.bindGroupLayout]
+    });
+    this.effectsPipeline = device.createComputePipeline({
+      label: "preview-color-effects",
+      layout,
+      compute: {
+        module: device.createShaderModule({ code: effectsComputeShader }),
+        entryPoint: "main"
+      }
+    });
+    this.blurPipeline = device.createComputePipeline({
+      label: "preview-blur",
+      layout,
+      compute: {
+        module: device.createShaderModule({ code: blurComputeShader }),
+        entryPoint: "main"
+      }
+    });
+
+    this.colorBuffer = device.createBuffer({
+      label: "preview-color-uniforms",
+      size: COLOR_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    this.blurBuffer = device.createBuffer({
+      label: "preview-blur-uniforms",
+      size: BLUR_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+  }
+
+  /** Returns a compatible bind group layout for callers that need it. */
+  getBindGroupLayout(): GPUBindGroupLayout {
+    return this.bindGroupLayout;
+  }
+
+  /**
+   * Run the effects chain on `source` and return a GPU texture with the
+   * processed pixels. If no effects are enabled, returns `source` itself
+   * (caller should not destroy it on the assumption it's owned).
+   */
+  process(
+    poolKey: string,
+    source: GPUTexture,
+    width: number,
+    height: number,
+    effects: ClipEffect[]
+  ): GPUTexture {
+    const enabled = effects.filter((e) => e.enabled);
+    if (enabled.length === 0) return source;
+
+    const color = aggregateColor(enabled);
+    const blur = enabled.find((e): e is ClipEffect & { type: "blur" } =>
+      e.type === "blur"
+    );
+    const colorActive = isColorActive(color);
+    const blurActive = blur != null && blur.radius >= 0.5;
+    if (!colorActive && !blurActive) return source;
+
+    const pool = this.getPool(poolKey, width, height);
+    const encoder = this.device.createCommandEncoder({
+      label: `preview-effects-${poolKey}`
+    });
+
+    // Seed: copy source → textures[0]
+    encoder.copyTextureToTexture(
+      { texture: source },
+      { texture: pool.textures[0] },
+      { width, height }
+    );
+    pool.currentIndex = 0;
+
+    if (colorActive) {
+      this.writeColor(color);
+      this.dispatch(encoder, pool, this.effectsPipeline);
+    }
+    if (blurActive && blur) {
+      // Horizontal then vertical pass.
+      this.writeBlur(blur.radius, blur.sigma ?? blur.radius / 3, 1, 0);
+      this.dispatch(encoder, pool, this.blurPipeline);
+      this.writeBlur(blur.radius, blur.sigma ?? blur.radius / 3, 0, 1);
+      this.dispatch(encoder, pool, this.blurPipeline);
+    }
+
+    this.device.queue.submit([encoder.finish()]);
+    return pool.textures[pool.currentIndex];
+  }
+
+  private writeColor(c: AggregatedColor): void {
+    const data = new Float32Array([
+      c.brightness,
+      c.contrast,
+      c.saturation,
+      c.hue,
+      c.temperature,
+      c.tint,
+      c.shadows,
+      c.highlights
+    ]);
+    this.device.queue.writeBuffer(this.colorBuffer, 0, data.buffer, 0, data.byteLength);
+  }
+
+  private writeBlur(radius: number, sigma: number, dx: number, dy: number): void {
+    const data = new Float32Array([radius, sigma, dx, dy]);
+    this.device.queue.writeBuffer(this.blurBuffer, 0, data.buffer, 0, data.byteLength);
+  }
+
+  private dispatch(
+    encoder: GPUCommandEncoder,
+    pool: IntermediatePool,
+    pipeline: GPUComputePipeline
+  ): void {
+    const inIdx = pool.currentIndex;
+    const outIdx = (1 - inIdx) as 0 | 1;
+    const uniformBuffer =
+      pipeline === this.effectsPipeline ? this.colorBuffer : this.blurBuffer;
+
+    const bindGroup = this.device.createBindGroup({
+      layout: this.bindGroupLayout,
+      entries: [
+        { binding: 0, resource: pool.textures[inIdx].createView() },
+        { binding: 1, resource: pool.textures[outIdx].createView() },
+        { binding: 2, resource: { buffer: uniformBuffer } },
+        { binding: 3, resource: { buffer: pool.dimsBuffer } }
+      ]
+    });
+
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(
+      Math.ceil(pool.width / 16),
+      Math.ceil(pool.height / 16),
+      1
+    );
+    pass.end();
+
+    pool.currentIndex = outIdx;
+  }
+
+  private getPool(key: string, width: number, height: number): IntermediatePool {
+    const existing = this.pools.get(key);
+    if (existing && existing.width === width && existing.height === height) {
+      return existing;
+    }
+    if (existing) {
+      existing.textures[0].destroy();
+      existing.textures[1].destroy();
+      existing.dimsBuffer.destroy();
+    }
+    const make = (label: string) =>
+      this.device.createTexture({
+        label,
+        size: { width, height },
+        format: "rgba8unorm",
+        usage:
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.STORAGE_BINDING |
+          GPUTextureUsage.COPY_SRC |
+          GPUTextureUsage.COPY_DST
+      });
+    const dimsBuffer = this.device.createBuffer({
+      label: `preview-effects-dims-${key}`,
+      size: DIMS_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    const dims = new Uint32Array([width, height, 0, 0]);
+    this.device.queue.writeBuffer(dimsBuffer, 0, dims.buffer, 0, dims.byteLength);
+    const pool: IntermediatePool = {
+      width,
+      height,
+      textures: [make(`preview-effects-${key}-a`), make(`preview-effects-${key}-b`)],
+      dimsBuffer,
+      currentIndex: 0
+    };
+    this.pools.set(key, pool);
+    return pool;
+  }
+
+  releasePool(key: string): void {
+    const pool = this.pools.get(key);
+    if (!pool) return;
+    pool.textures[0].destroy();
+    pool.textures[1].destroy();
+    pool.dimsBuffer.destroy();
+    this.pools.delete(key);
+  }
+
+  retainOnly(keys: Iterable<string>): void {
+    const keep = new Set(keys);
+    for (const key of [...this.pools.keys()]) {
+      if (!keep.has(key)) this.releasePool(key);
+    }
+  }
+
+  dispose(): void {
+    for (const pool of this.pools.values()) {
+      pool.textures[0].destroy();
+      pool.textures[1].destroy();
+      pool.dimsBuffer.destroy();
+    }
+    this.pools.clear();
+    this.colorBuffer.destroy();
+    this.blurBuffer.destroy();
+  }
+}
+
+function aggregateColor(effects: ClipEffect[]): AggregatedColor {
+  const out: AggregatedColor = { ...NEUTRAL_COLOR };
+  for (const e of effects) {
+    if (e.type !== "color") continue;
+    const c = e as ClipColorEffect;
+    out.brightness += c.brightness ?? 0;
+    out.contrast *= c.contrast ?? 1;
+    out.saturation *= c.saturation ?? 1;
+    out.hue += c.hue ?? 0;
+    out.temperature += c.temperature ?? 0;
+    out.tint += c.tint ?? 0;
+    out.shadows += c.shadows ?? 0;
+    out.highlights += c.highlights ?? 0;
+  }
+  out.brightness = clamp(out.brightness, -1, 1);
+  out.contrast = clamp(out.contrast, 0, 4);
+  out.saturation = clamp(out.saturation, 0, 4);
+  out.hue = ((out.hue % 360) + 540) % 360 - 180;
+  out.temperature = clamp(out.temperature, -1, 1);
+  out.tint = clamp(out.tint, -1, 1);
+  out.shadows = clamp(out.shadows, -1, 1);
+  out.highlights = clamp(out.highlights, -1, 1);
+  return out;
+}
+
+function isColorActive(c: AggregatedColor): boolean {
+  return (
+    Math.abs(c.brightness) > 0.001 ||
+    Math.abs(c.contrast - 1) > 0.001 ||
+    Math.abs(c.saturation - 1) > 0.001 ||
+    Math.abs(c.hue) > 0.001 ||
+    Math.abs(c.temperature) > 0.001 ||
+    Math.abs(c.tint) > 0.001 ||
+    Math.abs(c.shadows) > 0.001 ||
+    Math.abs(c.highlights) > 0.001
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}

--- a/web/src/components/timeline/preview/gpu/shaders.ts
+++ b/web/src/components/timeline/preview/gpu/shaders.ts
@@ -1,14 +1,27 @@
 /**
- * Single composite shader: full-screen quad, per-layer scale (object-fit:
- * contain), per-layer opacity. Blend mode is selected at the pipeline level
- * via fixed-function blend state — no shader-side compositing.
+ * Transform shader: vertex stage applies a 4x4 matrix per layer; fragment
+ * samples the source texture and applies opacity. Two-triangle quad with
+ * explicit UVs (no full-screen triangle trick — UV math has to stay clean
+ * after we scale/rotate the quad in clip space).
+ *
+ * Matrix layout matches openreel's createTransformMatrix:
+ *   columns = [scale.x*cos, scale.x*sin, 0, 0,
+ *              -scale.y*sin, scale.y*cos, 0, 0,
+ *              0, 0, 1, 0,
+ *              tx, ty, 0, 1]
+ *
+ * Uniform buffer (96 bytes total):
+ *   matrix: 64
+ *   opacity: 4
+ *   _pad0:   4
+ *   _pad1:   8 (unused — kept for layout symmetry with the border-radius variant)
  */
-export const compositeShader = /* wgsl */ `
+export const transformShader = /* wgsl */ `
 struct Uniforms {
-  scaleX: f32,
-  scaleY: f32,
+  matrix: mat4x4<f32>,
   opacity: f32,
-  _pad: f32,
+  _pad0: f32,
+  _pad1: vec2<f32>,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -38,9 +51,8 @@ fn vs(@builtin(vertex_index) i: u32) -> VsOut {
     vec2<f32>(1.0, 1.0),
     vec2<f32>(1.0, 0.0),
   );
-  let p = positions[i];
   var out: VsOut;
-  out.pos = vec4<f32>(p.x * u.scaleX, p.y * u.scaleY, 0.0, 1.0);
+  out.pos = u.matrix * vec4<f32>(positions[i], 0.0, 1.0);
   out.uv = uvs[i];
   return out;
 }
@@ -49,5 +61,266 @@ fn vs(@builtin(vertex_index) i: u32) -> VsOut {
 fn fs(in: VsOut) -> @location(0) vec4<f32> {
   let c = textureSample(tex, samp, in.uv);
   return vec4<f32>(c.rgb, c.a * u.opacity);
+}
+`;
+
+/**
+ * Border-radius variant: same vertex transform but the fragment uses an SDF
+ * to mask rounded corners with anti-aliased edges. `radius` is in normalized
+ * [0, 0.5] units (fraction of the shorter quad axis).
+ *
+ * Uniform buffer (96 bytes):
+ *   matrix: 64
+ *   opacity: 4
+ *   radius:  4
+ *   aspect:  4   (width/height of the source — corrects the SDF for non-square layers)
+ *   smooth:  4
+ *   _pad:    16
+ */
+export const borderRadiusShader = /* wgsl */ `
+struct Uniforms {
+  matrix: mat4x4<f32>,
+  opacity: f32,
+  radius: f32,
+  aspect: f32,
+  smoothness: f32,
+  _pad: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> u: Uniforms;
+@group(1) @binding(0) var samp: sampler;
+@group(1) @binding(1) var tex: texture_2d<f32>;
+
+struct VsOut {
+  @builtin(position) pos: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+  @location(1) local: vec2<f32>,
+};
+
+@vertex
+fn vs(@builtin(vertex_index) i: u32) -> VsOut {
+  var positions = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>( 1.0,  1.0),
+  );
+  var uvs = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+  );
+  var out: VsOut;
+  out.pos = u.matrix * vec4<f32>(positions[i], 0.0, 1.0);
+  out.uv = uvs[i];
+  out.local = positions[i];
+  return out;
+}
+
+fn sdRoundedRect(p: vec2<f32>, b: vec2<f32>, r: f32) -> f32 {
+  let q = abs(p) - b + vec2<f32>(r);
+  return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r;
+}
+
+@fragment
+fn fs(in: VsOut) -> @location(0) vec4<f32> {
+  let c = textureSample(tex, samp, in.uv);
+  // Stretch the local position to a square so the SDF gives a uniform corner.
+  var p = in.local;
+  if (u.aspect > 1.0) {
+    p.y = p.y / u.aspect;
+  } else {
+    p.x = p.x * u.aspect;
+  }
+  let halfSize = vec2<f32>(min(1.0, u.aspect), min(1.0, 1.0 / u.aspect));
+  let r = clamp(u.radius, 0.0, 0.5) * 2.0 * min(halfSize.x, halfSize.y);
+  let dist = sdRoundedRect(p, halfSize, r);
+  let alpha = 1.0 - smoothstep(-u.smoothness, u.smoothness, dist);
+  return vec4<f32>(c.rgb, c.a * u.opacity * alpha);
+}
+`;
+
+/**
+ * Color effects compute shader. Single pass that chains brightness →
+ * contrast → saturation → hue → temperature → tint → shadows/highlights.
+ * Ported verbatim from openreel-video's effects.wgsl.
+ */
+export const effectsComputeShader = /* wgsl */ `
+struct EffectUniforms {
+  brightness: f32,
+  contrast: f32,
+  saturation: f32,
+  hue: f32,
+  temperature: f32,
+  tint: f32,
+  shadows: f32,
+  highlights: f32,
+};
+struct Dimensions {
+  width: u32,
+  height: u32,
+  _pad: vec2<u32>,
+};
+
+@group(0) @binding(0) var inputTexture: texture_2d<f32>;
+@group(0) @binding(1) var outputTexture: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(2) var<uniform> effects: EffectUniforms;
+@group(0) @binding(3) var<uniform> dims: Dimensions;
+
+fn rgb2hsv(rgb: vec3<f32>) -> vec3<f32> {
+  let maxC = max(max(rgb.r, rgb.g), rgb.b);
+  let minC = min(min(rgb.r, rgb.g), rgb.b);
+  let delta = maxC - minC;
+  var h: f32 = 0.0;
+  var s: f32 = 0.0;
+  let v: f32 = maxC;
+  if (delta > 0.00001) {
+    s = delta / maxC;
+    if (maxC == rgb.r) {
+      h = (rgb.g - rgb.b) / delta;
+      if (rgb.g < rgb.b) { h = h + 6.0; }
+    } else if (maxC == rgb.g) {
+      h = 2.0 + (rgb.b - rgb.r) / delta;
+    } else {
+      h = 4.0 + (rgb.r - rgb.g) / delta;
+    }
+    h = h / 6.0;
+  }
+  return vec3<f32>(h, s, v);
+}
+
+fn hsv2rgb(hsv: vec3<f32>) -> vec3<f32> {
+  let h = hsv.x * 6.0;
+  let s = hsv.y;
+  let v = hsv.z;
+  let i = floor(h);
+  let f = h - i;
+  let p = v * (1.0 - s);
+  let q = v * (1.0 - s * f);
+  let t = v * (1.0 - s * (1.0 - f));
+  let idx = i32(i) % 6;
+  if (idx == 0) { return vec3<f32>(v, t, p); }
+  if (idx == 1) { return vec3<f32>(q, v, p); }
+  if (idx == 2) { return vec3<f32>(p, v, t); }
+  if (idx == 3) { return vec3<f32>(p, q, v); }
+  if (idx == 4) { return vec3<f32>(t, p, v); }
+  return vec3<f32>(v, p, q);
+}
+
+fn smoothstepCustom(e0: f32, e1: f32, x: f32) -> f32 {
+  let t = clamp((x - e0) / (e1 - e0), 0.0, 1.0);
+  return t * t * (3.0 - 2.0 * t);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  if (gid.x >= dims.width || gid.y >= dims.height) { return; }
+  let coords = vec2<i32>(i32(gid.x), i32(gid.y));
+  var color = textureLoad(inputTexture, coords, 0);
+  var rgb = color.rgb;
+
+  if (abs(effects.brightness) > 0.001) {
+    rgb = clamp(rgb + vec3<f32>(effects.brightness), vec3<f32>(0.0), vec3<f32>(1.0));
+  }
+  if (abs(effects.contrast - 1.0) > 0.001) {
+    rgb = clamp((rgb - 0.5) * effects.contrast + 0.5, vec3<f32>(0.0), vec3<f32>(1.0));
+  }
+  if (abs(effects.saturation - 1.0) > 0.001) {
+    let lum = dot(rgb, vec3<f32>(0.299, 0.587, 0.114));
+    rgb = clamp(mix(vec3<f32>(lum), rgb, effects.saturation), vec3<f32>(0.0), vec3<f32>(1.0));
+  }
+  if (abs(effects.hue) > 0.001) {
+    var hsv = rgb2hsv(rgb);
+    hsv.x = fract(hsv.x + effects.hue / 360.0);
+    rgb = hsv2rgb(hsv);
+  }
+  if (abs(effects.temperature) > 0.001) {
+    if (effects.temperature > 0.0) {
+      rgb.r = min(1.0, rgb.r + effects.temperature * 0.2);
+      rgb.g = min(1.0, rgb.g + effects.temperature * 0.1);
+      rgb.b = max(0.0, rgb.b - effects.temperature * 0.2);
+    } else {
+      rgb.r = max(0.0, rgb.r + effects.temperature * 0.2);
+      rgb.g = max(0.0, rgb.g + effects.temperature * 0.05);
+      rgb.b = min(1.0, rgb.b - effects.temperature * 0.2);
+    }
+  }
+  if (abs(effects.tint) > 0.001) {
+    rgb.r = clamp(rgb.r + effects.tint * 0.1, 0.0, 1.0);
+    rgb.g = clamp(rgb.g - effects.tint * 0.2, 0.0, 1.0);
+    rgb.b = clamp(rgb.b + effects.tint * 0.1, 0.0, 1.0);
+  }
+  if (abs(effects.shadows) > 0.001 || abs(effects.highlights) > 0.001) {
+    let lum = dot(rgb, vec3<f32>(0.299, 0.587, 0.114));
+    let shadowW = 1.0 - smoothstepCustom(0.0, 0.33, lum);
+    let highlightW = smoothstepCustom(0.66, 1.0, lum);
+    let adj = effects.shadows * shadowW * 0.3 + effects.highlights * highlightW * 0.3;
+    rgb = clamp(rgb + vec3<f32>(adj), vec3<f32>(0.0), vec3<f32>(1.0));
+  }
+
+  textureStore(outputTexture, coords, vec4<f32>(rgb, color.a));
+}
+`;
+
+/**
+ * Separable Gaussian blur compute shader. Caller dispatches twice — once
+ * with direction (1,0) and once with (0,1) — and ping-pongs textures.
+ */
+export const blurComputeShader = /* wgsl */ `
+struct BlurUniforms {
+  radius: f32,
+  sigma: f32,
+  direction: vec2<f32>,
+};
+struct Dimensions {
+  width: u32,
+  height: u32,
+  _pad: vec2<u32>,
+};
+
+@group(0) @binding(0) var inputTexture: texture_2d<f32>;
+@group(0) @binding(1) var outputTexture: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(2) var<uniform> blur: BlurUniforms;
+@group(0) @binding(3) var<uniform> dims: Dimensions;
+
+fn gaussianWeight(offset: f32, sigma: f32) -> f32 {
+  let s2 = sigma * sigma;
+  return exp(-(offset * offset) / (2.0 * s2)) / (sqrt(2.0 * 3.14159265) * sigma);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  if (gid.x >= dims.width || gid.y >= dims.height) { return; }
+  let coords = vec2<i32>(i32(gid.x), i32(gid.y));
+
+  if (blur.radius < 0.5) {
+    textureStore(outputTexture, coords, textureLoad(inputTexture, coords, 0));
+    return;
+  }
+
+  let kernelRadius = i32(min(blur.radius, 20.0));
+  let sigma = max(blur.sigma, blur.radius / 3.0);
+
+  var colorSum = vec4<f32>(0.0);
+  var weightSum: f32 = 0.0;
+  for (var i = -kernelRadius; i <= kernelRadius; i = i + 1) {
+    let offset = vec2<i32>(
+      i32(blur.direction.x * f32(i)),
+      i32(blur.direction.y * f32(i))
+    );
+    let s = vec2<i32>(
+      clamp(coords.x + offset.x, 0, i32(dims.width) - 1),
+      clamp(coords.y + offset.y, 0, i32(dims.height) - 1)
+    );
+    let w = gaussianWeight(f32(i), sigma);
+    colorSum = colorSum + textureLoad(inputTexture, s, 0) * w;
+    weightSum = weightSum + w;
+  }
+  textureStore(outputTexture, coords, colorSum / weightSum);
 }
 `;

--- a/web/src/components/timeline/preview/gpu/transform.ts
+++ b/web/src/components/timeline/preview/gpu/transform.ts
@@ -1,0 +1,89 @@
+import type { ClipTransform } from "@nodetool-ai/timeline";
+
+export const IDENTITY_TRANSFORM: ClipTransform = {
+  position: { x: 0, y: 0 },
+  scale: { x: 1, y: 1 },
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 }
+};
+
+/**
+ * Compute the contain-fit base scale (clip space) for a layer of given
+ * source size against a canvas. Mirrors `object-fit: contain` — the longer
+ * source axis fills the canvas, the other shrinks proportionally.
+ */
+export function containBaseScale(
+  layerWidth: number,
+  layerHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+): { x: number; y: number } {
+  if (
+    canvasWidth === 0 ||
+    canvasHeight === 0 ||
+    layerWidth === 0 ||
+    layerHeight === 0
+  ) {
+    return { x: 1, y: 1 };
+  }
+  const canvasAspect = canvasWidth / canvasHeight;
+  const layerAspect = layerWidth / layerHeight;
+  if (layerAspect > canvasAspect) {
+    return { x: 1, y: canvasAspect / layerAspect };
+  }
+  return { x: layerAspect / canvasAspect, y: 1 };
+}
+
+/**
+ * Build a 4x4 column-major transform matrix that takes a quad with
+ * positions in [-1,1]² and places it on the canvas with the layer's
+ * contain-fit base scale, then the user-supplied scale / rotation /
+ * position / anchor on top.
+ *
+ * Position is in canvas pixels relative to the canvas center.
+ * Anchor is normalized [0,1] (0.5 = quad center).
+ */
+export function buildTransformMatrix(
+  transform: ClipTransform,
+  base: { x: number; y: number },
+  canvasWidth: number,
+  canvasHeight: number
+): Float32Array {
+  const sx = base.x * transform.scale.x;
+  const sy = base.y * transform.scale.y;
+  const cos = Math.cos(transform.rotation);
+  const sin = Math.sin(transform.rotation);
+
+  // Position in clip space: x = px / (W/2), y = -py / (H/2). Y is flipped
+  // because canvas Y grows downward but clip-space Y grows upward.
+  const tx = canvasWidth === 0 ? 0 : (transform.position.x / canvasWidth) * 2;
+  const ty =
+    canvasHeight === 0 ? 0 : -(transform.position.y / canvasHeight) * 2;
+
+  // Anchor offset in clip space (-1..1). Default 0.5 → 0 offset.
+  const ax = (transform.anchor.x - 0.5) * 2;
+  const ay = (transform.anchor.y - 0.5) * 2;
+
+  const m = new Float32Array(16);
+  // Column 0
+  m[0] = sx * cos;
+  m[1] = sx * sin;
+  m[2] = 0;
+  m[3] = 0;
+  // Column 1
+  m[4] = -sy * sin;
+  m[5] = sy * cos;
+  m[6] = 0;
+  m[7] = 0;
+  // Column 2
+  m[8] = 0;
+  m[9] = 0;
+  m[10] = 1;
+  m[11] = 0;
+  // Column 3 (translation, anchor-corrected)
+  m[12] = tx + ax * (1 - sx * cos) + ay * sy * sin;
+  m[13] = ty + ay * (1 - sy * cos) - ax * sx * sin;
+  m[14] = 0;
+  m[15] = 1;
+  return m;
+}

--- a/web/src/components/timeline/preview/gpu/types.ts
+++ b/web/src/components/timeline/preview/gpu/types.ts
@@ -1,4 +1,8 @@
-import type { TimelineClip } from "@nodetool-ai/timeline";
+import type {
+  ClipEffect,
+  ClipTransform,
+  TimelineClip
+} from "@nodetool-ai/timeline";
 
 export type CompositorBlendMode = NonNullable<TimelineClip["blendMode"]>;
 
@@ -13,6 +17,12 @@ export interface CompositeLayer {
   opacity: number;
   blendMode: CompositorBlendMode;
   zIndex: number;
+  /** Optional 2D placement. Default: identity (centered, contain-fit). */
+  transform?: ClipTransform;
+  /** Rounded-corner radius in source pixels. Default 0. */
+  borderRadius?: number;
+  /** GPU effects applied as a pre-pass before this layer's composite draw. */
+  effects?: ClipEffect[];
 }
 
 export interface CompositorInitResult {


### PR DESCRIPTION
## Summary

Continues the openreel port. Adds the next tier on top of #3008's WebGPU compositor:

- **Per-layer transform** — `position` (canvas pixels from center), `scale` (on top of the contain-fit base), `rotation`, `anchor`. 4x4 matrix uploaded per layer; vertex stage in `transform.wgsl`.
- **Border-radius with anti-aliased edges** — SDF-based rounded corners in `border-radius.wgsl`. Compositor picks the rounded pipeline only when `clip.borderRadius > 0`, so unaffected clips don't pay for it.
- **Color grading** — brightness / contrast / saturation / hue / temperature / tint / shadows / highlights, run as one chained compute pass (`effects.wgsl`). Multiple `ClipColorEffect`s on a clip are aggregated into a single dispatch.
- **Gaussian blur** — separable `blur.wgsl`, dispatched horizontally then vertically through the same `WebGPUEffectsProcessor`.

Schema additions are all optional on `TimelineClip` — existing sequences keep working.

## Files

- `packages/timeline/src/types.ts` — `transform?`, `borderRadius?`, `effects?` plus `ClipTransform`, `ClipColorEffect`, `ClipBlurEffect`.
- `web/src/components/timeline/preview/gpu/`:
  - `shaders.ts` — transform / border-radius / effects / blur WGSL.
  - `transform.ts` — `buildTransformMatrix`, `containBaseScale`, identity helper.
  - `effectsProcessor.ts` — new `WebGPUEffectsProcessor`. Per-layer ping-pong intermediate textures pooled by id + source dimensions.
  - `compositor.ts` — two render pipelines per blend mode (plain / rounded), per-layer transform matrix + uniform buffer, effects pre-pass before each layer's draw.
  - `types.ts` — `CompositeLayer` carries optional transform / borderRadius / effects.
- `web/src/components/timeline/preview/PreviewCompositor.tsx` — forwards `clip.transform`, `clip.borderRadius`, `clip.effects` into the compositor's layer list.

## Test plan

- [x] `cd web && npm run typecheck` passes
- [x] `cd web && npm run lint` passes
- [x] `cd web && npx jest src/components/timeline/preview/` — 25/25 pass
- [x] `cd packages/timeline && npx vitest run` — 46/46 pass
- [ ] Manual: set `clip.transform` / `borderRadius` / `effects` on a sequence and verify they render correctly in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)