### PR TITLE
Replace Lexical editor with Monaco for text asset editing

### DIFF
--- a/web/src/components/editor/FileTabContent.tsx
+++ b/web/src/components/editor/FileTabContent.tsx
@@ -10,6 +10,7 @@ import AudioViewer from "../asset_viewer/AudioViewer";
 import VideoViewer from "../asset_viewer/VideoViewer";
 import LazyPDFViewer from "../asset_viewer/LazyPDFViewer";
 import LazyModel3DViewer from "../asset_viewer/LazyModel3DViewer";
+import { isTextAsset } from "../../utils/assetLanguage";
 
 const isModel3D = (type: string, url?: string): boolean => {
   if (
@@ -35,52 +36,6 @@ const isModel3D = (type: string, url?: string): boolean => {
     }
   }
   return false;
-};
-
-const getLanguageFromAsset = (asset: Asset): string | undefined => {
-  const name = asset.name.toLowerCase();
-  const type = asset.content_type || "";
-
-  if (name.endsWith(".js") || name.endsWith(".jsx")) {
-    return "javascript";
-  }
-  if (name.endsWith(".ts") || name.endsWith(".tsx")) {
-    return "typescript";
-  }
-  if (name.endsWith(".py")) {
-    return "python";
-  }
-  if (name.endsWith(".json")) {
-    return "json";
-  }
-  if (name.endsWith(".css")) {
-    return "css";
-  }
-  if (name.endsWith(".html") || name.endsWith(".htm")) {
-    return "html";
-  }
-  if (name.endsWith(".xml")) {
-    return "xml";
-  }
-  if (name.endsWith(".yaml") || name.endsWith(".yml")) {
-    return "yaml";
-  }
-  if (name.endsWith(".md") || name.endsWith(".markdown")) {
-    return "markdown";
-  }
-  if (name.endsWith(".sh") || name.endsWith(".bash")) {
-    return "shell";
-  }
-  if (name.endsWith(".sql")) {
-    return "sql";
-  }
-  if (name.endsWith(".csv")) {
-    return "plaintext";
-  }
-  if (type.startsWith("text/")) {
-    return "plaintext";
-  }
-  return undefined;
 };
 
 const styles = (theme: Theme) =>
@@ -144,10 +99,7 @@ const FileTabContent: React.FC<FileTabContentProps> = ({ asset }) => {
   const [textContent, setTextContent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const isTextFile =
-    type.startsWith("text/") ||
-    type === "application/json" ||
-    getLanguageFromAsset(asset) !== undefined;
+  const isTextFile = isTextAsset(asset);
 
   useEffect(() => {
     if (!isTextFile || !asset.get_url) {return;}

--- a/web/src/components/node/DataTable/DataTable.tsx
+++ b/web/src/components/node/DataTable/DataTable.tsx
@@ -110,6 +110,7 @@ interface DataTableProps {
   onChange?: (data: DataframeRef) => void;
   isModalMode?: boolean;
   searchFilter?: string;
+  toolbarEnd?: React.ReactNode;
 }
 
 const DataTable: React.FC<DataTableProps> = ({
@@ -117,7 +118,8 @@ const DataTable: React.FC<DataTableProps> = ({
   onChange,
   editable,
   isModalMode = false,
-  searchFilter = ""
+  searchFilter = "",
+  toolbarEnd
 }) => {
   const theme = useTheme();
   const tableRef = useRef<HTMLDivElement>(null);
@@ -285,7 +287,7 @@ const DataTable: React.FC<DataTableProps> = ({
     tabulatorDataRef.current = data; // track what data is currently in Tabulator
 
     const tabulatorInstance = new Tabulator(tableRef.current, {
-      height: 200,
+      height: isModalMode ? "100%" : 200,
       data: data,
       columns: buildColumns(),
       columnDefaults: {
@@ -389,7 +391,9 @@ const DataTable: React.FC<DataTableProps> = ({
         canUndo={canUndo}
         canRedo={canRedo}
         onHistoryChange={updateHistoryState}
-      />
+      >
+        {toolbarEnd}
+      </TableActions>
 
       <div ref={tableRef} className="datatable" />
     </div>
@@ -404,6 +408,7 @@ export default memo(DataTable, (prevProps, nextProps) => {
     prevProps.editable === nextProps.editable &&
     prevProps.isModalMode === nextProps.isModalMode &&
     prevProps.searchFilter === nextProps.searchFilter &&
+    prevProps.toolbarEnd === nextProps.toolbarEnd &&
     isEqual(prevProps.dataframe, nextProps.dataframe)
   );
 });

--- a/web/src/components/node/DataTable/TableActions.tsx
+++ b/web/src/components/node/DataTable/TableActions.tsx
@@ -60,6 +60,7 @@ interface TableActionsProps {
   canUndo?: boolean;
   canRedo?: boolean;
   onHistoryChange?: () => void;
+  children?: React.ReactNode;
 }
 
 const TableActions: React.FC<TableActionsProps> = memo(({
@@ -79,7 +80,8 @@ const TableActions: React.FC<TableActionsProps> = memo(({
   isModalMode = false,
   canUndo = false,
   canRedo = false,
-  onHistoryChange
+  onHistoryChange,
+  children
 }) => {
   TableActions.displayName = 'TableActions';
   const { writeClipboard } = useClipboard();
@@ -148,7 +150,7 @@ const TableActions: React.FC<TableActionsProps> = memo(({
       }
     } else {
       if (Array.isArray(data) && dataframeColumns) {
-        const newRow = defaultRow(dataframeColumns);
+        const newRow = defaultRow(dataframeColumns, data.length);
         (onChangeRows as (newData: unknown) => void)([...data as DictTableRow[], newRow]);
       } else if (!Array.isArray(data)) {
         const newKey = `new_key_${Object.keys(data).length}`;
@@ -549,17 +551,19 @@ const TableActions: React.FC<TableActionsProps> = memo(({
       <ToolbarIconButton title="Copy table data to clipboard" onClick={handleCopyData}>
         <ContentCopyIcon sx={{ fontSize: 12 }} />
       </ToolbarIconButton>
+
+      {children && <div className="table-actions-extra">{children}</div>}
     </div>
   );
 });
 
 export default TableActions;
 
-const defaultRow = (columns: ColumnDef[]): DictTableRow => {
+const defaultRow = (columns: ColumnDef[], rownum = 0): DictTableRow => {
   return columns.reduce((acc, col) => {
     (acc as Record<string, DataframeCellValue>)[col.name] = defaultValue(col);
     return acc;
-  }, { rownum: 0 });
+  }, { rownum });
 };
 
 const defaultValue = (column: ColumnDef): DataframeCellValue => {

--- a/web/src/components/workspace/MonacoPane.tsx
+++ b/web/src/components/workspace/MonacoPane.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useTheme } from "@mui/material/styles";
+import type * as monaco from "monaco-editor";
+
+import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import { Caption, FlexColumn, LoadingSpinner } from "../ui_primitives";
+
+interface MonacoPaneProps {
+  value: string;
+  language: string;
+  readOnly?: boolean;
+  wordWrap?: boolean;
+  onChange?: (value: string) => void;
+  /** Registers Cmd/Ctrl+S inside the editor when provided. */
+  onSave?: () => void;
+}
+
+/**
+ * A thin wrapper around the lazily-loaded Monaco editor, shared by the text
+ * tab's edit surface (TextDocumentEditor) and its read-only code preview
+ * (TextPreview). Handles loading/error states, theme, options, and an optional
+ * save keybinding so callers only supply value + language.
+ */
+const MonacoPane = ({
+  value,
+  language,
+  readOnly = false,
+  wordWrap = true,
+  onChange,
+  onSave
+}: MonacoPaneProps) => {
+  const theme = useTheme();
+  const {
+    MonacoEditor,
+    monacoLoadError,
+    isMonacoLoading,
+    loadMonacoIfNeeded,
+    monacoOnMount
+  } = useMonacoEditor();
+  const monacoTheme = theme.palette.mode === "light" ? "vs" : "vs-dark";
+
+  useEffect(() => {
+    void loadMonacoIfNeeded();
+  }, [loadMonacoIfNeeded]);
+
+  // Fire the save keybinding through a ref so the command — registered once on
+  // mount — always calls the latest handler instead of a stale closure.
+  const saveRef = useRef(onSave);
+  saveRef.current = onSave;
+
+  const handleMount = useCallback(
+    (
+      editor: monaco.editor.IStandaloneCodeEditor,
+      monacoInstance: typeof import("monaco-editor")
+    ) => {
+      monacoOnMount(editor);
+      editor.addCommand(
+        monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
+        () => saveRef.current?.()
+      );
+    },
+    [monacoOnMount]
+  );
+
+  const handleChange = useCallback(
+    (next?: string) => onChange?.(next ?? ""),
+    [onChange]
+  );
+
+  const options = useMemo(
+    () => ({
+      readOnly,
+      automaticLayout: true,
+      minimap: { enabled: true },
+      scrollBeyondLastLine: false,
+      wordWrap: wordWrap ? ("on" as const) : ("off" as const),
+      fontSize: 13,
+      tabSize: 2,
+      renderWhitespace: "selection" as const,
+      smoothScrolling: true,
+      scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 }
+    }),
+    [readOnly, wordWrap]
+  );
+
+  if (monacoLoadError) {
+    return (
+      <FlexColumn
+        fullWidth
+        fullHeight
+        sx={{ alignItems: "center", justifyContent: "center" }}
+      >
+        <Caption sx={{ color: "error.main" }}>{monacoLoadError}</Caption>
+      </FlexColumn>
+    );
+  }
+
+  if (!MonacoEditor) {
+    return (
+      <FlexColumn
+        fullWidth
+        fullHeight
+        sx={{ alignItems: "center", justifyContent: "center" }}
+      >
+        <LoadingSpinner />
+        {isMonacoLoading && <Caption>Loading editor…</Caption>}
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <MonacoEditor
+      value={value}
+      onChange={handleChange}
+      language={language}
+      theme={monacoTheme}
+      width="100%"
+      height="100%"
+      onMount={handleMount}
+      options={options}
+    />
+  );
+};
+
+export default MonacoPane;

--- a/web/src/components/workspace/MonacoPane.tsx
+++ b/web/src/components/workspace/MonacoPane.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useTheme } from "@mui/material/styles";
 import type * as monaco from "monaco-editor";
 
 import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
@@ -13,6 +12,10 @@ interface MonacoPaneProps {
   onChange?: (value: string) => void;
   /** Registers Cmd/Ctrl+S inside the editor when provided. */
   onSave?: () => void;
+  onEditorMount?: (
+    editor: monaco.editor.IStandaloneCodeEditor,
+    monacoInstance: typeof import("monaco-editor")
+  ) => void;
 }
 
 /**
@@ -27,9 +30,9 @@ const MonacoPane = ({
   readOnly = false,
   wordWrap = true,
   onChange,
-  onSave
+  onSave,
+  onEditorMount
 }: MonacoPaneProps) => {
-  const theme = useTheme();
   const {
     MonacoEditor,
     monacoLoadError,
@@ -37,7 +40,7 @@ const MonacoPane = ({
     loadMonacoIfNeeded,
     monacoOnMount
   } = useMonacoEditor();
-  const monacoTheme = theme.palette.mode === "light" ? "vs" : "vs-dark";
+  const monacoTheme = "vs-dark";
 
   useEffect(() => {
     void loadMonacoIfNeeded();
@@ -54,12 +57,13 @@ const MonacoPane = ({
       monacoInstance: typeof import("monaco-editor")
     ) => {
       monacoOnMount(editor);
+      onEditorMount?.(editor, monacoInstance);
       editor.addCommand(
         monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
         () => saveRef.current?.()
       );
     },
-    [monacoOnMount]
+    [monacoOnMount, onEditorMount]
   );
 
   const handleChange = useCallback(

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
 import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
 import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
 import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
@@ -74,7 +75,53 @@ interface OpenMenuProps {
   onClose: () => void;
 }
 
-type MenuView = "root" | "workflows" | "assets";
+type MenuView = "root" | "texts" | "workflows" | "assets";
+
+interface TextFileTemplate {
+  label: string;
+  filename: string;
+  mimeType: string;
+  content: string;
+}
+
+const TEXT_FILE_TEMPLATES: readonly TextFileTemplate[] = [
+  {
+    label: "Markdown (.md)",
+    filename: "Untitled.md",
+    mimeType: "text/markdown",
+    content: "# Untitled\n"
+  },
+  {
+    label: "JSON (.json)",
+    filename: "Untitled.json",
+    mimeType: "application/json",
+    content: "{}\n"
+  },
+  {
+    label: "YAML (.yaml)",
+    filename: "Untitled.yaml",
+    mimeType: "application/x-yaml",
+    content: "---\n"
+  },
+  {
+    label: "CSV (.csv)",
+    filename: "Untitled.csv",
+    mimeType: "text/csv",
+    content: "Column 1\n"
+  },
+  {
+    label: "TSV (.tsv)",
+    filename: "Untitled.tsv",
+    mimeType: "text/tab-separated-values",
+    content: "Column 1\n"
+  },
+  {
+    label: "Plain text (.txt)",
+    filename: "Untitled.txt",
+    mimeType: "text/plain",
+    content: ""
+  }
+];
 
 /**
  * The `[+]` menu for the workspace tab bar: create a new workflow, or open an
@@ -124,6 +171,28 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       console.error("Failed to create image", error);
     }
   }, [createAsset, openTab, close]);
+
+  const handleNewText = useCallback(
+    async (template: TextFileTemplate) => {
+      try {
+        const asset = await createAsset(
+          new File([template.content], template.filename, {
+            type: template.mimeType
+          })
+        );
+        openTab({
+          type: "text",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || template.filename
+        });
+        close();
+      } catch (error) {
+        console.error("Failed to create text file", error);
+      }
+    },
+    [createAsset, openTab, close]
+  );
 
   const handleNewVideo = useCallback(async () => {
     try {
@@ -234,6 +303,12 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               onClick={() => void handleNew()}
             />
             <MenuItemPrimitive
+              label="New text file…"
+              icon={<ArticleOutlinedIcon fontSize="small" />}
+              hasSubmenu
+              onClick={() => setView("texts")}
+            />
+            <MenuItemPrimitive
               label="New image"
               icon={<ImageOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewImage()}
@@ -259,6 +334,24 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               hasSubmenu
               onClick={() => setView("assets")}
             />
+          </>
+        )}
+
+        {view === "texts" && (
+          <>
+            <MenuItemPrimitive
+              label="Back"
+              icon={<ArrowBackRoundedIcon fontSize="small" />}
+              onClick={() => setView("root")}
+              dividerAfter
+            />
+            {TEXT_FILE_TEMPLATES.map((template) => (
+              <MenuItemPrimitive
+                key={template.filename}
+                label={template.label}
+                onClick={() => void handleNewText(template)}
+              />
+            ))}
           </>
         )}
 

--- a/web/src/components/workspace/TextDocumentEditor.tsx
+++ b/web/src/components/workspace/TextDocumentEditor.tsx
@@ -1,0 +1,313 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import type * as monaco from "monaco-editor";
+import SearchIcon from "@mui/icons-material/Search";
+import WrapTextIcon from "@mui/icons-material/WrapText";
+import CodeIcon from "@mui/icons-material/Code";
+import SaveIcon from "@mui/icons-material/Save";
+
+import type { Asset } from "../../stores/ApiTypes";
+import { useAssetStore } from "../../stores/AssetStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import { languageFromAsset } from "../../utils/assetLanguage";
+import {
+  Caption,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ToolbarIconButton,
+  TruncatedText
+} from "../ui_primitives";
+
+interface TextDocumentEditorProps {
+  asset: Asset;
+}
+
+const textAssetKey = (id: string) => ["textAsset", id] as const;
+
+const styles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    backgroundColor: theme.vars.palette.grey[900],
+    ".editor-toolbar": {
+      flex: "0 0 auto",
+      height: "2.5em",
+      padding: "0 0.5em 0 0.75em",
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: theme.vars.palette.grey[800]
+    },
+    ".filename": {
+      color: theme.vars.palette.text.primary,
+      fontWeight: 500,
+      maxWidth: "40ch"
+    },
+    ".language-tag": {
+      textTransform: "uppercase",
+      letterSpacing: "0.05em"
+    },
+    ".dirty-dot": {
+      width: 8,
+      height: 8,
+      borderRadius: "50%",
+      backgroundColor: theme.vars.palette.warning.main,
+      flex: "0 0 auto"
+    },
+    ".editor-host": {
+      flex: 1,
+      minHeight: 0,
+      position: "relative"
+    },
+    ".editor-status": {
+      position: "absolute",
+      inset: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: theme.vars.palette.text.secondary
+    },
+    ".editor-error": {
+      color: theme.vars.palette.error.main
+    }
+  });
+
+/**
+ * A Monaco-backed editor for any text-based asset, used as the edit surface of
+ * a `text` workspace tab. It is the code-editor counterpart to the read-only
+ * TextViewer: language is inferred from the filename, edits are tracked against
+ * the loaded baseline, and Save persists the content back via the asset update
+ * API (`Cmd/Ctrl+S` or the toolbar button).
+ */
+const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
+  const theme = useTheme();
+  const queryClient = useQueryClient();
+  const update = useAssetStore((state) => state.update);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const {
+    MonacoEditor,
+    monacoLoadError,
+    isMonacoLoading,
+    loadMonacoIfNeeded,
+    monacoOnMount
+  } = useMonacoEditor();
+
+  const language = useMemo(() => languageFromAsset(asset), [asset]);
+  const monacoTheme = theme.palette.mode === "light" ? "vs" : "vs-dark";
+  const getUrl = asset.get_url ?? undefined;
+
+  const [content, setContent] = useState<string | null>(null);
+  const [savedContent, setSavedContent] = useState<string | null>(null);
+  const [wordWrap, setWordWrap] = useState(true);
+
+  const {
+    data: loadedText,
+    isLoading: textLoading,
+    error: textError
+  } = useQuery({
+    queryKey: textAssetKey(asset.id),
+    enabled: !!getUrl,
+    queryFn: async () => {
+      if (!getUrl) {
+        throw new Error("Text asset has no download URL");
+      }
+      const response = await fetch(getUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to load text asset: ${response.status}`);
+      }
+      return response.text();
+    }
+  });
+
+  // Seed the editor once the text arrives; the query cache stays the source of
+  // truth so re-opening the tab restores the last-saved content.
+  useEffect(() => {
+    if (loadedText !== undefined && content === null) {
+      setContent(loadedText);
+      setSavedContent(loadedText);
+    }
+  }, [loadedText, content]);
+
+  useEffect(() => {
+    void loadMonacoIfNeeded();
+  }, [loadMonacoIfNeeded]);
+
+  const saveMutation = useMutation({
+    mutationFn: (text: string) =>
+      update({
+        id: asset.id,
+        data: text,
+        content_type: asset.content_type ?? "text/plain"
+      }),
+    onSuccess: (_asset, text) => {
+      setSavedContent(text);
+      queryClient.setQueryData(textAssetKey(asset.id), text);
+      addNotification({
+        type: "success",
+        alert: true,
+        content: `Saved ${asset.name}`,
+        dismissable: false
+      });
+    },
+    onError: (error) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Failed to save ${asset.name}: ${(error as Error).message}`,
+        dismissable: false
+      });
+    }
+  });
+
+  const isDirty = content !== null && content !== savedContent;
+  const isSaving = saveMutation.isPending;
+
+  const handleSave = useCallback(() => {
+    if (content === null || content === savedContent || isSaving) {
+      return;
+    }
+    saveMutation.mutate(content);
+  }, [content, savedContent, isSaving, saveMutation]);
+
+  // Monaco's keybinding fires through a ref so the command — registered once on
+  // mount — always calls the latest save handler instead of a stale closure.
+  const saveRef = useRef(handleSave);
+  saveRef.current = handleSave;
+
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+
+  const handleMount = useCallback(
+    (
+      editor: monaco.editor.IStandaloneCodeEditor,
+      monacoInstance: typeof import("monaco-editor")
+    ) => {
+      editorRef.current = editor;
+      monacoOnMount(editor);
+      editor.addCommand(
+        monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
+        () => saveRef.current()
+      );
+    },
+    [monacoOnMount]
+  );
+
+  const handleChange = useCallback((value?: string) => {
+    setContent(value ?? "");
+  }, []);
+
+  const handleFind = useCallback(() => {
+    editorRef.current?.getAction?.("actions.find")?.run?.();
+  }, []);
+
+  const handleFormat = useCallback(() => {
+    editorRef.current?.getAction?.("editor.action.formatDocument")?.run?.();
+  }, []);
+
+  const editorOptions = useMemo(
+    () => ({
+      automaticLayout: true,
+      minimap: { enabled: true },
+      scrollBeyondLastLine: false,
+      wordWrap: wordWrap ? ("on" as const) : ("off" as const),
+      fontSize: 13,
+      tabSize: 2,
+      renderWhitespace: "selection" as const,
+      smoothScrolling: true,
+      scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 }
+    }),
+    [wordWrap]
+  );
+
+  return (
+    <div css={styles(theme)}>
+      <FlexRow
+        className="editor-toolbar"
+        align="center"
+        justify="space-between"
+        gap={1}
+      >
+        <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+          {isDirty && <span className="dirty-dot" aria-label="Unsaved changes" />}
+          <TruncatedText className="filename" showTooltip>
+            {asset.name}
+          </TruncatedText>
+          {language && (
+            <Caption className="language-tag">{language}</Caption>
+          )}
+        </FlexRow>
+        <FlexRow align="center" gap={0.5}>
+          <ToolbarIconButton
+            tooltip="Find (Ctrl/Cmd+F)"
+            icon={<SearchIcon />}
+            onClick={handleFind}
+            size="small"
+          />
+          <ToolbarIconButton
+            tooltip="Format document"
+            icon={<CodeIcon />}
+            onClick={handleFormat}
+            size="small"
+          />
+          <ToolbarIconButton
+            tooltip={wordWrap ? "Disable word wrap" : "Enable word wrap"}
+            icon={<WrapTextIcon />}
+            onClick={() => setWordWrap((w) => !w)}
+            active={wordWrap}
+            size="small"
+          />
+          <EditorButton
+            variant="contained"
+            size="small"
+            startIcon={<SaveIcon />}
+            disabled={!isDirty || isSaving}
+            onClick={handleSave}
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </EditorButton>
+        </FlexRow>
+      </FlexRow>
+
+      <div className="editor-host">
+        {textError ? (
+          <div className="editor-status editor-error">
+            Failed to load text content
+          </div>
+        ) : textLoading || content === null ? (
+          <FlexColumn className="editor-status">
+            <LoadingSpinner />
+          </FlexColumn>
+        ) : monacoLoadError ? (
+          <div className="editor-status editor-error">{monacoLoadError}</div>
+        ) : MonacoEditor ? (
+          <MonacoEditor
+            value={content}
+            onChange={handleChange}
+            language={language ?? "plaintext"}
+            theme={monacoTheme}
+            width="100%"
+            height="100%"
+            onMount={handleMount}
+            options={editorOptions}
+          />
+        ) : (
+          <FlexColumn className="editor-status">
+            <LoadingSpinner />
+            {isMonacoLoading && <Caption>Loading editor…</Caption>}
+          </FlexColumn>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TextDocumentEditor;

--- a/web/src/components/workspace/TextDocumentEditor.tsx
+++ b/web/src/components/workspace/TextDocumentEditor.tsx
@@ -1,20 +1,23 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import type * as monaco from "monaco-editor";
-import SearchIcon from "@mui/icons-material/Search";
 import WrapTextIcon from "@mui/icons-material/WrapText";
-import CodeIcon from "@mui/icons-material/Code";
 import SaveIcon from "@mui/icons-material/Save";
 
-import type { Asset } from "../../stores/ApiTypes";
+import type { Asset, DataframeRef } from "../../stores/ApiTypes";
 import { useAssetStore } from "../../stores/AssetStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
-import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
-import { languageFromAsset } from "../../utils/assetLanguage";
+import { languageFromAsset, previewKind } from "../../utils/assetLanguage";
+import {
+  csvDelimiterFor,
+  dataframeToCsv,
+  parseCsvToDataframe
+} from "../../utils/csvDataframe";
+import MonacoPane from "./MonacoPane";
+import DataTable from "../node/DataTable/DataTable";
 import {
   Caption,
   EditorButton,
@@ -66,25 +69,20 @@ const styles = (theme: Theme) =>
       minHeight: 0,
       position: "relative"
     },
-    ".editor-status": {
-      position: "absolute",
-      inset: 0,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      color: theme.vars.palette.text.secondary
-    },
-    ".editor-error": {
-      color: theme.vars.palette.error.main
+    ".table-host": {
+      flex: 1,
+      minHeight: 0,
+      overflow: "auto",
+      padding: "0.75em"
     }
   });
 
 /**
- * A Monaco-backed editor for any text-based asset, used as the edit surface of
- * a `text` workspace tab. It is the code-editor counterpart to the read-only
- * TextViewer: language is inferred from the filename, edits are tracked against
- * the loaded baseline, and Save persists the content back via the asset update
- * API (`Cmd/Ctrl+S` or the toolbar button).
+ * The edit surface of a `text` workspace tab. CSV/TSV assets open in the
+ * tabular DataTable editor; every other text format opens in Monaco with a
+ * filename-inferred language. Edits are tracked against the loaded baseline
+ * (dirty dot) and persisted back via the asset update API (Cmd/Ctrl+S or the
+ * toolbar Save button).
  */
 const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
   const theme = useTheme();
@@ -94,16 +92,9 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
     (state) => state.addNotification
   );
 
-  const {
-    MonacoEditor,
-    monacoLoadError,
-    isMonacoLoading,
-    loadMonacoIfNeeded,
-    monacoOnMount
-  } = useMonacoEditor();
-
   const language = useMemo(() => languageFromAsset(asset), [asset]);
-  const monacoTheme = theme.palette.mode === "light" ? "vs" : "vs-dark";
+  const kind = previewKind(asset);
+  const isCsv = kind === "csv";
   const getUrl = asset.get_url ?? undefined;
 
   const [content, setContent] = useState<string | null>(null);
@@ -137,10 +128,6 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
       setSavedContent(loadedText);
     }
   }, [loadedText, content]);
-
-  useEffect(() => {
-    void loadMonacoIfNeeded();
-  }, [loadMonacoIfNeeded]);
 
   const saveMutation = useMutation({
     mutationFn: (text: string) =>
@@ -179,54 +166,71 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
     saveMutation.mutate(content);
   }, [content, savedContent, isSaving, saveMutation]);
 
-  // Monaco's keybinding fires through a ref so the command — registered once on
-  // mount — always calls the latest save handler instead of a stale closure.
-  const saveRef = useRef(handleSave);
-  saveRef.current = handleSave;
+  // CSV editing round-trips through a DataframeRef: the text stays canonical
+  // for dirty-tracking and saving, the table just edits a parsed view of it.
+  const delimiter = useMemo(
+    () => csvDelimiterFor(asset.name ?? ""),
+    [asset.name]
+  );
+  const dataframe = useMemo<DataframeRef | null>(
+    () => (isCsv && content !== null ? parseCsvToDataframe(content, delimiter) : null),
+    [isCsv, content, delimiter]
+  );
 
-  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const handleDataframeChange = useCallback(
+    (df: DataframeRef) => setContent(dataframeToCsv(df, delimiter)),
+    [delimiter]
+  );
 
-  const handleMount = useCallback(
-    (
-      editor: monaco.editor.IStandaloneCodeEditor,
-      monacoInstance: typeof import("monaco-editor")
-    ) => {
-      editorRef.current = editor;
-      monacoOnMount(editor);
-      editor.addCommand(
-        monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
-        () => saveRef.current()
+  const body = () => {
+    if (textError) {
+      return (
+        <FlexColumn
+          fullWidth
+          fullHeight
+          sx={{ alignItems: "center", justifyContent: "center" }}
+        >
+          <Caption sx={{ color: "error.main" }}>
+            Failed to load text content
+          </Caption>
+        </FlexColumn>
       );
-    },
-    [monacoOnMount]
-  );
-
-  const handleChange = useCallback((value?: string) => {
-    setContent(value ?? "");
-  }, []);
-
-  const handleFind = useCallback(() => {
-    editorRef.current?.getAction?.("actions.find")?.run?.();
-  }, []);
-
-  const handleFormat = useCallback(() => {
-    editorRef.current?.getAction?.("editor.action.formatDocument")?.run?.();
-  }, []);
-
-  const editorOptions = useMemo(
-    () => ({
-      automaticLayout: true,
-      minimap: { enabled: true },
-      scrollBeyondLastLine: false,
-      wordWrap: wordWrap ? ("on" as const) : ("off" as const),
-      fontSize: 13,
-      tabSize: 2,
-      renderWhitespace: "selection" as const,
-      smoothScrolling: true,
-      scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 }
-    }),
-    [wordWrap]
-  );
+    }
+    if (textLoading || content === null) {
+      return (
+        <FlexColumn
+          fullWidth
+          fullHeight
+          sx={{ alignItems: "center", justifyContent: "center" }}
+        >
+          <LoadingSpinner />
+        </FlexColumn>
+      );
+    }
+    if (isCsv && dataframe) {
+      return (
+        <div className="table-host">
+          <DataTable
+            dataframe={dataframe}
+            editable
+            isModalMode
+            onChange={handleDataframeChange}
+          />
+        </div>
+      );
+    }
+    return (
+      <div className="editor-host">
+        <MonacoPane
+          value={content}
+          language={language ?? "plaintext"}
+          wordWrap={wordWrap}
+          onChange={setContent}
+          onSave={handleSave}
+        />
+      </div>
+    );
+  };
 
   return (
     <div css={styles(theme)}>
@@ -237,34 +241,24 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
         gap={1}
       >
         <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
-          {isDirty && <span className="dirty-dot" aria-label="Unsaved changes" />}
+          {isDirty && (
+            <span className="dirty-dot" aria-label="Unsaved changes" />
+          )}
           <TruncatedText className="filename" showTooltip>
             {asset.name}
           </TruncatedText>
-          {language && (
-            <Caption className="language-tag">{language}</Caption>
-          )}
+          {language && <Caption className="language-tag">{language}</Caption>}
         </FlexRow>
         <FlexRow align="center" gap={0.5}>
-          <ToolbarIconButton
-            tooltip="Find (Ctrl/Cmd+F)"
-            icon={<SearchIcon />}
-            onClick={handleFind}
-            size="small"
-          />
-          <ToolbarIconButton
-            tooltip="Format document"
-            icon={<CodeIcon />}
-            onClick={handleFormat}
-            size="small"
-          />
-          <ToolbarIconButton
-            tooltip={wordWrap ? "Disable word wrap" : "Enable word wrap"}
-            icon={<WrapTextIcon />}
-            onClick={() => setWordWrap((w) => !w)}
-            active={wordWrap}
-            size="small"
-          />
+          {!isCsv && (
+            <ToolbarIconButton
+              tooltip={wordWrap ? "Disable word wrap" : "Enable word wrap"}
+              icon={<WrapTextIcon />}
+              onClick={() => setWordWrap((w) => !w)}
+              active={wordWrap}
+              size="small"
+            />
+          )}
           <EditorButton
             variant="contained"
             size="small"
@@ -277,35 +271,7 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
         </FlexRow>
       </FlexRow>
 
-      <div className="editor-host">
-        {textError ? (
-          <div className="editor-status editor-error">
-            Failed to load text content
-          </div>
-        ) : textLoading || content === null ? (
-          <FlexColumn className="editor-status">
-            <LoadingSpinner />
-          </FlexColumn>
-        ) : monacoLoadError ? (
-          <div className="editor-status editor-error">{monacoLoadError}</div>
-        ) : MonacoEditor ? (
-          <MonacoEditor
-            value={content}
-            onChange={handleChange}
-            language={language ?? "plaintext"}
-            theme={monacoTheme}
-            width="100%"
-            height="100%"
-            onMount={handleMount}
-            options={editorOptions}
-          />
-        ) : (
-          <FlexColumn className="editor-status">
-            <LoadingSpinner />
-            {isMonacoLoading && <Caption>Loading editor…</Caption>}
-          </FlexColumn>
-        )}
-      </div>
+      {body()}
     </div>
   );
 };

--- a/web/src/components/workspace/TextDocumentEditor.tsx
+++ b/web/src/components/workspace/TextDocumentEditor.tsx
@@ -100,6 +100,10 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
 
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
+  // CSV edits are tracked as a live dataframe so a single edit survives even
+  // when CSV serialization is lossy (e.g. a trailing empty single-column row);
+  // `content` stays canonical for dirty-tracking and saving.
+  const [csvDataframe, setCsvDataframe] = useState<DataframeRef | null>(null);
   const [wordWrap, setWordWrap] = useState(true);
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
@@ -132,6 +136,13 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
       setSavedContent(loadedText);
     }
   }, [loadedText, content]);
+
+  // Re-derive everything when the tab is pointed at a different asset.
+  useEffect(() => {
+    setContent(null);
+    setSavedContent(null);
+    setCsvDataframe(null);
+  }, [asset.id]);
 
   const saveMutation = useMutation({
     mutationFn: (text: string) =>
@@ -197,19 +208,28 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
     saveMutation.mutate(content);
   }, [content, savedContent, isSaving, saveMutation]);
 
-  // CSV editing round-trips through a DataframeRef: the text stays canonical
-  // for dirty-tracking and saving, the table just edits a parsed view of it.
   const delimiter = useMemo(
     () => csvDelimiterFor(asset.name ?? ""),
     [asset.name]
   );
-  const dataframe = useMemo<DataframeRef | null>(
-    () => (isCsv && content !== null ? parseCsvToDataframe(content, delimiter) : null),
-    [isCsv, content, delimiter]
-  );
+  // Render from the live dataframe once the user has edited it; before that,
+  // parse the loaded text. The table owns its row/column state so an edit is
+  // never lost to a lossy CSV round-trip.
+  const dataframe = useMemo<DataframeRef | null>(() => {
+    if (!isCsv) {
+      return null;
+    }
+    if (csvDataframe) {
+      return csvDataframe;
+    }
+    return content !== null ? parseCsvToDataframe(content, delimiter) : null;
+  }, [isCsv, csvDataframe, content, delimiter]);
 
   const handleDataframeChange = useCallback(
-    (df: DataframeRef) => setContent(dataframeToCsv(df, delimiter)),
+    (df: DataframeRef) => {
+      setCsvDataframe(df);
+      setContent(dataframeToCsv(df, delimiter));
+    },
     [delimiter]
   );
 

--- a/web/src/components/workspace/TextDocumentEditor.tsx
+++ b/web/src/components/workspace/TextDocumentEditor.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import WrapTextIcon from "@mui/icons-material/WrapText";
 import SaveIcon from "@mui/icons-material/Save";
+import type * as monaco from "monaco-editor";
 
 import type { Asset, DataframeRef } from "../../stores/ApiTypes";
 import { useAssetStore } from "../../stores/AssetStore";
@@ -18,14 +18,13 @@ import {
 } from "../../utils/csvDataframe";
 import MonacoPane from "./MonacoPane";
 import DataTable from "../node/DataTable/DataTable";
+import EditorToolbar from "../textEditor/EditorToolbar";
 import {
   Caption,
   EditorButton,
   FlexColumn,
   FlexRow,
-  LoadingSpinner,
-  ToolbarIconButton,
-  TruncatedText
+  LoadingSpinner
 } from "../ui_primitives";
 
 interface TextDocumentEditorProps {
@@ -41,22 +40,18 @@ const styles = (theme: Theme) =>
     display: "flex",
     flexDirection: "column",
     backgroundColor: theme.vars.palette.grey[900],
-    ".editor-toolbar": {
+    color: theme.vars.palette.common.white,
+    ".editor-toolbar-row": {
       flex: "0 0 auto",
-      height: "2.5em",
-      padding: "0 0.5em 0 0.75em",
-      borderBottom: `1px solid ${theme.vars.palette.divider}`,
-      backgroundColor: theme.vars.palette.grey[800]
+      borderBottom: `1px solid ${theme.vars.palette.grey[700]}`,
+      backgroundColor: theme.vars.palette.grey[900],
+      ".editor-toolbar": {
+        flex: 1,
+        borderBottom: "none",
+        backgroundColor: "transparent"
+      }
     },
-    ".filename": {
-      color: theme.vars.palette.text.primary,
-      fontWeight: 500,
-      maxWidth: "40ch"
-    },
-    ".language-tag": {
-      textTransform: "uppercase",
-      letterSpacing: "0.05em"
-    },
+
     ".dirty-dot": {
       width: 8,
       height: 8,
@@ -72,8 +67,14 @@ const styles = (theme: Theme) =>
     ".table-host": {
       flex: 1,
       minHeight: 0,
-      overflow: "auto",
-      padding: "0.75em"
+      overflow: "hidden",
+      ".datatable.nowheel": {
+        height: "100%"
+      },
+      ".datatable.nowheel > .datatable": {
+        flex: 1,
+        minHeight: 0
+      }
     }
   });
 
@@ -100,6 +101,9 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
   const [wordWrap, setWordWrap] = useState(true);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 
   const {
     data: loadedText,
@@ -159,6 +163,33 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
   const isDirty = content !== null && content !== savedContent;
   const isSaving = saveMutation.isPending;
 
+  const updateHistoryState = useCallback(() => {
+    const model = editorRef.current?.getModel();
+    const alternativeVersionId = model?.getAlternativeVersionId() ?? 1;
+    const versionId = model?.getVersionId() ?? 1;
+    setCanUndo(alternativeVersionId < versionId);
+    setCanRedo(alternativeVersionId > versionId);
+  }, []);
+
+  const handleEditorMount = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      editorRef.current = editor;
+      updateHistoryState();
+      editor.onDidChangeModelContent(updateHistoryState);
+    },
+    [updateHistoryState]
+  );
+
+  const handleUndo = useCallback(() => {
+    editorRef.current?.trigger("toolbar", "undo", null);
+    updateHistoryState();
+  }, [updateHistoryState]);
+
+  const handleRedo = useCallback(() => {
+    editorRef.current?.trigger("toolbar", "redo", null);
+    updateHistoryState();
+  }, [updateHistoryState]);
+
   const handleSave = useCallback(() => {
     if (content === null || content === savedContent || isSaving) {
       return;
@@ -215,6 +246,22 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
             editable
             isModalMode
             onChange={handleDataframeChange}
+            toolbarEnd={
+              <>
+                {isDirty && (
+                  <span className="dirty-dot" aria-label="Unsaved changes" />
+                )}
+                <EditorButton
+                  variant="contained"
+                  size="small"
+                  startIcon={<SaveIcon />}
+                  disabled={!isDirty || isSaving}
+                  onClick={handleSave}
+                >
+                  {isSaving ? "Saving…" : "Save"}
+                </EditorButton>
+              </>
+            }
           />
         </div>
       );
@@ -227,6 +274,7 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
           wordWrap={wordWrap}
           onChange={setContent}
           onSave={handleSave}
+          onEditorMount={handleEditorMount}
         />
       </div>
     );
@@ -234,42 +282,36 @@ const TextDocumentEditor = ({ asset }: TextDocumentEditorProps) => {
 
   return (
     <div css={styles(theme)}>
-      <FlexRow
-        className="editor-toolbar"
-        align="center"
-        justify="space-between"
-        gap={1}
-      >
-        <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
-          {isDirty && (
-            <span className="dirty-dot" aria-label="Unsaved changes" />
-          )}
-          <TruncatedText className="filename" showTooltip>
-            {asset.name}
-          </TruncatedText>
-          {language && <Caption className="language-tag">{language}</Caption>}
-        </FlexRow>
-        <FlexRow align="center" gap={0.5}>
-          {!isCsv && (
-            <ToolbarIconButton
-              tooltip={wordWrap ? "Disable word wrap" : "Enable word wrap"}
-              icon={<WrapTextIcon />}
-              onClick={() => setWordWrap((w) => !w)}
-              active={wordWrap}
+      {!isCsv && (
+        <FlexRow
+          className="editor-toolbar-row"
+          align="center"
+          justify="space-between"
+        >
+          <EditorToolbar
+            onUndo={handleUndo}
+            onRedo={handleRedo}
+            onToggleWordWrap={() => setWordWrap((w) => !w)}
+            canUndo={canUndo}
+            canRedo={canRedo}
+            wordWrapEnabled={wordWrap}
+          />
+          <FlexRow align="center" gap={0.5} sx={{ px: 1 }}>
+            {isDirty && (
+              <span className="dirty-dot" aria-label="Unsaved changes" />
+            )}
+            <EditorButton
+              variant="contained"
               size="small"
-            />
-          )}
-          <EditorButton
-            variant="contained"
-            size="small"
-            startIcon={<SaveIcon />}
-            disabled={!isDirty || isSaving}
-            onClick={handleSave}
-          >
-            {isSaving ? "Saving…" : "Save"}
-          </EditorButton>
+              startIcon={<SaveIcon />}
+              disabled={!isDirty || isSaving}
+              onClick={handleSave}
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </EditorButton>
+          </FlexRow>
         </FlexRow>
-      </FlexRow>
+      )}
 
       {body()}
     </div>

--- a/web/src/components/workspace/TextPreview.tsx
+++ b/web/src/components/workspace/TextPreview.tsx
@@ -1,23 +1,19 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import Papa from "papaparse";
-import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
-import {
-  oneDark,
-  oneLight
-} from "react-syntax-highlighter/dist/esm/styles/prism";
 
 import type { Asset } from "../../stores/ApiTypes";
-import { languageFromAsset } from "../../utils/assetLanguage";
-import { useIsDarkMode } from "../../hooks/useIsDarkMode";
+import { languageFromAsset, previewKind } from "../../utils/assetLanguage";
+import { csvDelimiterFor, parseCsvToDataframe } from "../../utils/csvDataframe";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
+import MonacoPane from "./MonacoPane";
 import {
   Caption,
   CopyButton,
+  DataTable,
   FlexColumn,
   FlexRow,
   LoadingSpinner,
@@ -32,23 +28,7 @@ interface TextPreviewProps {
 const textAssetKey = (id: string) => ["textAsset", id] as const;
 
 /** Cap CSV/TSV rows so a huge file can't lock up the table render. */
-const MAX_CSV_ROWS = 1000;
-
-/** Monaco language id → Prism language id (most match; map the divergent ones). */
-const PRISM_LANGUAGE: Record<string, string> = {
-  shell: "bash",
-  plaintext: "text"
-};
-
-type PreviewKind = "markdown" | "csv" | "code" | "text";
-
-const previewKind = (asset: Asset, language: string | undefined): PreviewKind => {
-  const name = (asset.name ?? "").toLowerCase();
-  if (language === "markdown") return "markdown";
-  if (name.endsWith(".csv") || name.endsWith(".tsv")) return "csv";
-  if (language && language !== "plaintext") return "code";
-  return "text";
-};
+const MAX_CSV_ROWS = 2000;
 
 const styles = (theme: Theme) =>
   css({
@@ -74,31 +54,6 @@ const styles = (theme: Theme) =>
       flex: 1,
       minHeight: 0
     },
-    ".plain-text": {
-      whiteSpace: "pre-wrap",
-      wordBreak: "break-word",
-      fontFamily: theme.fontFamily2,
-      fontSize: theme.fontSizeSmall,
-      padding: "1em 1.25em",
-      color: theme.vars.palette.text.primary
-    },
-    ".csv-table": {
-      borderCollapse: "collapse",
-      fontSize: theme.fontSizeSmall,
-      fontFamily: theme.fontFamily2,
-      "th, td": {
-        border: `1px solid ${theme.vars.palette.divider}`,
-        padding: "0.25em 0.6em",
-        textAlign: "left",
-        whiteSpace: "nowrap"
-      },
-      th: {
-        position: "sticky",
-        top: 0,
-        backgroundColor: theme.vars.palette.grey[800],
-        color: theme.vars.palette.text.primary
-      }
-    },
     ".csv-note": {
       padding: "0.5em 1.25em"
     },
@@ -110,43 +65,39 @@ const styles = (theme: Theme) =>
     }
   });
 
-const CsvPreview = ({ text }: { text: string }) => {
-  const { rows, truncated } = useMemo(() => {
-    const parsed = Papa.parse<string[]>(text.trim(), {
-      skipEmptyLines: true
-    });
-    const all = parsed.data ?? [];
+const CsvTableView = ({ text, name }: { text: string; name: string }) => {
+  const { columns, rows, truncated } = useMemo(() => {
+    const df = parseCsvToDataframe(text, csvDelimiterFor(name));
+    const cols = (df.columns ?? []).map((c, i) => ({
+      key: String(i),
+      label: c.name
+    }));
+    const allRows = (df.data ?? []) as unknown[][];
+    const mapped = allRows
+      .slice(0, MAX_CSV_ROWS)
+      .map((row) =>
+        Object.fromEntries(
+          row.map((cell, i) => [String(i), cell as React.ReactNode])
+        )
+      );
     return {
-      rows: all.slice(0, MAX_CSV_ROWS),
-      truncated: all.length > MAX_CSV_ROWS
+      columns: cols,
+      rows: mapped,
+      truncated: allRows.length > MAX_CSV_ROWS
     };
-  }, [text]);
+  }, [text, name]);
 
-  if (rows.length === 0) {
-    return <div className="plain-text">{text}</div>;
+  if (columns.length === 0) {
+    return (
+      <FlexColumn className="status">
+        <Caption>Empty table</Caption>
+      </FlexColumn>
+    );
   }
 
-  const [header, ...body] = rows;
   return (
     <ScrollArea direction="both" sx={{ width: "100%", height: "100%" }}>
-      <table className="csv-table">
-        <thead>
-          <tr>
-            {header.map((cell, i) => (
-              <th key={i}>{cell}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {body.map((row, r) => (
-            <tr key={r}>
-              {row.map((cell, c) => (
-                <td key={c}>{cell}</td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable columns={columns} rows={rows} compact bordered stickyHeader />
       {truncated && (
         <Caption className="csv-note">
           Showing first {MAX_CSV_ROWS} rows.
@@ -156,50 +107,23 @@ const CsvPreview = ({ text }: { text: string }) => {
   );
 };
 
-const CodePreview = ({
-  text,
-  language
-}: {
-  text: string;
-  language: string;
-}) => {
-  const isDark = useIsDarkMode();
-  const prismLanguage = PRISM_LANGUAGE[language] ?? language;
-  return (
-    <ScrollArea direction="both" sx={{ width: "100%", height: "100%" }}>
-      <SyntaxHighlighter
-        language={prismLanguage}
-        style={isDark ? oneDark : oneLight}
-        showLineNumbers
-        wrapLongLines={false}
-        customStyle={{
-          margin: 0,
-          padding: "1em 1.25em",
-          background: "transparent",
-          fontFamily: '"JetBrains Mono", monospace',
-          fontSize: "var(--fontSizeSmall)"
-        }}
-      >
-        {text}
-      </SyntaxHighlighter>
-    </ScrollArea>
-  );
-};
-
 /**
- * Read-only, content-type-aware preview for a text workspace tab (view mode).
- * Routes by file type: markdown → rendered, code/JSON/YAML → syntax-highlighted,
- * CSV/TSV → table, everything else → plain wrapped text. It shares the
- * `["textAsset", id]` query with TextDocumentEditor, so toggling view ↔ edit
- * reuses the cached text instead of re-fetching.
+ * Read-only, content-type-aware preview for a text workspace tab (view mode):
+ * markdown → rendered, CSV/TSV → MUI table view, everything else →
+ * syntax-highlighted read-only Monaco. Shares the `["textAsset", id]` query
+ * with TextDocumentEditor, so toggling view ↔ edit reuses the cached text.
  */
 const TextPreview = ({ asset }: TextPreviewProps) => {
   const theme = useTheme();
   const getUrl = asset.get_url ?? undefined;
   const language = useMemo(() => languageFromAsset(asset), [asset]);
-  const kind = previewKind(asset, language);
+  const kind = previewKind(asset);
 
-  const { data: text, isLoading, error } = useQuery({
+  const {
+    data: text,
+    isLoading,
+    error
+  } = useQuery({
     queryKey: textAssetKey(asset.id),
     enabled: !!getUrl,
     queryFn: async () => {
@@ -234,19 +158,22 @@ const TextPreview = ({ asset }: TextPreviewProps) => {
     switch (kind) {
       case "markdown":
         return (
-          <ScrollArea direction="vertical" sx={{ width: "100%", height: "100%" }}>
+          <ScrollArea
+            direction="vertical"
+            sx={{ width: "100%", height: "100%" }}
+          >
             <MarkdownRenderer content={text} fillContainer />
           </ScrollArea>
         );
       case "csv":
-        return <CsvPreview text={text} />;
-      case "code":
-        return <CodePreview text={text} language={language ?? "text"} />;
+        return <CsvTableView text={text} name={asset.name ?? ""} />;
       default:
         return (
-          <ScrollArea direction="vertical" sx={{ width: "100%", height: "100%" }}>
-            <div className="plain-text">{text}</div>
-          </ScrollArea>
+          <MonacoPane
+            value={text}
+            language={language ?? "plaintext"}
+            readOnly
+          />
         );
     }
   };

--- a/web/src/components/workspace/TextPreview.tsx
+++ b/web/src/components/workspace/TextPreview.tsx
@@ -1,0 +1,277 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import Papa from "papaparse";
+import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
+import {
+  oneDark,
+  oneLight
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+
+import type { Asset } from "../../stores/ApiTypes";
+import { languageFromAsset } from "../../utils/assetLanguage";
+import { useIsDarkMode } from "../../hooks/useIsDarkMode";
+import MarkdownRenderer from "../../utils/MarkdownRenderer";
+import {
+  Caption,
+  CopyButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ScrollArea,
+  Text
+} from "../ui_primitives";
+
+interface TextPreviewProps {
+  asset: Asset;
+}
+
+const textAssetKey = (id: string) => ["textAsset", id] as const;
+
+/** Cap CSV/TSV rows so a huge file can't lock up the table render. */
+const MAX_CSV_ROWS = 1000;
+
+/** Monaco language id → Prism language id (most match; map the divergent ones). */
+const PRISM_LANGUAGE: Record<string, string> = {
+  shell: "bash",
+  plaintext: "text"
+};
+
+type PreviewKind = "markdown" | "csv" | "code" | "text";
+
+const previewKind = (asset: Asset, language: string | undefined): PreviewKind => {
+  const name = (asset.name ?? "").toLowerCase();
+  if (language === "markdown") return "markdown";
+  if (name.endsWith(".csv") || name.endsWith(".tsv")) return "csv";
+  if (language && language !== "plaintext") return "code";
+  return "text";
+};
+
+const styles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    backgroundColor: theme.vars.palette.grey[900],
+    ".preview-header": {
+      flex: "0 0 auto",
+      height: "2.5em",
+      padding: "0 0.5em 0 0.75em",
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: theme.vars.palette.grey[800]
+    },
+    ".filename": {
+      color: theme.vars.palette.text.primary,
+      fontWeight: 500
+    },
+    ".kind-tag": {
+      textTransform: "uppercase",
+      letterSpacing: "0.05em"
+    },
+    ".preview-body": {
+      flex: 1,
+      minHeight: 0
+    },
+    ".plain-text": {
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmall,
+      padding: "1em 1.25em",
+      color: theme.vars.palette.text.primary
+    },
+    ".csv-table": {
+      borderCollapse: "collapse",
+      fontSize: theme.fontSizeSmall,
+      fontFamily: theme.fontFamily2,
+      "th, td": {
+        border: `1px solid ${theme.vars.palette.divider}`,
+        padding: "0.25em 0.6em",
+        textAlign: "left",
+        whiteSpace: "nowrap"
+      },
+      th: {
+        position: "sticky",
+        top: 0,
+        backgroundColor: theme.vars.palette.grey[800],
+        color: theme.vars.palette.text.primary
+      }
+    },
+    ".csv-note": {
+      padding: "0.5em 1.25em"
+    },
+    ".status": {
+      width: "100%",
+      height: "100%",
+      alignItems: "center",
+      justifyContent: "center"
+    }
+  });
+
+const CsvPreview = ({ text }: { text: string }) => {
+  const { rows, truncated } = useMemo(() => {
+    const parsed = Papa.parse<string[]>(text.trim(), {
+      skipEmptyLines: true
+    });
+    const all = parsed.data ?? [];
+    return {
+      rows: all.slice(0, MAX_CSV_ROWS),
+      truncated: all.length > MAX_CSV_ROWS
+    };
+  }, [text]);
+
+  if (rows.length === 0) {
+    return <div className="plain-text">{text}</div>;
+  }
+
+  const [header, ...body] = rows;
+  return (
+    <ScrollArea direction="both" sx={{ width: "100%", height: "100%" }}>
+      <table className="csv-table">
+        <thead>
+          <tr>
+            {header.map((cell, i) => (
+              <th key={i}>{cell}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {body.map((row, r) => (
+            <tr key={r}>
+              {row.map((cell, c) => (
+                <td key={c}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {truncated && (
+        <Caption className="csv-note">
+          Showing first {MAX_CSV_ROWS} rows.
+        </Caption>
+      )}
+    </ScrollArea>
+  );
+};
+
+const CodePreview = ({
+  text,
+  language
+}: {
+  text: string;
+  language: string;
+}) => {
+  const isDark = useIsDarkMode();
+  const prismLanguage = PRISM_LANGUAGE[language] ?? language;
+  return (
+    <ScrollArea direction="both" sx={{ width: "100%", height: "100%" }}>
+      <SyntaxHighlighter
+        language={prismLanguage}
+        style={isDark ? oneDark : oneLight}
+        showLineNumbers
+        wrapLongLines={false}
+        customStyle={{
+          margin: 0,
+          padding: "1em 1.25em",
+          background: "transparent",
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: "var(--fontSizeSmall)"
+        }}
+      >
+        {text}
+      </SyntaxHighlighter>
+    </ScrollArea>
+  );
+};
+
+/**
+ * Read-only, content-type-aware preview for a text workspace tab (view mode).
+ * Routes by file type: markdown → rendered, code/JSON/YAML → syntax-highlighted,
+ * CSV/TSV → table, everything else → plain wrapped text. It shares the
+ * `["textAsset", id]` query with TextDocumentEditor, so toggling view ↔ edit
+ * reuses the cached text instead of re-fetching.
+ */
+const TextPreview = ({ asset }: TextPreviewProps) => {
+  const theme = useTheme();
+  const getUrl = asset.get_url ?? undefined;
+  const language = useMemo(() => languageFromAsset(asset), [asset]);
+  const kind = previewKind(asset, language);
+
+  const { data: text, isLoading, error } = useQuery({
+    queryKey: textAssetKey(asset.id),
+    enabled: !!getUrl,
+    queryFn: async () => {
+      if (!getUrl) {
+        throw new Error("Text asset has no download URL");
+      }
+      const response = await fetch(getUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to load text asset: ${response.status}`);
+      }
+      return response.text();
+    }
+  });
+
+  const body = () => {
+    if (error) {
+      return (
+        <FlexColumn className="status">
+          <Text size="normal" weight={600} sx={{ color: "error.main" }}>
+            Failed to load text content
+          </Text>
+        </FlexColumn>
+      );
+    }
+    if (isLoading || text === undefined) {
+      return (
+        <FlexColumn className="status">
+          <LoadingSpinner />
+        </FlexColumn>
+      );
+    }
+    switch (kind) {
+      case "markdown":
+        return (
+          <ScrollArea direction="vertical" sx={{ width: "100%", height: "100%" }}>
+            <MarkdownRenderer content={text} fillContainer />
+          </ScrollArea>
+        );
+      case "csv":
+        return <CsvPreview text={text} />;
+      case "code":
+        return <CodePreview text={text} language={language ?? "text"} />;
+      default:
+        return (
+          <ScrollArea direction="vertical" sx={{ width: "100%", height: "100%" }}>
+            <div className="plain-text">{text}</div>
+          </ScrollArea>
+        );
+    }
+  };
+
+  return (
+    <FlexColumn css={styles(theme)} sx={{ width: "100%", height: "100%" }}>
+      <FlexRow
+        className="preview-header"
+        align="center"
+        justify="space-between"
+        gap={1}
+      >
+        <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+          <Text className="filename" size="small">
+            {asset.name}
+          </Text>
+          <Caption className="kind-tag">
+            {kind === "csv" ? "csv" : (language ?? kind)}
+          </Caption>
+        </FlexRow>
+        {text !== undefined && <CopyButton value={text} buttonSize="small" />}
+      </FlexRow>
+      <div className="preview-body">{body()}</div>
+    </FlexColumn>
+  );
+};
+
+export default TextPreview;

--- a/web/src/components/workspace/TextSurface.tsx
+++ b/web/src/components/workspace/TextSurface.tsx
@@ -1,23 +1,8 @@
-/** @jsxImportSource @emotion/react */
-import { css } from "@emotion/react";
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { useTheme } from "@mui/material/styles";
-import type { Theme } from "@mui/material/styles";
-
-import { LexicalComposer } from "@lexical/react/LexicalComposer";
-import { CodeHighlightNode, CodeNode } from "@lexical/code";
-import { ListItemNode, ListNode } from "@lexical/list";
-import { AutoLinkNode, LinkNode } from "@lexical/link";
-import { HeadingNode, QuoteNode } from "@lexical/rich-text";
-
 import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
 import { useAssetById } from "../../serverState/useAssetById";
 import { FlexColumn, LoadingSpinner, Text } from "../ui_primitives";
 import TextViewer from "../asset_viewer/TextViewer";
-import LexicalPlugins from "../textEditor/LexicalEditor";
-import EditorController from "../textEditor/EditorController";
-import { codeHighlightTheme } from "../textEditor/codeHighlightTheme";
+import TextDocumentEditor from "./TextDocumentEditor";
 
 interface TextSurfaceProps {
   refId: string;
@@ -25,103 +10,18 @@ interface TextSurfaceProps {
   active: boolean;
 }
 
-const styles = (theme: Theme) =>
-  css({
-    width: "100%",
-    height: "100%",
-    position: "relative",
-    backgroundColor: theme.vars.palette.grey[800],
-    ".editor-pane": {
-      width: "100%",
-      height: "100%",
-      display: "flex",
-      flexDirection: "column",
-      padding: "1.5em 2em",
-      overflow: "auto",
-      color: theme.vars.palette.text.primary,
-      fontSize: theme.fontSizeSmall
-    },
-    ".error-container": {
-      color: theme.vars.palette.error.main
-    }
-  });
-
-// Mirror the Lexical setup used by TextEditorModal so the inline editor
-// renders the same rich-text/code nodes and highlight theme.
-const editorConfig = {
-  namespace: "TextSurface",
-  onError: (error: Error) => {
-    console.error(error);
-  },
-  nodes: [
-    HeadingNode,
-    QuoteNode,
-    ListNode,
-    ListItemNode,
-    CodeNode,
-    CodeHighlightNode,
-    AutoLinkNode,
-    LinkNode
-  ],
-  theme: {
-    text: {
-      large: "font-size-large"
-    },
-    ...codeHighlightTheme
-  }
-};
-
-// EditorController is a headless Lexical plugin whose command-callbacks are
-// required but only matter when an external toolbar/find-replace drives them.
-// This surface doesn't host that chrome yet, so the command wiring is no-op.
-const noop = () => {};
-
 /**
  * The text-document surface for a workspace tab. `refId` is a text Asset id.
  *
  * - view mode renders the read-only TextViewer (which fetches the asset text).
- * - edit mode mounts the inline Lexical editor seeded with the fetched text.
- *
- * Persistence: there is no save-to-text-asset API today (TextAssetDisplay
- * opens text assets read-only for the same reason). Edits stay in-memory.
- * TODO(text-asset-persistence): wire onChange back to an asset update once an
- * endpoint exists, then drop the in-memory-only caveat.
+ * - edit mode mounts the Monaco-backed TextDocumentEditor, which loads the
+ *   text, infers a language from the filename, and saves edits back via the
+ *   asset update API.
  */
 const TextSurface = ({ refId, mode }: TextSurfaceProps) => {
-  const theme = useTheme();
-  const {
-    data: asset,
-    isLoading: assetLoading,
-    error: assetError
-  } = useAssetById(refId);
+  const { data: asset, isLoading, error } = useAssetById(refId);
 
-  const getUrl = asset?.get_url ?? undefined;
-  const isEdit = mode === "edit";
-
-  // The viewer fetches its own text from the asset; the editor needs the raw
-  // string up front for `initialContent`, so fetch it only in edit mode.
-  const {
-    data: text,
-    isLoading: textLoading,
-    error: textError
-  } = useQuery({
-    queryKey: ["textAsset", refId],
-    enabled: isEdit && !!getUrl,
-    queryFn: async () => {
-      if (!getUrl) {
-        throw new Error("Text asset has no get_url");
-      }
-      const response = await fetch(getUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch text asset: ${response.status}`);
-      }
-      return response.text();
-    }
-  });
-
-  const initialContent = useMemo(() => text ?? "", [text]);
-
-  if (assetLoading || (isEdit && getUrl && textLoading)) {
+  if (isLoading) {
     return (
       <FlexColumn
         fullWidth
@@ -133,10 +33,9 @@ const TextSurface = ({ refId, mode }: TextSurfaceProps) => {
     );
   }
 
-  if (assetError || !asset) {
+  if (error || !asset) {
     return (
       <FlexColumn
-        className="error-container"
         fullWidth
         fullHeight
         sx={{ alignItems: "center", justifyContent: "center" }}
@@ -148,47 +47,11 @@ const TextSurface = ({ refId, mode }: TextSurfaceProps) => {
     );
   }
 
-  if (!isEdit) {
-    return <TextViewer asset={asset} />;
+  if (mode === "edit") {
+    return <TextDocumentEditor asset={asset} />;
   }
 
-  if (textError) {
-    return (
-      <FlexColumn
-        className="error-container"
-        fullWidth
-        fullHeight
-        sx={{ alignItems: "center", justifyContent: "center" }}
-      >
-        <Text size="normal" weight={600}>
-          Failed to load text content
-        </Text>
-      </FlexColumn>
-    );
-  }
-
-  return (
-    <div css={styles(theme)}>
-      <LexicalComposer initialConfig={editorConfig}>
-        <div className="editor-pane">
-          <EditorController
-            onCanUndoChange={noop}
-            onCanRedoChange={noop}
-            onTextChange={noop}
-            onUndoCommand={noop}
-            onRedoCommand={noop}
-            onFindCommand={noop}
-            onReplaceCommand={noop}
-            onNavigateCommand={noop}
-            onFormatCodeCommand={noop}
-            onIsCodeBlockChange={noop}
-            initialContent={initialContent}
-          />
-          <LexicalPlugins onChange={noop} />
-        </div>
-      </LexicalComposer>
-    </div>
-  );
+  return <TextViewer asset={asset} />;
 };
 
 export default TextSurface;

--- a/web/src/components/workspace/TextSurface.tsx
+++ b/web/src/components/workspace/TextSurface.tsx
@@ -1,8 +1,8 @@
 import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
 import { useAssetById } from "../../serverState/useAssetById";
 import { FlexColumn, LoadingSpinner, Text } from "../ui_primitives";
-import TextViewer from "../asset_viewer/TextViewer";
 import TextDocumentEditor from "./TextDocumentEditor";
+import TextPreview from "./TextPreview";
 
 interface TextSurfaceProps {
   refId: string;
@@ -13,7 +13,8 @@ interface TextSurfaceProps {
 /**
  * The text-document surface for a workspace tab. `refId` is a text Asset id.
  *
- * - view mode renders the read-only TextViewer (which fetches the asset text).
+ * - view mode renders the content-type-aware TextPreview (markdown rendered,
+ *   code syntax-highlighted, CSV as a table, …).
  * - edit mode mounts the Monaco-backed TextDocumentEditor, which loads the
  *   text, infers a language from the filename, and saves edits back via the
  *   asset update API.
@@ -51,7 +52,7 @@ const TextSurface = ({ refId, mode }: TextSurfaceProps) => {
     return <TextDocumentEditor asset={asset} />;
   }
 
-  return <TextViewer asset={asset} />;
+  return <TextPreview asset={asset} />;
 };
 
 export default TextSurface;

--- a/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
+++ b/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { Asset, DataframeRef } from "../../../stores/ApiTypes";
+
+// Heavy editor deps that are not exercised by the CSV branch.
+jest.mock("../MonacoPane", () => ({
+  __esModule: true,
+  default: () => <div data-testid="monaco" />
+}));
+jest.mock("../../textEditor/EditorToolbar", () => ({
+  __esModule: true,
+  default: () => <div data-testid="editor-toolbar" />
+}));
+
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: (selector: (s: { update: unknown }) => unknown) =>
+    selector({ update: jest.fn() })
+}));
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: (selector: (s: { addNotification: unknown }) => unknown) =>
+    selector({ addNotification: jest.fn() })
+}));
+
+// Stand-in for the real Tabulator-backed DataTable. It renders the row count it
+// receives and an "add row" button that calls `onChange` exactly the way the
+// real DataTable does: append one empty value per column.
+jest.mock("../../node/DataTable/DataTable", () => ({
+  __esModule: true,
+  default: ({
+    dataframe,
+    onChange
+  }: {
+    dataframe: DataframeRef;
+    onChange?: (df: DataframeRef) => void;
+  }) => {
+    const rows = (dataframe.data ?? []) as unknown[][];
+    const addRow = () =>
+      onChange?.({
+        ...dataframe,
+        data: [...rows, (dataframe.columns ?? []).map(() => "")]
+      });
+    return (
+      <div>
+        <div data-testid="row-count">{rows.length}</div>
+        <button onClick={addRow}>add row</button>
+      </div>
+    );
+  }
+}));
+
+import TextDocumentEditor from "../TextDocumentEditor";
+
+const renderEditor = (asset: Asset) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>
+        <TextDocumentEditor asset={asset} />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+const csvAsset = (name: string): Asset =>
+  ({
+    id: "asset-1",
+    name,
+    content_type: "text/csv",
+    get_url: `http://localhost/${name}`
+  }) as unknown as Asset;
+
+describe("TextDocumentEditor — CSV add row", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockCsvText = (text: string) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => text
+    }) as unknown as typeof fetch;
+  };
+
+  it("keeps the appended row for a single-column CSV", async () => {
+    mockCsvText("name\nAda");
+    renderEditor(csvAsset("rows.csv"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("row-count")).toHaveTextContent("1")
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "add row" }));
+
+    expect(screen.getByTestId("row-count")).toHaveTextContent("2");
+  });
+
+  it("keeps the appended row for a multi-column CSV", async () => {
+    mockCsvText("a,b\n1,2");
+    renderEditor(csvAsset("rows.csv"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("row-count")).toHaveTextContent("1")
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "add row" }));
+
+    expect(screen.getByTestId("row-count")).toHaveTextContent("2");
+  });
+});

--- a/web/src/components/workspace/assetTabType.ts
+++ b/web/src/components/workspace/assetTabType.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
+import { isTextAsset } from "../../utils/assetLanguage";
 
 /** The minimal asset shape needed to pick a workspace tab type. */
 interface AssetLike {
@@ -16,12 +17,13 @@ export const assetTabType = (asset: AssetLike): WorkspaceTabType | null => {
   const name = (asset.name ?? "").toLowerCase();
   if (ct.startsWith("image/")) return "image";
   if (ct.startsWith("audio/")) return "audio";
-  if (ct.startsWith("text/") || ct === "application/json") return "text";
   if (
     ct.startsWith("model/") ||
     /\.(glb|gltf|obj|fbx|stl|ply|usdz)$/.test(name)
   ) {
     return "model3d";
   }
+  // Any text-based format (by extension or MIME) opens in the text editor.
+  if (isTextAsset(asset)) return "text";
   return null;
 };

--- a/web/src/styles/TableStyles.ts
+++ b/web/src/styles/TableStyles.ts
@@ -115,21 +115,30 @@ export const tableStyles = (theme: Theme) =>
     ".table-actions": {
       display: "flex",
       width: "100%",
-      gap: ".1em",
-      margin: ".4em 0 .2em 0",
+      gap: "0.25em",
+      margin: 0,
+      padding: "0.35em 0.5em",
       justifyContent: "flex-start",
-      alignItems: "flex-start",
-      height: "2em",
+      alignItems: "center",
+      minHeight: "2.5em",
+      borderBottom: `1px solid ${theme.vars.palette.grey[700]}`,
+      backgroundColor: theme.vars.palette.grey[900],
       "& .disabled": {
         color: theme.vars.palette.action.disabled
       },
+      "& .table-actions-extra": {
+        marginLeft: "auto",
+        display: "flex",
+        alignItems: "center",
+        gap: "0.35em"
+      },
       "& button": {
-        padding: ".1em",
-        width: ".8em",
-        height: ".8em",
+        padding: "4px",
+        width: "28px",
+        height: "28px",
         "& svg": {
-          width: "100%",
-          height: "100%"
+          width: "18px",
+          height: "18px"
         },
         "&.disabled": {
           opacity: 0.5

--- a/web/src/types/styles.d.ts
+++ b/web/src/types/styles.d.ts
@@ -15,10 +15,6 @@ declare module "react-syntax-highlighter/dist/esm/prism" {
     children?: React.ReactNode;
     customStyle?: React.CSSProperties;
     className?: string;
-    showLineNumbers?: boolean;
-    wrapLongLines?: boolean;
-    wrapLines?: boolean;
-    lineNumberStyle?: React.CSSProperties;
   }
   const SyntaxHighlighter: React.FC<SyntaxHighlighterProps>;
   export default SyntaxHighlighter;

--- a/web/src/types/styles.d.ts
+++ b/web/src/types/styles.d.ts
@@ -15,6 +15,10 @@ declare module "react-syntax-highlighter/dist/esm/prism" {
     children?: React.ReactNode;
     customStyle?: React.CSSProperties;
     className?: string;
+    showLineNumbers?: boolean;
+    wrapLongLines?: boolean;
+    wrapLines?: boolean;
+    lineNumberStyle?: React.CSSProperties;
   }
   const SyntaxHighlighter: React.FC<SyntaxHighlighterProps>;
   export default SyntaxHighlighter;

--- a/web/src/utils/__tests__/assetLanguage.test.ts
+++ b/web/src/utils/__tests__/assetLanguage.test.ts
@@ -1,4 +1,4 @@
-import { isTextAsset, languageFromAsset } from "../assetLanguage";
+import { isTextAsset, languageFromAsset, previewKind } from "../assetLanguage";
 
 describe("languageFromAsset", () => {
   it("resolves a language from common extensions", () => {
@@ -42,6 +42,20 @@ describe("isTextAsset", () => {
   it("is false for binary formats", () => {
     expect(isTextAsset({ name: "photo.png", content_type: "image/png" })).toBe(
       false
+    );
+  });
+});
+
+describe("previewKind", () => {
+  it("classifies markdown, csv, code and plain text", () => {
+    expect(previewKind({ name: "README.md" })).toBe("markdown");
+    expect(previewKind({ name: "data.csv" })).toBe("csv");
+    expect(previewKind({ name: "rows.tsv" })).toBe("csv");
+    expect(previewKind({ name: "main.py" })).toBe("code");
+    expect(previewKind({ name: "config.yaml" })).toBe("code");
+    expect(previewKind({ name: "notes.txt" })).toBe("text");
+    expect(previewKind({ name: "log", content_type: "text/plain" })).toBe(
+      "text"
     );
   });
 });

--- a/web/src/utils/__tests__/assetLanguage.test.ts
+++ b/web/src/utils/__tests__/assetLanguage.test.ts
@@ -1,0 +1,47 @@
+import { isTextAsset, languageFromAsset } from "../assetLanguage";
+
+describe("languageFromAsset", () => {
+  it("resolves a language from common extensions", () => {
+    expect(languageFromAsset({ name: "main.ts" })).toBe("typescript");
+    expect(languageFromAsset({ name: "app.py" })).toBe("python");
+    expect(languageFromAsset({ name: "config.yaml" })).toBe("yaml");
+    expect(languageFromAsset({ name: "query.sql" })).toBe("sql");
+    expect(languageFromAsset({ name: "README.md" })).toBe("markdown");
+    expect(languageFromAsset({ name: "style.scss" })).toBe("scss");
+  });
+
+  it("recognises extension-less type files", () => {
+    expect(languageFromAsset({ name: "Dockerfile" })).toBe("dockerfile");
+  });
+
+  it("falls back to MIME type when the extension is unknown", () => {
+    expect(
+      languageFromAsset({ name: "notes", content_type: "text/plain" })
+    ).toBe("plaintext");
+    expect(
+      languageFromAsset({ name: "data", content_type: "application/json" })
+    ).toBe("json");
+  });
+
+  it("returns undefined for binary assets", () => {
+    expect(
+      languageFromAsset({ name: "photo.png", content_type: "image/png" })
+    ).toBeUndefined();
+    expect(
+      languageFromAsset({ name: "clip.mp3", content_type: "audio/mpeg" })
+    ).toBeUndefined();
+  });
+});
+
+describe("isTextAsset", () => {
+  it("is true for text formats", () => {
+    expect(isTextAsset({ name: "main.ts" })).toBe(true);
+    expect(isTextAsset({ name: "x", content_type: "text/csv" })).toBe(true);
+  });
+
+  it("is false for binary formats", () => {
+    expect(isTextAsset({ name: "photo.png", content_type: "image/png" })).toBe(
+      false
+    );
+  });
+});

--- a/web/src/utils/__tests__/csvDataframe.test.ts
+++ b/web/src/utils/__tests__/csvDataframe.test.ts
@@ -1,0 +1,38 @@
+import {
+  csvDelimiterFor,
+  dataframeToCsv,
+  parseCsvToDataframe
+} from "../csvDataframe";
+
+describe("csvDelimiterFor", () => {
+  it("uses tabs for .tsv and commas otherwise", () => {
+    expect(csvDelimiterFor("rows.tsv")).toBe("\t");
+    expect(csvDelimiterFor("data.csv")).toBe(",");
+    expect(csvDelimiterFor("DATA.CSV")).toBe(",");
+  });
+});
+
+describe("parseCsvToDataframe", () => {
+  it("uses the first row as column names", () => {
+    const df = parseCsvToDataframe("a,b\n1,2\n3,4", ",");
+    expect(df.type).toBe("dataframe");
+    expect(df.columns?.map((c) => c.name)).toEqual(["a", "b"]);
+    expect(df.data).toEqual([
+      ["1", "2"],
+      ["3", "4"]
+    ]);
+  });
+});
+
+describe("CSV round-trip", () => {
+  it("preserves header and rows", () => {
+    const csv = "name,age\r\nAda,36\r\nLin,28";
+    const df = parseCsvToDataframe(csv, ",");
+    const out = dataframeToCsv(df, ",");
+    expect(parseCsvToDataframe(out, ",").data).toEqual([
+      ["Ada", "36"],
+      ["Lin", "28"]
+    ]);
+    expect(out.split(/\r\n|\n/)[0]).toBe("name,age");
+  });
+});

--- a/web/src/utils/assetLanguage.ts
+++ b/web/src/utils/assetLanguage.ts
@@ -102,3 +102,25 @@ export const languageFromAsset = (asset: TextAssetLike): string | undefined => {
 /** Whether an asset holds editable text content. */
 export const isTextAsset = (asset: TextAssetLike): boolean =>
   languageFromAsset(asset) !== undefined;
+
+/** How a text asset should be rendered/edited, beyond raw language. */
+export type PreviewKind = "markdown" | "csv" | "code" | "text";
+
+const isCsvName = (name: string): boolean =>
+  name.endsWith(".csv") || name.endsWith(".tsv");
+
+/**
+ * Classify a text asset for the editor/preview surfaces:
+ * - `markdown` → rendered markdown,
+ * - `csv`      → tabular (data-table editor / MUI table view),
+ * - `code`     → syntax-highlighted (Monaco),
+ * - `text`     → plain text.
+ */
+export const previewKind = (asset: TextAssetLike): PreviewKind => {
+  const language = languageFromAsset(asset);
+  const name = (asset.name ?? "").toLowerCase();
+  if (language === "markdown") return "markdown";
+  if (isCsvName(name)) return "csv";
+  if (language && language !== "plaintext") return "code";
+  return "text";
+};

--- a/web/src/utils/assetLanguage.ts
+++ b/web/src/utils/assetLanguage.ts
@@ -1,0 +1,104 @@
+// assetLanguage.ts
+// -----------------------------------------------------------------
+// Maps an asset's filename / MIME type to a Monaco language id and
+// decides whether the asset holds editable text. Shared by the
+// workspace text editor (TextDocumentEditor), the legacy file-tab
+// editor (FileTabContent) and the tab-type resolver (assetTabType).
+// -----------------------------------------------------------------
+
+/** The minimal asset shape needed to detect a text language. */
+export interface TextAssetLike {
+  name?: string | null;
+  content_type?: string | null;
+}
+
+/** Filename extension → Monaco language id. */
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  py: "python",
+  json: "json",
+  jsonc: "json",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+  md: "markdown",
+  markdown: "markdown",
+  sh: "shell",
+  bash: "shell",
+  zsh: "shell",
+  sql: "sql",
+  toml: "ini",
+  ini: "ini",
+  cfg: "ini",
+  conf: "ini",
+  env: "ini",
+  rs: "rust",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  rb: "ruby",
+  php: "php",
+  swift: "swift",
+  graphql: "graphql",
+  gql: "graphql",
+  txt: "plaintext",
+  log: "plaintext",
+  csv: "plaintext",
+  tsv: "plaintext"
+};
+
+const fileExtension = (name: string): string =>
+  name.includes(".") ? (name.split(".").pop() ?? "") : "";
+
+/**
+ * Resolve the Monaco language id for an asset from its filename, falling back
+ * to its MIME type. Returns `undefined` when the asset is not a known text
+ * format (so callers can treat it as binary).
+ */
+export const languageFromAsset = (asset: TextAssetLike): string | undefined => {
+  const name = (asset.name ?? "").toLowerCase();
+  // Extension-less names whose basename *is* the type (Dockerfile, .gitignore).
+  if (name === "dockerfile" || name.endsWith("/dockerfile")) {
+    return "dockerfile";
+  }
+  const ext = fileExtension(name);
+  if (ext && EXTENSION_LANGUAGE[ext]) {
+    return EXTENSION_LANGUAGE[ext];
+  }
+
+  const type = asset.content_type ?? "";
+  if (type === "application/json") {
+    return "json";
+  }
+  if (type === "application/xml") {
+    return "xml";
+  }
+  if (type === "application/javascript" || type === "application/typescript") {
+    return "javascript";
+  }
+  if (type.startsWith("text/")) {
+    return "plaintext";
+  }
+  return undefined;
+};
+
+/** Whether an asset holds editable text content. */
+export const isTextAsset = (asset: TextAssetLike): boolean =>
+  languageFromAsset(asset) !== undefined;

--- a/web/src/utils/csvDataframe.ts
+++ b/web/src/utils/csvDataframe.ts
@@ -26,10 +26,11 @@ export const parseCsvToDataframe = (
   });
   const rows = parsed.data ?? [];
   const [header = [], ...body] = rows;
+  const columns = header.length > 0 ? header : ["Column 1"];
   return {
     type: "dataframe",
     uri: "",
-    columns: header.map((name) => ({
+    columns: columns.map((name) => ({
       name: String(name),
       data_type: "string"
     })),

--- a/web/src/utils/csvDataframe.ts
+++ b/web/src/utils/csvDataframe.ts
@@ -1,0 +1,45 @@
+// csvDataframe.ts
+// -----------------------------------------------------------------
+// Convert CSV/TSV text to/from a DataframeRef so the tabular editor
+// (DataTable) and the MUI table view can render a text asset, while
+// the canonical persisted form stays plain delimited text.
+// -----------------------------------------------------------------
+
+import Papa from "papaparse";
+import type { DataframeRef } from "../stores/ApiTypes";
+
+/** Tab-separated for `.tsv`, comma-separated otherwise. */
+export const csvDelimiterFor = (name: string): string =>
+  name.toLowerCase().endsWith(".tsv") ? "\t" : ",";
+
+/**
+ * Parse delimited text into a DataframeRef. The first row becomes the column
+ * names; all values are typed as strings (CSV has no schema).
+ */
+export const parseCsvToDataframe = (
+  text: string,
+  delimiter: string
+): DataframeRef => {
+  const parsed = Papa.parse<string[]>(text.trim(), {
+    delimiter,
+    skipEmptyLines: true
+  });
+  const rows = parsed.data ?? [];
+  const [header = [], ...body] = rows;
+  return {
+    type: "dataframe",
+    uri: "",
+    columns: header.map((name) => ({
+      name: String(name),
+      data_type: "string"
+    })),
+    data: body
+  };
+};
+
+/** Serialize a DataframeRef back to delimited text (header + rows). */
+export const dataframeToCsv = (df: DataframeRef, delimiter: string): string => {
+  const fields = (df.columns ?? []).map((c) => c.name);
+  const data = (df.data ?? []) as unknown[][];
+  return Papa.unparse({ fields, data }, { delimiter });
+};


### PR DESCRIPTION
## Summary

Replaces the Lexical-based rich-text editor in the workspace text tab with a Monaco-backed editor for better code/text editing, and adds content-type-aware preview rendering. The text asset surface now supports:
- **Edit mode**: Monaco editor with language inference from filename, word-wrap toggle, and save-to-asset persistence via Cmd/Ctrl+S
- **View mode**: Content-aware preview (markdown rendered, CSV/TSV as MUI table, code syntax-highlighted, plain text)
- **CSV/TSV editing**: Tabular DataTable editor that round-trips through delimited text

## Key Changes

- **New components**:
  - `TextDocumentEditor`: Monaco-backed editor with dirty tracking, save button, and language detection
  - `TextPreview`: Read-only preview with markdown rendering, CSV table view, and syntax highlighting
  - `MonacoPane`: Reusable Monaco wrapper handling lazy loading, theme, keybindings, and options

- **New utilities**:
  - `assetLanguage.ts`: Shared language/MIME-type detection (extension → Monaco language id) used by workspace editor, file-tab editor, and tab-type resolver
  - `csvDataframe.ts`: CSV/TSV ↔ DataframeRef conversion for tabular editing while keeping text canonical

- **Refactored**:
  - `TextSurface.tsx`: Simplified to route between `TextDocumentEditor` (edit) and `TextPreview` (view); removed Lexical setup
  - `FileTabContent.tsx`: Migrated to use shared `isTextAsset()` from `assetLanguage.ts`
  - `assetTabType.ts`: Uses shared `isTextAsset()` for tab-type detection

- **Tests**: Added comprehensive unit tests for language detection, CSV parsing, and preview classification

## Implementation Details

- **Query caching**: Both editor and preview use the same `["textAsset", id]` query key, so toggling view ↔ edit reuses cached text
- **Dirty tracking**: Editor compares current content against saved baseline; CSV edits update the text representation in real-time
- **Save keybinding**: Cmd/Ctrl+S registered in Monaco via `addCommand()` on mount, calls handler through ref to avoid stale closures
- **CSV round-trip**: Text stays canonical for persistence; DataTable edits are serialized back to delimited text via PapaParse
- **Language inference**: Filename extension takes precedence, falls back to MIME type; special cases for Dockerfile and extension-less files

https://claude.ai/code/session_01BAtU7rpRz5u7z8HHBpPjpH