### PR TITLE
marketing: sharpen ComfyUI comparison copy

### DIFF
--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -47,7 +47,7 @@ export default function ComparisonSection({
         <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
             competitor="ComfyUI"
-            sentence="ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with masks, inpaint, outpaint, relight, upscale, and compositing built in."
+            sentence="ComfyUI is a node editor for diffusion models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away."
             reducedMotion={reducedMotion}
             delay={0}
           />

--- a/marketing/src/components/SeoHeroContent.tsx
+++ b/marketing/src/components/SeoHeroContent.tsx
@@ -77,10 +77,9 @@ export default function SeoHeroContent() {
         <div className="space-y-3 text-slate-300">
           <div>
             <strong className="text-white">vs ComfyUI:</strong> ComfyUI is a
-            Stable Diffusion power tool with engineer-first UX. NodeTool is a
-            full creative workspace — image, video, audio, and text on one
-            canvas — with the editing tools you rely on: masks, inpaint,
-            outpaint, relight, upscale, layers, compositing.
+            node editor for diffusion models. NodeTool is the studio around it:
+            image, video, music, and words on one canvas, every major model a
+            click away.
           </div>
           <div>
             <strong className="text-white">vs Weavy / closed SaaS canvases:</strong>{" "}

--- a/marketing/src/components/client/faqs.tsx
+++ b/marketing/src/components/client/faqs.tsx
@@ -22,7 +22,7 @@ const faqs = [
   {
     question: "How is this different from ComfyUI?",
     answer:
-      "ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with the editing tools creatives actually use: masks, inpaint, outpaint, relight, upscale, layers, compositing.",
+      "ComfyUI is a node editor for diffusion models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away.",
   },
   {
     question: "How is this different from Weavy and other closed canvases?",


### PR DESCRIPTION
Reframe the ComfyUI bullet from a feature-list ("masks, inpaint,
outpaint…") to a category contrast: ComfyUI is a diffusion node editor,
NodeTool is the studio around it. Updates the ComparisonSection card,
the FAQ answer, and the SEO hero "How NodeTool Differs" block so the
three surfaces stay in sync.