### PR TITLE
Update comparisons: replace n8n with Weavy, clarify positioning

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,41 +1,41 @@
 ---
 layout: page
 title: "How NodeTool Compares"
-description: "Where NodeTool sits relative to ComfyUI and n8n."
+description: "Where NodeTool sits relative to Weavy and ComfyUI."
 ---
 
-NodeTool is the open creative AI workspace: a node canvas for image, video, audio, and text models. Local on your machine or BYOK to cloud providers.
+NodeTool is the open creative AI workspace: one node canvas for image, video, audio, and text models. Runs on your machine, or BYOK to FAL, Kie, OpenAI, Anthropic, Gemini, Replicate, and more.
 
-ComfyUI is engineer-first and focused on diffusion internals. n8n is SaaS automation. NodeTool is for creative work that wires multiple modalities — and stays open and key-owned.
+Weavy is a closed SaaS canvas with its own credit system. ComfyUI is engineer-first and built around diffusion internals. NodeTool is the open alternative: every major model, your keys, your canvas — no credit markup, no vendor lock-in.
 
 ---
 
 ## Feature Comparison
 
-| Feature | NodeTool | n8n | ComfyUI |
-|---------|----------|-----|---------|
-| **Primary Focus** | ✅ Multi-modal AI workflows (text, image, audio, video) | ✅ Business automation and SaaS integrations | ✅ Image/video generation with diffusion models |
-| **AI Agents** | ✅ Built-in Agent nodes with tool calling and streaming | ⚠️ AI Agent node via LangChain integration | ⚠️ Via custom nodes (comfyui-ollama) |
-| **LLM Integration** | ✅ OpenAI, Anthropic, Google, Ollama, HuggingFace | ✅ OpenAI, Anthropic, Google via nodes | ⚠️ Via custom nodes (Ollama, OpenAI) |
-| **Image Generation** | ✅ Local: FLUX, Qwen Image · API: FAL, Kie, Replicate, OpenAI, Gemini | ⚠️ Via API integrations (GPT-Image, etc.) | ✅ Deep control over diffusion internals |
-| **Video Generation** | ✅ Local: Wan · API: Fal, Kie, Sora, Veo, Kling | ⚠️ Via API integrations only | ✅ Local diffusion-based video (AnimateDiff, etc.) |
-| **Audio Generation** | ✅ Local: MusicGen, AudioLDM, Stable Audio · API: Kie, ElevenLabs, MiniMax | ❌ Not a primary focus | ⚠️ Via custom nodes (ACE-Step, Stable Audio) |
-| **Text-to-Speech (TTS)** | ✅ Local: Kokoro, Sesame, Spark · API: OpenAI, Gemini, ElevenLabs | ⚠️ Via API integrations | ⚠️ Via custom nodes |
-| **Speech Recognition (ASR)** | ✅ Local: Whisper · API: OpenAI, FAL, Kie | ⚠️ Via API integrations | ⚠️ Via custom nodes (Whisper) |
-| **Real-time Streaming** | ✅ Token-by-token LLM responses, live progress | ⚠️ Limited streaming support | ❌ Queue-based execution |
-| **Local Execution** | ✅ Ollama, MLX (Apple Silicon), local Whisper | ✅ Self-hosted option available | ✅ Runs entirely local |
-| **SaaS Integrations** | ⚠️ HTTP requests, Gmail, RSS (limited) | ✅ 1300+ app integrations built-in | ❌ Not designed for SaaS |
-| **RAG / Vector Search** | ✅ Local Chroma DB | ✅ Via LangChain vector store nodes | ❌ Not supported |
-| **Visual Editor** | ✅ React-based drag-and-drop canvas | ✅ Web-based visual workflow editor | ✅ Node-based graph interface |
-| **Mini Apps / UI Generation** | ✅ Turn workflows into simple UIs | ⚠️ Form triggers and embeddable widgets | ❌ Developer-focused only |
-| **Diffusion Model Control** | ⚠️ Limited | ❌ Limited to API calls | ✅ Full control: latents, VAE, samplers, ControlNet |
-| **License** | AGPL-3.0 (open source) | Fair-code (sustainable source with restrictions) | GPL-3.0 (open source) |
+| Feature | NodeTool | Weavy | ComfyUI |
+|---------|----------|-------|---------|
+| **Category** | Open creative AI workspace | Closed SaaS creative canvas | Diffusion-focused node editor |
+| **License** | AGPL-3.0 (open source) | Proprietary SaaS | GPL-3.0 (open source) |
+| **Runs on your machine** | ✅ Mac, Windows, Linux desktop | ❌ Browser-only, hosted | ✅ Local-first |
+| **Bring your own keys (BYOK)** | ✅ FAL, Kie, OpenAI, Anthropic, Gemini, Replicate, Atlas, ElevenLabs, MiniMax | ❌ Credits only, provider markup | ⚠️ Via custom nodes for cloud APIs |
+| **Pricing model** | Pay providers directly, no markup | Proprietary credits | Free (you pay your own GPU/API) |
+| **Model coverage** | Image, video, audio, text, TTS, ASR — local + cloud | Image, video, audio — cloud only | Diffusion (image/video) — local |
+| **Image generation** | Local: FLUX, Qwen Image · API: FAL, Kie, Replicate, OpenAI, Gemini | Cloud: FLUX, Seedance, Ideogram, etc. | Deep control over diffusion internals |
+| **Video generation** | Local: Wan · API: FAL, Kie, Sora, Veo, Kling | Cloud: Kling, Veo, Runway, etc. | Local diffusion video (AnimateDiff, etc.) |
+| **Audio & music** | Local: MusicGen, AudioLDM, Stable Audio · API: Kie, ElevenLabs, MiniMax | Cloud: Suno, ElevenLabs, etc. | ⚠️ Via custom nodes |
+| **TTS / ASR** | Local: Kokoro, Sesame, Whisper · API: OpenAI, ElevenLabs | Cloud only | ⚠️ Via custom nodes |
+| **LLMs & agents** | Built-in agent nodes, tool calling, streaming, Ollama, MLX | Limited LLM nodes | ⚠️ Via custom nodes |
+| **Diffusion control** | Standard parameters | ❌ Hidden behind presets | ✅ Latents, VAE, samplers, ControlNet |
+| **RAG / vector search** | ✅ Local Chroma | ❌ | ❌ |
+| **Mini-apps from workflows** | ✅ Turn a graph into a simple UI | ⚠️ Share-as-template | ❌ |
+| **Real-time streaming** | ✅ Token-by-token, live progress | ✅ Live preview | ❌ Queue-based execution |
+| **Source available** | ✅ Full source on GitHub | ❌ | ✅ Full source on GitHub |
 
 ### When to pick each
 
-**NodeTool** — multi-modal creative work (text + image + audio + video) on one canvas, BYOK to providers, local Ollama/MLX, RAG, Mini-Apps.
+**NodeTool** — open creative AI workspace. Wire image, video, audio, and text models on one canvas, with your own keys, on your own machine.
 
-**n8n** — SaaS automation across 1,300+ apps, webhooks, CRMs, databases.
+**Weavy** — hosted SaaS canvas if you want a managed product with credits and don't need local execution, BYOK, or open source.
 
 **ComfyUI** — deep diffusion control: samplers, VAE, ControlNet, latents.
 


### PR DESCRIPTION
## Summary
Updated the comparisons documentation to reflect NodeTool's positioning against Weavy (a closed SaaS creative canvas) and ComfyUI, replacing the previous comparison with n8n (a business automation platform). This better represents NodeTool's actual competitive landscape in the creative AI space.

## Key Changes
- **Replaced comparison subject**: Changed from n8n to Weavy as the primary SaaS alternative
- **Refined positioning statement**: Updated description to emphasize NodeTool as "the open alternative" with BYOK, no credit markup, and no vendor lock-in
- **Restructured comparison table**: 
  - Reorganized columns to feature Weavy instead of n8n
  - Reordered rows to prioritize openness, licensing, and key ownership
  - Added new comparison dimensions: "Runs on your machine", "Bring your own keys (BYOK)", "Pricing model", "Source available"
  - Removed SaaS-focused rows (SaaS Integrations) and reframed others (Diffusion Model Control, Mini Apps)
- **Updated feature descriptions**: Clarified cloud provider support (FAL, Kie, OpenAI, Anthropic, Gemini, Replicate, Atlas, ElevenLabs, MiniMax)
- **Refined decision guidance**: Updated "When to pick each" section to reflect Weavy as a managed SaaS alternative vs. NodeTool's open, self-hosted approach

## Notable Details
The new comparison emphasizes NodeTool's core differentiators: open source (AGPL-3.0), local execution capability, bring-your-own-keys model, and multi-modal support—positioning it against Weavy's proprietary credit system and ComfyUI's diffusion-specific focus.

https://claude.ai/code/session_012Eo18FWEEd27e3rXf7Eqit