### PR TITLE
fix: timeline editor bug sweep

### DIFF
--- a/packages/timeline/src/trimClip.ts
+++ b/packages/timeline/src/trimClip.ts
@@ -22,6 +22,10 @@ export function trimClip(
     throw new Error("trimClip cannot extend before source start");
   }
 
+  if (nextStartMs < 0) {
+    throw new Error("trimClip cannot start before zero on the timeline");
+  }
+
   if (maxDurationMs !== undefined && nextOutPointMs > maxDurationMs) {
     throw new Error("trimClip cannot extend beyond source out-point");
   }

--- a/packages/timeline/tests/trimClip.test.ts
+++ b/packages/timeline/tests/trimClip.test.ts
@@ -68,6 +68,13 @@ describe("trimClip", () => {
     expect(() => trimClip(clip, "end", 500, 900)).toThrow(/beyond source out-point/);
   });
 
+  it("throws when the start edge would move before zero on the timeline", () => {
+    const clip: TimelineClip = { ...makeBaseClip(), startMs: 50, inPointMs: 200 };
+    expect(() => trimClip(clip, "start", 100, 1000)).toThrow(
+      /before zero on the timeline/
+    );
+  });
+
   it("preserves generation hash fields", () => {
     const clip = makeBaseClip();
     const trimmed = trimClip(clip, "end", -50, 1000);

--- a/web/src/components/timeline/ActivityIndicator.tsx
+++ b/web/src/components/timeline/ActivityIndicator.tsx
@@ -120,6 +120,7 @@ const ClipListPopover: React.FC<ClipListPopoverProps> = memo(
                 aria-label={`Select clip: ${clip.name}`}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
                     handleSelectClip(clip.id);
                   }
                 }}

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -333,8 +333,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
       setRubberBand({ left, top, width, height });
 
-      // Compute which clips overlap the rubber-band
-      const rbStartMs = (left + e.currentTarget.scrollLeft) * msPerPx;
+      // Compute which clips overlap the rubber-band. The lane itself is not
+      // the scroll container — TracksRegion is — so e.currentTarget.scrollLeft
+      // is always 0. Use the UI store's tracked scroll offset instead.
+      const rbStartMs = (left + scrollLeftPx) * msPerPx;
       const rbEndMs = rbStartMs + width * msPerPx;
 
       // Read clips lazily to avoid subscribing to the full array in render
@@ -351,7 +353,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
       setSelection(selected);
     },
-    [msPerPx, track.id, setSelection]
+    [msPerPx, scrollLeftPx, track.id, setSelection]
   );
 
   const handleLanePointerUp = useCallback(() => {

--- a/web/src/components/timeline/preview/AudioGraph.ts
+++ b/web/src/components/timeline/preview/AudioGraph.ts
@@ -36,6 +36,12 @@ interface TrackChainState {
 
 const DB_TO_LIN = (db: number): number => Math.pow(10, db / 20);
 
+/**
+ * LRU cap on decoded AudioBuffer entries. A 3-min stereo @ 48 kHz buffer is
+ * ~70 MB; we keep a small working set and rely on re-decode on miss.
+ */
+const BUFFER_CACHE_MAX = 16;
+
 export class AudioGraph {
   private ctx: AudioContext | null = null;
   private masterGain: GainNode | null = null;
@@ -61,7 +67,11 @@ export class AudioGraph {
 
   async loadBuffer(assetId: string, url: string): Promise<AudioBuffer | null> {
     if (this.bufferCache.has(assetId)) {
-      return this.bufferCache.get(assetId)!;
+      const buffer = this.bufferCache.get(assetId)!;
+      // Touch as most-recent for LRU ordering.
+      this.bufferCache.delete(assetId);
+      this.bufferCache.set(assetId, buffer);
+      return buffer;
     }
     if (this.loadingPromises.has(assetId)) {
       return this.loadingPromises.get(assetId)!;
@@ -79,6 +89,14 @@ export class AudioGraph {
       .then((buffer) => {
         this.bufferCache.set(assetId, buffer);
         this.loadingPromises.delete(assetId);
+        // Evict least-recently-used entries to bound memory. Sources that are
+        // already running hold their own buffer reference, so eviction here
+        // does not interrupt in-flight playback.
+        while (this.bufferCache.size > BUFFER_CACHE_MAX) {
+          const oldestKey = this.bufferCache.keys().next().value;
+          if (oldestKey === undefined || oldestKey === assetId) break;
+          this.bufferCache.delete(oldestKey);
+        }
         return buffer;
       })
       .catch((err) => {
@@ -350,9 +368,15 @@ export class AudioGraph {
         continue;
       }
 
+      // If the speed change has been baked into the asset, the asset already
+      // plays at the right speed → do not re-apply the rate, and treat the
+      // clip's timeline duration as 1:1 with the buffer.
+      const rate =
+        clip.speedBaked ? 1 : Math.max(0.0001, clip.speedMultiplier ?? 1);
+
       const src = ctx.createBufferSource();
       src.buffer = buffer;
-      src.playbackRate.value = clip.speedMultiplier ?? 1;
+      src.playbackRate.value = rate;
 
       const volumeLinear = clip.volumeDb
         ? Math.pow(10, clip.volumeDb / 20)
@@ -364,14 +388,23 @@ export class AudioGraph {
       // Schedule the clip's start on the audio clock. If the clip begins in
       // the future (relative to the playhead), defer src.start; otherwise
       // start immediately with a buffer offset for mid-clip seeks.
+      //
+      // `src.start(when, offset, duration)` takes offset/duration in
+      // *buffer* seconds, while clip.startMs / durationMs / inPointMs are
+      // *timeline* milliseconds. With playbackRate = r, 1 timeline second
+      // consumes r buffer seconds, so we multiply by `rate`.
       const clipLeadSec = Math.max(0, (clip.startMs - currentTimeMs) / 1000);
+      const intoClipTimelineSec =
+        Math.max(0, currentTimeMs - clip.startMs) / 1000;
       const bufferOffsetSec =
-        Math.max(0, currentTimeMs - clip.startMs) / 1000 +
-        (clip.inPointMs ?? 0) / 1000;
-      const remainingMs =
+        intoClipTimelineSec * rate + (clip.inPointMs ?? 0) / 1000;
+      const remainingTimelineMs =
         clip.startMs + clip.durationMs - Math.max(currentTimeMs, clip.startMs);
-      const durationSec = Math.max(0, remainingMs / 1000);
+      const remainingTimelineSec = Math.max(0, remainingTimelineMs / 1000);
+      const bufferDurationSec = remainingTimelineSec * rate;
       const startAt = now + clipLeadSec;
+      // Wall-clock time at which playback ends — used to schedule fade-out.
+      const clipEndAt = startAt + remainingTimelineSec;
 
       if (clip.fadeInMs && clip.fadeInMs > 0) {
         const fadeEndMs = clip.startMs + clip.fadeInMs;
@@ -388,7 +421,6 @@ export class AudioGraph {
       }
 
       if (clip.fadeOutMs && clip.fadeOutMs > 0) {
-        const clipEndAt = startAt + durationSec;
         const fadeSec = clip.fadeOutMs / 1000;
         const fadeOutStartAt = Math.max(startAt, clipEndAt - fadeSec);
         if (fadeOutStartAt < clipEndAt) {
@@ -401,7 +433,7 @@ export class AudioGraph {
       const trackGain = this.getTrackGain(clip.trackId);
       clipGain.connect(trackGain);
 
-      src.start(startAt, bufferOffsetSec, durationSec);
+      src.start(startAt, bufferOffsetSec, bufferDurationSec);
 
       this.clipSources.set(clip.id, src);
       this.clipGains.set(clip.id, clipGain);

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -35,6 +35,9 @@ const COLD_POOL_SIZE = 4;
 const TOTAL_POOL_SIZE = HOT_POOL_SIZE + COLD_POOL_SIZE;
 /** Preload upcoming clips within this lookahead window (ms). */
 const PRELOAD_LOOKAHEAD_MS = 30_000;
+/** LRU cap on cached decoded <img> elements. Keeps memory bounded in long
+ *  sessions that touch many unique image assets. */
+const IMAGE_CACHE_MAX = 64;
 /**
  * Top-of-UI track (lowest `track.index`) renders on top in the composite —
  * matches Premiere / Resolve / FCP. Compositor draws layers from low z to
@@ -230,7 +233,13 @@ export const PreviewCompositor: React.FC = memo(() => {
   const poolContainerRef = useRef<HTMLDivElement>(null);
 
   // Image element cache, keyed by URL — fed to the compositor as image layers.
+  // Capped LRU (insertion order = recency) to bound memory in long sessions.
   const imageElementCache = useRef<Map<string, HTMLImageElement>>(new Map());
+
+  // Pending video-element seek closures, keyed by the element. Stored on a
+  // ref so the once-attached `loadedmetadata` listener always runs the most
+  // recent target rather than a stale snapshot.
+  const pendingSeeks = useRef<Map<HTMLVideoElement, () => void>>(new Map());
 
   const containerRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -261,6 +270,7 @@ export const PreviewCompositor: React.FC = memo(() => {
     videoRefs.current = pool;
     setPoolReady(true);
 
+    const pendingSeeksMap = pendingSeeks.current;
     return () => {
       for (const el of pool) {
         el.pause();
@@ -270,6 +280,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         }
       }
       videoRefs.current = [];
+      pendingSeeksMap.clear();
       setPoolReady(false);
     };
   }, []);
@@ -488,27 +499,67 @@ export const PreviewCompositor: React.FC = memo(() => {
       }
 
       const clip = clipById.get(slot.clipId);
-      const clipOffsetMs =
-        currentTimeMs - (clip?.startMs ?? 0) + (clip?.inPointMs ?? 0);
-      const targetSec = Math.max(0, clipOffsetMs / 1000);
+      // If the speed change has been baked into the asset, the asset already
+      // plays at the right rate; otherwise the source media is at original
+      // speed and 1 timeline second consumes `rate` source seconds.
+      const rate = clip?.speedBaked
+        ? 1
+        : Math.max(0.0001, clip?.speedMultiplier ?? 1);
+      const intoClipTimelineSec =
+        (currentTimeMs - (clip?.startMs ?? 0)) / 1000;
+      const targetSec = Math.max(
+        0,
+        intoClipTimelineSec * rate + (clip?.inPointMs ?? 0) / 1000
+      );
 
-      if (!isPlaying) {
-        if (Math.abs(el.currentTime - targetSec) > 0.04) {
-          el.currentTime = targetSec;
+      // Setting currentTime before HAVE_METADATA is silently clamped to 0 and
+      // a subsequent play() can reject with AbortError. Defer until the
+      // element reports metadata; on next render the slot's pending closure
+      // (kept in pendingSeeks) re-runs with fresh state.
+      const applySeek = () => {
+        if (el.readyState < 1) return;
+        if (!isPlaying) {
+          if (Math.abs(el.currentTime - targetSec) > 0.04) {
+            el.currentTime = targetSec;
+          }
+        } else {
+          if (Math.abs(el.currentTime - targetSec) > 0.15) {
+            el.currentTime = targetSec;
+          }
         }
+        el.playbackRate = rate;
+
+        if (isPlaying && el.paused) {
+          void el.play().catch(() => {
+            // Autoplay blocked; continue scrubbing via currentTime.
+          });
+        } else if (!isPlaying && !el.paused) {
+          el.pause();
+        }
+      };
+
+      if (el.readyState >= 1) {
+        applySeek();
       } else {
-        if (Math.abs(el.currentTime - targetSec) > 0.15) {
-          el.currentTime = targetSec;
+        // Always stash the latest closure so the listener runs with the most
+        // recent target. Only attach the listener once; mark the element so
+        // re-runs of this effect don't pile up handlers.
+        pendingSeeks.current.set(el, applySeek);
+        if (el.getAttribute("data-seek-pending") !== "1") {
+          el.setAttribute("data-seek-pending", "1");
+          el.addEventListener(
+            "loadedmetadata",
+            () => {
+              el.removeAttribute("data-seek-pending");
+              const fn = pendingSeeks.current.get(el);
+              if (fn) {
+                pendingSeeks.current.delete(el);
+                fn();
+              }
+            },
+            { once: true }
+          );
         }
-      }
-      el.playbackRate = clip?.speedMultiplier ?? 1;
-
-      if (isPlaying && el.paused) {
-        void el.play().catch(() => {
-          // Autoplay blocked; continue scrubbing via currentTime.
-        });
-      } else if (!isPlaying && !el.paused) {
-        el.pause();
       }
     });
 
@@ -556,6 +607,9 @@ export const PreviewCompositor: React.FC = memo(() => {
       if (!url) return null;
       const cached = imageElementCache.current.get(url);
       if (cached) {
+        // Touch as most-recent for LRU ordering.
+        imageElementCache.current.delete(url);
+        imageElementCache.current.set(url, cached);
         return cached.complete && cached.naturalWidth > 0 ? cached : null;
       }
       const img = new Image();
@@ -567,6 +621,12 @@ export const PreviewCompositor: React.FC = memo(() => {
       };
       img.src = url;
       imageElementCache.current.set(url, img);
+      // Evict least-recently-used entries until under the cap.
+      while (imageElementCache.current.size > IMAGE_CACHE_MAX) {
+        const oldestKey = imageElementCache.current.keys().next().value;
+        if (oldestKey === undefined || oldestKey === url) break;
+        imageElementCache.current.delete(oldestKey);
+      }
       return null;
     },
     []

--- a/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
+++ b/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
@@ -217,6 +217,56 @@ describe("useTimelineAutosave", () => {
     ).toBe("2026-01-01T00:00:01Z");
   });
 
+  it("flushes immediately (no debounce) when unmounted with a save in flight", async () => {
+    seedSequence();
+    let resolveFirst: (v: unknown) => void = () => {};
+    (updateMutate as any).mockImplementationOnce(
+      () =>
+        new Promise((resolve: (v: unknown) => void) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const { unmount } = renderHook(() =>
+      useTimelineAutosave({ debounceMs: 50 })
+    );
+
+    act(() => {
+      useTimelineStore.getState().addTrack("video");
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+
+    // Queue another mutation while the first save is still pending, then
+    // unmount — the post-completion handler should bypass the debounce.
+    act(() => {
+      useTimelineStore.getState().addTrack("audio");
+    });
+    unmount();
+
+    await act(async () => {
+      resolveFirst({
+        id: "seq-1",
+        projectId: "proj-1",
+        name: "Seq",
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationMs: 0,
+        tracks: [],
+        clips: [],
+        markers: [],
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:02Z"
+      });
+    });
+
+    // The second save fires without waiting for the debounce timer.
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(2));
+  });
+
   it("notifies on save failure", async () => {
     seedSequence();
     (updateMutate as any).mockRejectedValueOnce(new Error("boom"));

--- a/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
+++ b/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
@@ -255,6 +255,55 @@ describe("useWorkflowFreshnessCheck", () => {
     expect(updated?.paramOverrides?.keepMe).toBe("yes");
   });
 
+  it("defers the check until clips load into the store (avoids running with an empty clip set)", async () => {
+    // Mount the hook BEFORE seeding any clips — simulates the real flow where
+    // useLoadTimelineIntoStore populates the store asynchronously after the
+    // freshness hook is wired up.
+    useTimelineStore.setState({
+      sequenceId: null,
+      tracks: [],
+      clips: []
+    });
+
+    mockWorkflowsGet.mockResolvedValue(
+      buildWorkflow({ id: "wf-1", updatedAt: NEWER_UPDATED_AT })
+    );
+
+    renderHook(() => useWorkflowFreshnessCheck("seq-1"));
+
+    // Give any premature check a chance to run — none should fire while the
+    // store is still empty.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    expect(mockWorkflowsGet).not.toHaveBeenCalled();
+
+    // Now load clips, mimicking the async tRPC populate.
+    const track = makeTrack({ type: "video" });
+    const clip = makeClip({
+      trackId: track.id,
+      workflowId: "wf-1",
+      sourceType: "generated",
+      status: "generated",
+      versions: [makeSuccessVersion(BASE_UPDATED_AT)]
+    });
+    act(() => {
+      useTimelineStore.setState({
+        sequenceId: "seq-1",
+        tracks: [track],
+        clips: [clip]
+      });
+    });
+
+    // The check fires once the store carries clips for this sequence.
+    await waitFor(() => {
+      const current = useTimelineStore
+        .getState()
+        .clips.find((c) => c.id === clip.id);
+      expect(current?.status).toBe("stale");
+    });
+  });
+
   it("auto-resolves a missing selectedOutputNodeId to the first available output and marks the clip stale", async () => {
     const track = makeTrack({ type: "video" });
     const clipA = makeClip({

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -312,6 +312,15 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
       throw new Error("Clip is not bound to a workflow");
     }
 
+    // Single-flight per clip: if a job is already queued or running for this
+    // clip, do nothing. Without this guard a rapid double-click registers a
+    // second job that overwrites the first in the store, orphans the local
+    // subscription, and leaves the original job running on the server.
+    const existing = useTimelineGenerationStore.getState().clipJobs[clip.id];
+    if (existing && (existing.status === "queued" || existing.status === "running")) {
+      return;
+    }
+
     const workflow = await queryClient.fetchQuery({
       queryKey: workflowQueryKey(workflowId),
       queryFn: () => fetchWorkflowById(workflowId),

--- a/web/src/hooks/timeline/useTimelineAutosave.ts
+++ b/web/src/hooks/timeline/useTimelineAutosave.ts
@@ -60,6 +60,11 @@ export function useTimelineAutosave(
 
   useEffect(() => {
     let scheduleFn: () => void = () => {};
+    // When the host component unmounts while a save is in flight, the
+    // post-completion handler should bypass the debounce and flush the
+    // pending edit immediately so we don't lose work if the page closes
+    // shortly after.
+    let flushImmediatelyOnComplete = false;
 
     const runSave = async (snapshot: DocumentSnapshot) => {
       if (!snapshot.sequenceId) return;
@@ -93,7 +98,11 @@ export function useTimelineAutosave(
       } finally {
         inFlightRef.current = false;
         if (pendingRef.current) {
-          scheduleFn();
+          if (flushImmediatelyOnComplete) {
+            flush();
+          } else {
+            scheduleFn();
+          }
         }
       }
     };
@@ -147,7 +156,15 @@ export function useTimelineAutosave(
 
     return () => {
       unsubscribe();
-      flush();
+      if (inFlightRef.current) {
+        // A save is already running. Setting this flag tells its `finally`
+        // handler to flush the still-pending snapshot immediately rather
+        // than re-debouncing — protects the last edit when the page closes
+        // shortly after unmount.
+        flushImmediatelyOnComplete = true;
+      } else {
+        flush();
+      }
     };
   }, [debounceMs]);
 }

--- a/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
+++ b/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
@@ -156,8 +156,29 @@ export function useWorkflowFreshnessCheck(
   ]);
 
   useEffect(() => {
-    if (!sequenceId || lastCheckedSequenceId.current === sequenceId) return;
-    lastCheckedSequenceId.current = sequenceId;
-    void runCheck();
+    if (!sequenceId) return;
+
+    // The check reads clips from the store, but `useLoadTimelineIntoStore`
+    // populates them asynchronously. Defer until the store carries clips for
+    // this sequence so we don't permanently skip the check by tripping
+    // `lastCheckedSequenceId` against an empty store.
+    const tryRun = (): boolean => {
+      if (lastCheckedSequenceId.current === sequenceId) return true;
+      const state = useTimelineStore.getState();
+      if (state.sequenceId !== sequenceId) return false;
+      if (state.clips.length === 0) return false;
+      lastCheckedSequenceId.current = sequenceId;
+      void runCheck();
+      return true;
+    };
+
+    if (tryRun()) return;
+
+    const unsubscribe = useTimelineStore.subscribe(() => {
+      if (tryRun()) {
+        unsubscribe();
+      }
+    });
+    return unsubscribe;
   }, [sequenceId, runCheck]);
 }


### PR DESCRIPTION
Fixes ten bugs found during a focused review of the timeline editor:

- Rubber-band selection: TrackLane was reading scrollLeft from the lane
  div (always 0) instead of the UI store's scroll offset, so multi-clip
  drag-select picked the wrong clips whenever the timeline was scrolled.
- speedMultiplier handling: AudioGraph and the video preview pool passed
  timeline-second offsets/durations into APIs that expect source-time,
  and re-applied playbackRate even when speedBaked was true. Both audio
  scheduling and video scrubbing now compute source time as
  timelineTime * rate (rate = 1 when speedBaked).
- Workflow freshness check ran before useLoadTimelineIntoStore populated
  the clip array, so the early-return on an empty clip set permanently
  skipped the check. It now defers via a store subscription until clips
  for the current sequence appear.
- useGenerateClip lacked single-flight protection; double-clicks could
  register a second job over the first, orphaning the prior subscription
  while the original server-side job kept running. Early-return when a
  job is already queued or running for the same clip.
- PreviewCompositor's imageElementCache and AudioGraph's bufferCache
  grew without bound; both are now LRU-capped with touch-on-hit.
- Video seek+play race: setting currentTime before HAVE_METADATA was
  silently clamped to 0 and the follow-up play() promise rejected. Seeks
  now defer behind a once-attached loadedmetadata handler that runs the
  latest pending closure.
- trimClip allowed the start edge to move before zero on the timeline;
  added validation + test coverage.
- ActivityIndicator clip rows handled Space without preventDefault, so
  selecting via keyboard also scrolled the page.
- useTimelineAutosave's unmount cleanup deferred the final save by the
  debounce interval when a save was already in flight; now the
  post-completion handler flushes immediately on unmount.

https://claude.ai/code/session_01RTNdGNXWbxgjMZgoYS5q9X