### PR TITLE
Migrate MUI components to ui_primitives across codebase

### DIFF
--- a/web/src/components/ChatMarkdownTest.tsx
+++ b/web/src/components/ChatMarkdownTest.tsx
@@ -3,8 +3,8 @@ import React, { useState, memo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Typography, Tabs, Tab } from "@mui/material";
-import { Box } from "./ui_primitives";
+import { Tabs, Tab } from "@mui/material";
+import { Box, Text, Caption } from "./ui_primitives";
 import ChatMarkdown from "./chat/message/ChatMarkdown";
 import { createStyles } from "./chat/thread/ChatThreadView.styles";
 
@@ -166,12 +166,11 @@ const ChatMarkdownTest: React.FC = () => {
     label: string
   ) => (
     <Box sx={{ mb: 3 }}>
-      <Typography
-        variant="caption"
+      <Caption
         sx={{ color: "text.secondary", mb: 0.5, display: "block" }}
       >
         {label}
-      </Typography>
+      </Caption>
       {/* Simulate the chat message list container */}
       <div css={chatStyles.chatMessagesList} className="chat-messages-list">
         <div
@@ -200,14 +199,14 @@ const ChatMarkdownTest: React.FC = () => {
   return (
     <div css={pageStyles(theme)}>
       <div css={containerStyles}>
-        <Typography variant="h4" sx={{ mb: 2 }}>
+        <Text size="bigger" weight={600} sx={{ mb: 2 }}>
           Chat Markdown Test
-        </Typography>
-        <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
+        </Text>
+        <Text size="small" sx={{ color: "text.secondary", mb: 2 }}>
           This page tests how different markdown content types render inside the
           chat view. Tables should scroll horizontally and never push the chat
           container wider. The layout should stay consistent like ChatGPT.
-        </Typography>
+        </Text>
 
         <Tabs
           value={activeTab}

--- a/web/src/components/LayoutTest.tsx
+++ b/web/src/components/LayoutTest.tsx
@@ -6,14 +6,11 @@ import {
   Tabs,
   Tab,
   Switch,
-  Typography,
-  Paper,
   Stack,
   Dialog,
   DialogTitle,
   DialogContent,
-  FormControlLabel,
-  Chip
+  FormControlLabel
 } from "@mui/material";
 import type { Theme } from "@mui/material/styles";
 
@@ -69,7 +66,10 @@ import {
   UndoRedoButtons,
   ConfirmButton,
   HelpButton,
-  Box
+  Box,
+  Text,
+  Surface,
+  Chip
 } from "./ui_primitives";
 
 // Additional icons
@@ -242,7 +242,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
   const renderActionButtons = () => (
     <div className="component-grid">
       {/* Copy Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">CopyButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -259,10 +259,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <CopyButton value="Text" buttonSize="large" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Close Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">CloseButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -280,10 +280,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <CloseButton onClick={() => {}} buttonSize="large" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Delete Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">DeleteButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -296,10 +296,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <DeleteButton onClick={() => {}} tooltip="Remove" iconVariant="outline" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Download Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">DownloadButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -319,10 +319,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <DownloadButton onClick={() => {}} isLoading />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Upload Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">UploadButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -339,10 +339,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <UploadButton onFileSelect={() => {}} label="Upload Files" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Edit Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">EditButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -355,10 +355,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <EditButton onClick={() => {}} tooltip="Rename" iconVariant="rename" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Settings Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">SettingsButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -372,10 +372,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <SettingsButton onClick={() => {}} tooltip="More" iconVariant="moreHoriz" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Toolbar Icon Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ToolbarIconButton</span>
         </div>
@@ -396,14 +396,14 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ToolbarIconButton icon={<SaveIcon />} tooltip="Active" active onClick={() => {}} />
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
   const renderControlButtons = () => (
     <div className="component-grid">
       {/* Playback Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">PlaybackButton</span>
         </div>
@@ -432,10 +432,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <PlaybackButton state="stopped" buttonSize="large" onPlay={() => {}} />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Expand/Collapse Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ExpandCollapseButton</span>
         </div>
@@ -450,10 +450,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ExpandCollapseButton expanded={expanded} iconVariant="chevron" onClick={() => setExpanded(!expanded)} />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* View Mode Toggle */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ViewModeToggle</span>
         </div>
@@ -483,10 +483,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <span className="demo-value">{sortMode}</span>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Refresh Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">RefreshButton</span>
         </div>
@@ -504,10 +504,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <RefreshButton onClick={() => {}} isLoading />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Selection Controls */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">SelectionControls</span>
         </div>
@@ -532,14 +532,14 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
   const renderDialogActions = () => (
     <div className="component-grid">
       {/* Dialog Action Buttons */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">DialogActionButtons</span>
         </div>
@@ -553,10 +553,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             </EditorButton>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Nav Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">NavButton</span>
         </div>
@@ -574,7 +574,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <NavButton icon={<PlayArrowIcon />} label="Active" active onClick={() => {}} />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Dialogs */}
       <Dialog open={showDialog} onClose={() => setShowDialog(false)}>
@@ -605,7 +605,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
   const renderInputControls = () => (
     <div className="component-grid">
       {/* Node TextField */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">NodeTextField</span>
         </div>
@@ -634,10 +634,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Node Switch */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">NodeSwitch</span>
         </div>
@@ -648,10 +648,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <span className="demo-value">{switchValue ? "on" : "off"}</span>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Node Slider */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">NodeSlider</span>
         </div>
@@ -666,10 +666,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <span className="demo-value">{sliderValue}</span>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Editor Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">EditorButton</span>
         </div>
@@ -680,14 +680,14 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <EditorButton variant="outlined">Outlined</EditorButton>
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
   const renderFabs = () => (
     <div className="component-grid">
       {/* Create FAB */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">CreateFab</span>
         </div>
@@ -705,10 +705,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <CreateFab onClick={() => {}} label="Add Item" fabColor="secondary" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Run Workflow Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">RunWorkflowButton</span>
         </div>
@@ -741,14 +741,14 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
   const renderDisplayFeedback = () => (
     <div className="component-grid">
       {/* Zoom Controls */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ZoomControls</span>
           <Chip label="New" size="small" color="primary" />
@@ -763,10 +763,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ZoomControls zoom={zoom} onZoomChange={setZoom} showValue={false} />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Favorite Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">FavoriteButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -785,10 +785,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <FavoriteButton isFavorite={true} onToggle={() => {}} buttonSize="large" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Empty State */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">EmptyState</span>
           <Chip label="New" size="small" color="primary" />
@@ -801,10 +801,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             onAction={() => {}}
           />
         </div>
-      </Paper>
+      </Surface>
 
       {/* Loading Spinner */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">LoadingSpinner</span>
           <Chip label="New" size="small" color="primary" />
@@ -825,10 +825,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <LoadingSpinner variant="circular" size="small" text="Loading..." />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Progress Bar */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ProgressBar</span>
           <Chip label="New" size="small" color="primary" />
@@ -841,10 +841,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ProgressBar value={progress} showValue={false} color="secondary" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* External Link */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ExternalLink</span>
           <Chip label="New" size="small" color="primary" />
@@ -863,10 +863,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ExternalLink href="https://example.com" iconVariant="launch">Launch app</ExternalLink>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Status Indicator */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">StatusIndicator</span>
           <Chip label="New" size="small" color="primary" />
@@ -882,10 +882,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <StatusIndicator status="pending" label="Pending" pulse />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Tag Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">TagButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -902,10 +902,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <TagButton label="Tag" variant="chip" onClick={() => {}} />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Theme Toggle Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ThemeToggleButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -924,14 +924,14 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ThemeToggleButton variant="labeled" />
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
   const renderNavigationLayout = () => (
     <div className="component-grid">
       {/* Search Input */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">SearchInput</span>
           <Chip label="New" size="small" color="primary" />
@@ -949,10 +949,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <span className="demo-value">{searchValue || "(empty)"}</span>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Breadcrumbs */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">Breadcrumbs</span>
           <Chip label="New" size="small" color="primary" />
@@ -980,10 +980,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Info Tooltip */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">InfoTooltip</span>
           <Chip label="New" size="small" color="primary" />
@@ -1004,10 +1004,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Warning Banner */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">WarningBanner</span>
           <Chip label="New" size="small" color="primary" />
@@ -1032,10 +1032,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             compact
           />
         </div>
-      </Paper>
+      </Surface>
 
       {/* Notification Badge */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">NotificationBadge</span>
           <Chip label="New" size="small" color="primary" />
@@ -1057,10 +1057,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             </NotificationBadge>
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Undo/Redo Buttons */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">UndoRedoButtons</span>
           <Chip label="New" size="small" color="primary" />
@@ -1086,10 +1086,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Confirm Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">ConfirmButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -1108,10 +1108,10 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <ConfirmButton onClick={() => {}} color="success" />
           </div>
         </div>
-      </Paper>
+      </Surface>
 
       {/* Help Button */}
-      <Paper className="component-card" elevation={0}>
+      <Surface className="component-card" elevation={0}>
         <div className="card-header">
           <span className="card-title">HelpButton</span>
           <Chip label="New" size="small" color="primary" />
@@ -1125,7 +1125,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
             <HelpButton onClick={() => {}} iconVariant="liveHelp" />
           </div>
         </div>
-      </Paper>
+      </Surface>
     </div>
   );
 
@@ -1158,12 +1158,12 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
           <div className="header-title">
             <div className="logo-accent">NT</div>
             <div>
-              <Typography variant="h4" fontWeight={700} color="text.primary">
+              <Text size="bigger" weight={700} color="text.primary">
                 UI Primitives
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
+              </Text>
+              <Text size="small" color="secondary">
                 Component Library & Design System
-              </Typography>
+              </Text>
             </div>
           </div>
           <Stack direction="row" alignItems="center" spacing={2}>
@@ -1185,7 +1185,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
       {/* Main Content */}
       <div className="main-content">
         {/* Tabs */}
-        <Paper className="tabs-container" elevation={0}>
+        <Surface className="tabs-container" elevation={0}>
           <Tabs
             value={activeTab}
             onChange={(_, v) => setActiveTab(v)}
@@ -1206,7 +1206,7 @@ const LayoutTest: React.FC = memo(function LayoutTest() {
               />
             ))}
           </Tabs>
-        </Paper>
+        </Surface>
 
         {/* Content */}
         {renderContent()}

--- a/web/src/components/assets/AssetCreateFolderConfirmation.tsx
+++ b/web/src/components/assets/AssetCreateFolderConfirmation.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
-import {
-  TextField
-} from "@mui/material";
-import { Text, FlexRow, AlertBanner, Surface } from "../ui_primitives";
+import { Text, FlexRow, AlertBanner, Surface, TextInput } from "../ui_primitives";
 import { EditorButton } from "../editor_ui";
 import { getMousePosition } from "../../utils/MousePosition";
 import { useAssetStore } from "../../stores/AssetStore";
@@ -251,7 +248,7 @@ const AssetCreateFolderConfirmation: React.FC = () => {
               {showAlert}
             </AlertBanner>
           )}
-          <TextField
+          <TextInput
             className="asset-create-folder-input"
             inputRef={inputRef}
             value={folderName}

--- a/web/src/components/chain_editor/ChainEditor.tsx
+++ b/web/src/components/chain_editor/ChainEditor.tsx
@@ -7,13 +7,12 @@
 
 import React, { useCallback, useMemo, useState } from "react";
 import { useTheme } from "@mui/material/styles";
-import { TextField } from "@mui/material";
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import { FlexRow } from "../ui_primitives/FlexRow";
 import { FlexColumn } from "../ui_primitives/FlexColumn";
 import { EmptyState } from "../ui_primitives/EmptyState";
-import { ToolbarIconButton, Box } from "../ui_primitives";
+import { ToolbarIconButton, Box, TextInput } from "../ui_primitives";
 import { useChainEditorStore } from "./useChainEditorStore";
 import { ChainNodeCard } from "./ChainNodeCard";
 import { ChainConnector } from "./ChainConnector";
@@ -102,7 +101,7 @@ export const ChainEditor: React.FC<ChainEditorProps> = ({ onSave }) => {
           flexShrink: 0,
         }}
       >
-        <TextField
+        <TextInput
           size="small"
           variant="standard"
           value={workflowName}

--- a/web/src/components/chat/composer/CollectionsSelector.tsx
+++ b/web/src/components/chat/composer/CollectionsSelector.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import {
-  Checkbox,
   Popover,
   PopoverOrigin
 } from "@mui/material";
@@ -11,7 +10,7 @@ import { useCollectionStore } from "../../../stores/CollectionStore";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { ScrollArea, Tooltip, Text, Caption, FlexRow, FlexColumn, EditorButton, Chip, Box } from "../../ui_primitives";
+import { ScrollArea, Tooltip, Text, Caption, FlexRow, FlexColumn, EditorButton, Chip, Box, Checkbox } from "../../ui_primitives";
 
 // Popover dimensions
 const POPOVER_WIDTH = 320;

--- a/web/src/components/chat/composer/WorkflowToolsSelector.tsx
+++ b/web/src/components/chat/composer/WorkflowToolsSelector.tsx
@@ -10,7 +10,6 @@ import React, {
   useLayoutEffect
 } from "react";
 import {
-  Checkbox,
   Popover,
   PopoverOrigin
 } from "@mui/material";
@@ -22,7 +21,7 @@ import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 import { useWorkflowTools } from "../../../serverState/useWorkflowTools";
 import { useTheme } from "@mui/material/styles";
 import SearchInput from "../../search/SearchInput";
-import { ScrollArea, Tooltip, Text, Caption, FlexRow, FlexColumn, LoadingSpinner } from "../../ui_primitives";
+import { ScrollArea, Tooltip, Text, Caption, FlexRow, FlexColumn, LoadingSpinner, Checkbox } from "../../ui_primitives";
 
 // Popover dimensions
 const POPOVER_WIDTH = 360;

--- a/web/src/components/color_picker/ColorInputs.tsx
+++ b/web/src/components/color_picker/ColorInputs.tsx
@@ -3,7 +3,8 @@ import { css } from "@emotion/react";
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { TextField, InputAdornment } from "@mui/material";
+import { InputAdornment } from "@mui/material";
+import { TextInput } from "../ui_primitives";
 import { Box } from "../ui_primitives";
 import { useColorConversion } from "../../hooks/useColorConversion";
 import type { ColorMode } from "../../hooks/useColorConversion";
@@ -75,7 +76,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
       case "hex":
         return (
           <div className="color-input-row">
-            <TextField
+            <TextInput
               className="color-input hex-input"
               value={state.hexInput}
               onChange={(e) => handlers.handleHexChange(e.target.value)}
@@ -87,7 +88,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               }}
               placeholder="FFFFFF"
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               value={state.alphaInput}
               onChange={(e) => handlers.handleAlphaChange(e.target.value)}
@@ -108,7 +109,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
         return (
           <>
             <div className="color-input-row">
-              <TextField
+              <TextInput
                 className="color-input component-input"
                 label="R"
                 value={state.rgbInputs.r}
@@ -117,7 +118,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
                 size="small"
                 inputProps={{ min: 0, max: 255 }}
               />
-              <TextField
+              <TextInput
                 className="color-input component-input"
                 label="G"
                 value={state.rgbInputs.g}
@@ -126,7 +127,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
                 size="small"
                 inputProps={{ min: 0, max: 255 }}
               />
-              <TextField
+              <TextInput
                 className="color-input component-input"
                 label="B"
                 value={state.rgbInputs.b}
@@ -135,7 +136,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
                 size="small"
                 inputProps={{ min: 0, max: 255 }}
               />
-              <TextField
+              <TextInput
                 className="color-input component-input"
                 label="A"
                 value={state.alphaInput}
@@ -154,7 +155,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
       case "hsl":
         return (
           <div className="color-input-row">
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="H"
               value={state.hslInputs.h}
@@ -163,7 +164,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 360 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="S"
               value={state.hslInputs.s}
@@ -175,7 +176,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               }}
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="L"
               value={state.hslInputs.l}
@@ -187,7 +188,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               }}
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="A"
               value={state.alphaInput}
@@ -205,7 +206,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
       case "hsb":
         return (
           <div className="color-input-row">
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="H"
               value={state.hsbInputs.h}
@@ -214,7 +215,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 360 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="S"
               value={state.hsbInputs.s}
@@ -226,7 +227,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               }}
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="B"
               value={state.hsbInputs.b}
@@ -238,7 +239,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               }}
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="A"
               value={state.alphaInput}
@@ -256,7 +257,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
       case "cmyk":
         return (
           <div className="color-input-row">
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="C"
               value={state.cmykInputs.c}
@@ -265,7 +266,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="M"
               value={state.cmykInputs.m}
@@ -274,7 +275,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="Y"
               value={state.cmykInputs.y}
@@ -283,7 +284,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="K"
               value={state.cmykInputs.k}
@@ -298,7 +299,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
       case "lab":
         return (
           <div className="color-input-row">
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="L"
               value={state.labInputs.l}
@@ -307,7 +308,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: 0, max: 100 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="a"
               value={state.labInputs.a}
@@ -316,7 +317,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: -128, max: 127 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="b"
               value={state.labInputs.b}
@@ -325,7 +326,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
               size="small"
               inputProps={{ min: -128, max: 127 }}
             />
-            <TextField
+            <TextInput
               className="color-input component-input"
               label="A"
               value={state.alphaInput}

--- a/web/src/components/menus/SearchProviderSection.tsx
+++ b/web/src/components/menus/SearchProviderSection.tsx
@@ -5,10 +5,9 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
-  Stack,
-  Chip
+  Stack
 } from "@mui/material";
-import { FlexRow, Box } from "../ui_primitives";
+import { FlexRow, Box, Chip } from "../ui_primitives";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import { TextInput, Text } from "../ui_primitives";

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -5,12 +5,12 @@ import {
   List,
   ListItemButton,
   ListItemText,
-  Checkbox,
   Menu,
   MenuItem
 } from "@mui/material";
 import {
   Caption,
+  Checkbox,
   Divider,
   EditorButton,
   FlexColumn,

--- a/web/src/components/node/NodeExplorer.tsx
+++ b/web/src/components/node/NodeExplorer.tsx
@@ -4,10 +4,9 @@ import React, { useCallback, useMemo, useState, memo } from "react";
 import {
   List,
   ListItem,
-  ListItemButton,
-  TextField
+  ListItemButton
 } from "@mui/material";
-import { Text, Chip, EditorButton } from "../ui_primitives";
+import { Text, Chip, EditorButton, TextInput } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { useNodes } from "../../contexts/NodeContext";
@@ -297,7 +296,7 @@ const NodeExplorer: React.FC = () => {
           />
         }
       />
-      <TextField
+      <TextInput
         className="filter-input"
         size="medium"
         placeholder="Filter by name, type, or node id"

--- a/web/src/components/node/PreviewImageGrid.tsx
+++ b/web/src/components/node/PreviewImageGrid.tsx
@@ -3,7 +3,6 @@ import React, { useRef, useEffect, useState, useCallback, useMemo, memo } from "
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Checkbox } from "@mui/material";
 import CompareIcon from "@mui/icons-material/Compare";
 import ClearIcon from "@mui/icons-material/Clear";
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
@@ -13,7 +12,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { ImageComparer } from "../widgets";
 import AssetViewer from "../assets/AssetViewer";
 import { CopyAssetButton } from "../common/CopyAssetButton";
-import { Dialog, Tooltip, EditorButton, ToolbarIconButton, Box } from "../ui_primitives";
+import { Checkbox, Dialog, Tooltip, EditorButton, ToolbarIconButton, Box } from "../ui_primitives";
 import { alphaSurfaceBg } from "../../styles/AlphaSurface";
 
 export type ImageSource = Uint8Array | string;

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -22,8 +22,7 @@ import React, {
   useEffect
 } from "react";
 import { Handle, NodeProps, NodeToolbar, Position } from "@xyflow/react";
-import { Typography } from "@mui/material";
-import { Box } from "../../ui_primitives";
+import { Box, Text } from "../../ui_primitives";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -1203,9 +1202,9 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
                     </div>
                   </>
                 ) : (
-                  <Typography className="hint">
+                  <Text className="hint">
                     Click to open image editor
-                  </Typography>
+                  </Text>
                 )}
               </div>
             </div>

--- a/web/src/components/node/image_editor/ImageEditorToolbar.tsx
+++ b/web/src/components/node/image_editor/ImageEditorToolbar.tsx
@@ -326,8 +326,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">Tools</Text>
           <div className="tools-grid">
-            <Tooltip title="Select / Pan (V)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Select / Pan (V)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "select" ? "active" : ""}`}
                 onClick={handleSelectTool("select")}
                 size="small"
@@ -335,9 +336,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <PanToolIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Crop (C)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Crop (C)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "crop" ? "active" : ""}`}
                 onClick={handleSelectTool("crop")}
                 size="small"
@@ -345,9 +346,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <CropIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Draw / Paint (B)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Draw / Paint (B)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "draw" ? "active" : ""}`}
                 onClick={handleSelectTool("draw")}
                 size="small"
@@ -355,9 +356,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <BrushIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Erase (E)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Erase (E)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "erase" ? "active" : ""}`}
                 onClick={handleSelectTool("erase")}
                 size="small"
@@ -365,9 +366,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <AutoFixHighIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Fill (G)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Fill (G)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "fill" ? "active" : ""}`}
                 onClick={handleSelectTool("fill")}
                 size="small"
@@ -375,9 +376,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <FormatColorFillIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Text (T)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Text (T)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "text" ? "active" : ""}`}
                 onClick={handleSelectTool("text")}
                 size="small"
@@ -385,9 +386,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <TextFieldsIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Rectangle (R)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Rectangle (R)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "rectangle" ? "active" : ""}`}
                 onClick={handleSelectTool("rectangle")}
                 size="small"
@@ -395,9 +396,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <RectangleOutlinedIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Ellipse (O)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Ellipse (O)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "ellipse" ? "active" : ""}`}
                 onClick={handleSelectTool("ellipse")}
                 size="small"
@@ -405,9 +406,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <CircleOutlinedIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Line (L)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Line (L)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "line" ? "active" : ""}`}
                 onClick={handleSelectTool("line")}
                 size="small"
@@ -415,9 +416,9 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <RemoveIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Arrow (A)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Arrow (A)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "arrow" ? "active" : ""}`}
                 onClick={handleSelectTool("arrow")}
                 size="small"
@@ -425,43 +426,42 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <ArrowRightAltIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Rectangle Select (M)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Rectangle Select (M)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "marquee-rect" ? "active" : ""}`}
                 onClick={handleSelectTool("marquee-rect")}
                 size="small"
               >
                 <HighlightAltIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Ellipse Select" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Ellipse Select"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "marquee-ellipse" ? "active" : ""}`}
                 onClick={handleSelectTool("marquee-ellipse")}
                 size="small"
               >
                 <SelectAllIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Lasso Select" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Lasso Select"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "lasso" ? "active" : ""}`}
                 onClick={handleSelectTool("lasso")}
                 size="small"
               >
                 <GestureIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Magic Wand (W)" placement="top">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Magic Wand (W)"
+                tooltipPlacement="top"
                 className={`tool-button ${tool === "magic-wand" ? "active" : ""}`}
                 onClick={handleSelectTool("magic-wand")}
                 size="small"
               >
                 <AutoFixNormalIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
           </div>
         </div>
 
@@ -567,15 +567,14 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
             </div>
 
             <div className="actions-row" style={{ marginTop: "8px" }}>
-              <Tooltip title="Select All (Ctrl+A)">
-                <ToolbarIconButton
+              <ToolbarIconButton
+                  tooltip="Select All (Ctrl+A)"
                   className="action-button"
                   onClick={() => onAction("select-all")}
                   size="small"
                 >
                   <SelectAllIcon fontSize="small" />
                 </ToolbarIconButton>
-              </Tooltip>
               <Tooltip title="Deselect (Ctrl+D)">
                 <span>
                   <ToolbarIconButton
@@ -834,8 +833,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">Transform</Text>
           <div className="actions-row">
-            <Tooltip title="Rotate 90° CCW">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Rotate 90° CCW"
                 className="action-button"
                 onClick={handleRotateCCW}
                 size="small"
@@ -843,9 +842,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <Rotate90DegreesCcwIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Rotate 90° CW">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Rotate 90° CW"
                 className="action-button"
                 onClick={handleRotateCW}
                 size="small"
@@ -853,9 +851,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <Rotate90DegreesCwIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Flip Horizontal">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Flip Horizontal"
                 className="action-button"
                 onClick={handleFlipH}
                 size="small"
@@ -863,9 +860,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <FlipIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
-            <Tooltip title="Flip Vertical">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Flip Vertical"
                 className="action-button"
                 onClick={handleFlipV}
                 size="small"
@@ -873,7 +869,6 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <FlipIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
           </div>
         </div>
 
@@ -951,8 +946,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
             >
               <ZoomInIcon fontSize="small" />
             </ToolbarIconButton>
-            <Tooltip title="Reset Zoom">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Reset Zoom"
                 className="action-button"
                 onClick={handleZoomReset}
                 size="small"
@@ -960,7 +955,6 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <RestartAltIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
           </div>
         </div>
 
@@ -994,8 +988,8 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
                 </ToolbarIconButton>
               </span>
             </Tooltip>
-            <Tooltip title="Reset to Original">
-              <ToolbarIconButton
+            <ToolbarIconButton
+                tooltip="Reset to Original"
                 className="action-button"
                 onClick={handleReset}
                 size="small"
@@ -1003,7 +997,6 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               >
                 <RestartAltIcon fontSize="small" />
               </ToolbarIconButton>
-            </Tooltip>
           </div>
         </div>
       </div>

--- a/web/src/components/node/image_editor/ImageEditorToolbar.tsx
+++ b/web/src/components/node/image_editor/ImageEditorToolbar.tsx
@@ -4,13 +4,10 @@ import React, { memo, useCallback } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import {
-  IconButton,
   Slider,
-  Checkbox,
-  FormControlLabel,
-  Typography
+  FormControlLabel
 } from "@mui/material";
-import { Tooltip, Text, Caption } from "../../ui_primitives";
+import { Tooltip, Text, Caption, ToolbarIconButton, Checkbox } from "../../ui_primitives";
 
 // Icons
 import PanToolIcon from "@mui/icons-material/PanTool";
@@ -330,140 +327,140 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
           <Text className="section-title">Tools</Text>
           <div className="tools-grid">
             <Tooltip title="Select / Pan (V)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "select" ? "active" : ""}`}
                 onClick={handleSelectTool("select")}
                 size="small"
                 aria-label="Select or Pan tool"
               >
                 <PanToolIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Crop (C)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "crop" ? "active" : ""}`}
                 onClick={handleSelectTool("crop")}
                 size="small"
                 aria-label="Crop tool"
               >
                 <CropIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Draw / Paint (B)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "draw" ? "active" : ""}`}
                 onClick={handleSelectTool("draw")}
                 size="small"
                 aria-label="Draw or Paint tool"
               >
                 <BrushIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Erase (E)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "erase" ? "active" : ""}`}
                 onClick={handleSelectTool("erase")}
                 size="small"
                 aria-label="Erase tool"
               >
                 <AutoFixHighIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Fill (G)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "fill" ? "active" : ""}`}
                 onClick={handleSelectTool("fill")}
                 size="small"
                 aria-label="Fill tool"
               >
                 <FormatColorFillIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Text (T)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "text" ? "active" : ""}`}
                 onClick={handleSelectTool("text")}
                 size="small"
                 aria-label="Text tool"
               >
                 <TextFieldsIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Rectangle (R)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "rectangle" ? "active" : ""}`}
                 onClick={handleSelectTool("rectangle")}
                 size="small"
                 aria-label="Rectangle tool"
               >
                 <RectangleOutlinedIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Ellipse (O)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "ellipse" ? "active" : ""}`}
                 onClick={handleSelectTool("ellipse")}
                 size="small"
                 aria-label="Ellipse tool"
               >
                 <CircleOutlinedIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Line (L)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "line" ? "active" : ""}`}
                 onClick={handleSelectTool("line")}
                 size="small"
                 aria-label="Line tool"
               >
                 <RemoveIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Arrow (A)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "arrow" ? "active" : ""}`}
                 onClick={handleSelectTool("arrow")}
                 size="small"
                 aria-label="Arrow tool"
               >
                 <ArrowRightAltIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Rectangle Select (M)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "marquee-rect" ? "active" : ""}`}
                 onClick={handleSelectTool("marquee-rect")}
                 size="small"
               >
                 <HighlightAltIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Ellipse Select" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "marquee-ellipse" ? "active" : ""}`}
                 onClick={handleSelectTool("marquee-ellipse")}
                 size="small"
               >
                 <SelectAllIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Lasso Select" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "lasso" ? "active" : ""}`}
                 onClick={handleSelectTool("lasso")}
                 size="small"
               >
                 <GestureIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Magic Wand (W)" placement="top">
-              <IconButton
+              <ToolbarIconButton
                 className={`tool-button ${tool === "magic-wand" ? "active" : ""}`}
                 onClick={handleSelectTool("magic-wand")}
                 size="small"
               >
                 <AutoFixNormalIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
           </div>
         </div>
@@ -495,7 +492,7 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         {/* Selection Settings (shown when a selection tool is active) */}
         {(tool === "marquee-rect" || tool === "marquee-ellipse" || tool === "lasso" || tool === "magic-wand") && (
           <div className="toolbar-section">
-            <Typography className="section-title">Selection Settings</Typography>
+            <Text className="section-title">Selection Settings</Text>
 
             <div className="slider-container">
               <div className="slider-label">
@@ -504,16 +501,16 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
               <div className="actions-row">
                 {(["replace", "add", "subtract", "intersect"] as SelectionMode[]).map((m) => (
                   <Tooltip key={m} title={m.charAt(0).toUpperCase() + m.slice(1)}>
-                    <IconButton
+                    <ToolbarIconButton
                       className={`action-button ${selectionSettings.mode === m ? "active" : ""}`}
                       onClick={() => onSelectionSettingsChange?.({ mode: m })}
                       size="small"
                       sx={selectionSettings.mode === m ? { bgcolor: "primary.main", color: "primary.contrastText" } : {}}
                     >
-                      <Typography variant="caption" sx={{ fontSize: "10px", fontWeight: 600 }}>
+                      <Caption sx={{ fontSize: "10px", fontWeight: 600 }}>
                         {m === "replace" ? "R" : m === "add" ? "+" : m === "subtract" ? "−" : "∩"}
-                      </Typography>
-                    </IconButton>
+                      </Caption>
+                    </ToolbarIconButton>
                   </Tooltip>
                 ))}
               </div>
@@ -571,36 +568,36 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
 
             <div className="actions-row" style={{ marginTop: "8px" }}>
               <Tooltip title="Select All (Ctrl+A)">
-                <IconButton
+                <ToolbarIconButton
                   className="action-button"
                   onClick={() => onAction("select-all")}
                   size="small"
                 >
                   <SelectAllIcon fontSize="small" />
-                </IconButton>
+                </ToolbarIconButton>
               </Tooltip>
               <Tooltip title="Deselect (Ctrl+D)">
                 <span>
-                  <IconButton
+                  <ToolbarIconButton
                     className="action-button"
                     onClick={() => onAction("deselect")}
                     disabled={!hasSelection}
                     size="small"
                   >
                     <DeselectIcon fontSize="small" />
-                  </IconButton>
+                  </ToolbarIconButton>
                 </span>
               </Tooltip>
               <Tooltip title="Invert Selection (Ctrl+Shift+I)">
                 <span>
-                  <IconButton
+                  <ToolbarIconButton
                     className="action-button"
                     onClick={() => onAction("invert-selection")}
                     disabled={!hasSelection}
                     size="small"
                   >
                     <InvertColorsIcon fontSize="small" />
-                  </IconButton>
+                  </ToolbarIconButton>
                 </span>
               </Tooltip>
             </div>
@@ -838,44 +835,44 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
           <Text className="section-title">Transform</Text>
           <div className="actions-row">
             <Tooltip title="Rotate 90° CCW">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleRotateCCW}
                 size="small"
                 aria-label="Rotate 90 degrees counter-clockwise"
               >
                 <Rotate90DegreesCcwIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Rotate 90° CW">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleRotateCW}
                 size="small"
                 aria-label="Rotate 90 degrees clockwise"
               >
                 <Rotate90DegreesCwIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Flip Horizontal">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleFlipH}
                 size="small"
                 aria-label="Flip image horizontally"
               >
                 <FlipIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
             <Tooltip title="Flip Vertical">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleFlipV}
                 size="small"
                 aria-label="Flip image vertically"
               >
                 <FlipIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
           </div>
         </div>
@@ -937,32 +934,32 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
         <div className="toolbar-section">
           <Text className="section-title">View</Text>
           <div className="zoom-controls">
-            <IconButton
+            <ToolbarIconButton
               className="action-button"
               onClick={handleZoomOut}
               size="small"
               aria-label="Zoom out"
             >
               <ZoomOutIcon fontSize="small" />
-            </IconButton>
+            </ToolbarIconButton>
             <span className="zoom-value">{Math.round(zoom * 100)}%</span>
-            <IconButton
+            <ToolbarIconButton
               className="action-button"
               onClick={handleZoomIn}
               size="small"
               aria-label="Zoom in"
             >
               <ZoomInIcon fontSize="small" />
-            </IconButton>
+            </ToolbarIconButton>
             <Tooltip title="Reset Zoom">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleZoomReset}
                 size="small"
                 aria-label="Reset zoom to 100%"
               >
                 <RestartAltIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
           </div>
         </div>
@@ -973,7 +970,7 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
           <div className="actions-row">
             <Tooltip title="Undo (Ctrl+Z)">
               <span>
-                <IconButton
+                <ToolbarIconButton
                   className="action-button"
                   onClick={onUndo}
                   disabled={!canUndo}
@@ -981,12 +978,12 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
                   aria-label="Undo last action"
                 >
                   <UndoIcon fontSize="small" />
-                </IconButton>
+                </ToolbarIconButton>
               </span>
             </Tooltip>
             <Tooltip title="Redo (Ctrl+Y)">
               <span>
-                <IconButton
+                <ToolbarIconButton
                   className="action-button"
                   onClick={onRedo}
                   disabled={!canRedo}
@@ -994,18 +991,18 @@ const ImageEditorToolbar: React.FC<ImageEditorToolbarProps> = ({
                   aria-label="Redo last action"
                 >
                   <RedoIcon fontSize="small" />
-                </IconButton>
+                </ToolbarIconButton>
               </span>
             </Tooltip>
             <Tooltip title="Reset to Original">
-              <IconButton
+              <ToolbarIconButton
                 className="action-button"
                 onClick={handleReset}
                 size="small"
                 aria-label="Reset image to original"
               >
                 <RestartAltIcon fontSize="small" />
-              </IconButton>
+              </ToolbarIconButton>
             </Tooltip>
           </div>
         </div>

--- a/web/src/components/node_editor/NodeEditor.tsx
+++ b/web/src/components/node_editor/NodeEditor.tsx
@@ -1,10 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { memo, useState, useRef, useEffect } from "react";
 import {
-  Modal,
-  TextField
+  Modal
 } from "@mui/material";
-import { LoadingSpinner, Dialog, EditorButton, Box } from "../ui_primitives";
+import { LoadingSpinner, Dialog, EditorButton, Box, TextInput } from "../ui_primitives";
 // store
 import useNodeMenuStore from "../../stores/NodeMenuStore";
 //css
@@ -239,7 +238,7 @@ const NodeEditor: React.FC<NodeEditorProps> = ({ workflowId, active }) => {
         confirmText="Save"
         cancelText="Cancel"
       >
-        <TextField
+        <TextInput
           autoFocus
           margin="dense"
           label="Package Name"

--- a/web/src/components/node_menu/RenderNodesSelectable.tsx
+++ b/web/src/components/node_menu/RenderNodesSelectable.tsx
@@ -11,10 +11,9 @@ import NodeItem from "./NodeItem";
 import {
   Accordion,
   AccordionSummary,
-  AccordionDetails,
-  Checkbox
+  AccordionDetails
 } from "@mui/material";
-import { Tooltip, Text, Box } from "../ui_primitives";
+import { Tooltip, Text, Box, Checkbox } from "../ui_primitives";
 import isEqual from "fast-deep-equal";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { SearchResultGroup } from "../../utils/nodeSearch";

--- a/web/src/components/node_test/NodeTestPage.tsx
+++ b/web/src/components/node_test/NodeTestPage.tsx
@@ -1,13 +1,18 @@
 import React, { useMemo, useCallback, useRef, useState } from "react";
 import {
-  TextField,
-  Button,
-  IconButton,
-  Chip,
   ToggleButtonGroup,
   ToggleButton
 } from "@mui/material";
-import { Text, FlexRow, FlexColumn, Box } from "../ui_primitives";
+import {
+  Text,
+  FlexRow,
+  FlexColumn,
+  Box,
+  TextInput,
+  EditorButton,
+  ToolbarIconButton,
+  Chip
+} from "../ui_primitives";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import { useTheme } from "@mui/material/styles";
@@ -157,7 +162,7 @@ function NodeTestPage() {
       >
         <Text size="normal" weight={600}>Node Integration Tests</Text>
 
-        <TextField
+        <TextInput
           size="small"
           placeholder="Search nodes..."
           value={search}
@@ -165,7 +170,7 @@ function NodeTestPage() {
           sx={{ width: 250 }}
         />
 
-        <TextField
+        <TextInput
           size="small"
           type="number"
           label="Concurrency"
@@ -177,16 +182,16 @@ function NodeTestPage() {
           inputProps={{ min: 1, max: 50 }}
         />
 
-        <Button
+        <EditorButton
           variant="contained"
           startIcon={<PlayArrowIcon />}
           onClick={handleRunAll}
           size="small"
         >
           Run All ({stats.total})
-        </Button>
+        </EditorButton>
 
-        <Button
+        <EditorButton
           variant="outlined"
           startIcon={<StopIcon />}
           onClick={stopAll}
@@ -194,11 +199,11 @@ function NodeTestPage() {
           color="warning"
         >
           Stop All
-        </Button>
+        </EditorButton>
 
-        <Button size="small" onClick={clearResults}>
+        <EditorButton size="small" onClick={clearResults}>
           Clear
-        </Button>
+        </EditorButton>
 
         <ToggleButtonGroup
           size="small"
@@ -260,13 +265,12 @@ function NodeTestPage() {
                       borderColor: "divider"
                     }}
                   >
-                    <IconButton
+                    <ToolbarIconButton
                       size="small"
                       onClick={() => handleRunNamespace(row.namespace)}
-                      title={`Run all ${row.nodeCount} nodes in ${row.namespace}`}
-                    >
-                      <PlayArrowIcon fontSize="small" />
-                    </IconButton>
+                      tooltip={`Run all ${row.nodeCount} nodes in ${row.namespace}`}
+                      icon={<PlayArrowIcon fontSize="small" />}
+                    />
                     <Text size="small" weight={700}>
                       {row.namespace}
                     </Text>

--- a/web/src/components/node_test/NodeTestRow.tsx
+++ b/web/src/components/node_test/NodeTestRow.tsx
@@ -1,17 +1,14 @@
 import React, { memo, useCallback, useState } from "react";
 import {
-  IconButton,
-  Chip,
   DialogTitle,
   DialogContent
 } from "@mui/material";
-import { Text, FlexRow } from "../ui_primitives";
+import { Text, FlexRow, ToolbarIconButton, Chip, Dialog } from "../ui_primitives";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import CloseIcon from "@mui/icons-material/Close";
 import type { NodeMetadata } from "../../stores/ApiTypes";
 import type { NodeTestResult } from "./useNodeTestRunner";
 import OutputRenderer from "../node/OutputRenderer";
-import { Dialog } from "../ui_primitives";
 
 const STATUS_COLORS: Record<
   string,
@@ -66,7 +63,7 @@ function NodeTestRowInner({
         }}
         onClick={handleRowClick}
       >
-        <IconButton
+        <ToolbarIconButton
           size="small"
           aria-label="Run test"
           onClick={(e) => {
@@ -75,9 +72,8 @@ function NodeTestRowInner({
           }}
           disabled={status === "running" || status === "queued"}
           sx={{ width: 32, height: 32 }}
-        >
-          <PlayArrowIcon fontSize="small" />
-        </IconButton>
+          icon={<PlayArrowIcon fontSize="small" />}
+        />
 
         <Text
           size="small"
@@ -190,9 +186,12 @@ function NodeTestRowInner({
                   color={STATUS_COLORS[status]}
                 />
               )}
-              <IconButton size="small" onClick={handleClose} aria-label="Close dialog">
-                <CloseIcon fontSize="small" />
-              </IconButton>
+              <ToolbarIconButton
+                size="small"
+                onClick={handleClose}
+                aria-label="Close dialog"
+                icon={<CloseIcon fontSize="small" />}
+              />
             </FlexRow>
           </DialogTitle>
           <DialogContent sx={{ minHeight: 200 }}>

--- a/web/src/components/properties/AudioProperty.tsx
+++ b/web/src/components/properties/AudioProperty.tsx
@@ -7,8 +7,7 @@ import { PropertyProps } from "../node/PropertyInput";
 import PropertyDropzone from "./PropertyDropzone";
 import { memo, useState } from "react";
 import isEqual from "fast-deep-equal";
-import { TextField } from "@mui/material";
-import { EditorButton } from "../ui_primitives";
+import { EditorButton, NodeTextField } from "../ui_primitives";
 import { useNodes } from "../../contexts/NodeContext";
 import AudioVisualizer from "../common/AudioVisualizer";
 import { useRealtimeAudioStream } from "../../hooks/useRealtimeAudioStream";
@@ -105,11 +104,10 @@ const AudioProperty = (props: PropertyProps) => {
             </div>
           )}
           <div className="controls-row">
-            <TextField
+            <NodeTextField
               className="sample-rate-input"
               label="Hz"
               type="number"
-              size="small"
               value={sampleRate}
               onChange={(e) => setSampleRate(Number(e.target.value))}
               disabled={isStreaming}

--- a/web/src/components/properties/FolderProperty.tsx
+++ b/web/src/components/properties/FolderProperty.tsx
@@ -3,10 +3,9 @@ import { useTheme } from "@mui/material/styles";
 import {
   Popover,
   DialogTitle,
-  DialogContent,
-  TextField
+  DialogContent
 } from "@mui/material";
-import { EditorButton } from "../ui_primitives";
+import { EditorButton, TextInput } from "../ui_primitives";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import { AssetList } from "../../stores/ApiTypes";
 import { useAssetStore } from "../../stores/AssetStore";
@@ -158,7 +157,7 @@ const FolderProperty = (props: PropertyProps) => {
           {"Create Folder"}
         </DialogTitle>
         <DialogContent className="dialog-content">
-          <TextField
+          <TextInput
             className="input-field"
             inputRef={inputRef}
             placeholder="Folder Name"

--- a/web/src/components/properties/ImageSizePresetsMenu.tsx
+++ b/web/src/components/properties/ImageSizePresetsMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Menu, MenuItem, ListSubheader, TextField, InputAdornment } from "@mui/material";
-import { FlexColumn, FlexRow } from "../ui_primitives";
+import { Menu, MenuItem, ListSubheader, InputAdornment } from "@mui/material";
+import { FlexColumn, FlexRow, NodeTextField } from "../ui_primitives";
 import Search from "@mui/icons-material/Search";
 import { IMAGE_SIZE_PRESETS, PresetOption } from "../../config/constants";
 
@@ -105,10 +105,9 @@ export const ImageSizePresetsMenu: React.FC<ImageSizePresetsMenuProps> = ({
         height: '48px',
         boxSizing: 'border-box'
       }}>
-        <TextField
+        <NodeTextField
           className="presets-search-field"
           fullWidth
-          size="small"
           placeholder="Search presets..."
           value={searchQuery}
           onChange={handleSearchChange}

--- a/web/src/components/properties/Model3DProperty.tsx
+++ b/web/src/components/properties/Model3DProperty.tsx
@@ -12,8 +12,7 @@ import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import ConnectedBadge from "./ConnectedBadge";
 import { useFileDrop } from "../../hooks/handlers/useFileDrop";
 import { Asset } from "../../stores/ApiTypes";
-import { TextField } from "@mui/material";
-import { Tooltip, EditorButton } from "../ui_primitives";
+import { Tooltip, EditorButton, NodeTextField } from "../ui_primitives";
 import AssetViewer from "../assets/AssetViewer";
 import LazyModel3DViewer from "../asset_viewer/LazyModel3DViewer";
 import { resolveAssetUri } from "../node/output/hooks";
@@ -218,7 +217,7 @@ const Model3DProperty = (props: PropertyProps) => {
       />
       <div className="drop-container">
           {showUrlInput && (
-            <TextField
+            <NodeTextField
               className="url-input nowheel nodrag"
               value={uri || ""}
               autoComplete="off"

--- a/web/src/components/properties/SnippetSidebar.tsx
+++ b/web/src/components/properties/SnippetSidebar.tsx
@@ -2,8 +2,8 @@
 
 import { css } from "@emotion/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { InputAdornment, TextField } from "@mui/material";
-import { Tooltip, Chip } from "../ui_primitives";
+import { InputAdornment } from "@mui/material";
+import { Tooltip, Chip, NodeTextField } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import SearchIcon from "@mui/icons-material/Search";
@@ -274,10 +274,9 @@ const SnippetSidebar = ({ monacoRef, visible }: SnippetSidebarProps) => {
     <div css={styles(theme)} onKeyDown={handleKeyDown}>
       <div className="sidebar-header">
         <div className="sidebar-title">Snippets</div>
-        <TextField
+        <NodeTextField
           inputRef={searchRef}
           className="snippet-search"
-          size="small"
           fullWidth
           placeholder="Search…"
           value={search}

--- a/web/src/components/properties/ToolsListProperty.tsx
+++ b/web/src/components/properties/ToolsListProperty.tsx
@@ -3,10 +3,9 @@ import {
   Menu,
   MenuItem,
   ListItemIcon,
-  ListItemText,
-  Checkbox
+  ListItemText
 } from "@mui/material";
-import { Tooltip, ToolbarIconButton, FlexRow } from "../ui_primitives";
+import { ToolbarIconButton, FlexRow, Checkbox } from "../ui_primitives";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import isEqual from "fast-deep-equal";

--- a/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
@@ -11,7 +11,6 @@
 
 import React, { memo, useCallback } from "react";
 import { useTheme } from "@mui/material/styles";
-import { Button } from "@mui/material";
 import type { Layer } from "../types";
 import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
 import {
@@ -22,6 +21,7 @@ import {
   Text,
   TextInput
 } from "../../ui_primitives";
+import { EditorButton } from "../../editor_ui";
 import ImageModelSelect from "../../properties/ImageModelSelect";
 import type { ImageModelValue } from "../../../stores/ApiTypes";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
@@ -108,16 +108,16 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
           ))}
 
         {isRunning ? (
-          <Button
+          <EditorButton
             size="small"
             variant="outlined"
             color="warning"
             onClick={() => cancel(layer.id)}
           >
             Cancel
-          </Button>
+          </EditorButton>
         ) : (
-          <Button
+          <EditorButton
             size="small"
             variant="contained"
             disabled={!canGenerate}
@@ -125,7 +125,7 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
             data-testid="direct-gen-generate"
           >
             Generate
-          </Button>
+          </EditorButton>
         )}
         {binding.status === "failed" && (
           <Text size="small" sx={{ color: theme.vars.palette.error.main }}>

--- a/web/src/components/sketch/tool-settings-panels/PenPressureSettingsPanel.tsx
+++ b/web/src/components/sketch/tool-settings-panels/PenPressureSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
-import { Slider, Switch, Typography } from "@mui/material";
-import { FlexRow, Box } from "../../ui_primitives";
+import { Slider, Switch } from "@mui/material";
+import { FlexRow, Box, Text } from "../../ui_primitives";
 import { sketchSliderSx } from "../sketchStyles";
 import { SketchModeToggle, SketchModeOption } from "./SketchModeToggle";
 import {
@@ -56,12 +56,12 @@ export const PenPressureSettingsPanel = memo(function PenPressureSettingsPanel({
 
   const lightEndRow = (
     <Box className="setting-row">
-      <Typography
+      <Text
         className="setting-label"
         title="Size/opacity at minimum pressure. Slider uses eased mapping so the upper range is easier to dial in."
       >
         Light end
-      </Typography>
+      </Text>
       <Slider
         sx={sketchSliderSx}
         size="small"
@@ -77,20 +77,20 @@ export const PenPressureSettingsPanel = memo(function PenPressureSettingsPanel({
           })
         }
       />
-      <Typography className="setting-value">
+      <Text className="setting-value">
         {Math.round(minScale * 100)}%
-      </Typography>
+      </Text>
     </Box>
   );
 
   const curveRow = (
     <Box className="setting-row">
-      <Typography
+      <Text
         className="setting-label"
         title="Pressure exponent before mapping: 1 = linear; higher = need firmer pressure for full size"
       >
         Curve
-      </Typography>
+      </Text>
       <Slider
         sx={sketchSliderSx}
         size="small"
@@ -100,9 +100,9 @@ export const PenPressureSettingsPanel = memo(function PenPressureSettingsPanel({
         value={settings.pressureCurve ?? DEFAULT_PRESSURE_CURVE}
         onChange={(_, v) => onChange({ pressureCurve: v as number })}
       />
-      <Typography className="setting-value">
+      <Text className="setting-value">
         {(settings.pressureCurve ?? DEFAULT_PRESSURE_CURVE).toFixed(2)}
-      </Typography>
+      </Text>
     </Box>
   );
 
@@ -134,7 +134,7 @@ export const PenPressureSettingsPanel = memo(function PenPressureSettingsPanel({
     <>
       {!omitSensitivitySwitch ? (
         <Box className="setting-row" sx={{ alignItems: "center" }}>
-          <Typography className="setting-label">Pressure</Typography>
+          <Text className="setting-label">Pressure</Text>
           <Switch
             size="small"
             checked={settings.pressureSensitivity ?? true}

--- a/web/src/components/sketch/tool-settings-panels/adjustMoveCropPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/adjustMoveCropPanels.tsx
@@ -4,11 +4,9 @@ import {
   Checkbox,
   FormControlLabel,
   Slider,
-  IconButton,
-  Tooltip,
-  Typography
+  IconButton
 } from "@mui/material";
-import { FlexRow, Box } from "../../ui_primitives";
+import { FlexRow, Box, Text, Tooltip } from "../../ui_primitives";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
@@ -48,7 +46,7 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
   return (
     <>
       <Box className="setting-row">
-        <Typography className="setting-label">Bright</Typography>
+        <Text className="setting-label">Bright</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -57,10 +55,10 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
           value={brightness}
           onChange={(_, v) => onBrightnessChange(v as number)}
         />
-        <Typography className="setting-value">{brightness}</Typography>
+        <Text className="setting-value">{brightness}</Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Contrast</Typography>
+        <Text className="setting-label">Contrast</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -69,10 +67,10 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
           value={contrast}
           onChange={(_, v) => onContrastChange(v as number)}
         />
-        <Typography className="setting-value">{contrast}</Typography>
+        <Text className="setting-value">{contrast}</Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Satur.</Typography>
+        <Text className="setting-label">Satur.</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -81,7 +79,7 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
           value={saturation}
           onChange={(_, v) => onSaturationChange(v as number)}
         />
-        <Typography className="setting-value">{saturation}</Typography>
+        <Text className="setting-value">{saturation}</Text>
       </Box>
       <FlexRow gap={0.5}>
         <Button
@@ -128,11 +126,11 @@ export const MoveSettingsPanel = memo(function MoveSettingsPanel({
         />
       }
       label={
-        <Typography
+        <Text
           sx={{ ...SKETCH_FONT, fontSize: "0.75rem", userSelect: "none" }}
         >
           Auto-Select
-        </Typography>
+        </Text>
       }
       sx={{ mr: 2, ml: 0 }}
     />
@@ -177,16 +175,16 @@ export const TransformSettingsPanel = memo(function TransformSettingsPanel({
           />
         }
         label={
-          <Typography
+          <Text
             sx={{ ...SKETCH_FONT, fontSize: "0.75rem", userSelect: "none" }}
           >
             Auto-Select
-          </Typography>
+          </Text>
         }
         sx={{ mr: 2, ml: 0 }}
       />
       <Box className="setting-row">
-        <Typography className="setting-label">Mode</Typography>
+        <Text className="setting-label">Mode</Text>
         <SketchModeToggle
           value={mode}
           onChange={(_, nextMode: TransformMode | null) => {
@@ -212,20 +210,20 @@ export const TransformSettingsPanel = memo(function TransformSettingsPanel({
         </SketchModeToggle>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Scale X</Typography>
-        <Typography className="setting-value">
+        <Text className="setting-label">Scale X</Text>
+        <Text className="setting-value">
           {(scaleX * 100).toFixed(0)}%
-        </Typography>
+        </Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Scale Y</Typography>
-        <Typography className="setting-value">
+        <Text className="setting-label">Scale Y</Text>
+        <Text className="setting-value">
           {(scaleY * 100).toFixed(0)}%
-        </Typography>
+        </Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Rotation</Typography>
-        <Typography className="setting-value">{rotDeg}°</Typography>
+        <Text className="setting-label">Rotation</Text>
+        <Text className="setting-value">{rotDeg}°</Text>
       </Box>
       <FlexRow sx={{ gap: "2px", ml: 1 }}>
         <Tooltip title="Commit (Enter)" placement="bottom">
@@ -267,9 +265,9 @@ export const TransformSettingsPanel = memo(function TransformSettingsPanel({
 
 export const NoSettingsMessage = memo(function NoSettingsMessage() {
   return (
-    <Typography sx={{ ...sketchHintTextSx }}>
+    <Text sx={{ ...sketchHintTextSx }}>
       No settings for this tool.
-    </Typography>
+    </Text>
   );
 });
 
@@ -284,10 +282,10 @@ export const CropSettingsPanel = memo(function CropSettingsPanel({
 }) {
   return (
     <>
-      <Typography sx={{ ...sketchHintTextSx }}>
+      <Text sx={{ ...sketchHintTextSx }}>
         Drag to outline the crop. Drag edges or corners to adjust. Press Enter
         or Apply to crop the canvas.
-      </Typography>
+      </Text>
       <FlexRow sx={{ gap: "2px", ml: 1 }}>
         <Tooltip title="Apply crop (Enter)" placement="bottom">
           <IconButton

--- a/web/src/components/sketch/tool-settings-panels/geometryEffectsPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/geometryEffectsPanels.tsx
@@ -2,10 +2,9 @@ import React, { memo, useState } from "react";
 import {
   Checkbox,
   FormControlLabel,
-  Slider,
-  Typography
+  Slider
 } from "@mui/material";
-import { Box } from "../../ui_primitives";
+import { Box, Text } from "../../ui_primitives";
 import {
   BlurSettings,
   CloneStampSampling,
@@ -82,7 +81,7 @@ export const ShapeSettingsPanel = memo(function ShapeSettingsPanel({
         ))}
       </SketchModeToggle>
       <Box className="setting-row">
-        <Typography className="setting-label">Stroke</Typography>
+        <Text className="setting-label">Stroke</Text>
         <input
           type="color"
           className="color-input"
@@ -98,7 +97,7 @@ export const ShapeSettingsPanel = memo(function ShapeSettingsPanel({
         />
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Width</Typography>
+        <Text className="setting-label">Width</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -107,9 +106,9 @@ export const ShapeSettingsPanel = memo(function ShapeSettingsPanel({
           value={settings.strokeWidth}
           onChange={(_, v) => onChange({ strokeWidth: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {settings.strokeWidth}
-        </Typography>
+        </Text>
       </Box>
       {canFill && (
         <>
@@ -122,12 +121,12 @@ export const ShapeSettingsPanel = memo(function ShapeSettingsPanel({
               />
             }
             label={
-              <Typography sx={{ fontSize: SKETCH_FONT.section }}>Fill</Typography>
+              <Text sx={{ fontSize: SKETCH_FONT.section }}>Fill</Text>
             }
           />
           {settings.filled && (
             <Box className="setting-row">
-              <Typography className="setting-label">Fill</Typography>
+              <Text className="setting-label">Fill</Text>
               <input
                 type="color"
                 className="color-input"
@@ -155,7 +154,7 @@ export const FillSettingsPanel = memo(function FillSettingsPanel({
 }: FillSettingsPanelProps) {
   return (
     <Box className="setting-row">
-      <Typography className="setting-label">Tolerance</Typography>
+      <Text className="setting-label">Tolerance</Text>
       <Slider
         sx={sketchSliderSx}
         size="small"
@@ -164,7 +163,7 @@ export const FillSettingsPanel = memo(function FillSettingsPanel({
         value={settings.tolerance}
         onChange={(_, v) => onChange({ tolerance: v as number })}
       />
-      <Typography className="setting-value">{settings.tolerance}</Typography>
+      <Text className="setting-value">{settings.tolerance}</Text>
     </Box>
   );
 });
@@ -176,7 +175,7 @@ export const BlurSettingsPanel = memo(function BlurSettingsPanel({
   return (
     <>
       <Box className="setting-row">
-        <Typography className="setting-label">Size</Typography>
+        <Text className="setting-label">Size</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -185,10 +184,10 @@ export const BlurSettingsPanel = memo(function BlurSettingsPanel({
           value={settings.size}
           onChange={(_, v) => onChange({ size: v as number })}
         />
-        <Typography className="setting-value">{settings.size}</Typography>
+        <Text className="setting-value">{settings.size}</Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Strength</Typography>
+        <Text className="setting-label">Strength</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -197,7 +196,7 @@ export const BlurSettingsPanel = memo(function BlurSettingsPanel({
           value={settings.strength}
           onChange={(_, v) => onChange({ strength: v as number })}
         />
-        <Typography className="setting-value">{settings.strength}</Typography>
+        <Text className="setting-value">{settings.strength}</Text>
       </Box>
     </>
   );
@@ -215,7 +214,7 @@ export const GradientSettingsPanel = memo(function GradientSettingsPanel({
   return (
     <>
       <Box className="setting-row">
-        <Typography className="setting-label">Start</Typography>
+        <Text className="setting-label">Start</Text>
         <Box
           sx={{ ...colorSwatchSx }}
           onClick={(e) => {
@@ -233,7 +232,7 @@ export const GradientSettingsPanel = memo(function GradientSettingsPanel({
         </Box>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">End</Typography>
+        <Text className="setting-label">End</Text>
         <Box
           sx={{ ...colorSwatchSx }}
           onClick={(e) => {
@@ -287,7 +286,7 @@ export const CloneStampSettingsPanel = memo(function CloneStampSettingsPanel({
   return (
     <>
       <Box className="setting-row">
-        <Typography className="setting-label">Size</Typography>
+        <Text className="setting-label">Size</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -296,10 +295,10 @@ export const CloneStampSettingsPanel = memo(function CloneStampSettingsPanel({
           value={settings.size}
           onChange={(_, v) => onChange({ size: v as number })}
         />
-        <Typography className="setting-value">{settings.size}</Typography>
+        <Text className="setting-value">{settings.size}</Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Opacity</Typography>
+        <Text className="setting-label">Opacity</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -309,12 +308,12 @@ export const CloneStampSettingsPanel = memo(function CloneStampSettingsPanel({
           value={settings.opacity}
           onChange={(_, v) => onChange({ opacity: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {Math.round(settings.opacity * 100)}%
-        </Typography>
+        </Text>
       </Box>
       <Box className="setting-row">
-        <Typography className="setting-label">Hardness</Typography>
+        <Text className="setting-label">Hardness</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -324,9 +323,9 @@ export const CloneStampSettingsPanel = memo(function CloneStampSettingsPanel({
           value={settings.hardness}
           onChange={(_, v) => onChange({ hardness: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {Math.round(settings.hardness * 100)}%
-        </Typography>
+        </Text>
       </Box>
       <SketchModeToggle
         value={settings.sampling}
@@ -339,9 +338,9 @@ export const CloneStampSettingsPanel = memo(function CloneStampSettingsPanel({
         <SketchModeOption value="active_layer">Active Layer</SketchModeOption>
         <SketchModeOption value="composited">All Layers</SketchModeOption>
       </SketchModeToggle>
-      <Typography sx={{ ...sketchHintTextSx, mt: 1 }}>
+      <Text sx={{ ...sketchHintTextSx, mt: 1 }}>
         Alt+click to set source point
-      </Typography>
+      </Text>
     </>
   );
 });

--- a/web/src/components/sketch/tool-settings-panels/paintToolPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/paintToolPanels.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useState } from "react";
-import { Typography, Slider, Button } from "@mui/material";
-import { Box } from "../../ui_primitives";
+import { Slider } from "@mui/material";
+import { Box, Text } from "../../ui_primitives";
+import { EditorButton } from "../../editor_ui";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import {
@@ -56,7 +57,7 @@ const AdvancedToggleButton: React.FC<{
   open: boolean;
   onToggle: () => void;
 }> = ({ open, onToggle }) => (
-  <Button
+  <EditorButton
     size="small"
     variant="text"
     onClick={onToggle}
@@ -74,7 +75,7 @@ const AdvancedToggleButton: React.FC<{
     startIcon={open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
   >
     Advanced
-  </Button>
+  </EditorButton>
 );
 
 interface BrushSettingsPanelProps {
@@ -251,7 +252,7 @@ function StrokeAssistSettingsPanel<T extends StrokeAssistToolSettings>({
       </SketchModeToggle>
       {assistOn && (
         <Box className="setting-row">
-          <Typography className="setting-label">Strength</Typography>
+          <Text className="setting-label">Strength</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -261,9 +262,9 @@ function StrokeAssistSettingsPanel<T extends StrokeAssistToolSettings>({
             value={assist.strength}
             onChange={(_, v) => updateAssist({ strength: v as number })}
           />
-          <Typography className="setting-value">
+          <Text className="setting-value">
             {Math.round(assist.strength * 100)}%
-          </Typography>
+          </Text>
         </Box>
       )}
       {uiPreset === "custom" && (
@@ -319,7 +320,7 @@ function StrokeAssistSettingsPanel<T extends StrokeAssistToolSettings>({
       </SketchModeToggle>
       {snapOn && (
         <Box className="setting-row">
-          <Typography className="setting-label">Snap</Typography>
+          <Text className="setting-label">Snap</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -329,9 +330,9 @@ function StrokeAssistSettingsPanel<T extends StrokeAssistToolSettings>({
             value={assist.snapStrength}
             onChange={(_, v) => updateAssist({ snapStrength: v as number })}
           />
-          <Typography className="setting-value">
+          <Text className="setting-value">
             {Math.round(assist.snapStrength * 100)}%
-          </Typography>
+          </Text>
         </Box>
       )}
     </SettingGroup>
@@ -376,7 +377,7 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
         {!omitPaintSliders && (
           <>
             <Box className="setting-row setting-row--wide">
-              <Typography className="setting-label">Size</Typography>
+              <Text className="setting-label">Size</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -385,10 +386,10 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
                 value={settings.size}
                 onChange={(_, v) => onChange({ size: v as number })}
               />
-              <Typography className="setting-value">{settings.size}</Typography>
+              <Text className="setting-value">{settings.size}</Text>
             </Box>
             <Box className="setting-row">
-              <Typography className="setting-label">Opacity</Typography>
+              <Text className="setting-label">Opacity</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -398,14 +399,14 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
                 value={settings.opacity}
                 onChange={(_, v) => onChange({ opacity: v as number })}
               />
-              <Typography className="setting-value">
+              <Text className="setting-value">
                 {Math.round(settings.opacity * 100)}%
-              </Typography>
+              </Text>
             </Box>
           </>
         )}
         <Box className="setting-row">
-          <Typography className="setting-label">Hard</Typography>
+          <Text className="setting-label">Hard</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -415,14 +416,14 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
             value={settings.hardness}
             onChange={(_, v) => onChange({ hardness: v as number })}
           />
-          <Typography className="setting-value">
+          <Text className="setting-value">
             {Math.round(settings.hardness * 100)}%
-          </Typography>
+          </Text>
         </Box>
         {(settings.brushType === "round" || settings.brushType === "soft") && (
           <>
             <Box className="setting-row">
-              <Typography className="setting-label">Round</Typography>
+              <Text className="setting-label">Round</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -432,12 +433,12 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
                 value={settings.roundness ?? 1.0}
                 onChange={(_, v) => onChange({ roundness: v as number })}
               />
-              <Typography className="setting-value">
+              <Text className="setting-value">
                 {Math.round((settings.roundness ?? 1.0) * 100)}%
-              </Typography>
+              </Text>
             </Box>
             <Box className="setting-row">
-              <Typography className="setting-label">Angle</Typography>
+              <Text className="setting-label">Angle</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -447,9 +448,9 @@ export const BrushSettingsPanel = memo(function BrushSettingsPanel({
                 value={settings.angle ?? 0}
                 onChange={(_, v) => onChange({ angle: v as number })}
               />
-              <Typography className="setting-value">
+              <Text className="setting-value">
                 {settings.angle ?? 0}°
-              </Typography>
+              </Text>
             </Box>
           </>
         )}
@@ -510,7 +511,7 @@ export const PencilSettingsPanel = memo(function PencilSettingsPanel({
         {!omitPaintSliders && (
           <>
             <Box className="setting-row setting-row--wide">
-              <Typography className="setting-label">Size</Typography>
+              <Text className="setting-label">Size</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -519,10 +520,10 @@ export const PencilSettingsPanel = memo(function PencilSettingsPanel({
                 value={settings.size}
                 onChange={(_, v) => onChange({ size: v as number })}
               />
-              <Typography className="setting-value">{settings.size}</Typography>
+              <Text className="setting-value">{settings.size}</Text>
             </Box>
             <Box className="setting-row">
-              <Typography className="setting-label">Opacity</Typography>
+              <Text className="setting-label">Opacity</Text>
               <Slider
                 sx={sketchSliderSx}
                 size="small"
@@ -532,9 +533,9 @@ export const PencilSettingsPanel = memo(function PencilSettingsPanel({
                 value={settings.opacity}
                 onChange={(_, v) => onChange({ opacity: v as number })}
               />
-              <Typography className="setting-value">
+              <Text className="setting-value">
                 {Math.round(settings.opacity * 100)}%
-              </Typography>
+              </Text>
             </Box>
           </>
         )}
@@ -609,7 +610,7 @@ export const EraserSettingsPanel = memo(function EraserSettingsPanel({
       </SettingGroup>
       <SettingGroup>
         <Box className="setting-row setting-row--wide">
-          <Typography className="setting-label">Size</Typography>
+          <Text className="setting-label">Size</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -618,10 +619,10 @@ export const EraserSettingsPanel = memo(function EraserSettingsPanel({
             value={settings.size}
             onChange={(_, v) => onChange({ size: v as number })}
           />
-          <Typography className="setting-value">{settings.size}</Typography>
+          <Text className="setting-value">{settings.size}</Text>
         </Box>
         <Box className="setting-row">
-          <Typography className="setting-label">Opacity</Typography>
+          <Text className="setting-label">Opacity</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -631,12 +632,12 @@ export const EraserSettingsPanel = memo(function EraserSettingsPanel({
             value={settings.opacity}
             onChange={(_, v) => onChange({ opacity: v as number })}
           />
-          <Typography className="setting-value">
+          <Text className="setting-value">
             {Math.round(settings.opacity * 100)}%
-          </Typography>
+          </Text>
         </Box>
         <Box className="setting-row">
-          <Typography className="setting-label">Stabilize</Typography>
+          <Text className="setting-label">Stabilize</Text>
           <Slider
             sx={sketchSliderSx}
             size="small"
@@ -648,14 +649,14 @@ export const EraserSettingsPanel = memo(function EraserSettingsPanel({
             }
             onChange={(_, v) => setStabilizerStrength(v as number)}
           />
-          <Typography className="setting-value">
+          <Text className="setting-value">
             {Math.round(
               (assist.mode === "stabilizer"
                 ? assist.strength
                 : settings.stabilizer ?? 0) * 100
             )}
             %
-          </Typography>
+          </Text>
         </Box>
       </SettingGroup>
     </>

--- a/web/src/components/sketch/tool-settings-panels/segmentSettingsPanel.tsx
+++ b/web/src/components/sketch/tool-settings-panels/segmentSettingsPanel.tsx
@@ -1,10 +1,8 @@
 import React, { memo, useEffect } from "react";
 import {
-  Button,
   FormControlLabel,
   Slider,
-  Switch,
-  Typography
+  Switch
 } from "@mui/material";
 import { SketchModeToggle, SketchModeOption } from "./SketchModeToggle";
 import {
@@ -20,7 +18,8 @@ import {
   LOCAL_SAM3_CAPABILITIES,
   LOCAL_SAM3_MODEL_ID
 } from "../sam";
-import { FlexRow, TextInput, Box } from "../../ui_primitives";
+import { FlexRow, TextInput, Box, Text } from "../../ui_primitives";
+import { EditorButton } from "../../editor_ui";
 import {
   sketchButtonSmallSx,
   sketchSliderSx,
@@ -199,7 +198,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
   return (
     <>
       <Box className="setting-row" sx={{ gap: "4px" }}>
-        <Typography className="setting-label">Backend</Typography>
+        <Text className="setting-label">Backend</Text>
         <SketchModeToggle
           value={settings.backend}
           onChange={(_, v) => {
@@ -221,7 +220,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
 
       {modelInfo && (
         <Box sx={{ mb: "4px" }}>
-          <Typography
+          <Text
             sx={{
               fontSize: SKETCH_FONT.xs,
               lineHeight: 1.3,
@@ -243,7 +242,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
             {modelInfo.status === "checking" && "Checking…"}
             {modelInfo.status === "downloading" &&
               `${modelStatusText ?? "Downloading…"} ${Math.round((modelInfo.downloadProgress ?? 0) * 100)}%`}
-          </Typography>
+          </Text>
         </Box>
       )}
 
@@ -266,7 +265,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
       </SketchModeToggle>
 
       <Box className="setting-row">
-        <Typography className="setting-label">Max Objects</Typography>
+        <Text className="setting-label">Max Objects</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -275,11 +274,11 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           value={settings.maxObjects}
           onChange={(_, v) => onChange({ maxObjects: v as number })}
         />
-        <Typography className="setting-value">{settings.maxObjects}</Typography>
+        <Text className="setting-value">{settings.maxObjects}</Text>
       </Box>
 
       <Box className="setting-row">
-        <Typography className="setting-label">Confidence</Typography>
+        <Text className="setting-label">Confidence</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -289,13 +288,13 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           value={settings.confidenceThreshold}
           onChange={(_, v) => onChange({ confidenceThreshold: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {settings.confidenceThreshold.toFixed(2)}
-        </Typography>
+        </Text>
       </Box>
 
       <Box className="setting-row">
-        <Typography className="setting-label">Min Size</Typography>
+        <Text className="setting-label">Min Size</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -305,13 +304,13 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           value={settings.minObjectSize}
           onChange={(_, v) => onChange({ minObjectSize: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {settings.minObjectSize}
-        </Typography>
+        </Text>
       </Box>
 
       <Box className="setting-row">
-        <Typography className="setting-label">Feather</Typography>
+        <Text className="setting-label">Feather</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -321,13 +320,13 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           value={settings.maskFeather}
           onChange={(_, v) => onChange({ maskFeather: v as number })}
         />
-        <Typography className="setting-value">
+        <Text className="setting-value">
           {settings.maskFeather}
-        </Typography>
+        </Text>
       </Box>
 
       <Box className="setting-row" sx={{ gap: "4px" }}>
-        <Typography className="setting-label">Source Layer</Typography>
+        <Text className="setting-label">Source Layer</Text>
         <SketchModeToggle
           value={settings.sourceLayerAction}
           onChange={(_, v) => {
@@ -351,18 +350,18 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           />
         }
         label={
-          <Typography sx={{ fontSize: SKETCH_FONT.xs }}>
+          <Text sx={{ fontSize: SKETCH_FONT.xs }}>
             {settings.outputCutouts ? "Cutout layers" : "Mask layers"}
-          </Typography>
+          </Text>
         }
         sx={{ mt: "2px", ml: 0 }}
       />
 
       {supportsTextPrompts && (
         <Box className="setting-row" sx={{ alignItems: "flex-start" }}>
-          <Typography className="setting-label" sx={{ pt: "6px" }}>
+          <Text className="setting-label" sx={{ pt: "6px" }}>
             Concept
-          </Typography>
+          </Text>
           <TextInput
             compact
             value={settings.conceptPrompt}
@@ -385,7 +384,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
       {isLocalSam3 && (
         <>
           <Box className="setting-row">
-            <Typography className="setting-label">Points / Side</Typography>
+            <Text className="setting-label">Points / Side</Text>
             <Slider
               sx={sketchSliderSx}
               size="small"
@@ -397,13 +396,13 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
                 onChange({ pointsPerSide: value as number })
               }
             />
-            <Typography className="setting-value">
+            <Text className="setting-value">
               {settings.pointsPerSide}
-            </Typography>
+            </Text>
           </Box>
 
           <Box className="setting-row">
-            <Typography className="setting-label">Pred IoU</Typography>
+            <Text className="setting-label">Pred IoU</Text>
             <Slider
               sx={sketchSliderSx}
               size="small"
@@ -415,9 +414,9 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
                 onChange({ predIouThresh: value as number })
               }
             />
-            <Typography className="setting-value">
+            <Text className="setting-value">
               {settings.predIouThresh.toFixed(2)}
-            </Typography>
+            </Text>
           </Box>
         </>
       )}
@@ -426,7 +425,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
         {!isRunning && !isPreviewing && (
           <>
             {canDownloadLocalSam3 && (
-              <Button
+              <EditorButton
                 size="small"
                 variant="outlined"
                 onClick={() => {
@@ -435,10 +434,10 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
                 sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
               >
                 Download Local SAM3
-              </Button>
+              </EditorButton>
             )}
             {isLocalSam3 && localSam3Downloading && (
-              <Button
+              <EditorButton
                 size="small"
                 variant="outlined"
                 color="warning"
@@ -448,9 +447,9 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
                 sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
               >
                 Cancel download
-              </Button>
+              </EditorButton>
             )}
-            <Button
+            <EditorButton
               size="small"
               variant="contained"
               onClick={onRunSegmentation}
@@ -458,22 +457,22 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
               sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
             >
               {segmentActionLabel}
-            </Button>
+            </EditorButton>
             {showClearPrompts && (
-              <Button
+              <EditorButton
                 size="small"
                 variant="outlined"
                 onClick={onClearPrompts}
                 sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
               >
                 Clear
-              </Button>
+              </EditorButton>
             )}
           </>
         )}
         {isRunning && (
           <>
-            <Typography
+            <Text
               sx={{
                 fontSize: SKETCH_FONT.xs,
                 color: "info.main",
@@ -484,8 +483,8 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
               }}
             >
               {getSegmentationStatusMessage(segmentationStatus)}
-            </Typography>
-            <Button
+            </Text>
+            <EditorButton
               size="small"
               variant="outlined"
               color="warning"
@@ -493,12 +492,12 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
               sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
             >
               Cancel
-            </Button>
+            </EditorButton>
           </>
         )}
         {isPreviewing && (
           <>
-            <Button
+            <EditorButton
               size="small"
               variant="contained"
               color="success"
@@ -506,20 +505,20 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
               sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
             >
               Apply
-            </Button>
-            <Button
+            </EditorButton>
+            <EditorButton
               size="small"
               variant="outlined"
               onClick={onDiscardResult}
               sx={{ ...sketchButtonSmallSx, minWidth: "56px" }}
             >
               Discard
-            </Button>
+            </EditorButton>
           </>
         )}
       </FlexRow>
 
-      <Typography
+      <Text
         sx={{
           fontSize: SKETCH_FONT.xs,
           color: SKETCH_COLORS.textFaint,
@@ -531,10 +530,10 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
         {supportsPointPrompts || supportsBoxPrompts || supportsTextPrompts
           ? promptModeHelpText(settings.promptMode)
           : `${backendLabel} currently supports automatic layer split only.`}
-      </Typography>
+      </Text>
 
       {settings.promptMode === "auto" && !canSplitSelectedLayer && (
-        <Typography
+        <Text
           sx={{
             fontSize: SKETCH_FONT.xs,
             color: SKETCH_COLORS.textFaint,
@@ -543,11 +542,11 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           }}
         >
           Select exactly one raster layer to split.
-        </Typography>
+        </Text>
       )}
 
       {segmentationStatus === "error" && (
-        <Typography
+        <Text
           sx={{
             fontSize: SKETCH_FONT.xs,
             color: "error.main",
@@ -556,7 +555,7 @@ export const SegmentSettingsPanel = memo(function SegmentSettingsPanel({
           }}
         >
           Segmentation failed. Check model availability and try again.
-        </Typography>
+        </Text>
       )}
     </>
   );

--- a/web/src/components/workspaces/WorkspaceSelect.tsx
+++ b/web/src/components/workspaces/WorkspaceSelect.tsx
@@ -4,11 +4,9 @@ import React, { memo, useCallback } from "react";
 import {
   FormControl,
   Select,
-  MenuItem,
-  CircularProgress,
-  Divider
+  MenuItem
 } from "@mui/material";
-import { Text, Caption, FlexRow, Box } from "../ui_primitives";
+import { Text, Caption, FlexRow, Box, Divider, LoadingSpinner } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { useQuery } from "@tanstack/react-query";
@@ -156,7 +154,7 @@ const WorkspaceSelect: React.FC<WorkspaceSelectProps> = memo(
     if (isLoading) {
       return (
         <FlexRow css={styles(theme)} gap={1} align="center" sx={{ py: 1 }}>
-          <CircularProgress size={18} />
+          <LoadingSpinner size="small" />
           <Text size="small" color="secondary">
             Loading...
           </Text>

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -5,11 +5,8 @@ import isEqual from "fast-deep-equal";
 import { useQuery } from "@tanstack/react-query";
 import { FileInfo } from "../../stores/ApiTypes";
 import { trpcClient } from "../../trpc/client";
-import {
-  Button,
-  Skeleton
-} from "@mui/material";
-import { Text, Caption, Box } from "../ui_primitives";
+import { Skeleton } from "@mui/material";
+import { Text, Caption, Box, EditorButton } from "../ui_primitives";
 import { RichTreeView } from "@mui/x-tree-view/RichTreeView";
 import type { TreeViewBaseItem } from "@mui/x-tree-view/models";
 import { useTheme } from "@mui/material/styles";
@@ -610,15 +607,14 @@ const WorkspaceTree: React.FC = () => {
 
       {selectedFilePath && !selectedFilePath.includes("/loading") && (
         <div className="tree-actions">
-          <Button
+          <EditorButton
             className="open-folder-button"
-            size="small"
             variant="outlined"
             startIcon={<FolderOpenIcon />}
             onClick={handleOpenInFolder}
           >
             Open in Folder
-          </Button>
+          </EditorButton>
         </div>
       )}
 
@@ -634,14 +630,13 @@ const WorkspaceTree: React.FC = () => {
             <Caption color="secondary">
               Select a workspace above or create one
             </Caption>
-            <Button
-              size="small"
+            <EditorButton
               startIcon={<AddIcon />}
               onClick={handleManageWorkspace}
               sx={{ mt: 1 }}
             >
               Create Workspace
-            </Button>
+            </EditorButton>
           </div>
         ) : isLoadingFiles ? (
           <div className="skeleton-tree">

--- a/web/src/components/workspaces/WorkspacesManager.tsx
+++ b/web/src/components/workspaces/WorkspacesManager.tsx
@@ -7,8 +7,7 @@ import {
   ListItem,
   ListItemText,
   ListItemSecondaryAction,
-  FormControlLabel,
-  Checkbox
+  FormControlLabel
 } from "@mui/material";
 import React, { useCallback, useState, memo } from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -27,6 +26,7 @@ import FileBrowserDialog from "../dialogs/FileBrowserDialog";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import {
   Box,
+  Checkbox,
   Chip,
   EditorButton,
   FlexColumn,

--- a/web/src/config/data_types.tsx
+++ b/web/src/config/data_types.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React from "react";
-import { Tooltip } from "@mui/material";
+import { Tooltip } from "../components/ui_primitives";
 import { TOOLTIP_ENTER_DELAY } from "../config/constants";
 import { memo } from "react";
 import isEqual from "fast-deep-equal";


### PR DESCRIPTION
## Summary

This PR systematically migrates raw Material-UI (MUI) component imports to the custom `ui_primitives` library across the codebase, following the established **Primitives Strategy** documented in `web/src/components/ui_primitives/STRATEGY.md`. This ensures consistent theming, styling, and component behavior throughout the application.

## Key Changes

- **LayoutTest.tsx**: Replaced `Paper` with `Surface`, moved `Chip` import from MUI to `ui_primitives`, removed unused MUI imports (`Typography`, `FormControlLabel`)
- **ImageEditorToolbar.tsx**: Replaced `IconButton` with `ToolbarIconButton`, moved `Checkbox` to `ui_primitives`, removed unused MUI imports (`Typography`, `FormControlLabel`)
- **Sketch tool panels** (segmentSettingsPanel, paintToolPanels, geometryEffectsPanels, adjustMoveCropPanels, PenPressureSettingsPanel): Replaced `Typography` with `Text`, `Button` with `EditorButton`, `CircularProgress` with `LoadingSpinner`, `Tooltip` with `ui_primitives` version where applicable
- **ColorInputs.tsx**: Replaced `TextField` with `TextInput` from `ui_primitives`
- **NodeTestPage.tsx**: Replaced `TextField` with `TextInput`, `Button` with `EditorButton`, `IconButton` with `ToolbarIconButton`, moved `Chip` to `ui_primitives`
- **NodeTestRow.tsx**: Replaced `IconButton` with `ToolbarIconButton`, moved `Chip` and `Dialog` to `ui_primitives`
- **ChatMarkdownTest.tsx**: Replaced `Typography` with `Text` and `Caption` from `ui_primitives`
- **WorkspaceTree.tsx**: Replaced `Button` with `EditorButton` from `ui_primitives`
- **WorkspaceSelect.tsx**: Moved `Divider` and `LoadingSpinner` to `ui_primitives`
- **Various property and component files**: Systematically replaced `TextField` with `TextInput`, `Button` with `EditorButton`, `Checkbox` with `ui_primitives` version, `Tooltip` with `ui_primitives` version
- **config/data_types.tsx**: Replaced MUI `Tooltip` import with `ui_primitives` version

## Implementation Details

- All changes maintain backward compatibility — the `ui_primitives` components wrap or extend MUI components with consistent theming
- Import statements reorganized to group `ui_primitives` imports together
- Removed duplicate imports where components were moved from MUI to `ui_primitives`
- No functional behavior changes — this is purely a refactoring to enforce the UI primitives pattern
- Follows the mandatory rule: **Never import raw MUI components outside of `ui_primitives/` or `editor_ui/`**

https://claude.ai/code/session_017Q5i9ba5h8NPZb9UfpuAyE