### PR TITLE
[T-20260513-0042] PR 14: Masks Extractor bespoke body

### DIFF
--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -72,7 +72,13 @@ jest.mock("../../ui_primitives", () => ({
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
           ? React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
-              onClick: () => onChange(null, (child as React.ReactElement<Record<string, unknown>>).props.value)
+              onClick: () =>
+                onChange(
+                  null,
+                  String(
+                    (child as React.ReactElement<Record<string, unknown>>).props.value
+                  )
+                )
             })
           : child
       )}

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -186,6 +186,8 @@ describe("MasksExtractorBody", () => {
     mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
       if (typeof selector === "function") {
         const state = {
+          getOutputResult: () => undefined,
+          getPreview: () => undefined,
           getResult: (_wf: string, nodeId: string) => {
             if (nodeId === "upstream-node") {
               return { output: { uri: "upstream.jpg" } };
@@ -208,6 +210,8 @@ describe("MasksExtractorBody", () => {
     mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
       if (typeof selector === "function") {
         const state = {
+          getOutputResult: () => undefined,
+          getPreview: () => undefined,
           getResult: (_wf: string, nodeId: string) => {
             if (nodeId === "node-1") {
               return { output: { uri: "mask.png" } };

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -1,0 +1,233 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MasksExtractorBody } from "./MasksExtractorBody";
+
+jest.mock("../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: jest.fn()
+}));
+
+jest.mock("../../../hooks/nodes/useRunSingleNode", () => ({
+  useRunSingleNode: jest.fn()
+}));
+
+jest.mock("../../node/HandleColumn", () => ({
+  __esModule: true,
+  default: () => <div data-testid="handle-column" />
+}));
+
+jest.mock("../../node/ImageView", () => ({
+  __esModule: true,
+  default: ({ source }: { source?: string | Uint8Array }) => (
+    <img data-testid="image-view" data-source={source} alt="preview" />
+  )
+}));
+
+jest.mock("../../node/NodeOutputs", () => ({
+  NodeOutputs: () => <div data-testid="node-outputs" />
+}));
+
+jest.mock("../../node/NodeProgress", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-progress" />
+}));
+
+jest.mock("../../ui_primitives", () => ({
+  CheckerDropzone: ({ message }: { message: string }) => (
+    <div data-testid="checker-dropzone">{message}</div>
+  ),
+  FlexColumn: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  FlexRow: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  RunModelButton: ({
+    label,
+    isRunning,
+    onClick
+  }: {
+    label: string;
+    isRunning: boolean;
+    onClick: () => void;
+  }) => (
+    <button data-testid="run-model-button" disabled={isRunning} onClick={onClick}>
+      {label}
+    </button>
+  ),
+  ToggleGroup: ({
+    children,
+    value,
+    onChange
+  }: {
+    children: React.ReactNode;
+    value: string;
+    onChange: (_: unknown, next: string) => void;
+  }) => (
+    <div data-testid="toggle-group" data-value={value}>
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child as React.ReactElement, {
+              onClick: () => onChange(null, (child as React.ReactElement).props.value)
+            })
+          : child
+      )}
+    </div>
+  ),
+  ToggleOption: ({
+    children,
+    value,
+    ...props
+  }: {
+    children: React.ReactNode;
+    value: string;
+    [key: string]: unknown;
+  }) => (
+    <button data-testid={`toggle-option-${value}`} {...props}>
+      {children}
+    </button>
+  )
+}));
+
+jest.mock("@mui/material/styles", () => ({
+  useTheme: () => ({
+    spacing: (n: number) => `${n * 8}px`,
+    vars: { palette: { grey: { 900: "#000" }, divider: "#ccc", common: { white: "#fff" }, text: { secondary: "#999", primary: "#fff" }, action: { hover: "#333" } } },
+    fontSizeSmaller: "0.75rem",
+    fontFamily2: "sans-serif"
+  })
+}));
+
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNodes } from "../../../contexts/NodeContext";
+import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+
+const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
+const mockUseNodes = useNodes as unknown as jest.Mock;
+const mockUseRunSingleNode = useRunSingleNode as unknown as jest.Mock;
+
+describe("MasksExtractorBody", () => {
+  const defaultProps = {
+    id: "node-1",
+    nodeType: "replicate.image.background.Bria_RemoveBackground",
+    nodeMetadata: {
+      node_type: "replicate.image.background.Bria_RemoveBackground",
+      properties: [{ name: "image", type: "image" }],
+      outputs: []
+    },
+    data: { properties: {} },
+    workflowId: "wf-1",
+    status: "idle",
+    isOutputNode: false
+  };
+
+  const mockRunSingleNode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseNodes.mockReturnValue(undefined);
+    mockUseResultsStore.mockReturnValue(undefined);
+    mockUseRunSingleNode.mockReturnValue({
+      runSingleNode: mockRunSingleNode,
+      isWorkflowRunning: false
+    });
+  });
+
+  it("renders the Image tab by default", () => {
+    render(
+      <MasksExtractorBody
+        {...defaultProps}
+        data={{ properties: { image: { uri: "test.jpg" } } }}
+      />
+    );
+    expect(screen.getByTestId("image-view")).toBeInTheDocument();
+  });
+
+  it("switches to Mask tab on toggle click", () => {
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const maskToggle = screen.getByTestId("toggle-option-mask");
+    fireEvent.click(maskToggle);
+
+    expect(screen.queryByTestId("image-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("checker-dropzone")).toHaveTextContent(
+      "Run the node to extract a mask"
+    );
+  });
+
+  it("shows upstream image in Image tab when edge is connected", () => {
+    mockUseNodes.mockReturnValue({
+      id: "edge-1",
+      source: "upstream-node",
+      target: "node-1",
+      sourceHandle: "output",
+      targetHandle: "image"
+    });
+
+    mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
+      if (typeof selector === "function") {
+        const state = {
+          getResult: (_wf: string, nodeId: string) => {
+            if (nodeId === "upstream-node") {
+              return { output: { uri: "upstream.jpg" } };
+            }
+            return undefined;
+          }
+        };
+        return selector(state);
+      }
+      return undefined;
+    });
+
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const img = screen.getByTestId("image-view");
+    expect(img).toHaveAttribute("data-source", "upstream.jpg");
+  });
+
+  it("shows own result in Mask tab", () => {
+    mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
+      if (typeof selector === "function") {
+        const state = {
+          getResult: (_wf: string, nodeId: string) => {
+            if (nodeId === "node-1") {
+              return { output: { uri: "mask.png" } };
+            }
+            return undefined;
+          }
+        };
+        return selector(state);
+      }
+      return undefined;
+    });
+
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const maskToggle = screen.getByTestId("toggle-option-mask");
+    fireEvent.click(maskToggle);
+
+    const img = screen.getByTestId("image-view");
+    expect(img).toHaveAttribute("data-source", "mask.png");
+  });
+
+  it("disables run button and shows progress when running", () => {
+    render(<MasksExtractorBody {...defaultProps} status="running" />);
+
+    expect(screen.getByTestId("run-model-button")).toBeDisabled();
+    expect(screen.getByTestId("node-progress")).toBeInTheDocument();
+  });
+
+  it("calls runSingleNode when Recalculate button is clicked", () => {
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const button = screen.getByTestId("run-model-button");
+    fireEvent.click(button);
+
+    expect(mockRunSingleNode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -71,8 +71,8 @@ jest.mock("../../ui_primitives", () => ({
     <div data-testid="toggle-group" data-value={value}>
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
-          ? React.cloneElement(child as React.ReactElement, {
-              onClick: () => onChange(null, (child as React.ReactElement).props.value)
+          ? React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+              onClick: () => onChange(null, (child as React.ReactElement<Record<string, unknown>>).props.value)
             })
           : child
       )}
@@ -119,11 +119,16 @@ describe("MasksExtractorBody", () => {
       properties: [{ name: "image", type: "image" }],
       outputs: []
     },
-    data: { properties: {} },
+    data: {
+      properties: {},
+      selectable: undefined,
+      dynamic_properties: {},
+      workflow_id: "wf-1"
+    },
     workflowId: "wf-1",
     status: "idle",
     isOutputNode: false
-  };
+  } as unknown as React.ComponentProps<typeof MasksExtractorBody>;
 
   const mockRunSingleNode = jest.fn();
 
@@ -142,7 +147,10 @@ describe("MasksExtractorBody", () => {
     render(
       <MasksExtractorBody
         {...defaultProps}
-        data={{ properties: { image: { uri: "test.jpg" } } }}
+        data={{
+          ...defaultProps.data,
+          properties: { image: { uri: "test.jpg" } }
+        }}
       />
     );
     expect(screen.getByTestId("image-view")).toBeInTheDocument();

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -1,0 +1,301 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * MasksExtractorBody — bespoke body for mask-extractor model nodes
+ * (plan §9.E6, PR 14).
+ *
+ * Top: tabbed preview — `Image` shows the source image fed into the node's
+ * `image` input, `Mask` shows the node's own output (the extracted mask /
+ * background-removed foreground).
+ *
+ * Bottom: `Recalculate` action button (RunModelButton) — triggers a
+ * single-node run via `useRunSingleNode`.
+ *
+ * Registered for the established mask-extractor providers (Bria /
+ * BackgroundRemover variants). Additional providers can be added to the
+ * registry as their bespoke targets are confirmed.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ImageIcon from "@mui/icons-material/Image";
+import { shallow } from "zustand/shallow";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  RunModelButton
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNodes } from "../../../contexts/NodeContext";
+import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+
+// Node types currently bound to this bespoke body. Mask-extractor / bg-removal
+// providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
+// additional providers are confirmed in §9.E11.
+const MASKS_EXTRACTOR_NODE_TYPES: ReadonlyArray<string> = [
+  "replicate.image.background.Bria_RemoveBackground",
+  "replicate.image.background.BackgroundRemover_851",
+  "replicate.image.background.BackgroundRemover_Codeplug",
+  "replicate.image.process.RemoveBackground"
+];
+
+type PreviewTab = "image" | "mask";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.masks-extractor-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& > .handle-column": {
+        top: 0,
+        bottom: 0,
+        left: `calc(${theme.spacing(-0.5)})`
+      },
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto",
+      paddingTop: theme.spacing(0.25)
+    },
+    ".tab-toggle": {
+      width: "100%",
+      ".MuiToggleButton-root": {
+        flex: "1 1 auto",
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+        fontSize: theme.fontSizeSmaller,
+        fontFamily: theme.fontFamily2,
+        textTransform: "none",
+        minWidth: 0
+      }
+    },
+    ".action-row": {
+      paddingTop: theme.spacing(0.25),
+      display: "flex",
+      justifyContent: "flex-end"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+interface ImageRefLike {
+  uri?: string;
+  data?: unknown;
+}
+
+const asImageRef = (value: unknown): ImageRefLike | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
+    data: v.data
+  };
+};
+
+const unwrapOutput = (value: unknown, handle?: string | null): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const v = value as Record<string, unknown>;
+  if (handle && handle in v) return v[handle];
+  if ("output" in v) return v.output;
+  return value;
+};
+
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
+  value,
+  placeholder
+}) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
+};
+
+export interface MasksExtractorBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
+  id,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const [tab, setTab] = useState<PreviewTab>("image");
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  // Resolve upstream image (cached result of whatever feeds our `image`
+  // input), so the Image tab can show what the node will receive on next run.
+  const upstreamEdge = useNodes(
+    (state) =>
+      state.edges.find(
+        (e) => e.target === id && (e.targetHandle ?? "") === "image"
+      ),
+    shallow
+  );
+
+  const upstreamResult = useResultsStore(
+    (state) =>
+      upstreamEdge
+        ? state.getResult(workflowId, upstreamEdge.source)
+        : undefined,
+    shallow
+  );
+
+  const myResult = useResultsStore(
+    (state) => state.getResult(workflowId, id),
+    shallow
+  );
+
+  const imageTabValue = useMemo(() => {
+    if (upstreamEdge) {
+      const v = unwrapOutput(upstreamResult, upstreamEdge.sourceHandle);
+      const ref = asImageRef(v);
+      if (ref && (ref.uri || ref.data)) return ref;
+    }
+    const constRef = asImageRef(data.properties?.image);
+    if (constRef && (constRef.uri || constRef.data)) return constRef;
+    return undefined;
+  }, [upstreamEdge, upstreamResult, data.properties?.image]);
+
+  const maskTabValue = useMemo(() => unwrapOutput(myResult), [myResult]);
+
+  const { runSingleNode, isWorkflowRunning } = useRunSingleNode(id);
+
+  const handleTabChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (next !== "image" && next !== "mask") return;
+      setTab(next);
+    },
+    []
+  );
+
+  const isRunning = status === "running" || isWorkflowRunning;
+
+  return (
+    <div
+      css={cssStyles}
+      className="masks-extractor-body"
+      data-bespoke-body="MasksExtractor"
+    >
+      <div className="preview-area">
+        {tab === "image" ? (
+          <ImagePreview
+            value={imageTabValue}
+            placeholder="Connect an image"
+          />
+        ) : (
+          <ImagePreview
+            value={maskTabValue}
+            placeholder="Run the node to extract a mask"
+          />
+        )}
+        <HandleColumn id={id} properties={imageProperty} />
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow align="center" gap={0.25}>
+          <ToggleButtonGroup
+            className="tab-toggle"
+            size="small"
+            value={tab}
+            exclusive
+            onChange={handleTabChange}
+            aria-label="Preview tab"
+          >
+            <ToggleButton value="image" aria-label="Image">
+              Image
+            </ToggleButton>
+            <ToggleButton value="mask" aria-label="Mask">
+              Mask
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </FlexRow>
+        <div className="action-row">
+          <RunModelButton
+            label="Recalculate Mask"
+            isRunning={isRunning}
+            onClick={runSingleNode}
+          />
+        </div>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs
+            id={id}
+            outputs={nodeMetadata.outputs}
+            isStreamingOutput={nodeMetadata.is_streaming_output}
+          />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const MasksExtractorBody = memo(MasksExtractorBodyInner);
+MasksExtractorBody.displayName = "MasksExtractorBody";
+
+export { MASKS_EXTRACTOR_NODE_TYPES };
+export default MasksExtractorBody;

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -19,8 +19,6 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import ImageIcon from "@mui/icons-material/Image";
 import { shallow } from "zustand/shallow";
 
@@ -28,7 +26,9 @@ import {
   CheckerDropzone,
   FlexColumn,
   FlexRow,
-  RunModelButton
+  RunModelButton,
+  ToggleGroup,
+  ToggleOption
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageView from "../../node/ImageView";
@@ -40,16 +40,17 @@ import type { NodeData } from "../../../stores/NodeData";
 import useResultsStore from "../../../stores/ResultsStore";
 import { useNodes } from "../../../contexts/NodeContext";
 import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+import { asImageRef, unwrapOutput } from "../../../utils/imageRef";
 
 // Node types currently bound to this bespoke body. Mask-extractor / bg-removal
 // providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
 // additional providers are confirmed in §9.E11.
-const MASKS_EXTRACTOR_NODE_TYPES: ReadonlyArray<string> = [
+const MASKS_EXTRACTOR_NODE_TYPES = [
   "replicate.image.background.Bria_RemoveBackground",
   "replicate.image.background.BackgroundRemover_851",
   "replicate.image.background.BackgroundRemover_Codeplug",
   "replicate.image.process.RemoveBackground"
-];
+] as const;
 
 type PreviewTab = "image" | "mask";
 
@@ -112,29 +113,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface ImageRefLike {
-  uri?: string;
-  data?: unknown;
-}
-
-const asImageRef = (value: unknown): ImageRefLike | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  const v = value as Record<string, unknown>;
-  return {
-    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
-    data: v.data
-  };
-};
-
-const unwrapOutput = (value: unknown, handle?: string | null): unknown => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-  const v = value as Record<string, unknown>;
-  if (handle && handle in v) return v[handle];
-  if ("output" in v) return v.output;
-  return value;
-};
-
-const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = memo(({
   value,
   placeholder
 }) => {
@@ -152,7 +131,8 @@ const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
     return <ImageView source={new Uint8Array(ref!.data as number[])} />;
   }
   return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
-};
+});
+ImagePreview.displayName = "ImagePreview";
 
 export interface MasksExtractorBodyProps {
   id: string;
@@ -254,7 +234,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
 
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.25}>
-          <ToggleButtonGroup
+          <ToggleGroup
             className="tab-toggle"
             size="small"
             value={tab}
@@ -262,13 +242,13 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
             onChange={handleTabChange}
             aria-label="Preview tab"
           >
-            <ToggleButton value="image" aria-label="Image">
+            <ToggleOption value="image" aria-label="Image">
               Image
-            </ToggleButton>
-            <ToggleButton value="mask" aria-label="Mask">
+            </ToggleOption>
+            <ToggleOption value="mask" aria-label="Mask">
               Mask
-            </ToggleButton>
-          </ToggleButtonGroup>
+            </ToggleOption>
+          </ToggleGroup>
         </FlexRow>
         <div className="action-row">
           <RunModelButton
@@ -289,7 +269,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
         </div>
       )}
 
-      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+      {isRunning && <NodeProgress id={id} workflowId={workflowId} />}
     </div>
   );
 };

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -20,7 +20,6 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
-import { shallow } from "zustand/shallow";
 
 import {
   CheckerDropzone,
@@ -37,10 +36,12 @@ import NodeProgress from "../../node/NodeProgress";
 
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
-import useResultsStore from "../../../stores/ResultsStore";
-import { useNodes } from "../../../contexts/NodeContext";
 import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
-import { asImageRef, unwrapOutput } from "../../../utils/imageRef";
+import {
+  useNodeOutput,
+  useUpstreamValue
+} from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
 
 // Node types currently bound to this bespoke body. Mask-extractor / bg-removal
 // providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
@@ -66,6 +67,11 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(0.5),
       minHeight: 0
     },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
@@ -76,11 +82,6 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      "& > .handle-column": {
-        top: 0,
-        bottom: 0,
-        left: `calc(${theme.spacing(-0.5)})`
-      },
       "& img": {
         display: "block",
         maxWidth: "100%",
@@ -163,41 +164,19 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
     [properties]
   );
 
-  // Resolve upstream image (cached result of whatever feeds our `image`
-  // input), so the Image tab can show what the node will receive on next run.
-  const upstreamEdge = useNodes(
-    (state) =>
-      state.edges.find(
-        (e) => e.target === id && (e.targetHandle ?? "") === "image"
-      ),
-    shallow
+  // Image tab shows the cached upstream input (what the node will receive
+  // on the next run). Mask tab shows the server's most recent output.
+  const inputValue = useUpstreamValue(
+    workflowId,
+    id,
+    "image",
+    data.properties?.image
   );
-
-  const upstreamResult = useResultsStore(
-    (state) =>
-      upstreamEdge
-        ? state.getResult(workflowId, upstreamEdge.source)
-        : undefined,
-    shallow
-  );
-
-  const myResult = useResultsStore(
-    (state) => state.getResult(workflowId, id),
-    shallow
-  );
-
   const imageTabValue = useMemo(() => {
-    if (upstreamEdge) {
-      const v = unwrapOutput(upstreamResult, upstreamEdge.sourceHandle);
-      const ref = asImageRef(v);
-      if (ref && (ref.uri || ref.data)) return ref;
-    }
-    const constRef = asImageRef(data.properties?.image);
-    if (constRef && (constRef.uri || constRef.data)) return constRef;
-    return undefined;
-  }, [upstreamEdge, upstreamResult, data.properties?.image]);
-
-  const maskTabValue = useMemo(() => unwrapOutput(myResult), [myResult]);
+    const ref = asImageRef(inputValue);
+    return ref && (ref.uri || ref.data) ? ref : undefined;
+  }, [inputValue]);
+  const maskTabValue = useNodeOutput(workflowId, id);
 
   const { runSingleNode, isWorkflowRunning } = useRunSingleNode(id);
 
@@ -217,6 +196,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
       className="masks-extractor-body"
       data-bespoke-body="MasksExtractor"
     >
+      <HandleColumn id={id} properties={imageProperty} />
       <div className="preview-area">
         {tab === "image" ? (
           <ImagePreview
@@ -229,7 +209,6 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
             placeholder="Run the node to extract a mask"
           />
         )}
-        <HandleColumn id={id} properties={imageProperty} />
       </div>
 
       <FlexColumn className="controls" gap={0.5}>

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -6,6 +6,7 @@ import {
 import BlurBody from "./BlurBody";
 import ChannelsBody from "./ChannelsBody";
 import CropBody from "./CropBody";
+import MasksExtractorBody from "./MasksExtractorBody";
 import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
 import type { NodeMetadata } from "../../../stores/ApiTypes";
@@ -37,6 +38,21 @@ describe("bespokeRegistry", () => {
     expect(isBespokeNode(m)).toBe(true);
     expect(getBespokeBody(m)).toBe(ChannelsBody);
     expect(BESPOKE_BODY_REGISTRY["nodetool.image.Channels"]).toBe(ChannelsBody);
+  });
+
+  it("maps mask-extractor node types → MasksExtractorBody", () => {
+    const types = [
+      "replicate.image.background.Bria_RemoveBackground",
+      "replicate.image.background.BackgroundRemover_851",
+      "replicate.image.background.BackgroundRemover_Codeplug",
+      "replicate.image.process.RemoveBackground"
+    ];
+    for (const t of types) {
+      const m = meta(t);
+      expect(isBespokeNode(m)).toBe(true);
+      expect(getBespokeBody(m)).toBe(MasksExtractorBody);
+      expect(BESPOKE_BODY_REGISTRY[t]).toBe(MasksExtractorBody);
+    }
   });
 
   it("maps nodetool.image.Crop → CropBody", () => {

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -16,6 +16,9 @@ import type { NodeData } from "../../../stores/NodeData";
 import BlurBody, { BLUR_NODE_TYPE } from "./BlurBody";
 import ChannelsBody, { CHANNELS_NODE_TYPE } from "./ChannelsBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
+import MasksExtractorBody, {
+  MASKS_EXTRACTOR_NODE_TYPES
+} from "./MasksExtractorBody";
 import ResizeBody, { RESIZE_NODE_TYPE } from "./ResizeBody";
 import RotateAndFlipBody, {
   ROTATE_AND_FLIP_NODE_TYPE
@@ -40,7 +43,10 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [CHANNELS_NODE_TYPE]: ChannelsBody,
   [CROP_NODE_TYPE]: CropBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
-  [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody
+  [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
+  ...Object.fromEntries(
+    MASKS_EXTRACTOR_NODE_TYPES.map((t) => [t, MasksExtractorBody] as const)
+  )
 };
 
 export const isBespokeNode = (

--- a/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRunSingleNode } from "../useRunSingleNode";
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodeStoreRef: jest.fn()
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWebsocketRunner: jest.fn()
+}));
+
+jest.mock("../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: jest.fn()
+}));
+
+jest.mock("../../../utils/edgeValue", () => ({
+  resolveExternalEdgeValue: jest.fn()
+}));
+
+import { useNodeStoreRef } from "../../../contexts/NodeContext";
+import { useWebsocketRunner } from "../../../stores/WorkflowRunner";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+import { resolveExternalEdgeValue } from "../../../utils/edgeValue";
+
+const mockUseNodeStoreRef = useNodeStoreRef as jest.Mock;
+const mockUseWebsocketRunner = useWebsocketRunner as jest.Mock;
+const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
+const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
+const mockResolveExternalEdgeValue = resolveExternalEdgeValue as jest.Mock;
+
+describe("useRunSingleNode", () => {
+  const mockRun = jest.fn();
+  const mockFindNode = jest.fn();
+  const mockGetResult = jest.fn();
+  const mockAddNotification = jest.fn();
+
+  const nodeId = "node-1";
+  const workflowId = "workflow-1";
+
+  const defaultNode = {
+    id: nodeId,
+    type: "nodetool.image.Crop",
+    data: {
+      properties: { left: 0 },
+      dynamic_properties: { image: "const-image" }
+    }
+  };
+
+  const defaultWorkflow = { id: workflowId, name: "Test Workflow" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockUseWebsocketRunner.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { run: mockRun, state: "idle" };
+        return selector(state);
+      }
+    );
+
+    mockUseResultsStore.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { getResult: mockGetResult };
+        return selector(state);
+      }
+    );
+
+    mockUseNotificationStore.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { addNotification: mockAddNotification };
+        return selector(state);
+      }
+    );
+
+    mockFindNode.mockImplementation((id: string) =>
+      id === nodeId ? defaultNode : undefined
+    );
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: undefined,
+      hasValue: false,
+      isFallback: false
+    });
+  });
+
+  it("returns early when workflow is already running", () => {
+    mockUseWebsocketRunner.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { run: mockRun, state: "running" };
+        return selector(state);
+      }
+    );
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("returns early when node is not found", () => {
+    mockFindNode.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("applies edge overrides to dynamic_properties when key exists there", () => {
+    const edge = {
+      id: "e1",
+      source: "upstream",
+      target: nodeId,
+      sourceHandle: "output",
+      targetHandle: "image"
+    };
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [edge],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: "upstream-image",
+      hasValue: true,
+      isFallback: false
+    });
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const nodesPassedToRun = mockRun.mock.calls[0][2];
+    const passedNode = nodesPassedToRun.find(
+      (n: { id: string }) => n.id === nodeId
+    );
+    expect(passedNode.data.dynamic_properties.image).toBe("upstream-image");
+  });
+
+  it("applies edge overrides to properties when key does not exist in dynamic_properties", () => {
+    const edge = {
+      id: "e1",
+      source: "upstream",
+      target: nodeId,
+      sourceHandle: "output",
+      targetHandle: "left"
+    };
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [edge],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: 42,
+      hasValue: true,
+      isFallback: false
+    });
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const nodesPassedToRun = mockRun.mock.calls[0][2];
+    const passedNode = nodesPassedToRun.find(
+      (n: { id: string }) => n.id === nodeId
+    );
+    expect(passedNode.data.properties.left).toBe(42);
+  });
+
+  it("passes subgraphNodeIds as a Set containing only the target node id", () => {
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const subgraphNodeIds = mockRun.mock.calls[0][5];
+    expect(subgraphNodeIds).toBeInstanceOf(Set);
+    expect(subgraphNodeIds.has(nodeId)).toBe(true);
+    expect(subgraphNodeIds.size).toBe(1);
+  });
+
+  it("shows notification after triggering run", () => {
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        alert: false
+      })
+    );
+  });
+});

--- a/web/src/hooks/nodes/useRunSingleNode.ts
+++ b/web/src/hooks/nodes/useRunSingleNode.ts
@@ -1,0 +1,108 @@
+import { useCallback } from "react";
+import { Edge, Node } from "@xyflow/react";
+
+import { NodeData } from "../../stores/NodeData";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import useResultsStore from "../../stores/ResultsStore";
+import { useWebsocketRunner } from "../../stores/WorkflowRunner";
+import { resolveExternalEdgeValue } from "../../utils/edgeValue";
+import { useNodeStoreRef } from "../../contexts/NodeContext";
+
+interface UseRunSingleNodeReturn {
+  runSingleNode: () => void;
+  isWorkflowRunning: boolean;
+}
+
+/**
+ * Run a single node by id. Inbound edges from non-selected upstream nodes
+ * are resolved to their last cached result (same strategy as
+ * `useRunSelectedNodes`), so the node executes with realistic inputs even
+ * when only this one node is "in the subgraph".
+ *
+ * Used by bespoke editing bodies (e.g. MasksExtractorBody) that expose a
+ * "Recalculate" action without requiring the user to select the node first.
+ */
+export function useRunSingleNode(nodeId: string): UseRunSingleNodeReturn {
+  const nodeStore = useNodeStoreRef();
+
+  const run = useWebsocketRunner((state) => state.run);
+  const isWorkflowRunning = useWebsocketRunner(
+    (state) => state.state === "running"
+  );
+  const getResult = useResultsStore((state) => state.getResult);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const runSingleNode = useCallback(() => {
+    if (isWorkflowRunning) {
+      return;
+    }
+
+    const { edges, workflow, findNode } = nodeStore.getState();
+    const node = findNode(nodeId);
+    if (!node) {
+      return;
+    }
+
+    const inboundEdges = edges.filter((e: Edge) => e.target === nodeId);
+
+    const overrides: Record<string, unknown> = {};
+    for (const edge of inboundEdges) {
+      if (!edge.targetHandle) {
+        continue;
+      }
+      const { value, hasValue } = resolveExternalEdgeValue(
+        edge,
+        workflow.id,
+        getResult,
+        findNode
+      );
+      if (hasValue) {
+        overrides[edge.targetHandle] = value;
+      }
+    }
+
+    const dynamicProps = node.data?.dynamic_properties || {};
+    const staticProps = node.data?.properties || {};
+    const updatedDynamicProps = { ...dynamicProps };
+    const updatedStaticProps = { ...staticProps };
+
+    for (const [key, value] of Object.entries(overrides)) {
+      if (Object.prototype.hasOwnProperty.call(dynamicProps, key)) {
+        updatedDynamicProps[key] = value;
+      } else {
+        updatedStaticProps[key] = value;
+      }
+    }
+
+    const nodeWithOverrides: Node<NodeData> = {
+      ...node,
+      data: {
+        ...node.data,
+        properties: updatedStaticProps,
+        dynamic_properties: updatedDynamicProps
+      }
+    };
+
+    run(
+      {},
+      workflow,
+      [nodeWithOverrides],
+      [],
+      undefined,
+      new Set([nodeId])
+    );
+
+    addNotification({
+      type: "info",
+      alert: false,
+      content: "Running node"
+    });
+  }, [nodeId, isWorkflowRunning, nodeStore, getResult, run, addNotification]);
+
+  return {
+    runSingleNode,
+    isWorkflowRunning
+  };
+}

--- a/web/src/hooks/nodes/useRunSingleNode.ts
+++ b/web/src/hooks/nodes/useRunSingleNode.ts
@@ -36,6 +36,7 @@ export function useRunSingleNode(nodeId: string): UseRunSingleNodeReturn {
 
   const runSingleNode = useCallback(() => {
     if (isWorkflowRunning) {
+      console.info("useRunSingleNode: workflow already running, skipping");
       return;
     }
 

--- a/web/src/utils/imageRef.ts
+++ b/web/src/utils/imageRef.ts
@@ -1,0 +1,28 @@
+export interface ImageRefLike {
+  uri?: string;
+  width?: number;
+  height?: number;
+  data?: unknown;
+}
+
+export const asImageRef = (value: unknown): ImageRefLike | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? v.uri : undefined,
+    width: typeof v.width === "number" ? v.width : undefined,
+    height: typeof v.height === "number" ? v.height : undefined,
+    data: v.data
+  };
+};
+
+export const unwrapOutput = (
+  value: unknown,
+  handle?: string | null
+): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const v = value as Record<string, unknown>;
+  if (handle && handle in v) return v[handle];
+  if ("output" in v) return v.output;
+  return value;
+};


### PR DESCRIPTION
## Summary
- Adds **MasksExtractorBody** bespoke body — top-of-card tabbed preview (`Image` | `Mask`), bottom **Recalculate Mask** `RunModelButton`.
- Adds **useRunSingleNode(id)** — single-node analogue of `useRunSelectedNodes`. Replaces external inbound-edge values with upstream nodes' cached results and submits a one-node subgraph via the websocket runner.
- Registers the body for confirmed mask-extractor / background-removal providers per §9.E11 verification: `replicate.image.background.Bria_RemoveBackground`, `replicate.image.background.BackgroundRemover_851`, `replicate.image.background.BackgroundRemover_Codeplug`, `replicate.image.process.RemoveBackground`.

Part of plan **P-2026-05-13-node-editor-redesign**, Track E (§9.E6), PR 14/17.

## Test plan
- [x] `npx jest src/components/node_types/editing/bespokeRegistry.test.ts` — 6/6 pass (includes a new spec asserting every mask-extractor type maps to MasksExtractorBody)
- [x] `tsc --noEmit` for the web project — no new errors (one pre-existing unrelated error in `paintToolPanels.tsx`)
- [ ] Manual: drop a Bria_RemoveBackground node, connect an image, toggle Image/Mask tabs, hit Recalculate Mask. Verify the node runs in isolation and the Mask tab shows the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)