### PR TITLE
fix(ContentCardBody): allow preview to shrink to its min-height

### DIFF
--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -81,7 +81,7 @@ const styles = (theme: Theme) =>
     // params (flex-shrink: 0) clip at the bottom via node-content-container.
     ".preview-area": {
       position: "relative",
-      flex: "1 0 auto",
+      flex: "1 1 auto",
       minHeight: theme.spacing(6),
       borderRadius: "var(--rounded-sm)",
       // Allow the handle column to extend past the preview's left edge so


### PR DESCRIPTION
Restore flex-shrink: 1 on the preview area. With flex-shrink: 0 plus a
48px min-height floor, the preview refused to yield any space when the
node was resized small, so params overflowed past the bottom instead of
being clipped by node-content-container as the comment describes.