### PR TITLE
fix(timeline-preview): top UI track is the top render layer

### DIFF
--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -35,6 +35,14 @@ const COLD_POOL_SIZE = 4;
 const TOTAL_POOL_SIZE = HOT_POOL_SIZE + COLD_POOL_SIZE;
 /** Preload upcoming clips within this lookahead window (ms). */
 const PRELOAD_LOOKAHEAD_MS = 30_000;
+/**
+ * Top-of-UI track (lowest `track.index`) renders on top in the composite —
+ * matches Premiere / Resolve / FCP. Compositor draws layers from low z to
+ * high z, so we invert the UI index. Constant offset keeps numbers
+ * positive for DOM placeholder z-indices too.
+ */
+const LAYER_Z_BASE = 1000;
+const trackZ = (uiIndex: number): number => LAYER_Z_BASE - uiIndex;
 
 const compositorStyles = css({
   position: "relative",
@@ -523,7 +531,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         source: el,
         opacity: slot.opacity,
         blendMode: slot.blendMode,
-        zIndex: slot.trackIndex,
+        zIndex: trackZ(slot.trackIndex),
         transform: slot.transform,
         borderRadius: slot.borderRadius,
         effects: slot.effects
@@ -539,7 +547,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         source: img,
         opacity: layer.opacity,
         blendMode: layer.blendMode,
-        zIndex: layer.trackIndex,
+        zIndex: trackZ(layer.trackIndex),
         transform: layer.transform,
         borderRadius: layer.borderRadius,
         effects: layer.effects
@@ -602,7 +610,7 @@ export const PreviewCompositor: React.FC = memo(() => {
             style={{
               position: "absolute",
               inset: 0,
-              zIndex: layer.trackIndex
+              zIndex: trackZ(layer.trackIndex)
             }}
           >
             <div css={placeholderLayerStyles(theme)}>


### PR DESCRIPTION
## Summary

The bottom-most timeline track was rendering on top of the others, opposite to what every video editor (Premiere, Resolve, FCP) does — where the topmost UI track is the foreground.

The compositor was getting \`zIndex = track.index\`, but \`track.index\` increases downward in the UI, so the bottom track ended up with the highest z-index and drew last (on top). Inverted via a single \`trackZ(uiIndex)\` helper applied at both the GPU compositor layer build and the placeholder DOM overlays.

## Test plan

- [x] \`cd web && npm run typecheck\`
- [x] \`cd web && npm run lint\`
- [x] \`cd web && npx jest src/components/timeline/preview/\` — 25/25 pass
- [ ] Manual: stack two video clips on different tracks, confirm the upper-track clip composites on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)