### PR TITLE
[T-20260513-0031] PR 3: Shared UI primitives (Node Editor Redesign)

### DIFF
--- a/web/src/components/ui_primitives/CheckerDropzone.tsx
+++ b/web/src/components/ui_primitives/CheckerDropzone.tsx
@@ -1,0 +1,150 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * CheckerDropzone
+ *
+ * Empty-state preview surface with a transparent-checker background.
+ * Used by ContentCardBody and editing-node bodies as the "no content yet"
+ * state for image / mask / 3d / video previews.
+ *
+ * Optional drop handling — when `onDrop` is set, the surface highlights
+ * on drag-over and emits the dropped files.
+ */
+
+import React, { memo, useCallback, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+const DEFAULT_CHECKER_SIZE = 12;
+
+const styles = (theme: Theme, checkerSize: number, isOver: boolean) =>
+  css({
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    minHeight: 80,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing(0.5),
+    borderRadius: "var(--rounded-sm)",
+    color: theme.vars.palette.grey[400],
+    fontFamily: theme.fontFamily1,
+    fontSize: theme.fontSizeSmall,
+    textAlign: "center",
+    overflow: "hidden",
+    // CSS-only checker pattern using two layered gradients
+    backgroundColor: theme.vars.palette.grey[900],
+    backgroundImage: `
+      linear-gradient(45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
+      linear-gradient(-45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, ${theme.vars.palette.grey[800]} 75%),
+      linear-gradient(-45deg, transparent 75%, ${theme.vars.palette.grey[800]} 75%)
+    `,
+    backgroundSize: `${checkerSize * 2}px ${checkerSize * 2}px`,
+    backgroundPosition: [
+      `0 0`,
+      `0 ${checkerSize}px`,
+      `${checkerSize}px -${checkerSize}px`,
+      `-${checkerSize}px 0px`
+    ].join(", "),
+    transition: "box-shadow 0.15s ease, border-color 0.15s ease",
+    outline: isOver
+      ? `2px dashed ${theme.vars.palette.primary.main}`
+      : "1px solid transparent",
+    outlineOffset: isOver ? -2 : 0,
+    ".checker-icon": {
+      opacity: 0.55,
+      "& svg": {
+        fontSize: 36,
+        display: "block"
+      }
+    },
+    ".checker-message": {
+      opacity: 0.85,
+      userSelect: "none"
+    }
+  });
+
+export interface CheckerDropzoneProps {
+  /** Optional message rendered below the icon */
+  message?: string;
+  /** Optional icon rendered above the message */
+  icon?: React.ReactNode;
+  /** Size of each checker square in px */
+  checkerSize?: number;
+  /** Called when files are dropped — when set, the surface accepts drops */
+  onDrop?: (files: File[]) => void;
+  /** Additional content rendered in place of the default icon + message */
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const CheckerDropzoneInner: React.FC<CheckerDropzoneProps> = ({
+  message,
+  icon,
+  checkerSize = DEFAULT_CHECKER_SIZE,
+  onDrop,
+  children,
+  className
+}) => {
+  const theme = useTheme();
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!onDrop) {return;}
+      e.preventDefault();
+      e.stopPropagation();
+      setIsOver(true);
+    },
+    [onDrop]
+  );
+
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!onDrop) {return;}
+      e.preventDefault();
+      e.stopPropagation();
+      setIsOver(false);
+    },
+    [onDrop]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!onDrop) {return;}
+      e.preventDefault();
+      e.stopPropagation();
+      setIsOver(false);
+      const files = Array.from(e.dataTransfer.files ?? []);
+      if (files.length > 0) {onDrop(files);}
+    },
+    [onDrop]
+  );
+
+  return (
+    <div
+      css={styles(theme, checkerSize, isOver)}
+      className={`checker-dropzone ${className ?? ""}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      role={onDrop ? "button" : undefined}
+      aria-label={onDrop ? message ?? "Drop files here" : undefined}
+    >
+      {children ?? (
+        <>
+          {icon && <span className="checker-icon">{icon}</span>}
+          {message && <span className="checker-message">{message}</span>}
+        </>
+      )}
+    </div>
+  );
+};
+
+export const CheckerDropzone = memo(CheckerDropzoneInner);
+CheckerDropzone.displayName = "CheckerDropzone";
+
+export default CheckerDropzone;

--- a/web/src/components/ui_primitives/DynamicInputButton.tsx
+++ b/web/src/components/ui_primitives/DynamicInputButton.tsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * DynamicInputButton
+ *
+ * Bottom-left "+ Add another X" action used by ContentCardBody and
+ * editing-node bodies that opt into `editableDynamicInputs`. Pure
+ * presentational primitive — call sites supply `onAdd` and (optionally)
+ * an item label like "image input", "text input", or "variable" so the
+ * default copy reads "+ Add another <item>".
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import { Button } from "@mui/material";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.dynamic-input-button": {
+      textTransform: "none",
+      fontFamily: theme.fontFamily1,
+      fontSize: theme.fontSizeSmall,
+      fontWeight: 500,
+      letterSpacing: "0.01em",
+      color: theme.vars.palette.text.secondary,
+      backgroundColor: "transparent",
+      border: `1px dashed ${theme.vars.palette.grey[600]}`,
+      borderRadius: "var(--rounded-sm)",
+      padding: "4px 10px",
+      minWidth: 0,
+      gap: 6,
+      transition:
+        "color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease",
+      "&:hover": {
+        color: theme.vars.palette.primary.main,
+        borderColor: theme.vars.palette.primary.main,
+        backgroundColor: `${theme.vars.palette.primary.main}14`
+      },
+      "&.Mui-disabled": {
+        opacity: 0.5
+      },
+      "& .MuiButton-startIcon": {
+        margin: 0
+      },
+      "& svg": {
+        fontSize: 16
+      }
+    }
+  });
+
+export interface DynamicInputButtonProps {
+  /**
+   * Full label override. When set, takes precedence over `itemLabel`.
+   * @example "Add variable"
+   */
+  label?: string;
+  /**
+   * Type of input being added — fills the template
+   * "+ Add another {itemLabel}". Ignored if `label` is set.
+   * @default "input"
+   */
+  itemLabel?: string;
+  /** Click handler */
+  onAdd: () => void;
+  /** Disabled state */
+  disabled?: boolean;
+  className?: string;
+}
+
+const DynamicInputButtonInner: React.FC<DynamicInputButtonProps> = ({
+  label,
+  itemLabel = "input",
+  onAdd,
+  disabled = false,
+  className
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+  const text = label ?? `Add another ${itemLabel}`;
+
+  return (
+    <Button
+      css={cssStyles}
+      className={`dynamic-input-button nodrag ${className ?? ""}`}
+      onClick={onAdd}
+      disabled={disabled}
+      startIcon={<AddIcon />}
+      aria-label={text}
+      size="small"
+    >
+      {text}
+    </Button>
+  );
+};
+
+export const DynamicInputButton = memo(DynamicInputButtonInner);
+DynamicInputButton.displayName = "DynamicInputButton";
+
+export default DynamicInputButton;

--- a/web/src/components/ui_primitives/EdgeEndpointLabel.tsx
+++ b/web/src/components/ui_primitives/EdgeEndpointLabel.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * EdgeEndpointLabel
+ *
+ * Small floating chip rendered near an edge endpoint, showing the
+ * property name (e.g. "Prompt", "Image", "Result"). Used by the edge
+ * renderer to label source/target endpoints on demand.
+ *
+ * Pure positional primitive — the call site is responsible for
+ * computing (x, y) from edge geometry and for suppressing this chip
+ * when it would overlap a sibling endpoint. Renders nothing when
+ * `visible` is false.
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+const styles = (theme: Theme, color?: string) =>
+  css({
+    "&.edge-endpoint-label": {
+      position: "absolute",
+      transform: "translate(-50%, -50%)",
+      padding: "1px 6px",
+      borderRadius: 8,
+      fontFamily: theme.fontFamily1,
+      fontSize: "0.7rem",
+      fontWeight: 500,
+      lineHeight: 1.3,
+      letterSpacing: "0.02em",
+      color: theme.vars.palette.common.white,
+      backgroundColor: color ?? theme.vars.palette.grey[800],
+      border: `1px solid ${theme.vars.palette.grey[900]}`,
+      boxShadow: "0 1px 3px rgba(0, 0, 0, 0.4)",
+      whiteSpace: "nowrap",
+      pointerEvents: "none",
+      userSelect: "none",
+      zIndex: 5
+    }
+  });
+
+export interface EdgeEndpointLabelProps {
+  /** Text shown in the chip */
+  label: string;
+  /** Absolute x position (px) inside the edge layer */
+  x: number;
+  /** Absolute y position (px) inside the edge layer */
+  y: number;
+  /** Hide entirely when false. Defaults to true. */
+  visible?: boolean;
+  /**
+   * Optional background color — usually derived from the edge's type
+   * color via `colorForType`. Defaults to the neutral grey chip.
+   */
+  color?: string;
+  className?: string;
+}
+
+const EdgeEndpointLabelInner: React.FC<EdgeEndpointLabelProps> = ({
+  label,
+  x,
+  y,
+  visible = true,
+  color,
+  className
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme, color), [theme, color]);
+
+  if (!visible) {return null;}
+
+  return (
+    <div
+      css={cssStyles}
+      className={`edge-endpoint-label ${className ?? ""}`}
+      style={{ left: x, top: y }}
+    >
+      {label}
+    </div>
+  );
+};
+
+export const EdgeEndpointLabel = memo(EdgeEndpointLabelInner);
+EdgeEndpointLabel.displayName = "EdgeEndpointLabel";
+
+export default EdgeEndpointLabel;

--- a/web/src/components/ui_primitives/RunModelButton.tsx
+++ b/web/src/components/ui_primitives/RunModelButton.tsx
@@ -1,0 +1,111 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * RunModelButton
+ *
+ * Bottom-right primary action used by ContentCardBody and editing-node
+ * bodies. Pure presentational primitive — call sites provide `isRunning`
+ * (typically derived from the workflow runner / status store) and
+ * `onClick` (typically triggers a single-node run via the existing
+ * runner API).
+ *
+ * For full-workflow run/stop controls, use `RunWorkflowButton` instead.
+ */
+
+import React, { forwardRef, memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import { Button } from "@mui/material";
+import { LoadingSpinner } from "./LoadingSpinner";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.run-model-button": {
+      textTransform: "none",
+      fontFamily: theme.fontFamily1,
+      fontSize: theme.fontSizeSmall,
+      fontWeight: 600,
+      letterSpacing: "0.01em",
+      color: theme.vars.palette.common.black,
+      backgroundColor: theme.vars.palette.primary.main,
+      borderRadius: "var(--rounded-sm)",
+      padding: "4px 12px",
+      minWidth: 0,
+      gap: 6,
+      boxShadow: "0 1px 3px rgba(0, 0, 0, 0.25)",
+      transition: "background-color 0.15s ease, box-shadow 0.15s ease",
+      "&:hover": {
+        backgroundColor: theme.vars.palette.primary.light,
+        boxShadow: "0 2px 6px rgba(0, 0, 0, 0.35)"
+      },
+      "&.Mui-disabled": {
+        opacity: 0.55,
+        color: theme.vars.palette.common.black,
+        backgroundColor: theme.vars.palette.primary.main
+      },
+      "&.running": {
+        backgroundColor: theme.vars.palette.primary.dark,
+        color: theme.vars.palette.common.white
+      },
+      "& .MuiButton-startIcon": {
+        margin: 0
+      },
+      "& svg": {
+        fontSize: 16
+      }
+    }
+  });
+
+export interface RunModelButtonProps {
+  /** Label shown next to the icon */
+  label?: string;
+  /** True while a single-node run is in flight */
+  isRunning?: boolean;
+  /** Disabled (overrides running visual when set) */
+  disabled?: boolean;
+  /** Click handler — call sites trigger the actual single-node run */
+  onClick: () => void;
+  className?: string;
+}
+
+const RunModelButtonInner = forwardRef<
+  HTMLButtonElement,
+  RunModelButtonProps
+>(({ label = "Run Model", isRunning = false, disabled = false, onClick, className }, ref) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const handleClick = useCallback(() => {
+    if (disabled || isRunning) {return;}
+    onClick();
+  }, [disabled, isRunning, onClick]);
+
+  return (
+    <Button
+      ref={ref}
+      css={cssStyles}
+      className={`run-model-button nodrag ${isRunning ? "running" : ""} ${className ?? ""}`}
+      onClick={handleClick}
+      disabled={disabled}
+      startIcon={
+        isRunning ? (
+          <LoadingSpinner inline size={14} color="inherit" />
+        ) : (
+          <PlayArrowIcon />
+        )
+      }
+      aria-label={label}
+      size="small"
+    >
+      {label}
+    </Button>
+  );
+});
+
+RunModelButtonInner.displayName = "RunModelButtonInner";
+
+export const RunModelButton = memo(RunModelButtonInner);
+RunModelButton.displayName = "RunModelButton";
+
+export default RunModelButton;

--- a/web/src/components/ui_primitives/VideoPlayer.tsx
+++ b/web/src/components/ui_primitives/VideoPlayer.tsx
@@ -1,0 +1,290 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * VideoPlayer
+ *
+ * Embeddable video player with custom controls — play/pause, seek,
+ * timestamp readout, and playback-speed selector. Used by ContentCardBody
+ * (video variant) and anywhere else a compact in-node video preview is needed.
+ *
+ * Controls auto-hide after a short delay of mouse inactivity over the surface
+ * and re-appear on hover/movement.
+ */
+
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import PauseIcon from "@mui/icons-material/Pause";
+import { IconButton } from "@mui/material";
+
+const SPEED_OPTIONS = [0.5, 1, 1.5, 2] as const;
+const CONTROLS_HIDE_DELAY_MS = 1800;
+
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) {return "0:00";}
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};
+
+const styles = (theme: Theme, controlsVisible: boolean) =>
+  css({
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    backgroundColor: theme.vars.palette.common.black,
+    overflow: "hidden",
+    borderRadius: "var(--rounded-sm)",
+    video: {
+      display: "block",
+      width: "100%",
+      height: "100%",
+      objectFit: "contain"
+    },
+    ".controls": {
+      position: "absolute",
+      left: 0,
+      right: 0,
+      bottom: 0,
+      padding: "6px 8px",
+      display: "flex",
+      alignItems: "center",
+      gap: 8,
+      background:
+        "linear-gradient(to top, rgba(0,0,0,0.65), rgba(0,0,0,0))",
+      color: theme.vars.palette.common.white,
+      opacity: controlsVisible ? 1 : 0,
+      transition: "opacity 0.2s ease",
+      pointerEvents: controlsVisible ? "auto" : "none",
+      fontFamily: theme.fontFamily1,
+      fontSize: theme.fontSizeSmall
+    },
+    ".play-button": {
+      width: 28,
+      height: 28,
+      padding: 0,
+      color: theme.vars.palette.common.white,
+      "& svg": { fontSize: 20 },
+      "&:hover": {
+        backgroundColor: "rgba(255, 255, 255, 0.14)"
+      }
+    },
+    ".seek": {
+      flex: 1,
+      height: 4,
+      appearance: "none",
+      background: "rgba(255, 255, 255, 0.25)",
+      borderRadius: 2,
+      cursor: "pointer",
+      "&::-webkit-slider-thumb": {
+        appearance: "none",
+        width: 10,
+        height: 10,
+        borderRadius: "50%",
+        backgroundColor: theme.vars.palette.primary.main,
+        cursor: "pointer"
+      },
+      "&::-moz-range-thumb": {
+        width: 10,
+        height: 10,
+        borderRadius: "50%",
+        backgroundColor: theme.vars.palette.primary.main,
+        border: "none",
+        cursor: "pointer"
+      }
+    },
+    ".timestamp": {
+      fontVariantNumeric: "tabular-nums",
+      minWidth: 70,
+      textAlign: "right",
+      opacity: 0.9
+    },
+    ".speed-select": {
+      appearance: "none",
+      background: "rgba(255, 255, 255, 0.1)",
+      color: theme.vars.palette.common.white,
+      border: `1px solid rgba(255, 255, 255, 0.2)`,
+      borderRadius: 4,
+      padding: "2px 6px",
+      fontSize: theme.fontSizeSmall,
+      fontFamily: theme.fontFamily1,
+      cursor: "pointer",
+      "&:hover": {
+        background: "rgba(255, 255, 255, 0.18)"
+      }
+    }
+  });
+
+export interface VideoPlayerProps {
+  /** Video source URL */
+  src: string;
+  /** Optional poster image */
+  poster?: string;
+  /** Autoplay (typically requires muted=true to satisfy browser policies) */
+  autoplay?: boolean;
+  /** Loop playback */
+  loop?: boolean;
+  /** Start muted */
+  muted?: boolean;
+  /** Called on every timeupdate with currentTime in seconds */
+  onTimeUpdate?: (time: number) => void;
+  className?: string;
+}
+
+const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
+  src,
+  poster,
+  autoplay = false,
+  loop = false,
+  muted = false,
+  onTimeUpdate,
+  className
+}) => {
+  const theme = useTheme();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [isPlaying, setIsPlaying] = useState(autoplay);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [speed, setSpeed] = useState(1);
+  const [controlsVisible, setControlsVisible] = useState(true);
+
+  const scheduleHide = useCallback(() => {
+    if (hideTimerRef.current) {clearTimeout(hideTimerRef.current);}
+    hideTimerRef.current = setTimeout(() => {
+      setControlsVisible(false);
+    }, CONTROLS_HIDE_DELAY_MS);
+  }, []);
+
+  const showControls = useCallback(() => {
+    setControlsVisible(true);
+    scheduleHide();
+  }, [scheduleHide]);
+
+  useEffect(
+    () => () => {
+      if (hideTimerRef.current) {clearTimeout(hideTimerRef.current);}
+    },
+    []
+  );
+
+  const handleTogglePlay = useCallback(() => {
+    const v = videoRef.current;
+    if (!v) {return;}
+    if (v.paused) {
+      void v.play();
+    } else {
+      v.pause();
+    }
+  }, []);
+
+  const handlePlay = useCallback(() => setIsPlaying(true), []);
+  const handlePause = useCallback(() => setIsPlaying(false), []);
+
+  const handleLoadedMetadata = useCallback(() => {
+    if (videoRef.current) {setDuration(videoRef.current.duration);}
+  }, []);
+
+  const handleVideoTimeUpdate = useCallback(() => {
+    const v = videoRef.current;
+    if (!v) {return;}
+    setCurrentTime(v.currentTime);
+    onTimeUpdate?.(v.currentTime);
+  }, [onTimeUpdate]);
+
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = videoRef.current;
+    if (!v) {return;}
+    const newTime = Number(e.target.value);
+    v.currentTime = newTime;
+    setCurrentTime(newTime);
+  }, []);
+
+  const handleSpeedChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newSpeed = Number(e.target.value);
+      setSpeed(newSpeed);
+      if (videoRef.current) {videoRef.current.playbackRate = newSpeed;}
+    },
+    []
+  );
+
+  const cssStyles = useMemo(
+    () => styles(theme, controlsVisible),
+    [theme, controlsVisible]
+  );
+
+  return (
+    <div
+      css={cssStyles}
+      className={`video-player ${className ?? ""}`}
+      onMouseMove={showControls}
+      onMouseEnter={showControls}
+      onMouseLeave={() => setControlsVisible(false)}
+    >
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        autoPlay={autoplay}
+        loop={loop}
+        muted={muted}
+        playsInline
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onLoadedMetadata={handleLoadedMetadata}
+        onTimeUpdate={handleVideoTimeUpdate}
+        onClick={handleTogglePlay}
+      />
+      <div className="controls">
+        <IconButton
+          className="play-button"
+          size="small"
+          onClick={handleTogglePlay}
+          aria-label={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+        </IconButton>
+        <input
+          type="range"
+          className="seek"
+          min={0}
+          max={duration || 0}
+          step={0.05}
+          value={currentTime}
+          onChange={handleSeek}
+          aria-label="Seek"
+        />
+        <span className="timestamp">
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </span>
+        <select
+          className="speed-select"
+          value={speed}
+          onChange={handleSpeedChange}
+          aria-label="Playback speed"
+        >
+          {SPEED_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {s}×
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export const VideoPlayer = memo(VideoPlayerInner);
+VideoPlayer.displayName = "VideoPlayer";
+
+export default VideoPlayer;

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -347,3 +347,21 @@ export type { DropZoneOverlayProps } from "./DropZoneOverlay";
 
 export { MetadataListRow } from "./MetadataListRow";
 export type { MetadataListRowProps, MetadataItem } from "./MetadataListRow";
+
+// Node-editor redesign (PR 3) — primitives for ContentCardBody,
+// editing-node bodies, and the edge renderer. Consumed by later PRs.
+
+export { CheckerDropzone } from "./CheckerDropzone";
+export type { CheckerDropzoneProps } from "./CheckerDropzone";
+
+export { VideoPlayer } from "./VideoPlayer";
+export type { VideoPlayerProps } from "./VideoPlayer";
+
+export { DynamicInputButton } from "./DynamicInputButton";
+export type { DynamicInputButtonProps } from "./DynamicInputButton";
+
+export { RunModelButton } from "./RunModelButton";
+export type { RunModelButtonProps } from "./RunModelButton";
+
+export { EdgeEndpointLabel } from "./EdgeEndpointLabel";
+export type { EdgeEndpointLabelProps } from "./EdgeEndpointLabel";


### PR DESCRIPTION
## Summary

Lands five presentational primitives that PR 4+ of the Node Editor Redesign plan will consume. No call sites yet — primitives ship standalone, no behavior change in the running app.

Part of plan **P-2026-05-13-node-editor-redesign** (Track B / E support).

| Primitive | Purpose |
|---|---|
| `CheckerDropzone` | Transparency-checker empty-state preview; optional file drop with hover outline |
| `VideoPlayer` | Embeddable `<video>` with custom controls — play/pause, seek, timestamp, speed (0.5×/1×/1.5×/2×); controls auto-hide after 1.8s |
| `DynamicInputButton` | "+ Add another &lt;item&gt;" dashed pill; pure `onAdd` callback |
| `RunModelButton` | Primary single-node run pill (`isRunning` / `disabled` / `onClick`); distinct from `RunWorkflowButton` which manages whole-workflow run/stop |
| `EdgeEndpointLabel` | Positional chip (`x`,`y`) for edge endpoint labels; supports per-type color tinting |

`TypedPortChip` was intentionally skipped — already shipped in PR 1 (T-20260513-0029).

## Conventions

All five follow [`STRATEGY.md`](web/src/components/ui_primitives/STRATEGY.md):
- Theme tokens only (`theme.vars.palette.*`, `theme.fontFamily*`); raw MUI is allowed inside `ui_primitives/`
- Props interfaces exported alongside components
- Memoised, `displayName` set, `forwardRef` on the button pattern
- Default size constants live next to the primitive
- Exports added to `ui_primitives/index.ts`

## Test plan

- [ ] `npm run typecheck` — clean (already passes locally)
- [ ] `npm run lint` — clean (already passes locally)
- [ ] No call sites are added; no UI regression possible from this PR alone
- [ ] Spot-check the index re-exports import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)