### PR TITLE
feat(nodes): metadata-driven content-card body opt-in

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -42,7 +42,6 @@
       "supabaseAnonKey": "sb_publishable_sGCndMc7Ku5J6Bct80D9WQ_Ik96Qu9a"
     },
     "plugins": [
-      "expo-web-browser",
       "@react-native-google-signin/google-signin"
     ]
   }

--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -884,6 +884,7 @@ export class RepeatAudioNode extends BaseNode {
 
 export class AudioMixerNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.AudioMixer";
+  static readonly body = "content_card";
   static readonly title = "Audio Mixer";
   static readonly description =
     "Mix multiple audio tracks together. Add tracks dynamically with the “add audio input” button; wire a Gain node upstream of any track that needs a different level.\n    audio, mix, combine, blend, layer, add, overlay";
@@ -1025,6 +1026,7 @@ export class CreateSilenceNode extends BaseNode {
 
 export class ConcatAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Concat";
+  static readonly body = "content_card";
   static readonly title = "Concatenate Audio";
   static readonly description =
     "Concatenates audio files together. Add inputs dynamically with the “add audio input” button.\n    audio, edit, join, +";
@@ -1075,6 +1077,7 @@ export class ConcatAudioListNode extends BaseNode {
 
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.TextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Text To Speech";
   static readonly description =
     "Generate speech audio from text using any supported TTS provider. Automatically routes to the appropriate backend (OpenAI, HuggingFace, MLX).\n    audio, generation, AI, text-to-speech, tts, voice";

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Claude Agent with Node Tools.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Claude Agent with Node Tools.json
@@ -50,7 +50,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Research the current state of open-source AI workflow tools in 2026. Use the available search tools to find information, then synthesize a brief research report with your findings. Search at least twice using different queries to get comprehensive coverage.",
           "model": {
@@ -59,11 +59,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a research analyst. You have access to search tools \u2014 use them to gather real data before writing your report. Be specific and cite sources.",
+          "system": "You are a research analyst. You have access to search tools \u2014 use them to gather real data before writing your report. Be specific and cite sources.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Amazon Product Detail.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Amazon Product Detail.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Amazon Product Detail tool to look up product ASIN 'B0D5CQDG3C'. Analyze the product: what is it, who is it for, strengths, concerns, and whether the price is justified. Give a buy/skip verdict.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Amazon Products.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Amazon Products.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Amazon Search tool to find 'USB-C hub laptop'. Compare prices, ratings, and features across products. Provide a best-value pick, a premium pick, and a budget pick with reasoning.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Bing Web.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Bing Web.json
@@ -39,7 +39,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Bing Search tool to research 'emerging AI frameworks 2026'. Compare results across multiple queries and write a concise market overview with key players and trends.",
           "model": {
@@ -48,11 +48,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a technology analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a technology analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - DuckDuckGo.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - DuckDuckGo.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the DuckDuckGo Search tool to research 'best privacy tools 2026'. Evaluate the results for source quality and reliability. Write an actionable brief with top recommendations and what's missing from the results.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Finance.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Finance.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Finance tool to look up 'AAPL'. Analyze the current price, key metrics, recent movement, sector comparison, and give a quick outlook (bullish/bearish/neutral) with reasoning.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Flights.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Flights.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Find the best round-trip flights from New York (JFK) to London (LHR) departing 2026-05-01 and returning 2026-05-08. Compare economy options by price, duration, and number of stops. Recommend the best overall value.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a travel planning assistant. Use Google Flights to search for flights and provide clear comparisons. Consider price, duration, stops, and airline reputation. Format results as a structured recommendation.",
+          "system": "You are a travel planning assistant. Use Google Flights to search for flights and provide clear comparisons. Consider price, duration, stops, and airline reputation. Format results as a structured recommendation.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Hotels.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Hotels.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Find hotels in Paris for a stay from 2026-06-15 to 2026-06-20 for 2 adults. I'd like 4-star or above, under $250/night. Compare the top options by location, amenities, and value. Write a recommendation.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a travel planning assistant specializing in accommodations. Use Google Hotels to search and compare options. Consider rating, price, location, and reviews. Provide structured recommendations with pros and cons.",
+          "system": "You are a travel planning assistant specializing in accommodations. Use Google Hotels to search and compare options. Consider rating, price, location, and reviews. Provide structured recommendations with pros and cons.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Images.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Images.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Images tool to search for 'futuristic city concept art'. Analyze image sources, visual themes, quality, and any licensing considerations. Curate a top-5 selection with reasoning.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Jobs.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Jobs.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Jobs tool to research the job market for 'machine learning engineer remote'. Analyze the results: salary ranges, required skills, top employers, and career advice for someone targeting these roles.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Lens.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Lens.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Lens tool with image URL 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Camponotus_flavomarginatus_ant.jpg/320px-Camponotus_flavomarginatus_ant.jpg'. Identify what the image shows, analyze visual matches, and summarize key findings.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Maps.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Maps.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Maps tool to find the 'best coffee shops San Francisco'. Analyze ratings, location clusters, price ranges, and provide a curated top-5 recommendation with reasoning.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google News.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google News.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google News tool to research 'artificial intelligence regulation 2026'. Search for recent developments, then write a news brief covering: breaking stories, key players, sentiment analysis, and where the narrative is heading.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Scholar.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Scholar.json
@@ -41,7 +41,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Scholar Search tool to research 'transformer architecture improvements 2025'. Identify the most cited papers, emerging research themes, methodology trends, and gaps in the literature. Write a summary suitable for a related-work section.",
           "model": {
@@ -50,11 +50,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Shopping.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Shopping.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Shopping tool to search for 'mechanical keyboard wireless'. Analyze price ranges, top brands, feature differences, and provide a buying guide with top picks per budget category.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Trends.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Trends.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Trends tool to analyze trends for 'artificial intelligence'. Examine trend direction, seasonal patterns, related topics, geographic insights, and forecast what to expect next.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Web.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Google Web.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Google Search tool to research 'best open source AI tools 2026'. Run multiple searches if needed to get comprehensive results. Analyze what you find and write a structured research brief with top resources, key themes, and actionable takeaways.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Walmart Products.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Walmart Products.json
@@ -49,7 +49,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "I'm looking for a good 4K TV under $500. Search Walmart for options, compare the top 3 by features and price, then get detailed info on the best value pick. Write a buying recommendation.",
           "model": {
@@ -58,11 +58,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a savvy shopping assistant. Use Walmart search to find products, then use Walmart product detail to get more info on promising items. Provide clear, actionable recommendations with price comparisons.",
+          "system": "You are a savvy shopping assistant. Use Walmart search to find products, then use Walmart product detail to get more info on promising items. Provide clear, actionable recommendations with price comparisons.",
           "max_turns": 15,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - Yelp.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - Yelp.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the Yelp Search tool to find 'best ramen restaurants New York'. Analyze ratings, review volume, price ranges, and neighborhoods. Provide a curated list for different occasions (quick lunch, date night, best overall).",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Search - YouTube.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Search - YouTube.json
@@ -40,7 +40,7 @@
     "nodes": [
       {
         "id": "claude-agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "Use the YouTube Search tool to find videos about 'multi-agent frameworks 2026'. Analyze which videos are most valuable, identify top creators, and create a prioritized watch list with reasoning.",
           "model": {
@@ -49,11 +49,9 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6"
           },
-          "system_prompt": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
+          "system": "You are a sharp research analyst. Use the available search tools to gather data, then provide structured, insightful analysis with specific references. Be concise but thorough.",
           "max_turns": 10,
-          "allowed_tools": [],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": []
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Travel Planner & Inspiration.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Travel Planner & Inspiration.json
@@ -5,121 +5,429 @@
   "updated_at": "2026-03-08T17:00:00.000000",
   "name": "Travel Planner & Inspiration",
   "tool_name": null,
-  "description": "An AI travel concierge that researches flights, hotels, events, and attractions, generates stunning AI destination images, and builds a complete interactive travel website — all orchestrated by a single Claude Agent.",
-  "tags": ["travel", "planner", "flights", "hotels", "events", "agent", "search", "website", "image"],
+  "description": "An AI travel concierge that researches flights, hotels, events, and attractions, generates stunning AI destination images, and builds a complete interactive travel website \u2014 all orchestrated by a single Claude Agent.",
+  "tags": [
+    "travel",
+    "planner",
+    "flights",
+    "hotels",
+    "events",
+    "agent",
+    "search",
+    "website",
+    "image"
+  ],
   "thumbnail": "",
   "thumbnail_url": null,
   "graph": {
     "edges": [
-      {"id": "e-ctrl-flights", "source": "agent", "sourceHandle": "__control__", "target": "flights", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-hotels", "source": "agent", "sourceHandle": "__control__", "target": "hotels", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-events", "source": "agent", "sourceHandle": "__control__", "target": "events", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-web", "source": "agent", "sourceHandle": "__control__", "target": "web-search", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-photos", "source": "agent", "sourceHandle": "__control__", "target": "photo-search", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-hero", "source": "agent", "sourceHandle": "__control__", "target": "gen-hero", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-scene1", "source": "agent", "sourceHandle": "__control__", "target": "gen-scene1", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-scene2", "source": "agent", "sourceHandle": "__control__", "target": "gen-scene2", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-scene3", "source": "agent", "sourceHandle": "__control__", "target": "gen-scene3", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-ctrl-scene4", "source": "agent", "sourceHandle": "__control__", "target": "gen-scene4", "targetHandle": "__control__", "edge_type": "control", "ui_properties": {}},
-      {"id": "e-save-html", "source": "agent", "sourceHandle": "text", "target": "save-html", "targetHandle": "text", "ui_properties": {"className": "str"}}
+      {
+        "id": "e-ctrl-flights",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "flights",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-hotels",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "hotels",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-events",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "events",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-web",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "web-search",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-photos",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "photo-search",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-hero",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "gen-hero",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-scene1",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "gen-scene1",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-scene2",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "gen-scene2",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-scene3",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "gen-scene3",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-ctrl-scene4",
+        "source": "agent",
+        "sourceHandle": "__control__",
+        "target": "gen-scene4",
+        "targetHandle": "__control__",
+        "edge_type": "control",
+        "ui_properties": {}
+      },
+      {
+        "id": "e-save-html",
+        "source": "agent",
+        "sourceHandle": "text",
+        "target": "save-html",
+        "targetHandle": "text",
+        "ui_properties": {
+          "className": "str"
+        }
+      }
     ],
     "nodes": [
       {
         "id": "agent",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
-          "prompt": "Plan an unforgettable 5-day trip to Berlin, Germany.\n\nDeparting from San Francisco (SFO) around 2026-05-01, returning 2026-05-06.\n2 adults, economy class, budget ~$150/night for hotels.\n\nPHASE 1 — RESEARCH:\n1. Search flights (nonstop + 1-stop options)\n2. Find hotels in Mitte, Kreuzberg, or Prenzlauer Berg\n3. Discover local events during those dates\n4. Research attractions, hidden gems, food\n5. Search for destination photos\n\nPHASE 2 — GENERATE IMAGES:\nGenerate 5 stunning AI images for the travel page. Call each image tool and note the handle if you get one. Then poll with get_result until all images are ready.\n- gen_hero: cinematic skyline at golden hour (wide 16:9)\n- gen_scene1: most iconic landmark/cultural site\n- gen_scene2: local food & market culture\n- gen_scene3: nightlife/evening atmosphere\n- gen_scene4: architecture, parks, or hidden gem\n\nWrite vivid, detailed prompts (50+ words each).\n\nIMPORTANT: Image tools may return a handle with status 'pending'. Call get_result(handle='xxx') every few seconds until you get the actual image data with a 'uri' field. Collect all 5 image URIs before building the HTML.\n\nPHASE 3 — BUILD WEBSITE:\nUsing ALL research data and the 5 generated image URIs, write a COMPLETE standalone HTML page.\n\nThe HTML must be a polished, dark-themed, agency-quality travel guide with:\n- Full-bleed hero image (from gen_hero URI)\n- Photo grid with 4 scene images (from gen_scene URIs) with hover zoom\n- Flights ranked cards, hotels cards with ratings/prices\n- Day-by-day itinerary timeline, budget stats\n- Hidden gems, events, practical tips\n- Scroll animations (IntersectionObserver), mobile responsive\n- Google Fonts: Space Grotesk + Playfair Display\n- Dark theme (#0c0c14) with amber/teal/coral/blue/purple accents\n- Footer crediting Nodetool\n\nOutput ONLY the raw HTML starting with <!DOCTYPE html>.",
-          "model": {"type": "language_model", "provider": "anthropic", "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"},
-          "system_prompt": "You are an elite travel concierge and web designer with access to search tools and AI image generation.\n\n## CRITICAL: Async tool polling protocol\n\nImage generation tools take 30-60 seconds. They return a JSON with status and handle:\n{\"status\": \"pending\", \"handle\": \"abc123\"}\n\nYou MUST follow this EXACT procedure:\n1. Call all 5 image generation tools to start them. Collect all handles.\n2. Poll ONE handle at a time using get_result(handle=\"xxx\").\n   Each call waits ~4 seconds internally before checking.\n3. If still pending, call get_result for the SAME handle again immediately.\n   Keep calling get_result repeatedly for each handle — it waits each time.\n4. After ~8-10 calls per handle (30-40 seconds of waiting), you should get the result.\n5. Once a handle returns data with a \"uri\" field, save that URI and move to the next handle.\n6. NEVER re-call the original image tool. NEVER give up. The image IS generating.\n7. Poll ALL 5 handles until all return results.\n\nThe image URIs look like: https://...supabase.co/storage/.../XXXX.png\nUse these URIs directly in your HTML <img> tags.\n\nFor image prompts, write rich cinematic descriptions (50+ words).\n\nYour final text output must be ONLY the raw HTML — no markdown, no explanation. Start with <!DOCTYPE html> and end with </html>.",
+          "prompt": "Plan an unforgettable 5-day trip to Berlin, Germany.\n\nDeparting from San Francisco (SFO) around 2026-05-01, returning 2026-05-06.\n2 adults, economy class, budget ~$150/night for hotels.\n\nPHASE 1 \u2014 RESEARCH:\n1. Search flights (nonstop + 1-stop options)\n2. Find hotels in Mitte, Kreuzberg, or Prenzlauer Berg\n3. Discover local events during those dates\n4. Research attractions, hidden gems, food\n5. Search for destination photos\n\nPHASE 2 \u2014 GENERATE IMAGES:\nGenerate 5 stunning AI images for the travel page. Call each image tool and note the handle if you get one. Then poll with get_result until all images are ready.\n- gen_hero: cinematic skyline at golden hour (wide 16:9)\n- gen_scene1: most iconic landmark/cultural site\n- gen_scene2: local food & market culture\n- gen_scene3: nightlife/evening atmosphere\n- gen_scene4: architecture, parks, or hidden gem\n\nWrite vivid, detailed prompts (50+ words each).\n\nIMPORTANT: Image tools may return a handle with status 'pending'. Call get_result(handle='xxx') every few seconds until you get the actual image data with a 'uri' field. Collect all 5 image URIs before building the HTML.\n\nPHASE 3 \u2014 BUILD WEBSITE:\nUsing ALL research data and the 5 generated image URIs, write a COMPLETE standalone HTML page.\n\nThe HTML must be a polished, dark-themed, agency-quality travel guide with:\n- Full-bleed hero image (from gen_hero URI)\n- Photo grid with 4 scene images (from gen_scene URIs) with hover zoom\n- Flights ranked cards, hotels cards with ratings/prices\n- Day-by-day itinerary timeline, budget stats\n- Hidden gems, events, practical tips\n- Scroll animations (IntersectionObserver), mobile responsive\n- Google Fonts: Space Grotesk + Playfair Display\n- Dark theme (#0c0c14) with amber/teal/coral/blue/purple accents\n- Footer crediting Nodetool\n\nOutput ONLY the raw HTML starting with <!DOCTYPE html>.",
+          "model": {
+            "type": "language_model",
+            "provider": "anthropic",
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6"
+          },
+          "system": "You are an elite travel concierge and web designer with access to search tools and AI image generation.\n\n## CRITICAL: Async tool polling protocol\n\nImage generation tools take 30-60 seconds. They return a JSON with status and handle:\n{\"status\": \"pending\", \"handle\": \"abc123\"}\n\nYou MUST follow this EXACT procedure:\n1. Call all 5 image generation tools to start them. Collect all handles.\n2. Poll ONE handle at a time using get_result(handle=\"xxx\").\n   Each call waits ~4 seconds internally before checking.\n3. If still pending, call get_result for the SAME handle again immediately.\n   Keep calling get_result repeatedly for each handle \u2014 it waits each time.\n4. After ~8-10 calls per handle (30-40 seconds of waiting), you should get the result.\n5. Once a handle returns data with a \"uri\" field, save that URI and move to the next handle.\n6. NEVER re-call the original image tool. NEVER give up. The image IS generating.\n7. Poll ALL 5 handles until all return results.\n\nThe image URIs look like: https://...supabase.co/storage/.../XXXX.png\nUse these URIs directly in your HTML <img> tags.\n\nFor image prompts, write rich cinematic descriptions (50+ words).\n\nYour final text output must be ONLY the raw HTML \u2014 no markdown, no explanation. Start with <!DOCTYPE html> and end with </html>.",
           "max_turns": 40,
-          "allowed_tools": ["Bash"],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": [
+            "Bash"
+          ]
         },
-        "ui_properties": {"position": {"x": 100, "y": 300}, "zIndex": 0, "width": 450, "selectable": true},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "ui_properties": {
+          "position": {
+            "x": 100,
+            "y": 300
+          },
+          "zIndex": 0,
+          "width": 450,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "flights",
         "type": "search.google_extra.GoogleFlights",
-        "data": {"departure_id": "", "arrival_id": "", "outbound_date": "", "return_date": "", "trip_type": 1, "adults": 2, "travel_class": 1, "currency": "USD", "stops": 0, "sort_by": 1},
-        "ui_properties": {"position": {"x": 650, "y": 50}, "zIndex": 0, "width": 260, "selectable": true, "title": "Google Flights"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "departure_id": "",
+          "arrival_id": "",
+          "outbound_date": "",
+          "return_date": "",
+          "trip_type": 1,
+          "adults": 2,
+          "travel_class": 1,
+          "currency": "USD",
+          "stops": 0,
+          "sort_by": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 650,
+            "y": 50
+          },
+          "zIndex": 0,
+          "width": 260,
+          "selectable": true,
+          "title": "Google Flights"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "hotels",
         "type": "search.google_extra.GoogleHotels",
-        "data": {"query": "", "check_in_date": "", "check_out_date": "", "adults": 2, "children": 0, "currency": "USD", "sort_by": 0, "min_price": 0, "max_price": 0, "hotel_class": 0},
-        "ui_properties": {"position": {"x": 650, "y": 180}, "zIndex": 0, "width": 260, "selectable": true, "title": "Google Hotels"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "query": "",
+          "check_in_date": "",
+          "check_out_date": "",
+          "adults": 2,
+          "children": 0,
+          "currency": "USD",
+          "sort_by": 0,
+          "min_price": 0,
+          "max_price": 0,
+          "hotel_class": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 650,
+            "y": 180
+          },
+          "zIndex": 0,
+          "width": 260,
+          "selectable": true,
+          "title": "Google Hotels"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "events",
         "type": "search.google_extra.GoogleEvents",
-        "data": {"query": "", "location": "", "num_results": 10},
-        "ui_properties": {"position": {"x": 650, "y": 310}, "zIndex": 0, "width": 260, "selectable": true, "title": "Local Events"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "query": "",
+          "location": "",
+          "num_results": 10
+        },
+        "ui_properties": {
+          "position": {
+            "x": 650,
+            "y": 310
+          },
+          "zIndex": 0,
+          "width": 260,
+          "selectable": true,
+          "title": "Local Events"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "web-search",
         "type": "search.google.GoogleSearch",
-        "data": {"keyword": "", "num_results": 10},
-        "ui_properties": {"position": {"x": 650, "y": 440}, "zIndex": 0, "width": 260, "selectable": true, "title": "Web Search"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "keyword": "",
+          "num_results": 10
+        },
+        "ui_properties": {
+          "position": {
+            "x": 650,
+            "y": 440
+          },
+          "zIndex": 0,
+          "width": 260,
+          "selectable": true,
+          "title": "Web Search"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "photo-search",
         "type": "search.google.GoogleImages",
-        "data": {"keyword": "", "num_results": 10},
-        "ui_properties": {"position": {"x": 650, "y": 570}, "zIndex": 0, "width": 260, "selectable": true, "title": "Destination Photos"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "keyword": "",
+          "num_results": 10
+        },
+        "ui_properties": {
+          "position": {
+            "x": 650,
+            "y": 570
+          },
+          "zIndex": 0,
+          "width": 260,
+          "selectable": true,
+          "title": "Destination Photos"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "gen-hero",
         "type": "fal.text_to_image.NanoBanana2",
-        "data": {"prompt": "", "resolution": "2K", "aspect_ratio": "16:9", "num_images": 1, "output_format": "png"},
-        "ui_properties": {"position": {"x": 1000, "y": 50}, "zIndex": 0, "width": 240, "selectable": true, "title": "Hero Image (16:9)"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "prompt": "",
+          "resolution": "2K",
+          "aspect_ratio": "16:9",
+          "num_images": 1,
+          "output_format": "png"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1000,
+            "y": 50
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "Hero Image (16:9)"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "gen-scene1",
         "type": "fal.text_to_image.NanoBanana2",
-        "data": {"prompt": "", "resolution": "1K", "aspect_ratio": "4:3", "num_images": 1, "output_format": "png"},
-        "ui_properties": {"position": {"x": 1000, "y": 200}, "zIndex": 0, "width": 240, "selectable": true, "title": "Scene 1 (4:3)"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "prompt": "",
+          "resolution": "1K",
+          "aspect_ratio": "4:3",
+          "num_images": 1,
+          "output_format": "png"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1000,
+            "y": 200
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "Scene 1 (4:3)"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "gen-scene2",
         "type": "fal.text_to_image.NanoBanana2",
-        "data": {"prompt": "", "resolution": "1K", "aspect_ratio": "4:3", "num_images": 1, "output_format": "png"},
-        "ui_properties": {"position": {"x": 1000, "y": 350}, "zIndex": 0, "width": 240, "selectable": true, "title": "Scene 2 (4:3)"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "prompt": "",
+          "resolution": "1K",
+          "aspect_ratio": "4:3",
+          "num_images": 1,
+          "output_format": "png"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1000,
+            "y": 350
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "Scene 2 (4:3)"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "gen-scene3",
         "type": "fal.text_to_image.NanoBanana2",
-        "data": {"prompt": "", "resolution": "1K", "aspect_ratio": "4:3", "num_images": 1, "output_format": "png"},
-        "ui_properties": {"position": {"x": 1000, "y": 500}, "zIndex": 0, "width": 240, "selectable": true, "title": "Scene 3 (4:3)"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "prompt": "",
+          "resolution": "1K",
+          "aspect_ratio": "4:3",
+          "num_images": 1,
+          "output_format": "png"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1000,
+            "y": 500
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "Scene 3 (4:3)"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "gen-scene4",
         "type": "fal.text_to_image.NanoBanana2",
-        "data": {"prompt": "", "resolution": "1K", "aspect_ratio": "4:3", "num_images": 1, "output_format": "png"},
-        "ui_properties": {"position": {"x": 1000, "y": 650}, "zIndex": 0, "width": 240, "selectable": true, "title": "Scene 4 (4:3)"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "prompt": "",
+          "resolution": "1K",
+          "aspect_ratio": "4:3",
+          "num_images": 1,
+          "output_format": "png"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1000,
+            "y": 650
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "Scene 4 (4:3)"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       },
       {
         "id": "save-html",
         "type": "nodetool.text.SaveText",
-        "data": {"text": "", "name": "travel-guide-%Y%m%d-%H%M%S.html"},
-        "ui_properties": {"position": {"x": 100, "y": 750}, "zIndex": 0, "width": 300, "selectable": true, "title": "Save Website"},
-        "dynamic_properties": {}, "dynamic_outputs": {}, "sync_mode": "on_any"
+        "data": {
+          "text": "",
+          "name": "travel-guide-%Y%m%d-%H%M%S.html"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 100,
+            "y": 750
+          },
+          "zIndex": 0,
+          "width": 300,
+          "selectable": true,
+          "title": "Save Website"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "sync_mode": "on_any"
       }
     ]
   },
-  "input_schema": {"type": "object", "properties": {}, "required": []},
-  "output_schema": {"type": "object", "properties": {}, "required": []},
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
   "settings": {},
   "package_name": "nodetool-base",
   "path": null,

--- a/packages/base-nodes/nodetool/examples/nodetool-base/YouTube Research with Claude Agent.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/YouTube Research with Claude Agent.json
@@ -56,7 +56,7 @@
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
           "headline": "YouTube Research with Claude Agent",
-          "comment": "This workflow searches YouTube for videos on a topic using SerpAPI, then feeds the results to a Claude Agent for in-depth analysis.\n\n1. YouTubeSearch fetches video results via SerpAPI\n2. FormatText builds a research prompt with the results\n3. ClaudeAgent analyzes the videos and produces a research report\n\nRequires: SERPAPI_API_KEY and ANTHROPIC_API_KEY in your settings."
+          "comment": "This workflow searches YouTube for videos on a topic using SerpAPI, then feeds the results to a Claude Agent for in-depth analysis.\n\n1. YouTubeSearch fetches video results via SerpAPI\n2. FormatText builds a research prompt with the results\n3. The Agent analyzes the videos and produces a research report\n\nRequires: SERPAPI_API_KEY and ANTHROPIC_API_KEY in your settings."
         },
         "ui_properties": {
           "position": {
@@ -95,7 +95,7 @@
         "id": "format-prompt-node",
         "type": "nodetool.text.FormatText",
         "data": {
-          "template": "You are a YouTube research analyst. I searched YouTube for \"multi-agent frameworks 2026\" and found these results:\n\n{{ search_results }}\n\nPlease analyze these videos and provide:\n\n1. **Overview**: What are the main themes and topics covered?\n2. **Top Picks**: Which 3-5 videos seem most valuable and why?\n3. **Content Gaps**: What aspects of multi-agent frameworks are NOT well covered?\n4. **Creators to Watch**: Which channels stand out for quality content?\n5. **Summary**: A concise research brief synthesizing the key insights.\n\nBe specific — reference video titles, channels, and view counts in your analysis."
+          "template": "You are a YouTube research analyst. I searched YouTube for \"multi-agent frameworks 2026\" and found these results:\n\n{{ search_results }}\n\nPlease analyze these videos and provide:\n\n1. **Overview**: What are the main themes and topics covered?\n2. **Top Picks**: Which 3-5 videos seem most valuable and why?\n3. **Content Gaps**: What aspects of multi-agent frameworks are NOT well covered?\n4. **Creators to Watch**: Which channels stand out for quality content?\n5. **Summary**: A concise research brief synthesizing the key insights.\n\nBe specific \u2014 reference video titles, channels, and view counts in your analysis."
         },
         "ui_properties": {
           "position": {
@@ -118,17 +118,19 @@
       },
       {
         "id": "claude-agent-node",
-        "type": "anthropic.agents.ClaudeAgent",
+        "type": "nodetool.agents.Agent",
         "data": {
           "prompt": "",
           "model": {
             "type": "language_model"
           },
-          "system_prompt": "You are a thorough research analyst specializing in YouTube content analysis. You provide structured, insightful analysis with specific references to the data provided. Be concise but comprehensive.",
+          "system": "You are a thorough research analyst specializing in YouTube content analysis. You provide structured, insightful analysis with specific references to the data provided. Be concise but comprehensive.",
           "max_turns": 5,
-          "allowed_tools": ["Read", "Write", "Bash"],
-          "permission_mode": "acceptEdits",
-          "use_claude_credentials": true
+          "tools": [
+            "Read",
+            "Write",
+            "Bash"
+          ]
         },
         "ui_properties": {
           "position": {

--- a/packages/base-nodes/tests/example-workflows-validation.test.ts
+++ b/packages/base-nodes/tests/example-workflows-validation.test.ts
@@ -51,7 +51,6 @@ const CLI_EXAMPLES_DIR = path.resolve(__dirname, "../../../examples/workflows");
  */
 const ALLOWED_UNREGISTERED_TYPES = new Set<string>([
   // ── 1. Sibling packages not loaded in base-nodes tests ─────────────────
-  "anthropic.agents.ClaudeAgent",
   "kie.image.NanoBanana",
   "fal.text_to_image.NanoBanana2",
   "vector.chroma.HybridSearch",

--- a/packages/data-nodes/src/nodes/data.ts
+++ b/packages/data-nodes/src/nodes/data.ts
@@ -1684,6 +1684,7 @@ export class FilterNoneNode extends BaseNode {
 
 export class DescribeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Describe";
+  static readonly body = "content_card";
   static readonly title = "Describe";
   static readonly description =
     "Compute summary statistics for each numeric column: count, mean, std, min, 25%, 50%, 75%, max.\n    dataframe, statistics, describe, summary, stats, mean, std, min, max, quartile";

--- a/packages/elevenlabs-nodes/src/nodes/realtime-stt.ts
+++ b/packages/elevenlabs-nodes/src/nodes/realtime-stt.ts
@@ -8,6 +8,7 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 export class RealtimeSpeechToTextNode extends BaseNode {
   static readonly nodeType = "elevenlabs.RealtimeSpeechToText";
+  static readonly body = "content_card";
   static readonly title = "Realtime Speech to Text";
   static readonly description =
     "Realtime speech-to-text transcription using ElevenLabs WebSocket API.\n" +

--- a/packages/elevenlabs-nodes/src/nodes/realtime-tts.ts
+++ b/packages/elevenlabs-nodes/src/nodes/realtime-tts.ts
@@ -13,6 +13,7 @@ import {
 
 export class RealtimeTextToSpeechNode extends BaseNode {
   static readonly nodeType = "elevenlabs.RealtimeTextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Realtime Text to Speech";
   static readonly description =
     "Stream text-to-speech using ElevenLabs WebSocket API.\n" +

--- a/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
+++ b/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
@@ -4,6 +4,7 @@ import { getElevenLabsApiKey } from "../elevenlabs-base.js";
 
 export class SpeechToTextNode extends BaseNode {
   static readonly nodeType = "elevenlabs.SpeechToText";
+  static readonly body = "content_card";
   static readonly title = "Speech to Text";
   static readonly description =
     "Transcribe audio or video files using ElevenLabs speech-to-text API.\n" +

--- a/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
+++ b/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
@@ -8,6 +8,7 @@ import {
 
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "elevenlabs.TextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Text to Speech";
   static readonly description =
     "Generate natural-sounding speech using ElevenLabs text-to-speech.\n" +

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -346,6 +346,13 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
       value: true,
       configurable: true
     });
+    // Media generators render as a content card (image/video/audio/3D body).
+    // This is the metadata-driven equivalent of the frontend's old
+    // "fal.* namespace + media output" heuristic.
+    Object.defineProperty(FalNodeClass, "body", {
+      value: "content_card",
+      configurable: true
+    });
   }
 
   if (isImageOutput) {

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -1280,6 +1280,7 @@ export class FitNode extends TransformImageNode {
 
 export class TextToImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.TextToImage";
+  static readonly body = "content_card";
   static readonly title = "Text To Image";
   static readonly description =
     "Generate images from text prompts using any supported image provider. Automatically routes to the appropriate backend (HuggingFace, FAL, MLX).\n    image, generation, AI, text-to-image, t2i";
@@ -1387,6 +1388,7 @@ export class TextToImageNode extends BaseNode {
 
 export class ImageToImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.ImageToImage";
+  static readonly body = "content_card";
   static readonly title = "Image To Image";
   static readonly description =
     "Transform images using text prompts with any supported image provider. Automatically routes to the appropriate backend (HuggingFace, FAL, MLX).\n    image, transformation, AI, image-to-image, i2i";
@@ -2351,6 +2353,7 @@ export class PainterNode extends BaseNode {
 
 export class UpscaleImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Upscale";
+  static readonly body = "content_card";
   static readonly title = "Upscale Image";
   static readonly description =
     "Increase the resolution and detail of an image using any supported upscaling provider.\n    image, upscale, super-resolution, enhance, AI";
@@ -2431,6 +2434,7 @@ export class UpscaleImageNode extends BaseNode {
 
 export class RemoveBackgroundNode extends BaseNode {
   static readonly nodeType = "nodetool.image.RemoveBackground";
+  static readonly body = "content_card";
   static readonly title = "Remove Background";
   static readonly description =
     "Remove the background from an image, returning a cutout with transparency.\n    image, background, remove, matte, cutout, AI";
@@ -2490,6 +2494,7 @@ export class RemoveBackgroundNode extends BaseNode {
 
 export class RelightImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Relight";
+  static readonly body = "content_card";
   static readonly title = "Relight Image";
   static readonly description =
     "Re-light a subject according to a text prompt using any supported relighting provider.\n    image, relight, lighting, AI";
@@ -2569,6 +2574,7 @@ export class RelightImageNode extends BaseNode {
 
 export class VectorizeImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Vectorize";
+  static readonly body = "content_card";
   static readonly title = "Vectorize Image";
   static readonly description =
     "Convert a raster image into a scalable vector (SVG) using any supported vectorization provider.\n    image, vector, svg, vectorize, trace, AI";

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -223,6 +223,16 @@ export class WorkflowRunner {
     }
   >();
 
+  /**
+   * Nodes whose actor has finished running. A control event sent to such a
+   * node can never be answered (the actor's run loop is gone), so
+   * sendControlEvent rejects instead of registering a promise that hangs
+   * forever. This guards against an agent dispatching a burst of control
+   * tool calls where the controlled node errors (and terminates) partway
+   * through.
+   */
+  private _completedNodes = new Set<string>();
+
   constructor(jobId: string, options: WorkflowRunnerOptions) {
     this.jobId = jobId;
     this._options = options;
@@ -791,13 +801,21 @@ export class WorkflowRunner {
           // After actor completes, send EOS to all downstream inboxes
           await this._sendEOS(node.id);
 
-          // Reject any pending sendControlEvent promise if the actor errored
-          if (result.error) {
-            const pending = this._pendingControlResponses.get(node.id);
-            if (pending) {
-              this._pendingControlResponses.delete(node.id);
-              pending.reject(new Error(result.error));
-            }
+          // The actor's run loop is gone — it can no longer answer control
+          // events. Mark it so future sendControlEvent calls reject fast
+          // rather than hang, and reject any response still waiting on it
+          // (the actor finished without producing the awaited output, e.g.
+          // it errored mid-burst).
+          this._completedNodes.add(node.id);
+          const pending = this._pendingControlResponses.get(node.id);
+          if (pending) {
+            this._pendingControlResponses.delete(node.id);
+            pending.reject(
+              new Error(
+                result.error ??
+                  `Controlled node ${node.id} completed without responding`
+              )
+            );
           }
 
           // If this is an output node, collect the result
@@ -1185,6 +1203,14 @@ export class WorkflowRunner {
     const inbox = this._inboxes.get(targetNodeId);
     if (!inbox) {
       throw new Error(`Target node not found or no inbox: ${targetNodeId}`);
+    }
+
+    // The target's actor has already finished — nothing will ever read its
+    // inbox again, so a registered response would hang forever. Reject now.
+    if (this._completedNodes.has(targetNodeId)) {
+      throw new Error(
+        `Target node already completed and cannot handle control events: ${targetNodeId}`
+      );
     }
 
     const promise = new Promise<Record<string, unknown>>((resolve, reject) => {

--- a/packages/kernel/tests/send-control-event.test.ts
+++ b/packages/kernel/tests/send-control-event.test.ts
@@ -88,6 +88,61 @@ describe("T-K-11: sendControlEvent", () => {
     expect(result.status).toBe("completed");
   }, 10000);
 
+  it("rejects (does not hang) when target actor already terminated", async () => {
+    // Regression: an agent that dispatches a *burst* of control tool calls
+    // to the same controlled node hangs forever if that node errors (and so
+    // terminates) on the first call — the 2nd/3rd sendControlEvent register
+    // a pending response that nothing can ever resolve. This reproduces a
+    // controlled node that throws on its first run.
+    const { nodes, edges } = makeControlSetup();
+
+    let resolveCtrl!: () => void;
+    const cancelledRef = { cancelled: false };
+    const ctrlStarted = new Promise<void>((r) => {
+      resolveCtrl = r;
+    });
+
+    const runner = new WorkflowRunner("job1", {
+      resolveExecutor: (node) => {
+        if (node.id === "ctrl") {
+          return {
+            async *genProcess() {
+              resolveCtrl();
+              yield {
+                __control__: { event_type: "run", properties: { x: 1 } }
+              };
+              while (!cancelledRef.cancelled) {
+                await new Promise((r) => setTimeout(r, 10));
+              }
+              yield { __control__: { event_type: "stop" } };
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        // Worker throws on its control event → its actor terminates.
+        return {
+          process: async () => {
+            throw new Error("worker boom");
+          }
+        };
+      }
+    });
+
+    const runPromise = runner.run({ job_id: "job1" }, { nodes, edges });
+    await ctrlStarted;
+    await new Promise((r) => setTimeout(r, 50));
+
+    // First dispatch: the worker errors → the pending response is rejected.
+    await expect(runner.sendControlEvent("worker", { x: 1 })).rejects.toThrow();
+
+    // Second dispatch to the now-terminated worker must reject promptly
+    // instead of hanging. The 10s test timeout fails the test if it hangs.
+    await expect(runner.sendControlEvent("worker", { x: 2 })).rejects.toThrow();
+
+    cancelledRef.cancelled = true;
+    await runPromise;
+  }, 10000);
+
   it("rejects if target node inbox not found", async () => {
     const runner = new WorkflowRunner("job1", {
       resolveExecutor: () => ({

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -442,6 +442,12 @@ export function createKieNodeClass(spec: KieManifestEntry): NodeClass {
       value: true,
       configurable: true
     });
+    // Media generators render as a content card. Metadata-driven equivalent of
+    // the frontend's old "kie.* namespace + media output" heuristic.
+    Object.defineProperty(KieNodeClass, "body", {
+      value: "content_card",
+      configurable: true
+    });
   }
   Object.defineProperty(KieNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType },

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1266,6 +1266,7 @@ const GEMMA_3_4B_IT_GGUF_BASE = {
 
 export class SummarizerNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Summarizer";
+  static readonly body = "content_card";
   static readonly title = "Summarizer";
   static readonly description =
     "Generate concise summaries of text content using LLM providers with streaming output.\n    text, summarization, nlp, content, streaming\n\n    Specialized for creating high-quality summaries with real-time streaming:\n    - Condensing long documents into key points\n    - Creating executive summaries with live output\n    - Extracting main ideas from text as they're generated\n    - Maintaining factual accuracy while reducing length";
@@ -1484,6 +1485,7 @@ export class CreateThreadNode extends BaseNode {
 
 export class ExtractorNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Extractor";
+  static readonly body = "content_card";
   static readonly title = "Extractor";
   static readonly description =
     "Extract structured data from text content using LLM providers.\n    data-extraction, structured-data, nlp, parsing\n\n    Specialized for extracting structured information:\n    - Converting unstructured text into structured data\n    - Identifying and extracting specific fields from documents\n    - Parsing text according to predefined schemas\n    - Creating structured records from natural language content";
@@ -1640,6 +1642,7 @@ export class ExtractorNode extends BaseNode {
 
 export class ClassifierNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Classifier";
+  static readonly body = "content_card";
   static readonly title = "Classifier";
   static readonly description =
     "Classify text into predefined or dynamic categories using LLM.\n    classification, nlp, categorization\n\n    Use cases:\n    - Sentiment analysis\n    - Topic classification\n    - Intent detection\n    - Content categorization";
@@ -1832,6 +1835,7 @@ export class ClassifierNode extends BaseNode {
 
 export class AgentNode extends BaseNode {
   static readonly nodeType: string = "nodetool.agents.Agent";
+  static readonly body = "content_card";
   static readonly title: string = "Agent";
   static readonly description: string =
     "Generate natural language responses using LLM providers and streams output.\n    llm, text-generation, chatbot, question-answering, streaming\n\n    Dynamic properties are substituted as {{variable}} (or {variable})\n    placeholders in both the prompt and system text. Add a property named\n    `subject` and write `Classify: {{subject}}` in the prompt — the wired\n    value replaces the placeholder at run time. Jinja-style filters are\n    supported: {{subject|upper}}, {{text|truncate(100)}}, etc. Unknown\n    placeholders are left intact.";

--- a/packages/llm-nodes/src/nodes/gemini.ts
+++ b/packages/llm-nodes/src/nodes/gemini.ts
@@ -224,6 +224,7 @@ export class EmbeddingNode extends BaseNode {
 
 export class ImageGenerationNode extends BaseNode {
   static readonly nodeType = "gemini.image.ImageGeneration";
+  static readonly body = "content_card";
   static readonly title = "Image Generation";
   static readonly inlineFields = [];
   static readonly inputFields = ["prompt", "image"];
@@ -391,6 +392,7 @@ export class ImageGenerationNode extends BaseNode {
 
 export class TextToVideoGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.video.TextToVideo";
+  static readonly body = "content_card";
   static readonly title = "Text To Video";
   static readonly inlineFields = [];
   static readonly inputFields: string[] = ["prompt"];
@@ -476,6 +478,7 @@ export class TextToVideoGeminiNode extends BaseNode {
 
 export class ImageToVideoGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.video.ImageToVideo";
+  static readonly body = "content_card";
   static readonly title = "Image To Video";
   static readonly inlineFields = [];
   static readonly inputFields = ["prompt", "image"];
@@ -635,6 +638,7 @@ function extractVideoFromResponse(data: Record<string, unknown>): string {
 
 export class TextToSpeechGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.audio.TextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Text To Speech";
   static readonly inlineFields = ["text"];
   static readonly inputFields: string[] = [];
@@ -804,6 +808,7 @@ export class TextToSpeechGeminiNode extends BaseNode {
 
 export class TranscribeGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.audio.Transcribe";
+  static readonly body = "content_card";
   static readonly title = "Transcribe";
   static readonly inlineFields: string[] = [];
   static readonly inputFields = ["audio", "prompt"];

--- a/packages/llm-nodes/src/nodes/mistral.ts
+++ b/packages/llm-nodes/src/nodes/mistral.ts
@@ -44,6 +44,7 @@ async function mistralPost(
 
 export class ChatComplete extends BaseNode {
   static readonly nodeType = "mistral.text.ChatComplete";
+  static readonly body = "content_card";
   static readonly title = "Chat Complete";
   static readonly description =
     "Generate text using Mistral AI's chat completion models.\n    mistral, chat, ai, text generation, llm, completion\n\n    Uses Mistral AI's chat models to generate responses from prompts.\n    Requires a Mistral API key.\n\n    Use cases:\n    - Generate text responses to prompts\n    - Build conversational AI applications\n    - Code generation with Codestral\n    - Multi-modal understanding with Pixtral";

--- a/packages/llm-nodes/src/nodes/openai.ts
+++ b/packages/llm-nodes/src/nodes/openai.ts
@@ -223,6 +223,7 @@ export class ModerationNode extends BaseNode {
 // ---------------------------------------------------------------------------
 export class CreateImageNode extends BaseNode {
   static readonly nodeType = "openai.image.CreateImage";
+  static readonly body = "content_card";
   static readonly title = "Create Image";
   static readonly inlineFields = [];
   static readonly inputFields: string[] = ["prompt"];
@@ -324,6 +325,7 @@ export class CreateImageNode extends BaseNode {
 // ---------------------------------------------------------------------------
 export class EditImageNode extends BaseNode {
   static readonly nodeType = "openai.image.EditImage";
+  static readonly body = "content_card";
   static readonly title = "Edit Image";
   static readonly inlineFields = [];
   static readonly inputFields = ["prompt", "image", "mask"];
@@ -483,6 +485,7 @@ async function refToBlob(ref: Record<string, unknown>): Promise<Blob> {
 // ---------------------------------------------------------------------------
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "openai.audio.TextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Text To Speech";
   static readonly description =
     "Converts text to speech using OpenAI TTS models.\n    audio, tts, text-to-speech, voice, synthesis";
@@ -563,6 +566,7 @@ export class TextToSpeechNode extends BaseNode {
 // ---------------------------------------------------------------------------
 export class TranslateNode extends BaseNode {
   static readonly nodeType = "openai.audio.Translate";
+  static readonly body = "content_card";
   static readonly title = "Translate";
   static readonly inlineFields: string[] = [];
   static readonly inputFields = ["audio"];
@@ -629,6 +633,7 @@ export class TranslateNode extends BaseNode {
 // ---------------------------------------------------------------------------
 export class TranscribeNode extends BaseNode {
   static readonly nodeType = "openai.audio.Transcribe";
+  static readonly body = "content_card";
   static readonly title = "Transcribe";
   static readonly description =
     "Converts speech to text using OpenAI's speech-to-text API.\n    audio, transcription, speech-to-text, stt, whisper";
@@ -854,6 +859,7 @@ export class TranscribeNode extends BaseNode {
 // ---------------------------------------------------------------------------
 export class RealtimeAgentNode extends BaseNode {
   static readonly nodeType = "openai.agents.RealtimeAgent";
+  static readonly body = "content_card";
   static readonly title = "Realtime Agent";
   static readonly description =
     "Realtime conversational agent using OpenAI’s WebSocket Realtime API.\n" +

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -58,6 +58,7 @@ export type NodeClass = {
   title: string;
   description: string;
   layout?: string;
+  body?: string;
 
   recommendedModels?: unknown[];
   inlineFields?: string[];
@@ -161,6 +162,13 @@ export abstract class BaseNode {
   static readonly title: string = "";
   static readonly description: string = "";
   static readonly layout: string | undefined = undefined;
+  /**
+   * Node body renderer key. Set to "content_card" to render a media/text-forward
+   * content card instead of the generic input/output body. Generator packages
+   * typically derive this from the primary output type on a shared base class
+   * (mirrors the Python `_body`/`body()` convention).
+   */
+  static readonly body: string | undefined = undefined;
 
   static readonly recommendedModels: unknown[] | undefined = undefined;
   static readonly inlineFields: string[] | undefined = undefined;

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -71,6 +71,13 @@ export interface NodeMetadata {
   namespace: string;
   node_type: string;
   layout?: string;
+  /**
+   * Node body renderer key. "content_card" makes the frontend render a
+   * media/text-forward content card instead of the generic input/output body.
+   * Node authors opt in via the class's `body` static (TS) or `_body`/`body()`
+   * (Python). Absent or "default" → generic body.
+   */
+  body?: string;
   properties: PropertyMetadata[];
   outputs: OutputSlotMetadata[];
 

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -157,7 +157,13 @@ function mergeMetadata(
         : (pyMetadata.outputs ?? []).map(cloneOutputMetadata),
     // Backfill optional fields from Python when TS doesn't set them
     layout: tsMetadata.layout ?? pyMetadata.layout,
-    body: tsMetadata.body ?? pyMetadata.body,
+    // `getNodeMetadata` emits the "default" sentinel when the TS class does not
+    // opt in, so treat it as unset — otherwise it would clobber a Python
+    // `body` (e.g. "content_card") and break the documented backfill path.
+    body:
+      tsMetadata.body && tsMetadata.body !== "default"
+        ? tsMetadata.body
+        : (pyMetadata.body ?? tsMetadata.body),
     model_packs: tsMetadata.model_packs ?? pyMetadata.model_packs,
     input_mode: tsMetadata.input_mode ?? pyMetadata.input_mode,
     output_correlation:

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -157,6 +157,7 @@ function mergeMetadata(
         : (pyMetadata.outputs ?? []).map(cloneOutputMetadata),
     // Backfill optional fields from Python when TS doesn't set them
     layout: tsMetadata.layout ?? pyMetadata.layout,
+    body: tsMetadata.body ?? pyMetadata.body,
     model_packs: tsMetadata.model_packs ?? pyMetadata.model_packs,
     input_mode: tsMetadata.input_mode ?? pyMetadata.input_mode,
     output_correlation:
@@ -252,6 +253,7 @@ export function getNodeMetadata(
     namespace,
     node_type: nodeType,
     layout: nodeClass.layout ?? "default",
+    body: nodeClass.body ?? "default",
     properties,
     outputs,
 

--- a/packages/node-sdk/tests/node-metadata.test.ts
+++ b/packages/node-sdk/tests/node-metadata.test.ts
@@ -664,6 +664,28 @@ describe("getNodeMetadata – decorator-based properties", () => {
     expect(meta.layout).toBe("default");
     expect(meta.model_packs).toEqual([{ id: "pack-1" }]);
   });
+
+  it("backfills a Python `body` opt-in when the TS class does not set one", () => {
+    // `Add` does not declare `body`, so getNodeMetadata emits the "default"
+    // sentinel. That sentinel must not clobber a Python `body: content_card`.
+    const pythonMetadata: NodeMetadata = {
+      title: "Python Title",
+      description: "Python description",
+      namespace: "nodetool.test",
+      node_type: "nodetool.test.Add",
+      layout: "default",
+      body: "content_card",
+      properties: [],
+      outputs: []
+    };
+
+    const meta = getNodeMetadata(Add, {
+      pythonMetadata,
+      mergePythonBackfill: true
+    });
+
+    expect(meta.body).toBe("content_card");
+  });
 });
 
 describe("getNodeMetadata – outputTypes support", () => {

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -600,6 +600,12 @@ export interface NodeMetadata {
   namespace: string;
   node_type: string;
   layout: string;
+  /**
+   * Node body renderer. "content_card" opts the node into the media/text-forward
+   * ContentCardBody (variant derived from the primary output type). Absent or
+   * "default" uses the generic input/output body.
+   */
+  body?: string;
   properties: Property[];
   outputs: OutputSlot[];
 

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -278,6 +278,12 @@ export function createReplicateNodeClass(
       value: true,
       configurable: true
     });
+    // Media generators render as a content card. Metadata-driven equivalent of
+    // the frontend's old "replicate.* namespace + media output" heuristic.
+    Object.defineProperty(ReplicateNodeClass, "body", {
+      value: "content_card",
+      configurable: true
+    });
   }
   Object.defineProperty(ReplicateNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType === "dict" ? "any" : spec.outputType },

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -1692,6 +1692,7 @@ function seededEmbedding(input: string, dims: number = 64): number[] {
 
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "nodetool.text.AutomaticSpeechRecognition";
+  static readonly body = "content_card";
   static readonly platforms = NODE_ONLY;
   static readonly title = "Automatic Speech Recognition";
   static readonly description =
@@ -2291,6 +2292,7 @@ export class FilterRegexStringNode extends BaseNode {
 
 export class ConcatTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Concat";
+  static readonly body = "content_card";
   static readonly title = "Concatenate Text";
   static readonly description =
     "Concatenates text inputs into a single output. Add inputs dynamically with the “add text input” button.\n    text, combine, add, concatenate, merge, join, append";

--- a/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
@@ -27,6 +27,7 @@ type TtsResult = {
 
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "transformers.TextToSpeech";
+  static readonly body = "content_card";
   static readonly title = "Text to Speech";
   static readonly description =
     "Synthesize speech from text using a Transformers.js text-to-speech pipeline.\n" +

--- a/packages/video-nodes/src/nodes/model3d/generation.ts
+++ b/packages/video-nodes/src/nodes/model3d/generation.ts
@@ -79,6 +79,7 @@ function normalizeOutputFormat(
 
 export class TextTo3DNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.TextTo3D";
+  static readonly body = "content_card";
   static readonly title = "Text To 3D";
   static readonly description =
     "Generate 3D models from text prompts using AI providers (Meshy, Rodin).\n    3d, generation, AI, text-to-3d, t3d, mesh, create\n\n    Use cases:\n    - Create 3D models from text descriptions\n    - Generate game assets from prompts\n    - Prototype 3D concepts quickly\n    - Create 3D content for AR/VR";
@@ -148,6 +149,7 @@ export class TextTo3DNode extends BaseNode {
 
 export class ImageTo3DNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.ImageTo3D";
+  static readonly body = "content_card";
   static readonly title = "Image To 3D";
   static readonly description =
     "Generate 3D models from images using AI providers (Meshy, Rodin).\n    3d, generation, AI, image-to-3d, i3d, mesh, reconstruction\n\n    Use cases:\n    - Convert product photos to 3D models\n    - Create 3D assets from concept art\n    - Generate 3D characters from drawings\n    - Reconstruct objects from images";

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -184,6 +184,7 @@ async function ffmpegTransform(
 
 export class TextToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.TextToVideo";
+  static readonly body = "content_card";
   static readonly title = "Text To Video";
   static readonly description =
     "Generate videos from text prompts using any supported video provider. Automatically routes to the appropriate backend (Gemini Veo, HuggingFace).\n    video, generation, AI, text-to-video, t2v";
@@ -291,6 +292,7 @@ export class TextToVideoNode extends BaseNode {
 
 export class ImageToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.ImageToVideo";
+  static readonly body = "content_card";
   static readonly title = "Image To Video";
   static readonly description =
     "Generate videos from input images using any supported video provider.\n    Animates static images into dynamic video content with AI-powered motion.\n    video, image-to-video, i2v, animation, AI, generation, sora, veo";
@@ -1013,6 +1015,7 @@ abstract class VideoTransformNode extends BaseNode {
 
 export class ConcatVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.Concat";
+  static readonly body = "content_card";
   static readonly title = "Concatenate Video";
   static readonly description =
     "Concatenate multiple video files into a single video, including audio when available. Add inputs dynamically with the “add video input” button.\n    video, concat, merge, combine, audio, +";
@@ -2568,6 +2571,7 @@ export class GetVideoInfoNode extends BaseNode {
 
 export class VideoToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.VideoToVideo";
+  static readonly body = "content_card";
   static readonly title = "Video To Video";
   static readonly description =
     "Restyle or edit an existing video with a text prompt using any supported video provider.\n    video, video-to-video, v2v, restyle, style-transfer, AI";
@@ -2650,6 +2654,7 @@ export class VideoToVideoNode extends BaseNode {
 
 export class LipSyncNode extends BaseNode {
   static readonly nodeType = "nodetool.video.LipSync";
+  static readonly body = "content_card";
   static readonly title = "Lip Sync";
   static readonly description =
     "Drive a face in a video to match speech in an audio track using any supported lip-sync provider.\n    video, lip-sync, lipsync, talking-head, dubbing, AI";

--- a/web/src/components/node/NodeContent.tsx
+++ b/web/src/components/node/NodeContent.tsx
@@ -56,6 +56,10 @@ const arePropsEqual = (
   if (
     prevProps.nodeMetadata.title !== nextProps.nodeMetadata.title ||
     prevProps.nodeMetadata.layout !== nextProps.nodeMetadata.layout ||
+    // `body` is the sole input to isContentCardNode — without it a node whose
+    // metadata flips to/from "content_card" (output shape unchanged) would
+    // keep its stale body mounted.
+    prevProps.nodeMetadata.body !== nextProps.nodeMetadata.body ||
     prevProps.nodeMetadata.supports_dynamic_inputs !== nextProps.nodeMetadata.supports_dynamic_inputs ||
     prevProps.nodeMetadata.supports_dynamic_outputs !==
       nextProps.nodeMetadata.supports_dynamic_outputs ||
@@ -79,8 +83,8 @@ const arePropsEqual = (
     return false;
   }
 
-  // The primary-output type drives body routing (isContentCardNode) and
-  // ContentCardBody variant. Two metadata objects with the same output count
+  // The primary-output type drives the ContentCardBody variant
+  // (image/audio/video/...). Two metadata objects with the same output count
   // but different primary-output types must re-render.
   const prevPrimary = prevProps.nodeMetadata.outputs?.[0];
   const nextPrimary = nextProps.nodeMetadata.outputs?.[0];

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -2,8 +2,9 @@
 /**
  * ContentCardBody
  *
- * Content-forward node body for nodes registered in `CONTENT_CARD_REGISTRY`
- * (image / video / text / etc. generators and "thin" image-edit nodes).
+ * Content-forward node body for nodes whose metadata declares
+ * `body: "content_card"` (image / video / text / etc. generators and "thin"
+ * image-edit nodes). See `isContentCardNode` in `contentCardRegistry`.
  * Three regions per plan §6.1:
  *
  *   1. Header           — already rendered by `NodeHeader` in `BaseNode`

--- a/web/src/components/node_types/__tests__/contentCardRegistry.test.ts
+++ b/web/src/components/node_types/__tests__/contentCardRegistry.test.ts
@@ -6,7 +6,6 @@ import {
   getContentCardVariant,
   getContentCardDefaultSize,
   getDynamicInputLabel,
-  CONTENT_CARD_REGISTRY,
   CONTENT_CARD_SIZES
 } from "../contentCardRegistry";
 
@@ -15,6 +14,7 @@ type TestMetadata = {
   node_type: string;
   outputs?: OutputSlot[];
   primary_output?: string;
+  body?: string;
 };
 
 describe("isContentCardNode", () => {
@@ -22,41 +22,38 @@ describe("isContentCardNode", () => {
     expect(isContentCardNode(undefined)).toBe(false);
   });
 
-  it("returns false for metadata with empty node_type", () => {
-    expect(isContentCardNode({ node_type: "" } as any)).toBe(false);
+  it("returns true iff metadata.body === 'content_card'", () => {
+    expect(
+      isContentCardNode({
+        node_type: "nodetool.image.TextToImage",
+        body: "content_card"
+      } as any)
+    ).toBe(true);
+    // Any namespace opts in via body alone — no name/namespace matching.
+    expect(
+      isContentCardNode({ node_type: "fal.SomeModel", body: "content_card" } as any)
+    ).toBe(true);
   });
 
-  it("returns true for explicit registry entries", () => {
+  it("returns false without body, even for previously-matched node types", () => {
+    // The old heuristics (registry / generator-name / namespace+media) are gone.
     expect(
       isContentCardNode({ node_type: "nodetool.image.TextToImage" } as any)
-    ).toBe(true);
-  });
-
-  it("returns true for generator pattern match", () => {
+    ).toBe(false);
+    expect(isContentCardNode({ node_type: "custom.TextToImage" } as any)).toBe(
+      false
+    );
     expect(
-      isContentCardNode({ node_type: "custom.TextToImage" } as any)
-    ).toBe(true);
+      isContentCardNode({
+        node_type: "fal.SomeModel",
+        outputs: [{ name: "output", type: { type: "image" } }]
+      } as any)
+    ).toBe(false);
   });
 
-  it("returns true for provider namespace with media output", () => {
-    const metadata: TestMetadata = {
-      node_type: "fal.SomeModel",
-      outputs: [{ name: "output", type: { type: "image" } }]
-    };
-    expect(isContentCardNode(metadata as any)).toBe(true);
-  });
-
-  it("returns false for provider namespace with non-media output", () => {
-    const metadata: TestMetadata = {
-      node_type: "fal.SomeModel",
-      outputs: [{ name: "output", type: { type: "int" } }]
-    };
-    expect(isContentCardNode(metadata as any)).toBe(false);
-  });
-
-  it("returns false for non-matching nodes", () => {
+  it("returns false for body values other than content_card", () => {
     expect(
-      isContentCardNode({ node_type: "nodetool.math.Add" } as any)
+      isContentCardNode({ node_type: "nodetool.math.Add", body: "default" } as any)
     ).toBe(false);
   });
 });
@@ -208,17 +205,6 @@ describe("getDynamicInputLabel", () => {
       outputs: [{ name: "o", type: { type: "tensor" } }]
     };
     expect(getDynamicInputLabel(metadata as any)).toBe("input");
-  });
-});
-
-describe("CONTENT_CARD_REGISTRY", () => {
-  it("is a non-empty set", () => {
-    expect(CONTENT_CARD_REGISTRY.size).toBeGreaterThan(0);
-  });
-
-  it("contains known entries", () => {
-    expect(CONTENT_CARD_REGISTRY.has("nodetool.image.TextToImage")).toBe(true);
-    expect(CONTENT_CARD_REGISTRY.has("openai.image.CreateImage")).toBe(true);
   });
 });
 

--- a/web/src/components/node_types/contentCardRegistry.test.ts
+++ b/web/src/components/node_types/contentCardRegistry.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTENT_CARD_REGISTRY,
   getDynamicInputLabel,
   isContentCardNode
 } from "./contentCardRegistry";
@@ -13,12 +12,14 @@ const mediaOutput = (kind: string): OutputSlot =>
 
 const meta = (
   node_type: string,
-  outputKind: string = "any"
+  outputKind: string = "any",
+  body?: string
 ): NodeMetadata =>
   ({
     node_type,
     namespace: node_type.split(".").slice(0, -1).join("."),
-    outputs: [mediaOutput(outputKind)]
+    outputs: [mediaOutput(outputKind)],
+    ...(body ? { body } : {})
   }) as unknown as NodeMetadata;
 
 describe("isContentCardNode", () => {
@@ -26,84 +27,33 @@ describe("isContentCardNode", () => {
     expect(isContentCardNode(undefined)).toBe(false);
   });
 
-  it("returns false for utility nodes", () => {
-    expect(isContentCardNode(meta("nodetool.control.If"))).toBe(false);
-    expect(isContentCardNode(meta("nodetool.control.Loop"))).toBe(false);
-    expect(isContentCardNode(meta("nodetool.constant.String", "str"))).toBe(
+  it("is driven solely by metadata.body === 'content_card'", () => {
+    expect(
+      isContentCardNode(
+        meta("nodetool.image.TextToImage", "image", "content_card")
+      )
+    ).toBe(true);
+    // Any namespace opts in via body — there is no name/namespace matching.
+    expect(
+      isContentCardNode(meta("comfy.image.SomeModel", "image", "content_card"))
+    ).toBe(true);
+    expect(
+      isContentCardNode(meta("some.pkg.Whatever", "dict", "content_card"))
+    ).toBe(true);
+  });
+
+  it("returns false when body is absent (no node_type matching)", () => {
+    // Node types the old heuristics matched no longer match without body.
+    expect(isContentCardNode(meta("nodetool.image.TextToImage", "image"))).toBe(
       false
     );
-  });
-
-  it("matches explicit registry entries", () => {
-    for (const t of CONTENT_CARD_REGISTRY) {
-      expect(isContentCardNode(meta(t))).toBe(true);
-    }
-  });
-
-  it("matches author opt-in via metadata.body, regardless of namespace/pattern", () => {
-    expect(
-      isContentCardNode({
-        ...meta("huggingface.text_to_image.StableDiffusion", "image"),
-        body: "content_card"
-      } as unknown as NodeMetadata)
-    ).toBe(true);
-    // A namespace that otherwise never matches still opts in via body.
-    expect(
-      isContentCardNode({
-        ...meta("comfy.image.SomeModel", "image"),
-        body: "content_card"
-      } as unknown as NodeMetadata)
-    ).toBe(true);
+    expect(isContentCardNode(meta("some.pkg.TextToImage", "image"))).toBe(false);
+    expect(isContentCardNode(meta("fal.image_to_image.X", "image"))).toBe(false);
   });
 
   it("ignores body values other than content_card", () => {
     expect(
-      isContentCardNode({
-        ...meta("some.util.Node", "dict"),
-        body: "default"
-      } as unknown as NodeMetadata)
-    ).toBe(false);
-  });
-
-  it("matches conventional generator name patterns in any namespace", () => {
-    expect(isContentCardNode(meta("some.pkg.TextToImage"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.ImageToImage"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.TextToVideo"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.ImageToVideo"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.TextToAudio"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.TextTo3D"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.CreateImage"))).toBe(true);
-    expect(isContentCardNode(meta("some.pkg.ImageGeneration"))).toBe(true);
-  });
-
-  it("does not match generator-shaped names embedded in longer words", () => {
-    expect(isContentCardNode(meta("foo.TextToImagePromptBuilder"))).toBe(false);
-  });
-
-  it("matches fal.* / replicate.* / kie.* nodes with media output", () => {
-    expect(isContentCardNode(meta("fal.image_to_image.Ultrashape", "image"))).toBe(
-      true
-    );
-    expect(
-      isContentCardNode(meta("replicate.video.SomeModel", "video"))
-    ).toBe(true);
-    expect(isContentCardNode(meta("kie.audio.SomeModel", "audio"))).toBe(true);
-    expect(
-      isContentCardNode(meta("fal.threed.MeshyV5Retexture", "model_3d"))
-    ).toBe(true);
-  });
-
-  it("does not match fal/replicate/kie nodes with non-media outputs", () => {
-    expect(isContentCardNode(meta("fal.misc.SomeUtil", "dict"))).toBe(false);
-    expect(isContentCardNode(meta("replicate.text.Summarize", "str"))).toBe(
-      false
-    );
-    expect(isContentCardNode(meta("kie.misc.Util", "any"))).toBe(false);
-  });
-
-  it("does not match arbitrary third-party namespaces", () => {
-    expect(
-      isContentCardNode(meta("comfy.image.SomeModel", "image"))
+      isContentCardNode(meta("some.util.Node", "dict", "default"))
     ).toBe(false);
   });
 

--- a/web/src/components/node_types/contentCardRegistry.test.ts
+++ b/web/src/components/node_types/contentCardRegistry.test.ts
@@ -40,6 +40,31 @@ describe("isContentCardNode", () => {
     }
   });
 
+  it("matches author opt-in via metadata.body, regardless of namespace/pattern", () => {
+    expect(
+      isContentCardNode({
+        ...meta("huggingface.text_to_image.StableDiffusion", "image"),
+        body: "content_card"
+      } as unknown as NodeMetadata)
+    ).toBe(true);
+    // A namespace that otherwise never matches still opts in via body.
+    expect(
+      isContentCardNode({
+        ...meta("comfy.image.SomeModel", "image"),
+        body: "content_card"
+      } as unknown as NodeMetadata)
+    ).toBe(true);
+  });
+
+  it("ignores body values other than content_card", () => {
+    expect(
+      isContentCardNode({
+        ...meta("some.util.Node", "dict"),
+        body: "default"
+      } as unknown as NodeMetadata)
+    ).toBe(false);
+  });
+
   it("matches conventional generator name patterns in any namespace", () => {
     expect(isContentCardNode(meta("some.pkg.TextToImage"))).toBe(true);
     expect(isContentCardNode(meta("some.pkg.ImageToImage"))).toBe(true);

--- a/web/src/components/node_types/contentCardRegistry.ts
+++ b/web/src/components/node_types/contentCardRegistry.ts
@@ -1,147 +1,33 @@
 /**
- * Content-Card Registry
+ * Content-Card predicate.
  *
- * Predicate that decides whether a node renders as a `ContentCardBody` (a
- * content-forward image/video/audio/3D/text body) instead of the generic
- * input/output layout.
+ * A node renders as a `ContentCardBody` (a content-forward
+ * image/video/audio/3D/text body) instead of the generic input/output layout
+ * iff its metadata declares `body: "content_card"`.
  *
- * Matching strategies, in order:
+ * This is the single source of truth — there is no namespace, name-pattern, or
+ * allow-list matching. Node authors opt in from the backend:
+ *   - Python nodes: set `_body = "content_card"` or override `body()` (often
+ *     derived from the primary output type on a shared base class, e.g. the
+ *     HuggingFace pipeline / replicate node bases).
+ *   - TypeScript nodes: `static readonly body = "content_card"`, or set it on a
+ *     shared base / node factory (e.g. the fal / kie / replicate generators
+ *     derive it from the output type).
  *
- *   0. Author opt-in — the node declares `body: "content_card"` in its
- *      metadata (Python `_body` / `body()`). Preferred: lets node authors
- *      configure content cards from the backend. The variant is still derived
- *      from the primary output type.
- *   1. Explicit allow-set — hand-picked entries for provider/base nodes that
- *      should always render as content cards, regardless of namespace.
- *   2. Generator-pattern match — node_type names that follow the conventional
- *      `*.TextToImage`, `*.ImageToImage`, `*.TextToVideo`, ... shapes used by
- *      first-party generators.
- *   3. Provider-namespace + output match — any node under a generator-
- *      aggregator namespace (`fal.`, `replicate.`, `kie.`) whose primary
- *      output is a media type (image/video/audio/3D).
- *
- * Utility nodes (`If`, `Loop`, `Map`, constants, control-flow) never match
- * any of the three strategies and stay on the generic body forever.
+ * The concrete variant (image/audio/video/text/3D) is still derived from the
+ * primary output type by `getContentCardVariant` below.
  */
 
 import type { NodeMetadata, OutputSlot } from "../../stores/ApiTypes";
 
 /**
- * Hand-curated entries — provider/base nodes that should always render as a
- * content card. Anything outside the predicate's namespace/pattern reach.
- */
-export const CONTENT_CARD_REGISTRY: ReadonlySet<string> = new Set([
-  // First-party generators (base-nodes)
-  "nodetool.image.TextToImage",
-  "nodetool.image.ImageToImage",
-  "nodetool.image.Upscale",
-  "nodetool.image.RemoveBackground",
-  "nodetool.image.Relight",
-  "nodetool.image.Vectorize",
-  "nodetool.video.TextToVideo",
-  "nodetool.video.ImageToVideo",
-  "nodetool.video.VideoToVideo",
-  "nodetool.video.LipSync",
-  "nodetool.audio.TextToSpeech",
-  "nodetool.audio.AudioMixer",
-  "nodetool.audio.Concat",
-  "nodetool.video.Concat",
-  "nodetool.text.AutomaticSpeechRecognition",
-
-  // Provider image/video/audio nodes
-  "openai.image.CreateImage",
-  "openai.image.EditImage",
-  "openai.audio.TextToSpeech",
-  "openai.audio.Transcribe",
-  "openai.audio.Translate",
-  "gemini.image.ImageGeneration",
-  "gemini.video.TextToVideo",
-  "gemini.video.ImageToVideo",
-  "gemini.audio.TextToSpeech",
-  "gemini.audio.Transcribe",
-
-  // ElevenLabs
-  "elevenlabs.TextToSpeech",
-  "elevenlabs.SpeechToText",
-  "elevenlabs.RealtimeTextToSpeech",
-  "elevenlabs.RealtimeSpeechToText",
-
-  // Text-content nodes (LLM-style, prompt templating)
-  "nodetool.agents.Agent",
-  "nodetool.agents.Summarizer",
-  "nodetool.agents.Extractor",
-  "nodetool.agents.Classifier",
-  "nodetool.text.Concat",
-  "nodetool.data.Describe",
-  "anthropic.agents.ClaudeAgent",
-  "openai.agents.RealtimeAgent",
-  "mistral.text.ChatComplete"
-]);
-
-/**
- * Namespace prefixes whose nodes are wholesale content cards when their
- * primary output is a media type. These are auto-generated aggregator
- * packages (fal, replicate, kie) where hand-listing every entry would be
- * untenable and rot every time the manifest regenerates.
- */
-const PROVIDER_NAMESPACE_PREFIXES = ["fal.", "replicate.", "kie."] as const;
-
-/**
- * Conventional generator-shaped class names. Matches any namespace.
- * Tail-anchored: `\b` boundary prevents accidental matches against
- * "TextToImagePromptBuilder" or similar.
- */
-const GENERATOR_NAME_PATTERNS: readonly RegExp[] = [
-  /\.(TextTo|ImageTo)(Image|Video|Audio|Speech|3D|Model3D)\b/,
-  /\.(CreateImage|EditImage|ImageGeneration)\b/
-];
-
-const MEDIA_VARIANTS: ReadonlySet<ContentCardVariant> = new Set([
-  "image",
-  "image_mask",
-  "video",
-  "audio",
-  "model_3d"
-]);
-
-/**
  * Decide whether a node should render as a content card.
  *
- * The full metadata is needed because the namespace-prefix branch consults
- * the primary output's variant. Pass the metadata you already have — every
- * caller in the app has it.
+ * Driven entirely by `metadata.body`; there is no node_type matching.
  */
 export const isContentCardNode = (
   metadata: NodeMetadata | undefined
-): boolean => {
-  if (!metadata) {
-    return false;
-  }
-  // Author opt-in (highest precedence): a node declares `body: "content_card"`
-  // in its metadata. The variant is still derived from the primary output type
-  // below. This lets node authors configure content cards from the backend
-  // without editing the hardcoded heuristics that follow.
-  if (metadata.body === "content_card") {
-    return true;
-  }
-  const t = metadata.node_type;
-  if (!t) {
-    return false;
-  }
-  if (CONTENT_CARD_REGISTRY.has(t)) {
-    return true;
-  }
-  if (GENERATOR_NAME_PATTERNS.some((re) => re.test(t))) {
-    return true;
-  }
-  if (PROVIDER_NAMESPACE_PREFIXES.some((p) => t.startsWith(p))) {
-    const variant = getContentCardVariant(getPrimaryOutput(metadata));
-    if (MEDIA_VARIANTS.has(variant)) {
-      return true;
-    }
-  }
-  return false;
-};
+): boolean => metadata?.body === "content_card";
 
 /**
  * Per-variant default card dimensions applied at node creation time
@@ -247,8 +133,7 @@ export const getContentCardDefaultSize = (
 
 /**
  * Prompt/template nodes that substitute `{{variables}}` — their dynamic-input
- * button reads "+ Add variable". This is the prompt-templating subset of
- * `CONTENT_CARD_REGISTRY` above; keep the two in sync.
+ * button reads "+ Add variable" instead of a media-input label.
  */
 const PROMPT_TEMPLATE_NODES = new Set<string>([
   "nodetool.agents.Agent",
@@ -257,7 +142,6 @@ const PROMPT_TEMPLATE_NODES = new Set<string>([
   "nodetool.agents.Classifier",
   "nodetool.text.Concat",
   "nodetool.data.Describe",
-  "anthropic.agents.ClaudeAgent",
   "openai.agents.RealtimeAgent",
   "mistral.text.ChatComplete"
 ]);

--- a/web/src/components/node_types/contentCardRegistry.ts
+++ b/web/src/components/node_types/contentCardRegistry.ts
@@ -5,8 +5,12 @@
  * content-forward image/video/audio/3D/text body) instead of the generic
  * input/output layout.
  *
- * Three matching strategies, in order:
+ * Matching strategies, in order:
  *
+ *   0. Author opt-in — the node declares `body: "content_card"` in its
+ *      metadata (Python `_body` / `body()`). Preferred: lets node authors
+ *      configure content cards from the backend. The variant is still derived
+ *      from the primary output type.
  *   1. Explicit allow-set — hand-picked entries for provider/base nodes that
  *      should always render as content cards, regardless of namespace.
  *   2. Generator-pattern match — node_type names that follow the conventional
@@ -112,6 +116,13 @@ export const isContentCardNode = (
 ): boolean => {
   if (!metadata) {
     return false;
+  }
+  // Author opt-in (highest precedence): a node declares `body: "content_card"`
+  // in its metadata. The variant is still derived from the primary output type
+  // below. This lets node authors configure content cards from the backend
+  // without editing the hardcoded heuristics that follow.
+  if (metadata.body === "content_card") {
+    return true;
   }
   const t = metadata.node_type;
   if (!t) {


### PR DESCRIPTION
## What

Node authors opt a node into the content-card body (the media/text-forward node body) from **backend metadata** instead of frontend heuristics. A node declares `body: "content_card"` in its `NodeMetadata`; the concrete variant (image / audio / video / text / 3D) is still derived from the primary output type, so "image generator → image body" falls out for free.

## Changes (this repo)
- `packages/node-sdk`: add optional `body?` to `NodeClass`, `BaseNode`, and `NodeMetadata`; `getNodeMetadata` emits `body` (defaulting to the `"default"` sentinel); `mergeMetadata` backfills `body` from Python, treating `"default"` as unset so a Python `body: "content_card"` is honored.
- Opt TS nodes in via `static readonly body = "content_card"` across audio / data / image / video / text / llm / elevenlabs, and derive it from the media output type in the fal / kie / replicate factories.
- `web` `contentCardRegistry`: **`isContentCardNode` is now `metadata.body === "content_card"` and nothing else** — the previous allow-list / generator-regex / provider-namespace heuristics are **removed**. Backend metadata (TS `body` static or Python `_body`/`body()`) is the single source of truth. `NodeContent`'s memo comparator now compares `body` so dynamic metadata flips re-render correctly.

> Behavior change vs. the first revision of this PR: the frontend heuristics are no longer a fallback. Any node that previously rendered as a content card *only* via a heuristic must now opt in explicitly from the backend (TS static or Python `_body`). The companion backend annotations cover the first-party + HF/MLX generators.

## Companion backend changes (already on main in their repos)
- **nodetool-core**: `body` field on `NodeMetadata`; `_body` ClassVar / `body()` on `BaseNode`; `get_metadata()` suppresses `inline_fields` for content-card nodes.
- **nodetool-huggingface**: media/text nodes opt in; classifiers / feature-extraction / segmentation stay generic.
- **nodetool-mlx**: MFlux generators, Whisper, MLX-TTS, and text generation opt in.

## Tests
- `contentCardRegistry.test.ts`: author opt-in via `body`, non-`content_card` values ignored.
- `node-metadata.test.ts`: Python `body` opt-in backfills when the TS class doesn't set one.
- Full web typecheck + jest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)