### PR TITLE
Rank generic nodes and popular models first in left-panel categories

### DIFF
--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -165,4 +165,41 @@ describe("quickAccessCategories", () => {
     ).map((m) => m.title);
     expect(titles).toEqual(["Alpha", "Bravo", "Charlie"]);
   });
+
+  it("floats generic nodetool nodes above models, then curated popular models", () => {
+    const all = [
+      meta("zzz.OtherModel", "image", "Zzz Other Model"),
+      meta("fal.text_to_image.FluxDev", "image", "Flux Dev"),
+      meta("fal.text_to_image.NanoBananaPro", "image", "Nano Banana Pro"),
+      meta("nodetool.image.TextToImage", "image", "Text To Image")
+    ];
+    const ids = filterNodesForCategory(getCategory("image-models")!, all).map(
+      (m) => m.node_type
+    );
+    // generic first, then popular models in curated order, then the rest
+    expect(ids).toEqual([
+      "nodetool.image.TextToImage",
+      "fal.text_to_image.NanoBananaPro",
+      "fal.text_to_image.FluxDev",
+      "zzz.OtherModel"
+    ]);
+  });
+
+  it("ranking falls back to title sort while searching", () => {
+    const all = [
+      meta("fal.text_to_image.NanoBananaPro", "image", "Nano Banana Pro"),
+      meta("nodetool.image.TextToImage", "image", "Generate via prompt")
+    ];
+    // Both match the query; with a query active the curated/generic ranking
+    // is dropped and results sort by title alphabetically.
+    const ids = filterNodesForCategory(
+      getCategory("image-models")!,
+      all,
+      "a"
+    ).map((m) => m.node_type);
+    expect(ids).toEqual([
+      "nodetool.image.TextToImage",
+      "fal.text_to_image.NanoBananaPro"
+    ]);
+  });
 });

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -91,6 +91,44 @@ const TOOLS_NODE_TYPES = new Set<string>([
   "lib.image.Mask"
 ]);
 
+/**
+ * Curated, ordered list of the models we want surfaced first in the model
+ * categories (after the generic capability nodes). Order here is the display
+ * order. Spans image/video/audio — each entry only shows up in a category if
+ * it also passes that category's `filter`, so one combined list is fine.
+ *
+ * This ranking only applies when the user is NOT searching; an active query
+ * falls back to plain alphabetical so matches aren't reordered under them.
+ */
+const POPULAR_MODELS_2026: readonly string[] = [
+  // Image
+  "fal.text_to_image.NanoBananaPro",
+  "fal.text_to_image.GptImage2",
+  "fal.text_to_image.Imagen4PreviewUltra",
+  "fal.text_to_image.FluxV1Pro",
+  "fal.text_to_image.FluxDev",
+  "fal.text_to_image.BytedanceSeedreamV45TextToImage",
+  "fal.text_to_image.QwenImage",
+  "fal.text_to_image.RecraftV3",
+  "fal.text_to_image.StableDiffusionV35Large",
+  "fal.image_to_image.NanoBananaProEdit",
+  // Video
+  "fal.text_to_video.Veo31",
+  "fal.text_to_video.Sora2TextToVideo",
+  "fal.text_to_video.KlingVideoV26ProTextToVideo",
+  "fal.text_to_video.SeeDanceV15ProTextToVideo",
+  "fal.text_to_video.MinimaxHailuo23ProTextToVideo",
+  "fal.text_to_video.WanV26TextToVideo",
+  // Audio
+  "fal.text_to_speech.ElevenlabsTtsTurboV25",
+  "fal.text_to_speech.MinimaxSpeech26Hd",
+  "fal.text_to_speech.MinimaxSpeech26Turbo"
+];
+
+const POPULAR_MODEL_RANK: ReadonlyMap<string, number> = new Map(
+  POPULAR_MODELS_2026.map((nodeType, index) => [nodeType, index])
+);
+
 export const QUICK_ACCESS_CATEGORIES: readonly QuickAccessCategory[] = [
   {
     id: "search",
@@ -226,6 +264,35 @@ export const filterNodesForCategory = (
       m.namespace.toLowerCase().includes(q)
     );
   });
-  matches.sort((a, b) => a.title.localeCompare(b.title));
+
+  // While searching, rank purely by title so matches aren't shuffled by the
+  // curated ordering. With no query, float generic capability nodes to the
+  // top, then the curated popular models, then everything else alphabetically.
+  if (q) {
+    matches.sort((a, b) => a.title.localeCompare(b.title));
+    return matches;
+  }
+
+  // 0 = generic (first-party nodetool.* nodes), 1 = curated popular model,
+  // 2 = everything else.
+  const tierOf = (m: NodeMetadata): number => {
+    if (m.node_type.startsWith("nodetool.")) {
+      return 0;
+    }
+    return POPULAR_MODEL_RANK.has(m.node_type) ? 1 : 2;
+  };
+
+  matches.sort((a, b) => {
+    const tierA = tierOf(a);
+    const tierB = tierOf(b);
+    if (tierA !== tierB) {
+      return tierA - tierB;
+    }
+    if (tierA === 1) {
+      return POPULAR_MODEL_RANK.get(a.node_type)! -
+        POPULAR_MODEL_RANK.get(b.node_type)!;
+    }
+    return a.title.localeCompare(b.title);
+  });
   return matches;
 };


### PR DESCRIPTION
Float first-party nodetool.* capability nodes to the top of the
model categories, followed by a curated list of popular 2026 models,
then everything else alphabetically. Ranking falls back to plain
title sort while a search query is active.

https://claude.ai/code/session_0147Efhkar2Ek7fivXWNpRwM