### PR TITLE
Enable sourcemaps in production builds

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -108,7 +108,7 @@ export default defineConfig(async ({ mode }) => {
       // worker bundling) cannot downlevel certain destructuring patterns in
       // monaco-editor's pre-bundled workers to those ancient targets.
       target: browserslistToEsbuild([">0.2%", "not dead", "not op_mini all", "not ios < 14"]),
-      sourcemap: isDebug,
+      sourcemap: true,
       minify: isDebug ? false : "esbuild",
       ...(isDebug
         ? {}


### PR DESCRIPTION
## Summary
Changed the Vite build configuration to always generate sourcemaps, regardless of debug mode. Previously, sourcemaps were only generated in debug builds (`sourcemap: isDebug`), but they are now always enabled (`sourcemap: true`).

## Changes
- **web/vite.config.ts**: Modified the build configuration to unconditionally enable sourcemaps
  - Changed `sourcemap: isDebug` to `sourcemap: true`
  - Minification behavior remains unchanged (disabled in debug, enabled in production)

## Rationale
Enabling sourcemaps in production builds improves debugging and error tracking capabilities in deployed environments while maintaining minification for bundle size optimization. This allows developers and monitoring tools to map minified code back to original source for better error diagnostics.

https://claude.ai/code/session_01Cnb65N1jG5i2jv9VJ9Yxxg