### PR TITLE
[T-20260513-0040] PR 12: Blur bespoke body + unified Blur backend node

### DIFF
--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -1667,6 +1667,95 @@ export class RotateAndFlipNode extends TransformImageNode {
   }
 }
 
+export class BlurNode extends TransformImageNode {
+  static readonly nodeType = "nodetool.image.Blur";
+  static readonly title = "Blur";
+  static readonly description =
+    "Blur an image — Box, Gaussian, or horizontal Motion variants.\n    image, blur, gaussian, box, motion, filter";
+  static readonly metadataOutputTypes = {
+    output: "image"
+  };
+  static readonly inlineFields = [];
+  static readonly inputFields = ["image"];
+
+  @prop({
+    type: "image",
+    default: {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
+    title: "Image",
+    description: "The image to blur."
+  })
+  declare image: any;
+
+  @prop({
+    type: "str",
+    default: "gaussian",
+    title: "Type",
+    description: "Blur algorithm: gaussian (smooth), box (boxcar), motion (horizontal streak).",
+    values: ["gaussian", "box", "motion"]
+  })
+  declare blur_type: any;
+
+  @prop({
+    type: "int",
+    default: 5,
+    title: "Size",
+    description: "Blur amount (0 = none, 100 = max).",
+    min: 0,
+    max: 100
+  })
+  declare size: any;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    const image = (this.image ?? {}) as ImageRefLike;
+    const size = Math.max(0, Math.min(100, Math.round(Number(this.size ?? 0))));
+    const blurType = String(this.blur_type ?? "gaussian");
+
+    if (size <= 0) {
+      const bytes = await imageBytesAsync(image, context);
+      return {
+        output: imageRef(bytes, {
+          uri: image.uri ?? "",
+          width: image.width ?? undefined,
+          height: image.height ?? undefined
+        })
+      };
+    }
+
+    // Sharp convolve kernels must be odd-sized.
+    const odd = (n: number): number => (n % 2 === 0 ? n + 1 : n);
+
+    const output = (await transformImage(
+      image,
+      (instance) => {
+        if (blurType === "gaussian") {
+          // sigma maps size 1..100 → 0.3..50.
+          const sigma = Math.max(0.3, size * 0.5);
+          return instance.blur(sigma);
+        }
+        if (blurType === "motion") {
+          const k = odd(Math.max(1, size));
+          const kernel = new Array(k).fill(1 / k);
+          return instance.convolve({ width: k, height: 1, kernel });
+        }
+        // box
+        const k = odd(Math.max(1, Math.min(31, size)));
+        const kernel = new Array(k * k).fill(1 / (k * k));
+        return instance.convolve({ width: k, height: k, kernel });
+      },
+      context
+    )) as Record<string, unknown>;
+    return { output };
+  }
+}
+
 export const IMAGE_NODES = [
   LoadImageFileNode,
   LoadImageFolderNode,
@@ -1684,6 +1773,7 @@ export const IMAGE_NODES = [
   RotateNode,
   FlipNode,
   RotateAndFlipNode,
+  BlurNode,
   TextToImageNode,
   ImageToImageNode,
   ImageEditorNode

--- a/web/src/components/node_types/editing/BlurBody.tsx
+++ b/web/src/components/node_types/editing/BlurBody.tsx
@@ -1,0 +1,308 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * BlurBody — bespoke body for `nodetool.image.Blur` (plan §9.E4, PR 12).
+ *
+ * Image preview at top with a CSS-filter approximation of the current blur
+ * for instant visual feedback; server reconciles on commit. Bottom: type
+ * dropdown (Gaussian / Box / Motion) and a 0–100 size slider.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import type { SelectChangeEvent } from "@mui/material/Select";
+import ImageIcon from "@mui/icons-material/Image";
+import { shallow } from "zustand/shallow";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  NodeSlider
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+
+const BLUR_NODE_TYPE = "nodetool.image.Blur";
+
+type BlurType = "gaussian" | "box" | "motion";
+
+const BLUR_TYPES: ReadonlyArray<{ value: BlurType; label: string }> = [
+  { value: "gaussian", label: "Gaussian" },
+  { value: "box", label: "Box" },
+  { value: "motion", label: "Motion" }
+];
+
+const SIZE_MARKS = [
+  { value: 0, label: "0" },
+  { value: 25 },
+  { value: 50, label: "50" },
+  { value: 75 },
+  { value: 100, label: "100" }
+];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.blur-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& > .handle-column": {
+        top: 0,
+        bottom: 0,
+        left: `calc(${theme.spacing(-0.5)})`
+      },
+      ".blur-wrap": {
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transition: "filter 60ms linear",
+        willChange: "filter"
+      },
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto",
+      paddingTop: theme.spacing(0.25)
+    },
+    ".type-row": {
+      paddingLeft: theme.spacing(0.5),
+      paddingRight: theme.spacing(0.5)
+    },
+    ".type-select": {
+      flex: "1 1 auto",
+      fontSize: theme.fontSizeSmaller,
+      ".MuiSelect-select": {
+        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+      }
+    },
+    ".size-row": {
+      paddingLeft: theme.spacing(0.5),
+      paddingRight: theme.spacing(0.5)
+    },
+    ".size-readout": {
+      flex: "0 0 auto",
+      minWidth: 32,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textAlign: "right"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const extractImageRef = (
+  value: unknown
+): { uri?: string; data?: unknown } => {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
+    data: v.data
+  };
+};
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const v = extractImageRef(value);
+  if (v.uri) {
+    return <ImageView source={v.uri} />;
+  }
+  if (v.data instanceof Uint8Array) {
+    return <ImageView source={v.data} />;
+  }
+  if (Array.isArray(v.data)) {
+    return <ImageView source={new Uint8Array(v.data as number[])} />;
+  }
+  return (
+    <CheckerDropzone
+      message="Connect an image, then run"
+      icon={<ImageIcon />}
+    />
+  );
+};
+
+export interface BlurBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const BlurBodyInner: React.FC<BlurBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const size = Math.max(0, Math.min(100, Number(props.size ?? 0)));
+  const rawType = String(props.blur_type ?? "gaussian");
+  const blurType: BlurType = (BLUR_TYPES.find((t) => t.value === rawType)
+    ?.value ?? "gaussian") as BlurType;
+
+  // Live preview filter — CSS `blur(Npx)` is a Gaussian; we use it as a
+  // visual approximation for all three modes and let the server output
+  // reconcile the exact algorithm once a run lands.
+  const filter = useMemo(() => {
+    if (!size) return "none";
+    const px = Math.max(0, size * 0.5);
+    return `blur(${px}px)`;
+  }, [size]);
+
+  const result = useResultsStore(
+    (state) => state.getResult(workflowId, id),
+    shallow
+  );
+  const previewValue = useMemo(() => {
+    if (result && typeof result === "object" && !Array.isArray(result)) {
+      const r = result as Record<string, unknown>;
+      if ("output" in r) {
+        return r.output;
+      }
+    }
+    return result;
+  }, [result]);
+
+  const { setProperty, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const handleTypeChange = useCallback(
+    (event: SelectChangeEvent<BlurType>) => {
+      setProperty("blur_type", event.target.value);
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  const handleSizeChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = Array.isArray(v) ? v[0] : v;
+      setProperty("size", Math.round(next));
+    },
+    [setProperty]
+  );
+
+  const handleSizeCommitted = useCallback(
+    () => setPropertyComplete(),
+    [setPropertyComplete]
+  );
+
+  return (
+    <div css={cssStyles} className="blur-body" data-bespoke-body="Blur">
+      <div className="preview-area">
+        <div className="blur-wrap" style={{ filter }}>
+          <ImagePreview value={previewValue} />
+        </div>
+        <HandleColumn id={id} properties={imageProperty} />
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow className="type-row" align="center" gap={0.5}>
+          <Select
+            className="type-select"
+            size="small"
+            variant="standard"
+            value={blurType}
+            onChange={handleTypeChange}
+            aria-label="Blur type"
+            disableUnderline
+          >
+            {BLUR_TYPES.map((t) => (
+              <MenuItem key={t.value} value={t.value} dense>
+                {t.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FlexRow>
+        <FlexRow className="size-row" align="center" gap={0.5}>
+          <NodeSlider
+            min={0}
+            max={100}
+            step={1}
+            marks={SIZE_MARKS}
+            value={size}
+            onChange={handleSizeChange}
+            onChangeCommitted={handleSizeCommitted}
+            aria-label="Blur size"
+          />
+          <span className="size-readout">{Math.round(size)}</span>
+        </FlexRow>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs
+            id={id}
+            outputs={nodeMetadata.outputs}
+            isStreamingOutput={nodeMetadata.is_streaming_output}
+          />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const BlurBody = memo(BlurBodyInner);
+BlurBody.displayName = "BlurBody";
+
+export { BLUR_NODE_TYPE };
+export default BlurBody;

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -3,6 +3,7 @@ import {
   getBespokeBody,
   isBespokeNode
 } from "./bespokeRegistry";
+import BlurBody from "./BlurBody";
 import CropBody from "./CropBody";
 import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
@@ -19,8 +20,15 @@ describe("bespokeRegistry", () => {
 
   it("does not match utility / generic nodes", () => {
     expect(isBespokeNode(meta("nodetool.control.If"))).toBe(false);
-    expect(isBespokeNode(meta("nodetool.image.Blur"))).toBe(false);
-    expect(getBespokeBody(meta("nodetool.image.Blur"))).toBeUndefined();
+    expect(isBespokeNode(meta("nodetool.image.Channels"))).toBe(false);
+    expect(getBespokeBody(meta("nodetool.image.Channels"))).toBeUndefined();
+  });
+
+  it("maps nodetool.image.Blur → BlurBody", () => {
+    const m = meta("nodetool.image.Blur");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(BlurBody);
+    expect(BESPOKE_BODY_REGISTRY["nodetool.image.Blur"]).toBe(BlurBody);
   });
 
   it("maps nodetool.image.Crop → CropBody", () => {

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -13,6 +13,7 @@
 import type React from "react";
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
+import BlurBody, { BLUR_NODE_TYPE } from "./BlurBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
 import ResizeBody, { RESIZE_NODE_TYPE } from "./ResizeBody";
 import RotateAndFlipBody, {
@@ -34,6 +35,7 @@ export type BespokeBodyComponent = React.ComponentType<BespokeBodyProps>;
 export const BESPOKE_BODY_REGISTRY: Readonly<
   Record<string, BespokeBodyComponent>
 > = {
+  [BLUR_NODE_TYPE]: BlurBody,
   [CROP_NODE_TYPE]: CropBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
   [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody


### PR DESCRIPTION
Plan §9.E4 (Node Editor Redesign — P-2026-05-13-node-editor-redesign).

Twelfth PR in the redesign series. Adds the next Track-E bespoke editing body. Backend gains a unified `nodetool.image.Blur` node exposing `blur_type` (gaussian / box / motion) and a 0–100 `size` slider, mirroring the unified pattern that RotateAndFlip (PR 10) established. Existing `lib.image.filter.Blur` stays for backward compatibility.

## Summary

**Backend** — `packages/base-nodes/src/nodes/image.ts`:
- New `BlurNode` (`nodetool.image.Blur`)
  - `blur_type ∈ {gaussian, box, motion}` (default `gaussian`)
  - `size ∈ [0, 100]` (default `5`)
  - `gaussian` → `sharp.blur(sigma = size * 0.5)`
  - `box` → square convolve kernel, odd size capped at 31 (avoids quadratic blowup at size=100)
  - `motion` → 1×N convolve kernel (horizontal streak)
  - `size = 0` short-circuits to identity pass-through
- Added to `IMAGE_NODES`.

**Frontend** — `web/src/components/node_types/editing/`:
- New `BlurBody.tsx`
  - Image preview from `ResultsStore` with `filter: blur(${size/2}px)` for instant visual feedback (coarse approximation across all three modes; the server reconciles via instant-update)
  - MUI `Select` for type, `NodeSlider` 0–100 with marks at 25/50/75 for size
  - `HandleColumn` renders the `image` input on the left edge
  - Wired through `useBespokePropertyWriter`
- `bespokeRegistry.ts` — register `nodetool.image.Blur → BlurBody`
- `bespokeRegistry.test.ts` — new mapping spec; swap sentinel from `Blur` to `Channels`

## Acceptance criteria
- [x] BlurBody.tsx renders image preview reflecting current blur (CSS approximation)
- [x] Type dropdown offers Box, Gaussian, Motion
- [x] Size slider 0–100 updates the blur amount
- [x] Backend coverage confirmed: Box, Gaussian, Motion all available via new `nodetool.image.Blur`
- [x] Registered in `bespokeRegistry.ts`

## Test plan
- [x] `npm --prefix packages/base-nodes run lint` — clean
- [x] `npm --prefix packages/base-nodes test -- regression-image` — 35/35 pass
- [x] `npx jest bespokeRegistry.test.ts` — 6/6 pass (incl. new Blur spec)
- [x] `npx tsc --noEmit` (web) — only the pre-existing `paintToolPanels.tsx` `StrokeAssistPreset` error remains
- [ ] Manual: drop a `nodetool.image.Blur` onto a graph, connect an image, sweep size + change type, verify run reconciles

🤖 Generated with [Claude Code](https://claude.com/claude-code)