### PR TITLE
Reorganize documentation structure and navigation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -38,38 +38,87 @@ titles_from_headings:
   strip_title: false
   collections: false
 
-# Navigation
+# Navigation (sidebar source of truth lives in _includes/sidebar.html;
+# this list mirrors section order for plugins and sitemap output)
 header_pages:
+  # Getting Started
   - index.md
-  - getting-started.md
-  - key-concepts.md
-  - user-interface.md
-  - workflow-editor.md
-  - image-editor.md
-  - vibecoding.md
-  - workflow-debugging.md
-  - mobile-app.md
-  - cookbook.md
-  - workflows/index.md
-  - comfyui-integration.md
-  - models-and-providers.md
-  - global-chat-agents.md
-  - deployment.md
-  - deployment-e2e-guide.md
-  - storage.md
-  - api-reference.md
-  - developer/index.md
-  - architecture.md
-  - installation.md
-  - troubleshooting.md
   - comparisons.md
-  - tips-and-tricks.md
+  - installation.md
+  - getting-started.md
+  # Core Concepts
+  - key-concepts.md
+  - workflow-editor.md
+  - nodes/index.md
+  - global-chat-agents.md
+  - models-and-providers.md
+  - glossary.md
+  # Workflow Editor
+  - user-interface.md
+  - editor-panels.md
+  - chain-editor.md
+  - workflow-graph-view.md
+  - workflow-debugging.md
+  - image-editor.md
+  - templates-gallery.md
+  - vibecoding.md
+  - comfyui-integration.md
+  # Chat & Agents
   - global-chat.md
+  - agent-config-schema.md
+  - agent-memory.md
+  # Models & Providers
   - models.md
   - providers.md
   - huggingface.md
+  - models-manager.md
+  # Examples
+  - cookbook.md
+  - workflows/index.md
+  # Configuration
+  - configuration.md
+  - storage.md
+  - vector-storage.md
+  - indexing.md
+  - collections.md
   - asset-management.md
-  - nodes/index.md
+  - authentication.md
+  - security-hardening.md
+  - proxy.md
+  # Deployment
+  - deployment.md
+  - deployment-e2e-guide.md
+  - self-hosted-deployment.md
+  - docker-resource-management.md
+  - runpod-deployment.md
+  - gcp-deployment.md
+  - supabase-deployment.md
+  # CLI
+  - cli.md
+  - chat-cli.md
+  - agent-cli.md
+  - chat-server.md
+  - api-server.md
+  - terminal-websocket.md
+  # API Reference
+  - api-reference.md
+  - workflow-api.md
+  - websocket-api.md
+  - chat-api.md
+  # Developers
+  - developer/index.md
+  - architecture.md
+  - packages.md
+  - python-bridge-protocol.md
+  - execution-strategies.md
+  - node-packs.md
+  # Apps
+  - desktop-app.md
+  - electron-views.md
+  - mobile-app.md
+  # Help
+  - troubleshooting.md
+  - tips-and-tricks.md
 
 # Collections (optional, for organizing docs)
 # collections:

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -13,21 +13,35 @@
     <nav class="sidebar-nav">
       <details class="nav-section" data-section="start" open>
         <summary class="nav-section-summary">
-          <h4 class="nav-section-title">New to NodeTool?</h4>
+          <h4 class="nav-section-title">Getting Started</h4>
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
+          <li><a href="{{ '/' | relative_url }}" class="sidebar-link" data-nav-path="/">Introduction</a></li>
+          <li><a href="{{ '/comparisons' | relative_url }}" class="sidebar-link" data-nav-path="/comparisons">Why NodeTool</a></li>
           <li><a href="{{ '/installation' | relative_url }}" class="sidebar-link" data-nav-path="/installation">Installation</a></li>
-          <li><a href="{{ '/getting-started' | relative_url }}" class="sidebar-link" data-nav-path="/getting-started">Getting Started</a></li>
-          <li><a href="{{ '/key-concepts' | relative_url }}" class="sidebar-link" data-nav-path="/key-concepts">Key Concepts</a></li>
-          <li><a href="{{ '/glossary' | relative_url }}" class="sidebar-link" data-nav-path="/glossary">Glossary</a></li>
-          <li><a href="{{ '/comparisons' | relative_url }}" class="sidebar-link" data-nav-path="/comparisons">How NodeTool Compares</a></li>
+          <li><a href="{{ '/getting-started' | relative_url }}" class="sidebar-link" data-nav-path="/getting-started">Quick Start</a></li>
         </ul>
       </details>
 
-      <details class="nav-section" data-section="learn" open>
+      <details class="nav-section" data-section="concepts" open>
         <summary class="nav-section-summary">
-          <h4 class="nav-section-title">Learn</h4>
+          <h4 class="nav-section-title">Core Concepts</h4>
+          <span class="nav-section-chevron" aria-hidden="true"></span>
+        </summary>
+        <ul class="nav-section-list">
+          <li><a href="{{ '/key-concepts' | relative_url }}" class="sidebar-link" data-nav-path="/key-concepts">Key Concepts</a></li>
+          <li><a href="{{ '/workflow-editor' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-editor">Workflows</a></li>
+          <li><a href="{{ '/nodes/' | relative_url }}" class="sidebar-link" data-nav-path="/nodes">Nodes</a></li>
+          <li><a href="{{ '/global-chat-agents' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat-agents">Agents</a></li>
+          <li><a href="{{ '/models-and-providers' | relative_url }}" class="sidebar-link" data-nav-path="/models-and-providers">Models</a></li>
+          <li><a href="{{ '/glossary' | relative_url }}" class="sidebar-link" data-nav-path="/glossary">Glossary</a></li>
+        </ul>
+      </details>
+
+      <details class="nav-section" data-section="editor">
+        <summary class="nav-section-summary">
+          <h4 class="nav-section-title">Workflow Editor</h4>
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
@@ -35,32 +49,25 @@
           <li><a href="{{ '/workflow-editor' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-editor">Workflow Editor</a></li>
           <li><a href="{{ '/editor-panels' | relative_url }}" class="sidebar-link" data-nav-path="/editor-panels">Editor Panels</a></li>
           <li><a href="{{ '/chain-editor' | relative_url }}" class="sidebar-link" data-nav-path="/chain-editor">Chain Editor</a></li>
-          <li><a href="{{ '/workflow-graph-view' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-graph-view">Workflow Graph View</a></li>
-          <li><a href="{{ '/workflow-debugging' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-debugging">Debugging Workflows</a></li>
-          <li><a href="{{ '/templates-gallery' | relative_url }}" class="sidebar-link" data-nav-path="/templates-gallery">Templates Gallery</a></li>
-          <li><a href="{{ '/collections' | relative_url }}" class="sidebar-link" data-nav-path="/collections">Collections</a></li>
-          <li><a href="{{ '/global-chat' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat">Global Chat</a></li>
-          <li><a href="{{ '/global-chat-agents' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat-agents">Global Chat &amp; Agents</a></li>
+          <li><a href="{{ '/workflow-graph-view' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-graph-view">Graph View</a></li>
+          <li><a href="{{ '/workflow-debugging' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-debugging">Debugging</a></li>
           <li><a href="{{ '/image-editor' | relative_url }}" class="sidebar-link" data-nav-path="/image-editor">Image Editor</a></li>
-          <li><a href="{{ '/comfyui-integration' | relative_url }}" class="sidebar-link" data-nav-path="/comfyui-integration">ComfyUI Integration</a></li>
+          <li><a href="{{ '/templates-gallery' | relative_url }}" class="sidebar-link" data-nav-path="/templates-gallery">Templates Gallery</a></li>
           <li><a href="{{ '/vibecoding' | relative_url }}" class="sidebar-link" data-nav-path="/vibecoding">VibeCoding</a></li>
-          <li><a href="{{ '/mobile-app' | relative_url }}" class="sidebar-link" data-nav-path="/mobile-app">Mobile App</a></li>
-          <li><a href="{{ '/electron-views' | relative_url }}" class="sidebar-link" data-nav-path="/electron-views">Desktop App Views</a></li>
-          <li><a href="{{ '/tips-and-tricks' | relative_url }}" class="sidebar-link" data-nav-path="/tips-and-tricks">Tips &amp; Tricks</a></li>
+          <li><a href="{{ '/comfyui-integration' | relative_url }}" class="sidebar-link" data-nav-path="/comfyui-integration">ComfyUI Integration</a></li>
         </ul>
       </details>
 
-      <details class="nav-section" data-section="examples">
+      <details class="nav-section" data-section="chat">
         <summary class="nav-section-summary">
-          <h4 class="nav-section-title">Examples &amp; Nodes</h4>
+          <h4 class="nav-section-title">Chat &amp; Agents</h4>
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/cookbook' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook">Cookbook</a></li>
-          <li><a href="{{ '/workflows/' | relative_url }}" class="sidebar-link" data-nav-path="/workflows">Workflow Examples</a></li>
-          <li><a href="{{ '/asset-management' | relative_url }}" class="sidebar-link" data-nav-path="/asset-management">Asset Management</a></li>
-          <li><a href="{{ '/nodes/' | relative_url }}" class="sidebar-link" data-nav-path="/nodes">Node Reference</a></li>
-          <li><a href="{{ '/node-packs' | relative_url }}" class="sidebar-link" data-nav-path="/node-packs">Node Packs</a></li>
+          <li><a href="{{ '/global-chat' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat">Global Chat</a></li>
+          <li><a href="{{ '/global-chat-agents' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat-agents">Chat &amp; Agents</a></li>
+          <li><a href="{{ '/agent-config-schema' | relative_url }}" class="sidebar-link" data-nav-path="/agent-config-schema">Agent Config</a></li>
+          <li><a href="{{ '/agent-memory' | relative_url }}" class="sidebar-link" data-nav-path="/agent-memory">Agent Memory</a></li>
         </ul>
       </details>
 
@@ -70,11 +77,24 @@
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/models-and-providers' | relative_url }}" class="sidebar-link" data-nav-path="/models-and-providers">Models &amp; Providers</a></li>
+          <li><a href="{{ '/models-and-providers' | relative_url }}" class="sidebar-link" data-nav-path="/models-and-providers">Overview</a></li>
           <li><a href="{{ '/models' | relative_url }}" class="sidebar-link" data-nav-path="/models">Local vs Cloud</a></li>
           <li><a href="{{ '/providers' | relative_url }}" class="sidebar-link" data-nav-path="/providers">Provider Reference</a></li>
           <li><a href="{{ '/huggingface' | relative_url }}" class="sidebar-link" data-nav-path="/huggingface">HuggingFace</a></li>
           <li><a href="{{ '/models-manager' | relative_url }}" class="sidebar-link" data-nav-path="/models-manager">Models Manager</a></li>
+        </ul>
+      </details>
+
+      <details class="nav-section" data-section="examples">
+        <summary class="nav-section-summary">
+          <h4 class="nav-section-title">Examples</h4>
+          <span class="nav-section-chevron" aria-hidden="true"></span>
+        </summary>
+        <ul class="nav-section-list">
+          <li><a href="{{ '/cookbook' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook">Cookbook</a></li>
+          <li><a href="{{ '/cookbook/core-concepts' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/core-concepts">Core Patterns</a></li>
+          <li><a href="{{ '/cookbook/patterns' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/patterns">Pipeline Patterns</a></li>
+          <li><a href="{{ '/workflows/' | relative_url }}" class="sidebar-link" data-nav-path="/workflows">Workflow Examples</a></li>
         </ul>
       </details>
 
@@ -88,10 +108,11 @@
           <li><a href="{{ '/storage' | relative_url }}" class="sidebar-link" data-nav-path="/storage">Storage</a></li>
           <li><a href="{{ '/vector-storage' | relative_url }}" class="sidebar-link" data-nav-path="/vector-storage">Vector Storage</a></li>
           <li><a href="{{ '/indexing' | relative_url }}" class="sidebar-link" data-nav-path="/indexing">Indexing</a></li>
+          <li><a href="{{ '/collections' | relative_url }}" class="sidebar-link" data-nav-path="/collections">Collections</a></li>
+          <li><a href="{{ '/asset-management' | relative_url }}" class="sidebar-link" data-nav-path="/asset-management">Asset Management</a></li>
           <li><a href="{{ '/authentication' | relative_url }}" class="sidebar-link" data-nav-path="/authentication">Authentication</a></li>
           <li><a href="{{ '/security-hardening' | relative_url }}" class="sidebar-link" data-nav-path="/security-hardening">Security Hardening</a></li>
           <li><a href="{{ '/proxy' | relative_url }}" class="sidebar-link" data-nav-path="/proxy">Proxy</a></li>
-          <li><a href="{{ '/troubleshooting' | relative_url }}" class="sidebar-link" data-nav-path="/troubleshooting">Troubleshooting</a></li>
         </ul>
       </details>
 
@@ -104,22 +125,22 @@
           <li><a href="{{ '/deployment' | relative_url }}" class="sidebar-link" data-nav-path="/deployment">Deployment Guide</a></li>
           <li><a href="{{ '/deployment-e2e-guide' | relative_url }}" class="sidebar-link" data-nav-path="/deployment-e2e-guide">End-to-End Guide</a></li>
           <li><a href="{{ '/self-hosted-deployment' | relative_url }}" class="sidebar-link" data-nav-path="/self-hosted-deployment">Self-Hosted</a></li>
+          <li><a href="{{ '/docker-resource-management' | relative_url }}" class="sidebar-link" data-nav-path="/docker-resource-management">Docker Resources</a></li>
           <li><a href="{{ '/runpod-deployment' | relative_url }}" class="sidebar-link" data-nav-path="/runpod-deployment">RunPod</a></li>
           <li><a href="{{ '/gcp-deployment' | relative_url }}" class="sidebar-link" data-nav-path="/gcp-deployment">Google Cloud Run</a></li>
           <li><a href="{{ '/supabase-deployment' | relative_url }}" class="sidebar-link" data-nav-path="/supabase-deployment">Supabase</a></li>
-          <li><a href="{{ '/docker-resource-management' | relative_url }}" class="sidebar-link" data-nav-path="/docker-resource-management">Docker Resources</a></li>
         </ul>
       </details>
 
       <details class="nav-section" data-section="cli">
         <summary class="nav-section-summary">
-          <h4 class="nav-section-title">CLI &amp; Servers</h4>
+          <h4 class="nav-section-title">CLI</h4>
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/cli' | relative_url }}" class="sidebar-link" data-nav-path="/cli">CLI</a></li>
-          <li><a href="{{ '/agent-cli' | relative_url }}" class="sidebar-link" data-nav-path="/agent-cli">Agent CLI</a></li>
+          <li><a href="{{ '/cli' | relative_url }}" class="sidebar-link" data-nav-path="/cli">CLI Overview</a></li>
           <li><a href="{{ '/chat-cli' | relative_url }}" class="sidebar-link" data-nav-path="/chat-cli">Chat CLI</a></li>
+          <li><a href="{{ '/agent-cli' | relative_url }}" class="sidebar-link" data-nav-path="/agent-cli">Agent CLI</a></li>
           <li><a href="{{ '/chat-server' | relative_url }}" class="sidebar-link" data-nav-path="/chat-server">Chat Server</a></li>
           <li><a href="{{ '/api-server' | relative_url }}" class="sidebar-link" data-nav-path="/api-server">API Server</a></li>
           <li><a href="{{ '/terminal-websocket' | relative_url }}" class="sidebar-link" data-nav-path="/terminal-websocket">Terminal WebSocket</a></li>
@@ -132,7 +153,7 @@
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/api-reference' | relative_url }}" class="sidebar-link" data-nav-path="/api-reference">API Overview</a></li>
+          <li><a href="{{ '/api-reference' | relative_url }}" class="sidebar-link" data-nav-path="/api-reference">Overview</a></li>
           <li><a href="{{ '/workflow-api' | relative_url }}" class="sidebar-link" data-nav-path="/workflow-api">Workflow API</a></li>
           <li><a href="{{ '/websocket-api' | relative_url }}" class="sidebar-link" data-nav-path="/websocket-api">WebSocket API</a></li>
           <li><a href="{{ '/chat-api' | relative_url }}" class="sidebar-link" data-nav-path="/chat-api">Chat API</a></li>
@@ -147,14 +168,38 @@
         <ul class="nav-section-list">
           <li><a href="{{ '/developer/' | relative_url }}" class="sidebar-link" data-nav-path="/developer">Developer Guide</a></li>
           <li><a href="{{ '/architecture' | relative_url }}" class="sidebar-link" data-nav-path="/architecture">Architecture</a></li>
+          <li><a href="{{ '/packages' | relative_url }}" class="sidebar-link" data-nav-path="/packages">Packages</a></li>
           <li><a href="{{ '/python-bridge-protocol' | relative_url }}" class="sidebar-link" data-nav-path="/python-bridge-protocol">Python Bridge Protocol</a></li>
           <li><a href="{{ '/execution-strategies' | relative_url }}" class="sidebar-link" data-nav-path="/execution-strategies">Execution Strategies</a></li>
-          <li><a href="{{ '/packages' | relative_url }}" class="sidebar-link" data-nav-path="/packages">Packages</a></li>
-          <li><a href="{{ '/developer/ts-dsl-guide' | relative_url }}" class="sidebar-link" data-nav-path="/developer/ts-dsl-guide">TypeScript DSL</a></li>
-          <li><a href="{{ '/developer/custom-nodes-guide' | relative_url }}" class="sidebar-link" data-nav-path="/developer/custom-nodes-guide">Custom Nodes Guide</a></li>
+          <li><a href="{{ '/developer/custom-nodes-guide' | relative_url }}" class="sidebar-link" data-nav-path="/developer/custom-nodes-guide">Custom Nodes</a></li>
           <li><a href="{{ '/developer/node-patterns' | relative_url }}" class="sidebar-link" data-nav-path="/developer/node-patterns">Node Patterns</a></li>
           <li><a href="{{ '/developer/node-reference' | relative_url }}" class="sidebar-link" data-nav-path="/developer/node-reference">Node Reference</a></li>
+          <li><a href="{{ '/developer/ts-dsl-guide' | relative_url }}" class="sidebar-link" data-nav-path="/developer/ts-dsl-guide">TypeScript DSL</a></li>
           <li><a href="{{ '/developer/gradio-conversion' | relative_url }}" class="sidebar-link" data-nav-path="/developer/gradio-conversion">Gradio Conversion</a></li>
+          <li><a href="{{ '/node-packs' | relative_url }}" class="sidebar-link" data-nav-path="/node-packs">Node Packs</a></li>
+        </ul>
+      </details>
+
+      <details class="nav-section" data-section="apps">
+        <summary class="nav-section-summary">
+          <h4 class="nav-section-title">Apps</h4>
+          <span class="nav-section-chevron" aria-hidden="true"></span>
+        </summary>
+        <ul class="nav-section-list">
+          <li><a href="{{ '/desktop-app' | relative_url }}" class="sidebar-link" data-nav-path="/desktop-app">Desktop App</a></li>
+          <li><a href="{{ '/electron-views' | relative_url }}" class="sidebar-link" data-nav-path="/electron-views">Desktop App Views</a></li>
+          <li><a href="{{ '/mobile-app' | relative_url }}" class="sidebar-link" data-nav-path="/mobile-app">Mobile App</a></li>
+        </ul>
+      </details>
+
+      <details class="nav-section" data-section="help">
+        <summary class="nav-section-summary">
+          <h4 class="nav-section-title">Help</h4>
+          <span class="nav-section-chevron" aria-hidden="true"></span>
+        </summary>
+        <ul class="nav-section-list">
+          <li><a href="{{ '/troubleshooting' | relative_url }}" class="sidebar-link" data-nav-path="/troubleshooting">Troubleshooting</a></li>
+          <li><a href="{{ '/tips-and-tricks' | relative_url }}" class="sidebar-link" data-nav-path="/tips-and-tricks">Tips &amp; Tricks</a></li>
         </ul>
       </details>
     </nav>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ NodeTool is organized into distinct packages, each responsible for a specific la
 |---------|---------|
 | **@nodetool-ai/deploy** | Deployment automation for self-hosted, RunPod, and GCP Cloud Run |
 | **@nodetool-ai/storage** | Asset storage backends (local filesystem, S3, Supabase) |
-| **@nodetool-ai/vectorstore** | Vector database integration (Chroma) for RAG workflows |
+| **@nodetool-ai/vectorstore** | Vector database integration (SQLite-vec, Pinecone, Supabase pgvector) for RAG workflows |
 | **@nodetool-ai/cli** | Command-line interface for workflow execution, deployment, and package management |
 | **@nodetool-ai/base-nodes** | Core node implementations and dynamic node generation |
 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,12 +1,38 @@
 ---
 layout: page
-title: "How NodeTool Compares"
-description: "Where NodeTool sits relative to Weavy and ComfyUI."
+title: "Why NodeTool"
+description: "The problems NodeTool solves for creative teams working with AI models."
 ---
 
-NodeTool is the open creative AI workspace: one node canvas for image, video, audio, and text models. Runs on your machine, or BYOK to FAL, Kie, OpenAI, Anthropic, Gemini, Replicate, and more.
+> NodeTool is the open creative AI workspace — every major model, your keys, one canvas.
 
-Weavy is a closed SaaS canvas with its own credit system. ComfyUI is engineer-first and built around diffusion internals. NodeTool is the open alternative: every major model, your keys, your canvas — no credit markup, no vendor lock-in.
+NodeTool replaces the chatbox with a node canvas where image, video, audio, and LLM models run side by side. Bring your keys, or run everything locally. Open source, AGPL-3.0.
+
+## The problem
+
+Creative AI is a tab graveyard:
+
+* **Every model lives behind its own UI.** Switching between Flux, ElevenLabs, Sora, and a chatbot means losing context every time. Outputs don't compose.
+* **SaaS canvases tax every token.** Hosted creative tools mark up provider credits 2–5x. You pay for the same OpenAI call twice.
+* **Local-only tools are model-narrow.** ComfyUI nails diffusion internals but treats LLMs, agents, and cloud APIs as second-class.
+* **Workflows aren't portable.** Prompts in chat history, settings in screenshots, pipelines in your head. Nothing is reproducible.
+* **Privacy is a yes/no toggle.** Either everything goes to a vendor, or nothing leaves your machine. No mixed mode.
+
+## How NodeTool solves this
+
+One canvas, every model, your keys:
+
+**One canvas for every modality.** Wire Flux to GPT-5 to ElevenLabs to Wan in a single graph. Outputs flow as typed edges — image, audio, text, embeddings — not pasted strings.
+
+**BYOK to every provider.** OpenAI, Anthropic, Gemini, Replicate, FAL, Kie, ElevenLabs, MiniMax, HuggingFace. Pay them directly. No credit markup, no provider lock-in.
+
+**Local + cloud, mixed.** Run Llama on MLX, route image gen to FAL, send audio to ElevenLabs — in one workflow. Toggle per node.
+
+**Workflows as files.** Save, share, version. Ship a workflow as a Mini-App with a one-click hide-the-graph mode.
+
+**Agents that drive pipelines.** Built-in planning, tool calling, streaming. Drop an agent node into any graph.
+
+**Open source, no markup.** AGPL-3.0. Cloud edition hosts the same code in this repo. Self-host the Docker images any time.
 
 ---
 
@@ -33,15 +59,15 @@ Weavy is a closed SaaS canvas with its own credit system. ComfyUI is engineer-fi
 
 ### When to pick each
 
-**NodeTool** — open creative AI workspace. Wire image, video, audio, and text models on one canvas, with your own keys, on your own machine.
+**NodeTool** — every modality, every provider, on one canvas. Local, cloud, or mixed.
 
-**Weavy** — hosted SaaS canvas if you want a managed product with credits and don't need local execution, BYOK, or open source.
+**Weavy** — hosted SaaS if you want a managed product with credits and don't need BYOK, local execution, or open source.
 
 **ComfyUI** — deep diffusion control: samplers, VAE, ControlNet, latents.
 
 ---
 
-## See Also
+## Next steps
 
-- [Getting Started](getting-started.md)
-- [Models & Providers](models-and-providers.md)
+- [Quick Start](getting-started.md) — install and run your first workflow in minutes.
+- [Models & Providers](models-and-providers.md) — every model NodeTool wires up.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -52,7 +52,7 @@ One canvas, every model, your keys:
 | **TTS / ASR** | Local: Kokoro, Sesame, Whisper · API: OpenAI, ElevenLabs | Cloud only | ⚠️ Via custom nodes |
 | **LLMs & agents** | Built-in agent nodes, tool calling, streaming, Ollama, MLX | Limited LLM nodes | ⚠️ Via custom nodes |
 | **Diffusion control** | Standard parameters | ❌ Hidden behind presets | ✅ Latents, VAE, samplers, ControlNet |
-| **RAG / vector search** | ✅ Local Chroma | ❌ | ❌ |
+| **RAG / vector search** | ✅ Local SQLite-vec, plus Pinecone & Supabase pgvector | ❌ | ❌ |
 | **Mini-apps from workflows** | ✅ Turn a graph into a simple UI | ⚠️ Share-as-template | ❌ |
 | **Real-time streaming** | ✅ Token-by-token, live progress | ✅ Live preview | ❌ Queue-based execution |
 | **Source available** | ✅ Full source on GitHub | ❌ | ✅ Full source on GitHub |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,7 @@ Security notes:
 | `DB_PATH` / `DATABASE_URL` | Database connection | no | Set only one. `DB_PATH` configures SQLite; `DATABASE_URL` supports PostgreSQL (`postgres://`, `postgresql://`) and SQLite (`file:`, `sqlite:`) |
 | `S3_*` | S3-compatible storage settings | yes | Includes access keys and region |
 | `ASSET_BUCKET` / `ASSET_TEMP_BUCKET` | Asset buckets | no | Use signed URLs for private buckets |
-| `CHROMA_PATH` / `CHROMA_URL` / `CHROMA_TOKEN` | Vector DB config | `CHROMA_TOKEN` | Path defaults to local share |
+| `NODETOOL_VECTOR_PROVIDER` / `VECTORSTORE_DB_PATH` | Vector store config | no | Default backend is local SQLite-vec; switch to `pinecone` or `supabase` for remote. See [Indexing](indexing.md). |
 | `NODE_SUPABASE_URL` / `NODE_SUPABASE_KEY` / `NODE_SUPABASE_SCHEMA` / `NODE_SUPABASE_TABLE_PREFIX` | User/node Supabase config | `NODE_SUPABASE_KEY` | Kept separate from core Supabase credentials and tables |
 | `NODETOOL_ENABLE_TERMINAL_WS` | Opt-in terminal WebSocket | no | Leave unset in production |
 | `LOG_LEVEL` | Logging level | no | Defaults to `INFO` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,10 @@
 ---
 layout: page
-title: "Getting Started"
-description: "Run your first NodeTool workflow."
+title: "Quick Start"
+description: "Install NodeTool, run a template, ship a Mini-App."
 ---
 
-Install NodeTool, open a template, run it, edit it, ship it as a Mini-App.
+Install, open a template, run it, edit it, ship it.
 
 ## Step 1 — Install
 
@@ -17,27 +17,27 @@ Install NodeTool, open a template, run it, edit it, ship it as a Mini-App.
 | **GPU** | None | 8 GB+ VRAM for local inference |
 | **OS** | macOS 13+, Windows 10+, Ubuntu 22+ | Latest |
 
-No GPU? Use cloud providers with your own keys. See [hardware notes](installation.md#what-different-tasks-need).
+No GPU? Use cloud providers with your keys. See [hardware notes](installation.md#what-different-tasks-need).
 
 ### Install
 
-1. Download from [nodetool.ai](https://nodetool.ai)
-2. Run the installer
-3. Launch — no setup wizard
+1. Download from [nodetool.ai](https://nodetool.ai).
+2. Run the installer.
+3. Launch. No setup wizard.
 
 ![Dashboard](assets/screenshots/dashboard-overview.png)
 
-Python and inference engines install on demand the first time you use local models. See the [installation guide](installation.md) for platform notes.
+Python and inference engines install on first use. [Installation guide](installation.md) for platform notes.
 
 ### Local models (optional)
 
-1. Open **Models** in the sidebar
+1. Open **Models** in the sidebar.
 2. Pick:
    - **Flux** or **Qwen Image** for images (8–12 GB VRAM)
    - **Llama** or **Qwen** for text
-3. Wait for downloads (~20 GB)
+3. Wait for downloads (~20 GB).
 
-Cloud-only: open **Settings → Providers**, paste your key from [OpenAI](https://platform.openai.com), [Anthropic](https://www.anthropic.com), or [Google](https://ai.google.dev). Skip the local download.
+Cloud-only: open **Settings → Providers** and paste a key from [OpenAI](https://platform.openai.com), [Anthropic](https://www.anthropic.com), or [Google](https://ai.google.dev). Skip the download.
 
 ---
 
@@ -49,43 +49,43 @@ Open a template from the Dashboard.
 
 ### Movie Posters
 
-1. Dashboard → Templates → **Movie Posters**
-2. The graph opens: inputs on the left, an agent in the middle, image generator on the right, preview at the end.
-3. Type into the inputs:
+1. Dashboard → Templates → **Movie Posters**.
+2. The graph opens: inputs left, agent middle, image generator right, preview last.
+3. Fill the inputs:
    - **Title**: Ocean Depths
    - **Genre**: Sci-Fi Thriller
    - **Audience**: Adults who love mystery
-4. Press <kbd>Ctrl/⌘ + Enter</kbd> to run.
+4. Press <kbd>Ctrl/⌘ + Enter</kbd>.
 
 ### Creative Story Ideas
 
 ![Editor](assets/screenshots/editor-empty-state.png)
 
-1. Dashboard → Templates → **Creative Story Ideas**
+1. Dashboard → Templates → **Creative Story Ideas**.
 2. Set inputs:
    - **Genre**: Cyberpunk
    - **Character**: Rogue AI detective
    - **Setting**: Neon-lit underwater city
-3. Run it.
+3. Run.
 
 ---
 
 ## Step 3 — Edit
 
 1. Save with <kbd>Ctrl/⌘ + S</kbd>.
-2. Change inputs and re-run.
-3. Click a node to see its settings on the right. Hover a connection to see the data flowing through it. Press `Space` and search "Preview" to drop a preview node anywhere on the canvas.
+2. Change inputs, re-run.
+3. Click a node to inspect it. Hover an edge to see the data flowing through. Press `Space`, search "Preview", drop one anywhere on the canvas.
 
 ---
 
 ## Step 4 — Ship as a Mini-App
 
-A Mini-App hides the graph and exposes only the inputs and outputs.
+A Mini-App hides the graph and exposes inputs and outputs only.
 
 1. Open the workflow.
 2. Click **Mini-App** in the toolbar.
 
-For a custom UI, see [VibeCoding](vibecoding.md).
+Custom UI? See [VibeCoding](vibecoding.md).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ description: "NodeTool — the open creative AI workspace. One node canvas for i
 * **Bring your own keys** — Pay OpenAI, Anthropic, Gemini, Replicate, FAL, and ElevenLabs directly. No credit markup, no provider tax.
 * **Ship a workflow as a Mini-App** — Hide the graph, expose just inputs and outputs. Share a link, no install required.
 * **Build agents that drive workflows** — Multi-step planning, tool calling, streaming. Drop them into any pipeline.
-* **Chat with your documents** — Local Chroma, embeddings, RAG. Your data never leaves the machine.
+* **Chat with your documents** — Local SQLite-vec, embeddings, RAG. Your data never leaves the machine.
 * **Iterate visually, not via prompts** — Click a node, change a value, re-run. Watch data flow through every edge.
 
 ## Studio or Cloud

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
 layout: home
-description: "NodeTool — the open creative AI workspace. Every major model, your own keys, one node-based canvas. Runs on your machine or in the browser."
+description: "NodeTool — the open creative AI workspace. One node canvas for image, video, audio, and LLM models. Bring your own keys, or run locally."
 ---
 
 <section class="home-hero">
   <p class="eyebrow">The open creative AI workspace</p>
   <h1>Every model. Your keys. Your canvas.</h1>
   <p class="lead">
-   One node-based canvas for making images, video, sound, and stories with AI. Wire up Flux, Qwen, Wan, Seedance, Sora, Veo, Kling, ElevenLabs, MusicGen, and the major LLMs side by side — bring your own keys, or run locally. Open source, AGPL-3.0.
+   NodeTool replaces the chatbox with a node canvas where image, video, audio, and LLM models run side by side. Bring your keys, or run everything locally. Open source, AGPL-3.0.
   </p>
   <img src="{{ '/assets/home.png' | relative_url }}" alt="NodeTool canvas" class="home-screenshot">
   <div class="cta-row">
@@ -17,52 +17,60 @@ description: "NodeTool — the open creative AI workspace. Every major model, yo
   </div>
 </section>
 
+## Use cases
+
+* **Mix models from every vendor** — Wire Flux next to GPT-5 next to ElevenLabs in one graph. Pick the best model per step, not per project.
+* **Run frontier models locally** — Ollama, MLX, and GGUF on your hardware. Works offline. Files never leave your disk.
+* **Bring your own keys** — Pay OpenAI, Anthropic, Gemini, Replicate, FAL, and ElevenLabs directly. No credit markup, no provider tax.
+* **Ship a workflow as a Mini-App** — Hide the graph, expose just inputs and outputs. Share a link, no install required.
+* **Build agents that drive workflows** — Multi-step planning, tool calling, streaming. Drop them into any pipeline.
+* **Chat with your documents** — Local Chroma, embeddings, RAG. Your data never leaves the machine.
+* **Iterate visually, not via prompts** — Click a node, change a value, re-run. Watch data flow through every edge.
+
 ## Studio or Cloud
 
-Both editions are open source under AGPL-3.0 and built from the same code. Workflows are portable between them.
+Same code, same workflows. Both AGPL-3.0.
 
 <div class="pattern-grid">
   <article class="pattern-card">
     <h5>NodeTool Studio — desktop</h5>
     <p>
-      Runs on macOS, Windows, and Linux. Local inference via Ollama, MLX, and GGUF on your hardware. Works offline. Files, prompts, and outputs stay on disk. Bring your keys for cloud providers when you want them.
+      Mac, Windows, Linux. Local inference via Ollama, MLX, and GGUF. Works offline. Prompts and outputs stay on disk. BYOK for cloud providers when you want them.
     </p>
-    <p><strong>For:</strong> local inference, offline work, GPU owners, privacy.</p>
     <a href="https://nodetool.ai/studio">Download Studio →</a>
   </article>
   <article class="pattern-card">
     <h5>NodeTool Cloud — browser</h5>
     <p>
-      Hosted, no install. Same canvas, same nodes. Bring your keys for every cloud provider — OpenAI, Anthropic, Gemini, Replicate, FAL, ElevenLabs, HuggingFace. Does not run local models.
+      Hosted, no install. Same canvas, same nodes. BYOK for every cloud provider — OpenAI, Anthropic, Gemini, Replicate, FAL, ElevenLabs, HuggingFace. No local models.
     </p>
-    <p><strong>For:</strong> no setup, working across devices, no GPU.</p>
     <a href="https://nodetool.ai/cloud">Open Cloud →</a>
   </article>
 </div>
 
-> **No credit markup.** Cloud is managed hosting of the code in this repo. You can self-host the same Docker images and CLI any time. You pay providers directly.
+> **No credit markup.** Cloud hosts the same code in this repo. Self-host the Docker images any time. You pay providers directly.
 
 ## What you can build
 
 <div class="pattern-grid">
   <article class="pattern-card">
     <h5>Image and video</h5>
-    <p>Posters, characters, scenes. Flux, Qwen, Wan, Seedance, Sora, Veo, Kling on one canvas.</p>
+    <p>Flux, Qwen, Wan, Seedance, Sora, Veo, Kling on one canvas.</p>
     <a href="{{ '/workflows/movie-posters' | relative_url }}">Movie Posters →</a>
   </article>
   <article class="pattern-card">
     <h5>Story to video</h5>
-    <p>Turn a prompt into a storyboard, narrate it, animate it, score it.</p>
+    <p>Prompt to storyboard to narration to animation to score.</p>
     <a href="{{ '/workflows/story-to-video-generator' | relative_url }}">Story to Video →</a>
   </article>
   <article class="pattern-card">
     <h5>Sound and voice</h5>
-    <p>Music, sound design, narration. ElevenLabs, MusicGen, Whisper wired into the graph.</p>
+    <p>Music, sound design, narration. ElevenLabs, MusicGen, Whisper in the graph.</p>
     <a href="{{ '/workflows/image-to-audio-story' | relative_url }}">Image to Audio Story →</a>
   </article>
   <article class="pattern-card">
     <h5>Agents</h5>
-    <p>Multi-step agents that plan, call tools, and drive your creative pipelines.</p>
+    <p>Multi-step agents that plan, call tools, and drive pipelines.</p>
     <a href="{{ '/workflows/realtime-agent' | relative_url }}">Realtime Agent →</a>
   </article>
 </div>
@@ -73,14 +81,14 @@ More patterns — pipelines, data, RAG, email — in the [Cookbook]({{ '/cookboo
 
 <ol class="step-sequence">
   <li><a href="{{ '/installation' | relative_url }}">Download NodeTool</a> for macOS, Windows, or Linux.</li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-2--run-your-first-workflow">Open a template</a>, press Run, watch results stream.</li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-3--customize-and-iterate">Edit and iterate.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-2--run-a-workflow">Open a template, press Run.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-3--edit">Edit, re-run, ship as a Mini-App.</a></li>
 </ol>
 
 ## Explore
 
 - **New here:** [Getting Started]({{ '/getting-started' | relative_url }}) · [Key Concepts]({{ '/key-concepts' | relative_url }}) · [UI]({{ '/user-interface' | relative_url }})
-- **Building:** [Global Chat & Agents]({{ '/global-chat-agents' | relative_url }}) · [Cookbook]({{ '/cookbook' | relative_url }}) · [Examples]({{ '/workflows/' | relative_url }})
+- **Building:** [Chat & Agents]({{ '/global-chat-agents' | relative_url }}) · [Cookbook]({{ '/cookbook' | relative_url }}) · [Examples]({{ '/workflows/' | relative_url }})
 - **Self-hosting:** [Deployment]({{ '/deployment' | relative_url }}) · [Configuration]({{ '/configuration' | relative_url }}) · [API]({{ '/api-reference' | relative_url }})
 - **Extending:** [Developer Guide]({{ '/developer/' | relative_url }}) · [Custom Nodes]({{ '/developer/node-reference' | relative_url }}) · [CLI]({{ '/cli' | relative_url }})
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -10,29 +10,31 @@ NodeTool ships a lightweight ingestion pipeline for semantic search and retrieva
 ## Overview
 
 - **Collection metadata** (`CollectionResponse` in `@nodetool-ai/protocol` `packages/protocol/src/api-types.ts`) stores ingest configuration, including an optional workflow ID.
-- **Vector store** -- the default backend is SQLite-vec (`@nodetool-ai/vectorstore` `packages/vectorstore/src/sqlite-vec-store.ts`), with a Chroma-compatible chunking helper in `packages/vectorstore/src/chroma-client.ts`. Embeddings flow through the `VectorProvider` abstraction — see [Vector Storage](vector-storage.md) for swapping backends (Supabase/pgvector, Pinecone).
+- **Vector store** -- the default backend is SQLite-vec (`@nodetool-ai/vectorstore` `packages/vectorstore/src/sqlite-vec-store.ts`). Embeddings flow through the `VectorProvider` abstraction — see [Vector Storage](vector-storage.md) for swapping backends (Pinecone, Supabase/pgvector).
 - **Indexing route** -- `indexFileToCollection()` (`@nodetool-ai/deploy` `packages/deploy/src/collection-routes.ts`) orchestrates ingestion based on collection metadata.
 
 ### Default Flow
 
 1. `indexFileToCollection()` resolves the target collection via `getCollection()` (`@nodetool-ai/vectorstore` `packages/vectorstore/src/index.ts`).
 2. If the collection specifies a custom workflow ID, the service executes it by constructing a `RunJobRequest` (`@nodetool-ai/protocol` `packages/protocol/src/api-types.ts`) with `CollectionInput` and `FileInput` nodes populated.
-3. Otherwise, it falls back to the default ingestion path, which splits the document with `splitDocument()` (`@nodetool-ai/vectorstore` `packages/vectorstore/src/chroma-client.ts`), embeds it, and stores embeddings in SQLite-vec.
+3. Otherwise, it falls back to the default ingestion path, which splits the document with `splitDocument()` (`@nodetool-ai/vectorstore`), embeds it, and stores embeddings in SQLite-vec.
 
 ### Messages & Progress
 
 While custom workflows run, the service streams `JobUpdate`, `NodeUpdate`, and progress messages (from `@nodetool-ai/protocol` `packages/protocol/src/messages.ts`). Tests under `packages/deploy/tests/collection-routes.test.ts` cover expected message sequences.
 
-## Configuring Chroma
+## Configuring the vector store
 
-Environment variables:
+The default backend is local SQLite-vec. Switch backends with `NODETOOL_VECTOR_PROVIDER`.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CHROMA_URL` | Remote Chroma server URL | `None` (use local DB) |
-| `CHROMA_PATH` | Local data directory | `~/.local/share/nodetool/chroma` |
+| `NODETOOL_VECTOR_PROVIDER` | `sqlite-vec`, `pinecone`, or `supabase` | `sqlite-vec` |
+| `VECTORSTORE_DB_PATH` | Local SQLite-vec database file | `~/.local/share/nodetool/vectorstore.db` |
+| `PINECONE_API_KEY` | Required when provider is `pinecone` | — |
+| `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` | Required when provider is `supabase` | — |
 
-The SQLite-vec store uses local storage by default. For remote Chroma (legacy), set `CHROMA_TOKEN` if authentication is required.
+See [Vector Storage](vector-storage.md) for backend-specific setup.
 
 ## Custom Ingestion Workflows
 
@@ -52,8 +54,8 @@ Return values can include summaries, metadata, or alternate embeddings. Review `
 ## Troubleshooting
 
 - **Missing collection metadata** – ensure the collection exists and includes the required `workflow` entry when using custom workflows.
-- **Chroma connection errors** – verify `CHROMA_URL`/`CHROMA_TOKEN` and network reachability; fall back to local mode by clearing the URL.
-- **Large files** – increase `CHROMA_PATH` disk quota or configure cloud storage; the default ingestion workflow streams chunks to reduce memory usage.
+- **Remote backend errors** – for `pinecone` or `supabase`, verify credentials and network reachability; fall back to local SQLite-vec by setting `NODETOOL_VECTOR_PROVIDER=sqlite-vec`.
+- **Large files** – ensure `VECTORSTORE_DB_PATH` has disk headroom, or move to a remote backend; the default ingestion workflow streams chunks to reduce memory usage.
 
 ## Related Documentation
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -63,7 +63,7 @@ NodeTool is an open-source, local-first visual environment for building AI workf
 
 - [Configuration]({{ site.url }}/configuration): Settings and environment variables.
 - [Storage]({{ site.url }}/storage): Local and S3 storage backends.
-- [Vector Storage]({{ site.url }}/vector-storage): SQLite-vec, ChromaDB, FAISS.
+- [Vector Storage]({{ site.url }}/vector-storage): SQLite-vec (default), Pinecone, Supabase pgvector.
 - [Indexing]({{ site.url }}/indexing): Document ingestion and RAG pipelines.
 - [Collections]({{ site.url }}/collections): Vector collections for RAG.
 - [Asset Management]({{ site.url }}/asset-management): Files, images, datasets.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,123 @@
+---
+layout: null
+permalink: /llms.txt
+---
+# NodeTool Documentation
+
+> {{ site.description }}
+
+NodeTool is an open-source, local-first visual environment for building AI workflows. Wire image, video, audio, text, and agent models on a node-based canvas. Runs on macOS, Windows, Linux (Studio), or in the browser (Cloud). AGPL-3.0.
+
+## Getting Started
+
+- [Introduction]({{ site.url }}/): Overview of NodeTool — Studio vs Cloud, what you can build.
+- [Why NodeTool]({{ site.url }}/comparisons): How NodeTool compares to ComfyUI, n8n, LangChain, etc.
+- [Installation]({{ site.url }}/installation): Install NodeTool Studio on macOS, Windows, or Linux.
+- [Quick Start]({{ site.url }}/getting-started): Install, run a template, edit and iterate.
+
+## Core Concepts
+
+- [Key Concepts]({{ site.url }}/key-concepts): Canvas, nodes, edges, workflows, agents, providers.
+- [Workflows]({{ site.url }}/workflow-editor): Building, running, and managing workflow graphs.
+- [Nodes]({{ site.url }}/nodes/): Catalog of available nodes by category.
+- [Agents]({{ site.url }}/global-chat-agents): Planning agents, tools, multi-step execution.
+- [Models]({{ site.url }}/models-and-providers): Local and cloud model providers.
+- [Glossary]({{ site.url }}/glossary): Terminology used across NodeTool.
+
+## Workflow Editor
+
+- [User Interface]({{ site.url }}/user-interface): UI tour and shortcuts.
+- [Workflow Editor]({{ site.url }}/workflow-editor): Canvas, ports, edges, execution.
+- [Editor Panels]({{ site.url }}/editor-panels): Inspector, assets, models, chat panels.
+- [Chain Editor]({{ site.url }}/chain-editor): Linear chain authoring mode.
+- [Graph View]({{ site.url }}/workflow-graph-view): Read-only graph navigation.
+- [Debugging]({{ site.url }}/workflow-debugging): Inspect runs, errors, logs.
+- [Image Editor]({{ site.url }}/image-editor): Mask, paint, layer images inline.
+- [Templates Gallery]({{ site.url }}/templates-gallery): Browse and open starter workflows.
+- [VibeCoding]({{ site.url }}/vibecoding): Generate workflows from natural language.
+- [ComfyUI Integration]({{ site.url }}/comfyui-integration): Import and run ComfyUI graphs.
+
+## Chat & Agents
+
+- [Global Chat]({{ site.url }}/global-chat): Provider-agnostic chat interface.
+- [Chat & Agents]({{ site.url }}/global-chat-agents): Use agents from chat.
+- [Agent Config]({{ site.url }}/agent-config-schema): YAML schema for agent definitions.
+- [Agent Memory]({{ site.url }}/agent-memory): How agents persist context.
+
+## Models & Providers
+
+- [Overview]({{ site.url }}/models-and-providers): All supported providers.
+- [Local vs Cloud]({{ site.url }}/models): When to use which.
+- [Provider Reference]({{ site.url }}/providers): Per-provider configuration.
+- [HuggingFace]({{ site.url }}/huggingface): Models from the Hub.
+- [Models Manager]({{ site.url }}/models-manager): Download and manage local models.
+
+## Examples
+
+- [Cookbook]({{ site.url }}/cookbook): End-to-end patterns and recipes.
+- [Core Patterns]({{ site.url }}/cookbook/core-concepts): Foundational workflow patterns.
+- [Pipeline Patterns]({{ site.url }}/cookbook/patterns): Composition patterns.
+- [Workflow Examples]({{ site.url }}/workflows/): Ready-to-run sample workflows.
+
+## Configuration
+
+- [Configuration]({{ site.url }}/configuration): Settings and environment variables.
+- [Storage]({{ site.url }}/storage): Local and S3 storage backends.
+- [Vector Storage]({{ site.url }}/vector-storage): SQLite-vec, ChromaDB, FAISS.
+- [Indexing]({{ site.url }}/indexing): Document ingestion and RAG pipelines.
+- [Collections]({{ site.url }}/collections): Vector collections for RAG.
+- [Asset Management]({{ site.url }}/asset-management): Files, images, datasets.
+- [Authentication]({{ site.url }}/authentication): Auth setup for hosted deployments.
+- [Security Hardening]({{ site.url }}/security-hardening): Production security guidance.
+- [Proxy]({{ site.url }}/proxy): HTTP/HTTPS proxy configuration.
+
+## Deployment
+
+- [Deployment Guide]({{ site.url }}/deployment): Where and how to deploy.
+- [End-to-End Guide]({{ site.url }}/deployment-e2e-guide): Full production walkthrough.
+- [Self-Hosted]({{ site.url }}/self-hosted-deployment): Run on your own infra with Docker.
+- [Docker Resources]({{ site.url }}/docker-resource-management): GPU, memory, volumes.
+- [RunPod]({{ site.url }}/runpod-deployment): Serverless GPU deployment.
+- [Google Cloud Run]({{ site.url }}/gcp-deployment): GCP managed deployment.
+- [Supabase]({{ site.url }}/supabase-deployment): Postgres + auth backend.
+
+## CLI
+
+- [CLI Overview]({{ site.url }}/cli): `nodetool` command reference.
+- [Chat CLI]({{ site.url }}/chat-cli): Interactive chat with agent mode.
+- [Agent CLI]({{ site.url }}/agent-cli): Run agent configs from the terminal.
+- [Chat Server]({{ site.url }}/chat-server): Standalone chat WebSocket server.
+- [API Server]({{ site.url }}/api-server): REST + WebSocket API server.
+- [Terminal WebSocket]({{ site.url }}/terminal-websocket): Browser terminal protocol.
+
+## API Reference
+
+- [API Overview]({{ site.url }}/api-reference): REST API conventions.
+- [Workflow API]({{ site.url }}/workflow-api): Create, run, manage workflows.
+- [WebSocket API]({{ site.url }}/websocket-api): Streaming run protocol.
+- [Chat API]({{ site.url }}/chat-api): OpenAI-compatible chat endpoint.
+
+## Developers
+
+- [Developer Guide]({{ site.url }}/developer/): Build and extend NodeTool.
+- [Architecture]({{ site.url }}/architecture): Backend packages, kernel, runtime, providers.
+- [Packages]({{ site.url }}/packages): NPM workspace package map.
+- [Python Bridge Protocol]({{ site.url }}/python-bridge-protocol): Stdio msgpack bridge to Python nodes.
+- [Execution Strategies]({{ site.url }}/execution-strategies): Subprocess, Docker, in-process.
+- [Custom Nodes]({{ site.url }}/developer/custom-nodes-guide): Implement BaseNode subclasses.
+- [Node Patterns]({{ site.url }}/developer/node-patterns): process / genProcess / streaming.
+- [Node Reference]({{ site.url }}/developer/node-reference): @prop, types, decorators.
+- [TypeScript DSL]({{ site.url }}/developer/ts-dsl-guide): Define workflows in TS.
+- [Gradio Conversion]({{ site.url }}/developer/gradio-conversion): Convert Gradio apps to nodes.
+- [Node Packs]({{ site.url }}/node-packs): Distribute nodes as installable packs.
+
+## Apps
+
+- [Desktop App]({{ site.url }}/desktop-app): NodeTool Studio (Electron).
+- [Desktop App Views]({{ site.url }}/electron-views): Windows and panels.
+- [Mobile App]({{ site.url }}/mobile-app): React Native client.
+
+## Help
+
+- [Troubleshooting]({{ site.url }}/troubleshooting): Common errors and fixes.
+- [Tips & Tricks]({{ site.url }}/tips-and-tricks): Productivity shortcuts.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -25,7 +25,7 @@ Passing `use_s3: true` when obtaining asset storage forces S3 even in developmen
 | `ASSET_BUCKET` | Bucket name (S3) or Supabase Storage bucket name, or folder name (local). |
 | `ASSET_DOMAIN` | Public domain serving assets (S3 only). Not used for Supabase. |
 | `ASSET_TEMP_BUCKET` / `ASSET_TEMP_DOMAIN` | Optional separate bucket for temporary assets. |
-| `FONT_PATH`, `COMFY_FOLDER`, `CHROMA_PATH` | Additional paths for specific nodes (registered in `@nodetool-ai/websocket` / `src/settings-api.ts`). |
+| `FONT_PATH`, `COMFY_FOLDER`, `VECTORSTORE_DB_PATH` | Additional paths for specific nodes (registered in `@nodetool-ai/websocket` / `src/settings-api.ts`). |
 
 For S3-compatible services, set:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -191,7 +191,7 @@ When a workflow isn't working as expected, work through this checklist systemati
 
 #### Diagnostic Steps
 
-1. **Check collection status** – Verify documents are indexed in ChromaDB/FAISS
+1. **Check collection status** – Verify documents are indexed in SQLite-vec (or your configured backend)
 2. **Inspect embeddings** – Use Preview nodes to see what's being embedded
 3. **Test search directly** – Run search node separately with known queries
 4. **Review chunk size** – Check if documents are split appropriately
@@ -485,7 +485,7 @@ Include these details when asking for help:
 7. **Workflow file** — export the workflow JSON if possible
 
 **Good example:**
-> I'm running NodeTool 1.5.0 on macOS 14.1. When I run the Chat with Docs workflow (attached JSON), I get "Collection not found: docs". I've already run the Index PDFs workflow and can see the collection in ChromaDB. Screenshots attached.
+> I'm running NodeTool 1.5.0 on macOS 14.1. When I run the Chat with Docs workflow (attached JSON), I get "Collection not found: docs". I've already run the Index PDFs workflow and can see the collection in the SQLite-vec store. Screenshots attached.
 
 **Poor example:**
 > Chat with docs doesn't work, help!

--- a/docs/workflows/index-pdfs.md
+++ b/docs/workflows/index-pdfs.md
@@ -5,7 +5,7 @@ title: "Index PDFs"
 
 ## Overview
 
-Index PDFs from a folder into a Chroma collection for vector search.
+Index PDFs from a folder into a SQLite-vec collection for vector search.
 
 ## Tags
 


### PR DESCRIPTION
## Summary

Restructured the documentation site to improve information architecture and navigation. Reorganized sidebar sections, updated page titles and descriptions, and created a new `llms.txt` file as a machine-readable documentation index.

## Key Changes

- **New documentation index**: Added `docs/llms.txt` — a Jekyll-formatted, machine-readable index of all documentation organized by section (Getting Started, Core Concepts, Workflow Editor, Chat & Agents, Models & Providers, Examples, Configuration, Deployment, CLI, API Reference, Developers, Apps, Help).

- **Sidebar reorganization**: Restructured `docs/_includes/sidebar.html` into clearer, more logical sections:
  - Renamed "New to NodeTool?" → "Getting Started" with Introduction and Why NodeTool links
  - New "Core Concepts" section grouping key-concepts, workflows, nodes, agents, models, glossary
  - New "Chat & Agents" section with global chat, agent config, and memory
  - Moved Examples to its own section with cookbook patterns and workflow examples
  - Consolidated Configuration section with collections and asset management
  - Moved troubleshooting to Help section at the end
  - Reordered and renamed links for clarity (e.g., "Workflow Graph View" → "Graph View", "Debugging Workflows" → "Debugging")

- **Updated `_config.yml`**: Reorganized `header_pages` list to mirror the new sidebar structure with section comments, ensuring consistent navigation across the site.

- **Refreshed landing pages**:
  - `index.md`: Simplified hero copy, added "Use cases" section highlighting key capabilities (mix models, local inference, BYOK, Mini-Apps, agents, RAG, visual iteration)
  - `comparisons.md`: Retitled "Why NodeTool", expanded problem statement and solution narrative, updated comparison table (SQLite-vec instead of Chroma, removed Weavy/ComfyUI positioning)
  - `getting-started.md`: Retitled "Quick Start", tightened copy, improved step-by-step clarity

- **Minor content updates**:
  - `indexing.md`: Updated vector store references (SQLite-vec as default, Pinecone/Supabase as alternatives)
  - `troubleshooting.md`: Updated ChromaDB reference to SQLite-vec
  - `architecture.md`, `configuration.md`, `storage.md`: Minor reference updates

## Implementation Details

- All changes are documentation-only; no code or package changes.
- The new `llms.txt` file uses Jekyll front matter (`layout: null`, `permalink: /llms.txt`) to serve as a static, SEO-friendly documentation map.
- Sidebar section order now matches the conceptual flow: onboarding → core concepts → editor features → chat/agents → models → examples → configuration → deployment → CLI → API → developers → apps → help.
- Page titles and descriptions updated for consistency and clarity (e.g., "Getting Started" → "Quick Start", "How NodeTool Compares" → "Why NodeTool").

https://claude.ai/code/session_015dHrYg1XFzgPGZU5gpcvpn