### PR TITLE
[T-20260511-0003] Add a /api/health endpoint returning version + uptime

### DIFF
--- a/packages/websocket/src/routes/health.ts
+++ b/packages/websocket/src/routes/health.ts
@@ -1,8 +1,25 @@
 import type { FastifyPluginAsync } from "fastify";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { sql } from "drizzle-orm";
 import { getDb, getDbType, getRawDb } from "@nodetool-ai/models";
 
 const serverStartTime = Date.now();
+
+// Read version from package.json
+function getVersion(): string {
+  try {
+    const packageJsonPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../package.json"
+    );
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+    return packageJson.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 const healthRoute: FastifyPluginAsync = async (app) => {
   /**
@@ -47,6 +64,18 @@ const healthRoute: FastifyPluginAsync = async (app) => {
    */
   app.get("/ready", async (_req, reply) => {
     return reply.status(200).send({ status: "ok" });
+  });
+
+  /**
+   * GET /api/health — version and uptime information.
+   * Returns 200 with version from package.json and uptime in seconds.
+   * No authentication required.
+   */
+  app.get("/api/health", async (_req, reply) => {
+    return reply.status(200).send({
+      version: getVersion(),
+      uptime: Math.floor((Date.now() - serverStartTime) / 1000)
+    });
   });
 };
 

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -580,6 +580,7 @@ app.addHook("onRequest", async (req, reply) => {
   if (
     pathname === "/health" ||
     pathname === "/ready" ||
+    pathname === "/api/health" ||
     pathname.startsWith("/api/oauth/") ||
     pathname === "/api/assets/packages" ||
     pathname.startsWith("/api/assets/packages/") ||

--- a/packages/websocket/tests/health-api.test.ts
+++ b/packages/websocket/tests/health-api.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the /api/health endpoint
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import healthRoute from "../src/routes/health.js";
+
+describe("/api/health endpoint", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await app.register(healthRoute);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("returns 200 status", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns version from package.json", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+    const body = JSON.parse(res.body);
+
+    expect(body).toHaveProperty("version");
+    expect(typeof body.version).toBe("string");
+    expect(body.version.length).toBeGreaterThan(0);
+  });
+
+  it("returns uptime in seconds", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+    const body = JSON.parse(res.body);
+
+    expect(body).toHaveProperty("uptime");
+    expect(typeof body.uptime).toBe("number");
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns expected JSON structure", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+    const body = JSON.parse(res.body);
+
+    expect(Object.keys(body).sort()).toEqual(["uptime", "version"]);
+  });
+
+  it("uptime increases over time", async () => {
+    const res1 = await app.inject({ method: "GET", url: "/api/health" });
+    const body1 = JSON.parse(res1.body);
+
+    // Wait a bit
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const res2 = await app.inject({ method: "GET", url: "/api/health" });
+    const body2 = JSON.parse(res2.body);
+
+    // Uptime should be the same or slightly higher (both calls happen within the same second usually)
+    expect(body2.uptime).toBeGreaterThanOrEqual(body1.uptime);
+  });
+});


### PR DESCRIPTION
## Summary

Added a new `/api/health` endpoint to the websocket package that returns version information from package.json and server uptime in seconds.

**Changes:**
- Modified `packages/websocket/src/routes/health.ts` to add the `/api/health` endpoint with a `getVersion()` helper that reads from package.json
- Modified `packages/websocket/src/server.ts` to whitelist `/api/health` in the public routes list (no authentication required)
- Created `packages/websocket/tests/health-api.test.ts` with comprehensive unit tests covering status code, response structure, version, and uptime fields

All acceptance criteria met:
- ✓ GET /api/health returns 200
- ✓ Response includes version from package.json
- ✓ Response includes uptime in seconds  
- ✓ Unit test covers the endpoint

TypeScript typecheck passes with no errors.

---

Closes task **T-20260511-0003**: Add a /api/health endpoint returning version + uptime.


### Acceptance criteria
- [x] GET /api/health returns 200
- [x] Response includes version from package.json
- [x] Response includes uptime in seconds
- [x] Unit test covers the endpoint