### PR TITLE
🎨 Palette: Add ARIA labels to SketchLayersPanel buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-05-09 - Dynamic aria-labels in Dialogs/Drawers
 **Learning:** Found that generic UI containers like `DrawerPanel` used hardcoded `aria-label="Close drawer"` on their close buttons, limiting context for screen reader users when multiple drawers exist.
 **Action:** When creating or updating generic container components with close buttons, use dynamic `aria-label`s based on the container's title (e.g., `aria-label={title ? \`Close ${title} drawer\` : "Close drawer"}`) to provide specific context.
+
+## 2026-06-25 - ARIA Labels on Icon Buttons in SketchLayersPanel
+**Learning:** Found that numerous native Material-UI `<IconButton>` instances across the heavily-used `SketchLayersPanel` (e.g., duplicate, clear, merge, delete layer) lacked `aria-label`s, rendering them inaccessible to screen readers despite having visual `<Tooltip>` wrappers.
+**Action:** Always ensure that `IconButton` instances, especially within dense panels like `SketchLayersPanel`, have an explicit `aria-label` that matches their tooltip text to guarantee screen reader compatibility. Do not assume the tooltip alone provides an accessible name.

--- a/web/src/components/sketch/SketchLayersPanel.tsx
+++ b/web/src/components/sketch/SketchLayersPanel.tsx
@@ -985,6 +985,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         >
           <Tooltip title="Add Transparent Layer" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Add Transparent Layer"
               size="small"
               onClick={() => onAddLayer(null)}
               sx={{
@@ -1004,6 +1005,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           </Tooltip>
           <Tooltip title="Add Black Layer" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Add Black Layer"
               size="small"
               onClick={() => onAddLayer("#000000")}
               sx={{
@@ -1026,6 +1028,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           </Tooltip>
           <Tooltip title="Add White Layer" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Add White Layer"
               size="small"
               onClick={() => onAddLayer("#ffffff")}
               sx={{
@@ -1048,6 +1051,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           </Tooltip>
           <Tooltip title="Add Gray Layer" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Add Gray Layer"
               size="small"
               onClick={() => onAddLayer("#808080")}
               sx={{
@@ -1070,6 +1074,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           </Tooltip>
           <Tooltip title="New empty layer group (folder)" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="New empty layer group (folder)"
               size="small"
               onClick={() => onAddGroup()}
               sx={{
@@ -1096,6 +1101,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}
           >
             <IconButton
+              aria-label="Generate Layer (Text-to-Image)"
               size="small"
               onClick={() => setGenerateDialogOpen(true)}
               data-testid="layers-panel-generate-layer"
@@ -1134,6 +1140,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         >
           <Tooltip title="Duplicate Layer" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Duplicate Layer"
               size="small"
               onClick={() => onDuplicateLayer(activeLayerId)}
             >
@@ -1149,6 +1156,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           >
             <span>
               <IconButton
+                aria-label="Delete active layer"
                 size="small"
                 onClick={() =>
                   hasMultiLayerSelection
@@ -1162,7 +1170,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             </span>
           </Tooltip>
           <Tooltip title="Flatten Visible" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
-            <IconButton size="small" onClick={onFlattenVisible}>
+            <IconButton aria-label="Flatten Visible" size="small" onClick={onFlattenVisible}>
               <LayersIcon sx={{ fontSize: "1.125rem" }} />
             </IconButton>
           </Tooltip>
@@ -1176,6 +1184,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}
           >
             <IconButton
+              aria-label={maskLayerId === activeLayerId ? "Remove Mask Designation" : "Set as Mask Layer"}
               size="small"
               onClick={() =>
                 onSetMaskLayer(
@@ -1197,6 +1206,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}
           >
             <IconButton
+              aria-label={layers.find((l) => l.id === activeLayerId)?.alphaLock ? "Unlock Transparency" : "Lock Transparency"}
               size="small"
               onClick={() => onToggleAlphaLock(activeLayerId)}
               color={
@@ -1210,6 +1220,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           </Tooltip>
           <Tooltip title="Trim Active Layer To Bounds" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton
+              aria-label="Trim Active Layer To Bounds"
               size="small"
               onClick={onTrimLayerToBounds}
               disabled={
@@ -1310,7 +1321,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           {selectedLayerIds.length >= 2 ? (
             <>
               <Tooltip title="Group selected layers (adjacent siblings, same parent)" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
-                <IconButton size="small" onClick={onGroupSelectedLayers}>
+                <IconButton aria-label="Group selected layers" size="small" onClick={onGroupSelectedLayers}>
                   <CreateNewFolderIcon sx={{ fontSize: "1.125rem" }} />
                 </IconButton>
               </Tooltip>
@@ -1328,6 +1339,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
               </Tooltip>
               <Tooltip title="Delete selected layers" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
                 <IconButton
+                  aria-label="Delete selected layers"
                   size="small"
                   color="error"
                   onClick={onDeleteSelectedLayers}
@@ -1349,6 +1361,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
           {activeLayer?.type === "group" ? (
             <Tooltip title="Ungroup" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
               <IconButton
+                aria-label="Ungroup"
                 size="small"
                 onClick={() => onUngroupLayer(activeLayerId)}
               >
@@ -1373,6 +1386,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         <Tooltip title="Clear Layer (Delete)" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
           <span>
             <IconButton
+              aria-label="Clear Layer (Delete)"
               size="small"
               onClick={onClearLayer}
               disabled={pixelLayerCanvasActionsDisabled}
@@ -1384,6 +1398,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         <Tooltip title="Flip Layer Horizontal" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
           <span>
             <IconButton
+              aria-label="Flip Layer Horizontal"
               size="small"
               onClick={onFlipHorizontal}
               disabled={pixelLayerCanvasActionsDisabled}
@@ -1395,6 +1410,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         <Tooltip title="Flip Layer Vertical" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
           <span>
             <IconButton
+              aria-label="Flip Layer Vertical"
               size="small"
               onClick={onFlipVertical}
               disabled={pixelLayerCanvasActionsDisabled}
@@ -1408,6 +1424,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         <Tooltip title="Merge Down" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
           <span>
             <IconButton
+              aria-label="Merge Down"
               size="small"
               onClick={onMergeDown}
               disabled={!canMergeDown}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only `IconButton` components in `web/src/components/sketch/SketchLayersPanel.tsx`.
🎯 Why: The buttons were wrapped in visual `Tooltip` components, but lacked explicit `aria-label`s, rendering them inaccessible or confusing for screen reader users. This change ensures proper accessibility mapping.
♿ Accessibility: Provides explicit, descriptive names for critical layer operations (e.g., adding layers, duplicating, grouping, merging, deleting, flipping) to assistive technologies.

---
*PR created automatically by Jules for task [8561285508621437802](https://jules.google.com/task/8561285508621437802) started by @georgi*