### PR TITLE
fix(timeline-preview): keep last frame on screen during scrub

### DIFF
--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -478,7 +478,10 @@ export const PreviewCompositor: React.FC = memo(() => {
 
     activeVideoSlots.forEach((slot, slotIndex) => {
       const el = pool[slotIndex];
-      if (!el || el.readyState < 2) return; // HAVE_CURRENT_DATA
+      // Keep the layer in the list even if the video momentarily drops below
+      // HAVE_CURRENT_DATA (e.g. during a scrub seek). The compositor reuses
+      // the previously uploaded texture so we don't flash to black.
+      if (!el || el.videoWidth === 0) return;
       out.push({
         id: `v:${slot.clipId}`,
         source: el,

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -84,6 +84,17 @@ function uploadKey(source: CompositeSource): string {
   return `b:${source.width}x${source.height}`;
 }
 
+function isSourceReady(source: CompositeSource): boolean {
+  if (source instanceof HTMLVideoElement) {
+    // HAVE_CURRENT_DATA = 2 — the current frame is decoded.
+    return source.readyState >= 2;
+  }
+  if (source instanceof HTMLImageElement) {
+    return source.complete && source.naturalWidth > 0;
+  }
+  return source.width > 0;
+}
+
 function sourceDimensions(source: CompositeSource): {
   width: number;
   height: number;
@@ -255,12 +266,18 @@ export class WebGPUCompositor {
 
   /**
    * Allocates / reuses a source GPU texture for the layer and copies its
-   * current pixels into it. Returns null if the source isn't ready yet.
+   * current pixels into it. If the source isn't ready right now (e.g. a
+   * `<video>` mid-seek with `readyState < HAVE_CURRENT_DATA`) the texture
+   * is left unchanged and we return the previous entry — keeps the last
+   * good frame on screen instead of flashing to black during a scrub.
+   * Returns null only if there's no texture to fall back on yet.
    */
   private uploadSource(layer: CompositeLayer): SourceTexture | null {
     if (!this.device) return null;
     const { width, height } = sourceDimensions(layer.source);
-    if (width === 0 || height === 0) return null;
+    if (width === 0 || height === 0) {
+      return this.sourceTextures.get(layer.id) ?? null;
+    }
 
     const key = uploadKey(layer.source);
     let entry = this.sourceTextures.get(layer.id);
@@ -286,13 +303,18 @@ export class WebGPUCompositor {
       this.sourceTextures.set(layer.id, entry);
     }
 
-    if (entry.lastUploadKey !== key) {
+    if (entry.lastUploadKey !== key && isSourceReady(layer.source)) {
       this.device.queue.copyExternalImageToTexture(
         { source: layer.source, flipY: false },
         { texture: entry.texture, premultipliedAlpha: false },
         { width, height }
       );
       entry.lastUploadKey = key;
+    }
+    // If we couldn't upload yet AND have never uploaded for this entry,
+    // there's nothing to draw — skip the layer this frame.
+    if (entry.lastUploadKey === "") {
+      return null;
     }
     return entry;
   }


### PR DESCRIPTION
## Summary

Scrubbing the playhead made the preview flicker to black. While the `<video>` element was seeking, its `readyState` briefly dropped below `HAVE_CURRENT_DATA` (2). `buildLayers` filtered the layer out → compositor got an empty layer list → render pass cleared to black until the new frame finished decoding.

## Fix

- `PreviewCompositor.tsx`: include the layer as long as `videoWidth > 0`. The compositor decides what to do.
- `gpu/compositor.ts`: in `uploadSource`, only call `copyExternalImageToTexture` when `isSourceReady(source)` (video readyState >= 2 / image complete). If the source isn't ready but we already have a previously uploaded texture for that layer, return it — last good frame stays on screen until the next one arrives.

## Test plan

- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run lint`
- [x] `cd web && npx jest src/components/timeline/preview/` — 25/25 pass
- [ ] Manual: drag the playhead across a video clip and confirm no black flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)