### PR TITLE
fix(ci): cover ImageEditorNode and align retarget test with React flow

### DIFF
--- a/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
+++ b/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
@@ -35,6 +35,7 @@ import {
   GetMetadataNode,
   BatchToListNode,
   ImagesToListNode,
+  ImageEditorNode,
   PasteNode,
   ScaleNode,
   ResizeNode,
@@ -1366,6 +1367,38 @@ describe("image nodes — full coverage", () => {
     const result = await _n.process();
     // Dynamic node: non-null non-array values are pushed individually; nulls are skipped
     expect(result.output).toEqual(["not-array"]);
+  });
+
+  it("ImageEditorNode passes through image, mask, and layers from properties", async () => {
+    const image = imageRef();
+    const mask = imageRef();
+    const layers = [imageRef(), imageRef()];
+    const _n = new ImageEditorNode();
+    _n.assign({ image, mask, layers });
+    const result = await _n.process();
+    expect(result.image).toBe(image);
+    expect(result.mask).toBe(mask);
+    expect(result.layers).toEqual(layers);
+  });
+
+  it("ImageEditorNode forwards dynamic layer_out_* properties", async () => {
+    const overlay = imageRef();
+    const _n = new ImageEditorNode();
+    _n.assign({
+      image: imageRef(),
+      layer_out_top: overlay,
+      ignored_extra: "skip"
+    });
+    const result = await _n.process();
+    expect(result.layer_out_top).toBe(overlay);
+    expect(result).not.toHaveProperty("ignored_extra");
+  });
+
+  it("ImageEditorNode coerces non-array layers to an empty list", async () => {
+    const _n = new ImageEditorNode();
+    _n.assign({ image: imageRef(), layers: "not-an-array" });
+    const result = await _n.process();
+    expect(result.layers).toEqual([]);
   });
 });
 

--- a/web/src/components/sketch/__tests__/phase2TransformLifecycle.test.ts
+++ b/web/src/components/sketch/__tests__/phase2TransformLifecycle.test.ts
@@ -140,6 +140,11 @@ describe("TransformTool in-transform undo/redo", () => {
       transform: { x: 40, y: 40, scaleX: 1, scaleY: 1, rotation: 0 }
     };
     ctx.doc.layers = [firstLayer, secondLayer];
+    // Simulate React's onAutoPickLayer flow: when the parent receives the
+    // callback, it updates doc.activeLayerId before the next gizmo draw.
+    ctx.onAutoPickLayer = jest.fn((id: string) => {
+      ctx.doc.activeLayerId = id;
+    });
 
     tool.onActivate!(ctx);
     expect(tool.getTargetSet().getIds()).toEqual([firstLayer.id]);


### PR DESCRIPTION
- Add ImageEditorNode tests in coverage-media-nodes.test.ts so the
  exported-node-coverage audit (Packages Test job) recognizes the new
  node introduced with @nodetool-ai/image-editor.
- Update phase2TransformLifecycle "click retargets" test to mutate
  ctx.doc.activeLayerId from the onAutoPickLayer mock, mirroring the
  React state update that runs in production. Without this, drawGizmo's
  syncTransformTargets call read a stale activeLayerId and reset the
  target back to the first layer, causing Web Test to fail.