### PR TITLE
Add in-browser audio sample editor with waveform UI

### DIFF
--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -322,6 +322,12 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
     [currentAsset]
   );
 
+  // Check if current asset is audio (editable in the sample editor)
+  const isAudio = useMemo(() => {
+    const ct = currentAsset?.content_type || contentType;
+    return ct?.startsWith("audio/") || false;
+  }, [currentAsset?.content_type, contentType]);
+
   // Check if there are multiple images to compare
   const imageAssets = useMemo(
     () => assetsToUse.filter((a) => a.content_type?.startsWith("image/")),
@@ -405,6 +411,19 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
       handleClose();
     }
   }, [currentAsset, isModel3D, openTab, navigate, handleClose]);
+
+  const handleOpenAudioEditor = useCallback(() => {
+    if (currentAsset && isAudio) {
+      openTab({
+        type: "audio",
+        ref: currentAsset.id,
+        mode: "edit",
+        title: currentAsset.name || "Audio"
+      });
+      navigate("/workspace");
+      handleClose();
+    }
+  }, [currentAsset, isAudio, openTab, navigate, handleClose]);
 
 
   // Copy to clipboard state and handler
@@ -747,6 +766,16 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
               icon={<EditIcon />}
               tooltip="Edit in 3D Editor"
               onClick={handleOpenModel3DEditor}
+              className="button edit"
+              nodrag={false}
+              sx={viewerActionButtonSx}
+            />
+          )}
+          {isAudio && !compareMode && (
+            <ToolbarIconButton
+              icon={<EditIcon />}
+              tooltip="Edit Audio"
+              onClick={handleOpenAudioEditor}
               className="button edit"
               nodrag={false}
               sx={viewerActionButtonSx}

--- a/web/src/components/audio_editor/AudioEditorToolbar.tsx
+++ b/web/src/components/audio_editor/AudioEditorToolbar.tsx
@@ -1,0 +1,179 @@
+import { memo } from "react";
+
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import PauseIcon from "@mui/icons-material/Pause";
+import StopIcon from "@mui/icons-material/Stop";
+import RepeatIcon from "@mui/icons-material/Repeat";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import FitScreenIcon from "@mui/icons-material/FitScreen";
+import UndoIcon from "@mui/icons-material/Undo";
+import RedoIcon from "@mui/icons-material/Redo";
+
+import { Box, FlexRow, ToolbarIconButton } from "../ui_primitives";
+import { EditorButton } from "../editor_ui";
+
+export interface AudioEditorToolbarProps {
+  isPlaying: boolean;
+  loop: boolean;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+  hasSelection: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  onTogglePlay: () => void;
+  onStop: () => void;
+  onToggleLoop: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomFit: () => void;
+  onTrim: () => void;
+  onDelete: () => void;
+  onSilence: () => void;
+  onFadeIn: () => void;
+  onFadeOut: () => void;
+  onNormalize: () => void;
+  onAmplify: () => void;
+  onQuieten: () => void;
+  onReverse: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+}
+
+const Separator = () => (
+  <Box
+    sx={{
+      width: "1px",
+      alignSelf: "stretch",
+      mx: 0.5,
+      my: 0.25,
+      backgroundColor: "var(--palette-divider)"
+    }}
+  />
+);
+
+/**
+ * The audio editor's command bar: transport, zoom, region edits, and
+ * undo/redo. Memoized so it does not re-render on every playback frame — only
+ * the playhead and clock update while audio is playing.
+ */
+const AudioEditorToolbar = memo(function AudioEditorToolbar({
+  isPlaying,
+  loop,
+  canZoomIn,
+  canZoomOut,
+  hasSelection,
+  canUndo,
+  canRedo,
+  onTogglePlay,
+  onStop,
+  onToggleLoop,
+  onZoomIn,
+  onZoomOut,
+  onZoomFit,
+  onTrim,
+  onDelete,
+  onSilence,
+  onFadeIn,
+  onFadeOut,
+  onNormalize,
+  onAmplify,
+  onQuieten,
+  onReverse,
+  onUndo,
+  onRedo
+}: AudioEditorToolbarProps) {
+  return (
+    <FlexRow
+      align="center"
+      gap={0.5}
+      sx={{
+        flexShrink: 0,
+        flexWrap: "wrap",
+        px: 1,
+        py: 0.5,
+        borderBottom: "1px solid var(--palette-divider)"
+      }}
+    >
+      <ToolbarIconButton
+        icon={isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+        tooltip={isPlaying ? "Pause" : "Play"}
+        onClick={onTogglePlay}
+      />
+      <ToolbarIconButton icon={<StopIcon />} tooltip="Stop" onClick={onStop} />
+      <ToolbarIconButton
+        icon={<RepeatIcon />}
+        tooltip="Loop"
+        active={loop}
+        onClick={onToggleLoop}
+      />
+
+      <Separator />
+
+      <ToolbarIconButton
+        icon={<ZoomOutIcon />}
+        tooltip="Zoom out"
+        onClick={onZoomOut}
+        disabled={!canZoomOut}
+      />
+      <ToolbarIconButton
+        icon={<ZoomInIcon />}
+        tooltip="Zoom in"
+        onClick={onZoomIn}
+        disabled={!canZoomIn}
+      />
+      <ToolbarIconButton
+        icon={<FitScreenIcon />}
+        tooltip="Fit to window"
+        onClick={onZoomFit}
+      />
+
+      <Separator />
+
+      <EditorButton size="small" onClick={onTrim} disabled={!hasSelection}>
+        Trim
+      </EditorButton>
+      <EditorButton size="small" onClick={onDelete} disabled={!hasSelection}>
+        Delete
+      </EditorButton>
+      <EditorButton size="small" onClick={onSilence} disabled={!hasSelection}>
+        Silence
+      </EditorButton>
+      <EditorButton size="small" onClick={onFadeIn} disabled={!hasSelection}>
+        Fade in
+      </EditorButton>
+      <EditorButton size="small" onClick={onFadeOut} disabled={!hasSelection}>
+        Fade out
+      </EditorButton>
+      <EditorButton size="small" onClick={onNormalize}>
+        Normalize
+      </EditorButton>
+      <EditorButton size="small" onClick={onAmplify}>
+        Amplify
+      </EditorButton>
+      <EditorButton size="small" onClick={onQuieten}>
+        Quieten
+      </EditorButton>
+      <EditorButton size="small" onClick={onReverse}>
+        Reverse
+      </EditorButton>
+
+      <Separator />
+
+      <ToolbarIconButton
+        icon={<UndoIcon />}
+        tooltip="Undo"
+        onClick={onUndo}
+        disabled={!canUndo}
+      />
+      <ToolbarIconButton
+        icon={<RedoIcon />}
+        tooltip="Redo"
+        onClick={onRedo}
+        disabled={!canRedo}
+      />
+    </FlexRow>
+  );
+});
+
+export default AudioEditorToolbar;

--- a/web/src/components/audio_editor/AudioEditorToolbar.tsx
+++ b/web/src/components/audio_editor/AudioEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
 
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import PauseIcon from "@mui/icons-material/Pause";
@@ -10,23 +10,35 @@ import FitScreenIcon from "@mui/icons-material/FitScreen";
 import UndoIcon from "@mui/icons-material/Undo";
 import RedoIcon from "@mui/icons-material/Redo";
 
-import { Box, FlexRow, ToolbarIconButton } from "../ui_primitives";
+import {
+  Box,
+  Caption,
+  FlexRow,
+  NodeSlider,
+  ToolbarIconButton
+} from "../ui_primitives";
 import { EditorButton } from "../editor_ui";
 
 export interface AudioEditorToolbarProps {
   isPlaying: boolean;
   loop: boolean;
+  zoom: number;
+  minZoom: number;
+  maxZoom: number;
   canZoomIn: boolean;
   canZoomOut: boolean;
   hasSelection: boolean;
   canUndo: boolean;
   canRedo: boolean;
+  saving: boolean;
+  canSave: boolean;
   onTogglePlay: () => void;
   onStop: () => void;
   onToggleLoop: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
   onZoomFit: () => void;
+  onZoomChange: (zoom: number) => void;
   onTrim: () => void;
   onDelete: () => void;
   onSilence: () => void;
@@ -38,6 +50,8 @@ export interface AudioEditorToolbarProps {
   onReverse: () => void;
   onUndo: () => void;
   onRedo: () => void;
+  onSave: () => void;
+  onDone: () => void;
 }
 
 const Separator = () => (
@@ -52,6 +66,30 @@ const Separator = () => (
   />
 );
 
+const ZOOM_SLIDER_MIN = 0;
+const ZOOM_SLIDER_MAX = 100;
+const ZOOM_SLIDER_STEP = 1;
+
+const zoomToSliderValue = (zoom: number, minZoom: number, maxZoom: number) => {
+  const minLog = Math.log(minZoom);
+  const maxLog = Math.log(maxZoom);
+  const clampedZoom = Math.min(maxZoom, Math.max(minZoom, zoom));
+  return (
+    ((Math.log(clampedZoom) - minLog) / (maxLog - minLog)) * ZOOM_SLIDER_MAX
+  );
+};
+
+const sliderValueToZoom = (
+  sliderValue: number,
+  minZoom: number,
+  maxZoom: number
+) => {
+  const minLog = Math.log(minZoom);
+  const maxLog = Math.log(maxZoom);
+  const ratio = sliderValue / ZOOM_SLIDER_MAX;
+  return Math.exp(minLog + ratio * (maxLog - minLog));
+};
+
 /**
  * The audio editor's command bar: transport, zoom, region edits, and
  * undo/redo. Memoized so it does not re-render on every playback frame — only
@@ -60,17 +98,23 @@ const Separator = () => (
 const AudioEditorToolbar = memo(function AudioEditorToolbar({
   isPlaying,
   loop,
+  zoom,
+  minZoom,
+  maxZoom,
   canZoomIn,
   canZoomOut,
   hasSelection,
   canUndo,
   canRedo,
+  saving,
+  canSave,
   onTogglePlay,
   onStop,
   onToggleLoop,
   onZoomIn,
   onZoomOut,
   onZoomFit,
+  onZoomChange,
   onTrim,
   onDelete,
   onSilence,
@@ -81,8 +125,20 @@ const AudioEditorToolbar = memo(function AudioEditorToolbar({
   onQuieten,
   onReverse,
   onUndo,
-  onRedo
+  onRedo,
+  onSave,
+  onDone
 }: AudioEditorToolbarProps) {
+  const zoomSliderValue = zoomToSliderValue(zoom, minZoom, maxZoom);
+  const handleZoomSliderChange = useCallback(
+    (_event: Event, value: number | number[]) => {
+      if (typeof value === "number") {
+        onZoomChange(sliderValueToZoom(value, minZoom, maxZoom));
+      }
+    },
+    [maxZoom, minZoom, onZoomChange]
+  );
+
   return (
     <FlexRow
       align="center"
@@ -127,6 +183,20 @@ const AudioEditorToolbar = memo(function AudioEditorToolbar({
         tooltip="Fit to window"
         onClick={onZoomFit}
       />
+      <FlexRow align="center" gap={0.75} sx={{ width: 160, mx: 0.5 }}>
+        <NodeSlider
+          aria-label="Waveform zoom"
+          value={zoomSliderValue}
+          min={ZOOM_SLIDER_MIN}
+          max={ZOOM_SLIDER_MAX}
+          step={ZOOM_SLIDER_STEP}
+          onChange={handleZoomSliderChange}
+          sx={{ flex: 1 }}
+        />
+        <Caption sx={{ minWidth: 44, textAlign: "right" }}>
+          {Math.round(zoom * 100)}%
+        </Caption>
+      </FlexRow>
 
       <Separator />
 
@@ -172,6 +242,20 @@ const AudioEditorToolbar = memo(function AudioEditorToolbar({
         onClick={onRedo}
         disabled={!canRedo}
       />
+
+      <Box sx={{ flexGrow: 1 }} />
+
+      <EditorButton
+        variant="contained"
+        size="small"
+        onClick={onSave}
+        disabled={saving || !canSave}
+      >
+        {saving ? "Saving…" : "Save to audio"}
+      </EditorButton>
+      <EditorButton variant="text" size="small" onClick={onDone}>
+        Done
+      </EditorButton>
     </FlexRow>
   );
 });

--- a/web/src/components/audio_editor/AudioSampleEditor.tsx
+++ b/web/src/components/audio_editor/AudioSampleEditor.tsx
@@ -1,0 +1,490 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  Box,
+  Caption,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  Text
+} from "../ui_primitives";
+import { EditorButton } from "../editor_ui";
+import { BASE_URL } from "../../stores/BASE_URL";
+import type { Asset } from "../../stores/ApiTypes";
+import { useSaveAudioToAsset } from "../../hooks/audio/useSaveAudioToAsset";
+import WaveformView, { type Selection } from "./WaveformView";
+import AudioEditorToolbar from "./AudioEditorToolbar";
+import { useEditHistory } from "./useEditHistory";
+import {
+  applyGain,
+  audioBufferToSample,
+  cropToRange,
+  deleteRange,
+  fade,
+  normalize,
+  reverseRange,
+  sampleDuration,
+  sampleToAudioBuffer,
+  silenceRange,
+  type AudioSample
+} from "./audioSample";
+
+interface AudioSampleEditorProps {
+  asset: Asset;
+  onClose: () => void;
+}
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 64;
+const ZOOM_STEP = 1.5;
+
+const resolveMediaUrl = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (trimmed === "") return null;
+  if (/^(https?:|data:|blob:)/.test(trimmed)) return trimmed;
+  return trimmed.startsWith("/") ? `${BASE_URL}${trimmed}` : trimmed;
+};
+
+const getAudioContextCtor = (): typeof AudioContext | null => {
+  if (typeof window === "undefined") return null;
+  return (
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext ??
+    null
+  );
+};
+
+const formatTime = (seconds: number): string => {
+  const safe = Math.max(0, seconds);
+  const m = Math.floor(safe / 60);
+  const s = Math.floor(safe % 60);
+  const ms = Math.floor((safe % 1) * 1000);
+  return `${m}:${String(s).padStart(2, "0")}.${String(ms).padStart(3, "0")}`;
+};
+
+/**
+ * In-browser audio sample editor (Audacity-style): decode an asset into PCM,
+ * select a region on the waveform, apply destructive edits (trim, delete,
+ * silence, fade, normalize, reverse, gain) with undo/redo, audition with the
+ * transport, and save the result back to the asset as WAV.
+ */
+const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
+  const history = useEditHistory<AudioSample>();
+  const sample = history.present;
+  const sampleRef = useRef<AudioSample | null>(null);
+  sampleRef.current = sample;
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const selectionRef = useRef<Selection | null>(null);
+  selectionRef.current = selection;
+
+  const [playhead, setPlayheadState] = useState(0);
+  const playheadRef = useRef(0);
+  const setPlayhead = useCallback((value: number) => {
+    playheadRef.current = value;
+    setPlayheadState(value);
+  }, []);
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [loop, setLoop] = useState(false);
+  const loopRef = useRef(loop);
+  loopRef.current = loop;
+  const [zoom, setZoom] = useState(1);
+
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const sourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const startCtxTimeRef = useRef(0);
+  const startOffsetRef = useRef(0);
+  const endRef = useRef(0);
+
+  const getUrlRef = useRef(asset.get_url);
+  getUrlRef.current = asset.get_url;
+
+  const { save, saving } = useSaveAudioToAsset(asset);
+
+  const getCtx = useCallback((): AudioContext => {
+    if (!audioCtxRef.current) {
+      const Ctor = getAudioContextCtor();
+      if (!Ctor) throw new Error("Web Audio API is not available");
+      audioCtxRef.current = new Ctor();
+    }
+    return audioCtxRef.current;
+  }, []);
+
+  const teardownSource = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const src = sourceRef.current;
+    if (src) {
+      src.onended = null;
+      try {
+        src.stop();
+      } catch {
+        // already stopped
+      }
+      src.disconnect();
+      sourceRef.current = null;
+    }
+  }, []);
+
+  const play = useCallback(() => {
+    const current = sampleRef.current;
+    if (!current) return;
+    const ctx = getCtx();
+    void ctx.resume();
+    teardownSource();
+
+    const duration = sampleDuration(current);
+    const sel = selectionRef.current;
+    const useLoop = loopRef.current;
+    const begin = Math.max(
+      0,
+      Math.min(sel ? sel.start : playheadRef.current, duration)
+    );
+    const end = sel ? sel.end : duration;
+
+    const src = ctx.createBufferSource();
+    src.buffer = sampleToAudioBuffer(current, ctx);
+    src.connect(ctx.destination);
+    if (useLoop) {
+      src.loop = true;
+      if (sel) {
+        src.loopStart = sel.start;
+        src.loopEnd = sel.end;
+      }
+    }
+
+    startCtxTimeRef.current = ctx.currentTime;
+    startOffsetRef.current = begin;
+    endRef.current = end;
+    src.start(0, begin, useLoop ? undefined : Math.max(0, end - begin));
+    src.onended = () => {
+      if (loopRef.current) return;
+      teardownSource();
+      setIsPlaying(false);
+      setPlayhead(selectionRef.current ? selectionRef.current.start : begin);
+    };
+    sourceRef.current = src;
+    setIsPlaying(true);
+
+    const tick = () => {
+      const elapsed = getCtx().currentTime - startCtxTimeRef.current;
+      let t = startOffsetRef.current + elapsed;
+      const s = selectionRef.current;
+      if (loopRef.current && s && s.end > s.start) {
+        t = s.start + ((t - s.start) % (s.end - s.start));
+      } else if (t > endRef.current) {
+        t = endRef.current;
+      }
+      setPlayhead(t);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [getCtx, teardownSource, setPlayhead]);
+
+  const pause = useCallback(() => {
+    teardownSource();
+    setIsPlaying(false);
+  }, [teardownSource]);
+
+  const stop = useCallback(() => {
+    teardownSource();
+    setIsPlaying(false);
+    setPlayhead(selectionRef.current ? selectionRef.current.start : 0);
+  }, [teardownSource, setPlayhead]);
+
+  const togglePlay = useCallback(() => {
+    if (isPlaying) pause();
+    else play();
+  }, [isPlaying, pause, play]);
+
+  // Load + decode the asset once per identity. get_url changes after our own
+  // save must not reload and wipe in-progress edits.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const url = resolveMediaUrl(getUrlRef.current);
+    if (!url) {
+      setError("This audio asset has no URL to load.");
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch audio (HTTP ${response.status})`);
+        }
+        const arrayBuffer = await response.arrayBuffer();
+        const decoded = await getCtx().decodeAudioData(arrayBuffer);
+        if (cancelled) return;
+        history.reset(audioBufferToSample(decoded));
+        setLoading(false);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [asset.id]);
+
+  // Stop playback and re-clamp selection/playhead whenever the sample changes
+  // (edit, undo, or redo).
+  useEffect(() => {
+    if (!sample) return;
+    teardownSource();
+    setIsPlaying(false);
+    const duration = sampleDuration(sample);
+    setSelection((sel) => {
+      if (!sel) return null;
+      const start = Math.min(sel.start, duration);
+      const end = Math.min(sel.end, duration);
+      return end > start ? { start, end } : null;
+    });
+    if (playheadRef.current > duration) {
+      setPlayhead(duration);
+    }
+  }, [sample, teardownSource, setPlayhead]);
+
+  useEffect(
+    () => () => {
+      teardownSource();
+      if (audioCtxRef.current) {
+        void audioCtxRef.current.close();
+        audioCtxRef.current = null;
+      }
+    },
+    [teardownSource]
+  );
+
+  const waveAreaRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  useEffect(() => {
+    const el = waveAreaRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      setContainerWidth(entries[0]?.contentRect.width ?? 0);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const duration = sample ? sampleDuration(sample) : 0;
+  const fitPps =
+    duration > 0 && containerWidth > 0 ? containerWidth / duration : 100;
+  const pixelsPerSecond = Math.max(1, fitPps * zoom);
+
+  const hasSelection = !!selection && selection.end > selection.start;
+
+  const commitEdit = useCallback(
+    (fn: (s: AudioSample) => AudioSample) => {
+      const current = sampleRef.current;
+      if (!current) return;
+      history.commit(fn(current));
+    },
+    [history]
+  );
+
+  const handleTrim = useCallback(() => {
+    if (!selection) return;
+    commitEdit((s) => cropToRange(s, selection.start, selection.end));
+    setSelection(null);
+    setPlayhead(0);
+  }, [selection, commitEdit, setPlayhead]);
+
+  const handleDelete = useCallback(() => {
+    if (!selection) return;
+    const start = selection.start;
+    commitEdit((s) => deleteRange(s, selection.start, selection.end));
+    setSelection(null);
+    setPlayhead(start);
+  }, [selection, commitEdit, setPlayhead]);
+
+  const handleSilence = useCallback(() => {
+    if (!selection) return;
+    commitEdit((s) => silenceRange(s, selection.start, selection.end));
+  }, [selection, commitEdit]);
+
+  const handleFade = useCallback(
+    (direction: "in" | "out") => {
+      if (!selection) return;
+      commitEdit((s) => fade(s, selection.start, selection.end, direction));
+    },
+    [selection, commitEdit]
+  );
+
+  const handleNormalize = useCallback(() => {
+    commitEdit((s) => normalize(s, selection?.start, selection?.end));
+  }, [selection, commitEdit]);
+
+  const handleReverse = useCallback(() => {
+    commitEdit((s) => reverseRange(s, selection?.start, selection?.end));
+  }, [selection, commitEdit]);
+
+  const handleGain = useCallback(
+    (factor: number) => {
+      commitEdit((s) => applyGain(s, factor, selection?.start, selection?.end));
+    },
+    [selection, commitEdit]
+  );
+
+  const handleFadeIn = useCallback(() => handleFade("in"), [handleFade]);
+  const handleFadeOut = useCallback(() => handleFade("out"), [handleFade]);
+  const handleAmplify = useCallback(() => handleGain(1.4), [handleGain]);
+  const handleQuieten = useCallback(() => handleGain(0.7), [handleGain]);
+  const handleToggleLoop = useCallback(() => setLoop((v) => !v), []);
+
+  const handleSave = useCallback(() => {
+    if (sampleRef.current) void save(sampleRef.current);
+  }, [save]);
+
+  const zoomIn = useCallback(
+    () => setZoom((z) => Math.min(MAX_ZOOM, z * ZOOM_STEP)),
+    []
+  );
+  const zoomOut = useCallback(
+    () => setZoom((z) => Math.max(MIN_ZOOM, z / ZOOM_STEP)),
+    []
+  );
+  const zoomFit = useCallback(() => setZoom(1), []);
+
+  const headerBar = useMemo(
+    () => (
+      <FlexRow
+        align="center"
+        justify="space-between"
+        sx={{
+          flexShrink: 0,
+          px: 1.5,
+          py: 0.75,
+          borderBottom: "1px solid var(--palette-divider)"
+        }}
+      >
+        <FlexColumn gap={0} sx={{ minWidth: 0 }}>
+          <Text size="normal" weight={600}>
+            {asset.name || "Audio"}
+          </Text>
+          <Caption>Audio sample editor</Caption>
+        </FlexColumn>
+        <FlexRow align="center" gap={1} sx={{ flexShrink: 0 }}>
+          <EditorButton
+            variant="contained"
+            size="small"
+            onClick={handleSave}
+            disabled={saving || loading || !!error}
+          >
+            {saving ? "Saving…" : "Save to audio"}
+          </EditorButton>
+          <EditorButton variant="text" size="small" onClick={onClose}>
+            Done
+          </EditorButton>
+        </FlexRow>
+      </FlexRow>
+    ),
+    [asset.name, handleSave, saving, loading, error, onClose]
+  );
+
+  if (loading) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <LoadingSpinner />
+      </FlexColumn>
+    );
+  }
+
+  if (error || !sample) {
+    return (
+      <FlexColumn fullWidth fullHeight>
+        {headerBar}
+        <FlexColumn fullWidth fullHeight align="center" justify="center">
+          <EmptyState
+            variant="error"
+            title="Could not open audio editor"
+            description={error ?? "Audio could not be decoded."}
+          />
+        </FlexColumn>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <FlexColumn fullWidth fullHeight sx={{ overflow: "hidden" }}>
+      {headerBar}
+
+      <AudioEditorToolbar
+        isPlaying={isPlaying}
+        loop={loop}
+        canZoomIn={zoom < MAX_ZOOM}
+        canZoomOut={zoom > MIN_ZOOM}
+        hasSelection={hasSelection}
+        canUndo={history.canUndo}
+        canRedo={history.canRedo}
+        onTogglePlay={togglePlay}
+        onStop={stop}
+        onToggleLoop={handleToggleLoop}
+        onZoomIn={zoomIn}
+        onZoomOut={zoomOut}
+        onZoomFit={zoomFit}
+        onTrim={handleTrim}
+        onDelete={handleDelete}
+        onSilence={handleSilence}
+        onFadeIn={handleFadeIn}
+        onFadeOut={handleFadeOut}
+        onNormalize={handleNormalize}
+        onAmplify={handleAmplify}
+        onQuieten={handleQuieten}
+        onReverse={handleReverse}
+        onUndo={history.undo}
+        onRedo={history.redo}
+      />
+
+      <Box ref={waveAreaRef} sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+        <WaveformView
+          sample={sample}
+          pixelsPerSecond={pixelsPerSecond}
+          selection={selection}
+          playheadSec={playhead}
+          onSelectionChange={setSelection}
+          onSeek={setPlayhead}
+        />
+      </Box>
+
+      <FlexRow
+        align="center"
+        justify="space-between"
+        sx={{
+          flexShrink: 0,
+          px: 1.5,
+          py: 0.5,
+          borderTop: "1px solid var(--palette-divider)"
+        }}
+      >
+        <Caption>
+          {hasSelection && selection
+            ? `Selection ${formatTime(selection.start)} – ${formatTime(
+                selection.end
+              )} (${formatTime(selection.end - selection.start)})`
+            : "Drag to select · Click to seek"}
+        </Caption>
+        <Caption>
+          {formatTime(playhead)} / {formatTime(duration)}
+        </Caption>
+      </FlexRow>
+    </FlexColumn>
+  );
+};
+
+export default AudioSampleEditor;

--- a/web/src/components/audio_editor/AudioSampleEditor.tsx
+++ b/web/src/components/audio_editor/AudioSampleEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   Box,
@@ -6,10 +6,8 @@ import {
   EmptyState,
   FlexColumn,
   FlexRow,
-  LoadingSpinner,
-  Text
+  LoadingSpinner
 } from "../ui_primitives";
-import { EditorButton } from "../editor_ui";
 import { BASE_URL } from "../../stores/BASE_URL";
 import type { Asset } from "../../stores/ApiTypes";
 import { useSaveAudioToAsset } from "../../hooks/audio/useSaveAudioToAsset";
@@ -361,42 +359,6 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
   );
   const zoomFit = useCallback(() => setZoom(1), []);
 
-  const headerBar = useMemo(
-    () => (
-      <FlexRow
-        align="center"
-        justify="space-between"
-        sx={{
-          flexShrink: 0,
-          px: 1.5,
-          py: 0.75,
-          borderBottom: "1px solid var(--palette-divider)"
-        }}
-      >
-        <FlexColumn gap={0} sx={{ minWidth: 0 }}>
-          <Text size="normal" weight={600}>
-            {asset.name || "Audio"}
-          </Text>
-          <Caption>Audio sample editor</Caption>
-        </FlexColumn>
-        <FlexRow align="center" gap={1} sx={{ flexShrink: 0 }}>
-          <EditorButton
-            variant="contained"
-            size="small"
-            onClick={handleSave}
-            disabled={saving || loading || !!error}
-          >
-            {saving ? "Saving…" : "Save to audio"}
-          </EditorButton>
-          <EditorButton variant="text" size="small" onClick={onClose}>
-            Done
-          </EditorButton>
-        </FlexRow>
-      </FlexRow>
-    ),
-    [asset.name, handleSave, saving, loading, error, onClose]
-  );
-
   if (loading) {
     return (
       <FlexColumn fullWidth fullHeight align="center" justify="center">
@@ -407,37 +369,40 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
 
   if (error || !sample) {
     return (
-      <FlexColumn fullWidth fullHeight>
-        {headerBar}
-        <FlexColumn fullWidth fullHeight align="center" justify="center">
-          <EmptyState
-            variant="error"
-            title="Could not open audio editor"
-            description={error ?? "Audio could not be decoded."}
-          />
-        </FlexColumn>
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <EmptyState
+          variant="error"
+          title="Could not open audio editor"
+          description={error ?? "Audio could not be decoded."}
+          actionText="Done"
+          onAction={onClose}
+        />
       </FlexColumn>
     );
   }
 
   return (
     <FlexColumn fullWidth fullHeight sx={{ overflow: "hidden" }}>
-      {headerBar}
-
       <AudioEditorToolbar
         isPlaying={isPlaying}
         loop={loop}
+        zoom={zoom}
+        minZoom={MIN_ZOOM}
+        maxZoom={MAX_ZOOM}
         canZoomIn={zoom < MAX_ZOOM}
         canZoomOut={zoom > MIN_ZOOM}
         hasSelection={hasSelection}
         canUndo={history.canUndo}
         canRedo={history.canRedo}
+        saving={saving}
+        canSave={!loading && !error}
         onTogglePlay={togglePlay}
         onStop={stop}
         onToggleLoop={handleToggleLoop}
         onZoomIn={zoomIn}
         onZoomOut={zoomOut}
         onZoomFit={zoomFit}
+        onZoomChange={setZoom}
         onTrim={handleTrim}
         onDelete={handleDelete}
         onSilence={handleSilence}
@@ -449,6 +414,8 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
         onReverse={handleReverse}
         onUndo={history.undo}
         onRedo={history.redo}
+        onSave={handleSave}
+        onDone={onClose}
       />
 
       <Box ref={waveAreaRef} sx={{ flex: 1, minHeight: 0, position: "relative" }}>

--- a/web/src/components/audio_editor/WaveformView.tsx
+++ b/web/src/components/audio_editor/WaveformView.tsx
@@ -1,0 +1,232 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import {
+  numChannels,
+  numFrames,
+  sampleDuration,
+  type AudioSample
+} from "./audioSample";
+
+export interface Selection {
+  start: number;
+  end: number;
+}
+
+interface WaveformViewProps {
+  sample: AudioSample;
+  /** Horizontal scale; total content width is `duration * pixelsPerSecond`. */
+  pixelsPerSecond: number;
+  selection: Selection | null;
+  playheadSec: number;
+  onSelectionChange: (selection: Selection | null) => void;
+  onSeek: (seconds: number) => void;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    overflowX: "auto",
+    overflowY: "hidden",
+    backgroundColor: theme.vars.palette.grey[900],
+
+    "& .waveform-inner": {
+      position: "relative",
+      height: "100%",
+      minWidth: "100%",
+      cursor: "text"
+    },
+    "& canvas": {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      display: "block"
+    },
+    "& .selection": {
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      backgroundColor: theme.vars.palette.primary.main,
+      opacity: 0.22,
+      pointerEvents: "none"
+    },
+    "& .playhead": {
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      width: "1px",
+      backgroundColor: theme.vars.palette.secondary.main,
+      pointerEvents: "none"
+    }
+  });
+
+const DRAG_THRESHOLD_PX = 3;
+
+/**
+ * Canvas waveform with click-to-seek and drag-to-select. Channels are drawn as
+ * stacked min/max lanes. The waveform canvas only repaints when the sample,
+ * zoom, or size changes; the selection band and playhead are positioned DOM
+ * nodes so seeking and playback don't trigger a redraw.
+ */
+const WaveformView = ({
+  sample,
+  pixelsPerSecond,
+  selection,
+  playheadSec,
+  onSelectionChange,
+  onSeek
+}: WaveformViewProps) => {
+  const theme = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragRef = useRef<{ startX: number; moved: boolean } | null>(null);
+
+  const duration = sampleDuration(sample);
+  const width = Math.max(1, Math.ceil(duration * pixelsPerSecond));
+
+  const waveColor = theme.vars.palette.grey[300];
+  const midColor = theme.vars.palette.grey[700];
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const height = container.clientHeight;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(width * dpr);
+    canvas.height = Math.floor(height * dpr);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    const channels = sample.channels;
+    const lanes = numChannels(sample);
+    const laneHeight = height / lanes;
+    const frames = numFrames(sample);
+    const samplesPerPx = frames / width;
+
+    for (let c = 0; c < lanes; c += 1) {
+      const data = channels[c];
+      const mid = laneHeight * c + laneHeight / 2;
+      const amp = (laneHeight / 2) * 0.92;
+
+      ctx.fillStyle = midColor;
+      ctx.fillRect(0, Math.round(mid), width, 1);
+
+      ctx.fillStyle = waveColor;
+      for (let x = 0; x < width; x += 1) {
+        const startI = Math.floor(x * samplesPerPx);
+        const endI = Math.min(frames, Math.floor((x + 1) * samplesPerPx));
+        let min = 1;
+        let max = -1;
+        if (endI <= startI) {
+          const v = data[Math.min(startI, frames - 1)] ?? 0;
+          min = v;
+          max = v;
+        } else {
+          for (let i = startI; i < endI; i += 1) {
+            const v = data[i];
+            if (v < min) min = v;
+            if (v > max) max = v;
+          }
+        }
+        const yMax = mid - max * amp;
+        const yMin = mid - min * amp;
+        ctx.fillRect(x, yMax, 1, Math.max(1, yMin - yMax));
+      }
+    }
+  }, [sample, width, waveColor, midColor]);
+
+  const secondsFromEvent = useCallback(
+    (clientX: number): number => {
+      const inner = innerRef.current;
+      if (!inner) return 0;
+      const rect = inner.getBoundingClientRect();
+      const x = Math.max(0, Math.min(width, clientX - rect.left));
+      return pixelsPerSecond > 0 ? x / pixelsPerSecond : 0;
+    },
+    [pixelsPerSecond, width]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      if (event.button !== 0) return;
+      innerRef.current?.setPointerCapture(event.pointerId);
+      dragRef.current = { startX: event.clientX, moved: false };
+    },
+    []
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      if (Math.abs(event.clientX - drag.startX) > DRAG_THRESHOLD_PX) {
+        drag.moved = true;
+      }
+      if (drag.moved) {
+        const a = secondsFromEvent(drag.startX);
+        const b = secondsFromEvent(event.clientX);
+        onSelectionChange({ start: Math.min(a, b), end: Math.max(a, b) });
+      }
+    },
+    [secondsFromEvent, onSelectionChange]
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent) => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      if (innerRef.current?.hasPointerCapture(event.pointerId)) {
+        innerRef.current.releasePointerCapture(event.pointerId);
+      }
+      if (!drag) return;
+      if (!drag.moved) {
+        onSelectionChange(null);
+        onSeek(secondsFromEvent(event.clientX));
+      }
+    },
+    [secondsFromEvent, onSelectionChange, onSeek]
+  );
+
+  const selectionStyle = useMemo(() => {
+    if (!selection) return undefined;
+    return {
+      left: `${selection.start * pixelsPerSecond}px`,
+      width: `${Math.max(1, (selection.end - selection.start) * pixelsPerSecond)}px`
+    };
+  }, [selection, pixelsPerSecond]);
+
+  return (
+    <div ref={containerRef} css={styles(theme)} className="waveform-view">
+      <div
+        ref={innerRef}
+        className="waveform-inner"
+        style={{ width: `${width}px` }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        <canvas ref={canvasRef} />
+        {selectionStyle && <div className="selection" style={selectionStyle} />}
+        <div
+          className="playhead"
+          style={{ left: `${playheadSec * pixelsPerSecond}px` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default WaveformView;

--- a/web/src/components/audio_editor/WaveformView.tsx
+++ b/web/src/components/audio_editor/WaveformView.tsx
@@ -49,7 +49,7 @@ const styles = (theme: Theme) =>
     },
     "& .selection": {
       position: "absolute",
-      top: 0,
+      top: `${RULER_HEIGHT}px`,
       bottom: 0,
       backgroundColor: theme.vars.palette.primary.main,
       opacity: 0.22,
@@ -66,6 +66,57 @@ const styles = (theme: Theme) =>
   });
 
 const DRAG_THRESHOLD_PX = 3;
+const RULER_HEIGHT = 24;
+const MIN_TICK_SPACING_PX = 80;
+const TICK_INTERVALS_SECONDS = [
+  0.01,
+  0.025,
+  0.05,
+  0.1,
+  0.25,
+  0.5,
+  1,
+  2,
+  5,
+  10,
+  15,
+  30,
+  60,
+  120,
+  300,
+  600,
+  900,
+  1800,
+  3600
+];
+
+const chooseTickInterval = (pixelsPerSecond: number): number => {
+  const minSeconds = MIN_TICK_SPACING_PX / Math.max(1, pixelsPerSecond);
+  return (
+    TICK_INTERVALS_SECONDS.find((interval) => interval >= minSeconds) ??
+    TICK_INTERVALS_SECONDS[TICK_INTERVALS_SECONDS.length - 1]
+  );
+};
+
+const formatRulerTime = (seconds: number, interval: number): string => {
+  if (interval < 1) {
+    return `${seconds.toFixed(interval < 0.1 ? 2 : 1)}s`;
+  }
+
+  const rounded = Math.round(seconds);
+  const hours = Math.floor(rounded / 3600);
+  const minutes = Math.floor((rounded % 3600) / 60);
+  const secs = rounded % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(
+      2,
+      "0"
+    )}`;
+  }
+
+  return `${minutes}:${String(secs).padStart(2, "0")}`;
+};
 
 /**
  * Canvas waveform with click-to-seek and drag-to-select. Channels are drawn as
@@ -90,8 +141,10 @@ const WaveformView = ({
   const duration = sampleDuration(sample);
   const width = Math.max(1, Math.ceil(duration * pixelsPerSecond));
 
-  const waveColor = theme.vars.palette.grey[300];
-  const midColor = theme.vars.palette.grey[700];
+  const waveColor = theme.palette.grey[300];
+  const midColor = theme.palette.grey[700];
+  const rulerColor = theme.palette.text.secondary;
+  const rulerLineColor = theme.palette.divider;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -99,6 +152,7 @@ const WaveformView = ({
     if (!canvas || !container) return;
 
     const height = container.clientHeight;
+    const waveformHeight = Math.max(1, height - RULER_HEIGHT);
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(width * dpr);
     canvas.height = Math.floor(height * dpr);
@@ -110,15 +164,31 @@ const WaveformView = ({
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, width, height);
 
+    const tickInterval = chooseTickInterval(pixelsPerSecond);
+    ctx.strokeStyle = rulerLineColor;
+    ctx.fillStyle = rulerColor;
+    ctx.font = `${theme.fontSizeTiny} ${theme.fontFamily2}`;
+    ctx.textBaseline = "top";
+    ctx.beginPath();
+    ctx.moveTo(0, RULER_HEIGHT - 0.5);
+    ctx.lineTo(width, RULER_HEIGHT - 0.5);
+    for (let t = 0; t <= duration; t += tickInterval) {
+      const x = Math.round(t * pixelsPerSecond) + 0.5;
+      ctx.moveTo(x, RULER_HEIGHT - 8);
+      ctx.lineTo(x, RULER_HEIGHT);
+      ctx.fillText(formatRulerTime(t, tickInterval), x + 4, 4);
+    }
+    ctx.stroke();
+
     const channels = sample.channels;
     const lanes = numChannels(sample);
-    const laneHeight = height / lanes;
+    const laneHeight = waveformHeight / lanes;
     const frames = numFrames(sample);
     const samplesPerPx = frames / width;
 
     for (let c = 0; c < lanes; c += 1) {
       const data = channels[c];
-      const mid = laneHeight * c + laneHeight / 2;
+      const mid = RULER_HEIGHT + laneHeight * c + laneHeight / 2;
       const amp = (laneHeight / 2) * 0.92;
 
       ctx.fillStyle = midColor;
@@ -146,7 +216,18 @@ const WaveformView = ({
         ctx.fillRect(x, yMax, 1, Math.max(1, yMin - yMax));
       }
     }
-  }, [sample, width, waveColor, midColor]);
+  }, [
+    sample,
+    width,
+    duration,
+    pixelsPerSecond,
+    waveColor,
+    midColor,
+    rulerColor,
+    rulerLineColor,
+    theme.fontSizeTiny,
+    theme.fontFamily2
+  ]);
 
   const secondsFromEvent = useCallback(
     (clientX: number): number => {

--- a/web/src/components/audio_editor/__tests__/audioSample.test.ts
+++ b/web/src/components/audio_editor/__tests__/audioSample.test.ts
@@ -1,0 +1,161 @@
+import {
+  applyGain,
+  arrayBufferToBase64,
+  cropToRange,
+  deleteRange,
+  encodeWav,
+  fade,
+  normalize,
+  numFrames,
+  reverseRange,
+  sampleDuration,
+  secondsToFrame,
+  silenceRange,
+  type AudioSample
+} from "../audioSample";
+
+const makeSample = (channels: number[][], sampleRate = 4): AudioSample => ({
+  sampleRate,
+  channels: channels.map((c) => Float32Array.from(c))
+});
+
+/** Decode a 16-bit PCM WAV produced by encodeWav back into channels. */
+const decodeWav = (
+  buffer: ArrayBuffer
+): { sampleRate: number; channels: Float32Array[] } => {
+  const view = new DataView(buffer);
+  const channelCount = view.getUint16(22, true);
+  const sampleRate = view.getUint32(24, true);
+  const dataSize = view.getUint32(40, true);
+  const frames = dataSize / (channelCount * 2);
+  const channels = Array.from(
+    { length: channelCount },
+    () => new Float32Array(frames)
+  );
+  let offset = 44;
+  for (let i = 0; i < frames; i += 1) {
+    for (let c = 0; c < channelCount; c += 1) {
+      channels[c][i] = view.getInt16(offset, true) / 0x8000;
+      offset += 2;
+    }
+  }
+  return { sampleRate, channels };
+};
+
+describe("audioSample frame helpers", () => {
+  it("reports frame count and duration", () => {
+    const sample = makeSample([[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]], 8);
+    expect(numFrames(sample)).toBe(8);
+    expect(sampleDuration(sample)).toBe(1);
+    expect(secondsToFrame(sample, 0.5)).toBe(4);
+  });
+});
+
+describe("cropToRange", () => {
+  it("keeps only the selected range", () => {
+    const sample = makeSample([[0, 1, 2, 3, 4, 5, 6, 7]], 8);
+    const cropped = cropToRange(sample, 0.25, 0.625); // frames 2..5
+    expect(Array.from(cropped.channels[0])).toEqual([2, 3, 4]);
+  });
+
+  it("does not mutate the input", () => {
+    const sample = makeSample([[0, 1, 2, 3]], 4);
+    cropToRange(sample, 0, 0.5);
+    expect(Array.from(sample.channels[0])).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe("deleteRange", () => {
+  it("removes the range and joins surrounding audio across channels", () => {
+    const sample = makeSample(
+      [
+        [0, 1, 2, 3, 4, 5, 6, 7],
+        [10, 11, 12, 13, 14, 15, 16, 17]
+      ],
+      8
+    );
+    const result = deleteRange(sample, 0.25, 0.625); // remove frames 2..5
+    expect(Array.from(result.channels[0])).toEqual([0, 1, 5, 6, 7]);
+    expect(Array.from(result.channels[1])).toEqual([10, 11, 15, 16, 17]);
+  });
+});
+
+describe("silenceRange", () => {
+  it("zeroes the selected range only", () => {
+    const sample = makeSample([[1, 1, 1, 1]], 4);
+    const result = silenceRange(sample, 0.25, 0.75); // frames 1..3
+    expect(Array.from(result.channels[0])).toEqual([1, 0, 0, 1]);
+  });
+});
+
+describe("normalize", () => {
+  it("scales the loudest sample to full scale", () => {
+    const sample = makeSample([[0, 0.25, -0.5, 0.25]], 4);
+    const result = normalize(sample);
+    expect(Array.from(result.channels[0])).toEqual([0, 0.5, -1, 0.5]);
+  });
+
+  it("leaves silent audio untouched", () => {
+    const sample = makeSample([[0, 0, 0]], 4);
+    expect(Array.from(normalize(sample).channels[0])).toEqual([0, 0, 0]);
+  });
+});
+
+describe("applyGain", () => {
+  it("multiplies and clamps to [-1, 1]", () => {
+    const sample = makeSample([[0.5, -0.5, 0.8]], 4);
+    const result = applyGain(sample, 2);
+    expect(Array.from(result.channels[0])).toEqual([1, -1, 1]);
+  });
+});
+
+describe("fade", () => {
+  it("ramps up linearly for a fade in", () => {
+    const sample = makeSample([[1, 1, 1, 1, 1]], 5);
+    const result = fade(sample, 0, 1, "in");
+    const values = Array.from(result.channels[0]);
+    expect(values[0]).toBeCloseTo(0);
+    expect(values[4]).toBeCloseTo(1);
+    expect(values[2]).toBeCloseTo(0.5);
+  });
+});
+
+describe("reverseRange", () => {
+  it("reverses the whole sample when no range is given", () => {
+    const sample = makeSample([[1, 2, 3, 4]], 4);
+    expect(Array.from(reverseRange(sample).channels[0])).toEqual([4, 3, 2, 1]);
+  });
+});
+
+describe("encodeWav", () => {
+  it("writes a valid header and round-trips samples within 16-bit precision", () => {
+    const sample = makeSample(
+      [
+        [0, 0.5, -0.5, 1],
+        [0.25, -0.25, 0.75, -1]
+      ],
+      44100
+    );
+    const wav = encodeWav(sample);
+    const view = new DataView(wav);
+
+    expect(String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3))).toBe("RIFF");
+    expect(view.getUint16(20, true)).toBe(1); // PCM
+    expect(view.getUint16(22, true)).toBe(2); // channels
+    expect(view.getUint32(24, true)).toBe(44100);
+    expect(view.getUint16(34, true)).toBe(16); // bits per sample
+
+    const decoded = decodeWav(wav);
+    expect(decoded.sampleRate).toBe(44100);
+    expect(decoded.channels[0][0]).toBeCloseTo(0, 4);
+    expect(decoded.channels[0][1]).toBeCloseTo(0.5, 3);
+    expect(decoded.channels[1][2]).toBeCloseTo(0.75, 3);
+  });
+});
+
+describe("arrayBufferToBase64", () => {
+  it("encodes bytes to base64", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    expect(arrayBufferToBase64(bytes.buffer)).toBe("SGVsbG8=");
+  });
+});

--- a/web/src/components/audio_editor/__tests__/useEditHistory.test.ts
+++ b/web/src/components/audio_editor/__tests__/useEditHistory.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useEditHistory } from "../useEditHistory";
+
+describe("useEditHistory", () => {
+  it("starts empty with no undo/redo", () => {
+    const { result } = renderHook(() => useEditHistory<number>());
+    expect(result.current.present).toBeNull();
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("commits, undoes, and redoes", () => {
+    const { result } = renderHook(() => useEditHistory<number>());
+
+    act(() => result.current.reset(1));
+    expect(result.current.present).toBe(1);
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => result.current.commit(2));
+    act(() => result.current.commit(3));
+    expect(result.current.present).toBe(3);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => result.current.undo());
+    expect(result.current.present).toBe(2);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.undo());
+    expect(result.current.present).toBe(1);
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => result.current.redo());
+    expect(result.current.present).toBe(2);
+  });
+
+  it("clears the redo branch on a new commit", () => {
+    const { result } = renderHook(() => useEditHistory<number>());
+    act(() => result.current.reset(1));
+    act(() => result.current.commit(2));
+    act(() => result.current.undo());
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.commit(9));
+    expect(result.current.present).toBe(9);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("reset discards history", () => {
+    const { result } = renderHook(() => useEditHistory<number>());
+    act(() => result.current.reset(1));
+    act(() => result.current.commit(2));
+    act(() => result.current.reset(5));
+    expect(result.current.present).toBe(5);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+});

--- a/web/src/components/audio_editor/audioSample.ts
+++ b/web/src/components/audio_editor/audioSample.ts
@@ -1,0 +1,296 @@
+/**
+ * Pure, side-effect-free helpers for editing decoded audio.
+ *
+ * The editor works on an `AudioSample` — sample-rate plus one Float32Array per
+ * channel — rather than the Web Audio `AudioBuffer`, so every edit is a plain
+ * array transform that can be unit-tested without an `AudioContext`. Each
+ * operation returns a new `AudioSample` and never mutates its input, which lets
+ * the undo/redo history hold previous states by reference.
+ *
+ * Conversions to/from `AudioBuffer` (for decoding and playback) live at the
+ * bottom and are the only functions that touch the Web Audio API.
+ */
+
+export interface AudioSample {
+  readonly sampleRate: number;
+  /** One Float32Array per channel; all the same length, at least one channel. */
+  readonly channels: Float32Array[];
+}
+
+export type FadeDirection = "in" | "out";
+
+export const numFrames = (sample: AudioSample): number =>
+  sample.channels[0]?.length ?? 0;
+
+export const numChannels = (sample: AudioSample): number =>
+  sample.channels.length;
+
+export const sampleDuration = (sample: AudioSample): number =>
+  sample.sampleRate > 0 ? numFrames(sample) / sample.sampleRate : 0;
+
+export const secondsToFrame = (sample: AudioSample, seconds: number): number =>
+  Math.round(seconds * sample.sampleRate);
+
+export const frameToSeconds = (sample: AudioSample, frame: number): number =>
+  sample.sampleRate > 0 ? frame / sample.sampleRate : 0;
+
+interface FrameRange {
+  start: number;
+  end: number;
+}
+
+const clampFrame = (sample: AudioSample, frame: number): number =>
+  Math.max(0, Math.min(numFrames(sample), Math.round(frame)));
+
+/**
+ * Resolve a (possibly reversed or out-of-bounds) seconds range to a valid,
+ * non-empty frame range, or the whole sample when no range is given. Returns
+ * `null` when the range collapses to nothing.
+ */
+const resolveRange = (
+  sample: AudioSample,
+  startSec?: number,
+  endSec?: number
+): FrameRange | null => {
+  if (startSec == null || endSec == null) {
+    const frames = numFrames(sample);
+    return frames > 0 ? { start: 0, end: frames } : null;
+  }
+  let start = clampFrame(sample, secondsToFrame(sample, startSec));
+  let end = clampFrame(sample, secondsToFrame(sample, endSec));
+  if (start > end) {
+    [start, end] = [end, start];
+  }
+  return end > start ? { start, end } : null;
+};
+
+const mapChannels = (
+  sample: AudioSample,
+  fn: (channel: Float32Array) => Float32Array
+): AudioSample => ({
+  sampleRate: sample.sampleRate,
+  channels: sample.channels.map(fn)
+});
+
+/** Keep only the selected range (trim/crop). */
+export const cropToRange = (
+  sample: AudioSample,
+  startSec: number,
+  endSec: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  return mapChannels(sample, (channel) => channel.slice(range.start, range.end));
+};
+
+/** Remove the selected range, joining the surrounding audio. */
+export const deleteRange = (
+  sample: AudioSample,
+  startSec: number,
+  endSec: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  const removed = range.end - range.start;
+  const remaining = numFrames(sample) - removed;
+  return mapChannels(sample, (channel) => {
+    const out = new Float32Array(remaining);
+    out.set(channel.subarray(0, range.start), 0);
+    out.set(channel.subarray(range.end), range.start);
+    return out;
+  });
+};
+
+/** Replace the selected range (or whole sample) with silence. */
+export const silenceRange = (
+  sample: AudioSample,
+  startSec?: number,
+  endSec?: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  return mapChannels(sample, (channel) => {
+    const out = channel.slice();
+    out.fill(0, range.start, range.end);
+    return out;
+  });
+};
+
+const gainRange = (
+  sample: AudioSample,
+  gain: number,
+  range: FrameRange
+): AudioSample =>
+  mapChannels(sample, (channel) => {
+    const out = channel.slice();
+    for (let i = range.start; i < range.end; i += 1) {
+      out[i] = Math.max(-1, Math.min(1, out[i] * gain));
+    }
+    return out;
+  });
+
+/** Multiply amplitude by `gain` over the range (or the whole sample). */
+export const applyGain = (
+  sample: AudioSample,
+  gain: number,
+  startSec?: number,
+  endSec?: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  return gainRange(sample, gain, range);
+};
+
+/** Scale so the loudest sample in the range (or whole) hits full scale. */
+export const normalize = (
+  sample: AudioSample,
+  startSec?: number,
+  endSec?: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  let peak = 0;
+  for (const channel of sample.channels) {
+    for (let i = range.start; i < range.end; i += 1) {
+      const v = Math.abs(channel[i]);
+      if (v > peak) peak = v;
+    }
+  }
+  if (peak === 0) return sample;
+  return gainRange(sample, 1 / peak, range);
+};
+
+/** Apply a linear fade in or out across the range. */
+export const fade = (
+  sample: AudioSample,
+  startSec: number,
+  endSec: number,
+  direction: FadeDirection
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  const span = range.end - range.start;
+  const denom = span > 1 ? span - 1 : 1;
+  return mapChannels(sample, (channel) => {
+    const out = channel.slice();
+    for (let i = 0; i < span; i += 1) {
+      const t = i / denom;
+      out[range.start + i] *= direction === "in" ? t : 1 - t;
+    }
+    return out;
+  });
+};
+
+/** Reverse the samples in the range (or the whole sample). */
+export const reverseRange = (
+  sample: AudioSample,
+  startSec?: number,
+  endSec?: number
+): AudioSample => {
+  const range = resolveRange(sample, startSec, endSec);
+  if (!range) return sample;
+  return mapChannels(sample, (channel) => {
+    const out = channel.slice();
+    let lo = range.start;
+    let hi = range.end - 1;
+    while (lo < hi) {
+      const tmp = out[lo];
+      out[lo] = out[hi];
+      out[hi] = tmp;
+      lo += 1;
+      hi -= 1;
+    }
+    return out;
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+const writeAscii = (view: DataView, offset: number, text: string): void => {
+  for (let i = 0; i < text.length; i += 1) {
+    view.setUint8(offset + i, text.charCodeAt(i));
+  }
+};
+
+/** Encode the sample as a 16-bit PCM WAV file. */
+export const encodeWav = (sample: AudioSample): ArrayBuffer => {
+  const channels = sample.channels;
+  const channelCount = Math.max(1, channels.length);
+  const frames = numFrames(sample);
+  const bytesPerSample = 2;
+  const blockAlign = channelCount * bytesPerSample;
+  const dataSize = frames * blockAlign;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // PCM fmt chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sample.sampleRate, true);
+  view.setUint32(28, sample.sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true); // bits per sample
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (let i = 0; i < frames; i += 1) {
+    for (let c = 0; c < channelCount; c += 1) {
+      const v = Math.max(-1, Math.min(1, channels[c][i]));
+      view.setInt16(offset, v < 0 ? v * 0x8000 : v * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return buffer;
+};
+
+/** Base64-encode an ArrayBuffer, chunked to stay within argument limits. */
+export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
+  }
+  return btoa(binary);
+};
+
+// ---------------------------------------------------------------------------
+// Web Audio interop
+// ---------------------------------------------------------------------------
+
+/** Copy a decoded AudioBuffer into a detached AudioSample. */
+export const audioBufferToSample = (buffer: AudioBuffer): AudioSample => {
+  const channels: Float32Array[] = [];
+  for (let c = 0; c < buffer.numberOfChannels; c += 1) {
+    channels.push(Float32Array.from(buffer.getChannelData(c)));
+  }
+  if (channels.length === 0) {
+    channels.push(new Float32Array(buffer.length));
+  }
+  return { sampleRate: buffer.sampleRate, channels };
+};
+
+/** Build a playable AudioBuffer from a sample (length forced to at least 1). */
+export const sampleToAudioBuffer = (
+  sample: AudioSample,
+  ctx: BaseAudioContext
+): AudioBuffer => {
+  const frames = Math.max(1, numFrames(sample));
+  const buffer = ctx.createBuffer(numChannels(sample), frames, sample.sampleRate);
+  sample.channels.forEach((channel, i) => {
+    if (channel.length > 0) {
+      // Channels are always ArrayBuffer-backed at runtime; the cast narrows the
+      // default ArrayBufferLike element type that copyToChannel rejects.
+      buffer.copyToChannel(channel as Float32Array<ArrayBuffer>, i);
+    }
+  });
+  return buffer;
+};

--- a/web/src/components/audio_editor/useEditHistory.ts
+++ b/web/src/components/audio_editor/useEditHistory.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from "react";
+
+/**
+ * A tiny undo/redo stack for an immutable editor value.
+ *
+ * `commit` replaces the present and clears the redo branch; `undo`/`redo` walk
+ * the stack. The value is held by reference, so callers must produce new
+ * objects on each edit (the audio ops in `audioSample.ts` already do). Past
+ * states are capped so long sessions don't grow without bound.
+ */
+
+const MAX_HISTORY = 50;
+
+interface HistoryState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+}
+
+export interface EditHistory<T> {
+  present: T | null;
+  canUndo: boolean;
+  canRedo: boolean;
+  /** Discard history and start fresh from `value`. */
+  reset: (value: T) => void;
+  /** Push a new present, clearing the redo branch. */
+  commit: (value: T) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+export function useEditHistory<T>(): EditHistory<T> {
+  const [state, setState] = useState<HistoryState<T> | null>(null);
+
+  const reset = useCallback((value: T) => {
+    setState({ past: [], present: value, future: [] });
+  }, []);
+
+  const commit = useCallback((value: T) => {
+    setState((prev) =>
+      prev
+        ? {
+            past: [...prev.past, prev.present].slice(-MAX_HISTORY),
+            present: value,
+            future: []
+          }
+        : { past: [], present: value, future: [] }
+    );
+  }, []);
+
+  const undo = useCallback(() => {
+    setState((prev) => {
+      if (!prev || prev.past.length === 0) return prev;
+      const present = prev.past[prev.past.length - 1];
+      return {
+        past: prev.past.slice(0, -1),
+        present,
+        future: [prev.present, ...prev.future]
+      };
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setState((prev) => {
+      if (!prev || prev.future.length === 0) return prev;
+      const [present, ...future] = prev.future;
+      return { past: [...prev.past, prev.present], present, future };
+    });
+  }, []);
+
+  return {
+    present: state?.present ?? null,
+    canUndo: !!state && state.past.length > 0,
+    canRedo: !!state && state.future.length > 0,
+    reset,
+    commit,
+    undo,
+    redo
+  };
+}

--- a/web/src/components/workspace/AudioSurface.tsx
+++ b/web/src/components/workspace/AudioSurface.tsx
@@ -1,6 +1,10 @@
+import { useCallback } from "react";
+
 import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
+import { tabId, useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { useAssetById } from "../../serverState/useAssetById";
 import AudioViewer from "../asset_viewer/AudioViewer";
+import AudioSampleEditor from "../audio_editor/AudioSampleEditor";
 import { FlexColumn, LoadingSpinner } from "../ui_primitives";
 
 interface AudioSurfaceProps {
@@ -10,25 +14,33 @@ interface AudioSurfaceProps {
 }
 
 /**
- * The surface for an audio tab. Audio is a view-only type (there is no audio
- * editor yet), so the waveform AudioViewer renders for both "view" and "edit"
- * modes. The asset is loaded by id here and passed down, so the viewer stays
- * untouched. `active` is accepted to match the surface contract; the player
- * does not autoplay, so there is nothing to gate on foreground state.
+ * The document surface for an audio asset tab. View mode renders the waveform
+ * AudioViewer; edit mode embeds the sample editor, which decodes the asset into
+ * PCM, applies destructive edits, and saves the result back as WAV.
+ *
+ * The editor is mounted only while the tab is `active`: it owns an AudioContext
+ * and playback, so keeping it alive in hidden background tabs (all tabs stay
+ * mounted in the shell) would leak audio resources. Inactive edit tabs fall
+ * back to the (hidden) viewer.
  */
-const AudioSurface = ({ refId }: AudioSurfaceProps) => {
+const AudioSurface = ({ refId, mode, active }: AudioSurfaceProps) => {
   const { data: asset } = useAssetById(refId);
+  const setMode = useWorkspaceTabsStore((state) => state.setMode);
+
+  const returnToView = useCallback(() => {
+    setMode(tabId("audio", refId), "view");
+  }, [setMode, refId]);
 
   if (!asset) {
     return (
-      <FlexColumn
-        fullWidth
-        fullHeight
-        sx={{ alignItems: "center", justifyContent: "center" }}
-      >
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
         <LoadingSpinner />
       </FlexColumn>
     );
+  }
+
+  if (mode === "edit" && active) {
+    return <AudioSampleEditor asset={asset} onClose={returnToView} />;
   }
 
   return <AudioViewer asset={asset} />;

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -22,7 +22,7 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   timeline: true,
   model3d: true,
   text: true,
-  audio: false
+  audio: true
 };
 
 const TYPE_GLYPH: Record<WorkspaceTabType, string> = {

--- a/web/src/hooks/audio/useSaveAudioToAsset.ts
+++ b/web/src/hooks/audio/useSaveAudioToAsset.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from "react";
+
+import { useAssetStore } from "../../stores/AssetStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  arrayBufferToBase64,
+  encodeWav,
+  type AudioSample
+} from "../../components/audio_editor/audioSample";
+import type { Asset } from "../../stores/ApiTypes";
+
+/**
+ * Encode the edited sample to 16-bit PCM WAV and overwrite the asset's bytes.
+ *
+ * The sample editor is lossless and destructive, so it always writes WAV and
+ * sets the asset's content type to `audio/wav` regardless of the original
+ * format. Invalidates the asset query so the viewer reloads the new audio.
+ */
+export function useSaveAudioToAsset(asset: Asset | undefined) {
+  const updateAsset = useAssetStore((state) => state.update);
+  const invalidateQueries = useAssetStore((state) => state.invalidateQueries);
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(
+    async (sample: AudioSample) => {
+      if (!asset) return;
+      setSaving(true);
+      try {
+        const base64 = arrayBufferToBase64(encodeWav(sample));
+        await updateAsset({
+          id: asset.id,
+          data: base64,
+          data_encoding: "base64",
+          content_type: "audio/wav"
+        });
+        invalidateQueries(["asset", asset.id]);
+        if (asset.parent_id) {
+          invalidateQueries(["assets", { parent_id: asset.parent_id }]);
+        }
+        useNotificationStore.getState().addNotification({
+          type: "success",
+          content: "Saved edits to audio."
+        });
+      } catch (error) {
+        useNotificationStore.getState().addNotification({
+          type: "error",
+          alert: true,
+          content: `Failed to save audio: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [asset, updateAsset, invalidateQueries]
+  );
+
+  return { save, saving };
+}


### PR DESCRIPTION
## Summary

Adds a full-featured, in-browser audio sample editor (Audacity-style) that allows users to decode audio assets, select regions on an interactive waveform, apply destructive edits with undo/redo, audition with transport controls, and save results back to the asset as WAV.

## Key Changes

- **AudioSampleEditor component** (`AudioSampleEditor.tsx`): Main editor UI that orchestrates audio loading, decoding, playback, editing, and saving. Manages playhead, selection, zoom, and transport state. Integrates with Web Audio API for decoding and playback.

- **WaveformView component** (`WaveformView.tsx`): Canvas-based waveform renderer with click-to-seek and drag-to-select. Draws channels as stacked min/max lanes. Uses pointer events for interaction and DOM nodes for selection/playhead positioning to avoid redraws during playback.

- **AudioEditorToolbar component** (`AudioEditorToolbar.tsx`): Memoized command bar with transport (play/pause/stop), zoom controls, region edits (trim/delete/silence/fade/normalize/reverse/gain), and undo/redo. Disabled states reflect selection and history availability.

- **audioSample module** (`audioSample.ts`): Pure, side-effect-free helpers for editing decoded audio. Works on `AudioSample` (sample rate + Float32Array channels) rather than Web Audio `AudioBuffer`, enabling unit-testable transforms without an `AudioContext`. Operations include:
  - Crop, delete, silence ranges
  - Fade in/out, normalize, reverse, apply gain
  - WAV encoding (16-bit PCM) and base64 serialization
  - Conversions to/from `AudioBuffer`

- **useEditHistory hook** (`useEditHistory.ts`): Tiny undo/redo stack for immutable editor state. Caps history at 50 entries to prevent unbounded growth in long sessions.

- **useSaveAudioToAsset hook** (`useSaveAudioToAsset.ts`): Encodes edited sample to WAV, overwrites asset bytes, and invalidates queries so the viewer reloads the new audio.

- **AudioSurface integration** (`AudioSurface.tsx`): Updated to support both "view" and "edit" modes for audio tabs. Edit mode opens the sample editor in a modal/overlay.

- **AssetViewer integration** (`AssetViewer.tsx`): Added "Edit audio" button for audio assets that opens the sample editor in a new tab.

- **WorkspaceTabBar** (`WorkspaceTabBar.tsx`): Enabled both-modes support for audio tabs (`audio: true`).

- **Tests**: Comprehensive unit tests for `audioSample` operations (crop, delete, silence, normalize, fade, reverse, WAV encoding/decoding) and `useEditHistory` (commit, undo, redo, history clearing).

## Notable Implementation Details

- **Immutable edits**: All audio operations return new `AudioSample` objects; inputs are never mutated. This enables undo/redo by holding past states by reference.
- **Efficient waveform rendering**: Canvas redraws only when sample, zoom, or container size changes. Selection band and playhead are positioned DOM nodes, so seeking and playback don't trigger redraws.
- **Web Audio interop**: Decoding uses `AudioContext.decodeAudioData()`. Playback uses `AudioBufferSourceNode` with loop support and frame-accurate seeking via `requestAnimationFrame`.
- **Responsive zoom**: Zoom range 1–64× with 1.5× step. Fit-to-window resets zoom to 1.
- **Selection-aware playback**: Loop mode respects selection bounds; playback without selection plays from playhead to end.
- **WAV encoding**: 16-bit PCM, multi-channel, with proper RIFF headers. Base64 serialization for asset storage.

https://claude.ai/code/session_019epWv5PsZSCXCRC2eFZUiA