### PR TITLE
marketing: strengthen narrative across hero and SEO copy

### DIFF
--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -30,7 +30,7 @@ export default function ComparisonSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            What NodeTool is
+            Where NodeTool fits in your stack
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
@@ -39,7 +39,8 @@ export default function ComparisonSection({
             transition={{ duration: 0.5, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
-            Where we sit next to the tools you&apos;re already using.
+            You&apos;re probably using two or three of these already. Here&apos;s
+            what changes when they live on one canvas.
           </motion.p>
         </header>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -40,9 +40,10 @@ export default function NodeToolHero() {
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-400 md:text-lg">
-            Every major model from every major provider, called with your own
-            keys, wired into one node-based canvas. Pay providers directly at
-            provider prices. Swap models the day they launch.
+            One canvas. Every major model from every major provider, called
+            with your own keys. Pay providers what they charge — no credits, no
+            markup, no curated roster. When the next model ships, swap one node
+            and you&apos;re on it the same day.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -57,10 +57,11 @@ export default function OwnershipSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Creative tools shouldn&apos;t lock you into someone else&apos;s
-            pricing, model roster, or roadmap. NodeTool calls whatever models
-            you choose, charges you what the providers charge, and outlives
-            whoever built it.
+            Every closed AI tool ends the same way: a price hike, a worse
+            roster, or an acquisition that quietly rewrites the roadmap.
+            NodeTool calls whatever models you choose, charges you what the
+            providers charge, and ships under a license that outlives whoever
+            built it.
           </motion.p>
         </div>
 

--- a/marketing/src/components/SeoHeroContent.tsx
+++ b/marketing/src/components/SeoHeroContent.tsx
@@ -15,10 +15,12 @@ export default function SeoHeroContent() {
         </h1>
         <p className="text-lg text-slate-300 mb-8 leading-relaxed">
           NodeTool is the open-source creative AI workspace — every major model
-          from every major provider, called with your own keys, wired into one
-          node-based canvas you run on your machine. Bring your own keys to FAL,
-          KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Pay providers
-          directly at provider prices. Swap models the day they launch.
+          from every major provider, wired into one node-based canvas you run
+          on your own machine. Bring your own keys to FAL, KIE, OpenAI,
+          Anthropic, Gemini, Replicate, and the rest. Pay providers what they
+          charge — no credits, no markup, no curated roster. When the next
+          state-of-the-art model ships, you swap one node and you&apos;re on it
+          the same day.
         </p>
       </section>
 
@@ -28,12 +30,13 @@ export default function SeoHeroContent() {
           What Problem Does NodeTool Solve?
         </h2>
         <p className="text-slate-300 leading-relaxed">
-          Creative pros working with AI are stuck choosing between ComfyUI&apos;s
-          engineer-first UX, closed SaaS canvases that lock you into a credit
-          system and a curated model roster, or a dozen browser tabs across
-          Midjourney, Runway, and Photoshop. NodeTool is the open alternative:
-          one canvas, every provider, your keys, no credit markup, no vendor
-          lock-in.
+          A new state-of-the-art model ships every other week. Reaching it
+          today means juggling Midjourney, Runway, ElevenLabs, and Photoshop
+          across a dozen tabs — or paying a closed SaaS canvas to mark up its
+          curated, lagging roster — or wrestling ComfyUI&apos;s
+          engineer-first UX. NodeTool is the open alternative: one canvas,
+          every provider, your keys, provider prices. The roster updates the
+          same day the model does.
         </p>
       </section>
 
@@ -57,11 +60,12 @@ export default function SeoHeroContent() {
           What Vendor Neutrality Actually Buys You
         </h2>
         <p className="text-slate-300 leading-relaxed">
-          Seedance is the best video model right now. It&apos;s available on
-          FAL, Replicate, and KIE at different price points. NodeTool lets you
-          pick the cheapest. When Veo 4 ships, you swap one node and you&apos;re
-          on it the same day. The best model for the job changes every month —
-          your tool shouldn&apos;t slow that down.
+          Seedance is the best video model right now. It runs on FAL, Replicate,
+          and KIE at three different prices — NodeTool lets you pick the
+          cheapest, no contract, no markup. When Veo 4 ships next month, the
+          same canvas runs it the day the endpoint goes live. The best model
+          for the job changes every few weeks. Your tool shouldn&apos;t be the
+          thing that slows that down.
         </p>
       </section>
 

--- a/marketing/src/components/agents/AgentsHero.tsx
+++ b/marketing/src/components/agents/AgentsHero.tsx
@@ -48,9 +48,11 @@ export default function AgentsHero() {
             </h1>
 
             <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
-              Agents are nodes you wire into the same canvas as your image, video, and
-              text models. Give one an objective and it&apos;ll call the right models and
-              tools to finish the job — then hand the result to the next node.
+              Agents are nodes. Wire one into the same canvas as your image,
+              video, and text models, hand it an objective, and it picks the
+              tools, calls the models, and ships the result to the next node.
+              Reasoning lives on the canvas — not in a chat window you can&apos;t
+              re-run.
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/marketing/src/components/business/BusinessHero.tsx
+++ b/marketing/src/components/business/BusinessHero.tsx
@@ -27,8 +27,10 @@ export default function BusinessHero() {
         </h1>
 
         <p className="text-xl md:text-2xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-          For small studios, post-production shops, and agency teams: every major model,
-          your own keys, your workflows. No credit markup, no vendor lock-in, no acquisition risk.
+          For small studios, post houses, and agency teams who can&apos;t afford
+          to rebuild their pipeline every time a vendor gets acquired or
+          hikes credit prices. Every major model, your keys, your workflows —
+          on disks you own.
         </p>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -42,9 +42,10 @@ export default function DevelopersHero() {
           transition={{ duration: 0.5, delay: 0.2 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
-          NodeTool is a TypeScript-first workspace built on an async Node.js runtime. Add custom
-          nodes, drive the canvas from a CLI or SDK, and build the integrations your team needs —
-          all on the same open-source codebase.
+          TypeScript-first, async Node.js under the hood, the same open-source
+          codebase that ships Studio and Cloud. Write a custom node, drive the
+          canvas from a CLI, generate workflows in code — and put the result in
+          front of your team without rewriting it for a different runtime.
         </motion.p>
 
         {/* Feature Pills */}


### PR DESCRIPTION
Tighten landing-page prose so each section opens with a stakes-driven
beat instead of a feature list. Replace list-y subtitles with sentences
that name the cost of the status quo (vendor lock-in, credit markup,
acquisition risk) and the same-day-on-new-models payoff. Touches the
homepage hero, SEO content, comparison/ownership leads, and the
developers, agents, and business hero subtitles. No layout or
positioning changes.

https://claude.ai/code/session_01DjqSMngaXSMaJKxbfi1o3H