### PR TITLE
feat(timeline): typical video-scrubber feel for the playhead

### DIFF
--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -3,58 +3,88 @@
  * Playhead
  *
  * Single absolute-positioned vertical line spanning all track lanes.
- * - A drag handle sits in the ruler area (top of the line).
- * - Subscribes to `currentTimeMs` via a fine-grained selector so only
- *   the playhead re-renders on each frame — not the full track tree.
- * - Drag handle allows scrubbing by dragging left/right.
+ * - The line + a 16px-wide invisible hit area around it are draggable —
+ *   grab anywhere along the playhead, not just the small handle.
+ * - The handle is a visible affordance at the top; it expands on hover
+ *   and active drag.
+ * - Click-and-drag uses a "jump-and-grab" pattern: pointerdown anywhere
+ *   on the hit area starts the scrub from the current position; the
+ *   pointer's delta drives currentTime from there.
+ * - Keyboard: ArrowLeft/Right nudge ±1 frame; Shift +/- 10 frames;
+ *   Home / End jump to the bounds.
  */
 
-import React, { memo, useCallback, useRef } from "react";
+import React, { memo, useCallback, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-const HANDLE_SIZE_PX = 12;
+const LINE_WIDTH_PX = 2;
+const HIT_AREA_WIDTH_PX = 16;
+const HANDLE_SIZE_PX = 14;
+const HANDLE_HOVER_SIZE_PX = 18;
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
-const lineStyles = (theme: Theme) =>
+/**
+ * Outer hit area — invisibly wider than the line so the user can grab the
+ * playhead anywhere along its full height. The visible 2px line is centred
+ * inside via `::before`. The handle sits as a positioned child on top.
+ */
+const hitAreaStyles = (theme: Theme, dragging: boolean) =>
   css({
     position: "absolute",
     top: 0,
     bottom: 0,
-    width: 2,
-    backgroundColor: theme.vars.palette.primary.main,
-    pointerEvents: "none",
-    zIndex: 10,
-    // The handle is the only interactive part
-    "& .playhead-handle": {
-      pointerEvents: "all"
-    }
-  });
-
-const handleStyles = (theme: Theme) =>
-  css({
-    position: "absolute",
-    top: -4,
-    left: "50%",
-    transform: "translateX(-50%)",
-    width: HANDLE_SIZE_PX,
-    height: HANDLE_SIZE_PX,
-    borderRadius: "50%",
-    backgroundColor: theme.vars.palette.primary.main,
-    cursor: "ew-resize",
+    width: HIT_AREA_WIDTH_PX,
+    transform: `translateX(-${HIT_AREA_WIDTH_PX / 2}px)`,
+    cursor: dragging ? "grabbing" : "ew-resize",
     touchAction: "none",
+    zIndex: 10,
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      left: "50%",
+      transform: "translateX(-50%)",
+      width: LINE_WIDTH_PX,
+      backgroundColor: theme.vars.palette.primary.main,
+      pointerEvents: "none"
+    },
     "&:focus-visible": {
       outline: `2px solid ${theme.vars.palette.primary.main}`,
       outlineOffset: 2
     }
   });
+
+const handleStyles = (theme: Theme, hovered: boolean, dragging: boolean) => {
+  const size =
+    hovered || dragging ? HANDLE_HOVER_SIZE_PX : HANDLE_SIZE_PX;
+  return css({
+    position: "absolute",
+    top: -size / 2 + 2,
+    left: "50%",
+    transform: "translateX(-50%)",
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    backgroundColor: theme.vars.palette.primary.main,
+    boxShadow: dragging
+      ? `0 0 0 4px ${theme.vars.palette.primary.main}40`
+      : hovered
+        ? `0 0 0 3px ${theme.vars.palette.primary.main}30`
+        : "none",
+    transition: "width 80ms, height 80ms, box-shadow 80ms",
+    pointerEvents: "none"
+  });
+};
 
 // ── Component ──────────────────────────────────────────────────────────────
 
@@ -69,19 +99,25 @@ export const Playhead: React.FC<PlayheadProps> = memo(
   ({ trackAreaOffsetPx = 0, heightPx }) => {
     const theme = useTheme();
 
-    // Fine-grained selector — only re-render when position changes
     const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
     const msPerPx = useTimelineUIStore((s) => s.msPerPx);
     const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
     const setCurrentTimeMs = useTimelinePlaybackStore(
       (s) => s.setCurrentTimeMs
     );
+    const fps = useTimelineStore((s) => s.fps);
+    const durationMs = useTimelineStore((s) => s.durationMs);
+
+    const [hovered, setHovered] = useState(false);
+    const [dragging, setDragging] = useState(false);
 
     const leftPx =
       trackAreaOffsetPx + currentTimeMs / msPerPx - scrollLeftPx;
 
-    // ── Drag scrub ──────────────────────────────────────────────────────────
-
+    // Drag baseline: where the pointer started and what currentTimeMs was
+    // at that moment. Delta is applied to that snapshot — so the pointer
+    // tracks the playhead exactly even if the store is being written
+    // concurrently elsewhere.
     const dragStartXRef = useRef(0);
     const dragStartMsRef = useRef(0);
 
@@ -91,41 +127,70 @@ export const Playhead: React.FC<PlayheadProps> = memo(
         e.currentTarget.setPointerCapture(e.pointerId);
         dragStartXRef.current = e.clientX;
         dragStartMsRef.current = currentTimeMs;
+        setDragging(true);
       },
       [currentTimeMs]
     );
 
     const handlePointerMove = useCallback(
       (e: React.PointerEvent<HTMLDivElement>) => {
-        if (e.buttons !== 1) {
-          return;
-        }
+        if (e.buttons !== 1) return;
         const deltaPx = e.clientX - dragStartXRef.current;
         const deltaMs = deltaPx * msPerPx;
-        setCurrentTimeMs(Math.max(0, dragStartMsRef.current + deltaMs));
+        const cap = durationMs > 0 ? durationMs : Number.MAX_SAFE_INTEGER;
+        setCurrentTimeMs(
+          Math.max(0, Math.min(cap, dragStartMsRef.current + deltaMs))
+        );
       },
-      [msPerPx, setCurrentTimeMs]
+      [msPerPx, durationMs, setCurrentTimeMs]
+    );
+
+    const handlePointerUp = useCallback(() => {
+      setDragging(false);
+    }, []);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        const frameMs = 1000 / Math.max(1, fps);
+        const cap = durationMs > 0 ? durationMs : Number.MAX_SAFE_INTEGER;
+        let next: number | null = null;
+        if (e.key === "ArrowLeft") {
+          next = currentTimeMs - frameMs * (e.shiftKey ? 10 : 1);
+        } else if (e.key === "ArrowRight") {
+          next = currentTimeMs + frameMs * (e.shiftKey ? 10 : 1);
+        } else if (e.key === "Home") {
+          next = 0;
+        } else if (e.key === "End") {
+          next = cap;
+        }
+        if (next != null) {
+          e.preventDefault();
+          setCurrentTimeMs(Math.max(0, Math.min(cap, next)));
+        }
+      },
+      [currentTimeMs, durationMs, fps, setCurrentTimeMs]
     );
 
     return (
       <div
-        css={lineStyles(theme)}
+        css={hitAreaStyles(theme, dragging)}
         style={{ left: leftPx, height: heightPx }}
         data-testid="playhead"
-        aria-hidden="true"
+        role="slider"
+        tabIndex={0}
+        aria-label="Playhead"
+        aria-valuenow={Math.round(currentTimeMs)}
+        aria-valuemin={0}
+        aria-valuemax={Math.round(durationMs)}
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
       >
-        {/* Drag handle — interactive */}
-        <div
-          className="playhead-handle"
-          css={handleStyles(theme)}
-          tabIndex={0}
-          role="slider"
-          aria-label="Playhead"
-          aria-valuenow={Math.round(currentTimeMs)}
-          aria-valuemin={0}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-        />
+        <div css={handleStyles(theme, hovered, dragging)} aria-hidden />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Grabbing the playhead was hard — the handle was a 12 px circle and the rest of the line was \`pointer-events: none\`. Brings the playhead in line with how seekbars in video players behave.

- **Wide hit area**: 16 px-wide invisible draggable column centred on the 2 px playhead line. Grab the playhead anywhere along its full height.
- **Bigger handle**: 14 px default, grows to 18 px with a soft halo on hover / active drag. Hover and grabbing cursors.
- **Drag baseline**: pointerdown captures current time + pointer x; pointer delta drives currentTime from there. Clamped to \`durationMs\`.
- **Keyboard nudge**: ArrowLeft/Right = ±1 frame, Shift = ±10 frames, Home/End jump to bounds. Uses sequence \`fps\` from the store.

## Test plan

- [x] \`cd web && npm run typecheck\`
- [x] \`cd web && npm run lint\`
- [x] \`cd web && npx jest src/components/timeline/preview/\` — 25/25 pass
- [ ] Manual: drag the playhead from the line (not the handle), confirm it scrubs; arrow keys nudge by frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)