### PR TITLE
feat(timeline): redesign tracks view, inspector, and toggleable asset panel

### DIFF
--- a/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
@@ -1,0 +1,554 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Inspector primitives
+ *
+ * Small visual building blocks used by `TimelineInspector` and its child
+ * panels to keep the inspector's distinctive look (eyebrow header, identity
+ * card, label-on-left + value-pill rows, iOS-style switches) consistent
+ * without leaking these styles into the project-wide `ui_primitives`.
+ */
+
+import React, {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useState
+} from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import Switch from "@mui/material/Switch";
+
+import { Tooltip } from "../../ui_primitives";
+
+// ── Header ─────────────────────────────────────────────────────────────────
+
+const headerStyles = css({
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  height: 36,
+  padding: "0 4px 0 4px"
+});
+
+const eyebrowStyles = (theme: Theme) =>
+  css({
+    flex: "1 1 auto",
+    color: theme.vars.palette.text.secondary,
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    userSelect: "none"
+  });
+
+const headerActionsStyles = css({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 2
+});
+
+const headerIconButtonStyles = (theme: Theme) =>
+  css({
+    width: 28,
+    height: 26,
+    background: "transparent",
+    border: "1px solid transparent",
+    color: theme.vars.palette.text.secondary,
+    cursor: "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 6,
+    transition: "background-color 120ms, color 120ms, border-color 120ms",
+    "&:hover": {
+      backgroundColor: theme.vars.palette.action.hover,
+      color: theme.vars.palette.text.primary,
+      borderColor: theme.vars.palette.divider
+    },
+    "&:focus-visible": {
+      outline: "none",
+      borderColor: theme.vars.palette.primary.main
+    },
+    "& svg": {
+      fontSize: 16
+    }
+  });
+
+export interface InspectorHeaderAction {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  variant?: "default" | "danger";
+}
+
+export interface InspectorHeaderProps {
+  eyebrow: string;
+  actions?: InspectorHeaderAction[];
+}
+
+/** Eyebrow label + trailing action icon row (e.g. `+`, `✂`, `🗑`). */
+export const InspectorHeader: React.FC<InspectorHeaderProps> = memo(
+  ({ eyebrow, actions }) => {
+    const theme = useTheme();
+    return (
+      <div css={headerStyles}>
+        <div css={eyebrowStyles(theme)}>{eyebrow}</div>
+        {actions && actions.length > 0 && (
+          <div css={headerActionsStyles}>
+            {actions.map((action) => (
+              <Tooltip key={action.label} title={action.label}>
+                <button
+                  type="button"
+                  css={headerIconButtonStyles(theme)}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  aria-label={action.label}
+                  style={
+                    action.variant === "danger"
+                      ? { color: theme.vars.palette.error.main }
+                      : undefined
+                  }
+                >
+                  {action.icon}
+                </button>
+              </Tooltip>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+InspectorHeader.displayName = "InspectorHeader";
+
+// ── Identity card ──────────────────────────────────────────────────────────
+
+const identityWrapStyles = css({
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+  padding: "10px 4px 14px 14px"
+});
+
+const identityAccentStyles = (color: string) =>
+  css({
+    position: "absolute",
+    left: 4,
+    top: 12,
+    bottom: 16,
+    width: 3,
+    borderRadius: 2,
+    backgroundColor: color
+  });
+
+const identityNameStyles = (theme: Theme) =>
+  css({
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 14,
+    fontWeight: 500,
+    color: theme.vars.palette.text.primary,
+    lineHeight: 1.3,
+    wordBreak: "break-all"
+  });
+
+const identityMetaStyles = (theme: Theme) =>
+  css({
+    color: theme.vars.palette.text.secondary,
+    fontSize: 12,
+    lineHeight: 1.3
+  });
+
+export interface ClipIdentityCardProps {
+  name: string;
+  metadata: ReadonlyArray<string>;
+  /** Color of the left accent bar — usually the track-type accent. */
+  accentColor?: string;
+}
+
+/** "kling_v3_out_…" + "video · 4.60s · 1920×1080" identity block. */
+export const ClipIdentityCard: React.FC<ClipIdentityCardProps> = memo(
+  ({ name, metadata, accentColor }) => {
+    const theme = useTheme();
+    const accent = accentColor ?? theme.vars.palette.secondary.main;
+    return (
+      <div css={identityWrapStyles}>
+        <div css={identityAccentStyles(accent)} aria-hidden />
+        <div css={identityNameStyles(theme)} title={name}>
+          {name}
+        </div>
+        {metadata.length > 0 && (
+          <div css={identityMetaStyles(theme)}>{metadata.join(" · ")}</div>
+        )}
+      </div>
+    );
+  }
+);
+ClipIdentityCard.displayName = "ClipIdentityCard";
+
+// ── Rows ────────────────────────────────────────────────────────────────────
+
+const rowStyles = css({
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  minHeight: 32,
+  padding: "0 4px"
+});
+
+const rowLabelStyles = (theme: Theme) =>
+  css({
+    flex: "1 1 auto",
+    minWidth: 0,
+    color: theme.vars.palette.text.secondary,
+    fontSize: 13,
+    fontWeight: 400,
+    lineHeight: 1.3
+  });
+
+const rowControlStyles = css({
+  flex: "0 0 auto",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  minWidth: 120
+});
+
+export interface InspectorRowProps {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  htmlFor?: string;
+}
+
+export const InspectorRow: React.FC<InspectorRowProps> = memo(
+  ({ label, children, htmlFor }) => {
+    const theme = useTheme();
+    return (
+      <div css={rowStyles}>
+        {htmlFor ? (
+          <label css={rowLabelStyles(theme)} htmlFor={htmlFor}>
+            {label}
+          </label>
+        ) : (
+          <span css={rowLabelStyles(theme)}>{label}</span>
+        )}
+        <div css={rowControlStyles}>{children}</div>
+      </div>
+    );
+  }
+);
+InspectorRow.displayName = "InspectorRow";
+
+// ── Pill input ─────────────────────────────────────────────────────────────
+
+const pillWrapStyles = (theme: Theme, disabled: boolean, focused: boolean) =>
+  css({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    height: 28,
+    padding: "0 10px",
+    backgroundColor: theme.vars.palette.background.default,
+    border: `1px solid ${
+      focused ? theme.vars.palette.primary.main : "rgba(255, 255, 255, 0.05)"
+    }`,
+    borderRadius: 7,
+    minWidth: 92,
+    justifyContent: "flex-end",
+    opacity: disabled ? 0.5 : 1,
+    transition: "border-color 120ms",
+    "&:hover": {
+      borderColor: focused
+        ? theme.vars.palette.primary.main
+        : theme.vars.palette.divider
+    }
+  });
+
+const pillInputStyles = (theme: Theme) =>
+  css({
+    flex: "1 1 auto",
+    minWidth: 0,
+    background: "transparent",
+    border: "none",
+    outline: "none",
+    color: theme.vars.palette.text.primary,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 12,
+    fontWeight: 500,
+    letterSpacing: "0",
+    textAlign: "right",
+    padding: 0,
+    width: "100%"
+  });
+
+const pillUnitStyles = (theme: Theme) =>
+  css({
+    color: theme.vars.palette.text.secondary,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 11,
+    fontWeight: 500,
+    flexShrink: 0
+  });
+
+export interface InspectorPillInputProps {
+  value: string;
+  onCommit: (raw: string) => void;
+  /** Small trailing unit token, e.g. "s", "×", "px". */
+  unit?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  id?: string;
+  /** Optional minWidth override for the pill (for long timecodes etc.). */
+  minWidth?: number;
+}
+
+export const InspectorPillInput = memo(
+  forwardRef<HTMLInputElement, InspectorPillInputProps>(
+    function InspectorPillInput(
+      {
+        value,
+        onCommit,
+        unit,
+        placeholder,
+        disabled = false,
+        ariaLabel,
+        id,
+        minWidth
+      },
+      ref
+    ) {
+      const theme = useTheme();
+      const [draft, setDraft] = useState(value);
+      const [focused, setFocused] = useState(false);
+
+      useEffect(() => {
+        if (!focused) {
+          setDraft(value);
+        }
+      }, [value, focused]);
+
+      const commit = useCallback(() => {
+        if (draft !== value) {
+          onCommit(draft);
+        }
+      }, [draft, value, onCommit]);
+
+      const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+          if (e.key === "Enter") {
+            (e.target as HTMLInputElement).blur();
+          } else if (e.key === "Escape") {
+            setDraft(value);
+            (e.target as HTMLInputElement).blur();
+          }
+        },
+        [value]
+      );
+
+      return (
+        <div
+          css={pillWrapStyles(theme, disabled, focused)}
+          style={minWidth ? { minWidth } : undefined}
+        >
+          <input
+            id={id}
+            ref={ref}
+            type="text"
+            css={pillInputStyles(theme)}
+            value={draft}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            onChange={(e) => setDraft(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => {
+              setFocused(false);
+              commit();
+            }}
+            onKeyDown={handleKeyDown}
+          />
+          {unit && <span css={pillUnitStyles(theme)}>{unit}</span>}
+        </div>
+      );
+    }
+  )
+);
+
+// ── Toggle row ─────────────────────────────────────────────────────────────
+
+const toggleSwitchSx = {
+  width: 36,
+  height: 20,
+  padding: 0,
+  "& .MuiSwitch-switchBase": {
+    padding: 0,
+    margin: "2px",
+    transitionDuration: "180ms",
+    "&.Mui-checked": {
+      transform: "translateX(16px)",
+      color: "#fff",
+      "& + .MuiSwitch-track": {
+        backgroundColor: "var(--palette-secondary-main)",
+        opacity: 1,
+        border: 0
+      }
+    }
+  },
+  "& .MuiSwitch-thumb": {
+    boxSizing: "border-box",
+    width: 16,
+    height: 16,
+    boxShadow: "0 1px 2px rgba(0,0,0,0.4)"
+  },
+  "& .MuiSwitch-track": {
+    borderRadius: 10,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    opacity: 1
+  }
+} as const;
+
+export interface InspectorToggleRowProps {
+  label: React.ReactNode;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+}
+
+export const InspectorToggleRow: React.FC<InspectorToggleRowProps> = memo(
+  ({ label, checked, onChange, disabled }) => {
+    const id = useId();
+    return (
+      <InspectorRow label={label} htmlFor={id}>
+        <Switch
+          id={id}
+          size="small"
+          checked={checked}
+          disabled={disabled}
+          onChange={(_e, next) => onChange(next)}
+          sx={toggleSwitchSx}
+        />
+      </InspectorRow>
+    );
+  }
+);
+InspectorToggleRow.displayName = "InspectorToggleRow";
+
+// ── Section title (for CollapsibleSection title prop) ──────────────────────
+
+const sectionTitleStyles = (theme: Theme) =>
+  css({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    color: theme.vars.palette.text.primary,
+    fontSize: 15,
+    fontWeight: 500,
+    letterSpacing: "-0.005em"
+  });
+
+const sectionTitleIconStyles = (theme: Theme) =>
+  css({
+    color: theme.vars.palette.text.secondary,
+    display: "inline-flex",
+    "& svg": { fontSize: 14 }
+  });
+
+export interface InspectorSectionTitleProps {
+  title: string;
+  icon?: React.ReactNode;
+}
+
+export const InspectorSectionTitle: React.FC<InspectorSectionTitleProps> = memo(
+  ({ title, icon }) => {
+    const theme = useTheme();
+    return (
+      <span css={sectionTitleStyles(theme)}>
+        {icon && <span css={sectionTitleIconStyles(theme)}>{icon}</span>}
+        {title}
+      </span>
+    );
+  }
+);
+InspectorSectionTitle.displayName = "InspectorSectionTitle";
+
+// ── Section divider ────────────────────────────────────────────────────────
+
+export const InspectorDivider: React.FC = memo(() => {
+  const theme = useTheme();
+  return (
+    <div
+      style={{
+        height: 1,
+        backgroundColor: theme.vars.palette.divider,
+        margin: "4px 0"
+      }}
+      role="separator"
+    />
+  );
+});
+InspectorDivider.displayName = "InspectorDivider";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Formats ms as HH:MM:SS:FF (frames) — used for the Start field. */
+export function formatTimecode(ms: number, fps: number): string {
+  const safeFps = Math.max(1, Math.round(fps));
+  const totalFrames = Math.max(0, Math.round((ms / 1000) * safeFps));
+  const ff = totalFrames % safeFps;
+  const totalSec = Math.floor(totalFrames / safeFps);
+  const ss = totalSec % 60;
+  const mm = Math.floor(totalSec / 60) % 60;
+  const hh = Math.floor(totalSec / 3600);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(hh)}:${pad(mm)}:${pad(ss)}:${pad(ff)}`;
+}
+
+/** Parses HH:MM:SS:FF (or M:SS, or plain ms) back into milliseconds. */
+export function parseTimecode(input: string, fps: number): number | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+  const safeFps = Math.max(1, Math.round(fps));
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const n = Number(trimmed);
+    if (!Number.isFinite(n) || n < 0) return null;
+    return n;
+  }
+  const parts = trimmed.split(":").map((p) => p.trim());
+  if (parts.some((p) => !/^\d+$/.test(p))) return null;
+  const nums = parts.map(Number);
+  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
+  let hh = 0;
+  let mm = 0;
+  let ss = 0;
+  let ff = 0;
+  if (nums.length === 4) {
+    [hh, mm, ss, ff] = nums;
+  } else if (nums.length === 3) {
+    [hh, mm, ss] = nums;
+  } else if (nums.length === 2) {
+    [mm, ss] = nums;
+  } else if (nums.length === 1) {
+    [ss] = nums;
+  } else {
+    return null;
+  }
+  const totalSec = hh * 3600 + mm * 60 + ss;
+  return Math.round(totalSec * 1000 + (ff * 1000) / safeFps);
+}
+
+/** "4.60s" → 4.6 seconds, returns ms. */
+export function parseSeconds(input: string): number | null {
+  const trimmed = input.trim().replace(/s$/i, "").trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 1000);
+}

--- a/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
@@ -519,7 +519,7 @@ export function parseTimecode(input: string, fps: number): number | null {
   if (/^\d+(\.\d+)?$/.test(trimmed)) {
     const n = Number(trimmed);
     if (!Number.isFinite(n) || n < 0) return null;
-    return n;
+    return Math.round(n);
   }
   const parts = trimmed.split(":").map((p) => p.trim());
   if (parts.some((p) => !/^\d+$/.test(p))) return null;

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -144,6 +144,7 @@ export const TimelineInspector: React.FC = memo(() => {
   const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
   const patchClip = useTimelineStore((s) => s.patchClip);
   const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
+  const setSelection = useTimelineUIStore((s) => s.setSelection);
   const [toast, setToast] = useState<string | null>(null);
 
   const onPatchNumber = useCallback(
@@ -165,8 +166,9 @@ export const TimelineInspector: React.FC = memo(() => {
 
   const handleDuplicate = useCallback(() => {
     if (!clipId) return;
-    duplicateSelected(new Set([clipId]));
-  }, [clipId, duplicateSelected]);
+    const newIds = duplicateSelected(new Set([clipId]));
+    if (newIds.length > 0) setSelection(newIds);
+  }, [clipId, duplicateSelected, setSelection]);
 
   const handleSplitAtPlayhead = useCallback(() => {
     if (!clip) return;
@@ -181,7 +183,8 @@ export const TimelineInspector: React.FC = memo(() => {
   const handleDelete = useCallback(() => {
     if (!clipId) return;
     deleteSelected(new Set([clipId]));
-  }, [clipId, deleteSelected]);
+    setSelection([]);
+  }, [clipId, deleteSelected, setSelection]);
 
   // ── Identity metadata ───────────────────────────────────────────────────
 

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -1,10 +1,17 @@
 /** @jsxImportSource @emotion/react */
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import ContentCutOutlinedIcon from "@mui/icons-material/ContentCutOutlined";
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import WbSunnyOutlinedIcon from "@mui/icons-material/WbSunnyOutlined";
+import BlurOnOutlinedIcon from "@mui/icons-material/BlurOnOutlined";
 
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { usePersistedFold } from "./usePersistedFold";
 import type {
   BlendMode,
@@ -22,32 +29,51 @@ import {
   EmptyState,
   FlexColumn,
   FlexRow,
-  FormField,
-  LabeledSwitch,
   NodeSelect,
   NodeSlider,
-  NodeTextField,
   NodeMenuItem,
   Panel,
   Text,
   Toast
 } from "../../ui_primitives";
+import { trackTypeAccent } from "../Tracks/trackVisuals";
+import {
+  ClipIdentityCard,
+  InspectorDivider,
+  InspectorHeader,
+  InspectorPillInput,
+  InspectorRow,
+  InspectorSectionTitle,
+  InspectorToggleRow,
+  formatTimecode,
+  parseSeconds,
+  parseTimecode
+} from "./InspectorPrimitives";
 import { ClipActions } from "./ClipActions";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
 import { DirectGenClipPanel } from "./DirectGenClipPanel";
+
+// ── Styles ─────────────────────────────────────────────────────────────────
 
 const containerStyles = css({
   width: "100%",
   minWidth: 0,
   maxWidth: "100%",
   boxSizing: "border-box",
-  padding: 8,
+  padding: "8px 12px 24px",
   overflow: "auto"
 });
-const sectionContentStyles = css({ padding: 8 });
 
-/** Stable IDs for the inspector-managed effects so they can round-trip in
- *  `clip.effects` without an add/remove UI. Each clip has at most one of each. */
+const sectionContentStyles = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+  padding: "4px 0 10px"
+});
+
+// ── Effect IDs ─────────────────────────────────────────────────────────────
+
+/** Stable IDs so the inspector-owned effects round-trip in `clip.effects`. */
 const COLOR_EFFECT_ID = "inspector:color";
 const BLUR_EFFECT_ID = "inspector:blur";
 
@@ -58,7 +84,8 @@ const IDENTITY_TRANSFORM: ClipTransform = {
   anchor: { x: 0.5, y: 0.5 }
 };
 
-const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
 
 function findColorEffect(clip: TimelineClip): ClipColorEffect | undefined {
   return clip.effects?.find(
@@ -84,48 +111,12 @@ function upsertEffect(
   return [...existing, next];
 }
 
-/**
- * Numeric field with local draft state — only commits on blur or Enter.
- * Avoids patching the store on every keystroke.
- */
-const NumericField: React.FC<{
-  label: string;
-  value: number | undefined;
-  onCommit: (raw: string) => void;
-}> = ({ label, value, onCommit }) => {
-  const initial = value ?? "";
-  const [draft, setDraft] = useState<string>(String(initial));
-
-  // Re-sync when the underlying value changes (e.g. clip selection swap).
-  useEffect(() => {
-    setDraft(value == null ? "" : String(value));
-  }, [value]);
-
-  const commit = () => {
-    if (draft === String(value ?? "")) return;
-    onCommit(draft);
-  };
-
-  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
-    if (e.key === "Enter") {
-      (e.target as HTMLInputElement).blur();
-    }
-  };
-
-  return (
-    <FormField label={label}>
-      <NodeTextField
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={commit}
-        onKeyDown={handleKeyDown}
-      />
-    </FormField>
-  );
-};
+// ── Component ──────────────────────────────────────────────────────────────
 
 export const TimelineInspector: React.FC = memo(() => {
+  const theme = useTheme();
   const navigate = useNavigate();
+
   const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
   const clipId = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
   const selectedCount = selectedClipIds.size;
@@ -141,45 +132,115 @@ export const TimelineInspector: React.FC = memo(() => {
   const [transitionOpen, setTransitionOpen] = usePersistedFold("transition");
   const [actionsOpen, setActionsOpen] = usePersistedFold("actions");
 
-  const clip = useTimelineStore((s) => (clipId ? s.clips.find((c) => c.id === clipId) : null));
-  const track = useTimelineStore((s) => (clip ? s.tracks.find((t) => t.id === clip.trackId) : null));
+  const clip = useTimelineStore((s) =>
+    clipId ? s.clips.find((c) => c.id === clipId) : null
+  );
+  const track = useTimelineStore((s) =>
+    clip ? s.tracks.find((t) => t.id === clip.trackId) : null
+  );
+  const fps = useTimelineStore((s) => s.fps);
   const deleteSelected = useTimelineStore((s) => s.deleteSelected);
+  const duplicateSelected = useTimelineStore((s) => s.duplicateSelected);
+  const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
   const patchClip = useTimelineStore((s) => s.patchClip);
+  const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
   const [toast, setToast] = useState<string | null>(null);
 
-  const onPatchNumber = useCallback((field: string, raw: string, min?: number, max?: number) => {
-    if (!clipId) return;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed)) return;
-    const value = min != null && max != null ? clamp(parsed, min, max) : parsed;
-    patchClip(clipId, { [field]: value });
-  }, [clipId, patchClip]);
+  const onPatchNumber = useCallback(
+    (field: string, raw: string, min?: number, max?: number) => {
+      if (!clipId) return;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed)) return;
+      const value =
+        min != null && max != null ? clamp(parsed, min, max) : parsed;
+      patchClip(clipId, { [field]: value });
+    },
+    [clipId, patchClip]
+  );
 
   const isAudio = clip?.mediaType === "audio";
   const isOverlay = track?.type === "overlay";
 
+  // ── Header action handlers ──────────────────────────────────────────────
+
+  const handleDuplicate = useCallback(() => {
+    if (!clipId) return;
+    duplicateSelected(new Set([clipId]));
+  }, [clipId, duplicateSelected]);
+
+  const handleSplitAtPlayhead = useCallback(() => {
+    if (!clip) return;
+    const at = currentTimeMs;
+    if (at > clip.startMs && at < clip.startMs + clip.durationMs) {
+      splitClipAtTime(clip.id, at);
+    } else {
+      setToast("Move the playhead inside the clip to split it.");
+    }
+  }, [clip, currentTimeMs, splitClipAtTime]);
+
+  const handleDelete = useCallback(() => {
+    if (!clipId) return;
+    deleteSelected(new Set([clipId]));
+  }, [clipId, deleteSelected]);
+
+  // ── Identity metadata ───────────────────────────────────────────────────
+
+  const accentColor = useMemo(
+    () => (track ? trackTypeAccent(theme, track.type) : undefined),
+    [track, theme]
+  );
+
+  const identityMeta = useMemo<string[]>(() => {
+    if (!clip) return [];
+    const parts: string[] = [clip.mediaType];
+    const secs = clip.durationMs / 1000;
+    parts.push(secs < 10 ? `${secs.toFixed(2)}s` : `${secs.toFixed(1)}s`);
+    if (clip.width && clip.height) {
+      parts.push(`${clip.width}×${clip.height}`);
+    }
+    return parts;
+  }, [clip]);
+
+  // ── Empty / multi-selection states ──────────────────────────────────────
+
   if (selectedCount === 0) {
-    return <EmptyState variant="empty" size="small" title="Inspector" description="Select a clip to inspect" />;
+    return (
+      <Panel css={containerStyles}>
+        <InspectorHeader eyebrow="Inspector" />
+        <EmptyState
+          variant="empty"
+          size="small"
+          title="No selection"
+          description="Select a clip on the timeline to edit its properties."
+        />
+      </Panel>
+    );
   }
 
   if (selectedCount > 1) {
     return (
-      <Panel sx={{ width: "100%", p: 1 }}>
-        <Text weight={500}>{selectedCount} clips selected</Text>
-        <FlexRow gap={1} sx={{ mt: 1 }}>
-          <EditorButton onClick={() => deleteSelected(selectedClipIds)}>Delete</EditorButton>
-          <EditorButton disabled>Lock</EditorButton>
-          <EditorButton disabled>Mute</EditorButton>
-        </FlexRow>
+      <Panel css={containerStyles}>
+        <InspectorHeader
+          eyebrow={`${selectedCount} Clips`}
+          actions={[
+            {
+              icon: <DeleteOutlineOutlinedIcon />,
+              label: "Delete selection",
+              onClick: () => deleteSelected(selectedClipIds),
+              variant: "danger"
+            }
+          ]}
+        />
+        <Text size="small" sx={{ px: 0.5, color: "text.secondary" }}>
+          Multi-clip editing is not yet supported.
+        </Text>
       </Panel>
     );
   }
 
   if (!clip) return null;
 
-  // Direct-gen clips (text-to-image / image-to-image / text-to-video /
-  // text-to-audio) get the prompt-driven inspector; workflow-bound generated
-  // clips get the workflow inputs view.
+  // Direct-gen and workflow-bound generated clips keep their bespoke panels.
   if (clip.sourceType === "generated") {
     if (
       clip.bindingKind === "text-to-image" ||
@@ -192,109 +253,290 @@ export const TimelineInspector: React.FC = memo(() => {
     return <GeneratedClipPanel clipId={clip.id} />;
   }
 
+  // ── Imported-clip inspector ─────────────────────────────────────────────
+
   return (
     <Panel css={containerStyles}>
-      <FlexColumn gap={1}>
-        <CollapsibleSection title="Media" open={mediaOpen} onToggle={setMediaOpen}>
-          <FlexColumn css={sectionContentStyles} gap={1}>
-            <Text size="small">Name: {clip.name}</Text>
-            <Text size="small">Type: {clip.mediaType}</Text>
-            <Text size="small">Asset: {clip.currentAssetId ?? "—"}</Text>
-          </FlexColumn>
-        </CollapsibleSection>
+      <InspectorHeader
+        eyebrow="Clip"
+        actions={[
+          {
+            icon: <AddIcon />,
+            label: "Duplicate clip",
+            onClick: handleDuplicate
+          },
+          {
+            icon: <ContentCutOutlinedIcon />,
+            label: "Split at playhead",
+            onClick: handleSplitAtPlayhead
+          },
+          {
+            icon: <DeleteOutlineOutlinedIcon />,
+            label: "Delete clip",
+            onClick: handleDelete,
+            variant: "danger"
+          }
+        ]}
+      />
 
-        <CollapsibleSection title="Timing" open={timingOpen} onToggle={setTimingOpen}>
-          <FlexColumn css={sectionContentStyles} gap={1}>
-            <NumericField label="Start (ms)" value={clip.startMs} onCommit={(v) => onPatchNumber("startMs", v, 0, Number.MAX_SAFE_INTEGER)} />
-            <NumericField label="Duration (ms)" value={clip.durationMs} onCommit={(v) => onPatchNumber("durationMs", v, 1, Number.MAX_SAFE_INTEGER)} />
-            <NumericField label="In point (ms)" value={clip.inPointMs ?? 0} onCommit={(v) => onPatchNumber("inPointMs", v, 0, Number.MAX_SAFE_INTEGER)} />
-            <NumericField label="Out point (ms)" value={clip.outPointMs ?? clip.durationMs} onCommit={(v) => onPatchNumber("outPointMs", v, 1, Number.MAX_SAFE_INTEGER)} />
-            <NumericField label="Speed" value={clip.speedMultiplier ?? 1} onCommit={(v) => onPatchNumber("speedMultiplier", v, 0.1, 8)} />
-          </FlexColumn>
-        </CollapsibleSection>
+      <ClipIdentityCard
+        name={clip.name}
+        metadata={identityMeta}
+        accentColor={accentColor}
+      />
 
-        <CollapsibleSection title="Render" open={renderOpen} onToggle={setRenderOpen}>
-          <FlexColumn css={sectionContentStyles} gap={1}>
-            {!isAudio && (
-              <FormField label="Opacity">
-                <NodeSlider min={0} max={1} step={0.01} value={clip.opacity ?? 1} onChange={(_e, value) => patchClip(clip.id, { opacity: Array.isArray(value) ? value[0] : value })} />
-              </FormField>
-            )}
-            {isOverlay && !isAudio && (
-              <FormField label="Blend mode">
-                <NodeSelect value={clip.blendMode ?? "normal"} onChange={(e) => patchClip(clip.id, { blendMode: e.target.value as BlendMode })}>
-                  {BLEND_MODES.map((mode) => <NodeMenuItem key={mode.value} value={mode.value}>{mode.label}</NodeMenuItem>)}
-                </NodeSelect>
-              </FormField>
-            )}
-            {isAudio && (
-              <>
-                <NumericField label="Volume (dB)" value={clip.volumeDb ?? 0} onCommit={(v) => onPatchNumber("volumeDb", v, -60, 12)} />
-                <NumericField label="Fade in (ms)" value={clip.fadeInMs ?? 0} onCommit={(v) => onPatchNumber("fadeInMs", v, 0, Math.floor(clip.durationMs / 2))} />
-                <NumericField label="Fade out (ms)" value={clip.fadeOutMs ?? 0} onCommit={(v) => onPatchNumber("fadeOutMs", v, 0, Math.floor(clip.durationMs / 2))} />
-              </>
-            )}
-          </FlexColumn>
-        </CollapsibleSection>
+      <CollapsibleSection
+        title={<InspectorSectionTitle title="Media" />}
+        open={mediaOpen}
+        onToggle={setMediaOpen}
+      >
+        <FlexColumn css={sectionContentStyles}>
+          <InspectorRow label="Type">
+            <InspectorPillInput
+              value={clip.mediaType}
+              onCommit={() => {
+                /* read-only — committed on change elsewhere */
+              }}
+              disabled
+              ariaLabel="Media type"
+            />
+          </InspectorRow>
+          <InspectorRow label="Asset">
+            <Text size="small" sx={{ color: "text.secondary" }}>
+              {clip.currentAssetId ?? "—"}
+            </Text>
+          </InspectorRow>
+        </FlexColumn>
+      </CollapsibleSection>
 
-        {!isAudio && (
-          <CollapsibleSection title="Transform" open={transformOpen} onToggle={setTransformOpen}>
-            <FlexColumn css={sectionContentStyles} gap={1}>
+      <InspectorDivider />
+
+      <CollapsibleSection
+        title={<InspectorSectionTitle title="Timing" />}
+        open={timingOpen}
+        onToggle={setTimingOpen}
+      >
+        <FlexColumn css={sectionContentStyles}>
+          <InspectorRow label="Start">
+            <InspectorPillInput
+              value={formatTimecode(clip.startMs, fps)}
+              onCommit={(raw) => {
+                const ms = parseTimecode(raw, fps);
+                if (ms == null) return;
+                patchClip(clip.id, { startMs: Math.max(0, ms) });
+              }}
+              minWidth={112}
+              ariaLabel="Start timecode"
+            />
+          </InspectorRow>
+          <InspectorRow label="Duration">
+            <InspectorPillInput
+              value={(clip.durationMs / 1000).toFixed(2)}
+              unit="s"
+              onCommit={(raw) => {
+                const ms = parseSeconds(raw);
+                if (ms == null || ms < 1) return;
+                patchClip(clip.id, { durationMs: ms });
+              }}
+              ariaLabel="Duration in seconds"
+            />
+          </InspectorRow>
+          <InspectorRow label="Speed">
+            <InspectorPillInput
+              value={(clip.speedMultiplier ?? 1).toFixed(2)}
+              unit="×"
+              onCommit={(raw) =>
+                onPatchNumber("speedMultiplier", raw, 0.1, 8)
+              }
+              ariaLabel="Playback speed"
+            />
+          </InspectorRow>
+          <InspectorToggleRow
+            label="Hidden"
+            checked={!!clip.hidden}
+            onChange={(next) => patchClip(clip.id, { hidden: next })}
+          />
+        </FlexColumn>
+      </CollapsibleSection>
+
+      <InspectorDivider />
+
+      <CollapsibleSection
+        title={<InspectorSectionTitle title="Render" />}
+        open={renderOpen}
+        onToggle={setRenderOpen}
+      >
+        <FlexColumn css={sectionContentStyles}>
+          {!isAudio && (
+            <InspectorRow label="Opacity">
+              <NodeSlider
+                min={0}
+                max={1}
+                step={0.01}
+                value={clip.opacity ?? 1}
+                onChange={(_e, value) =>
+                  patchClip(clip.id, {
+                    opacity: Array.isArray(value) ? value[0] : value
+                  })
+                }
+              />
+            </InspectorRow>
+          )}
+          {isOverlay && !isAudio && (
+            <InspectorRow label="Blend">
+              <NodeSelect
+                value={clip.blendMode ?? "normal"}
+                onChange={(e) =>
+                  patchClip(clip.id, {
+                    blendMode: e.target.value as BlendMode
+                  })
+                }
+              >
+                {BLEND_MODES.map((mode) => (
+                  <NodeMenuItem key={mode.value} value={mode.value}>
+                    {mode.label}
+                  </NodeMenuItem>
+                ))}
+              </NodeSelect>
+            </InspectorRow>
+          )}
+          {isAudio && (
+            <>
+              <InspectorRow label="Volume">
+                <InspectorPillInput
+                  value={(clip.volumeDb ?? 0).toFixed(1)}
+                  unit="dB"
+                  onCommit={(raw) => onPatchNumber("volumeDb", raw, -60, 12)}
+                  ariaLabel="Volume (dB)"
+                />
+              </InspectorRow>
+              <InspectorRow label="Fade in">
+                <InspectorPillInput
+                  value={((clip.fadeInMs ?? 0) / 1000).toFixed(2)}
+                  unit="s"
+                  onCommit={(raw) => {
+                    const ms = parseSeconds(raw);
+                    if (ms == null) return;
+                    onPatchNumber(
+                      "fadeInMs",
+                      String(ms),
+                      0,
+                      Math.floor(clip.durationMs / 2)
+                    );
+                  }}
+                  ariaLabel="Fade in (seconds)"
+                />
+              </InspectorRow>
+              <InspectorRow label="Fade out">
+                <InspectorPillInput
+                  value={((clip.fadeOutMs ?? 0) / 1000).toFixed(2)}
+                  unit="s"
+                  onCommit={(raw) => {
+                    const ms = parseSeconds(raw);
+                    if (ms == null) return;
+                    onPatchNumber(
+                      "fadeOutMs",
+                      String(ms),
+                      0,
+                      Math.floor(clip.durationMs / 2)
+                    );
+                  }}
+                  ariaLabel="Fade out (seconds)"
+                />
+              </InspectorRow>
+            </>
+          )}
+        </FlexColumn>
+      </CollapsibleSection>
+
+      {!isAudio && (
+        <>
+          <InspectorDivider />
+          <CollapsibleSection
+            title={<InspectorSectionTitle title="Transform" />}
+            open={transformOpen}
+            onToggle={setTransformOpen}
+          >
+            <FlexColumn css={sectionContentStyles}>
               {(() => {
                 const t = clip.transform ?? IDENTITY_TRANSFORM;
                 const setTransform = (next: ClipTransform) =>
                   patchClip(clip.id, { transform: next });
                 const setPos = (axis: "x" | "y", v: number) =>
-                  setTransform({ ...t, position: { ...t.position, [axis]: v } });
+                  setTransform({
+                    ...t,
+                    position: { ...t.position, [axis]: v }
+                  });
                 const setScale = (axis: "x" | "y", v: number) =>
-                  setTransform({ ...t, scale: { ...t.scale, [axis]: v } });
+                  setTransform({
+                    ...t,
+                    scale: { ...t.scale, [axis]: v }
+                  });
                 const setAnchor = (axis: "x" | "y", v: number) =>
-                  setTransform({ ...t, anchor: { ...t.anchor, [axis]: v } });
+                  setTransform({
+                    ...t,
+                    anchor: { ...t.anchor, [axis]: v }
+                  });
                 const setRotationDeg = (deg: number) =>
                   setTransform({ ...t, rotation: (deg * Math.PI) / 180 });
                 return (
                   <>
-                    <NumericField
-                      label="X (px)"
-                      value={t.position.x}
-                      onCommit={(v) => {
-                        const n = Number(v);
-                        if (Number.isFinite(n)) setPos("x", n);
-                      }}
-                    />
-                    <NumericField
-                      label="Y (px)"
-                      value={t.position.y}
-                      onCommit={(v) => {
-                        const n = Number(v);
-                        if (Number.isFinite(n)) setPos("y", n);
-                      }}
-                    />
-                    <NumericField
-                      label="Scale X"
-                      value={t.scale.x}
-                      onCommit={(v) => {
-                        const n = Number(v);
-                        if (Number.isFinite(n)) setScale("x", n);
-                      }}
-                    />
-                    <NumericField
-                      label="Scale Y"
-                      value={t.scale.y}
-                      onCommit={(v) => {
-                        const n = Number(v);
-                        if (Number.isFinite(n)) setScale("y", n);
-                      }}
-                    />
-                    <NumericField
-                      label="Rotation (deg)"
-                      value={(t.rotation * 180) / Math.PI}
-                      onCommit={(v) => {
-                        const n = Number(v);
-                        if (Number.isFinite(n)) setRotationDeg(n);
-                      }}
-                    />
-                    <FormField label={`Anchor X (${t.anchor.x.toFixed(2)})`}>
+                    <InspectorRow label="X">
+                      <InspectorPillInput
+                        value={t.position.x.toFixed(0)}
+                        unit="px"
+                        onCommit={(raw) => {
+                          const n = Number(raw);
+                          if (Number.isFinite(n)) setPos("x", n);
+                        }}
+                        ariaLabel="Position X"
+                      />
+                    </InspectorRow>
+                    <InspectorRow label="Y">
+                      <InspectorPillInput
+                        value={t.position.y.toFixed(0)}
+                        unit="px"
+                        onCommit={(raw) => {
+                          const n = Number(raw);
+                          if (Number.isFinite(n)) setPos("y", n);
+                        }}
+                        ariaLabel="Position Y"
+                      />
+                    </InspectorRow>
+                    <InspectorRow label="Scale X">
+                      <InspectorPillInput
+                        value={t.scale.x.toFixed(2)}
+                        unit="×"
+                        onCommit={(raw) => {
+                          const n = Number(raw);
+                          if (Number.isFinite(n)) setScale("x", n);
+                        }}
+                        ariaLabel="Scale X"
+                      />
+                    </InspectorRow>
+                    <InspectorRow label="Scale Y">
+                      <InspectorPillInput
+                        value={t.scale.y.toFixed(2)}
+                        unit="×"
+                        onCommit={(raw) => {
+                          const n = Number(raw);
+                          if (Number.isFinite(n)) setScale("y", n);
+                        }}
+                        ariaLabel="Scale Y"
+                      />
+                    </InspectorRow>
+                    <InspectorRow label="Rotation">
+                      <InspectorPillInput
+                        value={((t.rotation * 180) / Math.PI).toFixed(1)}
+                        unit="°"
+                        onCommit={(raw) => {
+                          const n = Number(raw);
+                          if (Number.isFinite(n)) setRotationDeg(n);
+                        }}
+                        ariaLabel="Rotation in degrees"
+                      />
+                    </InspectorRow>
+                    <InspectorRow label={`Anchor X (${t.anchor.x.toFixed(2)})`}>
                       <NodeSlider
                         min={0}
                         max={1}
@@ -304,8 +546,8 @@ export const TimelineInspector: React.FC = memo(() => {
                           setAnchor("x", Array.isArray(value) ? value[0] : value)
                         }
                       />
-                    </FormField>
-                    <FormField label={`Anchor Y (${t.anchor.y.toFixed(2)})`}>
+                    </InspectorRow>
+                    <InspectorRow label={`Anchor Y (${t.anchor.y.toFixed(2)})`}>
                       <NodeSlider
                         min={0}
                         max={1}
@@ -315,8 +557,8 @@ export const TimelineInspector: React.FC = memo(() => {
                           setAnchor("y", Array.isArray(value) ? value[0] : value)
                         }
                       />
-                    </FormField>
-                    <FormField label="Border radius (px)">
+                    </InspectorRow>
+                    <InspectorRow label="Radius">
                       <NodeSlider
                         min={0}
                         max={500}
@@ -324,31 +566,48 @@ export const TimelineInspector: React.FC = memo(() => {
                         value={clip.borderRadius ?? 0}
                         onChange={(_e, value) =>
                           patchClip(clip.id, {
-                            borderRadius: Array.isArray(value) ? value[0] : value
+                            borderRadius: Array.isArray(value)
+                              ? value[0]
+                              : value
                           })
                         }
                       />
-                    </FormField>
-                    <EditorButton
-                      onClick={() =>
-                        patchClip(clip.id, {
-                          transform: undefined,
-                          borderRadius: undefined
-                        })
-                      }
-                    >
-                      Reset transform
-                    </EditorButton>
+                    </InspectorRow>
+                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                      <EditorButton
+                        size="small"
+                        onClick={() =>
+                          patchClip(clip.id, {
+                            transform: undefined,
+                            borderRadius: undefined
+                          })
+                        }
+                      >
+                        Reset transform
+                      </EditorButton>
+                    </FlexRow>
                   </>
                 );
               })()}
             </FlexColumn>
           </CollapsibleSection>
-        )}
+        </>
+      )}
 
-        {!isAudio && (
-          <CollapsibleSection title="Color" open={colorOpen} onToggle={setColorOpen}>
-            <FlexColumn css={sectionContentStyles} gap={1}>
+      {!isAudio && (
+        <>
+          <InspectorDivider />
+          <CollapsibleSection
+            title={
+              <InspectorSectionTitle
+                title="Color"
+                icon={<WbSunnyOutlinedIcon />}
+              />
+            }
+            open={colorOpen}
+            onToggle={setColorOpen}
+          >
+            <FlexColumn css={sectionContentStyles}>
               {(() => {
                 const color = findColorEffect(clip);
                 const enabled = color?.enabled ?? false;
@@ -373,7 +632,10 @@ export const TimelineInspector: React.FC = memo(() => {
                 };
                 const slider = (
                   label: string,
-                  key: keyof Omit<ClipColorEffect, "id" | "type" | "enabled">,
+                  key: keyof Omit<
+                    ClipColorEffect,
+                    "id" | "type" | "enabled"
+                  >,
                   min: number,
                   max: number,
                   step: number,
@@ -381,7 +643,7 @@ export const TimelineInspector: React.FC = memo(() => {
                 ) => {
                   const v = color?.[key] ?? defaultV;
                   return (
-                    <FormField label={`${label} (${v.toFixed(2)})`}>
+                    <InspectorRow label={`${label} (${v.toFixed(2)})`}>
                       <NodeSlider
                         min={min}
                         max={max}
@@ -394,15 +656,15 @@ export const TimelineInspector: React.FC = memo(() => {
                           } as Partial<ClipColorEffect>)
                         }
                       />
-                    </FormField>
+                    </InspectorRow>
                   );
                 };
                 return (
                   <>
-                    <LabeledSwitch
-                      label="Enable color grading"
+                    <InspectorToggleRow
+                      label="Enable"
                       checked={enabled}
-                      onChange={(checked) => update({ enabled: checked })}
+                      onChange={(next) => update({ enabled: next })}
                     />
                     {slider("Brightness", "brightness", -1, 1, 0.01, 0)}
                     {slider("Contrast", "contrast", 0, 4, 0.01, 1)}
@@ -412,28 +674,43 @@ export const TimelineInspector: React.FC = memo(() => {
                     {slider("Tint", "tint", -1, 1, 0.01, 0)}
                     {slider("Shadows", "shadows", -1, 1, 0.01, 0)}
                     {slider("Highlights", "highlights", -1, 1, 0.01, 0)}
-                    <EditorButton
-                      disabled={!color}
-                      onClick={() =>
-                        patchClip(clip.id, {
-                          effects: clip.effects?.filter(
-                            (e) => e.id !== COLOR_EFFECT_ID
-                          )
-                        })
-                      }
-                    >
-                      Clear color effect
-                    </EditorButton>
+                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                      <EditorButton
+                        size="small"
+                        disabled={!color}
+                        onClick={() =>
+                          patchClip(clip.id, {
+                            effects: clip.effects?.filter(
+                              (e) => e.id !== COLOR_EFFECT_ID
+                            )
+                          })
+                        }
+                      >
+                        Clear color
+                      </EditorButton>
+                    </FlexRow>
                   </>
                 );
               })()}
             </FlexColumn>
           </CollapsibleSection>
-        )}
+        </>
+      )}
 
-        {!isAudio && (
-          <CollapsibleSection title="Blur" open={blurOpen} onToggle={setBlurOpen}>
-            <FlexColumn css={sectionContentStyles} gap={1}>
+      {!isAudio && (
+        <>
+          <InspectorDivider />
+          <CollapsibleSection
+            title={
+              <InspectorSectionTitle
+                title="Blur"
+                icon={<BlurOnOutlinedIcon />}
+              />
+            }
+            open={blurOpen}
+            onToggle={setBlurOpen}
+          >
+            <FlexColumn css={sectionContentStyles}>
               {(() => {
                 const blur = findBlurEffect(clip);
                 const enabled = blur?.enabled ?? false;
@@ -453,12 +730,12 @@ export const TimelineInspector: React.FC = memo(() => {
                 };
                 return (
                   <>
-                    <LabeledSwitch
-                      label="Enable blur"
+                    <InspectorToggleRow
+                      label="Enable"
                       checked={enabled}
-                      onChange={(checked) => updateBlur({ enabled: checked })}
+                      onChange={(next) => updateBlur({ enabled: next })}
                     />
-                    <FormField label={`Radius (${radius.toFixed(0)} px)`}>
+                    <InspectorRow label={`Radius (${radius.toFixed(0)} px)`}>
                       <NodeSlider
                         min={0}
                         max={20}
@@ -471,29 +748,39 @@ export const TimelineInspector: React.FC = memo(() => {
                           })
                         }
                       />
-                    </FormField>
-                    <EditorButton
-                      disabled={!blur}
-                      onClick={() =>
-                        patchClip(clip.id, {
-                          effects: clip.effects?.filter(
-                            (e) => e.id !== BLUR_EFFECT_ID
-                          )
-                        })
-                      }
-                    >
-                      Clear blur effect
-                    </EditorButton>
+                    </InspectorRow>
+                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                      <EditorButton
+                        size="small"
+                        disabled={!blur}
+                        onClick={() =>
+                          patchClip(clip.id, {
+                            effects: clip.effects?.filter(
+                              (e) => e.id !== BLUR_EFFECT_ID
+                            )
+                          })
+                        }
+                      >
+                        Clear blur
+                      </EditorButton>
+                    </FlexRow>
                   </>
                 );
               })()}
             </FlexColumn>
           </CollapsibleSection>
-        )}
+        </>
+      )}
 
-        {!isAudio && (
-          <CollapsibleSection title="Transition" open={transitionOpen} onToggle={setTransitionOpen}>
-            <FlexColumn css={sectionContentStyles} gap={1}>
+      {!isAudio && (
+        <>
+          <InspectorDivider />
+          <CollapsibleSection
+            title={<InspectorSectionTitle title="Transition" />}
+            open={transitionOpen}
+            onToggle={setTransitionOpen}
+          >
+            <FlexColumn css={sectionContentStyles}>
               {(() => {
                 const t = clip.transitionIn;
                 const type: "none" | "crossfade" = t?.type ?? "none";
@@ -511,7 +798,7 @@ export const TimelineInspector: React.FC = memo(() => {
                 };
                 return (
                   <>
-                    <FormField label="Type">
+                    <InspectorRow label="Type">
                       <NodeSelect
                         value={type}
                         onChange={(e) =>
@@ -521,26 +808,32 @@ export const TimelineInspector: React.FC = memo(() => {
                         <NodeMenuItem value="none">None</NodeMenuItem>
                         <NodeMenuItem value="crossfade">Crossfade</NodeMenuItem>
                       </NodeSelect>
-                    </FormField>
+                    </InspectorRow>
                     {type === "crossfade" && (
                       <>
-                        <NumericField
-                          label="Duration (ms)"
-                          value={duration}
-                          onCommit={(v) => {
-                            const n = Number(v);
-                            if (!Number.isFinite(n) || n < 0) return;
-                            patchClip(clip.id, {
-                              transitionIn: {
-                                type: "crossfade",
-                                durationMs: Math.max(0, Math.floor(n))
-                              }
-                            });
-                          }}
-                        />
-                        <Text size="small">
-                          Overlap this clip with the previous clip on the same
-                          track to see the cross-fade.
+                        <InspectorRow label="Duration">
+                          <InspectorPillInput
+                            value={(duration / 1000).toFixed(2)}
+                            unit="s"
+                            onCommit={(raw) => {
+                              const ms = parseSeconds(raw);
+                              if (ms == null) return;
+                              patchClip(clip.id, {
+                                transitionIn: {
+                                  type: "crossfade",
+                                  durationMs: Math.max(0, ms)
+                                }
+                              });
+                            }}
+                            ariaLabel="Transition duration"
+                          />
+                        </InspectorRow>
+                        <Text
+                          size="small"
+                          sx={{ px: 0.5, color: "text.secondary" }}
+                        >
+                          Overlap with the previous clip on the same track to
+                          see the cross-fade.
                         </Text>
                       </>
                     )}
@@ -549,19 +842,49 @@ export const TimelineInspector: React.FC = memo(() => {
               })()}
             </FlexColumn>
           </CollapsibleSection>
-        )}
+        </>
+      )}
 
-        <CollapsibleSection title="Actions" open={actionsOpen} onToggle={setActionsOpen}>
-          <FlexColumn css={sectionContentStyles} gap={1}>
-            <ClipActions clipId={clip.id} />
-            <EditorButton onClick={() => setToast("Replace media picker coming soon")}>Replace Media</EditorButton>
-            <EditorButton onClick={() => navigate("/assets")}>Reveal in Library</EditorButton>
-            <EditorButton onClick={() => setToast("Convert to Generated Clip will be wired in NOD-306")}>Convert to Generated Clip</EditorButton>
-          </FlexColumn>
-        </CollapsibleSection>
+      <InspectorDivider />
 
-      </FlexColumn>
-      <Toast open={toast !== null} message={toast ?? ""} onClose={() => setToast(null)} severity="info" />
+      <CollapsibleSection
+        title={<InspectorSectionTitle title="Actions" />}
+        open={actionsOpen}
+        onToggle={setActionsOpen}
+      >
+        <FlexColumn css={sectionContentStyles} gap={1}>
+          <ClipActions clipId={clip.id} />
+          <FlexRow gap={1} sx={{ px: 0.5, flexWrap: "wrap" }}>
+            <EditorButton
+              size="small"
+              onClick={() => setToast("Replace media picker coming soon")}
+            >
+              Replace media
+            </EditorButton>
+            <EditorButton
+              size="small"
+              onClick={() => navigate("/assets")}
+            >
+              Reveal in library
+            </EditorButton>
+            <EditorButton
+              size="small"
+              onClick={() =>
+                setToast("Convert to Generated Clip will be wired in NOD-306")
+              }
+            >
+              Convert to generated
+            </EditorButton>
+          </FlexRow>
+        </FlexColumn>
+      </CollapsibleSection>
+
+      <Toast
+        open={toast !== null}
+        message={toast ?? ""}
+        onClose={() => setToast(null)}
+        severity="info"
+      />
     </Panel>
   );
 });

--- a/web/src/components/timeline/TimelineAssetPanel.tsx
+++ b/web/src/components/timeline/TimelineAssetPanel.tsx
@@ -6,17 +6,27 @@
  * drag images, video, audio, or overlay assets onto track lanes. Wraps the grid
  * in `ContextMenuProvider` + `ContextMenus` so right-click menus on assets
  * continue to work, matching the setup used by `PanelLeft`.
+ *
+ * Toggleable: when collapsed via `TimelineUIStore.toggleAssetPanel`, the
+ * editor swaps in `TimelineAssetPanelRail` — a 28px-wide vertical strip with
+ * an expand chevron — so the panel is always re-openable without a menu trip.
  */
 
-import React, { memo } from "react";
+import React, { memo, useCallback } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 
 import AssetGrid from "../assets/AssetGrid";
 import ContextMenus from "../context_menus/ContextMenus";
 import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
-import { FlexColumn, Text } from "../ui_primitives";
+import { FlexColumn, Text, Tooltip } from "../ui_primitives";
+import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
+
+const ASSET_PANEL_RAIL_WIDTH_PX = 28;
 
 const panelStyles = (theme: Theme) =>
   css({
@@ -31,10 +41,61 @@ const headerStyles = (theme: Theme) =>
   css({
     height: 32,
     flexShrink: 0,
-    padding: `0 ${theme.spacing(1)}`,
+    padding: "0 6px 0 12px",
     display: "flex",
     alignItems: "center",
+    gap: 8,
     borderBottom: `1px solid ${theme.vars.palette.divider}`
+  });
+
+const headerLabelStyles = css({
+  flex: "1 1 auto",
+  minWidth: 0,
+  display: "flex",
+  alignItems: "center",
+  gap: 8
+});
+
+const iconButtonStyles = (theme: Theme) =>
+  css({
+    width: 24,
+    height: 22,
+    background: "transparent",
+    border: "1px solid transparent",
+    padding: 0,
+    cursor: "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: theme.vars.palette.text.secondary,
+    borderRadius: 5,
+    transition: "background-color 120ms, color 120ms, border-color 120ms",
+    "&:hover": {
+      backgroundColor: theme.vars.palette.action.hover,
+      color: theme.vars.palette.text.primary,
+      borderColor: theme.vars.palette.divider
+    },
+    "&:focus-visible": {
+      outline: "none",
+      borderColor: theme.vars.palette.primary.main
+    },
+    "& svg": {
+      fontSize: 16
+    }
+  });
+
+const railStyles = (theme: Theme) =>
+  css({
+    width: ASSET_PANEL_RAIL_WIDTH_PX,
+    height: "100%",
+    flexShrink: 0,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    paddingTop: 6,
+    gap: 6,
+    backgroundColor: theme.vars.palette.background.paper,
+    borderRight: `1px solid ${theme.vars.palette.divider}`
   });
 
 const gridContainerStyles = css({
@@ -46,13 +107,34 @@ const gridContainerStyles = css({
 
 export const TimelineAssetPanel: React.FC = memo(() => {
   const theme = useTheme();
+  const toggleAssetPanel = useTimelineUIStore((s) => s.toggleAssetPanel);
+
+  const handleCollapse = useCallback(() => {
+    toggleAssetPanel();
+  }, [toggleAssetPanel]);
 
   return (
     <FlexColumn css={panelStyles(theme)}>
       <div css={headerStyles(theme)}>
-        <Text size="small" weight={600}>
-          Assets
-        </Text>
+        <div css={headerLabelStyles}>
+          <FolderOutlinedIcon
+            sx={{ fontSize: 14, color: "text.secondary" }}
+            aria-hidden
+          />
+          <Text size="small" weight={600}>
+            Assets
+          </Text>
+        </div>
+        <Tooltip title="Collapse asset panel">
+          <button
+            type="button"
+            css={iconButtonStyles(theme)}
+            onClick={handleCollapse}
+            aria-label="Collapse asset panel"
+          >
+            <ChevronLeftIcon />
+          </button>
+        </Tooltip>
       </div>
       <div css={gridContainerStyles}>
         <ContextMenuProvider>
@@ -65,5 +147,37 @@ export const TimelineAssetPanel: React.FC = memo(() => {
 });
 
 TimelineAssetPanel.displayName = "TimelineAssetPanel";
+
+export const TimelineAssetPanelRail: React.FC = memo(() => {
+  const theme = useTheme();
+  const toggleAssetPanel = useTimelineUIStore((s) => s.toggleAssetPanel);
+
+  return (
+    <div css={railStyles(theme)} data-testid="asset-panel-rail">
+      <Tooltip title="Show asset panel" placement="right">
+        <button
+          type="button"
+          css={iconButtonStyles(theme)}
+          onClick={toggleAssetPanel}
+          aria-label="Show asset panel"
+        >
+          <ChevronRightIcon />
+        </button>
+      </Tooltip>
+      <Tooltip title="Show asset panel" placement="right">
+        <button
+          type="button"
+          css={iconButtonStyles(theme)}
+          onClick={toggleAssetPanel}
+          aria-label="Show assets"
+        >
+          <FolderOutlinedIcon />
+        </button>
+      </Tooltip>
+    </div>
+  );
+});
+
+TimelineAssetPanelRail.displayName = "TimelineAssetPanelRail";
 
 export default TimelineAssetPanel;

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -32,7 +32,10 @@ import {
 
 import { TopBar } from "./TopBar";
 import { BottomStatusBar } from "./BottomStatusBar";
-import { TimelineAssetPanel } from "./TimelineAssetPanel";
+import {
+  TimelineAssetPanel,
+  TimelineAssetPanelRail
+} from "./TimelineAssetPanel";
 import {
   useCreateTimeline,
   useTimeline,
@@ -86,6 +89,11 @@ const assetPanelRegionStyles = css({
   flex: "0 0 280px",
   minWidth: 240,
   maxWidth: 360,
+  overflow: "hidden"
+});
+
+const assetPanelRailRegionStyles = css({
+  flex: "0 0 auto",
   overflow: "hidden"
 });
 
@@ -244,6 +252,7 @@ export const TimelineEditor: React.FC = memo(() => {
   // Zoom ← wired to TimelineUIStore so TracksRegion + BottomStatusBar stay in sync
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
   const setZoom = useTimelineUIStore((s) => s.setZoom);
+  const assetPanelVisible = useTimelineUIStore((s) => s.assetPanelVisible);
   // Convert msPerPx to a dimensionless ratio for ZoomControls (1 = default zoom)
   const zoom = DEFAULT_MS_PER_PX / msPerPx;
   const handleZoomChange = useCallback(
@@ -392,9 +401,15 @@ export const TimelineEditor: React.FC = memo(() => {
         css={middleAreaStyles(theme)}
         sx={{ flex: "1 1 auto", overflow: "hidden" }}
       >
-        <div css={assetPanelRegionStyles}>
-          <TimelineAssetPanel />
-        </div>
+        {assetPanelVisible ? (
+          <div css={assetPanelRegionStyles}>
+            <TimelineAssetPanel />
+          </div>
+        ) : (
+          <div css={assetPanelRailRegionStyles}>
+            <TimelineAssetPanelRail />
+          </div>
+        )}
         <PreviewRegion
           isLoading={isLoading}
           sequence={sequence}

--- a/web/src/components/timeline/ToolToggle.tsx
+++ b/web/src/components/timeline/ToolToggle.tsx
@@ -2,38 +2,124 @@
 /**
  * ToolToggle — Select / Cut tool buttons for the timeline editor.
  *
- * Pairs with the V (select) / C (cut) keyboard shortcuts handled in
- * TracksRegion. The active button is rendered with primary color and
- * `aria-pressed=true` for screen readers.
+ * Labeled ghost buttons (icon + text). The active button picks up the
+ * primary accent + subtle filled background; tooltip carries the shortcut.
+ * Pairs with the V (select) / C (cut) keyboard shortcuts in TracksRegion.
  */
 import React, { memo } from "react";
-import NearMeIcon from "@mui/icons-material/NearMe";
-import ContentCutIcon from "@mui/icons-material/ContentCut";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ContentCutOutlinedIcon from "@mui/icons-material/ContentCutOutlined";
 
-import { FlexRow, ToolbarIconButton } from "../ui_primitives";
+import { FlexRow, Tooltip } from "../ui_primitives";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
+
+/** Custom pointer cursor — monoline, 1.6px stroke. */
+const PointerIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M5 3.5 5 19.5 9.2 15.2 11.7 21 14.5 19.8 12 14.2 18 14.2 Z" />
+  </svg>
+);
+
+const buttonStyles = (theme: Theme, active: boolean) =>
+  css({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    height: 24,
+    padding: "0 10px 0 8px",
+    background: active ? theme.vars.palette.action.selected : "transparent",
+    border: `1px solid ${active ? theme.vars.palette.divider : "transparent"}`,
+    color: active
+      ? theme.vars.palette.text.primary
+      : theme.vars.palette.text.secondary,
+    cursor: "pointer",
+    fontSize: 12,
+    fontWeight: 500,
+    letterSpacing: "0.01em",
+    fontFamily: theme.typography.fontFamily,
+    borderRadius: 6,
+    transition: "background-color 120ms, color 120ms, border-color 120ms",
+    "&:hover": {
+      backgroundColor: active
+        ? theme.vars.palette.action.selected
+        : theme.vars.palette.action.hover,
+      color: theme.vars.palette.text.primary,
+      borderColor: theme.vars.palette.divider
+    },
+    "&:focus-visible": {
+      outline: "none",
+      borderColor: theme.vars.palette.primary.main
+    },
+    "& svg": {
+      fontSize: 14
+    }
+  });
+
+interface ToolButtonProps {
+  label: string;
+  shortcut: string;
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+const ToolButton: React.FC<ToolButtonProps> = ({
+  label,
+  shortcut,
+  active,
+  onClick,
+  children
+}) => {
+  const theme = useTheme();
+  return (
+    <Tooltip title={`${label} (${shortcut})`}>
+      <button
+        type="button"
+        css={buttonStyles(theme, active)}
+        onClick={onClick}
+        aria-label={label}
+        aria-pressed={active}
+      >
+        {children}
+        <span>{label}</span>
+      </button>
+    </Tooltip>
+  );
+};
 
 export const ToolToggle: React.FC = memo(() => {
   const activeTool = useTimelineUIStore((s) => s.activeTool);
   const setActiveTool = useTimelineUIStore((s) => s.setActiveTool);
   return (
-    <FlexRow gap={0.25} align="center">
-      <ToolbarIconButton
-        icon={<NearMeIcon />}
-        tooltip="Select tool (V)"
+    <FlexRow gap={0.5} align="center">
+      <ToolButton
+        label="Select"
+        shortcut="V"
         active={activeTool === "select"}
         onClick={() => setActiveTool("select")}
-        aria-label="Select tool"
-        aria-pressed={activeTool === "select"}
-      />
-      <ToolbarIconButton
-        icon={<ContentCutIcon />}
-        tooltip="Cut tool (C) — click a clip to split"
+      >
+        <PointerIcon />
+      </ToolButton>
+      <ToolButton
+        label="Cut"
+        shortcut="C"
         active={activeTool === "cut"}
         onClick={() => setActiveTool("cut")}
-        aria-label="Cut tool"
-        aria-pressed={activeTool === "cut"}
-      />
+      >
+        <ContentCutOutlinedIcon />
+      </ToolButton>
     </FlexRow>
   );
 });

--- a/web/src/components/timeline/Tracks/AddTrackButton.tsx
+++ b/web/src/components/timeline/Tracks/AddTrackButton.tsx
@@ -2,10 +2,10 @@
 /**
  * AddTrackButton
  *
- * Small button rendered at the bottom of the track header column. Click opens
- * a popover with the four track types (video / audio / overlay / subtitle).
- * Selecting one calls `TimelineStore.addTrack(type)`, which appends a new
- * track with an auto-generated name.
+ * Compact "+ Track" affordance in the timeline toolbar. Opens a popover with
+ * the four track types (video / audio / overlay / subtitle); selecting one
+ * calls `TimelineStore.addTrack(type)`, which appends a new track with an
+ * auto-generated name.
  */
 
 import React, { memo, useCallback, useState } from "react";
@@ -14,42 +14,41 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { MenuItem, ListItemIcon, ListItemText } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
-import VideocamIcon from "@mui/icons-material/Videocam";
-import AudiotrackIcon from "@mui/icons-material/Audiotrack";
-import LayersIcon from "@mui/icons-material/Layers";
-import SubtitlesIcon from "@mui/icons-material/Subtitles";
+import VideocamOutlinedIcon from "@mui/icons-material/VideocamOutlined";
+import AudiotrackOutlinedIcon from "@mui/icons-material/AudiotrackOutlined";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
 
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { Popover } from "../../ui_primitives";
-import { TRACK_HEADER_WIDTH_PX } from "./TrackHeader";
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
 const buttonStyles = (theme: Theme) =>
   css({
-    width: TRACK_HEADER_WIDTH_PX,
-    flexShrink: 0,
-    display: "flex",
+    display: "inline-flex",
     alignItems: "center",
-    justifyContent: "center",
-    gap: theme.spacing(0.5),
-    height: 32,
-    background: "none",
-    border: "none",
-    borderRight: `1px solid ${theme.vars.palette.divider}`,
-    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    gap: 6,
+    height: 24,
+    padding: "0 10px 0 8px",
+    background: "transparent",
+    border: "1px solid transparent",
     color: theme.vars.palette.text.secondary,
     cursor: "pointer",
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: 12,
+    fontWeight: 500,
+    letterSpacing: "0.01em",
     fontFamily: theme.typography.fontFamily,
-    padding: 0,
+    borderRadius: 6,
+    transition: "background-color 120ms, color 120ms, border-color 120ms",
     "&:hover": {
       backgroundColor: theme.vars.palette.action.hover,
-      color: theme.vars.palette.text.primary
+      color: theme.vars.palette.text.primary,
+      borderColor: theme.vars.palette.divider
     },
     "& svg": {
-      fontSize: 16
+      fontSize: 14
     }
   });
 
@@ -62,13 +61,25 @@ interface TrackTypeOption {
 }
 
 const TRACK_TYPES: TrackTypeOption[] = [
-  { type: "video", label: "Video", icon: <VideocamIcon fontSize="small" /> },
-  { type: "audio", label: "Audio", icon: <AudiotrackIcon fontSize="small" /> },
-  { type: "overlay", label: "Overlay", icon: <LayersIcon fontSize="small" /> },
+  {
+    type: "video",
+    label: "Video",
+    icon: <VideocamOutlinedIcon fontSize="small" />
+  },
+  {
+    type: "audio",
+    label: "Audio",
+    icon: <AudiotrackOutlinedIcon fontSize="small" />
+  },
+  {
+    type: "overlay",
+    label: "Overlay",
+    icon: <LayersOutlinedIcon fontSize="small" />
+  },
   {
     type: "subtitle",
     label: "Subtitle",
-    icon: <SubtitlesIcon fontSize="small" />
+    icon: <SubtitlesOutlinedIcon fontSize="small" />
   }
 ];
 

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -20,7 +20,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "
 import { css, keyframes } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import LockIcon from "@mui/icons-material/Lock";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 
 import type { TimelineClip, TimelineTrack, ClipStatus } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
@@ -41,6 +41,7 @@ import { useClipThumbnails } from "./useClipThumbnails";
 import { useAudioPeaks } from "./useAudioPeaks";
 import { samplePeaksWindow } from "./audioPeaks";
 import { isCompatibleWithTrack } from "../dnd/assetToClipAdapter";
+import { clipSurfaceTint, clipBorderTint } from "./trackVisuals";
 
 /** Clip-side wrapper: TimelineClip.mediaType also includes "overlay";
  *  treat those as video-track-compatible. */
@@ -59,6 +60,9 @@ function isClipCompatibleWithTrack(
 const TRIM_HANDLE_WIDTH_PX = 8;
 const SNAP_THRESHOLD_PX = 8;
 const MIN_CLIP_WIDTH_PX = 4;
+const CLIP_RADIUS_PX = 6;
+/** Width below which we suppress secondary chrome (duration label). */
+const COMPACT_THRESHOLD_PX = 96;
 
 // ── Status mapping (PRD §5.5) ──────────────────────────────────────────────
 
@@ -75,17 +79,29 @@ const CLIP_STATUS_MAP: Record<ClipStatus, { status: StatusType; label: string; p
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
-const clipStyles = (theme: Theme, selected: boolean, locked: boolean) =>
+const clipStyles = (
+  theme: Theme,
+  selected: boolean,
+  locked: boolean,
+  mediaType: TimelineClip["mediaType"]
+) =>
   css({
     position: "absolute",
-    top: 4,
-    bottom: 4,
-    borderRadius: 4,
+    top: 6,
+    bottom: 6,
+    borderRadius: CLIP_RADIUS_PX,
     overflow: "hidden",
-    backgroundColor: theme.vars.palette.primary.dark,
+    backgroundColor: theme.vars.palette.background.paper,
+    backgroundImage: `linear-gradient(0deg, ${clipSurfaceTint(
+      theme,
+      mediaType
+    )}, ${clipSurfaceTint(theme, mediaType)})`,
     border: selected
-      ? `2px solid ${theme.vars.palette.primary.light}`
-      : `1px solid ${theme.vars.palette.primary.main}`,
+      ? `1.5px solid ${theme.vars.palette.secondary.main}`
+      : `1px solid ${clipBorderTint(theme, mediaType)}`,
+    boxShadow: selected
+      ? `0 0 0 3px rgba(232, 121, 249, 0.18), 0 4px 12px rgba(0, 0, 0, 0.35)`
+      : "none",
     cursor: locked ? "not-allowed" : "grab",
     "&:active": {
       cursor: locked ? "not-allowed" : "grabbing"
@@ -93,33 +109,73 @@ const clipStyles = (theme: Theme, selected: boolean, locked: boolean) =>
     userSelect: "none",
     touchAction: "none",
     minWidth: MIN_CLIP_WIDTH_PX,
-    boxSizing: "border-box",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "flex-end",
-    padding: "2px 4px"
+    boxSizing: "border-box"
+  });
+
+const clipHeaderRowStyles = css({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 18,
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "0 8px",
+  pointerEvents: "none",
+  zIndex: 4
+});
+
+const clipDotStyles = (accent: string) =>
+  css({
+    width: 6,
+    height: 6,
+    borderRadius: "50%",
+    backgroundColor: accent,
+    boxShadow: `0 0 0 1px rgba(0, 0, 0, 0.45)`,
+    flexShrink: 0
   });
 
 const clipNameStyles = (theme: Theme) =>
   css({
     fontSize: 11,
-    color: theme.vars.palette.primary.contrastText,
+    fontWeight: 500,
+    letterSpacing: "-0.005em",
+    color: theme.vars.palette.text.primary,
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
     pointerEvents: "none",
-    lineHeight: 1.2,
-    position: "relative",
-    zIndex: 1,
-    textShadow: "0 1px 2px rgba(0,0,0,0.6)"
+    lineHeight: 1.4,
+    textShadow: "0 1px 2px rgba(0, 0, 0, 0.7)",
+    flex: "1 1 auto",
+    minWidth: 0
+  });
+
+const clipDurationStyles = (theme: Theme) =>
+  css({
+    flexShrink: 0,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 10,
+    fontWeight: 500,
+    color: theme.vars.palette.text.secondary,
+    letterSpacing: "0",
+    textShadow: "0 1px 2px rgba(0, 0, 0, 0.7)"
   });
 
 const filmstripStyles = css({
   position: "absolute",
-  inset: 0,
+  left: 6,
+  right: 6,
+  top: 20,
+  bottom: 6,
   display: "flex",
+  gap: 1,
   pointerEvents: "none",
-  zIndex: 0
+  zIndex: 0,
+  borderRadius: 3,
+  overflow: "hidden"
 });
 
 const waveformStyles = css({
@@ -153,7 +209,7 @@ const generatingOverlayStyles = (theme: Theme) =>
     pointerEvents: "none",
     zIndex: 3,
     overflow: "hidden",
-    borderRadius: 4,
+    borderRadius: CLIP_RADIUS_PX,
     "&::before": {
       content: '""',
       position: "absolute",
@@ -164,10 +220,10 @@ const generatingOverlayStyles = (theme: Theme) =>
       background: `linear-gradient(
         100deg,
         transparent 0%,
-        ${theme.vars.palette.primary.light} 50%,
+        ${theme.vars.palette.secondary.light} 50%,
         transparent 100%
       )`,
-      opacity: 0.85,
+      opacity: 0.75,
       mixBlendMode: "screen",
       filter: "blur(2px)",
       animation: `${shimmerSweep} 1.2s linear infinite`,
@@ -178,7 +234,7 @@ const generatingOverlayStyles = (theme: Theme) =>
       position: "absolute",
       inset: 0,
       borderRadius: "inherit",
-      boxShadow: `inset 0 0 0 2px ${theme.vars.palette.primary.light}`,
+      boxShadow: `inset 0 0 0 1.5px ${theme.vars.palette.secondary.light}`,
       animation: `${outlinePulse} 1.4s ease-in-out infinite`
     },
     "@media (prefers-reduced-motion: reduce)": {
@@ -238,7 +294,7 @@ const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
       barCount
     );
     const mid = cssHeight / 2;
-    ctx.fillStyle = theme.vars.palette.primary.main;
+    ctx.fillStyle = theme.vars.palette.success.main;
     for (let i = 0; i < slice.length; i += 1) {
       const amp = slice[i];
       const h = Math.max(1, amp * (cssHeight - 2));
@@ -252,15 +308,14 @@ const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
 };
 WaveformCanvas.displayName = "WaveformCanvas";
 
-const filmstripCellStyles = (url: string, withDivider: boolean) =>
+const filmstripCellStyles = (url: string) =>
   css({
     flex: 1,
     height: "100%",
     backgroundImage: `url(${url})`,
     backgroundSize: "cover",
     backgroundPosition: "center",
-    opacity: 0.7,
-    borderRight: withDivider ? "1px solid rgba(0,0,0,0.2)" : "none"
+    opacity: 0.78
   });
 
 const trimHandleStyles = (
@@ -284,16 +339,16 @@ const trimHandleStyles = (
 
 const statusBadgeStyles = css({
   position: "absolute",
-  top: 3,
-  right: 4,
+  bottom: 4,
+  right: 6,
   zIndex: 3,
   pointerEvents: "none"
 });
 
 const lockIconStyles = css({
   position: "absolute",
-  top: 3,
-  left: 4,
+  bottom: 4,
+  left: 8,
   zIndex: 3,
   pointerEvents: "none",
   opacity: 0.85,
@@ -822,9 +877,25 @@ const ClipBody: React.FC<ClipBodyProps> = ({
     return cells;
   }, [thumbnails, cellCount]);
 
+  const accent = (() => {
+    switch (clip.mediaType) {
+      case "audio":
+        return theme.vars.palette.success.main;
+      case "overlay":
+        return theme.vars.palette.secondary.main;
+      case "image":
+      case "video":
+      default:
+        return theme.vars.palette.info.main;
+    }
+  })();
+
+  const showDuration = widthPx >= COMPACT_THRESHOLD_PX;
+  const durationLabel = formatClipDuration(clip.durationMs);
+
   return (
     <div
-      css={clipStyles(theme, isSelected, clip.locked)}
+      css={clipStyles(theme, isSelected, clip.locked, clip.mediaType)}
       style={{ left: leftPx, width: widthPx, cursor: cutMode ? "crosshair" : undefined }}
       onPointerDown={handleDragPointerDown}
       onClick={handleClick}
@@ -836,10 +907,7 @@ const ClipBody: React.FC<ClipBodyProps> = ({
       {filmstripCells && (
         <div css={filmstripStyles}>
           {filmstripCells.map((cell, i) => (
-            <div
-              key={i}
-              css={filmstripCellStyles(cell.url, i < filmstripCells.length - 1)}
-            />
+            <div key={i} css={filmstripCellStyles(cell.url)} />
           ))}
         </div>
       )}
@@ -851,7 +919,7 @@ const ClipBody: React.FC<ClipBodyProps> = ({
             backgroundImage: `url(${imageUrl})`,
             backgroundSize: "cover",
             backgroundPosition: "center",
-            opacity: 0.7
+            opacity: 0.78
           }}
         />
       )}
@@ -864,6 +932,15 @@ const ClipBody: React.FC<ClipBodyProps> = ({
           widthPx={widthPx}
         />
       )}
+
+      {/* Header strip: type dot · name · duration */}
+      <div css={clipHeaderRowStyles}>
+        <span css={clipDotStyles(accent)} aria-hidden />
+        <span css={clipNameStyles(theme)}>{clip.name}</span>
+        {showDuration && (
+          <span css={clipDurationStyles(theme)}>{durationLabel}</span>
+        )}
+      </div>
 
       <div
         css={trimHandleStyles(theme, "start", clip.locked)}
@@ -883,7 +960,7 @@ const ClipBody: React.FC<ClipBodyProps> = ({
 
       {clip.locked && (
         <div css={lockIconStyles}>
-          <LockIcon sx={{ fontSize: 12 }} aria-label="Clip locked" />
+          <LockOutlinedIcon sx={{ fontSize: 12 }} aria-label="Clip locked" />
         </div>
       )}
 
@@ -911,10 +988,20 @@ const ClipBody: React.FC<ClipBodyProps> = ({
             />
           </div>
         )}
-
-      <div css={clipNameStyles(theme)}>{clip.name}</div>
     </div>
   );
 };
+
+/** "4.6s" for sub-minute, "1:23" for ≥1 min. Visible on selected clips. */
+function formatClipDuration(durationMs: number): string {
+  if (durationMs < 60_000) {
+    const sec = durationMs / 1000;
+    return sec < 10 ? `${sec.toFixed(1)}s` : `${Math.round(sec)}s`;
+  }
+  const totalSec = Math.round(durationMs / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
 
 Clip.displayName = "Clip";

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -992,7 +992,7 @@ const ClipBody: React.FC<ClipBodyProps> = ({
   );
 };
 
-/** "4.6s" for sub-minute, "1:23" for ≥1 min. Visible on selected clips. */
+/** "4.6s" for sub-minute, "1:23" for ≥1 min. Shown when clip width ≥ compact threshold. */
 function formatClipDuration(durationMs: number): string {
   if (durationMs < 60_000) {
     const sec = durationMs / 1000;

--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -19,6 +19,7 @@ import type { Theme } from "@mui/material/styles";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { formatTimecode } from "../Inspector/InspectorPrimitives";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -91,19 +92,6 @@ const pillStyles = (theme: Theme, dragging: boolean, hovered: boolean) =>
   });
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-/** Formats ms as HH:MM:SS:FF (frames) for the playhead pill. */
-function formatPlayheadTimecode(ms: number, fps: number): string {
-  const safeFps = Math.max(1, Math.round(fps));
-  const totalFrames = Math.max(0, Math.round((ms / 1000) * safeFps));
-  const ff = totalFrames % safeFps;
-  const totalSec = Math.floor(totalFrames / safeFps);
-  const ss = totalSec % 60;
-  const mm = Math.floor(totalSec / 60) % 60;
-  const hh = Math.floor(totalSec / 3600);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${pad(hh)}:${pad(mm)}:${pad(ss)}:${pad(ff)}`;
-}
 
 // ── Component ──────────────────────────────────────────────────────────────
 
@@ -212,7 +200,7 @@ export const Playhead: React.FC<PlayheadProps> = memo(
           aria-hidden
           data-testid="playhead-pill"
         >
-          {formatPlayheadTimecode(currentTimeMs, fps)}
+          {formatTimecode(currentTimeMs, fps)}
         </div>
       </div>
     );

--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -2,14 +2,11 @@
 /**
  * Playhead
  *
- * Single absolute-positioned vertical line spanning all track lanes.
- * - The line + a 16px-wide invisible hit area around it are draggable —
- *   grab anywhere along the playhead, not just the small handle.
- * - The handle is a visible affordance at the top; it expands on hover
- *   and active drag.
- * - Click-and-drag uses a "jump-and-grab" pattern: pointerdown anywhere
- *   on the hit area starts the scrub from the current position; the
- *   pointer's delta drives currentTime from there.
+ * Vertical magenta line + timecode pill at the top, spanning all track lanes.
+ * - The 16px-wide invisible hit area around the line is draggable — grab
+ *   anywhere along the playhead, not just the pill.
+ * - The pill at the top is the visible affordance; it sits above the ruler.
+ * - Click-and-drag uses a "jump-and-grab" pattern.
  * - Keyboard: ArrowLeft/Right nudge ±1 frame; Shift +/- 10 frames;
  *   Home / End jump to the bounds.
  */
@@ -25,17 +22,16 @@ import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-const LINE_WIDTH_PX = 2;
+const LINE_WIDTH_PX = 1.5;
 const HIT_AREA_WIDTH_PX = 16;
-const HANDLE_SIZE_PX = 14;
-const HANDLE_HOVER_SIZE_PX = 18;
+const PILL_HEIGHT_PX = 20;
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
 /**
  * Outer hit area — invisibly wider than the line so the user can grab the
- * playhead anywhere along its full height. The visible 2px line is centred
- * inside via `::before`. The handle sits as a positioned child on top.
+ * playhead anywhere along its full height. The visible line is centred via
+ * `::before`. The pill sits as a positioned child on top.
  */
 const hitAreaStyles = (theme: Theme, dragging: boolean) =>
   css({
@@ -46,6 +42,7 @@ const hitAreaStyles = (theme: Theme, dragging: boolean) =>
     transform: `translateX(-${HIT_AREA_WIDTH_PX / 2}px)`,
     cursor: dragging ? "grabbing" : "ew-resize",
     touchAction: "none",
+    pointerEvents: "auto",
     zIndex: 10,
     "&::before": {
       content: '""',
@@ -55,36 +52,58 @@ const hitAreaStyles = (theme: Theme, dragging: boolean) =>
       left: "50%",
       transform: "translateX(-50%)",
       width: LINE_WIDTH_PX,
-      backgroundColor: theme.vars.palette.primary.main,
+      backgroundColor: theme.vars.palette.secondary.main,
+      boxShadow: `0 0 10px ${theme.vars.palette.secondary.main}66`,
       pointerEvents: "none"
     },
     "&:focus-visible": {
-      outline: `2px solid ${theme.vars.palette.primary.main}`,
+      outline: `2px solid ${theme.vars.palette.secondary.main}`,
       outlineOffset: 2
     }
   });
 
-const handleStyles = (theme: Theme, hovered: boolean, dragging: boolean) => {
-  const size =
-    hovered || dragging ? HANDLE_HOVER_SIZE_PX : HANDLE_SIZE_PX;
-  return css({
+const pillStyles = (theme: Theme, dragging: boolean, hovered: boolean) =>
+  css({
     position: "absolute",
-    top: -size / 2 + 2,
+    top: 4,
     left: "50%",
     transform: "translateX(-50%)",
-    width: size,
-    height: size,
-    borderRadius: "50%",
-    backgroundColor: theme.vars.palette.primary.main,
-    boxShadow: dragging
-      ? `0 0 0 4px ${theme.vars.palette.primary.main}40`
-      : hovered
-        ? `0 0 0 3px ${theme.vars.palette.primary.main}30`
-        : "none",
-    transition: "width 80ms, height 80ms, box-shadow 80ms",
+    height: PILL_HEIGHT_PX,
+    padding: "0 8px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: PILL_HEIGHT_PX / 2,
+    backgroundColor: theme.vars.palette.secondary.main,
+    color: "rgba(8, 9, 10, 0.92)",
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: "0",
+    whiteSpace: "nowrap",
+    boxShadow:
+      dragging || hovered
+        ? `0 0 0 3px ${theme.vars.palette.secondary.main}33, 0 4px 12px rgba(0,0,0,0.4)`
+        : "0 2px 6px rgba(0,0,0,0.35)",
+    transition: "box-shadow 120ms",
     pointerEvents: "none"
   });
-};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Formats ms as HH:MM:SS:FF (frames) for the playhead pill. */
+function formatPlayheadTimecode(ms: number, fps: number): string {
+  const safeFps = Math.max(1, Math.round(fps));
+  const totalFrames = Math.max(0, Math.round((ms / 1000) * safeFps));
+  const ff = totalFrames % safeFps;
+  const totalSec = Math.floor(totalFrames / safeFps);
+  const ss = totalSec % 60;
+  const mm = Math.floor(totalSec / 60) % 60;
+  const hh = Math.floor(totalSec / 3600);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(hh)}:${pad(mm)}:${pad(ss)}:${pad(ff)}`;
+}
 
 // ── Component ──────────────────────────────────────────────────────────────
 
@@ -115,9 +134,7 @@ export const Playhead: React.FC<PlayheadProps> = memo(
       trackAreaOffsetPx + currentTimeMs / msPerPx - scrollLeftPx;
 
     // Drag baseline: where the pointer started and what currentTimeMs was
-    // at that moment. Delta is applied to that snapshot — so the pointer
-    // tracks the playhead exactly even if the store is being written
-    // concurrently elsewhere.
+    // at that moment.
     const dragStartXRef = useRef(0);
     const dragStartMsRef = useRef(0);
 
@@ -190,7 +207,13 @@ export const Playhead: React.FC<PlayheadProps> = memo(
         onPointerCancel={handlePointerUp}
         onKeyDown={handleKeyDown}
       >
-        <div css={handleStyles(theme, hovered, dragging)} aria-hidden />
+        <div
+          css={pillStyles(theme, dragging, hovered)}
+          aria-hidden
+          data-testid="playhead-pill"
+        >
+          {formatPlayheadTimecode(currentTimeMs, fps)}
+        </div>
       </div>
     );
   }

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -3,10 +3,8 @@
  * TrackHeader
  *
  * Left-hand strip showing track metadata and controls:
- *   - Track name (inline-editable on double-click)
- *   - Visibility toggle (eye icon)
- *   - Lock toggle
- *   - Mute / Solo toggles (audio tracks only)
+ *   - Type glyph + name + index chip (V1, A1, …) on the top row
+ *   - Visibility / lock / mute / solo / fx / delete row beneath
  *   - Height resize handle at the bottom edge
  */
 
@@ -14,14 +12,14 @@ import React, { memo, useCallback, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import VisibilityIcon from "@mui/icons-material/Visibility";
-import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
-import LockIcon from "@mui/icons-material/Lock";
-import LockOpenIcon from "@mui/icons-material/LockOpen";
-import VolumeOffIcon from "@mui/icons-material/VolumeOff";
-import VolumeUpIcon from "@mui/icons-material/VolumeUp";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
+import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import LockOpenOutlinedIcon from "@mui/icons-material/LockOpenOutlined";
+import VolumeOffOutlinedIcon from "@mui/icons-material/VolumeOffOutlined";
+import VolumeUpOutlinedIcon from "@mui/icons-material/VolumeUpOutlined";
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import GraphicEqOutlinedIcon from "@mui/icons-material/GraphicEqOutlined";
 
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
@@ -31,11 +29,16 @@ import {
   DEFAULT_TRACK_HEIGHT_PX as SHARED_DEFAULT_TRACK_HEIGHT_PX,
   FX_PANEL_HEIGHT_PX
 } from "./trackHeight";
+import {
+  trackTypeMeta,
+  trackTypeAccent,
+  trackIndexWithinType
+} from "./trackVisuals";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-export const TRACK_HEADER_WIDTH_PX = 160;
-const MIN_TRACK_HEIGHT_PX = 40;
+export const TRACK_HEADER_WIDTH_PX = 192;
+const MIN_TRACK_HEIGHT_PX = 48;
 const MAX_TRACK_HEIGHT_PX = 300;
 const DEFAULT_TRACK_HEIGHT_PX = SHARED_DEFAULT_TRACK_HEIGHT_PX;
 const RESIZE_HANDLE_HEIGHT_PX = 6;
@@ -51,52 +54,121 @@ const headerStyles = (theme: Theme, heightPx: number) =>
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-between",
-    padding: theme.spacing(0.5, 1),
-    backgroundColor: theme.vars.palette.background.paper,
-    borderRight: `1px solid ${theme.vars.palette.divider}`,
+    padding: "10px 12px 12px",
+    backgroundColor: theme.vars.palette.background.default,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     overflow: "hidden",
     userSelect: "none"
   });
+
+const topRowStyles = css({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 10,
+  minWidth: 0
+});
+
+const typeGlyphStyles = (theme: Theme, accent: string) =>
+  css({
+    width: 26,
+    height: 26,
+    flexShrink: 0,
+    borderRadius: 6,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.vars.palette.background.paper,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    color: accent,
+    "& svg": {
+      fontSize: 15
+    }
+  });
+
+const nameWrapStyles = css({
+  flex: "1 1 auto",
+  minWidth: 0,
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 6
+});
 
 const nameInputStyles = (theme: Theme) =>
   css({
     border: "none",
     background: "transparent",
     color: theme.vars.palette.text.primary,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: 13,
+    fontWeight: 500,
+    letterSpacing: "-0.005em",
     fontFamily: theme.typography.fontFamily,
-    width: "100%",
+    minWidth: 0,
+    flex: "0 1 auto",
     padding: 0,
     outline: "none",
     cursor: "default",
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
     "&:focus": {
       cursor: "text",
-      borderBottom: `1px solid ${theme.vars.palette.primary.main}`
+      color: theme.vars.palette.text.primary
     }
+  });
+
+const indexChipStyles = (theme: Theme) =>
+  css({
+    flexShrink: 0,
+    height: 18,
+    padding: "0 6px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 4,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: "0.04em",
+    color: theme.vars.palette.text.secondary,
+    backgroundColor: "transparent"
   });
 
 const controlsRowStyles = css({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
-  gap: 4
+  gap: 2,
+  marginLeft: -4 // align icon edges flush with the type glyph
 });
 
 const iconButtonStyles = (theme: Theme, active = true) =>
   css({
-    background: "none",
-    border: "none",
-    padding: "2px",
+    width: 24,
+    height: 22,
+    background: "transparent",
+    border: "1px solid transparent",
+    padding: 0,
     cursor: "pointer",
     display: "flex",
     alignItems: "center",
+    justifyContent: "center",
     color: active
-      ? theme.vars.palette.text.primary
+      ? theme.vars.palette.text.secondary
       : theme.vars.palette.text.disabled,
-    borderRadius: 3,
+    borderRadius: 5,
+    transition: "background-color 120ms, color 120ms, border-color 120ms",
     "&:hover": {
-      backgroundColor: theme.vars.palette.action.hover
+      backgroundColor: theme.vars.palette.action.hover,
+      color: theme.vars.palette.text.primary,
+      borderColor: theme.vars.palette.divider
+    },
+    "&:focus-visible": {
+      outline: "none",
+      borderColor: theme.vars.palette.primary.main
     },
     "& svg": {
       fontSize: 14
@@ -114,7 +186,7 @@ const resizeHandleStyles = (theme: Theme) =>
     backgroundColor: "transparent",
     "&:hover": {
       backgroundColor: theme.vars.palette.primary.main,
-      opacity: 0.4
+      opacity: 0.3
     }
   });
 
@@ -134,8 +206,13 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
   const setTrackHeight = useTimelineStore((s) => s.setTrackHeight);
   const setTrackName = useTimelineStore((s) => s.setTrackName);
   const removeTrack = useTimelineStore((s) => s.removeTrack);
+  const tracks = useTimelineStore((s) => s.tracks);
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
+  const meta = trackTypeMeta(track.type);
+  const accent = trackTypeAccent(theme, track.type);
+  const TypeIcon = meta.Icon;
+  const typedIndex = trackIndexWithinType(tracks, track.id);
 
   // ── Inline name edit ────────────────────────────────────────────────────
 
@@ -222,18 +299,37 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
       css={headerStyles(theme, heightPx)}
       data-testid={`track-header-${track.id}`}
     >
-      {/* Track name */}
-      <input
-        ref={inputRef}
-        css={nameInputStyles(theme)}
-        value={editingName ? localName : track.name}
-        readOnly={!editingName}
-        onChange={(e) => setLocalName(e.target.value)}
-        onDoubleClick={handleNameDoubleClick}
-        onBlur={commitName}
-        onKeyDown={handleNameKeyDown}
-        aria-label={`Track name: ${track.name}`}
-      />
+      {/* Top row: type glyph · name · index chip */}
+      <div css={topRowStyles}>
+        <div
+          css={typeGlyphStyles(theme, accent)}
+          aria-hidden
+          title={meta.label}
+        >
+          <TypeIcon />
+        </div>
+        <div css={nameWrapStyles}>
+          <input
+            ref={inputRef}
+            css={nameInputStyles(theme)}
+            value={editingName ? localName : track.name}
+            readOnly={!editingName}
+            onChange={(e) => setLocalName(e.target.value)}
+            onDoubleClick={handleNameDoubleClick}
+            onBlur={commitName}
+            onKeyDown={handleNameKeyDown}
+            aria-label={`Track name: ${track.name}`}
+          />
+          <span
+            css={indexChipStyles(theme)}
+            aria-label={`${meta.label} track ${typedIndex}`}
+            title={`${meta.label} ${typedIndex}`}
+          >
+            {meta.prefix}
+            {typedIndex}
+          </span>
+        </div>
+      </div>
 
       {/* Controls row */}
       <div css={controlsRowStyles}>
@@ -245,9 +341,9 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
             aria-pressed={!track.visible}
           >
             {track.visible ? (
-              <VisibilityIcon />
+              <VisibilityOutlinedIcon />
             ) : (
-              <VisibilityOffIcon />
+              <VisibilityOffOutlinedIcon />
             )}
           </button>
         </Tooltip>
@@ -259,7 +355,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
             aria-label={track.locked ? "Unlock track" : "Lock track"}
             aria-pressed={track.locked}
           >
-            {track.locked ? <LockIcon /> : <LockOpenIcon />}
+            {track.locked ? <LockOutlinedIcon /> : <LockOpenOutlinedIcon />}
           </button>
         </Tooltip>
 
@@ -272,7 +368,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
                 aria-label={track.muted ? "Unmute" : "Mute"}
                 aria-pressed={!!track.muted}
               >
-                {track.muted ? <VolumeOffIcon /> : <VolumeUpIcon />}
+                {track.muted ? <VolumeOffOutlinedIcon /> : <VolumeUpOutlinedIcon />}
               </button>
             </Tooltip>
 
@@ -283,7 +379,15 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
                 aria-label={track.solo ? "Unsolo" : "Solo"}
                 aria-pressed={!!track.solo}
               >
-                <span style={{ fontSize: 11, fontWeight: 700 }}>S</span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: "0.04em"
+                  }}
+                >
+                  S
+                </span>
               </button>
             </Tooltip>
           </>
@@ -304,7 +408,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
               aria-pressed={fxExpanded}
               data-testid={`track-fx-${track.id}`}
             >
-              <GraphicEqIcon />
+              <GraphicEqOutlinedIcon />
             </button>
           </Tooltip>
         )}
@@ -321,7 +425,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
             }}
             aria-label="Remove track"
           >
-            <DeleteOutlineIcon />
+            <DeleteOutlineOutlinedIcon />
           </button>
         </Tooltip>
       </div>

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -31,8 +31,7 @@ import {
 } from "./trackHeight";
 import {
   trackTypeMeta,
-  trackTypeAccent,
-  trackIndexWithinType
+  trackTypeAccent
 } from "./trackVisuals";
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -194,9 +193,11 @@ const resizeHandleStyles = (theme: Theme) =>
 
 export interface TrackHeaderProps {
   track: TimelineTrack;
+  /** Pre-computed 1-based index within the track's type group. */
+  typedIndex: number;
 }
 
-export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
+export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex }) => {
   const theme = useTheme();
 
   const setTrackVisible = useTimelineStore((s) => s.setTrackVisible);
@@ -206,13 +207,11 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track }) => {
   const setTrackHeight = useTimelineStore((s) => s.setTrackHeight);
   const setTrackName = useTimelineStore((s) => s.setTrackName);
   const removeTrack = useTimelineStore((s) => s.removeTrack);
-  const tracks = useTimelineStore((s) => s.tracks);
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
   const meta = trackTypeMeta(track.type);
   const accent = trackTypeAccent(theme, track.type);
   const TypeIcon = meta.Icon;
-  const typedIndex = trackIndexWithinType(tracks, track.id);
 
   // ── Inline name edit ────────────────────────────────────────────────────
 

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -58,14 +58,15 @@ const laneStyles = (
     width: "100%",
     height: heightPx,
     flexShrink: 0,
-    backgroundColor: visible
-      ? theme.vars.palette.background.default
-      : theme.vars.palette.action.disabledBackground,
-    borderBottom: `1px solid ${isDragReject
-      ? theme.vars.palette.error.main
-      : isDragOver
-        ? theme.vars.palette.primary.main
-        : theme.vars.palette.divider}`,
+    backgroundColor: theme.vars.palette.background.default,
+    opacity: visible ? 1 : 0.55,
+    borderBottom: `1px solid ${
+      isDragReject
+        ? theme.vars.palette.error.main
+        : isDragOver
+          ? theme.vars.palette.primary.main
+          : theme.vars.palette.divider
+    }`,
     outline: isDragOver
       ? `2px solid ${theme.vars.palette.primary.main}`
       : isDragReject
@@ -74,19 +75,14 @@ const laneStyles = (
     outlineOffset: "-2px",
     overflow: "hidden",
     cursor: isRubberBanding ? "crosshair" : "default",
-    // Subtle alternating stripe
-    "&:nth-of-type(even)": {
-      backgroundColor: visible
-        ? theme.vars.palette.background.paper
-        : theme.vars.palette.action.disabledBackground
-    }
+    transition: "opacity 120ms"
   });
 
 const rubberBandStyles = (theme: Theme) =>
   css({
     position: "absolute",
-    border: `1px solid ${theme.vars.palette.primary.main}`,
-    backgroundColor: `${theme.vars.palette.primary.main}22`,
+    border: `1px solid ${theme.vars.palette.secondary.main}`,
+    backgroundColor: `${theme.vars.palette.secondary.main}22`,
     pointerEvents: "none",
     zIndex: 20
   });

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -68,18 +68,58 @@ const containerStyles = (theme: Theme) =>
 
 const toolbarStyles = (theme: Theme) =>
   css({
-    height: 32,
+    height: 36,
     flexShrink: 0,
-    padding: `0 ${theme.spacing(0.75)}`,
+    padding: "0 12px 0 8px",
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     backgroundColor: theme.vars.palette.background.paper
   });
 
-const headerColumnStyles = css({
-  flexShrink: 0,
-  overflowY: "hidden",
-  overflowX: "hidden"
-});
+const tracksSectionHeaderStyles = (theme: Theme) =>
+  css({
+    width: TRACK_HEADER_WIDTH_PX,
+    height: 28,
+    flexShrink: 0,
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "0 12px",
+    backgroundColor: theme.vars.palette.background.paper,
+    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    color: theme.vars.palette.text.secondary,
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    userSelect: "none"
+  });
+
+const trackCountChipStyles = (theme: Theme) =>
+  css({
+    marginLeft: "auto",
+    minWidth: 18,
+    height: 16,
+    padding: "0 5px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 4,
+    backgroundColor: theme.vars.palette.action.hover,
+    color: theme.vars.palette.text.secondary,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: "0"
+  });
+
+const headerColumnStyles = (theme: Theme) =>
+  css({
+    flexShrink: 0,
+    overflowY: "hidden",
+    overflowX: "hidden",
+    borderRight: `1px solid ${theme.vars.palette.divider}`
+  });
 
 const scrollableAreaStyles = css({
   flex: "1 1 auto",
@@ -183,9 +223,10 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       1000
     );
 
-    // Track area height minus ruler
+    // Track area height minus toolbar + ruler
+    const TOOLBAR_HEIGHT = 36;
     const RULER_HEIGHT = 28;
-    const lanesHeight = heightPx - RULER_HEIGHT;
+    const lanesHeight = Math.max(0, heightPx - TOOLBAR_HEIGHT - RULER_HEIGHT);
 
     // ── Scroll sync ────────────────────────────────────────────────────────
 
@@ -341,19 +382,30 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         {/* ── Tool toolbar (above the ruler) ──────────────────────────── */}
         <FlexRow
           align="center"
-          justify="center"
           gap={0.5}
           css={toolbarStyles(theme)}
           data-testid="timeline-toolbar"
         >
           <ToolToggle />
+          <div style={{ flex: "1 1 auto" }} />
+          <AddTrackButton />
         </FlexRow>
 
-        {/* ── Ruler (spans full width) ─────────────────────────────────── */}
-        <TimeRuler
-          totalWidthPx={totalWidthPx}
-          headerWidthPx={TRACK_HEADER_WIDTH_PX}
-        />
+        {/* ── Sub-header: TRACKS label + ruler ────────────────────────── */}
+        <FlexRow align="stretch" fullWidth>
+          <div css={tracksSectionHeaderStyles(theme)}>
+            <span>Tracks</span>
+            <span
+              css={trackCountChipStyles(theme)}
+              aria-label={`${tracks.length} tracks`}
+            >
+              {tracks.length}
+            </span>
+          </div>
+          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+            <TimeRuler totalWidthPx={totalWidthPx} headerWidthPx={0} />
+          </div>
+        </FlexRow>
 
         {/* ── Track rows ──────────────────────────────────────────────── */}
         <FlexRow
@@ -366,7 +418,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           fullWidth
         >
           {/* Header column */}
-          <div css={headerColumnStyles}>
+          <div css={headerColumnStyles(theme)}>
             {tracks.map((track) => (
               <React.Fragment key={track.id}>
                 <TrackHeader track={track} />
@@ -378,7 +430,6 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                 )}
               </React.Fragment>
             ))}
-            <AddTrackButton />
           </div>
 
           {/* Scrollable lanes */}
@@ -413,11 +464,30 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                 </React.Fragment>
               ))}
             </div>
-
-            {/* Playhead overlaid on the lanes */}
-            <Playhead heightPx={lanesHeight} trackAreaOffsetPx={0} />
           </div>
         </FlexRow>
+
+        {/* Playhead overlay: spans ruler + lanes so the pill sits in the
+         *  ruler. Positioned at the TracksRegion level so it isn't clipped
+         *  by the scrollable area's overflow-y. The wrapper is
+         *  pointer-events:none so it doesn't swallow clicks on the ruler or
+         *  lanes; the Playhead's hit-area opts back into pointer events. */}
+        <div
+          style={{
+            position: "absolute",
+            top: TOOLBAR_HEIGHT,
+            bottom: 0,
+            left: TRACK_HEADER_WIDTH_PX,
+            right: 0,
+            pointerEvents: "none",
+            overflow: "hidden"
+          }}
+        >
+          <Playhead
+            heightPx={RULER_HEIGHT + lanesHeight}
+            trackAreaOffsetPx={0}
+          />
+        </div>
       </div>
     );
   }

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -26,7 +26,7 @@
  * Horizontal scroll: native overflow-x scroll on the scrollable panel.
  */
 
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -47,6 +47,7 @@ import { FlexColumn, FlexRow } from "../../ui_primitives";
 import { deserializeDragData } from "../../../lib/dragdrop";
 import type { Asset } from "../../../stores/ApiTypes";
 import { assetMediaType } from "../dnd/assetToClipAdapter";
+import { buildTypedIndexMap } from "./trackVisuals";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -350,6 +351,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       (s) => s.expandedFxTrackId
     );
 
+    // Precompute per-type index map (O(n)) to avoid O(n²) per-header lookups.
+    const typedIndexMap = useMemo(() => buildTypedIndexMap(tracks), [tracks]);
+
     const totalTracksHeight = tracks.reduce(
       (sum, t) =>
         sum +
@@ -421,7 +425,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           <div css={headerColumnStyles(theme)}>
             {tracks.map((track) => (
               <React.Fragment key={track.id}>
-                <TrackHeader track={track} />
+                <TrackHeader track={track} typedIndex={typedIndexMap.get(track.id) ?? 1} />
                 {expandedFxTrackId === track.id && (
                   <div
                     style={{ height: FX_PANEL_HEIGHT_PX }}

--- a/web/src/components/timeline/Tracks/trackVisuals.ts
+++ b/web/src/components/timeline/Tracks/trackVisuals.ts
@@ -1,0 +1,114 @@
+/**
+ * Track / clip visual language
+ *
+ * Single source of truth for the track-type accents used by TrackHeader,
+ * TrackLane, Clip and the index chip (V1/A1/T1/O1). Keeping this in one
+ * file means the header dot, the chip prefix, and the clip tint can't drift
+ * out of sync.
+ */
+import type { Theme } from "@mui/material/styles";
+import type { TimelineTrack, TimelineClip } from "@nodetool-ai/timeline";
+
+import VideocamOutlinedIcon from "@mui/icons-material/VideocamOutlined";
+import AudiotrackOutlinedIcon from "@mui/icons-material/AudiotrackOutlined";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import type { SvgIconComponent } from "@mui/icons-material";
+
+export type TrackTypeKey = TimelineTrack["type"];
+export type ClipMediaKey = TimelineClip["mediaType"];
+
+interface TrackTypeMeta {
+  /** Single-letter prefix used in the index chip: V1, A1, T1, O1. */
+  prefix: string;
+  /** Long-form label for tooltips and aria. */
+  label: string;
+  Icon: SvgIconComponent;
+}
+
+const TRACK_TYPES: Record<TrackTypeKey, TrackTypeMeta> = {
+  video: { prefix: "V", label: "Video", Icon: VideocamOutlinedIcon },
+  audio: { prefix: "A", label: "Audio", Icon: AudiotrackOutlinedIcon },
+  overlay: { prefix: "O", label: "Overlay", Icon: LayersOutlinedIcon },
+  subtitle: { prefix: "T", label: "Text", Icon: SubtitlesOutlinedIcon }
+};
+
+const CLIP_MEDIA_ICONS: Record<ClipMediaKey, SvgIconComponent> = {
+  video: VideocamOutlinedIcon,
+  audio: AudiotrackOutlinedIcon,
+  image: ImageOutlinedIcon,
+  overlay: LayersOutlinedIcon
+};
+
+export function trackTypeMeta(type: TrackTypeKey): TrackTypeMeta {
+  return TRACK_TYPES[type] ?? TRACK_TYPES.video;
+}
+
+export function clipMediaIcon(media: ClipMediaKey): SvgIconComponent {
+  return CLIP_MEDIA_ICONS[media] ?? VideocamOutlinedIcon;
+}
+
+/** The dot/border/text accent for a track row. */
+export function trackTypeAccent(theme: Theme, type: TrackTypeKey): string {
+  switch (type) {
+    case "video":
+      return theme.vars.palette.info.main; // cyan — visible on dark canvas
+    case "audio":
+      return theme.vars.palette.success.main; // green — distinguishes waveform tracks
+    case "overlay":
+      return theme.vars.palette.secondary.main; // magenta — overlays read as "on top"
+    case "subtitle":
+      return theme.vars.palette.warning.main; // amber — type/captions
+    default:
+      return theme.vars.palette.info.main;
+  }
+}
+
+/** Subtle background tint behind a clip body, scoped to track type. */
+export function clipSurfaceTint(theme: Theme, type: ClipMediaKey): string {
+  switch (type) {
+    case "video":
+      return "rgba(34, 211, 238, 0.10)"; // info / cyan, low-chroma wash
+    case "audio":
+      return "rgba(80, 250, 123, 0.08)"; // success / green
+    case "image":
+      return "rgba(34, 211, 238, 0.08)";
+    case "overlay":
+      return "rgba(232, 121, 249, 0.10)"; // secondary / magenta
+    default:
+      return "rgba(255, 255, 255, 0.04)";
+  }
+}
+
+/** Subtle border tint for an unselected clip; resolves over the lane. */
+export function clipBorderTint(theme: Theme, type: ClipMediaKey): string {
+  switch (type) {
+    case "video":
+    case "image":
+      return "rgba(34, 211, 238, 0.35)";
+    case "audio":
+      return "rgba(80, 250, 123, 0.35)";
+    case "overlay":
+      return "rgba(232, 121, 249, 0.40)";
+    default:
+      return theme.vars.palette.divider;
+  }
+}
+
+/** Per-track-type index across the track list (1-based). */
+export function trackIndexWithinType(
+  tracks: readonly TimelineTrack[],
+  trackId: string
+): number {
+  const target = tracks.find((t) => t.id === trackId);
+  if (!target) return 1;
+  let i = 0;
+  for (const t of tracks) {
+    if (t.type === target.type) {
+      i += 1;
+      if (t.id === trackId) return i;
+    }
+  }
+  return i || 1;
+}

--- a/web/src/components/timeline/Tracks/trackVisuals.ts
+++ b/web/src/components/timeline/Tracks/trackVisuals.ts
@@ -112,3 +112,19 @@ export function trackIndexWithinType(
   }
   return i || 1;
 }
+
+/**
+ * Precompute a map from trackId → per-type index (1-based) in a single O(n) pass.
+ * Avoids calling trackIndexWithinType per-header which results in O(n²).
+ */
+export function buildTypedIndexMap(
+  tracks: readonly TimelineTrack[]
+): Map<string, number> {
+  const result = new Map<string, number>();
+  const counters: Partial<Record<TrackTypeKey, number>> = {};
+  for (const t of tracks) {
+    counters[t.type] = (counters[t.type] ?? 0) + 1;
+    result.set(t.id, counters[t.type]!);
+  }
+  return result;
+}

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -42,6 +42,8 @@ export interface TimelineUIState {
    * shown at a time to keep vertical layout tractable.
    */
   expandedFxTrackId: string | null;
+  /** Whether the left-side asset panel is visible. Collapses to a thin rail when false. */
+  assetPanelVisible: boolean;
 
   // ── Selection ────────────────────────────────────────────────────────────
 
@@ -85,6 +87,11 @@ export interface TimelineUIState {
   setExpandedFxTrackId: (trackId: string | null) => void;
   /** Toggle the inline DSP chain editor for the given track. */
   toggleExpandedFx: (trackId: string) => void;
+
+  // ── Asset panel ──────────────────────────────────────────────────────────
+
+  setAssetPanelVisible: (visible: boolean) => void;
+  toggleAssetPanel: () => void;
 }
 
 const MIN_MS_PER_PX = 0.5;
@@ -98,6 +105,7 @@ export const useTimelineUIStore = create<TimelineUIState>((set, get) => ({
   scrollLeftPx: 0,
   fullscreen: false,
   expandedFxTrackId: null,
+  assetPanelVisible: true,
 
   selectClip: (id) => set({ selectedClipIds: new Set([id]) }),
 
@@ -145,7 +153,12 @@ export const useTimelineUIStore = create<TimelineUIState>((set, get) => ({
     set((state) => ({
       expandedFxTrackId:
         state.expandedFxTrackId === trackId ? null : trackId
-    }))
+    })),
+
+  setAssetPanelVisible: (visible) => set({ assetPanelVisible: visible }),
+
+  toggleAssetPanel: () =>
+    set((state) => ({ assetPanelVisible: !state.assetPanelVisible }))
 }));
 
 // ── Convenience selectors ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Tracks view** redesigned to a pro-tool aesthetic: type-glyph + V1/A1 index chips on each header, magenta playhead with a HH:MM:SS:FF timecode pill, clips with type-tinted surfaces and a top dot/name/duration strip, labeled Select/Cut toolbar, outlined monoline icons throughout, and a `TRACKS` sub-header above the header column.
- **Right inspector** rebuilt around new Inspector primitives — eyebrow header with action icons, identity card (track-accent bar + JetBrains-Mono clip name + meta line), label-on-left/pill-input-on-right rows with unit subscripts, iOS-style toggle switches. Existing fold state, effects, and clip behaviors are preserved.
- **Asset panel** is now toggleable: `TimelineUIStore.toggleAssetPanel` swaps the full panel for a 28-px expand rail so the panel is always reachable.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx jest src/components/timeline src/stores/timeline` — 231/231 pass
- [x] `npm run lint` — no new warnings introduced in touched files
- [ ] Manual: select a clip and confirm the inspector header actions (duplicate / split-at-playhead / delete) work
- [ ] Manual: collapse + reopen the asset panel via the chevron and rail
- [ ] Manual: scrub the playhead and confirm the timecode pill stays glued and the line stays magenta
- [ ] Manual: drag/trim a clip, then verify selection ring + waveform recolor land correctly
- [ ] Manual: try each track type (video/audio/overlay/subtitle) and confirm accent + index chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)