### PR TITLE
fix(timeline-preview): swallow transient video upload errors

### DIFF
--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -304,12 +304,19 @@ export class WebGPUCompositor {
     }
 
     if (entry.lastUploadKey !== key && isSourceReady(layer.source)) {
-      this.device.queue.copyExternalImageToTexture(
-        { source: layer.source, flipY: false },
-        { texture: entry.texture, premultipliedAlpha: false },
-        { width, height }
-      );
-      entry.lastUploadKey = key;
+      try {
+        this.device.queue.copyExternalImageToTexture(
+          { source: layer.source, flipY: false },
+          { texture: entry.texture, premultipliedAlpha: false },
+          { width, height }
+        );
+        entry.lastUploadKey = key;
+      } catch {
+        // The browser claimed the frame was ready (readyState >= 2) but its
+        // GPU-side resource is gone — happens transiently during seeks in
+        // Chrome ("doesn't have back resource"). Keep the previous texture
+        // and try again on the next render.
+      }
     }
     // If we couldn't upload yet AND have never uploaded for this entry,
     // there's nothing to draw — skip the layer this frame.


### PR DESCRIPTION
## Summary

`copyExternalImageToTexture` occasionally throws

> Failed to import texture from video element that doesn't have back resource

while a `<video>` element is mid-seek. `readyState` reports `>= 2` (HAVE_CURRENT_DATA) but the GPU-side decoded frame is briefly gone (Chrome race, especially during scrubbing). The unhandled exception was crashing the compositor effect.

Wrap the upload in try/catch — on failure keep the previously uploaded texture and retry on the next render. End-user effect: a single frame may be repeated for a tick, but no flicker and no crash.

## Test plan

- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run lint`
- [x] `cd web && npx jest src/components/timeline/preview/` — 25/25 pass
- [ ] Manual: scrub aggressively across video clips, confirm no console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)