### PR TITLE
fix(electron): prevent Mac launch crash from split logger bundle

### DIFF
--- a/electron/scripts/verify-bundle.mjs
+++ b/electron/scripts/verify-bundle.mjs
@@ -58,9 +58,28 @@ const main = (() => {
   }
 })();
 
+function listJsFiles(rootDir, currentDir = rootDir) {
+  const entries = readdirSync(currentDir, { withFileTypes: true });
+  const jsFiles = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      jsFiles.push(...listJsFiles(rootDir, entryPath));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".js")) {
+      continue;
+    }
+    jsFiles.push(path.relative(rootDir, entryPath).replaceAll(path.sep, "/"));
+  }
+
+  return jsFiles;
+}
+
 const bundleFiles = (() => {
   try {
-    return readdirSync(DIST_ELECTRON).filter((name) => name.endsWith(".js"));
+    return listJsFiles(DIST_ELECTRON);
   } catch (e) {
     fail(`could not read ${DIST_ELECTRON}: ${e.message}`);
   }

--- a/electron/scripts/verify-bundle.mjs
+++ b/electron/scripts/verify-bundle.mjs
@@ -16,12 +16,18 @@
  *        Exits 1 with diagnostics if any check fails.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const ELECTRON_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const MAIN_JS = path.join(ELECTRON_DIR, "dist-electron", "main.js");
+const DIST_ELECTRON = path.join(ELECTRON_DIR, "dist-electron");
+const MAIN_JS = path.join(DIST_ELECTRON, "main.js");
+const ALLOWED_BUNDLE_FILES = new Set([
+  "main.js",
+  "preload.js",
+  "preload-workflow.js",
+]);
 
 // Markers that indicate a native module was inlined into main.js by Rollup.
 // Each entry is { pattern, module, why }. We use plain substring matching for
@@ -51,6 +57,28 @@ const main = (() => {
     fail(`could not read ${MAIN_JS}: ${e.message}`);
   }
 })();
+
+const bundleFiles = (() => {
+  try {
+    return readdirSync(DIST_ELECTRON).filter((name) => name.endsWith(".js"));
+  } catch (e) {
+    fail(`could not read ${DIST_ELECTRON}: ${e.message}`);
+  }
+})();
+
+const unexpectedChunks = bundleFiles.filter((name) => !ALLOWED_BUNDLE_FILES.has(name));
+if (unexpectedChunks.length > 0) {
+  console.error("verify-bundle: unexpected code-split chunks in dist-electron/");
+  for (const name of unexpectedChunks) {
+    console.error(`  - ${name}`);
+  }
+  console.error(
+    "\nThe Electron main process must be a single main.js bundle. " +
+      "Split chunks (e.g. logger-*.js) break circular imports at launch. " +
+      "Set inlineDynamicImports: true and codeSplitting: false in vite.config.ts."
+  );
+  process.exit(1);
+}
 
 const leaked = FORBIDDEN_MARKERS.filter(({ pattern }) => main.includes(pattern));
 

--- a/electron/src/__tests__/logger.behavior.test.ts
+++ b/electron/src/__tests__/logger.behavior.test.ts
@@ -42,7 +42,7 @@ describe('logger.logMessage', () => {
       .mockImplementation((relativePath: string) =>
         path.join('/mock/system', relativePath),
       );
-    jest.doMock('../config', () => ({
+    jest.doMock('../systemPaths', () => ({
       getSystemDataPath: getSystemDataPathMock,
     }));
 
@@ -92,7 +92,7 @@ describe('logger.logMessage', () => {
       .mockImplementation((relativePath: string) =>
         path.join('/mock/system', relativePath),
       );
-    jest.doMock('../config', () => ({
+    jest.doMock('../systemPaths', () => ({
       getSystemDataPath: getSystemDataPathMock,
     }));
 

--- a/electron/src/__tests__/logger.test.ts
+++ b/electron/src/__tests__/logger.test.ts
@@ -9,7 +9,7 @@ jest.mock("electron-log", () => ({
   },
 }));
 
-jest.mock("../config", () => ({
+jest.mock("../systemPaths", () => ({
   getSystemDataPath: jest.fn((name: string) => `/tmp/nodetool-test/${name}`),
 }));
 

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -4,6 +4,7 @@ import { app } from "electron";
 import { logMessage } from "./logger";
 import * as fs from "fs";
 import { readSettings, updateSetting } from "./settings";
+import { getSystemDataPath } from "./systemPaths";
 
 // Base paths
 const resourcesPath: string = process.resourcesPath;
@@ -178,31 +179,6 @@ const getLlamaServerPath = (): string => {
 interface ProcessEnv {
   [key: string]: string;
 }
-
-/**
- * Returns the system data path matching Python's get_system_data_path() function
- * This ensures logs are stored in the same location as the Python backend expects
- * @param filename - The filename or subdirectory to append
- * @returns {string} The full path to the data directory
- */
-const getSystemDataPath = (filename: string): string => {
-  const homeDir = os.homedir();
-
-  switch (process.platform) {
-    case "darwin":
-    case "linux":
-      return path.join(homeDir, ".local", "share", "nodetool", filename);
-    case "win32": {
-      const localAppData = process.env.LOCALAPPDATA;
-      if (localAppData) {
-        return path.join(localAppData, "nodetool", filename);
-      }
-      return path.join("data", filename);
-    }
-    default:
-      return path.join("data", filename);
-  }
-};
 
 /**
  * Returns the default assets directory.

--- a/electron/src/logger.ts
+++ b/electron/src/logger.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import log from "electron-log";
 import { createWriteStream, existsSync, mkdirSync, WriteStream } from "fs";
-import { getSystemDataPath } from "./config";
+import { getSystemDataPath } from "./systemPaths";
 
 /** The log level for the logger */
 type LogLevel = "info" | "warn" | "error";

--- a/electron/src/systemPaths.ts
+++ b/electron/src/systemPaths.ts
@@ -1,0 +1,27 @@
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Returns the system data path matching Python's get_system_data_path() function.
+ * Kept separate from config.ts so logger can resolve log paths without importing
+ * config (which imports logger and would create a circular dependency that breaks
+ * when Vite code-splits the Electron main bundle).
+ */
+export function getSystemDataPath(filename: string): string {
+  const homeDir = os.homedir();
+
+  switch (process.platform) {
+    case "darwin":
+    case "linux":
+      return path.join(homeDir, ".local", "share", "nodetool", filename);
+    case "win32": {
+      const localAppData = process.env.LOCALAPPDATA;
+      if (localAppData) {
+        return path.join(localAppData, "nodetool", filename);
+      }
+      return path.join("data", filename);
+    }
+    default:
+      return path.join("data", filename);
+  }
+}

--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -51,10 +51,15 @@ const externalModules = ["electron", "electron/common", ...builtins];
 const mainExternalModules = [
   ...externalModules,
   "@nodetool-ai/protocol",
+  "electron-log",
+  "electron-updater",
   "zod",
   "sharp",
   /^@img\/sharp-/,
 ];
+
+// Vite 8 adds `codeSplitting`; Rollup 4 typings (used by tsc) do not include it yet.
+const vite8MainOutput = { codeSplitting: false } satisfies Record<string, unknown>;
 
 export default defineConfig({
   base: "./",
@@ -75,7 +80,13 @@ export default defineConfig({
               output: {
                 format: "cjs",
                 entryFileNames: "[name].js",
-                codeSplitting: false,
+                // Vite 6 / Rollup 4: inlineDynamicImports disables code splitting.
+                // Vite 8: codeSplitting replaces the deprecated inlineDynamicImports.
+                // Keep both so Mac CI (Vite 8) and local dev (Vite 6 plugin path)
+                // always emit a single main.js — split chunks break circular deps
+                // between logger and config at launch (e.a is not a function).
+                inlineDynamicImports: true,
+                ...vite8MainOutput,
               },
             },
           },


### PR DESCRIPTION
Vite 8 code-split the main process into logger-*.js chunks, which broke the logger/config circular import at launch (TypeError: e.a is not a function). Extract getSystemDataPath to systemPaths.ts, force a single main.js bundle, externalize electron-log, and reject unexpected dist-electron chunks in verify-bundle.