### PR TITLE
Reorganize homepage sections for improved product narrative flow

### DIFF
--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -540,14 +540,7 @@ export default function Home() {
           </div>
         </section>
 
-        {/* How it works (Build / Run / Deploy) */}
-        <section aria-labelledby="how-title" className="rhythm-section pt-4">
-          <div className={`${sectionContainer}`}>
-            <BuildRunDeploy />
-          </div>
-        </section>
-
-        {/* Demo video */}
+        {/* Demo video — surface the product immediately after the hero */}
         <section id="demo-video" aria-label="NodeTool Demo" className="rhythm-section relative scroll-mt-24">
           <div className={`${sectionContainer}`}>
             <motion.div
@@ -575,37 +568,40 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Chat UI */}
-        <ChatUISection />
-
-        {/* Comparisons with alternatives */}
+        {/* Position the product first: "What NodeTool is" */}
         <ComparisonSection reducedMotion={reducedMotion} />
 
-        {/* Your tools, your data, your way */}
-        <OwnershipSection reducedMotion={reducedMotion} />
+        {/* How it works (Build / Run / Deploy) — the 3-step mental model */}
+        <section aria-labelledby="how-title" className="rhythm-section pt-4">
+          <div className={`${sectionContainer}`}>
+            <BuildRunDeploy />
+          </div>
+        </section>
 
-        {/* Local Model Support - MLX & GGML/GGUF */}
-        <ModelSupportSection reducedMotion={reducedMotion} />
+        {/* What the canvas does */}
+        <FeaturesSection />
 
-        {/* Model Manager */}
-        <ModelManagerSection />
+        {/* What's in the canvas */}
+        <NodeMenuSection />
 
-        {/* Video Generation */}
+        {/* A flagship capability example */}
         <VideoGenerationSection reducedMotion={reducedMotion} />
+
+        {/* Asset Manager — companion to the canvas story */}
+        <AssetManagerSection />
+
+        {/* Alternate interface: drive workflows by chat (payoff after canvas) */}
+        <ChatUISection />
+
+        {/* Ownership block — three adjacent sections that share the BYOK / your-stack story */}
+        <OwnershipSection reducedMotion={reducedMotion} />
+        <ModelSupportSection reducedMotion={reducedMotion} />
+        <ModelManagerSection />
 
         {/* Templates Gallery */}
         {/* <ExamplesGrid /> */}
 
-        {/* Features */}
-        <FeaturesSection />
-
-        {/* Node Menu */}
-        <NodeMenuSection />
-
-        {/* Asset Manager */}
-        <AssetManagerSection />
-
-        {/* Deploy */}
+        {/* Self-host / deploy */}
         <DeploySection reducedMotion={reducedMotion} />
 
         {/* Feature Modal (accessible) */}


### PR DESCRIPTION
## Summary
Restructured the homepage layout to present NodeTool's value proposition in a more logical, narrative-driven order. The changes reorder major sections to establish the product story progressively: from immediate product demonstration, through core capabilities, to advanced features and deployment options.

## Key Changes
- **Moved demo video** immediately after hero section to surface the product early
- **Repositioned comparison section** to follow demo, establishing "what NodeTool is"
- **Reordered canvas-related sections** (Features, Node Menu, Asset Manager) to tell a cohesive story about the canvas interface
- **Grouped ownership/stack sections** together (Ownership, Model Support, Model Manager) to reinforce the "your tools, your data, your way" narrative
- **Moved chat UI section** after canvas sections to present it as an alternate interface
- **Moved video generation** earlier in the flow as a flagship capability example
- **Moved deploy section** to the end as the final step in the user journey
- **Updated section comments** to clarify the narrative purpose of each section

## Implementation Details
- No component logic changes; this is purely a reordering of existing sections
- All sections maintain their original functionality and props
- Comments updated to reflect the new information architecture and user journey flow
- The reorganization creates a clearer progression: Hero → Demo → What it is → How it works → What it does → Advanced features → Deploy

https://claude.ai/code/session_01CeCn85dgLvbK9nM6m7AHNB