### PR TITLE
feat(correlation): add input mode and output correlation metadata

### DIFF
--- a/packages/base-nodes/src/nodes/anthropic.ts
+++ b/packages/base-nodes/src/nodes/anthropic.ts
@@ -5,6 +5,7 @@
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 export class ClaudeAgentNode extends BaseNode {
   static readonly nodeType = "anthropic.agents.ClaudeAgent";
@@ -20,6 +21,12 @@ export class ClaudeAgentNode extends BaseNode {
   static readonly requiredSettings = ["ANTHROPIC_API_KEY"];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "single", source: "__execution__" },
+    chunk: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: "",

--- a/packages/base-nodes/src/nodes/audio.ts
+++ b/packages/base-nodes/src/nodes/audio.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -80,6 +81,13 @@ export class LoadAudioAssetsNode extends BaseNode {
   static readonly inputFields: string[] = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    audio: { kind: "iteration", source: "__execution__", group: "items" },
+    name: { kind: "iteration", source: "__execution__", group: "items" },
+    audios: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "folder",
     default: {
@@ -187,6 +195,13 @@ export class LoadAudioFolderNode extends BaseNode {
   static readonly inputFields: string[] = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    audio: { kind: "iteration", source: "__execution__", group: "items" },
+    path: { kind: "iteration", source: "__execution__", group: "items" },
+    audios: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: "",
@@ -1218,6 +1233,11 @@ export class TextToSpeechNode extends BaseNode {
   static readonly exposeAsTool = true;
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    audio: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "tts_model",
     default: {

--- a/packages/base-nodes/src/nodes/audio.ts
+++ b/packages/base-nodes/src/nodes/audio.ts
@@ -1235,7 +1235,12 @@ export class TextToSpeechNode extends BaseNode {
   static readonly isStreamingOutput = true;
   static readonly inputMode: InputMode = "buffered";
   static readonly outputCorrelation: Record<string, OutputCorrelation> = {
-    audio: { kind: "single", source: "__execution__" }
+    audio: { kind: "single", source: "__execution__" },
+    // `chunk` is declared on the output schema but the current process()
+    // accumulates and returns only `audio`. PR 1 classifies it as single
+    // (aspirational) per the design's stale-chunk-port guidance; a follow-up
+    // either makes the node stream real chunks or removes the handle.
+    chunk: { kind: "single", source: "__execution__" }
   };
 
   @prop({

--- a/packages/base-nodes/src/nodes/control.ts
+++ b/packages/base-nodes/src/nodes/control.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { StreamingInputs, StreamingOutputs } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 export class IfNode extends BaseNode {
   static readonly nodeType = "nodetool.control.If";
@@ -15,6 +16,11 @@ export class IfNode extends BaseNode {
 
   static readonly isStreamingOutput = true;
   static readonly syncMode = "zip_all" as const;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    if_true: { kind: "forward", source: "value" },
+    if_false: { kind: "forward", source: "value" }
+  };
   @prop({
     type: "bool",
     default: false,
@@ -55,6 +61,11 @@ export class ForEachNode extends BaseNode {
   static readonly inputFields = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "iteration", source: "__execution__", group: "items" },
+    index: { kind: "iteration", source: "__execution__", group: "items" }
+  };
   @prop({
     type: "list[any]",
     default: [],
@@ -105,6 +116,11 @@ export class TakeNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" },
+    index: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -163,6 +179,10 @@ export class CollectNode extends BaseNode {
 
   static readonly syncMode = "on_any" as const;
   static readonly isStreamingInput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "aggregate", source: "input_item", collapse: "innermost" }
+  };
 
   @prop({
     type: "any",
@@ -201,6 +221,10 @@ export class RerouteNode extends BaseNode {
 
   static readonly isStreamingOutput = true;
   static readonly syncMode = "on_any" as const;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_value" }
+  };
   @prop({
     type: "any",
     default: [],
@@ -226,6 +250,12 @@ export class SwitchNode extends BaseNode {
   };
   static readonly inlineFields = [];
   static readonly inputFields = [];
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    matched: { kind: "forward", source: "input" },
+    default: { kind: "forward", source: "input" },
+    index: { kind: "single", source: "input" }
+  };
 
   @prop({
     type: "any",
@@ -277,6 +307,12 @@ export class TryCatchNode extends BaseNode {
   };
   static readonly inlineFields = [];
   static readonly inputFields = [];
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "value" },
+    error: { kind: "single", source: "value" },
+    has_error: { kind: "single", source: "value" }
+  };
 
   @prop({
     type: "any",
@@ -322,6 +358,11 @@ export class DropNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" },
+    index: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -387,6 +428,10 @@ export class FilterEqualNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -460,6 +505,10 @@ export class FilterCodeNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -509,6 +558,11 @@ export class ChunkNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "iteration", source: "input_item", group: "batch" },
+    index: { kind: "iteration", source: "input_item", group: "batch" }
+  };
 
   @prop({
     type: "any",
@@ -568,6 +622,10 @@ export class LastNode extends BaseNode {
   static readonly inputFields = [];
 
   static readonly isStreamingInput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "aggregate", source: "input_item", collapse: "innermost" }
+  };
 
   @prop({
     type: "any",
@@ -609,6 +667,10 @@ export class CountStreamNode extends BaseNode {
   static readonly inputFields = [];
 
   static readonly isStreamingInput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "aggregate", source: "input_item", collapse: "innermost" }
+  };
 
   @prop({
     type: "any",
@@ -675,6 +737,10 @@ export class DistinctNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -726,6 +792,10 @@ export class TakeWhileNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -779,6 +849,10 @@ export class DropWhileNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",
@@ -830,6 +904,10 @@ export class TapNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "input_item" }
+  };
 
   @prop({
     type: "any",

--- a/packages/base-nodes/src/nodes/data.ts
+++ b/packages/base-nodes/src/nodes/data.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -873,6 +874,12 @@ export class RowIteratorNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    dict: { kind: "iteration", source: "dataframe", group: "items" },
+    index: { kind: "iteration", source: "dataframe", group: "items" }
+  };
+
   @prop({
     type: "dataframe",
     default: {
@@ -1079,6 +1086,12 @@ export class ForEachRowNode extends BaseNode {
   static readonly exposeAsTool = true;
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    row: { kind: "iteration", source: "dataframe", group: "items" },
+    index: { kind: "iteration", source: "dataframe", group: "items" }
+  };
+
   @prop({
     type: "dataframe",
     default: {
@@ -1122,6 +1135,14 @@ export class LoadCSVAssetsNode extends BaseNode {
   static readonly exposeAsTool = true;
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    dataframe: { kind: "iteration", source: "folder", group: "items" },
+    name: { kind: "iteration", source: "folder", group: "items" },
+    dataframes: { kind: "single", source: "folder" },
+    names: { kind: "single", source: "folder" }
+  };
+
   @prop({
     type: "folder",
     default: {
@@ -1614,6 +1635,11 @@ export class FilterNoneNode extends BaseNode {
 
   static readonly isStreamingInput = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "value" }
+  };
+
   @prop({
     type: "any",
     default: [],

--- a/packages/base-nodes/src/nodes/document.ts
+++ b/packages/base-nodes/src/nodes/document.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -196,6 +197,12 @@ export class ListDocumentsNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    document: { kind: "iteration", source: "__execution__", group: "items" },
+    documents: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: "~",
@@ -330,6 +337,14 @@ export class SplitDocumentNode extends BaseNode {
   ];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "iteration", source: "document", group: "items" },
+    source_id: { kind: "iteration", source: "document", group: "items" },
+    start_index: { kind: "iteration", source: "document", group: "items" },
+    chunks: { kind: "single", source: "document" }
+  };
+
   @prop({
     type: "language_model",
     default: {
@@ -428,6 +443,14 @@ export class SplitHTMLNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "iteration", source: "document", group: "items" },
+    source_id: { kind: "iteration", source: "document", group: "items" },
+    start_index: { kind: "iteration", source: "document", group: "items" },
+    chunks: { kind: "single", source: "document" }
+  };
+
   @prop({
     type: "document",
     default: {
@@ -563,6 +586,14 @@ export class SplitJSONNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "iteration", source: "document", group: "items" },
+    source_id: { kind: "iteration", source: "document", group: "items" },
+    start_index: { kind: "iteration", source: "document", group: "items" },
+    chunks: { kind: "single", source: "document" }
+  };
+
   @prop({
     type: "document",
     default: {
@@ -705,6 +736,14 @@ export class SplitRecursivelyNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "iteration", source: "document", group: "items" },
+    source_id: { kind: "iteration", source: "document", group: "items" },
+    start_index: { kind: "iteration", source: "document", group: "items" },
+    chunks: { kind: "single", source: "document" }
+  };
+
   @prop({
     type: "document",
     default: {
@@ -870,6 +909,14 @@ export class SplitMarkdownNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    text: { kind: "iteration", source: "document", group: "items" },
+    source_id: { kind: "iteration", source: "document", group: "items" },
+    start_index: { kind: "iteration", source: "document", group: "items" },
+    chunks: { kind: "single", source: "document" }
+  };
+
   @prop({
     type: "document",
     default: {

--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { promises as fs } from "node:fs";
@@ -267,6 +268,12 @@ export class LoadImageFolderNode extends BaseNode {
   static readonly inputFields = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    image: { kind: "iteration", source: "__execution__", group: "items" },
+    images: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: "",
@@ -476,6 +483,13 @@ export class LoadImageAssetsNode extends BaseNode {
   static readonly inputFields = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    image: { kind: "iteration", source: "__execution__", group: "items" },
+    name: { kind: "iteration", source: "__execution__", group: "items" },
+    images: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "folder",
     default: {

--- a/packages/base-nodes/src/nodes/image.ts
+++ b/packages/base-nodes/src/nodes/image.ts
@@ -271,6 +271,7 @@ export class LoadImageFolderNode extends BaseNode {
   static readonly inputMode: InputMode = "buffered";
   static readonly outputCorrelation: Record<string, OutputCorrelation> = {
     image: { kind: "iteration", source: "__execution__", group: "items" },
+    path: { kind: "iteration", source: "__execution__", group: "items" },
     images: { kind: "single", source: "__execution__" }
   };
 

--- a/packages/base-nodes/src/nodes/input.ts
+++ b/packages/base-nodes/src/nodes/input.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 export class FloatInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FloatInput";
@@ -1338,6 +1339,10 @@ export class RealtimeAudioInputNode extends BaseNode {
   static readonly inlineFields = [];
   static readonly inputFields = ["value"];
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    chunk: { kind: "single", source: "__execution__" }
+  };
 
   @prop({
     type: "str",

--- a/packages/base-nodes/src/nodes/input.ts
+++ b/packages/base-nodes/src/nodes/input.ts
@@ -1340,8 +1340,12 @@ export class RealtimeAudioInputNode extends BaseNode {
   static readonly inputFields = ["value"];
   static readonly isStreamingOutput = true;
   static readonly inputMode: InputMode = "buffered";
+  // RealtimeAudioInput pushes successive audio frames for a single logical
+  // stream via runner.pushInputValue. Each chunk is a chunk of one logical
+  // realtime stream, so kind: "chunk" preserves the repeats-per-key
+  // semantics downstream rather than collapsing to one.
   static readonly outputCorrelation: Record<string, OutputCorrelation> = {
-    chunk: { kind: "single", source: "__execution__" }
+    chunk: { kind: "chunk", source: "__execution__" }
   };
 
   @prop({

--- a/packages/base-nodes/src/nodes/lib-mail.ts
+++ b/packages/base-nodes/src/nodes/lib-mail.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 export class SendEmailLibNode extends BaseNode {
   static readonly nodeType = "lib.mail.SendEmail";
@@ -167,6 +168,18 @@ export class GmailSearchLibNode extends BaseNode {
   static readonly exposeAsTool = true;
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    email: { kind: "iteration", source: "__execution__", group: "items" },
+    message_id: { kind: "iteration", source: "__execution__", group: "items" },
+    subject: { kind: "iteration", source: "__execution__", group: "items" },
+    sender: { kind: "iteration", source: "__execution__", group: "items" },
+    date: { kind: "iteration", source: "__execution__", group: "items" },
+    body: { kind: "iteration", source: "__execution__", group: "items" },
+    emails: { kind: "single", source: "__execution__" },
+    message_ids: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: "",

--- a/packages/base-nodes/src/nodes/lib-notion.ts
+++ b/packages/base-nodes/src/nodes/lib-notion.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 function notionHeaders(token: string): Record<string, string> {
   return {
@@ -100,6 +101,11 @@ export class NotionSearchLibNode extends BaseNode {
   static readonly exposeAsTool = true;
   static readonly requiredSettings = ["NOTION_API_KEY"];
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    result: { kind: "iteration", source: "__execution__", group: "items" },
+    results: { kind: "single", source: "__execution__" }
+  };
 
   @prop({
     type: "str",
@@ -303,6 +309,11 @@ export class NotionGetPageContentLibNode extends BaseNode {
   static readonly exposeAsTool = true;
   static readonly requiredSettings = ["NOTION_API_KEY"];
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    block: { kind: "iteration", source: "__execution__", group: "items" },
+    blocks: { kind: "single", source: "__execution__" }
+  };
 
   @prop({
     type: "str",
@@ -599,6 +610,11 @@ export class NotionQueryDatabaseLibNode extends BaseNode {
   static readonly exposeAsTool = true;
   static readonly requiredSettings = ["NOTION_API_KEY"];
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    result: { kind: "iteration", source: "__execution__", group: "items" },
+    results: { kind: "single", source: "__execution__" }
+  };
 
   @prop({
     type: "str",

--- a/packages/base-nodes/src/nodes/lib-s3.ts
+++ b/packages/base-nodes/src/nodes/lib-s3.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getS3Client(
@@ -91,6 +92,11 @@ export class S3ListObjectsLibNode extends BaseNode {
     "AWS_SECRET_ACCESS_KEY"
   ];
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    object: { kind: "iteration", source: "__execution__", group: "items" },
+    objects: { kind: "single", source: "__execution__" }
+  };
 
   @prop({
     type: "str",

--- a/packages/base-nodes/src/nodes/lib-twilio.ts
+++ b/packages/base-nodes/src/nodes/lib-twilio.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 const TWILIO_TIMEOUT = 30000;
 
@@ -272,6 +273,11 @@ export class TwilioGetMessagesLibNode extends BaseNode {
   };
   static readonly exposeAsTool = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    message: { kind: "iteration", source: "__execution__", group: "items" },
+    messages: { kind: "single", source: "__execution__" }
+  };
   static readonly requiredSettings = [
     "TWILIO_ACCOUNT_SID",
     "TWILIO_AUTH_TOKEN"

--- a/packages/base-nodes/src/nodes/messaging.ts
+++ b/packages/base-nodes/src/nodes/messaging.ts
@@ -1,5 +1,6 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 // ── Discord Nodes ───────────────────────────────────────────────────────────
 
@@ -24,6 +25,19 @@ export class DiscordBotTrigger extends BaseNode {
   static readonly requiredSettings = ["DISCORD_BOT_TOKEN"];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    message_id: { kind: "iteration", source: "__execution__", group: "messages" },
+    content: { kind: "iteration", source: "__execution__", group: "messages" },
+    author: { kind: "iteration", source: "__execution__", group: "messages" },
+    channel: { kind: "iteration", source: "__execution__", group: "messages" },
+    guild: { kind: "iteration", source: "__execution__", group: "messages" },
+    attachments: { kind: "iteration", source: "__execution__", group: "messages" },
+    timestamp: { kind: "iteration", source: "__execution__", group: "messages" },
+    source: { kind: "iteration", source: "__execution__", group: "messages" },
+    event_type: { kind: "iteration", source: "__execution__", group: "messages" }
+  };
+
   @prop({
     type: "int",
     default: 0,
@@ -228,6 +242,22 @@ export class TelegramBotTrigger extends BaseNode {
   static readonly requiredSettings = ["TELEGRAM_BOT_TOKEN"];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    update_id: { kind: "iteration", source: "__execution__", group: "messages" },
+    update_type: { kind: "iteration", source: "__execution__", group: "messages" },
+    message_id: { kind: "iteration", source: "__execution__", group: "messages" },
+    text: { kind: "iteration", source: "__execution__", group: "messages" },
+    caption: { kind: "iteration", source: "__execution__", group: "messages" },
+    entities: { kind: "iteration", source: "__execution__", group: "messages" },
+    chat: { kind: "iteration", source: "__execution__", group: "messages" },
+    from_user: { kind: "iteration", source: "__execution__", group: "messages" },
+    attachments: { kind: "iteration", source: "__execution__", group: "messages" },
+    timestamp: { kind: "iteration", source: "__execution__", group: "messages" },
+    source: { kind: "iteration", source: "__execution__", group: "messages" },
+    event_type: { kind: "iteration", source: "__execution__", group: "messages" }
+  };
+
   @prop({
     type: "int",
     default: 0,

--- a/packages/base-nodes/src/nodes/output.ts
+++ b/packages/base-nodes/src/nodes/output.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { audioBytesAsync } from "../lib/audio-wav.js";
 
@@ -116,6 +117,11 @@ export class OutputNode extends BaseNode {
   static readonly inputFields = ["value"];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "forward", source: "value" }
+  };
+
   @prop({
     type: "str",
     default: "",

--- a/packages/base-nodes/src/nodes/team.ts
+++ b/packages/base-nodes/src/nodes/team.ts
@@ -13,6 +13,7 @@
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import {
   TeamExecutor,
   DbTaskBoard,
@@ -41,6 +42,10 @@ export class TeamAgentNode extends BaseNode {
   static readonly description =
     "An individual AI agent that receives work from a TeamLead via control edges.\n    agent, team, controlled, worker";
   static readonly isControlled = true;
+  static readonly inputMode: InputMode = "controlled";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    result: { kind: "single", source: "__execution__" }
+  };
   static readonly metadataOutputTypes = {
     result: "str"
   };

--- a/packages/base-nodes/src/nodes/video.ts
+++ b/packages/base-nodes/src/nodes/video.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { VideoRef, StreamingInputs, StreamingOutputs } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { execFile as execFileCb } from "node:child_process";
@@ -533,6 +534,14 @@ export class LoadVideoAssetsNode extends BaseNode {
   static readonly inputFields: string[] = [];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    video: { kind: "iteration", source: "__execution__", group: "items" },
+    name: { kind: "iteration", source: "__execution__", group: "items" },
+    videos: { kind: "single", source: "__execution__" },
+    names: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "folder",
     default: {
@@ -684,6 +693,13 @@ export class FrameIteratorNode extends BaseNode {
   static readonly inputFields: string[] = ["video"];
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    frame: { kind: "iteration", source: "__execution__", group: "items" },
+    index: { kind: "iteration", source: "__execution__", group: "items" },
+    fps: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "video",
     default: {
@@ -861,6 +877,11 @@ export class FrameToVideoNode extends BaseNode {
   static readonly description =
     "Combine a sequence of frames into a single video file.\n    video, frames, combine, sequence";
   static readonly isStreamingInput = true;
+  static readonly inputMode: InputMode = "stream";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "aggregate", source: "frame", collapse: "innermost" }
+  };
+
   static readonly metadataOutputTypes = {
     output: "video"
   };

--- a/packages/base-nodes/src/nodes/workflow.ts
+++ b/packages/base-nodes/src/nodes/workflow.ts
@@ -1,7 +1,7 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import { WorkflowRunner, Graph } from "@nodetool-ai/kernel";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import type { NodeDescriptor, Edge } from "@nodetool-ai/protocol";
+import type { NodeDescriptor, Edge, InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import { randomUUID } from "node:crypto";
 
 /**
@@ -20,6 +20,10 @@ export class WorkflowNode extends BaseNode {
   static readonly isDynamic = true;
   static readonly supportsDynamicOutputs = true;
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    output: { kind: "single", source: "__execution__" }
+  };
   static readonly inlineFields = ["workflow_id"];
   static readonly inputFields = [];
 

--- a/packages/base-nodes/src/nodes/workspace.ts
+++ b/packages/base-nodes/src/nodes/workspace.ts
@@ -1,4 +1,5 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import { root as fsSafeRoot, type Root } from "@openclaw/fs-safe";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -139,6 +140,12 @@ export class ListWorkspaceFilesNode extends BaseNode {
   };
 
   static readonly isStreamingOutput = true;
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    file: { kind: "iteration", source: "__execution__", group: "items" },
+    files: { kind: "single", source: "__execution__" }
+  };
+
   @prop({
     type: "str",
     default: ".",

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -383,9 +383,12 @@ export class Graph {
           descriptorDefaults.is_streaming_output ||
           node.is_streaming_output ||
           false,
-        input_mode: descriptorDefaults.input_mode ?? node.input_mode,
-        output_correlation:
-          descriptorDefaults.output_correlation ?? node.output_correlation,
+        // Correlation metadata is authoritative from the registry. Saved JSON
+        // is treated as a cache and overwritten — including when the resolver
+        // intentionally returns undefined for a node type that no longer
+        // declares correlation. See docs/correlation-design.md §1.
+        input_mode: descriptorDefaults.input_mode,
+        output_correlation: descriptorDefaults.output_correlation,
         is_controlled:
           descriptorDefaults.is_controlled || node.is_controlled || false
       };

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -383,6 +383,9 @@ export class Graph {
           descriptorDefaults.is_streaming_output ||
           node.is_streaming_output ||
           false,
+        input_mode: descriptorDefaults.input_mode ?? node.input_mode,
+        output_correlation:
+          descriptorDefaults.output_correlation ?? node.output_correlation,
         is_controlled:
           descriptorDefaults.is_controlled || node.is_controlled || false
       };

--- a/packages/kernel/tests/graph-load-fromdict.test.ts
+++ b/packages/kernel/tests/graph-load-fromdict.test.ts
@@ -19,7 +19,11 @@ describe("Graph.loadFromDict", () => {
           descriptorDefaults: {
             name: "Resolved Input",
             sync_mode: "on_any",
-            is_streaming_output: false
+            is_streaming_output: false,
+            input_mode: "buffered",
+            output_correlation: {
+              output: { kind: "single", source: "__execution__" }
+            }
           }
         };
       }
@@ -38,7 +42,48 @@ describe("Graph.loadFromDict", () => {
     expect(node?.propertyTypes).toEqual({ value: "int" });
     expect(node?.outputs).toEqual({ output: "int" });
     expect(node?.sync_mode).toBe("on_any");
+    expect(node?.input_mode).toBe("buffered");
+    expect(node?.output_correlation).toEqual({
+      output: { kind: "single", source: "__execution__" }
+    });
     expect(node?.name).toBe("Resolved Input");
+  });
+
+  it("prefers resolver correlation metadata over saved node metadata", async () => {
+    const graph = await Graph.loadFromDict(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.Node",
+            input_mode: "stream",
+            output_correlation: {
+              output: { kind: "forward", source: "old_input" }
+            }
+          }
+        ],
+        edges: []
+      },
+      {
+        resolver: {
+          resolveNodeType: async (nodeType) => ({
+            nodeType,
+            descriptorDefaults: {
+              input_mode: "buffered",
+              output_correlation: {
+                output: { kind: "single", source: "__execution__" }
+              }
+            }
+          })
+        }
+      }
+    );
+
+    const node = graph.findNode("n1");
+    expect(node?.input_mode).toBe("buffered");
+    expect(node?.output_correlation).toEqual({
+      output: { kind: "single", source: "__execution__" }
+    });
   });
 
   it("drops unresolved nodes and connected edges when skipErrors is true", async () => {

--- a/packages/kernel/tests/graph-load-fromdict.test.ts
+++ b/packages/kernel/tests/graph-load-fromdict.test.ts
@@ -86,6 +86,41 @@ describe("Graph.loadFromDict", () => {
     });
   });
 
+  it("drops saved correlation metadata when resolver omits it", async () => {
+    // Resolver-wins is absolute: when the registry no longer declares
+    // correlation metadata for a node type, stale saved values must not
+    // resurface from the workflow JSON cache.
+    const graph = await Graph.loadFromDict(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.Node",
+            input_mode: "stream",
+            output_correlation: {
+              output: { kind: "forward", source: "stale" }
+            }
+          }
+        ],
+        edges: []
+      },
+      {
+        resolver: {
+          resolveNodeType: async (nodeType) => ({
+            nodeType,
+            descriptorDefaults: {
+              name: "No Correlation"
+            }
+          })
+        }
+      }
+    );
+
+    const node = graph.findNode("n1");
+    expect(node?.input_mode).toBeUndefined();
+    expect(node?.output_correlation).toBeUndefined();
+  });
+
   it("drops unresolved nodes and connected edges when skipErrors is true", async () => {
     const graph = await Graph.loadFromDict(
       {

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -1,4 +1,9 @@
-import type { NodeDescriptor, SyncMode } from "@nodetool-ai/protocol";
+import type {
+  InputMode,
+  NodeDescriptor,
+  OutputCorrelation,
+  SyncMode
+} from "@nodetool-ai/protocol";
 import type { NodeExecutor } from "@nodetool-ai/kernel";
 import type {
   ProcessingContext,
@@ -61,6 +66,8 @@ export type NodeClass = {
   requiredRuntimes?: string[];
   isStreamingInput: boolean;
   isStreamingOutput: boolean;
+  inputMode?: InputMode;
+  outputCorrelation?: Record<string, OutputCorrelation>;
   isDynamic: boolean;
   syncMode: SyncMode;
   isControlled: boolean;
@@ -121,6 +128,10 @@ export abstract class BaseNode {
   static readonly requiredRuntimes: string[] | undefined = undefined;
   static readonly isStreamingInput: boolean = false;
   static readonly isStreamingOutput: boolean = false;
+  static readonly inputMode: InputMode | undefined = undefined;
+  static readonly outputCorrelation:
+    | Record<string, OutputCorrelation>
+    | undefined = undefined;
   static readonly isDynamic: boolean = false;
   static readonly syncMode: SyncMode = "zip_all";
   static readonly isControlled: boolean = false;
@@ -388,6 +399,8 @@ export abstract class BaseNode {
       name: cls.title,
       is_streaming_input: cls.isStreamingInput,
       is_streaming_output: cls.isStreamingOutput,
+      input_mode: cls.inputMode,
+      output_correlation: cls.outputCorrelation,
       sync_mode: cls.syncMode,
       is_controlled: cls.isControlled
     };

--- a/packages/node-sdk/src/correlation-validation.ts
+++ b/packages/node-sdk/src/correlation-validation.ts
@@ -1,0 +1,109 @@
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
+
+export interface CorrelationValidationIssue {
+  nodeType: string;
+  handle?: string;
+  message: string;
+}
+
+export class CorrelationMetadataError extends Error {
+  readonly issues: readonly CorrelationValidationIssue[];
+
+  constructor(issues: readonly CorrelationValidationIssue[]) {
+    const first = issues[0];
+    const summary =
+      issues.length === 1
+        ? `${first?.nodeType}: ${first?.message}`
+        : `${issues.length} correlation metadata issues:\n` +
+          issues
+            .map(
+              (i) =>
+                `  - ${i.nodeType}${i.handle ? `.${i.handle}` : ""}: ${i.message}`
+            )
+            .join("\n");
+    super(summary);
+    this.name = "CorrelationMetadataError";
+    this.issues = issues;
+  }
+}
+
+/**
+ * Descriptor-level validation of `output_correlation` per docs/correlation-design.md §3.
+ *
+ * Only checks rules that depend solely on the node metadata. Graph-topology rules
+ * (multi-edge list source scopes, strict-prefix invocation scope, Zip constraints)
+ * belong to the static-correlation analyzer added in PR 3.
+ */
+export function validateOutputCorrelation(
+  nodeType: string,
+  inputMode: InputMode | undefined,
+  outputCorrelation: Record<string, OutputCorrelation> | undefined,
+  declaredOutputs: readonly string[]
+): CorrelationValidationIssue[] {
+  if (!outputCorrelation) return [];
+
+  const issues: CorrelationValidationIssue[] = [];
+  const groupSources = new Map<string, string>();
+  const declaredOutputSet = new Set(declaredOutputs);
+
+  for (const [handle, corr] of Object.entries(outputCorrelation)) {
+    if (!corr.source) {
+      issues.push({
+        nodeType,
+        handle,
+        message: `output "${handle}" must declare an explicit source (use "__execution__" or an input handle name)`
+      });
+      continue;
+    }
+
+    if (corr.kind === "forward") {
+      if (corr.source === "__execution__") {
+        issues.push({
+          nodeType,
+          handle,
+          message: `forward output "${handle}" cannot use source "__execution__"; specify an input handle`
+        });
+      }
+    }
+
+    if (corr.kind === "aggregate") {
+      if (!corr.collapse) {
+        issues.push({
+          nodeType,
+          handle,
+          message: `aggregate output "${handle}" must declare a collapse spec (e.g. "innermost")`
+        });
+      }
+      if (inputMode === "buffered") {
+        issues.push({
+          nodeType,
+          handle,
+          message: `aggregate output "${handle}" is not allowed on buffered nodes; set input_mode: "stream"`
+        });
+      }
+    }
+
+    if (corr.kind === "iteration" && corr.group) {
+      const existing = groupSources.get(corr.group);
+      if (existing !== undefined && existing !== corr.source) {
+        issues.push({
+          nodeType,
+          handle,
+          message: `iteration group "${corr.group}" has conflicting sources: "${existing}" and "${corr.source}" — handles in one group must share one source`
+        });
+      } else {
+        groupSources.set(corr.group, corr.source);
+      }
+    }
+
+    if (declaredOutputSet.size > 0 && !declaredOutputSet.has(handle)) {
+      issues.push({
+        nodeType,
+        handle,
+        message: `output_correlation references handle "${handle}" not in declared outputs`
+      });
+    }
+  }
+
+  return issues;
+}

--- a/packages/node-sdk/src/correlation-validation.ts
+++ b/packages/node-sdk/src/correlation-validation.ts
@@ -105,5 +105,20 @@ export function validateOutputCorrelation(
     }
   }
 
+  // Every declared output must have a correlation entry. A node may opt out
+  // of correlation entirely by leaving output_correlation undefined; once it
+  // declares any entry it has committed to the per-output contract.
+  if (declaredOutputSet.size > 0) {
+    for (const handle of declaredOutputSet) {
+      if (!(handle in outputCorrelation)) {
+        issues.push({
+          nodeType,
+          handle,
+          message: `declared output "${handle}" is missing a correlation entry`
+        });
+      }
+    }
+  }
+
   return issues;
 }

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -8,6 +8,7 @@ export * from "./node-metadata.js";
 export * from "./decorators.js";
 export * from "./search.js";
 export * from "./validation.js";
+export * from "./correlation-validation.js";
 export * from "./nodes/test-nodes.js";
 export * from "./package-registry-client.js";
 export * from "./docs/index.js";

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import os from "node:os";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 
 export interface TypeMetadata {
   type: string;
@@ -59,6 +60,8 @@ export interface NodeMetadata {
   is_dynamic?: boolean;
   is_streaming_input?: boolean;
   is_streaming_output?: boolean;
+  input_mode?: InputMode;
+  output_correlation?: Record<string, OutputCorrelation>;
   is_controlled?: boolean;
   expose_as_tool?: boolean;
   supports_dynamic_outputs?: boolean;

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -155,7 +155,10 @@ function mergeMetadata(
         : (pyMetadata.outputs ?? []).map(cloneOutputMetadata),
     // Backfill optional fields from Python when TS doesn't set them
     layout: tsMetadata.layout ?? pyMetadata.layout,
-    model_packs: tsMetadata.model_packs ?? pyMetadata.model_packs
+    model_packs: tsMetadata.model_packs ?? pyMetadata.model_packs,
+    input_mode: tsMetadata.input_mode ?? pyMetadata.input_mode,
+    output_correlation:
+      tsMetadata.output_correlation ?? pyMetadata.output_correlation
   };
 }
 

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -14,6 +14,10 @@ import type {
   TypeMetadata
 } from "./metadata.js";
 import type { DeclaredPropertyMetadata } from "./decorators.js";
+import {
+  CorrelationMetadataError,
+  validateOutputCorrelation
+} from "./correlation-validation.js";
 
 export interface GetNodeMetadataOptions {
   pythonMetadata?: NodeMetadata;
@@ -225,6 +229,18 @@ export function getNodeMetadata(
     type: toMetadataType(o.type)
   }));
 
+  if (nodeClass.outputCorrelation) {
+    const issues = validateOutputCorrelation(
+      nodeType,
+      nodeClass.inputMode,
+      nodeClass.outputCorrelation,
+      outputs.map((o) => o.name)
+    );
+    if (issues.length > 0) {
+      throw new CorrelationMetadataError(issues);
+    }
+  }
+
   const tsMetadata: NodeMetadata = {
     title: nodeClass.title || nodeType,
     description: nodeClass.description || "",
@@ -241,6 +257,8 @@ export function getNodeMetadata(
     required_runtimes: nodeClass.requiredRuntimes ?? [],
     is_streaming_input: nodeClass.isStreamingInput || false,
     is_streaming_output: nodeClass.isStreamingOutput || false,
+    input_mode: nodeClass.inputMode,
+    output_correlation: nodeClass.outputCorrelation,
     is_controlled: nodeClass.isControlled || false,
     is_dynamic: nodeClass.isDynamic || false,
     expose_as_tool: nodeClass.exposeAsTool,

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -272,6 +272,10 @@ export function createGraphNodeTypeResolver(
           name: metadata.title,
           ...(metadata.is_streaming_input && { is_streaming_input: true }),
           ...(metadata.is_streaming_output && { is_streaming_output: true }),
+          ...(metadata.input_mode && { input_mode: metadata.input_mode }),
+          ...(metadata.output_correlation && {
+            output_correlation: metadata.output_correlation
+          }),
           ...(metadata.is_controlled && { is_controlled: true }),
           ...(syncMode !== undefined && { sync_mode: syncMode }),
           ...(Object.keys(propertyMeta).length > 0 && { propertyMeta })

--- a/packages/node-sdk/tests/base-node.test.ts
+++ b/packages/node-sdk/tests/base-node.test.ts
@@ -104,6 +104,26 @@ describe("BaseNode", () => {
     expect(desc.is_controlled).toBe(false);
   });
 
+  it("toDescriptor() includes correlation metadata", () => {
+    class CorrelatedNode extends BaseNode {
+      static readonly nodeType = "test.Correlated";
+      static readonly inputMode = "stream" as const;
+      static readonly outputCorrelation = {
+        output: { kind: "forward", source: "input" }
+      } as const;
+
+      async process() {
+        return {};
+      }
+    }
+
+    const desc = CorrelatedNode.toDescriptor("my-id");
+    expect(desc.input_mode).toBe("stream");
+    expect(desc.output_correlation).toEqual({
+      output: { kind: "forward", source: "input" }
+    });
+  });
+
   it("toDescriptor() uses nodeType as id when none provided", () => {
     const desc = ConcreteNode.toDescriptor();
     expect(desc.id).toBe("test.Concrete");

--- a/packages/node-sdk/tests/correlation-validation.test.ts
+++ b/packages/node-sdk/tests/correlation-validation.test.ts
@@ -150,6 +150,20 @@ describe("validateOutputCorrelation", () => {
     expect(issues).toEqual([]);
   });
 
+  it("rejects declared outputs that are missing a correlation entry", () => {
+    const issues = validateOutputCorrelation(
+      "test.Partial",
+      "buffered",
+      {
+        output: { kind: "single", source: "__execution__" }
+      },
+      ["output", "metadata"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].handle).toBe("metadata");
+    expect(issues[0].message).toMatch(/missing a correlation entry/);
+  });
+
   it("collects multiple issues at once", () => {
     const issues = validateOutputCorrelation(
       "test.Multi",

--- a/packages/node-sdk/tests/correlation-validation.test.ts
+++ b/packages/node-sdk/tests/correlation-validation.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { validateOutputCorrelation } from "../src/correlation-validation.js";
+
+describe("validateOutputCorrelation", () => {
+  it("returns no issues for valid metadata", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "buffered",
+      {
+        output: { kind: "single", source: "__execution__" }
+      },
+      ["output"]
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("returns no issues when output_correlation is undefined", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "buffered",
+      undefined,
+      ["output"]
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects outputs missing a source", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "buffered",
+      // @ts-expect-error: deliberately missing source
+      { output: { kind: "single" } },
+      ["output"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].handle).toBe("output");
+    expect(issues[0].message).toMatch(/explicit source/);
+  });
+
+  it("rejects forward outputs that use __execution__ as source", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "buffered",
+      {
+        output: { kind: "forward", source: "__execution__" }
+      },
+      ["output"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/forward output .* cannot use source "__execution__"/);
+  });
+
+  it("rejects aggregate outputs without collapse", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "stream",
+      {
+        output: { kind: "aggregate", source: "input_item" }
+      },
+      ["output"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/aggregate output .* must declare a collapse spec/);
+  });
+
+  it("rejects aggregate outputs on buffered nodes", () => {
+    const issues = validateOutputCorrelation(
+      "test.Node",
+      "buffered",
+      {
+        output: {
+          kind: "aggregate",
+          source: "input_item",
+          collapse: "innermost"
+        }
+      },
+      ["output"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/aggregate output .* is not allowed on buffered nodes/);
+  });
+
+  it("allows aggregate outputs on stream nodes", () => {
+    const issues = validateOutputCorrelation(
+      "test.Aggregator",
+      "stream",
+      {
+        output: {
+          kind: "aggregate",
+          source: "input_item",
+          collapse: "innermost"
+        }
+      },
+      ["output"]
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects iteration groups with conflicting sources", () => {
+    const issues = validateOutputCorrelation(
+      "test.Bad",
+      "buffered",
+      {
+        output: { kind: "iteration", source: "list_a", group: "items" },
+        index: { kind: "iteration", source: "list_b", group: "items" }
+      },
+      ["output", "index"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/iteration group "items" has conflicting sources/);
+  });
+
+  it("allows iteration siblings in one group with the same source", () => {
+    const issues = validateOutputCorrelation(
+      "test.ForEach",
+      "buffered",
+      {
+        output: { kind: "iteration", source: "__execution__", group: "items" },
+        index: { kind: "iteration", source: "__execution__", group: "items" }
+      },
+      ["output", "index"]
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("rejects references to handles not declared on the node", () => {
+    const issues = validateOutputCorrelation(
+      "test.Mismatch",
+      "buffered",
+      {
+        ghost: { kind: "single", source: "__execution__" }
+      },
+      ["output"]
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/not in declared outputs/);
+  });
+
+  it("skips the declared-outputs check when the declared list is empty", () => {
+    // Dynamic-output nodes (supportsDynamicOutputs) may declare correlation
+    // for handles not in the static output set.
+    const issues = validateOutputCorrelation(
+      "test.Dynamic",
+      "buffered",
+      {
+        output: { kind: "single", source: "__execution__" }
+      },
+      []
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("collects multiple issues at once", () => {
+    const issues = validateOutputCorrelation(
+      "test.Multi",
+      "buffered",
+      {
+        a: { kind: "forward", source: "__execution__" },
+        b: { kind: "aggregate", source: "input" }
+      },
+      ["a", "b"]
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(3);
+    expect(issues.some((i) => i.handle === "a")).toBe(true);
+    expect(issues.some((i) => i.handle === "b")).toBe(true);
+  });
+});

--- a/packages/node-sdk/tests/graph-resolver.test.ts
+++ b/packages/node-sdk/tests/graph-resolver.test.ts
@@ -20,7 +20,11 @@ const sampleMetadata: NodeMetadata = {
       type: { type: "list", type_args: [{ type: "string", type_args: [] }] }
     }
   ],
-  is_streaming_output: true
+  is_streaming_output: true,
+  input_mode: "buffered",
+  output_correlation: {
+    output: { kind: "single", source: "__execution__" }
+  }
 };
 
 class LazyNode extends BaseNode {
@@ -58,7 +62,11 @@ describe("createGraphNodeTypeResolver", () => {
       isDynamic: false,
       descriptorDefaults: {
         name: "Strict Node",
-        is_streaming_output: true
+        is_streaming_output: true,
+        input_mode: "buffered",
+        output_correlation: {
+          output: { kind: "single", source: "__execution__" }
+        }
       }
     });
   });
@@ -119,6 +127,10 @@ describe("createGraphNodeTypeResolver", () => {
     expect(resolved?.descriptorDefaults).toEqual({
       name: "Zip Node",
       is_streaming_output: true,
+      input_mode: "buffered",
+      output_correlation: {
+        output: { kind: "single", source: "__execution__" }
+      },
       sync_mode: "zip_all"
     });
   });

--- a/packages/node-sdk/tests/node-metadata.test.ts
+++ b/packages/node-sdk/tests/node-metadata.test.ts
@@ -60,6 +60,52 @@ describe("getNodeMetadata", () => {
     expect(meta.is_streaming_output).toBe(true);
   });
 
+  it("includes correlation metadata", () => {
+    class CorrelatedNode extends BaseNode {
+      static readonly nodeType = "nodetool.test.Correlated";
+      static readonly title = "Correlated";
+      static readonly description = "Has correlation metadata";
+      static readonly inputMode = "stream" as const;
+      static readonly outputCorrelation = {
+        output: { kind: "forward", source: "input" }
+      } as const;
+
+      async process() {
+        return {};
+      }
+    }
+
+    const meta = getNodeMetadata(CorrelatedNode);
+    expect(meta.input_mode).toBe("stream");
+    expect(meta.output_correlation).toEqual({
+      output: { kind: "forward", source: "input" }
+    });
+  });
+
+  it("throws on invalid correlation metadata", () => {
+    class BadAggregateNode extends BaseNode {
+      static readonly nodeType = "nodetool.test.BadAggregate";
+      static readonly title = "Bad Aggregate";
+      static readonly description = "Aggregate on a buffered node — rejected";
+      static readonly inputMode = "buffered" as const;
+      static readonly outputCorrelation = {
+        output: {
+          kind: "aggregate",
+          source: "input",
+          collapse: "innermost"
+        }
+      } as const;
+
+      async process() {
+        return {};
+      }
+    }
+
+    expect(() => getNodeMetadata(BadAggregateNode)).toThrow(
+      /aggregate output .* is not allowed on buffered nodes/
+    );
+  });
+
   it("infers string types from defaults", () => {
     const meta = getNodeMetadata(StringConcat);
     const propA = meta.properties.find((p) => p.name === "a");

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -6,7 +6,7 @@
  * Used by both the backend HTTP handlers and the frontend stores.
  */
 
-import type { Edge } from "./graph.js";
+import type { Edge, InputMode, OutputCorrelation } from "./graph.js";
 
 // ---------------------------------------------------------------------------
 // Media Refs
@@ -560,6 +560,8 @@ export interface NodeMetadata {
   required_settings: string[];
   is_dynamic: boolean;
   is_streaming_output: boolean;
+  input_mode?: InputMode;
+  output_correlation?: Record<string, OutputCorrelation>;
   expose_as_tool: boolean;
   supports_dynamic_outputs: boolean;
   model_packs?: ModelPack[];

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -54,6 +54,24 @@ export type ControlEvent = RunEvent | StopEvent;
 
 export type SyncMode = "on_any" | "zip_all";
 
+export type InputMode = "buffered" | "stream" | "controlled";
+
+export type OutputKind =
+  | "single"
+  | "iteration"
+  | "chunk"
+  | "forward"
+  | "aggregate";
+
+export type CollapseSpec = "innermost";
+
+export interface OutputCorrelation {
+  kind: OutputKind;
+  source: string;
+  group?: string;
+  collapse?: CollapseSpec;
+}
+
 /**
  * Minimal node descriptor for graph operations.
  * The full BaseNode equivalent lives in the node-sdk package.
@@ -86,6 +104,12 @@ export interface NodeDescriptor {
 
   /** Whether this node produces streaming output. */
   is_streaming_output?: boolean;
+
+  /** Correlation-aware input execution mode. */
+  input_mode?: InputMode;
+
+  /** Per-output correlation metadata. */
+  output_correlation?: Record<string, OutputCorrelation>;
 
   /** Sync mode: fire-on-first or wait-all. */
   sync_mode?: SyncMode;


### PR DESCRIPTION
PR 1 of docs/correlation-design.md — purely additive metadata, no scheduler change.

- Add InputMode, OutputKind, CollapseSpec, OutputCorrelation types to @nodetool-ai/protocol; NodeDescriptor and NodeMetadata gain input_mode and per-output output_correlation fields
- Add BaseNode.inputMode and BaseNode.outputCorrelation statics; propagate through toDescriptor(), getNodeMetadata(), createGraphNodeTypeResolver, and Graph.loadFromDict (resolver metadata wins over saved JSON)
- Classify 49 nodes across 17 base-nodes files as iteration/forward/chunk/single/aggregate per their actual emit pattern. Stale chunk ports on aspirational streamers (ClaudeAgent, TextToSpeech, Workflow, bot triggers) declared as single or iteration over declared output schema.
- Add descriptor-level validation in node-sdk: every output needs source; forward source != __execution__; aggregate requires collapse and isn't allowed on buffered nodes; iteration groups must share one source; output_correlation handles must be in declared outputs. Wired into getNodeMetadata; throws CorrelationMetadataError on bad metadata.

Legacy isStreamingInput/Output and syncMode flags untouched — the old scheduler still uses them. Static-graph rules (multi-edge list scopes, strict-prefix invocation scope, Zip constraints) wait for PR 3's _analyzeCorrelation pass.