### PR TITLE
[T-20260513-0029] PR 1 — Track A: ports + edges polish

### DIFF
--- a/web/src/components/node/NodeInputs.tsx
+++ b/web/src/components/node/NodeInputs.tsx
@@ -101,6 +101,7 @@ const NodeInput: React.FC<NodeInputProps> = memo(function NodeInput({
       tabIndex={tabIndex}
       isDynamicProperty={isDynamicProperty}
       data={data}
+      isConnected={isConnected}
     />
   );
 },

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -15,6 +15,7 @@ import HandleTooltip from "../HandleTooltip";
 import { NodeData } from "../../stores/NodeData";
 import usePropertyValidationStore from "../../stores/PropertyValidationStore";
 import { Tooltip } from "../ui_primitives/Tooltip";
+import TypedPortChip from "./TypedPortChip";
 
 export type PropertyFieldProps = {
   id: string;
@@ -32,6 +33,8 @@ export type PropertyFieldProps = {
   isDynamicProperty?: boolean;
   hideActionIcons?: boolean;
   data: NodeData;
+  /** True when an edge is connected to this property's target handle. */
+  isConnected?: boolean;
   onValueChange?: (value: any) => void;
 };
 
@@ -52,6 +55,7 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
   isDynamicProperty,
   hideActionIcons,
   data,
+  isConnected = false,
   onValueChange
 }) => {
   const controlKeyPressed = useKeyPressedStore((state) =>
@@ -139,7 +143,21 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
 
   const fieldClass = `node-property ${Slugify(property.type.type)}${
     validationError ? " has-validation-error" : ""
-  }`;
+  }${isConnected ? " is-connected" : ""}`;
+
+  // Position the typed-port chip just inside the handle so it visually
+  // labels the port type without intercepting pointer events.
+  const typedChipStyle = useMemo<React.CSSProperties>(
+    () => ({
+      position: "absolute",
+      left: 6,
+      top: "50%",
+      transform: "translateY(-50%)",
+      zIndex: 2,
+      pointerEvents: "none"
+    }),
+    []
+  );
 
   const inner = (
     <div className={fieldClass}>
@@ -162,6 +180,11 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
               onContextMenu={handleContextMenu}
             />
           </HandleTooltip>
+          <TypedPortChip
+            type={property.type}
+            side="left"
+            style={typedChipStyle}
+          />
         </div>
       )}
 

--- a/web/src/components/node/TypedPortChip.tsx
+++ b/web/src/components/node/TypedPortChip.tsx
@@ -1,0 +1,95 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { memo } from "react";
+import isEqual from "fast-deep-equal";
+import { IconForType, colorForType } from "../../config/data_types";
+import { TypeMetadata } from "../../stores/ApiTypes";
+
+const CHIP_SIZE_PX = 14;
+
+export interface TypedPortChipProps {
+  type: TypeMetadata;
+  /**
+   * Side of the port the chip belongs to. Used by callers to position it.
+   * The component itself stays a small square — positioning is the parent's job.
+   */
+  side?: "left" | "right";
+  /**
+   * Optional override for the chip background color. Defaults to
+   * `colorForType(type.type)` at low opacity.
+   */
+  color?: string;
+  /**
+   * Forwarded inline style overrides (positioning, transforms, etc.).
+   */
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+const chipStyles = (chipColor: string) =>
+  css({
+    width: `${CHIP_SIZE_PX}px`,
+    height: `${CHIP_SIZE_PX}px`,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 3,
+    pointerEvents: "none",
+    background: `color-mix(in srgb, ${chipColor} 22%, transparent)`,
+    border: `1px solid color-mix(in srgb, ${chipColor} 55%, transparent)`,
+    color: chipColor,
+    boxSizing: "border-box",
+    transition: "background-color 120ms ease-out, border-color 120ms ease-out",
+    "& svg": {
+      width: "10px",
+      height: "10px",
+      fill: "currentColor"
+    },
+    ".icon-container": {
+      width: "10px !important",
+      height: "10px !important"
+    },
+    ".icon-bg": {
+      background: "transparent !important",
+      width: "100%",
+      height: "100%"
+    }
+  });
+
+/**
+ * TypedPortChip — a small (~14×14) visual indicator placed adjacent to a port
+ * handle that shows the port's type via {@link IconForType}. Purely visual:
+ * does not capture pointer events and does not replace the underlying handle.
+ */
+const TypedPortChipImpl: React.FC<TypedPortChipProps> = ({
+  type,
+  side,
+  color,
+  style,
+  className
+}) => {
+  const chipColor = color ?? colorForType(type.type);
+  const dataSide = side ?? "left";
+
+  return (
+    <span
+      css={chipStyles(chipColor)}
+      style={style}
+      className={`typed-port-chip typed-port-chip-${dataSide}${
+        className ? ` ${className}` : ""
+      }`}
+      aria-hidden
+    >
+      <IconForType
+        iconName={type.type}
+        showTooltip={false}
+        iconSize="small"
+        containerStyle={{ width: 10, height: 10 }}
+        bgStyle={{ background: "transparent" }}
+      />
+    </span>
+  );
+};
+
+export const TypedPortChip = memo(TypedPortChipImpl, isEqual);
+export default TypedPortChip;

--- a/web/src/components/node_editor/CustomEdge.tsx
+++ b/web/src/components/node_editor/CustomEdge.tsx
@@ -13,6 +13,41 @@ import {
 } from "@xyflow/react";
 import { Tooltip } from "../ui_primitives";
 import { memo, useMemo } from "react";
+import { titleizeString } from "../../utils/titleizeString";
+
+/**
+ * A2: minimum pixel distance between source and target endpoint chips before
+ * the target chip is suppressed to avoid visual overlap on very short edges.
+ */
+const ENDPOINT_CHIP_MIN_DISTANCE_PX = 56;
+
+/**
+ * A2/OQ-2: when the target node has more than this many input ports the
+ * target endpoint chip is hidden by default to keep dense nodes readable;
+ * it still appears on hover / when the edge is selected.
+ */
+const TARGET_CHIP_INPUT_THRESHOLD = 6;
+
+const endpointChipBaseStyle: React.CSSProperties = {
+  position: "absolute",
+  pointerEvents: "all",
+  background: "var(--palette-background-default)",
+  color: "var(--palette-text-secondary)",
+  padding: "1px 6px",
+  borderRadius: 8,
+  fontSize: 9,
+  fontWeight: 500,
+  lineHeight: "12px",
+  letterSpacing: "0.01em",
+  border:
+    "1px solid color-mix(in srgb, var(--palette-text-secondary) 25%, transparent)",
+  whiteSpace: "nowrap",
+  maxWidth: 120,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  userSelect: "none",
+  transition: "opacity 120ms ease-out"
+};
 
 export function CustomEdge({
   id,
@@ -38,6 +73,10 @@ export function CustomEdge({
 
   const counter = data?.counter as number | undefined;
   const dataTypeLabel = data?.dataTypeLabel as string | undefined;
+  const sourceTypeColor = data?.sourceTypeColor as string | undefined;
+  const sourceHandleName = data?.sourceHandleName as string | undefined;
+  const targetHandleName = data?.targetHandleName as string | undefined;
+  const targetInputCount = data?.targetInputCount as number | undefined;
   const showLabel = counter && counter > 1;
 
   // EXPERIMENTAL: Check if edge has active data flow
@@ -78,16 +117,107 @@ export function CustomEdge({
     [labelX, labelY, selected]
   );
 
-  // EXPERIMENTAL: Enhanced edge style with particle animation support
-  const enhancedStyle = useMemo(
-    () => ({
+  // A4: Selected edges get a 2px stroke + a subtle outer glow that uses the
+  // source type's color so the highlight reads as "this typed wire" rather
+  // than a generic UI selection. Unselected edges keep the 1.5px stroke
+  // applied in useProcessedEdges. CSS transitions animate the color change.
+  const enhancedStyle = useMemo(() => {
+    const accent = sourceTypeColor || "currentColor";
+    return {
       ...style,
+      ...(selected && {
+        strokeWidth: 2,
+        filter: `drop-shadow(0 0 4px color-mix(in srgb, ${accent} 60%, transparent))`
+      }),
       ...(isActive && {
         strokeDasharray: "14 10",
         animation: "edgeFlow 2s linear infinite"
       })
+    } as React.CSSProperties;
+  }, [style, isActive, selected, sourceTypeColor]);
+
+  // A2: pre-compute endpoint chip placements + visibility.
+  const endpoints = useMemo(() => {
+    const sourceText = sourceHandleName ? titleizeString(sourceHandleName) : "";
+    const targetText = targetHandleName ? titleizeString(targetHandleName) : "";
+    const dx = targetX - sourceX;
+    const dy = targetY - sourceY;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    // Nudge chips along the handle's outward axis so they sit just past the
+    // socket and above the wire — keeps them from covering the port itself.
+    const sourceShiftX = sourcePosition === "left" ? -10 : 10;
+    const targetShiftX = targetPosition === "left" ? -10 : 10;
+    const verticalShift = -10;
+
+    const sourceVisible = Boolean(sourceText);
+    const dense = (targetInputCount ?? 0) > TARGET_CHIP_INPUT_THRESHOLD;
+    const overlapping = dist < ENDPOINT_CHIP_MIN_DISTANCE_PX;
+    const targetVisibleAlways = Boolean(targetText) && !dense && !overlapping;
+    const targetVisibleOnHover = Boolean(targetText) && (dense || overlapping);
+
+    // translate(-100%, -100%) anchors the chip's bottom-right corner at the
+    // handle when the port is on the left side (and vice versa) so the chip
+    // never covers the port pin.
+    const sourceAnchor =
+      sourcePosition === "left" ? "translate(-100%, -100%)" : "translate(0, -100%)";
+    const targetAnchor =
+      targetPosition === "left" ? "translate(-100%, -100%)" : "translate(0, -100%)";
+
+    return {
+      sourceText,
+      targetText,
+      sourceVisible,
+      targetVisibleAlways,
+      targetVisibleOnHover,
+      sourceTransform: `translate(${sourceX + sourceShiftX}px, ${
+        sourceY + verticalShift
+      }px) ${sourceAnchor}`,
+      targetTransform: `translate(${targetX + targetShiftX}px, ${
+        targetY + verticalShift
+      }px) ${targetAnchor}`
+    };
+  }, [
+    sourceHandleName,
+    targetHandleName,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    targetInputCount
+  ]);
+
+  const chipAccentBorder = sourceTypeColor
+    ? `color-mix(in srgb, ${sourceTypeColor} 45%, transparent)`
+    : endpointChipBaseStyle.borderColor;
+
+  const sourceChipStyle = useMemo<React.CSSProperties>(
+    () => ({
+      ...endpointChipBaseStyle,
+      transform: endpoints.sourceTransform,
+      opacity: selected ? 1 : 0.85,
+      borderColor: chipAccentBorder
     }),
-    [style, isActive]
+    [endpoints.sourceTransform, selected, chipAccentBorder]
+  );
+
+  const targetChipBaseStyle = useMemo<React.CSSProperties>(
+    () => ({
+      ...endpointChipBaseStyle,
+      transform: endpoints.targetTransform,
+      opacity: selected ? 1 : 0.85,
+      borderColor: chipAccentBorder
+    }),
+    [endpoints.targetTransform, selected, chipAccentBorder]
+  );
+
+  const targetChipHoverOnlyStyle = useMemo<React.CSSProperties>(
+    () => ({
+      ...targetChipBaseStyle,
+      opacity: selected ? 1 : 0
+    }),
+    [targetChipBaseStyle, selected]
   );
 
   return (
@@ -98,15 +228,43 @@ export function CustomEdge({
         style={enhancedStyle}
         markerEnd={markerEnd}
       />
-      {showLabel && (
-        <EdgeLabelRenderer>
+      <EdgeLabelRenderer>
+        {endpoints.sourceVisible && (
+          <div
+            className="edge-endpoint-chip edge-endpoint-source nodrag nopan"
+            style={sourceChipStyle}
+            title={endpoints.sourceText}
+          >
+            {endpoints.sourceText}
+          </div>
+        )}
+        {endpoints.targetVisibleAlways && (
+          <div
+            className="edge-endpoint-chip edge-endpoint-target nodrag nopan"
+            style={targetChipBaseStyle}
+            title={endpoints.targetText}
+          >
+            {endpoints.targetText}
+          </div>
+        )}
+        {endpoints.targetVisibleOnHover && (
+          <div
+            className="edge-endpoint-chip edge-endpoint-target edge-endpoint-target--hover nodrag nopan"
+            style={targetChipHoverOnlyStyle}
+            title={endpoints.targetText}
+            data-edge-id={id}
+          >
+            {endpoints.targetText}
+          </div>
+        )}
+        {showLabel && (
           <Tooltip title={tooltipText} placement="top" arrow delay={300}>
             <div style={labelStyle} className="nodrag nopan">
               {counter}
             </div>
           </Tooltip>
-        </EdgeLabelRenderer>
-      )}
+        )}
+      </EdgeLabelRenderer>
     </>
   );
 }
@@ -124,6 +282,10 @@ const MemoizedCustomEdge = memo(CustomEdge, (prevProps, nextProps) => {
     prevProps.style === nextProps.style &&
     prevProps.data?.counter === nextProps.data?.counter &&
     prevProps.data?.dataTypeLabel === nextProps.data?.dataTypeLabel &&
+    prevProps.data?.sourceTypeColor === nextProps.data?.sourceTypeColor &&
+    prevProps.data?.sourceHandleName === nextProps.data?.sourceHandleName &&
+    prevProps.data?.targetHandleName === nextProps.data?.targetHandleName &&
+    prevProps.data?.targetInputCount === nextProps.data?.targetInputCount &&
     prevProps.data?.status === nextProps.data?.status // Compare status for particle animation
   );
 });

--- a/web/src/components/node_editor/CustomEdge.tsx
+++ b/web/src/components/node_editor/CustomEdge.tsx
@@ -12,7 +12,7 @@ import {
   type EdgeProps
 } from "@xyflow/react";
 import { Tooltip } from "../ui_primitives";
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { titleizeString } from "../../utils/titleizeString";
 
 /**
@@ -188,6 +188,10 @@ export function CustomEdge({
     targetInputCount
   ]);
 
+  const [hovered, setHovered] = useState(false);
+  const onMouseEnter = useCallback(() => setHovered(true), []);
+  const onMouseLeave = useCallback(() => setHovered(false), []);
+
   const chipAccentBorder = sourceTypeColor
     ? `color-mix(in srgb, ${sourceTypeColor} 45%, transparent)`
     : endpointChipBaseStyle.borderColor;
@@ -215,13 +219,13 @@ export function CustomEdge({
   const targetChipHoverOnlyStyle = useMemo<React.CSSProperties>(
     () => ({
       ...targetChipBaseStyle,
-      opacity: selected ? 1 : 0
+      opacity: selected || hovered ? 1 : 0
     }),
-    [targetChipBaseStyle, selected]
+    [targetChipBaseStyle, selected, hovered]
   );
 
   return (
-    <>
+    <g onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <BaseEdge
         id={id}
         path={edgePath}
@@ -234,6 +238,8 @@ export function CustomEdge({
             className="edge-endpoint-chip edge-endpoint-source nodrag nopan"
             style={sourceChipStyle}
             title={endpoints.sourceText}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             {endpoints.sourceText}
           </div>
@@ -243,6 +249,8 @@ export function CustomEdge({
             className="edge-endpoint-chip edge-endpoint-target nodrag nopan"
             style={targetChipBaseStyle}
             title={endpoints.targetText}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             {endpoints.targetText}
           </div>
@@ -252,7 +260,8 @@ export function CustomEdge({
             className="edge-endpoint-chip edge-endpoint-target edge-endpoint-target--hover nodrag nopan"
             style={targetChipHoverOnlyStyle}
             title={endpoints.targetText}
-            data-edge-id={id}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             {endpoints.targetText}
           </div>
@@ -265,7 +274,7 @@ export function CustomEdge({
           </Tooltip>
         )}
       </EdgeLabelRenderer>
-    </>
+    </g>
   );
 }
 
@@ -279,6 +288,8 @@ const MemoizedCustomEdge = memo(CustomEdge, (prevProps, nextProps) => {
     prevProps.sourceY === nextProps.sourceY &&
     prevProps.targetX === nextProps.targetX &&
     prevProps.targetY === nextProps.targetY &&
+    prevProps.sourcePosition === nextProps.sourcePosition &&
+    prevProps.targetPosition === nextProps.targetPosition &&
     prevProps.style === nextProps.style &&
     prevProps.data?.counter === nextProps.data?.counter &&
     prevProps.data?.dataTypeLabel === nextProps.data?.dataTypeLabel &&
@@ -286,7 +297,7 @@ const MemoizedCustomEdge = memo(CustomEdge, (prevProps, nextProps) => {
     prevProps.data?.sourceHandleName === nextProps.data?.sourceHandleName &&
     prevProps.data?.targetHandleName === nextProps.data?.targetHandleName &&
     prevProps.data?.targetInputCount === nextProps.data?.targetInputCount &&
-    prevProps.data?.status === nextProps.data?.status // Compare status for particle animation
+    prevProps.data?.status === nextProps.data?.status
   );
 });
 

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -238,11 +238,12 @@ function useStructurallyProcessedEdges({
         } else if (targetNode.type) {
           const targetMetadata = getMetadata(targetNode.type);
           if (targetMetadata) {
+            const dynamicInputKeys = new Set([
+              ...Object.keys(targetNode.data?.dynamic_inputs ?? {}),
+              ...Object.keys(targetNode.data?.dynamic_properties ?? {})
+            ]);
             targetInputCount =
-              (targetMetadata.properties?.length ?? 0) +
-              (targetNode.data?.dynamic_inputs
-                ? Object.keys(targetNode.data.dynamic_inputs).length
-                : 0);
+              (targetMetadata.properties?.length ?? 0) + dynamicInputKeys.size;
             const inputHandle = findInputHandle(
               targetNode as Node<NodeData>,
               normalizedTargetHandle,

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -217,6 +217,7 @@ function useStructurallyProcessedEdges({
       let sourceColor = defaultColor;
       let sourceTypeLabel = "Any";
       let targetTypeSlug = "any";
+      let targetInputCount: number | undefined;
 
       if (sourceNode && normalizedSourceHandle) {
         const effective = getEffectiveSourceType(
@@ -237,6 +238,11 @@ function useStructurallyProcessedEdges({
         } else if (targetNode.type) {
           const targetMetadata = getMetadata(targetNode.type);
           if (targetMetadata) {
+            targetInputCount =
+              (targetMetadata.properties?.length ?? 0) +
+              (targetNode.data?.dynamic_inputs
+                ? Object.keys(targetNode.data.dynamic_inputs).length
+                : 0);
             const inputHandle = findInputHandle(
               targetNode as Node<NodeData>,
               normalizedTargetHandle,
@@ -244,8 +250,8 @@ function useStructurallyProcessedEdges({
             );
             if (inputHandle?.type?.type) {
               const typeString = inputHandle.type.type;
-              const t = dataTypeByValue.get(typeString) || 
-                        dataTypeByName.get(typeString) || 
+              const t = dataTypeByValue.get(typeString) ||
+                        dataTypeByName.get(typeString) ||
                         dataTypeBySlug.get(typeString);
               if (t) {
                 targetTypeSlug = t.slug;
@@ -293,11 +299,18 @@ function useStructurallyProcessedEdges({
         style: {
           ...edge.style,
           stroke: strokeStyle,
-          strokeWidth: 2
+          // A4: unselected edges use 1.5px stroke. Selected edges are
+          // promoted to 2px + glow in CustomEdge (CSS controls hover/selected).
+          strokeWidth: 1.5,
+          transition: "stroke 180ms ease-out, stroke-width 120ms ease-out, filter 180ms ease-out"
         },
         data: {
           ...edge.data,
-          dataTypeLabel: sourceTypeLabel
+          dataTypeLabel: sourceTypeLabel,
+          sourceTypeColor: sourceColor,
+          sourceHandleName: normalizedSourceHandle ?? undefined,
+          targetHandleName: normalizedTargetHandle ?? undefined,
+          targetInputCount
         }
       };
     });

--- a/web/src/stores/NodeData.ts
+++ b/web/src/stores/NodeData.ts
@@ -23,6 +23,8 @@ export type NodeData = {
   collapsed?: boolean;
   /** Last expanded body height (px) before header-only collapse — restore on expand; not in `properties` */
   expandedHeightPx?: number;
+  /** Last expanded width (px) before header-only collapse — restore on expand; not in `properties` */
+  expandedWidthPx?: number;
   bypassed?: boolean; // When true, node is bypassed and passes inputs through to outputs
   showResultPreference?: boolean; // User preference: true = show results after run, false/undefined = show inputs
   // Original node type from the workflow graph (useful when React Flow falls back to "default" type)

--- a/web/src/stores/collapseNodeLayout.ts
+++ b/web/src/stores/collapseNodeLayout.ts
@@ -3,7 +3,13 @@ import type { NodeData } from "./NodeData";
 import { DEFAULT_NODE_WIDTH } from "./nodeUiDefaults";
 
 /** Keep in sync with `--node-collapsed-height` in `styles/vars.css` */
-export const NODE_COLLAPSED_STRIP_HEIGHT_PX = 45;
+export const NODE_COLLAPSED_STRIP_HEIGHT_PX = 40;
+
+/**
+ * A5: minimum width of a collapsed node strip. Keeps enough room for the
+ * icon + title + collapse toggle without forcing the full expanded width.
+ */
+export const NODE_COLLAPSED_MIN_WIDTH_PX = 140;
 
 const MIN_EXPANDED_BODY_PX = 100;
 
@@ -97,49 +103,76 @@ export function getCollapseTogglePatches(
 
   if (nextCollapsed) {
     const expandedH = readExpandedBodyHeightPx(node);
-    const widthPx =
-      w ?? (typeof node.measured?.width === "number" ? node.measured.width : undefined) ??
+    const expandedWidthPx =
+      w ??
+      (typeof node.measured?.width === "number" ? node.measured.width : undefined) ??
       (typeof node.width === "number" ? node.width : undefined) ??
       DEFAULT_NODE_WIDTH;
+    // A5: when collapsing, drop the width constraint so the strip shrinks
+    // to match its header content. React Flow needs *some* width to position
+    // handles, so we publish the min-width here and let the DOM measurement
+    // pass overwrite it once the rendered header is sized.
     return {
-      data: { collapsed: true, expandedHeightPx: expandedH },
+      data: {
+        collapsed: true,
+        expandedHeightPx: expandedH,
+        expandedWidthPx
+      },
       node: {
         height: strip,
-        measured: { width: widthPx, height: strip },
+        // Clearing `measured` forces React Flow to remeasure and pick up the
+        // narrower header-content width on the next layout pass.
+        measured: undefined,
         style: {
           ...node.style,
           height: strip,
-          width: widthPx
+          width: undefined
         }
       }
     };
   }
 
+  // A5: when expanding, restore the width the node had before collapse if we
+  // saved it. Otherwise fall back to the current (possibly auto-measured) w.
+  const savedWidth =
+    typeof node.data.expandedWidthPx === "number" && node.data.expandedWidthPx > 0
+      ? node.data.expandedWidthPx
+      : w;
+  const widthPatch = savedWidth != null ? { width: savedWidth } : {};
+
   const saved = node.data.expandedHeightPx;
   if (typeof saved === "number" && saved > strip) {
     return {
-      data: { collapsed: false, expandedHeightPx: undefined },
+      data: {
+        collapsed: false,
+        expandedHeightPx: undefined,
+        expandedWidthPx: undefined
+      },
       node: {
         height: saved,
         measured: undefined,
         style: {
           ...node.style,
           height: saved,
-          ...(w != null ? { width: w } : {})
+          ...widthPatch
         }
       }
     };
   }
 
   return {
-    data: { collapsed: false, expandedHeightPx: undefined },
+    data: {
+      collapsed: false,
+      expandedHeightPx: undefined,
+      expandedWidthPx: undefined
+    },
     node: {
       height: undefined,
       measured: undefined,
       style: {
         ...node.style,
         height: undefined,
-        ...(w != null ? { width: w } : {})
+        ...widthPatch
       }
     }
   };

--- a/web/src/styles/collapsed.css
+++ b/web/src/styles/collapsed.css
@@ -16,6 +16,11 @@
   height: var(--node-collapsed-height) !important;
   /* Side handles protrude past the compact strip — do not clip on the RF shell */
   overflow: visible !important;
+  /* A5: collapsed strips shrink to header content. React Flow writes its own
+     inline width before our remeasure pass picks up the narrower size; the
+     min-width keeps room for the icon + title + collapse toggle at all times. */
+  min-width: var(--node-collapsed-min-width) !important;
+  width: max-content !important;
 }
 
 /* BaseNode (`base-node`): hide chrome but keep sockets (handles live under NodeContent). */

--- a/web/src/styles/handle_edge_tooltip.css
+++ b/web/src/styles/handle_edge_tooltip.css
@@ -90,12 +90,16 @@
   }
 }
 
-/* edge */
+/* edge — A4: default static stroke is 1.5px (typed color set inline by
+   useProcessedEdges via colorForType(source.type)). Width is intentionally
+   *not* !important here so per-edge inline width (selected: 2, hover: 4,
+   streaming variants) wins. Stroke color animates on change. */
 .react-flow .react-flow__edge-path,
 .react-flow .react-flow__connection-path {
   stroke: var(--palette-grey-400);
-  stroke-width: 2.5 !important;
+  stroke-width: 1.5;
   transition:
+    stroke 0.18s ease-in-out,
     stroke-opacity 0.2s ease-in-out,
     stroke-width 0.15s ease-in-out,
     filter 0.2s ease-in-out;
@@ -130,16 +134,15 @@
     drop-shadow(0 0 3px rgba(255, 255, 255, 0.15));
 }
 
-/* edge selected */
+/* edge selected — A4: keep the typed stroke color (set inline by
+   useProcessedEdges) and rely on CustomEdge's inline 2px width + outer
+   glow so the highlight tints with the source type instead of a flat
+   text-primary slash. */
 .react-flow
   .react-flow__edges
   .react-flow__edge.selected
   .react-flow__edge-path {
-  stroke: var(--palette-text-primary) !important;
-  stroke-width: 3 !important;
   stroke-opacity: 1;
-  filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.8))
-    drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
 }
 
 /* Flow animation for edges on message_sent or running source node */
@@ -179,17 +182,15 @@
   stroke-opacity: 1;
 }
 
-/* Selected streaming edge */
+/* Selected streaming edge — A4: preserve the typed stroke color, only
+   boost width and apply a glow (CustomEdge supplies the type-tinted glow). */
 .react-flow
   .react-flow__edges
   .react-flow__edge.streaming-edge.selected
   .react-flow__edge-path {
-  stroke: var(--palette-text-primary) !important;
   stroke-dasharray: 8;
   stroke-width: 4 !important;
   stroke-opacity: 1;
-  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.9))
-    drop-shadow(0 0 4px rgba(255, 255, 255, 0.25));
 }
 
 .react-flow__edge .react-flow__edge-text {

--- a/web/src/styles/properties.css
+++ b/web/src/styles/properties.css
@@ -37,20 +37,16 @@
 .react-flow__node:hover .base-node .node-property .property-label {
   opacity: 1;
 }
-/* Output handles in DynamicOutputItem mirror the same affordance. */
-.base-node .multi-outputs li > label,
-.base-node .multi-outputs li > .output-label {
+/* Output handles in DynamicOutputItem mirror the same affordance.
+   Text renders as a <p> inside HandleTooltip, so use descendant selectors. */
+.base-node .multi-outputs li p {
   opacity: 0;
   transition: opacity 120ms ease-out;
 }
-.base-node:hover .multi-outputs li > label,
-.base-node:hover .multi-outputs li > .output-label,
-.base-node.selected .multi-outputs li > label,
-.base-node.selected .multi-outputs li > .output-label,
-.react-flow__node.selected .base-node .multi-outputs li > label,
-.react-flow__node.selected .base-node .multi-outputs li > .output-label,
-.react-flow__node:hover .base-node .multi-outputs li > label,
-.react-flow__node:hover .base-node .multi-outputs li > .output-label {
+.base-node:hover .multi-outputs li p,
+.base-node.selected .multi-outputs li p,
+.react-flow__node.selected .base-node .multi-outputs li p,
+.react-flow__node:hover .base-node .multi-outputs li p {
   opacity: 1;
 }
 

--- a/web/src/styles/properties.css
+++ b/web/src/styles/properties.css
@@ -20,6 +20,40 @@
   margin-bottom: 0;
 }
 
+/* A1 — Hover/select reveal for property labels.
+   Labels are hidden by default and fade in (~120ms) when the parent node is
+   hovered or selected. Connected properties keep their label visible so the
+   user can read the wire endpoint at all times. The selectors target the
+   `.base-node` container (BaseNode root) and the React Flow `.selected`
+   wrapper so the effect works for both pointer hover and keyboard selection. */
+.base-node .node-property .property-label {
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+.base-node .node-property.is-connected .property-label,
+.base-node:hover .node-property .property-label,
+.base-node.selected .node-property .property-label,
+.react-flow__node.selected .base-node .node-property .property-label,
+.react-flow__node:hover .base-node .node-property .property-label {
+  opacity: 1;
+}
+/* Output handles in DynamicOutputItem mirror the same affordance. */
+.base-node .multi-outputs li > label,
+.base-node .multi-outputs li > .output-label {
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+.base-node:hover .multi-outputs li > label,
+.base-node:hover .multi-outputs li > .output-label,
+.base-node.selected .multi-outputs li > label,
+.base-node.selected .multi-outputs li > .output-label,
+.react-flow__node.selected .base-node .multi-outputs li > label,
+.react-flow__node.selected .base-node .multi-outputs li > .output-label,
+.react-flow__node:hover .base-node .multi-outputs li > label,
+.react-flow__node:hover .base-node .multi-outputs li > .output-label {
+  opacity: 1;
+}
+
 /* Pre-flight validation: a property value is missing or invalid for the
    declared type. Goal is to draw the eye without overwhelming the node:
    a thin left accent bar, red label, and a focus-style ring on the input.

--- a/web/src/styles/vars.css
+++ b/web/src/styles/vars.css
@@ -38,8 +38,9 @@
 
   /* Collapsed workflow node (header strip) — shared: vars.css, collapsed.css, collapsedNodeTokens.ts
      Use a real height: `auto` + flex `node-content-container` kept BaseNodes visually expanded. */
-  --node-collapsed-height: 45px;
-  --node-collapsed-min-height: 45px;
+  --node-collapsed-height: 40px;
+  --node-collapsed-min-height: 40px;
+  --node-collapsed-min-width: 140px;
   --node-collapsed-max-height: none;
   --node-collapsed-overflow: visible;
   /* Pixels along node — % is relative to ancestor height (often 0 in collapsed overlays) */


### PR DESCRIPTION
PR 1 of the node editor redesign — Track A polish for ports and edges.

- **A1 — Hover/select port label reveal.** Property labels start at `opacity: 0` and fade in (~120ms) when the parent node is hovered or selected. `.is-connected` rows keep labels lit so connection endpoints are always readable. Same affordance applied to `DynamicOutputItem` output labels. Selectors target both the Emotion `.base-node` wrapper and the outer `.react-flow__node` so pointer and keyboard selection both trigger the fade.
- **A2 — Edge endpoint chips.** `CustomEdge` renders small floating chips with source/target property names anchored just past each handle. Target chip auto-suppresses when the edge length is < 56 px (overlap) or the target node has > 6 inputs (OQ-2); a hover-only variant reappears on edge selection/hover. New chip data (`sourceHandleName`, `targetHandleName`, `targetInputCount`) flows from `useProcessedEdges`.
- **A3 — `TypedPortChip`.** New `web/src/components/node/TypedPortChip.tsx` renders the per-type icon (~14×14) next to input handles, tinted via `colorForType` + `color-mix`. Pure visual, `pointer-events: none`. Integrated into `PropertyField`.
- **A4 — Typed edge coloring.** Unselected edges keep the existing `colorForType(source.type)` stroke at 1.5 px. Selected edges get 2 px stroke + an outer `drop-shadow` glow tinted by the source type. CSS `stroke`/`stroke-width`/`filter` transitions animate the change. Removed the `var(--palette-text-primary) !important` override on `.react-flow__edge.selected .react-flow__edge-path` that was masking the typed color.
- **A5 — Collapsed state polish.** `--node-collapsed-height` set to 40 px; new `--node-collapsed-min-width: 140 px`. Collapse now clears inline `style.width` and `measured` so React Flow re-measures to fit the header content; expanded width is saved to `data.expandedWidthPx` and restored on expand. `collapsed.css` adds `width: max-content !important` + `min-width: var(--node-collapsed-min-width) !important` to the RF outer node. Ports remain functional on the header strip.

**Deviations from spec**

- The spec calls out `web/src/core/graph/` as the edge audit target; that directory doesn't exist in the repo. Edge rendering actually lives in `web/src/components/node_editor/CustomEdge.tsx` and `web/src/hooks/useProcessedEdges.ts`, which is where A4 was implemented.

---

Closes task **T-20260513-0029**: PR 1 — Track A: ports + edges polish.

### Acceptance criteria
- [x] A1: property labels hidden by default; visible while node hovered or selected; ~120ms transition
- [x] A1: connected properties keep labels visible regardless of hover
- [x] A2: edge endpoint chips render near tips with source/target property names
- [x] A2: nearby endpoint chips suppress target side to avoid overlap
- [x] A3: TypedPortChip component exists and renders per-handle type icon (~14×14)
- [x] A3: chip color comes from colorForType; handle itself unchanged
- [x] A4: all static edges use colorForType(source.type) for stroke
- [x] A4: selected edge is 2px with outer glow; unselected 1.5px
- [x] A5: collapsed nodes hide body, header ~40px, ports remain functional on header strip
- [x] A5: collapsed width matches header content width, not expanded width

🤖 Recovered from session #2 after a branch-name collision force-push.
