### PR TITLE
🎨 Palette: Add missing ARIA labels to text and dataframe editor buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -59,3 +59,6 @@
 ## 2025-02-28 - Missing ARIA Labels on Text/Image Layer Generation Icons
 **Learning:** Found that some newer `IconButton` tools inside `SketchLayersPanel.tsx` (Add Text-to-Image Layer, Add Image-to-Image Layer) were missing explicit `aria-label` attributes despite having Material-UI `Tooltip` components. Because tooltips alone do not reliably announce inner action intents to screen readers on interactable buttons, explicit ARIA labels are necessary.
 **Action:** Always add an explicit `aria-label` property mirroring the tooltip `title` onto standard Material-UI `IconButton` elements, particularly those responsible for core functionalities like generating specialized layer types.
+## 2026-05-14 - Adding ARIA labels to custom editor modal buttons
+**Learning:** Icon-only UI buttons inside custom modals, such as `TextEditorModal`, `DataframeEditorModal`, and `SnippetSidebar`, were found to lack `aria-label` attributes. While they had visual tooltips, screen readers and automation tools (like Playwright's `get_by_role`) could not identify their purpose.
+**Action:** Always provide explicit `aria-label` properties on interactive elements that rely solely on icons to convey their action, ensuring the label matches the visual tooltip text and appropriately reflects dynamic states.

--- a/web/src/components/properties/DataframeEditorModal.tsx
+++ b/web/src/components/properties/DataframeEditorModal.tsx
@@ -550,7 +550,11 @@ const DataframeEditorModal = ({
                   delay={TOOLTIP_ENTER_DELAY}
                   title={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
                 >
-                  <button className="button" onClick={toggleFullscreen}>
+                  <button
+                    className="button"
+                    onClick={toggleFullscreen}
+                    aria-label={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
+                  >
                     {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
                   </button>
                 </Tooltip>
@@ -558,7 +562,11 @@ const DataframeEditorModal = ({
                   delay={TOOLTIP_ENTER_DELAY}
                   title="Close Editor | Esc"
                 >
-                  <button className="button button-close" onClick={onClose}>
+                  <button
+                    className="button button-close"
+                    onClick={onClose}
+                    aria-label="Close Editor"
+                  >
                     <CloseIcon />
                   </button>
                 </Tooltip>

--- a/web/src/components/properties/SnippetSidebar.tsx
+++ b/web/src/components/properties/SnippetSidebar.tsx
@@ -345,6 +345,7 @@ const SnippetSidebar = ({ monacoRef, visible }: SnippetSidebarProps) => {
                       e.stopPropagation();
                       void copySnippet(snippet);
                     }}
+                    aria-label="Copy snippet"
                   >
                     <ContentCopyIcon
                       sx={{ fontSize: "0.75rem", color: copied === snippet.id ? "success.main" : undefined }}
@@ -358,6 +359,7 @@ const SnippetSidebar = ({ monacoRef, visible }: SnippetSidebarProps) => {
                       e.stopPropagation();
                       insertSnippet(snippet);
                     }}
+                    aria-label="Insert snippet"
                   >
                     <AddIcon sx={{ fontSize: "0.75rem" }} />
                   </button>

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -946,7 +946,11 @@ const TextEditorModal = ({
               {isCodeEditor && (
                 <div className="toolbar-group code-tools">
                   <Tooltip delay={TOOLTIP_ENTER_DELAY} title="Find">
-                    <button className="button-ghost" onClick={handleMonacoFind}>
+                    <button
+                      className="button-ghost"
+                      onClick={handleMonacoFind}
+                      aria-label="Find"
+                    >
                       <FindInPageIcon />
                     </button>
                   </Tooltip>
@@ -955,6 +959,7 @@ const TextEditorModal = ({
                       <button
                         className="button-ghost"
                         onClick={handleMonacoFormat}
+                        aria-label="Format"
                       >
                         <FormatAlignLeftIcon />
                       </button>
@@ -968,6 +973,7 @@ const TextEditorModal = ({
                       <button
                         className={`button-ghost snippet-toggle ${snippetSidebarVisible ? "active" : ""}`}
                         onClick={() => setSnippetSidebarVisible((v) => !v)}
+                        aria-label={snippetSidebarVisible ? "Hide Snippets" : "Show Snippets"}
                       >
                         <DataObjectIcon />
                       </button>
@@ -980,6 +986,7 @@ const TextEditorModal = ({
                     <button
                       className="button-ghost"
                       onClick={handleToggleWordWrap}
+                      aria-label={wordWrapEnabled ? "Disable wrap" : "Enable wrap"}
                     >
                       <WrapTextIcon />
                     </button>
@@ -1021,7 +1028,11 @@ const TextEditorModal = ({
                         : "Switch to Code Editor"
                     }
                   >
-                    <button className="button" onClick={handleToggleEditorMode}>
+                    <button
+                      className="button"
+                      onClick={handleToggleEditorMode}
+                      aria-label={isCodeEditor ? "Switch to Rich Text" : "Switch to Code Editor"}
+                    >
                       {isCodeEditor ? <TextFieldsIcon /> : <CodeIcon />}
                     </button>
                   </Tooltip>
@@ -1032,7 +1043,11 @@ const TextEditorModal = ({
                   delay={TOOLTIP_ENTER_DELAY}
                   title={assistantVisible ? "Hide Assistant" : "Show Assistant"}
                 >
-                  <button className="button" onClick={toggleAssistantVisible}>
+                  <button
+                    className="button"
+                    onClick={toggleAssistantVisible}
+                    aria-label={assistantVisible ? "Hide Assistant" : "Show Assistant"}
+                  >
                     {assistantVisible ? (
                       <ChatBubbleIcon />
                     ) : (
@@ -1041,7 +1056,11 @@ const TextEditorModal = ({
                   </button>
                 </Tooltip>
                 <Tooltip delay={TOOLTIP_ENTER_DELAY} title="Download">
-                  <button className="button" onClick={handleDownload}>
+                  <button
+                    className="button"
+                    onClick={handleDownload}
+                    aria-label="Download"
+                  >
                     <DownloadIcon />
                   </button>
                 </Tooltip>
@@ -1049,7 +1068,11 @@ const TextEditorModal = ({
                   delay={TOOLTIP_ENTER_DELAY}
                   title={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
                 >
-                  <button className="button" onClick={toggleFullscreen}>
+                  <button
+                    className="button"
+                    onClick={toggleFullscreen}
+                    aria-label={isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
+                  >
                     {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
                   </button>
                 </Tooltip>
@@ -1057,7 +1080,11 @@ const TextEditorModal = ({
                   delay={TOOLTIP_ENTER_DELAY}
                   title="Close Editor | Esc"
                 >
-                  <button className="button button-close" onClick={onClose}>
+                  <button
+                    className="button button-close"
+                    onClick={onClose}
+                    aria-label="Close Editor"
+                  >
                     <CloseIcon />
                   </button>
                 </Tooltip>


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to icon-only buttons across `TextEditorModal`, `DataframeEditorModal`, and `SnippetSidebar`.
🎯 **Why:** To improve accessibility for screen readers and ensure keyboard navigation correctly announces the actions associated with these buttons, addressing an issue where visual tooltips alone were insufficient.
♿ **Accessibility:**
- Dynamic ARIA labels added for stateful toggles (e.g., Fullscreen, Assistant, Snippet toggle).
- Explicit ARIA labels added for single-action buttons (e.g., Close, Format, Find, Download, Copy, Insert).

---
*PR created automatically by Jules for task [13578887278901583202](https://jules.google.com/task/13578887278901583202) started by @georgi*