### PR TITLE
Consolidate external link in header navigation

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -3,7 +3,7 @@
 <header class="site-header">
   <div class="header-container">
     <div class="logo-section">
-      <a href="{{ '/' | relative_url }}" class="logo">
+      <a href="https://nodetool.ai" class="logo" rel="noopener">
         <img src="{{ '/assets/logo.png' | relative_url }}" alt="NodeTool Logo" class="logo-image" />
         <span class="logo-text">nodetool</span>
       </a>
@@ -16,7 +16,6 @@
       </button>
 
       <ul class="nav-list">
-        <li><a href="https://nodetool.ai" class="nav-item nav-item-external" rel="noopener">nodetool.ai</a></li>
         <li><a href="{{ '/' | relative_url }}" class="nav-item {% if page.url == '/' %}active{% endif %}">Home</a></li>
         <li><a href="{{ '/getting-started' | relative_url }}" class="nav-item {% if page.url contains '/getting-started' %}active{% endif %}">Getting Started</a></li>
         <li><a href="{{ '/cookbook' | relative_url }}" class="nav-item {% if page.url contains '/cookbook' %}active{% endif %}">Cookbook</a></li>


### PR DESCRIPTION
## Summary
Removed the redundant "nodetool.ai" navigation link and updated the logo to link directly to the external website instead.

## Changes
- Updated the logo link to point to `https://nodetool.ai` instead of the relative root path `/`
- Added `rel="noopener"` attribute to the logo link for security best practices
- Removed the duplicate "nodetool.ai" navigation item from the nav list, eliminating redundancy

## Details
This change consolidates the external link navigation by making the logo itself serve as the primary link to the main website, while keeping the internal documentation navigation (Home, Getting Started, Cookbook, etc.) in the nav list. This reduces clutter in the navigation menu and provides a more intuitive user experience where clicking the logo takes you to the main site.

https://claude.ai/code/session_01BXYTBJmZ3XKSNvabR73HDT