### PR TITLE
feat(sidebar): add Audio Models quick-access category

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20793,6 +20793,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20809,6 +20810,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20825,6 +20827,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20841,6 +20844,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20857,6 +20861,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20873,6 +20878,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20889,6 +20895,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20905,6 +20912,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20921,6 +20929,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20937,6 +20946,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20953,6 +20963,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20969,6 +20980,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20985,6 +20997,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21001,6 +21014,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21017,6 +21031,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21033,6 +21048,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21049,6 +21065,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21065,6 +21082,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21081,6 +21099,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21097,6 +21116,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21113,6 +21133,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21129,6 +21150,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21145,6 +21167,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21161,6 +21184,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21177,6 +21201,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21193,6 +21218,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -22,7 +22,7 @@ const meta = (
   }) as unknown as NodeMetadata;
 
 describe("quickAccessCategories", () => {
-  it("ships nine categories in order", () => {
+  it("ships ten categories in order", () => {
     const ids = QUICK_ACCESS_CATEGORIES.map((c) => c.id);
     expect(ids).toEqual([
       "search",
@@ -31,6 +31,7 @@ describe("quickAccessCategories", () => {
       "assets",
       "image-models",
       "video-models",
+      "audio-models",
       "3d-models",
       "quick-access",
       "tools"
@@ -64,6 +65,12 @@ describe("quickAccessCategories", () => {
   it("video-models matches only video outputs", () => {
     const all = [meta("a.GenA", "video"), meta("b.GenB", "image")];
     const out = filterNodesForCategory(getCategory("video-models")!, all);
+    expect(out.map((m) => m.node_type)).toEqual(["a.GenA"]);
+  });
+
+  it("audio-models matches only audio outputs", () => {
+    const all = [meta("a.GenA", "audio"), meta("b.GenB", "image")];
+    const out = filterNodesForCategory(getCategory("audio-models")!, all);
     expect(out.map((m) => m.node_type)).toEqual(["a.GenA"]);
   });
 

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -16,6 +16,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import GridViewIcon from "@mui/icons-material/GridView";
 import ImageIcon from "@mui/icons-material/Image";
 import MovieIcon from "@mui/icons-material/Movie";
+import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import ViewInArIcon from "@mui/icons-material/ViewInAr";
 import BoltIcon from "@mui/icons-material/Bolt";
 import BuildIcon from "@mui/icons-material/Build";
@@ -34,6 +35,7 @@ export type QuickAccessCategoryId =
   | "assets"
   | "image-models"
   | "video-models"
+  | "audio-models"
   | "3d-models"
   | "quick-access"
   | "tools";
@@ -141,6 +143,13 @@ export const QUICK_ACCESS_CATEGORIES: readonly QuickAccessCategory[] = [
     icon: <MovieIcon />,
     kind: "tile-grid",
     filter: primaryVariantIs("video")
+  },
+  {
+    id: "audio-models",
+    label: "Audio Models",
+    icon: <AudiotrackIcon />,
+    kind: "tile-grid",
+    filter: primaryVariantIs("audio")
   },
   {
     id: "3d-models",

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -15,6 +15,7 @@ export type LeftPanelView =
   | "assets"
   | "image-models"
   | "video-models"
+  | "audio-models"
   | "3d-models"
   | "quick-access"
   | "tools";
@@ -186,6 +187,7 @@ export const usePanelStore = create<ResizePanelState>()(
           "assets",
           "image-models",
           "video-models",
+          "audio-models",
           "3d-models",
           "quick-access",
           "tools"


### PR DESCRIPTION
Mirrors the existing Image Models and Video Models entries: a tile-grid
category that filters nodes whose primary output variant is "audio".