### PR TITLE
Remove editions comparison from main marketing page

### DIFF
--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -53,10 +53,6 @@ const ComparisonSection = dynamic(
   () => import("../components/ComparisonSection"),
   { ssr: false }
 );
-const EditionsCompareSection = dynamic(
-  () => import("../components/EditionsCompareSection"),
-  { ssr: false }
-);
 import { XMarkIcon, Bars3Icon } from "@heroicons/react/24/outline";
 
 import { Feature, features } from "./features";
@@ -578,9 +574,6 @@ export default function Home() {
             </motion.div>
           </div>
         </section>
-
-        {/* Editions: Studio vs Cloud */}
-        <EditionsCompareSection reducedMotion={reducedMotion} />
 
         {/* Comparisons with alternatives */}
         <ComparisonSection reducedMotion={reducedMotion} />


### PR DESCRIPTION
The Studio vs Cloud comparison table is too dense for the home page.
Keep it on /studio and /cloud where visitors are actively deciding.

https://claude.ai/code/session_01N22DXJK5GTiSJZYMM6Bdsp