### PR TITLE
Centralize node type constants in dedicated module

### DIFF
--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -4,6 +4,7 @@ import { css, keyframes } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Collapse, LinearProgress } from "@mui/material";
+import { PREVIEW_NODE_TYPE } from "../../constants/nodeTypes";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
@@ -210,7 +211,7 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = memo(function ChainNo
           sx={{
             px: 1.75,
             pb: 1.5,
-            ...(node.nodeType !== "nodetool.workflows.base_node.Preview" && {
+            ...(node.nodeType !== PREVIEW_NODE_TYPE && {
               maxHeight: 300,
               overflow: "auto",
             }),

--- a/web/src/components/context_menus/EdgeContextMenu.tsx
+++ b/web/src/components/context_menus/EdgeContextMenu.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, memo } from "react";
 import { shallow } from "zustand/shallow";
 import { Menu } from "@mui/material";
 import ContextMenuItem from "./ContextMenuItem";
+import { REROUTE_NODE_TYPE } from "../../constants/nodeTypes";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import { useNodes } from "../../contexts/NodeContext";
 import { useReactFlow } from "@xyflow/react";
@@ -61,7 +62,7 @@ const EdgeContextMenuComponent: React.FC<EdgeContextMenuProps> = () => {
     });
 
     // Get metadata for the Reroute node
-    const rerouteMetadata = getMetadata("nodetool.control.Reroute");
+    const rerouteMetadata = getMetadata(REROUTE_NODE_TYPE);
     if (!rerouteMetadata) {
       console.error("Reroute node metadata not found");
       closeContextMenu();

--- a/web/src/components/context_menus/OutputContextMenu.tsx
+++ b/web/src/components/context_menus/OutputContextMenu.tsx
@@ -4,6 +4,7 @@ import { shallow } from "zustand/shallow";
 import { InputAdornment, Menu, TextField } from "@mui/material";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Divider, Text, ToolbarIconButton, Box } from "../ui_primitives";
+import { PREVIEW_NODE_TYPE, REROUTE_NODE_TYPE } from "../../constants/nodeTypes";
 import { useTheme } from "@mui/material/styles";
 //icons
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -191,7 +192,7 @@ const OutputContextMenu: React.FC = () => {
 
   const createPreviewNode = useCallback(
     (event: React.MouseEvent) => {
-      const metadata = getMetadata("nodetool.workflows.base_node.Preview");
+      const metadata = getMetadata(PREVIEW_NODE_TYPE);
       if (!metadata) {
         return;
       }
@@ -212,7 +213,7 @@ const OutputContextMenu: React.FC = () => {
 
   const createRerouteNode = useCallback(
     (event: React.MouseEvent) => {
-      const metadata = getMetadata("nodetool.control.Reroute");
+      const metadata = getMetadata(REROUTE_NODE_TYPE);
       if (!metadata) {
         return;
       }

--- a/web/src/components/graph_view/WorkflowGraphView.tsx
+++ b/web/src/components/graph_view/WorkflowGraphView.tsx
@@ -42,6 +42,7 @@ import CommentNode from "../node/CommentNode";
 import SketchNode, {
   SKETCH_NODE_TYPE
 } from "../node/SketchNode/SketchNode";
+import { GROUP_NODE_TYPE, COMMENT_NODE_TYPE } from "../../constants/nodeTypes";
 import CustomEdge from "../node_editor/CustomEdge";
 import ControlEdge from "../node_editor/ControlEdge";
 import type { Workflow } from "../../stores/ApiTypes";
@@ -111,8 +112,8 @@ function GraphInner() {
   const nodeTypes = useMemo(
     () => ({
       ...baseNodeTypes,
-      "nodetool.workflows.base_node.Group": GroupNode,
-      "nodetool.workflows.base_node.Comment": CommentNode,
+      [GROUP_NODE_TYPE]: GroupNode,
+      [COMMENT_NODE_TYPE]: CommentNode,
       [SKETCH_NODE_TYPE]: SketchNode,
       default: PlaceholderNode
     }),

--- a/web/src/components/miniapps/components/MiniAppResults.tsx
+++ b/web/src/components/miniapps/components/MiniAppResults.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { Text, ToolbarIconButton, LoadingSpinner } from "../../ui_primitives";
 import { Caption } from "../../ui_primitives";
+import { PREVIEW_NODE_TYPE } from "../../../constants/nodeTypes";
 import ClearIcon from "@mui/icons-material/Clear";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import CheckIcon from "@mui/icons-material/Check";
@@ -50,7 +51,7 @@ const MiniAppResults: React.FC<MiniAppResultsProps> = ({
             // Exclude bypassed nodes
             uiProps?.bypassed ||
             // Exclude PreviewNode - they shouldn't show in app mode
-            node.type === "nodetool.workflows.base_node.Preview"
+            node.type === PREVIEW_NODE_TYPE
           );
         })
         .map((node) => node.id)

--- a/web/src/components/node/DynamicFalSchemaNode/FalSchemaLoader.tsx
+++ b/web/src/components/node/DynamicFalSchemaNode/FalSchemaLoader.tsx
@@ -8,7 +8,7 @@ import { resolveFalSchemaClient } from "../../../utils/falDynamicSchema";
 import { NodeData } from "../../../stores/NodeData";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 
-export const DYNAMIC_FAL_NODE_TYPE = "fal.DynamicFal";
+export { DYNAMIC_FAL_NODE_TYPE } from "../../../constants/nodeTypes";
 
 interface FalSchemaLoaderProps {
   nodeId: string;

--- a/web/src/components/node/DynamicKieSchemaNode/KieSchemaLoader.tsx
+++ b/web/src/components/node/DynamicKieSchemaNode/KieSchemaLoader.tsx
@@ -8,7 +8,7 @@ import { resolveKieSchemaClient } from "../../../utils/kieDynamicSchema";
 import { NodeData } from "../../../stores/NodeData";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 
-export const DYNAMIC_KIE_NODE_TYPE = "kie.dynamic_schema.KieAI";
+export { DYNAMIC_KIE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 interface KieSchemaLoaderProps {
   nodeId: string;

--- a/web/src/components/node/DynamicReplicateNode/ReplicateSchemaLoader.tsx
+++ b/web/src/components/node/DynamicReplicateNode/ReplicateSchemaLoader.tsx
@@ -8,8 +8,7 @@ import { resolveReplicateSchemaClient } from "../../../utils/replicateDynamicSch
 import { NodeData } from "../../../stores/NodeData";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 
-export const DYNAMIC_REPLICATE_NODE_TYPE =
-  "replicate.DynamicReplicate";
+export { DYNAMIC_REPLICATE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 interface ReplicateSchemaLoaderProps {
   nodeId: string;

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -46,6 +46,13 @@ import {
   WORKFLOW_NODE_TYPE
 } from "../node/WorkflowNode";
 import { SubgraphNode, SUBGRAPH_NODE_TYPE } from "../node/SubgraphNode";
+import {
+  GROUP_NODE_TYPE,
+  COMMENT_NODE_TYPE,
+  PREVIEW_NODE_TYPE,
+  REROUTE_NODE_TYPE,
+  STRING_NODE_TYPE
+} from "../../constants/nodeTypes";
 import { useSubgraphTabsStore } from "../../stores/SubgraphTabsStore";
 import { useWorkflowManagerStore } from "../../contexts/WorkflowManagerContext";
 import ConstantStringNode from "../node/ConstantStringNode";
@@ -386,14 +393,14 @@ const ReactFlowWrapper = ({
   const nodeTypes = useMemo(
     () => ({
       ...baseNodeTypes,
-      "nodetool.workflows.base_node.Group": GroupNode,
-      "nodetool.workflows.base_node.Comment": CommentNode,
-      "nodetool.workflows.base_node.Preview": PreviewNode,
+      [GROUP_NODE_TYPE]: GroupNode,
+      [COMMENT_NODE_TYPE]: CommentNode,
+      [PREVIEW_NODE_TYPE]: PreviewNode,
       "nodetool.workflows.base_node.Output": OutputNode,
       "nodetool.output.Output": OutputNode,
       "nodetool.compare.CompareImages": CompareImagesNode,
-      "nodetool.constant.String": ConstantStringNode,
-      "nodetool.control.Reroute": RerouteNode,
+      [STRING_NODE_TYPE]: ConstantStringNode,
+      [REROUTE_NODE_TYPE]: RerouteNode,
       [DYNAMIC_FAL_NODE_TYPE]: DynamicFalSchemaNode,
       [DYNAMIC_KIE_NODE_TYPE]: DynamicKieSchemaNode,
       "kie.DynamicKie": DynamicKieSchemaNode,

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -335,7 +335,7 @@ function ensureEditableActiveLayer(doc: SketchDocument): SketchDocument {
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-export const SKETCH_NODE_TYPE = "nodetool.image.ImageEditor";
+export { SKETCH_NODE_TYPE } from "../../../constants/nodeTypes";
 
 /** Composited `image` output from the editor (flattenToDataUrl); preferred over re-flattening sketch_data alone. */
 function getSketchOutputImageUri(

--- a/web/src/components/node/SubgraphNode/index.ts
+++ b/web/src/components/node/SubgraphNode/index.ts
@@ -2,4 +2,4 @@ export { default as SubgraphNode } from "./SubgraphNode";
 export { SubgraphNodeContent } from "./SubgraphNodeContent";
 export { SubgraphSync } from "./SubgraphSync";
 
-export const SUBGRAPH_NODE_TYPE = "nodetool.workflows.subgraph.Subgraph";
+export { SUBGRAPH_NODE_TYPE } from "../../../constants/nodeTypes";

--- a/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
+++ b/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
@@ -11,7 +11,7 @@ import { useWorkflowManager } from "../../../contexts/WorkflowManagerContext";
 import { TypeMetadata, Workflow, WorkflowList } from "../../../stores/ApiTypes";
 import { NodeData } from "../../../stores/NodeData";
 
-export const WORKFLOW_NODE_TYPE = "nodetool.workflows.workflow_node.Workflow";
+export { WORKFLOW_NODE_TYPE } from "../../../constants/nodeTypes";
 
 /** Map input node types to TypeMetadata types */
 export const INPUT_TYPE_MAP: Record<string, string> = {

--- a/web/src/components/node/codeNodeUi.ts
+++ b/web/src/components/node/codeNodeUi.ts
@@ -1,6 +1,7 @@
 import type { NodeData } from "../../stores/NodeData";
+import { CODE_NODE_TYPE } from "../../constants/nodeTypes";
 
-export const CODE_NODE_TYPE = "nodetool.code.Code";
+export { CODE_NODE_TYPE };
 
 export function isCodeNode(nodeType: string): boolean {
   return nodeType === CODE_NODE_TYPE;

--- a/web/src/components/node_types/editing/BlurBody.tsx
+++ b/web/src/components/node_types/editing/BlurBody.tsx
@@ -26,8 +26,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const BLUR_NODE_TYPE = "nodetool.image.Blur";
+import { BLUR_NODE_TYPE } from "../../../constants/nodeTypes";
 
 type BlurType = "gaussian" | "box" | "motion";
 

--- a/web/src/components/node_types/editing/ChannelsBody.tsx
+++ b/web/src/components/node_types/editing/ChannelsBody.tsx
@@ -30,8 +30,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const CHANNELS_NODE_TYPE = "nodetool.image.Channels";
+import { CHANNELS_NODE_TYPE } from "../../../constants/nodeTypes";
 
 type Channel = "red" | "green" | "blue" | "alpha" | "luminance";
 

--- a/web/src/components/node_types/editing/CompositorBody.tsx
+++ b/web/src/components/node_types/editing/CompositorBody.tsx
@@ -51,8 +51,7 @@ import { useNodes, useNodeStoreRef } from "../../../contexts/NodeContext";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput, useUpstreamValues } from "../../../hooks/nodes/useNodeIO";
 import { useDynamicProperty } from "../../../hooks/nodes/useDynamicProperty";
-
-const COMPOSITOR_NODE_TYPE = "nodetool.image.Compositor";
+import { COMPOSITOR_NODE_TYPE } from "../../../constants/nodeTypes";
 
 /** Canonical blend modes are owned by `@nodetool-ai/gpu`. */
 export type CompositorBlendMode = BlendMode;

--- a/web/src/components/node_types/editing/CropBody.tsx
+++ b/web/src/components/node_types/editing/CropBody.tsx
@@ -43,8 +43,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput, useUpstreamValue } from "../../../hooks/nodes/useNodeIO";
-
-const CROP_NODE_TYPE = "nodetool.image.Crop";
+import { CROP_NODE_TYPE } from "../../../constants/nodeTypes";
 
 /** Aspect-ratio dropdown options. `free` means no constraint. */
 const ASPECT_OPTIONS = [

--- a/web/src/components/node_types/editing/CurvesBody.tsx
+++ b/web/src/components/node_types/editing/CurvesBody.tsx
@@ -31,8 +31,7 @@ import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
 import { asImageRef } from "../../../utils/imageRef";
-
-const CURVES_NODE_TYPE = "lib.image.color_grading.Curves";
+import { CURVES_NODE_TYPE } from "../../../constants/nodeTypes";
 
 interface SliderSpec {
   name: string;

--- a/web/src/components/node_types/editing/ExposureBody.tsx
+++ b/web/src/components/node_types/editing/ExposureBody.tsx
@@ -23,8 +23,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const EXPOSURE_NODE_TYPE = "lib.image.color_grading.Exposure";
+import { EXPOSURE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 interface SliderSpec {
   name: string;

--- a/web/src/components/node_types/editing/FitBody.tsx
+++ b/web/src/components/node_types/editing/FitBody.tsx
@@ -27,8 +27,7 @@ import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
 import { asImageRef } from "../../../utils/imageRef";
-
-const FIT_NODE_TYPE = "nodetool.image.Fit";
+import { FIT_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const PRESETS: ReadonlyArray<number> = [256, 512, 768, 1024];
 

--- a/web/src/components/node_types/editing/HSLAdjustBody.tsx
+++ b/web/src/components/node_types/editing/HSLAdjustBody.tsx
@@ -26,8 +26,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const HSL_ADJUST_NODE_TYPE = "lib.image.color_grading.HSLAdjust";
+import { HSL_ADJUST_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const COLOR_RANGES = [
   "all",

--- a/web/src/components/node_types/editing/LevelsBody.tsx
+++ b/web/src/components/node_types/editing/LevelsBody.tsx
@@ -46,8 +46,7 @@ import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropert
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
 import { computeHistogramAsync } from "../../../utils/histogram/histogramAsync";
 import type { ImageHistogram } from "../../../utils/histogram/computeHistogram";
-
-const LEVELS_NODE_TYPE = "nodetool.image.Levels";
+import { LEVELS_NODE_TYPE } from "../../../constants/nodeTypes";
 
 type ChannelKey = "r" | "g" | "b";
 type HistogramView = "r" | "g" | "b" | "luminance";

--- a/web/src/components/node_types/editing/MaskBody.tsx
+++ b/web/src/components/node_types/editing/MaskBody.tsx
@@ -32,8 +32,7 @@ import {
   useUpstreamValue
 } from "../../../hooks/nodes/useNodeIO";
 import { asImageRef } from "../../../utils/imageRef";
-
-const MASK_NODE_TYPE = "lib.image.Mask";
+import { MASK_NODE_TYPE } from "../../../constants/nodeTypes";
 
 type MaskTab = "image1" | "image2" | "mask" | "result";
 

--- a/web/src/components/node_types/editing/PainterBody.tsx
+++ b/web/src/components/node_types/editing/PainterBody.tsx
@@ -70,8 +70,7 @@ import { resolveExposedInputNames } from "../../../utils/exposedInputs";
 import { asImageRef } from "../../../utils/imageRef";
 import { createImageUrl } from "../../../utils/imageUtils";
 import { resolveAssetUri } from "../../node/output/hooks";
-
-const PAINTER_NODE_TYPE = "nodetool.image.Painter";
+import { PAINTER_NODE_TYPE } from "../../../constants/nodeTypes";
 
 // Max number of undo states retained. Keeps memory bounded; older
 // states are dropped from the front of the queue.

--- a/web/src/components/node_types/editing/PasteBody.tsx
+++ b/web/src/components/node_types/editing/PasteBody.tsx
@@ -29,8 +29,7 @@ import {
   useUpstreamValue
 } from "../../../hooks/nodes/useNodeIO";
 import { asImageRef } from "../../../utils/imageRef";
-
-const PASTE_NODE_TYPE = "nodetool.image.Paste";
+import { PASTE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -47,8 +47,7 @@ import {
   $setPromptFromString
 } from "./promptComposer/promptEditorState";
 import { PromptComposerContext } from "./promptComposer/promptComposerContext";
-
-const PROMPT_NODE_TYPE = "nodetool.text.Prompt";
+import { PROMPT_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/node_types/editing/ResizeBody.tsx
+++ b/web/src/components/node_types/editing/ResizeBody.tsx
@@ -26,8 +26,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const RESIZE_NODE_TYPE = "nodetool.image.Resize";
+import { RESIZE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/node_types/editing/RotateAndFlipBody.tsx
+++ b/web/src/components/node_types/editing/RotateAndFlipBody.tsx
@@ -31,8 +31,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const ROTATE_AND_FLIP_NODE_TYPE = "nodetool.image.RotateAndFlip";
+import { ROTATE_AND_FLIP_NODE_TYPE } from "../../../constants/nodeTypes";
 
 // 90° snap marks across the slider's full -360..360 range. Material UI's
 // `Slider` shows ticks for `marks`; the user can still drag freely between.

--- a/web/src/components/node_types/editing/ScaleBody.tsx
+++ b/web/src/components/node_types/editing/ScaleBody.tsx
@@ -23,8 +23,7 @@ import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-
-const SCALE_NODE_TYPE = "nodetool.image.Scale";
+import { SCALE_NODE_TYPE } from "../../../constants/nodeTypes";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/portal/welcomeTracks.ts
+++ b/web/src/components/portal/welcomeTracks.ts
@@ -33,8 +33,10 @@ export interface WelcomeTrack {
   outputHandle: string;
 }
 
-export const STRING_NODE_TYPE = "nodetool.constant.String";
-export const PREVIEW_NODE_TYPE = "nodetool.workflows.base_node.Preview";
+export {
+  STRING_NODE_TYPE,
+  PREVIEW_NODE_TYPE
+} from "../../constants/nodeTypes";
 
 export const WELCOME_TRACKS: WelcomeTrack[] = [
   {

--- a/web/src/components/sketch/sam/SamServiceFal.ts
+++ b/web/src/components/sketch/sam/SamServiceFal.ts
@@ -22,13 +22,13 @@ import type { SegmentationMask } from "../types";
 import useMetadataStore from "../../../stores/MetadataStore";
 import useSecretsStore from "../../../stores/SecretsStore";
 import { CoordinateMapper } from "../painting/CoordinateMapper";
+import { FAL_SAM_NODE_TYPE } from "../../../constants/nodeTypes";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const FAL_API_BASE = "https://queue.fal.run";
 const FAL_RESULT_BASE = "https://queue.fal.run";
 const SAM31_ENDPOINT = "fal-ai/sam-3-1/image";
-const FAL_SAM_NODE_TYPE = "fal.image_to_image.Sam3Image";
 const FAL_SAM_TEXT_PROMPT_INPUTS = ["prompt"] as const;
 const FAL_SAM_POINT_PROMPT_INPUTS = ["point_prompts"] as const;
 const FAL_SAM_BOX_PROMPT_INPUTS = ["box_prompts"] as const;

--- a/web/src/components/sketch/sam/SamServiceNode.ts
+++ b/web/src/components/sketch/sam/SamServiceNode.ts
@@ -34,8 +34,8 @@ import type { GraphNode, GraphEdge } from "./NodeExecutor";
 import { resizeForInference, MAX_INFERENCE_DIMENSION } from "./SamServiceFal";
 import { normalizeSamMasks } from "./normalizeSamMasks";
 import { CoordinateMapper } from "../painting/CoordinateMapper";
+import { LOCAL_SAM3_NODE_TYPE } from "../../../constants/nodeTypes";
 
-const LOCAL_SAM3_NODE_TYPE = "huggingface.image_segmentation.MaskGeneration";
 const LOCAL_SAM3_DOWNLOAD_TYPE = "hf.model";
 const LOCAL_SAM3_REQUIRED_INPUTS = [
   "image",

--- a/web/src/constants/nodeTypes.ts
+++ b/web/src/constants/nodeTypes.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical home for the `nodetool.*` node-type string identifiers the web UI
+ * references by name (special-cased nodes, dynamic-schema nodes, image-editing
+ * bodies, etc.).
+ *
+ * These strings originate in the Python/backend node definitions and are also
+ * generated into `packages/dsl/src/generated`. Until the web app consumes that
+ * generated metadata directly, this file is the single source of truth — define
+ * a node type here once and import it everywhere rather than re-declaring the
+ * literal (or, worse, the constant) in feature code.
+ */
+
+// --- Core workflow / base nodes -------------------------------------------
+export const GROUP_NODE_TYPE = "nodetool.workflows.base_node.Group";
+export const COMMENT_NODE_TYPE = "nodetool.workflows.base_node.Comment";
+export const PREVIEW_NODE_TYPE = "nodetool.workflows.base_node.Preview";
+export const REROUTE_NODE_TYPE = "nodetool.control.Reroute";
+export const WORKFLOW_NODE_TYPE = "nodetool.workflows.workflow_node.Workflow";
+export const SUBGRAPH_NODE_TYPE = "nodetool.workflows.subgraph.Subgraph";
+
+// --- Special editor nodes --------------------------------------------------
+export const SKETCH_NODE_TYPE = "nodetool.image.ImageEditor";
+export const CODE_NODE_TYPE = "nodetool.code.Code";
+export const STRING_NODE_TYPE = "nodetool.constant.String";
+
+// --- Dynamic-schema nodes --------------------------------------------------
+export const DYNAMIC_FAL_NODE_TYPE = "fal.DynamicFal";
+export const DYNAMIC_KIE_NODE_TYPE = "kie.dynamic_schema.KieAI";
+export const DYNAMIC_REPLICATE_NODE_TYPE = "replicate.DynamicReplicate";
+
+// --- Image segmentation (SAM) ----------------------------------------------
+export const FAL_SAM_NODE_TYPE = "fal.image_to_image.Sam3Image";
+export const LOCAL_SAM3_NODE_TYPE =
+  "huggingface.image_segmentation.MaskGeneration";
+
+// --- Image-editing node bodies ---------------------------------------------
+export const BLUR_NODE_TYPE = "nodetool.image.Blur";
+export const CHANNELS_NODE_TYPE = "nodetool.image.Channels";
+export const COMPOSITOR_NODE_TYPE = "nodetool.image.Compositor";
+export const CROP_NODE_TYPE = "nodetool.image.Crop";
+export const CURVES_NODE_TYPE = "lib.image.color_grading.Curves";
+export const EXPOSURE_NODE_TYPE = "lib.image.color_grading.Exposure";
+export const FIT_NODE_TYPE = "nodetool.image.Fit";
+export const HSL_ADJUST_NODE_TYPE = "lib.image.color_grading.HSLAdjust";
+export const LEVELS_NODE_TYPE = "nodetool.image.Levels";
+export const MASK_NODE_TYPE = "lib.image.Mask";
+export const PAINTER_NODE_TYPE = "nodetool.image.Painter";
+export const PASTE_NODE_TYPE = "nodetool.image.Paste";
+export const PROMPT_NODE_TYPE = "nodetool.text.Prompt";
+export const RESIZE_NODE_TYPE = "nodetool.image.Resize";
+export const ROTATE_AND_FLIP_NODE_TYPE = "nodetool.image.RotateAndFlip";
+export const SCALE_NODE_TYPE = "nodetool.image.Scale";

--- a/web/src/core/graph.ts
+++ b/web/src/core/graph.ts
@@ -1,6 +1,7 @@
 import { Edge, Node } from "@xyflow/react";
 import { NodeData } from "../stores/NodeData";
 import ELK, { ElkNode } from "elkjs/lib/elk.bundled.js";
+import { COMMENT_NODE_TYPE } from "../constants/nodeTypes";
 
 /**
  * Graph utilities for workflow layout and traversal.
@@ -213,7 +214,7 @@ export const autoLayout = async (
 
   // Filter out comment nodes
   const nonCommentNodes = nodes.filter(
-    (node) => node.type !== "nodetool.workflows.base_node.Comment"
+    (node) => node.type !== COMMENT_NODE_TYPE
   );
 
   // Group non-comment nodes by parentId
@@ -389,7 +390,7 @@ export const autoLayout = async (
   // Combine updated non-comment nodes with original comment nodes
   const updatedNonCommentNodes = Object.values(processedGroups).flat();
   const commentNodes = nodes.filter(
-    (node) => node.type === "nodetool.workflows.base_node.Comment"
+    (node) => node.type === COMMENT_NODE_TYPE
   );
 
   return [...updatedNonCommentNodes, ...commentNodes];

--- a/web/src/graph-entry.tsx
+++ b/web/src/graph-entry.tsx
@@ -38,6 +38,7 @@ import CommentNode from "./components/node/CommentNode";
 import SketchNode, {
   SKETCH_NODE_TYPE
 } from "./components/node/SketchNode/SketchNode";
+import { GROUP_NODE_TYPE, COMMENT_NODE_TYPE } from "./constants/nodeTypes";
 import PlaceholderNode from "./components/node_types/PlaceholderNode";
 import CustomEdge from "./components/node_editor/CustomEdge";
 import ControlEdge from "./components/node_editor/ControlEdge";
@@ -258,8 +259,8 @@ function GraphInner({
   const nodeTypes = useMemo(
     () => ({
       ...baseNodeTypes,
-      "nodetool.workflows.base_node.Group": GroupNode,
-      "nodetool.workflows.base_node.Comment": CommentNode,
+      [GROUP_NODE_TYPE]: GroupNode,
+      [COMMENT_NODE_TYPE]: CommentNode,
       [SKETCH_NODE_TYPE]: SketchNode,
       default: PlaceholderNode
     }),

--- a/web/src/hooks/handlers/useConnectionHandlers.ts
+++ b/web/src/hooks/handlers/useConnectionHandlers.ts
@@ -17,14 +17,16 @@ import {
   ConnectionMatchMenuPayload,
   ConnectionMatchOption
 } from "../../components/context_menus/ConnectionMatchMenu";
-import { DYNAMIC_KIE_NODE_TYPE } from "../../components/node/DynamicKieSchemaNode";
+import {
+  DYNAMIC_KIE_NODE_TYPE,
+  PREVIEW_NODE_TYPE,
+  REROUTE_NODE_TYPE
+} from "../../constants/nodeTypes";
 import { wouldCreateCycle } from "../../utils/graphCycle";
 import { CONTROL_HANDLE_ID } from "../../stores/graphEdgeToReactFlowEdge";
 import { shallow } from "zustand/shallow";
 
-const PREVIEW_NODE_TYPE = "nodetool.workflows.base_node.Preview";
 const PREVIEW_VALUE_HANDLE = "value";
-const REROUTE_NODE_TYPE = "nodetool.control.Reroute";
 const REROUTE_INPUT_HANDLE = "input_value";
 const REROUTE_OUTPUT_HANDLE = "output";
 

--- a/web/src/hooks/handlers/useSelectionEvents.ts
+++ b/web/src/hooks/handlers/useSelectionEvents.ts
@@ -9,6 +9,7 @@ import {
 } from "../../utils/selectionBounds";
 import { NodeData } from "../../stores/NodeData";
 import { shallow } from "zustand/shallow";
+import { GROUP_NODE_TYPE } from "../../constants/nodeTypes";
 
 interface UseSelectionEventsProps {
   reactFlowInstance: ReturnType<typeof useReactFlow>;
@@ -19,8 +20,6 @@ interface UseSelectionEventsProps {
   /** When true, the pane effect does not auto-select edges from selected nodes (node-only marquee). */
   setSuppressNodeDrivenEdgeSelection: (suppress: boolean) => void;
 }
-
-const GROUP_NODE_TYPE = "nodetool.workflows.base_node.Group";
 
 export function useSelectionEvents({
   reactFlowInstance,

--- a/web/src/hooks/nodes/useIsGroupable.ts
+++ b/web/src/hooks/nodes/useIsGroupable.ts
@@ -3,13 +3,14 @@
 import { useCallback } from "react";
 import { Node } from "@xyflow/react";
 import { NodeData } from "../../stores/NodeData";
+import { GROUP_NODE_TYPE } from "../../constants/nodeTypes";
 
 const useIsGroupable = () => {
   const isGroupable = useCallback((node: Node<NodeData>) => {
     return !(
       node.type === "nodetool.group.Loop" ||
       // node.type === "nodetool.workflows.base_node.Comment" ||
-      node.type === "nodetool.workflows.base_node.Group"
+      node.type === GROUP_NODE_TYPE
     );
   }, []);
 
@@ -17,7 +18,7 @@ const useIsGroupable = () => {
     return (
       node.type === "nodetool.group.Loop" ||
       // node.type === "nodetool.workflows.base_node.Comment" ||
-      node.type === "nodetool.workflows.base_node.Group"
+      node.type === GROUP_NODE_TYPE
     );
   }, []);
 

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -4,6 +4,7 @@ import { DataType } from "../config/data_types";
 import { NodeMetadata } from "../stores/ApiTypes";
 import { findOutputHandle, findInputHandle } from "../utils/handleUtils";
 import { NodeData } from "../stores/NodeData";
+import { REROUTE_NODE_TYPE } from "../constants/nodeTypes";
 
 /**
  * Options for processing edges in the workflow graph.
@@ -96,7 +97,6 @@ function useStructurallyProcessedEdges({
 
     const activeGradientKeys = new Set<string>();
 
-    const REROUTE_TYPE = "nodetool.control.Reroute";
     const REROUTE_INPUT = "input_value";
     const REROUTE_OUTPUT = "output";
 
@@ -139,7 +139,7 @@ function useStructurallyProcessedEdges({
 
       while (
         currentNode &&
-        currentNode.type === REROUTE_TYPE &&
+        currentNode.type === REROUTE_NODE_TYPE &&
         currentHandle === REROUTE_OUTPUT
       ) {
         if (visited.has(currentNode.id)) {break;}
@@ -230,7 +230,7 @@ function useStructurallyProcessedEdges({
 
       if (targetNode && normalizedTargetHandle) {
         if (
-          targetNode.type === REROUTE_TYPE &&
+          targetNode.type === REROUTE_NODE_TYPE &&
           normalizedTargetHandle === REROUTE_INPUT
         ) {
           targetTypeSlug = sourceTypeSlug;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -9,6 +9,7 @@ import type {} from "./window";
 import "./prismGlobal";
 
 import React, { Suspense, useEffect, useState } from "react";
+import { PREVIEW_NODE_TYPE } from "./constants/nodeTypes";
 import { useNavigate } from "react-router-dom";
 import { useWorkflowManager } from "./contexts/WorkflowManagerContext";
 import ReactDOM from "react-dom/client";
@@ -593,7 +594,7 @@ const preloadComfyMetadata = async (): Promise<void> => {
 
     const registeredNodeTypes = metadataStore.nodeTypes;
     const baseNodeComponent =
-      registeredNodeTypes["nodetool.workflows.base_node.Preview"] ||
+      registeredNodeTypes[PREVIEW_NODE_TYPE] ||
       Object.values(registeredNodeTypes)[0];
 
     if (baseNodeComponent) {

--- a/web/src/lib/tools/builtin/getGraph.ts
+++ b/web/src/lib/tools/builtin/getGraph.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { uiGetGraphParams } from "@nodetool-ai/protocol";
 import { FrontendToolRegistry } from "../frontendTools";
 import { resolveWorkflowId } from "./workflow";
+import { COMMENT_NODE_TYPE, GROUP_NODE_TYPE } from "../../../constants/nodeTypes";
 
 /**
  * Node types that are not expected to have incoming edges.
@@ -10,8 +11,8 @@ import { resolveWorkflowId } from "./workflow";
 const INPUT_OR_STRUCTURAL_PREFIXES = [
   "nodetool.input.",
   "nodetool.constant.",
-  "nodetool.workflows.base_node.Comment",
-  "nodetool.workflows.base_node.Group"
+  COMMENT_NODE_TYPE,
+  GROUP_NODE_TYPE
 ];
 
 function isInputOrStructural(nodeType: string | undefined): boolean {

--- a/web/src/serverState/useMetadata.ts
+++ b/web/src/serverState/useMetadata.ts
@@ -7,15 +7,16 @@ import { createConnectabilityMatrix } from "../components/node_menu/typeFilterUt
 import { generateSnippetMetadata } from "../config/snippetMetadata";
 import { attachBundleFalUnitPricing } from "../utils/attachBundleFalUnitPricing";
 import { attachBundleKieUnitPricing } from "../utils/attachBundleKieUnitPricing";
+import { WORKFLOW_NODE_TYPE, PREVIEW_NODE_TYPE } from "../constants/nodeTypes";
 
-export const WORKFLOW_NODE_TYPE = "nodetool.workflows.workflow_node.Workflow";
+export { WORKFLOW_NODE_TYPE };
 
 const defaultMetadata: Record<string, NodeMetadata> = {
-  "nodetool.workflows.base_node.Preview": {
+  [PREVIEW_NODE_TYPE]: {
     title: "Preview",
     description: "Preview",
     namespace: "default",
-    node_type: "nodetool.workflows.base_node.Preview",
+    node_type: PREVIEW_NODE_TYPE,
     layout: "default",
     supports_dynamic_inputs: false,
     properties: [

--- a/web/src/stores/ComfyUIStore.ts
+++ b/web/src/stores/ComfyUIStore.ts
@@ -12,6 +12,7 @@ import {
   normalizeComfyBaseUrl
 } from "../services/ComfyUIService";
 import useMetadataStore from "./MetadataStore";
+import { PREVIEW_NODE_TYPE } from "../constants/nodeTypes";
 import { comfyObjectInfoToMetadataMap } from "../utils/comfySchemaConverter";
 import { BASE_URL } from "./BASE_URL";
 
@@ -231,7 +232,7 @@ export const useComfyUIStore = create<ComfyUIState>((set, get) => ({
         });
         // Use an existing node component as base for all comfy nodes
         const baseComponent =
-          metaStore.nodeTypes["nodetool.workflows.base_node.Preview"] ||
+          metaStore.nodeTypes[PREVIEW_NODE_TYPE] ||
           Object.values(metaStore.nodeTypes)[0];
         if (baseComponent) {
           for (const nodeType of Object.keys(comfyMetadata)) {

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -48,6 +48,7 @@ import { reactFlowEdgeToGraphEdge } from "./reactFlowEdgeToGraphEdge";
 import { reactFlowNodeToGraphNode } from "./reactFlowNodeToGraphNode";
 import { isValidEdge, sanitizeGraph } from "../core/workflow/graphMapping";
 import { GROUP_NODE_TYPE } from "../utils/nodeUtils";
+import { PREVIEW_NODE_TYPE } from "../constants/nodeTypes";
 import { DEFAULT_NODE_WIDTH } from "./nodeUiDefaults";
 import { COMFY_WORKFLOW_FLAG } from "../utils/comfyWorkflowConverter";
 import { applyDefaultModels } from "../utils/applyDefaultModels";
@@ -1374,8 +1375,7 @@ export const createNodeStore = (
 
             // Set default size for nodes that host rich previews so content
             // fills a stable box instead of driving the initial layout.
-            const isPreviewNode =
-              metadata.node_type === "nodetool.workflows.base_node.Preview";
+            const isPreviewNode = metadata.node_type === PREVIEW_NODE_TYPE;
             const isCompareImagesNode =
               metadata.node_type === "nodetool.compare.CompareImages";
             const isModel3DConstantNode =

--- a/web/src/stores/graphNodeToReactFlowNode.ts
+++ b/web/src/stores/graphNodeToReactFlowNode.ts
@@ -6,6 +6,11 @@ import useMetadataStore from "./MetadataStore";
 import { applyDefaultModels } from "../utils/applyDefaultModels";
 import { reactFlowNodeChromeClassName } from "../utils/reactFlowNodeChromeClassName";
 import { NODE_COLLAPSED_STRIP_HEIGHT_PX } from "./collapseNodeLayout";
+import {
+  GROUP_NODE_TYPE,
+  COMMENT_NODE_TYPE,
+  PREVIEW_NODE_TYPE
+} from "../constants/nodeTypes";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -17,7 +22,7 @@ export function graphNodeToReactFlowNode(
 ): Node<NodeData> {
   const ui_properties = parseNodeUIProperties(node.ui_properties);
   const isCollapsed = ui_properties?.collapsed === true;
-  const isPreviewNode = node.type === "nodetool.workflows.base_node.Preview";
+  const isPreviewNode = node.type === PREVIEW_NODE_TYPE;
   const isCompareImagesNode = node.type === "nodetool.compare.CompareImages";
 
   // Debug: warn if node.data contains a stale workflow_id
@@ -73,8 +78,8 @@ export function graphNodeToReactFlowNode(
     dragHandle: ".node-drag-handle",
     expandParent: !(
       node.type === "nodetool.group.Loop" ||
-      node.type === "nodetool.workflows.base_node.Comment" ||
-      node.type === "nodetool.workflows.base_node.Group"
+      node.type === COMMENT_NODE_TYPE ||
+      node.type === GROUP_NODE_TYPE
     ),
     selectable,
     className: reactFlowNodeChromeClassName({
@@ -117,7 +122,7 @@ export function graphNodeToReactFlowNode(
     },
     zIndex:
       node.type === "nodetool.group.Loop" ||
-      node.type === "nodetool.workflows.base_node.Group"
+      node.type === GROUP_NODE_TYPE
         ? -10
         : ui_properties?.zIndex
   };

--- a/web/src/stores/reactFlowNodeToGraphNode.ts
+++ b/web/src/stores/reactFlowNodeToGraphNode.ts
@@ -3,6 +3,11 @@ import { Node as GraphNode } from "./ApiTypes";
 import { NodeData } from "./NodeData";
 import { NodeUIProperties, DEFAULT_NODE_WIDTH } from "./nodeUiDefaults";
 import { NODE_COLLAPSED_STRIP_HEIGHT_PX } from "./collapseNodeLayout";
+import {
+  GROUP_NODE_TYPE,
+  COMMENT_NODE_TYPE,
+  PREVIEW_NODE_TYPE
+} from "../constants/nodeTypes";
 
 export function reactFlowNodeToGraphNode(node: Node<NodeData>): GraphNode {
   const ui_properties: NodeUIProperties = {
@@ -61,9 +66,9 @@ export function reactFlowNodeToGraphNode(node: Node<NodeData>): GraphNode {
   }
 
   if (
-    node.type === "nodetool.workflows.base_node.Comment" ||
-    node.type === "nodetool.workflows.base_node.Group" ||
-    node.type === "nodetool.workflows.base_node.Preview"
+    node.type === COMMENT_NODE_TYPE ||
+    node.type === GROUP_NODE_TYPE ||
+    node.type === PREVIEW_NODE_TYPE
   ) {
     if (ui_properties.height === undefined) {
       ui_properties.height = node.measured?.height;

--- a/web/src/utils/ColorUtils.ts
+++ b/web/src/utils/ColorUtils.ts
@@ -1,4 +1,5 @@
 import chroma from "chroma-js";
+import { GROUP_NODE_TYPE, COMMENT_NODE_TYPE } from "../constants/nodeTypes";
 
 // Utility to detect CSS variable references (e.g. "var(--palette-primary-main)")
 function isCssVar(color: string): boolean {
@@ -199,10 +200,10 @@ export function createMinimapNodeColorFn(
 
     if (!useTypeColors) {
       // Original behavior: only special nodes get colors
-      if (node.type === "nodetool.workflows.base_node.Group") {
+      if (node.type === GROUP_NODE_TYPE) {
         return isDarkMode ? "#6366f1" : "#818cf8";
       }
-      if (node.type === "nodetool.workflows.base_node.Comment") {
+      if (node.type === COMMENT_NODE_TYPE) {
         return isDarkMode ? "#22c55e" : "#22c55e";
       }
       return isDarkMode ? "#94a3b8" : "#64748b";

--- a/web/src/utils/nodeUtils.ts
+++ b/web/src/utils/nodeUtils.ts
@@ -1,6 +1,7 @@
 import { NodeMetadata } from "../stores/ApiTypes";
+import { GROUP_NODE_TYPE, COMMENT_NODE_TYPE } from "../constants/nodeTypes";
 
-export const GROUP_NODE_TYPE = "nodetool.workflows.base_node.Group";
+export { GROUP_NODE_TYPE };
 
 /**
  * Default metadata used for creating a Group node when
@@ -28,7 +29,7 @@ export const GROUP_NODE_METADATA: NodeMetadata = {
  */
 export const COMMENT_NODE_METADATA: NodeMetadata = {
   namespace: "default",
-  node_type: "nodetool.workflows.base_node.Comment",
+  node_type: COMMENT_NODE_TYPE,
   properties: [],
   title: "Comment",
   description: "Comment",


### PR DESCRIPTION
## Summary

Created a canonical constants file (`web/src/constants/nodeTypes.ts`) to serve as the single source of truth for all `nodetool.*` node-type string identifiers used throughout the web UI. This eliminates scattered literal strings and duplicate constant definitions across the codebase.

## Key Changes

- **New file**: `web/src/constants/nodeTypes.ts` — centralized home for 30+ node type constants, organized into logical sections (core workflow nodes, special editors, dynamic-schema nodes, image segmentation, image-editing bodies)
- **Consolidated imports**: Updated 30+ files to import node type constants from the new module instead of defining them locally or using string literals
- **Removed duplicate definitions**: Eliminated redundant constant declarations in:
  - `DynamicFalSchemaNode/FalSchemaLoader.tsx`
  - `DynamicKieSchemaNode/KieSchemaLoader.tsx`
  - `DynamicReplicateNode/ReplicateSchemaLoader.tsx`
  - `SketchNode/SketchNode.tsx`
  - `SubgraphNode/index.ts`
  - `WorkflowNode/WorkflowLoader.tsx`
  - `codeNodeUi.ts`
  - `nodeUtils.ts`
  - `useMetadata.ts`
  - `welcomeTracks.ts`
  - `useSelectionEvents.ts`
  - All image-editing body components (Blur, Channels, Compositor, Crop, Curves, Exposure, Fit, HSL, Levels, Mask, Painter, Paste, Prompt, Resize, RotateAndFlip, Scale)

- **Updated references**: Replaced hardcoded string literals with imported constants in:
  - ReactFlow node type registrations
  - Graph node conversion utilities
  - Connection handlers
  - Edge processing
  - Context menus
  - Layout and styling utilities
  - Selection event handlers

## Implementation Details

- Constants are organized by category with clear section comments for maintainability
- File includes a docstring explaining its purpose as the canonical source for node-type identifiers
- All imports use named exports for clarity and tree-shaking
- No functional changes — purely a refactoring to improve code organization and reduce duplication

https://claude.ai/code/session_019SvTjYPyPh5dwkE47ccb2c