### PR TITLE
Auto-install updates when notification is clicked

### DIFF
--- a/electron/src/__tests__/updater.test.ts
+++ b/electron/src/__tests__/updater.test.ts
@@ -12,6 +12,7 @@
 const mockAutoUpdater = {
   setFeedURL: jest.fn(),
   checkForUpdates: jest.fn().mockResolvedValue(undefined),
+  quitAndInstall: jest.fn(),
   on: jest.fn(),
   logger: null,
   channel: "latest",
@@ -404,6 +405,63 @@ describe("Auto-updater Module", () => {
         "error",
         expect.any(Function)
       );
+    });
+  });
+
+  describe("update-downloaded notification", () => {
+    it("should install the update when the notification is clicked", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadSettingsAsync.mockResolvedValue({ autoUpdatesEnabled: true });
+
+      const clickHandlers: Record<string, () => void> = {};
+      class MockNotification {
+        opts: { title: string; body: string };
+        constructor(opts: { title: string; body: string }) {
+          this.opts = opts;
+        }
+        on(event: string, handler: () => void) {
+          if (event === "click") {
+            clickHandlers[this.opts.title] = handler;
+          }
+        }
+        show() {}
+        static isSupported() {
+          return true;
+        }
+      }
+
+      let setupAutoUpdater: (() => Promise<void>) | undefined;
+      jest.isolateModules(() => {
+        jest.doMock("electron", () => ({
+          app: { isPackaged: true, getVersion: jest.fn().mockReturnValue("1.0.0") },
+          Notification: MockNotification,
+        }));
+        jest.doMock("../settings", () => ({
+          readSettings: mockReadSettings,
+          readSettingsAsync: mockReadSettingsAsync,
+          getUpdateChannel: mockGetUpdateChannel,
+        }));
+        const updater = require("../updater");
+        setupAutoUpdater = updater.setupAutoUpdater;
+      });
+
+      if (setupAutoUpdater) {
+        await setupAutoUpdater();
+      }
+
+      const downloadedHandler = mockAutoUpdater.on.mock.calls.find(
+        (call) => call[0] === "update-downloaded"
+      )?.[1];
+      expect(downloadedHandler).toBeDefined();
+
+      await downloadedHandler({ version: "1.2.3" });
+
+      const clickHandler = clickHandlers["NodeTool Update Ready"];
+      expect(clickHandler).toBeDefined();
+
+      clickHandler();
+
+      expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalled();
     });
   });
 

--- a/electron/src/updater.ts
+++ b/electron/src/updater.ts
@@ -264,12 +264,8 @@ function setupAutoUpdaterEvents(): void {
           body: `Version ${info.version} has been downloaded. Click to restart and install.`,
         });
         notification.on("click", () => {
-          const win = getMainWindow();
-          if (win) {
-            if (win.isMinimized()) win.restore();
-            win.show();
-            win.focus();
-          }
+          logMessage("User clicked update notification — restarting to install");
+          autoUpdater.quitAndInstall();
         });
         notification.show();
       }


### PR DESCRIPTION
## Summary
Changed the update-downloaded notification behavior to automatically install updates when clicked, instead of just bringing the window to focus.

## Key Changes
- **updater.ts**: Modified the `update-downloaded` notification click handler to call `autoUpdater.quitAndInstall()` instead of restoring/focusing the main window. Added a log message to track when users trigger the installation.
- **updater.test.ts**: Added comprehensive test coverage for the new behavior, including:
  - Mock for `quitAndInstall` method on the auto-updater
  - New test suite "update-downloaded notification" that verifies the notification click handler correctly calls `quitAndInstall()`

## Implementation Details
The change simplifies the user experience by making the update notification actionable — clicking it now immediately installs the update and restarts the app, rather than requiring users to manually trigger the installation through another mechanism. The old behavior of focusing the window is no longer needed since the installation process will restart the application anyway.

https://claude.ai/code/session_01So6REWp8vgNhy81LCCZjfu