### PR TITLE
Add standalone Image Editor route and navigation

### DIFF
--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -23,6 +23,7 @@ import React, {
 } from "react";
 import { Handle, NodeProps, NodeToolbar, Position } from "@xyflow/react";
 import { Box, Typography } from "@mui/material";
+import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import EditIcon from "@mui/icons-material/Edit";
@@ -56,6 +57,7 @@ import useSelect from "../../../hooks/nodes/useSelect";
 import { useDelayedVisibility } from "../../../hooks/useDelayedVisibility";
 import useResultsStore from "../../../stores/ResultsStore";
 import { useNodeFocusStore } from "../../../stores/NodeFocusStore";
+import { useSettingsStore } from "../../../stores/SettingsStore";
 import type { Node as FlowNode } from "@xyflow/react";
 import {
   SKETCH_OUTPUT_LAYERS_HANDLE,
@@ -980,14 +982,44 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
     }
   }, [currentDocument, props.id, updateNodeProperties]);
 
+  const navigate = useNavigate();
+  const imageEditorOpenMode = useSettingsStore(
+    (s) => s.settings.imageEditorOpenMode
+  );
+
   const handleOpenEditor = useCallback(() => {
     // Use documentRef if available (may include async-loaded input image),
     // fall back to sketchDoc from serialized properties
     const docToOpen = documentRef.current || sketchDoc;
     documentRef.current = docToOpen;
+
+    // Standalone mode requires a persisted image_document id on the node.
+    // Until the node is wired to a document (NOD-319), fall back to modal.
+    const imageDocumentId = (props.data.properties as Record<string, unknown>)
+      ?.image_document_id;
+    if (
+      imageEditorOpenMode === "standalone" &&
+      typeof imageDocumentId === "string" &&
+      imageDocumentId.length > 0
+    ) {
+      const workflowId = props.data.workflow_id;
+      const fromParam = workflowId
+        ? `?from=editor:${workflowId}:${props.id}`
+        : "";
+      navigate(`/sketch/${imageDocumentId}${fromParam}`);
+      return;
+    }
+
     setEditorDocument(docToOpen);
     setIsModalOpen(true);
-  }, [sketchDoc]);
+  }, [
+    sketchDoc,
+    imageEditorOpenMode,
+    navigate,
+    props.id,
+    props.data.workflow_id,
+    props.data.properties
+  ]);
 
   const handleCloseEditor = useCallback(() => {
     flushPendingNodeSync();

--- a/web/src/components/panels/AppHeader.tsx
+++ b/web/src/components/panels/AppHeader.tsx
@@ -17,6 +17,7 @@ import { FlexRow, Tooltip } from "../ui_primitives";
 import WorkspaceSelect from "../workspaces/WorkspaceSelect";
 import { useCurrentWorkspace } from "../../hooks/useCurrentWorkspace";
 import { isProduction } from "../../lib/env";
+import { trpcClient } from "../../trpc/client";
 
 const workspacesEnabled = !isProduction;
 
@@ -155,6 +156,7 @@ const ModePills = memo(function ModePills({ currentPath }: { currentPath: string
   const isEditorActive = currentPath.startsWith("/editor");
   const isChatActive = currentPath.startsWith("/chat");
   const isAppActive = currentPath.startsWith("/apps");
+  const isSketchActive = currentPath.startsWith("/sketch");
 
   const handleEditorClick = useCallback(async () => {
     if (currentWorkflowId) {
@@ -190,6 +192,26 @@ const ModePills = memo(function ModePills({ currentPath }: { currentPath: string
       navigate(`/apps/${currentWorkflowId}`);
     }
   }, [navigate, currentWorkflowId]);
+
+  const handleSketchClick = useCallback(async () => {
+    try {
+      const docs = await trpcClient.sketch.list.query({});
+      if (docs.length > 0) {
+        const mostRecent = docs.reduce((acc, cur) =>
+          cur.updatedAt > acc.updatedAt ? cur : acc
+        );
+        navigate(`/sketch/${mostRecent.id}`);
+        return;
+      }
+      const created = await trpcClient.sketch.create.mutate({
+        name: "Untitled image",
+        projectId: "default"
+      });
+      navigate(`/sketch/${created.id}`);
+    } catch (error) {
+      console.error("Failed to open Image Editor:", error);
+    }
+  }, [navigate]);
 
   return (
     <div className="mode-pills">
@@ -229,6 +251,18 @@ const ModePills = memo(function ModePills({ currentPath }: { currentPath: string
             <span>App</span>
           </button>
         </span>
+      </Tooltip>
+      <Tooltip title="Image Editor" delay={TOOLTIP_ENTER_DELAY} placement="bottom">
+        <button
+          className={`mode-pill ${isSketchActive ? "active" : ""}`}
+          onClick={handleSketchClick}
+          tabIndex={-1}
+          aria-current={isSketchActive ? "page" : undefined}
+          aria-label="Image Editor"
+          data-testid="image-editor-mode-pill"
+        >
+          <span>Image</span>
+        </button>
       </Tooltip>
     </div>
   );
@@ -359,6 +393,54 @@ const ReturnToTimelinePill = memo(function ReturnToTimelinePill() {
   );
 });
 
+/**
+ * "Return to Sketch" pill — shown in the editor header when the user arrived
+ * via "Open in Node Editor" from the sketch (image-editor) inspector.
+ * The `from` query param carries `sketch:{documentId}:{layerId}`.
+ */
+const ReturnToSketchPill = memo(function ReturnToSketchPill() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // from=sketch:{documentId}:{layerId}
+  // Require at least 3 colon-separated parts: "sketch", documentId, layerId.
+  const fromParam = searchParams.get("from") ?? "";
+  const parts = fromParam.startsWith("sketch:") ? fromParam.split(":") : [];
+  const documentId = parts.length >= 3 ? parts[1] : "";
+
+  const handleReturn = useCallback(() => {
+    navigate(`/sketch/${documentId}`);
+  }, [navigate, documentId]);
+
+  if (!documentId) return null;
+
+  return (
+    <Tooltip title="Return to Image Editor" delay={TOOLTIP_ENTER_DELAY} placement="bottom">
+      <EditorButton
+        variant="outlined"
+        size="small"
+        onClick={handleReturn}
+        aria-label="Return to Image Editor"
+        data-testid="return-to-sketch-pill"
+        sx={{
+          height: "1.75em",
+          minWidth: "auto",
+          borderRadius: "var(--rounded-md)",
+          color: "var(--palette-primary-main)",
+          border: "1px solid var(--palette-primary-main)",
+          gap: "4px",
+          "&:hover": {
+            backgroundColor: "var(--palette-action-hover)"
+          }
+        }}
+      >
+        <ArrowBackIcon sx={{ fontSize: "14px" }} />
+        <span>Image</span>
+      </EditorButton>
+    </Tooltip>
+  );
+});
+
 const AppHeader: React.FC = memo(function AppHeader() {
   const theme = useTheme();
   const path = useLocation().pathname;
@@ -392,6 +474,8 @@ const AppHeader: React.FC = memo(function AppHeader() {
           <ModePills currentPath={path} />
           {/* Return to Timeline pill — only shown when opened from timeline */}
           {isEditorRoute && <ReturnToTimelinePill />}
+          {/* Return to Image Editor pill — only shown when opened from sketch */}
+          {isEditorRoute && <ReturnToSketchPill />}
           <Box sx={{ flexGrow: 1 }} />
         </FlexRow>
         <div className="buttons-right">

--- a/web/src/components/sketch/SketchEditorPage.tsx
+++ b/web/src/components/sketch/SketchEditorPage.tsx
@@ -10,12 +10,22 @@
  * the same components that render in the in-node `SketchModal`. Modal mode
  * remains unchanged.
  *
- * Document persistence (load/autosave) is wired in NOD-319; this shell only
- * fetches the requested document and seeds the editor with its `sketch`
- * payload as the initial document.
+ * ## Seed-once contract (until NOD-319 wires persistence)
+ *
+ * `useEditorLifecycle` calls `setDocument(initialDocument)` whenever the
+ * `initialDocument` prop identity changes. React Query background refetches
+ * (focus, staleTime, invalidation) would otherwise emit a fresh object and
+ * silently overwrite in-progress edits. Until autosave + conflict handling
+ * land in NOD-319, this page:
+ *
+ *   1. Disables all background refetches for the load query.
+ *   2. Captures the first non-null payload per `documentId` into local state
+ *      and feeds *that* stable reference to `SketchEditor`. Subsequent query
+ *      data is ignored for the lifetime of the route, and a new `documentId`
+ *      resets the seed.
  */
 
-import React, { memo, useMemo } from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
@@ -41,16 +51,34 @@ const SketchEditorPage: React.FC = memo(function SketchEditorPage() {
 
   const documentQuery = trpc.sketch.get.useQuery(
     { id: documentId ?? "" },
-    { enabled: !!documentId, staleTime: 30_000 }
+    {
+      enabled: !!documentId,
+      // Background refetches would replace `initialDocument` and clobber
+      // unsaved edits until NOD-319 wires autosave. Disable them here.
+      staleTime: Infinity,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false
+    }
   );
 
-  const initialDocument = useMemo<SketchDocument | undefined>(() => {
+  // Seed the editor exactly once per documentId. Keyed by id so navigating
+  // between documents in the same session correctly re-seeds.
+  const [seed, setSeed] = useState<{
+    id: string;
+    document: SketchDocument;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!documentId) return;
+    if (seed?.id === documentId) return;
     const data = documentQuery.data;
-    if (!data) return undefined;
+    if (!data) return;
     // The persisted `sketch` payload is the on-disk shape of `SketchDocument`.
     // Slice 1+2 widening of layer fields is handled inside the editor on load.
-    return data.document.sketch as unknown as SketchDocument;
-  }, [documentQuery.data]);
+    const sketch = data.document.sketch as unknown as SketchDocument;
+    setSeed({ id: documentId, document: sketch });
+  }, [documentId, documentQuery.data, seed?.id]);
 
   if (!documentId) {
     return (
@@ -68,7 +96,25 @@ const SketchEditorPage: React.FC = memo(function SketchEditorPage() {
     );
   }
 
-  if (documentQuery.isLoading) {
+  // Show the spinner until we've captured a seed for this documentId.
+  // Using `seed` (not the live query state) keeps the canvas mounted across
+  // any future background query state changes.
+  if (!seed || seed.id !== documentId) {
+    if (documentQuery.isError) {
+      return (
+        <FlexColumn
+          align="center"
+          justify="center"
+          sx={{ flex: 1, width: "100%", height: "100%" }}
+        >
+          <EmptyState
+            variant="error"
+            title="Sketch document not found"
+            description="The image document you requested does not exist or you do not have access to it."
+          />
+        </FlexColumn>
+      );
+    }
     return (
       <FlexColumn
         align="center"
@@ -80,25 +126,9 @@ const SketchEditorPage: React.FC = memo(function SketchEditorPage() {
     );
   }
 
-  if (documentQuery.isError || !documentQuery.data) {
-    return (
-      <FlexColumn
-        align="center"
-        justify="center"
-        sx={{ flex: 1, width: "100%", height: "100%" }}
-      >
-        <EmptyState
-          variant="error"
-          title="Sketch document not found"
-          description="The image document you requested does not exist or you do not have access to it."
-        />
-      </FlexColumn>
-    );
-  }
-
   return (
     <div className="sketch-editor-page" css={styles}>
-      <SketchEditor initialDocument={initialDocument} />
+      <SketchEditor initialDocument={seed.document} />
     </div>
   );
 });

--- a/web/src/components/sketch/SketchEditorPage.tsx
+++ b/web/src/components/sketch/SketchEditorPage.tsx
@@ -1,0 +1,108 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SketchEditorPage
+ *
+ * Top-level page shell for the standalone Image Editor at `/sketch/:documentId`.
+ *
+ * The page mounts the existing `SketchEditor` (which already composes
+ * `ConnectedToolbar`, `ConnectedToolTopBar`, `SketchCanvasPane`,
+ * `ConnectedLayersPanel`, and `ConnectedContextMenu`) inside the app shell —
+ * the same components that render in the in-node `SketchModal`. Modal mode
+ * remains unchanged.
+ *
+ * Document persistence (load/autosave) is wired in NOD-319; this shell only
+ * fetches the requested document and seeds the editor with its `sketch`
+ * payload as the initial document.
+ */
+
+import React, { memo, useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { EmptyState, FlexColumn, LoadingSpinner } from "../ui_primitives";
+import SketchEditor from "./SketchEditor";
+import { trpc } from "../../trpc/client";
+import type { SketchDocument } from "./types";
+
+const pageStyles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+    backgroundColor: theme.vars.palette.background.default
+  });
+
+const SketchEditorPage: React.FC = memo(function SketchEditorPage() {
+  const theme = useTheme();
+  const { documentId } = useParams<{ documentId: string }>();
+  const styles = useMemo(() => pageStyles(theme), [theme]);
+
+  const documentQuery = trpc.sketch.get.useQuery(
+    { id: documentId ?? "" },
+    { enabled: !!documentId, staleTime: 30_000 }
+  );
+
+  const initialDocument = useMemo<SketchDocument | undefined>(() => {
+    const data = documentQuery.data;
+    if (!data) return undefined;
+    // The persisted `sketch` payload is the on-disk shape of `SketchDocument`.
+    // Slice 1+2 widening of layer fields is handled inside the editor on load.
+    return data.document.sketch as unknown as SketchDocument;
+  }, [documentQuery.data]);
+
+  if (!documentId) {
+    return (
+      <FlexColumn
+        align="center"
+        justify="center"
+        sx={{ flex: 1, width: "100%", height: "100%" }}
+      >
+        <EmptyState
+          variant="error"
+          title="No document id"
+          description="The sketch route requires a documentId path parameter."
+        />
+      </FlexColumn>
+    );
+  }
+
+  if (documentQuery.isLoading) {
+    return (
+      <FlexColumn
+        align="center"
+        justify="center"
+        sx={{ flex: 1, width: "100%", height: "100%" }}
+      >
+        <LoadingSpinner />
+      </FlexColumn>
+    );
+  }
+
+  if (documentQuery.isError || !documentQuery.data) {
+    return (
+      <FlexColumn
+        align="center"
+        justify="center"
+        sx={{ flex: 1, width: "100%", height: "100%" }}
+      >
+        <EmptyState
+          variant="error"
+          title="Sketch document not found"
+          description="The image document you requested does not exist or you do not have access to it."
+        />
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <div className="sketch-editor-page" css={styles}>
+      <SketchEditor initialDocument={initialDocument} />
+    </div>
+  );
+});
+
+SketchEditorPage.displayName = "SketchEditorPage";
+
+export default SketchEditorPage;

--- a/web/src/components/sketch/index.ts
+++ b/web/src/components/sketch/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { default as SketchEditor } from "./SketchEditor";
+export { default as SketchEditorPage } from "./SketchEditorPage";
 export { default as SketchModal } from "./SketchModal";
 export { default as SketchCanvas } from "./SketchCanvas";
 export { default as SketchToolbar } from "./SketchToolbar";

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -128,6 +128,9 @@ const SettingsPage = React.lazy(
 const TimelineEditor = React.lazy(
   () => import("./components/timeline/TimelineEditor")
 );
+const SketchEditorPage = React.lazy(
+  () => import("./components/sketch/SketchEditorPage")
+);
 
 // Defer frontend tool registrations until after initial render
 const registerFrontendTools = () => {
@@ -503,6 +506,28 @@ function getRoutes() {
             <AppHeader />
             <React.Suspense fallback={<LoadingSpinner />}>
               <TimelineEditor />
+            </React.Suspense>
+          </div>
+        </ProtectedRoute>
+      )
+    },
+    {
+      path: "/sketch/:documentId",
+      element: (
+        <ProtectedRoute>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              height: "100%",
+              paddingTop: HEADER_HEIGHT
+            }}
+          >
+            <SkipLinks />
+            <AppHeader />
+            <React.Suspense fallback={<LoadingSpinner />}>
+              <SketchEditorPage />
             </React.Suspense>
           </div>
         </ProtectedRoute>

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -40,6 +40,12 @@ export interface Settings {
    */
   instantUpdate: boolean;
   editorViewMode: "graph" | "chain";
+  /**
+   * How the SketchNode opens the Image Editor when clicked:
+   * - "modal":      fullscreen modal portal inside the workflow editor (default).
+   * - "standalone": navigates to the standalone `/sketch/:documentId` route.
+   */
+  imageEditorOpenMode: "modal" | "standalone";
   autosave: AutosaveSettings;
 }
 
@@ -61,6 +67,7 @@ interface SettingsStore {
   setSoundNotifications: (value: boolean) => void;
   setInstantUpdate: (value: boolean) => void;
   setEditorViewMode: (value: "graph" | "chain") => void;
+  setImageEditorOpenMode: (value: "modal" | "standalone") => void;
   updateAutosaveSettings: (newSettings: Partial<AutosaveSettings>) => void;
 }
 
@@ -79,6 +86,7 @@ export const defaultSettings: Settings = {
   soundNotifications: true,
   instantUpdate: false,
   editorViewMode: "graph",
+  imageEditorOpenMode: "modal",
   autosave: { ...defaultAutosaveSettings }
 };
 
@@ -197,6 +205,13 @@ export const useSettingsStore = create<SettingsStore>()(
           settings: {
             ...state.settings,
             editorViewMode: value
+          }
+        })),
+      setImageEditorOpenMode: (value: "modal" | "standalone") =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            imageEditorOpenMode: value
           }
         })),
       updateAutosaveSettings: (newSettings: Partial<AutosaveSettings>) =>


### PR DESCRIPTION
## Summary
This PR adds a standalone Image Editor page accessible via `/sketch/:documentId` route, allowing users to open the sketch editor in a full-page view instead of just as a modal. It includes navigation between the workflow editor and the standalone image editor, plus a new setting to control the editor open mode.

## Key Changes

- **New `SketchEditorPage` component** (`web/src/components/sketch/SketchEditorPage.tsx`): Top-level page shell that mounts the existing `SketchEditor` inside the app shell with proper loading and error states. Fetches the sketch document via tRPC and seeds the editor with the initial document payload.

- **Route registration** (`web/src/index.tsx`): Added `/sketch/:documentId` route with proper layout (header, suspense boundary, protected route wrapper).

- **Image Editor mode pill** (`web/src/components/panels/AppHeader.tsx`): Added "Image" mode pill to the header that navigates to the most recent sketch document or creates a new one if none exist.

- **Return to Image Editor navigation** (`web/src/components/panels/AppHeader.tsx`): Added `ReturnToSketchPill` component that appears in the editor header when navigating from the sketch editor via `?from=sketch:documentId:layerId` query param, allowing users to return to the image editor.

- **SketchNode integration** (`web/src/components/node/SketchNode/SketchNode.tsx`): Updated `handleOpenEditor` to check the new `imageEditorOpenMode` setting and navigate to the standalone route when enabled (if the node has a persisted `image_document_id`), otherwise falls back to modal mode.

- **Settings store** (`web/src/stores/SettingsStore.ts`): Added `imageEditorOpenMode` setting ("modal" | "standalone") to control how the SketchNode opens the editor, with "modal" as the default.

- **Export** (`web/src/components/sketch/index.ts`): Exported the new `SketchEditorPage` component.

## Implementation Details

- The standalone editor requires a persisted `image_document_id` on the SketchNode; without it, the editor falls back to modal mode.
- Navigation between editors uses query parameters (`from=editor:workflowId:nodeId` and `from=sketch:documentId:layerId`) to enable return navigation.
- Document persistence (load/autosave) is noted as being wired in a separate ticket (NOD-319).
- The page properly handles loading, error, and missing document ID states with appropriate UI feedback.

https://claude.ai/code/session_01S7rS1sNam84gdWvc5rzjhU