### PR TITLE
Smoke test updater release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,19 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-nightly.*"
+  schedule:
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel"
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - nightly
       version:
         description: "Release version (without leading v). Leave empty to use the tag."
         required: false
@@ -31,12 +42,50 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       VERSION: ${{ github.event.inputs.version != '' && github.event.inputs.version || github.ref_name }}
+      RELEASE_CHANNEL: stable
+      RELEASE_TAG: ${{ github.event.inputs.version != '' && format('v{0}', github.event.inputs.version) || github.ref_name }}
+      RELEASE_NAME: Nodetool ${{ github.event.inputs.version != '' && format('v{0}', github.event.inputs.version) || github.ref_name }}
+      RELEASE_PRERELEASE: "false"
+      RELEASE_MAKE_LATEST: "true"
+      UPDATE_MANIFEST: latest.yml
+      UPDATE_MAC_MANIFEST: latest-mac.yml
+      UPDATE_LINUX_MANIFEST: latest-linux.yml
 
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || ( "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${{ github.event.inputs.channel }}" == "nightly" ) ]]; then
+            nightly_date="$(date -u -d "${{ github.run_started_at }}" +%Y%m%d)"
+            node scripts/resolve-nightly-release.mjs \
+              --date "$nightly_date" \
+              --run-number "${{ github.run_number }}" \
+              --sha "${{ github.sha }}" \
+              --github-output
+            version="$(grep '^version=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+            tag="$(grep '^tag=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+            name="$(grep '^name=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+            echo "VERSION=$version" >> "$GITHUB_ENV"
+            echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+            echo "RELEASE_NAME=$name" >> "$GITHUB_ENV"
+            echo "RELEASE_CHANNEL=nightly" >> "$GITHUB_ENV"
+            echo "RELEASE_PRERELEASE=true" >> "$GITHUB_ENV"
+            echo "RELEASE_MAKE_LATEST=false" >> "$GITHUB_ENV"
+            echo "UPDATE_MANIFEST=nightly.yml" >> "$GITHUB_ENV"
+            echo "UPDATE_MAC_MANIFEST=nightly-mac.yml" >> "$GITHUB_ENV"
+            echo "UPDATE_LINUX_MANIFEST=nightly-linux.yml" >> "$GITHUB_ENV"
+          else
+            version="${VERSION#v}"
+            echo "VERSION=$version" >> "$GITHUB_ENV"
+            echo "RELEASE_TAG=v$version" >> "$GITHUB_ENV"
+            echo "RELEASE_NAME=Nodetool v$version" >> "$GITHUB_ENV"
+          fi
+
       - name: Print selected version
-        run: echo "Using VERSION=$VERSION"
+        run: echo "Using VERSION=$VERSION channel=$RELEASE_CHANNEL tag=$RELEASE_TAG"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -45,7 +94,6 @@ jobs:
           cache: "npm"
 
       - name: Sync package versions to release tag
-        if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.version != ''
         shell: bash
         run: |
           set -euo pipefail
@@ -64,6 +112,10 @@ jobs:
               console.log(`Updated ${p} to ${version}`);
             }
           '
+
+      - name: Configure Electron update channel
+        shell: bash
+        run: node scripts/configure-electron-update-channel.mjs "$VERSION"
 
       - name: Install Apple Certificate
         if: matrix.os == 'macos-latest'
@@ -139,10 +191,13 @@ jobs:
           echo "archive_name=nodetool-web-${VERSION_NO_V}.zip" >> $GITHUB_OUTPUT
 
       - name: Upload Web Build to GitHub Release
-        if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'ubuntu-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          prerelease: ${{ env.RELEASE_PRERELEASE }}
+          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
           files: ${{ steps.create_archive.outputs.archive_name }}
 
       - name: Build Electron (Windows, unpacked)
@@ -199,7 +254,7 @@ jobs:
           echo "WIN_UNPACKED_ARCHIVE=${ARCHIVE_PATH}" >> "${GITHUB_ENV}"
 
       - name: Decide whether to sign (skip test tags)
-        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         shell: bash -l {0}
         run: |
           set -euo pipefail
@@ -212,7 +267,7 @@ jobs:
           echo "Windows signing enabled: ${SHOULD_SIGN}"
 
       - name: Sign main app exe (SSL.com eSigner)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: sslcom/esigner-codesign@develop
         with:
           command: sign
@@ -226,7 +281,7 @@ jobs:
           environment_name: PROD
 
       - name: Move signed app exe back to unpacked directory
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         shell: bash -l {0}
         run: |
           set -euo pipefail
@@ -274,7 +329,7 @@ jobs:
           fi
 
       - name: Sign installer exe (SSL.com eSigner)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: sslcom/esigner-codesign@develop
         with:
           command: sign
@@ -288,7 +343,7 @@ jobs:
           environment_name: PROD
 
       - name: Move signed installer back to dist directory
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         shell: bash -l {0}
         run: |
           set -euo pipefail
@@ -302,7 +357,7 @@ jobs:
           echo "Moved signed installer to ${INSTALLER_PATH}"
 
       - name: Update latest.yml sha512/size for signed installer (Windows)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         shell: bash -l {0}
         run: |
           set -euo pipefail
@@ -317,10 +372,10 @@ jobs:
           const version = process.env.VERSION;
           const installerName = `Nodetool-Setup-${version}.exe`;
           const installerPath = process.env.INSTALLER_PATH;
-          const latestPath = path.join(distDir, "latest.yml");
+          const latestPath = path.join(distDir, process.env.UPDATE_MANIFEST || "latest.yml");
 
           if (!fs.existsSync(latestPath)) {
-            console.warn(`latest.yml not found at ${latestPath}; skipping update`);
+            console.warn(`update manifest not found at ${latestPath}; skipping update`);
             process.exit(0);
           }
           if (!fs.existsSync(installerPath)) {
@@ -356,26 +411,32 @@ jobs:
           }
 
           fs.writeFileSync(latestPath, yaml.dump(doc, { lineWidth: 120 }), "utf8");
-          console.log(`Updated latest.yml for signed installer: sha512=${sha512.slice(0, 16)}... size=${size}`);
+          console.log(`Updated ${path.basename(latestPath)} for signed installer: sha512=${sha512.slice(0, 16)}... size=${size}`);
           NODE
 
       - name: Upload Windows assets to GitHub Release (signed)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          prerelease: ${{ env.RELEASE_PRERELEASE }}
+          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
           files: |
             ${{ env.DIST_DIR }}/Nodetool-Setup-${{ env.VERSION }}.exe
-            ${{ env.DIST_DIR }}/latest.yml
+            ${{ env.DIST_DIR }}/${{ env.UPDATE_MANIFEST }}
 
       - name: Upload Windows assets to GitHub Release (unsigned)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'false' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'false' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          prerelease: ${{ env.RELEASE_PRERELEASE }}
+          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
           files: |
             ${{ env.DIST_DIR }}/Nodetool-Setup-${{ env.VERSION }}.exe
-            ${{ env.DIST_DIR }}/latest.yml
+            ${{ env.DIST_DIR }}/${{ env.UPDATE_MANIFEST }}
 
       - name: Build Electron (macOS/Linux)
         if: matrix.os != 'windows-latest'
@@ -503,23 +564,29 @@ jobs:
           fi
 
       - name: Upload macOS assets to GitHub Release
-        if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'macos-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          prerelease: ${{ env.RELEASE_PRERELEASE }}
+          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
           files: |
             electron/dist/*.dmg
             electron/dist/*.zip
-            electron/dist/latest-mac.yml
+            electron/dist/${{ env.UPDATE_MAC_MANIFEST }}
 
       - name: Upload Linux assets to GitHub Release
-        if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.os == 'ubuntu-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          prerelease: ${{ env.RELEASE_PRERELEASE }}
+          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
           files: |
             electron/dist/*.AppImage
-            electron/dist/latest-linux.yml
+            electron/dist/${{ env.UPDATE_LINUX_MANIFEST }}
 
       # ── Workflow artifacts (downloadable from the Actions run page) ────
       - name: Upload web build artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,11 +61,67 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-  release-build:
+  preflight:
+    name: Resolve release metadata
     needs: [check_changes]
     if: |
       !failure() && !cancelled() &&
       (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+    runs-on: ubuntu-latest
+    outputs:
+      release_channel: ${{ steps.meta.outputs.release_channel }}
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      release_name: ${{ steps.meta.outputs.name }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
+      make_latest: ${{ steps.meta.outputs.make_latest }}
+      update_manifest: ${{ steps.meta.outputs.update_manifest }}
+      update_mac_manifest: ${{ steps.meta.outputs.update_mac_manifest }}
+      update_linux_manifest: ${{ steps.meta.outputs.update_linux_manifest }}
+      ref: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: meta
+        name: Resolve release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || ( "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${{ github.event.inputs.channel }}" == "nightly" ) ]]; then
+            nightly_date="$(date -u -d "${{ github.run_started_at }}" +%Y%m%d)"
+            node scripts/resolve-nightly-release.mjs \
+              --date "$nightly_date" \
+              --run-number "${{ github.run_number }}" \
+              --sha "${{ github.sha }}" \
+              --github-output
+            echo "release_channel=nightly" >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "update_manifest=nightly.yml" >> "$GITHUB_OUTPUT"
+            echo "update_mac_manifest=nightly-mac.yml" >> "$GITHUB_OUTPUT"
+            echo "update_linux_manifest=nightly-linux.yml" >> "$GITHUB_OUTPUT"
+          else
+            raw="${{ github.event.inputs.version != '' && github.event.inputs.version || github.ref_name }}"
+            version="${raw#v}"
+            echo "release_channel=stable" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "tag=v$version" >> "$GITHUB_OUTPUT"
+            echo "name=Nodetool v$version" >> "$GITHUB_OUTPUT"
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+              echo "make_latest=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "update_manifest=latest.yml" >> "$GITHUB_OUTPUT"
+            echo "update_mac_manifest=latest-mac.yml" >> "$GITHUB_OUTPUT"
+            echo "update_linux_manifest=latest-linux.yml" >> "$GITHUB_OUTPUT"
+          fi
+
+  release-build:
+    needs: [preflight]
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,48 +135,20 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      VERSION: ${{ github.event.inputs.version != '' && github.event.inputs.version || github.ref_name }}
-      RELEASE_CHANNEL: stable
-      RELEASE_TAG: ${{ github.event.inputs.version != '' && format('v{0}', github.event.inputs.version) || github.ref_name }}
-      RELEASE_NAME: Nodetool ${{ github.event.inputs.version != '' && format('v{0}', github.event.inputs.version) || github.ref_name }}
-      RELEASE_PRERELEASE: "false"
-      RELEASE_MAKE_LATEST: "true"
-      UPDATE_MANIFEST: latest.yml
-      UPDATE_MAC_MANIFEST: latest-mac.yml
-      UPDATE_LINUX_MANIFEST: latest-linux.yml
+      VERSION: ${{ needs.preflight.outputs.version }}
+      RELEASE_CHANNEL: ${{ needs.preflight.outputs.release_channel }}
+      RELEASE_TAG: ${{ needs.preflight.outputs.tag }}
+      RELEASE_NAME: ${{ needs.preflight.outputs.release_name }}
+      RELEASE_PRERELEASE: ${{ needs.preflight.outputs.is_prerelease }}
+      RELEASE_MAKE_LATEST: ${{ needs.preflight.outputs.make_latest }}
+      UPDATE_MANIFEST: ${{ needs.preflight.outputs.update_manifest }}
+      UPDATE_MAC_MANIFEST: ${{ needs.preflight.outputs.update_mac_manifest }}
+      UPDATE_LINUX_MANIFEST: ${{ needs.preflight.outputs.update_linux_manifest }}
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Resolve release metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || ( "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${{ github.event.inputs.channel }}" == "nightly" ) ]]; then
-            nightly_date="$(date -u -d "${{ github.run_started_at }}" +%Y%m%d)"
-            node scripts/resolve-nightly-release.mjs \
-              --date "$nightly_date" \
-              --run-number "${{ github.run_number }}" \
-              --sha "${{ github.sha }}" \
-              --github-output
-            version="$(grep '^version=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
-            tag="$(grep '^tag=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
-            name="$(grep '^name=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
-            echo "VERSION=$version" >> "$GITHUB_ENV"
-            echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
-            echo "RELEASE_NAME=$name" >> "$GITHUB_ENV"
-            echo "RELEASE_CHANNEL=nightly" >> "$GITHUB_ENV"
-            echo "RELEASE_PRERELEASE=true" >> "$GITHUB_ENV"
-            echo "RELEASE_MAKE_LATEST=false" >> "$GITHUB_ENV"
-            echo "UPDATE_MANIFEST=nightly.yml" >> "$GITHUB_ENV"
-            echo "UPDATE_MAC_MANIFEST=nightly-mac.yml" >> "$GITHUB_ENV"
-            echo "UPDATE_LINUX_MANIFEST=nightly-linux.yml" >> "$GITHUB_ENV"
-          else
-            version="${VERSION#v}"
-            echo "VERSION=$version" >> "$GITHUB_ENV"
-            echo "RELEASE_TAG=v$version" >> "$GITHUB_ENV"
-            echo "RELEASE_NAME=Nodetool v$version" >> "$GITHUB_ENV"
-          fi
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Print selected version
         run: echo "Using VERSION=$VERSION channel=$RELEASE_CHANNEL tag=$RELEASE_TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -625,12 +625,20 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
       - name: Download release artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: '*'
           merge-multiple: true
           path: release-assets
+
+      - name: Validate release assets
+        run: node scripts/validate-release-assets.mjs release-assets "${{ needs.preflight.outputs.release_channel }}"
 
       - name: Publish release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -640,6 +640,9 @@ jobs:
       - name: Validate release assets
         run: node scripts/validate-release-assets.mjs release-assets "${{ needs.preflight.outputs.release_channel }}"
 
+      - name: Smoke-test updater manifests
+        run: node scripts/smoke-release-updater-assets.mjs release-assets "${{ needs.preflight.outputs.version }}" "${{ needs.preflight.outputs.release_channel }}"
+
       - name: Publish release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,45 @@ permissions:
   contents: write
 
 jobs:
+  check_changes:
+    name: Check for changes since last nightly
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        name: Compare HEAD to last nightly tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          last_nightly_tag=$(git tag --list 'v*-nightly.*' --sort=-creatordate | head -n 1)
+          if [[ -z "$last_nightly_tag" ]]; then
+            echo "No previous nightly tag found. Proceeding with release."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          last_nightly_sha=$(git rev-parse "$last_nightly_tag^{commit}")
+          head_sha=$(git rev-parse HEAD)
+          if [[ "$last_nightly_sha" == "$head_sha" ]]; then
+            echo "No changes since last nightly release ($last_nightly_tag). Skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected since $last_nightly_tag. Proceeding."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
   release-build:
+    needs: [check_changes]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -256,16 +256,6 @@ jobs:
           ls -lh nodetool-web-${VERSION_NO_V}.zip
           echo "archive_name=nodetool-web-${VERSION_NO_V}.zip" >> $GITHUB_OUTPUT
 
-      - name: Upload Web Build to GitHub Release
-        if: matrix.os == 'ubuntu-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_NAME }}
-          prerelease: ${{ env.RELEASE_PRERELEASE }}
-          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
-          files: ${{ steps.create_archive.outputs.archive_name }}
-
       - name: Build Electron (Windows, unpacked)
         if: matrix.os == 'windows-latest'
         shell: bash -l {0}
@@ -480,30 +470,6 @@ jobs:
           console.log(`Updated ${path.basename(latestPath)} for signed installer: sha512=${sha512.slice(0, 16)}... size=${size}`);
           NODE
 
-      - name: Upload Windows assets to GitHub Release (signed)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'true' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_NAME }}
-          prerelease: ${{ env.RELEASE_PRERELEASE }}
-          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
-          files: |
-            ${{ env.DIST_DIR }}/Nodetool-Setup-${{ env.VERSION }}.exe
-            ${{ env.DIST_DIR }}/${{ env.UPDATE_MANIFEST }}
-
-      - name: Upload Windows assets to GitHub Release (unsigned)
-        if: matrix.os == 'windows-latest' && env.SHOULD_SIGN == 'false' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_NAME }}
-          prerelease: ${{ env.RELEASE_PRERELEASE }}
-          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
-          files: |
-            ${{ env.DIST_DIR }}/Nodetool-Setup-${{ env.VERSION }}.exe
-            ${{ env.DIST_DIR }}/${{ env.UPDATE_MANIFEST }}
-
       - name: Build Electron (macOS/Linux)
         if: matrix.os != 'windows-latest'
         shell: bash
@@ -629,31 +595,6 @@ jobs:
             exit 1
           fi
 
-      - name: Upload macOS assets to GitHub Release
-        if: matrix.os == 'macos-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_NAME }}
-          prerelease: ${{ env.RELEASE_PRERELEASE }}
-          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
-          files: |
-            electron/dist/*.dmg
-            electron/dist/*.zip
-            electron/dist/${{ env.UPDATE_MAC_MANIFEST }}
-
-      - name: Upload Linux assets to GitHub Release
-        if: matrix.os == 'ubuntu-latest' && (startsWith(github.ref, 'refs/tags/') || env.RELEASE_CHANNEL == 'nightly')
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_NAME }}
-          prerelease: ${{ env.RELEASE_PRERELEASE }}
-          make_latest: ${{ env.RELEASE_MAKE_LATEST }}
-          files: |
-            electron/dist/*.AppImage
-            electron/dist/${{ env.UPDATE_LINUX_MANIFEST }}
-
       # ── Workflow artifacts (downloadable from the Actions run page) ────
       - name: Upload web build artifact
         if: matrix.os == 'ubuntu-latest' && always()
@@ -676,4 +617,33 @@ jobs:
             electron/dist/*.zip
             electron/dist/*.AppImage
             electron/dist/*.exe
-            electron/dist/latest*.yml
+            electron/dist/*.yml
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [preflight, release-build]
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release-build.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: '*'
+          merge-multiple: true
+          path: release-assets
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.preflight.outputs.tag }}
+          name: ${{ needs.preflight.outputs.release_name }}
+          prerelease: ${{ needs.preflight.outputs.is_prerelease }}
+          make_latest: ${{ needs.preflight.outputs.make_latest }}
+          files: |
+            release-assets/*.zip
+            release-assets/*.dmg
+            release-assets/*.AppImage
+            release-assets/*.exe
+            release-assets/*.yml
+          fail_on_unmatched_files: true
+

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,77 @@
+# Release Process
+
+This document covers Nodetool desktop stable and nightly releases.
+
+## Channels
+
+- **Stable** follows tagged releases such as `v0.7.0` and publishes updater metadata as `latest*.yml`.
+- **Nightly** follows scheduled or manually-dispatched prereleases and publishes updater metadata as `nightly*.yml`.
+
+Nightly desktop versions use:
+
+```text
+X.Y.(Z+1)-nightly.YYYYMMDD.<run_number>
+```
+
+A packaged app whose version matches that suffix defaults to the `nightly` updater channel. Users can also choose the update channel in the desktop Settings page.
+
+## Workflow
+
+Workflow file: `.github/workflows/release.yaml`.
+
+Triggers:
+
+- Stable: push a tag matching `v*`, excluding `v*-nightly.*`.
+- Nightly: scheduled daily at `09:00 UTC`.
+- Manual: `workflow_dispatch` with `channel=stable|nightly`.
+
+Scheduled nightlies compare the current commit to the latest nightly tag and skip the release when there are no changes.
+
+## Release metadata
+
+The `preflight` job resolves release metadata once and passes it to build and publish jobs:
+
+- release channel
+- semver version
+- Git tag
+- release name
+- prerelease/latest flags
+- expected updater manifest names
+
+Nightly metadata is resolved by `scripts/resolve-nightly-release.mjs`.
+
+## Build and publish
+
+The matrix build produces artifacts for:
+
+- Windows NSIS installer
+- macOS DMG and updater zip
+- Linux AppImage
+- web build archive
+
+Matrix jobs upload workflow artifacts only. A single `publish-release` job downloads all artifacts, validates the expected stable/nightly assets, and publishes one GitHub Release.
+
+## Required updater assets
+
+Stable releases should include:
+
+- `latest.yml`
+- `latest-mac.yml`
+- `latest-linux.yml`
+
+Nightly releases should include:
+
+- `nightly.yml`
+- `nightly-mac.yml`
+- `nightly-linux.yml`
+
+The publish job runs `scripts/validate-release-assets.mjs` before creating/updating the GitHub Release.
+
+## Desktop updater behavior
+
+The Electron updater reads the selected desktop update channel from settings. If the user has not configured a channel, the default is inferred from the packaged app version:
+
+- `*-nightly.YYYYMMDD.<run_number>` defaults to `nightly`
+- all other versions default to `latest`
+
+For nightly, the app sets `autoUpdater.channel = "nightly"` and enables prerelease updates.

--- a/docs/release.md
+++ b/docs/release.md
@@ -65,7 +65,7 @@ Nightly releases should include:
 - `nightly-mac.yml`
 - `nightly-linux.yml`
 
-The publish job runs `scripts/validate-release-assets.mjs` before creating/updating the GitHub Release.
+The publish job runs `scripts/validate-release-assets.mjs` before creating/updating the GitHub Release. It then runs `scripts/smoke-release-updater-assets.mjs` to ensure each updater manifest has the expected version, checksum, path, and matching artifact file.
 
 ## Desktop updater behavior
 

--- a/electron/src/__tests__/preload.contract.test.ts
+++ b/electron/src/__tests__/preload.contract.test.ts
@@ -61,6 +61,8 @@ const IpcChannels = {
   SETTINGS_SET_CLOSE_BEHAVIOR: "settings-set-close-behavior",
   SETTINGS_GET_AUTO_UPDATES: "settings-get-auto-updates",
   SETTINGS_SET_AUTO_UPDATES: "settings-set-auto-updates",
+  SETTINGS_GET_UPDATE_CHANNEL: "settings-get-update-channel",
+  SETTINGS_SET_UPDATE_CHANNEL: "settings-set-update-channel",
   SETTINGS_GET_MODEL_SERVICES_STARTUP: "settings-get-model-services-startup",
   SETTINGS_SET_MODEL_SERVICES_STARTUP: "settings-set-model-services-startup",
   SHOW_SETTINGS: "show-settings",

--- a/electron/src/__tests__/updater.test.ts
+++ b/electron/src/__tests__/updater.test.ts
@@ -14,6 +14,9 @@ const mockAutoUpdater = {
   checkForUpdates: jest.fn().mockResolvedValue(undefined),
   on: jest.fn(),
   logger: null,
+  channel: "latest",
+  allowPrerelease: false,
+  allowDowngrade: false,
 };
 
 jest.mock("electron-updater", () => ({
@@ -31,6 +34,7 @@ jest.mock("electron", () => ({
   app: {
     isPackaged: false,
     getPath: jest.fn().mockReturnValue("/mock/path"),
+    getVersion: jest.fn().mockReturnValue("1.0.0"),
   },
 }));
 
@@ -54,9 +58,11 @@ jest.mock("../state", () => ({
 // Mock settings module to control auto-updates setting
 const mockReadSettings = jest.fn().mockReturnValue({ autoUpdatesEnabled: true });
 const mockReadSettingsAsync = jest.fn().mockResolvedValue({ autoUpdatesEnabled: true });
+const mockGetUpdateChannel = jest.fn().mockReturnValue("latest");
 jest.mock("../settings", () => ({
   readSettings: mockReadSettings,
   readSettingsAsync: mockReadSettingsAsync,
+  getUpdateChannel: mockGetUpdateChannel,
 }));
 
 // Store original process.resourcesPath
@@ -68,6 +74,10 @@ describe("Auto-updater Module", () => {
     // Reset the mocks
     mockExistsSync.mockReturnValue(true);
     mockAutoUpdater.checkForUpdates.mockResolvedValue(undefined);
+    mockAutoUpdater.channel = "latest";
+    mockAutoUpdater.allowPrerelease = false;
+    mockAutoUpdater.allowDowngrade = false;
+    mockGetUpdateChannel.mockReturnValue("latest");
     // Default to auto-updates enabled for backward-compatible tests
     mockReadSettings.mockReturnValue({ autoUpdatesEnabled: true });
     mockReadSettingsAsync.mockResolvedValue({ autoUpdatesEnabled: true });
@@ -112,11 +122,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -141,11 +152,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -169,11 +181,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -206,11 +219,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -241,11 +255,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -276,11 +291,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -308,11 +324,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -367,11 +384,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;
@@ -407,11 +425,12 @@ describe("Auto-updater Module", () => {
       let setupAutoUpdater: (() => Promise<void>) | undefined;
       jest.isolateModules(() => {
         jest.doMock("electron", () => ({
-          app: { isPackaged: true },
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
         }));
         jest.doMock("../settings", () => ({
           readSettings: mockReadSettings,
           readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
         }));
         const updater = require("../updater");
         setupAutoUpdater = updater.setupAutoUpdater;

--- a/electron/src/ipc.ts
+++ b/electron/src/ipc.ts
@@ -5,6 +5,7 @@ import {
   globalShortcut,
   shell,
   dialog,
+  app,
 } from "electron";
 import fs from "fs/promises";
 import path from "path";
@@ -33,6 +34,9 @@ import {
   updateSetting,
   getModelServiceStartupSettings,
   updateModelServiceStartupSettings,
+  getUpdateChannel,
+  normalizeUpdateChannel,
+  setUpdateChannel,
 } from "./settings";
 import { createPackageManagerWindow, createSettingsWindow } from "./window";
 import { IpcRequest } from "./types.d";
@@ -1329,6 +1333,23 @@ export function initializeIpcHandlers(): void {
     async (_event, enabled) => {
       logMessage(`Setting auto-updates to: ${enabled}`);
       updateSetting("autoUpdatesEnabled", enabled);
+    },
+  );
+
+  createIpcMainHandler(IpcChannels.SETTINGS_GET_UPDATE_CHANNEL, async () => {
+    const settings = await readSettingsAsync();
+    return getUpdateChannel(settings, app.getVersion());
+  });
+
+  createIpcMainHandler(
+    IpcChannels.SETTINGS_SET_UPDATE_CHANNEL,
+    async (_event, channel) => {
+      const nextChannel = normalizeUpdateChannel(channel);
+      if (!nextChannel) {
+        throw new Error(`Invalid update channel: ${String(channel)}`);
+      }
+      logMessage(`Setting update channel to: ${nextChannel}`);
+      return setUpdateChannel(nextChannel);
     },
   );
 

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -634,6 +634,14 @@ const api = {
     setAutoUpdates: (enabled: boolean) =>
       ipcRenderer.invoke(IpcChannels.SETTINGS_SET_AUTO_UPDATES, enabled),
 
+    /** Get the selected desktop update channel */
+    getUpdateChannel: () =>
+      ipcRenderer.invoke(IpcChannels.SETTINGS_GET_UPDATE_CHANNEL),
+
+    /** Set the selected desktop update channel */
+    setUpdateChannel: (channel: "latest" | "nightly") =>
+      ipcRenderer.invoke(IpcChannels.SETTINGS_SET_UPDATE_CHANNEL, channel),
+
     /** Get startup settings for managed local model services */
     getModelServicesStartup: () =>
       ipcRenderer.invoke(IpcChannels.SETTINGS_GET_MODEL_SERVICES_STARTUP),

--- a/electron/src/settings.ts
+++ b/electron/src/settings.ts
@@ -15,6 +15,38 @@ type SettingsRecord = Record<string, unknown>;
 let settingsCache: SettingsRecord | null = null;
 
 const START_LLAMA_CPP_ON_STARTUP_KEY = "START_LLAMA_CPP_ON_STARTUP";
+const UPDATE_CHANNEL_KEY = "updateChannel";
+const UPDATE_CHANNEL_CONFIGURED_BY_USER_KEY = "updateChannelConfiguredByUser";
+const NIGHTLY_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
+
+export type UpdateChannel = "latest" | "nightly";
+
+export function isNightlyVersion(version: string): boolean {
+  return NIGHTLY_VERSION_PATTERN.test(version);
+}
+
+export function getDefaultUpdateChannel(version: string): UpdateChannel {
+  return isNightlyVersion(version) ? "nightly" : "latest";
+}
+
+export function normalizeUpdateChannel(value: unknown): UpdateChannel | null {
+  return value === "latest" || value === "nightly" ? value : null;
+}
+
+export function getUpdateChannel(settings: SettingsRecord | undefined, version: string): UpdateChannel {
+  const source = settings ?? readSettings();
+  const configuredByUser = source[UPDATE_CHANNEL_CONFIGURED_BY_USER_KEY] === true;
+  const storedChannel = normalizeUpdateChannel(source[UPDATE_CHANNEL_KEY]);
+  return configuredByUser && storedChannel ? storedChannel : getDefaultUpdateChannel(version);
+}
+
+export function setUpdateChannel(channel: UpdateChannel): UpdateChannel {
+  updateSettings({
+    [UPDATE_CHANNEL_KEY]: channel,
+    [UPDATE_CHANNEL_CONFIGURED_BY_USER_KEY]: true,
+  });
+  return channel;
+}
 
 export interface ModelServiceStartupSettings {
   startLlamaCppOnStartup: boolean;

--- a/electron/src/types.d.ts
+++ b/electron/src/types.d.ts
@@ -547,6 +547,8 @@ export enum IpcChannels {
   SETTINGS_SET_CLOSE_BEHAVIOR = "settings-set-close-behavior",
   SETTINGS_GET_AUTO_UPDATES = "settings-get-auto-updates",
   SETTINGS_SET_AUTO_UPDATES = "settings-set-auto-updates",
+  SETTINGS_GET_UPDATE_CHANNEL = "settings-get-update-channel",
+  SETTINGS_SET_UPDATE_CHANNEL = "settings-set-update-channel",
   SETTINGS_GET_MODEL_SERVICES_STARTUP = "settings-get-model-services-startup",
   SETTINGS_SET_MODEL_SERVICES_STARTUP = "settings-set-model-services-startup",
   SHOW_SETTINGS = "show-settings",
@@ -702,6 +704,8 @@ export interface IpcRequest {
   [IpcChannels.SETTINGS_SET_CLOSE_BEHAVIOR]: WindowCloseAction;
   [IpcChannels.SETTINGS_GET_AUTO_UPDATES]: void;
   [IpcChannels.SETTINGS_SET_AUTO_UPDATES]: boolean;
+  [IpcChannels.SETTINGS_GET_UPDATE_CHANNEL]: void;
+  [IpcChannels.SETTINGS_SET_UPDATE_CHANNEL]: UpdateChannel;
   [IpcChannels.SETTINGS_GET_MODEL_SERVICES_STARTUP]: void;
   [IpcChannels.SETTINGS_SET_MODEL_SERVICES_STARTUP]: ModelServicesStartupSettingsUpdate;
   [IpcChannels.SHOW_SETTINGS]: void;
@@ -725,6 +729,7 @@ export interface IpcRequest {
 }
 
 export type WindowCloseAction = "ask" | "quit" | "background";
+export type UpdateChannel = "latest" | "nightly";
 
 export interface ModelServicesStartupSettings {
   startLlamaCppOnStartup: boolean;
@@ -798,6 +803,8 @@ export interface IpcResponse {
   [IpcChannels.SETTINGS_SET_CLOSE_BEHAVIOR]: void;
   [IpcChannels.SETTINGS_GET_AUTO_UPDATES]: boolean;
   [IpcChannels.SETTINGS_SET_AUTO_UPDATES]: void;
+  [IpcChannels.SETTINGS_GET_UPDATE_CHANNEL]: UpdateChannel;
+  [IpcChannels.SETTINGS_SET_UPDATE_CHANNEL]: UpdateChannel;
   [IpcChannels.SETTINGS_GET_MODEL_SERVICES_STARTUP]: ModelServicesStartupSettings;
   [IpcChannels.SETTINGS_SET_MODEL_SERVICES_STARTUP]: ModelServicesStartupSettings;
   [IpcChannels.SHOW_SETTINGS]: void;

--- a/electron/src/updater.ts
+++ b/electron/src/updater.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import { logMessage } from "./logger";
 import { getMainWindow } from "./state";
 import { IpcChannels } from "./types.d";
-import { readSettingsAsync } from "./settings";
+import { getUpdateChannel, readSettingsAsync } from "./settings";
 
 let updateAvailable: boolean = false;
 
@@ -131,13 +131,24 @@ async function setupAutoUpdater(): Promise<void> {
   }
 
   try {
+    const settings = await readSettingsAsync();
+    const updateChannel = getUpdateChannel(settings, app.getVersion());
+    const allowPrerelease = updateChannel === "nightly";
+
+    autoUpdater.channel = updateChannel;
+    autoUpdater.allowPrerelease = allowPrerelease;
+    autoUpdater.allowDowngrade = true;
     autoUpdater.setFeedURL({
       provider: "github",
       owner: "nodetool-ai",
       repo: "nodetool",
       updaterCacheDirName: "nodetool-updater",
+      ...(updateChannel === "nightly" ? { channel: "nightly" } : {}),
     });
 
+    logMessage(
+      `Auto-updater using ${updateChannel} channel (allowPrerelease=${allowPrerelease})`
+    );
     autoUpdater.logger = log;
 
     autoUpdater.checkForUpdates().catch((err: Error) => {

--- a/scripts/configure-electron-update-channel.mjs
+++ b/scripts/configure-electron-update-channel.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const version = process.argv[2] ?? process.env.VERSION ?? "";
+const configPath = "electron/electron-builder.json";
+const isNightly = /-nightly\.\d{8}\.\d+$/.test(version);
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+const publish = Array.isArray(config.publish) ? config.publish : [];
+config.publish = publish.map((entry) => {
+  if (!entry || entry.provider !== "github") return entry;
+  const next = { ...entry };
+  if (isNightly) {
+    next.channel = "nightly";
+    next.releaseType = "prerelease";
+  } else {
+    delete next.channel;
+    next.releaseType = "release";
+  }
+  return next;
+});
+fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+console.log(`Configured Electron updater channel: ${isNightly ? "nightly" : "latest"}`);

--- a/scripts/resolve-nightly-release.mjs
+++ b/scripts/resolve-nightly-release.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+function arg(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function flag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+function baseVersion(version) {
+  const stable = version.replace(/[-+].*$/, "");
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(stable);
+  if (!match) throw new Error(`Invalid version '${version}'`);
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+}
+
+const root = path.resolve(arg("root") ?? process.cwd());
+const date = arg("date");
+const runNumber = arg("run-number");
+const sha = arg("sha") ?? "";
+if (!/^\d{8}$/.test(date ?? "")) throw new Error("--date must be YYYYMMDD");
+if (!/^\d+$/.test(runNumber ?? "")) throw new Error("--run-number must be numeric");
+if (!/^[0-9a-f]{7,40}$/i.test(sha)) throw new Error("--sha must be a git SHA");
+
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "electron", "package.json"), "utf8"));
+const targetBase = baseVersion(pkg.version);
+const version = `${targetBase}-nightly.${date}.${runNumber}`;
+const shortSha = sha.slice(0, 12);
+const entries = {
+  base_version: targetBase,
+  version,
+  tag: `v${version}`,
+  name: `Nodetool Nightly ${version} (${shortSha})`,
+  short_sha: shortSha,
+};
+
+const output = Object.entries(entries).map(([key, value]) => `${key}=${value}\n`).join("");
+if (flag("github-output")) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, output);
+} else {
+  process.stdout.write(output);
+}

--- a/scripts/smoke-release-updater-assets.mjs
+++ b/scripts/smoke-release-updater-assets.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
 
 const dir = path.resolve(process.argv[2] ?? "release-assets");
 const expectedVersion = process.argv[3];
-const channel = process.argv[4] === "nightly" ? "nightly" : "latest";
-if (!expectedVersion) {
-  console.error("Usage: smoke-release-updater-assets.mjs <asset-dir> <version> <latest|nightly>");
+const channelArg = process.argv[4];
+const channel = channelArg === "nightly" ? "nightly" : channelArg === "stable" || channelArg === "latest" ? "latest" : null;
+
+if (!expectedVersion || channel == null) {
+  console.error("Usage: smoke-release-updater-assets.mjs <asset-dir> <version> <stable|nightly>");
   process.exit(2);
 }
 
@@ -16,11 +18,49 @@ const manifests = [
   channel === "nightly" ? "nightly-mac.yml" : "latest-mac.yml",
   channel === "nightly" ? "nightly-linux.yml" : "latest-linux.yml",
 ];
+const parseManifest = (manifestPath) => {
+  const fields = {};
+  const text = fs.readFileSync(manifestPath, "utf8");
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      continue;
+    }
+    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    fields[match[1]] = value;
+  }
+  return fields;
+};
+
+const getSha512Base64 = (filePath) =>
+  crypto
+    .createHash("sha512")
+    .update(fs.readFileSync(filePath))
+    .digest("base64");
+
+const ensurePathInDir = (baseDir, filePath) => {
+  const resolvedBaseDir = path.resolve(baseDir);
+  const resolvedFilePath = path.resolve(baseDir, filePath);
+  if (resolvedFilePath !== resolvedBaseDir && !resolvedFilePath.startsWith(`${resolvedBaseDir}${path.sep}`)) {
+    throw new Error(`Manifest path escapes asset directory: ${filePath}`);
+  }
+  return resolvedFilePath;
+};
 
 for (const manifest of manifests) {
   const manifestPath = path.join(dir, manifest);
-  const doc = yaml.load(fs.readFileSync(manifestPath, "utf8"));
-  if (!doc || typeof doc !== "object") {
+  const doc = parseManifest(manifestPath);
+  if (Object.keys(doc).length === 0) {
     throw new Error(`${manifest} is empty or invalid`);
   }
   if (doc.version !== expectedVersion) {
@@ -32,9 +72,16 @@ for (const manifest of manifests) {
   if (typeof doc.sha512 !== "string" || doc.sha512.length === 0) {
     throw new Error(`${manifest} is missing sha512`);
   }
-  const artifact = path.join(dir, path.basename(doc.path));
+  const artifact = ensurePathInDir(dir, doc.path);
   if (!fs.existsSync(artifact)) {
     throw new Error(`${manifest} points to missing artifact ${doc.path}`);
+  }
+  if (!fs.statSync(artifact).isFile()) {
+    throw new Error(`${manifest} points to a non-file artifact ${doc.path}`);
+  }
+  const actualSha512 = getSha512Base64(artifact);
+  if (actualSha512 !== doc.sha512) {
+    throw new Error(`${manifest} sha512 mismatch for ${doc.path}`);
   }
   console.log(`${manifest}: ${doc.version} -> ${doc.path}`);
 }

--- a/scripts/smoke-release-updater-assets.mjs
+++ b/scripts/smoke-release-updater-assets.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+
+const dir = path.resolve(process.argv[2] ?? "release-assets");
+const expectedVersion = process.argv[3];
+const channel = process.argv[4] === "nightly" ? "nightly" : "latest";
+if (!expectedVersion) {
+  console.error("Usage: smoke-release-updater-assets.mjs <asset-dir> <version> <latest|nightly>");
+  process.exit(2);
+}
+
+const manifests = [
+  channel === "nightly" ? "nightly.yml" : "latest.yml",
+  channel === "nightly" ? "nightly-mac.yml" : "latest-mac.yml",
+  channel === "nightly" ? "nightly-linux.yml" : "latest-linux.yml",
+];
+
+for (const manifest of manifests) {
+  const manifestPath = path.join(dir, manifest);
+  const doc = yaml.load(fs.readFileSync(manifestPath, "utf8"));
+  if (!doc || typeof doc !== "object") {
+    throw new Error(`${manifest} is empty or invalid`);
+  }
+  if (doc.version !== expectedVersion) {
+    throw new Error(`${manifest} version ${doc.version} does not match ${expectedVersion}`);
+  }
+  if (typeof doc.path !== "string" || doc.path.length === 0) {
+    throw new Error(`${manifest} is missing path`);
+  }
+  if (typeof doc.sha512 !== "string" || doc.sha512.length === 0) {
+    throw new Error(`${manifest} is missing sha512`);
+  }
+  const artifact = path.join(dir, path.basename(doc.path));
+  if (!fs.existsSync(artifact)) {
+    throw new Error(`${manifest} points to missing artifact ${doc.path}`);
+  }
+  console.log(`${manifest}: ${doc.version} -> ${doc.path}`);
+}
+
+console.log(`Updater asset smoke test passed for ${channel} ${expectedVersion}.`);

--- a/scripts/smoke-release-updater-assets.mjs
+++ b/scripts/smoke-release-updater-assets.mjs
@@ -6,9 +6,17 @@ import path from "node:path";
 const dir = path.resolve(process.argv[2] ?? "release-assets");
 const expectedVersion = process.argv[3];
 const channelArg = process.argv[4];
-const channel = channelArg === "nightly" ? "nightly" : channelArg === "stable" || channelArg === "latest" ? "latest" : null;
+const channel = (() => {
+  if (channelArg === "nightly") {
+    return "nightly";
+  }
+  if (channelArg === "stable" || channelArg === "latest") {
+    return "latest";
+  }
+  return null;
+})();
 
-if (!expectedVersion || channel == null) {
+if (!expectedVersion || channel === null) {
   console.error("Usage: smoke-release-updater-assets.mjs <asset-dir> <version> <stable|nightly>");
   process.exit(2);
 }
@@ -18,17 +26,22 @@ const manifests = [
   channel === "nightly" ? "nightly-mac.yml" : "latest-mac.yml",
   channel === "nightly" ? "nightly-linux.yml" : "latest-linux.yml",
 ];
+const MANIFEST_FIELD_PATTERN = /^([A-Za-z0-9_-]+):\s*([^\r\n]*)$/;
+// Flat electron-updater manifests are simple key-value pairs.
 const parseManifest = (manifestPath) => {
   const fields = {};
   const text = fs.readFileSync(manifestPath, "utf8");
   for (const line of text.split(/\r?\n/)) {
     const trimmed = line.trim();
-    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+    if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed === "---") {
       continue;
     }
-    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(trimmed);
-    if (!match) {
+    if (line !== line.trimStart()) {
       continue;
+    }
+    const match = MANIFEST_FIELD_PATTERN.exec(trimmed);
+    if (!match) {
+      throw new Error(`Invalid manifest line in ${path.basename(manifestPath)}: ${line}`);
     }
     let value = match[2].trim();
     if (
@@ -50,8 +63,15 @@ const getSha512Base64 = (filePath) =>
 
 const ensurePathInDir = (baseDir, filePath) => {
   const resolvedBaseDir = path.resolve(baseDir);
-  const resolvedFilePath = path.resolve(baseDir, filePath);
-  if (resolvedFilePath !== resolvedBaseDir && !resolvedFilePath.startsWith(`${resolvedBaseDir}${path.sep}`)) {
+  const normalizedFilePath = path.normalize(filePath);
+  const resolvedFilePath = path.resolve(baseDir, normalizedFilePath);
+  const relativePath = path.relative(resolvedBaseDir, resolvedFilePath);
+  if (
+    relativePath.length === 0 ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
     throw new Error(`Manifest path escapes asset directory: ${filePath}`);
   }
   return resolvedFilePath;

--- a/scripts/validate-release-assets.mjs
+++ b/scripts/validate-release-assets.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const dir = path.resolve(process.argv[2] ?? "release-assets");
+const channel = process.argv[3] === "nightly" ? "nightly" : "latest";
+const files = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+const has = (predicate) => files.some(predicate);
+const required = [
+  channel === "nightly" ? "nightly.yml" : "latest.yml",
+  channel === "nightly" ? "nightly-mac.yml" : "latest-mac.yml",
+  channel === "nightly" ? "nightly-linux.yml" : "latest-linux.yml",
+];
+const missing = required.filter((file) => !files.includes(file));
+
+const checks = [
+  ["Windows installer", (f) => /^Nodetool-Setup-.+\.exe$/.test(f)],
+  ["macOS DMG", (f) => f.endsWith(".dmg")],
+  ["macOS zip", (f) => f.endsWith(".zip") && f.includes("Nodetool-")],
+  ["Linux AppImage", (f) => f.endsWith(".AppImage")],
+  ["web archive", (f) => /^nodetool-web-.+\.zip$/.test(f)],
+];
+for (const [label, predicate] of checks) {
+  if (!has(predicate)) missing.push(label);
+}
+
+if (missing.length > 0) {
+  console.error(`Release asset validation failed for ${channel} channel.`);
+  console.error(`Directory: ${dir}`);
+  console.error(`Missing: ${missing.join(", ")}`);
+  console.error(`Found:\n${files.map((file) => `  - ${file}`).join("\n")}`);
+  process.exit(1);
+}
+
+console.log(`Release asset validation passed for ${channel} channel.`);
+console.log(files.map((file) => `  - ${file}`).join("\n"));

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -137,6 +137,8 @@ function SettingsPage() {
   const [closeBehavior, setCloseBehavior] = useState<
     "ask" | "quit" | "background"
   >("ask");
+  const [autoUpdatesEnabled, setAutoUpdatesEnabled] = useState(false);
+  const [updateChannel, setUpdateChannel] = useState<"latest" | "nightly">("latest");
 
   // Load close behavior setting on mount (Electron only)
   useEffect(() => {
@@ -146,6 +148,12 @@ function SettingsPage() {
         .then((action: "ask" | "quit" | "background") => {
           setCloseBehavior(action);
         });
+    }
+    if (isElectron && window.api?.settings?.getAutoUpdates) {
+      window.api.settings.getAutoUpdates().then(setAutoUpdatesEnabled);
+    }
+    if (isElectron && window.api?.settings?.getUpdateChannel) {
+      window.api.settings.getUpdateChannel().then(setUpdateChannel);
     }
   }, []);
 
@@ -158,6 +166,17 @@ function SettingsPage() {
     },
     []
   );
+
+  const handleAutoUpdatesChange = useCallback((checked: boolean) => {
+    setAutoUpdatesEnabled(checked);
+    window.api?.settings?.setAutoUpdates?.(checked);
+  }, []);
+
+  const handleUpdateChannelChange = useCallback((value: string) => {
+    const channel = value === "nightly" ? "nightly" : "latest";
+    setUpdateChannel(channel);
+    window.api?.settings?.setUpdateChannel?.(channel).then(setUpdateChannel);
+  }, []);
 
   // Subscribe to secrets store changes to update sidebar when secrets are modified
   useEffect(() => {
@@ -300,7 +319,8 @@ function SettingsPage() {
       category: "Workspace",
       items: [
         { id: "editor", label: "Editor" },
-        { id: "appearance", label: "Appearance" }
+        { id: "appearance", label: "Appearance" },
+        ...(isElectron ? [{ id: "updates", label: "Updates" }] : [])
       ]
     },
     {
@@ -468,6 +488,36 @@ function SettingsPage() {
                           onChange={handleSoundNotificationsChange}
                           description="Play a system beep sound when workflows complete, exports finish, or other important events occur."
                         />
+                      </div>
+                    )}
+
+                    {isElectron && (
+                      <div className="settings-item">
+                        <LabeledSwitch
+                          label="Automatic Updates"
+                          checked={autoUpdatesEnabled}
+                          onChange={handleAutoUpdatesChange}
+                          description="Check for and download desktop app updates from the selected release channel."
+                        />
+                      </div>
+                    )}
+
+                    {isElectron && (
+                      <div id="updates" className="settings-item">
+                        <SelectField
+                          label="Update Channel"
+                          value={updateChannel}
+                          variant="standard"
+                          onChange={handleUpdateChannelChange}
+                          options={[
+                            { value: "latest", label: "Stable" },
+                            { value: "nightly", label: "Nightly" }
+                          ]}
+                        />
+                        <Text className="description">
+                          Stable follows full releases. Nightly follows prerelease nightly builds.
+                          Nightly builds default to the Nightly channel.
+                        </Text>
                       </div>
                     )}
 

--- a/web/src/window.d.ts
+++ b/web/src/window.d.ts
@@ -269,13 +269,17 @@ declare global {
         ) => () => void;
       };
 
-      // Settings module - Application settings (Windows only)
+      // Settings module - Application settings
       settings?: {
         getCloseBehavior: () => Promise<"ask" | "quit" | "background">;
         setCloseBehavior: (
           action: "ask" | "quit" | "background"
         ) => Promise<void>;
         getSystemInfo: () => Promise<SystemInfo>;
+        getAutoUpdates?: () => Promise<boolean>;
+        setAutoUpdates?: (enabled: boolean) => Promise<void>;
+        getUpdateChannel?: () => Promise<"latest" | "nightly">;
+        setUpdateChannel?: (channel: "latest" | "nightly") => Promise<"latest" | "nightly">;
       };
 
       // Debug module - Debug bundle export


### PR DESCRIPTION
## Summary
- add an updater manifest smoke-test script
- verify manifest version, path, sha512, and referenced artifact existence before release publishing
- document the updater smoke test in release docs

## Validation
- smoke script runs in the release workflow after asset validation