### PR TITLE
Extract Collapse to ui_primitives wrapper component

### DIFF
--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -26,14 +26,14 @@ import {
   FlexRow,
   FlexColumn,
   ToolbarIconButton,
-  LoadingSpinner
+  LoadingSpinner,
+  Collapse
 } from "../../ui_primitives";
 import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import PersonOutlineRoundedIcon from "@mui/icons-material/PersonOutlineRounded";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
-import { Collapse } from "@mui/material";
 
 
 import AgentExecutionView from "./AgentExecutionView";

--- a/web/src/components/ui_primitives/Collapse.tsx
+++ b/web/src/components/ui_primitives/Collapse.tsx
@@ -1,0 +1,25 @@
+/**
+ * Collapse Component
+ *
+ * A thin wrapper around MUI Collapse for animation-only use cases where the
+ * toggle control lives elsewhere (e.g. a separate button in a custom header).
+ *
+ * For the common "clickable title header + collapsible body" pattern, prefer
+ * `CollapsibleSection`, which bundles the toggle header with the animation.
+ */
+
+import React from "react";
+import { Collapse as MuiCollapse, CollapseProps as MuiCollapseProps } from "@mui/material";
+
+export type CollapseProps = MuiCollapseProps;
+
+/**
+ * Collapse - Expand/collapse animation wrapper
+ *
+ * @example
+ * // Externally controlled toggle, animation only
+ * <Collapse in={open} timeout="auto" unmountOnExit>
+ *   <DetailContent />
+ * </Collapse>
+ */
+export const Collapse: React.FC<CollapseProps> = (props) => <MuiCollapse {...props} />;

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -278,6 +278,9 @@ export type { PopoverProps, PopoverPlacement } from "./Popover";
 export { CollapsibleSection } from "./CollapsibleSection";
 export type { CollapsibleSectionProps } from "./CollapsibleSection";
 
+export { Collapse } from "./Collapse";
+export type { CollapseProps } from "./Collapse";
+
 export { ListGroup, ListItemRow } from "./ListGroup";
 export type { ListGroupProps, ListItemRowProps } from "./ListGroup";
 


### PR DESCRIPTION
## Summary
Extracted MUI's `Collapse` component into a dedicated ui_primitives wrapper following the project's UI primitives strategy. This ensures all MUI component usage goes through the centralized primitives layer.

## Changes
- **New component**: `web/src/components/ui_primitives/Collapse.tsx`
  - Thin wrapper around `@mui/material/Collapse` for animation-only use cases
  - Includes documentation distinguishing it from `CollapsibleSection` (which bundles toggle header + animation)
  - Exports `CollapseProps` type alias for convenience

- **Updated imports**: `web/src/components/chat/message/MessageView.tsx`
  - Changed from direct MUI import (`import { Collapse } from "@mui/material"`) to ui_primitives import
  - Maintains identical functionality while adhering to the primitives strategy

- **Exported from index**: `web/src/components/ui_primitives/index.ts`
  - Added `Collapse` and `CollapseProps` exports alongside other primitives

## Implementation Details
The wrapper is intentionally minimal—it passes all props directly to MUI's `Collapse` without modification. This follows the pattern for animation-only wrappers where the toggle control lives elsewhere (e.g., a separate button in a custom header).

https://claude.ai/code/session_011829NBZtorwbX2WnNwPXcZ