### PR TITLE
Hide agents page node graph on mobile

### DIFF
--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -136,7 +136,9 @@ export default function AgentsGraphHero() {
                 </div>
 
                 {/* The Visualization Stage */}
-                <GraphVisualization />
+                <div className="hidden md:block">
+                    <GraphVisualization />
+                </div>
 
             </div>
         </div>


### PR DESCRIPTION
The interactive node graph visualization on /agents is cramped and
animation-heavy on small screens. Wrap it in `hidden md:block` to match
the existing convention used in DeploySection and AgentBuildRunDeploy.

https://claude.ai/code/session_01AWwYema9A5tcGYsYXo7Ggc