### PR TITLE
Fix web typecheck errors in exposedInputs

### DIFF
--- a/web/src/utils/__tests__/exposedInputs.test.ts
+++ b/web/src/utils/__tests__/exposedInputs.test.ts
@@ -161,8 +161,16 @@ describe("exposedInputs utility", () => {
       const md = baseMetadata({
         input_fields: ["image"],
         properties: [
-          { name: "image", type: { type: "image", type_args: [], optional: false } },
-          { name: "prompt", type: { type: "str", type_args: [], optional: false } }
+          {
+            name: "image",
+            required: true,
+            type: { type: "image", type_args: [], optional: false }
+          },
+          {
+            name: "prompt",
+            required: true,
+            type: { type: "str", type_args: [], optional: false }
+          }
         ]
       });
       expect(canConfigureExposedPlacement(md, "image")).toBe(true);

--- a/web/src/utils/exposedInputs.ts
+++ b/web/src/utils/exposedInputs.ts
@@ -21,9 +21,14 @@ export const nextExposedInputPlacement = (
   return null;
 };
 
+type ExposedPlacementMetadata = Pick<
+  NodeMetadata,
+  "input_fields" | "inline_fields"
+>;
+
 /** Metadata default before per-node overrides. */
 export const getDefaultExposedPlacement = (
-  metadata: NodeMetadata,
+  metadata: ExposedPlacementMetadata,
   propertyName: string
 ): ExposedInputPlacement | null => {
   if ((metadata.input_fields ?? []).includes(propertyName)) {
@@ -174,7 +179,7 @@ export type ExposedInputListsPatch = {
  * inline_fields). Uses override lists only when target differs from default.
  */
 export const applyExposedPlacementTarget = (
-  metadata: NodeMetadata,
+  metadata: ExposedPlacementMetadata,
   data: ExposedInputPlacementData,
   propertyName: string,
   target: ExposedInputPlacement | null
@@ -231,7 +236,7 @@ export const patchExposedInputPlacement = (
   placement: ExposedInputPlacement | null
 ): ExposedInputListsPatch =>
   applyExposedPlacementTarget(
-    { input_fields: [], inline_fields: [] } as NodeMetadata,
+    { input_fields: [], inline_fields: [] },
     data,
     propertyName,
     placement


### PR DESCRIPTION
Narrow the metadata parameter of getDefaultExposedPlacement and
applyExposedPlacementTarget to Pick<NodeMetadata, "input_fields" |
"inline_fields"> so patchExposedInputPlacement no longer needs an
invalid cast to NodeMetadata. Add required: true to the test fixtures
to match the current Property type.

https://claude.ai/code/session_01TmsKKtoXXieSJWShEGW13s