### PR TITLE
fix: drop unsupported -Dgcrypt meson option from libsecret module

### DIFF
--- a/electron/ai.nodetool.NodeTool.flatpak.yml
+++ b/electron/ai.nodetool.NodeTool.flatpak.yml
@@ -78,7 +78,6 @@ modules:
       - -Dvapi=false
       - -Dgtk_doc=false
       - -Dintrospection=false
-      - -Dgcrypt=false
       - -Dtpm2=false
     cleanup:
       - /include


### PR DESCRIPTION
libsecret 0.21.4 no longer recognizes the gcrypt meson option, causing
flatpak-builder to fail with "Unknown options: gcrypt" during the
Build Flatpak CI step.