### PR TITLE
fix(compositor): contain-fit default placement so larger layers don't crop to black

### DIFF
--- a/packages/gpu/src/compositor/headless.ts
+++ b/packages/gpu/src/compositor/headless.ts
@@ -19,6 +19,7 @@
 import { WebGPULayerCompositor } from "./compositor.js";
 import { FULLSCREEN_QUAD_VERTEX, UNPREMULTIPLY_FRAGMENT } from "./shaders.js";
 import {
+  defaultLayerTransform,
   layerTransformToInverseAffine,
   type LayerTransform2D
 } from "./transform.js";
@@ -119,13 +120,7 @@ export async function compositeLayersHeadless(
     sources.push(source);
 
     const transform =
-      layer.transform ?? {
-        x: lw / 2,
-        y: lh / 2,
-        scaleX: 1,
-        scaleY: 1,
-        rotation: 0
-      };
+      layer.transform ?? defaultLayerTransform(lw, lh, width, height);
     compositor.renderBlendPass(encoder, read, write, {
       source,
       opacity: layer.opacity,

--- a/packages/gpu/src/compositor/transform.ts
+++ b/packages/gpu/src/compositor/transform.ts
@@ -29,16 +29,32 @@ export interface LayerTransform2D {
   rotation: number;
 }
 
-/** Transform that places a `width`×`height` layer's top-left at the origin. */
+/**
+ * Default placement for a layer with no explicit transform: contain-fit
+ * centered on the canvas, never upscaled.
+ *
+ * Scale is `min(canvasW/layerW, canvasH/layerH, 1)` — large layers shrink to
+ * fit, smaller layers keep their native size. The layer center is pinned to
+ * the canvas center. For a same-size base layer this reduces to scale=1 with
+ * the top-left at the canvas origin (the historical "untransformed paste"),
+ * so single-layer pipelines are unaffected.
+ */
 export function defaultLayerTransform(
-  width: number,
-  height: number
+  layerWidth: number,
+  layerHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
 ): LayerTransform2D {
+  const safeLW = Math.max(1, layerWidth);
+  const safeLH = Math.max(1, layerHeight);
+  const safeCW = Math.max(1, canvasWidth);
+  const safeCH = Math.max(1, canvasHeight);
+  const scale = Math.min(safeCW / safeLW, safeCH / safeLH, 1);
   return {
-    x: width / 2,
-    y: height / 2,
-    scaleX: 1,
-    scaleY: 1,
+    x: safeCW / 2,
+    y: safeCH / 2,
+    scaleX: scale,
+    scaleY: scale,
     rotation: 0
   };
 }

--- a/packages/gpu/tests/transform.test.ts
+++ b/packages/gpu/tests/transform.test.ts
@@ -19,17 +19,54 @@ function applyInverse(
 }
 
 describe("layerTransformToInverseAffine", () => {
-  it("default transform maps canvas px 1:1 onto texels (top-left at origin)", () => {
+  it("default transform on same-size canvas is a 1:1 top-left paste", () => {
     const w = 100;
     const h = 60;
     const m = layerTransformToInverseAffine(
-      defaultLayerTransform(w, h),
+      defaultLayerTransform(w, h, w, h),
       w,
       h
     );
-    expect(applyInverse(m, 0, 0)).toEqual({ tx: 0, ty: 0 });
-    expect(applyInverse(m, 50, 30)).toEqual({ tx: 50, ty: 30 });
-    expect(applyInverse(m, w, h)).toEqual({ tx: w, ty: h });
+    expect(applyInverse(m, 0, 0).tx).toBeCloseTo(0);
+    expect(applyInverse(m, 0, 0).ty).toBeCloseTo(0);
+    expect(applyInverse(m, 50, 30).tx).toBeCloseTo(50);
+    expect(applyInverse(m, 50, 30).ty).toBeCloseTo(30);
+    expect(applyInverse(m, w, h).tx).toBeCloseTo(w);
+    expect(applyInverse(m, w, h).ty).toBeCloseTo(h);
+  });
+
+  it("default transform contain-fits a layer larger than the canvas, centered", () => {
+    // 200×200 layer on 100×100 canvas → scale = 0.5, centered.
+    const t = defaultLayerTransform(200, 200, 100, 100);
+    expect(t.scaleX).toBeCloseTo(0.5);
+    expect(t.scaleY).toBeCloseTo(0.5);
+    expect(t.x).toBeCloseTo(50);
+    expect(t.y).toBeCloseTo(50);
+    // Canvas center maps to layer texel center (100, 100).
+    const m = layerTransformToInverseAffine(t, 200, 200);
+    const center = applyInverse(m, 50, 50);
+    expect(center.tx).toBeCloseTo(100);
+    expect(center.ty).toBeCloseTo(100);
+    // Canvas top-left maps to layer texel (0, 0).
+    const tl = applyInverse(m, 0, 0);
+    expect(tl.tx).toBeCloseTo(0);
+    expect(tl.ty).toBeCloseTo(0);
+  });
+
+  it("default transform keeps small layers at native size, centered", () => {
+    // 40×40 layer on 100×100 canvas → scale = 1 (no upscale), centered.
+    const t = defaultLayerTransform(40, 40, 100, 100);
+    expect(t.scaleX).toBeCloseTo(1);
+    expect(t.scaleY).toBeCloseTo(1);
+    expect(t.x).toBeCloseTo(50);
+    expect(t.y).toBeCloseTo(50);
+  });
+
+  it("default transform contains anisotropic layers preserving aspect ratio", () => {
+    // 200×100 layer on 100×100 canvas → scale = min(0.5, 1, 1) = 0.5.
+    const t = defaultLayerTransform(200, 100, 100, 100);
+    expect(t.scaleX).toBeCloseTo(0.5);
+    expect(t.scaleY).toBeCloseTo(0.5);
   });
 
   it("translation moves the sampled region", () => {

--- a/web/src/components/compositor/CompositorEditor.tsx
+++ b/web/src/components/compositor/CompositorEditor.tsx
@@ -198,8 +198,11 @@ const CompositorEditorInner: React.FC<CompositorEditorProps> = ({
   const selectedTransform: LayerTransform2D | null = useMemo(() => {
     if (!selectedLayer) return null;
     const { width, height } = dimsFor(selectedLayer.id);
-    return selectedLayer.transform ?? defaultTransform(width, height);
-  }, [selectedLayer, dimsFor]);
+    return (
+      selectedLayer.transform ??
+      defaultTransform(width, height, canvasWidth, canvasHeight)
+    );
+  }, [selectedLayer, dimsFor, canvasWidth, canvasHeight]);
 
   const handleFieldChange = useCallback(
     (transform: LayerTransform2D, complete: boolean) => {
@@ -214,8 +217,21 @@ const CompositorEditorInner: React.FC<CompositorEditorProps> = ({
     if (!selectedId) return;
     const idx = indexOf(selectedId);
     const { width, height } = dimsFor(selectedId);
-    if (idx >= 0) onTransformChange(idx, defaultTransform(width, height), true);
-  }, [selectedId, indexOf, dimsFor, onTransformChange]);
+    if (idx >= 0) {
+      onTransformChange(
+        idx,
+        defaultTransform(width, height, canvasWidth, canvasHeight),
+        true
+      );
+    }
+  }, [
+    selectedId,
+    indexOf,
+    dimsFor,
+    onTransformChange,
+    canvasWidth,
+    canvasHeight
+  ]);
 
   // Render the stack top-first (highest index on top of the composite).
   const stack = useMemo(

--- a/web/src/components/compositor/CompositorEditorCanvas.tsx
+++ b/web/src/components/compositor/CompositorEditorCanvas.tsx
@@ -19,7 +19,10 @@ import React, {
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import type { LayerTransform2D } from "@nodetool-ai/gpu/webgpu";
+import {
+  defaultLayerTransform,
+  type LayerTransform2D
+} from "@nodetool-ai/gpu/webgpu";
 
 import { EmptyState } from "../ui_primitives";
 import { useWebGPUPreview, type PreviewLayer } from "./useWebGPUPreview";
@@ -208,15 +211,10 @@ const CompositorEditorCanvasInner: React.FC<CompositorEditorCanvasProps> = ({
     if (!layer) return null;
     const { width, height } = dimsFor(selectedId);
     return (
-      layer.transform ?? {
-        x: width / 2,
-        y: height / 2,
-        scaleX: 1,
-        scaleY: 1,
-        rotation: 0
-      }
+      layer.transform ??
+      defaultLayerTransform(width, height, canvasWidth, canvasHeight)
     );
-  }, [selectedId, layers, dimsFor]);
+  }, [selectedId, layers, dimsFor, canvasWidth, canvasHeight]);
 
   // ── Gizmo geometry in canvas space ──────────────────────────────
   const gizmo = useMemo(() => {
@@ -318,13 +316,8 @@ const CompositorEditorCanvasInner: React.FC<CompositorEditorCanvasProps> = ({
         if (!layer.visible) continue;
         const { width, height } = dimsFor(layer.id);
         const t =
-          layer.transform ?? {
-            x: width / 2,
-            y: height / 2,
-            scaleX: 1,
-            scaleY: 1,
-            rotation: 0
-          };
+          layer.transform ??
+          defaultLayerTransform(width, height, canvasWidth, canvasHeight);
         if (pointInLayer(t, width, height, p)) {
           onSelect(layer.id);
           dragRef.current = {
@@ -349,7 +342,9 @@ const CompositorEditorCanvasInner: React.FC<CompositorEditorCanvasProps> = ({
       transformForSelected,
       dimsFor,
       layers,
-      onSelect
+      onSelect,
+      canvasWidth,
+      canvasHeight
     ]
   );
 

--- a/web/src/components/compositor/types.ts
+++ b/web/src/components/compositor/types.ts
@@ -3,7 +3,10 @@
  */
 
 import type { BlendMode } from "@nodetool-ai/gpu";
-import type { LayerTransform2D } from "@nodetool-ai/gpu/webgpu";
+import {
+  defaultLayerTransform,
+  type LayerTransform2D
+} from "@nodetool-ai/gpu/webgpu";
 
 export type { LayerTransform2D };
 
@@ -19,10 +22,17 @@ export interface CompositorEditorLayer {
   transform?: LayerTransform2D;
 }
 
-/** Default transform placing a `w`×`h` layer's top-left at the canvas origin. */
+/** Contain-fit, centered default for a layer with no explicit transform. */
 export function defaultTransform(
-  width: number,
-  height: number
+  layerWidth: number,
+  layerHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
 ): LayerTransform2D {
-  return { x: width / 2, y: height / 2, scaleX: 1, scaleY: 1, rotation: 0 };
+  return defaultLayerTransform(
+    layerWidth,
+    layerHeight,
+    canvasWidth,
+    canvasHeight
+  );
 }

--- a/web/src/components/compositor/useWebGPUPreview.ts
+++ b/web/src/components/compositor/useWebGPUPreview.ts
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   WebGPULayerCompositor,
+  defaultLayerTransform,
   layerTransformToInverseAffine,
   type LayerTransform2D
 } from "@nodetool-ai/gpu/webgpu";
@@ -198,13 +199,8 @@ export function useWebGPUPreview(
       const source = getOrUploadTexture(device, layer);
       if (!source) continue;
       const transform =
-        layer.transform ?? {
-          x: layer.width / 2,
-          y: layer.height / 2,
-          scaleX: 1,
-          scaleY: 1,
-          rotation: 0
-        };
+        layer.transform ??
+        defaultLayerTransform(layer.width, layer.height, width, height);
       compositor.renderBlendPass(encoder, read, write, {
         source,
         opacity: layer.opacity,


### PR DESCRIPTION
## Summary

The Compositor node rendered "slight gradient over black" whenever a wired layer was larger than the canvas. Root cause was the **default per-layer transform**, not the GPU/shader path: the fallback when no per-layer transform was saved pinned the layer's top-left to the canvas origin at native size. With the canvas size defaulting to the first layer's dimensions, larger overlay layers showed only their top-left crop — for product photos with dark backgrounds, that's a near-black composite with the subject sitting off-canvas.

Reproduced exactly: 2-layer composite of a 1024² cat + 2500×3000 watch onto a 1024² canvas. Mean RGB `(11, 14, 17)` (cropped black background). After this fix: `(58, 61, 65)` with the watch centered and scaled to fit.

## Fix

New default placement: **contain-fit, centered, never upscaled.** `scale = min(canvasW/layerW, canvasH/layerH, 1)`, layer center pinned to the canvas center.

- Same-size base layers still produce the historical 1:1 top-left paste (scale=1, top-left at origin) — single-layer pipelines unaffected.
- Layers with a saved per-layer transform are unaffected.
- Small layers keep their native size (no upscaling) and sit centered.

`defaultLayerTransform` (in `@nodetool-ai/gpu`) is now the single source of truth. Every fallback that previously inlined its own `{x: w/2, y: h/2, scale: 1}` literal now calls it: headless server compose, live WebGPU editor preview, gizmo geometry, hit-testing, and the editor's reset-transform button.

## Test plan

- [x] `packages/gpu/tests/transform.test.ts` — 3 new cases (contain-fit large-layer, no-upscale small-layer, anisotropic aspect preservation) plus the existing same-size 1:1 paste case
- [x] `packages/base-nodes/tests/regression-compositor.test.ts` — all 10 compositor regression tests still pass on real Dawn GPU
- [x] `npm test --prefix packages/gpu` — 680 passed
- [x] `npm test --prefix packages/base-nodes` — 2997 passed
- [x] Full web Jest suite — 8616 passed
- [x] `tsc --noEmit` clean
- [x] Manual repro: ran the user's "Compositor" workflow (cat + watch) — composite now shows the watch centered at correct scale instead of an all-black crop

🤖 Generated with [Claude Code](https://claude.com/claude-code)