### PR TITLE
fix(web): open assets as workspace tabs and load images into the sketch editor

### DIFF
--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -41,7 +41,7 @@ import type { SxProps, Theme } from "@mui/material/styles";
 import { useAssetDownload } from "../../hooks/assets/useAssetDownload";
 import { useAssetNavigation } from "../../hooks/assets/useAssetNavigation";
 import { useAssetDisplay } from "../../hooks/assets/useAssetDisplay";
-import { useOpenImageInSketch } from "../../hooks/sketch/useOpenImageInSketch";
+import { useNavigate } from "react-router-dom";
 import { isEditableModel3DAsset } from "../model_editor/isEditableModel3D";
 import { isElectron } from "../../utils/browser";
 import { copyAssetToClipboard, isClipboardSupported } from "../../utils/clipboardUtils";
@@ -290,6 +290,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
   // Editing opens the asset in a workspace tab (image → sketch editor,
   // model3d → 3D editor), retiring the legacy /assets/edit route.
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const navigate = useNavigate();
 
   // Reset compare mode when viewer closes
   useEffect(() => {
@@ -379,12 +380,18 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
     setCompareAssetB(null);
   }, []);
 
-  const openImageInSketch = useOpenImageInSketch();
   const handleOpenImageEditor = useCallback(() => {
     if (currentAsset && isImage) {
-      void openImageInSketch(currentAsset);
+      openTab({
+        type: "image",
+        ref: currentAsset.id,
+        mode: "edit",
+        title: currentAsset.name || "Image"
+      });
+      navigate("/workspace");
+      handleClose();
     }
-  }, [currentAsset, isImage, openImageInSketch]);
+  }, [currentAsset, isImage, openTab, navigate, handleClose]);
 
   const handleOpenModel3DEditor = useCallback(() => {
     if (currentAsset && isModel3D) {
@@ -394,9 +401,10 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
         mode: "edit",
         title: currentAsset.name || "3D model"
       });
+      navigate("/workspace");
       handleClose();
     }
-  }, [currentAsset, isModel3D, openTab, handleClose]);
+  }, [currentAsset, isModel3D, openTab, navigate, handleClose]);
 
 
   // Copy to clipboard state and handler

--- a/web/src/components/context_menus/AssetItemContextMenu.tsx
+++ b/web/src/components/context_menus/AssetItemContextMenu.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent } from "react";
 import { useCallback, memo } from "react";
+import { useNavigate } from "react-router-dom";
 //mui
 import { Menu, MenuItem } from "@mui/material";
 import { Text, Divider } from "../ui_primitives";
@@ -18,7 +19,8 @@ import useContextMenuStore from "../../stores/ContextMenuStore";
 import { useAssetStore } from "../../stores/AssetStore";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
-import { useFileTabsStore } from "../../stores/FileTabsStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { assetTabType } from "../workspace/assetTabType";
 import { isElectron } from "../../utils/browser";
 import { copyAssetToClipboard, isClipboardSupported } from "../../utils/clipboardUtils";
 import AssetInfoPanel from "./AssetInfoPanel";
@@ -51,7 +53,8 @@ const AssetItemContextMenu = () => {
   const download = useAssetStore((state) => state.download);
   const addNotification = useNotificationStore((state) => state.addNotification);
 
-  const openFileTab = useFileTabsStore((state) => state.openFileTab);
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const navigate = useNavigate();
 
   const isFolder = selectedAssets.some(
     (asset) => asset.content_type === "folder"
@@ -68,10 +71,13 @@ const AssetItemContextMenu = () => {
     selectedAssets.length === 2 &&
     selectedAssets.every((asset) => asset.content_type?.startsWith("image/"));
 
-  // Check if a single non-folder asset is selected (for "Open as Tab")
-  const isSingleNonFolderAsset =
-    selectedAssets.length === 1 &&
-    selectedAssets[0]?.content_type !== "folder";
+  // Resolve the workspace tab type for a single selected asset ("Open as Tab").
+  // Null when nothing is openable as a tab (multi-select, folder, or a content
+  // type with no document surface, e.g. video).
+  const openableTabType =
+    selectedAssets.length === 1 && selectedAssets[0]
+      ? assetTabType(selectedAssets[0])
+      : null;
 
   // Determine if we have non-folder assets selected for moving to new folder
   const hasSelectedAssets = selectedAssets.length > 0 && !isFolder;
@@ -158,8 +164,15 @@ const AssetItemContextMenu = () => {
   });
 
   const handleOpenAsTab = withMenuClose(() => {
-    if (isSingleNonFolderAsset && selectedAssets[0]) {
-      openFileTab(selectedAssets[0]);
+    const asset = selectedAssets[0];
+    if (openableTabType && asset) {
+      openTab({
+        type: openableTabType,
+        ref: asset.id,
+        mode: "view",
+        title: asset.name || "Untitled"
+      });
+      navigate("/workspace");
     }
   });
 
@@ -205,7 +218,7 @@ const AssetItemContextMenu = () => {
           IconComponent={<DriveFileRenameOutlineIcon />}
           tooltip="Rename selected assets"
         />
-        {isSingleNonFolderAsset && (
+        {openableTabType && (
           <ContextMenuItem
             onClick={handleOpenAsTab}
             label="Open as Tab"

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -21,6 +21,7 @@ import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 import type { Layer } from "./types";
 import { summarizeLayerImageReference } from "./types";
 import { getLayerDataImageUrl } from "./serialization";
+import { resolveAssetUri } from "../node/output/hooks";
 import {
   SKETCH_FONT,
   SKETCH_SPACING,
@@ -140,7 +141,10 @@ const LayerItem: React.FC<LayerItemProps> = ({
   bindingStatus
 }) => {
   const isGroup = layer.type === "group";
-  const thumbnailSrc = isGroup ? null : getLayerDataImageUrl(layer.data);
+  // Resolve the image ref to a fetchable URL — a raw `asset://` scheme is
+  // blocked by the page CSP when set directly as an <img src>.
+  const layerImage = isGroup ? null : getLayerDataImageUrl(layer.data);
+  const thumbnailSrc = layerImage ? resolveAssetUri(layerImage) : null;
 
   // Mockup-style sub-label under the name: blend mode + opacity (or MASK).
   const opacityPct = Math.round(layer.opacity * 100);

--- a/web/src/components/sketch/hooks/useEditorLifecycle.ts
+++ b/web/src/components/sketch/hooks/useEditorLifecycle.ts
@@ -156,16 +156,20 @@ export function useEditorLifecycle({
   // On revisit of the same document we'd otherwise re-hydrate it from the
   // trpc cache — and that cache lags real edits whenever an autosave is
   // mid-flight on the way out of the page, which would wipe a freshly-added
-  // layer the moment the user comes back. The session store's
-  // `documentId` is the authoritative "currently loaded doc" marker and
-  // persists across unmounts; if it already matches the incoming id we
-  // trust the in-memory store and skip the rehydrate.
+  // layer the moment the user comes back.
+  //
+  // The gate keys on `hydratedDocumentId` — the doc the editor has actually
+  // seeded into the global store — NOT the session `documentId`. The latter
+  // is set the moment a document's metadata loads, which in the standalone
+  // editor happens in the parent before this child mounts; gating on it made
+  // every fresh load look like a same-doc revisit and skip the seed, leaving
+  // the global store on its default blank document.
   useLayoutEffect(() => {
     initialDocumentRef.current = initialDocument;
 
-    const sessionDocId = useSketchSessionStore.getState().documentId;
+    const session = useSketchSessionStore.getState();
     const isSameDocRevisit =
-      documentId !== undefined && sessionDocId === documentId;
+      documentId !== undefined && session.hydratedDocumentId === documentId;
     if (!isSameDocRevisit) {
       if (initialEditorState) {
         hydrateSketchStore({
@@ -178,6 +182,9 @@ export function useEditorLifecycle({
         });
       } else if (initialDocument) {
         setDocument(initialDocument);
+      }
+      if (documentId !== undefined) {
+        session.markHydrated(documentId);
       }
     }
     setCanvasReady(true);

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -24,6 +24,7 @@ import {
   useWorkspaceTabsStore,
   type WorkspaceTabType
 } from "../../stores/WorkspaceTabsStore";
+import { assetTabType } from "./assetTabType";
 import type { WorkflowList, AssetWithPath } from "../../stores/ApiTypes";
 
 /** Render a blank white PNG to seed a "New image" canvas asset. */
@@ -74,22 +75,6 @@ interface OpenMenuProps {
 }
 
 type MenuView = "root" | "workflows" | "assets";
-
-/** Map an asset's content type to the workspace tab type that can open it. */
-const assetTabType = (asset: AssetWithPath): WorkspaceTabType | null => {
-  const ct = asset.content_type ?? "";
-  const name = (asset.name ?? "").toLowerCase();
-  if (ct.startsWith("image/")) return "image";
-  if (ct.startsWith("audio/")) return "audio";
-  if (ct.startsWith("text/") || ct === "application/json") return "text";
-  if (
-    ct.startsWith("model/") ||
-    /\.(glb|gltf|obj|fbx|stl|ply|usdz)$/.test(name)
-  ) {
-    return "model3d";
-  }
-  return null;
-};
 
 /**
  * The `[+]` menu for the workspace tab bar: create a new workflow, or open an

--- a/web/src/components/workspace/assetTabType.ts
+++ b/web/src/components/workspace/assetTabType.ts
@@ -1,0 +1,27 @@
+import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
+
+/** The minimal asset shape needed to pick a workspace tab type. */
+interface AssetLike {
+  content_type?: string | null;
+  name?: string | null;
+}
+
+/**
+ * Map an asset's content type to the workspace tab type that can open it, or
+ * `null` when no surface handles it (e.g. video, which only exists as a
+ * timeline sequence, not a standalone asset tab).
+ */
+export const assetTabType = (asset: AssetLike): WorkspaceTabType | null => {
+  const ct = asset.content_type ?? "";
+  const name = (asset.name ?? "").toLowerCase();
+  if (ct.startsWith("image/")) return "image";
+  if (ct.startsWith("audio/")) return "audio";
+  if (ct.startsWith("text/") || ct === "application/json") return "text";
+  if (
+    ct.startsWith("model/") ||
+    /\.(glb|gltf|obj|fbx|stl|ply|usdz)$/.test(name)
+  ) {
+    return "model3d";
+  }
+  return null;
+};

--- a/web/src/hooks/sketch/__tests__/buildSeededImageDocument.test.ts
+++ b/web/src/hooks/sketch/__tests__/buildSeededImageDocument.test.ts
@@ -32,9 +32,9 @@ function makeBaseDoc(): sketch.ImageDocumentData {
 }
 
 describe("buildSeededImageDocument", () => {
-  it("seeds the first layer with an asset:// reference and full-canvas bounds", () => {
+  it("seeds the first layer with the given image URI and full-canvas bounds", () => {
     const result = buildSeededImageDocument(makeBaseDoc(), {
-      assetId: "asset-123",
+      imageUri: "asset://asset-123.png",
       width: 10,
       height: 20,
       name: "photo.png"
@@ -49,13 +49,15 @@ describe("buildSeededImageDocument", () => {
     const decoded = JSON.parse(
       atob((layer.data as string).slice(SERIALIZED_PREFIX.length))
     );
-    expect(decoded.image).toBe("asset://asset-123");
+    // The reference must carry the file extension — a bare asset://{id} would
+    // resolve to /api/storage/{id} and 404.
+    expect(decoded.image).toBe("asset://asset-123.png");
     expect(decoded.bounds).toEqual({ x: 0, y: 0, width: 10, height: 20 });
   });
 
   it("preserves canvas, active layer, and bindings from the source document", () => {
     const result = buildSeededImageDocument(makeBaseDoc(), {
-      assetId: "a",
+      imageUri: "asset://a.png",
       width: 10,
       height: 20,
       name: "x"

--- a/web/src/hooks/sketch/buildSeededImageDocument.ts
+++ b/web/src/hooks/sketch/buildSeededImageDocument.ts
@@ -8,24 +8,28 @@ type ImageDocumentData = sketch.ImageDocumentData;
  * raster layer that references an existing image asset, so the standalone
  * editor opens with that image as its editable base layer.
  *
- * The layer `data` holds an `asset://{id}` reference rather than inline pixels:
- * `Canvas2DRuntime.setLayerData` resolves the scheme and fetches the bytes on
- * load, so the persisted document stays tiny (no megabytes of base64) and never
- * trips the sketch autosave size guard. Once the user paints, the live canvas
- * is serialized to owned pixels on the next autosave.
+ * The layer `data` holds an `asset://{id}.{ext}` reference rather than inline
+ * pixels: `Canvas2DRuntime.setLayerData` resolves the scheme and fetches the
+ * bytes on load, so the persisted document stays tiny (no megabytes of base64)
+ * and never trips the sketch autosave size guard. Once the user paints, the
+ * live canvas is serialized to owned pixels on the next autosave.
+ *
+ * The reference MUST carry the file extension — the storage endpoint serves
+ * files by name, so `/api/storage/{id}` (no extension) 404s while
+ * `/api/storage/{id}.png` resolves. The caller passes the qualified URI.
  */
 export function buildSeededImageDocument(
   base: ImageDocumentData,
-  params: { assetId: string; width: number; height: number; name: string }
+  params: { imageUri: string; width: number; height: number; name: string }
 ): ImageDocumentData {
-  const { assetId, width, height, name } = params;
+  const { imageUri, width, height, name } = params;
   const bounds = { x: 0, y: 0, width, height };
   const layers = base.sketch.layers as Array<Record<string, unknown>>;
   const [firstLayer, ...rest] = layers;
   const seededLayer = {
     ...firstLayer,
     name,
-    data: serializeLayerData(`asset://${assetId}`, bounds),
+    data: serializeLayerData(imageUri, bounds),
     contentBounds: bounds
   };
   return {

--- a/web/src/hooks/sketch/ensureSketchDocumentForAsset.ts
+++ b/web/src/hooks/sketch/ensureSketchDocumentForAsset.ts
@@ -24,6 +24,26 @@ function assetImageUrl(asset: Asset): string {
   return `${BASE_URL}/api/storage/${asset.id}`;
 }
 
+/**
+ * Stable `asset://{id}.{ext}` reference for the seeded base layer. The storage
+ * endpoint serves files by name, so the extension is required (a bare
+ * `asset://{id}` resolves to `/api/storage/{id}` and 404s). The authoritative
+ * filename lives in the asset's `get_url` (server-built `{id}.{ext}`); we lift
+ * just the storage key from it so the persisted reference never embeds a signed,
+ * expiring URL. Falls back to the bare id when no URL is available.
+ */
+function assetLayerUri(asset: Asset): string {
+  const url = asset.get_url ?? asset.thumb_url ?? "";
+  const path = url.split("?")[0].split("#")[0];
+  const marker = "/api/storage/";
+  const markerIndex = path.indexOf(marker);
+  const key =
+    markerIndex >= 0
+      ? path.slice(markerIndex + marker.length)
+      : path.split("/").pop() || asset.id;
+  return `asset://${key}`;
+}
+
 function loadImageSize(
   url: string
 ): Promise<{ width: number; height: number }> {
@@ -61,7 +81,7 @@ export async function ensureSketchDocumentForAsset(
   });
 
   const document = buildSeededImageDocument(created.document, {
-    assetId: asset.id,
+    imageUri: assetLayerUri(asset),
     width,
     height,
     name: asset.name || "Image"

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -96,6 +96,14 @@ const EMPTY_EXTRAS: LayerHashExtras = {
 interface SketchSessionState {
   // ── Document metadata ────────────────────────────────────────────────
   documentId: string | null;
+  /**
+   * Id of the document whose content the editor has actually hydrated into
+   * the global sketch store. Distinct from `documentId` (set the moment a
+   * document's *metadata* loads, before the editor mounts): the lifecycle
+   * hook uses this to decide whether a freshly-mounted editor still needs to
+   * seed the global store, vs. a revisit where the in-memory edits should win.
+   */
+  hydratedDocumentId: string | null;
   name: string;
   baseUpdatedAt: string | null;
   lastServerHash: string | null;
@@ -111,6 +119,8 @@ interface SketchSessionState {
     response: Pick<SketchDocumentResponse, "id" | "name" | "updatedAt">,
     serverHash: string
   ) => void;
+  /** Record that the editor has seeded the global store from this document. */
+  markHydrated: (documentId: string) => void;
   markSaving: () => void;
   markSaved: (updatedAt: string, serverHash: string) => void;
   markSaveFailed: (conflict: boolean) => void;
@@ -210,6 +220,7 @@ const getExtras = (
 export const useSketchSessionStore = create<SketchSessionState>((set, get) => ({
   // Document metadata ----------------------------------------------------
   documentId: null,
+  hydratedDocumentId: null,
   name: "",
   baseUpdatedAt: null,
   lastServerHash: null,
@@ -229,6 +240,7 @@ export const useSketchSessionStore = create<SketchSessionState>((set, get) => ({
       saveState: "idle",
       hasConflict: false
     }),
+  markHydrated: (documentId) => set({ hydratedDocumentId: documentId }),
   markSaving: () => set({ saveState: "saving", hasConflict: false }),
   markSaved: (updatedAt, serverHash) =>
     set({
@@ -241,6 +253,7 @@ export const useSketchSessionStore = create<SketchSessionState>((set, get) => ({
   reset: () =>
     set({
       documentId: null,
+      hydratedDocumentId: null,
       name: "",
       baseUpdatedAt: null,
       lastServerHash: null,


### PR DESCRIPTION
## What

Fixes "Open as Tab" in the assets grid (it did nothing) and wires ImageViewer's **Edit** button to open as a workspace tab. While verifying the image-edit flow, fixed three further bugs that left the sketch editor blank/wrong-sized.

## Why it was broken

**Open as Tab** wrote to the legacy `FileTabsStore`, whose tabs are only rendered by the old node editor — so from the assets explorer the action silently did nothing. The live tab system is `WorkspaceTabsStore` + `/workspace`.

Opening an image in the sketch editor then surfaced three independent bugs (found via DB inspection + a live CDP browser repro):

1. **Document never hydrated** → editor showed its default blank **512×512 "Background"** doc. `useEditorLifecycle`'s "same-doc revisit" guard keyed on the session `documentId`, which `useStandaloneSketchDocument` sets (on metadata load) in the parent *before* the child editor mounts — so every fresh load looked like a revisit and skipped the seed.
2. **Layer pixels 404'd** → the seeded base layer referenced `asset://{id}`, resolving to `/api/storage/{id}`, which 404s (the storage endpoint serves files by name; `/api/storage/{id}.png` → 200).
3. **CSP console error** → `LayerItem` set a raw `asset://` `<img src>`, blocked by the page `img-src` CSP.

## Changes

- **Open as Tab / Edit button** → route through `WorkspaceTabsStore.openTab` + navigate to `/workspace`. New shared `assetTabType` helper (extracted from `OpenMenu`) gates the menu item to openable types. (`AssetItemContextMenu`, `AssetViewer`, `OpenMenu`, `assetTabType.ts`)
- **Hydration fix** → add a distinct `hydratedDocumentId` marker to `SketchSessionStore`, set by `useEditorLifecycle` after it actually seeds; the revisit guard keys on that instead of the prematurely-set `documentId`.
- **Seed fix** → store `asset://{id}.{ext}` (key lifted from the asset's `get_url`, so no signed/expiring URL is persisted). (`buildSeededImageDocument`, `ensureSketchDocumentForAsset`)
- **CSP fix** → resolve the layer thumbnail through `resolveAssetUri`. (`LayerItem`)

The "load the linked sketch if present" path already existed (`readSketchDocumentId`) and now works thanks to fix #1.

## Verification

- `npm run typecheck` + `npm run lint` clean; sketch test suites pass (9 suites / 77 tests).
- Live repro against the running app: image renders as pixels at the correct 1024×1024, layer thumbnail shows, console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)