### PR TITLE
Add video support to node history viewer and auto-save for video nodes

### DIFF
--- a/packages/base-nodes/src/nodes/video.ts
+++ b/packages/base-nodes/src/nodes/video.ts
@@ -221,6 +221,7 @@ export class TextToVideoNode extends BaseNode {
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["prompt"];
   static readonly exposeAsTool = true;
+  static readonly autoSaveAsset = true;
 
   @prop({
     type: "video_model",
@@ -327,6 +328,7 @@ export class ImageToVideoNode extends BaseNode {
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["image", "prompt"];
   static readonly exposeAsTool = true;
+  static readonly autoSaveAsset = true;
 
   @prop({
     type: "image",
@@ -2601,6 +2603,7 @@ export class VideoToVideoNode extends BaseNode {
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["video", "prompt"];
   static readonly exposeAsTool = true;
+  static readonly autoSaveAsset = true;
 
   @prop({
     type: "video_model",
@@ -2682,6 +2685,7 @@ export class LipSyncNode extends BaseNode {
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["video", "audio"];
   static readonly exposeAsTool = true;
+  static readonly autoSaveAsset = true;
 
   @prop({
     type: "video_model",

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -145,10 +145,11 @@ const styles = (theme: Theme) =>
         borderColor: theme.vars.palette.primary.main
       }
     },
-    ".thumb img": {
+    ".thumb img, .thumb video": {
       width: "100%",
       height: "100%",
-      objectFit: "cover"
+      objectFit: "cover",
+      display: "block"
     },
     ".thumb-label": {
       position: "absolute",
@@ -328,7 +329,9 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           <div className="grid nodrag nopan" role="list" aria-label="Output history">
             {mediaAssets.map((asset, i) => {
               const isImage = asset.content_type?.startsWith("image/");
-              const thumbUrl = asset.thumb_url || asset.get_url || "";
+              const isVideo = asset.content_type?.startsWith("video/");
+              const imgUrl = asset.thumb_url || asset.get_url || "";
+              const videoUrl = asset.get_url || "";
               return (
                 <div
                   key={asset.id}
@@ -336,8 +339,20 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
                   role="listitem"
                   onClick={() => handleSelectThumb(i)}
                 >
-                  {isImage && thumbUrl ? (
-                    <img src={thumbUrl} alt={asset.name || asset.id} />
+                  {isImage && imgUrl ? (
+                    <img src={imgUrl} alt={asset.name || asset.id} />
+                  ) : isVideo && (asset.thumb_url || videoUrl) ? (
+                    asset.thumb_url ? (
+                      <img src={asset.thumb_url} alt={asset.name || asset.id} />
+                    ) : (
+                      <video
+                        src={`${videoUrl}#t=0.1`}
+                        preload="metadata"
+                        muted
+                        playsInline
+                        aria-label={asset.name || asset.id}
+                      />
+                    )
                   ) : (
                     <div style={{
                       width: "100%",


### PR DESCRIPTION
## Summary
Extends the node history viewer to display video assets alongside images, and enables automatic asset saving for all video generation nodes.

## Key Changes

**NodeHistoryViewer.tsx:**
- Updated CSS selector to apply styles to both `img` and `video` elements in thumbnails
- Added `display: block` to prevent inline spacing issues
- Added video content type detection (`isVideo`)
- Implemented video thumbnail rendering with fallback logic:
  - Uses `thumb_url` if available (pre-generated thumbnail)
  - Falls back to video preview frame at 0.1s using `#t=0.1` fragment
- Video element configured with `preload="metadata"`, `muted`, and `playsInline` for optimal UX

**video.ts (base-nodes):**
- Added `static readonly autoSaveAsset = true` to four video generation nodes:
  - `TextToVideoNode`
  - `ImageToVideoNode`
  - `VideoToVideoNode`
  - `LipSyncNode`
- This ensures video outputs are automatically persisted to storage

## Implementation Details
- Video thumbnails gracefully degrade: if a pre-generated thumbnail exists, it's used; otherwise, the video itself is displayed with a frame preview
- The `#t=0.1` fragment tells the browser to seek to 0.1 seconds, providing a meaningful preview without playing audio
- All video elements are properly labeled with `aria-label` for accessibility

https://claude.ai/code/session_01WJED7LBHRPFZYwerpVbRgB