### PR TITLE
Add transform gizmo overlay for timeline clip editing

### DIFF
--- a/web/src/components/timeline/preview/ClipTransformContextMenu.tsx
+++ b/web/src/components/timeline/preview/ClipTransformContextMenu.tsx
@@ -1,0 +1,147 @@
+/**
+ * ClipTransformContextMenu — right-click quick transform actions for a
+ * timeline clip. Mirrors the sketch editor's TransformContextMenu (rotate /
+ * flip / reset) using the shared `ui_primitives` menu components.
+ *
+ * @module timeline/preview/ClipTransformContextMenu
+ */
+
+import React, { memo, useEffect } from "react";
+import { useTheme } from "@mui/material/styles";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import RotateLeftIcon from "@mui/icons-material/RotateLeft";
+import RotateRightIcon from "@mui/icons-material/RotateRight";
+import Rotate90DegreesCwIcon from "@mui/icons-material/Rotate90DegreesCw";
+import FlipIcon from "@mui/icons-material/Flip";
+import TransformIcon from "@mui/icons-material/Transform";
+
+import {
+  ContextMenu,
+  Divider,
+  FlexRow,
+  MenuItemPrimitive,
+  Text
+} from "../../ui_primitives";
+
+export interface ClipTransformContextMenuProps {
+  open: boolean;
+  position: { x: number; y: number } | null;
+  onClose: () => void;
+  onReset: () => void;
+  onRotate90CW: () => void;
+  onRotate90CCW: () => void;
+  onRotate180: () => void;
+  onFlipHorizontal: () => void;
+  onFlipVertical: () => void;
+}
+
+const ClipTransformContextMenu: React.FC<ClipTransformContextMenuProps> = ({
+  open,
+  position,
+  onClose,
+  onReset,
+  onRotate90CW,
+  onRotate90CCW,
+  onRotate180,
+  onFlipHorizontal,
+  onFlipVertical
+}) => {
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [open, onClose]);
+
+  const run = (fn: () => void) => () => {
+    fn();
+    onClose();
+  };
+
+  return (
+    <ContextMenu
+      open={open}
+      onClose={onClose}
+      position={position}
+      transitionDuration={{ enter: 60, exit: 40 }}
+      transformOrigin={{ vertical: "top", horizontal: "left" }}
+      disableRestoreFocus
+      minWidth={200}
+      paperSx={{
+        maxWidth: 280,
+        borderRadius: "10px",
+        backgroundImage: "none",
+        backgroundColor: theme.vars.palette.grey[900],
+        backdropFilter: "blur(16px)",
+        boxShadow: theme.shadows[12],
+        py: 0.5
+      }}
+    >
+      <FlexRow align="center" sx={{ gap: 1, px: 2, py: 0.75, mb: 0.25 }}>
+        <TransformIcon sx={{ fontSize: 16, color: "primary.light" }} />
+        <Text sx={{ fontSize: 12, fontWeight: 700, color: "text.primary" }}>
+          Transform
+        </Text>
+      </FlexRow>
+
+      <Divider sx={{ mx: 1, borderColor: theme.vars.palette.grey[800] }} />
+
+      <MenuItemPrimitive
+        label="Reset"
+        icon={<RestartAltIcon sx={{ fontSize: 16 }} />}
+        shortcut="."
+        compact
+        onClick={run(onReset)}
+      />
+
+      <Divider sx={{ mx: 1, my: 0.5, borderColor: theme.vars.palette.grey[800] }} />
+
+      <MenuItemPrimitive
+        label="Rotate 180°"
+        icon={<Rotate90DegreesCwIcon sx={{ fontSize: 16 }} />}
+        compact
+        onClick={run(onRotate180)}
+      />
+      <MenuItemPrimitive
+        label="Rotate 90° CW"
+        icon={<RotateRightIcon sx={{ fontSize: 16 }} />}
+        compact
+        onClick={run(onRotate90CW)}
+      />
+      <MenuItemPrimitive
+        label="Rotate 90° CCW"
+        icon={<RotateLeftIcon sx={{ fontSize: 16 }} />}
+        compact
+        onClick={run(onRotate90CCW)}
+      />
+
+      <Divider sx={{ mx: 1, my: 0.5, borderColor: theme.vars.palette.grey[800] }} />
+
+      <MenuItemPrimitive
+        label="Flip Horizontal"
+        icon={<FlipIcon sx={{ fontSize: 16 }} />}
+        compact
+        onClick={run(onFlipHorizontal)}
+      />
+      <MenuItemPrimitive
+        label="Flip Vertical"
+        icon={<FlipIcon sx={{ fontSize: 16, transform: "rotate(90deg)" }} />}
+        compact
+        onClick={run(onFlipVertical)}
+      />
+    </ContextMenu>
+  );
+};
+
+export { ClipTransformContextMenu };
+export default memo(ClipTransformContextMenu);

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -17,11 +17,13 @@ import { shallow } from "zustand/shallow";
 import type { TimelineClip, TrackEffect } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
 
 import { WebGPUCompositor } from "./gpu/compositor";
 import type { CompositeLayer, CompositorBlendMode } from "./gpu/types";
+import { TransformGizmoOverlay } from "./TransformGizmoOverlay";
 
 interface PlaceholderLayer {
   clipId: string;
@@ -194,6 +196,11 @@ export const PreviewCompositor: React.FC = memo(() => {
     shallow
   );
 
+  const patchClip = useTimelineStore((s) => s.patchClip);
+  const selectedClipId = useTimelineUIStore((s) =>
+    s.selectedClipIds.size === 1 ? [...s.selectedClipIds][0] : null
+  );
+
   const assetUrlCache = useRef<Map<string, string>>(new Map());
   const [urlCacheVersion, setUrlCacheVersion] = useState(0);
   const getAsset = useAssetStore((s) => s.get);
@@ -247,6 +254,11 @@ export const PreviewCompositor: React.FC = memo(() => {
   const compositorRef = useRef<WebGPUCompositor | null>(null);
   const [gpuReady, setGpuReady] = useState(false);
   const [gpuFailed, setGpuFailed] = useState(false);
+
+  // Frame element CSS size and canvas backing size, mirrored into state so the
+  // transform gizmo overlay can map clip space → screen pixels.
+  const [frameSize, setFrameSize] = useState({ w: 0, h: 0 });
+  const [canvasSize, setCanvasSize] = useState({ w: 0, h: 0 });
 
   useLayoutEffect(() => {
     const container = poolContainerRef.current;
@@ -342,6 +354,9 @@ export const PreviewCompositor: React.FC = memo(() => {
           : { w: rect.height * aspect, h: rect.height };
       frame.style.width = `${fit.w}px`;
       frame.style.height = `${fit.h}px`;
+      setFrameSize((prev) =>
+        prev.w === fit.w && prev.h === fit.h ? prev : { w: fit.w, h: fit.h }
+      );
 
       const dpr = window.devicePixelRatio || 1;
       const w = Math.max(1, Math.floor(fit.w * dpr));
@@ -351,6 +366,9 @@ export const PreviewCompositor: React.FC = memo(() => {
         canvas.height = h;
         compositorRef.current?.resize(w, h);
       }
+      setCanvasSize((prev) =>
+        prev.w === w && prev.h === h ? prev : { w, h }
+      );
     };
     apply();
     const ro = new ResizeObserver(apply);
@@ -460,6 +478,45 @@ export const PreviewCompositor: React.FC = memo(() => {
       placeholderLayers: placeholders
     };
   }, [sortedTracks, clipsByTrackId, currentTimeMs, resolveUrl, urlCacheVersion]);
+
+  // Source dims + transform for the single selected clip, but only while it is
+  // actually rendered (active at the playhead) so the gizmo traces a visible
+  // box. Dimensions come from the already-decoded media elements.
+  const selectedGizmo = useMemo(() => {
+    if (!selectedClipId) return null;
+    const clip = clipById.get(selectedClipId);
+    if (!clip) return null;
+
+    let w = 0;
+    let h = 0;
+    const vSlot = activeVideoSlots.find((s) => s.clipId === selectedClipId);
+    const iLayer = activeImageLayers.find((l) => l.clipId === selectedClipId);
+    if (vSlot) {
+      const idx = clipSlotMap.current.get(selectedClipId);
+      const el = idx !== undefined ? videoRefs.current[idx] : undefined;
+      w = el?.videoWidth ?? 0;
+      h = el?.videoHeight ?? 0;
+    } else if (iLayer?.assetUrl) {
+      const img = imageElementCache.current.get(iLayer.assetUrl);
+      w = img?.naturalWidth ?? 0;
+      h = img?.naturalHeight ?? 0;
+    } else {
+      return null;
+    }
+    if (w <= 0 || h <= 0) return null;
+    return {
+      clipId: selectedClipId,
+      transform: clip.transform,
+      sourceWidth: w,
+      sourceHeight: h
+    };
+  }, [
+    selectedClipId,
+    clipById,
+    activeVideoSlots,
+    activeImageLayers,
+    urlCacheVersion
+  ]);
 
   // Drive the HTMLVideoElement pool (src/seek/play state). Same logic as
   // before, just without setting display/zIndex/blendMode — those are owned
@@ -724,6 +781,20 @@ export const PreviewCompositor: React.FC = memo(() => {
             pointerEvents: "none"
           }}
         />
+
+        {selectedGizmo && (
+          <TransformGizmoOverlay
+            clipId={selectedGizmo.clipId}
+            transform={selectedGizmo.transform}
+            sourceWidth={selectedGizmo.sourceWidth}
+            sourceHeight={selectedGizmo.sourceHeight}
+            canvasWidth={canvasSize.w}
+            canvasHeight={canvasSize.h}
+            frameWidth={frameSize.w}
+            frameHeight={frameSize.h}
+            onChange={(id, next) => patchClip(id, { transform: next })}
+          />
+        )}
 
         {placeholderLayers.map((layer) => (
           <div

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -18,7 +18,7 @@
  * @module timeline/preview/TransformGizmoOverlay
  */
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import type { ClipTransform } from "@nodetool-ai/timeline";
 
 import { buildTransformMatrix, containBaseScale } from "./gpu/transform";
@@ -26,6 +26,8 @@ import {
   HANDLE_SIZE,
   ROTATION_HANDLE_OFFSET,
   ROTATION_HANDLE_RADIUS_FACTOR,
+  PIVOT_CROSSHAIR_SIZE,
+  PIVOT_SNAP_DISTANCE,
   GIZMO_PRIMARY_COLOR,
   GIZMO_PRIMARY_SEMI,
   GIZMO_PRIMARY_FAINT,
@@ -36,6 +38,7 @@ import {
   BOUNDING_BOX_DASH_ON,
   BOUNDING_BOX_DASH_OFF
 } from "../../sketch/tools/gizmo/gizmoConstants";
+import { ClipTransformContextMenu } from "./ClipTransformContextMenu";
 
 interface Point {
   x: number;
@@ -55,7 +58,18 @@ const ROTATION_SNAP_RAD = (15 * Math.PI) / 180;
 type CornerHandle = "tl" | "tr" | "br" | "bl";
 type EdgeHandle = "t" | "r" | "b" | "l";
 type ScaleHandle = CornerHandle | EdgeHandle;
-type GizmoTarget = ScaleHandle | "rotate" | "body";
+type GizmoTarget = ScaleHandle | "rotate" | "pivot" | "body";
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
+/** Snap a normalized [0,1] coord to 0/0.5/1 when within the pixel threshold. */
+const snapAnchor = (norm01: number, dimPx: number): number => {
+  for (const target of [0, 0.5, 1]) {
+    if (Math.abs(norm01 - target) * dimPx < PIVOT_SNAP_DISTANCE) {
+      return target;
+    }
+  }
+  return clamp01(norm01);
+};
 
 export interface TransformGizmoOverlayProps {
   /** Selected clip id (target of mutations). */
@@ -92,8 +106,8 @@ interface BoxGeometry {
   /** [TL, TR, BR, BL] in frame CSS px. */
   corners: [Point, Point, Point, Point];
   center: Point;
-  /** Screen rotation of the box in degrees (for the rotation-line group). */
-  rotationDeg: number;
+  /** Pivot (anchor) point in frame CSS px. */
+  pivot: Point;
 }
 
 function computeGeometry(
@@ -121,9 +135,10 @@ function computeGeometry(
     at(-1, -1)
   ];
   const center = at(0, 0);
-  // Screen rotation is the negative of clip rotation due to the Y flip.
-  const rotationDeg = (-t.rotation * 180) / Math.PI;
-  return { corners, center, rotationDeg };
+  // The anchor point's quad coordinate; buildTransformMatrix keeps it fixed
+  // under rotation/scale, so it is the true pivot.
+  const pivot = at((t.anchor.x - 0.5) * 2, (t.anchor.y - 0.5) * 2);
+  return { corners, center, pivot };
 }
 
 const sub = (a: Point, b: Point): Point => ({ x: a.x - b.x, y: a.y - b.y });
@@ -151,10 +166,16 @@ interface DragSession {
   /** Distance from fixed point to dragged handle, along each axis, at start. */
   startProjU: number;
   startProjV: number;
-  /** Box center in CSS at drag start (rotation pivot). */
+  /** Box center in CSS at drag start (kept fixed during scale). */
   startCenter: Point;
-  /** Angle from center to pointer at drag start (screen radians). */
+  /** Reference point for rotation (the pivot) in CSS at drag start. */
+  rotationRef: Point;
+  /** Angle from rotation ref to pointer at drag start (screen radians). */
   startAngle: number;
+  /** Top-left corner + box axis lengths at start (for pivot mapping). */
+  tl: Point;
+  widthU: number;
+  heightV: number;
 }
 
 interface SquareHandleProps {
@@ -213,6 +234,7 @@ export function TransformGizmoOverlay({
   onChange
 }: TransformGizmoOverlayProps): React.ReactElement | null {
   const dragRef = useRef<DragSession | null>(null);
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
 
   if (
     sourceWidth <= 0 ||
@@ -310,16 +332,21 @@ export function TransformGizmoOverlay({
   };
 
   const beginDrag = (target: GizmoTarget) => (e: React.PointerEvent) => {
+    if (e.button !== 0) {
+      return;
+    }
     e.stopPropagation();
     e.preventDefault();
-    svgOf(e).setPointerCapture?.(e.pointerId);
+    const svg = svgOf(e);
+    svg.setPointerCapture?.(e.pointerId);
+    svg.focus?.({ preventScroll: true });
     const axisU = norm(sub(tr, tl));
     const axisV = norm(sub(bl, tl));
     const pointer = pointerInFrame(e);
     let fixed = geo.center;
     let startProjU = 1;
     let startProjV = 1;
-    if (target !== "rotate" && target !== "body") {
+    if (target !== "rotate" && target !== "body" && target !== "pivot") {
       fixed = fixedPointFor(target);
       const moving = movingPointFor(target);
       const rel = sub(moving, fixed);
@@ -341,7 +368,11 @@ export function TransformGizmoOverlay({
       startProjU,
       startProjV,
       startCenter: geo.center,
-      startAngle: Math.atan2(pointer.y - geo.center.y, pointer.x - geo.center.x)
+      rotationRef: geo.pivot,
+      startAngle: Math.atan2(pointer.y - geo.pivot.y, pointer.x - geo.pivot.x),
+      tl,
+      widthU: len(sub(tr, tl)),
+      heightV: len(sub(bl, tl))
     };
   };
 
@@ -369,15 +400,31 @@ export function TransformGizmoOverlay({
 
     if (drag.target === "rotate") {
       const angle = Math.atan2(
-        pointer.y - drag.startCenter.y,
-        pointer.x - drag.startCenter.x
+        pointer.y - drag.rotationRef.y,
+        pointer.x - drag.rotationRef.x
       );
-      // Screen angle is the negative of clip rotation.
+      // Screen angle is the negative of clip rotation. The matrix keeps the
+      // pivot fixed, so no position compensation is needed.
       let next = start.rotation - (angle - drag.startAngle);
       if (e.shiftKey) {
         next = Math.round(next / ROTATION_SNAP_RAD) * ROTATION_SNAP_RAD;
       }
-      const candidate: ClipTransform = { ...start, rotation: next };
+      onChange(clipId, { ...start, rotation: next });
+      return;
+    }
+
+    if (drag.target === "pivot") {
+      // Map the pointer onto the box's local axes → normalized anchor, then
+      // compensate position so the rendered clip stays put (only the pivot
+      // moves). Y is flipped: anchor.y = 1 at the top edge.
+      const rel = sub(pointer, drag.tl);
+      const projU = dot(rel, drag.axisU) / (drag.widthU || 1);
+      const projV = dot(rel, drag.axisV) / (drag.heightV || 1);
+      const anchor = {
+        x: snapAnchor(projU, drag.widthU),
+        y: snapAnchor(1 - projV, drag.heightV)
+      };
+      const candidate: ClipTransform = { ...start, anchor };
       onChange(clipId, keepCenter(candidate, start, drag.startCenter));
       return;
     }
@@ -508,11 +555,68 @@ export function TransformGizmoOverlay({
     }
   };
 
+  // ── Quick transform operations (context menu + keyboard) ────────────────
+  const rotateBy = (rad: number) =>
+    onChange(clipId, { ...t, rotation: t.rotation + rad });
+  const flipH = () =>
+    onChange(clipId, { ...t, scale: { ...t.scale, x: -t.scale.x } });
+  const flipV = () =>
+    onChange(clipId, { ...t, scale: { ...t.scale, y: -t.scale.y } });
+  const reset = () =>
+    onChange(clipId, {
+      position: { x: 0, y: 0 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+      anchor: { x: 0.5, y: 0.5 }
+    });
+  const nudge = (dxPx: number, dyPx: number) =>
+    onChange(clipId, {
+      ...t,
+      position: { x: t.position.x + dxPx, y: t.position.y + dyPx }
+    });
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const step = e.shiftKey ? 10 : 1;
+    switch (e.key) {
+      case "ArrowLeft":
+        nudge(-step, 0);
+        break;
+      case "ArrowRight":
+        nudge(step, 0);
+        break;
+      case "ArrowUp":
+        nudge(0, -step);
+        break;
+      case "ArrowDown":
+        nudge(0, step);
+        break;
+      case ".":
+        reset();
+        break;
+      default:
+        return;
+    }
+    // Only swallow keys we actually handled, so frame-stepping still works
+    // when the gizmo is not the keyboard target.
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  };
+
   const polyPoints = geo.corners.map((c) => `${c.x},${c.y}`).join(" ");
 
   return (
+    <>
     <svg
       data-testid="timeline-transform-gizmo"
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      onContextMenu={onContextMenu}
       style={{
         position: "absolute",
         inset: 0,
@@ -521,7 +625,8 @@ export function TransformGizmoOverlay({
         overflow: "visible",
         zIndex: 10000,
         pointerEvents: "none",
-        touchAction: "none"
+        touchAction: "none",
+        outline: "none"
       }}
       onPointerMove={onPointerMove}
       onPointerUp={endDrag}
@@ -569,6 +674,54 @@ export function TransformGizmoOverlay({
       <SquareHandle cx={rightMid.x} cy={rightMid.y} cursor="ew-resize" onDown={beginDrag("r")} />
       <SquareHandle cx={bottomMid.x} cy={bottomMid.y} cursor="ns-resize" onDown={beginDrag("b")} />
       <SquareHandle cx={leftMid.x} cy={leftMid.y} cursor="ew-resize" onDown={beginDrag("l")} />
+
+      {/* Pivot crosshair — drag to move the rotation/scale center. */}
+      <g
+        style={{ cursor: "move", pointerEvents: "all" }}
+        onPointerDown={beginDrag("pivot")}
+        data-testid="timeline-transform-pivot"
+      >
+        <circle cx={geo.pivot.x} cy={geo.pivot.y} r={PIVOT_CROSSHAIR_SIZE + 2} fill="transparent" />
+        <line
+          x1={geo.pivot.x - PIVOT_CROSSHAIR_SIZE}
+          y1={geo.pivot.y}
+          x2={geo.pivot.x + PIVOT_CROSSHAIR_SIZE}
+          y2={geo.pivot.y}
+          stroke={GIZMO_PRIMARY_COLOR}
+          strokeWidth={GIZMO_LINE_WIDTH}
+        />
+        <line
+          x1={geo.pivot.x}
+          y1={geo.pivot.y - PIVOT_CROSSHAIR_SIZE}
+          x2={geo.pivot.x}
+          y2={geo.pivot.y + PIVOT_CROSSHAIR_SIZE}
+          stroke={GIZMO_PRIMARY_COLOR}
+          strokeWidth={GIZMO_LINE_WIDTH}
+        />
+        <circle
+          cx={geo.pivot.x}
+          cy={geo.pivot.y}
+          r={3}
+          fill={HANDLE_FILL_DEFAULT}
+          stroke={GIZMO_PRIMARY_COLOR}
+          strokeWidth={GIZMO_LINE_WIDTH}
+        />
+      </g>
+
     </svg>
+    {menuPos && (
+      <ClipTransformContextMenu
+        open
+        position={menuPos}
+        onClose={() => setMenuPos(null)}
+        onReset={reset}
+        onRotate90CW={() => rotateBy(Math.PI / 2)}
+        onRotate90CCW={() => rotateBy(-Math.PI / 2)}
+        onRotate180={() => rotateBy(Math.PI)}
+        onFlipHorizontal={flipH}
+        onFlipVertical={flipV}
+      />
+    )}
+    </>
   );
 }

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -1,0 +1,574 @@
+/**
+ * TransformGizmoOverlay — interactive transform handles for the selected
+ * timeline clip, drawn over the preview frame.
+ *
+ * Ports the sketch editor's transform UX (dashed bounding box + square
+ * corner/edge handles + a rotation handle) to the timeline. Reuses the
+ * shared gizmo styling constants so the visual language matches the sketch
+ * editor exactly.
+ *
+ * Geometry is derived from the same {@link buildTransformMatrix} the GPU
+ * compositor uses, so the box always traces the rendered clip. Dragging
+ * mutates the clip's {@link ClipTransform} live via `onChange`:
+ *   - body            → move (position)
+ *   - corner handles  → scale around the opposite corner (Shift = uniform)
+ *   - edge handles    → scale one axis around the opposite edge
+ *   - rotation handle → rotate around the box center (Shift = 15° snap)
+ *
+ * @module timeline/preview/TransformGizmoOverlay
+ */
+
+import React, { useRef } from "react";
+import type { ClipTransform } from "@nodetool-ai/timeline";
+
+import { buildTransformMatrix, containBaseScale } from "./gpu/transform";
+import {
+  HANDLE_SIZE,
+  ROTATION_HANDLE_OFFSET,
+  ROTATION_HANDLE_RADIUS_FACTOR,
+  GIZMO_PRIMARY_COLOR,
+  GIZMO_PRIMARY_SEMI,
+  GIZMO_PRIMARY_FAINT,
+  HANDLE_FILL_DEFAULT,
+  HANDLE_FILL_HOVERED,
+  GIZMO_LINE_WIDTH,
+  GIZMO_LINE_WIDTH_HOVERED,
+  BOUNDING_BOX_DASH_ON,
+  BOUNDING_BOX_DASH_OFF
+} from "../../sketch/tools/gizmo/gizmoConstants";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const IDENTITY_TRANSFORM: ClipTransform = {
+  position: { x: 0, y: 0 },
+  scale: { x: 1, y: 1 },
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 }
+};
+
+const BOX_DASH = `${BOUNDING_BOX_DASH_ON} ${BOUNDING_BOX_DASH_OFF}`;
+const ROTATION_SNAP_RAD = (15 * Math.PI) / 180;
+
+type CornerHandle = "tl" | "tr" | "br" | "bl";
+type EdgeHandle = "t" | "r" | "b" | "l";
+type ScaleHandle = CornerHandle | EdgeHandle;
+type GizmoTarget = ScaleHandle | "rotate" | "body";
+
+export interface TransformGizmoOverlayProps {
+  /** Selected clip id (target of mutations). */
+  clipId: string;
+  /** Current transform (undefined → identity). */
+  transform: ClipTransform | undefined;
+  /** Source pixel width of the clip's decoded media. */
+  sourceWidth: number;
+  /** Source pixel height of the clip's decoded media. */
+  sourceHeight: number;
+  /** GPU canvas backing width (px) — matches the compositor. */
+  canvasWidth: number;
+  /** GPU canvas backing height (px) — matches the compositor. */
+  canvasHeight: number;
+  /** Frame element CSS width (px). */
+  frameWidth: number;
+  /** Frame element CSS height (px). */
+  frameHeight: number;
+  /** Commit a new transform for the clip. */
+  onChange: (clipId: string, transform: ClipTransform) => void;
+}
+
+/** clip space [-1,1]² → frame CSS pixels (clip Y up → screen Y down). */
+function clipToCss(
+  cx: number,
+  cy: number,
+  frameW: number,
+  frameH: number
+): Point {
+  return { x: ((cx + 1) / 2) * frameW, y: ((1 - cy) / 2) * frameH };
+}
+
+interface BoxGeometry {
+  /** [TL, TR, BR, BL] in frame CSS px. */
+  corners: [Point, Point, Point, Point];
+  center: Point;
+  /** Screen rotation of the box in degrees (for the rotation-line group). */
+  rotationDeg: number;
+}
+
+function computeGeometry(
+  t: ClipTransform,
+  srcW: number,
+  srcH: number,
+  canvasW: number,
+  canvasH: number,
+  frameW: number,
+  frameH: number
+): BoxGeometry {
+  const base = containBaseScale(srcW, srcH, canvasW, canvasH);
+  const m = buildTransformMatrix(t, base, canvasW, canvasH);
+  const at = (qx: number, qy: number): Point =>
+    clipToCss(
+      m[0] * qx + m[4] * qy + m[12],
+      m[1] * qx + m[5] * qy + m[13],
+      frameW,
+      frameH
+    );
+  const corners: [Point, Point, Point, Point] = [
+    at(-1, 1),
+    at(1, 1),
+    at(1, -1),
+    at(-1, -1)
+  ];
+  const center = at(0, 0);
+  // Screen rotation is the negative of clip rotation due to the Y flip.
+  const rotationDeg = (-t.rotation * 180) / Math.PI;
+  return { corners, center, rotationDeg };
+}
+
+const sub = (a: Point, b: Point): Point => ({ x: a.x - b.x, y: a.y - b.y });
+const dot = (a: Point, b: Point): number => a.x * b.x + a.y * b.y;
+const len = (a: Point): number => Math.hypot(a.x, a.y) || 1;
+const norm = (a: Point): Point => {
+  const l = len(a);
+  return { x: a.x / l, y: a.y / l };
+};
+const mid = (a: Point, b: Point): Point => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2
+});
+
+/** Drag session captured on pointer down. */
+interface DragSession {
+  target: GizmoTarget;
+  startTransform: ClipTransform;
+  startPointer: Point;
+  /** Fixed (anchored) point in CSS for scale ops. */
+  fixed: Point;
+  /** Box local axes (unit) at drag start. */
+  axisU: Point;
+  axisV: Point;
+  /** Distance from fixed point to dragged handle, along each axis, at start. */
+  startProjU: number;
+  startProjV: number;
+  /** Box center in CSS at drag start (rotation pivot). */
+  startCenter: Point;
+  /** Angle from center to pointer at drag start (screen radians). */
+  startAngle: number;
+}
+
+interface SquareHandleProps {
+  cx: number;
+  cy: number;
+  cursor: string;
+  onDown: (e: React.PointerEvent) => void;
+}
+
+function SquareHandle({ cx, cy, cursor, onDown }: SquareHandleProps) {
+  const hs = HANDLE_SIZE;
+  return (
+    <rect
+      x={cx - hs / 2}
+      y={cy - hs / 2}
+      width={hs}
+      height={hs}
+      fill={HANDLE_FILL_DEFAULT}
+      stroke={GIZMO_PRIMARY_COLOR}
+      strokeWidth={GIZMO_LINE_WIDTH}
+      style={{ cursor, pointerEvents: "all" }}
+      onPointerDown={onDown}
+      onPointerEnter={(e) => {
+        (e.currentTarget as SVGRectElement).setAttribute(
+          "fill",
+          HANDLE_FILL_HOVERED
+        );
+        (e.currentTarget as SVGRectElement).setAttribute(
+          "stroke-width",
+          String(GIZMO_LINE_WIDTH_HOVERED)
+        );
+      }}
+      onPointerLeave={(e) => {
+        (e.currentTarget as SVGRectElement).setAttribute(
+          "fill",
+          HANDLE_FILL_DEFAULT
+        );
+        (e.currentTarget as SVGRectElement).setAttribute(
+          "stroke-width",
+          String(GIZMO_LINE_WIDTH)
+        );
+      }}
+    />
+  );
+}
+
+export function TransformGizmoOverlay({
+  clipId,
+  transform,
+  sourceWidth,
+  sourceHeight,
+  canvasWidth,
+  canvasHeight,
+  frameWidth,
+  frameHeight,
+  onChange
+}: TransformGizmoOverlayProps): React.ReactElement | null {
+  const dragRef = useRef<DragSession | null>(null);
+
+  if (
+    sourceWidth <= 0 ||
+    sourceHeight <= 0 ||
+    canvasWidth <= 0 ||
+    canvasHeight <= 0 ||
+    frameWidth <= 0 ||
+    frameHeight <= 0
+  ) {
+    return null;
+  }
+
+  const t = transform ?? IDENTITY_TRANSFORM;
+  const geo = computeGeometry(
+    t,
+    sourceWidth,
+    sourceHeight,
+    canvasWidth,
+    canvasHeight,
+    frameWidth,
+    frameHeight
+  );
+  const [tl, tr, br, bl] = geo.corners;
+
+  const topMid = mid(tl, tr);
+  const rightMid = mid(tr, br);
+  const bottomMid = mid(br, bl);
+  const leftMid = mid(bl, tl);
+
+  // Outward unit vector through the top edge midpoint (for the rotate stem).
+  const outward = norm(sub(topMid, geo.center));
+  const rotHandle: Point = {
+    x: topMid.x + outward.x * ROTATION_HANDLE_OFFSET,
+    y: topMid.y + outward.y * ROTATION_HANDLE_OFFSET
+  };
+
+  /** CSS px → position px delta along each canvas axis. */
+  const cssToPosX = (dxCss: number): number => (dxCss * canvasWidth) / frameWidth;
+  const cssToPosY = (dyCss: number): number =>
+    (dyCss * canvasHeight) / frameHeight;
+
+  const fixedPointFor = (target: ScaleHandle): Point => {
+    switch (target) {
+      case "tl":
+        return br;
+      case "tr":
+        return bl;
+      case "br":
+        return tl;
+      case "bl":
+        return tr;
+      case "t":
+        return bottomMid;
+      case "b":
+        return topMid;
+      case "l":
+        return rightMid;
+      case "r":
+        return leftMid;
+    }
+  };
+
+  const movingPointFor = (target: ScaleHandle): Point => {
+    switch (target) {
+      case "tl":
+        return tl;
+      case "tr":
+        return tr;
+      case "br":
+        return br;
+      case "bl":
+        return bl;
+      case "t":
+        return topMid;
+      case "b":
+        return bottomMid;
+      case "l":
+        return leftMid;
+      case "r":
+        return rightMid;
+    }
+  };
+
+  const scalesX = (target: ScaleHandle): boolean => target !== "t" && target !== "b";
+  const scalesY = (target: ScaleHandle): boolean => target !== "l" && target !== "r";
+
+  const svgOf = (e: React.PointerEvent): SVGSVGElement => {
+    const el = e.currentTarget as SVGElement;
+    return (el.ownerSVGElement ?? el) as SVGSVGElement;
+  };
+
+  const pointerInFrame = (e: React.PointerEvent): Point => {
+    const rect = svgOf(e).getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const beginDrag = (target: GizmoTarget) => (e: React.PointerEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    svgOf(e).setPointerCapture?.(e.pointerId);
+    const axisU = norm(sub(tr, tl));
+    const axisV = norm(sub(bl, tl));
+    const pointer = pointerInFrame(e);
+    let fixed = geo.center;
+    let startProjU = 1;
+    let startProjV = 1;
+    if (target !== "rotate" && target !== "body") {
+      fixed = fixedPointFor(target);
+      const moving = movingPointFor(target);
+      const rel = sub(moving, fixed);
+      startProjU = dot(rel, axisU);
+      startProjV = dot(rel, axisV);
+    }
+    dragRef.current = {
+      target,
+      startTransform: {
+        position: { ...t.position },
+        scale: { ...t.scale },
+        rotation: t.rotation,
+        anchor: { ...t.anchor }
+      },
+      startPointer: pointer,
+      fixed,
+      axisU,
+      axisV,
+      startProjU,
+      startProjV,
+      startCenter: geo.center,
+      startAngle: Math.atan2(pointer.y - geo.center.y, pointer.x - geo.center.x)
+    };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    e.preventDefault();
+    const pointer = pointerInFrame(e);
+    const start = drag.startTransform;
+
+    if (drag.target === "body") {
+      const dx = pointer.x - drag.startPointer.x;
+      const dy = pointer.y - drag.startPointer.y;
+      onChange(clipId, {
+        ...start,
+        position: {
+          x: start.position.x + cssToPosX(dx),
+          y: start.position.y + cssToPosY(dy)
+        }
+      });
+      return;
+    }
+
+    if (drag.target === "rotate") {
+      const angle = Math.atan2(
+        pointer.y - drag.startCenter.y,
+        pointer.x - drag.startCenter.x
+      );
+      // Screen angle is the negative of clip rotation.
+      let next = start.rotation - (angle - drag.startAngle);
+      if (e.shiftKey) {
+        next = Math.round(next / ROTATION_SNAP_RAD) * ROTATION_SNAP_RAD;
+      }
+      const candidate: ClipTransform = { ...start, rotation: next };
+      onChange(clipId, keepCenter(candidate, start, drag.startCenter));
+      return;
+    }
+
+    // Scale handles.
+    const rel = sub(pointer, drag.fixed);
+    let factorU = scalesX(drag.target)
+      ? dot(rel, drag.axisU) / (drag.startProjU || 1)
+      : 1;
+    let factorV = scalesY(drag.target)
+      ? dot(rel, drag.axisV) / (drag.startProjV || 1)
+      : 1;
+
+    const isCorner =
+      drag.target === "tl" ||
+      drag.target === "tr" ||
+      drag.target === "br" ||
+      drag.target === "bl";
+    if (isCorner && e.shiftKey) {
+      // Uniform scale: lock both axes to the dominant factor.
+      const f =
+        Math.abs(factorU) > Math.abs(factorV) ? factorU : factorV;
+      factorU = f;
+      factorV = f;
+    }
+
+    const clampF = (f: number): number =>
+      Math.sign(f || 1) * Math.max(0.01, Math.abs(f));
+    const candidate: ClipTransform = {
+      ...start,
+      scale: {
+        x: scalesX(drag.target) ? start.scale.x * clampF(factorU) : start.scale.x,
+        y: scalesY(drag.target) ? start.scale.y * clampF(factorV) : start.scale.y
+      }
+    };
+    onChange(clipId, keepFixed(candidate, start, drag));
+  };
+
+  const endDrag = (e: React.PointerEvent) => {
+    if (dragRef.current) {
+      const svg = svgOf(e);
+      if (svg.hasPointerCapture?.(e.pointerId)) {
+        svg.releasePointerCapture(e.pointerId);
+      }
+      dragRef.current = null;
+    }
+  };
+
+  /**
+   * Adjust `candidate.position` so the box's fixed (anchored) corner stays
+   * put after a scale change, giving "scale from opposite corner" behavior.
+   */
+  const keepFixed = (
+    candidate: ClipTransform,
+    start: ClipTransform,
+    drag: DragSession
+  ): ClipTransform => {
+    const g = computeGeometry(
+      candidate,
+      sourceWidth,
+      sourceHeight,
+      canvasWidth,
+      canvasHeight,
+      frameWidth,
+      frameHeight
+    );
+    // Re-derive the fixed corner position under the new scale.
+    const fixedNow = fixedPointFromGeometry(g, drag.target as ScaleHandle);
+    const dx = drag.fixed.x - fixedNow.x;
+    const dy = drag.fixed.y - fixedNow.y;
+    return {
+      ...candidate,
+      position: {
+        x: start.position.x + cssToPosX(dx),
+        y: start.position.y + cssToPosY(dy)
+      }
+    };
+  };
+
+  /** Keep the box center fixed after a rotation change. */
+  const keepCenter = (
+    candidate: ClipTransform,
+    start: ClipTransform,
+    startCenter: Point
+  ): ClipTransform => {
+    const g = computeGeometry(
+      candidate,
+      sourceWidth,
+      sourceHeight,
+      canvasWidth,
+      canvasHeight,
+      frameWidth,
+      frameHeight
+    );
+    const dx = startCenter.x - g.center.x;
+    const dy = startCenter.y - g.center.y;
+    return {
+      ...candidate,
+      position: {
+        x: start.position.x + cssToPosX(dx),
+        y: start.position.y + cssToPosY(dy)
+      }
+    };
+  };
+
+  const fixedPointFromGeometry = (
+    g: BoxGeometry,
+    target: ScaleHandle
+  ): Point => {
+    const [gtl, gtr, gbr, gbl] = g.corners;
+    switch (target) {
+      case "tl":
+        return gbr;
+      case "tr":
+        return gbl;
+      case "br":
+        return gtl;
+      case "bl":
+        return gtr;
+      case "t":
+        return mid(gbr, gbl);
+      case "b":
+        return mid(gtl, gtr);
+      case "l":
+        return mid(gtr, gbr);
+      case "r":
+        return mid(gbl, gtl);
+    }
+  };
+
+  const polyPoints = geo.corners.map((c) => `${c.x},${c.y}`).join(" ");
+
+  return (
+    <svg
+      data-testid="timeline-transform-gizmo"
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        overflow: "visible",
+        zIndex: 10000,
+        pointerEvents: "none",
+        touchAction: "none"
+      }}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    >
+      {/* Body — drag to move. */}
+      <polygon
+        points={polyPoints}
+        fill="transparent"
+        stroke={GIZMO_PRIMARY_SEMI}
+        strokeWidth={GIZMO_LINE_WIDTH}
+        strokeDasharray={BOX_DASH}
+        style={{ cursor: "move", pointerEvents: "all" }}
+        onPointerDown={beginDrag("body")}
+      />
+
+      {/* Rotation stem + handle. */}
+      <line
+        x1={topMid.x}
+        y1={topMid.y}
+        x2={rotHandle.x}
+        y2={rotHandle.y}
+        stroke={GIZMO_PRIMARY_FAINT}
+        strokeWidth={GIZMO_LINE_WIDTH}
+      />
+      <circle
+        cx={rotHandle.x}
+        cy={rotHandle.y}
+        r={HANDLE_SIZE * ROTATION_HANDLE_RADIUS_FACTOR}
+        fill={HANDLE_FILL_DEFAULT}
+        stroke={GIZMO_PRIMARY_COLOR}
+        strokeWidth={GIZMO_LINE_WIDTH}
+        style={{ cursor: "grab", pointerEvents: "all" }}
+        onPointerDown={beginDrag("rotate")}
+      />
+
+      {/* Corner handles. */}
+      <SquareHandle cx={tl.x} cy={tl.y} cursor="nwse-resize" onDown={beginDrag("tl")} />
+      <SquareHandle cx={tr.x} cy={tr.y} cursor="nesw-resize" onDown={beginDrag("tr")} />
+      <SquareHandle cx={br.x} cy={br.y} cursor="nwse-resize" onDown={beginDrag("br")} />
+      <SquareHandle cx={bl.x} cy={bl.y} cursor="nesw-resize" onDown={beginDrag("bl")} />
+
+      {/* Edge handles. */}
+      <SquareHandle cx={topMid.x} cy={topMid.y} cursor="ns-resize" onDown={beginDrag("t")} />
+      <SquareHandle cx={rightMid.x} cy={rightMid.y} cursor="ew-resize" onDown={beginDrag("r")} />
+      <SquareHandle cx={bottomMid.x} cy={bottomMid.y} cursor="ns-resize" onDown={beginDrag("b")} />
+      <SquareHandle cx={leftMid.x} cy={leftMid.y} cursor="ew-resize" onDown={beginDrag("l")} />
+    </svg>
+  );
+}

--- a/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
 import type { ClipTransform } from "@nodetool-ai/timeline";
+import mockTheme from "../../../../__mocks__/themeMock";
 import { TransformGizmoOverlay } from "../TransformGizmoOverlay";
 
 // jsdom ships no PointerEvent, so testing-library would otherwise drop
@@ -95,5 +97,91 @@ describe("TransformGizmoOverlay", () => {
     const [, next] = onChange.mock.calls.at(-1)!;
     expect(next.scale.x).toBeCloseTo(0.5, 2);
     expect(next.scale.y).toBeCloseTo(0.5, 2);
+  });
+
+  it("rotates around the pivot without moving it", () => {
+    const onChange = jest.fn();
+    const { container, getByTestId } = render(
+      <TransformGizmoOverlay {...baseProps} onChange={onChange} />
+    );
+    const svg = getByTestId("timeline-transform-gizmo");
+    // Rotation handle is the circle sitting above the top edge midpoint
+    // (100,0); pivot/center is (100,50).
+    const circle = Array.from(container.querySelectorAll("circle")).find(
+      (c) => Math.abs(Number(c.getAttribute("cx")) - 100) < 0.001
+    )!;
+    fireEvent.pointerDown(circle, { clientX: 100, clientY: -24, pointerId: 3 });
+    // Swing 90° around the center: from straight up to pointing right.
+    fireEvent.pointerMove(svg, { clientX: 150, clientY: 50, pointerId: 3 });
+
+    const [, next] = onChange.mock.calls.at(-1)!;
+    expect(Math.abs(next.rotation)).toBeCloseTo(Math.PI / 2, 2);
+    // Pivot/position is untouched — rotation pivots around the anchor.
+    expect(next.position.x).toBeCloseTo(0, 6);
+    expect(next.position.y).toBeCloseTo(0, 6);
+  });
+
+  it("moves the anchor on a pivot drag, snapping to the corner", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <TransformGizmoOverlay {...baseProps} onChange={onChange} />
+    );
+    const svg = getByTestId("timeline-transform-gizmo");
+    const pivot = getByTestId("timeline-transform-pivot");
+    fireEvent.pointerDown(pivot, { clientX: 100, clientY: 50, pointerId: 4 });
+    // Drag toward the top-left corner (50,0) → anchor (0,1).
+    fireEvent.pointerMove(svg, { clientX: 52, clientY: 2, pointerId: 4 });
+
+    const [, next] = onChange.mock.calls.at(-1)!;
+    expect(next.anchor.x).toBeCloseTo(0, 3);
+    expect(next.anchor.y).toBeCloseTo(1, 3);
+  });
+
+  it("nudges with arrow keys and resets with '.'", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <TransformGizmoOverlay
+        {...baseProps}
+        transform={{
+          position: { x: 5, y: 5 },
+          scale: { x: 2, y: 2 },
+          rotation: 1,
+          anchor: { x: 0.5, y: 0.5 }
+        }}
+        onChange={onChange}
+      />
+    );
+    const svg = getByTestId("timeline-transform-gizmo");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(onChange.mock.calls.at(-1)![1].position.x).toBeCloseTo(6, 6);
+
+    fireEvent.keyDown(svg, { key: "ArrowUp", shiftKey: true });
+    expect(onChange.mock.calls.at(-1)![1].position.y).toBeCloseTo(-5, 6);
+
+    fireEvent.keyDown(svg, { key: "." });
+    const reset = onChange.mock.calls.at(-1)![1];
+    expect(reset).toEqual({
+      position: { x: 0, y: 0 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+      anchor: { x: 0.5, y: 0.5 }
+    });
+  });
+
+  it("opens a context menu whose flip action negates scale", () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <ThemeProvider theme={mockTheme}>
+        <TransformGizmoOverlay {...baseProps} onChange={onChange} />
+      </ThemeProvider>
+    );
+    const polygon = container.querySelector("polygon")!;
+    fireEvent.contextMenu(polygon, { clientX: 100, clientY: 50 });
+
+    fireEvent.click(screen.getByText("Flip Horizontal"));
+    const [, next] = onChange.mock.calls.at(-1)!;
+    expect(next.scale.x).toBeCloseTo(-1, 6);
+    expect(next.scale.y).toBeCloseTo(1, 6);
   });
 });

--- a/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import type { ClipTransform } from "@nodetool-ai/timeline";
+import { TransformGizmoOverlay } from "../TransformGizmoOverlay";
+
+// jsdom ships no PointerEvent, so testing-library would otherwise drop
+// clientX/clientY. Back it with MouseEvent (which carries the coords) and a
+// no-op pointer-capture API on SVG elements.
+class FakePointerEvent extends MouseEvent {
+  pointerId: number;
+  constructor(type: string, props: PointerEventInit = {}) {
+    super(type, props);
+    this.pointerId = props.pointerId ?? 0;
+  }
+}
+// @ts-expect-error — augmenting the jsdom global for tests.
+window.PointerEvent = FakePointerEvent;
+Element.prototype.setPointerCapture = () => {};
+Element.prototype.releasePointerCapture = () => {};
+Element.prototype.hasPointerCapture = () => false;
+
+// Square source on a 2:1 canvas/frame. containBaseScale → {x:0.5, y:1}, so the
+// identity box spans x 50..150, y 0..100 with center (100,50).
+const baseProps = {
+  clipId: "clip-1",
+  transform: undefined as ClipTransform | undefined,
+  sourceWidth: 100,
+  sourceHeight: 100,
+  canvasWidth: 200,
+  canvasHeight: 100,
+  frameWidth: 200,
+  frameHeight: 100
+};
+
+describe("TransformGizmoOverlay", () => {
+  it("renders the gizmo box for a visible selected clip", () => {
+    const { getByTestId, container } = render(
+      <TransformGizmoOverlay {...baseProps} onChange={() => {}} />
+    );
+    expect(getByTestId("timeline-transform-gizmo")).toBeInTheDocument();
+    const polygon = container.querySelector("polygon");
+    expect(polygon?.getAttribute("points")).toBe("50,0 150,0 150,100 50,100");
+  });
+
+  it("returns null when source dimensions are unknown", () => {
+    const { container } = render(
+      <TransformGizmoOverlay
+        {...baseProps}
+        sourceWidth={0}
+        sourceHeight={0}
+        onChange={() => {}}
+      />
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("translates a body drag into a position change", () => {
+    const onChange = jest.fn();
+    const { container, getByTestId } = render(
+      <TransformGizmoOverlay {...baseProps} onChange={onChange} />
+    );
+    const polygon = container.querySelector("polygon")!;
+    const svg = getByTestId("timeline-transform-gizmo");
+
+    fireEvent.pointerDown(polygon, { clientX: 100, clientY: 50, pointerId: 1 });
+    fireEvent.pointerMove(svg, { clientX: 130, clientY: 70, pointerId: 1 });
+
+    expect(onChange).toHaveBeenCalled();
+    const [, next] = onChange.mock.calls.at(-1)!;
+    // canvas/frame are equal so 1 CSS px == 1 position px here.
+    expect(next.position.x).toBeCloseTo(30, 3);
+    expect(next.position.y).toBeCloseTo(20, 3);
+  });
+
+  it("scales toward a corner when a corner handle is dragged", () => {
+    const onChange = jest.fn();
+    const { container, getByTestId } = render(
+      <TransformGizmoOverlay {...baseProps} onChange={onChange} />
+    );
+    const svg = getByTestId("timeline-transform-gizmo");
+    // The bottom-right handle sits at (150,100); the fixed corner is (50,0).
+    const rects = Array.from(container.querySelectorAll("rect"));
+    const br = rects.find(
+      (r) =>
+        Number(r.getAttribute("x")) + 4 === 150 &&
+        Number(r.getAttribute("y")) + 4 === 100
+    )!;
+    expect(br).toBeTruthy();
+
+    fireEvent.pointerDown(br, { clientX: 150, clientY: 100, pointerId: 2 });
+    // Drag the corner halfway back toward the fixed corner → ~0.5 scale.
+    fireEvent.pointerMove(svg, { clientX: 100, clientY: 50, pointerId: 2 });
+
+    expect(onChange).toHaveBeenCalled();
+    const [, next] = onChange.mock.calls.at(-1)!;
+    expect(next.scale.x).toBeCloseTo(0.5, 2);
+    expect(next.scale.y).toBeCloseTo(0.5, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an interactive transform gizmo overlay to the timeline preview, enabling direct manipulation of clip position, scale, rotation, and anchor point via mouse/touch. The gizmo mirrors the sketch editor's transform UX (dashed bounding box, corner/edge handles, rotation handle) and reuses shared gizmo styling constants for visual consistency.

## Key Changes

- **TransformGizmoOverlay.tsx** (727 lines): New component that renders an SVG overlay with interactive handles for:
  - **Body drag** → translate clip position
  - **Corner handles** → scale around opposite corner (Shift = uniform scale)
  - **Edge handles** → scale one axis around opposite edge
  - **Rotation handle** → rotate around pivot (Shift = 15° snap)
  - **Pivot crosshair** → move anchor point with snap-to-grid (0/0.5/1)
  - **Keyboard shortcuts**: Arrow keys for nudge (±1px, ±10px with Shift), `.` to reset
  - **Context menu**: Right-click for rotate 90°/180°, flip H/V, reset

- **ClipTransformContextMenu.tsx** (147 lines): Context menu component for quick transform operations, styled to match the sketch editor's menu design with icons and keyboard hints.

- **TransformGizmoOverlay.test.tsx** (187 lines): Comprehensive test suite covering:
  - Gizmo rendering and visibility
  - Body drag translation
  - Corner handle scaling with fixed-point behavior
  - Rotation around pivot without moving it
  - Pivot drag with anchor snapping
  - Keyboard nudge and reset
  - Context menu flip actions

- **PreviewCompositor.tsx** (modified): Integrated the gizmo overlay:
  - Track frame and canvas backing dimensions in state
  - Extract source media dimensions from decoded clips
  - Pass selected clip's transform and dimensions to gizmo
  - Wire `onChange` callback to `patchClip` for live mutations

## Implementation Details

- **Geometry derivation**: Reuses `buildTransformMatrix` and `containBaseScale` from the GPU compositor to ensure the gizmo box always traces the rendered clip exactly.
- **Coordinate mapping**: Converts between clip space ([-1,1]²), canvas backing pixels, and frame CSS pixels to handle DPI scaling and aspect-fit layout.
- **Drag sessions**: Captures transform state, pointer position, and box geometry at drag start; computes scale factors and position deltas on move; applies `keepFixed` and `keepCenter` adjustments to maintain anchor behavior.
- **Styling**: Imports gizmo constants (`HANDLE_SIZE`, `GIZMO_PRIMARY_COLOR`, etc.) from sketch editor to ensure visual language parity.
- **Pointer capture**: Uses SVG pointer capture for smooth dragging outside the frame bounds; handles both PointerEvent and fallback MouseEvent for jsdom testing.

https://claude.ai/code/session_018q6HQ9pNB5dRiTmyb21TFR