### PR TITLE
feat(timeline-preview): real shader-side blend modes (overlay et al.)

### DIFF
--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -1,5 +1,5 @@
 import { WebGPUEffectsProcessor } from "./effectsProcessor";
-import { borderRadiusShader, transformShader } from "./shaders";
+import { blitShader, compositeShader } from "./shaders";
 import {
   IDENTITY_TRANSFORM,
   buildTransformMatrix,
@@ -12,59 +12,16 @@ import type {
   CompositorInitResult
 } from "./types";
 
-const TRANSFORM_UNIFORM_BYTES = 96;
-const BORDER_RADIUS_UNIFORM_BYTES = 96;
+const LAYER_UNIFORM_BYTES = 96;
+const ACCUM_FORMAT: GPUTextureFormat = "rgba8unorm";
 
-const BLEND_MODES: CompositorBlendMode[] = [
-  "normal",
-  "add",
-  "multiply",
-  "screen",
-  "overlay"
-];
-
-function blendStateFor(mode: CompositorBlendMode): GPUBlendState {
-  switch (mode) {
-    case "add":
-      return {
-        color: { srcFactor: "src-alpha", dstFactor: "one", operation: "add" },
-        alpha: { srcFactor: "one", dstFactor: "one", operation: "add" }
-      };
-    case "multiply":
-      return {
-        color: { srcFactor: "dst", dstFactor: "zero", operation: "add" },
-        alpha: {
-          srcFactor: "one",
-          dstFactor: "one-minus-src-alpha",
-          operation: "add"
-        }
-      };
-    case "screen":
-      return {
-        color: {
-          srcFactor: "one",
-          dstFactor: "one-minus-src",
-          operation: "add"
-        },
-        alpha: { srcFactor: "one", dstFactor: "one", operation: "add" }
-      };
-    case "normal":
-    case "overlay":
-    default:
-      return {
-        color: {
-          srcFactor: "src-alpha",
-          dstFactor: "one-minus-src-alpha",
-          operation: "add"
-        },
-        alpha: {
-          srcFactor: "one",
-          dstFactor: "one-minus-src-alpha",
-          operation: "add"
-        }
-      };
-  }
-}
+const BLEND_MODE_INDEX: Record<CompositorBlendMode, number> = {
+  normal: 0,
+  add: 1,
+  multiply: 2,
+  screen: 3,
+  overlay: 4
+};
 
 interface SourceTexture {
   texture: GPUTexture;
@@ -74,19 +31,8 @@ interface SourceTexture {
   lastUploadKey: string;
 }
 
-function uploadKey(source: CompositeSource): string {
-  if (source instanceof HTMLVideoElement) {
-    return `v:${source.currentTime}:${source.videoWidth}x${source.videoHeight}`;
-  }
-  if (source instanceof HTMLImageElement) {
-    return `i:${source.src}:${source.naturalWidth}x${source.naturalHeight}`;
-  }
-  return `b:${source.width}x${source.height}`;
-}
-
 function isSourceReady(source: CompositeSource): boolean {
   if (source instanceof HTMLVideoElement) {
-    // HAVE_CURRENT_DATA = 2 — the current frame is decoded.
     return source.readyState >= 2;
   }
   if (source instanceof HTMLImageElement) {
@@ -114,9 +60,14 @@ function sourceDimensions(source: CompositeSource): {
   return { width: source.width, height: source.height };
 }
 
-interface PipelinePair {
-  plain: GPURenderPipeline;
-  rounded: GPURenderPipeline;
+function uploadKey(source: CompositeSource): string {
+  if (source instanceof HTMLVideoElement) {
+    return `v:${source.currentTime}:${source.videoWidth}x${source.videoHeight}`;
+  }
+  if (source instanceof HTMLImageElement) {
+    return `i:${source.src}:${source.naturalWidth}x${source.naturalHeight}`;
+  }
+  return `b:${source.width}x${source.height}`;
 }
 
 export class WebGPUCompositor {
@@ -124,13 +75,22 @@ export class WebGPUCompositor {
   private context: GPUCanvasContext | null = null;
   private canvasFormat: GPUTextureFormat = "rgba8unorm";
 
-  private uniformLayout: GPUBindGroupLayout | null = null;
-  private textureLayout: GPUBindGroupLayout | null = null;
+  private layerUniformLayout: GPUBindGroupLayout | null = null;
+  private layerTextureLayout: GPUBindGroupLayout | null = null;
+  private accumTextureLayout: GPUBindGroupLayout | null = null;
+  private blitTextureLayout: GPUBindGroupLayout | null = null;
+
+  private layerPipeline: GPURenderPipeline | null = null;
+  private blitPipeline: GPURenderPipeline | null = null;
+
   private sampler: GPUSampler | null = null;
-  private pipelines = new Map<CompositorBlendMode, PipelinePair>();
 
   private canvasWidth = 0;
   private canvasHeight = 0;
+
+  private accumA: GPUTexture | null = null;
+  private accumB: GPUTexture | null = null;
+  private accumIdx: 0 | 1 = 0;
 
   private sourceTextures = new Map<string, SourceTexture>();
   private uniformBuffers: GPUBuffer[] = [];
@@ -165,8 +125,8 @@ export class WebGPUCompositor {
       alphaMode: "premultiplied"
     });
 
-    this.uniformLayout = device.createBindGroupLayout({
-      label: "preview-uniform-layout",
+    this.layerUniformLayout = device.createBindGroupLayout({
+      label: "preview-layer-uniforms",
       entries: [
         {
           binding: 0,
@@ -175,8 +135,38 @@ export class WebGPUCompositor {
         }
       ]
     });
-    this.textureLayout = device.createBindGroupLayout({
-      label: "preview-texture-layout",
+    this.layerTextureLayout = device.createBindGroupLayout({
+      label: "preview-layer-texture",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" }
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: { sampleType: "float" }
+        }
+      ]
+    });
+    this.accumTextureLayout = device.createBindGroupLayout({
+      label: "preview-accum-texture",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" }
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: { sampleType: "float" }
+        }
+      ]
+    });
+    this.blitTextureLayout = device.createBindGroupLayout({
+      label: "preview-blit-texture",
       entries: [
         {
           binding: 0,
@@ -199,53 +189,80 @@ export class WebGPUCompositor {
       addressModeV: "clamp-to-edge"
     });
 
-    const transformModule = device.createShaderModule({
-      label: "preview-transform",
-      code: transformShader
+    const compositeModule = device.createShaderModule({
+      label: "preview-composite",
+      code: compositeShader
     });
-    const borderRadiusModule = device.createShaderModule({
-      label: "preview-border-radius",
-      code: borderRadiusShader
+    const layerPipelineLayout = device.createPipelineLayout({
+      bindGroupLayouts: [
+        this.layerUniformLayout,
+        this.layerTextureLayout,
+        this.accumTextureLayout
+      ]
     });
-    const pipelineLayout = device.createPipelineLayout({
-      bindGroupLayouts: [this.uniformLayout, this.textureLayout]
+    // Single layer pipeline — blend math runs in the fragment shader,
+    // so no fixed-function blend state.
+    this.layerPipeline = device.createRenderPipeline({
+      label: "preview-layer-pipeline",
+      layout: layerPipelineLayout,
+      vertex: { module: compositeModule, entryPoint: "vs" },
+      fragment: {
+        module: compositeModule,
+        entryPoint: "fs",
+        targets: [{ format: ACCUM_FORMAT }]
+      },
+      primitive: { topology: "triangle-list" }
     });
 
-    for (const mode of BLEND_MODES) {
-      const blend = blendStateFor(mode);
-      const plain = device.createRenderPipeline({
-        label: `preview-pipeline-${mode}`,
-        layout: pipelineLayout,
-        vertex: { module: transformModule, entryPoint: "vs" },
-        fragment: {
-          module: transformModule,
-          entryPoint: "fs",
-          targets: [{ format: this.canvasFormat, blend }]
-        },
-        primitive: { topology: "triangle-list" }
-      });
-      const rounded = device.createRenderPipeline({
-        label: `preview-pipeline-rounded-${mode}`,
-        layout: pipelineLayout,
-        vertex: { module: borderRadiusModule, entryPoint: "vs" },
-        fragment: {
-          module: borderRadiusModule,
-          entryPoint: "fs",
-          targets: [{ format: this.canvasFormat, blend }]
-        },
-        primitive: { topology: "triangle-list" }
-      });
-      this.pipelines.set(mode, { plain, rounded });
-    }
+    const blitModule = device.createShaderModule({
+      label: "preview-blit",
+      code: blitShader
+    });
+    this.blitPipeline = device.createRenderPipeline({
+      label: "preview-blit-pipeline",
+      layout: device.createPipelineLayout({
+        bindGroupLayouts: [this.blitTextureLayout]
+      }),
+      vertex: { module: blitModule, entryPoint: "vs" },
+      fragment: {
+        module: blitModule,
+        entryPoint: "fs",
+        targets: [{ format: this.canvasFormat }]
+      },
+      primitive: { topology: "triangle-list" }
+    });
 
     this.effects = new WebGPUEffectsProcessor(device);
+    this.allocateAccumTextures();
 
     return { ok: true };
   }
 
   resize(width: number, height: number): void {
+    if (width === this.canvasWidth && height === this.canvasHeight) return;
     this.canvasWidth = width;
     this.canvasHeight = height;
+    this.allocateAccumTextures();
+  }
+
+  private allocateAccumTextures(): void {
+    if (!this.device || this.canvasWidth === 0 || this.canvasHeight === 0) return;
+    this.accumA?.destroy();
+    this.accumB?.destroy();
+    const make = (label: string): GPUTexture =>
+      this.device!.createTexture({
+        label,
+        size: { width: this.canvasWidth, height: this.canvasHeight },
+        format: ACCUM_FORMAT,
+        usage:
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.RENDER_ATTACHMENT |
+          GPUTextureUsage.COPY_SRC |
+          GPUTextureUsage.COPY_DST
+      });
+    this.accumA = make("preview-accum-a");
+    this.accumB = make("preview-accum-b");
+    this.accumIdx = 0;
   }
 
   setLayers(layers: CompositeLayer[]): void {
@@ -264,14 +281,6 @@ export class WebGPUCompositor {
     this.effects?.retainOnly(liveIds);
   }
 
-  /**
-   * Allocates / reuses a source GPU texture for the layer and copies its
-   * current pixels into it. If the source isn't ready right now (e.g. a
-   * `<video>` mid-seek with `readyState < HAVE_CURRENT_DATA`) the texture
-   * is left unchanged and we return the previous entry — keeps the last
-   * good frame on screen instead of flashing to black during a scrub.
-   * Returns null only if there's no texture to fall back on yet.
-   */
   private uploadSource(layer: CompositeLayer): SourceTexture | null {
     if (!this.device) return null;
     const { width, height } = sourceDimensions(layer.source);
@@ -312,21 +321,15 @@ export class WebGPUCompositor {
         );
         entry.lastUploadKey = key;
       } catch {
-        // The browser claimed the frame was ready (readyState >= 2) but its
-        // GPU-side resource is gone — happens transiently during seeks in
-        // Chrome ("doesn't have back resource"). Keep the previous texture
-        // and try again on the next render.
+        // Browser claimed readyState >= 2 but the GPU side resource is
+        // gone (Chrome scrub race). Keep the previous texture.
       }
     }
-    // If we couldn't upload yet AND have never uploaded for this entry,
-    // there's nothing to draw — skip the layer this frame.
-    if (entry.lastUploadKey === "") {
-      return null;
-    }
+    if (entry.lastUploadKey === "") return null;
     return entry;
   }
 
-  private getUniformBuffer(index: number, size: number): GPUBuffer {
+  private getUniformBuffer(index: number): GPUBuffer {
     if (!this.device) {
       throw new Error("Compositor not initialized");
     }
@@ -334,7 +337,7 @@ export class WebGPUCompositor {
     if (!buffer) {
       buffer = this.device.createBuffer({
         label: `preview-layer-uniforms-${index}`,
-        size: Math.max(size, TRANSFORM_UNIFORM_BYTES),
+        size: LAYER_UNIFORM_BYTES,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
       });
       this.uniformBuffers[index] = buffer;
@@ -347,33 +350,44 @@ export class WebGPUCompositor {
       !this.device ||
       !this.context ||
       !this.sampler ||
-      !this.uniformLayout ||
-      !this.textureLayout
+      !this.layerUniformLayout ||
+      !this.layerTextureLayout ||
+      !this.accumTextureLayout ||
+      !this.blitTextureLayout ||
+      !this.layerPipeline ||
+      !this.blitPipeline ||
+      !this.accumA ||
+      !this.accumB
     ) {
       return;
     }
 
-    const view = this.context.getCurrentTexture().createView();
-    const encoder = this.device.createCommandEncoder({ label: "preview-frame" });
-    const pass = encoder.beginRenderPass({
-      label: "preview-pass",
-      colorAttachments: [
-        {
-          view,
-          clearValue: { r: 0, g: 0, b: 0, a: 1 },
-          loadOp: "clear",
-          storeOp: "store"
-        }
-      ]
-    });
+    const device = this.device;
+    const sampler = this.sampler;
+
+    // 1. Clear the starting accumulation to opaque black.
+    this.accumIdx = 0;
+    {
+      const encoder = device.createCommandEncoder({ label: "preview-clear" });
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: this.accumA.createView(),
+            clearValue: { r: 0, g: 0, b: 0, a: 1 },
+            loadOp: "clear",
+            storeOp: "store"
+          }
+        ]
+      });
+      pass.end();
+      device.queue.submit([encoder.finish()]);
+    }
 
     let drawn = 0;
     for (const layer of this.layers) {
       const src = this.uploadSource(layer);
       if (!src) continue;
 
-      // Run effects pre-pass if any. Effects uses its own command encoder
-      // and submits before we record this draw — so the result is ready.
       const effectsList = layer.effects ?? [];
       const processedTexture =
         effectsList.length > 0 && this.effects
@@ -399,50 +413,111 @@ export class WebGPUCompositor {
         radiusPx > 0 && src.width > 0 && src.height > 0
           ? Math.min(0.5, radiusPx / Math.min(src.width, src.height))
           : 0;
-      const useRadius = radiusNormalized > 0.001;
       const aspect = src.height === 0 ? 1 : src.width / src.height;
+      const blendIndex = BLEND_MODE_INDEX[layer.blendMode] ?? 0;
 
-      const uniformBuffer = this.getUniformBuffer(
-        drawn,
-        useRadius ? BORDER_RADIUS_UNIFORM_BYTES : TRANSFORM_UNIFORM_BYTES
-      );
-      // Both pipelines use 96-byte buffers but the tail layout differs.
-      const data = new Float32Array(24);
-      data.set(matrix, 0);
-      data[16] = layer.opacity;
-      if (useRadius) {
-        data[17] = radiusNormalized;
-        data[18] = aspect;
-        data[19] = 0.01; // smoothness — small, anti-alias band
-      }
-      this.device.queue.writeBuffer(uniformBuffer, 0, data.buffer, 0, data.byteLength);
+      const uniformBuffer = this.getUniformBuffer(drawn);
+      const data = new ArrayBuffer(LAYER_UNIFORM_BYTES);
+      const f = new Float32Array(data);
+      const u = new Uint32Array(data);
+      f.set(matrix, 0);
+      f[16] = layer.opacity;
+      f[17] = radiusNormalized;
+      f[18] = aspect;
+      f[19] = 0.01; // smoothness band for SDF
+      u[20] = blendIndex;
+      device.queue.writeBuffer(uniformBuffer, 0, data);
 
-      const uniformBindGroup = this.device.createBindGroup({
-        layout: this.uniformLayout,
-        entries: [{ binding: 0, resource: { buffer: uniformBuffer } }]
+      const accumIn = this.accumIdx === 0 ? this.accumA : this.accumB;
+      const accumOut = this.accumIdx === 0 ? this.accumB : this.accumA;
+
+      // Seed the next ping-pong target with the current accumulation, so
+      // pixels outside the layer's transformed quad keep their previous
+      // value. Compositing math (which needs to read accumIn) happens in
+      // the layer fragment shader and writes accumOut.
+      const encoder = device.createCommandEncoder({
+        label: `preview-layer-${drawn}`
       });
-      const textureBindGroup = this.device.createBindGroup({
-        layout: this.textureLayout,
-        entries: [
-          { binding: 0, resource: this.sampler },
-          { binding: 1, resource: processedTexture.createView() }
+      encoder.copyTextureToTexture(
+        { texture: accumIn },
+        { texture: accumOut },
+        { width: this.canvasWidth, height: this.canvasHeight }
+      );
+
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: accumOut.createView(),
+            loadOp: "load",
+            storeOp: "store"
+          }
         ]
       });
-
-      const pair =
-        this.pipelines.get(layer.blendMode) ?? this.pipelines.get("normal");
-      if (!pair) continue;
-      const pipeline = useRadius ? pair.rounded : pair.plain;
-
-      pass.setPipeline(pipeline);
-      pass.setBindGroup(0, uniformBindGroup);
-      pass.setBindGroup(1, textureBindGroup);
+      pass.setPipeline(this.layerPipeline);
+      pass.setBindGroup(
+        0,
+        device.createBindGroup({
+          layout: this.layerUniformLayout,
+          entries: [{ binding: 0, resource: { buffer: uniformBuffer } }]
+        })
+      );
+      pass.setBindGroup(
+        1,
+        device.createBindGroup({
+          layout: this.layerTextureLayout,
+          entries: [
+            { binding: 0, resource: sampler },
+            { binding: 1, resource: processedTexture.createView() }
+          ]
+        })
+      );
+      pass.setBindGroup(
+        2,
+        device.createBindGroup({
+          layout: this.accumTextureLayout,
+          entries: [
+            { binding: 0, resource: sampler },
+            { binding: 1, resource: accumIn.createView() }
+          ]
+        })
+      );
       pass.draw(6);
+      pass.end();
+      device.queue.submit([encoder.finish()]);
+
+      this.accumIdx = (1 - this.accumIdx) as 0 | 1;
       drawn++;
     }
 
-    pass.end();
-    this.device.queue.submit([encoder.finish()]);
+    // 2. Final blit: present the latest accumulation to the swapchain.
+    const finalAccum = this.accumIdx === 0 ? this.accumA : this.accumB;
+    const presentEncoder = device.createCommandEncoder({
+      label: "preview-present"
+    });
+    const presentPass = presentEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: this.context.getCurrentTexture().createView(),
+          loadOp: "clear",
+          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          storeOp: "store"
+        }
+      ]
+    });
+    presentPass.setPipeline(this.blitPipeline);
+    presentPass.setBindGroup(
+      0,
+      device.createBindGroup({
+        layout: this.blitTextureLayout,
+        entries: [
+          { binding: 0, resource: sampler },
+          { binding: 1, resource: finalAccum.createView() }
+        ]
+      })
+    );
+    presentPass.draw(6);
+    presentPass.end();
+    device.queue.submit([presentEncoder.finish()]);
   }
 
   dispose(): void {
@@ -454,12 +529,19 @@ export class WebGPUCompositor {
       buffer.destroy();
     }
     this.uniformBuffers = [];
-    this.pipelines.clear();
+    this.accumA?.destroy();
+    this.accumB?.destroy();
+    this.accumA = null;
+    this.accumB = null;
+    this.layerPipeline = null;
+    this.blitPipeline = null;
     this.effects?.dispose();
     this.effects = null;
     this.sampler = null;
-    this.uniformLayout = null;
-    this.textureLayout = null;
+    this.layerUniformLayout = null;
+    this.layerTextureLayout = null;
+    this.accumTextureLayout = null;
+    this.blitTextureLayout = null;
     this.context = null;
     this.device?.destroy();
     this.device = null;

--- a/web/src/components/timeline/preview/gpu/shaders.ts
+++ b/web/src/components/timeline/preview/gpu/shaders.ts
@@ -1,101 +1,54 @@
 /**
- * Transform shader: vertex stage applies a 4x4 matrix per layer; fragment
- * samples the source texture and applies opacity. Two-triangle quad with
- * explicit UVs (no full-screen triangle trick — UV math has to stay clean
- * after we scale/rotate the quad in clip space).
+ * Composite shader. The full preview pipeline is:
  *
- * Matrix layout matches openreel's createTransformMatrix:
- *   columns = [scale.x*cos, scale.x*sin, 0, 0,
- *              -scale.y*sin, scale.y*cos, 0, 0,
- *              0, 0, 1, 0,
- *              tx, ty, 0, 1]
+ *   accumA (cleared) ──► accumB ──► accumA ──► … ──► swapchain
+ *                  layer 1   layer 2          blit
  *
- * Uniform buffer (96 bytes total):
- *   matrix: 64
- *   opacity: 4
- *   _pad0:   4
- *   _pad1:   8 (unused — kept for layout symmetry with the border-radius variant)
+ * Each layer renders a transformed quad into the next ping-pong target
+ * (`loadOp: "load"`, the contents of the previous accumulation copied in
+ * via `copyTextureToTexture` first). Inside the quad, the fragment shader
+ * samples both the previous accumulation (at the fragment's screen UV)
+ * and the layer source (at the layer-local UV), and combines them per
+ * the active blend mode. Fixed-function blend state stays at "no blend"
+ * — all compositing math lives in the shader.
+ *
+ * Uniform layout (96 bytes for both transform + border-radius variants):
+ *   matrix:     64
+ *   opacity:     4
+ *   borderRadius:4   (normalized 0..0.5; 0 = sharp corners)
+ *   aspect:      4   (source w/h)
+ *   smoothness:  4
+ *   blendMode:   4   (u32 enum — see BLEND_MODE_* constants below)
+ *   _pad:       12
  */
-export const transformShader = /* wgsl */ `
-struct Uniforms {
-  matrix: mat4x4<f32>,
-  opacity: f32,
-  _pad0: f32,
-  _pad1: vec2<f32>,
-};
-
-@group(0) @binding(0) var<uniform> u: Uniforms;
-@group(1) @binding(0) var samp: sampler;
-@group(1) @binding(1) var tex: texture_2d<f32>;
-
-struct VsOut {
-  @builtin(position) pos: vec4<f32>,
-  @location(0) uv: vec2<f32>,
-};
-
-@vertex
-fn vs(@builtin(vertex_index) i: u32) -> VsOut {
-  var positions = array<vec2<f32>, 6>(
-    vec2<f32>(-1.0, -1.0),
-    vec2<f32>( 1.0, -1.0),
-    vec2<f32>(-1.0,  1.0),
-    vec2<f32>(-1.0,  1.0),
-    vec2<f32>( 1.0, -1.0),
-    vec2<f32>( 1.0,  1.0),
-  );
-  var uvs = array<vec2<f32>, 6>(
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(1.0, 1.0),
-    vec2<f32>(0.0, 0.0),
-    vec2<f32>(0.0, 0.0),
-    vec2<f32>(1.0, 1.0),
-    vec2<f32>(1.0, 0.0),
-  );
-  var out: VsOut;
-  out.pos = u.matrix * vec4<f32>(positions[i], 0.0, 1.0);
-  out.uv = uvs[i];
-  return out;
-}
-
-@fragment
-fn fs(in: VsOut) -> @location(0) vec4<f32> {
-  let c = textureSample(tex, samp, in.uv);
-  return vec4<f32>(c.rgb, c.a * u.opacity);
-}
-`;
-
-/**
- * Border-radius variant: same vertex transform but the fragment uses an SDF
- * to mask rounded corners with anti-aliased edges. `radius` is in normalized
- * [0, 0.5] units (fraction of the shorter quad axis).
- *
- * Uniform buffer (96 bytes):
- *   matrix: 64
- *   opacity: 4
- *   radius:  4
- *   aspect:  4   (width/height of the source — corrects the SDF for non-square layers)
- *   smooth:  4
- *   _pad:    16
- */
-export const borderRadiusShader = /* wgsl */ `
+export const compositeShader = /* wgsl */ `
 struct Uniforms {
   matrix: mat4x4<f32>,
   opacity: f32,
   radius: f32,
   aspect: f32,
   smoothness: f32,
-  _pad: vec4<f32>,
+  blendMode: u32,
+  _pad: vec3<u32>,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
 @group(1) @binding(0) var samp: sampler;
-@group(1) @binding(1) var tex: texture_2d<f32>;
+@group(1) @binding(1) var layerTex: texture_2d<f32>;
+@group(2) @binding(0) var accumSamp: sampler;
+@group(2) @binding(1) var accumTex: texture_2d<f32>;
 
 struct VsOut {
   @builtin(position) pos: vec4<f32>,
   @location(0) uv: vec2<f32>,
   @location(1) local: vec2<f32>,
 };
+
+const BLEND_NORMAL: u32   = 0u;
+const BLEND_ADD: u32      = 1u;
+const BLEND_MULTIPLY: u32 = 2u;
+const BLEND_SCREEN: u32   = 3u;
+const BLEND_OVERLAY: u32  = 4u;
 
 @vertex
 fn vs(@builtin(vertex_index) i: u32) -> VsOut {
@@ -127,29 +80,107 @@ fn sdRoundedRect(p: vec2<f32>, b: vec2<f32>, r: f32) -> f32 {
   return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r;
 }
 
+fn applyBlend(src: vec3<f32>, dst: vec3<f32>, mode: u32) -> vec3<f32> {
+  if (mode == BLEND_ADD) {
+    return min(src + dst, vec3<f32>(1.0));
+  }
+  if (mode == BLEND_MULTIPLY) {
+    return src * dst;
+  }
+  if (mode == BLEND_SCREEN) {
+    return src + dst - src * dst;
+  }
+  if (mode == BLEND_OVERLAY) {
+    let lt = step(dst, vec3<f32>(0.5));
+    let dark = 2.0 * src * dst;
+    let light = vec3<f32>(1.0) - 2.0 * (vec3<f32>(1.0) - src) * (vec3<f32>(1.0) - dst);
+    return mix(light, dark, lt);
+  }
+  return src; // BLEND_NORMAL
+}
+
 @fragment
 fn fs(in: VsOut) -> @location(0) vec4<f32> {
-  let c = textureSample(tex, samp, in.uv);
-  // Stretch the local position to a square so the SDF gives a uniform corner.
-  var p = in.local;
-  if (u.aspect > 1.0) {
-    p.y = p.y / u.aspect;
-  } else {
-    p.x = p.x * u.aspect;
+  // Screen-space UV for sampling the previous accumulation. WebGPU's
+  // builtin(position).xy is in pixels relative to the viewport origin.
+  let dims = vec2<f32>(textureDimensions(accumTex, 0));
+  let screenUv = in.pos.xy / dims;
+  let dst = textureSample(accumTex, accumSamp, screenUv);
+
+  // Sample the layer source.
+  let layer = textureSample(layerTex, samp, in.uv);
+  var layerAlpha = layer.a * u.opacity;
+
+  // Border-radius mask via SDF in layer-local space (-1..1).
+  if (u.radius > 0.0) {
+    var p = in.local;
+    if (u.aspect > 1.0) {
+      p.y = p.y / u.aspect;
+    } else {
+      p.x = p.x * u.aspect;
+    }
+    let halfSize = vec2<f32>(min(1.0, u.aspect), min(1.0, 1.0 / u.aspect));
+    let r = clamp(u.radius, 0.0, 0.5) * 2.0 * min(halfSize.x, halfSize.y);
+    let dist = sdRoundedRect(p, halfSize, r);
+    let mask = 1.0 - smoothstep(-u.smoothness, u.smoothness, dist);
+    layerAlpha = layerAlpha * mask;
   }
-  let halfSize = vec2<f32>(min(1.0, u.aspect), min(1.0, 1.0 / u.aspect));
-  let r = clamp(u.radius, 0.0, 0.5) * 2.0 * min(halfSize.x, halfSize.y);
-  let dist = sdRoundedRect(p, halfSize, r);
-  let alpha = 1.0 - smoothstep(-u.smoothness, u.smoothness, dist);
-  return vec4<f32>(c.rgb, c.a * u.opacity * alpha);
+
+  // Blend math runs in non-premultiplied RGB; the layer's effective alpha
+  // is its texture alpha × layer opacity × border-radius mask.
+  let blended = applyBlend(layer.rgb, dst.rgb, u.blendMode);
+  let outRgb = mix(dst.rgb, blended, layerAlpha);
+  let outA = layerAlpha + dst.a * (1.0 - layerAlpha);
+  return vec4<f32>(outRgb, outA);
 }
 `;
 
 /**
- * Color effects compute shader. Single pass that chains brightness →
- * contrast → saturation → hue → temperature → tint → shadows/highlights.
- * Ported verbatim from openreel-video's effects.wgsl.
+ * Blit shader — fullscreen quad that samples a single texture and writes
+ * it straight through. Used to (a) seed the next ping-pong target with
+ * the previous accumulation before each layer pass, and (b) present the
+ * final accumulation to the swapchain.
  */
+export const blitShader = /* wgsl */ `
+@group(0) @binding(0) var samp: sampler;
+@group(0) @binding(1) var tex: texture_2d<f32>;
+
+struct VsOut {
+  @builtin(position) pos: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs(@builtin(vertex_index) i: u32) -> VsOut {
+  var positions = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>( 1.0,  1.0),
+  );
+  var uvs = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+  );
+  var out: VsOut;
+  out.pos = vec4<f32>(positions[i], 0.0, 1.0);
+  out.uv = uvs[i];
+  return out;
+}
+
+@fragment
+fn fs(in: VsOut) -> @location(0) vec4<f32> {
+  return textureSample(tex, samp, in.uv);
+}
+`;
+
+/** Color-grading compute shader (unchanged from before). */
 export const effectsComputeShader = /* wgsl */ `
 struct EffectUniforms {
   brightness: f32,
@@ -267,10 +298,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 }
 `;
 
-/**
- * Separable Gaussian blur compute shader. Caller dispatches twice — once
- * with direction (1,0) and once with (0,1) — and ping-pongs textures.
- */
+/** Separable Gaussian blur compute shader (unchanged). */
 export const blurComputeShader = /* wgsl */ `
 struct BlurUniforms {
   radius: f32,


### PR DESCRIPTION
## Summary

Per-mode fixed-function GPU blend state can express \`normal\`, \`add\`, \`multiply\`, \`screen\` correctly but can't do \`overlay\` (and won't extend to any future modes that read the destination — soft-light, hard-light, color-burn, …). Compositor refactored to a ping-pong accumulation texture so blend math runs in the fragment shader.

## How it works

\`\`\`
accumA ──► accumB ──► accumA ──► … ──► swapchain
       layer 1   layer 2          blit
\`\`\`

1. Clear \`accumA\` to opaque black.
2. Per layer:
   - \`copyTextureToTexture\` seeds \`accumOut\` with \`accumIn\` so pixels outside the layer's transformed quad keep their previous value.
   - Render pass on \`accumOut\` with \`loadOp: "load"\`. Fragment samples \`accumIn\` (screen-space UV from \`@builtin(position)\`) + the layer source (layer-local UV), applies the border-radius SDF mask, then runs \`applyBlend\` per the \`blendMode\` uniform. Single layer pipeline, no fixed-function blend.
   - Swap ping-pong index.
3. Final blit: simple full-screen copy from the latest accumulation to the swapchain.

All five existing \`TimelineClip.blendMode\` values (\`normal\` / \`add\` / \`multiply\` / \`screen\` / \`overlay\`) now produce correct results. Adding more later is one branch in the WGSL \`applyBlend()\` function.

## Test plan

- [x] \`cd web && npm run typecheck\`
- [x] \`cd web && npm run lint\`
- [x] \`cd web && npx jest src/components/timeline/preview/\` — 25/25 pass
- [ ] Manual: stack two clips on different tracks, set the upper clip's blendMode in the inspector to each mode (incl. overlay), confirm the composite matches Photoshop / standard expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)