### PR TITLE
Skip unchanged scheduled nightlies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
     needs: [check_changes]
     if: |
       always() && !failure() && !cancelled() &&
-      (needs.check_changes.result == 'skipped' || github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+      (needs.check_changes.result == 'skipped' || needs.check_changes.outputs.has_changes == 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,45 @@ permissions:
   contents: write
 
 jobs:
+  check_changes:
+    name: Check for changes since last nightly
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        name: Compare HEAD to last nightly tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          last_nightly_tag=$(git tag --list 'v*-nightly.*' --sort=-creatordate | head -n 1)
+          if [[ -z "$last_nightly_tag" ]]; then
+            echo "No previous nightly tag found. Proceeding with release."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          last_nightly_sha=$(git rev-parse "$last_nightly_tag^{commit}")
+          head_sha=$(git rev-parse HEAD)
+          if [[ "$last_nightly_sha" == "$head_sha" ]]; then
+            echo "No changes since last nightly release ($last_nightly_tag). Skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected since $last_nightly_tag. Proceeding."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
   release-build:
+    needs: [check_changes]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,8 +64,8 @@ jobs:
   release-build:
     needs: [check_changes]
     if: |
-      !failure() && !cancelled() &&
-      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+      always() && !failure() && !cancelled() &&
+      (needs.check_changes.result == 'skipped' || github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add a scheduled-nightly guard that compares HEAD with the latest nightly tag
- skip the release matrix when the scheduled run has no changes to publish

## Validation
- workflow-only change, not run locally