### PR TITLE
Add unit tests for SearchInput component

### DIFF
--- a/web/src/components/search/__tests__/SearchInput.test.tsx
+++ b/web/src/components/search/__tests__/SearchInput.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import SearchInput from "../SearchInput";
+import mockTheme from "../../../__mocks__/themeMock";
+
+// Tooltip pulls in heavy theme overrides we don't need for these unit tests.
+jest.mock("../../ui_primitives", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}));
+
+// No modifier keys held during these tests.
+jest.mock("../../../stores/KeyPressedStore", () => ({
+  useKeyPressedStore: () => false
+}));
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("SearchInput", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("lets the local draft lead while typing and debounces onSearchChange", () => {
+    jest.useFakeTimers();
+    const onSearchChange = jest.fn();
+    renderWithTheme(
+      <SearchInput
+        onSearchChange={onSearchChange}
+        searchTerm=""
+        debounceTime={50}
+        focusSearchInput={false}
+      />
+    );
+
+    const input = screen.getByTestId("search-input-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "hello" } });
+
+    // The field reflects what the user typed immediately, before the debounce fires.
+    expect(input.value).toBe("hello");
+    expect(onSearchChange).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    expect(onSearchChange).toHaveBeenCalledWith("hello");
+  });
+
+  // Regression guard: `searchTerm` is store-backed in real callers and can change
+  // for reasons other than this input's own typing (programmatic reset, shared
+  // state). The effect that mirrors `searchTerm` into local state is what keeps the
+  // field in sync with those external changes — removing it would break this.
+  it("reflects external searchTerm changes into the field", () => {
+    const { rerender } = renderWithTheme(
+      <SearchInput
+        onSearchChange={jest.fn()}
+        searchTerm="initial"
+        focusSearchInput={false}
+      />
+    );
+
+    const input = screen.getByTestId("search-input-field") as HTMLInputElement;
+    expect(input.value).toBe("initial");
+
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <SearchInput
+          onSearchChange={jest.fn()}
+          searchTerm="external-reset"
+          focusSearchInput={false}
+        />
+      </ThemeProvider>
+    );
+    expect(input.value).toBe("external-reset");
+  });
+
+  it("clears the field and notifies the parent when the clear button is clicked", () => {
+    const onSearchChange = jest.fn();
+    renderWithTheme(
+      <SearchInput
+        onSearchChange={onSearchChange}
+        searchTerm=""
+        focusSearchInput={false}
+      />
+    );
+
+    const input = screen.getByTestId("search-input-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect(input.value).toBe("abc");
+
+    fireEvent.click(screen.getByTestId("search-clear-btn"));
+    expect(input.value).toBe("");
+    expect(onSearchChange).toHaveBeenLastCalledWith("");
+  });
+});


### PR DESCRIPTION
## Summary
Added comprehensive unit tests for the `SearchInput` component to ensure correct behavior around debouncing, external state synchronization, and user interactions.

## Key Changes
- **New test file**: `web/src/components/search/__tests__/SearchInput.test.tsx`
  - Test setup with theme provider and mocked dependencies (Tooltip, KeyPressedStore)
  - **Debounce behavior**: Verifies that local draft state leads while typing and `onSearchChange` is called only after the debounce delay
  - **External state sync**: Regression guard ensuring the component reflects external `searchTerm` prop changes into the input field (critical for store-backed state and programmatic resets)
  - **Clear button**: Tests that clicking the clear button empties the field and notifies the parent with an empty string

## Implementation Details
- Uses Jest fake timers to test debounce timing without waiting for real delays
- Mocks heavy theme overrides from Tooltip to keep tests lightweight
- Mocks `KeyPressedStore` to simulate no modifier keys being held
- Tests both controlled updates (via props) and uncontrolled user input to ensure the component handles both patterns correctly

https://claude.ai/code/session_01HDyCJ2okewSN2Hz21cgvBN