### PR TITLE
feat(timeline): filmstrip thumbnails on clips

### DIFF
--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -16,7 +16,7 @@
  * selection membership (id selector), and msPerPx.
  */
 
-import React, { memo, useCallback, useMemo, useRef } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -30,11 +30,14 @@ import {
 } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineGenerationStore } from "../../../stores/timeline/TimelineGenerationStore";
+import { useAssetStore } from "../../../stores/AssetStore";
+import { getAssetUrl } from "../../../utils/assetHelpers";
 import useErrorStore, { hasNodeError, nodeErrorToDisplayString } from "../../../stores/ErrorStore";
 import { StatusIndicator } from "../../ui_primitives";
 import type { StatusType } from "../../ui_primitives/StatusIndicator";
 import { deriveClipStatus } from "../status/clipStatusReducer";
 import type { ClipGenerationState, ClipErrorState } from "../status/clipStatusReducer";
+import { useClipThumbnails } from "./useClipThumbnails";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -90,7 +93,29 @@ const clipNameStyles = (theme: Theme) =>
     overflow: "hidden",
     textOverflow: "ellipsis",
     pointerEvents: "none",
-    lineHeight: 1.2
+    lineHeight: 1.2,
+    position: "relative",
+    zIndex: 1,
+    textShadow: "0 1px 2px rgba(0,0,0,0.6)"
+  });
+
+const filmstripStyles = css({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  pointerEvents: "none",
+  zIndex: 0
+});
+
+const filmstripCellStyles = (url: string, withDivider: boolean) =>
+  css({
+    flex: 1,
+    height: "100%",
+    backgroundImage: `url(${url})`,
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    opacity: 0.7,
+    borderRight: withDivider ? "1px solid rgba(0,0,0,0.2)" : "none"
   });
 
 const trimHandleStyles = (
@@ -396,6 +421,129 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   const statusInfo = CLIP_STATUS_MAP[derivedStatus];
 
   return (
+    <ClipBody
+      clip={clip}
+      leftPx={leftPx}
+      widthPx={widthPx}
+      isSelected={isSelected}
+      derivedStatus={derivedStatus}
+      statusInfo={statusInfo}
+      handleDragPointerDown={handleDragPointerDown}
+      handleDragPointerMove={handleDragPointerMove}
+      handleDragPointerUp={handleDragPointerUp}
+      handleClick={handleClick}
+      handleTrimStartPointerDown={handleTrimStartPointerDown}
+      handleTrimStartPointerMove={handleTrimStartPointerMove}
+      handleTrimEndPointerDown={handleTrimEndPointerDown}
+      handleTrimEndPointerMove={handleTrimEndPointerMove}
+    />
+  );
+});
+
+interface ClipBodyProps {
+  clip: TimelineClip;
+  leftPx: number;
+  widthPx: number;
+  isSelected: boolean;
+  derivedStatus: ClipStatus;
+  statusInfo: typeof CLIP_STATUS_MAP[ClipStatus];
+  handleDragPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleDragPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleDragPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleTrimStartPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimStartPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimEndPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimEndPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+}
+
+const ClipBody: React.FC<ClipBodyProps> = ({
+  clip,
+  leftPx,
+  widthPx,
+  isSelected,
+  derivedStatus,
+  statusInfo,
+  handleDragPointerDown,
+  handleDragPointerMove,
+  handleDragPointerUp,
+  handleClick,
+  handleTrimStartPointerDown,
+  handleTrimStartPointerMove,
+  handleTrimEndPointerDown,
+  handleTrimEndPointerMove
+}) => {
+  const theme = useTheme();
+  const clipId = clip.id;
+
+  // Resolve asset URL for thumbnail extraction. Only video clips trigger
+  // a fetch — image clips are handled below with a single backgroundImage.
+  const assetIdForThumb =
+    clip.mediaType === "video" || clip.mediaType === "overlay"
+      ? clip.currentAssetId
+      : undefined;
+  const imageAssetId =
+    clip.mediaType === "image" ? clip.currentAssetId : undefined;
+
+  const getAsset = useAssetStore((s) => s.get);
+  const [videoUrl, setVideoUrl] = useState<string | undefined>(undefined);
+  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!assetIdForThumb) {
+      setVideoUrl(undefined);
+      return;
+    }
+    getAsset(assetIdForThumb)
+      .then((asset) => {
+        if (!cancelled) setVideoUrl(getAssetUrl(asset) ?? undefined);
+      })
+      .catch(() => {
+        // Asset unavailable — leave url undefined; clip renders without filmstrip.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assetIdForThumb, getAsset]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!imageAssetId) {
+      setImageUrl(undefined);
+      return;
+    }
+    getAsset(imageAssetId)
+      .then((asset) => {
+        if (!cancelled) setImageUrl(getAssetUrl(asset) ?? undefined);
+      })
+      .catch(() => {
+        // ignored
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [imageAssetId, getAsset]);
+
+  const thumbnails = useClipThumbnails(videoUrl);
+  // openreel uses ~60px per cell; matches their visual density.
+  const cellCount = Math.max(1, Math.floor(widthPx / 60));
+
+  const filmstripCells = useMemo(() => {
+    if (!thumbnails || thumbnails.length === 0) return null;
+    const cells: { url: string }[] = [];
+    for (let i = 0; i < cellCount; i++) {
+      const progress = cellCount === 1 ? 0 : i / (cellCount - 1);
+      const idx = Math.min(
+        Math.floor(progress * thumbnails.length),
+        thumbnails.length - 1
+      );
+      cells.push({ url: thumbnails[idx].dataUrl });
+    }
+    return cells;
+  }, [thumbnails, cellCount]);
+
+  return (
     <div
       css={clipStyles(theme, isSelected, clip.locked)}
       style={{ left: leftPx, width: widthPx }}
@@ -408,7 +556,29 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       role="option"
       aria-label={clip.name || `Clip ${clip.id}`}
     >
-      {/* Trim handle — start */}
+      {filmstripCells && (
+        <div css={filmstripStyles}>
+          {filmstripCells.map((cell, i) => (
+            <div
+              key={i}
+              css={filmstripCellStyles(cell.url, i < filmstripCells.length - 1)}
+            />
+          ))}
+        </div>
+      )}
+
+      {imageUrl && (
+        <div
+          css={filmstripStyles}
+          style={{
+            backgroundImage: `url(${imageUrl})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            opacity: 0.7
+          }}
+        />
+      )}
+
       <div
         css={trimHandleStyles(theme, "start", clip.locked)}
         onPointerDown={handleTrimStartPointerDown}
@@ -417,7 +587,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         data-testid={`clip-trim-start-${clipId}`}
       />
 
-      {/* Trim handle — end */}
       <div
         css={trimHandleStyles(theme, "end", clip.locked)}
         onPointerDown={handleTrimEndPointerDown}
@@ -426,14 +595,12 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         data-testid={`clip-trim-end-${clipId}`}
       />
 
-      {/* Lock icon — top-left when clip is locked */}
       {clip.locked && (
         <div css={lockIconStyles}>
           <LockIcon sx={{ fontSize: 12 }} aria-label="Clip locked" />
         </div>
       )}
 
-      {/* Status badge — hidden for "draft" to keep the clip chrome clean */}
       {derivedStatus !== "draft" && (
         <div css={statusBadgeStyles}>
           <StatusIndicator
@@ -445,10 +612,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         </div>
       )}
 
-      {/* Clip name */}
       <div css={clipNameStyles(theme)}>{clip.name}</div>
     </div>
   );
-});
+};
 
 Clip.displayName = "Clip";

--- a/web/src/components/timeline/Tracks/clipThumbnails.ts
+++ b/web/src/components/timeline/Tracks/clipThumbnails.ts
@@ -1,0 +1,187 @@
+/**
+ * Clip filmstrip thumbnails — extracts N frames from a video URL via a
+ * hidden HTMLVideoElement + canvas. Same idea as openreel's
+ * `generateFilmstripThumbnails`, but without the MediaBunny dependency.
+ *
+ * Singleton: components that need thumbnails for the same URL share one
+ * extraction pass and one set of data URLs. A small concurrency limit
+ * keeps the page responsive while many clips request thumbnails at once.
+ */
+
+export interface ClipThumbnail {
+  /** Frame timestamp in seconds within the source video. */
+  time: number;
+  /** JPEG data URL of the rendered frame. */
+  dataUrl: string;
+}
+
+interface CacheEntry {
+  state: "pending" | "ready" | "failed";
+  thumbnails?: ClipThumbnail[];
+  promise?: Promise<ClipThumbnail[]>;
+}
+
+const cache = new Map<string, CacheEntry>();
+const subscribers = new Map<string, Set<() => void>>();
+
+const MAX_CONCURRENT = 2;
+let active = 0;
+const queue: Array<() => void> = [];
+
+function runNext(): void {
+  if (active >= MAX_CONCURRENT) return;
+  const fn = queue.shift();
+  if (!fn) return;
+  active++;
+  fn();
+}
+
+function notify(url: string): void {
+  const set = subscribers.get(url);
+  if (!set) return;
+  for (const cb of set) cb();
+}
+
+function extract(
+  url: string,
+  count: number,
+  width: number
+): Promise<ClipThumbnail[]> {
+  return new Promise((resolve, reject) => {
+    const start = (): void => {
+      const video = document.createElement("video");
+      video.crossOrigin = "anonymous";
+      video.preload = "auto";
+      video.muted = true;
+      video.playsInline = true;
+      video.src = url;
+
+      const canvas = document.createElement("canvas");
+      const out: ClipThumbnail[] = [];
+
+      const cleanup = (): void => {
+        video.removeAttribute("src");
+        video.load();
+        active--;
+        runNext();
+      };
+
+      const fail = (err: unknown): void => {
+        cleanup();
+        reject(err);
+      };
+
+      video.addEventListener(
+        "loadedmetadata",
+        () => {
+          if (!Number.isFinite(video.duration) || video.duration <= 0) {
+            fail(new Error("video has no duration"));
+            return;
+          }
+          const aspect = video.videoHeight / video.videoWidth || 9 / 16;
+          canvas.width = width;
+          canvas.height = Math.max(1, Math.round(width * aspect));
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            fail(new Error("2d context unavailable"));
+            return;
+          }
+
+          const duration = video.duration;
+          const timestamps =
+            count <= 1
+              ? [0]
+              : Array.from({ length: count }, (_, i) =>
+                  (i / (count - 1)) * duration
+                );
+
+          let i = 0;
+          const seekNext = (): void => {
+            if (i >= timestamps.length) {
+              cleanup();
+              resolve(out);
+              return;
+            }
+            const onSeeked = (): void => {
+              video.removeEventListener("seeked", onSeeked);
+              try {
+                ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+                out.push({
+                  time: video.currentTime,
+                  dataUrl: canvas.toDataURL("image/jpeg", 0.7)
+                });
+                i++;
+                seekNext();
+              } catch (err) {
+                fail(err);
+              }
+            };
+            video.addEventListener("seeked", onSeeked);
+            video.currentTime = Math.min(duration, timestamps[i]);
+          };
+
+          seekNext();
+        },
+        { once: true }
+      );
+
+      video.addEventListener("error", () => fail(video.error ?? new Error("video error")), {
+        once: true
+      });
+    };
+
+    queue.push(start);
+    runNext();
+  });
+}
+
+/** Get cached thumbnails synchronously (or null if not ready). */
+export function getThumbnails(url: string): ClipThumbnail[] | null {
+  const entry = cache.get(url);
+  return entry?.state === "ready" ? entry.thumbnails ?? null : null;
+}
+
+/**
+ * Kick off thumbnail extraction for `url` if it hasn't started yet. Calls
+ * to this function with the same URL share a single extraction. Notifies
+ * subscribers when the result is ready.
+ */
+export function requestThumbnails(
+  url: string,
+  count: number,
+  width: number
+): void {
+  if (!url) return;
+  const existing = cache.get(url);
+  if (existing) return; // already pending or ready/failed
+
+  const entry: CacheEntry = { state: "pending" };
+  const promise = extract(url, count, width)
+    .then((thumbs) => {
+      entry.state = "ready";
+      entry.thumbnails = thumbs;
+      notify(url);
+      return thumbs;
+    })
+    .catch((err) => {
+      entry.state = "failed";
+      notify(url);
+      throw err;
+    });
+  entry.promise = promise;
+  cache.set(url, entry);
+}
+
+/** Subscribe to thumbnail-ready notifications for `url`. Returns unsubscribe. */
+export function subscribeThumbnails(url: string, cb: () => void): () => void {
+  let set = subscribers.get(url);
+  if (!set) {
+    set = new Set();
+    subscribers.set(url, set);
+  }
+  set.add(cb);
+  return () => {
+    set?.delete(cb);
+    if (set && set.size === 0) subscribers.delete(url);
+  };
+}

--- a/web/src/components/timeline/Tracks/useClipThumbnails.ts
+++ b/web/src/components/timeline/Tracks/useClipThumbnails.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import {
+  getThumbnails,
+  requestThumbnails,
+  subscribeThumbnails,
+  type ClipThumbnail
+} from "./clipThumbnails";
+
+const THUMB_WIDTH_PX = 160;
+/** Source-side count — enough samples to interpolate any visible filmstrip
+ *  density, capped to keep the extraction quick. */
+const SOURCE_COUNT = 24;
+
+/**
+ * Returns the cached thumbnails for `url`, kicking off extraction the
+ * first time the URL is seen. Re-renders when the result becomes ready.
+ */
+export function useClipThumbnails(url: string | undefined): ClipThumbnail[] | null {
+  const [, force] = useState(0);
+
+  useEffect(() => {
+    if (!url) return;
+    requestThumbnails(url, SOURCE_COUNT, THUMB_WIDTH_PX);
+    return subscribeThumbnails(url, () => force((v) => v + 1));
+  }, [url]);
+
+  return url ? getThumbnails(url) : null;
+}


### PR DESCRIPTION
## Summary

Mirrors openreel's clip-component thumbnail layout (apps/web/.../timeline/ClipComponent.tsx). Each video clip on the timeline now shows a filmstrip across its body; image clips show their asset full-width.

- **\`clipThumbnails.ts\`** — singleton cache + extraction queue. Hidden \`HTMLVideoElement\` seeks to N evenly-spaced timestamps and draws each frame to a canvas, encoded as a JPEG data URL. Concurrency limited to 2 simultaneous extractions so dropping in a long timeline doesn't lock the page. Skipped MediaBunny in favour of the plain DOM path to keep deps lean.
- **\`useClipThumbnails\`** — small React hook that requests + subscribes to the cache for a given URL.
- **\`Clip.tsx\`** — split into \`Clip\` (memo / store-aware) and \`ClipBody\` (renderer with asset URL + thumbnails). Cell count = \`floor(widthPx / 60)\`, picked to match openreel's visual density. Clip name has a soft text shadow so it stays readable on bright frames.

## Test plan

- [x] \`cd web && npm run typecheck\`
- [x] \`cd web && npm run lint\` (Clip.tsx + new files)
- [x] \`cd web && npx jest src/components/timeline/preview src/components/timeline/Tracks\` — 25/25 pass
- [ ] Manual: drop a video onto a track, confirm filmstrip appears once frames are extracted; image clips show their image; thumbs survive panning/zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)