### PR TITLE
Fix subgraph tabs selector stability with useShallow

### DIFF
--- a/web/src/components/editor/TabsBar.tsx
+++ b/web/src/components/editor/TabsBar.tsx
@@ -9,6 +9,7 @@ import { WorkflowAttributes } from "../../stores/ApiTypes";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useFileTabsStore } from "../../stores/FileTabsStore";
 import { useSubgraphTabsStore } from "../../stores/SubgraphTabsStore";
+import { useShallow } from "zustand/react/shallow";
 import { useNavigate } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 
@@ -177,9 +178,13 @@ const TabsBar = ({ workflows, currentWorkflowId }: TabsBarProps) => {
     (state) => state.closeOtherFileTabs
   );
 
-  // Subgraph tabs (only those belonging to the current workflow)
-  const subgraphTabs = useSubgraphTabsStore((state) =>
-    state.tabs.filter((t) => t.workflowId === currentWorkflowId)
+  // Subgraph tabs (only those belonging to the current workflow).
+  // `.filter()` produces a fresh array each call — wrap with `useShallow`
+  // so React's snapshot equality in `useSyncExternalStore` stays stable.
+  const subgraphTabs = useSubgraphTabsStore(
+    useShallow((state) =>
+      state.tabs.filter((t) => t.workflowId === currentWorkflowId)
+    )
   );
   const activeSubgraphKey = useSubgraphTabsStore((state) => state.activeKey);
   const setActiveSubgraph = useSubgraphTabsStore((state) => state.setActive);


### PR DESCRIPTION
## Summary
Wraps the subgraph tabs selector with `useShallow` to ensure stable snapshot equality in Zustand's `useSyncExternalStore`, preventing unnecessary re-renders caused by the `.filter()` operation producing a fresh array on each call.

## Changes
- Imported `useShallow` from `zustand/react/shallow`
- Wrapped the subgraph tabs selector with `useShallow()` to stabilize the filtered array reference
- Updated comment to explain why `useShallow` is needed for the `.filter()` operation

## Implementation Details
The `.filter()` method creates a new array instance on every call, which breaks Zustand's snapshot equality check even when the filtered contents haven't changed. By wrapping the selector with `useShallow`, we ensure that React's external store subscription only triggers re-renders when the actual tab data changes, not on every store update.

This follows the established pattern in the codebase for multi-value Zustand selections (as documented in CLAUDE.md: "shallow equality for multi-value Zustand selections").

https://claude.ai/code/session_015gw6kEVRh2QFLa7cGKvxWD