### PR TITLE
fix(agents): break step-executor ↔ run-subtask-tool TLA import cycle

### DIFF
--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -34,7 +34,7 @@ import { Tool } from "./tools/base-tool.js";
 import { ControlNodeTool } from "./tools/control-tool.js";
 import { FinishStepTool } from "./tools/finish-step-tool.js";
 import { getMemoryTools } from "./tools/memory-tools.js";
-import { TOOL_CALL_ID_FIELD } from "./tools/run-subtask-tool.js";
+import { TOOL_CALL_ID_FIELD } from "./tools/subtask-fields.js";
 import { DEFAULT_TOKEN_LIMIT, MAX_TOOL_RESULT_CHARS } from "./constants.js";
 
 const log = createLogger("nodetool.agents.step-executor");

--- a/packages/agents/src/tools/run-subtask-tool.ts
+++ b/packages/agents/src/tools/run-subtask-tool.ts
@@ -18,13 +18,10 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
 import { Tool } from "./base-tool.js";
 import { StepExecutor } from "../step-executor.js";
+import { SUBTASK_DEPTH_KEY, TOOL_CALL_ID_FIELD } from "./subtask-fields.js";
 import type { Step, Task } from "../types.js";
 
-/** Context variable carrying the current subtask depth (0 at the chat root). */
-export const SUBTASK_DEPTH_KEY = "__subtask_depth";
-
-/** Reserved input-schema field StepExecutor sets to the LLM-provided tool_call_id. */
-export const TOOL_CALL_ID_FIELD = "_tool_call_id";
+export { SUBTASK_DEPTH_KEY, TOOL_CALL_ID_FIELD } from "./subtask-fields.js";
 
 const DEFAULT_MAX_DEPTH = 3;
 const DEFAULT_MAX_ITERATIONS = 20;

--- a/packages/agents/src/tools/subtask-fields.ts
+++ b/packages/agents/src/tools/subtask-fields.ts
@@ -1,0 +1,12 @@
+/**
+ * Reserved field names shared between {@link StepExecutor} and the
+ * `run_subtask` tool. Kept in this leaf module (no imports) so the two
+ * modules don't have to import each other — importing across that boundary
+ * created a top-level-await cycle that deadlocked the bundled server.
+ */
+
+/** Context variable carrying the current subtask depth (0 at the chat root). */
+export const SUBTASK_DEPTH_KEY = "__subtask_depth";
+
+/** Reserved input-schema field StepExecutor sets to the LLM-provided tool_call_id. */
+export const TOOL_CALL_ID_FIELD = "_tool_call_id";

--- a/web/src/core/chat/toolCallFields.ts
+++ b/web/src/core/chat/toolCallFields.ts
@@ -4,7 +4,7 @@
  *
  * Single source of truth — keep mirrored with
  * `packages/agents/src/tools/base-tool.ts` (`USER_MESSAGE_FIELD`) and
- * `packages/agents/src/tools/run-subtask-tool.ts` (`TOOL_CALL_ID_FIELD`).
+ * `packages/agents/src/tools/subtask-fields.ts` (`TOOL_CALL_ID_FIELD`).
  */
 
 /** LLM-authored user-facing status. Surfaced via `tc.message`. */


### PR DESCRIPTION
## Summary

The packaged desktop backend crashes on startup with **Node exit code 13 ("unsettled top-level await")**, stranding the app on the splash screen (`watchdog: process died before becoming reachable`).

Root cause: a circular import across a top-level-await boundary in `packages/agents`:

- `step-executor.ts` imported only `TOOL_CALL_ID_FIELD` (a string constant) from `tools/run-subtask-tool.ts`
- `run-subtask-tool.ts` imports the `StepExecutor` class from `step-executor.ts` (genuinely needed at runtime)

Both files are async modules (transitive top-level await), so esbuild bundles the cycle into a hard deadlock — each module's `__esm` wrapper `await`s the other's still-pending in-flight promise, the event loop drains, and Node exits 13.

## Fix

- Move the two reserved-field constants (`TOOL_CALL_ID_FIELD`, `SUBTASK_DEPTH_KEY`) into a new zero-import leaf module `packages/agents/src/tools/subtask-fields.ts`.
- `step-executor.ts` now imports the constant from the leaf — it no longer imports `run-subtask-tool.ts` at all, so the cycle is gone.
- `run-subtask-tool.ts` imports the constants from the leaf and re-exports them, preserving the public `@nodetool-ai/agents` API (`index.ts` re-export path unchanged).
- Updated the stale doc-comment path reference in `web/src/core/chat/toolCallFields.ts`.

In the rebuilt bundle, `step-executor`'s init now does a synchronous `init_subtask_fields()` instead of `await init_run_subtask_tool()`.

## Test plan

- [x] Rebuilt the esbuild backend bundle (`electron/scripts/bundle-backend.mjs`) and ran it: **no unsettled-await warning**, reaches `Server listening on http://127.0.0.1:7799`, Python bridge connects (previously exited 13 on `init_dist36`).
- [x] `npm run test --workspace=packages/agents` — 982/982 pass.
- [x] `npm run lint --workspace=packages/agents` (tsc --noEmit) — clean.
- [x] `npm run build:packages` — all 50 tasks succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)