### PR TITLE
feat(prompt): expand video mentions and wire audio/video into atlascloud nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41633,7 +41633,8 @@
       "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
-        "@nodetool-ai/node-sdk": "*"
+        "@nodetool-ai/node-sdk": "*",
+        "@nodetool-ai/runtime": "*"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/atlascloud-nodes/package.json
+++ b/packages/atlascloud-nodes/package.json
@@ -11,7 +11,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@nodetool-ai/node-sdk": "*"
+    "@nodetool-ai/node-sdk": "*",
+    "@nodetool-ai/runtime": "*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -16,6 +16,12 @@ import {
   registerDeclaredProperty
 } from "@nodetool-ai/node-sdk";
 import type { NodeClass, PropOptions } from "@nodetool-ai/node-sdk";
+import { mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
+import type {
+  AssetMediaKind,
+  PromptAssetInputField,
+  PromptAssetTextField
+} from "@nodetool-ai/runtime";
 import {
   atlasPoll,
   atlasSubmit,
@@ -308,6 +314,58 @@ function computeFieldClassification(fields: AtlasFieldDef[]) {
   return classifyFields(fields.map((f) => ({ name: f.name, propType: f.type })));
 }
 
+/** Whether an asset ref already points at a source (so a mention shouldn't fill it). */
+function refHasSource(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const r = value as AssetRef & { asset_id?: unknown };
+  if (typeof r.uri === "string" && r.uri.trim() !== "") return true;
+  if (typeof r.data === "string" && r.data.length > 0) return true;
+  if (r.data instanceof Uint8Array && r.data.byteLength > 0) return true;
+  return r.asset_id != null && r.asset_id !== "";
+}
+
+/**
+ * Route `asset://` media mentioned inline in a node's text inputs onto its
+ * empty image/audio/video inputs (and strip the mentions from the text). Shared
+ * with FAL / KIE / Replicate / image-to-image via `mapPromptAssetsToInputs` —
+ * lets a Seedance reference-to-video node pull its reference image, audio track
+ * and video clip straight from the prompt's @-mentions.
+ */
+function promptAssetOverrides(
+  instance: Record<string, unknown>,
+  spec: AtlasManifestEntry,
+  context: ProcessContext | undefined
+): Promise<Record<string, unknown>> {
+  const textFields: PromptAssetTextField[] = [];
+  const assetFields: PromptAssetInputField[] = [];
+  for (const field of spec.fields) {
+    const value = instance[field.name];
+    if (ASSET_TYPES.has(field.type)) {
+      assetFields.push({
+        name: field.name,
+        kind: field.type as AssetMediaKind,
+        list: false,
+        hasSource: refHasSource(value)
+      });
+      continue;
+    }
+    const listMatch = LIST_ASSET_RE.exec(field.type);
+    if (listMatch) {
+      assetFields.push({
+        name: field.name,
+        kind: listMatch[1] as AssetMediaKind,
+        list: true,
+        hasSource: Array.isArray(value) && value.some(refHasSource)
+      });
+      continue;
+    }
+    if (field.type === "str") {
+      textFields.push({ name: field.name, value: String(value ?? "") });
+    }
+  }
+  return mapPromptAssetsToInputs(textFields, assetFields, context);
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -324,8 +382,18 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
       const apiKey = getApiKey(this._secrets);
       const input: Record<string, unknown> = {};
 
+      const overrides = await promptAssetOverrides(
+        this as unknown as Record<string, unknown>,
+        specRef,
+        context
+      );
+      const readValue = (name: string): unknown =>
+        name in overrides
+          ? overrides[name]
+          : (this as unknown as Record<string, unknown>)[name];
+
       for (const f of specRef.fields) {
-        const v = (this as unknown as Record<string, unknown>)[f.name];
+        const v = readValue(f.name);
         if (v === undefined || v === null) continue;
 
         if (ASSET_TYPES.has(f.type)) {

--- a/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
@@ -376,6 +376,136 @@ describe("createAtlasNodeClass.process", () => {
     expect((out.output as Record<string, unknown>).data).toBeTruthy();
   });
 
+  it("routes prompt @-mentions onto image / audio / video inputs", async () => {
+    const submitted: { body: Record<string, unknown> } = { body: {} };
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/generateVideo")) {
+        submitted.body = JSON.parse(init!.body as string);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "v" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/v")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.mp4"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.mp4") {
+        return {
+          ok: true,
+          arrayBuffer: async () => Uint8Array.from([1, 2]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const Cls = createAtlasNodeClass(
+      makeSpec({
+        modality: "video",
+        outputType: "video",
+        fields: [
+          { name: "prompt", type: "str", default: "" },
+          { name: "image", type: "image", default: null },
+          { name: "audio", type: "audio", default: null },
+          { name: "video", type: "video", default: null }
+        ]
+      })
+    ) as unknown as new () => {
+      prompt: string;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "drive asset://clip.mp4 with asset://track.wav and asset://ref.png";
+
+    const assetBytes = Uint8Array.from([1, 2, 3]);
+    const b64 = Buffer.from(assetBytes).toString("base64");
+    await node.process({
+      storage: null,
+      resolveAssetBytes: async () => ({ bytes: assetBytes })
+    });
+
+    expect(submitted.body).toEqual({
+      model: "test/model/t2i",
+      prompt: "drive video with audio and image",
+      image: `data:image/png;base64,${b64}`,
+      audio: `data:audio/wav;base64,${b64}`,
+      video: `data:video/mp4;base64,${b64}`
+    });
+  });
+
+  it("does not override a wired media input from a mention", async () => {
+    const submitted: { body: Record<string, unknown> } = { body: {} };
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/generateVideo")) {
+        submitted.body = JSON.parse(init!.body as string);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "v" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/v")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.mp4"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.mp4") {
+        return { ok: true, arrayBuffer: async () => Uint8Array.from([1]).buffer } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const Cls = createAtlasNodeClass(
+      makeSpec({
+        modality: "video",
+        outputType: "video",
+        fields: [
+          { name: "prompt", type: "str", default: "" },
+          { name: "video", type: "video", default: null }
+        ]
+      })
+    ) as unknown as new () => {
+      prompt: string;
+      video: unknown;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "restyle asset://clip.mp4 now";
+    node.video = { uri: "https://input/wired.mp4" };
+
+    await node.process({
+      storage: null,
+      resolveAssetBytes: async () => ({ bytes: Uint8Array.from([9]) })
+    });
+
+    // Wired slot wins; the mention is dropped from the prompt rather than left dangling.
+    expect(submitted.body).toEqual({
+      model: "test/model/t2i",
+      prompt: "restyle now",
+      video: "https://input/wired.mp4"
+    });
+  });
+
   it("propagates structured AtlasCloud job failures", async () => {
     global.fetch = vi.fn(async (url: string | URL) => {
       const u = String(url);

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -142,8 +142,8 @@ function computeFieldClassification(
 
 /**
  * Route `asset://` media mentioned inline in a node's text inputs onto its
- * empty image/audio inputs (and strip the mentions from the text). Shared with
- * KIE / Replicate / image-to-image via `mapPromptAssetsToInputs`.
+ * empty image/audio/video inputs (and strip the mentions from the text).
+ * Shared with KIE / Replicate / image-to-image via `mapPromptAssetsToInputs`.
  */
 async function promptAssetOverrides(
   instance: BaseNode,
@@ -156,7 +156,7 @@ async function promptAssetOverrides(
   for (const field of spec.inputFields) {
     if (field.parentField) continue;
     const kind = assetKind(field.propType);
-    if (kind === "image" || kind === "audio") {
+    if (kind === "image" || kind === "audio" || kind === "video") {
       const list = isListAsset(field.propType);
       const value = values[field.name];
       const hasSource = list

--- a/packages/fal-nodes/tests/fal-prompt-asset.test.ts
+++ b/packages/fal-nodes/tests/fal-prompt-asset.test.ts
@@ -203,3 +203,80 @@ describe("FAL multi-image video mapping", () => {
     expect(args.prompt).toBe("start from image_url only");
   });
 });
+
+/** A Seedance-style reference-to-video node taking image + audio + video. */
+function makeOmniReferenceNode() {
+  return createFalNodeClass({
+    endpointId: "bytedance/seedance-2.0/reference-to-video",
+    className: "Seedance2Reference",
+    moduleName: "video",
+    docstring: "test",
+    tags: [],
+    useCases: [],
+    outputType: "video",
+    outputFields: [{ name: "video", propType: "video" }],
+    enums: [],
+    inputFields: [
+      {
+        name: "prompt",
+        propType: "str",
+        tsType: "string",
+        default: "",
+        description: "",
+        fieldType: "input",
+        required: true
+      },
+      imageField("image_url"),
+      {
+        name: "audio_url",
+        propType: "audio",
+        tsType: "object",
+        default: { type: "audio", uri: "", asset_id: null, data: null, metadata: null },
+        description: "",
+        fieldType: "input",
+        required: false
+      },
+      {
+        name: "video_url",
+        propType: "video",
+        tsType: "object",
+        default: {
+          type: "video",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null,
+          duration: null,
+          format: null
+        },
+        description: "",
+        fieldType: "input",
+        required: false
+      }
+    ]
+  });
+}
+
+describe("FAL omni reference-to-video mapping", () => {
+  beforeEach(() => {
+    falSubmit.mockReset();
+    falSubmit.mockResolvedValue({ video: { url: "out.mp4" } });
+  });
+
+  it("routes image, audio and video mentions to their typed inputs", async () => {
+    const NodeClass = makeOmniReferenceNode();
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({
+      prompt: "drive asset://clip.mp4 with asset://track.wav and asset://ref.png"
+    });
+
+    await node.process(ctx as never);
+
+    const args = falSubmit.mock.calls[0][2] as Record<string, unknown>;
+    // Image takes the data-URL path; audio and video upload via the CDN path.
+    expect(args.image_url).toBe(`data:image/png;base64,${b64}`);
+    expect(args.audio_url).toBe(`falcdn:${b64}`);
+    expect(args.video_url).toBe(`falcdn:${b64}`);
+    expect(args.prompt).toBe("drive video_url with audio_url and image_url");
+  });
+});

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -225,8 +225,8 @@ async function buildVideoClips(
 
 /**
  * Route `asset://` media mentioned inline in a node's text inputs onto its
- * empty image/audio uploads (and strip the mentions from the text). Shared with
- * FAL / Replicate / image-to-image via `mapPromptAssetsToInputs`.
+ * empty image/audio/video uploads (and strip the mentions from the text).
+ * Shared with FAL / Replicate / image-to-image via `mapPromptAssetsToInputs`.
  */
 async function promptAssetOverrides(
   instance: BaseNode,
@@ -239,8 +239,15 @@ async function promptAssetOverrides(
     .map((f) => ({ name: f.name, value: String(values[f.name] ?? "") }));
   const assetFields: PromptAssetInputField[] = [];
   for (const upload of spec.uploads ?? []) {
+    // Video-clip uploads carry per-clip start/end timing, not a plain ref, so
+    // they aren't a target for inline mentions; plain video uploads are.
     if (upload.isVideoClip) continue;
-    if (upload.kind !== "image" && upload.kind !== "audio") continue;
+    if (
+      upload.kind !== "image" &&
+      upload.kind !== "audio" &&
+      upload.kind !== "video"
+    )
+      continue;
     const value = values[upload.field];
     const list = Boolean(upload.isList);
     const hasSource = list

--- a/packages/kie-nodes/tests/kie-prompt-asset.test.ts
+++ b/packages/kie-nodes/tests/kie-prompt-asset.test.ts
@@ -9,12 +9,19 @@ vi.mock("../src/kie-base.js", async (importOriginal) => {
     kieExecuteTask: vi.fn(),
     kieImageRef: vi.fn(async (b64: string) => ({ type: "image", data: b64 })),
     reportKieProviderCost: vi.fn(),
-    uploadImageInput: vi.fn(async () => "https://cdn.example.com/img.png")
+    uploadImageInput: vi.fn(async () => "https://cdn.example.com/img.png"),
+    uploadAudioInput: vi.fn(async () => "https://cdn.example.com/audio.wav"),
+    uploadVideoInput: vi.fn(async () => "https://cdn.example.com/clip.mp4")
   };
 });
 
 const { createKieNodeClass } = await import("../src/kie-factory.js");
-import { kieExecuteTask, uploadImageInput } from "../src/kie-base.js";
+import {
+  kieExecuteTask,
+  uploadAudioInput,
+  uploadImageInput,
+  uploadVideoInput
+} from "../src/kie-base.js";
 
 function makeEditNode() {
   const spec: KieManifestEntry = {
@@ -59,6 +66,8 @@ describe("KIE prompt asset mapping", () => {
       creditsConsumed: 0
     } as never);
     vi.mocked(uploadImageInput).mockClear();
+    vi.mocked(uploadAudioInput).mockClear();
+    vi.mocked(uploadVideoInput).mockClear();
   });
 
   it("routes an asset:// mention into the image upload and strips it", async () => {
@@ -104,5 +113,57 @@ describe("KIE prompt asset mapping", () => {
       unknown
     >;
     expect(params.prompt).toBe("enhance now");
+  });
+
+  it("routes image, audio and video mentions onto their uploads", async () => {
+    const spec: KieManifestEntry = {
+      className: "Seedance2Reference",
+      moduleName: "video",
+      modelId: "bytedance-seedance-2",
+      title: "Seedance 2.0 Reference to Video",
+      description: "test",
+      outputType: "video",
+      pollInterval: 1000,
+      maxAttempts: 2,
+      fields: [
+        { name: "prompt", type: "str", default: "", required: true },
+        { name: "image", type: "image", default: null },
+        { name: "audio", type: "audio", default: null },
+        { name: "video", type: "video", default: null }
+      ],
+      uploads: [
+        { field: "image", kind: "image", paramName: "image_url" },
+        { field: "audio", kind: "audio", paramName: "audio_url" },
+        { field: "video", kind: "video", paramName: "video_url" }
+      ]
+    };
+    const NodeClass = createKieNodeClass(spec);
+    const node = new (NodeClass as new () => InstanceType<typeof NodeClass>)();
+    node.assign({
+      prompt: "drive asset://clip.mp4 with asset://track.wav and asset://ref.png"
+    });
+    node.setDynamic("_secrets", { KIE_API_KEY: "test" });
+
+    await node.process(ctx as never);
+
+    // Each kind was resolved to bytes and handed to the matching uploader.
+    expect(
+      (vi.mocked(uploadImageInput).mock.calls[0][1] as Record<string, unknown>).data
+    ).toBe(b64);
+    expect(
+      (vi.mocked(uploadAudioInput).mock.calls[0][1] as Record<string, unknown>).data
+    ).toBe(b64);
+    expect(
+      (vi.mocked(uploadVideoInput).mock.calls[0][1] as Record<string, unknown>).data
+    ).toBe(b64);
+
+    const params = vi.mocked(kieExecuteTask).mock.calls[0][2] as Record<
+      string,
+      unknown
+    >;
+    expect(params.image_url).toBe("https://cdn.example.com/img.png");
+    expect(params.audio_url).toBe("https://cdn.example.com/audio.wav");
+    expect(params.video_url).toBe("https://cdn.example.com/clip.mp4");
+    expect(params.prompt).toBe("drive video_url with audio_url and image_url");
   });
 });

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -493,11 +493,15 @@ export function expandAssetReferences(prompt: string): MessageContent[] {
         type: "image_url",
         image: { uri: ref.uri, mimeType: ref.mime }
       });
-    } else {
+    } else if (ref.kind === "audio") {
       parts.push({
         type: "audio",
         audio: { uri: ref.uri, mimeType: ref.mime }
       });
+    } else {
+      // Video (and any other non-chat media): keep the mention as literal text
+      // so the model still sees the reference rather than a mislabeled block.
+      pushText(ref.uri);
     }
     cursor = ref.index + ref.length;
   }

--- a/packages/llm-nodes/tests/prompt-asset-references.test.ts
+++ b/packages/llm-nodes/tests/prompt-asset-references.test.ts
@@ -29,6 +29,14 @@ describe("expandAssetReferences", () => {
     ]);
   });
 
+  it("keeps a video mention as literal text rather than a media block", () => {
+    expect(expandAssetReferences("clip asset://reel.mp4 here")).toEqual([
+      { type: "text", text: "clip " },
+      { type: "text", text: "asset://reel.mp4" },
+      { type: "text", text: " here" }
+    ]);
+  });
+
   it("does not swallow a trailing sentence period into the reference", () => {
     const parts = expandAssetReferences("Here: asset://abc.png.");
     expect(parts).toEqual([

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -148,8 +148,8 @@ function computeFieldClassification(fields: ReplicateFieldDef[]) {
 
 /**
  * Route `asset://` media mentioned inline in a node's text inputs onto its
- * empty image/audio inputs (and strip the mentions from the text). Shared with
- * FAL / KIE / image-to-image via `mapPromptAssetsToInputs`.
+ * empty image/audio/video inputs (and strip the mentions from the text).
+ * Shared with FAL / KIE / image-to-image via `mapPromptAssetsToInputs`.
  */
 async function promptAssetOverrides(
   instance: BaseNode,
@@ -163,7 +163,7 @@ async function promptAssetOverrides(
     if (field.parentField) continue;
     if (EXCLUDED_FIELDS.has(field.name)) continue;
     const kind = assetKind(field.propType);
-    if (kind === "image" || kind === "audio") {
+    if (kind === "image" || kind === "audio" || kind === "video") {
       const list = isListAsset(field.propType);
       const value = values[field.name];
       const hasSource = list

--- a/packages/replicate-nodes/tests/replicate-prompt-asset.test.ts
+++ b/packages/replicate-nodes/tests/replicate-prompt-asset.test.ts
@@ -69,6 +69,63 @@ function makeI2INode() {
   });
 }
 
+function makeOmniNode() {
+  return createReplicateNodeClass({
+    endpointId: "owner/omni",
+    className: "OmniModel",
+    moduleName: "video.generate",
+    docstring: "test",
+    tags: [],
+    useCases: [],
+    outputType: "video",
+    inputFields: [
+      {
+        name: "prompt",
+        propType: "str",
+        tsType: "string",
+        default: "",
+        description: "",
+        fieldType: "input",
+        required: true
+      },
+      {
+        name: "video",
+        propType: "video",
+        tsType: "object",
+        default: {
+          type: "video",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null,
+          duration: null,
+          format: null
+        },
+        description: "",
+        fieldType: "input",
+        required: false
+      },
+      {
+        name: "audio",
+        propType: "audio",
+        tsType: "object",
+        default: {
+          type: "audio",
+          uri: "",
+          asset_id: null,
+          data: null,
+          metadata: null
+        },
+        description: "",
+        fieldType: "input",
+        required: false
+      }
+    ],
+    outputFields: [],
+    enums: []
+  });
+}
+
 const assetBytes = new Uint8Array([7, 8, 9]);
 const b64 = Buffer.from(assetBytes).toString("base64");
 const ctx = { resolveAssetBytes: async () => ({ bytes: assetBytes }) };
@@ -104,5 +161,20 @@ describe("Replicate prompt asset mapping", () => {
     const args = replicateSubmit.mock.calls[0][2] as Record<string, unknown>;
     expect(args.image).toBe("uploaded:https://example.com/wired.png");
     expect(args.prompt).toBe("enhance now");
+  });
+
+  it("routes video and audio mentions into their respective inputs", async () => {
+    const NodeClass = makeOmniNode();
+    const instance = new NodeClass({});
+    instance.assign({
+      prompt: "drive asset://clip.mp4 with asset://track.wav"
+    });
+
+    await instance.process(ctx as never);
+
+    const args = replicateSubmit.mock.calls[0][2] as Record<string, unknown>;
+    expect(args.video).toContain(b64);
+    expect(args.audio).toContain(b64);
+    expect(args.prompt).toBe("drive video with audio");
   });
 });

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -13,6 +13,7 @@
 import type { AssetRef, ProcessingMessage, ProviderCost } from "@nodetool-ai/protocol";
 import { AgentMemory } from "./agent-memory.js";
 import { encodeRawImageRef } from "./image-codec.js";
+import { inlineTextAssetRefs } from "./prompt-asset-refs.js";
 import { importNodeBuiltin } from "@nodetool-ai/config";
 
 // `node:fs/promises`, `node:path`, `node:url`, `node:crypto` are loaded
@@ -2056,6 +2057,14 @@ export class ProcessingContext {
             });
             continue;
           }
+        }
+        if (part.type === "text" && part.text.includes("asset://")) {
+          // Inline any plain-text document mention (asset://doc.md, .txt, .csv …)
+          // as its decoded contents. Resolved here, at call time, so the stored
+          // thread message keeps the compact asset:// URI like media does.
+          const inlined = await inlineTextAssetRefs(part.text, this);
+          parts.push(inlined === part.text ? part : { type: "text", text: inlined });
+          continue;
         }
         parts.push(part);
       }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -77,12 +77,16 @@ export { PythonNodeExecutor } from "./python-node-executor.js";
 export { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 export {
   classifyAssetToken,
+  classifyTextToken,
   findAssetRefs,
   findImageAssetRefs,
+  findTextAssetRefs,
+  inlineTextAssetRefs,
   stripAssetRefs,
   mapPromptAssetsToInputs,
   type AssetMediaKind,
   type PromptAssetRef,
+  type TextAssetRef,
   type PromptAssetTextField,
   type PromptAssetInputField,
   type InjectedAssetRef

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -55,22 +55,66 @@ const VIDEO_EXT_MIME: Record<string, string> = {
 };
 
 /**
+ * Plain-text document extensions. Unlike media, a text mention has no typed
+ * input to route to — its decoded content is inlined into the prompt string in
+ * place of the token (see {@link inlineTextAssetRefs}).
+ */
+const TEXT_EXT_MIME: Record<string, string> = {
+  txt: "text/plain",
+  text: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  json: "application/json",
+  jsonl: "application/json",
+  ndjson: "application/json",
+  xml: "application/xml",
+  yaml: "application/yaml",
+  yml: "application/yaml",
+  html: "text/html",
+  htm: "text/html",
+  log: "text/plain",
+  rst: "text/x-rst",
+  ini: "text/plain",
+  toml: "text/plain",
+  srt: "text/plain",
+  vtt: "text/vtt"
+};
+
+/** Lowercased extension of an `asset://<id>.<ext>` token (without the dot). */
+function tokenExt(token: string): string {
+  const noScheme = token.slice("asset://".length);
+  const primary = noScheme.split(/[?#]/)[0];
+  return (primary.split(".").pop() ?? "").toLowerCase();
+}
+
+/**
  * Classify an `asset://<id>.<ext>` token by its extension. Image, audio and
  * video are provider-consumable media (reference-to-video / lipsync models take
  * a video clip); everything else (text, unknown) returns null so the reference
- * is left as literal text in the prompt.
+ * is left for the text-inlining pass or kept as literal text in the prompt.
  */
 export function classifyAssetToken(
   token: string
 ): { kind: AssetMediaKind; mime: string } | null {
   if (!token.startsWith("asset://")) return null;
-  const noScheme = token.slice("asset://".length);
-  const primary = noScheme.split(/[?#]/)[0];
-  const ext = (primary.split(".").pop() ?? "").toLowerCase();
+  const ext = tokenExt(token);
   if (ext in IMAGE_EXT_MIME) return { kind: "image", mime: IMAGE_EXT_MIME[ext] };
   if (ext in AUDIO_EXT_MIME) return { kind: "audio", mime: AUDIO_EXT_MIME[ext] };
   if (ext in VIDEO_EXT_MIME) return { kind: "video", mime: VIDEO_EXT_MIME[ext] };
   return null;
+}
+
+/**
+ * Classify an `asset://<id>.<ext>` token as a plain-text document. Returns null
+ * for non-text tokens (media, folders, unknown) so they are left untouched by
+ * the text-inlining pass.
+ */
+export function classifyTextToken(token: string): { mime: string } | null {
+  if (!token.startsWith("asset://")) return null;
+  const ext = tokenExt(token);
+  return ext in TEXT_EXT_MIME ? { mime: TEXT_EXT_MIME[ext] } : null;
 }
 
 /**
@@ -105,15 +149,15 @@ export interface PromptAssetRef {
 }
 
 /**
- * Find every classifiable media reference in a prompt, in source order.
- *
- * Trailing dots on a token are treated as sentence punctuation (not part of
- * the extension), so `asset://a.png.` yields the `asset://a.png` ref and leaves
- * the period in the surrounding text. Unclassifiable tokens (no/unknown
- * extension, e.g. `asset://doc.txt`) are skipped and remain literal text.
+ * Scan a prompt for `asset://` tokens in source order, yielding each token with
+ * its source offset. Trailing dots are treated as sentence punctuation (not
+ * part of the extension), so `asset://a.png.` yields `asset://a.png` and leaves
+ * the period in the surrounding text. Classification is left to the caller.
  */
-export function findAssetRefs(prompt: string): PromptAssetRef[] {
-  const refs: PromptAssetRef[] = [];
+function scanAssetTokens(
+  prompt: string
+): Array<{ token: string; index: number }> {
+  const out: Array<{ token: string; index: number }> = [];
   ASSET_URI_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = ASSET_URI_RE.exec(prompt)) !== null) {
@@ -122,17 +166,85 @@ export function findAssetRefs(prompt: string): PromptAssetRef[] {
     if (trailingDots) {
       token = token.slice(0, token.length - trailingDots[0].length);
     }
+    out.push({ token, index: match.index });
+  }
+  return out;
+}
+
+/**
+ * Find every classifiable media reference in a prompt, in source order.
+ *
+ * Unclassifiable tokens (no/unknown extension, e.g. `asset://doc.txt`) are
+ * skipped and remain literal text — text documents are handled separately by
+ * {@link findTextAssetRefs} / {@link inlineTextAssetRefs}.
+ */
+export function findAssetRefs(prompt: string): PromptAssetRef[] {
+  const refs: PromptAssetRef[] = [];
+  for (const { token, index } of scanAssetTokens(prompt)) {
     const classification = classifyAssetToken(token);
     if (!classification) continue;
     refs.push({
       uri: token,
       kind: classification.kind,
       mime: classification.mime,
-      index: match.index,
+      index,
       length: token.length
     });
   }
   return refs;
+}
+
+/** A text-document reference found inline in a prompt. */
+export interface TextAssetRef {
+  uri: string;
+  mime: string;
+  index: number;
+  length: number;
+}
+
+/** Find every plain-text document reference in a prompt, in source order. */
+export function findTextAssetRefs(prompt: string): TextAssetRef[] {
+  const refs: TextAssetRef[] = [];
+  for (const { token, index } of scanAssetTokens(prompt)) {
+    const classification = classifyTextToken(token);
+    if (!classification) continue;
+    refs.push({ uri: token, mime: classification.mime, index, length: token.length });
+  }
+  return refs;
+}
+
+/**
+ * Replace each plain-text document mention in `prompt` with the asset's decoded
+ * UTF-8 contents, inline. A mention that can't be resolved to bytes is left as
+ * its literal token (never silently dropped). Media mentions are untouched.
+ */
+export async function inlineTextAssetRefs(
+  prompt: string,
+  context?: ProcessingContext
+): Promise<string> {
+  if (!context || !prompt.includes("asset://")) return prompt;
+  const refs = findTextAssetRefs(prompt);
+  if (refs.length === 0) return prompt;
+
+  const decoder = new TextDecoder();
+  const contents = await Promise.all(
+    refs.map(async (ref) => {
+      const bytes = await loadMediaRefBytes({ type: "text", uri: ref.uri }, context);
+      return bytes && bytes.length > 0 ? decoder.decode(bytes) : null;
+    })
+  );
+
+  let result = "";
+  let cursor = 0;
+  refs.forEach((ref, i) => {
+    if (ref.index < cursor) return;
+    result += prompt.slice(cursor, ref.index);
+    // Inline the decoded text, or keep the literal token when resolution failed.
+    result += contents[i] ?? prompt.slice(ref.index, ref.index + ref.length);
+    cursor = ref.index + ref.length;
+  });
+  result += prompt.slice(cursor);
+  return result;
 }
 
 /** Convenience: only the image references in a prompt. */
@@ -304,19 +416,33 @@ export async function mapPromptAssetsToInputs(
   context?: ProcessingContext
 ): Promise<Record<string, unknown>> {
   const overrides: Record<string, unknown> = {};
-  if (assetFields.length === 0) return overrides;
-
   const acceptedKinds = new Set(assetFields.map((f) => f.kind));
 
-  // Expand any folder mentions into their member assets first, then work off
-  // the expanded text. The original value is kept to decide whether the field
-  // actually changed (a folder that expanded to nothing still rewrites text).
+  // Expand any folder mentions into their member assets first (only meaningful
+  // when the node has media inputs to receive them), then work off the expanded
+  // text. The original value is kept to decide whether the field actually
+  // changed (a folder that expanded to nothing still rewrites text).
   const expandedByField = new Map<string, string>();
   for (const tf of textFields) {
     expandedByField.set(
       tf.name,
-      await expandFolderRefs(tf.value, context, acceptedKinds)
+      assetFields.length > 0
+        ? await expandFolderRefs(tf.value, context, acceptedKinds)
+        : tf.value
     );
+  }
+
+  // A node with no typed media inputs still inlines plain-text document
+  // mentions into its prompt — that's the only transformation that applies.
+  if (assetFields.length === 0) {
+    for (const tf of textFields) {
+      const inlined = await inlineTextAssetRefs(
+        expandedByField.get(tf.name) ?? tf.value,
+        context
+      );
+      if (inlined !== tf.value) overrides[tf.name] = inlined;
+    }
+    return overrides;
   }
 
   // Refs of accepted kinds, queued per kind in source order across all text
@@ -379,18 +505,21 @@ export async function mapPromptAssetsToInputs(
     }
   }
 
-  // Rewrite each text input off its (folder-)expanded value: a placed mention
-  // becomes a reference to the input label it now lives in; a mention that
-  // could not be placed is dropped. Compared against the original so a folder
-  // that expanded to nothing still rewrites the field.
+  // Rewrite each text input off its (folder-)expanded value: a placed media
+  // mention becomes a reference to the input label it now lives in; an unplaced
+  // one is dropped. Then inline any plain-text document mentions into the
+  // result — done after the media rewrite so the document's own whitespace
+  // isn't touched by the gap-collapsing in `replaceAssetRefs`. Compared against
+  // the original so a folder that expanded to nothing still rewrites the field.
   for (const tf of textFields) {
     const expanded = expandedByField.get(tf.name) ?? tf.value;
     const refs = refsByField.get(tf.name) ?? [];
-    const rewritten = replaceAssetRefs(
+    const relabeled = replaceAssetRefs(
       expanded,
       refs,
       (ref) => labelByRef.get(ref) ?? ""
     );
+    const rewritten = await inlineTextAssetRefs(relabeled, context);
     if (rewritten !== tf.value) overrides[tf.name] = rewritten;
   }
 

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -13,8 +13,12 @@
  * `asset://` URI to {@link loadMediaRefBytes} / `resolveMessageMediaUris`,
  * which dereference it to bytes / a data URI just before it is consumed. The
  * higher-level {@link mapPromptAssetsToInputs} does resolve, so provider nodes
- * (FAL / KIE / Replicate / image-to-image) can route a mentioned image into a
- * typed asset input with bytes already in hand.
+ * (FAL / KIE / Replicate / image-to-image) can route a mentioned image / audio
+ * / video into a typed asset input with bytes already in hand.
+ *
+ * A mentioned plain-text document (`.md`, `.txt`, `.csv`, `.json`, …) has no
+ * typed input to route to — {@link inlineTextAssetRefs} substitutes its decoded
+ * contents into the prompt text in place of the token.
  */
 
 import type { ProcessingContext } from "./context.js";
@@ -404,6 +408,10 @@ async function expandFolderRefs(
  *     tell which slot holds which image; mentions that could not be placed
  *     (an input was already wired, or capacity ran out) are dropped rather
  *     than left as a dangling URI.
+ *
+ * Plain-text document mentions are inlined into the prompt as their decoded
+ * contents (see {@link inlineTextAssetRefs}). This applies even when the node
+ * has no media inputs at all (e.g. a text-to-image prompt referencing a brief).
  *
  * Inputs that already carry a source are left untouched. Returns a flat map of
  * field name → replacement value (cleaned string for text fields, an

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -20,7 +20,7 @@
 import type { ProcessingContext } from "./context.js";
 import { loadMediaRefBytes } from "./media-ref-bytes.js";
 
-export type AssetMediaKind = "image" | "audio";
+export type AssetMediaKind = "image" | "audio" | "video";
 
 /** Matches an inline `asset://<id>.<ext>` token (greedy over the URI charset). */
 const ASSET_URI_RE = /asset:\/\/[A-Za-z0-9._~\-/]+/g;
@@ -46,10 +46,19 @@ const AUDIO_EXT_MIME: Record<string, string> = {
   opus: "audio/opus"
 };
 
+const VIDEO_EXT_MIME: Record<string, string> = {
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  mkv: "video/x-matroska",
+  avi: "video/x-msvideo"
+};
+
 /**
- * Classify an `asset://<id>.<ext>` token by its extension. Only image and
- * audio are provider-consumable media; everything else (text, video, unknown)
- * returns null so the reference is left as literal text in the prompt.
+ * Classify an `asset://<id>.<ext>` token by its extension. Image, audio and
+ * video are provider-consumable media (reference-to-video / lipsync models take
+ * a video clip); everything else (text, unknown) returns null so the reference
+ * is left as literal text in the prompt.
  */
 export function classifyAssetToken(
   token: string
@@ -60,13 +69,14 @@ export function classifyAssetToken(
   const ext = (primary.split(".").pop() ?? "").toLowerCase();
   if (ext in IMAGE_EXT_MIME) return { kind: "image", mime: IMAGE_EXT_MIME[ext] };
   if (ext in AUDIO_EXT_MIME) return { kind: "audio", mime: AUDIO_EXT_MIME[ext] };
+  if (ext in VIDEO_EXT_MIME) return { kind: "video", mime: VIDEO_EXT_MIME[ext] };
   return null;
 }
 
 /**
  * Pick a media extension for a content type so a stored asset can be turned
  * back into a classifiable `asset://<id>.<ext>` token. Returns null for content
- * types that aren't a recognized image/audio kind (folders, video, documents).
+ * types that aren't a recognized image/audio/video kind (folders, documents).
  */
 function extForContentType(contentType: string): string | null {
   const ct = (contentType ?? "").toLowerCase().split(";")[0].trim();
@@ -76,8 +86,10 @@ function extForContentType(contentType: string): string | null {
   let sub = ct.slice(slash + 1).split("+")[0];
   if (ct === "audio/mpeg" || ct === "audio/mp3") sub = "mp3";
   else if (ct === "audio/mp4") sub = "m4a";
+  else if (ct === "video/quicktime") sub = "mov";
   if (top === "image" && sub in IMAGE_EXT_MIME) return sub;
   if (top === "audio" && sub in AUDIO_EXT_MIME) return sub;
+  if (top === "video" && sub in VIDEO_EXT_MIME) return sub;
   return null;
 }
 
@@ -311,7 +323,8 @@ export async function mapPromptAssetsToInputs(
   // fields, plus the per-field ref list used for relabeling.
   const queues: Record<AssetMediaKind, PromptAssetRef[]> = {
     image: [],
-    audio: []
+    audio: [],
+    video: []
   };
   const refsByField = new Map<string, PromptAssetRef[]>();
   for (const tf of textFields) {
@@ -344,7 +357,7 @@ export async function mapPromptAssetsToInputs(
   // Fill empty inputs in declaration order from the matching kind's queue,
   // recording which input label each placed mention was routed into.
   const labelByRef = new Map<PromptAssetRef, string>();
-  const cursor: Record<AssetMediaKind, number> = { image: 0, audio: 0 };
+  const cursor: Record<AssetMediaKind, number> = { image: 0, audio: 0, video: 0 };
   for (const field of assetFields) {
     if (field.hasSource) continue;
     const queue = queues[field.kind];

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -891,6 +891,29 @@ describe("ProcessingContext – asset helper methods", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("resolveMessageMediaUris inlines asset:// text documents into text parts", async () => {
+    const storage = new InMemoryStorageAdapter();
+    await storage.store(
+      "brief.md",
+      new TextEncoder().encode("# Brief\nMake it cinematic."),
+      "text/markdown"
+    );
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      {
+        role: "user",
+        content: [{ type: "text", text: "follow asset://brief.md exactly" }]
+      }
+    ]);
+
+    const parts = resolved[0].content as Array<Record<string, any>>;
+    expect(parts[0]).toEqual({
+      type: "text",
+      text: "follow # Brief\nMake it cinematic. exactly"
+    });
+  });
 });
 
 class MockProvider extends BaseProvider {

--- a/packages/runtime/tests/prompt-asset-refs.test.ts
+++ b/packages/runtime/tests/prompt-asset-refs.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
   classifyAssetToken,
+  classifyTextToken,
   findAssetRefs,
   findImageAssetRefs,
+  findTextAssetRefs,
+  inlineTextAssetRefs,
   stripAssetRefs,
   mapPromptAssetsToInputs,
   type InjectedAssetRef
@@ -12,6 +15,18 @@ import {
 const fakeContext = (bytes: Uint8Array) =>
   ({
     resolveAssetBytes: async () => ({ bytes })
+  }) as never;
+
+/** Context that resolves each asset:// URI to per-URI UTF-8 text. */
+const textContext = (byUri: Record<string, string>) =>
+  ({
+    resolveAssetBytes: async (uri: string) => {
+      const text = byUri[uri];
+      return {
+        bytes:
+          text === undefined ? null : new TextEncoder().encode(text)
+      };
+    }
   }) as never;
 
 describe("classifyAssetToken", () => {
@@ -38,6 +53,64 @@ describe("classifyAssetToken", () => {
     expect(classifyAssetToken("asset://doc.txt")).toBeNull();
     expect(classifyAssetToken("asset://noext")).toBeNull();
     expect(classifyAssetToken("https://x/a.png")).toBeNull();
+  });
+});
+
+describe("classifyTextToken", () => {
+  it("classifies text-document extensions", () => {
+    expect(classifyTextToken("asset://a.txt")).toEqual({ mime: "text/plain" });
+    expect(classifyTextToken("asset://b.md")).toEqual({ mime: "text/markdown" });
+    expect(classifyTextToken("asset://c.json")).toEqual({
+      mime: "application/json"
+    });
+  });
+
+  it("returns null for media and unknown tokens", () => {
+    expect(classifyTextToken("asset://a.png")).toBeNull();
+    expect(classifyTextToken("asset://b.mp4")).toBeNull();
+    expect(classifyTextToken("asset://noext")).toBeNull();
+  });
+});
+
+describe("findTextAssetRefs", () => {
+  it("locates text mentions and ignores media", () => {
+    const refs = findTextAssetRefs("read asset://notes.md not asset://a.png");
+    expect(refs.map((r) => r.uri)).toEqual(["asset://notes.md"]);
+  });
+});
+
+describe("inlineTextAssetRefs", () => {
+  it("replaces a text mention with the asset's decoded content", async () => {
+    const out = await inlineTextAssetRefs(
+      "summarize asset://notes.md please",
+      textContext({ "asset://notes.md": "# Title\n- one\n- two" })
+    );
+    expect(out).toBe("summarize # Title\n- one\n- two please");
+  });
+
+  it("preserves the document's own whitespace verbatim", async () => {
+    const doc = "col1,  col2\nx,    y";
+    const out = await inlineTextAssetRefs(
+      "data: asset://t.csv",
+      textContext({ "asset://t.csv": doc })
+    );
+    expect(out).toBe(`data: ${doc}`);
+  });
+
+  it("leaves the literal token when the asset can't be resolved", async () => {
+    const out = await inlineTextAssetRefs(
+      "open asset://missing.txt now",
+      textContext({})
+    );
+    expect(out).toBe("open asset://missing.txt now");
+  });
+
+  it("leaves media mentions untouched", async () => {
+    const out = await inlineTextAssetRefs(
+      "look asset://a.png here",
+      textContext({})
+    );
+    expect(out).toBe("look asset://a.png here");
   });
 });
 
@@ -224,6 +297,33 @@ describe("mapPromptAssetsToInputs", () => {
     // Slot is wired, so neither mention is placed; both are dropped from text.
     expect(overrides.video).toBeUndefined();
     expect(overrides.prompt).toBe("restyle and");
+  });
+
+  it("inlines a text-document mention even when the node has no media inputs", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "use this brief: asset://brief.md" }],
+      [],
+      textContext({ "asset://brief.md": "Make it cinematic." })
+    );
+    expect(overrides.prompt).toBe("use this brief: Make it cinematic.");
+  });
+
+  it("inlines text and routes media in the same prompt", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [
+        {
+          name: "prompt",
+          value: "style asset://ref.png per asset://notes.txt thanks"
+        }
+      ],
+      [{ name: "image", label: "image_url", kind: "image", hasSource: false }],
+      textContext({ "asset://notes.txt": "soft pastel palette" })
+    );
+    // Image mention relabeled to its slot; text mention inlined to its content.
+    expect(overrides.prompt).toBe(
+      "style image_url per soft pastel palette thanks"
+    );
+    expect((overrides.image as InjectedAssetRef).uri).toBe("asset://ref.png");
   });
 });
 

--- a/packages/runtime/tests/prompt-asset-refs.test.ts
+++ b/packages/runtime/tests/prompt-asset-refs.test.ts
@@ -15,7 +15,7 @@ const fakeContext = (bytes: Uint8Array) =>
   }) as never;
 
 describe("classifyAssetToken", () => {
-  it("classifies image and audio extensions", () => {
+  it("classifies image, audio and video extensions", () => {
     expect(classifyAssetToken("asset://a.png")).toEqual({
       kind: "image",
       mime: "image/png"
@@ -23,6 +23,14 @@ describe("classifyAssetToken", () => {
     expect(classifyAssetToken("asset://b.mp3")).toEqual({
       kind: "audio",
       mime: "audio/mpeg"
+    });
+    expect(classifyAssetToken("asset://c.mp4")).toEqual({
+      kind: "video",
+      mime: "video/mp4"
+    });
+    expect(classifyAssetToken("asset://d.mov")).toEqual({
+      kind: "video",
+      mime: "video/quicktime"
     });
   });
 
@@ -179,6 +187,43 @@ describe("mapPromptAssetsToInputs", () => {
       fakeContext(bytes)
     );
     expect(overrides).toEqual({});
+  });
+
+  it("routes image, audio and video mentions onto an omni node's slots", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [
+        {
+          name: "prompt",
+          value: "drive asset://clip.mp4 with asset://track.wav and asset://ref.png"
+        }
+      ],
+      [
+        { name: "image", label: "image_url", kind: "image", hasSource: false },
+        { name: "audio", label: "audio_url", kind: "audio", hasSource: false },
+        { name: "video", label: "video_url", kind: "video", hasSource: false }
+      ],
+      fakeContext(bytes)
+    );
+    expect(overrides.video).toEqual({
+      type: "video",
+      uri: "asset://clip.mp4",
+      mimeType: "video/mp4",
+      data: b64
+    } satisfies InjectedAssetRef);
+    expect((overrides.audio as InjectedAssetRef).uri).toBe("asset://track.wav");
+    expect((overrides.image as InjectedAssetRef).uri).toBe("asset://ref.png");
+    expect(overrides.prompt).toBe("drive video_url with audio_url and image_url");
+  });
+
+  it("fills a wired video input from a mention only when empty", async () => {
+    const overrides = await mapPromptAssetsToInputs(
+      [{ name: "prompt", value: "restyle asset://a.mp4 and asset://b.webm" }],
+      [{ name: "video", label: "video_url", kind: "video", hasSource: true }],
+      fakeContext(bytes)
+    );
+    // Slot is wired, so neither mention is placed; both are dropped from text.
+    expect(overrides.video).toBeUndefined();
+    expect(overrides.prompt).toBe("restyle and");
   });
 });
 


### PR DESCRIPTION
Generalize the prompt @-mention asset mapper to a third media kind, video,
and route audio/video mentions everywhere a node has a prompt plus typed
media inputs:

- runtime: add `video` to AssetMediaKind, a VIDEO_EXT_MIME table, and
  video classification/queueing in mapPromptAssetsToInputs. Folder mentions
  now expand video members too. The composer already encodes video mentions
  (mp4/webm/mov/mkv/avi) — they were being left as dangling asset:// URIs.
- fal / replicate / kie factories: widen the prompt-asset filter from
  image|audio to also include video, so reference-to-video / lipsync /
  video-edit models pull a mentioned clip into their video slot.
- atlascloud-nodes: wire the factory into mapPromptAssetsToInputs (image +
  audio + video). Seedance 2.0 reference-to-video now pulls its reference
  image, audio track and video clip straight from the prompt's mentions
  instead of dropping them.

Tests: runtime parser/mapper video cases; per-family integration tests
proving image/audio/video mention -> resolved bytes -> provider input with
the prompt relabeled, plus wired-input precedence.