### PR TITLE
fix(timeline-inspector): pane no longer grows on first content render

### DIFF
--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -32,7 +32,14 @@ import { ClipActions } from "./ClipActions";
 import { NodePropertyEditor } from "./NodePropertyEditor";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
 
-const containerStyles = css({ width: "100%", padding: 8, overflow: "auto" });
+const containerStyles = css({
+  width: "100%",
+  minWidth: 0,
+  maxWidth: "100%",
+  boxSizing: "border-box",
+  padding: 8,
+  overflow: "auto"
+});
 const sectionContentStyles = css({ padding: 8 });
 
 const BLEND_MODES = ["normal", "screen", "multiply", "add", "overlay"] as const;
@@ -224,42 +231,38 @@ export const TimelineInspector: React.FC = memo(() => {
                   setTransform({ ...t, rotation: (deg * Math.PI) / 180 });
                 return (
                   <>
-                    <FlexRow gap={1}>
-                      <NumericField
-                        label="X (px)"
-                        value={t.position.x}
-                        onCommit={(v) => {
-                          const n = Number(v);
-                          if (Number.isFinite(n)) setPos("x", n);
-                        }}
-                      />
-                      <NumericField
-                        label="Y (px)"
-                        value={t.position.y}
-                        onCommit={(v) => {
-                          const n = Number(v);
-                          if (Number.isFinite(n)) setPos("y", n);
-                        }}
-                      />
-                    </FlexRow>
-                    <FlexRow gap={1}>
-                      <NumericField
-                        label="Scale X"
-                        value={t.scale.x}
-                        onCommit={(v) => {
-                          const n = Number(v);
-                          if (Number.isFinite(n)) setScale("x", n);
-                        }}
-                      />
-                      <NumericField
-                        label="Scale Y"
-                        value={t.scale.y}
-                        onCommit={(v) => {
-                          const n = Number(v);
-                          if (Number.isFinite(n)) setScale("y", n);
-                        }}
-                      />
-                    </FlexRow>
+                    <NumericField
+                      label="X (px)"
+                      value={t.position.x}
+                      onCommit={(v) => {
+                        const n = Number(v);
+                        if (Number.isFinite(n)) setPos("x", n);
+                      }}
+                    />
+                    <NumericField
+                      label="Y (px)"
+                      value={t.position.y}
+                      onCommit={(v) => {
+                        const n = Number(v);
+                        if (Number.isFinite(n)) setPos("y", n);
+                      }}
+                    />
+                    <NumericField
+                      label="Scale X"
+                      value={t.scale.x}
+                      onCommit={(v) => {
+                        const n = Number(v);
+                        if (Number.isFinite(n)) setScale("x", n);
+                      }}
+                    />
+                    <NumericField
+                      label="Scale Y"
+                      value={t.scale.y}
+                      onCommit={(v) => {
+                        const n = Number(v);
+                        if (Number.isFinite(n)) setScale("y", n);
+                      }}
+                    />
                     <NumericField
                       label="Rotation (deg)"
                       value={(t.rotation * 180) / Math.PI}

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -146,7 +146,7 @@ const PreviewRegion: React.FC<{
     <FlexColumn
       css={previewRegionStyles(theme)}
       fullHeight
-      sx={{ flex: "55 55 0", minWidth: 0 }}
+      sx={{ flex: "0 1 55%", minWidth: 0, width: 0 }}
     >
       {isLoading ? (
         <LoadingSpinner text="Loading sequence…" />
@@ -210,7 +210,7 @@ const InspectorRegion: React.FC = () => {
     <FlexColumn
       css={inspectorRegionStyles(theme)}
       fullHeight
-      sx={{ flex: "45 45 0", minWidth: 0 }}
+      sx={{ flex: "0 1 45%", minWidth: 0, width: 0 }}
     >
       <TimelineInspector />
     </FlexColumn>


### PR DESCRIPTION
## Summary

Selecting a clip caused the inspector pane to grow sideways and push the preview / asset panel out of place. Two layout fixes:

1. **Flex sizing**: changed the preview / inspector flex from \`"55 55 0"\` / \`"45 45 0"\` (basis 0 — content can dominate sizing) to \`"0 1 55%"\` / \`"0 1 45%"\` with \`width: 0\`. Fixed-percentage basis gives a deterministic split that's not influenced by inner content's min-content width.
2. **Inspector container**: \`containerStyles\` now sets \`minWidth: 0\`, \`maxWidth: 100%\`, \`boxSizing: border-box\` so the inner Panel respects the pane.
3. **Transform section**: stack Position X/Y and Scale X/Y vertically instead of side-by-side. Two MUI TextFields side-by-side had a min-content width wider than a typical inspector pane and were the proximate cause of the push.

## Test plan

- [x] \`cd web && npm run typecheck\`
- [x] \`cd web && npm run lint\`
- [x] \`cd web && npx jest src/components/timeline/preview\` — 25/25 pass
- [ ] Manual: select a clip and confirm the inspector pane width stays the same as before selection; preview + asset panel don't jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)