### PR TITLE
Prompt node: composer-style body with @-asset mentions and variable chips

### DIFF
--- a/packages/base-nodes/src/nodes/agents.ts
+++ b/packages/base-nodes/src/nodes/agents.ts
@@ -460,12 +460,104 @@ function logThreadWarning(
   });
 }
 
+const ASSET_URI_RE = /asset:\/\/[A-Za-z0-9._~\-/]+/g;
+
+const IMAGE_EXT_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  svg: "image/svg+xml"
+};
+
+const AUDIO_EXT_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  mpeg: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  opus: "audio/opus"
+};
+
+/**
+ * Classify an `asset://<id>.<ext>` token by its extension. Only image and
+ * audio are provider-consumable media; everything else (text, video, unknown)
+ * returns null so the reference is left as literal text in the prompt.
+ */
+function classifyAssetToken(
+  token: string
+): { kind: "image" | "audio"; mime: string } | null {
+  const noScheme = token.slice("asset://".length);
+  const primary = noScheme.split(/[?#]/)[0];
+  const ext = (primary.split(".").pop() ?? "").toLowerCase();
+  if (ext in IMAGE_EXT_MIME) return { kind: "image", mime: IMAGE_EXT_MIME[ext] };
+  if (ext in AUDIO_EXT_MIME) return { kind: "audio", mime: AUDIO_EXT_MIME[ext] };
+  return null;
+}
+
+/**
+ * Split a prompt containing inline `asset://<id>.<ext>` references into a
+ * multimodal content array: text segments interleaved with image / audio
+ * blocks that carry the `asset://` URI verbatim. The blocks are NOT resolved
+ * here — the runtime layer (`ProcessingContext.resolveMessageMediaUris`)
+ * dereferences the URIs to data URIs just before the provider call. Tokens
+ * that aren't a supported media type (text, video, unknown) stay as literal
+ * text so the model still sees the mention.
+ */
+export function expandAssetReferences(prompt: string): MessageContent[] {
+  ASSET_URI_RE.lastIndex = 0;
+  if (!ASSET_URI_RE.test(prompt)) {
+    return [{ type: "text", text: prompt }];
+  }
+
+  const parts: MessageContent[] = [];
+  const pushText = (text: string) => {
+    if (text) parts.push({ type: "text", text });
+  };
+
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  ASSET_URI_RE.lastIndex = 0;
+  while ((match = ASSET_URI_RE.exec(prompt)) !== null) {
+    let token = match[0];
+    // A trailing dot is sentence punctuation, not part of the extension.
+    const trailingDots = token.match(/\.+$/);
+    if (trailingDots) {
+      token = token.slice(0, token.length - trailingDots[0].length);
+    }
+    const classification = classifyAssetToken(token);
+    if (!classification) {
+      continue;
+    }
+    pushText(prompt.slice(cursor, match.index));
+    if (classification.kind === "image") {
+      parts.push({
+        type: "image_url",
+        image: { uri: token, mimeType: classification.mime }
+      });
+    } else {
+      parts.push({
+        type: "audio",
+        audio: { uri: token, mimeType: classification.mime }
+      });
+    }
+    cursor = match.index + token.length;
+  }
+  pushText(prompt.slice(cursor));
+
+  return parts.length > 0 ? parts : [{ type: "text", text: prompt }];
+}
+
 function buildUserMessage(
   prompt: string,
   image: unknown,
   audio: unknown
 ): Message {
-  const content: MessageContent[] = [{ type: "text", text: prompt }];
+  const content: MessageContent[] = expandAssetReferences(prompt);
   const imageRef = normalizeBinaryRef(image);
   if (imageRef) {
     content.push({ type: "image_url", image: imageRef });
@@ -2455,6 +2547,15 @@ export class AgentNode extends BaseNode {
 
     if (threadId) {
       await saveThreadMessage(context, threadId, messages[messages.length - 1]);
+    }
+
+    // Dereference inline asset:// references (mentioned in the prompt) to data
+    // URIs before the provider call. Resolution lives in the runtime layer so
+    // it's shared across nodes and providers stay asset-agnostic. Saved to the
+    // thread above first, so the stored message keeps the compact asset:// URI.
+    if (typeof context.resolveMessageMediaUris === "function") {
+      const resolved = await context.resolveMessageMediaUris(messages);
+      messages.splice(0, messages.length, ...resolved);
     }
 
     let lastTextOutput: string | null = null;

--- a/packages/base-nodes/tests/prompt-asset-references.test.ts
+++ b/packages/base-nodes/tests/prompt-asset-references.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { expandAssetReferences } from "../src/nodes/agents.js";
+
+describe("expandAssetReferences", () => {
+  it("returns a single text block when there is no asset reference", () => {
+    expect(expandAssetReferences("just some text")).toEqual([
+      { type: "text", text: "just some text" }
+    ]);
+  });
+
+  it("splits an inline image reference into text + image block", () => {
+    const parts = expandAssetReferences("Describe asset://abc.png please");
+    expect(parts).toEqual([
+      { type: "text", text: "Describe " },
+      { type: "image_url", image: { uri: "asset://abc.png", mimeType: "image/png" } },
+      { type: "text", text: " please" }
+    ]);
+  });
+
+  it("encodes audio references as audio blocks carrying the asset URI", () => {
+    expect(expandAssetReferences("asset://clip.mp3")).toEqual([
+      { type: "audio", audio: { uri: "asset://clip.mp3", mimeType: "audio/mpeg" } }
+    ]);
+  });
+
+  it("leaves unsupported media types as literal text", () => {
+    expect(expandAssetReferences("open asset://doc.txt now")).toEqual([
+      { type: "text", text: "open asset://doc.txt now" }
+    ]);
+  });
+
+  it("does not swallow a trailing sentence period into the reference", () => {
+    const parts = expandAssetReferences("Here: asset://abc.png.");
+    expect(parts).toEqual([
+      { type: "text", text: "Here: " },
+      { type: "image_url", image: { uri: "asset://abc.png", mimeType: "image/png" } },
+      { type: "text", text: "." }
+    ]);
+  });
+
+  it("handles multiple references and keeps the URI verbatim for resolution", () => {
+    const parts = expandAssetReferences(
+      "compare asset://a.jpg and asset://b.webp"
+    );
+    expect(parts).toEqual([
+      { type: "text", text: "compare " },
+      { type: "image_url", image: { uri: "asset://a.jpg", mimeType: "image/jpeg" } },
+      { type: "text", text: " and " },
+      { type: "image_url", image: { uri: "asset://b.webp", mimeType: "image/webp" } }
+    ]);
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1541,7 +1541,9 @@ export class ProcessingContext {
     }
     const raw =
       trimmed.startsWith("asset://") ? trimmed.slice("asset://".length) : trimmed;
-    const primary = raw.split(/[/?#]/)[0];
+    // Preserve sub-paths: `asset://user-1/image.png` -> primary `user-1/image.png`,
+    // so storage keys with hierarchical layouts still resolve.
+    const primary = raw.split(/[?#]/)[0];
     if (!primary) {
       return [];
     }
@@ -1620,24 +1622,36 @@ export class ProcessingContext {
       // Extension-tolerant fallback: locate the stored file whose name starts
       // with the id, since the URN extension may differ from the one on disk
       // (e.g. jpeg vs jpg). Only reached when the exact-key lookups all miss.
+      //
+      // Try a narrow prefix first (S3 treats `list(bareId)` as a raw-string
+      // prefix match — bounded to a handful of entries) before falling back to
+      // a root listing for adapters that treat the prefix as a folder path
+      // (memory/supabase). Avoids `list("")` becoming a multi-thousand-object
+      // scan on production S3 backends.
       const bareId = idCandidates[idCandidates.length - 1];
       if (bareId) {
-        try {
-          const listing = await this.storage.list("");
-          const match = listing.entries.find((entry) => {
-            const base = entry.key.split("/").pop() ?? "";
-            return base.startsWith(`${bareId}.`) && !base.includes("_thumb");
-          });
-          if (match) {
-            const bytes = await tryStorageUri(match.uri);
-            if (bytes) {
-              return { bytes, attempts };
+        const tryListing = async (prefix: string): Promise<Uint8Array | null> => {
+          try {
+            const listing = await this.storage!.list(prefix);
+            const match = listing.entries.find((entry) => {
+              const base = entry.key.split("/").pop() ?? "";
+              return base.startsWith(`${bareId}.`) && !base.includes("_thumb");
+            });
+            if (match) {
+              return await tryStorageUri(match.uri);
             }
+          } catch (error) {
+            attempts.push(
+              `storage list error (${error instanceof Error ? error.message : String(error)})`
+            );
           }
-        } catch (error) {
-          attempts.push(
-            `storage list error (${error instanceof Error ? error.message : String(error)})`
-          );
+          return null;
+        };
+        for (const prefix of [bareId, ""]) {
+          const bytes = await tryListing(prefix);
+          if (bytes) {
+            return { bytes, attempts };
+          }
         }
       }
     }

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1551,44 +1551,98 @@ export class ProcessingContext {
 
   /**
    * Resolve an `asset://<id>[.ext]` reference (or bare id / storage URI) to its
-   * raw bytes. Tries storage backends first (memory/file/s3), then falls back
-   * to the asset API. Returns the bytes plus the `attempts` trail for callers
-   * that want to build a detailed error; `null` bytes means unresolved.
+   * raw bytes.
+   *
+   * Server-uploaded assets are stored under the key `<id>.<ext>` and served at
+   * `/api/storage/<id>.<ext>`; runtime-materialized refs live under `assets/`.
+   * Resolution order: the in-process storage adapter (file/s3/supabase/memory),
+   * a prefix listing that tolerates extension mismatches, then an HTTP download
+   * from the server's `/api/storage` route. Returns the bytes plus an `attempts`
+   * trail for callers that build detailed errors; `null` bytes means unresolved.
    */
   async resolveAssetBytes(
     assetId: string
   ): Promise<{ bytes: Uint8Array | null; attempts: string[] }> {
-    const uriCandidates = new Set<string>();
     const idCandidates = this.parseAssetIdCandidates(assetId);
     const trimmed = assetId.trim();
     const attempts: string[] = [];
 
-    if (trimmed.includes("://") && !trimmed.startsWith("asset://")) {
-      uriCandidates.add(trimmed);
-    }
-    for (const candidate of idCandidates) {
-      for (const prefix of ["memory://", "file://", "s3://"]) {
-        uriCandidates.add(`${prefix}${candidate}`);
-        uriCandidates.add(`${prefix}assets/${candidate}`);
+    const tryStorageUri = async (uri: string): Promise<Uint8Array | null> => {
+      if (!this.storage) {
+        return null;
       }
-    }
+      try {
+        const retrieved = await this.storage.retrieve(uri);
+        if (retrieved) {
+          return retrieved;
+        }
+        attempts.push(`storage miss: ${uri}`);
+      } catch (error) {
+        attempts.push(
+          `storage error: ${uri} (${error instanceof Error ? error.message : String(error)})`
+        );
+      }
+      return null;
+    };
 
-    if (this.storage) {
-      for (const uri of uriCandidates) {
+    // A concrete storage URI / http URL handed in directly.
+    if (trimmed.includes("://") && !trimmed.startsWith("asset://")) {
+      const direct = await tryStorageUri(trimmed);
+      if (direct) {
+        return { bytes: direct, attempts };
+      }
+      if (/^https?:\/\//.test(trimmed)) {
         try {
-          const retrieved = await this.storage.retrieve(uri);
-          if (retrieved) {
-            return { bytes: retrieved, attempts };
-          }
-          attempts.push(`storage miss: ${uri}`);
+          const bytes = await this.downloadFile(trimmed, {
+            retry: { maxRetries: 1, backoffMs: 200 }
+          });
+          attempts.push(`downloaded: ${trimmed}`);
+          return { bytes, attempts };
         } catch (error) {
           attempts.push(
-            `storage error: ${uri} (${error instanceof Error ? error.message : String(error)})`
+            `http error: ${trimmed} (${error instanceof Error ? error.message : String(error)})`
           );
         }
       }
     }
 
+    if (this.storage) {
+      // Keys assets are written under: `<id>.<ext>` (uploads, at root) and
+      // `assets/<id>` (runtime-materialized refs).
+      for (const candidate of idCandidates) {
+        for (const key of [candidate, `assets/${candidate}`]) {
+          const bytes = await tryStorageUri(this.storage.uriForKey(key));
+          if (bytes) {
+            return { bytes, attempts };
+          }
+        }
+      }
+      // Extension-tolerant fallback: locate the stored file whose name starts
+      // with the id, since the URN extension may differ from the one on disk
+      // (e.g. jpeg vs jpg). Only reached when the exact-key lookups all miss.
+      const bareId = idCandidates[idCandidates.length - 1];
+      if (bareId) {
+        try {
+          const listing = await this.storage.list("");
+          const match = listing.entries.find((entry) => {
+            const base = entry.key.split("/").pop() ?? "";
+            return base.startsWith(`${bareId}.`) && !base.includes("_thumb");
+          });
+          if (match) {
+            const bytes = await tryStorageUri(match.uri);
+            if (bytes) {
+              return { bytes, attempts };
+            }
+          }
+        } catch (error) {
+          attempts.push(
+            `storage list error (${error instanceof Error ? error.message : String(error)})`
+          );
+        }
+      }
+    }
+
+    // HTTP fallback: the server streams bytes at `/api/storage/<key>`.
     let baseUrl =
       this.environment.NODETOOL_API_URL ??
       process.env.NODETOOL_API_URL ??
@@ -1597,13 +1651,33 @@ export class ProcessingContext {
       baseUrl = baseUrl.slice(0, -1);
     }
     for (const candidate of idCandidates) {
+      if (!candidate.includes(".")) {
+        continue; // the storage route is keyed by filename (`<id>.<ext>`)
+      }
+      const url = `${baseUrl}/api/storage/${encodeURIComponent(candidate)}`;
+      try {
+        const bytes = await this.downloadFile(url, {
+          retry: { maxRetries: 1, backoffMs: 200 }
+        });
+        attempts.push(`downloaded: ${url}`);
+        return { bytes, attempts };
+      } catch (error) {
+        attempts.push(
+          `http miss: ${url} (${error instanceof Error ? error.message : String(error)})`
+        );
+      }
+    }
+
+    // Last resort: ask the asset API for metadata and follow its `get_url`.
+    // Handles bare ids (no extension, so the storage route can't be addressed
+    // directly) and backends that expose a single-asset metadata endpoint.
+    for (const candidate of idCandidates) {
       try {
         const metaResponse = await this.httpGet(
           `${baseUrl}/api/assets/${encodeURIComponent(candidate)}`
         );
         const metadata = (await metaResponse.json()) as Record<string, unknown>;
         const getUrl = metadata.get_url;
-        const uri = metadata.uri;
         if (typeof getUrl === "string" && getUrl) {
           const downloadUrl = getUrl.startsWith("/")
             ? `${baseUrl}${getUrl}`
@@ -1614,13 +1688,12 @@ export class ProcessingContext {
           attempts.push(`downloaded: ${downloadUrl}`);
           return { bytes, attempts };
         }
-        if (typeof uri === "string" && this.storage) {
-          const retrieved = await this.storage.retrieve(uri);
-          if (retrieved) {
-            attempts.push(`storage hit via metadata: ${uri}`);
-            return { bytes: retrieved, attempts };
+        const uri = metadata.uri;
+        if (typeof uri === "string") {
+          const bytes = await tryStorageUri(uri);
+          if (bytes) {
+            return { bytes, attempts };
           }
-          attempts.push(`storage miss via metadata: ${uri}`);
         }
       } catch (error) {
         attempts.push(

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1549,12 +1549,19 @@ export class ProcessingContext {
     return Array.from(new Set([primary, withoutExt].filter(Boolean)));
   }
 
-  async assetToSandbox(assetId: string, path: string): Promise<string> {
-    const outputPath = this.resolveSandboxFilePath(path);
+  /**
+   * Resolve an `asset://<id>[.ext]` reference (or bare id / storage URI) to its
+   * raw bytes. Tries storage backends first (memory/file/s3), then falls back
+   * to the asset API. Returns the bytes plus the `attempts` trail for callers
+   * that want to build a detailed error; `null` bytes means unresolved.
+   */
+  async resolveAssetBytes(
+    assetId: string
+  ): Promise<{ bytes: Uint8Array | null; attempts: string[] }> {
     const uriCandidates = new Set<string>();
     const idCandidates = this.parseAssetIdCandidates(assetId);
     const trimmed = assetId.trim();
-    const resolutionAttempts: string[] = [];
+    const attempts: string[] = [];
 
     if (trimmed.includes("://") && !trimmed.startsWith("asset://")) {
       uriCandidates.add(trimmed);
@@ -1566,73 +1573,72 @@ export class ProcessingContext {
       }
     }
 
-    let bytes: Uint8Array | null = null;
     if (this.storage) {
       for (const uri of uriCandidates) {
         try {
           const retrieved = await this.storage.retrieve(uri);
           if (retrieved) {
-            bytes = retrieved;
-            break;
+            return { bytes: retrieved, attempts };
           }
-          resolutionAttempts.push(`storage miss: ${uri}`);
+          attempts.push(`storage miss: ${uri}`);
         } catch (error) {
-          resolutionAttempts.push(
+          attempts.push(
             `storage error: ${uri} (${error instanceof Error ? error.message : String(error)})`
           );
         }
       }
     }
 
-    if (!bytes) {
-      let baseUrl = (
-        this.environment.NODETOOL_API_URL ??
-        process.env.NODETOOL_API_URL ??
-        "http://localhost:7777"
-      );
-      while (baseUrl.endsWith("/")) {
-        baseUrl = baseUrl.slice(0, -1);
-      }
-      for (const candidate of idCandidates) {
-        try {
-          const metaResponse = await this.httpGet(
-            `${baseUrl}/api/assets/${encodeURIComponent(candidate)}`
-          );
-          const metadata = (await metaResponse.json()) as Record<string, unknown>;
-          const getUrl = metadata.get_url;
-          const uri = metadata.uri;
-          if (typeof getUrl === "string" && getUrl) {
-            const downloadUrl = getUrl.startsWith("/")
-              ? `${baseUrl}${getUrl}`
-              : getUrl;
-            bytes = await this.downloadFile(downloadUrl, {
-              retry: { maxRetries: 1, backoffMs: 200 }
-            });
-            resolutionAttempts.push(`downloaded: ${downloadUrl}`);
-            break;
-          }
-          if (typeof uri === "string" && this.storage) {
-            const retrieved = await this.storage.retrieve(uri);
-            if (retrieved) {
-              bytes = retrieved;
-              resolutionAttempts.push(`storage hit via metadata: ${uri}`);
-              break;
-            }
-            resolutionAttempts.push(`storage miss via metadata: ${uri}`);
-          }
-        } catch (error) {
-          resolutionAttempts.push(
-            `api lookup error for ${candidate}: ${error instanceof Error ? error.message : String(error)}`
-          );
+    let baseUrl =
+      this.environment.NODETOOL_API_URL ??
+      process.env.NODETOOL_API_URL ??
+      "http://localhost:7777";
+    while (baseUrl.endsWith("/")) {
+      baseUrl = baseUrl.slice(0, -1);
+    }
+    for (const candidate of idCandidates) {
+      try {
+        const metaResponse = await this.httpGet(
+          `${baseUrl}/api/assets/${encodeURIComponent(candidate)}`
+        );
+        const metadata = (await metaResponse.json()) as Record<string, unknown>;
+        const getUrl = metadata.get_url;
+        const uri = metadata.uri;
+        if (typeof getUrl === "string" && getUrl) {
+          const downloadUrl = getUrl.startsWith("/")
+            ? `${baseUrl}${getUrl}`
+            : getUrl;
+          const bytes = await this.downloadFile(downloadUrl, {
+            retry: { maxRetries: 1, backoffMs: 200 }
+          });
+          attempts.push(`downloaded: ${downloadUrl}`);
+          return { bytes, attempts };
         }
+        if (typeof uri === "string" && this.storage) {
+          const retrieved = await this.storage.retrieve(uri);
+          if (retrieved) {
+            attempts.push(`storage hit via metadata: ${uri}`);
+            return { bytes: retrieved, attempts };
+          }
+          attempts.push(`storage miss via metadata: ${uri}`);
+        }
+      } catch (error) {
+        attempts.push(
+          `api lookup error for ${candidate}: ${error instanceof Error ? error.message : String(error)}`
+        );
       }
     }
 
+    return { bytes: null, attempts };
+  }
+
+  async assetToSandbox(assetId: string, path: string): Promise<string> {
+    const outputPath = this.resolveSandboxFilePath(path);
+    const { bytes, attempts } = await this.resolveAssetBytes(assetId);
+
     if (!bytes) {
       const details =
-        resolutionAttempts.length > 0
-          ? ` Attempts: ${resolutionAttempts.join("; ")}`
-          : "";
+        attempts.length > 0 ? ` Attempts: ${attempts.join("; ")}` : "";
       throw new Error(
         `Unable to resolve asset '${assetId}' to sandbox bytes.${details}`
       );
@@ -1759,13 +1765,25 @@ export class ProcessingContext {
   }
 
   /**
-   * Resolve /api/storage/ URIs in message content to data URIs so providers
-   * can fetch them without needing a base URL.
+   * Retrieve raw bytes for a media URI referenced in message content. Handles
+   * the `asset://<id>` reference scheme (via {@link resolveAssetBytes}) as well
+   * as opaque storage URIs (memory/file/s3) via the storage adapter.
    */
-  private async resolveMessageMediaUris(
-    messages: Message[]
-  ): Promise<Message[]> {
-    if (!this.storage) return messages;
+  private async retrieveMediaBytes(uri: string): Promise<Uint8Array | null> {
+    if (uri.startsWith("asset://")) {
+      const { bytes } = await this.resolveAssetBytes(uri);
+      return bytes;
+    }
+    return this.storage ? await this.storage.retrieve(uri) : null;
+  }
+
+  /**
+   * Resolve non-data, non-http media URIs in message content to data URIs so
+   * providers can consume them directly. Covers `/api/storage/` and other
+   * storage URIs as well as the `asset://<id>` reference scheme (assets
+   * mentioned inline in a prompt).
+   */
+  async resolveMessageMediaUris(messages: Message[]): Promise<Message[]> {
     const resolved: Message[] = [];
     for (const msg of messages) {
       if (!Array.isArray(msg.content)) {
@@ -1780,7 +1798,7 @@ export class ProcessingContext {
           !part.image.uri.startsWith("data:") &&
           !part.image.uri.startsWith("http")
         ) {
-          const bytes = await this.storage.retrieve(part.image.uri);
+          const bytes = await this.retrieveMediaBytes(part.image.uri);
           if (bytes) {
             const ext = part.image.uri.split(".").pop()?.toLowerCase() ?? "png";
             const mime: Record<string, string> = {
@@ -1805,7 +1823,7 @@ export class ProcessingContext {
           !part.audio.uri.startsWith("data:") &&
           !part.audio.uri.startsWith("http")
         ) {
-          const bytes = await this.storage.retrieve(part.audio.uri);
+          const bytes = await this.retrieveMediaBytes(part.audio.uri);
           if (bytes) {
             const ext = part.audio.uri.split(".").pop()?.toLowerCase() ?? "mp3";
             const mime: Record<string, string> = {

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -654,6 +654,58 @@ describe("FileStorageAdapter", () => {
   });
 });
 
+describe("ProcessingContext.resolveAssetBytes", () => {
+  it("resolves an asset:// URN against the storage adapter (key <id>.<ext>)", async () => {
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("abc123.png", new Uint8Array([7, 8, 9]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://abc123.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([7, 8, 9]));
+  });
+
+  it("tolerates an extension mismatch between the URN and the stored file", async () => {
+    const storage = new InMemoryStorageAdapter();
+    // Stored as .jpg, but the prompt references .jpeg.
+    await storage.store("def456.jpg", new Uint8Array([1, 2]), "image/jpeg");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://def456.jpeg");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([1, 2]));
+  });
+
+  it("does not return the thumbnail when resolving by id prefix", async () => {
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("ghi789_thumb.jpg", new Uint8Array([9, 9]), "image/jpeg");
+    await storage.store("ghi789.webp", new Uint8Array([4, 5, 6]), "image/webp");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    // URN extension mismatches the stored file, forcing the prefix listing.
+    const { bytes } = await ctx.resolveAssetBytes("asset://ghi789.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("falls back to the /api/storage route when no adapter is configured", async () => {
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      environment: { NODETOOL_API_URL: "http://server.test" }
+    });
+    const payload = new Uint8Array([42, 43]);
+    const fetchSpy = vi
+      .spyOn(ctx as unknown as { _fetch: typeof fetch }, "_fetch")
+      .mockResolvedValue(
+        new Response(payload, { status: 200 }) as unknown as Response
+      );
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://zzz000.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(payload);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://server.test/api/storage/zzz000.png",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+});
+
 describe("ProcessingContext – asset helper methods", () => {
   const assetValue = {
     image: {

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -771,6 +771,56 @@ describe("ProcessingContext – asset helper methods", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("resolveMessageMediaUris dereferences asset:// image URIs to data URIs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nodetool-resolve-asset-media-"));
+    try {
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        userId: "u1",
+        workspaceDir: root,
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.endsWith("/api/assets/abc.png")) {
+            return new Response(
+              JSON.stringify({ id: "abc", get_url: "/api/storage/abc.png" }),
+              { status: 200, headers: { "content-type": "application/json" } }
+            );
+          }
+          if (url.endsWith("/api/storage/abc.png")) {
+            return new Response(pngBytes, {
+              status: 200,
+              headers: { "content-type": "image/png" }
+            });
+          }
+          return new Response("not found", { status: 404 });
+        }
+      });
+
+      const resolved = await ctx.resolveMessageMediaUris([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe " },
+            {
+              type: "image_url",
+              image: { uri: "asset://abc.png", mimeType: "image/png" }
+            }
+          ]
+        }
+      ]);
+
+      const parts = resolved[0].content as Array<Record<string, any>>;
+      expect(parts[0]).toEqual({ type: "text", text: "describe " });
+      expect(parts[1].type).toBe("image_url");
+      expect(parts[1].image.uri).toBe(
+        `data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 class MockProvider extends BaseProvider {

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -1,0 +1,326 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * PromptComposerBody — bespoke body for `nodetool.text.Prompt`.
+ *
+ * A composer-style editor for the prompt string:
+ *   - `@` opens an asset typeahead; picking an asset inserts a chip encoded
+ *     as `asset://<id>.<ext>`. The runtime dereferences these to image/audio
+ *     content before the prompt reaches a provider.
+ *   - The node's dynamic inputs render as insertable `{{ variable }}` chips so
+ *     references are visible at a glance; clicking one drops it at the caret.
+ *
+ * Chips are purely a visual aid — the node still stores a plain prompt string
+ * (`asset://…`, `{{ name }}`), so existing `{{variable}}` substitution and the
+ * backend asset dereferencing work whether or not a token is chipped.
+ */
+import React, { memo, useCallback, useMemo, useRef } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { shallow } from "zustand/shallow";
+import { $insertNodes, type EditorState } from "lexical";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import type { InitialConfigType } from "@lexical/react/LexicalComposer";
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+
+import { DynamicInputButton } from "../../ui_primitives";
+import { NodeInputs } from "../../node/NodeInputs";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata, Property } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useDynamicProperty } from "../../../hooks/nodes/useDynamicProperty";
+import { debounce } from "../../../utils/lodashAlternatives";
+
+import { AssetMentionNode } from "./promptComposer/AssetMentionNode";
+import { VariableNode, $createVariableNode } from "./promptComposer/VariableNode";
+import AssetMentionPlugin from "./promptComposer/AssetMentionPlugin";
+import {
+  $serializePrompt,
+  $setPromptFromString
+} from "./promptComposer/promptEditorState";
+import { PromptComposerContext } from "./promptComposer/promptComposerContext";
+
+const PROMPT_NODE_TYPE = "nodetool.text.Prompt";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.prompt-composer-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".composer-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 90,
+      borderRadius: "var(--rounded-sm, 4px)",
+      border: `1px solid ${theme.vars.palette.divider}`,
+      background: theme.vars.palette.background.default,
+      padding: theme.spacing(0.75),
+      overflow: "auto"
+    },
+    ".composer-input": {
+      outline: "none",
+      minHeight: 72,
+      width: "100%",
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmall,
+      lineHeight: 1.5,
+      color: theme.vars.palette.text.primary,
+      "& p": { margin: 0 }
+    },
+    ".composer-placeholder": {
+      position: "absolute",
+      top: theme.spacing(0.75),
+      left: theme.spacing(0.75),
+      color: theme.vars.palette.text.disabled,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmall,
+      pointerEvents: "none"
+    },
+    ".variable-bar": {
+      flex: "0 0 auto",
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: theme.spacing(0.5)
+    },
+    ".variable-bar-label": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em"
+    },
+    ".variable-insert-chip": {
+      cursor: "pointer",
+      padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+      borderRadius: "var(--rounded-sm, 4px)",
+      border: `1px solid ${theme.vars.palette.divider}`,
+      background: "transparent",
+      color: theme.vars.palette.text.primary,
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      lineHeight: 1.4,
+      "&:hover": { borderColor: theme.vars.palette.primary.main }
+    },
+    ".dynamic-inputs": { flex: "0 0 auto" },
+    ".outputs-row": { flex: "0 0 auto" }
+  });
+
+const composerTheme = {
+  paragraph: "composer-paragraph"
+};
+
+/** Quick-insert bar: one chip per dynamic input + the add-variable button. */
+const VariableInsertBar: React.FC<{
+  variableNames: string[];
+  onAdd: () => void;
+}> = ({ variableNames, onAdd }) => {
+  const [editor] = useLexicalComposerContext();
+  const insertVariable = useCallback(
+    (name: string) => {
+      editor.update(() => {
+        $insertNodes([$createVariableNode(name)]);
+      });
+    },
+    [editor]
+  );
+  return (
+    <div className="variable-bar">
+      <span className="variable-bar-label">Variables</span>
+      {variableNames.map((name) => (
+        <button
+          key={name}
+          type="button"
+          className="variable-insert-chip nodrag"
+          onClick={() => insertVariable(name)}
+          aria-label={`Insert variable ${name}`}
+        >
+          {`{{ ${name} }}`}
+        </button>
+      ))}
+      <DynamicInputButton itemLabel="variable" onAdd={onAdd} />
+    </div>
+  );
+};
+
+export interface PromptComposerBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const { setProperties, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const dynamicProperties = useMemo(
+    () => (data.dynamic_properties ?? {}) as Record<string, unknown>,
+    [data.dynamic_properties]
+  );
+  const variableNames = useMemo(
+    () => Object.keys(dynamicProperties),
+    [dynamicProperties]
+  );
+  const knownVariables = useMemo(
+    () => new Set(variableNames),
+    [variableNames]
+  );
+
+  const { handleAddProperty, handleDeleteProperty, handleUpdatePropertyName } =
+    useDynamicProperty(id, dynamicProperties);
+
+  const handleAddVariable = useCallback(() => {
+    let i = 1;
+    while (`var_${i}` in dynamicProperties) {
+      i += 1;
+    }
+    handleAddProperty(`var_${i}`);
+  }, [dynamicProperties, handleAddProperty]);
+
+  // Capture the initial prompt once — the editor owns the value after mount.
+  const initialPromptRef = useRef<string>(
+    typeof data.properties?.prompt === "string"
+      ? (data.properties.prompt as string)
+      : ""
+  );
+  const lastWrittenRef = useRef<string>(initialPromptRef.current);
+
+  const initialConfig = useMemo<InitialConfigType>(
+    () => ({
+      namespace: "PromptComposer",
+      nodes: [AssetMentionNode, VariableNode],
+      theme: composerTheme,
+      editorState: () => {
+        $setPromptFromString(initialPromptRef.current);
+      },
+      onError: (error: Error) => {
+        console.error(error);
+      }
+    }),
+    []
+  );
+
+  const writePrompt = useMemo(
+    () =>
+      debounce((text: string) => {
+        if (text === lastWrittenRef.current) {
+          return;
+        }
+        lastWrittenRef.current = text;
+        setProperties({ prompt: text });
+        setPropertyComplete();
+      }, 400),
+    [setProperties, setPropertyComplete]
+  );
+
+  const handleEditorChange = useCallback(
+    (editorState: EditorState) => {
+      editorState.read(() => {
+        writePrompt($serializePrompt());
+      });
+    },
+    [writePrompt]
+  );
+
+  const promptProperties = useMemo<Property[]>(() => [], []);
+
+  return (
+    <PromptComposerContext.Provider value={{ knownVariables }}>
+      <div css={cssStyles} className="prompt-composer-body node-drag-handle">
+        <LexicalComposer initialConfig={initialConfig}>
+          <div className="composer-area nodrag nowheel">
+            <PlainTextPlugin
+              contentEditable={
+                <ContentEditable
+                  className="composer-input"
+                  aria-label="Prompt"
+                  spellCheck={false}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              }
+              placeholder={
+                <div className="composer-placeholder">
+                  Write a prompt… @ to mention an asset
+                </div>
+              }
+              ErrorBoundary={() => null}
+            />
+            <HistoryPlugin />
+            <OnChangePlugin onChange={handleEditorChange} />
+            <AssetMentionPlugin />
+          </div>
+
+          <VariableInsertBar
+            variableNames={variableNames}
+            onAdd={handleAddVariable}
+          />
+        </LexicalComposer>
+
+        {variableNames.length > 0 && (
+          <div className="dynamic-inputs">
+            <NodeInputs
+              id={id}
+              nodeType={nodeType}
+              nodeMetadata={nodeMetadata}
+              layout={nodeMetadata.layout}
+              properties={promptProperties}
+              data={data}
+              showFields={true}
+              editableDynamicInputs={true}
+              onDeleteProperty={handleDeleteProperty}
+              onUpdatePropertyName={handleUpdatePropertyName}
+            />
+          </div>
+        )}
+
+        {!isOutputNode && (
+          <div className="outputs-row">
+            <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+          </div>
+        )}
+
+        {status === "running" && (
+          <NodeProgress id={id} workflowId={workflowId} />
+        )}
+      </div>
+    </PromptComposerContext.Provider>
+  );
+};
+
+export const PromptComposerBody = memo(PromptComposerBodyInner);
+PromptComposerBody.displayName = "PromptComposerBody";
+
+export { PROMPT_NODE_TYPE };
+export default PromptComposerBody;

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -25,6 +25,7 @@ import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 
 import { DynamicInputButton } from "../../ui_primitives";
@@ -41,6 +42,7 @@ import { debounce } from "../../../utils/lodashAlternatives";
 import { AssetMentionNode } from "./promptComposer/AssetMentionNode";
 import { VariableNode, $createVariableNode } from "./promptComposer/VariableNode";
 import AssetMentionPlugin from "./promptComposer/AssetMentionPlugin";
+import AssetDropPlugin from "./promptComposer/AssetDropPlugin";
 import {
   $serializePrompt,
   $setPromptFromString
@@ -275,11 +277,12 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
                   Write a prompt… @ to mention an asset
                 </div>
               }
-              ErrorBoundary={() => null}
+              ErrorBoundary={LexicalErrorBoundary}
             />
             <HistoryPlugin />
             <OnChangePlugin onChange={handleEditorChange} />
             <AssetMentionPlugin />
+            <AssetDropPlugin />
           </div>
 
           <VariableInsertBar

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -13,11 +13,10 @@
  * (`asset://…`, `{{ name }}`), so existing `{{variable}}` substitution and the
  * backend asset dereferencing work whether or not a token is chipped.
  */
-import React, { memo, useCallback, useMemo, useRef } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { shallow } from "zustand/shallow";
 import { $insertNodes, type EditorState } from "lexical";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer";
@@ -246,6 +245,12 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
       }, 400),
     [setProperties, setPropertyComplete]
   );
+
+  useEffect(() => {
+    return () => {
+      writePrompt.cancel();
+    };
+  }, [writePrompt]);
 
   const handleEditorChange = useCallback(
     (editorState: EditorState) => {

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PromptComposerBody } from "../PromptComposerBody";
 import mockTheme from "../../../../__mocks__/themeMock";
 import "@testing-library/jest-dom";
@@ -41,12 +42,22 @@ jest.mock("../../../node/NodeProgress", () => ({
 }));
 
 const mockSearch = jest.fn().mockResolvedValue({ assets: [] });
+const mockGet = jest.fn();
 jest.mock("../../../../stores/AssetStore", () => ({
-  useAssetStore: (selector: any) => selector({ search: mockSearch })
+  useAssetStore: (selector: any) =>
+    selector({ search: mockSearch, get: mockGet })
 }));
 
-const renderWithTheme = (ui: React.ReactElement) =>
-  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+const renderWithTheme = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>
+    </QueryClientProvider>
+  );
+};
 
 const makeProps = (overrides: Record<string, unknown> = {}) => ({
   id: "node-1",
@@ -99,5 +110,42 @@ describe("PromptComposerBody", () => {
     expect(input).not.toBeNull();
     expect(input?.textContent).toContain("Describe");
     expect(input?.textContent).toContain("in detail");
+  });
+
+  it("renders a variable chip decorator inside the composer body", async () => {
+    const { container } = renderWithTheme(
+      <PromptComposerBody {...makeProps()} />
+    );
+    await waitFor(() => {
+      const chip = container.querySelector(".prompt-variable-chip");
+      expect(chip).not.toBeNull();
+      expect(chip?.textContent).toContain("subject");
+    });
+  });
+
+  it("renders an inline image preview for an asset URN in the prompt", async () => {
+    mockGet.mockResolvedValue({
+      id: "abc123",
+      content_type: "image/png",
+      get_url: "https://example.test/abc123.png"
+    });
+    const { container } = renderWithTheme(
+      <PromptComposerBody
+        {...makeProps({
+          data: {
+            properties: { prompt: "look at asset://abc123.png here" },
+            dynamic_properties: {}
+          }
+        })}
+      />
+    );
+    await waitFor(() => {
+      const img = container.querySelector(".asset-mention-preview img");
+      expect(img).not.toBeNull();
+      expect(img?.getAttribute("src")).toBe(
+        "https://example.test/abc123.png"
+      );
+    });
+    expect(mockGet).toHaveBeenCalledWith("abc123");
   });
 });

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { PromptComposerBody } from "../PromptComposerBody";
+import mockTheme from "../../../../__mocks__/themeMock";
+import "@testing-library/jest-dom";
+
+const mockSetProperties = jest.fn();
+const mockSetPropertyComplete = jest.fn();
+const mockAddProperty = jest.fn();
+
+jest.mock("../../../../hooks/nodes/useBespokePropertyWriter", () => ({
+  useBespokePropertyWriter: jest.fn(() => ({
+    setProperty: jest.fn(),
+    setProperties: mockSetProperties,
+    setPropertyComplete: mockSetPropertyComplete
+  }))
+}));
+
+jest.mock("../../../../hooks/nodes/useDynamicProperty", () => ({
+  useDynamicProperty: jest.fn(() => ({
+    handleAddProperty: mockAddProperty,
+    handleDeleteProperty: jest.fn(),
+    handleUpdatePropertyName: jest.fn()
+  }))
+}));
+
+jest.mock("../../../node/NodeInputs", () => ({
+  __esModule: true,
+  NodeInputs: () => <div data-testid="node-inputs" />
+}));
+
+jest.mock("../../../node/NodeOutputs", () => ({
+  __esModule: true,
+  NodeOutputs: () => <div data-testid="node-outputs" />
+}));
+
+jest.mock("../../../node/NodeProgress", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-progress" />
+}));
+
+const mockSearch = jest.fn().mockResolvedValue({ assets: [] });
+jest.mock("../../../../stores/AssetStore", () => ({
+  useAssetStore: (selector: any) => selector({ search: mockSearch })
+}));
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+const makeProps = (overrides: Record<string, unknown> = {}) => ({
+  id: "node-1",
+  nodeType: "nodetool.text.Prompt",
+  nodeMetadata: {
+    node_type: "nodetool.text.Prompt",
+    properties: [],
+    outputs: [{ name: "output", type: { type: "str" } }],
+    is_dynamic: true
+  } as unknown as Parameters<typeof PromptComposerBody>[0]["nodeMetadata"],
+  data: {
+    properties: { prompt: "Describe {{ subject }} in detail" },
+    dynamic_properties: { subject: "" }
+  } as unknown as Parameters<typeof PromptComposerBody>[0]["data"],
+  workflowId: "wf-1",
+  isOutputNode: false,
+  ...overrides
+});
+
+describe("PromptComposerBody", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the composer placeholder when the prompt is empty", () => {
+    renderWithTheme(
+      <PromptComposerBody
+        {...makeProps({
+          data: { properties: { prompt: "" }, dynamic_properties: {} }
+        })}
+      />
+    );
+    expect(
+      screen.getByText("Write a prompt… @ to mention an asset")
+    ).toBeInTheDocument();
+  });
+
+  it("renders an insert chip for each dynamic input", () => {
+    renderWithTheme(<PromptComposerBody {...makeProps()} />);
+    expect(
+      screen.getByLabelText("Insert variable subject")
+    ).toBeInTheDocument();
+  });
+
+  it("loads the existing prompt text into the composer", () => {
+    const { container } = renderWithTheme(
+      <PromptComposerBody {...makeProps()} />
+    );
+    const input = container.querySelector(".composer-input");
+    expect(input).not.toBeNull();
+    expect(input?.textContent).toContain("Describe");
+    expect(input?.textContent).toContain("in detail");
+  });
+});

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -27,6 +27,7 @@ import MasksExtractorBody, {
   MASKS_EXTRACTOR_NODE_TYPES
 } from "./MasksExtractorBody";
 import PainterBody, { PAINTER_NODE_TYPE } from "./PainterBody";
+import PromptComposerBody, { PROMPT_NODE_TYPE } from "./PromptComposerBody";
 import PasteBody, { PASTE_NODE_TYPE } from "./PasteBody";
 import ResizeBody, { RESIZE_NODE_TYPE } from "./ResizeBody";
 import RotateAndFlipBody, {
@@ -64,6 +65,7 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [MASK_NODE_TYPE]: MaskBody,
   [PAINTER_NODE_TYPE]: PainterBody,
   [PASTE_NODE_TYPE]: PasteBody,
+  [PROMPT_NODE_TYPE]: PromptComposerBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
   [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
   [SCALE_NODE_TYPE]: ScaleBody,

--- a/web/src/components/node_types/editing/promptComposer/AssetDropPlugin.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetDropPlugin.tsx
@@ -1,0 +1,130 @@
+/**
+ * Drop assets from the asset browser / search straight into the composer.
+ *
+ * Each dropped asset becomes an asset-mention chip at the drop caret, encoded
+ * as `asset://<id>.<ext>`. Single-asset drags carry the whole asset (instant
+ * thumbnail); multi-select drags carry ids, which we resolve via the store.
+ */
+import { useEffect } from "react";
+import {
+  $createRangeSelection,
+  $setSelection,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  DRAGOVER_COMMAND,
+  DROP_COMMAND,
+  type LexicalEditor
+} from "lexical";
+import { mergeRegister } from "@lexical/utils";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+
+import { useAssetStore } from "../../../../stores/AssetStore";
+import type { Asset } from "../../../../stores/ApiTypes";
+import { $createAssetMentionNode } from "./AssetMentionNode";
+import { $insertAssetMention } from "./promptEditorState";
+import { assetToUri } from "./promptTokens";
+import { hasAssetDrag, readAssetDrag } from "./assetDrag";
+
+/** Best-effort caret position from drop coordinates, across browsers. */
+const rangeFromPoint = (x: number, y: number): Range | null => {
+  if (typeof document.caretRangeFromPoint === "function") {
+    return document.caretRangeFromPoint(x, y);
+  }
+  const pos = (
+    document as Document & {
+      caretPositionFromPoint?: (
+        x: number,
+        y: number
+      ) => { offsetNode: Node; offset: number } | null;
+    }
+  ).caretPositionFromPoint?.(x, y);
+  if (pos) {
+    const range = document.createRange();
+    range.setStart(pos.offsetNode, pos.offset);
+    range.collapse(true);
+    return range;
+  }
+  return null;
+};
+
+const insertAssets = (
+  editor: LexicalEditor,
+  assets: Asset[],
+  range: Range | null
+): void => {
+  if (assets.length === 0) {
+    return;
+  }
+  editor.update(() => {
+    if (range) {
+      const selection = $createRangeSelection();
+      selection.applyDOMRange(range);
+      $setSelection(selection);
+    }
+    for (const asset of assets) {
+      $insertAssetMention(
+        $createAssetMentionNode(
+          assetToUri(asset),
+          asset.name || asset.id,
+          asset.thumb_url || asset.get_url || undefined
+        )
+      );
+    }
+  });
+};
+
+const AssetDropPlugin: React.FC = () => {
+  const [editor] = useLexicalComposerContext();
+  const getAsset = useAssetStore((state) => state.get);
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        DRAGOVER_COMMAND,
+        (event) => {
+          if (!hasAssetDrag(event.dataTransfer)) {
+            return false;
+          }
+          event.preventDefault();
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = "copy";
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_LOW
+      ),
+      editor.registerCommand(
+        DROP_COMMAND,
+        (event) => {
+          const drag = readAssetDrag(event.dataTransfer);
+          if (!drag) {
+            return false;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          const range = rangeFromPoint(event.clientX, event.clientY);
+          if (drag.assets.length > 0) {
+            insertAssets(editor, drag.assets, range);
+          }
+          if (drag.pendingIds.length > 0) {
+            Promise.all(
+              drag.pendingIds.map((id) => getAsset(id).catch(() => null))
+            ).then((resolved) => {
+              insertAssets(
+                editor,
+                resolved.filter((a): a is Asset => a !== null),
+                range
+              );
+            });
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH
+      )
+    );
+  }, [editor, getAsset]);
+
+  return null;
+};
+
+export default AssetDropPlugin;

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionNode.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionNode.tsx
@@ -1,0 +1,150 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+import AudiotrackIcon from "@mui/icons-material/Audiotrack";
+import MovieIcon from "@mui/icons-material/Movie";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
+import {
+  DecoratorNode,
+  type DOMExportOutput,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread
+} from "lexical";
+
+import { assetMediaKind, parseAssetUri } from "./promptTokens";
+
+export type SerializedAssetMentionNode = Spread<
+  {
+    type: "asset-mention";
+    version: 1;
+    uri: string;
+    label: string;
+  },
+  SerializedLexicalNode
+>;
+
+const chipStyles = (theme: Theme) =>
+  css({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.25em",
+    verticalAlign: "baseline",
+    margin: "0 1px",
+    padding: "0 0.4em",
+    borderRadius: "var(--rounded-sm, 4px)",
+    backgroundColor: theme.vars.palette.primary.main,
+    color: theme.vars.palette.primary.contrastText,
+    fontFamily: theme.fontFamily2,
+    fontSize: theme.fontSizeSmaller,
+    lineHeight: 1.6,
+    whiteSpace: "nowrap",
+    userSelect: "none",
+    "& svg": { fontSize: "1em" }
+  });
+
+const AssetMentionChip: React.FC<{ uri: string; label: string }> = ({
+  uri,
+  label
+}) => {
+  const theme = useTheme();
+  const { ext } = parseAssetUri(uri);
+  const kind = assetMediaKind(ext);
+  const Icon =
+    kind === "image"
+      ? ImageIcon
+      : kind === "audio"
+        ? AudiotrackIcon
+        : kind === "video"
+          ? MovieIcon
+          : InsertDriveFileIcon;
+  return (
+    <span
+      css={chipStyles(theme)}
+      className="asset-mention-chip nodrag"
+      contentEditable={false}
+      title={uri}
+    >
+      <Icon />
+      {label}
+    </span>
+  );
+};
+
+export class AssetMentionNode extends DecoratorNode<React.JSX.Element> {
+  __uri: string;
+  __label: string;
+
+  static getType(): string {
+    return "asset-mention";
+  }
+
+  static clone(node: AssetMentionNode): AssetMentionNode {
+    return new AssetMentionNode(node.__uri, node.__label, node.__key);
+  }
+
+  constructor(uri: string, label: string, key?: NodeKey) {
+    super(key);
+    this.__uri = uri;
+    this.__label = label;
+  }
+
+  static importJSON(serialized: SerializedAssetMentionNode): AssetMentionNode {
+    return $createAssetMentionNode(serialized.uri, serialized.label);
+  }
+
+  exportJSON(): SerializedAssetMentionNode {
+    return {
+      type: "asset-mention",
+      version: 1,
+      uri: this.__uri,
+      label: this.__label
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.style.display = "inline-block";
+    return span;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.textContent = this.__uri;
+    return { element };
+  }
+
+  isInline(): true {
+    return true;
+  }
+
+  /** On-disk encoding — the asset URN that the runtime dereferences. */
+  getTextContent(): string {
+    return this.__uri;
+  }
+
+  getUri(): string {
+    return this.__uri;
+  }
+
+  decorate(): React.JSX.Element {
+    return <AssetMentionChip uri={this.__uri} label={this.__label} />;
+  }
+}
+
+export const $createAssetMentionNode = (
+  uri: string,
+  label: string
+): AssetMentionNode => new AssetMentionNode(uri, label || uri);
+
+export const $isAssetMentionNode = (
+  node: LexicalNode | null | undefined
+): node is AssetMentionNode => node instanceof AssetMentionNode;

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionNode.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionNode.tsx
@@ -16,6 +16,7 @@ import {
   type Spread
 } from "lexical";
 
+import { useAssetById } from "../../../../serverState/useAssetById";
 import { assetMediaKind, parseAssetUri } from "./promptTokens";
 
 export type SerializedAssetMentionNode = Spread<
@@ -24,6 +25,7 @@ export type SerializedAssetMentionNode = Spread<
     version: 1;
     uri: string;
     label: string;
+    thumb?: string;
   },
   SerializedLexicalNode
 >;
@@ -47,13 +49,53 @@ const chipStyles = (theme: Theme) =>
     "& svg": { fontSize: "1em" }
   });
 
-const AssetMentionChip: React.FC<{ uri: string; label: string }> = ({
-  uri,
-  label
-}) => {
+const previewStyles = (theme: Theme) =>
+  css({
+    display: "inline-flex",
+    verticalAlign: "middle",
+    margin: "0 2px",
+    borderRadius: "var(--rounded-sm, 4px)",
+    overflow: "hidden",
+    border: `1px solid ${theme.vars.palette.primary.main}`,
+    userSelect: "none",
+    "& img": {
+      display: "block",
+      height: "2.6em",
+      maxWidth: 160,
+      objectFit: "cover"
+    }
+  });
+
+const AssetMentionChip: React.FC<{
+  uri: string;
+  label: string;
+  thumb?: string;
+}> = ({ uri, label, thumb }) => {
   const theme = useTheme();
-  const { ext } = parseAssetUri(uri);
+  const { assetId, ext } = parseAssetUri(uri);
   const kind = assetMediaKind(ext);
+  const wantsPreview = kind === "image" || kind === "video";
+  // Resolve the preview from the store only when we weren't handed one (e.g.
+  // after reloading a saved prompt, where the chip starts from the URN alone).
+  const { data: resolved } = useAssetById(
+    wantsPreview && !thumb ? assetId : undefined
+  );
+  const previewUrl =
+    thumb || resolved?.thumb_url || resolved?.get_url || undefined;
+
+  if (wantsPreview && previewUrl) {
+    return (
+      <span
+        css={previewStyles(theme)}
+        className="asset-mention-chip asset-mention-preview nodrag"
+        contentEditable={false}
+        title={label}
+      >
+        <img src={previewUrl} alt={label} />
+      </span>
+    );
+  }
+
   const Icon =
     kind === "image"
       ? ImageIcon
@@ -78,23 +120,35 @@ const AssetMentionChip: React.FC<{ uri: string; label: string }> = ({
 export class AssetMentionNode extends DecoratorNode<React.JSX.Element> {
   __uri: string;
   __label: string;
+  /** Display-only preview URL; never part of the on-disk prompt string. */
+  __thumb?: string;
 
   static getType(): string {
     return "asset-mention";
   }
 
   static clone(node: AssetMentionNode): AssetMentionNode {
-    return new AssetMentionNode(node.__uri, node.__label, node.__key);
+    return new AssetMentionNode(
+      node.__uri,
+      node.__label,
+      node.__thumb,
+      node.__key
+    );
   }
 
-  constructor(uri: string, label: string, key?: NodeKey) {
+  constructor(uri: string, label: string, thumb?: string, key?: NodeKey) {
     super(key);
     this.__uri = uri;
     this.__label = label;
+    this.__thumb = thumb;
   }
 
   static importJSON(serialized: SerializedAssetMentionNode): AssetMentionNode {
-    return $createAssetMentionNode(serialized.uri, serialized.label);
+    return $createAssetMentionNode(
+      serialized.uri,
+      serialized.label,
+      serialized.thumb
+    );
   }
 
   exportJSON(): SerializedAssetMentionNode {
@@ -102,7 +156,8 @@ export class AssetMentionNode extends DecoratorNode<React.JSX.Element> {
       type: "asset-mention",
       version: 1,
       uri: this.__uri,
-      label: this.__label
+      label: this.__label,
+      ...(this.__thumb != null && { thumb: this.__thumb })
     };
   }
 
@@ -136,14 +191,21 @@ export class AssetMentionNode extends DecoratorNode<React.JSX.Element> {
   }
 
   decorate(): React.JSX.Element {
-    return <AssetMentionChip uri={this.__uri} label={this.__label} />;
+    return (
+      <AssetMentionChip
+        uri={this.__uri}
+        label={this.__label}
+        thumb={this.__thumb}
+      />
+    );
   }
 }
 
 export const $createAssetMentionNode = (
   uri: string,
-  label: string
-): AssetMentionNode => new AssetMentionNode(uri, label || uri);
+  label: string,
+  thumb?: string
+): AssetMentionNode => new AssetMentionNode(uri, label || uri, thumb);
 
 export const $isAssetMentionNode = (
   node: LexicalNode | null | undefined

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionPlugin.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionPlugin.tsx
@@ -9,7 +9,7 @@ import * as ReactDOM from "react-dom";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { $createTextNode, $insertNodes } from "lexical";
+import { $createTextNode } from "lexical";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
   LexicalTypeaheadMenuPlugin,
@@ -20,6 +20,7 @@ import {
 import { useAssetStore } from "../../../../stores/AssetStore";
 import type { Asset } from "../../../../stores/ApiTypes";
 import { $createAssetMentionNode } from "./AssetMentionNode";
+import { $insertAssetMention } from "./promptEditorState";
 import { assetToUri } from "./promptTokens";
 
 class AssetTypeaheadOption extends MenuOption {
@@ -171,14 +172,10 @@ const AssetMentionPlugin: React.FC = () => {
         const { asset } = selectedOption;
         const node = $createAssetMentionNode(
           assetToUri(asset),
-          asset.name || asset.id
+          asset.name || asset.id,
+          asset.thumb_url || asset.get_url || undefined
         );
-        if (nodeToReplace) {
-          nodeToReplace.replace(node);
-        } else {
-          $insertNodes([node]);
-        }
-        node.insertAfter($createTextNode(" "));
+        $insertAssetMention(node, nodeToReplace);
         closeMenu();
       });
     },

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionPlugin.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionPlugin.tsx
@@ -1,0 +1,229 @@
+/** @jsxImportSource @emotion/react */
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from "react";
+import * as ReactDOM from "react-dom";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { $createTextNode, $insertNodes } from "lexical";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  useBasicTypeaheadTriggerMatch
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+
+import { useAssetStore } from "../../../../stores/AssetStore";
+import type { Asset } from "../../../../stores/ApiTypes";
+import { $createAssetMentionNode } from "./AssetMentionNode";
+import { assetToUri } from "./promptTokens";
+
+class AssetTypeaheadOption extends MenuOption {
+  asset: Asset;
+  constructor(asset: Asset) {
+    super(asset.id);
+    this.asset = asset;
+  }
+}
+
+const menuStyles = (theme: Theme) =>
+  css({
+    minWidth: 220,
+    maxWidth: 320,
+    maxHeight: 260,
+    overflowY: "auto",
+    background: theme.vars.palette.background.paper,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    borderRadius: "var(--rounded-sm, 4px)",
+    boxShadow: theme.shadows[6],
+    padding: theme.spacing(0.5),
+    zIndex: 2000,
+    ".asset-option": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1),
+      padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
+      borderRadius: "var(--rounded-sm, 4px)",
+      cursor: "pointer",
+      fontFamily: theme.fontFamily1,
+      fontSize: theme.fontSizeSmall,
+      color: theme.vars.palette.text.primary,
+      "&.selected": {
+        background: theme.vars.palette.action.selected
+      }
+    },
+    ".asset-thumb": {
+      width: 28,
+      height: 28,
+      flex: "0 0 auto",
+      objectFit: "cover",
+      borderRadius: 3,
+      background: theme.vars.palette.grey[800]
+    },
+    ".asset-meta": {
+      minWidth: 0,
+      display: "flex",
+      flexDirection: "column"
+    },
+    ".asset-name": {
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".asset-type": {
+      color: theme.vars.palette.text.secondary,
+      fontSize: theme.fontSizeSmaller
+    },
+    ".asset-empty": {
+      padding: theme.spacing(1),
+      color: theme.vars.palette.text.secondary,
+      fontSize: theme.fontSizeSmall
+    }
+  });
+
+const AssetOptionRow: React.FC<{
+  option: AssetTypeaheadOption;
+  selected: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+}> = ({ option, selected, onClick, onMouseEnter }) => {
+  const { asset } = option;
+  return (
+    <div
+      className={`asset-option${selected ? " selected" : ""}`}
+      role="option"
+      aria-selected={selected}
+      ref={option.setRefElement}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+    >
+      {asset.thumb_url ? (
+        <img className="asset-thumb" src={asset.thumb_url} alt="" />
+      ) : (
+        <span className="asset-thumb" />
+      )}
+      <span className="asset-meta">
+        <span className="asset-name">{asset.name || asset.id}</span>
+        <span className="asset-type">{asset.content_type}</span>
+      </span>
+    </div>
+  );
+};
+
+/**
+ * `@`-triggered typeahead that searches assets and inserts an asset-mention
+ * chip (encoded as `asset://<id>.<ext>`).
+ */
+const AssetMentionPlugin: React.FC = () => {
+  const theme = useTheme();
+  const [editor] = useLexicalComposerContext();
+  const search = useAssetStore((state) => state.search);
+  const [queryString, setQueryString] = useState<string | null>(null);
+  const [assets, setAssets] = useState<Asset[]>([]);
+
+  const triggerFn = useBasicTypeaheadTriggerMatch("@", {
+    minLength: 0,
+    maxLength: 64
+  });
+
+  useEffect(() => {
+    if (queryString === null) {
+      setAssets([]);
+      return;
+    }
+    let active = true;
+    const handle = setTimeout(() => {
+      search({ query: queryString, page_size: 8 })
+        .then((result) => {
+          if (active) {
+            setAssets(result.assets ?? []);
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setAssets([]);
+          }
+        });
+    }, 150);
+    return () => {
+      active = false;
+      clearTimeout(handle);
+    };
+  }, [queryString, search]);
+
+  const options = useMemo(
+    () => assets.map((asset) => new AssetTypeaheadOption(asset)),
+    [assets]
+  );
+
+  const onSelectOption = useCallback(
+    (
+      selectedOption: AssetTypeaheadOption,
+      nodeToReplace: ReturnType<typeof $createTextNode> | null,
+      closeMenu: () => void
+    ) => {
+      editor.update(() => {
+        const { asset } = selectedOption;
+        const node = $createAssetMentionNode(
+          assetToUri(asset),
+          asset.name || asset.id
+        );
+        if (nodeToReplace) {
+          nodeToReplace.replace(node);
+        } else {
+          $insertNodes([node]);
+        }
+        node.insertAfter($createTextNode(" "));
+        closeMenu();
+      });
+    },
+    [editor]
+  );
+
+  return (
+    <LexicalTypeaheadMenuPlugin<AssetTypeaheadOption>
+      options={options}
+      triggerFn={triggerFn}
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
+      ) => {
+        if (anchorElementRef.current === null) {
+          return null;
+        }
+        return ReactDOM.createPortal(
+          <div css={menuStyles(theme)} className="asset-mention-menu nowheel">
+            {options.length === 0 ? (
+              <div className="asset-empty">
+                {queryString ? "No matching assets" : "Type to search assets"}
+              </div>
+            ) : (
+              options.map((option, index) => (
+                <AssetOptionRow
+                  key={option.key}
+                  option={option}
+                  selected={index === selectedIndex}
+                  onClick={() => {
+                    setHighlightedIndex(index);
+                    selectOptionAndCleanUp(option);
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                />
+              ))
+            )}
+          </div>,
+          anchorElementRef.current
+        );
+      }}
+    />
+  );
+};
+
+export default AssetMentionPlugin;

--- a/web/src/components/node_types/editing/promptComposer/VariableNode.tsx
+++ b/web/src/components/node_types/editing/promptComposer/VariableNode.tsx
@@ -1,0 +1,137 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import {
+  DecoratorNode,
+  type DOMExportOutput,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread
+} from "lexical";
+
+import { usePromptComposerContext } from "./promptComposerContext";
+
+export type SerializedVariableNode = Spread<
+  {
+    type: "prompt-variable";
+    version: 1;
+    expr: string;
+  },
+  SerializedLexicalNode
+>;
+
+const chipStyles = (theme: Theme, known: boolean) =>
+  css({
+    display: "inline-flex",
+    alignItems: "center",
+    verticalAlign: "baseline",
+    margin: "0 1px",
+    padding: "0 0.4em",
+    borderRadius: "var(--rounded-sm, 4px)",
+    border: `1px solid ${
+      known ? theme.vars.palette.success.main : theme.vars.palette.warning.main
+    }`,
+    backgroundColor: known
+      ? `rgba(${theme.vars.palette.success.mainChannel} / 0.18)`
+      : `rgba(${theme.vars.palette.warning.mainChannel} / 0.18)`,
+    color: theme.vars.palette.text.primary,
+    fontFamily: theme.fontFamily2,
+    fontSize: theme.fontSizeSmaller,
+    lineHeight: 1.6,
+    whiteSpace: "nowrap",
+    userSelect: "none"
+  });
+
+const VariableChip: React.FC<{ expr: string }> = ({ expr }) => {
+  const theme = useTheme();
+  const { knownVariables } = usePromptComposerContext();
+  // The leading identifier (before any filter) is the dynamic-input name.
+  const name = expr.split("|")[0].trim();
+  const known = knownVariables.has(name);
+  return (
+    <span
+      css={chipStyles(theme, known)}
+      className="prompt-variable-chip nodrag"
+      contentEditable={false}
+      title={
+        known
+          ? `Variable "${name}"`
+          : `"${name}" has no matching input — add it as a variable`
+      }
+    >
+      {expr}
+    </span>
+  );
+};
+
+export class VariableNode extends DecoratorNode<React.JSX.Element> {
+  __expr: string;
+
+  static getType(): string {
+    return "prompt-variable";
+  }
+
+  static clone(node: VariableNode): VariableNode {
+    return new VariableNode(node.__expr, node.__key);
+  }
+
+  constructor(expr: string, key?: NodeKey) {
+    super(key);
+    this.__expr = expr;
+  }
+
+  static importJSON(serialized: SerializedVariableNode): VariableNode {
+    return $createVariableNode(serialized.expr);
+  }
+
+  exportJSON(): SerializedVariableNode {
+    return {
+      type: "prompt-variable",
+      version: 1,
+      expr: this.__expr
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.style.display = "inline-block";
+    return span;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.textContent = this.getTextContent();
+    return { element };
+  }
+
+  isInline(): true {
+    return true;
+  }
+
+  /** On-disk encoding — the `{{ expr }}` placeholder substituted at runtime. */
+  getTextContent(): string {
+    return `{{ ${this.__expr} }}`;
+  }
+
+  getExpr(): string {
+    return this.__expr;
+  }
+
+  decorate(): React.JSX.Element {
+    return <VariableChip expr={this.__expr} />;
+  }
+}
+
+export const $createVariableNode = (expr: string): VariableNode =>
+  new VariableNode(expr);
+
+export const $isVariableNode = (
+  node: LexicalNode | null | undefined
+): node is VariableNode => node instanceof VariableNode;

--- a/web/src/components/node_types/editing/promptComposer/__tests__/assetDrag.test.ts
+++ b/web/src/components/node_types/editing/promptComposer/__tests__/assetDrag.test.ts
@@ -1,0 +1,46 @@
+import { hasAssetDrag, readAssetDrag } from "../assetDrag";
+import { DRAG_DATA_MIME } from "../../../../../lib/dragdrop/serialization";
+
+/** Minimal DataTransfer stand-in: a key/value map + a `types` list. */
+const fakeDataTransfer = (entries: Record<string, string>): DataTransfer =>
+  ({
+    types: Object.keys(entries),
+    files: [] as unknown as FileList,
+    getData: (key: string) => entries[key] ?? ""
+  }) as unknown as DataTransfer;
+
+describe("assetDrag", () => {
+  it("reads a single full asset from a drop", () => {
+    const asset = { id: "a1", name: "cat.png", content_type: "image/png" };
+    const dt = fakeDataTransfer({
+      [DRAG_DATA_MIME]: JSON.stringify({ type: "asset", payload: asset }),
+      asset: JSON.stringify(asset)
+    });
+    const drag = readAssetDrag(dt);
+    expect(drag).toEqual({ assets: [asset], pendingIds: [] });
+  });
+
+  it("reads pending ids from a multi-asset drop", () => {
+    const dt = fakeDataTransfer({
+      [DRAG_DATA_MIME]: JSON.stringify({
+        type: "assets-multiple",
+        payload: ["a1", "a2"]
+      })
+    });
+    const drag = readAssetDrag(dt);
+    expect(drag).toEqual({ assets: [], pendingIds: ["a1", "a2"] });
+  });
+
+  it("returns null for non-asset drags", () => {
+    expect(readAssetDrag(fakeDataTransfer({}))).toBeNull();
+    expect(readAssetDrag(null)).toBeNull();
+  });
+
+  it("detects asset drags during dragover without reading payloads", () => {
+    expect(hasAssetDrag(fakeDataTransfer({ asset: "x" }))).toBe(true);
+    expect(hasAssetDrag(fakeDataTransfer({ selectedAssetIds: "x" }))).toBe(true);
+    expect(hasAssetDrag(fakeDataTransfer({ [DRAG_DATA_MIME]: "x" }))).toBe(true);
+    expect(hasAssetDrag(fakeDataTransfer({ "text/plain": "x" }))).toBe(false);
+    expect(hasAssetDrag(null)).toBe(false);
+  });
+});

--- a/web/src/components/node_types/editing/promptComposer/__tests__/insertAssetMention.test.ts
+++ b/web/src/components/node_types/editing/promptComposer/__tests__/insertAssetMention.test.ts
@@ -1,0 +1,87 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor
+} from "lexical";
+
+import { AssetMentionNode, $createAssetMentionNode } from "../AssetMentionNode";
+import { VariableNode } from "../VariableNode";
+import { $insertAssetMention, $serializePrompt } from "../promptEditorState";
+
+const makeEditor = () =>
+  createEditor({
+    namespace: "test",
+    nodes: [AssetMentionNode, VariableNode],
+    onError: (e) => {
+      throw e;
+    }
+  });
+
+/** Run an update synchronously and read back the serialized prompt. */
+const serializeAfter = (
+  build: () => void
+): Promise<string> =>
+  new Promise((resolve) => {
+    const editor = makeEditor();
+    editor.update(build, {
+      onUpdate: () => {
+        resolve(editor.getEditorState().read(() => $serializePrompt()));
+      }
+    });
+  });
+
+describe("$insertAssetMention", () => {
+  it("pads a URN dropped into the middle of a word", async () => {
+    const out = await serializeAfter(() => {
+      const root = $getRoot();
+      root.clear();
+      const p = $createParagraphNode();
+      const text = $createTextNode("foobar");
+      p.append(text);
+      root.append(p);
+      text.select(3, 3);
+      $insertAssetMention($createAssetMentionNode("asset://abc.png", "abc"));
+    });
+    expect(out).toBe("foo asset://abc.png bar");
+  });
+
+  it("adds no leading space at the start of a line", async () => {
+    const out = await serializeAfter(() => {
+      const root = $getRoot();
+      root.clear();
+      const p = $createParagraphNode();
+      root.append(p);
+      p.select();
+      $insertAssetMention($createAssetMentionNode("asset://abc.png", "abc"));
+    });
+    expect(out).toBe("asset://abc.png ");
+  });
+
+  it("does not double an existing trailing space", async () => {
+    const out = await serializeAfter(() => {
+      const root = $getRoot();
+      root.clear();
+      const p = $createParagraphNode();
+      const text = $createTextNode("see  rest");
+      p.append(text);
+      root.append(p);
+      text.select(4, 4); // caret between the two spaces of "see  rest"
+      $insertAssetMention($createAssetMentionNode("asset://abc.png", "abc"));
+    });
+    expect(out).toBe("see asset://abc.png rest");
+  });
+
+  it("keeps consecutive mentions space-separated", async () => {
+    const out = await serializeAfter(() => {
+      const root = $getRoot();
+      root.clear();
+      const p = $createParagraphNode();
+      root.append(p);
+      p.select();
+      $insertAssetMention($createAssetMentionNode("asset://a.png", "a"));
+      $insertAssetMention($createAssetMentionNode("asset://b.png", "b"));
+    });
+    expect(out).toBe("asset://a.png asset://b.png ");
+  });
+});

--- a/web/src/components/node_types/editing/promptComposer/__tests__/promptTokens.test.ts
+++ b/web/src/components/node_types/editing/promptComposer/__tests__/promptTokens.test.ts
@@ -1,0 +1,116 @@
+import {
+  assetMediaKind,
+  assetToUri,
+  extForAsset,
+  parseAssetUri,
+  tokenizePrompt,
+  tokenizePromptLine,
+  tokensToPrompt,
+  variablesInPrompt
+} from "../promptTokens";
+
+describe("promptTokens", () => {
+  describe("tokenizePromptLine", () => {
+    it("returns a single text token for plain text", () => {
+      expect(tokenizePromptLine("hello world")).toEqual([
+        { kind: "text", text: "hello world" }
+      ]);
+    });
+
+    it("splits an asset mention from surrounding text", () => {
+      expect(tokenizePromptLine("see asset://abc.png here")).toEqual([
+        { kind: "text", text: "see " },
+        { kind: "asset", uri: "asset://abc.png", assetId: "abc", ext: "png" },
+        { kind: "text", text: " here" }
+      ]);
+    });
+
+    it("splits a variable reference", () => {
+      expect(tokenizePromptLine("Hi {{ name }}!")).toEqual([
+        { kind: "text", text: "Hi " },
+        { kind: "variable", expr: "name" },
+        { kind: "text", text: "!" }
+      ]);
+    });
+
+    it("preserves a filter expression inside a variable", () => {
+      expect(tokenizePromptLine("{{ title|upper }}")).toEqual([
+        { kind: "variable", expr: "title|upper" }
+      ]);
+    });
+
+    it("does not consume a trailing sentence period into the asset URI", () => {
+      expect(tokenizePromptLine("look at asset://x.jpg.")).toEqual([
+        { kind: "text", text: "look at " },
+        { kind: "asset", uri: "asset://x.jpg", assetId: "x", ext: "jpg" },
+        { kind: "text", text: "." }
+      ]);
+    });
+
+    it("handles adjacent asset and variable tokens", () => {
+      expect(tokenizePromptLine("asset://a.png{{ v }}")).toEqual([
+        { kind: "asset", uri: "asset://a.png", assetId: "a", ext: "png" },
+        { kind: "variable", expr: "v" }
+      ]);
+    });
+  });
+
+  describe("round-trip", () => {
+    it("re-serializes a multi-line prompt to canonical form", () => {
+      const original =
+        "Describe asset://img-1.png\nfor {{ audience }} in {{ tone }} tone";
+      expect(tokensToPrompt(tokenizePrompt(original))).toBe(original);
+    });
+
+    it("canonicalizes variable spacing on round-trip", () => {
+      expect(tokensToPrompt(tokenizePrompt("{{name}}"))).toBe("{{ name }}");
+    });
+
+    it("preserves blank lines", () => {
+      const original = "line one\n\nline three";
+      expect(tokensToPrompt(tokenizePrompt(original))).toBe(original);
+    });
+  });
+
+  describe("asset helpers", () => {
+    it("derives an extension from the asset name", () => {
+      expect(extForAsset({ name: "photo.JPEG", content_type: "image/jpeg" })).toBe(
+        "jpeg"
+      );
+    });
+
+    it("falls back to the content type when the name has no extension", () => {
+      expect(extForAsset({ name: "clip", content_type: "audio/mpeg" })).toBe(
+        "mp3"
+      );
+    });
+
+    it("builds an asset URN", () => {
+      expect(
+        assetToUri({ id: "abc123", name: "x.png", content_type: "image/png" })
+      ).toBe("asset://abc123.png");
+    });
+
+    it("parses an asset URN back to id + ext", () => {
+      expect(parseAssetUri("asset://abc123.png")).toEqual({
+        assetId: "abc123",
+        ext: "png"
+      });
+    });
+
+    it("classifies media kinds by extension", () => {
+      expect(assetMediaKind("png")).toBe("image");
+      expect(assetMediaKind("mp3")).toBe("audio");
+      expect(assetMediaKind("mp4")).toBe("video");
+      expect(assetMediaKind("txt")).toBe("other");
+    });
+  });
+
+  describe("variablesInPrompt", () => {
+    it("collects distinct variable names", () => {
+      expect(
+        variablesInPrompt("{{ a }} and {{ b }} and {{ a }}")
+      ).toEqual(["a", "b"]);
+    });
+  });
+});

--- a/web/src/components/node_types/editing/promptComposer/assetDrag.ts
+++ b/web/src/components/node_types/editing/promptComposer/assetDrag.ts
@@ -1,0 +1,46 @@
+/**
+ * Bridge between the app's drag-and-drop payloads and the Prompt composer.
+ *
+ * Assets dragged from the asset browser / search arrive either as a single
+ * full `Asset` (`type: "asset"`) or as a list of ids (`type: "assets-multiple"`).
+ * The composer turns each into an asset-mention chip (`asset://<id>.<ext>`).
+ */
+import type { Asset } from "../../../../stores/ApiTypes";
+import {
+  DRAG_DATA_MIME,
+  deserializeDragData
+} from "../../../../lib/dragdrop/serialization";
+
+export interface AssetDrag {
+  /** Fully-resolved assets (single-asset drags carry the whole object). */
+  assets: Asset[];
+  /** Asset ids that still need resolving (multi-select drags carry ids only). */
+  pendingIds: string[];
+}
+
+/** Cheap check usable during `dragover`, where payload contents are hidden. */
+export const hasAssetDrag = (dataTransfer: DataTransfer | null): boolean =>
+  !!dataTransfer &&
+  (dataTransfer.types.includes(DRAG_DATA_MIME) ||
+    dataTransfer.types.includes("asset") ||
+    dataTransfer.types.includes("selectedAssetIds"));
+
+/** Read a drop's asset payload, or `null` when it isn't an asset drag. */
+export const readAssetDrag = (
+  dataTransfer: DataTransfer | null
+): AssetDrag | null => {
+  if (!dataTransfer) {
+    return null;
+  }
+  const data = deserializeDragData(dataTransfer);
+  if (!data) {
+    return null;
+  }
+  if (data.type === "asset") {
+    return { assets: [data.payload as Asset], pendingIds: [] };
+  }
+  if (data.type === "assets-multiple") {
+    return { assets: [], pendingIds: data.payload as string[] };
+  }
+  return null;
+};

--- a/web/src/components/node_types/editing/promptComposer/promptComposerContext.ts
+++ b/web/src/components/node_types/editing/promptComposer/promptComposerContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+export interface PromptComposerContextValue {
+  /** Names of the node's dynamic inputs — variables that resolve at runtime. */
+  knownVariables: Set<string>;
+}
+
+export const PromptComposerContext = createContext<PromptComposerContextValue>({
+  knownVariables: new Set<string>()
+});
+
+export const usePromptComposerContext = (): PromptComposerContextValue =>
+  useContext(PromptComposerContext);

--- a/web/src/components/node_types/editing/promptComposer/promptEditorState.ts
+++ b/web/src/components/node_types/editing/promptComposer/promptEditorState.ts
@@ -6,12 +6,16 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $insertNodes,
   $isElementNode,
-  type ElementNode
+  $isTextNode,
+  type ElementNode,
+  type LexicalNode
 } from "lexical";
 
 import {
-  $createAssetMentionNode
+  $createAssetMentionNode,
+  type AssetMentionNode
 } from "./AssetMentionNode";
 import { $createVariableNode } from "./VariableNode";
 import { parseAssetUri, tokenizePrompt } from "./promptTokens";
@@ -21,6 +25,38 @@ const shortAssetLabel = (uri: string): string => {
   const { assetId, ext } = parseAssetUri(uri);
   const id = assetId.length > 10 ? `${assetId.slice(0, 8)}…` : assetId;
   return ext ? `${id}.${ext}` : id;
+};
+
+const endsWithSpace = (text: string): boolean => /\s$/.test(text);
+const startsWithSpace = (text: string): boolean => /^\s/.test(text);
+
+/**
+ * Insert an asset-mention chip at the current selection (or in place of
+ * `nodeToReplace`), guaranteeing the URN ends up surrounded by spaces so it
+ * never glues to adjacent text in the serialized prompt.
+ */
+export const $insertAssetMention = (
+  node: AssetMentionNode,
+  nodeToReplace?: LexicalNode | null
+): void => {
+  if (nodeToReplace) {
+    nodeToReplace.replace(node);
+  } else {
+    $insertNodes([node]);
+  }
+  const prev = node.getPreviousSibling();
+  const prevIsSpacedText = $isTextNode(prev) && endsWithSpace(prev.getTextContent());
+  // No leading space at the very start of a line; otherwise pad unless the
+  // preceding text already ends in whitespace.
+  if (prev !== null && !prevIsSpacedText) {
+    node.insertBefore($createTextNode(" "));
+  }
+  const next = node.getNextSibling();
+  const nextIsSpacedText =
+    $isTextNode(next) && startsWithSpace(next.getTextContent());
+  if (!nextIsSpacedText) {
+    node.insertAfter($createTextNode(" "));
+  }
 };
 
 /** Serialize the editor tree to the canonical prompt string. */

--- a/web/src/components/node_types/editing/promptComposer/promptEditorState.ts
+++ b/web/src/components/node_types/editing/promptComposer/promptEditorState.ts
@@ -1,0 +1,64 @@
+/**
+ * Lexical `$`-helpers that bridge the editor tree and the on-disk prompt
+ * string. Run inside an `editor.update` / `editorState.read` callback.
+ */
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  type ElementNode
+} from "lexical";
+
+import {
+  $createAssetMentionNode
+} from "./AssetMentionNode";
+import { $createVariableNode } from "./VariableNode";
+import { parseAssetUri, tokenizePrompt } from "./promptTokens";
+
+/** Short, human-friendly chip label for an asset URN seen at load time. */
+const shortAssetLabel = (uri: string): string => {
+  const { assetId, ext } = parseAssetUri(uri);
+  const id = assetId.length > 10 ? `${assetId.slice(0, 8)}…` : assetId;
+  return ext ? `${id}.${ext}` : id;
+};
+
+/** Serialize the editor tree to the canonical prompt string. */
+export const $serializePrompt = (): string =>
+  $getRoot()
+    .getChildren()
+    .map((block) =>
+      $isElementNode(block)
+        ? (block as ElementNode)
+            .getChildren()
+            .map((child) => child.getTextContent())
+            .join("")
+        : block.getTextContent()
+    )
+    .join("\n");
+
+/** Replace the editor contents with the parsed representation of `text`. */
+export const $setPromptFromString = (text: string): void => {
+  const root = $getRoot();
+  root.clear();
+  const lines = tokenizePrompt(text);
+  if (lines.length === 0) {
+    root.append($createParagraphNode());
+    return;
+  }
+  for (const lineTokens of lines) {
+    const paragraph = $createParagraphNode();
+    for (const token of lineTokens) {
+      if (token.kind === "text") {
+        paragraph.append($createTextNode(token.text));
+      } else if (token.kind === "asset") {
+        paragraph.append(
+          $createAssetMentionNode(token.uri, shortAssetLabel(token.uri))
+        );
+      } else {
+        paragraph.append($createVariableNode(token.expr));
+      }
+    }
+    root.append(paragraph);
+  }
+};

--- a/web/src/components/node_types/editing/promptComposer/promptTokens.ts
+++ b/web/src/components/node_types/editing/promptComposer/promptTokens.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure tokenizer + (de)serialization helpers for the Prompt composer.
+ *
+ * The Prompt node stores its prompt as a plain string. Two kinds of inline
+ * reference get a chip in the composer and a stable text encoding on disk:
+ *
+ *   - Asset mentions  → `asset://<id>.<ext>`  (dereferenced to media by the
+ *                        runtime before the prompt reaches a provider)
+ *   - Variables       → `{{ name }}`          (substituted from the node's
+ *                        dynamic inputs at runtime)
+ *
+ * Keeping the parsing here (free of Lexical) makes the round-trip testable and
+ * lets the Lexical nodes/plugins stay thin.
+ */
+
+export interface TextToken {
+  kind: "text";
+  text: string;
+}
+
+export interface AssetToken {
+  kind: "asset";
+  /** Full `asset://<id>.<ext>` reference, stored verbatim. */
+  uri: string;
+  assetId: string;
+  /** Lowercased extension without the dot, or "" when absent. */
+  ext: string;
+}
+
+export interface VariableToken {
+  kind: "variable";
+  /** Inner expression, e.g. "name" or "name|upper". */
+  expr: string;
+}
+
+export type PromptToken = TextToken | AssetToken | VariableToken;
+
+// Group 1: asset URI. Group 2: variable inner expression.
+const TOKEN_RE = /(asset:\/\/[A-Za-z0-9._~\-/]+)|\{\{\s*([^}]+?)\s*\}\}/g;
+
+const IMAGE_EXTS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "svg"
+]);
+const AUDIO_EXTS = new Set([
+  "mp3",
+  "mpeg",
+  "wav",
+  "ogg",
+  "m4a",
+  "aac",
+  "flac",
+  "opus"
+]);
+const VIDEO_EXTS = new Set(["mp4", "webm", "mov", "mkv", "avi"]);
+
+export type AssetMediaKind = "image" | "audio" | "video" | "other";
+
+const CONTENT_TYPE_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/ogg": "ogg",
+  "audio/mp4": "m4a",
+  "audio/flac": "flac",
+  "video/mp4": "mp4",
+  "video/webm": "webm"
+};
+
+/** Derive a file extension for an asset from its name, then content type. */
+export const extForAsset = (asset: {
+  name?: string | null;
+  content_type?: string | null;
+}): string => {
+  const name = asset.name ?? "";
+  const dot = name.lastIndexOf(".");
+  if (dot > 0 && dot < name.length - 1) {
+    return name.slice(dot + 1).toLowerCase();
+  }
+  const ct = (asset.content_type ?? "").toLowerCase();
+  if (ct in CONTENT_TYPE_EXT) {
+    return CONTENT_TYPE_EXT[ct];
+  }
+  const slash = ct.indexOf("/");
+  if (slash >= 0) {
+    const sub = ct.slice(slash + 1).split("+")[0];
+    if (sub) {
+      return sub;
+    }
+  }
+  return "";
+};
+
+/** Build the `asset://<id>.<ext>` URN for a mentioned asset. */
+export const assetToUri = (asset: {
+  id: string;
+  name?: string | null;
+  content_type?: string | null;
+}): string => {
+  const ext = extForAsset(asset);
+  return ext ? `asset://${asset.id}.${ext}` : `asset://${asset.id}`;
+};
+
+export const parseAssetUri = (
+  uri: string
+): { assetId: string; ext: string } => {
+  const noScheme = uri.startsWith("asset://")
+    ? uri.slice("asset://".length)
+    : uri;
+  const primary = noScheme.split(/[?#]/)[0];
+  const dot = primary.lastIndexOf(".");
+  if (dot > 0 && dot < primary.length - 1) {
+    return {
+      assetId: primary.slice(0, dot),
+      ext: primary.slice(dot + 1).toLowerCase()
+    };
+  }
+  return { assetId: primary, ext: "" };
+};
+
+export const assetMediaKind = (ext: string): AssetMediaKind => {
+  const e = ext.toLowerCase();
+  if (IMAGE_EXTS.has(e)) {
+    return "image";
+  }
+  if (AUDIO_EXTS.has(e)) {
+    return "audio";
+  }
+  if (VIDEO_EXTS.has(e)) {
+    return "video";
+  }
+  return "other";
+};
+
+/** Serialize a single token back to its on-disk text encoding. */
+export const tokenToString = (token: PromptToken): string => {
+  switch (token.kind) {
+    case "text":
+      return token.text;
+    case "asset":
+      return token.uri;
+    case "variable":
+      return `{{ ${token.expr} }}`;
+  }
+};
+
+/**
+ * Split a single line (no newlines) into ordered tokens. Trailing dots on an
+ * asset URI are treated as sentence punctuation, not part of the extension.
+ */
+export const tokenizePromptLine = (line: string): PromptToken[] => {
+  const tokens: PromptToken[] = [];
+  const pushText = (text: string) => {
+    if (!text) {
+      return;
+    }
+    const last = tokens[tokens.length - 1];
+    if (last && last.kind === "text") {
+      last.text += text;
+    } else {
+      tokens.push({ kind: "text", text });
+    }
+  };
+
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((match = TOKEN_RE.exec(line)) !== null) {
+    if (match[1] !== undefined) {
+      let uri = match[1];
+      const trailingDots = uri.match(/\.+$/);
+      if (trailingDots) {
+        uri = uri.slice(0, uri.length - trailingDots[0].length);
+      }
+      pushText(line.slice(cursor, match.index));
+      const { assetId, ext } = parseAssetUri(uri);
+      tokens.push({ kind: "asset", uri, assetId, ext });
+      cursor = match.index + uri.length;
+    } else {
+      pushText(line.slice(cursor, match.index));
+      tokens.push({ kind: "variable", expr: (match[2] ?? "").trim() });
+      cursor = match.index + match[0].length;
+    }
+  }
+  pushText(line.slice(cursor));
+  return tokens;
+};
+
+/** Tokenize a full multi-line prompt into one token list per line. */
+export const tokenizePrompt = (text: string): PromptToken[][] =>
+  text.split("\n").map(tokenizePromptLine);
+
+/** Re-join tokenized lines back into the on-disk prompt string. */
+export const tokensToPrompt = (lines: PromptToken[][]): string =>
+  lines.map((line) => line.map(tokenToString).join("")).join("\n");
+
+/** Collect the distinct variable expressions referenced in a prompt string. */
+export const variablesInPrompt = (text: string): string[] => {
+  const names = new Set<string>();
+  for (const line of tokenizePrompt(text)) {
+    for (const token of line) {
+      if (token.kind === "variable") {
+        names.add(token.expr);
+      }
+    }
+  }
+  return Array.from(names);
+};

--- a/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
+++ b/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
@@ -4,8 +4,7 @@ const mockFetch = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // @ts-expect-error
-  global.fetch = mockFetch;
+  global.fetch = mockFetch as unknown as typeof fetch;
 });
 
 describe("fetchLiveFalPricing", () => {

--- a/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
+++ b/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
@@ -4,7 +4,8 @@ const mockFetch = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
-  global.fetch = mockFetch as unknown as typeof fetch;
+  // @ts-expect-error
+  global.fetch = mockFetch;
 });
 
 describe("fetchLiveFalPricing", () => {


### PR DESCRIPTION
## Summary

Gives the **Prompt** node (`nodetool.text.Prompt`) a bespoke composer-style body, and makes inline asset references actually reach providers as media.

- **`@`-mention assets** — typing `@` in the composer opens an asset typeahead (searches assets via the store); selecting one inserts a chip encoded as `asset://<id>.<ext>`.
- **Asset dereferencing before the provider** — assets mentioned in a prompt now arrive at the LLM as real image/audio content instead of literal text. The Agent node splits its prompt into a multimodal content array (text interleaved with media blocks carrying the `asset://` URI), and the runtime layer dereferences those URIs to data URIs just before the provider call.
- **Variable chips** — the node's dynamic inputs render as insertable `{{ variable }}` chips so references are visible at a glance; clicking one drops it at the caret, and "+ Add variable" creates a new dynamic input. Missing references are styled distinctly.

### Where things live (per design decisions in the task)
- **URN scheme:** reuses the existing `asset://<id>` reference scheme (no new scheme).
- **Resolution location:** the **runtime layer**, not the node or the providers. The node only does the cheap text→blocks split; `ProcessingContext.resolveMessageMediaUris` (now public) resolves `asset://` URIs via the new `resolveAssetBytes` helper, so providers stay asset-agnostic and the saved thread keeps the compact `asset://` reference.
- **Scope:** the Prompt node only this pass. The composer/mention pieces are factored to be reusable later.

Chips are a visual aid only — the node still stores a plain prompt string, so existing `{{variable}}` substitution and asset dereferencing work whether or not a token is chipped.

## Changes

**Backend** (`packages/`)
- `runtime/src/context.ts`: add `resolveAssetBytes(assetId)`; make `resolveMessageMediaUris` public and resolve `asset://` URIs (image + audio) in addition to storage URIs.
- `base-nodes/src/nodes/agents.ts`: `expandAssetReferences` splits a prompt into text + `image_url`/`audio` blocks carrying `asset://` URIs; the Agent node routes its messages through `resolveMessageMediaUris` before the provider loop.

**Frontend** (`web/`)
- `node_types/editing/PromptComposerBody.tsx`: the bespoke body (Lexical `PlainText` composer + variable bar + dynamic inputs + outputs).
- `node_types/editing/promptComposer/`: `AssetMentionNode`, `VariableNode`, `AssetMentionPlugin` (`@` typeahead), pure `promptTokens` (tokenize/serialize), `promptEditorState` ($-helpers), and a small context for known-variable styling.
- Registered `nodetool.text.Prompt` → `PromptComposerBody` in `bespokeRegistry`.

## Test plan
- [x] `packages/base-nodes` — `expandAssetReferences` unit tests (split, audio, trailing-period, unsupported types, multi-ref) + existing agent/messaging suites pass.
- [x] `packages/runtime` — `resolveMessageMediaUris` dereferences `asset://` image URIs to data URIs; full `context.test` passes.
- [x] `web` — `promptTokens` round-trip/parse unit tests (15) + `PromptComposerBody` mount smoke tests; full `node_types` suite passes; typecheck + eslint clean on changed files.
- [ ] **Manual UI not run in this environment** (headless container, no browser): verify in-app that `@` opens the asset menu, a picked image renders as a chip, the prompt reaches a vision model as an image, and clicking a variable chip inserts it.

https://claude.ai/code/session_01VoDJWf1VC53hXdoA3ei6Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoDJWf1VC53hXdoA3ei6Ry)_