### PR TITLE
fix(sketch): preserve cancel intent for direct-gen layers and fix tests

### DIFF
--- a/web/src/hooks/sketch/__tests__/useGenerateLayer.test.ts
+++ b/web/src/hooks/sketch/__tests__/useGenerateLayer.test.ts
@@ -108,7 +108,8 @@ describe("useGenerateLayer", () => {
       })
     };
     getWorkflowRunnerStoreMock.mockReturnValue({
-      getState: () => runnerState
+      getState: () => runnerState,
+      setState: jest.fn()
     });
 
     const onComplete = jest.fn();
@@ -164,7 +165,8 @@ describe("useGenerateLayer", () => {
       })
     };
     getWorkflowRunnerStoreMock.mockReturnValue({
-      getState: () => runnerState
+      getState: () => runnerState,
+      setState: jest.fn()
     });
 
     const onComplete = jest.fn();
@@ -239,7 +241,8 @@ describe("useGenerateLayer", () => {
       })
     };
     getWorkflowRunnerStoreMock.mockReturnValue({
-      getState: () => runnerState
+      getState: () => runnerState,
+      setState: jest.fn()
     });
 
     const onFailed = jest.fn();

--- a/web/src/hooks/sketch/useDirectGenJob.ts
+++ b/web/src/hooks/sketch/useDirectGenJob.ts
@@ -48,6 +48,19 @@ export interface UseDirectGenJobApi {
   cancel: (layerId: string) => void;
 }
 
+// Module-level so cancel() can tear down an in-flight subscription started by
+// start() in a different render. Without this the RPC handler keeps running
+// after cancel and overwrites the user-set "draft" status with "generated".
+const inFlight = new Map<string, () => void>();
+
+const clearInFlight = (layerId: string): void => {
+  const teardown = inFlight.get(layerId);
+  if (teardown) {
+    teardown();
+    inFlight.delete(layerId);
+  }
+};
+
 export function useDirectGenJob(): UseDirectGenJobApi {
   const start = useCallback(async (layerId: string) => {
     const bindings = useSketchSessionStore.getState();
@@ -109,6 +122,11 @@ export function useDirectGenJob(): UseDirectGenJobApi {
       }
     }
 
+    // Tear down any stale subscription left behind by a previous run on this
+    // layer (e.g. cancelled but the RPC still in flight) so its handler can't
+    // settle on top of this one.
+    clearInFlight(layerId);
+
     const requestId = randomId();
     bindings.patchBinding(layerId, { status: "generating" });
 
@@ -118,6 +136,7 @@ export function useDirectGenJob(): UseDirectGenJobApi {
         unsubscribe();
         unsubscribe = undefined;
       }
+      inFlight.delete(layerId);
     };
 
     const settle = async (msg: DirectGenRpcResponse) => {
@@ -179,6 +198,7 @@ export function useDirectGenJob(): UseDirectGenJobApi {
       if (msg.type !== "rpc_response") return;
       void settle(msg as DirectGenRpcResponse);
     });
+    inFlight.set(layerId, cleanup);
 
     try {
       await globalWebSocketManager.send({
@@ -206,6 +226,7 @@ export function useDirectGenJob(): UseDirectGenJobApi {
   }, []);
 
   const cancel = useCallback((layerId: string) => {
+    clearInFlight(layerId);
     useSketchSessionStore
       .getState()
       .patchBinding(layerId, { status: "draft" });


### PR DESCRIPTION
useDirectGenJob's cancel() only patched the binding status to "draft" — the
in-flight WebSocket subscription stayed active. When the RPC eventually
returned, settle() ran and overwrote the cancel with "generated"/"failed",
also breaking re-runs against the same layer. Move the per-layer teardown
into a module-level map so cancel() can dispose the subscription (and a
fresh start() can clear any stale one from a prior cancel).

Also fix useGenerateLayer tests: the WorkflowRunner store mock missed
setState, which production handleJobMessage calls to clear runner state on
terminal job_update statuses, leaving 3 cross-contaminated test failures.

https://claude.ai/code/session_01MKUshCoYN7mAixb8wZReiy