### PR TITLE
Fix MiniMapNavigator css prop syntax

### DIFF
--- a/web/src/components/node/MiniMapNavigator.tsx
+++ b/web/src/components/node/MiniMapNavigator.tsx
@@ -135,7 +135,7 @@ const MiniMapNavigator: React.FC = () => {
 
   return (
     <>
-      <div className="minimap-navigator" css={{ minimapStyle }}>
+      <div className="minimap-navigator" css={minimapStyle}>
         <div
           style={{
             position: "relative",


### PR DESCRIPTION
## Summary
Fixed incorrect Emotion `css` prop syntax in the MiniMapNavigator component by removing unnecessary object wrapper.

## Changes
- **MiniMapNavigator.tsx**: Changed `css={{ minimapStyle }}` to `css={minimapStyle}` on line 138
  - The `css` prop from Emotion accepts a style object directly, not a nested object
  - This fixes a potential styling issue where the minimapStyle object was being double-wrapped

## Details
The Emotion `css` prop expects the style object to be passed directly. The previous syntax `css={{ minimapStyle }}` would create an object with a `minimapStyle` property rather than applying the styles themselves. The corrected syntax `css={minimapStyle}` properly passes the style object to Emotion for processing.

https://claude.ai/code/session_0145gHi4zEJJnE5yBSnrJHmh