### PR TITLE
[T-20260513-0043] PR 15: Levels bespoke body + Levels backend node

### DIFF
--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -1723,6 +1723,225 @@ export class BlurNode extends TransformImageNode {
   }
 }
 
+export class LevelsNode extends TransformImageNode {
+  static readonly nodeType = "nodetool.image.Levels";
+  static readonly title = "Levels";
+  static readonly description =
+    "Adjust input black point, gamma, and white point per RGB channel.\n    image, levels, color, tone, curves";
+  static readonly metadataOutputTypes = {
+    output: "image"
+  };
+  static readonly inlineFields = [];
+  static readonly inputFields = ["image"];
+
+  @prop({
+    type: "image",
+    default: {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
+    title: "Image",
+    description: "The image to adjust."
+  })
+  declare image: any;
+
+  @prop({
+    type: "int",
+    default: 0,
+    title: "Red Black",
+    description: "Red channel input black point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare r_black: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Red Gamma",
+    description: "Red channel gamma (0.01–10).",
+    min: 0.01,
+    max: 10
+  })
+  declare r_gamma: any;
+
+  @prop({
+    type: "int",
+    default: 255,
+    title: "Red White",
+    description: "Red channel input white point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare r_white: any;
+
+  @prop({
+    type: "int",
+    default: 0,
+    title: "Green Black",
+    description: "Green channel input black point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare g_black: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Green Gamma",
+    description: "Green channel gamma (0.01–10).",
+    min: 0.01,
+    max: 10
+  })
+  declare g_gamma: any;
+
+  @prop({
+    type: "int",
+    default: 255,
+    title: "Green White",
+    description: "Green channel input white point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare g_white: any;
+
+  @prop({
+    type: "int",
+    default: 0,
+    title: "Blue Black",
+    description: "Blue channel input black point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare b_black: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Blue Gamma",
+    description: "Blue channel gamma (0.01–10).",
+    min: 0.01,
+    max: 10
+  })
+  declare b_gamma: any;
+
+  @prop({
+    type: "int",
+    default: 255,
+    title: "Blue White",
+    description: "Blue channel input white point (0–255).",
+    min: 0,
+    max: 255
+  })
+  declare b_white: any;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    const image = (this.image ?? {}) as ImageRefLike;
+    const bytes = await imageBytesAsync(image, context);
+    if (bytes.length === 0) {
+      return {
+        output: imageRef(bytes, {
+          uri: image.uri ?? "",
+          width: image.width ?? undefined,
+          height: image.height ?? undefined
+        })
+      };
+    }
+
+    const clamp255 = (n: number): number =>
+      Math.max(0, Math.min(255, Math.round(n)));
+    const clampGamma = (n: number): number =>
+      Math.max(0.01, Math.min(10, n));
+
+    const rBlack = clamp255(Number(this.r_black ?? 0));
+    const rWhite = clamp255(Number(this.r_white ?? 255));
+    const rGamma = clampGamma(Number(this.r_gamma ?? 1));
+    const gBlack = clamp255(Number(this.g_black ?? 0));
+    const gWhite = clamp255(Number(this.g_white ?? 255));
+    const gGamma = clampGamma(Number(this.g_gamma ?? 1));
+    const bBlack = clamp255(Number(this.b_black ?? 0));
+    const bWhite = clamp255(Number(this.b_white ?? 255));
+    const bGamma = clampGamma(Number(this.b_gamma ?? 1));
+
+    const identity =
+      rBlack === 0 && rWhite === 255 && rGamma === 1 &&
+      gBlack === 0 && gWhite === 255 && gGamma === 1 &&
+      bBlack === 0 && bWhite === 255 && bGamma === 1;
+    if (identity) {
+      return {
+        output: imageRef(bytes, {
+          uri: image.uri ?? "",
+          ...this.transformMeta()
+        })
+      };
+    }
+
+    const buildLut = (black: number, gamma: number, white: number) => {
+      const lut = new Uint8Array(256);
+      const denom = Math.max(1, white - black);
+      const invGamma = 1 / gamma;
+      for (let i = 0; i < 256; i++) {
+        const t = Math.max(0, Math.min(1, (i - black) / denom));
+        lut[i] = clamp255(Math.pow(t, invGamma) * 255);
+      }
+      return lut;
+    };
+
+    const lutR = buildLut(rBlack, rGamma, rWhite);
+    const lutG = buildLut(gBlack, gGamma, gWhite);
+    const lutB = buildLut(bBlack, bGamma, bWhite);
+
+    try {
+      const { data: raw, info } = await sharp(bytes, { failOn: "none" })
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+
+      const channels = info.channels;
+      const out = Buffer.allocUnsafe(raw.length);
+      for (let i = 0; i < raw.length; i += channels) {
+        out[i] = lutR[raw[i]];
+        out[i + 1] = lutG[raw[i + 1]];
+        out[i + 2] = lutB[raw[i + 2]];
+        if (channels >= 4) {
+          out[i + 3] = raw[i + 3];
+        }
+      }
+
+      const outputBytes = await sharp(out, {
+        raw: {
+          width: info.width,
+          height: info.height,
+          channels: info.channels
+        }
+      })
+        .png()
+        .toBuffer();
+      const meta = await metadataFor(outputBytes);
+      return {
+        output: imageRef(outputBytes, {
+          uri: image.uri ?? "",
+          mimeType: inferImageMime(image.uri, outputBytes),
+          width: meta.width,
+          height: meta.height
+        })
+      };
+    } catch {
+      return {
+        output: imageRef(bytes, {
+          uri: image.uri ?? "",
+          ...this.transformMeta()
+        })
+      };
+    }
+  }
+}
+
 export const IMAGE_NODES = [
   LoadImageFileNode,
   LoadImageFolderNode,
@@ -1740,6 +1959,7 @@ export const IMAGE_NODES = [
   RotateAndFlipNode,
   ChannelsNode,
   BlurNode,
+  LevelsNode,
   TextToImageNode,
   ImageToImageNode,
   ImageEditorNode

--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -1898,6 +1898,7 @@ export class LevelsNode extends TransformImageNode {
 
     try {
       const { data: raw, info } = await sharp(bytes, { failOn: "none" })
+        .toColorspace("srgb")
         .ensureAlpha()
         .raw()
         .toBuffer({ resolveWithObject: true });
@@ -1931,7 +1932,8 @@ export class LevelsNode extends TransformImageNode {
           height: meta.height
         })
       };
-    } catch {
+    } catch (err) {
+      console.error("LevelsNode processing failed:", err);
       return {
         output: imageRef(bytes, {
           uri: image.uri ?? "",

--- a/packages/base-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/base-nodes/tests/regression-image-nodes.test.ts
@@ -648,15 +648,16 @@ describe("LevelsNode — processing", () => {
 
     const outBuf = Buffer.from(output.data as string, "base64");
     const { data: outRaw } = await sharp(outBuf).raw().toBuffer({ resolveWithObject: true });
-    // Gamma 2 on 128 should darken it: (128/255)^2 * 255 ≈ 64
-    expect(outRaw[0]).toBeLessThan(100);
+    // Gamma 2 with invGamma = 1/2 brightens midtones: (128/255)^0.5 * 255 ≈ 181
+    expect(outRaw[0]).toBeGreaterThan(150);
   });
 
   it("handles grayscale input without crashing", async () => {
-    // Create a grayscale PNG (1 channel)
+    // Create a grayscale PNG by converting an RGB image to greyscale.
     const grayBuf = await sharp({
-      create: { width: 4, height: 4, channels: 1, background: { r: 128, g: 128, b: 128 } }
+      create: { width: 4, height: 4, channels: 3, background: { r: 128, g: 128, b: 128 } }
     })
+      .greyscale()
       .png()
       .toBuffer();
     const imgRef = imageRefFromBuffer(grayBuf);

--- a/packages/base-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/base-nodes/tests/regression-image-nodes.test.ts
@@ -26,6 +26,7 @@ import {
   BatchToListNode,
   ChannelsNode
 } from "../src/index.js";
+import { LevelsNode } from "../src/nodes/image.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -556,5 +557,121 @@ describe("ChannelsNode — channel extraction", () => {
     expect(output).toBeDefined();
     const { info } = await decodeChannel(output);
     expect(info.channels).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. LevelsNode — LUT math, identity short-circuit, and channel handling
+// ---------------------------------------------------------------------------
+
+describe("LevelsNode — processing", () => {
+  it("returns original image when all params are at identity", async () => {
+    const png = await makePngBuffer(4, 4, 128, 64, 32);
+    const imgRef = imageRefFromBuffer(png);
+
+    const node = new LevelsNode();
+    node.assign({ image: imgRef });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+
+    expect(typeof output.data).toBe("string");
+    expect((output.data as string).length).toBeGreaterThan(0);
+
+    // Decode and verify pixels are unchanged
+    const inBuf = Buffer.from(imgRef.data as string, "base64");
+    const outBuf = Buffer.from(output.data as string, "base64");
+    const { data: inRaw } = await sharp(inBuf).raw().toBuffer({ resolveWithObject: true });
+    const { data: outRaw } = await sharp(outBuf).raw().toBuffer({ resolveWithObject: true });
+    expect(inRaw.length).toBe(outRaw.length);
+    for (let i = 0; i < inRaw.length; i++) {
+      expect(outRaw[i]).toBe(inRaw[i]);
+    }
+  });
+
+  it("adjusts black/white points and changes pixels", async () => {
+    const png = await makePngBuffer(4, 4, 128, 64, 32);
+    const imgRef = imageRefFromBuffer(png);
+
+    const node = new LevelsNode();
+    node.assign({
+      image: imgRef,
+      r_black: 64,
+      r_white: 192,
+      r_gamma: 1,
+      g_black: 0,
+      g_white: 255,
+      g_gamma: 1,
+      b_black: 0,
+      b_white: 255,
+      b_gamma: 1
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+
+    expect(typeof output.data).toBe("string");
+    expect((output.data as string).length).toBeGreaterThan(0);
+
+    // Output should differ from input
+    const inBuf = Buffer.from(imgRef.data as string, "base64");
+    const outBuf = Buffer.from(output.data as string, "base64");
+    const { data: inRaw } = await sharp(inBuf).raw().toBuffer({ resolveWithObject: true });
+    const { data: outRaw } = await sharp(outBuf).raw().toBuffer({ resolveWithObject: true });
+    let differs = false;
+    for (let i = 0; i < inRaw.length; i++) {
+      if (inRaw[i] !== outRaw[i]) {
+        differs = true;
+        break;
+      }
+    }
+    expect(differs).toBe(true);
+  });
+
+  it("applies gamma correctly", async () => {
+    const png = await makePngBuffer(4, 4, 128, 128, 128);
+    const imgRef = imageRefFromBuffer(png);
+
+    const node = new LevelsNode();
+    node.assign({
+      image: imgRef,
+      r_black: 0,
+      r_white: 255,
+      r_gamma: 2,
+      g_black: 0,
+      g_white: 255,
+      g_gamma: 1,
+      b_black: 0,
+      b_white: 255,
+      b_gamma: 1
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+
+    const outBuf = Buffer.from(output.data as string, "base64");
+    const { data: outRaw } = await sharp(outBuf).raw().toBuffer({ resolveWithObject: true });
+    // Gamma 2 on 128 should darken it: (128/255)^2 * 255 ≈ 64
+    expect(outRaw[0]).toBeLessThan(100);
+  });
+
+  it("handles grayscale input without crashing", async () => {
+    // Create a grayscale PNG (1 channel)
+    const grayBuf = await sharp({
+      create: { width: 4, height: 4, channels: 1, background: { r: 128, g: 128, b: 128 } }
+    })
+      .png()
+      .toBuffer();
+    const imgRef = imageRefFromBuffer(grayBuf);
+
+    const node = new LevelsNode();
+    node.assign({
+      image: imgRef,
+      r_black: 0,
+      r_white: 255,
+      r_gamma: 1.5
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+
+    expect(typeof output.data).toBe("string");
+    expect((output.data as string).length).toBeGreaterThan(0);
   });
 });

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -48,6 +48,8 @@ export default {
     "^.*contexts/WorkflowManagerContext$": "<rootDir>/src/__mocks__/WorkflowManagerContext.tsx",
     "^.*selection/magicWandAsync$": "<rootDir>/src/__mocks__/magicWandAsync.ts",
     "^.*selection/magicWandAsync\\.js$": "<rootDir>/src/__mocks__/magicWandAsync.ts",
+    "^.*utils/histogram/histogramAsync$": "<rootDir>/src/__mocks__/histogramAsync.ts",
+    "^.*utils/histogram/histogramAsync\\.js$": "<rootDir>/src/__mocks__/histogramAsync.ts",
     "^react-pdf$": "<rootDir>/src/__mocks__/emptyModule.ts",
     "^react-pdf/.*$": "<rootDir>/src/__mocks__/emptyModule.ts",
     "^.*components/asset_viewer/PDFViewer$": "<rootDir>/src/__mocks__/emptyModule.ts",

--- a/web/src/__mocks__/histogramAsync.ts
+++ b/web/src/__mocks__/histogramAsync.ts
@@ -1,0 +1,15 @@
+export async function computeHistogramAsync(): Promise<{
+  r: Uint32Array;
+  g: Uint32Array;
+  b: Uint32Array;
+  luminance: Uint32Array;
+  pixelCount: number;
+}> {
+  return {
+    r: new Uint32Array(256),
+    g: new Uint32Array(256),
+    b: new Uint32Array(256),
+    luminance: new Uint32Array(256),
+    pixelCount: 0
+  };
+}

--- a/web/src/components/node_types/editing/LevelsBody.tsx
+++ b/web/src/components/node_types/editing/LevelsBody.tsx
@@ -24,8 +24,7 @@ import React, {
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import { ToggleGroup, ToggleOption } from "../../ui_primitives";
 import ImageIcon from "@mui/icons-material/Image";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { shallow } from "zustand/shallow";
@@ -214,7 +213,7 @@ async function loadRgba(
   source: string | undefined,
   signal: AbortSignal
 ): Promise<{ rgba: Uint8ClampedArray; width: number; height: number } | null> {
-  if (!source) return null;
+  if (!source || signal.aborted) return null;
   const img = new Image();
   img.crossOrigin = "anonymous";
   await new Promise<void>((resolve, reject) => {
@@ -342,6 +341,21 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
     return undefined;
   }, [previewValue]);
 
+  // Revoke blob URLs on unmount / change to prevent leaks.
+  const blobUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    const current = previewSource;
+    if (current && current.startsWith("blob:")) {
+      blobUrlRef.current = current;
+    }
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [previewSource]);
+
   const [histogram, setHistogram] = useState<ImageHistogram | null>(null);
   const [histView, setHistView] = useState<HistogramView>("luminance");
 
@@ -406,7 +420,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
         black: r_black,
         gamma: r_gamma,
         white: r_white,
-        keys: ["r_black", "r_gamma", "r_white"] as const
+        keys: ["r_black", "r_gamma", "r_white"]
       };
     }
     if (channel === "g") {
@@ -414,14 +428,14 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
         black: g_black,
         gamma: g_gamma,
         white: g_white,
-        keys: ["g_black", "g_gamma", "g_white"] as const
+        keys: ["g_black", "g_gamma", "g_white"]
       };
     }
     return {
       black: b_black,
       gamma: b_gamma,
       white: b_white,
-      keys: ["b_black", "b_gamma", "b_white"] as const
+      keys: ["b_black", "b_gamma", "b_white"]
     };
   }, [
     channel,
@@ -488,7 +502,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
 
       <div className="histogram-area">
         <canvas ref={canvasRef} className="histogram-canvas" />
-        <ToggleButtonGroup
+        <ToggleGroup
           className="hist-toggle"
           size="small"
           value={histView}
@@ -497,16 +511,16 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
           aria-label="Histogram channel"
         >
           {HIST_VIEW_OPTIONS.map((o) => (
-            <ToggleButton key={o.value} value={o.value} aria-label={o.label}>
+            <ToggleOption key={o.value} value={o.value} aria-label={o.label}>
               {o.label}
-            </ToggleButton>
+            </ToggleOption>
           ))}
-        </ToggleButtonGroup>
+        </ToggleGroup>
       </div>
 
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.25}>
-          <ToggleButtonGroup
+          <ToggleGroup
             className="channel-toggle"
             size="small"
             value={channel}
@@ -515,11 +529,11 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
             aria-label="Channel"
           >
             {CHANNEL_OPTIONS.map((o) => (
-              <ToggleButton key={o.value} value={o.value} aria-label={o.label}>
+              <ToggleOption key={o.value} value={o.value} aria-label={o.label}>
                 {o.label}
-              </ToggleButton>
+              </ToggleOption>
             ))}
-          </ToggleButtonGroup>
+          </ToggleGroup>
         </FlexRow>
 
         <FlexRow className="slider-row" align="center" gap={0.5}>
@@ -539,7 +553,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
           <span className="slider-label">Gamma</span>
           <NodeSlider
             min={0.1}
-            max={5}
+            max={10}
             step={0.01}
             value={channelProps.gamma}
             onChange={handleGammaChange}

--- a/web/src/components/node_types/editing/LevelsBody.tsx
+++ b/web/src/components/node_types/editing/LevelsBody.tsx
@@ -1,0 +1,595 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * LevelsBody — bespoke body for `nodetool.image.Levels` (plan §9.E1, PR 15).
+ *
+ * Layout:
+ *   • Full-bleed image preview (top)
+ *   • Histogram canvas with R / G / B / Luminance view toggle
+ *   • Channel selector (R / G / B) → 3 sliders (Black / Gamma / White)
+ *   • Reset button restores neutral values
+ *
+ * Histogram is computed off the node's own output image via
+ * `computeHistogramAsync`, which auto-offloads to a web worker for images
+ * with > 1024² pixels (1_048_576) to keep the main thread responsive.
+ */
+
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ImageIcon from "@mui/icons-material/Image";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import { shallow } from "zustand/shallow";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  NodeSlider,
+  StateIconButton
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { computeHistogramAsync } from "../../../utils/histogram/histogramAsync";
+import type { ImageHistogram } from "../../../utils/histogram/computeHistogram";
+
+const LEVELS_NODE_TYPE = "nodetool.image.Levels";
+
+type ChannelKey = "r" | "g" | "b";
+type HistogramView = "r" | "g" | "b" | "luminance";
+
+const CHANNEL_OPTIONS: ReadonlyArray<{ value: ChannelKey; label: string }> = [
+  { value: "r", label: "R" },
+  { value: "g", label: "G" },
+  { value: "b", label: "B" }
+];
+
+const HIST_VIEW_OPTIONS: ReadonlyArray<{ value: HistogramView; label: string }> = [
+  { value: "r", label: "R" },
+  { value: "g", label: "G" },
+  { value: "b", label: "B" },
+  { value: "luminance", label: "L" }
+];
+
+const HIST_HEIGHT = 56;
+const HIST_DPR_CAP = 2;
+
+const styles = (theme: Theme) =>
+  css({
+    "&.levels-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& > .handle-column": {
+        top: 0,
+        bottom: 0,
+        left: `calc(${theme.spacing(-0.5)})`
+      },
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".histogram-area": {
+      flex: "0 0 auto",
+      position: "relative",
+      backgroundColor: theme.vars.palette.grey[900],
+      borderRadius: "var(--rounded-sm)",
+      padding: theme.spacing(0.5),
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.25)
+    },
+    ".histogram-canvas": {
+      width: "100%",
+      height: HIST_HEIGHT,
+      display: "block"
+    },
+    ".controls": {
+      flex: "0 0 auto"
+    },
+    ".channel-toggle, .hist-toggle": {
+      width: "100%",
+      ".MuiToggleButton-root": {
+        flex: "1 1 auto",
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+        fontSize: theme.fontSizeSmaller,
+        fontFamily: theme.fontFamily2,
+        textTransform: "none",
+        minWidth: 0
+      }
+    },
+    ".slider-row": {
+      paddingLeft: theme.spacing(0.5),
+      paddingRight: theme.spacing(0.5)
+    },
+    ".slider-label": {
+      flex: "0 0 auto",
+      minWidth: 48,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary
+    },
+    ".slider-readout": {
+      flex: "0 0 auto",
+      minWidth: 36,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textAlign: "right"
+    },
+    ".action-row": {
+      paddingTop: theme.spacing(0.25),
+      display: "flex",
+      justifyContent: "flex-end"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+interface ImageRefLike {
+  uri?: string;
+  width?: number;
+  height?: number;
+  data?: unknown;
+}
+
+const asImageRef = (value: unknown): ImageRefLike | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
+    width: typeof v.width === "number" ? (v.width as number) : undefined,
+    height: typeof v.height === "number" ? (v.height as number) : undefined,
+    data: v.data
+  };
+};
+
+const unwrapOutput = (value: unknown): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const v = value as Record<string, unknown>;
+  if ("output" in v) return v.output;
+  return value;
+};
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return (
+    <CheckerDropzone
+      message="Connect an image, then run"
+      icon={<ImageIcon />}
+    />
+  );
+};
+
+/** Decode any image source the result store gives us into RGBA pixels. */
+async function loadRgba(
+  source: string | undefined,
+  signal: AbortSignal
+): Promise<{ rgba: Uint8ClampedArray; width: number; height: number } | null> {
+  if (!source) return null;
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error("Image load failed"));
+    img.src = source;
+  });
+  if (signal.aborted) return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(img, 0, 0);
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return {
+    rgba: data.data,
+    width: canvas.width,
+    height: canvas.height
+  };
+}
+
+function drawHistogram(
+  canvas: HTMLCanvasElement,
+  bins: Uint32Array,
+  colorRgb: string
+): void {
+  const dpr = Math.min(HIST_DPR_CAP, window.devicePixelRatio || 1);
+  const cssW = canvas.clientWidth || 256;
+  const cssH = HIST_HEIGHT;
+  if (canvas.width !== cssW * dpr || canvas.height !== cssH * dpr) {
+    canvas.width = cssW * dpr;
+    canvas.height = cssH * dpr;
+  }
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, cssW, cssH);
+
+  let peak = 0;
+  for (let i = 0; i < 256; i++) {
+    if (bins[i] > peak) peak = bins[i];
+  }
+  if (peak === 0) return;
+
+  // Clip extreme outliers so the histogram is readable.
+  const cap = Math.max(1, peak * 0.85);
+  const binW = cssW / 256;
+  ctx.fillStyle = colorRgb;
+  for (let i = 0; i < 256; i++) {
+    const h = Math.min(1, bins[i] / cap) * cssH;
+    ctx.fillRect(i * binW, cssH - h, Math.max(1, binW), h);
+  }
+}
+
+const HIST_COLORS: Record<HistogramView, string> = {
+  r: "rgba(244, 67, 54, 0.85)",
+  g: "rgba(76, 175, 80, 0.85)",
+  b: "rgba(33, 150, 243, 0.85)",
+  luminance: "rgba(255, 255, 255, 0.85)"
+};
+
+export interface LevelsBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const clamp255 = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+  const clampGamma = (n: number) => Math.max(0.01, Math.min(10, n));
+
+  const r_black = clamp255(Number(props.r_black ?? 0));
+  const r_gamma = clampGamma(Number(props.r_gamma ?? 1));
+  const r_white = clamp255(Number(props.r_white ?? 255));
+  const g_black = clamp255(Number(props.g_black ?? 0));
+  const g_gamma = clampGamma(Number(props.g_gamma ?? 1));
+  const g_white = clamp255(Number(props.g_white ?? 255));
+  const b_black = clamp255(Number(props.b_black ?? 0));
+  const b_gamma = clampGamma(Number(props.b_gamma ?? 1));
+  const b_white = clamp255(Number(props.b_white ?? 255));
+
+  const result = useResultsStore(
+    (state) => state.getResult(workflowId, id),
+    shallow
+  );
+  const previewValue = useMemo(() => unwrapOutput(result), [result]);
+
+  const previewSource = useMemo<string | undefined>(() => {
+    if (typeof previewValue === "string" && previewValue) return previewValue;
+    const ref = asImageRef(previewValue);
+    if (ref?.uri) return ref.uri;
+    if (ref?.data instanceof Uint8Array) {
+      const buf = new ArrayBuffer(ref.data.byteLength);
+      new Uint8Array(buf).set(ref.data);
+      return URL.createObjectURL(new Blob([buf]));
+    }
+    if (Array.isArray(ref?.data)) {
+      return URL.createObjectURL(
+        new Blob([new Uint8Array(ref!.data as number[])])
+      );
+    }
+    return undefined;
+  }, [previewValue]);
+
+  const [histogram, setHistogram] = useState<ImageHistogram | null>(null);
+  const [histView, setHistView] = useState<HistogramView>("luminance");
+
+  // Recompute histogram when the preview source changes.
+  useEffect(() => {
+    if (!previewSource) {
+      setHistogram(null);
+      return;
+    }
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        const rgba = await loadRgba(previewSource, ctrl.signal);
+        if (!rgba || ctrl.signal.aborted) return;
+        const hist = await computeHistogramAsync(rgba);
+        if (ctrl.signal.aborted) return;
+        setHistogram(hist);
+      } catch {
+        // Decode / worker errors — silently leave the previous histogram.
+      }
+    })();
+    return () => ctrl.abort();
+  }, [previewSource]);
+
+  // Paint the canvas whenever histogram or view changes.
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !histogram) return;
+    drawHistogram(canvas, histogram[histView], HIST_COLORS[histView]);
+  }, [histogram, histView]);
+
+  const { setProperty, setProperties, setPropertyComplete } =
+    useBespokePropertyWriter({ nodeId: id, nodeType });
+
+  const [channel, setChannel] = useState<ChannelKey>("r");
+
+  const handleChannelChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (next === "r" || next === "g" || next === "b") setChannel(next);
+    },
+    []
+  );
+
+  const handleHistViewChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (
+        next === "r" ||
+        next === "g" ||
+        next === "b" ||
+        next === "luminance"
+      ) {
+        setHistView(next);
+      }
+    },
+    []
+  );
+
+  const channelProps = useMemo(() => {
+    if (channel === "r") {
+      return {
+        black: r_black,
+        gamma: r_gamma,
+        white: r_white,
+        keys: ["r_black", "r_gamma", "r_white"] as const
+      };
+    }
+    if (channel === "g") {
+      return {
+        black: g_black,
+        gamma: g_gamma,
+        white: g_white,
+        keys: ["g_black", "g_gamma", "g_white"] as const
+      };
+    }
+    return {
+      black: b_black,
+      gamma: b_gamma,
+      white: b_white,
+      keys: ["b_black", "b_gamma", "b_white"] as const
+    };
+  }, [
+    channel,
+    r_black,
+    r_gamma,
+    r_white,
+    g_black,
+    g_gamma,
+    g_white,
+    b_black,
+    b_gamma,
+    b_white
+  ]);
+
+  const handleBlackChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = clamp255(Array.isArray(v) ? v[0] : v);
+      setProperty(channelProps.keys[0], next);
+    },
+    [setProperty, channelProps.keys]
+  );
+  const handleGammaChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = clampGamma(Array.isArray(v) ? v[0] : v);
+      setProperty(channelProps.keys[1], next);
+    },
+    [setProperty, channelProps.keys]
+  );
+  const handleWhiteChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = clamp255(Array.isArray(v) ? v[0] : v);
+      setProperty(channelProps.keys[2], next);
+    },
+    [setProperty, channelProps.keys]
+  );
+
+  const commit = useCallback(() => setPropertyComplete(), [setPropertyComplete]);
+
+  const handleReset = useCallback(() => {
+    setProperties({
+      r_black: 0,
+      r_gamma: 1,
+      r_white: 255,
+      g_black: 0,
+      g_gamma: 1,
+      g_white: 255,
+      b_black: 0,
+      b_gamma: 1,
+      b_white: 255
+    });
+    setPropertyComplete();
+  }, [setProperties, setPropertyComplete]);
+
+  return (
+    <div
+      css={cssStyles}
+      className="levels-body"
+      data-bespoke-body="Levels"
+    >
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+        <HandleColumn id={id} properties={imageProperty} />
+      </div>
+
+      <div className="histogram-area">
+        <canvas ref={canvasRef} className="histogram-canvas" />
+        <ToggleButtonGroup
+          className="hist-toggle"
+          size="small"
+          value={histView}
+          exclusive
+          onChange={handleHistViewChange}
+          aria-label="Histogram channel"
+        >
+          {HIST_VIEW_OPTIONS.map((o) => (
+            <ToggleButton key={o.value} value={o.value} aria-label={o.label}>
+              {o.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow align="center" gap={0.25}>
+          <ToggleButtonGroup
+            className="channel-toggle"
+            size="small"
+            value={channel}
+            exclusive
+            onChange={handleChannelChange}
+            aria-label="Channel"
+          >
+            {CHANNEL_OPTIONS.map((o) => (
+              <ToggleButton key={o.value} value={o.value} aria-label={o.label}>
+                {o.label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </FlexRow>
+
+        <FlexRow className="slider-row" align="center" gap={0.5}>
+          <span className="slider-label">Black</span>
+          <NodeSlider
+            min={0}
+            max={255}
+            step={1}
+            value={channelProps.black}
+            onChange={handleBlackChange}
+            onChangeCommitted={commit}
+            aria-label="Black point"
+          />
+          <span className="slider-readout">{channelProps.black}</span>
+        </FlexRow>
+        <FlexRow className="slider-row" align="center" gap={0.5}>
+          <span className="slider-label">Gamma</span>
+          <NodeSlider
+            min={0.1}
+            max={5}
+            step={0.01}
+            value={channelProps.gamma}
+            onChange={handleGammaChange}
+            onChangeCommitted={commit}
+            aria-label="Gamma"
+          />
+          <span className="slider-readout">{channelProps.gamma.toFixed(2)}</span>
+        </FlexRow>
+        <FlexRow className="slider-row" align="center" gap={0.5}>
+          <span className="slider-label">White</span>
+          <NodeSlider
+            min={0}
+            max={255}
+            step={1}
+            value={channelProps.white}
+            onChange={handleWhiteChange}
+            onChangeCommitted={commit}
+            aria-label="White point"
+          />
+          <span className="slider-readout">{channelProps.white}</span>
+        </FlexRow>
+
+        <div className="action-row">
+          <StateIconButton
+            size="small"
+            icon={<RestartAltIcon fontSize="small" />}
+            tooltip="Reset levels"
+            ariaLabel="Reset levels"
+            onClick={handleReset}
+          />
+        </div>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs
+            id={id}
+            outputs={nodeMetadata.outputs}
+            isStreamingOutput={nodeMetadata.is_streaming_output}
+          />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const LevelsBody = memo(LevelsBodyInner);
+LevelsBody.displayName = "LevelsBody";
+
+export { LEVELS_NODE_TYPE };
+export default LevelsBody;

--- a/web/src/components/node_types/editing/LevelsBody.tsx
+++ b/web/src/components/node_types/editing/LevelsBody.tsx
@@ -27,7 +27,6 @@ import type { Theme } from "@mui/material/styles";
 import { ToggleGroup, ToggleOption } from "../../ui_primitives";
 import ImageIcon from "@mui/icons-material/Image";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
-import { shallow } from "zustand/shallow";
 
 import {
   CheckerDropzone,
@@ -43,8 +42,8 @@ import NodeProgress from "../../node/NodeProgress";
 
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
-import useResultsStore from "../../../stores/ResultsStore";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
 import { computeHistogramAsync } from "../../../utils/histogram/histogramAsync";
 import type { ImageHistogram } from "../../../utils/histogram/computeHistogram";
 
@@ -81,6 +80,11 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(0.5),
       minHeight: 0
     },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
@@ -91,11 +95,6 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      "& > .handle-column": {
-        top: 0,
-        bottom: 0,
-        left: `calc(${theme.spacing(-0.5)})`
-      },
       "& img": {
         display: "block",
         maxWidth: "100%",
@@ -177,13 +176,6 @@ const asImageRef = (value: unknown): ImageRefLike | undefined => {
     height: typeof v.height === "number" ? (v.height as number) : undefined,
     data: v.data
   };
-};
-
-const unwrapOutput = (value: unknown): unknown => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-  const v = value as Record<string, unknown>;
-  if ("output" in v) return v.output;
-  return value;
 };
 
 const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
@@ -318,11 +310,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
   const b_gamma = clampGamma(Number(props.b_gamma ?? 1));
   const b_white = clamp255(Number(props.b_white ?? 255));
 
-  const result = useResultsStore(
-    (state) => state.getResult(workflowId, id),
-    shallow
-  );
-  const previewValue = useMemo(() => unwrapOutput(result), [result]);
+  const previewValue = useNodeOutput(workflowId, id);
 
   const previewSource = useMemo<string | undefined>(() => {
     if (typeof previewValue === "string" && previewValue) return previewValue;
@@ -495,9 +483,9 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
       className="levels-body"
       data-bespoke-body="Levels"
     >
+      <HandleColumn id={id} properties={imageProperty} />
       <div className="preview-area">
         <ImagePreview value={previewValue} />
-        <HandleColumn id={id} properties={imageProperty} />
       </div>
 
       <div className="histogram-area">

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -72,7 +72,13 @@ jest.mock("../../ui_primitives", () => ({
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
           ? React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
-              onClick: () => onChange(null, (child as React.ReactElement<Record<string, unknown>>).props.value)
+              onClick: () =>
+                onChange(
+                  null,
+                  String(
+                    (child as React.ReactElement<Record<string, unknown>>).props.value
+                  )
+                )
             })
           : child
       )}

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -186,6 +186,8 @@ describe("MasksExtractorBody", () => {
     mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
       if (typeof selector === "function") {
         const state = {
+          getOutputResult: () => undefined,
+          getPreview: () => undefined,
           getResult: (_wf: string, nodeId: string) => {
             if (nodeId === "upstream-node") {
               return { output: { uri: "upstream.jpg" } };
@@ -208,6 +210,8 @@ describe("MasksExtractorBody", () => {
     mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
       if (typeof selector === "function") {
         const state = {
+          getOutputResult: () => undefined,
+          getPreview: () => undefined,
           getResult: (_wf: string, nodeId: string) => {
             if (nodeId === "node-1") {
               return { output: { uri: "mask.png" } };

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -1,0 +1,233 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MasksExtractorBody } from "./MasksExtractorBody";
+
+jest.mock("../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: jest.fn()
+}));
+
+jest.mock("../../../hooks/nodes/useRunSingleNode", () => ({
+  useRunSingleNode: jest.fn()
+}));
+
+jest.mock("../../node/HandleColumn", () => ({
+  __esModule: true,
+  default: () => <div data-testid="handle-column" />
+}));
+
+jest.mock("../../node/ImageView", () => ({
+  __esModule: true,
+  default: ({ source }: { source?: string | Uint8Array }) => (
+    <img data-testid="image-view" data-source={source} alt="preview" />
+  )
+}));
+
+jest.mock("../../node/NodeOutputs", () => ({
+  NodeOutputs: () => <div data-testid="node-outputs" />
+}));
+
+jest.mock("../../node/NodeProgress", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-progress" />
+}));
+
+jest.mock("../../ui_primitives", () => ({
+  CheckerDropzone: ({ message }: { message: string }) => (
+    <div data-testid="checker-dropzone">{message}</div>
+  ),
+  FlexColumn: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  FlexRow: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  RunModelButton: ({
+    label,
+    isRunning,
+    onClick
+  }: {
+    label: string;
+    isRunning: boolean;
+    onClick: () => void;
+  }) => (
+    <button data-testid="run-model-button" disabled={isRunning} onClick={onClick}>
+      {label}
+    </button>
+  ),
+  ToggleGroup: ({
+    children,
+    value,
+    onChange
+  }: {
+    children: React.ReactNode;
+    value: string;
+    onChange: (_: unknown, next: string) => void;
+  }) => (
+    <div data-testid="toggle-group" data-value={value}>
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child as React.ReactElement, {
+              onClick: () => onChange(null, (child as React.ReactElement).props.value)
+            })
+          : child
+      )}
+    </div>
+  ),
+  ToggleOption: ({
+    children,
+    value,
+    ...props
+  }: {
+    children: React.ReactNode;
+    value: string;
+    [key: string]: unknown;
+  }) => (
+    <button data-testid={`toggle-option-${value}`} {...props}>
+      {children}
+    </button>
+  )
+}));
+
+jest.mock("@mui/material/styles", () => ({
+  useTheme: () => ({
+    spacing: (n: number) => `${n * 8}px`,
+    vars: { palette: { grey: { 900: "#000" }, divider: "#ccc", common: { white: "#fff" }, text: { secondary: "#999", primary: "#fff" }, action: { hover: "#333" } } },
+    fontSizeSmaller: "0.75rem",
+    fontFamily2: "sans-serif"
+  })
+}));
+
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNodes } from "../../../contexts/NodeContext";
+import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+
+const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
+const mockUseNodes = useNodes as unknown as jest.Mock;
+const mockUseRunSingleNode = useRunSingleNode as unknown as jest.Mock;
+
+describe("MasksExtractorBody", () => {
+  const defaultProps = {
+    id: "node-1",
+    nodeType: "replicate.image.background.Bria_RemoveBackground",
+    nodeMetadata: {
+      node_type: "replicate.image.background.Bria_RemoveBackground",
+      properties: [{ name: "image", type: "image" }],
+      outputs: []
+    },
+    data: { properties: {} },
+    workflowId: "wf-1",
+    status: "idle",
+    isOutputNode: false
+  };
+
+  const mockRunSingleNode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseNodes.mockReturnValue(undefined);
+    mockUseResultsStore.mockReturnValue(undefined);
+    mockUseRunSingleNode.mockReturnValue({
+      runSingleNode: mockRunSingleNode,
+      isWorkflowRunning: false
+    });
+  });
+
+  it("renders the Image tab by default", () => {
+    render(
+      <MasksExtractorBody
+        {...defaultProps}
+        data={{ properties: { image: { uri: "test.jpg" } } }}
+      />
+    );
+    expect(screen.getByTestId("image-view")).toBeInTheDocument();
+  });
+
+  it("switches to Mask tab on toggle click", () => {
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const maskToggle = screen.getByTestId("toggle-option-mask");
+    fireEvent.click(maskToggle);
+
+    expect(screen.queryByTestId("image-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("checker-dropzone")).toHaveTextContent(
+      "Run the node to extract a mask"
+    );
+  });
+
+  it("shows upstream image in Image tab when edge is connected", () => {
+    mockUseNodes.mockReturnValue({
+      id: "edge-1",
+      source: "upstream-node",
+      target: "node-1",
+      sourceHandle: "output",
+      targetHandle: "image"
+    });
+
+    mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
+      if (typeof selector === "function") {
+        const state = {
+          getResult: (_wf: string, nodeId: string) => {
+            if (nodeId === "upstream-node") {
+              return { output: { uri: "upstream.jpg" } };
+            }
+            return undefined;
+          }
+        };
+        return selector(state);
+      }
+      return undefined;
+    });
+
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const img = screen.getByTestId("image-view");
+    expect(img).toHaveAttribute("data-source", "upstream.jpg");
+  });
+
+  it("shows own result in Mask tab", () => {
+    mockUseResultsStore.mockImplementation((selector: (state: unknown) => unknown) => {
+      if (typeof selector === "function") {
+        const state = {
+          getResult: (_wf: string, nodeId: string) => {
+            if (nodeId === "node-1") {
+              return { output: { uri: "mask.png" } };
+            }
+            return undefined;
+          }
+        };
+        return selector(state);
+      }
+      return undefined;
+    });
+
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const maskToggle = screen.getByTestId("toggle-option-mask");
+    fireEvent.click(maskToggle);
+
+    const img = screen.getByTestId("image-view");
+    expect(img).toHaveAttribute("data-source", "mask.png");
+  });
+
+  it("disables run button and shows progress when running", () => {
+    render(<MasksExtractorBody {...defaultProps} status="running" />);
+
+    expect(screen.getByTestId("run-model-button")).toBeDisabled();
+    expect(screen.getByTestId("node-progress")).toBeInTheDocument();
+  });
+
+  it("calls runSingleNode when Recalculate button is clicked", () => {
+    render(<MasksExtractorBody {...defaultProps} />);
+
+    const button = screen.getByTestId("run-model-button");
+    fireEvent.click(button);
+
+    expect(mockRunSingleNode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -71,8 +71,8 @@ jest.mock("../../ui_primitives", () => ({
     <div data-testid="toggle-group" data-value={value}>
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
-          ? React.cloneElement(child as React.ReactElement, {
-              onClick: () => onChange(null, (child as React.ReactElement).props.value)
+          ? React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+              onClick: () => onChange(null, (child as React.ReactElement<Record<string, unknown>>).props.value)
             })
           : child
       )}
@@ -119,11 +119,16 @@ describe("MasksExtractorBody", () => {
       properties: [{ name: "image", type: "image" }],
       outputs: []
     },
-    data: { properties: {} },
+    data: {
+      properties: {},
+      selectable: undefined,
+      dynamic_properties: {},
+      workflow_id: "wf-1"
+    },
     workflowId: "wf-1",
     status: "idle",
     isOutputNode: false
-  };
+  } as unknown as React.ComponentProps<typeof MasksExtractorBody>;
 
   const mockRunSingleNode = jest.fn();
 
@@ -142,7 +147,10 @@ describe("MasksExtractorBody", () => {
     render(
       <MasksExtractorBody
         {...defaultProps}
-        data={{ properties: { image: { uri: "test.jpg" } } }}
+        data={{
+          ...defaultProps.data,
+          properties: { image: { uri: "test.jpg" } }
+        }}
       />
     );
     expect(screen.getByTestId("image-view")).toBeInTheDocument();

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -1,0 +1,301 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * MasksExtractorBody — bespoke body for mask-extractor model nodes
+ * (plan §9.E6, PR 14).
+ *
+ * Top: tabbed preview — `Image` shows the source image fed into the node's
+ * `image` input, `Mask` shows the node's own output (the extracted mask /
+ * background-removed foreground).
+ *
+ * Bottom: `Recalculate` action button (RunModelButton) — triggers a
+ * single-node run via `useRunSingleNode`.
+ *
+ * Registered for the established mask-extractor providers (Bria /
+ * BackgroundRemover variants). Additional providers can be added to the
+ * registry as their bespoke targets are confirmed.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ImageIcon from "@mui/icons-material/Image";
+import { shallow } from "zustand/shallow";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  RunModelButton
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNodes } from "../../../contexts/NodeContext";
+import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+
+// Node types currently bound to this bespoke body. Mask-extractor / bg-removal
+// providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
+// additional providers are confirmed in §9.E11.
+const MASKS_EXTRACTOR_NODE_TYPES: ReadonlyArray<string> = [
+  "replicate.image.background.Bria_RemoveBackground",
+  "replicate.image.background.BackgroundRemover_851",
+  "replicate.image.background.BackgroundRemover_Codeplug",
+  "replicate.image.process.RemoveBackground"
+];
+
+type PreviewTab = "image" | "mask";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.masks-extractor-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& > .handle-column": {
+        top: 0,
+        bottom: 0,
+        left: `calc(${theme.spacing(-0.5)})`
+      },
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto",
+      paddingTop: theme.spacing(0.25)
+    },
+    ".tab-toggle": {
+      width: "100%",
+      ".MuiToggleButton-root": {
+        flex: "1 1 auto",
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+        fontSize: theme.fontSizeSmaller,
+        fontFamily: theme.fontFamily2,
+        textTransform: "none",
+        minWidth: 0
+      }
+    },
+    ".action-row": {
+      paddingTop: theme.spacing(0.25),
+      display: "flex",
+      justifyContent: "flex-end"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+interface ImageRefLike {
+  uri?: string;
+  data?: unknown;
+}
+
+const asImageRef = (value: unknown): ImageRefLike | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
+    data: v.data
+  };
+};
+
+const unwrapOutput = (value: unknown, handle?: string | null): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const v = value as Record<string, unknown>;
+  if (handle && handle in v) return v[handle];
+  if ("output" in v) return v.output;
+  return value;
+};
+
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
+  value,
+  placeholder
+}) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
+};
+
+export interface MasksExtractorBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
+  id,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const [tab, setTab] = useState<PreviewTab>("image");
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  // Resolve upstream image (cached result of whatever feeds our `image`
+  // input), so the Image tab can show what the node will receive on next run.
+  const upstreamEdge = useNodes(
+    (state) =>
+      state.edges.find(
+        (e) => e.target === id && (e.targetHandle ?? "") === "image"
+      ),
+    shallow
+  );
+
+  const upstreamResult = useResultsStore(
+    (state) =>
+      upstreamEdge
+        ? state.getResult(workflowId, upstreamEdge.source)
+        : undefined,
+    shallow
+  );
+
+  const myResult = useResultsStore(
+    (state) => state.getResult(workflowId, id),
+    shallow
+  );
+
+  const imageTabValue = useMemo(() => {
+    if (upstreamEdge) {
+      const v = unwrapOutput(upstreamResult, upstreamEdge.sourceHandle);
+      const ref = asImageRef(v);
+      if (ref && (ref.uri || ref.data)) return ref;
+    }
+    const constRef = asImageRef(data.properties?.image);
+    if (constRef && (constRef.uri || constRef.data)) return constRef;
+    return undefined;
+  }, [upstreamEdge, upstreamResult, data.properties?.image]);
+
+  const maskTabValue = useMemo(() => unwrapOutput(myResult), [myResult]);
+
+  const { runSingleNode, isWorkflowRunning } = useRunSingleNode(id);
+
+  const handleTabChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (next !== "image" && next !== "mask") return;
+      setTab(next);
+    },
+    []
+  );
+
+  const isRunning = status === "running" || isWorkflowRunning;
+
+  return (
+    <div
+      css={cssStyles}
+      className="masks-extractor-body"
+      data-bespoke-body="MasksExtractor"
+    >
+      <div className="preview-area">
+        {tab === "image" ? (
+          <ImagePreview
+            value={imageTabValue}
+            placeholder="Connect an image"
+          />
+        ) : (
+          <ImagePreview
+            value={maskTabValue}
+            placeholder="Run the node to extract a mask"
+          />
+        )}
+        <HandleColumn id={id} properties={imageProperty} />
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow align="center" gap={0.25}>
+          <ToggleButtonGroup
+            className="tab-toggle"
+            size="small"
+            value={tab}
+            exclusive
+            onChange={handleTabChange}
+            aria-label="Preview tab"
+          >
+            <ToggleButton value="image" aria-label="Image">
+              Image
+            </ToggleButton>
+            <ToggleButton value="mask" aria-label="Mask">
+              Mask
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </FlexRow>
+        <div className="action-row">
+          <RunModelButton
+            label="Recalculate Mask"
+            isRunning={isRunning}
+            onClick={runSingleNode}
+          />
+        </div>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs
+            id={id}
+            outputs={nodeMetadata.outputs}
+            isStreamingOutput={nodeMetadata.is_streaming_output}
+          />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const MasksExtractorBody = memo(MasksExtractorBodyInner);
+MasksExtractorBody.displayName = "MasksExtractorBody";
+
+export { MASKS_EXTRACTOR_NODE_TYPES };
+export default MasksExtractorBody;

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -19,8 +19,6 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import ImageIcon from "@mui/icons-material/Image";
 import { shallow } from "zustand/shallow";
 
@@ -28,7 +26,9 @@ import {
   CheckerDropzone,
   FlexColumn,
   FlexRow,
-  RunModelButton
+  RunModelButton,
+  ToggleGroup,
+  ToggleOption
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageView from "../../node/ImageView";
@@ -40,16 +40,17 @@ import type { NodeData } from "../../../stores/NodeData";
 import useResultsStore from "../../../stores/ResultsStore";
 import { useNodes } from "../../../contexts/NodeContext";
 import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
+import { asImageRef, unwrapOutput } from "../../../utils/imageRef";
 
 // Node types currently bound to this bespoke body. Mask-extractor / bg-removal
 // providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
 // additional providers are confirmed in §9.E11.
-const MASKS_EXTRACTOR_NODE_TYPES: ReadonlyArray<string> = [
+const MASKS_EXTRACTOR_NODE_TYPES = [
   "replicate.image.background.Bria_RemoveBackground",
   "replicate.image.background.BackgroundRemover_851",
   "replicate.image.background.BackgroundRemover_Codeplug",
   "replicate.image.process.RemoveBackground"
-];
+] as const;
 
 type PreviewTab = "image" | "mask";
 
@@ -112,29 +113,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface ImageRefLike {
-  uri?: string;
-  data?: unknown;
-}
-
-const asImageRef = (value: unknown): ImageRefLike | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  const v = value as Record<string, unknown>;
-  return {
-    uri: typeof v.uri === "string" ? (v.uri as string) : undefined,
-    data: v.data
-  };
-};
-
-const unwrapOutput = (value: unknown, handle?: string | null): unknown => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-  const v = value as Record<string, unknown>;
-  if (handle && handle in v) return v[handle];
-  if ("output" in v) return v.output;
-  return value;
-};
-
-const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = memo(({
   value,
   placeholder
 }) => {
@@ -152,7 +131,8 @@ const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = ({
     return <ImageView source={new Uint8Array(ref!.data as number[])} />;
   }
   return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
-};
+});
+ImagePreview.displayName = "ImagePreview";
 
 export interface MasksExtractorBodyProps {
   id: string;
@@ -254,7 +234,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
 
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.25}>
-          <ToggleButtonGroup
+          <ToggleGroup
             className="tab-toggle"
             size="small"
             value={tab}
@@ -262,13 +242,13 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
             onChange={handleTabChange}
             aria-label="Preview tab"
           >
-            <ToggleButton value="image" aria-label="Image">
+            <ToggleOption value="image" aria-label="Image">
               Image
-            </ToggleButton>
-            <ToggleButton value="mask" aria-label="Mask">
+            </ToggleOption>
+            <ToggleOption value="mask" aria-label="Mask">
               Mask
-            </ToggleButton>
-          </ToggleButtonGroup>
+            </ToggleOption>
+          </ToggleGroup>
         </FlexRow>
         <div className="action-row">
           <RunModelButton
@@ -289,7 +269,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
         </div>
       )}
 
-      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+      {isRunning && <NodeProgress id={id} workflowId={workflowId} />}
     </div>
   );
 };

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -20,7 +20,6 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
-import { shallow } from "zustand/shallow";
 
 import {
   CheckerDropzone,
@@ -37,10 +36,12 @@ import NodeProgress from "../../node/NodeProgress";
 
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
-import useResultsStore from "../../../stores/ResultsStore";
-import { useNodes } from "../../../contexts/NodeContext";
 import { useRunSingleNode } from "../../../hooks/nodes/useRunSingleNode";
-import { asImageRef, unwrapOutput } from "../../../utils/imageRef";
+import {
+  useNodeOutput,
+  useUpstreamValue
+} from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
 
 // Node types currently bound to this bespoke body. Mask-extractor / bg-removal
 // providers: per §9.E6 we ship the known Bria + 851-labs variants. Extend as
@@ -66,6 +67,11 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(0.5),
       minHeight: 0
     },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
@@ -76,11 +82,6 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      "& > .handle-column": {
-        top: 0,
-        bottom: 0,
-        left: `calc(${theme.spacing(-0.5)})`
-      },
       "& img": {
         display: "block",
         maxWidth: "100%",
@@ -163,41 +164,19 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
     [properties]
   );
 
-  // Resolve upstream image (cached result of whatever feeds our `image`
-  // input), so the Image tab can show what the node will receive on next run.
-  const upstreamEdge = useNodes(
-    (state) =>
-      state.edges.find(
-        (e) => e.target === id && (e.targetHandle ?? "") === "image"
-      ),
-    shallow
+  // Image tab shows the cached upstream input (what the node will receive
+  // on the next run). Mask tab shows the server's most recent output.
+  const inputValue = useUpstreamValue(
+    workflowId,
+    id,
+    "image",
+    data.properties?.image
   );
-
-  const upstreamResult = useResultsStore(
-    (state) =>
-      upstreamEdge
-        ? state.getResult(workflowId, upstreamEdge.source)
-        : undefined,
-    shallow
-  );
-
-  const myResult = useResultsStore(
-    (state) => state.getResult(workflowId, id),
-    shallow
-  );
-
   const imageTabValue = useMemo(() => {
-    if (upstreamEdge) {
-      const v = unwrapOutput(upstreamResult, upstreamEdge.sourceHandle);
-      const ref = asImageRef(v);
-      if (ref && (ref.uri || ref.data)) return ref;
-    }
-    const constRef = asImageRef(data.properties?.image);
-    if (constRef && (constRef.uri || constRef.data)) return constRef;
-    return undefined;
-  }, [upstreamEdge, upstreamResult, data.properties?.image]);
-
-  const maskTabValue = useMemo(() => unwrapOutput(myResult), [myResult]);
+    const ref = asImageRef(inputValue);
+    return ref && (ref.uri || ref.data) ? ref : undefined;
+  }, [inputValue]);
+  const maskTabValue = useNodeOutput(workflowId, id);
 
   const { runSingleNode, isWorkflowRunning } = useRunSingleNode(id);
 
@@ -217,6 +196,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
       className="masks-extractor-body"
       data-bespoke-body="MasksExtractor"
     >
+      <HandleColumn id={id} properties={imageProperty} />
       <div className="preview-area">
         {tab === "image" ? (
           <ImagePreview
@@ -229,7 +209,6 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
             placeholder="Run the node to extract a mask"
           />
         )}
-        <HandleColumn id={id} properties={imageProperty} />
       </div>
 
       <FlexColumn className="controls" gap={0.5}>

--- a/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
@@ -20,7 +20,9 @@ jest.mock("../../../../stores/ResultsStore", () => ({
   __esModule: true,
   default: jest.fn((selector: any) =>
     selector({
-      getResult: () => null
+      getOutputResult: () => undefined,
+      getResult: () => undefined,
+      getPreview: () => undefined
     })
   )
 }));
@@ -42,8 +44,10 @@ const defaultProps = {
   nodeType: "nodetool.image.Levels",
   nodeMetadata: {
     node_type: "nodetool.image.Levels",
-    properties: [{ name: "image", type: "image" }],
-    outputs: [{ name: "output", type: "image" }],
+    properties: [
+      { name: "image", type: { type: "image", type_args: [] } }
+    ],
+    outputs: [{ name: "output", type: { type: "image", type_args: [] } }],
     is_streaming_output: false
   } as unknown as import("../../../../stores/ApiTypes").NodeMetadata,
   data: { properties: {} } as import("../../../../stores/NodeData").NodeData,
@@ -70,7 +74,12 @@ describe("LevelsBody", () => {
       output: { uri: "http://example.com/image.png" }
     }));
     require("../../../../stores/ResultsStore").default.mockImplementation(
-      (selector: any) => selector({ getResult: mockGetResult })
+      (selector: any) =>
+        selector({
+          getOutputResult: () => undefined,
+          getPreview: () => undefined,
+          getResult: mockGetResult
+        })
     );
 
     renderWithTheme(<LevelsBody {...defaultProps} />);

--- a/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import LevelsBody from "../LevelsBody";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+const mockSetProperty = jest.fn();
+const mockSetProperties = jest.fn();
+const mockSetPropertyComplete = jest.fn();
+
+jest.mock("../../../../hooks/nodes/useBespokePropertyWriter", () => ({
+  useBespokePropertyWriter: jest.fn(() => ({
+    setProperty: mockSetProperty,
+    setProperties: mockSetProperties,
+    setPropertyComplete: mockSetPropertyComplete
+  }))
+}));
+
+jest.mock("../../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector: any) =>
+    selector({
+      getResult: () => null
+    })
+  )
+}));
+
+jest.mock("../../../../utils/histogram/histogramAsync", () => ({
+  computeHistogramAsync: jest.fn(() =>
+    Promise.resolve({
+      r: new Uint32Array(256),
+      g: new Uint32Array(256),
+      b: new Uint32Array(256),
+      luminance: new Uint32Array(256),
+      pixelCount: 0
+    })
+  )
+}));
+
+const defaultProps = {
+  id: "node-1",
+  nodeType: "nodetool.image.Levels",
+  nodeMetadata: {
+    node_type: "nodetool.image.Levels",
+    properties: [{ name: "image", type: "image" }],
+    outputs: [{ name: "output", type: "image" }],
+    is_streaming_output: false
+  } as unknown as import("../../../../stores/ApiTypes").NodeMetadata,
+  data: { properties: {} } as import("../../../../stores/NodeData").NodeData,
+  workflowId: "wf-1",
+  status: "completed",
+  isOutputNode: false
+};
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("LevelsBody", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dropzone when no image is connected", () => {
+    renderWithTheme(<LevelsBody {...defaultProps} />);
+    expect(screen.getByText(/Connect an image/i)).toBeInTheDocument();
+  });
+
+  it("renders with an image result", () => {
+    const mockGetResult = jest.fn(() => ({
+      output: { uri: "http://example.com/image.png" }
+    }));
+    require("../../../../stores/ResultsStore").default.mockImplementation(
+      (selector: any) => selector({ getResult: mockGetResult })
+    );
+
+    renderWithTheme(<LevelsBody {...defaultProps} />);
+    expect(document.querySelector(".levels-body")).toBeInTheDocument();
+  });
+
+  it("switches channel when toggle buttons are clicked", () => {
+    renderWithTheme(<LevelsBody {...defaultProps} />);
+    const gButton = screen.getByRole("button", { name: /G/i });
+    fireEvent.click(gButton);
+    expect(gButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("calls setProperty when a slider changes", () => {
+    renderWithTheme(<LevelsBody {...defaultProps} />);
+    const sliders = screen.getAllByRole("slider");
+    expect(sliders.length).toBeGreaterThanOrEqual(3);
+
+    fireEvent.change(sliders[0], { target: { value: "50" } });
+    expect(mockSetProperty).toHaveBeenCalledWith("r_black", 50);
+  });
+
+  it("calls setProperties with defaults on reset", () => {
+    renderWithTheme(<LevelsBody {...defaultProps} />);
+    const resetButton = screen.getByRole("button", { name: /Reset levels/i });
+    fireEvent.click(resetButton);
+    expect(mockSetProperties).toHaveBeenCalledWith({
+      r_black: 0,
+      r_gamma: 1,
+      r_white: 255,
+      g_black: 0,
+      g_gamma: 1,
+      g_white: 255,
+      b_black: 0,
+      b_gamma: 1,
+      b_white: 255
+    });
+    expect(mockSetPropertyComplete).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -6,6 +6,7 @@ import {
 import BlurBody from "./BlurBody";
 import ChannelsBody from "./ChannelsBody";
 import CropBody from "./CropBody";
+import MasksExtractorBody from "./MasksExtractorBody";
 import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
 import type { NodeMetadata } from "../../../stores/ApiTypes";
@@ -37,6 +38,21 @@ describe("bespokeRegistry", () => {
     expect(isBespokeNode(m)).toBe(true);
     expect(getBespokeBody(m)).toBe(ChannelsBody);
     expect(BESPOKE_BODY_REGISTRY["nodetool.image.Channels"]).toBe(ChannelsBody);
+  });
+
+  it("maps mask-extractor node types → MasksExtractorBody", () => {
+    const types = [
+      "replicate.image.background.Bria_RemoveBackground",
+      "replicate.image.background.BackgroundRemover_851",
+      "replicate.image.background.BackgroundRemover_Codeplug",
+      "replicate.image.process.RemoveBackground"
+    ];
+    for (const t of types) {
+      const m = meta(t);
+      expect(isBespokeNode(m)).toBe(true);
+      expect(getBespokeBody(m)).toBe(MasksExtractorBody);
+      expect(BESPOKE_BODY_REGISTRY[t]).toBe(MasksExtractorBody);
+    }
   });
 
   it("maps nodetool.image.Crop → CropBody", () => {

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -6,6 +6,7 @@ import {
 import BlurBody from "./BlurBody";
 import ChannelsBody from "./ChannelsBody";
 import CropBody from "./CropBody";
+import LevelsBody from "./LevelsBody";
 import MasksExtractorBody from "./MasksExtractorBody";
 import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
@@ -21,9 +22,8 @@ describe("bespokeRegistry", () => {
   });
 
   it("does not match utility / generic nodes", () => {
-    expect(isBespokeNode(meta("nodetool.control.If"))).toBe(false);
-    expect(isBespokeNode(meta("nodetool.image.Levels"))).toBe(false);
-    expect(getBespokeBody(meta("nodetool.image.Levels"))).toBeUndefined();
+    expect(isBespokeNode(meta("nodetool.image.Compositor"))).toBe(false);
+    expect(getBespokeBody(meta("nodetool.image.Compositor"))).toBeUndefined();
   });
 
   it("maps nodetool.image.Blur → BlurBody", () => {
@@ -53,6 +53,13 @@ describe("bespokeRegistry", () => {
       expect(getBespokeBody(m)).toBe(MasksExtractorBody);
       expect(BESPOKE_BODY_REGISTRY[t]).toBe(MasksExtractorBody);
     }
+  });
+
+  it("maps nodetool.image.Levels → LevelsBody", () => {
+    const m = meta("nodetool.image.Levels");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(LevelsBody);
+    expect(BESPOKE_BODY_REGISTRY["nodetool.image.Levels"]).toBe(LevelsBody);
   });
 
   it("maps nodetool.image.Crop → CropBody", () => {

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -16,6 +16,9 @@ import type { NodeData } from "../../../stores/NodeData";
 import BlurBody, { BLUR_NODE_TYPE } from "./BlurBody";
 import ChannelsBody, { CHANNELS_NODE_TYPE } from "./ChannelsBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
+import MasksExtractorBody, {
+  MASKS_EXTRACTOR_NODE_TYPES
+} from "./MasksExtractorBody";
 import ResizeBody, { RESIZE_NODE_TYPE } from "./ResizeBody";
 import RotateAndFlipBody, {
   ROTATE_AND_FLIP_NODE_TYPE
@@ -40,7 +43,10 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [CHANNELS_NODE_TYPE]: ChannelsBody,
   [CROP_NODE_TYPE]: CropBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
-  [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody
+  [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
+  ...Object.fromEntries(
+    MASKS_EXTRACTOR_NODE_TYPES.map((t) => [t, MasksExtractorBody] as const)
+  )
 };
 
 export const isBespokeNode = (

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -16,6 +16,7 @@ import type { NodeData } from "../../../stores/NodeData";
 import BlurBody, { BLUR_NODE_TYPE } from "./BlurBody";
 import ChannelsBody, { CHANNELS_NODE_TYPE } from "./ChannelsBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
+import LevelsBody, { LEVELS_NODE_TYPE } from "./LevelsBody";
 import MasksExtractorBody, {
   MASKS_EXTRACTOR_NODE_TYPES
 } from "./MasksExtractorBody";
@@ -42,6 +43,7 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [BLUR_NODE_TYPE]: BlurBody,
   [CHANNELS_NODE_TYPE]: ChannelsBody,
   [CROP_NODE_TYPE]: CropBody,
+  [LEVELS_NODE_TYPE]: LevelsBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
   [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
   ...Object.fromEntries(

--- a/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRunSingleNode } from "../useRunSingleNode";
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodeStoreRef: jest.fn()
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWebsocketRunner: jest.fn()
+}));
+
+jest.mock("../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: jest.fn()
+}));
+
+jest.mock("../../../utils/edgeValue", () => ({
+  resolveExternalEdgeValue: jest.fn()
+}));
+
+import { useNodeStoreRef } from "../../../contexts/NodeContext";
+import { useWebsocketRunner } from "../../../stores/WorkflowRunner";
+import useResultsStore from "../../../stores/ResultsStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+import { resolveExternalEdgeValue } from "../../../utils/edgeValue";
+
+const mockUseNodeStoreRef = useNodeStoreRef as jest.Mock;
+const mockUseWebsocketRunner = useWebsocketRunner as jest.Mock;
+const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
+const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
+const mockResolveExternalEdgeValue = resolveExternalEdgeValue as jest.Mock;
+
+describe("useRunSingleNode", () => {
+  const mockRun = jest.fn();
+  const mockFindNode = jest.fn();
+  const mockGetResult = jest.fn();
+  const mockAddNotification = jest.fn();
+
+  const nodeId = "node-1";
+  const workflowId = "workflow-1";
+
+  const defaultNode = {
+    id: nodeId,
+    type: "nodetool.image.Crop",
+    data: {
+      properties: { left: 0 },
+      dynamic_properties: { image: "const-image" }
+    }
+  };
+
+  const defaultWorkflow = { id: workflowId, name: "Test Workflow" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockUseWebsocketRunner.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { run: mockRun, state: "idle" };
+        return selector(state);
+      }
+    );
+
+    mockUseResultsStore.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { getResult: mockGetResult };
+        return selector(state);
+      }
+    );
+
+    mockUseNotificationStore.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { addNotification: mockAddNotification };
+        return selector(state);
+      }
+    );
+
+    mockFindNode.mockImplementation((id: string) =>
+      id === nodeId ? defaultNode : undefined
+    );
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: undefined,
+      hasValue: false,
+      isFallback: false
+    });
+  });
+
+  it("returns early when workflow is already running", () => {
+    mockUseWebsocketRunner.mockImplementation(
+      (selector: (state: Record<string, unknown>) => unknown) => {
+        const state = { run: mockRun, state: "running" };
+        return selector(state);
+      }
+    );
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("returns early when node is not found", () => {
+    mockFindNode.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("applies edge overrides to dynamic_properties when key exists there", () => {
+    const edge = {
+      id: "e1",
+      source: "upstream",
+      target: nodeId,
+      sourceHandle: "output",
+      targetHandle: "image"
+    };
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [edge],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: "upstream-image",
+      hasValue: true,
+      isFallback: false
+    });
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const nodesPassedToRun = mockRun.mock.calls[0][2];
+    const passedNode = nodesPassedToRun.find(
+      (n: { id: string }) => n.id === nodeId
+    );
+    expect(passedNode.data.dynamic_properties.image).toBe("upstream-image");
+  });
+
+  it("applies edge overrides to properties when key does not exist in dynamic_properties", () => {
+    const edge = {
+      id: "e1",
+      source: "upstream",
+      target: nodeId,
+      sourceHandle: "output",
+      targetHandle: "left"
+    };
+
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        edges: [edge],
+        workflow: defaultWorkflow,
+        findNode: mockFindNode
+      })
+    });
+
+    mockResolveExternalEdgeValue.mockReturnValue({
+      value: 42,
+      hasValue: true,
+      isFallback: false
+    });
+
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const nodesPassedToRun = mockRun.mock.calls[0][2];
+    const passedNode = nodesPassedToRun.find(
+      (n: { id: string }) => n.id === nodeId
+    );
+    expect(passedNode.data.properties.left).toBe(42);
+  });
+
+  it("passes subgraphNodeIds as a Set containing only the target node id", () => {
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const subgraphNodeIds = mockRun.mock.calls[0][5];
+    expect(subgraphNodeIds).toBeInstanceOf(Set);
+    expect(subgraphNodeIds.has(nodeId)).toBe(true);
+    expect(subgraphNodeIds.size).toBe(1);
+  });
+
+  it("shows notification after triggering run", () => {
+    const { result } = renderHook(() => useRunSingleNode(nodeId));
+
+    act(() => {
+      result.current.runSingleNode();
+    });
+
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        alert: false
+      })
+    );
+  });
+});

--- a/web/src/hooks/nodes/useRunSingleNode.ts
+++ b/web/src/hooks/nodes/useRunSingleNode.ts
@@ -1,0 +1,108 @@
+import { useCallback } from "react";
+import { Edge, Node } from "@xyflow/react";
+
+import { NodeData } from "../../stores/NodeData";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import useResultsStore from "../../stores/ResultsStore";
+import { useWebsocketRunner } from "../../stores/WorkflowRunner";
+import { resolveExternalEdgeValue } from "../../utils/edgeValue";
+import { useNodeStoreRef } from "../../contexts/NodeContext";
+
+interface UseRunSingleNodeReturn {
+  runSingleNode: () => void;
+  isWorkflowRunning: boolean;
+}
+
+/**
+ * Run a single node by id. Inbound edges from non-selected upstream nodes
+ * are resolved to their last cached result (same strategy as
+ * `useRunSelectedNodes`), so the node executes with realistic inputs even
+ * when only this one node is "in the subgraph".
+ *
+ * Used by bespoke editing bodies (e.g. MasksExtractorBody) that expose a
+ * "Recalculate" action without requiring the user to select the node first.
+ */
+export function useRunSingleNode(nodeId: string): UseRunSingleNodeReturn {
+  const nodeStore = useNodeStoreRef();
+
+  const run = useWebsocketRunner((state) => state.run);
+  const isWorkflowRunning = useWebsocketRunner(
+    (state) => state.state === "running"
+  );
+  const getResult = useResultsStore((state) => state.getResult);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const runSingleNode = useCallback(() => {
+    if (isWorkflowRunning) {
+      return;
+    }
+
+    const { edges, workflow, findNode } = nodeStore.getState();
+    const node = findNode(nodeId);
+    if (!node) {
+      return;
+    }
+
+    const inboundEdges = edges.filter((e: Edge) => e.target === nodeId);
+
+    const overrides: Record<string, unknown> = {};
+    for (const edge of inboundEdges) {
+      if (!edge.targetHandle) {
+        continue;
+      }
+      const { value, hasValue } = resolveExternalEdgeValue(
+        edge,
+        workflow.id,
+        getResult,
+        findNode
+      );
+      if (hasValue) {
+        overrides[edge.targetHandle] = value;
+      }
+    }
+
+    const dynamicProps = node.data?.dynamic_properties || {};
+    const staticProps = node.data?.properties || {};
+    const updatedDynamicProps = { ...dynamicProps };
+    const updatedStaticProps = { ...staticProps };
+
+    for (const [key, value] of Object.entries(overrides)) {
+      if (Object.prototype.hasOwnProperty.call(dynamicProps, key)) {
+        updatedDynamicProps[key] = value;
+      } else {
+        updatedStaticProps[key] = value;
+      }
+    }
+
+    const nodeWithOverrides: Node<NodeData> = {
+      ...node,
+      data: {
+        ...node.data,
+        properties: updatedStaticProps,
+        dynamic_properties: updatedDynamicProps
+      }
+    };
+
+    run(
+      {},
+      workflow,
+      [nodeWithOverrides],
+      [],
+      undefined,
+      new Set([nodeId])
+    );
+
+    addNotification({
+      type: "info",
+      alert: false,
+      content: "Running node"
+    });
+  }, [nodeId, isWorkflowRunning, nodeStore, getResult, run, addNotification]);
+
+  return {
+    runSingleNode,
+    isWorkflowRunning
+  };
+}

--- a/web/src/hooks/nodes/useRunSingleNode.ts
+++ b/web/src/hooks/nodes/useRunSingleNode.ts
@@ -36,6 +36,7 @@ export function useRunSingleNode(nodeId: string): UseRunSingleNodeReturn {
 
   const runSingleNode = useCallback(() => {
     if (isWorkflowRunning) {
+      console.info("useRunSingleNode: workflow already running, skipping");
       return;
     }
 

--- a/web/src/utils/histogram/__tests__/computeHistogram.test.ts
+++ b/web/src/utils/histogram/__tests__/computeHistogram.test.ts
@@ -35,4 +35,42 @@ describe("computeHistogramFromRgba", () => {
     expect(sum).toBe(1);
     expect(hist.luminance[54]).toBe(1);
   });
+
+  it("throws when buffer length is not a multiple of 4", () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0]);
+    expect(() => computeHistogramFromRgba(rgba)).toThrow(/multiple of 4/);
+  });
+
+  it("handles empty array", () => {
+    const rgba = new Uint8ClampedArray(0);
+    const hist = computeHistogramFromRgba(rgba);
+    expect(hist.pixelCount).toBe(0);
+    expect(hist.r.reduce((a, b) => a + b, 0)).toBe(0);
+  });
+
+  it("handles all-black image", () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      0, 0, 0, 255
+    ]);
+    const hist = computeHistogramFromRgba(rgba);
+    expect(hist.pixelCount).toBe(2);
+    expect(hist.r[0]).toBe(2);
+    expect(hist.g[0]).toBe(2);
+    expect(hist.b[0]).toBe(2);
+    expect(hist.luminance[0]).toBe(2);
+  });
+
+  it("handles all-white image", () => {
+    const rgba = new Uint8ClampedArray([
+      255, 255, 255, 255,
+      255, 255, 255, 255
+    ]);
+    const hist = computeHistogramFromRgba(rgba);
+    expect(hist.pixelCount).toBe(2);
+    expect(hist.r[255]).toBe(2);
+    expect(hist.g[255]).toBe(2);
+    expect(hist.b[255]).toBe(2);
+    expect(hist.luminance[255]).toBe(2);
+  });
 });

--- a/web/src/utils/histogram/__tests__/computeHistogram.test.ts
+++ b/web/src/utils/histogram/__tests__/computeHistogram.test.ts
@@ -1,0 +1,38 @@
+import { computeHistogramFromRgba } from "../computeHistogram";
+
+describe("computeHistogramFromRgba", () => {
+  it("returns 256-bin Uint32Arrays for each channel", () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255]);
+    const hist = computeHistogramFromRgba(rgba);
+    expect(hist.r.length).toBe(256);
+    expect(hist.g.length).toBe(256);
+    expect(hist.b.length).toBe(256);
+    expect(hist.luminance.length).toBe(256);
+  });
+
+  it("counts every pixel in each per-channel histogram", () => {
+    // 4 pixels: white, black, gray, gray
+    const rgba = new Uint8ClampedArray([
+      255, 255, 255, 255,
+      0, 0, 0, 255,
+      128, 128, 128, 255,
+      128, 128, 128, 255
+    ]);
+    const hist = computeHistogramFromRgba(rgba);
+    expect(hist.pixelCount).toBe(4);
+    expect(hist.r[255]).toBe(1);
+    expect(hist.r[0]).toBe(1);
+    expect(hist.r[128]).toBe(2);
+    expect(hist.g[128]).toBe(2);
+    expect(hist.b[128]).toBe(2);
+  });
+
+  it("computes Rec. 709 luminance bucketed to 0–255", () => {
+    // Pure red → Y ≈ 0.2126 * 255 ≈ 54
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    const hist = computeHistogramFromRgba(rgba);
+    const sum = hist.luminance.reduce((a, b) => a + b, 0);
+    expect(sum).toBe(1);
+    expect(hist.luminance[54]).toBe(1);
+  });
+});

--- a/web/src/utils/histogram/__tests__/histogramAsync.test.ts
+++ b/web/src/utils/histogram/__tests__/histogramAsync.test.ts
@@ -1,0 +1,120 @@
+import { computeHistogramAsync } from "../histogramAsync";
+
+describe("computeHistogramAsync", () => {
+  it("falls back to inline computation for small images", async () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    const hist = await computeHistogramAsync({
+      rgba,
+      width: 1,
+      height: 1
+    });
+    expect(hist.pixelCount).toBe(1);
+    expect(hist.r[255]).toBe(1);
+  });
+
+  it("falls back to inline when Worker is undefined", async () => {
+    const originalWorker = global.Worker;
+    // @ts-expect-error simulate environment without Worker
+    global.Worker = undefined;
+
+    const rgba = new Uint8ClampedArray([
+      255, 255, 255, 255,
+      0, 0, 0, 255
+    ]);
+    const hist = await computeHistogramAsync({
+      rgba,
+      width: 1,
+      height: 2
+    });
+    expect(hist.pixelCount).toBe(2);
+
+    global.Worker = originalWorker;
+  });
+
+  it("uses a Worker for large images when available", async () => {
+    const mockPostMessage = jest.fn();
+    const mockTerminate = jest.fn();
+    const listeners: Record<string, ((e: unknown) => void)[]> = {};
+
+    class MockWorker {
+      addEventListener = jest.fn((event: string, handler: (e: unknown) => void) => {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+      });
+      removeEventListener = jest.fn();
+      postMessage = mockPostMessage;
+      terminate = mockTerminate;
+    }
+
+    const originalWorker = global.Worker;
+    // @ts-expect-error Mock Worker constructor
+    global.Worker = MockWorker;
+
+    const rgba = new Uint8ClampedArray(4 * 1024 * 1024 + 4);
+    rgba[0] = 128;
+    const promise = computeHistogramAsync({
+      rgba,
+      width: 1024,
+      height: 1024 + 1
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    const postArgs = mockPostMessage.mock.calls[0];
+    expect(postArgs[0]).toHaveProperty("id");
+    expect(postArgs[0]).toHaveProperty("rgbaBuffer");
+
+    // Simulate successful worker response
+    const messageHandlers = listeners["message"] || [];
+    const response = {
+      id: postArgs[0].id,
+      r: new Uint32Array(256).buffer,
+      g: new Uint32Array(256).buffer,
+      b: new Uint32Array(256).buffer,
+      luminance: new Uint32Array(256).buffer,
+      pixelCount: rgba.length / 4
+    };
+    messageHandlers.forEach((h) =>
+      h({ data: response } as MessageEvent)
+    );
+
+    const hist = await promise;
+    expect(hist.pixelCount).toBe(rgba.length / 4);
+    expect(mockTerminate).toHaveBeenCalledTimes(1);
+
+    global.Worker = originalWorker;
+  });
+
+  it("rejects only the affected request when a Worker errors", async () => {
+    const listeners: Record<string, ((e: unknown) => void)[]> = {};
+
+    class MockWorker {
+      addEventListener = jest.fn((event: string, handler: (e: unknown) => void) => {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+      });
+      removeEventListener = jest.fn();
+      postMessage = jest.fn();
+      terminate = jest.fn();
+    }
+
+    const originalWorker = global.Worker;
+    // @ts-expect-error Mock Worker constructor
+    global.Worker = MockWorker;
+
+    const rgba = new Uint8ClampedArray(4 * 1024 * 1024 + 4);
+    const promise = computeHistogramAsync({
+      rgba,
+      width: 1024,
+      height: 1024 + 1
+    });
+
+    const errorHandlers = listeners["error"] || [];
+    errorHandlers.forEach((h) =>
+      h(new ErrorEvent("error", { message: "worker crash" }))
+    );
+
+    await expect(promise).rejects.toThrow("worker crash");
+
+    global.Worker = originalWorker;
+  });
+});

--- a/web/src/utils/histogram/computeHistogram.ts
+++ b/web/src/utils/histogram/computeHistogram.ts
@@ -21,6 +21,9 @@ export function computeHistogramFromRgba(
   const b = new Uint32Array(256);
   const luminance = new Uint32Array(256);
   const len = rgba.length;
+  if (len % 4 !== 0) {
+    throw new Error(`RGBA buffer length must be a multiple of 4, got ${len}`);
+  }
   let pixels = 0;
 
   for (let i = 0; i < len; i += 4) {

--- a/web/src/utils/histogram/computeHistogram.ts
+++ b/web/src/utils/histogram/computeHistogram.ts
@@ -1,0 +1,39 @@
+/**
+ * Histogram computation for RGBA pixel data (used by LevelsBody).
+ *
+ * Each output channel is a 256-bin Uint32Array (count of pixels per
+ * intensity). Luminance is Rec. 709 weights (0.2126 R + 0.7152 G + 0.0722 B).
+ */
+
+export interface ImageHistogram {
+  r: Uint32Array;
+  g: Uint32Array;
+  b: Uint32Array;
+  luminance: Uint32Array;
+  pixelCount: number;
+}
+
+export function computeHistogramFromRgba(
+  rgba: Uint8ClampedArray | Uint8Array
+): ImageHistogram {
+  const r = new Uint32Array(256);
+  const g = new Uint32Array(256);
+  const b = new Uint32Array(256);
+  const luminance = new Uint32Array(256);
+  const len = rgba.length;
+  let pixels = 0;
+
+  for (let i = 0; i < len; i += 4) {
+    const cr = rgba[i];
+    const cg = rgba[i + 1];
+    const cb = rgba[i + 2];
+    r[cr]++;
+    g[cg]++;
+    b[cb]++;
+    const y = Math.round(0.2126 * cr + 0.7152 * cg + 0.0722 * cb);
+    luminance[y > 255 ? 255 : y < 0 ? 0 : y]++;
+    pixels++;
+  }
+
+  return { r, g, b, luminance, pixelCount: pixels };
+}

--- a/web/src/utils/histogram/histogramAsync.ts
+++ b/web/src/utils/histogram/histogramAsync.ts
@@ -11,15 +11,6 @@ import {
 
 const WORKER_THRESHOLD_PIXELS = 1024 * 1024;
 
-interface PendingRequest {
-  resolve: (hist: ImageHistogram) => void;
-  reject: (err: Error) => void;
-}
-
-let workerInstance: Worker | null = null;
-let nextRequestId = 1;
-const pending = new Map<number, PendingRequest>();
-
 interface HistogramWorkerResponse {
   id: number;
   r: ArrayBuffer;
@@ -27,45 +18,6 @@ interface HistogramWorkerResponse {
   b: ArrayBuffer;
   luminance: ArrayBuffer;
   pixelCount: number;
-}
-
-function handleWorkerMessage(
-  event: MessageEvent<HistogramWorkerResponse>
-): void {
-  const p = pending.get(event.data.id);
-  if (!p) return;
-  pending.delete(event.data.id);
-  p.resolve({
-    r: new Uint32Array(event.data.r),
-    g: new Uint32Array(event.data.g),
-    b: new Uint32Array(event.data.b),
-    luminance: new Uint32Array(event.data.luminance),
-    pixelCount: event.data.pixelCount
-  });
-}
-
-function handleWorkerError(event: ErrorEvent): void {
-  const err =
-    event.error instanceof Error
-      ? event.error
-      : new Error(event.message || "Histogram worker failed");
-  for (const [, p] of pending) {
-    p.reject(err);
-  }
-  pending.clear();
-  workerInstance = null;
-}
-
-function getWorker(): Worker {
-  if (!workerInstance) {
-    workerInstance = new Worker(
-      new URL("./histogramWorker.ts", import.meta.url),
-      { type: "module" }
-    );
-    workerInstance.addEventListener("message", handleWorkerMessage);
-    workerInstance.addEventListener("error", handleWorkerError);
-  }
-  return workerInstance;
 }
 
 export interface HistogramRequest {
@@ -84,15 +36,41 @@ export function computeHistogramAsync(
     return Promise.resolve(computeHistogramFromRgba(request.rgba));
   }
 
-  const worker = getWorker();
-  const id = nextRequestId++;
   return new Promise<ImageHistogram>((resolve, reject) => {
-    pending.set(id, { resolve, reject });
+    const worker = new Worker(
+      new URL("./histogramWorker.ts", import.meta.url),
+      { type: "module" }
+    );
+
+    const handleMessage = (event: MessageEvent<HistogramWorkerResponse>) => {
+      worker.removeEventListener("message", handleMessage);
+      worker.removeEventListener("error", handleError);
+      worker.terminate();
+      resolve({
+        r: new Uint32Array(event.data.r),
+        g: new Uint32Array(event.data.g),
+        b: new Uint32Array(event.data.b),
+        luminance: new Uint32Array(event.data.luminance),
+        pixelCount: event.data.pixelCount
+      });
+    };
+
+    const handleError = (event: ErrorEvent) => {
+      worker.removeEventListener("message", handleMessage);
+      worker.removeEventListener("error", handleError);
+      worker.terminate();
+      reject(
+        event.error instanceof Error
+          ? event.error
+          : new Error(event.message || "Histogram worker failed")
+      );
+    };
+
+    worker.addEventListener("message", handleMessage);
+    worker.addEventListener("error", handleError);
+
     const { buffer, byteOffset, byteLength } = request.rgba;
-    const rgbaBuffer = buffer.slice(
-      byteOffset,
-      byteOffset + byteLength
-    ) as ArrayBuffer;
-    worker.postMessage({ id, rgbaBuffer }, [rgbaBuffer]);
+    const rgbaBuffer = buffer.slice(byteOffset, byteOffset + byteLength);
+    worker.postMessage({ id: 1, rgbaBuffer }, [rgbaBuffer]);
   });
 }

--- a/web/src/utils/histogram/histogramAsync.ts
+++ b/web/src/utils/histogram/histogramAsync.ts
@@ -1,0 +1,98 @@
+/**
+ * Async histogram API used by LevelsBody. For images larger than the
+ * threshold (1024² = 1_048_576 pixels), computation is offloaded to a
+ * dedicated web worker; smaller images run on the main thread.
+ */
+
+import {
+  computeHistogramFromRgba,
+  type ImageHistogram
+} from "./computeHistogram";
+
+const WORKER_THRESHOLD_PIXELS = 1024 * 1024;
+
+interface PendingRequest {
+  resolve: (hist: ImageHistogram) => void;
+  reject: (err: Error) => void;
+}
+
+let workerInstance: Worker | null = null;
+let nextRequestId = 1;
+const pending = new Map<number, PendingRequest>();
+
+interface HistogramWorkerResponse {
+  id: number;
+  r: ArrayBuffer;
+  g: ArrayBuffer;
+  b: ArrayBuffer;
+  luminance: ArrayBuffer;
+  pixelCount: number;
+}
+
+function handleWorkerMessage(
+  event: MessageEvent<HistogramWorkerResponse>
+): void {
+  const p = pending.get(event.data.id);
+  if (!p) return;
+  pending.delete(event.data.id);
+  p.resolve({
+    r: new Uint32Array(event.data.r),
+    g: new Uint32Array(event.data.g),
+    b: new Uint32Array(event.data.b),
+    luminance: new Uint32Array(event.data.luminance),
+    pixelCount: event.data.pixelCount
+  });
+}
+
+function handleWorkerError(event: ErrorEvent): void {
+  const err =
+    event.error instanceof Error
+      ? event.error
+      : new Error(event.message || "Histogram worker failed");
+  for (const [, p] of pending) {
+    p.reject(err);
+  }
+  pending.clear();
+  workerInstance = null;
+}
+
+function getWorker(): Worker {
+  if (!workerInstance) {
+    workerInstance = new Worker(
+      new URL("./histogramWorker.ts", import.meta.url),
+      { type: "module" }
+    );
+    workerInstance.addEventListener("message", handleWorkerMessage);
+    workerInstance.addEventListener("error", handleWorkerError);
+  }
+  return workerInstance;
+}
+
+export interface HistogramRequest {
+  rgba: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+export function computeHistogramAsync(
+  request: HistogramRequest
+): Promise<ImageHistogram> {
+  const pixelCount = request.width * request.height;
+
+  // Small image or no Worker support → run inline.
+  if (pixelCount < WORKER_THRESHOLD_PIXELS || typeof Worker === "undefined") {
+    return Promise.resolve(computeHistogramFromRgba(request.rgba));
+  }
+
+  const worker = getWorker();
+  const id = nextRequestId++;
+  return new Promise<ImageHistogram>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    const { buffer, byteOffset, byteLength } = request.rgba;
+    const rgbaBuffer = buffer.slice(
+      byteOffset,
+      byteOffset + byteLength
+    ) as ArrayBuffer;
+    worker.postMessage({ id, rgbaBuffer }, [rgbaBuffer]);
+  });
+}

--- a/web/src/utils/histogram/histogramWorker.ts
+++ b/web/src/utils/histogram/histogramWorker.ts
@@ -1,0 +1,42 @@
+/**
+ * Web worker for histogram computation. Receives RGBA byte buffer +
+ * dimensions, returns four 256-entry Uint32Arrays packed back as
+ * transferable ArrayBuffers.
+ */
+
+import { computeHistogramFromRgba } from "./computeHistogram";
+
+interface HistogramRequest {
+  id: number;
+  rgbaBuffer: ArrayBuffer;
+}
+
+interface HistogramResponse {
+  id: number;
+  r: ArrayBuffer;
+  g: ArrayBuffer;
+  b: ArrayBuffer;
+  luminance: ArrayBuffer;
+  pixelCount: number;
+}
+
+self.addEventListener("message", (event: MessageEvent<HistogramRequest>) => {
+  const { id, rgbaBuffer } = event.data;
+  const rgba = new Uint8ClampedArray(rgbaBuffer);
+  const hist = computeHistogramFromRgba(rgba);
+  const response: HistogramResponse = {
+    id,
+    r: hist.r.buffer as ArrayBuffer,
+    g: hist.g.buffer as ArrayBuffer,
+    b: hist.b.buffer as ArrayBuffer,
+    luminance: hist.luminance.buffer as ArrayBuffer,
+    pixelCount: hist.pixelCount
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (self as any).postMessage(response, [
+    response.r,
+    response.g,
+    response.b,
+    response.luminance
+  ]);
+});

--- a/web/src/utils/histogram/histogramWorker.ts
+++ b/web/src/utils/histogram/histogramWorker.ts
@@ -1,7 +1,7 @@
 /**
- * Web worker for histogram computation. Receives RGBA byte buffer +
- * dimensions, returns four 256-entry Uint32Arrays packed back as
- * transferable ArrayBuffers.
+ * Web worker for histogram computation. Receives an RGBA byte buffer,
+ * returns four 256-entry Uint32Arrays packed back as transferable
+ * ArrayBuffers.
  */
 
 import { computeHistogramFromRgba } from "./computeHistogram";

--- a/web/src/utils/imageRef.ts
+++ b/web/src/utils/imageRef.ts
@@ -1,0 +1,28 @@
+export interface ImageRefLike {
+  uri?: string;
+  width?: number;
+  height?: number;
+  data?: unknown;
+}
+
+export const asImageRef = (value: unknown): ImageRefLike | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  return {
+    uri: typeof v.uri === "string" ? v.uri : undefined,
+    width: typeof v.width === "number" ? v.width : undefined,
+    height: typeof v.height === "number" ? v.height : undefined,
+    data: v.data
+  };
+};
+
+export const unwrapOutput = (
+  value: unknown,
+  handle?: string | null
+): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const v = value as Record<string, unknown>;
+  if (handle && handle in v) return v[handle];
+  if ("output" in v) return v.output;
+  return value;
+};


### PR DESCRIPTION
## Summary
- Adds **nodetool.image.Levels** unified image-edit node. Per-channel input black point / gamma / white point via a 256-entry LUT applied to raw RGBA pixels through sharp. Added to `IMAGE_NODES`.
- Adds **LevelsBody** bespoke body — full-bleed preview, canvas **histogram** with R/G/B/Luminance view toggle, channel selector (R/G/B) with three sliders (Black/Gamma/White), Reset action.
- Adds histogram util (`web/src/utils/histogram/`): pure `computeHistogramFromRgba`, dedicated web worker, async wrapper that **offloads to the worker for images > 1024²** and computes inline below that threshold. Memoized via the preview-source `useEffect` deps.
- Registers `LEVELS_NODE_TYPE` in the bespoke registry. Rotates the negative-case sentinel to `nodetool.image.Compositor` (next track-E PR) and adds a Levels mapping spec.

Part of plan **P-2026-05-13-node-editor-redesign**, Track E (§9.E1), PR 15/17.

## Test plan
- [x] `npm --prefix packages/base-nodes run lint` — clean
- [x] `npx jest src/components/node_types/editing/bespokeRegistry.test.ts src/utils/histogram/__tests__/computeHistogram.test.ts` — 9/9 pass (Levels mapping + histogram bucketing)
- [x] `tsc --noEmit` for the web project — no new errors (one pre-existing unrelated error in `paintToolPanels.tsx`)
- [ ] Manual: drop a Levels node, connect an image, run; verify histogram updates on output change, sliders move levels, Reset restores neutral, and a large (>1024²) image stays responsive (worker path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)