### PR TITLE
Refocus homepage and cookbook on creative AI workflows

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -16,26 +16,28 @@ Step-by-step guides with diagrams are on the [Workflow Examples Gallery]({{ '/wo
 
 Highlights:
 
-- [Image Enhance]({{ '/workflows/image-enhance' | relative_url }}) — Basic image enhancement
-- [Transcribe Audio]({{ '/workflows/transcribe-audio' | relative_url }}) — Speech-to-text with Whisper
-- [Chat with Docs]({{ '/workflows/chat-with-docs' | relative_url }}) — RAG-based document Q&A
-- [Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}) — Beginner tutorial
 - [Movie Posters]({{ '/workflows/movie-posters' | relative_url }}) — Multi-stage AI generation
+- [Story to Video Generator]({{ '/workflows/story-to-video-generator' | relative_url }}) — Prompt → storyboard → animated scenes
+- [Image to Audio Story]({{ '/workflows/image-to-audio-story' | relative_url }}) — Picture in, narrated story out
+- [Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}) — Beginner tutorial
+- [Image Enhance]({{ '/workflows/image-enhance' | relative_url }}) — Basic image enhancement
+- [Realtime Agent]({{ '/workflows/realtime-agent' | relative_url }}) — Voice-driven agent loop
 - [Data Visualization Pipeline]({{ '/workflows/data-visualization-pipeline' | relative_url }}) — Data fetching and charting
+- [Chat with Docs]({{ '/workflows/chat-with-docs' | relative_url }}) — RAG-based document Q&A
 
 ## Quick Reference: Choose Your Pattern
 
 | I want to… | Pattern | Key nodes |
 |------------|---------|-----------|
 | Generate creative content | 2 (Agent-Driven Generation) | `Agent`, `ListGenerator`, image/audio generators |
-| Answer questions about documents | 4 (RAG) | `IndexTextChunks`, `HybridSearch`, `Agent` |
-| Process emails automatically | 6 (Email Integration) | `GmailSearch`, `EmailFields`, `Classifier`/`Summarizer` |
-| Build a voice interface | 7 (Realtime Processing) | `RealtimeAudioInput`, `RealtimeAgent` |
-| Store data persistently | 5 (Database Persistence) | `CreateTable`, `Insert`, `Query` |
 | Transform images with AI | 9 (Advanced Image Processing) | `StableDiffusionControlNet`, `Canny`, `ImageToText` |
 | Generate videos from text | 11 (Text-to-Video) | `KlingTextToVideo`, `HailuoTextToVideoPro`, `Sora2TextToVideo` |
 | Animate images to video | 12 (Image-to-Video) | `KlingImageToVideo`, `HailuoImageToVideoPro`, `Wan26ImageToVideo` |
 | Create talking avatars | 13 (Talking Avatar) | `KlingAIAvatarPro`, `KlingAIAvatarStandard`, `InfinitalkV1` |
 | Enhance video quality | 14 (Video Enhancement) | `TopazVideoUpscale` |
 | Convert storyboards to video | 15 (Storyboard to Video) | `Sora2ProStoryboard` |
+| Build a voice interface | 7 (Realtime Processing) | `RealtimeAudioInput`, `RealtimeAgent` |
 | Fetch and visualize data | 10 (Data Processing Pipeline) | `GetRequest`, `ImportCSV`, `ChartGenerator` |
+| Process emails automatically | 6 (Email Integration) | `GmailSearch`, `EmailFields`, `Classifier`/`Summarizer` |
+| Store data persistently | 5 (Database Persistence) | `CreateTable`, `Insert`, `Query` |
+| Answer questions about documents | 4 (RAG) | `IndexTextChunks`, `HybridSearch`, `Agent` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: "NodeTool — the open creative AI workspace. Every major model, yo
   <p class="eyebrow">The open creative AI workspace</p>
   <h1>Every model. Your keys. Your canvas.</h1>
   <p class="lead">
-   One node-based canvas for image, video, audio, and text models. Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, ElevenLabs. Or run Flux, Qwen, and Llama locally. Open source, AGPL-3.0.
+   One node-based canvas for making images, video, sound, and stories with AI. Wire up Flux, Qwen, Wan, Seedance, Sora, Veo, Kling, ElevenLabs, MusicGen, and the major LLMs side by side — bring your own keys, or run locally. Open source, AGPL-3.0.
   </p>
   <img src="{{ '/assets/home.png' | relative_url }}" alt="NodeTool canvas" class="home-screenshot">
   <div class="cta-row">
@@ -46,26 +46,28 @@ Both editions are open source under AGPL-3.0 and built from the same code. Workf
 
 <div class="pattern-grid">
   <article class="pattern-card">
-    <h5>Agents</h5>
-    <p>Multi-step agents that plan and execute.</p>
-    <a href="{{ '/workflows/realtime-agent' | relative_url }}">Realtime Agent →</a>
-  </article>
-  <article class="pattern-card">
-    <h5>RAG</h5>
-    <p>Index documents, search, and answer from your sources.</p>
-    <a href="{{ '/workflows/chat-with-docs' | relative_url }}">Chat with Docs →</a>
-  </article>
-  <article class="pattern-card">
     <h5>Image and video</h5>
-    <p>Flux, Qwen, Wan, Seedance, Sora, Veo, Kling.</p>
+    <p>Posters, characters, scenes. Flux, Qwen, Wan, Seedance, Sora, Veo, Kling on one canvas.</p>
     <a href="{{ '/workflows/movie-posters' | relative_url }}">Movie Posters →</a>
   </article>
   <article class="pattern-card">
-    <h5>Pipelines</h5>
-    <p>Wire models, transforms, and tools into one graph.</p>
-    <a href="{{ '/cookbook' | relative_url }}">Patterns →</a>
+    <h5>Story to video</h5>
+    <p>Turn a prompt into a storyboard, narrate it, animate it, score it.</p>
+    <a href="{{ '/workflows/story-to-video-generator' | relative_url }}">Story to Video →</a>
+  </article>
+  <article class="pattern-card">
+    <h5>Sound and voice</h5>
+    <p>Music, sound design, narration. ElevenLabs, MusicGen, Whisper wired into the graph.</p>
+    <a href="{{ '/workflows/image-to-audio-story' | relative_url }}">Image to Audio Story →</a>
+  </article>
+  <article class="pattern-card">
+    <h5>Agents</h5>
+    <p>Multi-step agents that plan, call tools, and drive your creative pipelines.</p>
+    <a href="{{ '/workflows/realtime-agent' | relative_url }}">Realtime Agent →</a>
   </article>
 </div>
+
+More patterns — pipelines, data, RAG, email — in the [Cookbook]({{ '/cookbook' | relative_url }}).
 
 ## Get started
 


### PR DESCRIPTION
This PR reorganizes the documentation to better highlight NodeTool's core strength: creative AI generation across images, video, audio, and text.

## Summary
Updated the homepage and cookbook to emphasize creative workflows (image/video generation, story-to-video, audio/voice) while moving infrastructure patterns (RAG, email, database) to secondary positions. This reflects a shift in positioning toward creative professionals and content creators.

## Key changes

**Homepage (docs/index.md):**
- Rewrote the lead paragraph to emphasize creative use cases ("making images, video, sound, and stories") and feature specific models (Flux, Qwen, Sora, Veo, Kling, ElevenLabs, MusicGen)
- Reorganized the pattern cards to lead with creative workflows:
  - "Image and video" (moved up, expanded description)
  - New "Story to video" card with dedicated workflow link
  - New "Sound and voice" card highlighting audio/music capabilities
  - "Agents" moved to fourth position with updated description
  - Removed "RAG" and "Pipelines" cards from main grid
- Added a line directing users to the Cookbook for additional patterns (pipelines, data, RAG, email)

**Cookbook (docs/cookbook.md):**
- Reordered highlights list to prioritize creative workflows (Movie Posters, Story to Video, Image to Audio Story) at the top
- Moved infrastructure patterns (Chat with Docs, Data Visualization) lower in the list
- Reorganized the "Choose Your Pattern" reference table to group creative/media workflows first, then move data/integration patterns to the bottom
- Maintained all existing pattern links and descriptions

## Rationale
This change better surfaces NodeTool's differentiation in the creative AI space while keeping advanced patterns discoverable for users who need them.

https://claude.ai/code/session_01C8C3fs23YqW7RqCVpvRfCW