### PR TITLE
fix(sketch): narrow StrokeAssistPreset cast to unblock CI typecheck

### DIFF
--- a/web/src/components/sketch/tool-settings-panels/paintToolPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/paintToolPanels.tsx
@@ -89,7 +89,9 @@ function StrokeAssistSettingsPanel<T extends StrokeAssistToolSettings>({
         value={assist.preset}
         onChange={(_, v) => {
           if (v) {
-            pushAssist(createStrokeAssistPreset(v as StrokeAssistPreset));
+            pushAssist(
+              createStrokeAssistPreset(v as Exclude<StrokeAssistPreset, "custom">)
+            );
           }
         }}
         sx={{ mb: "4px", flexWrap: "wrap" }}


### PR DESCRIPTION
## Summary

- One-line type-narrowing fix at \`paintToolPanels.tsx:92\`.
- \`SketchModeToggle\` types its value prop as \`Exclude<StrokeAssistPreset, "custom">\`, so the onChange's \`v\` cannot be \`"custom"\` at runtime. Cast accordingly so it satisfies \`createStrokeAssistPreset\`'s parameter type.

## Why

The pre-existing TS error has been failing Web Test on every CI run on main and on every PR that branches from it, blocking the bespoke-node-body PR stack (#3155–#3159) from passing CI.

## Test plan

- [x] \`tsc --noEmit\` passes locally on the web package after the change.
- [ ] CI Web Test job goes green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)