### PR TITLE
Disable react-doctor query mutation invalidation rule

### DIFF
--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -167,7 +167,7 @@ Server state lives in TanStack Query (`web/src/serverState/`). Zustand and Query
 - **`staleTime` is set explicitly** for every query. Default `0` is wrong for most server data. Pick a value based on how often the underlying data changes; document in a comment if non-obvious.
 - **`enabled`** for conditional queries. Don't ship `useQuery` calls that depend on `undefined` ids.
 - **No fetching in `useEffect`.** Use `useQuery` / `useSuspenseQuery`.
-- **Mutations always invalidate**: every successful `useMutation` invalidates the related keys via `queryClient.invalidateQueries({ queryKey: [...] })`. Prefer narrow invalidations over broad ones.
+- **Mutations always invalidate**: every successful `useMutation` invalidates the related keys via `queryClient.invalidateQueries({ queryKey: [...] })`. Prefer narrow invalidations over broad ones. The call may be indirect — a named `onSuccess` callback, a store action invoked inside `mutationFn`, or inline in `mutationFn` — see [serverState/AGENTS.md](../web/src/serverState/AGENTS.md). Don't add a redundant second invalidation when one of these already covers the data.
 - **Optimistic updates** are required for any mutation that affects a list the user sees (workflows, assets, jobs). Roll back on error.
 - **Retry policy** — default `retry: 3` is too aggressive for mutations and for queries that fail predictably. Set `retry` per query: `false` for 4xx, `3` for network errors.
 - **`queryClient.setQueryData`** is the only way to write into the cache from outside a query. Never reach into internals.

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "react-doctor/no-unknown-property": "off"
+    "react-doctor/no-unknown-property": "off",
+    "react-doctor/query-mutation-missing-invalidation": "off"
   }
 }

--- a/web/src/serverState/AGENTS.md
+++ b/web/src/serverState/AGENTS.md
@@ -41,6 +41,26 @@ const { mutate } = useMutation({
 });
 ```
 
+### Cache invalidation may be indirect
+
+A mutation must keep the cache in sync, but the `invalidateQueries` call need
+not sit inline in `onSuccess`. All three forms are valid and in use here:
+
+- **Named `onSuccess` callback** — `onSuccess: invalidate`, where `invalidate`
+  calls `queryClient.invalidateQueries(...)` (`useWorkflowVersions.ts`,
+  `useAssets.ts`).
+- **Store action in `mutationFn`** — the AssetStore `create`/`update`/`delete`
+  actions invalidate `["assets", ...]` themselves, so a mutation that calls them
+  needs no extra `onSuccess` (`useAssetDeletion.ts`).
+- **Inside `mutationFn`** — invalidate right after the write
+  (`DeleteModelDialog.tsx`).
+
+Don't add a second invalidation when one of these already covers the data. The
+`react-doctor/query-mutation-missing-invalidation` rule is **off** (it only
+matches inline `onSuccess` and flags the patterns above as false positives), so
+this convention is review-enforced: when you add a mutation that writes server
+data, confirm the cache is invalidated somewhere in the success path.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
Disables the `react-doctor/query-mutation-missing-invalidation` ESLint rule in the project's react-doctor configuration.

## Changes
- Added `"react-doctor/query-mutation-missing-invalidation": "off"` to `react-doctor.config.json`

## Details
This rule enforcement is being disabled to allow flexibility in query invalidation patterns across the codebase. The project uses TanStack Query for server state management, and this rule can be overly restrictive in certain scenarios where manual invalidation strategies differ from the rule's expectations.

https://claude.ai/code/session_01T9Gr8LNpW9JZp1eV1iBd3A