### PR TITLE
fix(timeline): align ruler 0 with clip start and render paused-seek f…

### DIFF
--- a/web/src/components/timeline/Tracks/TimeRuler.tsx
+++ b/web/src/components/timeline/Tracks/TimeRuler.tsx
@@ -167,9 +167,11 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
 
       const { majorMs, minorMs } = computeTickIntervals(msPerPx);
 
-      // Visible time range (accounting for scroll and header offset)
+      // The canvas is already offset by the CSS paddingLeft (headerWidthPx),
+      // so its x=0 aligns with the scrollable lanes' left edge. We work in the
+      // canvas's own coordinate space here — no further header offset.
       const visibleStartMs = scrollLeftPx * msPerPx;
-      const visibleEndMs = visibleStartMs + (w - headerWidthPx) * msPerPx;
+      const visibleEndMs = visibleStartMs + w * msPerPx;
 
       // First tick time (floor to minorMs boundary)
       const firstTickMs =
@@ -184,10 +186,9 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
         tMs <= visibleEndMs + minorMs;
         tMs += minorMs
       ) {
-        const px =
-          headerWidthPx + (tMs / msPerPx) - scrollLeftPx;
+        const px = tMs / msPerPx - scrollLeftPx;
 
-        if (px < headerWidthPx || px > w) {
+        if (px < 0 || px > w) {
           continue;
         }
 
@@ -216,10 +217,10 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
           return 0;
         }
         const rect = canvas.getBoundingClientRect();
-        const localPx = clientX - rect.left - headerWidthPx;
+        const localPx = clientX - rect.left;
         return Math.max(0, localPx * msPerPx + scrollLeftPx * msPerPx);
       },
-      [msPerPx, scrollLeftPx, headerWidthPx]
+      [msPerPx, scrollLeftPx]
     );
 
     const handlePointerDown = useCallback(

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -678,14 +678,32 @@ export const PreviewCompositor: React.FC = memo(() => {
     return out;
   }, [activeVideoSlots, activeImageLayers, ensureImageElement]);
 
-  // One-shot render whenever scene state changes (paused mode + scrubbing).
-  useEffect(() => {
+  const renderFrame = useCallback(() => {
     if (!gpuReady) return;
     const compositor = compositorRef.current;
     if (!compositor) return;
     compositor.setLayers(buildLayers());
     compositor.render();
   }, [gpuReady, buildLayers]);
+
+  // One-shot render whenever scene state changes (paused mode + scrubbing).
+  useEffect(() => {
+    renderFrame();
+  }, [renderFrame]);
+
+  // A paused scrub sets el.currentTime, which decodes the target frame
+  // asynchronously — so the one-shot render above runs before the frame is
+  // ready and paints a stale (or empty) texture. Re-composite once each video
+  // element fires `seeked`, when the decoded frame is actually available.
+  useEffect(() => {
+    if (!poolReady) return;
+    const pool = videoRefs.current;
+    const onSeeked = () => renderFrame();
+    pool.forEach((el) => el.addEventListener("seeked", onSeeked));
+    return () => {
+      pool.forEach((el) => el.removeEventListener("seeked", onSeeked));
+    };
+  }, [poolReady, renderFrame]);
 
   // While playing, drive a rAF render loop so video frame textures stay fresh
   // between AudioContext-clock store updates.


### PR DESCRIPTION
…rames

The time ruler double-counted the header offset: the canvas is already shifted by the container's paddingLeft, but the draw math added headerWidthPx again, pushing tick "0" 160px right of where a clip at startMs=0 renders. Work in the canvas's own coordinate space so 0 lands at the lane's left edge; fix click/drag-to-seek mapping the same way.

The preview only painted while playing because a paused seek sets el.currentTime, which decodes the target frame asynchronously — the one-shot render fired before the frame was ready and composited stale/empty texture. Add a `seeked` listener on the pooled video elements that re-composites once the decoded frame is available.