### PR TITLE
🎨 Palette: Add missing aria-labels to layer generation icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,6 @@
 ## 2026-06-25 - ARIA Labels on Icon Buttons in SketchLayersPanel
 **Learning:** Found that numerous native Material-UI `<IconButton>` instances across the heavily-used `SketchLayersPanel` (e.g., duplicate, clear, merge, delete layer) lacked `aria-label`s, rendering them inaccessible to screen readers despite having visual `<Tooltip>` wrappers.
 **Action:** Always ensure that `IconButton` instances, especially within dense panels like `SketchLayersPanel`, have an explicit `aria-label` that matches their tooltip text to guarantee screen reader compatibility. Do not assume the tooltip alone provides an accessible name.
+## 2025-02-28 - Missing ARIA Labels on Text/Image Layer Generation Icons
+**Learning:** Found that some newer `IconButton` tools inside `SketchLayersPanel.tsx` (Add Text-to-Image Layer, Add Image-to-Image Layer) were missing explicit `aria-label` attributes despite having Material-UI `Tooltip` components. Because tooltips alone do not reliably announce inner action intents to screen readers on interactable buttons, explicit ARIA labels are necessary.
+**Action:** Always add an explicit `aria-label` property mirroring the tooltip `title` onto standard Material-UI `IconButton` elements, particularly those responsible for core functionalities like generating specialized layer types.

--- a/web/src/components/sketch/SketchLayersPanel.tsx
+++ b/web/src/components/sketch/SketchLayersPanel.tsx
@@ -1123,6 +1123,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}
           >
             <IconButton
+              aria-label="Add Text-to-Image Layer"
               size="small"
               onClick={() => addDirectGenLayer("text-to-image")}
               data-testid="layers-panel-add-text-to-image"
@@ -1150,6 +1151,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}
           >
             <IconButton
+              aria-label="Add Image-to-Image Layer"
               size="small"
               onClick={() => addDirectGenLayer("image-to-image")}
               data-testid="layers-panel-add-image-to-image"


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Add Text-to-Image Layer" and "Add Image-to-Image Layer" icon buttons in the sketch layers panel.
🎯 Why: Without explicit ARIA labels, screen readers may not accurately announce the purpose of these icon-only buttons, making it difficult for visually impaired users to generate these specialized layer types.
♿ Accessibility: Ensures that screen readers reliably announce the action intent of these icon buttons, rather than relying solely on the Material-UI Tooltip which may not be consistently captured.

---
*PR created automatically by Jules for task [8181143220200381296](https://jules.google.com/task/8181143220200381296) started by @georgi*