### PR TITLE
Fix broken marketing images: disable Next image optimization

### DIFF
--- a/marketing/next.config.mjs
+++ b/marketing/next.config.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   outputFileTracingRoot: __dirname,
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/marketing/src/components/client/header.tsx
+++ b/marketing/src/components/client/header.tsx
@@ -70,12 +70,14 @@ const Header: React.FC<HeaderProps> = ({ navigation, rightSlot }) => {
         <div className="flex lg:flex-1">
           <Link href="/" className="-m-1.5 p-1.5">
             <span className="sr-only">nodetool</span>
-            {/* <img
-              className="col-span-2 max-h-12 w-full object-contain lg:col-span-1"
+            <Image
+              className="max-h-12 w-auto object-contain"
               src="/logo_small.png"
-              width="64"
-              height="64"
-            /> */}
+              width={64}
+              height={64}
+              alt="nodetool"
+              priority
+            />
           </Link>
         </div>
         <div className="flex lg:hidden">


### PR DESCRIPTION
## Summary
- Marketing images served through Next's `/_next/image` optimizer return **HTTP 500** on Cloudflare because Image Transformations are not enabled for the `nodetool.ai` zone (the `IMAGES` binding optimizer throws at runtime).
- Set `images.unoptimized: true` in `marketing/next.config.mjs` so `next/image` serves the originals directly via the Cloudflare `ASSETS` binding. The raw asset URLs already return 200 (e.g. `/logo_small.png`), so all marketing images now render.
- Reversible: once Image Transformations are enabled on the zone, remove `unoptimized` to restore on-the-fly optimization. The `IMAGES` binding in `wrangler.jsonc` is left in place for that path.

## Test plan
- [ ] Merge, let Workers Build (`nodetool-marketing`) deploy
- [ ] Confirm images render across the site (logo, screenshots, use-case images)
- [ ] Verify `src` URLs resolve directly (e.g. `https://nodetool.ai/logo_small.png` → 200) instead of `/_next/image`

https://claude.ai/code/session_01EA8wnDkCxfKDxpSYpwN6Ya

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA8wnDkCxfKDxpSYpwN6Ya)_