### PR TITLE
feat(prompt): expand asset & folder mentions into typed media inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42131,7 +42131,8 @@
       "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
-        "@nodetool-ai/node-sdk": "*"
+        "@nodetool-ai/node-sdk": "*",
+        "@nodetool-ai/runtime": "*"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -42238,6 +42239,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
+        "@nodetool-ai/runtime": "*",
         "replicate": "*"
       },
       "devDependencies": {

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -13,7 +13,12 @@ import {
   registerDeclaredProperty
 } from "@nodetool-ai/node-sdk";
 import type { NodeClass, PropOptions } from "@nodetool-ai/node-sdk";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type {
+  ProcessingContext,
+  PromptAssetTextField,
+  PromptAssetInputField
+} from "@nodetool-ai/runtime";
+import { mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
 import {
   getFalApiKey,
   falSubmit,
@@ -135,6 +140,45 @@ function computeFieldClassification(
   );
 }
 
+/**
+ * Route `asset://` media mentioned inline in a node's text inputs onto its
+ * empty image/audio inputs (and strip the mentions from the text). Shared with
+ * KIE / Replicate / image-to-image via `mapPromptAssetsToInputs`.
+ */
+async function promptAssetOverrides(
+  instance: BaseNode,
+  spec: FalManifestEntry,
+  context?: ProcessingContext
+): Promise<Record<string, unknown>> {
+  const values = instance as unknown as Record<string, unknown>;
+  const textFields: PromptAssetTextField[] = [];
+  const assetFields: PromptAssetInputField[] = [];
+  for (const field of spec.inputFields) {
+    if (field.parentField) continue;
+    const kind = assetKind(field.propType);
+    if (kind === "image" || kind === "audio") {
+      const list = isListAsset(field.propType);
+      const value = values[field.name];
+      const hasSource = list
+        ? Array.isArray(value) && value.some(isRefSet)
+        : isRefSet(value);
+      assetFields.push({
+        name: field.name,
+        label: field.apiParamName ?? field.name,
+        kind,
+        list,
+        hasSource
+      });
+    } else if (field.propType.toLowerCase() === "str") {
+      textFields.push({
+        name: field.name,
+        value: String(values[field.name] ?? "")
+      });
+    }
+  }
+  return mapPromptAssetsToInputs(textFields, assetFields, context);
+}
+
 async function buildArgs(
   instance: BaseNode,
   spec: FalManifestEntry,
@@ -142,6 +186,7 @@ async function buildArgs(
   context?: ProcessingContext
 ): Promise<Record<string, unknown>> {
   const args: Record<string, unknown> = {};
+  const overrides = await promptAssetOverrides(instance, spec, context);
 
   for (const field of spec.inputFields) {
     if (field.parentField) continue;
@@ -154,7 +199,10 @@ async function buildArgs(
       continue;
     }
 
-    const value = (instance as unknown as Record<string, unknown>)[field.name];
+    const value =
+      field.name in overrides
+        ? overrides[field.name]
+        : (instance as unknown as Record<string, unknown>)[field.name];
     const apiName = field.apiParamName ?? field.name;
     const kind = assetKind(field.propType);
 

--- a/packages/fal-nodes/tests/fal-prompt-asset.test.ts
+++ b/packages/fal-nodes/tests/fal-prompt-asset.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const falSubmit = vi.fn();
+
+vi.mock("../src/fal-base.js", () => ({
+  assetToFalUrl: vi.fn(async (_key: string, ref: Record<string, unknown>) =>
+    ref?.data ? `falcdn:${ref.data as string}` : "https://fal.media/uploaded"
+  ),
+  falImageToRef: (image: Record<string, unknown>) => ({
+    type: "image",
+    uri: image.url
+  }),
+  falSubmit,
+  getFalApiKey: () => "test-key",
+  imageToDataUrl: vi.fn(async (ref: Record<string, unknown> | undefined) =>
+    ref?.data ? `data:image/png;base64,${ref.data as string}` : null
+  ),
+  isRefSet: (ref: unknown) =>
+    !!ref && typeof ref === "object" && Boolean((ref as Record<string, unknown>).data || (ref as Record<string, unknown>).uri),
+  removeNulls: (obj: Record<string, unknown>) => {
+    for (const k of Object.keys(obj)) {
+      if (obj[k] == null || obj[k] === "") delete obj[k];
+    }
+  }
+}));
+
+const { createFalNodeClass } = await import("../src/fal-factory.js");
+
+function makeI2INode() {
+  return createFalNodeClass({
+    endpointId: "fal-ai/flux/dev/image-to-image",
+    className: "FluxDevI2I",
+    moduleName: "image",
+    docstring: "test",
+    tags: [],
+    useCases: [],
+    outputType: "image",
+    outputFields: [{ name: "images", propType: "list[image]" }],
+    enums: [],
+    inputFields: [
+      {
+        name: "prompt",
+        propType: "str",
+        tsType: "string",
+        default: "",
+        description: "",
+        fieldType: "input",
+        required: true
+      },
+      {
+        name: "image_url",
+        propType: "image",
+        tsType: "object",
+        default: {
+          type: "image",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null
+        },
+        description: "",
+        fieldType: "input",
+        required: false
+      }
+    ]
+  });
+}
+
+const assetBytes = new Uint8Array([10, 20, 30, 40]);
+const b64 = Buffer.from(assetBytes).toString("base64");
+const ctx = { resolveAssetBytes: async () => ({ bytes: assetBytes }) };
+
+describe("FAL prompt asset mapping", () => {
+  beforeEach(() => {
+    falSubmit.mockReset();
+    falSubmit.mockResolvedValue({ images: [{ url: "out" }] });
+  });
+
+  it("routes an asset:// mention into the empty image input and strips it", async () => {
+    const NodeClass = makeI2INode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({ prompt: "make it pop asset://a.png please" });
+
+    await node.process(ctx as never);
+
+    const args = falSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.image_url).toBe(`data:image/png;base64,${b64}`);
+    expect(args.prompt).toBe("make it pop image_url please");
+  });
+
+  it("leaves a wired image input untouched but strips the mention", async () => {
+    const NodeClass = makeI2INode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({
+      prompt: "enhance asset://a.png now",
+      image_url: {
+        type: "image",
+        uri: "",
+        asset_id: null,
+        data: "WIRED",
+        metadata: null
+      }
+    });
+
+    await node.process(ctx as never);
+
+    const args = falSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.image_url).toBe("data:image/png;base64,WIRED");
+    expect(args.prompt).toBe("enhance now");
+  });
+});
+
+function imageField(name: string) {
+  return {
+    name,
+    propType: "image",
+    tsType: "object",
+    default: {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
+    description: "",
+    fieldType: "input",
+    required: false
+  };
+}
+
+/** A video node with two single frame inputs + a list[image] reference input. */
+function makeMultiFrameVideoNode() {
+  return createFalNodeClass({
+    endpointId: "fal-ai/kling/multi-frame",
+    className: "KlingMultiFrame",
+    moduleName: "video",
+    docstring: "test",
+    tags: [],
+    useCases: [],
+    outputType: "video",
+    outputFields: [{ name: "video", propType: "video" }],
+    enums: [],
+    inputFields: [
+      {
+        name: "prompt",
+        propType: "str",
+        tsType: "string",
+        default: "",
+        description: "",
+        fieldType: "input",
+        required: true
+      },
+      imageField("image_url"),
+      imageField("tail_image_url"),
+      {
+        ...imageField("reference_image_urls"),
+        propType: "list[image]",
+        default: []
+      }
+    ]
+  });
+}
+
+describe("FAL multi-image video mapping", () => {
+  beforeEach(() => {
+    falSubmit.mockReset();
+    falSubmit.mockResolvedValue({ video: { url: "out.mp4" } });
+  });
+
+  it("maps as many prompt mentions as there are image inputs", async () => {
+    const NodeClass = makeMultiFrameVideoNode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({
+      prompt: "from asset://a.png to asset://b.jpg via asset://c.webp end"
+    });
+
+    await node.process(ctx as never);
+
+    const args = falSubmit.mock.calls[0][2] as Record<string, unknown>;
+    // First two single frame inputs take the first two mentions...
+    expect(args.image_url).toBe(`data:image/png;base64,${b64}`);
+    expect(args.tail_image_url).toBe(`data:image/png;base64,${b64}`);
+    // ...and the list input absorbs the remainder (uploaded via the CDN path).
+    expect(args.reference_image_urls).toEqual([`falcdn:${b64}`]);
+    // Each mention is relabeled to the input slot it was routed into.
+    expect(args.prompt).toBe(
+      "from image_url to tail_image_url via reference_image_urls[0] end"
+    );
+  });
+
+  it("fills only what it can when there are fewer mentions than inputs", async () => {
+    const NodeClass = makeMultiFrameVideoNode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({ prompt: "start from asset://a.png only" });
+
+    await node.process(ctx as never);
+
+    const args = falSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.image_url).toBe(`data:image/png;base64,${b64}`);
+    // No second mention → tail frame and reference list stay empty (dropped by removeNulls).
+    expect(args.tail_image_url).toBeUndefined();
+    expect(args.reference_image_urls).toBeUndefined();
+    expect(args.prompt).toBe("start from image_url only");
+  });
+});

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -12,7 +12,10 @@ import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import { RAW_RGBA_MIME, isRawRgbaImage } from "@nodetool-ai/protocol";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import {
+  loadMediaRefBytes,
+  mapPromptAssetsToInputs
+} from "@nodetool-ai/runtime";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,6 +43,19 @@ async function imageBytesAsync(image: unknown, context?: ProcessingContext): Pro
   if (!image || typeof image !== "object") return new Uint8Array();
   const bytes = await loadMediaRefBytes(image as ImageRefLike, context);
   return bytes ?? new Uint8Array();
+}
+
+/**
+ * Whether an image ref already points at a source (a wired-in upstream image,
+ * a stored asset, or inline bytes) rather than the empty default. Used to
+ * decide if an inline `asset://` mention in the prompt should supply the input.
+ */
+function imageRefHasSource(image: unknown): boolean {
+  if (!image || typeof image !== "object") return false;
+  const ref = image as ImageRefLike & { asset_id?: unknown };
+  if (typeof ref.uri === "string" && ref.uri.trim() !== "") return true;
+  if (ref.data != null && ref.data !== "") return true;
+  return ref.asset_id != null && ref.asset_id !== "";
 }
 
 function filePath(uriOrPath: string): string {
@@ -1495,7 +1511,22 @@ export class ImageToImageNode extends BaseNode {
   declare timeout_seconds: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const image = (this.image ?? {}) as ImageRefLike;
+    let image = (this.image ?? {}) as ImageRefLike;
+    let prompt = String(this.prompt ?? "");
+
+    // Inline asset mentions (e.g. from the Prompt composer's @-mention) carry
+    // an `asset://<id>.<ext>` image reference in the prompt string. Text tasks
+    // expand these into image inputs; do the same here via the shared mapper —
+    // route the first referenced image into the transform input when none is
+    // wired in, and strip the mention out of the textual instruction.
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: prompt }],
+      [{ name: "image", kind: "image", hasSource: imageRefHasSource(image) }],
+      context
+    );
+    if (typeof overrides.prompt === "string") prompt = overrides.prompt;
+    if (overrides.image) image = overrides.image as ImageRefLike;
+
     const bytes = await imageBytesAsync(image, context);
     if (bytes.length === 0) {
       throw new Error("The input image is empty.");
@@ -1513,7 +1544,7 @@ export class ImageToImageNode extends BaseNode {
       model: modelId,
       params: {
         image: bytes,
-        prompt: String(this.prompt ?? ""),
+        prompt,
         negative_prompt: this.negative_prompt,
         target_width: width,
         target_height: height,

--- a/packages/image-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/image-nodes/tests/regression-image-nodes.test.ts
@@ -417,6 +417,71 @@ describe("ImageToImageNode — empty image validation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 7b. ImageToImage — inline asset:// prompt mapping
+// ---------------------------------------------------------------------------
+
+describe("ImageToImageNode — inline asset prompt mapping", () => {
+  it("routes an asset:// image mentioned in the prompt into the input and strips the mention", async () => {
+    const node = new ImageToImageNode();
+    node.assign({
+      // image left at its empty default — the prompt mention should supply it
+      prompt: "make it a watercolor asset://abc123.png please"
+    });
+
+    const assetBytes = new Uint8Array(await makePngBuffer());
+    let captured: Record<string, unknown> | undefined;
+    const context = {
+      resolveAssetBytes: async (uri: string) => {
+        expect(uri).toBe("asset://abc123.png");
+        return { bytes: assetBytes };
+      },
+      runProviderPrediction: async (req: Record<string, unknown>) => {
+        captured = req;
+        return new Uint8Array(await makePngBuffer());
+      }
+    };
+
+    await node.process(context as never);
+
+    const params = (captured as { params: Record<string, unknown> }).params;
+    expect(Array.from(params.image as Uint8Array)).toEqual(
+      Array.from(assetBytes)
+    );
+    expect(params.prompt).toBe("make it a watercolor image please");
+  });
+
+  it("keeps an explicitly wired image and still strips the prompt mention", async () => {
+    const node = new ImageToImageNode();
+    const wired = new Uint8Array(await makePngBuffer(2, 2));
+    node.assign({
+      image: {
+        type: "image",
+        data: Buffer.from(wired).toString("base64"),
+        uri: ""
+      },
+      prompt: "enhance asset://other.png now"
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    const context = {
+      resolveAssetBytes: async () => {
+        throw new Error("explicit image must take precedence over the mention");
+      },
+      runProviderPrediction: async (req: Record<string, unknown>) => {
+        captured = req;
+        return new Uint8Array(await makePngBuffer());
+      }
+    };
+
+    await node.process(context as never);
+
+    const params = (captured as { params: Record<string, unknown> }).params;
+    expect(Array.from(params.image as Uint8Array)).toEqual(Array.from(wired));
+    expect(params.prompt).toBe("enhance now");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 8. BatchToList validation
 // ---------------------------------------------------------------------------
 

--- a/packages/kie-nodes/package.json
+++ b/packages/kie-nodes/package.json
@@ -11,7 +11,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@nodetool-ai/node-sdk": "*"
+    "@nodetool-ai/node-sdk": "*",
+    "@nodetool-ai/runtime": "*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -13,6 +13,11 @@ import {
   registerDeclaredProperty
 } from "@nodetool-ai/node-sdk";
 import type { NodeClass, PropOptions } from "@nodetool-ai/node-sdk";
+import type {
+  PromptAssetTextField,
+  PromptAssetInputField
+} from "@nodetool-ai/runtime";
+import { mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
 import {
   getApiKey,
   kieExecuteTask,
@@ -218,6 +223,40 @@ async function buildVideoClips(
   );
 }
 
+/**
+ * Route `asset://` media mentioned inline in a node's text inputs onto its
+ * empty image/audio uploads (and strip the mentions from the text). Shared with
+ * FAL / Replicate / image-to-image via `mapPromptAssetsToInputs`.
+ */
+async function promptAssetOverrides(
+  instance: BaseNode,
+  spec: KieManifestEntry,
+  context?: Parameters<BaseNode["process"]>[0]
+): Promise<Record<string, unknown>> {
+  const values = instance as unknown as Record<string, unknown>;
+  const textFields: PromptAssetTextField[] = spec.fields
+    .filter((f) => f.type === "str")
+    .map((f) => ({ name: f.name, value: String(values[f.name] ?? "") }));
+  const assetFields: PromptAssetInputField[] = [];
+  for (const upload of spec.uploads ?? []) {
+    if (upload.isVideoClip) continue;
+    if (upload.kind !== "image" && upload.kind !== "audio") continue;
+    const value = values[upload.field];
+    const list = Boolean(upload.isList);
+    const hasSource = list
+      ? Array.isArray(value) && value.some(isRefSet)
+      : isRefSet(value);
+    assetFields.push({
+      name: upload.field,
+      label: upload.paramName ?? upload.field,
+      kind: upload.kind,
+      list,
+      hasSource
+    });
+  }
+  return mapPromptAssetsToInputs(textFields, assetFields, context);
+}
+
 async function buildParams(
   instance: BaseNode,
   spec: KieManifestEntry,
@@ -228,6 +267,11 @@ async function buildParams(
   const clipUploads = new Set(
     spec.uploads?.filter((u) => u.isVideoClip).map((u) => u.field) ?? []
   );
+  const overrides = await promptAssetOverrides(instance, spec, context);
+  const readValue = (name: string): unknown =>
+    name in overrides
+      ? overrides[name]
+      : (instance as unknown as Record<string, unknown>)[name];
 
   // Scalar and list[str] fields
   for (const field of spec.fields) {
@@ -241,7 +285,7 @@ async function buildParams(
       continue;
     }
 
-    const value = (instance as unknown as Record<string, unknown>)[field.name];
+    const value = readValue(field.name);
     const paramName = spec.paramNames?.[field.name] ?? field.name;
     const defLit = field.default ?? defaultForType(field.type);
 
@@ -276,9 +320,7 @@ async function buildParams(
     const groups = new Map<string, string[]>();
 
     for (const upload of spec.uploads) {
-      const value = (instance as unknown as Record<string, unknown>)[
-        upload.field
-      ];
+      const value = readValue(upload.field);
       const fn = uploadFnForKind(upload.kind);
 
       if (upload.isVideoClip) {

--- a/packages/kie-nodes/tests/kie-prompt-asset.test.ts
+++ b/packages/kie-nodes/tests/kie-prompt-asset.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { KieManifestEntry } from "../src/kie-factory.js";
+
+vi.mock("../src/kie-base.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/kie-base.js")>();
+  return {
+    ...actual,
+    getApiKey: () => "test-key",
+    kieExecuteTask: vi.fn(),
+    kieImageRef: vi.fn(async (b64: string) => ({ type: "image", data: b64 })),
+    reportKieProviderCost: vi.fn(),
+    uploadImageInput: vi.fn(async () => "https://cdn.example.com/img.png")
+  };
+});
+
+const { createKieNodeClass } = await import("../src/kie-factory.js");
+import { kieExecuteTask, uploadImageInput } from "../src/kie-base.js";
+
+function makeEditNode() {
+  const spec: KieManifestEntry = {
+    className: "FluxKontextEdit",
+    moduleName: "image",
+    modelId: "flux-kontext",
+    title: "Flux Kontext Edit",
+    description: "test",
+    outputType: "image",
+    pollInterval: 1000,
+    maxAttempts: 2,
+    fields: [
+      { name: "prompt", type: "str", default: "", required: true },
+      {
+        name: "image",
+        type: "image",
+        default: {
+          type: "image",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null
+        }
+      }
+    ],
+    uploads: [{ field: "image", kind: "image", paramName: "image_url" }]
+  };
+  return createKieNodeClass(spec);
+}
+
+const assetBytes = new Uint8Array([1, 2, 3, 4, 5]);
+const b64 = Buffer.from(assetBytes).toString("base64");
+const ctx = { resolveAssetBytes: async () => ({ bytes: assetBytes }) };
+
+describe("KIE prompt asset mapping", () => {
+  beforeEach(() => {
+    vi.mocked(kieExecuteTask).mockReset();
+    vi.mocked(kieExecuteTask).mockResolvedValue({
+      data: "RESULT",
+      items: ["RESULT"],
+      taskId: "t",
+      creditsConsumed: 0
+    } as never);
+    vi.mocked(uploadImageInput).mockClear();
+  });
+
+  it("routes an asset:// mention into the image upload and strips it", async () => {
+    const NodeClass = makeEditNode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({ prompt: "restyle asset://a.png now" });
+    node.setDynamic("_secrets", { KIE_API_KEY: "test" });
+
+    await node.process(ctx as never);
+
+    // The mapped asset was resolved to bytes and handed to the uploader.
+    const uploadedRef = vi.mocked(uploadImageInput).mock
+      .calls[0][1] as Record<string, unknown>;
+    expect(uploadedRef.data).toBe(b64);
+
+    // The provider params carry the uploaded URL and a cleaned prompt.
+    const params = vi.mocked(kieExecuteTask).mock.calls[0][2] as Record<
+      string,
+      unknown
+    >;
+    expect(params.image_url).toBe("https://cdn.example.com/img.png");
+    expect(params.prompt).toBe("restyle image_url now");
+  });
+
+  it("keeps a wired image upload but strips the mention", async () => {
+    const NodeClass = makeEditNode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({
+      prompt: "enhance asset://a.png now",
+      image: { type: "image", uri: "https://example.com/wired.png" }
+    });
+    node.setDynamic("_secrets", { KIE_API_KEY: "test" });
+
+    await node.process(ctx as never);
+
+    const uploadedRef = vi.mocked(uploadImageInput).mock
+      .calls[0][1] as Record<string, unknown>;
+    expect(uploadedRef.uri).toBe("https://example.com/wired.png");
+    expect(uploadedRef.data).toBeFalsy();
+
+    const params = vi.mocked(kieExecuteTask).mock.calls[0][2] as Record<
+      string,
+      unknown
+    >;
+    expect(params.prompt).toBe("enhance now");
+  });
+});

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -11,6 +11,7 @@ import type {
   ProviderStreamItem,
   ToolCall
 } from "@nodetool-ai/runtime";
+import { findAssetRefs } from "@nodetool-ai/runtime";
 import type {
   Chunk,
   LanguageModel,
@@ -461,45 +462,6 @@ function logThreadWarning(
   });
 }
 
-const ASSET_URI_RE = /asset:\/\/[A-Za-z0-9._~\-/]+/g;
-
-const IMAGE_EXT_MIME: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  bmp: "image/bmp",
-  svg: "image/svg+xml"
-};
-
-const AUDIO_EXT_MIME: Record<string, string> = {
-  mp3: "audio/mpeg",
-  mpeg: "audio/mpeg",
-  wav: "audio/wav",
-  ogg: "audio/ogg",
-  m4a: "audio/mp4",
-  aac: "audio/aac",
-  flac: "audio/flac",
-  opus: "audio/opus"
-};
-
-/**
- * Classify an `asset://<id>.<ext>` token by its extension. Only image and
- * audio are provider-consumable media; everything else (text, video, unknown)
- * returns null so the reference is left as literal text in the prompt.
- */
-function classifyAssetToken(
-  token: string
-): { kind: "image" | "audio"; mime: string } | null {
-  const noScheme = token.slice("asset://".length);
-  const primary = noScheme.split(/[?#]/)[0];
-  const ext = (primary.split(".").pop() ?? "").toLowerCase();
-  if (ext in IMAGE_EXT_MIME) return { kind: "image", mime: IMAGE_EXT_MIME[ext] };
-  if (ext in AUDIO_EXT_MIME) return { kind: "audio", mime: AUDIO_EXT_MIME[ext] };
-  return null;
-}
-
 /**
  * Split a prompt containing inline `asset://<id>.<ext>` references into a
  * multimodal content array: text segments interleaved with image / audio
@@ -508,10 +470,13 @@ function classifyAssetToken(
  * dereferences the URIs to data URIs just before the provider call. Tokens
  * that aren't a supported media type (text, video, unknown) stay as literal
  * text so the model still sees the mention.
+ *
+ * Parsing is shared with non-chat tasks via {@link findAssetRefs}; see
+ * `@nodetool-ai/runtime`'s `prompt-asset-refs` module.
  */
 export function expandAssetReferences(prompt: string): MessageContent[] {
-  ASSET_URI_RE.lastIndex = 0;
-  if (!ASSET_URI_RE.test(prompt)) {
+  const refs = findAssetRefs(prompt);
+  if (refs.length === 0) {
     return [{ type: "text", text: prompt }];
   }
 
@@ -521,32 +486,20 @@ export function expandAssetReferences(prompt: string): MessageContent[] {
   };
 
   let cursor = 0;
-  let match: RegExpExecArray | null;
-  ASSET_URI_RE.lastIndex = 0;
-  while ((match = ASSET_URI_RE.exec(prompt)) !== null) {
-    let token = match[0];
-    // A trailing dot is sentence punctuation, not part of the extension.
-    const trailingDots = token.match(/\.+$/);
-    if (trailingDots) {
-      token = token.slice(0, token.length - trailingDots[0].length);
-    }
-    const classification = classifyAssetToken(token);
-    if (!classification) {
-      continue;
-    }
-    pushText(prompt.slice(cursor, match.index));
-    if (classification.kind === "image") {
+  for (const ref of refs) {
+    pushText(prompt.slice(cursor, ref.index));
+    if (ref.kind === "image") {
       parts.push({
         type: "image_url",
-        image: { uri: token, mimeType: classification.mime }
+        image: { uri: ref.uri, mimeType: ref.mime }
       });
     } else {
       parts.push({
         type: "audio",
-        audio: { uri: token, mimeType: classification.mime }
+        audio: { uri: ref.uri, mimeType: ref.mime }
       });
     }
-    cursor = match.index + token.length;
+    cursor = ref.index + ref.length;
   }
   pushText(prompt.slice(cursor));
 

--- a/packages/protocol/src/api-schemas/assets.ts
+++ b/packages/protocol/src/api-schemas/assets.ts
@@ -125,9 +125,10 @@ export const recursiveOutput = z.object({
 export type RecursiveOutput = z.infer<typeof recursiveOutput>;
 
 // ── search (GET /api/assets/search) ──────────────────────────────
-// Minimum query length of 2 characters; matches by name substring.
+// Matches by name substring. An empty query matches everything, which lets
+// the `@`-mention typeahead show a list of assets before the user narrows it.
 export const searchInput = z.object({
-  query: z.string().min(2),
+  query: z.string(),
   content_type: z.string().optional(),
   page_size: z.number().int().min(1).max(10000).default(200),
   cursor: z.string().optional(),

--- a/packages/protocol/tests/api-schemas-assets.test.ts
+++ b/packages/protocol/tests/api-schemas-assets.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Contract tests for the asset API schemas.
+ *
+ * The `@`-mention typeahead (AssetMentionPlugin) opens on `@` alone and sends
+ * the search query as the user types — starting from an empty string. The
+ * schema must therefore accept empty and single-character queries so the
+ * typeahead can show a list of assets before the user narrows it down.
+ */
+
+import { describe, it, expect } from "vitest";
+import { searchInput } from "../src/api-schemas/assets.js";
+
+describe("assets.searchInput", () => {
+  it("accepts an empty query (typeahead opened on `@` alone)", () => {
+    const result = searchInput.safeParse({ query: "", page_size: 8 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a single-character query (typeahead mid-typing)", () => {
+    const result = searchInput.safeParse({ query: "a", page_size: 8 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a normal multi-character query", () => {
+    const result = searchInput.safeParse({ query: "photo" });
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults page_size when omitted", () => {
+    const result = searchInput.parse({ query: "cat" });
+    expect(result.page_size).toBe(200);
+  });
+});

--- a/packages/replicate-nodes/package.json
+++ b/packages/replicate-nodes/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@nodetool-ai/node-sdk": "*",
+    "@nodetool-ai/runtime": "*",
     "replicate": "*"
   },
   "devDependencies": {

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -13,6 +13,11 @@ import {
   registerDeclaredProperty
 } from "@nodetool-ai/node-sdk";
 import type { NodeClass, PropOptions } from "@nodetool-ai/node-sdk";
+import type {
+  PromptAssetTextField,
+  PromptAssetInputField
+} from "@nodetool-ai/runtime";
+import { mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
 import {
   getReplicateApiKey,
   replicateSubmit,
@@ -141,6 +146,46 @@ function computeFieldClassification(fields: ReplicateFieldDef[]) {
   );
 }
 
+/**
+ * Route `asset://` media mentioned inline in a node's text inputs onto its
+ * empty image/audio inputs (and strip the mentions from the text). Shared with
+ * FAL / KIE / image-to-image via `mapPromptAssetsToInputs`.
+ */
+async function promptAssetOverrides(
+  instance: BaseNode,
+  spec: ReplicateManifestEntry,
+  context?: Parameters<BaseNode["process"]>[0]
+): Promise<Record<string, unknown>> {
+  const values = instance as unknown as Record<string, unknown>;
+  const textFields: PromptAssetTextField[] = [];
+  const assetFields: PromptAssetInputField[] = [];
+  for (const field of spec.inputFields) {
+    if (field.parentField) continue;
+    if (EXCLUDED_FIELDS.has(field.name)) continue;
+    const kind = assetKind(field.propType);
+    if (kind === "image" || kind === "audio") {
+      const list = isListAsset(field.propType);
+      const value = values[field.name];
+      const hasSource = list
+        ? Array.isArray(value) && value.some(isRefSet)
+        : isRefSet(value);
+      assetFields.push({
+        name: field.name,
+        label: field.apiParamName ?? field.name,
+        kind,
+        list,
+        hasSource
+      });
+    } else if (field.propType.toLowerCase() === "str") {
+      textFields.push({
+        name: field.name,
+        value: String(values[field.name] ?? "")
+      });
+    }
+  }
+  return mapPromptAssetsToInputs(textFields, assetFields, context);
+}
+
 async function buildArgs(
   instance: BaseNode,
   spec: ReplicateManifestEntry,
@@ -148,6 +193,7 @@ async function buildArgs(
   context?: Parameters<BaseNode["process"]>[0]
 ): Promise<Record<string, unknown>> {
   const args: Record<string, unknown> = {};
+  const overrides = await promptAssetOverrides(instance, spec, context);
 
   for (const field of spec.inputFields) {
     if (field.parentField) continue;
@@ -161,7 +207,10 @@ async function buildArgs(
       continue;
     }
 
-    const value = (instance as unknown as Record<string, unknown>)[field.name];
+    const value =
+      field.name in overrides
+        ? overrides[field.name]
+        : (instance as unknown as Record<string, unknown>)[field.name];
     const apiName = field.apiParamName ?? field.name;
     const kind = assetKind(field.propType);
 

--- a/packages/replicate-nodes/tests/replicate-prompt-asset.test.ts
+++ b/packages/replicate-nodes/tests/replicate-prompt-asset.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assetToUrl = vi.fn(async (ref: Record<string, unknown>) =>
+  ref.data
+    ? `data:image/png;base64,${ref.data as string}`
+    : `uploaded:${String(ref.uri)}`
+);
+const replicateSubmit = vi.fn(async () => ({ output: "out" }));
+
+vi.mock("../src/replicate-base.js", () => ({
+  assetToUrl,
+  getReplicateApiKey: () => "test-key",
+  isRefSet: (ref: unknown) => {
+    if (!ref || typeof ref !== "object") return false;
+    const r = ref as Record<string, unknown>;
+    return Boolean(r.data || r.uri);
+  },
+  outputToAudioRef: (output: unknown) => ({ type: "audio", uri: output }),
+  outputToImageRef: (output: unknown) => ({ type: "image", uri: output }),
+  outputToString: (output: unknown) => String(output ?? ""),
+  outputToVideoRef: (output: unknown) => ({ type: "video", uri: output }),
+  removeNulls: (obj: Record<string, unknown>) => {
+    for (const key of Object.keys(obj)) {
+      if (obj[key] == null || obj[key] === "") delete obj[key];
+    }
+  },
+  replicateSubmit
+}));
+
+const { createReplicateNodeClass } = await import("../src/replicate-factory.js");
+
+function makeI2INode() {
+  return createReplicateNodeClass({
+    endpointId: "owner/i2i",
+    className: "I2IModel",
+    moduleName: "image.generate",
+    docstring: "test",
+    tags: [],
+    useCases: [],
+    outputType: "image",
+    inputFields: [
+      {
+        name: "prompt",
+        propType: "str",
+        tsType: "string",
+        default: "",
+        description: "",
+        fieldType: "input",
+        required: true
+      },
+      {
+        name: "image",
+        propType: "image",
+        tsType: "object",
+        default: {
+          type: "image",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null
+        },
+        description: "",
+        fieldType: "input",
+        required: false
+      }
+    ],
+    outputFields: [],
+    enums: []
+  });
+}
+
+const assetBytes = new Uint8Array([7, 8, 9]);
+const b64 = Buffer.from(assetBytes).toString("base64");
+const ctx = { resolveAssetBytes: async () => ({ bytes: assetBytes }) };
+
+describe("Replicate prompt asset mapping", () => {
+  beforeEach(() => {
+    assetToUrl.mockClear();
+    replicateSubmit.mockClear();
+  });
+
+  it("routes an asset:// mention into the empty image input and strips it", async () => {
+    const NodeClass = makeI2INode();
+    const instance = new NodeClass({});
+    instance.assign({ prompt: "restyle asset://a.png now" });
+
+    await instance.process(ctx as never);
+
+    const args = replicateSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.image).toBe(`data:image/png;base64,${b64}`);
+    expect(args.prompt).toBe("restyle image now");
+  });
+
+  it("keeps a wired image input but strips the mention", async () => {
+    const NodeClass = makeI2INode();
+    const instance = new NodeClass({});
+    instance.assign({
+      prompt: "enhance asset://a.png now",
+      image: { type: "image", uri: "https://example.com/wired.png" }
+    });
+
+    await instance.process(ctx as never);
+
+    const args = replicateSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.image).toBe("uploaded:https://example.com/wired.png");
+    expect(args.prompt).toBe("enhance now");
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -284,9 +284,25 @@ export interface AssetCreateParamsLike {
   nodeId?: string | null;
 }
 
+/** A non-folder asset surfaced when listing a folder's contents. */
+export interface FolderAssetEntry {
+  id: string;
+  content_type: string;
+  name: string;
+}
+
 export interface ProcessingContextModelInterfaces {
   getJob?: (args: { userId: string; jobId: string }) => Promise<unknown | null>;
   createAsset?: (args: AssetCreateParamsLike) => Promise<unknown>;
+  /**
+   * Recursively list the non-folder assets contained in `folderId`. Returns
+   * `null` when the id is not a folder (or does not exist) so callers can tell
+   * "not a folder" apart from "empty folder" (`[]`).
+   */
+  listFolderAssets?: (args: {
+    userId: string;
+    folderId: string;
+  }) => Promise<FolderAssetEntry[] | null>;
   createMessage?: (args: {
     userId: string;
     req: MessageCreateRequestLike;
@@ -1574,6 +1590,25 @@ export class ProcessingContext {
     nodeId?: string | null;
   }): Promise<unknown> {
     return this.createAsset(args);
+  }
+
+  /**
+   * Recursively list the non-folder assets in `folderId`, or `null` when the id
+   * is not a folder. Backed by the optional `listFolderAssets` model interface;
+   * returns `null` when that interface is not configured.
+   */
+  async listFolderAssets(
+    folderId: string
+  ): Promise<FolderAssetEntry[] | null> {
+    const fn = this._modelInterfaces?.listFolderAssets;
+    if (!fn) {
+      return null;
+    }
+    try {
+      return await fn({ userId: this.userId, folderId });
+    } catch {
+      return null;
+    }
   }
 
   private resolveSandboxFilePath(path: string): string {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,8 @@ export {
   resolveWorkspacePath,
   type AssetOutputMode,
   type CacheAdapter,
+  type FolderAssetEntry,
+  type ProcessingContextModelInterfaces,
   type S3Client,
   type StorageAdapter
 } from "./context.js";
@@ -73,6 +75,18 @@ export {
 } from "./image-codec.js";
 export { PythonNodeExecutor } from "./python-node-executor.js";
 export { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
+export {
+  classifyAssetToken,
+  findAssetRefs,
+  findImageAssetRefs,
+  stripAssetRefs,
+  mapPromptAssetsToInputs,
+  type AssetMediaKind,
+  type PromptAssetRef,
+  type PromptAssetTextField,
+  type PromptAssetInputField,
+  type InjectedAssetRef
+} from "./prompt-asset-refs.js";
 export { logPythonWorkerStderr } from "./python-worker-stderr.js";
 export {
   type NodeExecutor,

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -1,0 +1,385 @@
+/**
+ * Inline asset references in prompt text.
+ *
+ * Prompt-style surfaces (the Prompt composer, chat) let users mention an asset
+ * with `@`, which encodes as an `asset://<id>.<ext>` token inside the plain
+ * prompt string. Text-generation tasks expand these tokens into multimodal
+ * image / audio message blocks before the provider call. This module is the
+ * shared, provider-agnostic parser so other task types (e.g. image-to-image)
+ * can pull the same referenced media out of a prompt and route it to a typed
+ * input instead of leaving a dangling `asset://` URI in the text.
+ *
+ * The low-level parsing is resolution-free — callers hand the verbatim
+ * `asset://` URI to {@link loadMediaRefBytes} / `resolveMessageMediaUris`,
+ * which dereference it to bytes / a data URI just before it is consumed. The
+ * higher-level {@link mapPromptAssetsToInputs} does resolve, so provider nodes
+ * (FAL / KIE / Replicate / image-to-image) can route a mentioned image into a
+ * typed asset input with bytes already in hand.
+ */
+
+import type { ProcessingContext } from "./context.js";
+import { loadMediaRefBytes } from "./media-ref-bytes.js";
+
+export type AssetMediaKind = "image" | "audio";
+
+/** Matches an inline `asset://<id>.<ext>` token (greedy over the URI charset). */
+const ASSET_URI_RE = /asset:\/\/[A-Za-z0-9._~\-/]+/g;
+
+const IMAGE_EXT_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  svg: "image/svg+xml"
+};
+
+const AUDIO_EXT_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  mpeg: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  opus: "audio/opus"
+};
+
+/**
+ * Classify an `asset://<id>.<ext>` token by its extension. Only image and
+ * audio are provider-consumable media; everything else (text, video, unknown)
+ * returns null so the reference is left as literal text in the prompt.
+ */
+export function classifyAssetToken(
+  token: string
+): { kind: AssetMediaKind; mime: string } | null {
+  if (!token.startsWith("asset://")) return null;
+  const noScheme = token.slice("asset://".length);
+  const primary = noScheme.split(/[?#]/)[0];
+  const ext = (primary.split(".").pop() ?? "").toLowerCase();
+  if (ext in IMAGE_EXT_MIME) return { kind: "image", mime: IMAGE_EXT_MIME[ext] };
+  if (ext in AUDIO_EXT_MIME) return { kind: "audio", mime: AUDIO_EXT_MIME[ext] };
+  return null;
+}
+
+/**
+ * Pick a media extension for a content type so a stored asset can be turned
+ * back into a classifiable `asset://<id>.<ext>` token. Returns null for content
+ * types that aren't a recognized image/audio kind (folders, video, documents).
+ */
+function extForContentType(contentType: string): string | null {
+  const ct = (contentType ?? "").toLowerCase().split(";")[0].trim();
+  const slash = ct.indexOf("/");
+  if (slash <= 0) return null;
+  const top = ct.slice(0, slash);
+  let sub = ct.slice(slash + 1).split("+")[0];
+  if (ct === "audio/mpeg" || ct === "audio/mp3") sub = "mp3";
+  else if (ct === "audio/mp4") sub = "m4a";
+  if (top === "image" && sub in IMAGE_EXT_MIME) return sub;
+  if (top === "audio" && sub in AUDIO_EXT_MIME) return sub;
+  return null;
+}
+
+export interface PromptAssetRef {
+  /** Full `asset://<id>.<ext>` token, trailing sentence punctuation trimmed. */
+  uri: string;
+  kind: AssetMediaKind;
+  mime: string;
+  /** Start offset of the token in the source prompt. */
+  index: number;
+  /** Length of the (trimmed) token in the source prompt. */
+  length: number;
+}
+
+/**
+ * Find every classifiable media reference in a prompt, in source order.
+ *
+ * Trailing dots on a token are treated as sentence punctuation (not part of
+ * the extension), so `asset://a.png.` yields the `asset://a.png` ref and leaves
+ * the period in the surrounding text. Unclassifiable tokens (no/unknown
+ * extension, e.g. `asset://doc.txt`) are skipped and remain literal text.
+ */
+export function findAssetRefs(prompt: string): PromptAssetRef[] {
+  const refs: PromptAssetRef[] = [];
+  ASSET_URI_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ASSET_URI_RE.exec(prompt)) !== null) {
+    let token = match[0];
+    const trailingDots = token.match(/\.+$/);
+    if (trailingDots) {
+      token = token.slice(0, token.length - trailingDots[0].length);
+    }
+    const classification = classifyAssetToken(token);
+    if (!classification) continue;
+    refs.push({
+      uri: token,
+      kind: classification.kind,
+      mime: classification.mime,
+      index: match.index,
+      length: token.length
+    });
+  }
+  return refs;
+}
+
+/** Convenience: only the image references in a prompt. */
+export function findImageAssetRefs(prompt: string): PromptAssetRef[] {
+  return findAssetRefs(prompt).filter((ref) => ref.kind === "image");
+}
+
+/**
+ * Rewrite the given references inside the prompt, substituting each with the
+ * string `replace(ref)` returns (return `""` to drop it). Refs must come from
+ * {@link findAssetRefs} on the same string (they carry the source offsets).
+ * Horizontal whitespace left behind is collapsed so the result reads cleanly;
+ * newlines are preserved.
+ */
+function replaceAssetRefs(
+  prompt: string,
+  refs: PromptAssetRef[],
+  replace: (ref: PromptAssetRef) => string
+): string {
+  if (refs.length === 0) return prompt;
+  let result = "";
+  let cursor = 0;
+  for (const ref of refs) {
+    if (ref.index < cursor) continue;
+    result += prompt.slice(cursor, ref.index);
+    result += replace(ref);
+    cursor = ref.index + ref.length;
+  }
+  result += prompt.slice(cursor);
+  return result
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
+/**
+ * Remove the given references from the prompt, collapsing the horizontal
+ * whitespace left behind so the remaining text reads as a clean instruction.
+ * Refs must come from {@link findAssetRefs} on the same string. Newlines are
+ * preserved.
+ */
+export function stripAssetRefs(
+  prompt: string,
+  refs: PromptAssetRef[]
+): string {
+  return replaceAssetRefs(prompt, refs, () => "");
+}
+
+/** A free-text field whose value should be scanned for asset mentions. */
+export interface PromptAssetTextField {
+  name: string;
+  value: string;
+}
+
+/** A typed media input the node exposes (image/audio), with its current state. */
+export interface PromptAssetInputField {
+  name: string;
+  /**
+   * Token used to reference this input back in the prompt text once a mention
+   * is routed into it (e.g. the API param name `image_url`). Defaults to
+   * `name`. List inputs are indexed: `${label}[0]`, `${label}[1]`, …
+   */
+  label?: string;
+  kind: AssetMediaKind;
+  /** True for `list[...]` fields that accept multiple refs. */
+  list?: boolean;
+  /** True when the field already holds a real source (wired/set upstream). */
+  hasSource: boolean;
+}
+
+/** A resolved media ref ready to drop into a node's asset input. */
+export interface InjectedAssetRef {
+  type: AssetMediaKind;
+  /** The original `asset://` URI, kept for provenance / fallback resolution. */
+  uri: string;
+  mimeType: string;
+  /** base64 of the resolved bytes; present when resolution succeeded. */
+  data?: string;
+}
+
+/**
+ * Expand any folder mention in `text` into the `asset://<id>.<ext>` tokens of
+ * its members of an accepted kind, recursively. A folder mention is a bare
+ * `asset://<id>` (no extension) that {@link ProcessingContext.listFolderAssets}
+ * resolves to a folder; non-folder bare tokens and ordinary media tokens are
+ * left untouched. The expanded tokens then flow through the normal matcher, so
+ * a referenced folder fills as many of the node's media inputs as it can.
+ */
+async function expandFolderRefs(
+  text: string,
+  context: ProcessingContext | undefined,
+  acceptedKinds: Set<AssetMediaKind>
+): Promise<string> {
+  if (!context || !text.includes("asset://")) return text;
+
+  // Bare `asset://<id>` tokens (no extension) are folder candidates.
+  const candidates: { index: number; length: number; id: string }[] = [];
+  ASSET_URI_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ASSET_URI_RE.exec(text)) !== null) {
+    const token = match[0];
+    const id = token.slice("asset://".length);
+    if (id.includes(".")) continue; // has an extension → a media ref, not a folder
+    candidates.push({ index: match.index, length: token.length, id });
+  }
+  if (candidates.length === 0) return text;
+
+  const replacements = new Map<number, string>();
+  for (const candidate of candidates) {
+    const entries = await context.listFolderAssets(candidate.id);
+    if (!entries) continue; // not a folder → leave the token alone
+    const uris: string[] = [];
+    for (const entry of entries) {
+      const ext = extForContentType(entry.content_type);
+      if (!ext) continue;
+      const classification = classifyAssetToken(`asset://${entry.id}.${ext}`);
+      if (!classification || !acceptedKinds.has(classification.kind)) continue;
+      uris.push(`asset://${entry.id}.${ext}`);
+    }
+    replacements.set(candidate.index, uris.join(" "));
+  }
+  if (replacements.size === 0) return text;
+
+  let result = "";
+  let cursor = 0;
+  for (const candidate of candidates) {
+    const replacement = replacements.get(candidate.index);
+    if (replacement === undefined) continue;
+    result += text.slice(cursor, candidate.index);
+    result += replacement;
+    cursor = candidate.index + candidate.length;
+  }
+  result += text.slice(cursor);
+  return result
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
+/**
+ * Map media mentioned inline in a node's text inputs onto its typed media
+ * inputs. This is the generalized form of what text-generation tasks do when
+ * they expand `asset://` references into image / audio message blocks.
+ *
+ * A mention may be a single asset or a folder: folder mentions are expanded
+ * recursively to their member assets first (see {@link expandFolderRefs}), so a
+ * referenced folder fills as many inputs as it can.
+ *
+ * For every media kind the node actually accepts (derived from `assetFields`):
+ *   - mentions of that kind are pulled out of the text inputs, in order;
+ *   - each still-empty input of that kind is filled with the next mention,
+ *     resolved to bytes (`data`) so the provider's normal `data` path uploads
+ *     it — no provider needs to learn the `asset://` scheme;
+ *   - `list[...]` inputs absorb all remaining mentions of their kind;
+ *   - each placed mention is rewritten in the text to the input label it now
+ *     lives in (`image_url`, `reference_image_urls[0]`, …) so the model can
+ *     tell which slot holds which image; mentions that could not be placed
+ *     (an input was already wired, or capacity ran out) are dropped rather
+ *     than left as a dangling URI.
+ *
+ * Inputs that already carry a source are left untouched. Returns a flat map of
+ * field name → replacement value (cleaned string for text fields, an
+ * {@link InjectedAssetRef} or array for asset fields); fields that did not
+ * change are absent, so callers do `overrides[name] ?? instance[name]`.
+ */
+export async function mapPromptAssetsToInputs(
+  textFields: PromptAssetTextField[],
+  assetFields: PromptAssetInputField[],
+  context?: ProcessingContext
+): Promise<Record<string, unknown>> {
+  const overrides: Record<string, unknown> = {};
+  if (assetFields.length === 0) return overrides;
+
+  const acceptedKinds = new Set(assetFields.map((f) => f.kind));
+
+  // Expand any folder mentions into their member assets first, then work off
+  // the expanded text. The original value is kept to decide whether the field
+  // actually changed (a folder that expanded to nothing still rewrites text).
+  const expandedByField = new Map<string, string>();
+  for (const tf of textFields) {
+    expandedByField.set(
+      tf.name,
+      await expandFolderRefs(tf.value, context, acceptedKinds)
+    );
+  }
+
+  // Refs of accepted kinds, queued per kind in source order across all text
+  // fields, plus the per-field ref list used for relabeling.
+  const queues: Record<AssetMediaKind, PromptAssetRef[]> = {
+    image: [],
+    audio: []
+  };
+  const refsByField = new Map<string, PromptAssetRef[]>();
+  for (const tf of textFields) {
+    const refs = findAssetRefs(expandedByField.get(tf.name) ?? tf.value).filter(
+      (r) => acceptedKinds.has(r.kind)
+    );
+    if (refs.length === 0) continue;
+    refsByField.set(tf.name, refs);
+    for (const ref of refs) queues[ref.kind].push(ref);
+  }
+
+  const resolveRef = async (
+    ref: PromptAssetRef
+  ): Promise<InjectedAssetRef> => {
+    const injected: InjectedAssetRef = {
+      type: ref.kind,
+      uri: ref.uri,
+      mimeType: ref.mime
+    };
+    const bytes = await loadMediaRefBytes(
+      { type: ref.kind, uri: ref.uri },
+      context
+    );
+    if (bytes && bytes.length > 0) {
+      injected.data = Buffer.from(bytes).toString("base64");
+    }
+    return injected;
+  };
+
+  // Fill empty inputs in declaration order from the matching kind's queue,
+  // recording which input label each placed mention was routed into.
+  const labelByRef = new Map<PromptAssetRef, string>();
+  const cursor: Record<AssetMediaKind, number> = { image: 0, audio: 0 };
+  for (const field of assetFields) {
+    if (field.hasSource) continue;
+    const queue = queues[field.kind];
+    if (cursor[field.kind] >= queue.length) continue;
+    const label = field.label ?? field.name;
+    if (field.list) {
+      const remaining = queue.slice(cursor[field.kind]);
+      cursor[field.kind] = queue.length;
+      const resolved: InjectedAssetRef[] = [];
+      for (let i = 0; i < remaining.length; i++) {
+        labelByRef.set(remaining[i], `${label}[${i}]`);
+        resolved.push(await resolveRef(remaining[i]));
+      }
+      if (resolved.length > 0) overrides[field.name] = resolved;
+    } else {
+      const ref = queue[cursor[field.kind]++];
+      labelByRef.set(ref, label);
+      overrides[field.name] = await resolveRef(ref);
+    }
+  }
+
+  // Rewrite each text input off its (folder-)expanded value: a placed mention
+  // becomes a reference to the input label it now lives in; a mention that
+  // could not be placed is dropped. Compared against the original so a folder
+  // that expanded to nothing still rewrites the field.
+  for (const tf of textFields) {
+    const expanded = expandedByField.get(tf.name) ?? tf.value;
+    const refs = refsByField.get(tf.name) ?? [];
+    const rewritten = replaceAssetRefs(
+      expanded,
+      refs,
+      (ref) => labelByRef.get(ref) ?? ""
+    );
+    if (rewritten !== tf.value) overrides[tf.name] = rewritten;
+  }
+
+  return overrides;
+}

--- a/packages/runtime/tests/prompt-asset-refs.test.ts
+++ b/packages/runtime/tests/prompt-asset-refs.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyAssetToken,
+  findAssetRefs,
+  findImageAssetRefs,
+  stripAssetRefs,
+  mapPromptAssetsToInputs,
+  type InjectedAssetRef
+} from "../src/prompt-asset-refs.js";
+
+/** Minimal context that resolves any asset:// URI to fixed bytes. */
+const fakeContext = (bytes: Uint8Array) =>
+  ({
+    resolveAssetBytes: async () => ({ bytes })
+  }) as never;
+
+describe("classifyAssetToken", () => {
+  it("classifies image and audio extensions", () => {
+    expect(classifyAssetToken("asset://a.png")).toEqual({
+      kind: "image",
+      mime: "image/png"
+    });
+    expect(classifyAssetToken("asset://b.mp3")).toEqual({
+      kind: "audio",
+      mime: "audio/mpeg"
+    });
+  });
+
+  it("returns null for unknown / missing extensions and non-asset tokens", () => {
+    expect(classifyAssetToken("asset://doc.txt")).toBeNull();
+    expect(classifyAssetToken("asset://noext")).toBeNull();
+    expect(classifyAssetToken("https://x/a.png")).toBeNull();
+  });
+});
+
+describe("findAssetRefs", () => {
+  it("returns an empty list when there is no reference", () => {
+    expect(findAssetRefs("just some text")).toEqual([]);
+  });
+
+  it("locates an inline image reference with its offsets", () => {
+    expect(findAssetRefs("Describe asset://abc.png please")).toEqual([
+      {
+        uri: "asset://abc.png",
+        kind: "image",
+        mime: "image/png",
+        index: 9,
+        length: "asset://abc.png".length
+      }
+    ]);
+  });
+
+  it("does not swallow a trailing sentence period into the reference", () => {
+    const [ref] = findAssetRefs("Here: asset://abc.png.");
+    expect(ref.uri).toBe("asset://abc.png");
+    expect(ref.length).toBe("asset://abc.png".length);
+  });
+
+  it("skips unsupported media types", () => {
+    expect(findAssetRefs("open asset://doc.txt now")).toEqual([]);
+  });
+
+  it("finds multiple references in order", () => {
+    const refs = findAssetRefs("compare asset://a.jpg and asset://b.webp");
+    expect(refs.map((r) => r.uri)).toEqual([
+      "asset://a.jpg",
+      "asset://b.webp"
+    ]);
+  });
+});
+
+describe("findImageAssetRefs", () => {
+  it("keeps only image references", () => {
+    const refs = findImageAssetRefs("img asset://a.png clip asset://b.mp3");
+    expect(refs.map((r) => r.uri)).toEqual(["asset://a.png"]);
+  });
+});
+
+describe("stripAssetRefs", () => {
+  it("removes references and collapses the gap", () => {
+    const prompt = "Describe asset://abc.png please";
+    const refs = findImageAssetRefs(prompt);
+    expect(stripAssetRefs(prompt, refs)).toBe("Describe please");
+  });
+
+  it("returns an empty string when the prompt is only a reference", () => {
+    const prompt = "asset://abc.png";
+    expect(stripAssetRefs(prompt, findImageAssetRefs(prompt))).toBe("");
+  });
+
+  it("leaves the prompt untouched when there are no refs", () => {
+    expect(stripAssetRefs("plain text", [])).toBe("plain text");
+  });
+
+  it("preserves newlines while trimming trailing spaces", () => {
+    const prompt = "line one asset://a.png\nline two";
+    const refs = findImageAssetRefs(prompt);
+    expect(stripAssetRefs(prompt, refs)).toBe("line one\nline two");
+  });
+});
+
+describe("mapPromptAssetsToInputs", () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const b64 = Buffer.from(bytes).toString("base64");
+
+  it("returns no overrides when the node has no asset inputs", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "use asset://a.png" }],
+      [],
+      fakeContext(bytes)
+    );
+    expect(overrides).toEqual({});
+  });
+
+  it("fills an empty image input and relabels the mention", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "make it pop asset://a.png please" }],
+      [{ name: "image", label: "image_url", kind: "image", hasSource: false }],
+      fakeContext(bytes)
+    );
+    expect(overrides.prompt).toBe("make it pop image_url please");
+    expect(overrides.image).toEqual({
+      type: "image",
+      uri: "asset://a.png",
+      mimeType: "image/png",
+      data: b64
+    } satisfies InjectedAssetRef);
+  });
+
+  it("keeps a wired input but still strips the mention", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "enhance asset://a.png now" }],
+      [{ name: "image", kind: "image", hasSource: true }],
+      fakeContext(bytes)
+    );
+    expect(overrides.image).toBeUndefined();
+    expect(overrides.prompt).toBe("enhance now");
+  });
+
+  it("absorbs multiple mentions into a list input and indexes the labels", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "blend asset://a.png and asset://b.jpg" }],
+      [
+        {
+          name: "images",
+          label: "reference_image_urls",
+          kind: "image",
+          list: true,
+          hasSource: false
+        }
+      ],
+      fakeContext(bytes)
+    );
+    const list = overrides.images as InjectedAssetRef[];
+    expect(list.map((r) => r.uri)).toEqual(["asset://a.png", "asset://b.jpg"]);
+    expect(overrides.prompt).toBe(
+      "blend reference_image_urls[0] and reference_image_urls[1]"
+    );
+  });
+
+  it("routes mentions to inputs by kind and labels each", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "speak asset://v.mp3 over asset://a.png" }],
+      [
+        { name: "image", kind: "image", hasSource: false },
+        { name: "audio", kind: "audio", hasSource: false }
+      ],
+      fakeContext(bytes)
+    );
+    expect((overrides.image as InjectedAssetRef).uri).toBe("asset://a.png");
+    expect((overrides.audio as InjectedAssetRef).uri).toBe("asset://v.mp3");
+    expect(overrides.prompt).toBe("speak audio over image");
+  });
+
+  it("does not touch text when no mention matches an accepted kind", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "clip asset://v.mp3 here" }],
+      [{ name: "image", kind: "image", hasSource: false }],
+      fakeContext(bytes)
+    );
+    expect(overrides).toEqual({});
+  });
+});
+
+describe("mapPromptAssetsToInputs — folder mentions", () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+
+  /** Context whose folder `folder1` resolves to `entries`; everything else is not a folder. */
+  const folderContext = (
+    entries: Array<{ id: string; content_type: string; name: string }> | null
+  ) =>
+    ({
+      resolveAssetBytes: async () => ({ bytes }),
+      listFolderAssets: async (folderId: string) =>
+        folderId === "folder1" ? entries : null
+    }) as never;
+
+  it("expands a folder mention across image inputs, mapping as many as possible", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "use these: asset://folder1 thanks" }],
+      [
+        { name: "image", label: "image_url", kind: "image", hasSource: false },
+        {
+          name: "images",
+          label: "reference_image_urls",
+          kind: "image",
+          list: true,
+          hasSource: false
+        }
+      ],
+      folderContext([
+        { id: "a", content_type: "image/png", name: "a.png" },
+        { id: "b", content_type: "image/jpeg", name: "b.jpg" },
+        { id: "c", content_type: "image/webp", name: "c.webp" }
+      ])
+    );
+    expect((overrides.image as InjectedAssetRef).uri).toBe("asset://a.png");
+    const list = overrides.images as InjectedAssetRef[];
+    expect(list.map((r) => r.uri)).toEqual([
+      "asset://b.jpeg",
+      "asset://c.webp"
+    ]);
+    expect(overrides.prompt).toBe(
+      "use these: image_url reference_image_urls[0] reference_image_urls[1] thanks"
+    );
+  });
+
+  it("only expands members of accepted kinds", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "from asset://folder1 please" }],
+      [{ name: "image", kind: "image", hasSource: false }],
+      folderContext([
+        { id: "a", content_type: "image/png", name: "a.png" },
+        { id: "s", content_type: "audio/mpeg", name: "s.mp3" },
+        { id: "v", content_type: "video/mp4", name: "v.mp4" }
+      ])
+    );
+    expect((overrides.image as InjectedAssetRef).uri).toBe("asset://a.png");
+    expect(overrides.prompt).toBe("from image please");
+  });
+
+  it("leaves a bare token that is not a folder as literal text", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "see asset://not-a-folder ok" }],
+      [{ name: "image", kind: "image", hasSource: false }],
+      folderContext(null)
+    );
+    expect(overrides).toEqual({});
+  });
+
+  it("strips an empty folder mention from the text", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "use asset://folder1 now" }],
+      [{ name: "image", kind: "image", hasSource: false }],
+      folderContext([])
+    );
+    expect(overrides.image).toBeUndefined();
+    expect(overrides.prompt).toBe("use now");
+  });
+});

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -2,7 +2,7 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
 import type { VideoRef, StreamingInputs, StreamingOutputs } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import { loadMediaRefBytes, mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
 import { execFile as execFileCb } from "node:child_process";
 import { promises as fs } from "node:fs";
 import os from "node:os";
@@ -37,6 +37,19 @@ async function imageBytesAsync(
   if (!image || typeof image !== "object") return new Uint8Array();
   const bytes = await loadMediaRefBytes(image as ImageRefLike, context);
   return bytes ?? new Uint8Array();
+}
+
+/**
+ * Whether an image ref already points at a source (wired upstream, a stored
+ * asset, or inline bytes) rather than the empty default — used to decide if an
+ * inline `asset://` mention in the prompt should supply the input.
+ */
+function imageRefHasSource(image: unknown): boolean {
+  if (!image || typeof image !== "object") return false;
+  const ref = image as ImageRefLike & { asset_id?: unknown };
+  if (typeof ref.uri === "string" && ref.uri.trim() !== "") return true;
+  if (ref.data != null && ref.data !== "") return true;
+  return ref.asset_id != null && ref.asset_id !== "";
 }
 
 function filePath(uriOrPath: string): string {
@@ -390,8 +403,22 @@ export class ImageToVideoNode extends BaseNode {
   declare timeout_seconds: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const img = await imageBytesAsync(this.image, context);
-    const prompt = String(this.prompt ?? "");
+    let image = (this.image ?? {}) as ImageRefLike;
+    let prompt = String(this.prompt ?? "");
+
+    // An `asset://` image mentioned inline in the prompt (e.g. from the Prompt
+    // composer's @-mention) supplies the source frame when none is wired in,
+    // and is stripped from the textual instruction. Same mechanism as the
+    // image-to-image / provider video nodes.
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: prompt }],
+      [{ name: "image", kind: "image", hasSource: imageRefHasSource(image) }],
+      context
+    );
+    if (typeof overrides.prompt === "string") prompt = overrides.prompt;
+    if (overrides.image) image = overrides.image as ImageRefLike;
+
+    const img = await imageBytesAsync(image, context);
     const { providerId, modelId } = modelConfig(this.serialize());
     if (canUseProvider(context, providerId, modelId)) {
       const output = (await context.runProviderPrediction({

--- a/packages/video-nodes/tests/image-to-video-prompt-asset.test.ts
+++ b/packages/video-nodes/tests/image-to-video-prompt-asset.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { ImageToVideoNode } from "@nodetool-ai/video-nodes";
+
+const assetBytes = new Uint8Array([2, 4, 6, 8]);
+
+function makeContext() {
+  const captured: { req?: Record<string, unknown> } = {};
+  const context = {
+    resolveAssetBytes: async () => ({ bytes: assetBytes }),
+    runProviderPrediction: async (req: Record<string, unknown>) => {
+      captured.req = req;
+      return new Uint8Array([9, 9, 9]);
+    }
+  };
+  return { context, captured };
+}
+
+describe("ImageToVideoNode — inline asset prompt mapping", () => {
+  it("routes an asset:// mention into the image input and strips it", async () => {
+    const node = new ImageToVideoNode();
+    node.assign({ prompt: "animate asset://a.png slowly" });
+
+    const { context, captured } = makeContext();
+    await node.process(context as never);
+
+    const params = (captured.req as { params: Record<string, unknown> }).params;
+    expect(Array.from(params.image as Uint8Array)).toEqual(
+      Array.from(assetBytes)
+    );
+    expect(params.prompt).toBe("animate image slowly");
+  });
+
+  it("keeps a wired image input but strips the mention", async () => {
+    const node = new ImageToVideoNode();
+    node.assign({
+      prompt: "loop asset://a.png forever",
+      image: {
+        type: "image",
+        data: Buffer.from([5, 5, 5]).toString("base64"),
+        uri: ""
+      }
+    });
+
+    const { context, captured } = makeContext();
+    await node.process(context as never);
+
+    const params = (captured.req as { params: Record<string, unknown> }).params;
+    expect(Array.from(params.image as Uint8Array)).toEqual([5, 5, 5]);
+    expect(params.prompt).toBe("loop forever");
+  });
+});

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -568,6 +568,31 @@ function createRuntimeContext(opts: {
       }
       await asset.save();
       return asset;
+    },
+    listFolderAssets: async ({ userId, folderId }) => {
+      const folder = await Asset.find(userId, folderId);
+      if (!folder || folder.content_type !== "folder") return null;
+      const out: Array<{ id: string; content_type: string; name: string }> = [];
+      const seen = new Set<string>();
+      const visit = async (parentId: string): Promise<void> => {
+        if (seen.has(parentId)) return; // guard against cyclic parent links
+        seen.add(parentId);
+        const children = await Asset.getChildren(userId, parentId, 1000);
+        for (const child of children) {
+          if (child.content_type === "folder") {
+            await visit(child.id);
+          } else {
+            out.push({
+              id: child.id,
+              content_type: child.content_type,
+              name: child.name
+            });
+          }
+        }
+      };
+      await visit(folderId);
+      out.sort((a, b) => a.name.localeCompare(b.name));
+      return out;
     }
   });
 

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -13,7 +13,14 @@
  * (`asset://…`, `{{ name }}`), so existing `{{variable}}` substitution and the
  * backend asset dereferencing work whether or not a token is chipped.
  */
-import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -46,6 +53,7 @@ import {
   $serializePrompt,
   $setPromptFromString
 } from "./promptComposer/promptEditorState";
+import { variablesInPrompt } from "./promptComposer/promptTokens";
 import { PromptComposerContext } from "./promptComposer/promptComposerContext";
 import { PROMPT_NODE_TYPE } from "../../../constants/nodeTypes";
 
@@ -128,8 +136,9 @@ const composerTheme = {
 /** Quick-insert bar: one chip per dynamic input + the add-variable button. */
 const VariableInsertBar: React.FC<{
   variableNames: string[];
+  showLabel: boolean;
   onAdd: () => void;
-}> = ({ variableNames, onAdd }) => {
+}> = ({ variableNames, showLabel, onAdd }) => {
   const [editor] = useLexicalComposerContext();
   const insertVariable = useCallback(
     (name: string) => {
@@ -141,7 +150,7 @@ const VariableInsertBar: React.FC<{
   );
   return (
     <div className="variable-bar">
-      <span className="variable-bar-label">Variables</span>
+      {showLabel && <span className="variable-bar-label">Variables</span>}
       {variableNames.map((name) => (
         <button
           key={name}
@@ -217,6 +226,16 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
   );
   const lastWrittenRef = useRef<string>(initialPromptRef.current);
 
+  // Live prompt text, mirrored from the editor on every change so the
+  // "Variables" label can track whether the prompt actually references one.
+  const [promptText, setPromptText] = useState<string>(
+    initialPromptRef.current
+  );
+  const promptReferencesVariable = useMemo(
+    () => variablesInPrompt(promptText).length > 0,
+    [promptText]
+  );
+
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "PromptComposer",
@@ -254,7 +273,9 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
   const handleEditorChange = useCallback(
     (editorState: EditorState) => {
       editorState.read(() => {
-        writePrompt($serializePrompt());
+        const serialized = $serializePrompt();
+        setPromptText(serialized);
+        writePrompt(serialized);
       });
     },
     [writePrompt]
@@ -291,6 +312,7 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
 
           <VariableInsertBar
             variableNames={variableNames}
+            showLabel={promptReferencesVariable}
             onAdd={handleAddVariable}
           />
         </LexicalComposer>

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
@@ -123,6 +123,25 @@ describe("PromptComposerBody", () => {
     });
   });
 
+  it("shows the Variables label when the prompt references a variable", () => {
+    renderWithTheme(<PromptComposerBody {...makeProps()} />);
+    expect(screen.getByText("Variables")).toBeInTheDocument();
+  });
+
+  it("hides the Variables label when the prompt references none", () => {
+    renderWithTheme(
+      <PromptComposerBody
+        {...makeProps({
+          data: {
+            properties: { prompt: "what is this?" },
+            dynamic_properties: {}
+          }
+        })}
+      />
+    );
+    expect(screen.queryByText("Variables")).not.toBeInTheDocument();
+  });
+
   it("renders an inline image preview for an asset URN in the prompt", async () => {
     mockGet.mockResolvedValue({
       id: "abc123",


### PR DESCRIPTION
## Summary

When a user `@`-mentions an asset in a **Prompt** node, it lands in the prompt string as an `asset://<id>.<ext>` token. Text-generation providers already expand those tokens into multimodal image/audio blocks — but image/video **generation** nodes ignored them, leaving a dangling URI in the prompt and forcing the user to also wire the image into a separate input.

This PR generalizes that expansion into a single shared mechanism and applies it everywhere a node has a prompt **and** typed media inputs: native image-to-image / image-to-video nodes, and the FAL / KIE / Replicate node factories (~1,500 generated nodes). Mentions now flow into the node's media inputs automatically, and the prompt text is rewritten to reference the slot each image landed in. Folder mentions expand recursively to their member assets.

## The mechanism — `mapPromptAssetsToInputs` (`packages/runtime/src/prompt-asset-refs.ts`)

Given a node's text inputs and its typed media inputs, it:

1. **Expands folder mentions first.** A bare `asset://<id>` (no extension — exactly how the composer encodes a folder) is resolved via the new `ProcessingContext.listFolderAssets`; a folder is replaced inline by the `asset://<child>.<ext>` tokens of its members of an accepted kind, recursively. Non-folder bare tokens are left alone.
2. **Maps as many as possible.** Each empty image/audio input is filled in declaration order; `list[...]` inputs absorb the remainder. Already-wired inputs win and are skipped.
3. **Resolves to bytes.** Each placed mention is dereferenced once via `loadMediaRefBytes` and injected with `data` (base64), so every provider's existing `data` path uploads it — no provider needs to learn the `asset://` scheme.
4. **Relabels the prompt.** A placed mention is rewritten to the input label it now occupies — `image_url`, `reference_image_urls[0]` — so the model can tell which image is in which slot. Mentions that couldn't be placed (wired slot, or capacity exhausted) are dropped rather than left as a dangling URI.

The text-generation path (`expandAssetReferences` in `llm-nodes/agents.ts`) was refactored onto the same shared parser, removing a duplicate regex + MIME table (output is byte-identical; its tests are unchanged).

### Example

Prompt: `"blend asset://a.png with asset://b.png"` on a node exposing `image_url` + `tail_image_url`
→ `image_url` = a, `tail_image_url` = b, prompt becomes `"blend image_url with tail_image_url"`.

Folder of 5 images on a node with `image_url` + a `reference_image_urls` list
→ first image fills `image_url`, the rest fill the list; the mention becomes `image_url reference_image_urls[0] reference_image_urls[1] …`.

## Call sites wired

| Area | Node(s) |
|---|---|
| `image-nodes` | `ImageToImageNode` (refactored onto the shared helper) |
| `video-nodes` | `ImageToVideoNode` |
| `fal-nodes` | factory `buildArgs` → all generated FAL nodes |
| `replicate-nodes` | factory `buildArgs` → all generated Replicate nodes |
| `kie-nodes` | factory `buildParams` → all generated KIE nodes (assets come from `spec.uploads`, applied in both the scalar and upload loops) |

The factories pass the API param name (`field.apiParamName` / `upload.paramName`) as the prompt **label** while keeping the node field name as the override key.

## Folder support (`packages/runtime` + `packages/websocket`)

- New optional model interface `listFolderAssets({ userId, folderId })` and `ProcessingContext.listFolderAssets(folderId)` — returns the flattened non-folder descendants, or `null` when the id isn't a folder (so non-folder bare tokens aren't mistakenly stripped).
- Server implementation walks `Asset.getChildren` recursively (cycle-guarded, sorted by name, 1000/level cap).

## Prompt node UI (`web`)

- The Prompt node's **"Variables"** label now renders only when the prompt text actually references a variable (`{{ … }}`), tracked live as you type, instead of always showing.

## Protocol (pre-existing in the working tree, included here as it's on-theme)

- Asset search now accepts an empty query (was `min(2)`), so the `@`-mention typeahead can list assets — including folders — before the user narrows it. Has its own test.

## Why bytes, not just the URI

All three providers' resolvers (`assetToFalUrl`, `assetToUrl`, `resolveUploadBytes`) handle a ref carrying `data`, but **none** handle the `asset://` scheme. Resolving once in the helper and handing every provider a `data`-bearing ref keeps each provider untouched.

## Tests

- **runtime** — 22 tests for the parser, mapper (kind routing, list absorption, wired-precedence, label rewriting), and folder expansion (multi-image, accepted-kind filtering, non-folder passthrough, empty-folder strip).
- **image / video / fal / replicate / kie** — integration tests per family proving "mention → resolved bytes → provider input + relabeled prompt", wired-input precedence, and FAL multi-frame "map as many as possible".
- **llm-nodes** — existing `expandAssetReferences` suite unchanged (refactor is behavior-preserving).
- **web** — Prompt label visibility tests.

Suites: runtime 987, image 143, video 76, fal 119, replicate 54, kie 43, llm 423, protocol 4. All green; lint clean; all touched packages build.

## Known limits / follow-ups

- **List inputs are uncapped**: a folder of 100 images feeding a `list[image]` resolves and inlines all 100. Single-slot inputs only resolve what they place. A per-folder cap would be a small addition.
- **Provider-specific Gemini/OpenAI image+video nodes** are excluded — their `process()` has no `ProcessingContext`, so they can't resolve `asset://` without extra plumbing.
- **Dynamic raw FAL nodes** (`FalRawNode`/`FalDynamicNode`) bypass the factory `buildArgs` and aren't covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)