### PR TITLE
fix(web): migrate useLastDirectGenModel to Zustand v5 shallow API

### DIFF
--- a/web/src/hooks/timeline/useLastDirectGenModel.ts
+++ b/web/src/hooks/timeline/useLastDirectGenModel.ts
@@ -16,7 +16,7 @@
  * The shallow comparator keeps re-renders tight — consumers only re-render
  * when provider or model actually changes, not on every clips-array swap.
  */
-import { shallow } from "zustand/shallow";
+import { useShallow } from "zustand/react/shallow";
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 
 export interface LastDirectGenModel {
@@ -42,16 +42,18 @@ const matchesKind = (
 export const useLastDirectGenModel = (
   kind: DirectGenMediaKind = "image"
 ): LastDirectGenModel =>
-  useTimelineStore((state) => {
-    for (let i = state.clips.length - 1; i >= 0; i--) {
-      const c = state.clips[i];
-      if (matchesKind(c.bindingKind, kind) && c.provider && c.model) {
-        return {
-          provider: c.provider,
-          model: c.model,
-          voice: kind === "audio" ? c.voice : undefined
-        };
+  useTimelineStore(
+    useShallow((state) => {
+      for (let i = state.clips.length - 1; i >= 0; i--) {
+        const c = state.clips[i];
+        if (matchesKind(c.bindingKind, kind) && c.provider && c.model) {
+          return {
+            provider: c.provider,
+            model: c.model,
+            voice: kind === "audio" ? c.voice : undefined
+          };
+        }
       }
-    }
-    return { provider: undefined, model: undefined, voice: undefined };
-  }, shallow);
+      return { provider: undefined, model: undefined, voice: undefined };
+    })
+  );


### PR DESCRIPTION
## Summary
- Replace the removed `useStore(selector, shallow)` 2-arg form with `useShallow(selector)` to fix the `TS2554: Expected 0-1 arguments, but got 2` typecheck failure introduced after the Zustand v5 upgrade (#3305).

## Test plan
- [ ] `cd web && npm run typecheck` — no error from `useLastDirectGenModel.ts`
- [ ] Sanity-check timeline direct-gen flow still preselects the last-used provider/model

🤖 Generated with [Claude Code](https://claude.com/claude-code)