### PR TITLE
fix(web): zustand v5 infinite loop on /editor (useCopyPaste)

### DIFF
--- a/web/src/hooks/handlers/useCopyPaste.tsx
+++ b/web/src/hooks/handlers/useCopyPaste.tsx
@@ -5,6 +5,7 @@ import { useReactFlow, Edge, Node } from "@xyflow/react";
 import { uuidv4 } from "../../stores/uuidv4";
 import { NodeData } from "../../stores/NodeData";
 import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useNodeStoreRef } from "../../contexts/NodeContext";
 import useSessionStateStore from "../../stores/SessionStateStore";
 import { useClipboardContentPaste } from "./useClipboardContentPaste";
@@ -28,10 +29,10 @@ export const useCopyPaste = () => {
   // async effect scheduling (e.g. rubber-band select then immediately Ctrl+C).
   const nodeStore = useNodeStoreRef();
   const { setClipboardData, setIsClipboardValid } = useSessionStateStore(
-    (state) => ({
+    useShallow((state) => ({
       setClipboardData: state.setClipboardData,
       setIsClipboardValid: state.setIsClipboardValid
-    })
+    }))
   );
 
   const { handleContentPaste, readClipboardContent, readClipboardText } =


### PR DESCRIPTION
## Summary

Fixes the **minified React error #185** ("Maximum update depth exceeded") that fires on every `/editor/:workflow` load in production after the zustand v5 upgrade (#3305).

`useCopyPaste` was selecting two actions from the `create()`-bound `useSessionStateStore` with an inline-object selector and no `useShallow`:

```ts
// before
const { setClipboardData, setIsClipboardValid } = useSessionStateStore(
  (state) => ({
    setClipboardData: state.setClipboardData,
    setIsClipboardValid: state.setIsClipboardValid,
  }),
);
```

Under zustand v5 the bound `useStore` routes through `React.useSyncExternalStore` directly (no shim, no equality fn), so an unstable selector return trips React's max-update-depth guard → #185. `useCopyPaste` is mounted by `useNodeEditorShortcuts` inside `NodeEditor`, so it ran for every editor load.

```ts
// after
const { setClipboardData, setIsClipboardValid } = useSessionStateStore(
  useShallow((state) => ({
    setClipboardData: state.setClipboardData,
    setIsClipboardValid: state.setIsClipboardValid,
  })),
);
```

### Why it only repro'd in prod

A stale local `node_modules/zustand@4.5.7` was masking it in dev. After `rm -rf node_modules/zustand && npm install` pulled in 5.0.13 (matching `package-lock.json`), the bug reproduced locally on `/editor`.

### Audit

I swept every direct `create()`-bound `useXyzStore(selector)` call in `web/src` for unstable returns (inline objects, arrays, closures, `.filter/.map/.slice/.sort/.reduce/.concat/.flat`, `Object.values/keys/entries`, `Array.from`, `new Map/Set`, spread literals, conditional-fresh-ref). Excluded the known-safe wrappers that still respect equality fns in v5: `useNodes`, `useTemporalNodes`, `useWorkflowManager`, `useKeyPressedStore` (all wrap `useStoreWithEqualityFn` from `zustand/traditional`) and `useContextMenuStore` (a React Context). **This was the only site the #3305 migration missed.**

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only pre-existing warnings
- [x] `npx jest --testPathPattern='(handlers|editor|node_editor)'` — 432/432 pass
- [x] `useFloatingToolbarActions` + `SessionStateStore` tests — 29/29 pass
- [ ] Manual: load `/editor/<workflow-id>` in a prod build, confirm #185 is gone and copy/paste still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)