### PR TITLE
marketing: reframe /agents page for working creatives

### DIFF
--- a/marketing/src/app/agents/layout.tsx
+++ b/marketing/src/app/agents/layout.tsx
@@ -1,18 +1,22 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Agents on the canvas | NodeTool",
+  title: "Agents for creative work | NodeTool",
   description:
-    "Drop a planning agent into your canvas. It calls models and tools to finish a multi-step task — research, browse, write, generate — and hands the result back to the next node. Open source. BYOK. Runs on your machine or in the browser.",
+    "An art director that never sleeps. Drop an agent on the canvas, give it a brief, and watch it plan the shot, pick the model, generate variants, and hand the cut to the next node. Wire image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs — into agents that ship your work. Open source, BYOK, runs on your machine.",
   keywords: [
-    "AI agents",
-    "creative AI workspace",
-    "planning agent",
-    "agent node",
-    "BYOK agents",
-    "open source agents",
-    "node-based agents",
-    "multi-step tasks",
+    "creative AI agents",
+    "art director agent",
+    "brief to asset",
+    "automated brand pack",
+    "AI motion design agent",
+    "creative workflow automation",
+    "image generation agent",
+    "video generation agent",
+    "BYOK creative agents",
+    "open source creative agents",
+    "node-based creative pipeline",
+    "Flux Seedance Veo Suno ElevenLabs",
   ],
 };
 

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Terminal, Box, Zap, Globe, Cpu, Layers, ArrowRight, MessageSquare, Bot } from "lucide-react";
+import { Terminal, Box, Zap, RefreshCw, Cpu, Layers, ArrowRight, MessageSquare, Bot, Palette, Film, Sparkles } from "lucide-react";
 
 type AccentColor = "blue" | "purple" | "emerald";
 
@@ -23,10 +23,12 @@ export default function AgentBuildRunDeploy() {
             <div className="relative mx-auto max-w-6xl w-full z-10">
                 <div className="mb-12 text-center max-w-2xl mx-auto">
                     <h2 className="text-4xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white via-slate-200 to-slate-400 mb-4 tracking-tight">
-                        Plan. Act. Self-correct.
+                        Brief it. Direct it. Iterate.
                     </h2>
                     <p className="text-slate-400 text-lg">
-                        Design agents that plan a task, call the right tools, and self-correct as they go — then re-run them as a node in any workflow.
+                        Hand your agent a creative brief, watch it pick models and generate
+                        variants, then save the winning run as a node you can rerun for the
+                        next campaign.
                     </p>
                 </div>
 
@@ -42,8 +44,8 @@ export default function AgentBuildRunDeploy() {
 
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-3 relative z-10">
                     <Card
-                        title="Design"
-                        subtitle="Set the objective, pick a mode (loop, plan, or multi-agent), and wire in the tools and skills the agent should reach for."
+                        title="Write the brief"
+                        subtitle="Set the look, the mood, the deliverable. Wire in the image, video, and audio models you want the agent to direct — Flux, Seedance, Veo, Suno, ElevenLabs."
                         step={1}
                         accentColor="blue"
                     >
@@ -51,8 +53,8 @@ export default function AgentBuildRunDeploy() {
                     </Card>
 
                     <Card
-                        title="Observe"
-                        subtitle="Stream reasoning, tool calls, and task progress live. OpenTelemetry tracing built in so you can see exactly what the agent did."
+                        title="Watch it direct"
+                        subtitle="See the agent reason about the shot, choose the model, generate variants, and self-correct when a render misses the brief. Every decision is on screen."
                         step={2}
                         accentColor="purple"
                     >
@@ -60,8 +62,8 @@ export default function AgentBuildRunDeploy() {
                     </Card>
 
                     <Card
-                        title="Re-run"
-                        subtitle="Run a team of specialized agents in parallel via a shared task board, then re-run the whole thing as a node next time."
+                        title="Iterate the cut"
+                        subtitle="Tweak the prompt, swap a model, re-run a branch — or save the whole agent as a node and reuse it on the next campaign. Your taste, multiplied."
                         step={3}
                         accentColor="emerald"
                     >
@@ -186,9 +188,9 @@ function Card({ title, subtitle, children, step, accentColor }: CardProps) {
                     {/* Text Content */}
                     <div className="mt-auto relative z-10">
                         <h3 className={`text-xl font-bold mb-3 flex items-center gap-2 ${textAccents[accentColor]}`}>
-                            {step === 1 && <Box className="w-5 h-5" />}
-                            {step === 2 && <Bot className="w-5 h-5" />}
-                            {step === 3 && <Globe className="w-5 h-5" />}
+                            {step === 1 && <MessageSquare className="w-5 h-5" />}
+                            {step === 2 && <Palette className="w-5 h-5" />}
+                            {step === 3 && <RefreshCw className="w-5 h-5" />}
                             {title}
                         </h3>
                         <p className="text-slate-400 text-sm leading-relaxed font-medium">
@@ -307,19 +309,19 @@ function RunGraphic() {
             <div className="flex-1 flex flex-col p-3 font-mono text-[10px] text-slate-400 gap-2 bg-[#0B0C10]">
                 <div className="flex items-start gap-2 animate-[fadeIn_0.5s_ease-out_0.5s_both]">
                     <span className="text-green-400 shrink-0">➜</span>
-                    <span>User: Research &quot;Agents&quot;</span>
+                    <span>Brief: &quot;Sneaker launch, 9:16, neon noir&quot;</span>
                 </div>
                 <div className="flex items-start gap-2 text-blue-400 animate-[fadeIn_0.5s_ease-out_1.5s_both]">
-                    <span className="shrink-0">[PLANNER]</span>
-                    <span>Reasoning: I need to search the web for recent papers.</span>
+                    <span className="shrink-0">[DIRECTOR]</span>
+                    <span>Plan: 4 stills, then animate the hero shot.</span>
                 </div>
                 <div className="flex items-start gap-2 text-yellow-400 animate-[fadeIn_0.5s_ease-out_2.5s_both]">
-                    <span className="shrink-0">[TOOL]</span>
-                    <span>Calling: web_search(query=&quot;autonomous agents 2024&quot;)</span>
+                    <span className="shrink-0">[MODEL]</span>
+                    <span>flux_pro(prompt=&quot;rain-soaked alley, chrome accents&quot;)</span>
                 </div>
                 <div className="flex items-start gap-2 text-purple-400 animate-[fadeIn_0.5s_ease-out_3.5s_both]">
-                    <span className="shrink-0">[OUTPUT]</span>
-                    <span>Found 5 relevant papers...</span>
+                    <span className="shrink-0">[RENDER]</span>
+                    <span>4 variants ready · routing best to Seedance…</span>
                 </div>
             </div>
         </div>
@@ -339,7 +341,7 @@ function DeployGraphic() {
 
             {/* Center Core */}
             <div className="relative z-10 w-16 h-16 rounded-full bg-gradient-to-br from-emerald-900 to-slate-900 border border-emerald-500/50 flex items-center justify-center shadow-[0_0_30px_rgba(16,185,129,0.2)]">
-                <Globe className="w-8 h-8 text-emerald-400" />
+                <Film className="w-8 h-8 text-emerald-400" />
                 {/* Ping Effect */}
                 <div className="absolute inset-0 rounded-full border border-emerald-400 animate-ping opacity-20" />
             </div>
@@ -355,7 +357,7 @@ function DeployGraphic() {
             {/* Success Toast */}
             <div className="absolute -bottom-2 bg-emerald-900/80 border border-emerald-500/30 text-emerald-200 text-xs px-3 py-1 rounded-full flex items-center gap-1.5 shadow-lg backdrop-blur-md animate-[bounce_3s_infinite]">
                 <div className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                Agent Swarm Active
+                Saved as reusable node
             </div>
         </div>
     );

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -4,17 +4,13 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 import Tilt3D from "../Tilt3D";
 import {
-  Bot,
   Brain,
-  Code2,
   Eye,
   GitFork,
-  Lock,
-  Puzzle,
-  RefreshCw,
+  Palette,
   Sparkles,
-  Workflow,
-  Zap,
+  Users,
+  Wand2,
 } from "lucide-react";
 
 interface AgentFeaturesSectionProps {
@@ -27,44 +23,44 @@ export default function AgentFeaturesSection({
   const features = [
     {
       icon: Brain,
-      title: "Three Execution Modes",
+      title: "Briefs become storyboards",
       description:
-        "Loop mode for simple tasks, Plan mode for automatic task decomposition with parallel DAG execution, and Multi-Agent mode for team collaboration.",
+        "Drop in a one-line prompt or a full mood board. The agent plans the shots, picks the model for each one, and lays out a board you can rearrange before a single render runs.",
       color: "teal",
     },
     {
       icon: GitFork,
-      title: "Task Planning & Parallel Execution",
+      title: "Batch variants in parallel",
       description:
-        "TaskPlanner decomposes objectives into dependency graphs. ParallelTaskExecutor runs independent tasks concurrently with automatic result passing.",
+        "Need ten alts of the hero frame in five aspect ratios? The agent fans the work out across providers, runs them at the same time, and brings the cuts back ranked for review.",
       color: "blue",
     },
     {
-      icon: RefreshCw,
-      title: "Multi-Agent Teams",
+      icon: Users,
+      title: "A crew, not a single model",
       description:
-        "Coordinator, autonomous, or hybrid strategies. Agents communicate via message bus, share a task board, and specialize with different models and tools.",
+        "Run a director, a stylist, and a colorist as separate agents that hand off via a shared board. Each one gets the model and prompt that fits its job.",
       color: "cyan",
     },
     {
-      icon: Puzzle,
-      title: "50+ Built-in Tools",
+      icon: Wand2,
+      title: "Image, video, music — one room",
       description:
-        "Web search, browser automation, code execution, PDF processing, image generation, math, file operations, HTTP requests, and more.",
+        "Agents can call Flux, Nano Banana, and Ideogram for stills, Seedance, Veo, Kling, and Runway for motion, Suno for score, and ElevenLabs for voice. All on one canvas.",
       color: "emerald",
     },
     {
       icon: Eye,
-      title: "Full Observability",
+      title: "See every decision",
       description:
-        "Real-time streaming of reasoning traces, tool calls, and task progress. OpenTelemetry tracing and structured logging built in.",
+        "Watch the agent reason about composition, swap models when a render misses, and log every prompt it tried. No black boxes when the deadline hits.",
       color: "pink",
     },
     {
       icon: Sparkles,
-      title: "Skill System",
+      title: "Bottle your art direction",
       description:
-        "Auto-discoverable SKILL.md files inject domain expertise into agent prompts. Match skills by keyword or select explicitly.",
+        "Lock down a style guide as a reusable skill — palette, lens, mood, prompt patterns — and every agent on your canvas picks it up automatically.",
       color: "amber",
     },
   ];
@@ -84,9 +80,9 @@ export default function AgentFeaturesSection({
             initial={{ opacity: 0, scale: 0.9 }}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
-            className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-teal-500/10 border border-teal-500/20 shadow-lg shadow-teal-500/10"
+            className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-rose-500/10 border border-rose-500/20 shadow-lg shadow-rose-500/10"
           >
-            <Bot className="w-8 h-8 text-amber-400" />
+            <Palette className="w-8 h-8 text-rose-300" />
           </motion.div>
 
           <motion.h2
@@ -97,9 +93,9 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Agent{" "}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400">
-              Superpowers
+            Built to{" "}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 to-cyan-400">
+              direct, not babysit.
             </span>
           </motion.h2>
 
@@ -110,8 +106,9 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Agents are nodes. Use the same canvas you use for image, video, and text
-            workflows — just with a model that plans and acts.
+            Agents are nodes on the same canvas as your image, video, and audio
+            workflows — except these nodes have taste, a plan, and the ability to
+            self-correct when a render misses.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -2,18 +2,18 @@
 import React from "react";
 import { motion } from "framer-motion";
 import {
-  Globe,
-  Search,
-  Database,
-  Cloud,
-  FileText,
-  MessageCircle,
-  Calendar,
-  Mail,
-  Terminal,
   Braces,
-  Webhook,
+  Camera,
+  Cloud,
+  Film,
   Folder,
+  Image as ImageIcon,
+  Mic,
+  Music,
+  Palette,
+  Search,
+  Terminal,
+  Wand2,
 } from "lucide-react";
 
 interface AgentIntegrationsSectionProps {
@@ -22,64 +22,64 @@ interface AgentIntegrationsSectionProps {
 
 const integrations = [
   {
-    category: "LLM Providers",
+    category: "Image models",
     items: [
-      { name: "OpenAI", icon: "🤖" },
-      { name: "Anthropic", icon: "🧠" },
-      { name: "Gemini", icon: "💎" },
-      { name: "Ollama / Local", icon: "💻" },
+      { name: "Flux", icon: ImageIcon },
+      { name: "Nano Banana", icon: "🍌" },
+      { name: "Ideogram", icon: "🎨" },
+      { name: "gpt-image", icon: "🖼️" },
     ],
-    color: "teal",
+    color: "amber",
   },
   {
-    category: "Search & Web",
+    category: "Video models",
     items: [
-      { name: "Google Search", icon: Search },
-      { name: "Google News", icon: "📰" },
-      { name: "Browser Automation", icon: Globe },
-      { name: "HTTP Requests", icon: "🌐" },
-    ],
-    color: "blue",
-  },
-  {
-    category: "Data & Storage",
-    items: [
-      { name: "SQLite-vec (VectorDB)", icon: Database },
-      { name: "Files & Folders", icon: Folder },
-      { name: "Assets", icon: Cloud },
-      { name: "Downloads", icon: "📥" },
-    ],
-    color: "cyan",
-  },
-  {
-    category: "Documents & Media",
-    items: [
-      { name: "PDF Extract/Convert", icon: FileText },
-      { name: "Markdown", icon: "📝" },
-      { name: "Image Generation", icon: "🎨" },
-      { name: "Text-to-Speech", icon: "🔊" },
-    ],
-    color: "emerald",
-  },
-  {
-    category: "Code & Math",
-    items: [
-      { name: "JS/Python/Bash", icon: Terminal },
-      { name: "Calculator", icon: "🔢" },
-      { name: "Statistics", icon: "📊" },
-      { name: "Geometry", icon: "📐" },
+      { name: "Seedance", icon: Film },
+      { name: "Veo", icon: "🎬" },
+      { name: "Kling", icon: "📽️" },
+      { name: "Runway · Sora", icon: "🎞️" },
     ],
     color: "pink",
   },
   {
-    category: "Team Collaboration",
+    category: "Music & voice",
     items: [
-      { name: "Message Bus", icon: MessageCircle },
-      { name: "Task Board", icon: "📋" },
-      { name: "Email Search", icon: Mail },
-      { name: "Agent Handoff", icon: "🤝" },
+      { name: "Suno", icon: Music },
+      { name: "ElevenLabs", icon: Mic },
+      { name: "Whisper", icon: "🎙️" },
+      { name: "Stem split", icon: "🎚️" },
     ],
-    color: "amber",
+    color: "cyan",
+  },
+  {
+    category: "Retouch & edit",
+    items: [
+      { name: "Inpaint · Outpaint", icon: Wand2 },
+      { name: "Relight", icon: "💡" },
+      { name: "Upscale 4×", icon: Palette },
+      { name: "Color match", icon: Camera },
+    ],
+    color: "emerald",
+  },
+  {
+    category: "Brand & references",
+    items: [
+      { name: "Mood boards", icon: Folder },
+      { name: "Style guides", icon: "🎨" },
+      { name: "Reference images", icon: Cloud },
+      { name: "Web reference search", icon: Search },
+    ],
+    color: "blue",
+  },
+  {
+    category: "The model providers",
+    items: [
+      { name: "OpenAI", icon: "🤖" },
+      { name: "Anthropic", icon: "🧠" },
+      { name: "Gemini", icon: "💎" },
+      { name: "Local · Ollama", icon: "💻" },
+    ],
+    color: "teal",
   },
 ];
 
@@ -106,9 +106,9 @@ export default function AgentIntegrationsSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Connect to{" "}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400">
-              Everything
+            Every tool in the{" "}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 to-cyan-400">
+              creative kit.
             </span>
           </motion.h2>
           <motion.p
@@ -118,8 +118,9 @@ export default function AgentIntegrationsSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Agents can call any provider, browse the web, run code, query a vector
-            store, or hand off to another agent. Wire up what you need on the canvas.
+            The same models the studios use — wired into agents that know when to
+            reach for them. Hand your agent a brief and it picks the right tool for
+            the shot.
           </motion.p>
         </div>
 
@@ -190,11 +191,12 @@ export default function AgentIntegrationsSection({
           className="mt-16 rounded-2xl border border-white/10 bg-gradient-to-r from-teal-900/20 via-slate-900/50 to-blue-900/20 p-8 md:p-12 text-center"
         >
           <h3 className="text-2xl md:text-3xl font-bold text-white mb-4">
-            Need a tool that isn&apos;t here yet?
+            Your favorite model isn&apos;t in the list yet?
           </h3>
           <p className="text-slate-400 mb-6 max-w-2xl mx-auto">
-            NodeTool is open source and extensible. Add your own node, plug in a proprietary
-            model, or drive the canvas from the TypeScript SDK — same code path as the built-ins.
+            NodeTool is open source. Wrap any provider as a node, plug in a private
+            checkpoint, or drive the canvas from the TypeScript SDK — agents pick it up
+            like a first-class tool the moment it lands on the canvas.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
@@ -206,10 +208,10 @@ export default function AgentIntegrationsSection({
             </a>
             <a
               href="https://github.com/nodetool-ai/nodetool"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-500 transition-all"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-rose-600 text-white hover:bg-rose-500 transition-all"
             >
               <Terminal className="w-5 h-5" />
-              Build a custom node
+              Wire up your own model
             </a>
           </div>
         </motion.div>

--- a/marketing/src/components/agents/AgentUseCasesSection.tsx
+++ b/marketing/src/components/agents/AgentUseCasesSection.tsx
@@ -3,15 +3,15 @@ import React from "react";
 import { motion } from "framer-motion";
 import Tilt3D from "../Tilt3D";
 import {
-  Globe,
-  Database,
-  Code2,
-  Newspaper,
-  BookOpen,
-  GraduationCap,
-  Image,
-  Lightbulb,
-  Rocket,
+  Camera,
+  Film,
+  Image as ImageIcon,
+  LayoutGrid,
+  Megaphone,
+  Music,
+  Palette,
+  ScrollText,
+  Sparkles,
   LucideIcon,
 } from "lucide-react";
 
@@ -30,85 +30,85 @@ interface UseCase {
 
 const useCases: UseCase[] = [
   {
-    name: "Web Research Agent",
+    name: "Brand Pack Generator",
     description:
-      "Automate web research with agents that search, scrape, and synthesize information from multiple sources into comprehensive reports.",
-    icon: Globe,
-    iconBgFrom: "from-teal-600/20",
-    iconBgTo: "to-blue-600/20",
-    example: "Research AI trends and create a summary with citations",
+      "One agent, one brief, a full launch kit. Hero stills, social cuts, ad variants, and a music bed — all in your palette, all on brief. Hand it the style guide once and let it carry the look across the deliverables.",
+    icon: Palette,
+    iconBgFrom: "from-rose-600/20",
+    iconBgTo: "to-amber-600/20",
+    example: "Generate the launch pack for the spring drop in our brand palette",
   },
   {
-    name: "RAG Knowledge Base",
+    name: "Video Ad Director",
     description:
-      "Build Retrieval-Augmented Generation workflows that index documents in a SQLite-vec vector store and answer questions with source attribution.",
-    icon: Database,
-    iconBgFrom: "from-blue-600/20",
-    iconBgTo: "to-cyan-600/20",
-    example: "Index documentation and answer technical questions",
+      "An agent that storyboards a 15-second spot, picks Seedance for the hero shot and Kling for B-roll, animates the cuts, and drops a Suno track underneath. Bring your brief — it'll bring the cut.",
+    icon: Film,
+    iconBgFrom: "from-amber-600/20",
+    iconBgTo: "to-rose-600/20",
+    example: "Direct a 9:16 sneaker ad, neon noir, ending on the logo",
   },
   {
-    name: "Multi-Agent Research Team",
+    name: "Music Video Pipeline",
     description:
-      "Deploy a coordinator agent that decomposes research into subtasks, delegates to specialized agents, and synthesizes results via task board and message bus.",
-    icon: Newspaper,
+      "Drop in a track, let the agent pace cuts to the beat, pick scenes that match the lyrics, generate visuals across Flux and Veo, and stitch the final video. You direct, it edits.",
+    icon: Music,
     iconBgFrom: "from-cyan-600/20",
-    iconBgTo: "to-emerald-600/20",
-    example: "Research AI trends using a team of 3 specialized agents",
+    iconBgTo: "to-blue-600/20",
+    example: "Cut a moody music video for this Suno track, 4 scenes",
   },
   {
-    name: "News & Current Events",
+    name: "Batch Retouching Agent",
     description:
-      "Google News and grounded search integration. Get current events with source verification and citations.",
-    icon: BookOpen,
+      "Hand it a folder of raw shots. It color-matches to your reference, upscales, removes the bins in the background, and exports the keepers. Your repeatable retouching, run while you sleep.",
+    icon: Camera,
     iconBgFrom: "from-emerald-600/20",
-    iconBgTo: "to-green-600/20",
-    example: "Summarize today's tech news with sources",
+    iconBgTo: "to-teal-600/20",
+    example: "Retouch this shoot to match the editorial reference",
   },
   {
-    name: "Coding Assistant",
+    name: "Social Calendar Agent",
     description:
-      "AI agents that write, review, and refactor code. Execute JavaScript, Python, or Bash in sandboxed environments and iterate on results.",
-    icon: Code2,
+      "Give it the campaign and the calendar. It plans the posts, generates the visuals, drafts the captions, and queues 30 days of content in your voice across IG, TikTok, and X formats.",
+    icon: Megaphone,
     iconBgFrom: "from-pink-600/20",
     iconBgTo: "to-rose-600/20",
-    example: "Generate a function and run tests",
+    example: "Plan and generate four weeks of launch posts in our voice",
   },
   {
-    name: "Document Processing",
+    name: "Variant Explorer",
     description:
-      "Extract text and tables from PDFs, convert between formats, and chain with LLM analysis for automated document workflows.",
-    icon: GraduationCap,
+      "Ten alts of the hero frame in five aspect ratios, ranked by how on-brief they are. The agent fans out across providers, scores the results, and surfaces only the cuts worth your time.",
+    icon: LayoutGrid,
+    iconBgFrom: "from-indigo-600/20",
+    iconBgTo: "to-cyan-600/20",
+    example: "Give me 10 alts of the hero shot, ranked by brief match",
+  },
+  {
+    name: "Mood Board Researcher",
+    description:
+      "Tell it the vibe — \"Wong Kar-wai meets a Tokyo arcade\" — and it pulls references, distills a palette, drafts a shot list, and seeds prompts the rest of your canvas can run with.",
+    icon: ImageIcon,
+    iconBgFrom: "from-violet-600/20",
+    iconBgTo: "to-pink-600/20",
+    example: "Build a mood board for a perfume launch, dreamy + analog",
+  },
+  {
+    name: "Script-to-Storyboard",
+    description:
+      "Paste a script. The agent breaks it into beats, generates a storyboard frame for each, suggests camera moves, and hands the boards to a video model when you give the green light.",
+    icon: ScrollText,
     iconBgFrom: "from-amber-600/20",
     iconBgTo: "to-orange-600/20",
-    example: "Extract key findings from a research paper PDF",
+    example: "Storyboard this 60-second narration scene by scene",
   },
   {
-    name: "Image Generation",
+    name: "Voiceover & Localization",
     description:
-      "Generate images with gpt-image-2 (OpenAI GPT-Image), FLUX, or Imagen (Google Gemini API). Chain with text generation for creative workflows.",
-    icon: Image,
-    iconBgFrom: "from-indigo-600/20",
-    iconBgTo: "to-teal-600/20",
-    example: "Generate product mockups from descriptions",
-  },
-  {
-    name: "Planning Agent",
-    description:
-      "Automatic task decomposition into dependency DAGs with parallel execution. Separate planning and execution models for cost optimization.",
-    icon: Lightbulb,
-    iconBgFrom: "from-rose-600/20",
-    iconBgTo: "to-pink-600/20",
-    example: "Break down a complex project into executable steps",
-  },
-  {
-    name: "Browser Automation",
-    description:
-      "Agents that navigate the web, take screenshots, fill forms, and extract data. Built-in browser and screenshot tools.",
-    icon: Rocket,
+      "An ElevenLabs agent that drafts read-throughs, clones a presenter for pickups, and dubs the same spot into five languages — lip-sync timing intact, brand voice consistent.",
+    icon: Sparkles,
     iconBgFrom: "from-teal-600/20",
-    iconBgTo: "to-cyan-600/20",
-    example: "Scrape product pricing from competitor websites",
+    iconBgTo: "to-emerald-600/20",
+    example: "Localize this ad into ES, FR, DE, JP, PT — keep my voice",
   },
 ];
 
@@ -136,9 +136,9 @@ export default function AgentUseCasesSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Ready-to-Use{" "}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400">
-              Workflows
+            Agents your studio{" "}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 to-cyan-400">
+              actually ships with.
             </span>
           </motion.h2>
           <motion.p
@@ -148,8 +148,8 @@ export default function AgentUseCasesSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Build these workflows visually in the UI or run them as TypeScript scripts.
-            All examples are available in our{" "}
+            Open one, swap in your style guide, point it at the providers you already pay
+            for, and let it run while you direct. Starter workflows live in the{" "}
             <a
               href="https://github.com/nodetool-ai/nodetool/tree/main/examples"
               target="_blank"
@@ -198,7 +198,7 @@ export default function AgentUseCasesSection({
                   {/* Example */}
                   <div className="mt-auto pt-4 border-t border-white/5">
                     <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">
-                      Example Prompt
+                      Tell the agent
                     </p>
                     <p className="text-sm text-amber-300/80 italic">
                       &quot;{item.example}&quot;
@@ -222,9 +222,9 @@ export default function AgentUseCasesSection({
             href="https://github.com/nodetool-ai/nodetool/tree/main/examples/workflows"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-8 py-4 rounded-full bg-gradient-to-r from-teal-600/80 to-blue-600/80 text-white font-semibold hover:from-teal-500 hover:to-blue-500 transition-all shadow-lg shadow-teal-900/30 hover:shadow-teal-900/50"
+            className="inline-flex items-center gap-2 px-8 py-4 rounded-full bg-gradient-to-r from-rose-500/80 to-amber-500/80 text-white font-semibold hover:from-rose-400 hover:to-amber-400 transition-all shadow-lg shadow-rose-900/30 hover:shadow-rose-900/50"
           >
-            View All Examples on GitHub
+            Browse the starter workflows
             <span className="text-lg">→</span>
           </a>
         </motion.div>

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -5,7 +5,7 @@ import {
     useSpring,
     useTransform,
 } from "framer-motion";
-import { Brain, Search, Terminal, MessageSquare, Database, Command, Globe, Download } from "lucide-react";
+import { Brain, Palette, Film, MessageSquare, Music, Command, Sparkles, Download } from "lucide-react";
 import { SmartDownloadButton } from "../../app/SmartDownloadButton";
 
 // --- Types & Config ---
@@ -24,56 +24,56 @@ interface NodeData {
 }
 
 // Coordinate system for the graph
-// Adjusted for an Agentic flow: User Input -> Planner -> Tools -> Response
+// Creative flow: Brief -> Art Director Agent -> Image + Music models -> Finished spot
 const NODES: NodeData[] = [
     {
-        id: "user_input",
+        id: "brief",
         x: 10, // Far left
         y: 50,
-        title: "User Input",
+        title: "Creative Brief",
         icon: MessageSquare,
         hue: "sky",
-        meta: [{ label: "Type", value: "Chat" }, { label: "Query", value: "Research AI" }]
+        meta: [{ label: "Type", value: "Prompt" }, { label: "Spot", value: "Launch Ad" }]
     },
     {
-        id: "planner",
+        id: "art_director",
         x: 35,
         y: 50,
-        title: "Supervisor Agent",
+        title: "Art Director Agent",
         icon: Brain,
         hue: "teal",
-        inputs: ["user_input"],
-        meta: [{ label: "Model", value: "GPT-5.4" }, { label: "Role", value: "Orchestrator" }]
+        inputs: ["brief"],
+        meta: [{ label: "Mode", value: "Plan" }, { label: "Role", value: "Director" }]
     },
     {
-        id: "web_search",
+        id: "image",
         x: 65,
         y: 25,
-        title: "Web Search",
-        icon: Search,
+        title: "Image Generation",
+        icon: Palette,
         hue: "emerald",
-        inputs: ["planner"],
-        meta: [{ label: "Tool", value: "Google" }]
+        inputs: ["art_director"],
+        meta: [{ label: "Model", value: "Flux Pro" }]
     },
     {
-        id: "database",
+        id: "music",
         x: 65,
         y: 75,
-        title: "Knowledge Base",
-        icon: Database,
+        title: "Soundtrack",
+        icon: Music,
         hue: "amber",
-        inputs: ["planner"],
-        meta: [{ label: "Source", value: "Vector DB" }]
+        inputs: ["art_director"],
+        meta: [{ label: "Model", value: "Suno" }]
     },
     {
-        id: "response",
+        id: "render",
         x: 90,
         y: 50,
-        title: "Final Answer",
-        icon: Terminal,
+        title: "Final Spot",
+        icon: Film,
         hue: "rose",
-        inputs: ["web_search", "database"],
-        meta: [{ label: "Format", value: "Markdown" }]
+        inputs: ["image", "music"],
+        meta: [{ label: "Output", value: "MP4 1080p" }]
     }
 ];
 
@@ -97,40 +97,42 @@ export default function AgentsGraphHero() {
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ duration: 0.5 }}
                     >
-                        <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-teal-500/10 border border-teal-500/20 mb-6">
-                            <Brain className="w-4 h-4 text-amber-400" />
-                            <span className="text-sm font-medium text-amber-300">
-                                Agents on the canvas
+                        <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-rose-500/10 border border-rose-500/20 mb-6">
+                            <Sparkles className="w-4 h-4 text-rose-300" />
+                            <span className="text-sm font-medium text-rose-200">
+                                Agents for creative work
                             </span>
                         </div>
 
                         <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-white mb-8">
-                            Agents are <br />
-                            <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 via-fuchsia-400 to-rose-400">
-                                nodes on your canvas.
+                            An art director <br />
+                            <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 to-cyan-400">
+                                that never sleeps.
                             </span>
                         </h1>
 
                         <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
-                            Drop a planning agent into the canvas. It calls the right models and tools to
-                            finish a multi-step task — research, browse, write, generate — and hands the
-                            result to the next node. Watch the reasoning live.
+                            Drop an agent on the canvas, hand it a brief, and watch it plan the shot,
+                            pick the right model, generate variants, and stitch the cut — across Flux,
+                            Seedance, Veo, Kling, Suno, and ElevenLabs. You direct, it executes.
                         </p>
 
                         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-                            <a href="https://docs.nodetool.ai" className="px-8 py-4 rounded-xl font-semibold text-white bg-gradient-to-r from-teal-600 to-indigo-600 hover:from-teal-500 hover:to-indigo-500 transition-all shadow-lg shadow-teal-900/40 flex items-center gap-2">
-                                Get Started
-                            </a>
                             <SmartDownloadButton
                                 icon={<Download className="w-5 h-5" />}
-                                classNameOverride="px-8 py-4 rounded-xl font-semibold text-white bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500 transition-all shadow-lg shadow-emerald-900/40 flex items-center gap-2"
+                                classNameOverride="px-8 py-4 rounded-xl font-semibold text-white bg-gradient-to-r from-rose-500 to-amber-500 hover:from-rose-400 hover:to-amber-400 transition-all shadow-lg shadow-rose-900/40 flex items-center gap-2"
                             />
+                            <a href="/creatives" className="px-8 py-4 rounded-xl font-semibold text-white bg-white/5 border border-white/15 hover:bg-white/10 transition-all flex items-center gap-2">
+                                See the full studio
+                            </a>
                         </div>
 
                         <div className="mt-8 flex items-center justify-center gap-6 text-sm text-slate-500 font-medium">
                             <span className="flex items-center gap-2"><Command className="w-4 h-4" /> Open Source</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
-                            <span>Full Observability</span>
+                            <span>BYOK — pay providers direct</span>
+                            <span className="w-1 h-1 rounded-full bg-slate-700" />
+                            <span>Watch every step</span>
                         </div>
                     </motion.div>
                 </div>
@@ -235,7 +237,7 @@ function GraphVisualization() {
                 </div>
 
                 <div className="absolute bottom-6 right-8 text-xs font-mono text-slate-500 uppercase tracking-widest">
-                    Agent Reasoning • Step 3/5
+                    Directing the shot • Step 3/5
                 </div>
 
             </motion.div>


### PR DESCRIPTION
Recasts the agents marketing page from a generic "planning agent"
pitch to a creative-pro story: an art director that picks the right
image/video/music/voice model for the brief and lets you direct the
work instead of babysitting prompts.

- Hero: "An art director that never sleeps", swap research graph
  (User Input -> Supervisor -> Web Search/KB -> Answer) for a creative
  pipeline (Brief -> Art Director Agent -> Image + Soundtrack -> Spot)
- Build/Run/Deploy: Brief -> Direct -> Iterate, agent-trace example
  now reads a sneaker-ad shoot
- Features: lead with storyboards, batch variants, crew handoffs,
  one-canvas image/video/music, decision visibility, reusable art
  direction (skills)
- Use cases: brand pack generator, video ad director, music video
  pipeline, batch retouching, social calendar, variant explorer,
  mood board researcher, script-to-storyboard, voiceover &
  localization
- Integrations: regroup around image / video / music & voice /
  retouch / brand references / model providers - Flux, Seedance, Veo,
  Suno, ElevenLabs front and center
- Cross-links to /creatives so the two pages stay sibling pitches