### PR TITLE
Enable logo image in header with Next.js Image component

### DIFF
--- a/marketing/src/components/client/header.tsx
+++ b/marketing/src/components/client/header.tsx
@@ -70,12 +70,14 @@ const Header: React.FC<HeaderProps> = ({ navigation, rightSlot }) => {
         <div className="flex lg:flex-1">
           <Link href="/" className="-m-1.5 p-1.5">
             <span className="sr-only">nodetool</span>
-            {/* <img
-              className="col-span-2 max-h-12 w-full object-contain lg:col-span-1"
+            <Image
+              className="max-h-12 w-auto object-contain"
               src="/logo_small.png"
-              width="64"
-              height="64"
-            /> */}
+              width={64}
+              height={64}
+              alt="nodetool"
+              priority
+            />
           </Link>
         </div>
         <div className="flex lg:hidden">


### PR DESCRIPTION
## Summary
Uncommented and refactored the logo image in the marketing header component to use Next.js `Image` component instead of a raw `<img>` tag, with proper accessibility and performance attributes.

## Changes
- Replaced commented-out `<img>` element with Next.js `Image` component
- Updated className to use `w-auto` instead of `w-full` for proper aspect ratio preservation
- Changed width/height attributes from strings to numbers (64 and 64)
- Added `alt` attribute for accessibility ("nodetool")
- Added `priority` prop to optimize logo loading (above-the-fold image)

## Implementation Details
The logo is now properly optimized using Next.js Image component, which provides automatic format optimization, responsive sizing, and lazy loading (disabled via `priority` since it's in the header). The `w-auto` class ensures the logo maintains its aspect ratio while respecting the `max-h-12` constraint.

https://claude.ai/code/session_01EA8wnDkCxfKDxpSYpwN6Ya