### PR TITLE
[T-20260513-0034] PR 6: CONTENT_CARD_REGISTRY full rollout

### DIFF
--- a/web/src/components/node/NodeContent.tsx
+++ b/web/src/components/node/NodeContent.tsx
@@ -73,6 +73,19 @@ const arePropsEqual = (
     return false;
   }
 
+  // The primary-output type drives body routing (isContentCardNode) and
+  // ContentCardBody variant. Two metadata objects with the same output count
+  // but different primary-output types must re-render.
+  const prevPrimary = prevProps.nodeMetadata.outputs?.[0];
+  const nextPrimary = nextProps.nodeMetadata.outputs?.[0];
+  const prevPrimaryType =
+    (prevPrimary?.type as { type?: string } | undefined)?.type ?? "";
+  const nextPrimaryType =
+    (nextPrimary?.type as { type?: string } | undefined)?.type ?? "";
+  if (prevPrimaryType !== nextPrimaryType) {
+    return false;
+  }
+
   // Check data.properties - compare both keys and values
   const prevDataProps = prevProps.data.properties || {};
   const nextDataProps = nextProps.data.properties || {};

--- a/web/src/components/node/NodeContent.tsx
+++ b/web/src/components/node/NodeContent.tsx
@@ -152,7 +152,7 @@ const NodeContent: React.FC<NodeContentProps> = ({
   //       → generic body (this component's default layout)
   // Utility nodes (control flow, constants, etc.) intentionally never appear
   // in CONTENT_CARD_REGISTRY and stay on the generic body forever.
-  if (isContentCardNode(nodeType)) {
+  if (isContentCardNode(nodeMetadata)) {
     return (
       <ContentCardBody
         id={id}

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -55,6 +55,7 @@ import { useNodes } from "../../contexts/NodeContext";
 
 import {
   getContentCardVariant,
+  getDynamicInputLabel,
   getPrimaryOutput,
   type ContentCardVariant
 } from "./contentCardRegistry";
@@ -538,7 +539,10 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
 
       {isDynamic && (
         <FlexRow className="footer-strip" align="center" justify="flex-start">
-          <DynamicInputButton itemLabel="input" onAdd={handleAddDynamicInput} />
+          <DynamicInputButton
+            itemLabel={getDynamicInputLabel(nodeMetadata)}
+            onAdd={handleAddDynamicInput}
+          />
         </FlexRow>
       )}
 

--- a/web/src/components/node_types/contentCardRegistry.test.ts
+++ b/web/src/components/node_types/contentCardRegistry.test.ts
@@ -1,0 +1,110 @@
+import {
+  CONTENT_CARD_REGISTRY,
+  getDynamicInputLabel,
+  isContentCardNode
+} from "./contentCardRegistry";
+import type { NodeMetadata, OutputSlot } from "../../stores/ApiTypes";
+
+const mediaOutput = (kind: string): OutputSlot =>
+  ({
+    name: "output",
+    type: { type: kind }
+  }) as unknown as OutputSlot;
+
+const meta = (
+  node_type: string,
+  outputKind: string = "any"
+): NodeMetadata =>
+  ({
+    node_type,
+    namespace: node_type.split(".").slice(0, -1).join("."),
+    outputs: [mediaOutput(outputKind)]
+  }) as unknown as NodeMetadata;
+
+describe("isContentCardNode", () => {
+  it("returns false for undefined metadata", () => {
+    expect(isContentCardNode(undefined)).toBe(false);
+  });
+
+  it("returns false for utility nodes", () => {
+    expect(isContentCardNode(meta("nodetool.control.If"))).toBe(false);
+    expect(isContentCardNode(meta("nodetool.control.Loop"))).toBe(false);
+    expect(isContentCardNode(meta("nodetool.constant.String", "str"))).toBe(
+      false
+    );
+  });
+
+  it("matches explicit registry entries", () => {
+    for (const t of CONTENT_CARD_REGISTRY) {
+      expect(isContentCardNode(meta(t))).toBe(true);
+    }
+  });
+
+  it("matches conventional generator name patterns in any namespace", () => {
+    expect(isContentCardNode(meta("some.pkg.TextToImage"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.ImageToImage"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.TextToVideo"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.ImageToVideo"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.TextToAudio"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.TextTo3D"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.CreateImage"))).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.ImageGeneration"))).toBe(true);
+  });
+
+  it("does not match generator-shaped names embedded in longer words", () => {
+    expect(isContentCardNode(meta("foo.TextToImagePromptBuilder"))).toBe(false);
+  });
+
+  it("matches fal.* / replicate.* / kie.* nodes with media output", () => {
+    expect(isContentCardNode(meta("fal.image_to_image.Ultrashape", "image"))).toBe(
+      true
+    );
+    expect(
+      isContentCardNode(meta("replicate.video.SomeModel", "video"))
+    ).toBe(true);
+    expect(isContentCardNode(meta("kie.audio.SomeModel", "audio"))).toBe(true);
+    expect(
+      isContentCardNode(meta("fal.threed.MeshyV5Retexture", "model_3d"))
+    ).toBe(true);
+  });
+
+  it("does not match fal/replicate/kie nodes with non-media outputs", () => {
+    expect(isContentCardNode(meta("fal.misc.SomeUtil", "dict"))).toBe(false);
+    expect(isContentCardNode(meta("replicate.text.Summarize", "str"))).toBe(
+      false
+    );
+    expect(isContentCardNode(meta("kie.misc.Util", "any"))).toBe(false);
+  });
+
+  it("does not match arbitrary third-party namespaces", () => {
+    expect(
+      isContentCardNode(meta("comfy.image.SomeModel", "image"))
+    ).toBe(false);
+  });
+
+  it("returns false for metadata missing node_type", () => {
+    expect(isContentCardNode({} as unknown as NodeMetadata)).toBe(false);
+  });
+});
+
+describe("getDynamicInputLabel", () => {
+  it("returns 'variable' for prompt/template nodes", () => {
+    expect(getDynamicInputLabel(meta("nodetool.agents.Agent"))).toBe(
+      "variable"
+    );
+    expect(getDynamicInputLabel(meta("nodetool.text.Concat"))).toBe(
+      "variable"
+    );
+  });
+
+  it("derives label from primary-output variant", () => {
+    expect(getDynamicInputLabel(meta("foo.bar.X", "image"))).toBe("image input");
+    expect(getDynamicInputLabel(meta("foo.bar.X", "video"))).toBe("video input");
+    expect(getDynamicInputLabel(meta("foo.bar.X", "audio"))).toBe("audio input");
+    expect(getDynamicInputLabel(meta("foo.bar.X", "str"))).toBe("text input");
+  });
+
+  it("falls back to 'input' for generic outputs", () => {
+    expect(getDynamicInputLabel(meta("foo.bar.X", "dict"))).toBe("input");
+  });
+});

--- a/web/src/components/node_types/contentCardRegistry.ts
+++ b/web/src/components/node_types/contentCardRegistry.ts
@@ -237,12 +237,13 @@ export const getContentCardDefaultSize = (
 export const getDynamicInputLabel = (metadata: NodeMetadata): string => {
   const t = metadata.node_type ?? "";
   // Template-style nodes use {{variable}} substitution — say "variable".
+  // (Only nodes also matched by `isContentCardNode` show this button — keep
+  // this list in sync with the explicit allow-set above.)
   if (
     t === "nodetool.agents.Agent" ||
     t === "anthropic.agents.ClaudeAgent" ||
     t === "openai.agents.RealtimeAgent" ||
-    t === "nodetool.text.Concat" ||
-    t === "nodetool.text.FormatText"
+    t === "nodetool.text.Concat"
   ) {
     return "variable";
   }

--- a/web/src/components/node_types/contentCardRegistry.ts
+++ b/web/src/components/node_types/contentCardRegistry.ts
@@ -1,37 +1,127 @@
 /**
  * Content-Card Registry
  *
- * Opt-in list of node types that render as a `ContentCardBody` instead of
- * the generic input/output layout. Membership is permanent — this is how
- * nodes declare "I am a content-forward node (image, video, text, etc.)",
- * not a transitional flag.
+ * Predicate that decides whether a node renders as a `ContentCardBody` (a
+ * content-forward image/video/audio/3D/text body) instead of the generic
+ * input/output layout.
  *
- * Utility nodes (`If`, `Loop`, `Map`, control-flow, constants) stay on the
- * generic body forever and intentionally do not appear here.
+ * Three matching strategies, in order:
  *
- * Initial seed (per plan §6.4): 3 image-generator nodes for validation.
- * Expansion happens in PR 6 once the scaffold has soaked.
+ *   1. Explicit allow-set — hand-picked entries for provider/base nodes that
+ *      should always render as content cards, regardless of namespace.
+ *   2. Generator-pattern match — node_type names that follow the conventional
+ *      `*.TextToImage`, `*.ImageToImage`, `*.TextToVideo`, ... shapes used by
+ *      first-party generators.
+ *   3. Provider-namespace + output match — any node under a generator-
+ *      aggregator namespace (`fal.`, `replicate.`, `kie.`) whose primary
+ *      output is a media type (image/video/audio/3D).
+ *
+ * Utility nodes (`If`, `Loop`, `Map`, constants, control-flow) never match
+ * any of the three strategies and stay on the generic body forever.
  */
 
 import type { NodeMetadata, OutputSlot } from "../../stores/ApiTypes";
 
+/**
+ * Hand-curated entries — provider/base nodes that should always render as a
+ * content card. Anything outside the predicate's namespace/pattern reach.
+ */
 export const CONTENT_CARD_REGISTRY: ReadonlySet<string> = new Set([
-  // Image generators
-  "openai.image.CreateImage",
-  "openai.image.EditImage",
+  // First-party generators (base-nodes)
   "nodetool.image.TextToImage",
   "nodetool.image.ImageToImage",
-  // Video generators
   "nodetool.video.TextToVideo",
   "nodetool.video.ImageToVideo",
-  // Audio generators
   "nodetool.audio.TextToSpeech",
-  // Text generators
-  "nodetool.text.AutomaticSpeechRecognition"
+  "nodetool.text.AutomaticSpeechRecognition",
+
+  // Provider image/video/audio nodes
+  "openai.image.CreateImage",
+  "openai.image.EditImage",
+  "openai.audio.TextToSpeech",
+  "openai.audio.Transcribe",
+  "openai.audio.Translate",
+  "gemini.image.ImageGeneration",
+  "gemini.video.TextToVideo",
+  "gemini.video.ImageToVideo",
+  "gemini.audio.TextToSpeech",
+  "gemini.audio.Transcribe",
+
+  // ElevenLabs
+  "elevenlabs.TextToSpeech",
+  "elevenlabs.SpeechToText",
+  "elevenlabs.RealtimeTextToSpeech",
+  "elevenlabs.RealtimeSpeechToText",
+
+  // Text-content nodes (LLM-style, prompt templating)
+  "nodetool.agents.Agent",
+  "nodetool.agents.Summarizer",
+  "nodetool.agents.Extractor",
+  "nodetool.agents.Classifier",
+  "nodetool.text.Concat",
+  "nodetool.data.Describe",
+  "anthropic.agents.ClaudeAgent",
+  "openai.agents.RealtimeAgent",
+  "mistral.text.ChatComplete"
 ]);
 
-export const isContentCardNode = (nodeType: string | undefined): boolean =>
-  !!nodeType && CONTENT_CARD_REGISTRY.has(nodeType);
+/**
+ * Namespace prefixes whose nodes are wholesale content cards when their
+ * primary output is a media type. These are auto-generated aggregator
+ * packages (fal, replicate, kie) where hand-listing every entry would be
+ * untenable and rot every time the manifest regenerates.
+ */
+const PROVIDER_NAMESPACE_PREFIXES = ["fal.", "replicate.", "kie."] as const;
+
+/**
+ * Conventional generator-shaped class names. Matches any namespace.
+ * Tail-anchored: `\b` boundary prevents accidental matches against
+ * "TextToImagePromptBuilder" or similar.
+ */
+const GENERATOR_NAME_PATTERNS: readonly RegExp[] = [
+  /\.(TextTo|ImageTo)(Image|Video|Audio|Speech|3D|Model3D)\b/,
+  /\.(CreateImage|EditImage|ImageGeneration)\b/
+];
+
+const MEDIA_VARIANTS: ReadonlySet<ContentCardVariant> = new Set([
+  "image",
+  "image_mask",
+  "video",
+  "audio",
+  "model_3d"
+]);
+
+/**
+ * Decide whether a node should render as a content card.
+ *
+ * The full metadata is needed because the namespace-prefix branch consults
+ * the primary output's variant. Pass the metadata you already have — every
+ * caller in the app has it.
+ */
+export const isContentCardNode = (
+  metadata: NodeMetadata | undefined
+): boolean => {
+  if (!metadata) {
+    return false;
+  }
+  const t = metadata.node_type;
+  if (!t) {
+    return false;
+  }
+  if (CONTENT_CARD_REGISTRY.has(t)) {
+    return true;
+  }
+  if (GENERATOR_NAME_PATTERNS.some((re) => re.test(t))) {
+    return true;
+  }
+  if (PROVIDER_NAMESPACE_PREFIXES.some((p) => t.startsWith(p))) {
+    const variant = getContentCardVariant(getPrimaryOutput(metadata));
+    if (MEDIA_VARIANTS.has(variant)) {
+      return true;
+    }
+  }
+  return false;
+};
 
 /**
  * Per-variant default card dimensions applied at node creation time
@@ -82,8 +172,7 @@ export const getPrimaryOutput = (
 /**
  * Coarse classification of a primary output's type into a body variant.
  * The variant drives which preview the body renders (image / video / text /
- * audio / 3d / mask / generic). PR 4 only implements the `image` variant —
- * other variants land in PR 5.
+ * audio / 3d / mask / generic).
  */
 export type ContentCardVariant =
   | "image"
@@ -134,4 +223,43 @@ export const getContentCardDefaultSize = (
 ): { width: number; height: number } => {
   const variant = getContentCardVariant(getPrimaryOutput(metadata));
   return CONTENT_CARD_SIZES[variant];
+};
+
+/**
+ * Human label for the `DynamicInputButton` shown in a content card.
+ * Picked from primary-output variant — image generators say
+ * "+ Add another image input", text/prompt nodes say "+ Add variable", etc.
+ *
+ * Plan §6.5: "+ Add another image input" (image-multi-input generators),
+ * "+ Add another text input" (text concatenators), "+ Add variable"
+ * (Prompt / template nodes).
+ */
+export const getDynamicInputLabel = (metadata: NodeMetadata): string => {
+  const t = metadata.node_type ?? "";
+  // Template-style nodes use {{variable}} substitution — say "variable".
+  if (
+    t === "nodetool.agents.Agent" ||
+    t === "anthropic.agents.ClaudeAgent" ||
+    t === "openai.agents.RealtimeAgent" ||
+    t === "nodetool.text.Concat" ||
+    t === "nodetool.text.FormatText"
+  ) {
+    return "variable";
+  }
+  const variant = getContentCardVariant(getPrimaryOutput(metadata));
+  switch (variant) {
+    case "image":
+    case "image_mask":
+      return "image input";
+    case "video":
+      return "video input";
+    case "audio":
+      return "audio input";
+    case "model_3d":
+      return "input";
+    case "text":
+      return "text input";
+    default:
+      return "input";
+  }
 };

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -1342,7 +1342,7 @@ export const createNodeStore = (
               metadata.node_type === "nodetool.compare.CompareImages";
             const isModel3DConstantNode =
               metadata.node_type === "nodetool.constant.Model3D";
-            const isContentCard = isContentCardNode(metadata.node_type);
+            const isContentCard = isContentCardNode(metadata);
             let defaultStyle: { width: number; height?: number };
             if (isPreviewNode) {
               defaultStyle = { width: 400, height: 300 };

--- a/web/src/utils/__tests__/imageUtils.test.ts
+++ b/web/src/utils/__tests__/imageUtils.test.ts
@@ -82,6 +82,24 @@ describe("imageUtils", () => {
       expect(result.blobUrl).toBeNull();
     });
 
+    it("resolves asset:// URI on ImageSource to /api/storage/{id}", () => {
+      const source: ImageSource = { uri: "asset://abc123.png" };
+      const result = createImageUrl(source, null);
+      expect(result.url).toBe(
+        "http://localhost:7777/api/storage/abc123.png"
+      );
+      expect(result.blobUrl).toBeNull();
+    });
+
+    it("resolves raw asset:// string to /api/storage/{id}", () => {
+      const source: ImageData = "asset://abc123.png";
+      const result = createImageUrl(source, null);
+      expect(result.url).toBe(
+        "http://localhost:7777/api/storage/abc123.png"
+      );
+      expect(result.blobUrl).toBeNull();
+    });
+
     it("handles relative URL path (API storage)", () => {
       const source: ImageData = "/api/storage/341ebf3aec5711f0aa8400007c77feb7.jpg";
       const result = createImageUrl(source, null);

--- a/web/src/utils/imageUtils.ts
+++ b/web/src/utils/imageUtils.ts
@@ -12,6 +12,24 @@ export interface ImageSource {
 }
 
 /**
+ * Resolve a URI string to a fetchable URL.
+ * - `asset://{id}` → `${BASE_URL}/api/storage/{id}` (same mapping as
+ *   `resolveHistoryUri` in `useNodeResultHistory.ts`).
+ * - `/api/...` → prefixed with `BASE_URL`.
+ * - Other absolute URIs (`data:`, `blob:`, `http:`, `https:`) returned as-is.
+ */
+const resolveUri = (uri: string): string => {
+  if (uri.startsWith("asset://")) {
+    const assetId = uri.slice("asset://".length);
+    return `${BASE_URL}/api/storage/${assetId}`;
+  }
+  if (uri.startsWith("/api/")) {
+    return `${BASE_URL}${uri}`;
+  }
+  return uri;
+};
+
+/**
  * Converts image data to a displayable URL.
  * Handles: URI strings, data URIs, base64 strings, Uint8Array, and number arrays.
  *
@@ -55,8 +73,7 @@ export const createImageUrl = (
 
   // Case 1: URI is provided
   if (uri) {
-    const resolved = uri.startsWith("/api/") ? `${BASE_URL}${uri}` : uri;
-    return { url: resolved, blobUrl: null };
+    return { url: resolveUri(uri), blobUrl: null };
   }
 
   if (!data) {
@@ -68,9 +85,10 @@ export const createImageUrl = (
     if (
       data.startsWith("data:") ||
       data.startsWith("blob:") ||
-      data.startsWith("http")
+      data.startsWith("http") ||
+      data.startsWith("asset://")
     ) {
-      return { url: data, blobUrl: null };
+      return { url: resolveUri(data), blobUrl: null };
     }
     if (data.startsWith("/")) {
       const resolved = data.startsWith("/api/") ? `${BASE_URL}${data}` : data;


### PR DESCRIPTION
## Summary

- Switch `ContentCardBody` opt-in from a hand-curated `Set<string>` to a predicate covering the actual node universe. Manifests have **1140 fal + 403 replicate + 122 kie** generator nodes vs. the plan's ~80 estimate, so explicit enumeration was untenable.
- Three matching strategies in `contentCardRegistry.ts`:
  1. Explicit allow-set for base/provider nodes (OpenAI, Anthropic, Gemini, ElevenLabs, Mistral, nodetool agents/text).
  2. Generator-name patterns (`*.TextTo{Image,Video,Audio,Speech,3D}`, `*.ImageTo{…}`, `*.CreateImage`, `*.EditImage`, `*.ImageGeneration`).
  3. Provider-namespace prefix (`fal.`/`replicate.`/`kie.`) with primary-output variant in `{image, video, audio, model_3d}`.
- `DynamicInputButton` label is now variant-aware via `getDynamicInputLabel` ("variable" for prompt/template nodes, `{kind} input` otherwise).
- Fixes an image-preview bug found in QA: `createImageUrl` didn't recognize `asset://` URIs and produced `src="data:image/png;base64,asset://…"`. Added `resolveUri()` mapping `asset://{id}` → `${BASE_URL}/api/storage/{id}`.

## Deviations from plan §6.4 criteria

- **C229 (RunModelButton):** Out of scope. PR 4/5 design decision moved single-node run to the existing node toolbar (see `ContentCardBody.tsx` header comment); button was never built.
- **C230 (OQ-1 `{{variable}}` grammar):** Already exists in `nodetool.agents.Agent` (`packages/base-nodes/src/nodes/agents.ts:72`) and `nodetool.text.FormatText`. Nothing to invent.

## Test plan

- [x] `web/src/components/node_types/contentCardRegistry.test.ts` — 12 new tests cover all three matching strategies + label derivation.
- [x] `web/src/utils/__tests__/imageUtils.test.ts` — 2 new tests for `asset://` resolution on both `ImageSource.uri` and raw-string paths.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 0 errors on changed files (42 pre-existing warnings unchanged).
- [x] 78/78 tests pass across NodeStore / NodeContent / contentCard suites.
- [ ] Manual QA: drop fal/replicate image, video, audio, 3D generators and confirm content-card rendering + correct DynamicInputButton labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)