### PR TITLE
Centralize provider IDs in protocol package

### DIFF
--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -699,19 +699,73 @@ export interface ResourceLimits {
 // Models
 // ---------------------------------------------------------------------------
 
-export type Provider =
-  | "openai"
-  | "anthropic"
-  | "google"
-  | "ollama"
-  | "huggingface"
-  | "replicate"
-  | "fal"
-  | "elevenlabs"
-  | "aime"
-  | "local"
-  | "empty"
-  | string;
+/**
+ * Canonical registry of model-provider identifiers.
+ *
+ * This is the single source of truth for provider IDs across the monorepo:
+ * the runtime provider registry, the cost calculator, and the web model menu
+ * all derive from here instead of re-spelling the literals. Keys are stable
+ * UPPER_SNAKE references; values are the wire identifiers stored on models and
+ * passed to `getProvider()`.
+ *
+ * Adding a provider? Add it here first, then register it in
+ * `@nodetool-ai/runtime`'s provider index.
+ */
+export const PROVIDER_IDS = {
+  // Hosted LLM / multimodal APIs
+  OPENAI: "openai",
+  ANTHROPIC: "anthropic",
+  GEMINI: "gemini",
+  GROQ: "groq",
+  MISTRAL: "mistral",
+  MOONSHOT: "moonshot",
+  MINIMAX: "minimax",
+  DEEPSEEK: "deepseek",
+  XAI: "xai",
+  COHERE: "cohere",
+  OPENROUTER: "openrouter",
+  TOGETHER: "together",
+  CEREBRAS: "cerebras",
+  // Media / 3D / utility APIs
+  REPLICATE: "replicate",
+  FAL_AI: "fal_ai",
+  KIE: "kie",
+  TOPAZ: "topaz",
+  ATLASCLOUD: "atlascloud",
+  AKI: "aki",
+  MESHY: "meshy",
+  RODIN: "rodin",
+  // Embeddings / reranking
+  VOYAGE: "voyage",
+  JINA: "jina",
+  // Local / self-hosted
+  OLLAMA: "ollama",
+  LMSTUDIO: "lmstudio",
+  LLAMA_CPP: "llama_cpp",
+  VLLM: "vllm",
+  HUGGINGFACE: "huggingface",
+  TRANSFORMERS_JS: "transformers_js",
+  // Test-only (gated behind NODETOOL_ENABLE_FAKE_PROVIDER)
+  FAKE: "fake"
+} as const;
+
+/** A provider identifier known to the registry above. */
+export type KnownProviderId = (typeof PROVIDER_IDS)[keyof typeof PROVIDER_IDS];
+
+/**
+ * Provider identifier. Resolves to a known {@link PROVIDER_IDS} value with
+ * editor autocompletion, but still accepts arbitrary strings — dynamic
+ * sub-providers (OpenRouter, HuggingFace inference) and Python-bridged
+ * providers (MLX, local HF) supply IDs that aren't enumerated above. The
+ * `(string & {})` arm preserves the literal hints while keeping the type open.
+ */
+export type ProviderId = KnownProviderId | (string & {});
+
+/**
+ * Alias of {@link ProviderId}. Retained as the field-type name used across the
+ * model interfaces below (`LanguageModel.provider`, `ProviderInfo.provider`, …).
+ */
+export type Provider = ProviderId;
 
 export type InferenceProvider =
   | "cerebras"

--- a/packages/runtime/src/providers/cost-calculator.ts
+++ b/packages/runtime/src/providers/cost-calculator.ts
@@ -368,6 +368,7 @@ export interface UsageInfo {
 }
 
 import { createLogger } from "@nodetool-ai/config";
+import { PROVIDER_IDS, type ProviderId } from "@nodetool-ai/protocol";
 
 const log = createLogger("nodetool.runtime.cost");
 
@@ -379,7 +380,7 @@ export class CostCalculator {
    * @param provider - Provider name (e.g., "openai", "anthropic")
    * @returns The pricing tier name, or null if not found
    */
-  static getTier(modelId: string, provider: string): string | null {
+  static getTier(modelId: string, provider: ProviderId): string | null {
     const modelLower = modelId.toLowerCase();
     const providerLower = provider.toLowerCase();
 
@@ -422,7 +423,7 @@ export class CostCalculator {
   static calculate(
     modelId: string,
     usage: UsageInfo,
-    provider: string
+    provider: ProviderId
   ): number {
     const tierName = CostCalculator.getTier(modelId, provider);
     if (tierName === null) {
@@ -501,7 +502,7 @@ export function calculateChatCost(
   inputTokens: number,
   outputTokens: number,
   cachedTokens: number = 0,
-  provider: string = "openai"
+  provider: ProviderId = PROVIDER_IDS.OPENAI
 ): number {
   const usage: UsageInfo = { inputTokens, outputTokens, cachedTokens };
   return CostCalculator.calculate(modelId, usage, provider);
@@ -513,7 +514,7 @@ export function calculateChatCost(
 export function calculateEmbeddingCost(
   modelId: string,
   inputTokens: number,
-  provider: string = "openai"
+  provider: ProviderId = PROVIDER_IDS.OPENAI
 ): number {
   const usage: UsageInfo = { inputTokens };
   return CostCalculator.calculate(modelId, usage, provider);
@@ -525,7 +526,7 @@ export function calculateEmbeddingCost(
 export function calculateSpeechCost(
   modelId: string,
   inputChars: number,
-  provider: string = "openai"
+  provider: ProviderId = PROVIDER_IDS.OPENAI
 ): number {
   const usage: UsageInfo = { inputCharacters: inputChars };
   return CostCalculator.calculate(modelId, usage, provider);
@@ -537,7 +538,7 @@ export function calculateSpeechCost(
 export function calculateWhisperCost(
   modelId: string,
   durationSeconds: number,
-  provider: string = "openai"
+  provider: ProviderId = PROVIDER_IDS.OPENAI
 ): number {
   const usage: UsageInfo = { durationSeconds };
   return CostCalculator.calculate(modelId, usage, provider);
@@ -549,7 +550,7 @@ export function calculateWhisperCost(
  */
 export function calculateModel3DCost(
   modelId: string,
-  provider: string,
+  provider: ProviderId,
   taskCount: number = 1
 ): number {
   const usage: UsageInfo = { taskCount };
@@ -563,7 +564,7 @@ export function calculateImageCost(
   modelId: string,
   imageCount: number = 1,
   quality: string = "medium",
-  provider: string = "openai"
+  provider: ProviderId = PROVIDER_IDS.OPENAI
 ): number {
   // Adjust tier based on quality for gpt-image models
   if (modelId.toLowerCase().includes("gpt-image") && !modelId.includes("1.5")) {

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -103,6 +103,7 @@ export {
 } from "./provider-registry.js";
 export type { GetSecret } from "./provider-registry.js";
 import { registerProvider as registerBuiltinProvider } from "./provider-registry.js";
+import { PROVIDER_IDS } from "@nodetool-ai/protocol";
 export type {
   ProviderId,
   LanguageModel,
@@ -138,29 +139,29 @@ export type {
 // circuit the registry's resolution branch (which only re-resolves when the
 // kwarg is empty/null). Empty-string declarations force every getProvider()
 // call to ask the supplied `getSecret` (DB-then-env) at instantiation time.
-registerBuiltinProvider("openai", OpenAIProvider, { OPENAI_API_KEY: "" });
-registerBuiltinProvider("anthropic", AnthropicProvider, { ANTHROPIC_API_KEY: "" });
-registerBuiltinProvider("gemini", GeminiProvider, { GEMINI_API_KEY: "" });
-registerBuiltinProvider("groq", GroqProvider, { GROQ_API_KEY: "" });
-registerBuiltinProvider("mistral", MistralProvider, { MISTRAL_API_KEY: "" });
-registerBuiltinProvider("moonshot", MoonshotProvider, { KIMI_API_KEY: "" });
-registerBuiltinProvider("minimax", MinimaxProvider, { MINIMAX_API_KEY: "" });
-registerBuiltinProvider("replicate", ReplicateProvider, { REPLICATE_API_TOKEN: "" });
-registerBuiltinProvider("fal_ai", FalProvider, { FAL_API_KEY: "" });
-registerBuiltinProvider("kie", KieProvider, { KIE_API_KEY: "" });
-registerBuiltinProvider("topaz", TopazProvider, { TOPAZ_API_KEY: "" });
-registerBuiltinProvider("atlascloud", AtlasCloudProvider, { ATLASCLOUD_API_KEY: "" });
-registerBuiltinProvider("aki", AkiProvider, { AKI_API_KEY: "" });
-registerBuiltinProvider("meshy", MeshyProvider, { MESHY_API_KEY: "" });
-registerBuiltinProvider("rodin", RodinProvider, { RODIN_API_KEY: "" });
-registerBuiltinProvider("openrouter", OpenRouterProvider, { OPENROUTER_API_KEY: "" });
-registerBuiltinProvider("together", TogetherProvider, { TOGETHER_API_KEY: "" });
-registerBuiltinProvider("cerebras", CerebrasProvider, { CEREBRAS_API_KEY: "" });
-registerBuiltinProvider("cohere", CohereProvider, { COHERE_API_KEY: "" });
-registerBuiltinProvider("voyage", VoyageProvider, { VOYAGE_API_KEY: "" });
-registerBuiltinProvider("jina", JinaProvider, { JINA_API_KEY: "" });
-registerBuiltinProvider("deepseek", DeepSeekProvider, { DEEPSEEK_API_KEY: "" });
-registerBuiltinProvider("xai", XAIProvider, { XAI_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.OPENAI, OpenAIProvider, { OPENAI_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.ANTHROPIC, AnthropicProvider, { ANTHROPIC_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.GEMINI, GeminiProvider, { GEMINI_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.GROQ, GroqProvider, { GROQ_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.MISTRAL, MistralProvider, { MISTRAL_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.MOONSHOT, MoonshotProvider, { KIMI_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.MINIMAX, MinimaxProvider, { MINIMAX_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.REPLICATE, ReplicateProvider, { REPLICATE_API_TOKEN: "" });
+registerBuiltinProvider(PROVIDER_IDS.FAL_AI, FalProvider, { FAL_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.KIE, KieProvider, { KIE_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.TOPAZ, TopazProvider, { TOPAZ_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.ATLASCLOUD, AtlasCloudProvider, { ATLASCLOUD_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.AKI, AkiProvider, { AKI_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.MESHY, MeshyProvider, { MESHY_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.RODIN, RodinProvider, { RODIN_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.OPENROUTER, OpenRouterProvider, { OPENROUTER_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.TOGETHER, TogetherProvider, { TOGETHER_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.CEREBRAS, CerebrasProvider, { CEREBRAS_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.COHERE, CohereProvider, { COHERE_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.VOYAGE, VoyageProvider, { VOYAGE_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.JINA, JinaProvider, { JINA_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.DEEPSEEK, DeepSeekProvider, { DEEPSEEK_API_KEY: "" });
+registerBuiltinProvider(PROVIDER_IDS.XAI, XAIProvider, { XAI_API_KEY: "" });
 
 // Local-only providers — require local servers/CLIs, skip in production
 const _envProcess =
@@ -173,7 +174,7 @@ if (_envProcess.env["NODETOOL_ENV"] !== "production") {
   // take effect without a restart. Empty kwargs keep isProviderConfigured()
   // returning true for the zero-config localhost case.
   registerBuiltinProvider(
-    "ollama",
+    PROVIDER_IDS.OLLAMA,
     OllamaProvider,
     {},
     { OLLAMA_API_URL: "http://127.0.0.1:11434" }
@@ -186,7 +187,7 @@ if (_envProcess.env["NODETOOL_ENV"] !== "production") {
   // false when the user hasn't set anything (LM Studio runs at the default
   // localhost:1234 out of the box).
   registerBuiltinProvider(
-    "lmstudio",
+    PROVIDER_IDS.LMSTUDIO,
     LMStudioProvider,
     {},
     {
@@ -196,12 +197,12 @@ if (_envProcess.env["NODETOOL_ENV"] !== "production") {
   );
   // llama.cpp OpenAI-compatible server — URL only from Settings / env (no
   // default host). Empty kwarg keeps the provider "unavailable" until configured.
-  registerBuiltinProvider("llama_cpp", LlamaProvider, {
+  registerBuiltinProvider(PROVIDER_IDS.LLAMA_CPP, LlamaProvider, {
     LLAMA_CPP_URL: ""
   });
   // vLLM — base URL from Settings / env; optional API key defaults like LM Studio.
   registerBuiltinProvider(
-    "vllm",
+    PROVIDER_IDS.VLLM,
     VLLMProvider,
     { VLLM_BASE_URL: "" },
     { VLLM_API_KEY: "sk-no-key-required" }
@@ -214,5 +215,5 @@ if (
   _envProcess.env["NODETOOL_ENV"] !== "production" &&
   _envProcess.env["NODETOOL_ENABLE_FAKE_PROVIDER"] === "1"
 ) {
-  registerBuiltinProvider("fake", FakeProvider, {});
+  registerBuiltinProvider(PROVIDER_IDS.FAKE, FakeProvider, {});
 }

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -1,11 +1,10 @@
-import type { Chunk } from "@nodetool-ai/protocol";
+import type { Chunk, ProviderId } from "@nodetool-ai/protocol";
 
-export type ProviderId =
-  | "openai"
-  | "anthropic"
-  | "ollama"
-  | "llama_cpp"
-  | string;
+// Provider identifiers are owned by @nodetool-ai/protocol (the base dependency
+// for the whole monorepo). Re-exported here so existing runtime importers keep
+// resolving `ProviderId`/`PROVIDER_IDS` from `./types.js`.
+export { PROVIDER_IDS } from "@nodetool-ai/protocol";
+export type { ProviderId };
 
 export interface LanguageModel {
   id: string;

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -60,6 +60,8 @@ import {
   Property,
   PropertyTypeMetadata,
   Provider,
+  ProviderId,
+  PROVIDER_IDS,
   ProviderInfo,
   RepoPath,
   RunJobRequest,
@@ -175,6 +177,8 @@ export type { Prediction };
 export type { Property };
 export type { PropertyTypeMetadata };
 export type { Provider };
+export type { ProviderId };
+export { PROVIDER_IDS };
 export type { ProviderCost };
 export type { ProviderInfo };
 export type { RepoPath };

--- a/web/src/stores/ModelMenuStore.ts
+++ b/web/src/stores/ModelMenuStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { PROVIDER_IDS, type ProviderId } from "@nodetool-ai/protocol";
 import type {
   ImageModel,
   LanguageModel,
@@ -18,7 +19,7 @@ export type EnabledProvidersMap = Record<string, boolean>;
 
 export interface ModelSelectorModel {
   type: string;
-  provider: string;
+  provider: ProviderId;
   id: string;
   name: string;
   path?: string | null;
@@ -57,28 +58,33 @@ const isAkiProviderIdentifier = (provider: string): boolean => {
   }
 };
 
-export const requiredSecretForProvider = (provider?: string): string | null => {
+export const requiredSecretForProvider = (
+  provider?: ProviderId
+): string | null => {
   const p = (provider || "").toLowerCase();
-  if (p.includes("openai")) {return "OPENAI_API_KEY";}
-  if (p.includes("anthropic")) {return "ANTHROPIC_API_KEY";}
-  if (p.includes("gemini") || p.includes("google")) {return "GEMINI_API_KEY";}
-  if (p.includes("meshy")) {return "MESHY_API_KEY";}
-  if (p.includes("rodin")) {return "RODIN_API_KEY";}
+  // Canonical IDs come from PROVIDER_IDS; the extra literals below ("google",
+  // "fal", "kimi", "hf_", 3D providers, …) are aliases / Python-side IDs that
+  // aren't part of the TS provider registry but still map to a secret.
+  if (p.includes(PROVIDER_IDS.OPENAI)) {return "OPENAI_API_KEY";}
+  if (p.includes(PROVIDER_IDS.ANTHROPIC)) {return "ANTHROPIC_API_KEY";}
+  if (p.includes(PROVIDER_IDS.GEMINI) || p.includes("google")) {return "GEMINI_API_KEY";}
+  if (p.includes(PROVIDER_IDS.MESHY)) {return "MESHY_API_KEY";}
+  if (p.includes(PROVIDER_IDS.RODIN)) {return "RODIN_API_KEY";}
   if (p.includes("trellis")) {return "TRELLIS_API_KEY";}
   if (p.includes("tripo")) {return "TRIPO_API_KEY";}
   if (p.includes("hunyuan3d")) {return "HUNYUAN3D_API_KEY";}
   if (p.includes("shap_e") || p.includes("shap-e")) {return "SHAP_E_API_KEY";}
   if (p.includes("point_e") || p.includes("point-e")) {return "POINT_E_API_KEY";}
-  if (p.includes("huggingface") || p.includes("hf_")) {return "HF_TOKEN";}
-  if (p.includes("replicate")) {return "REPLICATE_API_TOKEN";}
+  if (p.includes(PROVIDER_IDS.HUGGINGFACE) || p.includes("hf_")) {return "HF_TOKEN";}
+  if (p.includes(PROVIDER_IDS.REPLICATE)) {return "REPLICATE_API_TOKEN";}
   if (p.includes("fal")) {return "FAL_API_KEY";}
   if (p.includes("aime")) {return "AIME_API_KEY";}
-  if (p.includes("moonshot") || p.includes("kimi")) {return "KIMI_API_KEY";}
-  if (p.includes("minimax")) {return "MINIMAX_API_KEY";}
-  if (p.includes("together")) {return "TOGETHER_API_KEY";}
-  if (p === "cohere") {return "COHERE_API_KEY";}
-  if (p === "voyage" || p === "voyage-ai" || p === "voyageai") {return "VOYAGE_API_KEY";}
-  if (p === "jina" || p === "jina-ai" || p === "jinaai") {return "JINA_API_KEY";}
+  if (p.includes(PROVIDER_IDS.MOONSHOT) || p.includes("kimi")) {return "KIMI_API_KEY";}
+  if (p.includes(PROVIDER_IDS.MINIMAX)) {return "MINIMAX_API_KEY";}
+  if (p.includes(PROVIDER_IDS.TOGETHER)) {return "TOGETHER_API_KEY";}
+  if (p === PROVIDER_IDS.COHERE) {return "COHERE_API_KEY";}
+  if (p === PROVIDER_IDS.VOYAGE || p === "voyage-ai" || p === "voyageai") {return "VOYAGE_API_KEY";}
+  if (p === PROVIDER_IDS.JINA || p === "jina-ai" || p === "jinaai") {return "JINA_API_KEY";}
   if (isAkiProviderIdentifier(p)) {return "AKI_API_KEY";}
   return null;
 };


### PR DESCRIPTION
## Summary

Establishes `PROVIDER_IDS` as the single source of truth for provider identifiers across the monorepo. Previously, provider strings were scattered as string literals across the runtime provider registry, cost calculator, and web model menu. This change consolidates them into a canonical registry in `@nodetool-ai/protocol`, enabling type-safe references and reducing duplication.

## Key Changes

- **`packages/protocol/src/api-types.ts`**
  - Replaced `Provider` union type (loose string literal union) with a structured `PROVIDER_IDS` constant object mapping `UPPER_SNAKE` keys to wire identifiers
  - Introduced `KnownProviderId` type for values from the registry
  - Redefined `ProviderId` as `KnownProviderId | (string & {})` to support both known providers (with editor autocompletion) and dynamic sub-providers (OpenRouter, HuggingFace inference, Python-bridged MLX/local HF)
  - Kept `Provider` as an alias of `ProviderId` for backward compatibility with existing field types

- **`packages/runtime/src/providers/index.ts`**
  - Imported `PROVIDER_IDS` from protocol
  - Updated all 27 `registerBuiltinProvider()` calls to use `PROVIDER_IDS.<KEY>` instead of string literals
  - Covers hosted LLM APIs (OpenAI, Anthropic, Gemini, Groq, Mistral, etc.), media/3D APIs (Replicate, FAL, KIE, etc.), embeddings (Voyage, Jina), and local providers (Ollama, LM Studio, llama.cpp, vLLM)

- **`packages/runtime/src/providers/types.ts`**
  - Removed local `ProviderId` type definition
  - Re-exported `ProviderId` and `PROVIDER_IDS` from protocol for backward compatibility with existing runtime importers

- **`packages/runtime/src/providers/cost-calculator.ts`**
  - Imported `PROVIDER_IDS` and `ProviderId` from protocol
  - Updated function signatures (`getTier`, `calculate`, `calculateChatCost`, `calculateEmbeddingCost`, `calculateSpeechCost`, `calculateWhisperCost`, `calculateModel3DCost`, `calculateImageCost`) to use `ProviderId` type
  - Updated default parameter values to use `PROVIDER_IDS.OPENAI` instead of string literal

- **`web/src/stores/ModelMenuStore.ts`**
  - Imported `PROVIDER_IDS` and `ProviderId` from protocol
  - Updated `ModelSelectorModel.provider` field type to `ProviderId`
  - Updated `requiredSecretForProvider()` function signature to accept `ProviderId`
  - Replaced string literal checks with `PROVIDER_IDS.<KEY>` references for canonical providers while preserving alias checks (e.g., "google" → Gemini, "hf_" → HuggingFace, "kimi" → Moonshot)

- **`web/src/stores/ApiTypes.ts`**
  - Added exports of `ProviderId` type and `PROVIDER_IDS` constant from protocol for web consumers

## Implementation Details

- The `PROVIDER_IDS` object uses `as const` to preserve literal types, enabling both type safety and editor autocompletion
- The `ProviderId` type remains open (`string & {}`) to accommodate dynamic providers from Python-side code and third-party integrations that aren't enumerated in the registry
- All 27 provider registrations now derive from a single source, eliminating the risk of typos or inconsistencies
- Backward compatibility maintained: `Provider` remains the field-type name across model interfaces, and runtime importers can still resolve `ProviderId` from `./types.js`

https://claude.ai/code/session_01JbLvdEgm6WFDy6ipoCdk59