### PR TITLE
Add nightly Docker image retagging to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -669,6 +669,64 @@ jobs:
             electron/dist/*.blockmap
             electron/dist/*.yml
 
+  nightly-docker-tag:
+    name: Retag GHCR image for nightly
+    needs: [preflight]
+    if: ${{ !failure() && !cancelled() && needs.preflight.outputs.release_channel == 'nightly' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The `docker.yml` workflow already built and pushed
+      # `ghcr.io/nodetool-ai/nodetool:main-<short_sha>` when this commit landed
+      # on main. Reuse that manifest under the nightly version tag instead of
+      # rebuilding. `buildx imagetools create` only writes a new tag pointing
+      # at the existing manifest — no layer pulls or pushes.
+      - name: Retag main-<sha> to nightly version
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          short_sha="${SHA:0:7}"
+          src="ghcr.io/nodetool-ai/nodetool:main-${short_sha}"
+          version_tag="ghcr.io/nodetool-ai/nodetool:${VERSION}"
+          nightly_tag="ghcr.io/nodetool-ai/nodetool:nightly"
+
+          # The docker.yml build for the same commit may still be running.
+          # Poll for the source manifest before retagging.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if docker buildx imagetools inspect "$src" > /dev/null 2>&1; then
+              echo "Found source image: $src"
+              break
+            fi
+            echo "Source image $src not found yet (attempt $attempt/10); sleeping 60s..."
+            sleep 60
+          done
+
+          if ! docker buildx imagetools inspect "$src" > /dev/null 2>&1; then
+            echo "Source image $src never appeared; failing." >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --tag "$version_tag" \
+            --tag "$nightly_tag" \
+            "$src"
+
+          echo "Retagged $src -> $version_tag, $nightly_tag"
+
   publish-release:
     name: Publish GitHub Release
     needs: [preflight, release-build]


### PR DESCRIPTION
## Summary

Adds a new `nightly-docker-tag` job to the release workflow that reuses the Docker image built by the `docker.yml` workflow and retaggs it with both the version tag and `nightly` tag when releasing a nightly build.

## Key Changes

- **New `nightly-docker-tag` job**: Runs after `preflight` when the release channel is `nightly`
  - Sets up Docker Buildx and authenticates to GHCR
  - Polls for the source image (`main-<short_sha>`) built by the `docker.yml` workflow with up to 10 attempts (60s intervals) to handle timing where the docker build may still be running
  - Uses `docker buildx imagetools create` to efficiently retag the existing manifest without rebuilding layers
  - Creates two tags: the version-specific tag and the `nightly` tag pointing to the same image manifest

## Implementation Details

- The job only runs on nightly releases (`needs.preflight.outputs.release_channel == 'nightly'`)
- Polling mechanism ensures the source image is available before attempting to retag, with clear error messaging if the image never appears
- Uses `buildx imagetools` which only writes new tags to existing manifests—no layer pulls or pushes, making it efficient
- Requires `packages: write` permission to push tags to GHCR

https://claude.ai/code/session_01YUxxN7DDiK399nfwxPsKLE