### PR TITLE
docs(developer): correct node API signatures and import paths

### DIFF
--- a/docs/developer/custom-nodes-guide.md
+++ b/docs/developer/custom-nodes-guide.md
@@ -212,11 +212,8 @@ The SDK uses **legacy (experimental) decorators** without runtime metadata emiss
 Every node extends `BaseNode` and declares its inputs with `@prop`. The runtime assigns properties on the instance *before* calling `process()` — your method reads inputs from `this.<field>`, **not** from a parameter.
 
 ```ts
-import {
-  BaseNode,
-  prop,
-  type ProcessingContext
-} from "@nodetool-ai/node-sdk";
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 export class AddOffsetNode extends BaseNode {
   // ── Identity ────────────────────────────────────────────────
@@ -411,7 +408,7 @@ Output keys returned by `process()` must match keys in `metadataOutputTypes` —
 The `context` passed to `process()` and `genProcess()` is your gateway to everything the runtime owns: secrets, storage, cache, HTTP, providers, messages. You only need it when a node has side effects.
 
 ```ts
-import type { ProcessingContext } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
 ```
 
 ### Identity
@@ -488,7 +485,8 @@ const n = context.get<number>("counter", 0);
 For nodes that produce results incrementally, override `genProcess` and set `isStreamingOutput`:
 
 ```ts
-import { BaseNode, prop, type ProcessingContext } from "@nodetool-ai/node-sdk";
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 export class WordStreamNode extends BaseNode {
   static readonly nodeType = "mypack.text.WordStream";

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -43,11 +43,14 @@ Export a `register(registry)` function from your package and NodeTool discovers 
 - **[Custom Nodes Guide](custom-nodes-guide.md)** -- **Start here!** End-to-end guide for authoring, packaging, and distributing TypeScript node packs.
 - [TypeScript DSL Guide](ts-dsl-guide.md) -- Type-safe workflow definitions with auto-generated factory functions.
 
-### Custom Node Development (Python)
+### Custom Node Reference (TypeScript)
 
 - [Node Implementation Quick Reference](node-reference.md) -- Templates and common `@prop` / `process()` patterns.
 - [Node Implementation Patterns](node-patterns.md) -- Architectural patterns: multi-output, streaming, stateful, secrets.
-- [Node Implementation Examples](node-examples.md) -- Real-world examples from the codebase.
+
+### Python Nodes
+
+- [Node Implementation Examples](node-examples.md) -- Python node examples for the Python bridge.
 
 ### Advanced
 

--- a/docs/developer/node-patterns.md
+++ b/docs/developer/node-patterns.md
@@ -6,7 +6,7 @@ description: "Architectural patterns for building TypeScript nodes: single-outpu
 
 ## Overview
 
-This guide covers the key implementation patterns you will encounter when building custom nodes for NodeTool. Every node extends **`BaseNode`** from `@nodetool-ai/node-sdk`, declares its inputs with the **`@prop`** decorator, and implements a `process()` or `genProcess()` method that receives an `inputs` record and returns an outputs record.
+This guide covers the key implementation patterns you will encounter when building custom nodes for NodeTool. Every node extends **`BaseNode`** from `@nodetool-ai/node-sdk`, declares its inputs with the **`@prop`** decorator, and implements a `process()` or `genProcess()` method that reads input values from `this.<field>` and returns an outputs record. The optional argument is a `ProcessingContext` from `@nodetool-ai/runtime`.
 
 ---
 
@@ -32,10 +32,7 @@ export class ConstantStringNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Value" })
   declare value: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    if ("value" in inputs) {
-      return { output: inputs.value };
-    }
+  async process(): Promise<Record<string, unknown>> {
     return { output: this.value ?? "" };
   }
 }
@@ -44,7 +41,7 @@ export class ConstantStringNode extends BaseNode {
 Key points:
 
 - **`metadataOutputTypes`** maps each output key to its type string (`"str"`, `"int"`, `"float"`, `"bool"`, `"image"`, `"audio"`, etc.).
-- Input resolution follows the pattern `inputs.field ?? this.field ?? default`.
+- The engine assigns connected input values onto the instance before calling `process()`, so read them as `this.field`.
 - The return value is always `Record<string, unknown>` -- a plain object whose keys match the output names.
 
 ---
@@ -77,14 +74,11 @@ export class IfNode extends BaseNode {
   @prop({ type: "any", default: [], title: "Value" })
   declare value: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const condition = Boolean(inputs.condition ?? this.condition ?? false);
-    const value = inputs.value ?? this.value ?? null;
-
-    if (condition) {
-      return { if_true: value, if_false: null };
+  async process(): Promise<Record<string, unknown>> {
+    if (this.condition) {
+      return { if_true: this.value, if_false: null };
     }
-    return { if_true: null, if_false: value };
+    return { if_true: null, if_false: this.value };
   }
 }
 ```
@@ -120,16 +114,13 @@ export class ForEachNode extends BaseNode {
   @prop({ type: "list[any]", default: [], title: "Input List" })
   declare input_list: any;
 
-  async process(_inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async process(): Promise<Record<string, unknown>> {
     return {};
   }
 
-  async *genProcess(
-    inputs: Record<string, unknown>
-  ): AsyncGenerator<Record<string, unknown>> {
-    const values = (inputs.input_list ?? this.input_list ?? []) as unknown[];
+  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+    const values = (this.input_list ?? []) as unknown[];
     const list = Array.isArray(values) ? values : [values];
-
     for (const [index, item] of list.entries()) {
       yield { output: item, index };
     }
@@ -139,7 +130,7 @@ export class ForEachNode extends BaseNode {
 
 Key points:
 
-- You must still provide a `process()` stub (it can return `{}`).
+- You must still provide a `process()` stub (it can return `{}`) — the base class requires it.
 - Each `yield` sends one batch of outputs to downstream nodes.
 - Set `isStreamingOutput = true` so the engine knows to iterate the generator.
 
@@ -147,23 +138,21 @@ Key points:
 
 ## Stateful Collector
 
-Some nodes accumulate values across multiple invocations within a single workflow run. Use **`syncMode = "on_any"`** to fire on every incoming value, and **`initialize()`** to reset state at the start of each run.
+Some nodes accumulate values across multiple invocations within a single workflow run. Use **`syncMode = "on_any"`** (when the node should fire on each incoming value) and **`initialize()`** to reset state at the start of each run.
 
-This pattern is taken from `CollectTextNode` in `base-nodes/src/nodes/text.ts`:
+This pattern is taken from `CollectTextNode` in `base-nodes/src/nodes/text-extra.ts`:
 
 ```ts
 export class CollectTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Collect";
-  static readonly title = "Collect";
+  static readonly title = "Collect Text";
   static readonly description =
-    "Collects a stream of text inputs into a single concatenated string.\n" +
-    "    text, collect, list, stream, aggregate";
+    "Collects streaming text inputs into a single concatenated string.\n" +
+    "    text, collect, stream, aggregate";
 
   static readonly metadataOutputTypes = {
     output: "str",
   };
-
-  static readonly syncMode = "on_any" as const;
 
   private _items: string[] = [];
 
@@ -177,19 +166,17 @@ export class CollectTextNode extends BaseNode {
     this._items = [];
   }
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const separator = String(inputs.separator ?? this.separator ?? "");
-    if ("input_item" in inputs) {
-      this._items.push(String(inputs.input_item ?? ""));
-    }
-    return { output: this._items.join(separator) };
+  async process(): Promise<Record<string, unknown>> {
+    this._items.push(String(this.input_item ?? ""));
+    const sep = String(this.separator ?? "");
+    return { output: this._items.join(sep) };
   }
 }
 ```
 
 Key points:
 
-- **`syncMode`** controls when the node fires. `"zip_all"` (the default) waits for all inputs; `"on_any"` fires as soon as any single input arrives.
+- **`syncMode`** controls when the node fires. `"zip_all"` (the default) waits for matched values on all inputs; `"on_any"` fires as soon as any single input arrives.
 - Private instance fields (like `_items`) hold state between invocations.
 - **`initialize()`** runs once at the start of each workflow execution -- use it to clear accumulated state.
 
@@ -199,7 +186,7 @@ Key points:
 
 Images, audio, and video are passed between nodes as **ref objects** -- plain objects with `uri`, `data`, and metadata fields. Nodes load bytes from the ref and return new refs after processing.
 
-This pattern is taken from `ResizeNode` in `base-nodes/src/nodes/image.ts`:
+`@nodetool-ai/runtime` provides a shared `loadMediaRefBytes(ref, context?)` helper. The pattern below shows the manual equivalent for reference:
 
 ```ts
 import sharp from "sharp";
@@ -231,11 +218,10 @@ export class ResizeNode extends BaseNode {
   @prop({ type: "int", default: 512, title: "Height", min: 0, max: 4096 })
   declare height: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const image = inputs.image ?? this.image ?? {};
-    const bytes = await imageBytesAsync(image);
-    const width = Number(inputs.width ?? this.width ?? 512);
-    const height = Number(inputs.height ?? this.height ?? 512);
+  async process(): Promise<Record<string, unknown>> {
+    const bytes = await imageBytesAsync(this.image ?? {});
+    const width = Number(this.width ?? 512);
+    const height = Number(this.height ?? 512);
 
     const outputBytes = await sharp(bytes).resize(width, height).toBuffer();
     return {
@@ -278,19 +264,19 @@ This pattern is taken from `FilterNumberNode` in `base-nodes/src/nodes/numbers.t
 declare filter_type: any;
 ```
 
-In your `process()` method, cast the value from `inputs`:
+In your `process()` method, read and cast the value from `this`:
 
 ```ts
-const filterType = String(inputs.filter_type ?? this.filter_type ?? "greater_than");
+const filterType = String(this.filter_type ?? "greater_than");
 ```
 
 ---
 
 ## Secret Access
 
-Nodes that call external APIs declare the keys they need in **`requiredSettings`**. The engine injects matching secrets into `inputs._secrets` before calling `process()`.
+Nodes that call external APIs declare the keys they need in **`requiredSettings`**. Before calling `process()`, the base class resolves each key from the runtime's secret store via `ProcessingContext.getSecret()` and exposes them as **`this._secrets`**.
 
-This pattern is taken from the OpenAI nodes in `base-nodes/src/nodes/openai.ts`:
+This pattern is adapted from the OpenAI nodes in `base-nodes/src/nodes/openai.ts`:
 
 ```ts
 export class EmbeddingNode extends BaseNode {
@@ -300,11 +286,14 @@ export class EmbeddingNode extends BaseNode {
 
   static readonly requiredSettings = ["OPENAI_API_KEY"];
 
-  // ... @prop declarations ...
+  @prop({ type: "str", default: "", title: "Input" })
+  declare input: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+  static readonly metadataOutputTypes = { output: "list[float]" };
+
+  async process(): Promise<Record<string, unknown>> {
     const apiKey =
-      (inputs._secrets as Record<string, string>)?.OPENAI_API_KEY ||
+      this._secrets.OPENAI_API_KEY ||
       process.env.OPENAI_API_KEY ||
       "";
     if (!apiKey) throw new Error("OPENAI_API_KEY is not configured");
@@ -315,7 +304,7 @@ export class EmbeddingNode extends BaseNode {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ input: inputs.input ?? this.input, model: "text-embedding-3-small" }),
+      body: JSON.stringify({ input: this.input, model: "text-embedding-3-small" }),
     });
     const data = await response.json();
     return { output: data.data[0].embedding };
@@ -326,7 +315,7 @@ export class EmbeddingNode extends BaseNode {
 Key points:
 
 - **`requiredSettings`** is a static string array of secret key names.
-- The base class `_injectSecrets()` method resolves secrets from the runtime's secret store and merges them into `inputs._secrets`.
+- The base class resolves each key from the active `ProcessingContext` and assigns them to `this._secrets` before `process()` runs.
 - Always fall back to `process.env` for local development.
 
 ---
@@ -335,13 +324,13 @@ Key points:
 
 ### Input Resolution
 
-Always resolve inputs with the three-level fallback:
+Property values for `@prop` fields are populated on the instance before `process()` is called. Resolve with:
 
 ```ts
-const value = inputs.field ?? this.field ?? defaultValue;
+const value = this.field ?? defaultValue;
 ```
 
-This ensures the node works whether the value comes from a connected edge (`inputs`), a manually set property (`this`), or the declared default.
+The engine handles connected edges, manually set values, and declared defaults — by the time `process()` runs, `this.field` already holds the effective value.
 
 ### Async / Await
 

--- a/docs/developer/node-reference.md
+++ b/docs/developer/node-reference.md
@@ -28,9 +28,8 @@ export class SimpleNode extends BaseNode {
   @prop({ type: "int", default: 100, title: "Threshold", min: 0, max: 255 })
   declare threshold: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const value = String(inputs.input_value ?? this.input_value ?? "");
-    return { output: `Result: ${value}` };
+  async process(): Promise<Record<string, unknown>> {
+    return { output: `Result: ${String(this.input_value ?? "")}` };
   }
 }
 
@@ -54,13 +53,11 @@ export class MultiOutputNode extends BaseNode {
   @prop({ type: "any", default: [], title: "Value" })
   declare value: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const condition = Boolean(inputs.condition ?? this.condition ?? false);
-    const value = inputs.value ?? this.value ?? null;
-    if (condition) {
-      return { if_true: value, if_false: null };
+  async process(): Promise<Record<string, unknown>> {
+    if (this.condition) {
+      return { if_true: this.value, if_false: null };
     }
-    return { if_true: null, if_false: value };
+    return { if_true: null, if_false: this.value };
   }
 }
 
@@ -81,14 +78,12 @@ export class StreamingNode extends BaseNode {
   @prop({ type: "list[any]", default: [], title: "Input List" })
   declare input_list: any;
 
-  async process(_inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async process(): Promise<Record<string, unknown>> {
     return {};
   }
 
-  async *genProcess(
-    inputs: Record<string, unknown>
-  ): AsyncGenerator<Record<string, unknown>> {
-    const values = (inputs.input_list ?? this.input_list ?? []) as unknown[];
+  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+    const values = (this.input_list ?? []) as unknown[];
     const list = Array.isArray(values) ? values : [values];
     for (const [index, item] of list.entries()) {
       yield { output: item, index };
@@ -118,10 +113,8 @@ export class CollectorNode extends BaseNode {
     this._items = [];
   }
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    if ("input_item" in inputs) {
-      this._items.push(inputs.input_item);
-    }
+  async process(): Promise<Record<string, unknown>> {
+    this._items.push(this.input_item);
     return { output: [...this._items] };
   }
 }
@@ -204,21 +197,16 @@ declare config: any;
 
 ## ProcessingContext Essentials
 
-The optional second argument to `process()` is a **`ProcessingContext`** from `@nodetool-ai/runtime`. It provides access to secrets, provider predictions, and runtime services.
+The optional argument to `process()` and `genProcess()` is a **`ProcessingContext`** from `@nodetool-ai/runtime`. It provides access to provider predictions, secrets, and runtime services. Property values for declared `@prop` fields are assigned to `this` before `process()` is called — read them directly from `this.<field>`.
 
 ```ts
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
-async process(
-  inputs: Record<string, unknown>,
-  context?: ProcessingContext
-): Promise<Record<string, unknown>> {
+async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
 
-  // Access injected secrets (requires static requiredSettings)
-  const apiKey =
-    (inputs._secrets as Record<string, string>)?.MY_API_KEY ||
-    process.env.MY_API_KEY ||
-    "";
+  // Access injected secrets (requires static requiredSettings).
+  // The base class resolves keys from context and exposes them on this._secrets.
+  const apiKey = this._secrets.MY_API_KEY ?? process.env.MY_API_KEY ?? "";
 
   // Run a provider prediction (image generation, TTS, etc.)
   if (context && typeof context.runProviderPrediction === "function") {
@@ -242,12 +230,12 @@ async process(
     }
   }
 
-  // Resolve a secret manually
+  // Resolve a secret manually (bypasses requiredSettings)
   if (context && typeof context.getSecret === "function") {
     const secret = await context.getSecret("SOME_KEY");
   }
 
-  return { output: result };
+  return { output: "result" };
 }
 ```
 
@@ -283,6 +271,8 @@ function audioRefFromBytes(data: Uint8Array, uri?: string): Record<string, unkno
 }
 ```
 
+`@nodetool-ai/runtime` exports a shared `loadMediaRefBytes(ref, context?)` helper that handles `data`, `uri`, and storage-backed refs in one call.
+
 ## Static Class Properties
 
 ```ts
@@ -308,7 +298,7 @@ static readonly isStreamingInput = true;
 static readonly syncMode = "zip_all" as const;   // wait for all inputs (default)
 static readonly syncMode = "on_any" as const;     // fire on any single input
 
-// Declare required secrets
+// Declare required secrets — injected onto this._secrets
 static readonly requiredSettings = ["OPENAI_API_KEY"];
 
 // Set basic fields shown first in UI
@@ -334,20 +324,18 @@ async finalize(): Promise<void> {}
 
 ```ts
 // Single output
-async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+async process(): Promise<Record<string, unknown>> {
   return { output: "result" };
 }
 
 // Multiple outputs
-async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+async process(): Promise<Record<string, unknown>> {
   return { text: "hello", score: 0.95 };
 }
 
 // Streaming (generator)
-async *genProcess(
-  inputs: Record<string, unknown>
-): AsyncGenerator<Record<string, unknown>> {
-  for (const item of items) {
+async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  for (const [i, item] of items.entries()) {
     yield { output: item, index: i };
   }
 }
@@ -418,8 +406,8 @@ export class MyNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Value" })
   declare value: any;
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
-    return { output: String(inputs.value ?? this.value ?? "").toUpperCase() };
+  async process(): Promise<Record<string, unknown>> {
+    return { output: String(this.value ?? "").toUpperCase() };
   }
 }
 
@@ -430,7 +418,7 @@ import { MyNode } from "../src/nodes/my-nodes.js";
 describe("MyNode", () => {
   it("uppercases input", async () => {
     const node = new MyNode({ value: "hello" });
-    const result = await node.process({ value: "hello" });
+    const result = await node.process();
     expect(result.output).toBe("HELLO");
   });
 });
@@ -441,10 +429,10 @@ describe("MyNode", () => {
 1. All `process()` and `genProcess()` methods must be **async**
 2. Always declare **`metadataOutputTypes`** -- it drives the UI output connectors
 3. Use **`@prop`** for every input -- it provides validation, defaults, and UI hints
-4. Resolve inputs with `inputs.field ?? this.field ?? default`
+4. Read input values from `this.<field>` -- the engine assigns them before `process()` runs
 5. Return a plain object whose keys match the `metadataOutputTypes` keys
 6. Use **`genProcess()`** with `yield` for streaming outputs
 7. Use **`initialize()`** to reset state in stateful / collector nodes
-8. Declare **`requiredSettings`** for API keys; read them from `inputs._secrets`
+8. Declare **`requiredSettings`** for API keys; read them from `this._secrets`
 9. Node discovery is automatic when classes are registered in the package index
 10. Test with `vitest` -- nodes are plain classes, easy to instantiate and call

--- a/docs/developer/suspendable-nodes.md
+++ b/docs/developer/suspendable-nodes.md
@@ -33,7 +33,7 @@ This is useful for:
 The simplest way to add suspension to a workflow is using the `WaitNode`:
 
 ```typescript
-import { WaitNode } from "@nodetool-ai/base-nodes/nodes/triggers";
+import { WaitNode } from "@nodetool-ai/base-nodes";
 
 // Create a wait node that suspends the workflow
 const waitNode = new WaitNode();
@@ -67,7 +67,7 @@ When resumed, the WaitNode outputs:
 For more control, create your own suspendable node by extending `SuspendableNode`:
 
 ```typescript
-import { SuspendableState } from "@nodetool-ai/kernel/suspendable";
+import { SuspendableState } from "@nodetool-ai/kernel";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 
 class ApprovalNode extends BaseNode {
@@ -79,7 +79,7 @@ class ApprovalNode extends BaseNode {
   // Compose a SuspendableState helper for this node
   private _suspend = new SuspendableState(ApprovalNode.nodeType);
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async process(): Promise<Record<string, unknown>> {
     // Check if resuming from suspension
     if (this._suspend.isResuming()) {
       const savedState = this._suspend.getSavedState();
@@ -244,7 +244,7 @@ When user clicks Resume:
 ## Example: Webhook Callback
 
 ```typescript
-import { SuspendableState } from "@nodetool-ai/kernel/suspendable";
+import { SuspendableState } from "@nodetool-ai/kernel";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 
 class WebhookWaitNode extends BaseNode {
@@ -255,7 +255,7 @@ class WebhookWaitNode extends BaseNode {
 
   private _suspend = new SuspendableState(WebhookWaitNode.nodeType);
 
-  async process(inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async process(): Promise<Record<string, unknown>> {
     if (this._suspend.isResuming()) {
       const state = this._suspend.getSavedState();
       return {


### PR DESCRIPTION
The TypeScript node reference and patterns docs documented a
process(inputs) signature that doesn't exist. The real signature is
process(context?: ProcessingContext) — input values arrive on the
instance as this.<field> before process() is called, and secrets
listed in requiredSettings are exposed as this._secrets.

Also fix ProcessingContext imports to come from @nodetool-ai/runtime
(not @nodetool-ai/node-sdk, which doesn't re-export it), fix
WaitNode/SuspendableState import paths to use the package roots, and
reclassify node-reference and node-patterns under the TypeScript
section of the developer index (they were mislabeled as Python).