### PR TITLE
perf: optimize SelectionContextMenu to use batch deletion (deleteNodes)

### DIFF
--- a/web/src/components/context_menus/SelectionContextMenu.tsx
+++ b/web/src/components/context_menus/SelectionContextMenu.tsx
@@ -32,8 +32,8 @@ interface SelectionContextMenuProps {
 
 const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
   const { handleCopy } = useCopyPaste();
-  const { deleteNode, toggleBypassSelected } = useNodes((state) => ({
-    deleteNode: state.deleteNode,
+  const { deleteNodes, toggleBypassSelected } = useNodes((state) => ({
+    deleteNodes: state.deleteNodes,
     toggleBypassSelected: state.toggleBypassSelected
   }), shallow);
   const duplicateNodes = useDuplicateNodes();
@@ -95,12 +95,11 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
   //delete
   const handleDelete = useCallback(() => {
     if (selectedNodes?.length) {
-      selectedNodes.forEach((node) => {
-        deleteNode(node.id);
-      });
+      // [PERF] Use batch deletion (deleteNodes) instead of iterating deleteNode(node.id) to avoid O(N) re-renders
+      deleteNodes(selectedNodes.map((node) => node.id));
     }
     closeContextMenu();
-  }, [closeContextMenu, deleteNode, selectedNodes]);
+  }, [closeContextMenu, deleteNodes, selectedNodes]);
 
   //select connected
   const handleSelectConnectedAll = useCallback(() => {

--- a/workspace/bolt.md
+++ b/workspace/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-03-08 - Batching node deletions to bypass O(N) Zustand churn
+**Learning:** Found an iterative Zustand action invocation (`deleteNode`) mapping over an array in `SelectionContextMenu.tsx`. For every iteration, `deleteNode` would wrap its own internal call to `deleteNodes([id])` resulting in redundant re-evaluations and subsequent component renders.
+**Action:** Always favor bulk/batch updates (`deleteNodes(selectedIds)`) over iterative individual state mutations inside React arrays/maps, especially on `Zustand` state managers where state changes instantly dispatch updates to all subscribed hooks.

--- a/⚡ Bolt: Batch delete optimization.md
+++ b/⚡ Bolt: Batch delete optimization.md
@@ -1,0 +1,17 @@
+# ⚡ Bolt: Batch delete optimization
+
+**💡 What:** Replaced iterative `deleteNode(node.id)` with batched `deleteNodes(ids)` in `SelectionContextMenu.tsx`.
+
+**🎯 Why:** Iterating `deleteNode` over multiple selected nodes triggers independent state updates per node, leading to `O(N)` cascading React component re-renders (specifically `getSelectedNodes` consumers). `deleteNodes` performs the deletion and updates state exactly once, avoiding UI stuttering and massive overhead when dealing with large group deletions.
+
+**📊 Impact:** Massively reduces frontend state churn. Given `N` selected nodes, deleting them will now trigger `1` render phase rather than `N` render phases, resulting in O(1) state overhead relative to selection size.
+
+**🔬 Measurement:** Select 100+ nodes, click `Delete` from the context menu, and measure the profile render graph.
+
+**🧪 Testing:**
+```bash
+cd web && npm run typecheck
+cd web && npx oxlint src
+cd web && pnpm test -- --passWithNoTests src/hooks/nodes/__tests__/useNodeContextMenu.test.ts
+```
+All commands succeeded with zero issues.


### PR DESCRIPTION
- Replaced `deleteNode` with `deleteNodes` in `SelectionContextMenu.tsx`.
- Updated `handleDelete` to map over `selectedNodes` and provide an array of IDs to `deleteNodes`.
- Avoids O(N) downstream renders upon selection deletion.
- Added documentation/metrics files according to persona.

---
*PR created automatically by Jules for task [11798625831495826534](https://jules.google.com/task/11798625831495826534) started by @georgi*