### PR TITLE
feat(timeline): clip-to-clip crossfade transitions

### DIFF
--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -99,6 +99,25 @@ export interface TimelineClip {
   borderRadius?: number;
   /** GPU effects applied to this clip in order. */
   effects?: ClipEffect[];
+  /**
+   * Transition into this clip from the previously-overlapping clip on the
+   * same track. The two clips must overlap in time by at least
+   * `durationMs` for the transition to be visible.
+   */
+  transitionIn?: ClipTransition;
+}
+
+/**
+ * Per-clip incoming transition. Only `crossfade` is implemented today; the
+ * union is open for future types (`fade`, `wipe`, etc.) without a schema
+ * break.
+ */
+export type ClipTransition = ClipCrossfadeTransition;
+
+export interface ClipCrossfadeTransition {
+  type: "crossfade";
+  /** Length of the cross-fade in milliseconds. */
+  durationMs: number;
 }
 
 /**

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -11,6 +11,7 @@ import type {
   ClipColorEffect,
   ClipEffect,
   ClipTransform,
+  ClipTransition,
   TimelineClip
 } from "@nodetool-ai/timeline";
 import {
@@ -137,6 +138,7 @@ export const TimelineInspector: React.FC = memo(() => {
   const [transformOpen, setTransformOpen] = usePersistedFold("transform");
   const [colorOpen, setColorOpen] = usePersistedFold("color");
   const [blurOpen, setBlurOpen] = usePersistedFold("blur");
+  const [transitionOpen, setTransitionOpen] = usePersistedFold("transition");
   const [actionsOpen, setActionsOpen] = usePersistedFold("actions");
   const [parametersOpen, setParametersOpen] = usePersistedFold("parameters");
 
@@ -473,6 +475,66 @@ export const TimelineInspector: React.FC = memo(() => {
                     >
                       Clear blur effect
                     </EditorButton>
+                  </>
+                );
+              })()}
+            </FlexColumn>
+          </CollapsibleSection>
+        )}
+
+        {!isAudio && (
+          <CollapsibleSection title="Transition" open={transitionOpen} onToggle={setTransitionOpen}>
+            <FlexColumn css={sectionContentStyles} gap={1}>
+              {(() => {
+                const t = clip.transitionIn;
+                const type: "none" | "crossfade" = t?.type ?? "none";
+                const duration = t?.durationMs ?? 500;
+                const setType = (next: "none" | "crossfade") => {
+                  if (next === "none") {
+                    patchClip(clip.id, { transitionIn: undefined });
+                  } else {
+                    const transition: ClipTransition = {
+                      type: "crossfade",
+                      durationMs: duration
+                    };
+                    patchClip(clip.id, { transitionIn: transition });
+                  }
+                };
+                return (
+                  <>
+                    <FormField label="Type">
+                      <NodeSelect
+                        value={type}
+                        onChange={(e) =>
+                          setType(e.target.value as "none" | "crossfade")
+                        }
+                      >
+                        <NodeMenuItem value="none">None</NodeMenuItem>
+                        <NodeMenuItem value="crossfade">Crossfade</NodeMenuItem>
+                      </NodeSelect>
+                    </FormField>
+                    {type === "crossfade" && (
+                      <>
+                        <NumericField
+                          label="Duration (ms)"
+                          value={duration}
+                          onCommit={(v) => {
+                            const n = Number(v);
+                            if (!Number.isFinite(n) || n < 0) return;
+                            patchClip(clip.id, {
+                              transitionIn: {
+                                type: "crossfade",
+                                durationMs: Math.max(0, Math.floor(n))
+                              }
+                            });
+                          }}
+                        />
+                        <Text size="small">
+                          Overlap this clip with the previous clip on the same
+                          track to see the cross-fade.
+                        </Text>
+                      </>
+                    )}
                   </>
                 );
               })()}

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -134,6 +134,20 @@ function isClipActive(clip: TimelineClip, currentTimeMs: number): boolean {
   );
 }
 
+/**
+ * Opacity multiplier for a clip given the playhead position. Implements
+ * the incoming `transitionIn` ramp (0→1 over `durationMs`). Returns 1 when
+ * no transition applies. Crossfade is the only type currently supported.
+ */
+function transitionOpacity(clip: TimelineClip, currentTimeMs: number): number {
+  const t = clip.transitionIn;
+  if (!t || t.durationMs <= 0) return 1;
+  const intoClip = currentTimeMs - clip.startMs;
+  if (intoClip >= t.durationMs) return 1;
+  if (intoClip <= 0) return 0;
+  return intoClip / t.durationMs;
+}
+
 function isClipUpcoming(clip: TimelineClip, currentTimeMs: number): boolean {
   return (
     clip.startMs > currentTimeMs &&
@@ -206,6 +220,10 @@ export const PreviewCompositor: React.FC = memo(() => {
   // Hidden HTMLVideoElement pool — still browser-decoded, but never rendered.
   // Their pixels are uploaded each frame to GPU textures by the compositor.
   const videoRefs = useRef<HTMLVideoElement[]>([]);
+  /** Stable clipId → hot-slot index binding. Survives neighbor-clip churn
+   *  during transition overlaps so an active clip keeps its HTMLVideoElement
+   *  (no reload + seek glitch when the previous clip ends). */
+  const clipSlotMap = useRef<Map<string, number>>(new Map());
   const [poolReady, setPoolReady] = useState(false);
   const poolContainerRef = useRef<HTMLDivElement>(null);
 
@@ -355,57 +373,68 @@ export const PreviewCompositor: React.FC = memo(() => {
     for (const track of sortedTracks) {
       if (!track.visible) continue;
       const trackClips = clipsByTrackId.get(track.id) ?? [];
-      const clip = trackClips.find((c) => isClipActive(c, currentTimeMs));
-      if (!clip || clip.mediaType === "audio") continue;
+      // All clips overlapping the playhead. With transitions, two adjacent
+      // clips can be active simultaneously during the cross-fade overlap.
+      // Order by startMs so the outgoing (older) clip composites first and
+      // the incoming clip blends on top.
+      const activeClips = trackClips
+        .filter((c) => isClipActive(c, currentTimeMs))
+        .sort((a, b) => a.startMs - b.startMs);
 
-      const assetId = effectiveAssetId(clip);
-      const url = resolveUrl(assetId);
+      for (const clip of activeClips) {
+        if (clip.mediaType === "audio") continue;
 
-      if (
-        clip.mediaType === "image" &&
-        (track.type === "video" || track.type === "overlay")
-      ) {
-        imageLayers.push({
-          clipId: clip.id,
-          trackIndex: track.index,
-          blendMode: resolveBlendMode(clip.blendMode),
-          opacity: clip.opacity ?? 1,
-          assetUrl: url ?? "",
-          status: clip.status,
-          transform: clip.transform,
-          borderRadius: clip.borderRadius,
-          effects: clip.effects
-        });
-        if (!url) {
-          placeholders.push({
-            clipId: clip.id,
-            trackIndex: track.index,
-            status: clip.status,
-            name: clip.name
-          });
-        }
-      } else if (
-        (clip.mediaType === "video" || clip.mediaType === "overlay") &&
-        (track.type === "video" || track.type === "overlay")
-      ) {
-        if (url && videoSlots.length < HOT_POOL_SIZE) {
-          videoSlots.push({
+        const assetId = effectiveAssetId(clip);
+        const url = resolveUrl(assetId);
+        const baseOpacity = clip.opacity ?? 1;
+        const opacity = baseOpacity * transitionOpacity(clip, currentTimeMs);
+
+        if (
+          clip.mediaType === "image" &&
+          (track.type === "video" || track.type === "overlay")
+        ) {
+          imageLayers.push({
             clipId: clip.id,
             trackIndex: track.index,
             blendMode: resolveBlendMode(clip.blendMode),
-            opacity: clip.opacity ?? 1,
-            assetUrl: url,
+            opacity,
+            assetUrl: url ?? "",
+            status: clip.status,
             transform: clip.transform,
             borderRadius: clip.borderRadius,
             effects: clip.effects
           });
-        } else if (!url) {
-          placeholders.push({
-            clipId: clip.id,
-            trackIndex: track.index,
-            status: clip.status,
-            name: clip.name
-          });
+          if (!url) {
+            placeholders.push({
+              clipId: clip.id,
+              trackIndex: track.index,
+              status: clip.status,
+              name: clip.name
+            });
+          }
+        } else if (
+          (clip.mediaType === "video" || clip.mediaType === "overlay") &&
+          (track.type === "video" || track.type === "overlay")
+        ) {
+          if (url && videoSlots.length < HOT_POOL_SIZE) {
+            videoSlots.push({
+              clipId: clip.id,
+              trackIndex: track.index,
+              blendMode: resolveBlendMode(clip.blendMode),
+              opacity,
+              assetUrl: url,
+              transform: clip.transform,
+              borderRadius: clip.borderRadius,
+              effects: clip.effects
+            });
+          } else if (!url) {
+            placeholders.push({
+              clipId: clip.id,
+              trackIndex: track.index,
+              status: clip.status,
+              name: clip.name
+            });
+          }
         }
       }
     }
@@ -424,8 +453,28 @@ export const PreviewCompositor: React.FC = memo(() => {
     if (!poolReady) return;
     const pool = videoRefs.current;
 
-    activeVideoSlots.forEach((slot, slotIndex) => {
-      if (slotIndex >= pool.length) return;
+    // Stable clipId→hot-slot binding. Reuse existing assignments first,
+    // then fill empty slots for newly-active clips. Slots whose clip is no
+    // longer active become free for reuse.
+    const activeIds = new Set(activeVideoSlots.map((s) => s.clipId));
+    for (const [id] of clipSlotMap.current) {
+      if (!activeIds.has(id)) clipSlotMap.current.delete(id);
+    }
+    const usedSlots = new Set(clipSlotMap.current.values());
+    for (const slot of activeVideoSlots) {
+      if (clipSlotMap.current.has(slot.clipId)) continue;
+      for (let i = 0; i < HOT_POOL_SIZE; i++) {
+        if (!usedSlots.has(i)) {
+          clipSlotMap.current.set(slot.clipId, i);
+          usedSlots.add(i);
+          break;
+        }
+      }
+    }
+
+    activeVideoSlots.forEach((slot) => {
+      const slotIndex = clipSlotMap.current.get(slot.clipId);
+      if (slotIndex === undefined || slotIndex >= pool.length) return;
       const el = pool[slotIndex];
 
       if (el.getAttribute("data-asset") !== slot.assetUrl) {
@@ -459,8 +508,9 @@ export const PreviewCompositor: React.FC = memo(() => {
       }
     });
 
-    // Pause + clear unused hot-pool slots so their decoders go idle.
-    for (let i = activeVideoSlots.length; i < HOT_POOL_SIZE; i++) {
+    // Pause unused hot-pool slots so their decoders go idle.
+    for (let i = 0; i < HOT_POOL_SIZE; i++) {
+      if (usedSlots.has(i)) continue;
       const el = pool[i];
       if (el && !el.paused) el.pause();
     }
@@ -523,7 +573,9 @@ export const PreviewCompositor: React.FC = memo(() => {
     const out: CompositeLayer[] = [];
     const pool = videoRefs.current;
 
-    activeVideoSlots.forEach((slot, slotIndex) => {
+    activeVideoSlots.forEach((slot) => {
+      const slotIndex = clipSlotMap.current.get(slot.clipId);
+      if (slotIndex === undefined) return;
       const el = pool[slotIndex];
       // Keep the layer in the list even if the video momentarily drops below
       // HAVE_CURRENT_DATA (e.g. during a scrub seek). The compositor reuses


### PR DESCRIPTION
## Summary
- New `TimelineClip.transitionIn` field with a `crossfade` type (extensible union — fade/wipe can be added later without a break).
- PreviewCompositor emits all overlapping clips per track and ramps the incoming clip's opacity 0→1 over the transition duration.
- Inspector "Transition" section (type + duration) on non-audio clips.
- Stable clipId→hot-pool slot binding so a clip's `<video>` element survives neighbor churn — no reload/seek glitch when the outgoing clip ends mid-fade.

## Test plan
- [ ] Drop two video clips on the same track, drag them to overlap by 1s, set transitionIn=Crossfade 1000ms on the second clip — observe smooth cross-fade in the preview during the overlap.
- [ ] Scrub through the transition window paused — opacity tracks the playhead position.
- [ ] Set transitionIn back to None — incoming clip cuts in at full opacity.
- [ ] No regression for tracks with a single active clip at any given time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)