### PR TITLE
feat(nodes): bespoke bodies for the rest of the Tools section

### DIFF
--- a/web/src/components/node_types/editing/CurvesBody.tsx
+++ b/web/src/components/node_types/editing/CurvesBody.tsx
@@ -1,0 +1,342 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * CurvesBody — bespoke body for `lib.image.color_grading.Curves`.
+ *
+ * Preview on top, eight sliders organized into two sections:
+ *   - Tonal: Black Point, White Point, Shadows, Midtones, Highlights
+ *   - RGB Midtones: Red, Green, Blue
+ * Plus a reset button that returns every slider to its defaults.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+
+import {
+  CheckerDropzone,
+  FlexRow,
+  NodeSlider,
+  StateIconButton
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
+
+const CURVES_NODE_TYPE = "lib.image.color_grading.Curves";
+
+interface SliderSpec {
+  name: string;
+  label: string;
+  min: number;
+  max: number;
+  default: number;
+}
+
+const TONAL_SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "black_point", label: "Black Point", min: 0, max: 0.5, default: 0 },
+  { name: "white_point", label: "White Point", min: 0.5, max: 1, default: 1 },
+  { name: "shadows", label: "Shadows", min: -0.5, max: 0.5, default: 0 },
+  { name: "midtones", label: "Midtones", min: -0.5, max: 0.5, default: 0 },
+  { name: "highlights", label: "Highlights", min: -0.5, max: 0.5, default: 0 }
+];
+
+const RGB_SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "red_midtones", label: "Red", min: -0.5, max: 0.5, default: 0 },
+  { name: "green_midtones", label: "Green", min: -0.5, max: 0.5, default: 0 },
+  { name: "blue_midtones", label: "Blue", min: -0.5, max: 0.5, default: 0 }
+];
+
+const ALL_SLIDERS: ReadonlyArray<SliderSpec> = [...TONAL_SLIDERS, ...RGB_SLIDERS];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.curves-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 140,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".section": {
+      flex: "0 0 auto",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.25)
+    },
+    ".section-header": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`
+    },
+    ".section-title": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.06em",
+      lineHeight: 1
+    },
+    ".controls": {
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
+      alignItems: "center",
+      padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)} ${theme.spacing(0.25)}`
+    },
+    ".ctrl-label": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em",
+      lineHeight: 1
+    },
+    ".ctrl-label.red": { color: theme.vars.palette.error.main },
+    ".ctrl-label.green": { color: theme.vars.palette.success.main },
+    ".ctrl-label.blue": { color: theme.vars.palette.info.main },
+    ".ctrl-value": {
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.primary,
+      minWidth: 40,
+      textAlign: "right",
+      lineHeight: 1
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return (
+    <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+  );
+};
+
+const clamp = (v: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, v));
+
+const formatValue = (spec: SliderSpec, v: number): string => {
+  // Black/white points are absolute levels (0..1); show plain. Other sliders
+  // are signed deltas; show with explicit sign so users can read "+0.10".
+  if (spec.name === "black_point" || spec.name === "white_point") {
+    return v.toFixed(2);
+  }
+  return `${v > 0 ? "+" : ""}${v.toFixed(2)}`;
+};
+
+const channelClass = (name: string): string => {
+  if (name === "red_midtones") return "red";
+  if (name === "green_midtones") return "green";
+  if (name === "blue_midtones") return "blue";
+  return "";
+};
+
+interface CurvesSliderProps {
+  spec: SliderSpec;
+  value: number;
+  onChange: (name: string, v: number) => void;
+  onCommit: () => void;
+}
+
+const CurvesSlider: React.FC<CurvesSliderProps> = ({
+  spec,
+  value,
+  onChange,
+  onCommit
+}) => {
+  const handleChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = Array.isArray(v) ? v[0] : v;
+      onChange(spec.name, Math.round(next * 100) / 100);
+    },
+    [onChange, spec.name]
+  );
+  const cls = channelClass(spec.name);
+  return (
+    <>
+      <span className={`ctrl-label${cls ? ` ${cls}` : ""}`}>{spec.label}</span>
+      <NodeSlider
+        min={spec.min}
+        max={spec.max}
+        step={0.01}
+        value={value}
+        onChange={handleChange}
+        onChangeCommitted={onCommit}
+        aria-label={`${spec.label} adjustment`}
+      />
+      <span className="ctrl-value">{formatValue(spec, value)}</span>
+    </>
+  );
+};
+
+export interface CurvesBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const CurvesBodyInner: React.FC<CurvesBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setProperties, setPropertyComplete } =
+    useBespokePropertyWriter({ nodeId: id, nodeType });
+
+  const handleChange = useCallback(
+    (name: string, v: number) => {
+      const spec = ALL_SLIDERS.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty]
+  );
+
+  const handleReset = useCallback(() => {
+    const defaults: Record<string, unknown> = {};
+    for (const s of ALL_SLIDERS) defaults[s.name] = s.default;
+    setProperties(defaults);
+    setPropertyComplete();
+  }, [setProperties, setPropertyComplete]);
+
+  return (
+    <div css={cssStyles} className="curves-body" data-bespoke-body="Curves">
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+      </div>
+
+      <div className="section">
+        <FlexRow className="section-header" align="center" justify="space-between">
+          <span className="section-title">Tonal</span>
+          <StateIconButton
+            size="small"
+            icon={<RestartAltIcon fontSize="small" />}
+            tooltip="Reset all curves"
+            ariaLabel="Reset all curves"
+            onClick={handleReset}
+          />
+        </FlexRow>
+        <div className="controls">
+          {TONAL_SLIDERS.map((spec) => {
+            const raw = Number(props[spec.name] ?? spec.default);
+            const value = clamp(raw, spec.min, spec.max);
+            return (
+              <CurvesSlider
+                key={spec.name}
+                spec={spec}
+                value={value}
+                onChange={handleChange}
+                onCommit={setPropertyComplete}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="section">
+        <FlexRow className="section-header" align="center" justify="space-between">
+          <span className="section-title">RGB Midtones</span>
+        </FlexRow>
+        <div className="controls">
+          {RGB_SLIDERS.map((spec) => {
+            const raw = Number(props[spec.name] ?? spec.default);
+            const value = clamp(raw, spec.min, spec.max);
+            return (
+              <CurvesSlider
+                key={spec.name}
+                spec={spec}
+                value={value}
+                onChange={handleChange}
+                onCommit={setPropertyComplete}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const CurvesBody = memo(CurvesBodyInner);
+CurvesBody.displayName = "CurvesBody";
+
+export { CURVES_NODE_TYPE };
+export default CurvesBody;

--- a/web/src/components/node_types/editing/FitBody.tsx
+++ b/web/src/components/node_types/editing/FitBody.tsx
@@ -1,0 +1,307 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * FitBody — bespoke body for `nodetool.image.Fit`.
+ *
+ * Preview on top with a dimensions badge, W/H number inputs underneath,
+ * and a row of common-size presets (256, 512, 768, 1024) that write both
+ * dimensions in one commit. Fit's underlying transform is a cover-fit
+ * resize, so there is no aspect-ratio toggle — the user is choosing the
+ * target frame.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+import NumberInput from "../../inputs/NumberInput";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
+
+const FIT_NODE_TYPE = "nodetool.image.Fit";
+
+const PRESETS: ReadonlyArray<number> = [256, 512, 768, 1024];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.fit-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "visible",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& > .handle-column": {
+        top: 0,
+        bottom: 0,
+        left: `calc(${theme.spacing(-0.5)})`
+      },
+      "& img": {
+        display: "block",
+        width: "100%",
+        height: "100%",
+        objectFit: "contain"
+      },
+      ".dimensions-badge": {
+        position: "absolute",
+        bottom: theme.spacing(0.5),
+        right: theme.spacing(0.5),
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+        background: "rgba(0,0,0,0.6)",
+        color: theme.vars.palette.common.white,
+        fontFamily: theme.fontFamily2,
+        fontSize: theme.fontSizeSmaller,
+        borderRadius: "var(--rounded-sm)",
+        pointerEvents: "none"
+      }
+    },
+    ".controls-row": {
+      flex: "0 0 auto",
+      display: "flex",
+      alignItems: "flex-end",
+      gap: theme.spacing(0.5)
+    },
+    ".dim-field": {
+      flex: "1 1 50%",
+      minWidth: 0
+    },
+    ".presets-row": {
+      flex: "0 0 auto",
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(0.5),
+      paddingTop: theme.spacing(0.25),
+      paddingLeft: theme.spacing(0.25),
+      paddingRight: theme.spacing(0.25)
+    },
+    ".presets-label": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em",
+      lineHeight: 1
+    },
+    ".preset-chip": {
+      cursor: "pointer",
+      padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+      borderRadius: "var(--rounded-sm)",
+      border: `1px solid ${theme.vars.palette.divider}`,
+      background: "transparent",
+      color: theme.vars.palette.text.primary,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      lineHeight: 1,
+      "&:hover": {
+        borderColor: theme.vars.palette.primary.main
+      },
+      "&.active": {
+        borderColor: theme.vars.palette.primary.main,
+        color: theme.vars.palette.primary.main
+      }
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return (
+    <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+  );
+};
+
+export interface FitBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const FitBodyInner: React.FC<FitBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+  const widthProperty = useMemo(
+    () => properties.find((p) => p.name === "width"),
+    [properties]
+  );
+  const heightProperty = useMemo(
+    () => properties.find((p) => p.name === "height"),
+    [properties]
+  );
+
+  const widthValue = Number(
+    data.properties?.width ?? widthProperty?.default ?? 512
+  );
+  const heightValue = Number(
+    data.properties?.height ?? heightProperty?.default ?? 512
+  );
+
+  const previewValue = useNodeOutput(workflowId, id);
+  const previewRef = useMemo(() => asImageRef(previewValue), [previewValue]);
+
+  const { setProperties, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const handleWidthChange = useCallback(
+    (_: React.ChangeEvent<HTMLInputElement> | null, value: number) => {
+      setProperties({ width: Math.max(1, Math.round(value)) });
+    },
+    [setProperties]
+  );
+  const handleHeightChange = useCallback(
+    (_: React.ChangeEvent<HTMLInputElement> | null, value: number) => {
+      setProperties({ height: Math.max(1, Math.round(value)) });
+    },
+    [setProperties]
+  );
+
+  const applyPreset = useCallback(
+    (size: number) => {
+      setProperties({ width: size, height: size });
+      setPropertyComplete();
+    },
+    [setProperties, setPropertyComplete]
+  );
+
+  return (
+    <div css={cssStyles} className="fit-body" data-bespoke-body="Fit">
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+        {previewRef?.width != null && previewRef.height != null && (
+          <span className="dimensions-badge">
+            {previewRef.width} × {previewRef.height}
+          </span>
+        )}
+        <HandleColumn id={id} properties={imageProperty} />
+      </div>
+
+      <FlexRow className="controls-row" align="flex-end" gap={0.5}>
+        <div className="dim-field">
+          {widthProperty && (
+            <NumberInput
+              id={`fit-width-${id}`}
+              nodeId={id}
+              name="width"
+              description={widthProperty.description ?? "Target width"}
+              value={widthValue}
+              min={widthProperty.min ?? 1}
+              max={widthProperty.max ?? 8192}
+              size="small"
+              color="secondary"
+              inputType="int"
+              showSlider={false}
+              onChange={handleWidthChange}
+              onChangeComplete={setPropertyComplete}
+            />
+          )}
+        </div>
+        <div className="dim-field">
+          {heightProperty && (
+            <NumberInput
+              id={`fit-height-${id}`}
+              nodeId={id}
+              name="height"
+              description={heightProperty.description ?? "Target height"}
+              value={heightValue}
+              min={heightProperty.min ?? 1}
+              max={heightProperty.max ?? 8192}
+              size="small"
+              color="secondary"
+              inputType="int"
+              showSlider={false}
+              onChange={handleHeightChange}
+              onChangeComplete={setPropertyComplete}
+            />
+          )}
+        </div>
+      </FlexRow>
+
+      <div className="presets-row">
+        <span className="presets-label">Presets</span>
+        {PRESETS.map((size) => {
+          const active = widthValue === size && heightValue === size;
+          return (
+            <button
+              key={size}
+              type="button"
+              className={`preset-chip nodrag${active ? " active" : ""}`}
+              onClick={() => applyPreset(size)}
+              aria-label={`Set ${size} by ${size}`}
+            >
+              {size}
+            </button>
+          );
+        })}
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const FitBody = memo(FitBodyInner);
+FitBody.displayName = "FitBody";
+
+export { FIT_NODE_TYPE };
+export default FitBody;

--- a/web/src/components/node_types/editing/MaskBody.tsx
+++ b/web/src/components/node_types/editing/MaskBody.tsx
@@ -1,0 +1,234 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * MaskBody — bespoke body for `lib.image.Mask`.
+ *
+ * Three image inputs (image1, image2, mask) and a tabbed preview that
+ * shows each of them plus the composite result. No controls — the node's
+ * compositing behaviour is entirely driven by the inputs.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  ToggleGroup,
+  ToggleOption
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import {
+  useNodeOutput,
+  useUpstreamValue
+} from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
+
+const MASK_NODE_TYPE = "lib.image.Mask";
+
+type MaskTab = "image1" | "image2" | "mask" | "result";
+
+const TAB_PLACEHOLDERS: Record<MaskTab, string> = {
+  image1: "Connect Image 1",
+  image2: "Connect Image 2",
+  mask: "Connect a mask",
+  result: "Run the node to composite"
+};
+
+const styles = (theme: Theme) =>
+  css({
+    "&.mask-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".tab-toggle": {
+      width: "100%",
+      ".MuiToggleButton-root": {
+        flex: "1 1 auto",
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+        fontSize: theme.fontSizeSmaller,
+        fontFamily: theme.fontFamily2,
+        textTransform: "none",
+        minWidth: 0
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = memo(
+  ({ value, placeholder }) => {
+    if (typeof value === "string" && value) {
+      return <ImageView source={value} />;
+    }
+    const ref = asImageRef(value);
+    if (ref?.uri) {
+      return <ImageView source={ref.uri} />;
+    }
+    if (ref?.data instanceof Uint8Array) {
+      return <ImageView source={ref.data} />;
+    }
+    if (Array.isArray(ref?.data)) {
+      return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+    }
+    return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
+  }
+);
+ImagePreview.displayName = "MaskImagePreview";
+
+export interface MaskBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const MaskBodyInner: React.FC<MaskBodyProps> = ({
+  id,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const [tab, setTab] = useState<MaskTab>("result");
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageHandles = useMemo(
+    () =>
+      properties.filter(
+        (p) => p.name === "image1" || p.name === "image2" || p.name === "mask"
+      ),
+    [properties]
+  );
+
+  const image1 = useUpstreamValue(
+    workflowId,
+    id,
+    "image1",
+    data.properties?.image1
+  );
+  const image2 = useUpstreamValue(
+    workflowId,
+    id,
+    "image2",
+    data.properties?.image2
+  );
+  const mask = useUpstreamValue(workflowId, id, "mask", data.properties?.mask);
+  const result = useNodeOutput(workflowId, id);
+
+  const tabValue: unknown =
+    tab === "image1"
+      ? image1
+      : tab === "image2"
+        ? image2
+        : tab === "mask"
+          ? mask
+          : result;
+
+  const handleTabChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (next !== "image1" && next !== "image2" && next !== "mask" && next !== "result") {
+        return;
+      }
+      setTab(next);
+    },
+    []
+  );
+
+  return (
+    <div css={cssStyles} className="mask-body" data-bespoke-body="Mask">
+      <HandleColumn id={id} properties={imageHandles} />
+      <div className="preview-area">
+        <ImagePreview value={tabValue} placeholder={TAB_PLACEHOLDERS[tab]} />
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow align="center" gap={0.25}>
+          <ToggleGroup
+            className="tab-toggle"
+            size="small"
+            value={tab}
+            exclusive
+            onChange={handleTabChange}
+            aria-label="Preview tab"
+          >
+            <ToggleOption value="image1" aria-label="Image 1">
+              Img 1
+            </ToggleOption>
+            <ToggleOption value="image2" aria-label="Image 2">
+              Img 2
+            </ToggleOption>
+            <ToggleOption value="mask" aria-label="Mask">
+              Mask
+            </ToggleOption>
+            <ToggleOption value="result" aria-label="Result">
+              Result
+            </ToggleOption>
+          </ToggleGroup>
+        </FlexRow>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const MaskBody = memo(MaskBodyInner);
+MaskBody.displayName = "MaskBody";
+
+export { MASK_NODE_TYPE };
+export default MaskBody;

--- a/web/src/components/node_types/editing/PasteBody.tsx
+++ b/web/src/components/node_types/editing/PasteBody.tsx
@@ -1,0 +1,301 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * PasteBody — bespoke body for `nodetool.image.Paste`.
+ *
+ * Preview on top with a faint outline showing the paste rectangle relative
+ * to the base image (derived from base dimensions, paste dimensions, and
+ * the Left/Top offset). Two image inputs on the left edge — `image` (base)
+ * and `paste` (overlay). Left/Top integer inputs underneath.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+import NumberInput from "../../inputs/NumberInput";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import {
+  useNodeOutput,
+  useUpstreamValue
+} from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
+
+const PASTE_NODE_TYPE = "nodetool.image.Paste";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.paste-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      },
+      ".overlay-rect": {
+        position: "absolute",
+        boxSizing: "border-box",
+        border: `1px dashed ${theme.vars.palette.primary.main}`,
+        background: `color-mix(in srgb, ${theme.vars.palette.primary.main} 12%, transparent)`,
+        pointerEvents: "none"
+      },
+      ".dimensions-badge": {
+        position: "absolute",
+        bottom: theme.spacing(0.5),
+        right: theme.spacing(0.5),
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+        background: "rgba(0,0,0,0.6)",
+        color: theme.vars.palette.common.white,
+        fontFamily: theme.fontFamily2,
+        fontSize: theme.fontSizeSmaller,
+        borderRadius: "var(--rounded-sm)",
+        pointerEvents: "none"
+      }
+    },
+    ".controls-row": {
+      flex: "0 0 auto",
+      display: "flex",
+      alignItems: "flex-end",
+      gap: theme.spacing(0.5)
+    },
+    ".coord-field": {
+      flex: "1 1 50%",
+      minWidth: 0
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const PreviewImage: React.FC<{ value: unknown; placeholder: string }> = ({
+  value,
+  placeholder
+}) => {
+  if (typeof value === "string" && value) {
+    return <ImageView source={value} />;
+  }
+  const ref = asImageRef(value);
+  if (ref?.uri) {
+    return <ImageView source={ref.uri} />;
+  }
+  if (ref?.data instanceof Uint8Array) {
+    return <ImageView source={ref.data} />;
+  }
+  if (Array.isArray(ref?.data)) {
+    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
+};
+
+export interface PasteBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const PasteBodyInner: React.FC<PasteBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const properties = nodeMetadata.properties ?? [];
+  // Both image inputs share the left-edge handle column; preserve metadata
+  // order so the visual stacking matches the property order.
+  const imageHandles = useMemo(
+    () =>
+      properties.filter((p) => p.name === "image" || p.name === "paste"),
+    [properties]
+  );
+  const leftProperty = useMemo(
+    () => properties.find((p) => p.name === "left"),
+    [properties]
+  );
+  const topProperty = useMemo(
+    () => properties.find((p) => p.name === "top"),
+    [properties]
+  );
+
+  const left = Math.max(0, Number(data.properties?.left ?? 0));
+  const top = Math.max(0, Number(data.properties?.top ?? 0));
+
+  const previewValue = useNodeOutput(workflowId, id);
+  const baseValue = useUpstreamValue(
+    workflowId,
+    id,
+    "image",
+    data.properties?.image
+  );
+  const pasteValue = useUpstreamValue(
+    workflowId,
+    id,
+    "paste",
+    data.properties?.paste
+  );
+
+  const baseRef = useMemo(() => asImageRef(baseValue), [baseValue]);
+  const pasteRef = useMemo(() => asImageRef(pasteValue), [pasteValue]);
+  const previewRef = useMemo(() => asImageRef(previewValue), [previewValue]);
+
+  // Overlay rectangle expressed as a percentage of the base image — only
+  // drawn when both source dimensions are known. The base may have changed
+  // since the last run, so we prefer the inputs' dimensions over the
+  // output's.
+  const overlayRect = useMemo(() => {
+    const bw = baseRef?.width;
+    const bh = baseRef?.height;
+    const pw = pasteRef?.width;
+    const ph = pasteRef?.height;
+    if (!bw || !bh || !pw || !ph) return undefined;
+    return {
+      leftPct: Math.max(0, Math.min(100, (left / bw) * 100)),
+      topPct: Math.max(0, Math.min(100, (top / bh) * 100)),
+      widthPct: Math.max(0, Math.min(100, (pw / bw) * 100)),
+      heightPct: Math.max(0, Math.min(100, (ph / bh) * 100))
+    };
+  }, [baseRef?.width, baseRef?.height, pasteRef?.width, pasteRef?.height, left, top]);
+
+  const { setProperties, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const handleLeftChange = useCallback(
+    (_: React.ChangeEvent<HTMLInputElement> | null, value: number) => {
+      setProperties({ left: Math.max(0, Math.round(value)) });
+    },
+    [setProperties]
+  );
+  const handleTopChange = useCallback(
+    (_: React.ChangeEvent<HTMLInputElement> | null, value: number) => {
+      setProperties({ top: Math.max(0, Math.round(value)) });
+    },
+    [setProperties]
+  );
+
+  return (
+    <div css={cssStyles} className="paste-body" data-bespoke-body="Paste">
+      <HandleColumn id={id} properties={imageHandles} />
+      <div className="preview-area">
+        <PreviewImage
+          value={previewValue ?? baseValue}
+          placeholder="Connect Image and Paste, then run"
+        />
+        {overlayRect && (
+          <div
+            className="overlay-rect"
+            style={{
+              left: `${overlayRect.leftPct}%`,
+              top: `${overlayRect.topPct}%`,
+              width: `${overlayRect.widthPct}%`,
+              height: `${overlayRect.heightPct}%`
+            }}
+          />
+        )}
+        {previewRef?.width != null && previewRef.height != null && (
+          <span className="dimensions-badge">
+            {previewRef.width} × {previewRef.height}
+          </span>
+        )}
+      </div>
+
+      <FlexRow className="controls-row" align="flex-end" gap={0.5}>
+        <div className="coord-field">
+          {leftProperty && (
+            <NumberInput
+              id={`paste-left-${id}`}
+              nodeId={id}
+              name="left"
+              description={leftProperty.description ?? "Left offset"}
+              value={left}
+              min={leftProperty.min ?? 0}
+              max={leftProperty.max ?? 4096}
+              size="small"
+              color="secondary"
+              inputType="int"
+              showSlider={false}
+              onChange={handleLeftChange}
+              onChangeComplete={setPropertyComplete}
+            />
+          )}
+        </div>
+        <div className="coord-field">
+          {topProperty && (
+            <NumberInput
+              id={`paste-top-${id}`}
+              nodeId={id}
+              name="top"
+              description={topProperty.description ?? "Top offset"}
+              value={top}
+              min={topProperty.min ?? 0}
+              max={topProperty.max ?? 4096}
+              size="small"
+              color="secondary"
+              inputType="int"
+              showSlider={false}
+              onChange={handleTopChange}
+              onChangeComplete={setPropertyComplete}
+            />
+          )}
+        </div>
+      </FlexRow>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const PasteBody = memo(PasteBodyInner);
+PasteBody.displayName = "PasteBody";
+
+export { PASTE_NODE_TYPE };
+export default PasteBody;

--- a/web/src/components/node_types/editing/SimpleFilterBody.tsx
+++ b/web/src/components/node_types/editing/SimpleFilterBody.tsx
@@ -1,0 +1,216 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SimpleFilterBody — bespoke body for stateless one-input image filters.
+ *
+ * Today: `lib.image.filter.Invert`, `lib.image.filter.ConvertToGrayscale`.
+ * Both nodes take a single `image` input and have no other parameters, so
+ * the bespoke body is a "Before / After" toggle preview — the Before tab
+ * shows the upstream value flowing into `image`, the After tab shows the
+ * node's own output. There are no controls to render; the preview itself
+ * is the differentiator from a generic body.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import {
+  CheckerDropzone,
+  FlexColumn,
+  FlexRow,
+  ToggleGroup,
+  ToggleOption
+} from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageView from "../../node/ImageView";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import {
+  useNodeOutput,
+  useUpstreamValue
+} from "../../../hooks/nodes/useNodeIO";
+import { asImageRef } from "../../../utils/imageRef";
+
+export const SIMPLE_FILTER_NODE_TYPES = [
+  "lib.image.filter.Invert",
+  "lib.image.filter.ConvertToGrayscale"
+] as const;
+
+type SimpleFilterTab = "before" | "after";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.simple-filter-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(-0.5)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".tab-toggle": {
+      width: "100%",
+      ".MuiToggleButton-root": {
+        flex: "1 1 auto",
+        padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+        fontSize: theme.fontSizeSmaller,
+        fontFamily: theme.fontFamily2,
+        textTransform: "none",
+        minWidth: 0
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown; placeholder: string }> = memo(
+  ({ value, placeholder }) => {
+    if (typeof value === "string" && value) {
+      return <ImageView source={value} />;
+    }
+    const ref = asImageRef(value);
+    if (ref?.uri) {
+      return <ImageView source={ref.uri} />;
+    }
+    if (ref?.data instanceof Uint8Array) {
+      return <ImageView source={ref.data} />;
+    }
+    if (Array.isArray(ref?.data)) {
+      return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+    }
+    return <CheckerDropzone message={placeholder} icon={<ImageIcon />} />;
+  }
+);
+ImagePreview.displayName = "SimpleFilterImagePreview";
+
+export interface SimpleFilterBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const SimpleFilterBodyInner: React.FC<SimpleFilterBodyProps> = ({
+  id,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const [tab, setTab] = useState<SimpleFilterTab>("after");
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const beforeValue = useUpstreamValue(
+    workflowId,
+    id,
+    "image",
+    data.properties?.image
+  );
+  const afterValue = useNodeOutput(workflowId, id);
+
+  const handleTabChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+      if (next !== "before" && next !== "after") return;
+      setTab(next);
+    },
+    []
+  );
+
+  return (
+    <div
+      css={cssStyles}
+      className="simple-filter-body"
+      data-bespoke-body="SimpleFilter"
+    >
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        {tab === "before" ? (
+          <ImagePreview value={beforeValue} placeholder="Connect an image" />
+        ) : (
+          <ImagePreview
+            value={afterValue}
+            placeholder="Run the node to see the result"
+          />
+        )}
+      </div>
+
+      <FlexColumn className="controls" gap={0.5}>
+        <FlexRow align="center" gap={0.25}>
+          <ToggleGroup
+            className="tab-toggle"
+            size="small"
+            value={tab}
+            exclusive
+            onChange={handleTabChange}
+            aria-label="Preview tab"
+          >
+            <ToggleOption value="before" aria-label="Before">
+              Before
+            </ToggleOption>
+            <ToggleOption value="after" aria-label="After">
+              After
+            </ToggleOption>
+          </ToggleGroup>
+        </FlexRow>
+      </FlexColumn>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const SimpleFilterBody = memo(SimpleFilterBodyInner);
+SimpleFilterBody.displayName = "SimpleFilterBody";
+
+export default SimpleFilterBody;

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -7,14 +7,19 @@ import BlurBody from "./BlurBody";
 import ChannelsBody from "./ChannelsBody";
 import CompositorBody from "./CompositorBody";
 import CropBody from "./CropBody";
+import CurvesBody from "./CurvesBody";
 import ExposureBody from "./ExposureBody";
+import FitBody from "./FitBody";
 import HSLAdjustBody from "./HSLAdjustBody";
 import LevelsBody from "./LevelsBody";
+import MaskBody from "./MaskBody";
 import MasksExtractorBody from "./MasksExtractorBody";
 import PainterBody from "./PainterBody";
+import PasteBody from "./PasteBody";
 import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
 import ScaleBody from "./ScaleBody";
+import SimpleFilterBody from "./SimpleFilterBody";
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 
 const meta = (node_type: string): NodeMetadata =>
@@ -129,5 +134,48 @@ describe("bespokeRegistry", () => {
     expect(BESPOKE_BODY_REGISTRY["lib.image.color_grading.HSLAdjust"]).toBe(
       HSLAdjustBody
     );
+  });
+
+  it("maps lib.image.color_grading.Curves → CurvesBody", () => {
+    const m = meta("lib.image.color_grading.Curves");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(CurvesBody);
+    expect(BESPOKE_BODY_REGISTRY["lib.image.color_grading.Curves"]).toBe(
+      CurvesBody
+    );
+  });
+
+  it("maps nodetool.image.Fit → FitBody", () => {
+    const m = meta("nodetool.image.Fit");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(FitBody);
+    expect(BESPOKE_BODY_REGISTRY["nodetool.image.Fit"]).toBe(FitBody);
+  });
+
+  it("maps nodetool.image.Paste → PasteBody", () => {
+    const m = meta("nodetool.image.Paste");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(PasteBody);
+    expect(BESPOKE_BODY_REGISTRY["nodetool.image.Paste"]).toBe(PasteBody);
+  });
+
+  it("maps lib.image.Mask → MaskBody", () => {
+    const m = meta("lib.image.Mask");
+    expect(isBespokeNode(m)).toBe(true);
+    expect(getBespokeBody(m)).toBe(MaskBody);
+    expect(BESPOKE_BODY_REGISTRY["lib.image.Mask"]).toBe(MaskBody);
+  });
+
+  it("maps simple-filter node types → SimpleFilterBody", () => {
+    const types = [
+      "lib.image.filter.Invert",
+      "lib.image.filter.ConvertToGrayscale"
+    ];
+    for (const t of types) {
+      const m = meta(t);
+      expect(isBespokeNode(m)).toBe(true);
+      expect(getBespokeBody(m)).toBe(SimpleFilterBody);
+      expect(BESPOKE_BODY_REGISTRY[t]).toBe(SimpleFilterBody);
+    }
   });
 });

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -17,18 +17,25 @@ import BlurBody, { BLUR_NODE_TYPE } from "./BlurBody";
 import ChannelsBody, { CHANNELS_NODE_TYPE } from "./ChannelsBody";
 import CompositorBody, { COMPOSITOR_NODE_TYPE } from "./CompositorBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
+import CurvesBody, { CURVES_NODE_TYPE } from "./CurvesBody";
 import ExposureBody, { EXPOSURE_NODE_TYPE } from "./ExposureBody";
+import FitBody, { FIT_NODE_TYPE } from "./FitBody";
 import HSLAdjustBody, { HSL_ADJUST_NODE_TYPE } from "./HSLAdjustBody";
 import LevelsBody, { LEVELS_NODE_TYPE } from "./LevelsBody";
+import MaskBody, { MASK_NODE_TYPE } from "./MaskBody";
 import MasksExtractorBody, {
   MASKS_EXTRACTOR_NODE_TYPES
 } from "./MasksExtractorBody";
 import PainterBody, { PAINTER_NODE_TYPE } from "./PainterBody";
+import PasteBody, { PASTE_NODE_TYPE } from "./PasteBody";
 import ResizeBody, { RESIZE_NODE_TYPE } from "./ResizeBody";
 import RotateAndFlipBody, {
   ROTATE_AND_FLIP_NODE_TYPE
 } from "./RotateAndFlipBody";
 import ScaleBody, { SCALE_NODE_TYPE } from "./ScaleBody";
+import SimpleFilterBody, {
+  SIMPLE_FILTER_NODE_TYPES
+} from "./SimpleFilterBody";
 
 export interface BespokeBodyProps {
   id: string;
@@ -49,15 +56,22 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [CHANNELS_NODE_TYPE]: ChannelsBody,
   [COMPOSITOR_NODE_TYPE]: CompositorBody,
   [CROP_NODE_TYPE]: CropBody,
+  [CURVES_NODE_TYPE]: CurvesBody,
   [EXPOSURE_NODE_TYPE]: ExposureBody,
+  [FIT_NODE_TYPE]: FitBody,
   [HSL_ADJUST_NODE_TYPE]: HSLAdjustBody,
   [LEVELS_NODE_TYPE]: LevelsBody,
+  [MASK_NODE_TYPE]: MaskBody,
   [PAINTER_NODE_TYPE]: PainterBody,
+  [PASTE_NODE_TYPE]: PasteBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
   [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
   [SCALE_NODE_TYPE]: ScaleBody,
   ...Object.fromEntries(
     MASKS_EXTRACTOR_NODE_TYPES.map((t) => [t, MasksExtractorBody] as const)
+  ),
+  ...Object.fromEntries(
+    SIMPLE_FILTER_NODE_TYPES.map((t) => [t, SimpleFilterBody] as const)
   )
 };
 


### PR DESCRIPTION
Completes the Tools quick-access category with custom bodies for the
remaining node_types that were still falling through to the generic
body:

- Fit         — preview + W/H number inputs + 256/512/768/1024 presets
- Paste       — preview with paste-rect overlay + L/T number inputs
- Curves      — preview + 8 sliders split into Tonal / RGB Midtones
                sections with a single reset
- Mask        — 3-input compositing with Img1 / Img2 / Mask / Result tabs
- SimpleFilter — shared body for Invert and ConvertToGrayscale, just a
                 Before / After preview toggle (these nodes are pure
                 one-shot filters with no parameters)

Every node listed in TOOLS_NODE_TYPES (web/src/config/quickAccessCategories.tsx)
now has a bespoke body registered.