### PR TITLE
fix(topaz-nodes): align with real Topaz Image/Video API spec

### DIFF
--- a/packages/topaz-nodes/src/topaz-base.ts
+++ b/packages/topaz-nodes/src/topaz-base.ts
@@ -6,9 +6,18 @@
  *  - Video: create job (with probed source metadata) → accept → PUT upload
  *    (single- or multi-part) → complete-upload → poll status → download.
  *
- * Topaz authenticates with the `X-API-Key` header (not Bearer). Uses native
- * fetch (Node 18+) and the system `ffprobe` (installed via the package manager)
- * to probe source video metadata, which Topaz requires at job-creation time.
+ * Wire spec (from developer.topazlabs.com/reference/api-endpoints):
+ *  - Auth: `X-API-Key` header (not Bearer).
+ *  - Image status states: Pending | Processing | Completed | Cancelled | Failed.
+ *  - Image download response: { download_url, head_url, expiry }.
+ *  - Video status states: requested | accepted | initializing | preprocessing
+ *    | processing | postprocessing | complete | canceling | canceled | failed.
+ *  - Video accept response: { uploadId, urls[] }. The signed download URL on a
+ *    completed video request lives at `download.url` (nested).
+ *
+ * Uses native fetch (Node 18+) and the system `ffprobe` (installed via the
+ * package manager) to probe source video metadata, which Topaz requires at
+ * job-creation time.
  */
 
 import { execFile as execFileCb } from "node:child_process";
@@ -23,6 +32,8 @@ const execFile = promisify(execFileCb);
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 const sleep = (ms: number): Promise<void> =>
   new Promise((r) => setTimeout(r, ms));
+
+export type TopazVideoKind = "upscale" | "interpolate";
 
 export interface TopazImageSpec {
   submitEndpoint: string;
@@ -39,6 +50,7 @@ export interface TopazVideoSpec {
   statusEndpoint: string;
   pollInterval: number;
   maxAttempts: number;
+  videoKind: TopazVideoKind;
 }
 
 export interface TopazVideoMetadata {
@@ -127,6 +139,16 @@ async function fetchWithRetry(
   return last as Response;
 }
 
+// Image API status states (per /reference/api-endpoints/image/status):
+//   Pending | Processing | Completed | Cancelled | Failed
+// Video API status states (per /reference/api-endpoints/video/get-request-status):
+//   requested | accepted | initializing | preprocessing | processing |
+//   postprocessing | complete | canceling | canceled | failed
+// We accept both vocabularies in one helper since callers point us at the
+// right endpoint and we lowercase the value before comparing.
+const SUCCESS_STATES = new Set(["completed", "complete"]);
+const FAILURE_STATES = new Set(["failed", "cancelled", "canceled"]);
+
 async function pollUntilTerminal(
   url: string,
   headers: Record<string, string>,
@@ -138,8 +160,8 @@ async function pollUntilTerminal(
     if (!resp.ok) throw new Error(`Topaz status poll failed: ${resp.status}`);
     const data = (await resp.json()) as Record<string, unknown>;
     const status = String(data.status ?? "").toLowerCase();
-    if (["completed", "succeeded", "success"].includes(status)) return data;
-    if (["failed", "error", "cancelled"].includes(status)) {
+    if (SUCCESS_STATES.has(status)) return data;
+    if (FAILURE_STATES.has(status)) {
       throw new Error(`Topaz job failed: ${JSON.stringify(data)}`);
     }
     await sleep(pollInterval);
@@ -354,7 +376,7 @@ export async function topazExecuteImageTask(
   form.set("image", blob, "input");
   for (const [k, v] of Object.entries(fields)) {
     if (v === null || v === undefined || v === "") continue;
-    // 0 for output_width/output_height means "derive from scale" — omit it.
+    // 0 for output_width/output_height means "infer from the other dim" — omit.
     if ((k === "output_width" || k === "output_height") && v === 0) continue;
     form.set(k, String(v));
   }
@@ -369,10 +391,13 @@ export async function topazExecuteImageTask(
       `Topaz submit failed: ${submit.status} ${await submit.text()}`
     );
   }
+  // Spec returns { process_id, source_id, eta }. The process_id is also
+  // available in the X-Process-ID response header.
   const submitJson = (await submit.json()) as Record<string, unknown>;
-  const processId = (submitJson.process_id ?? submitJson.id) as
-    | string
-    | undefined;
+  const processId =
+    (submitJson.process_id as string | undefined) ??
+    submit.headers?.get("X-Process-ID") ??
+    undefined;
   if (!processId) {
     throw new Error(
       `Topaz did not return a process_id: ${JSON.stringify(submitJson)}`
@@ -387,11 +412,12 @@ export async function topazExecuteImageTask(
     spec.maxAttempts
   );
 
+  // Spec: { download_url, head_url, expiry }.
   const downloadUrl = spec.downloadEndpoint.replace("{process_id}", processId);
   const dl = await fetchWithRetry(downloadUrl, { headers: authHeaders(apiKey) });
   if (!dl.ok) throw new Error(`Topaz download lookup failed: ${dl.status}`);
   const dlJson = (await dl.json()) as Record<string, unknown>;
-  const finalUrl = (dlJson.url ?? dlJson.download_url) as string | undefined;
+  const finalUrl = (dlJson.download_url ?? dlJson.url) as string | undefined;
   if (!finalUrl) {
     throw new Error(`No download URL in response: ${JSON.stringify(dlJson)}`);
   }
@@ -407,6 +433,110 @@ export async function topazExecuteImageTask(
 // Video executor
 // ---------------------------------------------------------------------------
 
+const INTERPOLATION_MODELS = new Set([
+  "apf-2",
+  "apo-8",
+  "chf-3",
+  "chr-2",
+  "aion-1"
+]);
+
+const AUDIO_MODE_MAP: Record<
+  string,
+  { audioTransfer: "Copy" | "Convert" | "None"; audioCodec?: "AAC" | "AC3" | "PCM" }
+> = {
+  copy: { audioTransfer: "Copy", audioCodec: "AAC" },
+  aac: { audioTransfer: "Convert", audioCodec: "AAC" },
+  ac3: { audioTransfer: "Convert", audioCodec: "AC3" },
+  pcm: { audioTransfer: "Convert", audioCodec: "PCM" },
+  none: { audioTransfer: "None" }
+};
+
+function num(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function buildUpscaleFilter(
+  fields: Record<string, unknown>
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = { model: String(fields.model) };
+  if (fields.video_type) filter.videoType = String(fields.video_type);
+  if (fields.auto) filter.auto = String(fields.auto);
+  // Manual-mode tuning. The API ignores out-of-range or unsupported values
+  // for a given model — the swagger says these are the documented controls.
+  const numericMap: Record<string, string> = {
+    compression: "compression",
+    details: "details",
+    noise: "noise",
+    halo: "halo",
+    blur: "blur",
+    recover_original_detail: "recoverOriginalDetailValue"
+  };
+  for (const [src, dst] of Object.entries(numericMap)) {
+    const v = num(fields[src]);
+    if (v !== undefined && v !== 0) filter[dst] = v;
+  }
+  return filter;
+}
+
+function buildInterpolationFilter(
+  fields: Record<string, unknown>
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = { model: String(fields.model) };
+  const slowmo = num(fields.slowmo);
+  if (slowmo !== undefined && slowmo !== 1) filter.slowmo = slowmo;
+  const fps = num(fields.fps);
+  if (fps !== undefined && fps > 0) filter.fps = fps;
+  if (fields.duplicate) filter.duplicate = true;
+  const threshold = num(fields.duplicate_threshold);
+  if (threshold !== undefined && fields.duplicate) {
+    filter.duplicateThreshold = threshold;
+  }
+  return filter;
+}
+
+function buildVideoFilters(
+  spec: TopazVideoSpec,
+  fields: Record<string, unknown>
+): Array<Record<string, unknown>> {
+  if (spec.videoKind === "interpolate") {
+    return [buildInterpolationFilter(fields)];
+  }
+  // Default to upscale when the model code is a known upscale model.
+  if (INTERPOLATION_MODELS.has(String(fields.model))) {
+    // Caller wired a frame-interpolation model into the Enhance node. Build
+    // the appropriate filter so the API call still succeeds.
+    return [buildInterpolationFilter(fields)];
+  }
+  return [buildUpscaleFilter(fields)];
+}
+
+function buildVideoOutput(
+  fields: Record<string, unknown>,
+  sourceMeta: TopazVideoMetadata
+): Record<string, unknown> {
+  const audioMode = String(fields.audio_mode ?? "copy").toLowerCase();
+  const audio = AUDIO_MODE_MAP[audioMode] ?? AUDIO_MODE_MAP.copy;
+
+  const output: Record<string, unknown> = {
+    resolution: {
+      width: num(fields.output_width) || sourceMeta.resolution.width,
+      height: num(fields.output_height) || sourceMeta.resolution.height
+    },
+    frameRate: num(fields.output_frame_rate) || sourceMeta.frameRate,
+    container: String(fields.output_container ?? "mp4"),
+    videoEncoder: String(fields.video_encoder ?? "H264"),
+    // One of dynamicCompressionLevel or videoBitrate is required.
+    dynamicCompressionLevel: String(fields.dynamic_compression_level ?? "Mid"),
+    audioTransfer: audio.audioTransfer
+  };
+  if (audio.audioCodec) output.audioCodec = audio.audioCodec;
+  if (fields.crop_to_fit) output.cropToFit = true;
+  return output;
+}
+
 export async function topazExecuteVideoTask(
   apiKey: string,
   spec: TopazVideoSpec,
@@ -414,22 +544,8 @@ export async function topazExecuteVideoTask(
   videoBytes: Uint8Array,
   sourceMeta: TopazVideoMetadata
 ): Promise<Uint8Array> {
-  const slowmo = Number(fields.slowmo ?? 1);
-  const filters: Array<Record<string, unknown>> = [{ model: fields.model }];
-  if (slowmo && slowmo !== 1) filters[0].slowmo = slowmo;
-
-  const audioCodec = String(fields.audio_codec ?? "copy");
-  const output = {
-    resolution: {
-      width: Number(fields.output_width) || sourceMeta.resolution.width,
-      height: Number(fields.output_height) || sourceMeta.resolution.height
-    },
-    frameRate: Number(fields.output_frame_rate) || sourceMeta.frameRate,
-    container: String(fields.output_container ?? "mp4"),
-    audioCodec,
-    audioTransfer: audioCodec === "copy" ? "copy" : "encode"
-  };
-
+  const filters = buildVideoFilters(spec, fields);
+  const output = buildVideoOutput(fields, sourceMeta);
   const createBody = { source: sourceMeta, output, filters };
 
   // 1. Create request
@@ -444,14 +560,14 @@ export async function topazExecuteVideoTask(
     );
   }
   const createJson = (await create.json()) as Record<string, unknown>;
-  const requestId = (createJson.id ?? createJson.requestID) as
+  const requestId = (createJson.requestId ?? createJson.id) as
     | string
     | undefined;
   if (!requestId) {
     throw new Error(`No request ID returned: ${JSON.stringify(createJson)}`);
   }
 
-  // 2. Accept → get upload URL(s)
+  // 2. Accept → get multi-part upload URLs
   const accept = await fetchWithRetry(
     spec.acceptEndpoint.replace("{request_id}", requestId),
     { method: "PATCH", headers: authHeaders(apiKey) }
@@ -462,7 +578,9 @@ export async function topazExecuteVideoTask(
     );
   }
   const acceptJson = (await accept.json()) as Record<string, unknown>;
-  const uploadUrls = (acceptJson.uploadUrls ??
+  // Spec: { uploadId, urls[] }. Tolerate legacy shapes just in case.
+  const uploadUrls = (acceptJson.urls ??
+    acceptJson.uploadUrls ??
     (acceptJson.uploadUrl ? [acceptJson.uploadUrl] : [])) as string[];
   if (!uploadUrls.length) {
     throw new Error(`No upload URL returned: ${JSON.stringify(acceptJson)}`);
@@ -515,8 +633,10 @@ export async function topazExecuteVideoTask(
     spec.maxAttempts
   );
 
-  // 6. Download result
-  const downloadUrl = (final.downloadUrl ??
+  // 6. Download result. Spec: { download: { url, expiresIn, expiresAt } }.
+  const download = (final.download ?? {}) as Record<string, unknown>;
+  const downloadUrl = (download.url ??
+    final.downloadUrl ??
     final.download_url ??
     final.url) as string | undefined;
   if (!downloadUrl) {

--- a/packages/topaz-nodes/src/topaz-factory.ts
+++ b/packages/topaz-nodes/src/topaz-factory.ts
@@ -23,6 +23,7 @@ import {
   topazExecuteVideoTask,
   topazImageRef,
   type TopazImageSpec,
+  type TopazVideoKind,
   type TopazVideoSpec
 } from "./topaz-base.js";
 
@@ -50,6 +51,7 @@ export interface TopazManifestEntry {
   title: string;
   description: string;
   outputType: "image" | "video";
+  videoKind?: TopazVideoKind;
   requiredRuntimes?: string[];
   submitEndpoint: string;
   statusEndpoint: string;
@@ -152,9 +154,18 @@ export function createTopazNodeClass(spec: TopazManifestEntry): NodeClass {
         const sourceContainer = sourceContainerFromRef(asset);
         const videoBytes = await refToBytes(asset, context);
         const sourceMeta = await probeVideoMetadata(videoBytes, sourceContainer);
+        const videoSpec: TopazVideoSpec = {
+          submitEndpoint: specRef.submitEndpoint,
+          acceptEndpoint: specRef.acceptEndpoint ?? "",
+          completeEndpoint: specRef.completeEndpoint ?? "",
+          statusEndpoint: specRef.statusEndpoint,
+          pollInterval: specRef.pollInterval,
+          maxAttempts: specRef.maxAttempts,
+          videoKind: specRef.videoKind ?? "upscale"
+        };
         const out = await topazExecuteVideoTask(
           apiKey,
-          specRef as unknown as TopazVideoSpec,
+          videoSpec,
           fields,
           videoBytes,
           sourceMeta
@@ -169,9 +180,16 @@ export function createTopazNodeClass(spec: TopazManifestEntry): NodeClass {
       }
 
       const imageBytes = await refToBytes(asset, context);
+      const imageSpec: TopazImageSpec = {
+        submitEndpoint: specRef.submitEndpoint,
+        statusEndpoint: specRef.statusEndpoint,
+        downloadEndpoint: specRef.downloadEndpoint ?? "",
+        pollInterval: specRef.pollInterval,
+        maxAttempts: specRef.maxAttempts
+      };
       const out = await topazExecuteImageTask(
         apiKey,
-        specRef as unknown as TopazImageSpec,
+        imageSpec,
         fields,
         imageBytes
       );

--- a/packages/topaz-nodes/src/topaz-manifest.json
+++ b/packages/topaz-nodes/src/topaz-manifest.json
@@ -4,7 +4,7 @@
     "moduleName": "image",
     "modelId": "topaz/image/enhance",
     "title": "Topaz Enhance Image",
-    "description": "Topaz Image API — Precision Upscale / Enhance.\n\n    topaz, image, upscale, enhance, restore\n\n    Async /image/v1/enhance/async endpoint with Topaz precision models (Standard V2, High Fidelity V2/V3, Low Resolution V2, CGI, Text Refine). Supports face enhancement, sharpening, denoising, and subject-targeted application.",
+    "description": "Topaz Image API — Precision Upscale / Enhance.\n\n    topaz, image, upscale, enhance, restore\n\n    Multipart POST /image/v1/enhance/async with Topaz precision models (Standard V2, High Fidelity V2, Low Resolution V2, CGI, Text Refine). Supports face enhancement, sharpening, denoising, compression repair, and subject-targeted application. Any model-specific parameters that are not supported by the chosen model are ignored by the API.",
     "outputType": "image",
     "submitEndpoint": "https://api.topazlabs.com/image/v1/enhance/async",
     "statusEndpoint": "https://api.topazlabs.com/image/v1/status/{process_id}",
@@ -16,7 +16,7 @@
         "name": "image",
         "type": "image",
         "title": "Image",
-        "description": "Source image to enhance.",
+        "description": "Source image to enhance. Supported formats: jpeg, png, tiff.",
         "required": true,
         "uploadField": true
       },
@@ -30,7 +30,6 @@
         "values": [
           "Standard V2",
           "High Fidelity V2",
-          "Upscale High Fidelity V3",
           "Low Resolution V2",
           "CGI",
           "Text Refine"
@@ -41,28 +40,20 @@
         "type": "int",
         "default": 0,
         "title": "Output Width",
-        "description": "Output width in pixels. Leave 0 to derive from scale.",
+        "description": "Output width in pixels (1-32000). 0 leaves height to drive proportional scaling.",
         "required": false,
-        "min": 0
+        "min": 0,
+        "max": 32000
       },
       {
         "name": "output_height",
         "type": "int",
         "default": 0,
         "title": "Output Height",
-        "description": "Output height in pixels. Leave 0 to derive from scale.",
+        "description": "Output height in pixels (1-32000). 0 leaves width to drive proportional scaling.",
         "required": false,
-        "min": 0
-      },
-      {
-        "name": "scale",
-        "type": "float",
-        "default": 2.0,
-        "title": "Scale",
-        "description": "Upscale factor when output_width and output_height are both 0.",
-        "required": false,
-        "min": 1.0,
-        "max": 6.0
+        "min": 0,
+        "max": 32000
       },
       {
         "name": "output_format",
@@ -72,6 +63,14 @@
         "description": "Encoded format of the returned image.",
         "required": false,
         "values": ["jpeg", "png", "tiff"]
+      },
+      {
+        "name": "crop_to_fill",
+        "type": "bool",
+        "default": false,
+        "title": "Crop To Fill",
+        "description": "Crop instead of letterbox when the output aspect differs from the source.",
+        "required": false
       },
       {
         "name": "face_enhancement",
@@ -86,7 +85,7 @@
         "type": "float",
         "default": 0.8,
         "title": "Face Enhancement Strength",
-        "description": "Intensity of face recovery (0 = off, 1 = strongest).",
+        "description": "Intensity of face recovery (0 = off, 1 = strongest). Required when face_enhancement=true.",
         "required": false,
         "min": 0.0,
         "max": 1.0
@@ -96,7 +95,7 @@
         "type": "float",
         "default": 0.3,
         "title": "Face Enhancement Creativity",
-        "description": "Realistic (0) ↔ creative (1) face recovery.",
+        "description": "Realistic (0) ↔ creative (1) face recovery. Required when face_enhancement=true.",
         "required": false,
         "min": 0.0,
         "max": 1.0
@@ -106,7 +105,7 @@
         "type": "float",
         "default": 0.0,
         "title": "Sharpen",
-        "description": "Sharpening strength.",
+        "description": "Sharpening strength (0-1).",
         "required": false,
         "min": 0.0,
         "max": 1.0
@@ -116,7 +115,7 @@
         "type": "float",
         "default": 0.0,
         "title": "Denoise",
-        "description": "Noise reduction strength.",
+        "description": "Noise reduction strength (0-1).",
         "required": false,
         "min": 0.0,
         "max": 1.0
@@ -126,7 +125,17 @@
         "type": "float",
         "default": 0.0,
         "title": "Fix Compression",
-        "description": "Reduce JPEG/compression artifacts.",
+        "description": "Reduce JPEG/compression artifacts (0-1).",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0
+      },
+      {
+        "name": "strength",
+        "type": "float",
+        "default": 0.0,
+        "title": "Strength",
+        "description": "Overall model strength (0.01-1). Too high can look unrealistic.",
         "required": false,
         "min": 0.0,
         "max": 1.0
@@ -136,7 +145,7 @@
         "type": "enum",
         "default": "",
         "title": "Subject Detection",
-        "description": "Apply enhancements only to a region.",
+        "description": "Restrict enhancements to a subject region.",
         "required": false,
         "values": ["", "foreground", "background", "all"]
       }
@@ -148,7 +157,7 @@
     "moduleName": "image",
     "modelId": "topaz/image/enhance-gen",
     "title": "Topaz Enhance Image (Generative)",
-    "description": "Topaz Image API — Generative Upscale (Redefine / Recover).\n\n    topaz, image, generative, upscale, prompt\n\n    Async /image/v1/enhance-gen/async endpoint. Prompt-guided enhancement with creativity and texture controls.",
+    "description": "Topaz Image API — Generative Upscale (Wonder / Bloom / Redefine).\n\n    topaz, image, generative, upscale, prompt\n\n    Multipart POST /image/v1/enhance-gen/async. Prompt-guided enhancement with creativity, texture, detail, and face recovery controls. Parameters not supported by the chosen model are ignored.",
     "outputType": "image",
     "submitEndpoint": "https://api.topazlabs.com/image/v1/enhance-gen/async",
     "statusEndpoint": "https://api.topazlabs.com/image/v1/status/{process_id}",
@@ -171,14 +180,23 @@
         "title": "Model",
         "description": "Topaz generative model.",
         "required": false,
-        "values": ["Redefine"]
+        "values": [
+          "Standard MAX",
+          "Recover 3",
+          "Wonder",
+          "Wonder 2",
+          "Wonder 3",
+          "Redefine",
+          "Bloom Realism",
+          "Bloom Creative"
+        ]
       },
       {
         "name": "prompt",
         "type": "str",
         "default": "",
         "title": "Prompt",
-        "description": "Text describing the desired enhancement (max 1024 chars).",
+        "description": "Description of the desired enhancement (max 1024 chars). Ignored when autoprompt=true.",
         "required": false,
         "max": 1024
       },
@@ -195,7 +213,7 @@
         "type": "int",
         "default": 3,
         "title": "Creativity",
-        "description": "Creative liberty level.",
+        "description": "Creative liberty level (1-9). Low = high fidelity; high = more creative.",
         "required": false,
         "min": 1,
         "max": 9
@@ -205,7 +223,7 @@
         "type": "int",
         "default": 3,
         "title": "Texture",
-        "description": "Texture addition amount.",
+        "description": "Texture addition amount (1-5).",
         "required": false,
         "min": 1,
         "max": 5
@@ -215,25 +233,20 @@
         "type": "int",
         "default": 0,
         "title": "Output Width",
+        "description": "Output width in pixels (1-32000). 0 leaves height to drive scaling.",
         "required": false,
-        "min": 0
+        "min": 0,
+        "max": 32000
       },
       {
         "name": "output_height",
         "type": "int",
         "default": 0,
         "title": "Output Height",
+        "description": "Output height in pixels (1-32000). 0 leaves width to drive scaling.",
         "required": false,
-        "min": 0
-      },
-      {
-        "name": "scale",
-        "type": "float",
-        "default": 2.0,
-        "title": "Scale",
-        "required": false,
-        "min": 1.0,
-        "max": 4.0
+        "min": 0,
+        "max": 32000
       },
       {
         "name": "output_format",
@@ -242,6 +255,14 @@
         "title": "Output Format",
         "required": false,
         "values": ["jpeg", "png", "tiff"]
+      },
+      {
+        "name": "crop_to_fill",
+        "type": "bool",
+        "default": false,
+        "title": "Crop To Fill",
+        "description": "Crop instead of letterbox when the output aspect differs from the source.",
+        "required": false
       },
       {
         "name": "face_enhancement",
@@ -258,6 +279,59 @@
         "required": false,
         "min": 0.0,
         "max": 1.0
+      },
+      {
+        "name": "face_enhancement_creativity",
+        "type": "float",
+        "default": 0.3,
+        "title": "Face Enhancement Creativity",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0
+      },
+      {
+        "name": "sharpen",
+        "type": "float",
+        "default": 0.0,
+        "title": "Sharpen",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0
+      },
+      {
+        "name": "denoise",
+        "type": "float",
+        "default": 0.0,
+        "title": "Denoise",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0
+      },
+      {
+        "name": "detail",
+        "type": "bool",
+        "default": false,
+        "title": "Add Detail",
+        "description": "Add a detail pass after the primary render.",
+        "required": false
+      },
+      {
+        "name": "detail_strength",
+        "type": "float",
+        "default": 1.0,
+        "title": "Detail Strength",
+        "description": "Strength of the detail pass (0-10). Required when detail=true.",
+        "required": false,
+        "min": 0.0,
+        "max": 10.0
+      },
+      {
+        "name": "subject_detection",
+        "type": "enum",
+        "default": "",
+        "title": "Subject Detection",
+        "required": false,
+        "values": ["", "foreground", "background", "all"]
       }
     ],
     "validation": []
@@ -267,12 +341,13 @@
     "moduleName": "video",
     "modelId": "topaz/video/enhance",
     "title": "Topaz Enhance Video",
-    "description": "Topaz Video API — full upload + process + download pipeline.\n\n    topaz, video, upscale, enhance, interpolate\n\n    Creates a job at /video/, accepts the upload URL, PUTs the source, completes the upload, polls /status, and downloads the result. Requires source metadata (resolution, frame rate, duration, frame count), probed locally via ffprobe.",
+    "description": "Topaz Video API — upscale / enhance pipeline.\n\n    topaz, video, upscale, enhance, restore\n\n    POST /video/ → PATCH /video/{id}/accept → multipart PUT upload → PATCH /video/{id}/complete-upload/ → GET /video/{id}/status. Requires source metadata (resolution, frame rate, duration, frame count), probed locally via ffprobe.",
     "outputType": "video",
+    "videoKind": "upscale",
     "requiredRuntimes": ["ffmpeg"],
     "submitEndpoint": "https://api.topazlabs.com/video/",
     "acceptEndpoint": "https://api.topazlabs.com/video/{request_id}/accept",
-    "completeEndpoint": "https://api.topazlabs.com/video/{request_id}/complete-upload",
+    "completeEndpoint": "https://api.topazlabs.com/video/{request_id}/complete-upload/",
     "statusEndpoint": "https://api.topazlabs.com/video/{request_id}/status",
     "pollInterval": 15000,
     "maxAttempts": 1000,
@@ -281,7 +356,7 @@
         "name": "video",
         "type": "video",
         "title": "Video",
-        "description": "Source video to enhance.",
+        "description": "Source video to enhance. mp4, mov, or mkv.",
         "required": true,
         "uploadField": true
       },
@@ -290,15 +365,53 @@
         "type": "enum",
         "default": "prob-4",
         "title": "Model",
-        "description": "Topaz video model.",
+        "description": "Topaz video upscale / enhancement model. Frame interpolation models live on the Interpolate Video node.",
         "required": false,
         "values": [
           "prob-4",
-          "apo-8",
+          "ahq-12",
+          "amq-13",
+          "alq-13",
+          "aaa-9",
+          "amqs-2",
+          "alqs-2",
+          "dtv-4",
+          "ddv-3",
+          "dtd-4",
+          "dtds-2",
+          "dtvs-2",
+          "ghq-5",
+          "gcg-5",
+          "iris-2",
+          "iris-3",
+          "thd-3",
+          "thf-4",
           "thm-2",
-          "iris-1",
-          "starlight-precise-2"
+          "rhea-1",
+          "nyx-3",
+          "nxf-1",
+          "nxl-1",
+          "nxhf-1",
+          "color-1"
         ]
+      },
+      {
+        "name": "video_type",
+        "type": "enum",
+        "default": "Progressive",
+        "title": "Video Type",
+        "description": "Frame/field type of the source.",
+        "required": false,
+        "values": ["Progressive", "Interlaced", "ProgressiveInterlaced"]
+      },
+      {
+        "name": "auto",
+        "type": "enum",
+        "default": "Auto",
+        "title": "Parameter Mode",
+        "description": "Auto = automatic estimation. Manual = use the values below. Relative = auto + manual offsets.",
+        "required": false,
+        "values": ["Auto", "Manual", "Relative"]
       },
       {
         "name": "output_width",
@@ -336,22 +449,223 @@
         "values": ["mp4", "mov", "mkv"]
       },
       {
-        "name": "audio_codec",
+        "name": "video_encoder",
+        "type": "enum",
+        "default": "H264",
+        "title": "Video Encoder",
+        "required": false,
+        "values": ["H264", "H265", "AV1", "VP9"]
+      },
+      {
+        "name": "dynamic_compression_level",
+        "type": "enum",
+        "default": "Mid",
+        "title": "Compression Level",
+        "description": "Automatic CQP selection. Use videoBitrate-style overrides via the API directly if you need a fixed bitrate.",
+        "required": false,
+        "values": ["Low", "Mid", "High"]
+      },
+      {
+        "name": "audio_mode",
         "type": "enum",
         "default": "copy",
-        "title": "Audio Codec",
+        "title": "Audio",
+        "description": "copy = keep source audio. aac/ac3/pcm = re-encode. none = drop audio.",
         "required": false,
-        "values": ["copy", "aac", "none"]
+        "values": ["copy", "aac", "ac3", "pcm", "none"]
+      },
+      {
+        "name": "crop_to_fit",
+        "type": "bool",
+        "default": false,
+        "title": "Crop To Fit",
+        "description": "Center-crop to the output dimensions instead of letterboxing.",
+        "required": false
+      },
+      {
+        "name": "compression",
+        "type": "float",
+        "default": 0.0,
+        "title": "Compression Recovery",
+        "description": "Strength of compression recovery (-1 to 1). Used when Parameter Mode is Manual/Relative.",
+        "required": false,
+        "min": -1.0,
+        "max": 1.0
+      },
+      {
+        "name": "details",
+        "type": "float",
+        "default": 0.0,
+        "title": "Details",
+        "description": "Detail reconstruction (-1 to 1).",
+        "required": false,
+        "min": -1.0,
+        "max": 1.0
+      },
+      {
+        "name": "noise",
+        "type": "float",
+        "default": 0.0,
+        "title": "Noise Reduction",
+        "description": "Noise reduction (-1 to 1).",
+        "required": false,
+        "min": -1.0,
+        "max": 1.0
+      },
+      {
+        "name": "halo",
+        "type": "float",
+        "default": 0.0,
+        "title": "Halo Reduction",
+        "description": "Halo reduction (-1 to 1).",
+        "required": false,
+        "min": -1.0,
+        "max": 1.0
+      },
+      {
+        "name": "blur",
+        "type": "float",
+        "default": 0.0,
+        "title": "Sharpness",
+        "description": "Sharpness applied to the result (-1 to 1).",
+        "required": false,
+        "min": -1.0,
+        "max": 1.0
+      },
+      {
+        "name": "recover_original_detail",
+        "type": "float",
+        "default": 0.0,
+        "title": "Recover Original Detail",
+        "description": "Reintroduce source detail into the output (0 to 1).",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0
+      }
+    ],
+    "validation": []
+  },
+  {
+    "className": "InterpolateVideo",
+    "moduleName": "video",
+    "modelId": "topaz/video/interpolate",
+    "title": "Topaz Interpolate Video",
+    "description": "Topaz Video API — frame interpolation pipeline.\n\n    topaz, video, interpolate, slowmo, fps\n\n    Same multi-step pipeline as Enhance Video but with a Frame Interpolation filter. Use Apollo (apo-8) for general slow-motion or fps boosts, Chronos (chr-2 / chf-3) for higher-motion content, Aperture Flow (apf-2) as a lightweight default, and Aion (aion-1) for high-resolution / complex motion.",
+    "outputType": "video",
+    "videoKind": "interpolate",
+    "requiredRuntimes": ["ffmpeg"],
+    "submitEndpoint": "https://api.topazlabs.com/video/",
+    "acceptEndpoint": "https://api.topazlabs.com/video/{request_id}/accept",
+    "completeEndpoint": "https://api.topazlabs.com/video/{request_id}/complete-upload/",
+    "statusEndpoint": "https://api.topazlabs.com/video/{request_id}/status",
+    "pollInterval": 15000,
+    "maxAttempts": 1000,
+    "fields": [
+      {
+        "name": "video",
+        "type": "video",
+        "title": "Video",
+        "description": "Source video to interpolate.",
+        "required": true,
+        "uploadField": true
+      },
+      {
+        "name": "model",
+        "type": "enum",
+        "default": "apo-8",
+        "title": "Model",
+        "description": "Frame interpolation model.",
+        "required": false,
+        "values": ["apo-8", "apf-2", "chf-3", "chr-2", "aion-1"]
       },
       {
         "name": "slowmo",
         "type": "float",
         "default": 1.0,
         "title": "Slow-mo Factor",
-        "description": "1.0 = no slow motion. >1 stretches duration.",
+        "description": "1.0 = no slow motion. >1 stretches duration (1-16).",
         "required": false,
-        "min": 0.1,
-        "max": 8.0
+        "min": 1.0,
+        "max": 16.0
+      },
+      {
+        "name": "fps",
+        "type": "float",
+        "default": 0,
+        "title": "Output FPS",
+        "description": "0 = same as source. Otherwise 15-240. Does not change duration.",
+        "required": false,
+        "min": 0,
+        "max": 240
+      },
+      {
+        "name": "duplicate",
+        "type": "bool",
+        "default": false,
+        "title": "Drop Duplicates",
+        "description": "Analyze input for duplicate frames and remove them before interpolation.",
+        "required": false
+      },
+      {
+        "name": "duplicate_threshold",
+        "type": "float",
+        "default": 0.01,
+        "title": "Duplicate Threshold",
+        "description": "Detection sensitivity for duplicates (0.001-0.1).",
+        "required": false,
+        "min": 0.001,
+        "max": 0.1
+      },
+      {
+        "name": "output_width",
+        "type": "int",
+        "default": 0,
+        "title": "Output Width",
+        "description": "0 = same as source.",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "output_height",
+        "type": "int",
+        "default": 0,
+        "title": "Output Height",
+        "description": "0 = same as source.",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "output_container",
+        "type": "enum",
+        "default": "mp4",
+        "title": "Container",
+        "required": false,
+        "values": ["mp4", "mov", "mkv"]
+      },
+      {
+        "name": "video_encoder",
+        "type": "enum",
+        "default": "H264",
+        "title": "Video Encoder",
+        "required": false,
+        "values": ["H264", "H265", "AV1", "VP9"]
+      },
+      {
+        "name": "dynamic_compression_level",
+        "type": "enum",
+        "default": "Mid",
+        "title": "Compression Level",
+        "required": false,
+        "values": ["Low", "Mid", "High"]
+      },
+      {
+        "name": "audio_mode",
+        "type": "enum",
+        "default": "copy",
+        "title": "Audio",
+        "description": "copy = keep source audio. aac/ac3/pcm = re-encode. none = drop audio.",
+        "required": false,
+        "values": ["copy", "aac", "ac3", "pcm", "none"]
       }
     ],
     "validation": []

--- a/packages/topaz-nodes/tests/topaz-base.test.ts
+++ b/packages/topaz-nodes/tests/topaz-base.test.ts
@@ -113,9 +113,14 @@ describe("topazExecuteImageTask", () => {
         return { ok: true, json: async () => ({ status: "Completed" }) } as Response;
       }
       if (u.includes("/download/")) {
+        // Spec response: { download_url, head_url, expiry }.
         return {
           ok: true,
-          json: async () => ({ url: "https://cdn.topaz/result.png" })
+          json: async () => ({
+            download_url: "https://cdn.topaz/result.png",
+            head_url: "https://cdn.topaz/result.png?head",
+            expiry: 0
+          })
         } as Response;
       }
       if (u === "https://cdn.topaz/result.png") {
@@ -130,7 +135,7 @@ describe("topazExecuteImageTask", () => {
     const out = await topazExecuteImageTask(
       "key",
       spec,
-      { model: "Standard V2", scale: 2, output_width: 0 },
+      { model: "Standard V2", output_width: 0 },
       Uint8Array.from([1, 2, 3])
     );
 
@@ -209,10 +214,11 @@ describe("topazExecuteVideoTask", () => {
     submitEndpoint: "https://api.topazlabs.com/video/",
     acceptEndpoint: "https://api.topazlabs.com/video/{request_id}/accept",
     completeEndpoint:
-      "https://api.topazlabs.com/video/{request_id}/complete-upload",
+      "https://api.topazlabs.com/video/{request_id}/complete-upload/",
     statusEndpoint: "https://api.topazlabs.com/video/{request_id}/status",
     pollInterval: 0,
-    maxAttempts: 5
+    maxAttempts: 5,
+    videoKind: "upscale"
   };
 
   const sourceMeta: TopazVideoMetadata = {
@@ -239,13 +245,18 @@ describe("topazExecuteVideoTask", () => {
       requests.push({ url: u, method, headers: init?.headers });
 
       if (u === spec.submitEndpoint && method === "POST") {
-        return { ok: true, json: async () => ({ id: "req-1" }) } as Response;
+        return {
+          ok: true,
+          json: async () => ({ requestId: "req-1" })
+        } as Response;
       }
       if (u.endsWith("/accept")) {
+        // Spec: { uploadId, urls[] }.
         return {
           ok: true,
           json: async () => ({
-            uploadUrls: [
+            uploadId: "upload-1",
+            urls: [
               "https://upload.topaz/part1",
               "https://upload.topaz/part2"
             ]
@@ -258,15 +269,16 @@ describe("topazExecuteVideoTask", () => {
         const headers = new Headers({ ETag: '"etag-' + u.slice(-5) + '"' });
         return { ok: true, headers } as unknown as Response;
       }
-      if (u.endsWith("/complete-upload")) {
+      if (u.endsWith("/complete-upload/")) {
         return { ok: true, json: async () => ({}) } as Response;
       }
       if (u.endsWith("/status")) {
+        // Spec: status="complete" (not "Completed"), download is nested.
         return {
           ok: true,
           json: async () => ({
-            status: "Completed",
-            downloadUrl: "https://cdn.topaz/result.mov"
+            status: "complete",
+            download: { url: "https://cdn.topaz/result.mov" }
           })
         } as Response;
       }
@@ -285,8 +297,7 @@ describe("topazExecuteVideoTask", () => {
       {
         model: "prob-4",
         output_container: "mp4",
-        audio_codec: "copy",
-        slowmo: 1
+        audio_mode: "copy"
       },
       Uint8Array.from(new Array(1024).fill(1)),
       sourceMeta
@@ -299,7 +310,9 @@ describe("topazExecuteVideoTask", () => {
       expect(c.contentType).toBe("video/quicktime");
     }
     // complete-upload body should reference the parts' ETags.
-    const completeReq = requests.find((r) => r.url.endsWith("/complete-upload"));
+    const completeReq = requests.find((r) =>
+      r.url.endsWith("/complete-upload/")
+    );
     expect(completeReq?.method).toBe("PATCH");
 
     // Create body should send the *source* container, not the output container.
@@ -317,10 +330,13 @@ describe("topazExecuteVideoTask", () => {
     global.fetch = vi.fn(async (url: string | URL) => {
       const u = String(url);
       if (u === spec.submitEndpoint) {
-        return { ok: true, json: async () => ({ id: "r" }) } as Response;
+        return {
+          ok: true,
+          json: async () => ({ requestId: "r" })
+        } as Response;
       }
       if (u.endsWith("/accept")) {
-        return { ok: true, json: async () => ({}) } as Response;
+        return { ok: true, json: async () => ({ uploadId: "u" }) } as Response;
       }
       throw new Error(`unexpected: ${u}`);
     }) as unknown as typeof fetch;
@@ -341,12 +357,18 @@ describe("topazExecuteVideoTask", () => {
     global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
       const u = String(url);
       if (u === spec.submitEndpoint) {
-        return { ok: true, json: async () => ({ id: "r2" }) } as Response;
+        return {
+          ok: true,
+          json: async () => ({ requestId: "r2" })
+        } as Response;
       }
       if (u.endsWith("/accept")) {
         return {
           ok: true,
-          json: async () => ({ uploadUrls: ["https://upload.topaz/only"] })
+          json: async () => ({
+            uploadId: "u",
+            urls: ["https://upload.topaz/only"]
+          })
         } as Response;
       }
       if (u === "https://upload.topaz/only") {
@@ -355,13 +377,16 @@ describe("topazExecuteVideoTask", () => {
         );
         return { ok: true, headers: new Headers() } as unknown as Response;
       }
-      if (u.endsWith("/complete-upload")) {
+      if (u.endsWith("/complete-upload/")) {
         return { ok: true, json: async () => ({}) } as Response;
       }
       if (u.endsWith("/status")) {
         return {
           ok: true,
-          json: async () => ({ status: "Completed", url: "https://cdn/x" })
+          json: async () => ({
+            status: "complete",
+            download: { url: "https://cdn/x" }
+          })
         } as Response;
       }
       if (u === "https://cdn/x") {


### PR DESCRIPTION
## Summary

Cross-checked `packages/topaz-nodes` against the real Topaz docs (via the new `topaz` MCP server) and fixed substantial drift. As shipped, the package would have **400'd on every video request** and **hung forever** on the status poll. The image side was sending phantom parameters and a non-existent model.

## What was broken

**Video** (`/video/...`):
- Terminal status set was `completed`/`succeeded`/`cancelled` — the API actually returns `complete` / `failed` / `canceled`, so the poll would never resolve.
- Accept response was read as `uploadUrls`; spec is `urls`.
- Completed download URL was read at top-level (`downloadUrl`); spec puts it at `download.url`.
- Audio codec/transfer sent lowercase (`copy`, `aac`); spec requires title-case `Copy`/`Convert`/`None` and uppercase `AAC`/`AC3`/`PCM`.
- `output` was missing the required `dynamicCompressionLevel` (or `videoBitrate`) and `videoEncoder`.
- `slowmo` was wedged into the upscale filter regardless of model; frame-interpolation models like `apo-8`/`apf-2`/`chf-3`/`chr-2`/`aion-1` need a separate `FrameInterpolationFilter`.
- `iris-1` doesn't exist (should be `iris-2`/`iris-3`); `starlight-precise-2` isn't in the supported model enum.
- `/complete-upload` was missing the spec's trailing slash.

**Image** (`/image/v1/...`):
- `Upscale High Fidelity V3` model doesn't exist.
- `scale` parameter doesn't exist in the API — was being sent and silently ignored.
- Missing `crop_to_fill`; width/height not capped at 32000.
- Generative model list was just `["Redefine"]`; real generative family includes Standard MAX, Recover 3, Wonder/2/3, Bloom Realism/Creative.
- Generative also has `detail`/`detail_strength`/`subject_detection` controls.

## What changed

- **`topaz-manifest.json`**: split into 4 nodes — `EnhanceImage`, `EnhanceImageGenerative`, `EnhanceVideo` (upscale), `InterpolateVideo` (frame interpolation, new). Real model lists and parameter sets per the swagger.
- **`topaz-base.ts`**: correct terminal status names; correct accept/status/download response shapes; audio mode mapping; `dynamicCompressionLevel` + `videoEncoder` in output; filter shape branches on `videoKind`; also reads `X-Process-ID` response header.
- **`topaz-factory.ts`**: threads `videoKind` through; constructs strict `TopazImageSpec`/`TopazVideoSpec` instead of unsafe casts.
- **`tests/topaz-base.test.ts`**: mocks updated to spec-accurate shapes.

## Test plan

- [x] `npm run lint` in `packages/topaz-nodes` — clean
- [x] `npm test` in `packages/topaz-nodes` — 20/20 pass
- [x] `npm run build` in `packages/topaz-nodes` — clean
- [ ] Smoke test against the real Topaz API with a valid `TOPAZ_API_KEY` (requires credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)