### PR TITLE
Remove video model cards grid from VideoGenerationSection

### DIFF
--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -106,8 +106,8 @@ export default function ModelSupportSection({
                         className="text-lg text-slate-400 leading-relaxed"
                     >
                         Frontier models from every major provider, called with
-                        the keys you already pay for. Switch the moment a better
-                        model ships. Run inference locally when you want to.
+                        the keys you already pay for. Swap models the day they
+                        launch. Run inference locally when you want to.
                     </motion.p>
                 </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -42,7 +42,7 @@ export default function NodeToolHero() {
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-400 md:text-lg">
             Every major model from every major provider, called with your own
             keys, wired into one node-based canvas. Pay providers directly at
-            provider prices. Switch the moment a better model ships.
+            provider prices. Swap models the day they launch.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/SeoHeroContent.tsx
+++ b/marketing/src/components/SeoHeroContent.tsx
@@ -18,7 +18,7 @@ export default function SeoHeroContent() {
           from every major provider, called with your own keys, wired into one
           node-based canvas you run on your machine. Bring your own keys to FAL,
           KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Pay providers
-          directly at provider prices. Switch the moment a better model ships.
+          directly at provider prices. Swap models the day they launch.
         </p>
       </section>
 

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 import React from "react";
 import { motion } from "framer-motion";
-import Tilt3D from "./Tilt3D";
-import { Film, Video, Image as ImageIcon, Cloud, Server } from "lucide-react";
+import { Film } from "lucide-react";
 
 interface VideoGenerationSectionProps {
   reducedMotion?: boolean;
@@ -74,117 +73,6 @@ export default function VideoGenerationSection({
             />
           </motion.div>
         </div>
-
-        <motion.div
-          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
-          initial="hidden"
-          whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
-          variants={{
-            show: { transition: { staggerChildren: 0.1 } },
-          }}
-        >
-          {[
-            {
-              title: "Wan 2.2",
-              description: "Open-weight video diffusion via Replicate—text-to-video and image-to-video.",
-              icon: Film,
-              category: "Open Weights",
-              features: ["Text-to-video", "Image-to-video", "Open model"],
-              color: "text-green-400",
-              bg: "bg-green-500/10",
-              border: "border-green-500/20",
-            },
-            {
-              title: "Kling v2.1",
-              description: "Kuaishou's Kling 2.1—5s and 10s clips at up to 1080p from a starting image.",
-              icon: Video,
-              category: "Text & Image to Video",
-              features: ["Image-to-video", "Up to 1080p", "Cinematic output"],
-              color: "text-cyan-400",
-              bg: "bg-cyan-500/10",
-              border: "border-cyan-500/20",
-            },
-            {
-              title: "Hailuo 02",
-              description: "MiniMax Hailuo 02—6s or 10s clips at 768p or 1080p with strong real-world physics.",
-              icon: Video,
-              category: "Text & Image to Video",
-              features: ["Text-to-video", "Image-to-video", "Real-world physics"],
-              color: "text-emerald-400",
-              bg: "bg-emerald-500/10",
-              border: "border-emerald-500/20",
-            },
-            {
-              title: "Google Veo 3.1",
-              description: "Latest Veo with image-to-video and high motion fidelity.",
-              icon: ImageIcon,
-              category: "Text & Image to Video",
-              features: ["Text-to-video", "Image-to-video", "High fidelity"],
-              color: "text-teal-400",
-              bg: "bg-teal-500/10",
-              border: "border-teal-500/20",
-            },
-            {
-              title: "HuggingFace",
-              description: "Pull any compatible video model from the Hub via inference providers.",
-              icon: Cloud,
-              category: "Cloud Video Models",
-              features: ["Text-to-video", "Multiple providers", "API access"],
-              color: "text-cyan-400",
-              bg: "bg-cyan-500/10",
-              border: "border-cyan-500/20",
-            },
-            {
-              title: "Local Generation",
-              description: "Run open-weight video models on your own GPU through the local HuggingFace bridge.",
-              icon: Server,
-              category: "Self-Hosted",
-              features: ["Open-weight models", "No API costs", "Full privacy"],
-              color: "text-blue-400",
-              bg: "bg-blue-500/10",
-              border: "border-blue-500/20",
-            },
-          ].map((item) => (
-            <motion.div
-              key={item.title}
-              variants={{
-                hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
-              }}
-            >
-              <Tilt3D className="h-full">
-                <div className="group relative h-full flex flex-col rounded-2xl border border-white/5 bg-slate-900/40 backdrop-blur-sm p-6 transition-all duration-300 hover:bg-slate-900/60 hover:border-white/10 hover:shadow-2xl">
-                  <div className={`w-12 h-12 rounded-xl flex items-center justify-center mb-6 ${item.bg} ${item.border} border`}>
-                    <item.icon className={`w-6 h-6 ${item.color}`} />
-                  </div>
-
-                  <div className="mb-2">
-                    <span className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${item.bg} ${item.color} border ${item.border}`}>
-                      {item.category}
-                    </span>
-                  </div>
-
-                  <h3 className="text-lg font-semibold text-white mb-2 group-hover:text-emerald-200 transition-colors">
-                    {item.title}
-                  </h3>
-                  <p className="text-sm text-slate-400 mb-4 flex-grow">
-                    {item.description}
-                  </p>
-
-                  <ul className="space-y-2 border-t border-white/5 pt-4">
-                    {item.features.map((feature) => (
-                      <li key={feature} className="flex items-center text-xs text-slate-500">
-                        <span className={`w-1.5 h-1.5 rounded-full mr-2 ${item.color.replace('text-', 'bg-')}`} />
-                        {feature}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </Tilt3D>
-            </motion.div>
-          ))}
-        </motion.div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
This PR removes the video model cards grid display from the VideoGenerationSection component and updates messaging across multiple marketing pages for consistency.

## Key Changes
- **Removed video model cards grid**: Deleted the entire 6-card grid displaying Wan 2.2, Kling v2.1, Hailuo 02, Google Veo 3.1, HuggingFace, and Local Generation models from VideoGenerationSection
- **Removed unused imports**: Cleaned up imports of `Tilt3D`, `Video`, `ImageIcon`, `Cloud`, and `Server` icons that were only used in the removed grid
- **Updated marketing copy**: Standardized messaging across multiple components:
  - Changed "Switch the moment a better model ships" to "Swap models the day they launch" in:
    - ModelSupportSection
    - NodeToolHero
    - SeoHeroContent

## Implementation Details
The removal simplifies the VideoGenerationSection to focus on the core video generation workflow without the model showcase cards. The messaging updates provide more concise and action-oriented language across the marketing pages, emphasizing the immediacy of model switching capability.

https://claude.ai/code/session_019JoruBgHgF5HsVKY12mFg7