### PR TITLE
refactor(ranking): lift node ranker to a generic ranker, reuse for models

### DIFF
--- a/web/src/stores/ModelMenuStore.ts
+++ b/web/src/stores/ModelMenuStore.ts
@@ -7,10 +7,10 @@ import type {
   ASRModel,
   VideoModel
 } from "./ApiTypes";
-import Fuse from "fuse.js";
 import useModelPreferencesStore from "./ModelPreferencesStore";
 import React from "react";
 import { useSecrets } from "../hooks/useSecrets";
+import { rankModels } from "../utils/modelRanking";
 
 type SidebarTab = "favorites" | "recent";
 
@@ -110,68 +110,23 @@ export const computeProvidersList = <TModel extends ModelSelectorModel>(
   return list;
 };
 
+export interface FilterModelsOptions {
+  recentKeys?: readonly string[];
+  favoriteKeys?: Iterable<string>;
+}
+
 export const filterModelsList = <TModel extends ModelSelectorModel>(
   models: TModel[] | undefined,
   selectedProvider: string | null,
   search: string,
-  enabledProviders: EnabledProvidersMap | undefined
+  enabledProviders: EnabledProvidersMap | undefined,
+  options: FilterModelsOptions = {}
 ): TModel[] => {
-  let list = models ?? [];
-
-  if (selectedProvider) {
-    if (/gemini|google/i.test(selectedProvider)) {
-      list = list.filter((m) => /gemini|google/i.test(m.provider || ""));
-    } else {
-      list = list.filter((m) => m.provider === selectedProvider);
-    }
-  }
-  if (!selectedProvider) {
-    // Filter by enabled providers: missing key means enabled (default true)
-    // Only filter out if explicitly set to false
-    list = list.filter((m) => {
-      const providerKey = String(m.provider || "");
-      const isEnabled = enabledProviders?.[providerKey] !== false;
-      return isEnabled;
-    });
-  }
-  const term = search.trim();
-  if (term.length > 0) {
-    list = list.filter((m) => enabledProviders?.[m.provider || ""] !== false);
-    const normalize = (s: string) =>
-      s
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, " ")
-        .trim();
-    const makeIndexText = (m: TModel) =>
-      normalize(`${m.name || ""} ${m.id || ""} ${m.provider || ""}`);
-    const tokens = normalize(term).split(/\s+/).filter(Boolean);
-
-    const tokenMatches = list.filter((m) => {
-      const text = makeIndexText(m);
-      return tokens.every((t) => text.includes(t));
-    });
-
-    const fuse = new Fuse(list, {
-      keys: ["name", "id", "provider"],
-      threshold: 0.3,
-      ignoreLocation: true,
-      distance: 1000,
-      minMatchCharLength: 1
-    });
-    const fuseItems = fuse.search(term).map((r) => r.item);
-
-    const merged: TModel[] = [...tokenMatches];
-    for (const it of fuseItems) {
-      if (!merged.includes(it)) {merged.push(it);}
-    }
-    return merged;
-  }
-
-  // Sort alphabetically by name (or id as fallback) when not searching
-  return [...list].sort((a, b) => {
-    const nameA = (a.path || a.name || a.id || "").toLowerCase();
-    const nameB = (b.path || b.name || b.id || "").toLowerCase();
-    return nameA.localeCompare(nameB);
+  return rankModels<TModel>(models, search, {
+    selectedProvider,
+    enabledProviders,
+    recentKeys: options.recentKeys,
+    favoriteKeys: options.favoriteKeys
   });
 };
 
@@ -193,9 +148,25 @@ export const useModelMenuData = <TModel extends ModelSelectorModel>(
 
   const providers = React.useMemo(() => computeProvidersList(models), [models]);
 
+  const recentKeys = React.useMemo(
+    () => recentsList.map((r) => `${r.provider}:${r.id}`),
+    [recentsList]
+  );
+
   const filteredModels = React.useMemo(
-    () => filterModelsList(models, selectedProvider, search, enabledProviders),
-    [models, selectedProvider, search, enabledProviders]
+    () =>
+      filterModelsList(models, selectedProvider, search, enabledProviders, {
+        recentKeys,
+        favoriteKeys: favoritesSet
+      }),
+    [
+      models,
+      selectedProvider,
+      search,
+      enabledProviders,
+      recentKeys,
+      favoritesSet
+    ]
   );
 
   const recentModels = React.useMemo(() => {

--- a/web/src/utils/__tests__/modelRanking.test.ts
+++ b/web/src/utils/__tests__/modelRanking.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+import { rankModels } from "../modelRanking";
+import type { ModelSelectorModel } from "../../stores/ModelMenuStore";
+
+const m = (
+  provider: string,
+  id: string,
+  name: string,
+  path?: string
+): ModelSelectorModel => ({ type: "image", provider, id, name, path });
+
+const models: ModelSelectorModel[] = [
+  m("openai", "gpt-4", "GPT-4"),
+  m("openai", "gpt-3.5-turbo", "GPT-3.5 Turbo"),
+  m("anthropic", "claude-3-opus", "Claude 3 Opus"),
+  m("anthropic", "claude-3-sonnet", "Claude 3 Sonnet"),
+  m("google", "gemini-1.5-pro", "Gemini 1.5 Pro"),
+  m("huggingface", "sdxl", "Stable Diffusion XL", "stabilityai/stable-diffusion-xl-base-1.0")
+];
+
+const keyOf = (model: ModelSelectorModel) => `${model.provider}:${model.id}`;
+
+describe("rankModels", () => {
+  it("returns empty for undefined or empty input", () => {
+    expect(rankModels(undefined, "")).toEqual([]);
+    expect(rankModels([], "anything")).toEqual([]);
+  });
+
+  it("returns all enabled models alphabetically when no term, no preferences", () => {
+    const result = rankModels(models, "");
+    const names = result.map((r) => r.path || r.name);
+    const sorted = [...names].sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
+    );
+    expect(names).toEqual(sorted);
+    expect(result).toHaveLength(models.length);
+  });
+
+  it("excludes models from disabled providers", () => {
+    const result = rankModels(models, "", {
+      enabledProviders: { openai: false }
+    });
+    expect(result.every((r) => r.provider !== "openai")).toBe(true);
+    expect(result.some((r) => r.provider === "anthropic")).toBe(true);
+  });
+
+  it("filters by selected provider regardless of enabled flag", () => {
+    const result = rankModels(models, "", {
+      selectedProvider: "openai",
+      enabledProviders: { openai: false }
+    });
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.provider === "openai")).toBe(true);
+  });
+
+  it("treats the gemini sidebar entry as gemini OR google", () => {
+    const withGemini = m("gemini", "gemini-flash", "Gemini Flash");
+    const result = rankModels([...models, withGemini], "", {
+      selectedProvider: "gemini"
+    });
+    const providers = new Set(result.map((r) => r.provider));
+    expect(providers).toContain("google");
+    expect(providers).toContain("gemini");
+  });
+
+  it("matches by name", () => {
+    const result = rankModels(models, "claude");
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0].provider).toBe("anthropic");
+  });
+
+  it("matches by id", () => {
+    const result = rankModels(models, "gpt-4");
+    expect(result.some((r) => r.id === "gpt-4")).toBe(true);
+  });
+
+  it("matches by HF path", () => {
+    const result = rankModels(models, "stabilityai");
+    expect(result.some((r) => r.id === "sdxl")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    const upper = rankModels(models, "CLAUDE");
+    const lower = rankModels(models, "claude");
+    expect(upper.map(keyOf)).toEqual(lower.map(keyOf));
+  });
+
+  it("handles multi-token queries (all tokens must match somewhere)", () => {
+    const result = rankModels(models, "gpt turbo");
+    // "gpt-3.5-turbo" hits on id (gpt + turbo) and name (GPT-3.5 Turbo)
+    expect(result.some((r) => r.id === "gpt-3.5-turbo")).toBe(true);
+  });
+
+  it("returns empty for non-matching query", () => {
+    expect(rankModels(models, "definitely-not-a-model")).toEqual([]);
+  });
+
+  it("ranks favorites above other matches", () => {
+    const favoriteKeys = new Set([keyOf(models[3])]); // claude-3-sonnet
+    const result = rankModels(models, "claude", { favoriteKeys });
+    expect(result[0].id).toBe("claude-3-sonnet");
+  });
+
+  it("ranks recents above other matches when scores would otherwise tie", () => {
+    const result = rankModels(models, "claude", {
+      recentKeys: [keyOf(models[3])] // claude-3-sonnet was used most recently
+    });
+    expect(result[0].id).toBe("claude-3-sonnet");
+  });
+
+  it("more-recent items rank higher than less-recent items", () => {
+    const result = rankModels(models, "", {
+      recentKeys: [
+        keyOf(models[5]), // sdxl — most recent
+        keyOf(models[0]) // gpt-4 — less recent
+      ]
+    });
+    expect(result[0].id).toBe("sdxl");
+    expect(result[1].id).toBe("gpt-4");
+  });
+});

--- a/web/src/utils/__tests__/ranking.test.ts
+++ b/web/src/utils/__tests__/ranking.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+import { rank, scoreItem, searchTermsFromQuery, type RankConfig } from "../ranking";
+
+type Item = {
+  id: string;
+  name: string;
+  description?: string;
+  kind?: string;
+};
+
+const baseConfig: RankConfig<Item> = {
+  fields: [
+    { get: (i) => i.name, weight: 6 },
+    { get: (i) => i.id, weight: 4 },
+    { get: (i) => i.description, weight: 1 }
+  ],
+  keyFn: (i) => i.id
+};
+
+const items: Item[] = [
+  { id: "alpha", name: "Alpha", description: "the first one" },
+  { id: "beta", name: "Beta", description: "the second one" },
+  { id: "gamma", name: "Gamma", description: "the third one" }
+];
+
+describe("searchTermsFromQuery", () => {
+  it("returns empty for whitespace", () => {
+    expect(searchTermsFromQuery("")).toEqual([]);
+    expect(searchTermsFromQuery("   ")).toEqual([]);
+  });
+
+  it("includes the full query and individual tokens", () => {
+    const terms = searchTermsFromQuery("hello world");
+    expect(terms).toContain("hello world");
+    expect(terms).toContain("hello");
+    expect(terms).toContain("world");
+  });
+
+  it("deduplicates", () => {
+    const terms = searchTermsFromQuery("foo");
+    expect(terms).toEqual(["foo"]);
+  });
+});
+
+describe("scoreItem", () => {
+  it("returns 0 when no terms", () => {
+    expect(scoreItem(items[0], [], baseConfig)).toBe(0);
+  });
+
+  it("scores name matches higher than description matches", () => {
+    const nameMatch = scoreItem(items[0], ["alpha"], baseConfig);
+    const descMatch = scoreItem(items[0], ["first"], baseConfig);
+    expect(nameMatch).toBeGreaterThan(descMatch);
+  });
+
+  it("applies the per-item multiplier", () => {
+    const cfg: RankConfig<Item> = {
+      ...baseConfig,
+      multiplier: (i) => (i.kind === "core" ? 2 : 1)
+    };
+    const normal = scoreItem({ ...items[0] }, ["alpha"], cfg);
+    const boosted = scoreItem({ ...items[0], kind: "core" }, ["alpha"], cfg);
+    expect(boosted).toBe(normal * 2);
+  });
+
+  it("respects the prefilter", () => {
+    const cfg: RankConfig<Item> = {
+      ...baseConfig,
+      prefilter: (i) => i.id !== "alpha"
+    };
+    expect(scoreItem(items[0], ["alpha"], cfg)).toBe(0);
+    expect(scoreItem(items[1], ["beta"], cfg)).toBeGreaterThan(0);
+  });
+
+  it("gives exact-subtoken matches an extra bonus", () => {
+    const item: Item = { id: "x", name: "image to image" };
+    const cfg: RankConfig<Item> = {
+      ...baseConfig,
+      fields: [{ get: (i) => i.name, weight: 6 }]
+    };
+    // "image" is an exact subtoken → weight*(1 + exactTokenBonus)
+    expect(scoreItem(item, ["image"], cfg)).toBe(6 + 6 * 2);
+    // "mage" is a substring but not a subtoken → just weight
+    expect(scoreItem(item, ["mage"], cfg)).toBe(6);
+  });
+});
+
+describe("rank", () => {
+  it("returns only items that match the terms, sorted by score", () => {
+    const terms = searchTermsFromQuery("alpha");
+    const results = rank(items, terms, baseConfig);
+    expect(results.length).toBe(1);
+    expect(results[0].item.id).toBe("alpha");
+  });
+
+  it("returns all items (after prefilter) when no terms", () => {
+    const results = rank(items, [], baseConfig);
+    expect(results.length).toBe(3);
+  });
+
+  it("boosts recent items", () => {
+    const terms = searchTermsFromQuery("the");
+    const without = rank(items, terms, baseConfig);
+    const with_ = rank(items, terms, {
+      ...baseConfig,
+      recentKeys: ["gamma"]
+    });
+    const gammaWithout = without.find((r) => r.item.id === "gamma")!;
+    const gammaWith = with_.find((r) => r.item.id === "gamma")!;
+    expect(gammaWith.score).toBeGreaterThan(gammaWithout.score);
+  });
+
+  it("boosts curated/boosted items", () => {
+    const terms = searchTermsFromQuery("the");
+    const without = rank(items, terms, baseConfig);
+    const with_ = rank(items, terms, {
+      ...baseConfig,
+      boostedKeys: ["beta"]
+    });
+    const betaWithout = without.find((r) => r.item.id === "beta")!;
+    const betaWith = with_.find((r) => r.item.id === "beta")!;
+    expect(betaWith.score).toBeGreaterThan(betaWithout.score);
+  });
+
+  it("applies candidate boosts", () => {
+    const terms = searchTermsFromQuery("alpha");
+    const results = rank(items, terms, {
+      ...baseConfig,
+      candidateBoosts: new Map([["beta", 100]]),
+      includeCandidateOnlyMatches: true
+    });
+    expect(results[0].item.id).toBe("beta");
+  });
+
+  it("excludes candidate-only matches when the flag is off", () => {
+    const terms = searchTermsFromQuery("alpha");
+    const results = rank(items, terms, {
+      ...baseConfig,
+      candidateBoosts: new Map([["beta", 100]])
+    });
+    expect(results.map((r) => r.item.id)).toEqual(["alpha"]);
+  });
+
+  it("uses the supplied tie-break", () => {
+    const results = rank(items, [], {
+      ...baseConfig,
+      tieBreak: (a, b) => b.name.localeCompare(a.name)
+    });
+    expect(results.map((r) => r.item.id)).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  it("recency bonus decays with index", () => {
+    const cfg: RankConfig<Item> = {
+      ...baseConfig,
+      recentKeys: ["alpha", "beta", "gamma"]
+    };
+    const results = rank(items, [], cfg);
+    // alpha is most recent → highest recency bonus
+    expect(results[0].item.id).toBe("alpha");
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+    expect(results[1].score).toBeGreaterThan(results[2].score);
+  });
+});

--- a/web/src/utils/modelRanking.ts
+++ b/web/src/utils/modelRanking.ts
@@ -1,0 +1,109 @@
+import {
+  rank,
+  searchTermsFromQuery,
+  type RankConfig,
+  type RankField
+} from "./ranking";
+import type {
+  EnabledProvidersMap,
+  ModelSelectorModel
+} from "../stores/ModelMenuStore";
+
+const FIELD_WEIGHTS = {
+  name: 6,
+  id: 4,
+  path: 4,
+  provider: 2,
+  tasks: 1
+} as const;
+
+const modelKey = (m: ModelSelectorModel): string =>
+  `${m.provider ?? ""}:${m.id ?? ""}`;
+
+const tasksAsText = (m: ModelSelectorModel): string | undefined =>
+  m.supported_tasks && m.supported_tasks.length > 0
+    ? m.supported_tasks.join(" ")
+    : undefined;
+
+const MODEL_FIELDS: ReadonlyArray<RankField<ModelSelectorModel>> = [
+  { get: (m) => m.name, weight: FIELD_WEIGHTS.name },
+  { get: (m) => m.id, weight: FIELD_WEIGHTS.id },
+  { get: (m) => m.path ?? undefined, weight: FIELD_WEIGHTS.path },
+  { get: (m) => m.provider, weight: FIELD_WEIGHTS.provider },
+  { get: tasksAsText, weight: FIELD_WEIGHTS.tasks }
+];
+
+const isGeminiOrGoogle = (provider: string | undefined): boolean =>
+  /gemini|google/i.test(provider || "");
+
+/**
+ * Provider matches the user-selected sidebar entry.
+ * The "gemini" entry intentionally covers both gemini and google providers,
+ * preserving prior behavior from filterModelsList().
+ */
+const providerMatches = (
+  modelProvider: string | undefined,
+  selected: string
+): boolean => {
+  if (isGeminiOrGoogle(selected)) return isGeminiOrGoogle(modelProvider);
+  return modelProvider === selected;
+};
+
+const isProviderEnabled = (
+  provider: string | undefined,
+  enabled: EnabledProvidersMap | undefined
+): boolean => {
+  if (!enabled) return true;
+  return enabled[provider ?? ""] !== false;
+};
+
+const compareByDisplayName = (
+  a: ModelSelectorModel,
+  b: ModelSelectorModel
+): number => {
+  const an = (a.path || a.name || a.id || "").toLowerCase();
+  const bn = (b.path || b.name || b.id || "").toLowerCase();
+  return an.localeCompare(bn);
+};
+
+export interface ModelRankOptions {
+  selectedProvider?: string | null;
+  enabledProviders?: EnabledProvidersMap;
+  /** Keys (`${provider}:${id}`) of recently used models, most-recent first. */
+  recentKeys?: readonly string[];
+  /** Keys (`${provider}:${id}`) of favorited models. */
+  favoriteKeys?: Iterable<string>;
+}
+
+export function rankModels<T extends ModelSelectorModel>(
+  models: readonly T[] | undefined,
+  searchTerm: string,
+  options: ModelRankOptions = {}
+): T[] {
+  if (!models || models.length === 0) return [];
+
+  const terms = searchTermsFromQuery(searchTerm);
+  const { selectedProvider, enabledProviders, recentKeys, favoriteKeys } =
+    options;
+
+  const prefilter = (m: T): boolean => {
+    // When a provider is explicitly selected, ignore enable/disable flags so
+    // the user can still see models under a provider they've toggled off.
+    if (selectedProvider) {
+      return providerMatches(m.provider, selectedProvider);
+    }
+    return isProviderEnabled(m.provider, enabledProviders);
+  };
+
+  const config: RankConfig<T> = {
+    fields: MODEL_FIELDS as ReadonlyArray<RankField<T>>,
+    keyFn: modelKey,
+    prefilter,
+    recentKeys,
+    boostedKeys: favoriteKeys,
+    tieBreak: compareByDisplayName
+  };
+
+  const scored = rank<T>(models, terms, config);
+  return scored.map(({ item }) => item);
+}

--- a/web/src/utils/nodeRanking.ts
+++ b/web/src/utils/nodeRanking.ts
@@ -1,4 +1,11 @@
 import { NodeMetadata } from "../stores/ApiTypes";
+import {
+  rank,
+  scoreItem,
+  searchTermsFromQuery as genericSearchTermsFromQuery,
+  type RankConfig,
+  type RankField
+} from "./ranking";
 
 const PROVIDER_NAMESPACES = new Set([
   "openai",
@@ -34,12 +41,6 @@ export interface ScoredNode<T extends NodeMetadata = NodeMetadata> {
   score: number;
 }
 
-const isReadonlyMap = (
-  value: ReadonlyMap<string, number> | Record<string, number>
-): value is ReadonlyMap<string, number> => {
-  return typeof (value as ReadonlyMap<string, number>).get === "function";
-};
-
 const FIELD_WEIGHTS = {
   title: 6,
   nodeType: 4,
@@ -47,31 +48,19 @@ const FIELD_WEIGHTS = {
   description: 1
 } as const;
 
-const EXACT_TOKEN_BONUS = 2;
 const CORE_MULTIPLIER = 1.5;
-const RECENT_NODE_BONUS = 10;
-const BOOSTED_NODE_BONUS = 6;
 
-export function searchTermsFromQuery(query: string): string[] {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return [];
-  }
+const NODE_FIELDS: ReadonlyArray<RankField<NodeMetadata>> = [
+  { get: (meta) => meta.title, weight: FIELD_WEIGHTS.title },
+  { get: (meta) => meta.node_type, weight: FIELD_WEIGHTS.nodeType },
+  { get: (meta) => meta.namespace, weight: FIELD_WEIGHTS.namespace },
+  { get: (meta) => meta.description, weight: FIELD_WEIGHTS.description }
+];
 
-  const terms = new Set<string>([trimmed]);
-  trimmed
-    .split(/[\s,]+/)
-    .map((term) => term.trim())
-    .filter(Boolean)
-    .forEach((term) => terms.add(term));
-
-  return Array.from(terms);
-}
+export const searchTermsFromQuery = genericSearchTermsFromQuery;
 
 function namespaceClass(namespace: string | undefined): NamespaceClass {
-  if (!namespace) {
-    return "other";
-  }
+  if (!namespace) return "other";
   if (namespace.startsWith("nodetool.") || namespace === "nodetool") {
     return "core";
   }
@@ -79,25 +68,39 @@ function namespaceClass(namespace: string | undefined): NamespaceClass {
   return PROVIDER_NAMESPACES.has(root) ? "provider" : "other";
 }
 
-function fieldScore(
-  field: string | undefined,
-  term: string,
-  weight: number
-): number {
-  if (!field) {
-    return 0;
-  }
-  const lower = field.toLowerCase();
-  if (!lower.includes(term)) {
-    return 0;
-  }
+function buildPrefilter(
+  options: ScoreOptions
+): (meta: NodeMetadata) => boolean {
+  return (meta) => {
+    if (
+      options.namespacePrefix &&
+      !(meta.namespace ?? "").startsWith(options.namespacePrefix)
+    ) {
+      return false;
+    }
+    if (
+      namespaceClass(meta.namespace) === "provider" &&
+      options.includeProviderNodes !== true
+    ) {
+      return false;
+    }
+    return true;
+  };
+}
 
-  let score = weight;
-  const tokens = lower.split(/[\s._\-/]+/).filter(Boolean);
-  if (tokens.includes(term)) {
-    score += weight * EXACT_TOKEN_BONUS;
-  }
-  return score;
+function buildConfig<T extends NodeMetadata>(
+  options: ScoreOptions
+): RankConfig<T> {
+  return {
+    fields: NODE_FIELDS as ReadonlyArray<RankField<T>>,
+    keyFn: (meta) => meta.node_type,
+    multiplier: (meta) => (namespaceClass(meta.namespace) === "core" ? CORE_MULTIPLIER : 1),
+    prefilter: buildPrefilter(options),
+    recentKeys: options.recentNodeTypes,
+    boostedKeys: options.boostedNodeTypes,
+    candidateBoosts: options.candidateBoosts,
+    includeCandidateOnlyMatches: options.includeCandidateOnlyMatches
+  };
 }
 
 export function scoreNodeMetadata(
@@ -105,38 +108,7 @@ export function scoreNodeMetadata(
   terms: readonly string[],
   options: ScoreOptions = {}
 ): number {
-  if (terms.length === 0) {
-    return 0;
-  }
-
-  if (
-    options.namespacePrefix &&
-    !(meta.namespace ?? "").startsWith(options.namespacePrefix)
-  ) {
-    return 0;
-  }
-
-  const cls = namespaceClass(meta.namespace);
-  if (cls === "provider" && options.includeProviderNodes !== true) {
-    return 0;
-  }
-
-  let raw = 0;
-  for (const rawTerm of terms) {
-    const term = rawTerm.toLowerCase();
-    if (!term) {
-      continue;
-    }
-    raw += fieldScore(meta.title, term, FIELD_WEIGHTS.title);
-    raw += fieldScore(meta.node_type, term, FIELD_WEIGHTS.nodeType);
-    raw += fieldScore(meta.namespace, term, FIELD_WEIGHTS.namespace);
-    raw += fieldScore(meta.description, term, FIELD_WEIGHTS.description);
-  }
-
-  if (raw === 0) {
-    return 0;
-  }
-  return cls === "core" ? raw * CORE_MULTIPLIER : raw;
+  return scoreItem(meta, terms, buildConfig<NodeMetadata>(options));
 }
 
 export function rankNodeMetadata<T extends NodeMetadata>(
@@ -144,55 +116,6 @@ export function rankNodeMetadata<T extends NodeMetadata>(
   terms: readonly string[],
   options: ScoreOptions = {}
 ): ScoredNode<T>[] {
-  const recentRank = new Map<string, number>();
-  options.recentNodeTypes?.forEach((nodeType, index) => {
-    recentRank.set(nodeType, index);
-  });
-  const boostedNodeTypes = new Set(options.boostedNodeTypes);
-  const getCandidateBoost = (nodeType: string) => {
-    if (!options.candidateBoosts) {
-      return 0;
-    }
-    if (isReadonlyMap(options.candidateBoosts)) {
-      return options.candidateBoosts.get(nodeType) ?? 0;
-    }
-    return options.candidateBoosts[nodeType] ?? 0;
-  };
-
-  const hasTerms = terms.some((term) => term.trim().length > 0);
-  const scored: ScoredNode<T>[] = [];
-  for (const meta of nodes) {
-    const score = hasTerms ? scoreNodeMetadata(meta, terms, options) : 0;
-    const candidateBoost = getCandidateBoost(meta.node_type);
-    const isProviderNode = namespaceClass(meta.namespace) === "provider";
-    const matchesNamespace =
-      !options.namespacePrefix ||
-      (meta.namespace ?? "").startsWith(options.namespacePrefix);
-
-    if (
-      matchesNamespace &&
-      (!isProviderNode || options.includeProviderNodes === true) &&
-      (!hasTerms || score > 0 ||
-        (options.includeCandidateOnlyMatches === true && candidateBoost > 0))
-    ) {
-      const recentIndex = recentRank.get(meta.node_type);
-      const recentBonus =
-        recentIndex === undefined ? 0 : RECENT_NODE_BONUS / (recentIndex + 1);
-      const boostedBonus = boostedNodeTypes.has(meta.node_type)
-        ? BOOSTED_NODE_BONUS
-        : 0;
-      scored.push({
-        meta,
-        score: score + candidateBoost + recentBonus + boostedBonus
-      });
-    }
-  }
-
-  scored.sort((a, b) => {
-    if (b.score !== a.score) {
-      return b.score - a.score;
-    }
-    return a.meta.node_type.localeCompare(b.meta.node_type);
-  });
-  return scored;
+  const scored = rank<T>(nodes, terms, buildConfig<T>(options));
+  return scored.map(({ item, score }) => ({ meta: item, score }));
 }

--- a/web/src/utils/ranking.ts
+++ b/web/src/utils/ranking.ts
@@ -1,0 +1,164 @@
+/**
+ * Generic ranker. Powers both the node menu and the model menu.
+ *
+ *   score = base(field weights + exact-token bonus) * multiplier
+ *         + candidateBoost
+ *         + recentBonus
+ *         + boostedBonus
+ *
+ * Domain-specific behavior (which fields, which namespaces get a multiplier,
+ * which items are filtered out before scoring) is supplied by the caller via
+ * RankConfig — the ranker itself knows nothing about nodes or models.
+ */
+
+export interface RankField<T> {
+  get: (item: T) => string | undefined;
+  weight: number;
+}
+
+export interface RankConfig<T> {
+  fields: ReadonlyArray<RankField<T>>;
+  keyFn: (item: T) => string;
+  /** Bonus multiplier applied when a search token matches a whole subtoken. */
+  exactTokenBonus?: number;
+  /** Per-item score multiplier (e.g. core-namespace boost for nodes). */
+  multiplier?: (item: T) => number;
+  /** Drop items that fail this check before any scoring. */
+  prefilter?: (item: T) => boolean;
+  /** Keys (as produced by keyFn) of recently used items, most-recent first. */
+  recentKeys?: readonly string[];
+  recentBonus?: number;
+  /** Keys (as produced by keyFn) of curated/boosted items. */
+  boostedKeys?: Iterable<string>;
+  boostedBonus?: number;
+  /** Pre-computed per-key boosts (from a secondary search index, etc.). */
+  candidateBoosts?: ReadonlyMap<string, number> | Record<string, number>;
+  /** Keep items that have a candidate boost but no field match. */
+  includeCandidateOnlyMatches?: boolean;
+  /** Tie-break when scores are equal. Defaults to lexicographic keyFn order. */
+  tieBreak?: (a: T, b: T) => number;
+}
+
+export interface Scored<T> {
+  item: T;
+  score: number;
+}
+
+const DEFAULT_EXACT_TOKEN_BONUS = 2;
+const DEFAULT_RECENT_BONUS = 10;
+const DEFAULT_BOOSTED_BONUS = 6;
+
+const isReadonlyMap = (
+  value: ReadonlyMap<string, number> | Record<string, number>
+): value is ReadonlyMap<string, number> =>
+  typeof (value as ReadonlyMap<string, number>).get === "function";
+
+const getCandidateBoost = (
+  source: ReadonlyMap<string, number> | Record<string, number> | undefined,
+  key: string
+): number => {
+  if (!source) return 0;
+  return isReadonlyMap(source) ? source.get(key) ?? 0 : source[key] ?? 0;
+};
+
+export function searchTermsFromQuery(query: string): string[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const terms = new Set<string>([trimmed]);
+  trimmed
+    .split(/[\s,]+/)
+    .map((term) => term.trim())
+    .filter(Boolean)
+    .forEach((term) => terms.add(term));
+  return Array.from(terms);
+}
+
+function fieldScore(
+  field: string | undefined,
+  term: string,
+  weight: number,
+  exactTokenBonus: number
+): number {
+  if (!field) return 0;
+  const lower = field.toLowerCase();
+  if (!lower.includes(term)) return 0;
+
+  let score = weight;
+  const tokens = lower.split(/[\s._\-/]+/).filter(Boolean);
+  if (tokens.includes(term)) {
+    score += weight * exactTokenBonus;
+  }
+  return score;
+}
+
+export function scoreItem<T>(
+  item: T,
+  terms: readonly string[],
+  config: RankConfig<T>
+): number {
+  if (terms.length === 0) return 0;
+  if (config.prefilter && !config.prefilter(item)) return 0;
+
+  const exactBonus = config.exactTokenBonus ?? DEFAULT_EXACT_TOKEN_BONUS;
+
+  let raw = 0;
+  for (const rawTerm of terms) {
+    const term = rawTerm.toLowerCase();
+    if (!term) continue;
+    for (const field of config.fields) {
+      raw += fieldScore(field.get(item), term, field.weight, exactBonus);
+    }
+  }
+
+  if (raw === 0) return 0;
+  const multiplier = config.multiplier ? config.multiplier(item) : 1;
+  return raw * multiplier;
+}
+
+export function rank<T>(
+  items: readonly T[],
+  terms: readonly string[],
+  config: RankConfig<T>
+): Scored<T>[] {
+  const recentRank = new Map<string, number>();
+  config.recentKeys?.forEach((key, index) => recentRank.set(key, index));
+  const boostedKeys = new Set<string>(config.boostedKeys ?? []);
+  const recentBonus = config.recentBonus ?? DEFAULT_RECENT_BONUS;
+  const boostedBonus = config.boostedBonus ?? DEFAULT_BOOSTED_BONUS;
+
+  const hasTerms = terms.some((term) => term.trim().length > 0);
+  const scored: Scored<T>[] = [];
+
+  for (const item of items) {
+    if (config.prefilter && !config.prefilter(item)) continue;
+
+    const key = config.keyFn(item);
+    const candidateBoost = getCandidateBoost(config.candidateBoosts, key);
+    const baseScore = hasTerms ? scoreItem(item, terms, config) : 0;
+    const matchedByCandidateOnly =
+      config.includeCandidateOnlyMatches === true && candidateBoost > 0;
+
+    if (hasTerms && baseScore === 0 && !matchedByCandidateOnly) continue;
+
+    const recentIndex = recentRank.get(key);
+    const recencyBoost =
+      recentIndex === undefined ? 0 : recentBonus / (recentIndex + 1);
+    const curatedBoost = boostedKeys.has(key) ? boostedBonus : 0;
+
+    scored.push({
+      item,
+      score: baseScore + candidateBoost + recencyBoost + curatedBoost
+    });
+  }
+
+  const tieBreak =
+    config.tieBreak ??
+    ((a: T, b: T) => config.keyFn(a).localeCompare(config.keyFn(b)));
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return tieBreak(a.item, b.item);
+  });
+  return scored;
+}


### PR DESCRIPTION
Extracts the field-weighted scoring + recent/boosted/candidate-boost
algorithm from nodeRanking into a generic rank<T>() utility, then wires
the model menu through it so favorites and recents now influence the
main list ranking (not just the dedicated tab views).

- web/src/utils/ranking.ts: generic rank/scoreItem parameterized by
  RankField<T>[], keyFn, optional multiplier/prefilter/tieBreak.
- nodeRanking.ts: thin adapter, public API unchanged. All 21 existing
  ranking tests + 20 search tests still pass.
- modelRanking.ts: ModelSelectorModel adapter (name 6, id 4, path 4,
  provider 2, supported_tasks 1; key=provider:id; tie-break by name).
- ModelMenuStore.filterModelsList: delegates to rankModels and accepts
  recent/favorite keys so the main list reflects user preferences.

Sets up adding HF popularity, per-user usage counts, or curated lists
as additional boost sources without further algorithm changes.

https://claude.ai/code/session_01SV7s854bjfJBvgffT8fXXz