### PR TITLE
Extract default URLs and constants to shared modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42423,6 +42423,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
         "@aws-sdk/s3-request-presigner": "^3.1029.0",
+        "@nodetool-ai/config": "*",
         "@openclaw/fs-safe": "^0.1.2",
         "@supabase/supabase-js": "^2.98.0"
       },

--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -19,7 +19,9 @@ import {
   MoonshotProvider,
   AkiProvider,
   LMStudioProvider,
-  BaseProvider as BaseProviderClass
+  BaseProvider as BaseProviderClass,
+  OLLAMA_DEFAULT_URL,
+  LMSTUDIO_DEFAULT_URL
 } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { getSecret } from "@nodetool-ai/models";
@@ -71,14 +73,14 @@ export async function createProvider(
     case "ollama":
       return new OllamaProvider({
         OLLAMA_API_URL:
-          (await resolveKey("OLLAMA_API_URL")) ?? "http://127.0.0.1:11434"
+          (await resolveKey("OLLAMA_API_URL")) ?? OLLAMA_DEFAULT_URL
       });
     case "gemini":
       return new GeminiProvider({
         GEMINI_API_KEY: await resolveKey("GEMINI_API_KEY")
       });
     case "lmstudio":
-      return new LMStudioProvider({}, { baseURL: "http://127.0.0.1:1234" })
+      return new LMStudioProvider({}, { baseURL: LMSTUDIO_DEFAULT_URL })
     case "mistral":
       return new MistralProvider({
         MISTRAL_API_KEY: await resolveKey("MISTRAL_API_KEY")
@@ -98,7 +100,7 @@ export async function createProvider(
     default:
       return new OllamaProvider({
         OLLAMA_API_URL:
-          (await resolveKey("OLLAMA_API_URL")) ?? "http://127.0.0.1:11434"
+          (await resolveKey("OLLAMA_API_URL")) ?? OLLAMA_DEFAULT_URL
       });
   }
 }

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -64,6 +64,8 @@ vi.mock("@nodetool-ai/runtime", () => {
         void cfg;
       }
     },
+    OLLAMA_DEFAULT_URL: "http://127.0.0.1:11434",
+    LMSTUDIO_DEFAULT_URL: "http://127.0.0.1:1234",
     BaseProvider: FakeProvider
   };
 });

--- a/packages/runtime/src/providers/defaults.ts
+++ b/packages/runtime/src/providers/defaults.ts
@@ -1,0 +1,13 @@
+/**
+ * Default base URLs for local OpenAI-compatible / Ollama servers.
+ *
+ * These are the out-of-the-box ports the respective tools listen on. They are
+ * used only as the final fallback after an explicit option, the secret store,
+ * and the environment variable have all been consulted.
+ */
+
+/** Standard Ollama daemon port. */
+export const OLLAMA_DEFAULT_URL = "http://127.0.0.1:11434";
+
+/** Standard LM Studio OpenAI-compatible server port. */
+export const LMSTUDIO_DEFAULT_URL = "http://127.0.0.1:1234";

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -8,6 +8,8 @@ export {
   calculateImageCost
 } from "./cost-calculator.js";
 export type { PricingTier, UsageInfo } from "./cost-calculator.js";
+export { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
+import { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import { GeminiProvider } from "./gemini-provider.js";
 import { LlamaProvider } from "./llama-provider.js";
@@ -176,7 +178,7 @@ if (_envProcess.env["NODETOOL_ENV"] !== "production") {
     "ollama",
     OllamaProvider,
     {},
-    { OLLAMA_API_URL: "http://127.0.0.1:11434" }
+    { OLLAMA_API_URL: OLLAMA_DEFAULT_URL }
   );
   // LM Studio: URL (and optional API key) are user-configurable via the
   // Settings → API Keys panel. Register them as optionalKwargs so the
@@ -190,7 +192,7 @@ if (_envProcess.env["NODETOOL_ENV"] !== "production") {
     LMStudioProvider,
     {},
     {
-      LMSTUDIO_API_URL: "http://127.0.0.1:1234",
+      LMSTUDIO_API_URL: LMSTUDIO_DEFAULT_URL,
       LMSTUDIO_API_KEY: "lm-studio"
     }
   );

--- a/packages/runtime/src/providers/lmstudio-provider.ts
+++ b/packages/runtime/src/providers/lmstudio-provider.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { OpenAIProvider } from "./openai-provider.js";
+import { LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import type { LanguageModel } from "./types.js";
 
 interface LMStudioProviderOptions {
@@ -29,7 +30,7 @@ export class LMStudioProvider extends OpenAIProvider {
       options.baseURL ??
       secrets.LMSTUDIO_API_URL ??
       process.env["LMSTUDIO_API_URL"] ??
-      "http://127.0.0.1:1234";
+      LMSTUDIO_DEFAULT_URL;
     const baseURL = rawBaseURL.replace(/\/+$/, "");
     const apiKey = secrets.LMSTUDIO_API_KEY ?? "lm-studio";
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1029.0",
     "@aws-sdk/s3-request-presigner": "^3.1029.0",
+    "@nodetool-ai/config": "*",
     "@openclaw/fs-safe": "^0.1.2",
     "@supabase/supabase-js": "^2.98.0"
   },

--- a/packages/storage/src/url-builder.ts
+++ b/packages/storage/src/url-builder.ts
@@ -10,10 +10,8 @@
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createClient } from "@supabase/supabase-js";
+import { SIGNED_URL_TTL } from "@nodetool-ai/config";
 import type { StorageConfig } from "./factory.js";
-
-/** 7 days — S3/Supabase maximum. */
-const SIGNED_URL_TTL = 604800;
 
 export function createAssetUrlBuilder(
   config: StorageConfig

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -7,6 +7,7 @@ import {
 import { gzipSync } from "node:zlib";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import nodePath from "node:path";
+import { GZIP_THRESHOLD } from "./lib/compression.js";
 import { withCacheBuster } from "./lib/example-thumbnail.js";
 import {
   loadExampleGraph,
@@ -1897,7 +1898,6 @@ export async function handleNodeHttpRequest(
 
   // Gzip-compress large JSON responses for performance (e.g. /api/nodes/metadata
   // is ~5 MB uncompressed, ~550 KB compressed).
-  const GZIP_THRESHOLD = 256 * 1024;
   const acceptEncoding = req.headers["accept-encoding"] ?? "";
   if (bodyBuffer.length > GZIP_THRESHOLD && acceptEncoding.includes("gzip")) {
     const compressed = gzipSync(bodyBuffer);

--- a/packages/websocket/src/lib/bridge.ts
+++ b/packages/websocket/src/lib/bridge.ts
@@ -1,7 +1,6 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 import { gzipSync } from "node:zlib";
-
-const GZIP_THRESHOLD = 256 * 1024;
+import { GZIP_THRESHOLD } from "./compression.js";
 
 /**
  * Converts a Fastify request into a Web API Request, calls the handler,

--- a/packages/websocket/src/lib/compression.ts
+++ b/packages/websocket/src/lib/compression.ts
@@ -1,0 +1,2 @@
+/** Minimum response size (bytes) before gzip compression is worth applying. */
+export const GZIP_THRESHOLD = 256 * 1024;

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -9,6 +9,8 @@ import {
   listRegisteredProviderIds,
   providerCapabilities,
   RECOMMENDED_MODELS,
+  OLLAMA_DEFAULT_URL,
+  LMSTUDIO_DEFAULT_URL,
   type ASRModel,
   type EmbeddingModel,
   type ImageModel,
@@ -500,9 +502,9 @@ async function getServerAvailability(): Promise<Record<string, boolean>> {
   };
 
   const [ollamaUrl, llamaUrl, lmstudioUrl, vllmUrl] = await Promise.all([
-    resolve("OLLAMA_API_URL", "http://127.0.0.1:11434"),
+    resolve("OLLAMA_API_URL", OLLAMA_DEFAULT_URL),
     resolve("LLAMA_CPP_URL", ""),
-    resolve("LMSTUDIO_API_URL", "http://127.0.0.1:1234"),
+    resolve("LMSTUDIO_API_URL", LMSTUDIO_DEFAULT_URL),
     resolve("VLLM_BASE_URL", "")
   ]);
 

--- a/packages/websocket/src/openai-api.ts
+++ b/packages/websocket/src/openai-api.ts
@@ -11,7 +11,8 @@ import type { BaseProvider } from "@nodetool-ai/runtime";
 import {
   OllamaProvider,
   OpenAIProvider,
-  AnthropicProvider
+  AnthropicProvider,
+  OLLAMA_DEFAULT_URL
 } from "@nodetool-ai/runtime";
 import { getSecret } from "@nodetool-ai/models";
 import type {
@@ -204,7 +205,7 @@ export async function resolveProvider(
 
   // Default to Ollama
   return new OllamaProvider({
-    OLLAMA_API_URL: process.env.OLLAMA_API_URL ?? "http://127.0.0.1:11434"
+    OLLAMA_API_URL: process.env.OLLAMA_API_URL ?? OLLAMA_DEFAULT_URL
   });
 }
 

--- a/packages/websocket/src/trpc/routers/models.ts
+++ b/packages/websocket/src/trpc/routers/models.ts
@@ -7,6 +7,8 @@ import {
   listRegisteredProviderIds,
   providerCapabilities,
   RECOMMENDED_MODELS,
+  OLLAMA_DEFAULT_URL,
+  LMSTUDIO_DEFAULT_URL,
   type ProviderId,
   type RecommendedUnifiedModel
 } from "@nodetool-ai/runtime";
@@ -504,9 +506,9 @@ async function getServerAvailability(): Promise<Record<string, boolean>> {
   };
 
   const [ollamaUrl, llamaUrl, lmstudioUrl, vllmUrl] = await Promise.all([
-    resolve("OLLAMA_API_URL", "http://127.0.0.1:11434"),
+    resolve("OLLAMA_API_URL", OLLAMA_DEFAULT_URL),
     resolve("LLAMA_CPP_URL", ""),
-    resolve("LMSTUDIO_API_URL", "http://127.0.0.1:1234"),
+    resolve("LMSTUDIO_API_URL", LMSTUDIO_DEFAULT_URL),
     resolve("VLLM_BASE_URL", "")
   ]);
 


### PR DESCRIPTION
## Summary
Consolidates hardcoded default URLs and configuration constants into dedicated modules for better maintainability and DRY principles. This refactoring extracts `OLLAMA_DEFAULT_URL`, `LMSTUDIO_DEFAULT_URL`, and `GZIP_THRESHOLD` into centralized locations where they can be imported across the codebase.

## Key Changes

- **New module `packages/runtime/src/providers/defaults.ts`**: Defines `OLLAMA_DEFAULT_URL` and `LMSTUDIO_DEFAULT_URL` constants with documentation explaining they are fallback defaults after explicit options, secrets, and environment variables.

- **New module `packages/websocket/src/lib/compression.ts`**: Extracts `GZIP_THRESHOLD` constant (256 KB) used for response compression decisions.

- **Updated `packages/runtime/src/providers/index.ts`**: Exports the new default URL constants from `defaults.ts` for use across packages.

- **Updated provider implementations**: 
  - `packages/runtime/src/providers/lmstudio-provider.ts` now imports `LMSTUDIO_DEFAULT_URL`
  - `packages/cli/src/providers.ts` imports and uses both default URL constants
  - `packages/websocket/src/openai-api.ts` imports `OLLAMA_DEFAULT_URL`
  - `packages/websocket/src/models-api.ts` and `packages/websocket/src/trpc/routers/models.ts` import both default URL constants

- **Updated HTTP API**: `packages/websocket/src/http-api.ts` now imports `GZIP_THRESHOLD` from the new compression module.

- **Updated bridge**: `packages/websocket/src/lib/bridge.ts` imports `GZIP_THRESHOLD` from compression module.

- **Storage package dependency**: Added `@nodetool-ai/config` dependency to `packages/storage/package.json` and moved `SIGNED_URL_TTL` constant to `packages/config/` (implied by the import change in `packages/storage/src/url-builder.ts`).

- **Test mocks**: Updated `packages/cli/tests/providers.test.ts` to mock the exported default URL constants.

## Implementation Details

- All hardcoded URLs (`"http://127.0.0.1:11434"` and `"http://127.0.0.1:1234"`) are now replaced with named constants, improving readability and reducing duplication across 7+ files.
- Constants are properly documented with JSDoc comments explaining their purpose as final fallbacks in the configuration resolution chain.
- Exports are added to the runtime package's public API (`index.ts`) for consumption by CLI, WebSocket, and other packages.

https://claude.ai/code/session_01MnhEK3pcNn9A4oXzdsv9AL