### PR TITLE
feat(web/timeline): frame-by-frame video export, 1:1 with live preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16487,6 +16487,21 @@
         "@types/ssh2": "*"
       }
     },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+      "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
@@ -31966,6 +31981,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/mediabunny": {
+      "version": "1.45.4",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.45.4.tgz",
+      "integrity": "sha512-NtJl4va2wUhkNDAsS9ZVkK8cP54DK3jvqgQOf4h3DV5j8GS0rOXHCQTbjZehOkhrfUPLA5qls/zEtMAuGiVCyw==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
     "node_modules/memfs": {
       "version": "4.57.2",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
@@ -43252,6 +43285,7 @@
         "fuse.js": "^7.4.0",
         "jszip": "^3.10.1",
         "lexical": "^0.32.1",
+        "mediabunny": "^1.45.4",
         "monaco-editor": "^0.55.1",
         "papaparse": "^5.5.3",
         "plotly.js": "^3.5.1",

--- a/web/package.json
+++ b/web/package.json
@@ -46,6 +46,7 @@
     "fuse.js": "^7.4.0",
     "jszip": "^3.10.1",
     "lexical": "^0.32.1",
+    "mediabunny": "^1.45.4",
     "monaco-editor": "^0.55.1",
     "papaparse": "^5.5.3",
     "plotly.js": "^3.5.1",

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -9,11 +9,13 @@ import { ToolbarIconButton, FlexColumn, Box } from "../ui_primitives";
 import { useResizePanel } from "../../hooks/handlers/useResizePanel";
 import { useAuditCuratedCategories } from "../../hooks/useAuditCuratedCategories";
 import isEqual from "fast-deep-equal";
-import { memo, useCallback, useEffect } from "react";
+import { memo, useCallback, useEffect, useMemo } from "react";
 import AssetGrid from "../assets/AssetGrid";
 import WorkflowList from "../workflows/WorkflowList";
 import WorkflowForm from "../workflows/WorkflowForm";
 import CreateWorkflowButton from "../workflows/CreateWorkflowButton";
+import TimelineListPanel, { CreateTimelineButton } from "../timeline/TimelineListPanel";
+import SketchListPanel, { CreateSketchButton } from "../sketch/SketchListPanel";
 import PanelChat from "../chat/containers/PanelChat";
 import HistoryTilesPanel from "../node_menu/HistoryTilesPanel";
 import FavoritesTiles from "../node_menu/FavoritesTiles";
@@ -28,6 +30,7 @@ import {
   usePanelStore
 } from "../../stores/PanelStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import {
   LEFT_PANEL_TOP_LEVEL,
   getTopLevelCategory
@@ -53,6 +56,16 @@ const HEADER_HEIGHT_MOBILE = 40;
 const CHAT_ROUTE_HIDDEN_VIEWS: readonly LeftPanelView[] = LEFT_PANEL_TOP_LEVEL.filter(
   (cat) => cat.id !== "assets"
 ).map((cat) => cat.id);
+
+const WORKFLOW_EDIT_ONLY_VIEWS: readonly LeftPanelView[] = [
+  "nodes",
+  "settings",
+  "history",
+  "favorites"
+];
+
+const isWorkflowEditOnlyView = (view: string): view is LeftPanelView =>
+  (WORKFLOW_EDIT_ONLY_VIEWS as readonly string[]).includes(view);
 
 const styles = (
   theme: Theme,
@@ -352,6 +365,42 @@ const PanelContent = memo(function PanelContent({
           </ScrollArea>
         </FlexColumn>
       )}
+      {activeView === "sketches" && (
+        <FlexColumn
+          className="sketch-list-container"
+          fullWidth
+          fullHeight
+          sx={{
+            overflow: "hidden"
+          }}
+        >
+          {!isMobile && (
+            <PanelHeadline
+              title="Sketches"
+              actions={<CreateSketchButton />}
+            />
+          )}
+          <SketchListPanel />
+        </FlexColumn>
+      )}
+      {activeView === "timelines" && (
+        <FlexColumn
+          className="timeline-list-container"
+          fullWidth
+          fullHeight
+          sx={{
+            overflow: "hidden"
+          }}
+        >
+          {!isMobile && (
+            <PanelHeadline
+              title="Timelines"
+              actions={<CreateTimelineButton />}
+            />
+          )}
+          <TimelineListPanel />
+        </FlexColumn>
+      )}
       {activeView === "settings" && currentWorkflow && (
         <Box
           className="workflow-settings-container"
@@ -493,7 +542,7 @@ const MobilePanelLeft: React.FC<{
         className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
         css={mobileLauncherStyles(theme, hasHeader)}
         onClick={isVisible ? onClose : onOpen}
-        ariaLabel={isVisible ? "Close panel" : "Open workflows panel"}
+        ariaLabel={isVisible ? "Close panel" : "Open left panel"}
         aria-expanded={isVisible}
         tabIndex={-1}
         icon={<MenuIcon />}
@@ -503,7 +552,7 @@ const MobilePanelLeft: React.FC<{
         open={isVisible}
         onClose={onClose}
         title={launcherTitle}
-        ariaLabel="Workflows and assets panel"
+        ariaLabel="Workflows, sketches, timelines, and assets panel"
         headerExtras={
           <div css={mobileHeaderExtrasStyles(theme)}>
             <Tooltip title="Workflows" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
@@ -513,6 +562,24 @@ const MobilePanelLeft: React.FC<{
                 ariaLabel="Show workflows"
                 tabIndex={-1}
                 icon={<GridViewIcon />}
+              />
+            </Tooltip>
+            <Tooltip title="Sketches" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+              <ToolbarIconButton
+                className={`tab-button ${activeView === "sketches" ? "active" : ""}`}
+                onClick={() => handleSheetViewChange("sketches")}
+                ariaLabel="Show sketches"
+                tabIndex={-1}
+                icon={<IconForType iconName="image" showTooltip={false} iconSize="small" />}
+              />
+            </Tooltip>
+            <Tooltip title="Timelines" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+              <ToolbarIconButton
+                className={`tab-button ${activeView === "timelines" ? "active" : ""}`}
+                onClick={() => handleSheetViewChange("timelines")}
+                ariaLabel="Show timelines"
+                tabIndex={-1}
+                icon={<IconForType iconName="video" showTooltip={false} iconSize="small" />}
               />
             </Tooltip>
             <Tooltip title="Assets" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
@@ -527,6 +594,8 @@ const MobilePanelLeft: React.FC<{
 
             <Box sx={{ flex: 1 }} />
             {activeView === "workflows" && <CreateWorkflowButton />}
+            {activeView === "sketches" && <CreateSketchButton />}
+            {activeView === "timelines" && <CreateTimelineButton />}
           </div>
         }
       >
@@ -558,6 +627,10 @@ const PanelLeft: React.FC = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const location = useLocation();
+  const activeWorkspaceTab = useWorkspaceTabsStore((state) => {
+    const activeTabId = state.activeTabId;
+    return state.tabs.find((tab) => tab.id === activeTabId) ?? null;
+  });
 
   const isStandaloneMode =
     location.pathname.startsWith("/standalone-chat") ||
@@ -569,6 +642,11 @@ const PanelLeft: React.FC = () => {
   // conversation sidebar, so the rail's "Agent" entry is redundant. The chat
   // route also drops the AppHeader, so the rail runs full-height there.
   const isChatRoute = location.pathname.startsWith("/chat");
+  const isWorkflowEditActive =
+    location.pathname.startsWith("/editor/") ||
+    (location.pathname.startsWith("/workspace") &&
+      activeWorkspaceTab?.type === "workflow" &&
+      activeWorkspaceTab.mode === "edit");
   const hasHeader = !isStandaloneMode && !isChatRoute;
 
   const {
@@ -591,21 +669,37 @@ const PanelLeft: React.FC = () => {
     (state) => state.setActiveNodeCategory
   );
   const setVisibility = usePanelStore((state) => state.setVisibility);
+  const setActiveView = usePanelStore((state) => state.setActiveView);
+
+  const displayActiveView: LeftPanelView =
+    isWorkflowEditOnlyView(activeView) && !isWorkflowEditActive
+      ? "workflows"
+      : (activeView as LeftPanelView);
+
+  const hiddenViews = useMemo<readonly LeftPanelView[] | undefined>(() => {
+    if (isChatRoute) {
+      return CHAT_ROUTE_HIDDEN_VIEWS;
+    }
+    return isWorkflowEditActive ? undefined : WORKFLOW_EDIT_ONLY_VIEWS;
+  }, [isChatRoute, isWorkflowEditActive]);
 
   const onViewChange = useCallback(
     (view: LeftPanelView) => {
+      if (isWorkflowEditOnlyView(view) && !isWorkflowEditActive) {
+        return;
+      }
       handlePanelToggle(view);
     },
-    [handlePanelToggle]
+    [handlePanelToggle, isWorkflowEditActive]
   );
 
   const handlePanelToggleClick = useCallback(() => {
-    handlePanelToggle(activeView);
-  }, [handlePanelToggle, activeView]);
+    handlePanelToggle(displayActiveView);
+  }, [handlePanelToggle, displayActiveView]);
 
   const handleMobileOpen = useCallback(() => {
-    handlePanelToggle(activeView);
-  }, [handlePanelToggle, activeView]);
+    handlePanelToggle(displayActiveView);
+  }, [handlePanelToggle, displayActiveView]);
 
   const handleMobileClose = useCallback(() => {
     setVisibility(false);
@@ -620,6 +714,12 @@ const PanelLeft: React.FC = () => {
     }
   }, [isChatRoute, setVisibility]);
 
+  useEffect(() => {
+    if (!isWorkflowEditActive && isWorkflowEditOnlyView(activeView)) {
+      setActiveView("workflows");
+    }
+  }, [activeView, isWorkflowEditActive, setActiveView]);
+
   if (isMobile && isChatRoute) {
     return null;
   }
@@ -627,7 +727,7 @@ const PanelLeft: React.FC = () => {
   if (isMobile) {
     return (
       <MobilePanelLeft
-        activeView={activeView as LeftPanelView}
+        activeView={displayActiveView}
         activeNodeCategory={activeNodeCategory}
         setActiveNodeCategory={setActiveNodeCategory}
         isVisible={isVisible}
@@ -644,17 +744,17 @@ const PanelLeft: React.FC = () => {
     <div
       css={styles(theme, hasHeader, false)}
       className={`panel-left-container ${
-        activeView === "nodes" ? "is-nodes" : ""
+        displayActiveView === "nodes" ? "is-nodes" : ""
       }`}
     >
       <ContextMenuProvider>
         <ContextMenus />
         <VerticalToolbar
-          activeView={activeView}
+          activeView={displayActiveView}
           onViewChange={onViewChange}
           handlePanelToggle={handlePanelToggleClick}
           showAppMenu={isWorkspace || isChatRoute}
-          hiddenViews={isChatRoute ? CHAT_ROUTE_HIDDEN_VIEWS : undefined}
+          hiddenViews={hiddenViews}
         />
 
         {isVisible && (
@@ -670,7 +770,10 @@ const PanelLeft: React.FC = () => {
             onKeyDown={(e) => {
               if (
                 e.key === "Escape" &&
-                (activeView === "nodes" || activeView === "workflows")
+                (displayActiveView === "nodes" ||
+                  displayActiveView === "workflows" ||
+                  displayActiveView === "sketches" ||
+                  displayActiveView === "timelines")
               ) {
                 e.stopPropagation();
                 setVisibility(false);
@@ -689,7 +792,7 @@ const PanelLeft: React.FC = () => {
             />
             <div className="panel-inner-content">
               <PanelContent
-                activeView={activeView}
+                activeView={displayActiveView}
                 activeNodeCategory={activeNodeCategory}
                 setActiveNodeCategory={setActiveNodeCategory}
                 handlePanelToggle={handlePanelToggle}

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -1,0 +1,281 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import BrushOutlinedIcon from "@mui/icons-material/BrushOutlined";
+import { memo, useCallback, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { usePanelStore } from "../../stores/PanelStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { trpc } from "../../trpc/client";
+import CategorySearchBar from "../node_menu/CategorySearchBar";
+import {
+  Caption,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ToolbarIconButton,
+  TruncatedText,
+  Tooltip
+} from "../ui_primitives";
+
+const styles = (theme: Theme) =>
+  css({
+    height: "100%",
+    minHeight: 0,
+    ".sketch-search": {
+      paddingBottom: theme.spacing(1)
+    },
+    ".sketch-list": {
+      minHeight: 0,
+      overflowY: "auto",
+      paddingRight: theme.spacing(0.5)
+    },
+    ".sketch-item": {
+      width: "100%",
+      border: 0,
+      borderRadius: theme.rounded.md,
+      backgroundColor: "transparent",
+      color: theme.vars.palette.text.primary,
+      cursor: "pointer",
+      padding: theme.spacing(1),
+      textAlign: "left",
+      transition: "background-color 120ms ease, color 120ms ease",
+      "&:hover": {
+        backgroundColor: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
+      },
+      "&.active": {
+        backgroundColor: theme.vars.palette.action.selected
+      }
+    },
+    ".sketch-icon": {
+      flexShrink: 0,
+      color: theme.vars.palette.text.secondary,
+      fontSize: 20
+    },
+    ".sketch-meta": {
+      color: theme.vars.palette.text.secondary
+    }
+  });
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit"
+});
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Updated recently";
+  }
+  return `Updated ${dateFormatter.format(date)}`;
+}
+
+interface SketchListItemProps {
+  id: string;
+  name: string;
+  updatedAt: string;
+  active: boolean;
+  onOpen: (id: string, name: string) => void;
+}
+
+const SketchListItem = memo(function SketchListItem({
+  id,
+  name,
+  updatedAt,
+  active,
+  onOpen
+}: SketchListItemProps) {
+  const handleClick = useCallback(() => onOpen(id, name), [id, name, onOpen]);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onOpen(id, name);
+      }
+    },
+    [id, name, onOpen]
+  );
+
+  return (
+    <button
+      type="button"
+      className={`sketch-item ${active ? "active" : ""}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-current={active ? "page" : undefined}
+    >
+      <FlexRow align="center" gap={1} fullWidth>
+        <BrushOutlinedIcon className="sketch-icon" />
+        <FlexColumn gap={0.25} sx={{ minWidth: 0, flex: 1 }}>
+          <TruncatedText
+            component="span"
+            sx={{ fontSize: "var(--fontSizeSmall)", fontWeight: 600 }}
+          >
+            {name || "Untitled sketch"}
+          </TruncatedText>
+          <Caption className="sketch-meta">
+            {formatUpdatedAt(updatedAt)}
+          </Caption>
+        </FlexColumn>
+      </FlexRow>
+    </button>
+  );
+});
+
+export const CreateSketchButton = memo(function CreateSketchButton() {
+  const utils = trpc.useUtils();
+  const createSketch = trpc.sketch.create.useMutation({
+    onSuccess: () => {
+      void utils.sketch.list.invalidate();
+    }
+  });
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const setVisibility = usePanelStore((state) => state.setVisibility);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleCreate = useCallback(async () => {
+    try {
+      const sketch = await createSketch.mutateAsync({
+        name: "Untitled sketch",
+        projectId: "default"
+      });
+      if (location.pathname.startsWith("/workspace")) {
+        openTab({
+          type: "sketch",
+          ref: sketch.id,
+          mode: "edit",
+          title: sketch.name || "Untitled sketch"
+        });
+      } else {
+        navigate(`/sketch/${sketch.id}`);
+      }
+      setVisibility(false);
+    } catch (error) {
+      console.error("Failed to create sketch", error);
+    }
+  }, [createSketch, location.pathname, navigate, openTab, setVisibility]);
+
+  return (
+    <Tooltip title="New sketch" placement="right-start">
+      <ToolbarIconButton
+        ariaLabel="New sketch"
+        onClick={() => void handleCreate()}
+        disabled={createSketch.isPending}
+        tabIndex={-1}
+        icon={<AddIcon />}
+      />
+    </Tooltip>
+  );
+});
+
+const SketchListPanel = () => {
+  const theme = useTheme();
+  const [filterValue, setFilterValue] = useState("");
+  const { data, isLoading, isError, error } = trpc.sketch.list.useQuery(
+    {},
+    { staleTime: 30_000 }
+  );
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
+  const setVisibility = usePanelStore((state) => state.setVisibility);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const activeSketchId = activeTabId?.startsWith("sketch:")
+    ? activeTabId.slice("sketch:".length)
+    : location.pathname.startsWith("/sketch/")
+      ? location.pathname.split("/")[2]
+      : null;
+
+  const sketches = useMemo(() => {
+    const all = data ?? [];
+    const needle = filterValue.trim().toLowerCase();
+    const filtered = needle
+      ? all.filter((sketch) => sketch.name.toLowerCase().includes(needle))
+      : all;
+    return [...filtered].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+  }, [data, filterValue]);
+
+  const handleOpen = useCallback(
+    (id: string, name: string) => {
+      if (location.pathname.startsWith("/workspace")) {
+        openTab({
+          type: "sketch",
+          ref: id,
+          mode: "edit",
+          title: name || "Untitled sketch"
+        });
+      } else {
+        navigate(`/sketch/${id}`);
+      }
+      setVisibility(false);
+    },
+    [location.pathname, navigate, openTab, setVisibility]
+  );
+
+  return (
+    <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
+      <div className="sketch-search">
+        <CategorySearchBar
+          value={filterValue}
+          onChange={setFilterValue}
+          placeholder="Search sketches..."
+        />
+      </div>
+
+      {isLoading ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1 }}>
+          <LoadingSpinner size="large" text="Loading sketches" />
+        </FlexColumn>
+      ) : isError ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1, px: 2 }}>
+          <EmptyState
+            variant="error"
+            title="Could not load sketches"
+            description={error?.message ?? "Try again later."}
+          />
+        </FlexColumn>
+      ) : sketches.length === 0 ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1, px: 2 }}>
+          <EmptyState
+            title={filterValue ? "No matching sketches" : "No sketches yet"}
+            description={
+              filterValue
+                ? "Try a different search term."
+                : "Create a new sketch with the + button above."
+            }
+          />
+        </FlexColumn>
+      ) : (
+        <FlexColumn className="sketch-list" gap={0.5}>
+          {sketches.map((sketch) => (
+            <SketchListItem
+              key={sketch.id}
+              id={sketch.id}
+              name={sketch.name}
+              updatedAt={sketch.updatedAt}
+              active={sketch.id === activeSketchId}
+              onOpen={handleOpen}
+            />
+          ))}
+        </FlexColumn>
+      )}
+    </FlexColumn>
+  );
+};
+
+export default memo(SketchListPanel);

--- a/web/src/components/sketch/SketchModal.tsx
+++ b/web/src/components/sketch/SketchModal.tsx
@@ -387,7 +387,7 @@ const SketchModal: React.FC<SketchModalProps> = ({
             </Tooltip>
           )}
 
-          <Tooltip title={`Export Image (${displayCombo("export-png")})`} enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
+          <Tooltip title="Export Image" enterDelay={SKETCH_TOOLTIP_DELAY_MS} enterNextDelay={SKETCH_TOOLTIP_DELAY_MS}>
             <IconButton size="small" aria-label="Export Image" onClick={() => editorRef.current?.exportPng()}>
               <SaveAltIcon sx={{ fontSize: "var(--fontSizeBig)" }} />
             </IconButton>

--- a/web/src/components/sketch/StandaloneSketchEditor.tsx
+++ b/web/src/components/sketch/StandaloneSketchEditor.tsx
@@ -21,16 +21,19 @@
  *      resets the seed.
  */
 
-import React, { memo, useEffect, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { css } from "@emotion/react";
+import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
+import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { EmptyState, FlexColumn, LoadingSpinner } from "../ui_primitives";
-import SketchEditor from "./SketchEditor";
+import { EmptyState, EditorButton, FlexColumn, FlexRow, LoadingSpinner } from "../ui_primitives";
+import SketchEditor, { type SketchEditorHandle } from "./SketchEditor";
 import { trpc } from "../../trpc/client";
 import type { SketchDocument } from "./types";
 import { useStandaloneSketchDocument } from "../../stores/sketch/SketchSessionStore";
+import { useSaveSketchDocument } from "../../hooks/sketch/useSaveSketchDocument";
 
 const containerStyles = (theme: Theme) =>
   css({
@@ -52,6 +55,8 @@ const StandaloneSketchEditor: React.FC<StandaloneSketchEditorProps> = memo(
   function StandaloneSketchEditor({ documentId, headerActions }) {
     const theme = useTheme();
     const styles = useMemo(() => containerStyles(theme), [theme]);
+    const editorRef = useRef<SketchEditorHandle | null>(null);
+    const { save, saving } = useSaveSketchDocument();
 
     const documentQuery = trpc.sketch.get.useQuery(
       { id: documentId },
@@ -84,6 +89,54 @@ const StandaloneSketchEditor: React.FC<StandaloneSketchEditorProps> = memo(
       setSeed({ id: documentId, document: initialEditorState.document });
     }, [documentId, initialEditorState, seed?.id]);
 
+    const handleSave = useCallback(() => {
+      void save();
+    }, [save]);
+
+    useEffect(() => {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+          return;
+        }
+        if (event.key.toLowerCase() !== "s") {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        void save();
+      };
+      window.addEventListener("keydown", handleKeyDown, true);
+      return () => window.removeEventListener("keydown", handleKeyDown, true);
+    }, [save]);
+
+    const handleExportPng = () => {
+      editorRef.current?.exportPng();
+    };
+
+    const documentActions = (
+      <FlexRow gap={0.5} align="center" sx={{ flexShrink: 0 }}>
+        <EditorButton
+          size="small"
+          variant="outlined"
+          onClick={handleSave}
+          disabled={saving}
+          startIcon={<SaveOutlinedIcon fontSize="small" />}
+          data-testid="sketch-save-document"
+        >
+          {saving ? "Saving…" : "Save"}
+        </EditorButton>
+        <EditorButton
+          size="small"
+          variant="outlined"
+          onClick={handleExportPng}
+          startIcon={<FileDownloadOutlinedIcon fontSize="small" />}
+          data-testid="sketch-export-png"
+        >
+          Export PNG
+        </EditorButton>
+      </FlexRow>
+    );
+
     // Show the spinner until we've captured a seed for this documentId.
     // Using `seed` (not the live query state) keeps the canvas mounted across
     // any future background query state changes.
@@ -109,10 +162,20 @@ const StandaloneSketchEditor: React.FC<StandaloneSketchEditorProps> = memo(
     return (
       <div className="sketch-editor-page" css={styles}>
         <SketchEditor
+          ref={editorRef}
           documentId={documentId}
           initialDocument={seed.document}
           initialEditorState={initialEditorState ?? undefined}
-          headerActions={headerActions}
+          headerActions={
+            headerActions ? (
+              <>
+                {documentActions}
+                {headerActions}
+              </>
+            ) : (
+              documentActions
+            )
+          }
         />
       </div>
     );

--- a/web/src/components/sketch/shortcuts/bindingCatalog.ts
+++ b/web/src/components/sketch/shortcuts/bindingCatalog.ts
@@ -45,7 +45,6 @@ export const BINDING_CATALOG: readonly BindingEntry[] = [
   { key: "i", modifiers: { ctrl: true, shift: true }, actionId: "invert-selection", scope: "global" },
 
   // ── Global: Canvas ────────────────────────────────────────────────────────
-  { key: "s", modifiers: { ctrl: true }, actionId: "export-png", scope: "global" },
   { key: "0", modifiers: { ctrl: true }, actionId: "zoom-reset", scope: "global" },
   { key: "1", modifiers: { ctrl: true }, actionId: "zoom-100", scope: "global" },
   { key: "+", modifiers: {}, actionId: "zoom-in", scope: "global" },

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -56,6 +56,14 @@ const sectionStyles = (theme: Theme) =>
     padding: theme.spacing(1)
   });
 
+const panelSx = {
+  width: "100%",
+  height: "100%",
+  maxHeight: "100%",
+  minHeight: 0,
+  overflow: "auto"
+};
+
 const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   clipId
 }) => {
@@ -179,7 +187,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   const generateLabel = clip.currentAssetId ? "Regenerate" : "Generate";
 
   return (
-    <Panel sx={{ width: "100%", overflow: "auto" }}>
+    <Panel sx={panelSx}>
       <FlexColumn gap={0}>
         <GeneratedClipHeader clip={clip} />
 

--- a/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
@@ -40,6 +40,14 @@ export interface GeneratedClipPanelProps {
   clipId: string;
 }
 
+const panelSx = {
+  width: "100%",
+  height: "100%",
+  maxHeight: "100%",
+  minHeight: 0,
+  overflow: "auto"
+};
+
 const inputsContainerStyles = (theme: Theme) =>
   css({
     ".inputs-card, .application-card": {
@@ -125,7 +133,7 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
     const paramOverrides = clip.paramOverrides ?? {};
 
     return (
-      <Panel sx={{ width: "100%", overflow: "auto" }}>
+      <Panel sx={panelSx}>
         <FlexColumn gap={0}>
           <GeneratedClipHeader clip={clip} />
 

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -73,6 +73,14 @@ const sectionContentStyles = css({
   padding: "4px 0 10px"
 });
 
+const inspectorPanelSx = {
+  height: "100%",
+  maxHeight: "100%",
+  minHeight: 0,
+  overflow: "auto",
+  boxSizing: "border-box"
+};
+
 // ── Effect IDs ─────────────────────────────────────────────────────────────
 
 /** Stable IDs so the inspector-owned effects round-trip in `clip.effects`. */
@@ -210,7 +218,7 @@ export const TimelineInspector: React.FC = memo(() => {
 
   if (selectedCount === 0) {
     return (
-      <Panel css={containerStyles}>
+      <Panel css={containerStyles} sx={inspectorPanelSx}>
         <InspectorHeader eyebrow="Inspector" />
         <EmptyState
           variant="empty"
@@ -224,7 +232,7 @@ export const TimelineInspector: React.FC = memo(() => {
 
   if (selectedCount > 1) {
     return (
-      <Panel css={containerStyles}>
+      <Panel css={containerStyles} sx={inspectorPanelSx}>
         <InspectorHeader
           eyebrow={`${selectedCount} Clips`}
           actions={[
@@ -261,7 +269,7 @@ export const TimelineInspector: React.FC = memo(() => {
   // ── Imported-clip inspector ─────────────────────────────────────────────
 
   return (
-    <Panel css={containerStyles}>
+    <Panel css={containerStyles} sx={inspectorPanelSx}>
       <InspectorHeader
         eyebrow="Clip"
         actions={[

--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -46,3 +46,27 @@ Every `TimelineStore` mutation (clip add, move, trim, split, delete) is
 observed by the autosave hook, which PATCHes the sequence document via the
 timeline REST API (NOD-299). Changes survive a page refresh. Concurrent
 edits from another tab are out of scope (last-write-wins via `updated_at`).
+
+## Video Export (frame-by-frame, 1:1 with live)
+
+The **Export** action in the `TopBar` renders the sequence to an MP4 entirely
+in the browser. It reuses the *same* compositor and scene description as the
+live preview, so an exported frame is identical to what playback showed:
+
+- `preview/sceneModel.ts` — the single source of truth for "what is on screen
+  at time *t*" (`computeActiveLayers`). Both `PreviewCompositor` (live) and the
+  renderer drive their GPU layer lists from it.
+- `render/TimelineRenderer.ts` — steps the playhead in exact `1 / fps`
+  increments, seeks each video element to the precise source frame (waiting for
+  `seeked` so decoding is deterministic, not best-effort), composites at full
+  sequence resolution with the shared `WebGPUCompositor`, then encodes each
+  frame with WebCodecs and muxes to MP4 via [mediabunny](https://mediabunny.dev).
+- `render/renderAudio.ts` — mixes the audio tracks down through the same
+  `AudioGraph` (clip gain, fades, speed, mute/solo, DSP chain) driven by an
+  `OfflineAudioContext`.
+- `useTimelineExport` (`hooks/timeline/`) — wires the store + asset URLs to the
+  renderer, reports progress, and downloads the resulting file.
+
+The renderer composites at the sequence's true `width × height` (clamped to even
+dimensions for H.264). mediabunny and the WebGPU compositor are dynamically
+imported only when an export runs, keeping the editor importable under jsdom.

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -97,9 +97,10 @@ const previewRegionStyles = (theme: Theme) =>
 const inspectorRegionStyles = (theme: Theme) =>
   css({
     overflow: "hidden",
+    minHeight: 0,
     backgroundColor: theme.vars.palette.background.default,
-    alignItems: "center",
-    justifyContent: "center"
+    alignItems: "stretch",
+    justifyContent: "flex-start"
   });
 
 const dragHandleStyles = (theme: Theme) =>
@@ -160,7 +161,7 @@ const PreviewRegion: React.FC<{
     <FlexColumn
       css={previewRegionStyles(theme)}
       fullHeight
-      sx={{ flex: "0 1 55%", minWidth: 0, width: 0 }}
+      sx={{ flex: "0 1 55%", minWidth: 0, minHeight: 0, width: 0 }}
     >
       {isLoading ? (
         <LoadingSpinner text="Loading sequence…" />
@@ -224,7 +225,7 @@ const InspectorRegion: React.FC = () => {
     <FlexColumn
       css={inspectorRegionStyles(theme)}
       fullHeight
-      sx={{ flex: "0 1 45%", minWidth: 0, width: 0 }}
+      sx={{ flex: "0 1 45%", minWidth: 0, minHeight: 0, width: 0 }}
     >
       <TimelineInspector />
     </FlexColumn>
@@ -431,7 +432,7 @@ export const TimelineEditor: React.FC<TimelineEditorProps> = memo(({
       <FlexRow
         fullWidth
         css={middleAreaStyles(theme)}
-        sx={{ flex: "1 1 auto", overflow: "hidden" }}
+        sx={{ flex: "1 1 auto", minHeight: 0, overflow: "hidden" }}
       >
         <PreviewRegion
           isLoading={isLoading}

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -23,11 +23,14 @@ import type { Theme } from "@mui/material/styles";
 
 import {
   Caption,
+  Dialog,
   EditorButton,
   EmptyState,
   FlexColumn,
   FlexRow,
-  LoadingSpinner
+  LoadingSpinner,
+  ProgressBar,
+  Text
 } from "../ui_primitives";
 
 import { TopBar } from "./TopBar";
@@ -50,6 +53,7 @@ import { useWorkflowFreshnessCheck } from "../../hooks/timeline/useWorkflowFresh
 import { useTimelineGenerationSubscriptions } from "../../hooks/timeline/useGenerateClip";
 import { useLoadTimelineIntoStore } from "../../hooks/timeline/useLoadTimelineIntoStore";
 import { useTimelineAutosave } from "../../hooks/timeline/useTimelineAutosave";
+import { useTimelineExport } from "../../hooks/timeline/useTimelineExport";
 
 // ── Drag-handle constants ──────────────────────────────────────────────────
 
@@ -114,6 +118,23 @@ const dragHandleStyles = (theme: Theme) =>
       boxShadow: `0 0 0 2px ${theme.vars.palette.primary.main}`
     }
   });
+
+/** Human-readable label for the current export phase. */
+function exportPhaseLabel(
+  progress: { phase: string; frame: number; totalFrames: number } | null
+): string {
+  if (!progress) return "Preparing…";
+  switch (progress.phase) {
+    case "audio":
+      return "Mixing audio…";
+    case "video":
+      return `Encoding frame ${progress.frame} / ${progress.totalFrames}`;
+    case "finalizing":
+      return "Finalizing…";
+    default:
+      return "Preparing…";
+  }
+}
 
 // ── Sub-region placeholder components ─────────────────────────────────────
 
@@ -260,6 +281,19 @@ export const TimelineEditor: React.FC<TimelineEditorProps> = memo(({
   const generatingCount = useGeneratingCount();
   const failedCount = useFailedCount();
 
+  // Offline video export (frame-by-frame, 1:1 with the live preview).
+  const {
+    exportVideo,
+    cancel: cancelExport,
+    clearError: clearExportError,
+    isExporting,
+    progress: exportProgress,
+    error: exportError
+  } = useTimelineExport();
+  const handleExportVideo = useCallback(() => {
+    void exportVideo(sequence?.name);
+  }, [exportVideo, sequence?.name]);
+
   // Tracks resize ─────────────────────────────────────────────────────────
   const [tracksHeight, setTracksHeight] = useState(DEFAULT_TRACKS_HEIGHT_PX);
   const [isDragging, setIsDragging] = useState(false);
@@ -388,6 +422,8 @@ export const TimelineEditor: React.FC<TimelineEditorProps> = memo(({
           sequence?.name ??
           (sequenceUnavailable ? sequenceId : undefined)
         }
+        onExportVideo={sequenceUnavailable ? undefined : handleExportVideo}
+        isExporting={isExporting}
         activitySlot={<ActivityIndicator />}
       />
 
@@ -437,6 +473,40 @@ export const TimelineEditor: React.FC<TimelineEditorProps> = memo(({
         generatingCount={generatingCount}
         failedCount={failedCount}
       />
+
+      {/* ── Export progress / error dialog ────────────────────────── */}
+      <Dialog
+        open={isExporting || exportError != null}
+        onClose={isExporting ? undefined : clearExportError}
+        title={exportError != null ? "Export failed" : "Exporting video"}
+        actions={
+          <EditorButton
+            variant={isExporting ? "outlined" : "contained"}
+            size="small"
+            onClick={isExporting ? cancelExport : clearExportError}
+          >
+            {isExporting ? "Cancel" : "Close"}
+          </EditorButton>
+        }
+      >
+        {exportError != null ? (
+          <Text size="small" sx={{ color: "error.main" }}>
+            {exportError}
+          </Text>
+        ) : (
+          <FlexColumn gap={1} sx={{ minWidth: 360, py: 1 }}>
+            <ProgressBar
+              value={Math.round((exportProgress?.ratio ?? 0) * 100)}
+              progressVariant={
+                exportProgress && exportProgress.totalFrames > 0
+                  ? "determinate"
+                  : "indeterminate"
+              }
+              label={exportPhaseLabel(exportProgress)}
+            />
+          </FlexColumn>
+        )}
+      </Dialog>
 
     </FlexColumn>
   );

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -1,0 +1,273 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
+import { memo, useCallback, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useCreateTimeline, useTimelines } from "../../hooks/useTimelineSequence";
+import { usePanelStore } from "../../stores/PanelStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import CategorySearchBar from "../node_menu/CategorySearchBar";
+import {
+  Caption,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ToolbarIconButton,
+  TruncatedText,
+  Tooltip
+} from "../ui_primitives";
+
+const styles = (theme: Theme) =>
+  css({
+    height: "100%",
+    minHeight: 0,
+    ".timeline-search": {
+      paddingBottom: theme.spacing(1)
+    },
+    ".timeline-list": {
+      minHeight: 0,
+      overflowY: "auto",
+      paddingRight: theme.spacing(0.5)
+    },
+    ".timeline-item": {
+      width: "100%",
+      border: 0,
+      borderRadius: theme.rounded.md,
+      backgroundColor: "transparent",
+      color: theme.vars.palette.text.primary,
+      cursor: "pointer",
+      padding: theme.spacing(1),
+      textAlign: "left",
+      transition: "background-color 120ms ease, color 120ms ease",
+      "&:hover": {
+        backgroundColor: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
+      },
+      "&.active": {
+        backgroundColor: theme.vars.palette.action.selected
+      }
+    },
+    ".timeline-icon": {
+      flexShrink: 0,
+      color: theme.vars.palette.text.secondary,
+      fontSize: 20
+    },
+    ".timeline-meta": {
+      color: theme.vars.palette.text.secondary
+    }
+  });
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit"
+});
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Updated recently";
+  }
+  return `Updated ${dateFormatter.format(date)}`;
+}
+
+interface TimelineListItemProps {
+  id: string;
+  name: string;
+  updatedAt: string;
+  active: boolean;
+  onOpen: (id: string, name: string) => void;
+}
+
+const TimelineListItem = memo(function TimelineListItem({
+  id,
+  name,
+  updatedAt,
+  active,
+  onOpen
+}: TimelineListItemProps) {
+  const handleClick = useCallback(() => onOpen(id, name), [id, name, onOpen]);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onOpen(id, name);
+      }
+    },
+    [id, name, onOpen]
+  );
+
+  return (
+    <button
+      type="button"
+      className={`timeline-item ${active ? "active" : ""}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-current={active ? "page" : undefined}
+    >
+      <FlexRow align="center" gap={1} fullWidth>
+        <MovieOutlinedIcon className="timeline-icon" />
+        <FlexColumn gap={0.25} sx={{ minWidth: 0, flex: 1 }}>
+          <TruncatedText
+            component="span"
+            sx={{ fontSize: "var(--fontSizeSmall)", fontWeight: 600 }}
+          >
+            {name || "Untitled video"}
+          </TruncatedText>
+          <Caption className="timeline-meta">
+            {formatUpdatedAt(updatedAt)}
+          </Caption>
+        </FlexColumn>
+      </FlexRow>
+    </button>
+  );
+});
+
+export const CreateTimelineButton = memo(function CreateTimelineButton() {
+  const createTimeline = useCreateTimeline();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const setVisibility = usePanelStore((state) => state.setVisibility);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleCreate = useCallback(async () => {
+    try {
+      const timeline = await createTimeline.mutateAsync({
+        name: "Untitled video",
+        projectId: "default"
+      });
+      if (location.pathname.startsWith("/workspace")) {
+        openTab({
+          type: "timeline",
+          ref: timeline.id,
+          mode: "edit",
+          title: timeline.name || "Untitled video"
+        });
+      } else {
+        navigate(`/timeline/${timeline.id}`);
+      }
+      setVisibility(false);
+    } catch (error) {
+      console.error("Failed to create timeline", error);
+    }
+  }, [createTimeline, location.pathname, navigate, openTab, setVisibility]);
+
+  return (
+    <Tooltip title="New timeline" placement="right-start">
+      <ToolbarIconButton
+        ariaLabel="New timeline"
+        onClick={() => void handleCreate()}
+        disabled={createTimeline.isPending}
+        tabIndex={-1}
+        icon={<AddIcon />}
+      />
+    </Tooltip>
+  );
+});
+
+const TimelineListPanel = () => {
+  const theme = useTheme();
+  const [filterValue, setFilterValue] = useState("");
+  const { data, isLoading, isError, error } = useTimelines();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
+  const setVisibility = usePanelStore((state) => state.setVisibility);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const activeTimelineId = activeTabId?.startsWith("timeline:")
+    ? activeTabId.slice("timeline:".length)
+    : location.pathname.startsWith("/timeline/")
+      ? location.pathname.split("/")[2]
+      : null;
+
+  const timelines = useMemo(() => {
+    const all = data ?? [];
+    const needle = filterValue.trim().toLowerCase();
+    const filtered = needle
+      ? all.filter((timeline) => timeline.name.toLowerCase().includes(needle))
+      : all;
+    return [...filtered].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+  }, [data, filterValue]);
+
+  const handleOpen = useCallback(
+    (id: string, name: string) => {
+      if (location.pathname.startsWith("/workspace")) {
+        openTab({
+          type: "timeline",
+          ref: id,
+          mode: "edit",
+          title: name || "Untitled video"
+        });
+      } else {
+        navigate(`/timeline/${id}`);
+      }
+      setVisibility(false);
+    },
+    [location.pathname, navigate, openTab, setVisibility]
+  );
+
+  return (
+    <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
+      <div className="timeline-search">
+        <CategorySearchBar
+          value={filterValue}
+          onChange={setFilterValue}
+          placeholder="Search timelines..."
+        />
+      </div>
+
+      {isLoading ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1 }}>
+          <LoadingSpinner size="large" text="Loading timelines" />
+        </FlexColumn>
+      ) : isError ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1, px: 2 }}>
+          <EmptyState
+            variant="error"
+            title="Could not load timelines"
+            description={error?.message ?? "Try again later."}
+          />
+        </FlexColumn>
+      ) : timelines.length === 0 ? (
+        <FlexColumn gap={2} justify="center" align="center" sx={{ flex: 1, px: 2 }}>
+          <EmptyState
+            title={filterValue ? "No matching timelines" : "No timelines yet"}
+            description={
+              filterValue
+                ? "Try a different search term."
+                : "Create a new video timeline with the + button above."
+            }
+          />
+        </FlexColumn>
+      ) : (
+        <FlexColumn className="timeline-list" gap={0.5}>
+          {timelines.map((timeline) => (
+            <TimelineListItem
+              key={timeline.id}
+              id={timeline.id}
+              name={timeline.name}
+              updatedAt={timeline.updatedAt}
+              active={timeline.id === activeTimelineId}
+              onOpen={handleOpen}
+            />
+          ))}
+        </FlexColumn>
+      )}
+    </FlexColumn>
+  );
+};
+
+export default memo(TimelineListPanel);

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -3,8 +3,7 @@
  * TopBar — Timeline Editor top bar.
  *
  * Contains: project name, save status, Project / Library / Exports buttons,
- * Render All primary action, and an activity indicator slot (filled later by
- * NOD-311).
+ * export action, and an activity indicator slot.
  */
 
 import React, { memo } from "react";
@@ -17,7 +16,6 @@ import {
   Caption,
   EditorButton
 } from "../ui_primitives";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 
@@ -56,8 +54,6 @@ export interface TopBarProps {
   saveStatus?: string;
   /** Called when the user clicks the project name dropdown */
   onProjectNameClick?: () => void;
-  /** Called when the user clicks Render All */
-  onRenderAll?: () => void;
   /** Called when the user clicks Export (renders the timeline to a video file) */
   onExportVideo?: () => void;
   /** True while an export render is in progress. */
@@ -71,7 +67,6 @@ export const TopBar: React.FC<TopBarProps> = memo(
     sequenceName = "Untitled Sequence",
     saveStatus,
     onProjectNameClick,
-    onRenderAll,
     onExportVideo,
     isExporting = false,
     activitySlot
@@ -115,7 +110,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
         {/* Center: quick-prompt generation bar */}
         <TopBarPrompt />
 
-        {/* Right: activity slot + Render All */}
+        {/* Right: activity slot + export */}
         <FlexRow gap={1} align="center">
           {/* Activity indicator slot — filled by NOD-311 */}
           {activitySlot}
@@ -132,14 +127,6 @@ export const TopBar: React.FC<TopBarProps> = memo(
             </EditorButton>
           )}
 
-          <EditorButton
-            variant="contained"
-            onClick={onRenderAll}
-            startIcon={<PlayArrowIcon />}
-            size="small"
-          >
-            Render All
-          </EditorButton>
         </FlexRow>
       </FlexRow>
     );

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -19,6 +19,7 @@ import {
 } from "../ui_primitives";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
 
 import { TopBarPrompt } from "./TopBarPrompt";
 
@@ -57,6 +58,10 @@ export interface TopBarProps {
   onProjectNameClick?: () => void;
   /** Called when the user clicks Render All */
   onRenderAll?: () => void;
+  /** Called when the user clicks Export (renders the timeline to a video file) */
+  onExportVideo?: () => void;
+  /** True while an export render is in progress. */
+  isExporting?: boolean;
   /** Optional slot for an activity indicator (NOD-311) */
   activitySlot?: React.ReactNode;
 }
@@ -67,6 +72,8 @@ export const TopBar: React.FC<TopBarProps> = memo(
     saveStatus,
     onProjectNameClick,
     onRenderAll,
+    onExportVideo,
+    isExporting = false,
     activitySlot
   }) => {
     const theme = useTheme();
@@ -112,6 +119,18 @@ export const TopBar: React.FC<TopBarProps> = memo(
         <FlexRow gap={1} align="center">
           {/* Activity indicator slot — filled by NOD-311 */}
           {activitySlot}
+
+          {onExportVideo && (
+            <EditorButton
+              variant="outlined"
+              onClick={onExportVideo}
+              disabled={isExporting}
+              startIcon={<FileDownloadIcon />}
+              size="small"
+            >
+              {isExporting ? "Exporting…" : "Export"}
+            </EditorButton>
+          )}
 
           <EditorButton
             variant="contained"

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -202,8 +202,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         const trackType: "video" | "audio" =
           mediaType === "audio" ? "audio" : "video";
 
-        const rect = e.currentTarget.getBoundingClientRect();
-        const dropX = e.clientX - rect.left;
+        const rect = scrollableRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        const dropX = Math.max(0, e.clientX - rect.left);
         const startMs = Math.max(
           0,
           Math.round((dropX + scrollLeftPx) * msPerPx)
@@ -420,6 +421,8 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             alignItems: "flex-start"
           }}
           fullWidth
+          onDragOver={handleEmptyAreaDragOver}
+          onDrop={handleEmptyAreaDrop}
         >
           {/* Header column */}
           <div css={headerColumnStyles(theme)}>
@@ -442,8 +445,6 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             css={scrollableAreaStyles}
             onScroll={handleScroll}
             onWheel={handleWheel}
-            onDragOver={handleEmptyAreaDragOver}
-            onDrop={handleEmptyAreaDrop}
           >
             <div
               css={lanesContainerStyles}

--- a/web/src/components/timeline/preview/AudioGraph.ts
+++ b/web/src/components/timeline/preview/AudioGraph.ts
@@ -51,10 +51,19 @@ export class AudioGraph {
   private bufferCache = new Map<string, AudioBuffer>();
   private loadingPromises = new Map<string, Promise<AudioBuffer | null>>();
 
+  /**
+   * Optional pre-supplied context. The live preview leaves this undefined and
+   * lazily creates a real-time `AudioContext`; the offline renderer injects an
+   * `OfflineAudioContext` so the exact same scheduling + DSP graph mixes down
+   * the exported audio. Both are `BaseAudioContext`s for every node-creation
+   * call AudioGraph makes, so it is typed as `AudioContext` for the live path.
+   */
+  constructor(private readonly injectedContext?: AudioContext) {}
+
   /** Must be called from a user-gesture handler — triggers the autoplay policy. */
   getContext(): AudioContext {
     if (!this.ctx) {
-      this.ctx = new AudioContext();
+      this.ctx = this.injectedContext ?? new AudioContext();
       this.masterGain = this.ctx.createGain();
       this.masterGain.connect(this.ctx.destination);
     }
@@ -464,11 +473,14 @@ export class AudioGraph {
   }
 
   suspend(): void {
-    void this.ctx?.suspend();
+    // No-op on an OfflineAudioContext (no parameterless suspend).
+    const c = this.ctx as Partial<AudioContext> | null;
+    if (c && typeof c.suspend === "function") void c.suspend();
   }
 
   resume(): void {
-    void this.ctx?.resume();
+    const c = this.ctx as Partial<AudioContext> | null;
+    if (c && typeof c.resume === "function") void c.resume();
   }
 
   dispose(): void {
@@ -490,7 +502,9 @@ export class AudioGraph {
       }
     }
     this.trackChains.clear();
-    void this.ctx?.close();
+    // OfflineAudioContext has no close(); only close a real-time context.
+    const c = this.ctx as Partial<AudioContext> | null;
+    if (c && typeof c.close === "function") void c.close();
     this.ctx = null;
     this.masterGain = null;
   }

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -24,6 +24,14 @@ import { getAssetUrl } from "../../../utils/assetHelpers";
 import { WebGPUCompositor } from "./gpu/compositor";
 import type { CompositeLayer, CompositorBlendMode } from "./gpu/types";
 import { TransformGizmoOverlay } from "./TransformGizmoOverlay";
+import {
+  clipSourceTimeSec,
+  computeActiveLayers,
+  effectiveAssetId,
+  isClipActive,
+  trackZ,
+  MAX_VIDEO_LAYERS
+} from "./sceneModel";
 
 interface PlaceholderLayer {
   clipId: string;
@@ -32,7 +40,7 @@ interface PlaceholderLayer {
   name: string;
 }
 
-const HOT_POOL_SIZE = 8;
+const HOT_POOL_SIZE = MAX_VIDEO_LAYERS;
 const COLD_POOL_SIZE = 4;
 const TOTAL_POOL_SIZE = HOT_POOL_SIZE + COLD_POOL_SIZE;
 /** Preload upcoming clips within this lookahead window (ms). */
@@ -40,14 +48,6 @@ const PRELOAD_LOOKAHEAD_MS = 30_000;
 /** LRU cap on cached decoded <img> elements. Keeps memory bounded in long
  *  sessions that touch many unique image assets. */
 const IMAGE_CACHE_MAX = 64;
-/**
- * Top-of-UI track (lowest `track.index`) renders on top in the composite —
- * matches Premiere / Resolve / FCP. Compositor draws layers from low z to
- * high z, so we invert the UI index. Constant offset keeps numbers
- * positive for DOM placeholder z-indices too.
- */
-const LAYER_Z_BASE = 1000;
-const trackZ = (uiIndex: number): number => LAYER_Z_BASE - uiIndex;
 
 const compositorStyles = css({
   position: "relative",
@@ -134,50 +134,11 @@ interface ActiveImageLayer {
   trackEffects?: TrackEffect[];
 }
 
-function isClipActive(clip: TimelineClip, currentTimeMs: number): boolean {
-  return (
-    currentTimeMs >= clip.startMs &&
-    currentTimeMs < clip.startMs + clip.durationMs
-  );
-}
-
-/**
- * Opacity multiplier for a clip given the playhead position. Implements
- * the incoming `transitionIn` ramp (0→1 over `durationMs`). Returns 1 when
- * no transition applies. Crossfade is the only type currently supported.
- */
-function transitionOpacity(clip: TimelineClip, currentTimeMs: number): number {
-  const t = clip.transitionIn;
-  if (!t || t.durationMs <= 0) return 1;
-  const intoClip = currentTimeMs - clip.startMs;
-  if (intoClip >= t.durationMs) return 1;
-  if (intoClip <= 0) return 0;
-  return intoClip / t.durationMs;
-}
-
 function isClipUpcoming(clip: TimelineClip, currentTimeMs: number): boolean {
   return (
     clip.startMs > currentTimeMs &&
     clip.startMs <= currentTimeMs + PRELOAD_LOOKAHEAD_MS
   );
-}
-
-function effectiveAssetId(clip: TimelineClip): string | undefined {
-  switch (clip.status) {
-    case "generated":
-    case "stale":
-    case "locked":
-    case "generating":
-      return clip.currentAssetId;
-    default:
-      return undefined;
-  }
-}
-
-function resolveBlendMode(
-  b: TimelineClip["blendMode"]
-): CompositorBlendMode {
-  return b ?? "normal";
 }
 
 export const PreviewCompositor: React.FC = memo(() => {
@@ -375,21 +336,6 @@ export const PreviewCompositor: React.FC = memo(() => {
     return () => ro.disconnect();
   }, [sequenceWidth, sequenceHeight]);
 
-  const sortedTracks = useMemo(
-    () => [...tracks].sort((a, b) => a.index - b.index),
-    [tracks]
-  );
-
-  const clipsByTrackId = useMemo(() => {
-    const m = new Map<string, TimelineClip[]>();
-    for (const c of clips) {
-      const arr = m.get(c.trackId);
-      if (arr) arr.push(c);
-      else m.set(c.trackId, [c]);
-    }
-    return m;
-  }, [clips]);
-
   const clipById = useMemo(
     () => new Map(clips.map((c) => [c.id, c])),
     [clips]
@@ -400,74 +346,49 @@ export const PreviewCompositor: React.FC = memo(() => {
     const imageLayers: ActiveImageLayer[] = [];
     const placeholders: PlaceholderLayer[] = [];
 
-    for (const track of sortedTracks) {
-      if (!track.visible) continue;
-      const trackClips = clipsByTrackId.get(track.id) ?? [];
-      // All clips overlapping the playhead. With transitions, two adjacent
-      // clips can be active simultaneously during the cross-fade overlap.
-      // Order by startMs so the outgoing (older) clip composites first and
-      // the incoming clip blends on top.
-      const activeClips = trackClips
-        .filter((c) => isClipActive(c, currentTimeMs))
-        .sort((a, b) => a.startMs - b.startMs);
+    // Same scene description the offline renderer consumes — so the preview
+    // and the exported video composite identical frames.
+    const layers = computeActiveLayers(tracks, clips, currentTimeMs, {
+      maxVideoLayers: HOT_POOL_SIZE
+    });
 
-      for (const clip of activeClips) {
-        if (clip.mediaType === "audio") continue;
+    for (const layer of layers) {
+      const url = resolveUrl(layer.assetId);
+      const placeholder: PlaceholderLayer = {
+        clipId: layer.clipId,
+        trackIndex: layer.trackIndex,
+        status: layer.clip.status,
+        name: layer.clip.name
+      };
 
-        const assetId = effectiveAssetId(clip);
-        const url = resolveUrl(assetId);
-        const baseOpacity = clip.opacity ?? 1;
-        const opacity = baseOpacity * transitionOpacity(clip, currentTimeMs);
-
-        if (
-          clip.mediaType === "image" &&
-          (track.type === "video" || track.type === "overlay")
-        ) {
-          imageLayers.push({
-            clipId: clip.id,
-            trackIndex: track.index,
-            blendMode: resolveBlendMode(clip.blendMode),
-            opacity,
-            assetUrl: url ?? "",
-            status: clip.status,
-            transform: clip.transform,
-            borderRadius: clip.borderRadius,
-            effects: clip.effects,
-            trackEffects: track.effects
-          });
-          if (!url) {
-            placeholders.push({
-              clipId: clip.id,
-              trackIndex: track.index,
-              status: clip.status,
-              name: clip.name
-            });
-          }
-        } else if (
-          (clip.mediaType === "video" || clip.mediaType === "overlay") &&
-          (track.type === "video" || track.type === "overlay")
-        ) {
-          if (url && videoSlots.length < HOT_POOL_SIZE) {
-            videoSlots.push({
-              clipId: clip.id,
-              trackIndex: track.index,
-              blendMode: resolveBlendMode(clip.blendMode),
-              opacity,
-              assetUrl: url,
-              transform: clip.transform,
-              borderRadius: clip.borderRadius,
-              effects: clip.effects,
-              trackEffects: track.effects
-            });
-          } else if (!url) {
-            placeholders.push({
-              clipId: clip.id,
-              trackIndex: track.index,
-              status: clip.status,
-              name: clip.name
-            });
-          }
-        }
+      if (layer.kind === "image") {
+        imageLayers.push({
+          clipId: layer.clipId,
+          trackIndex: layer.trackIndex,
+          blendMode: layer.blendMode,
+          opacity: layer.opacity,
+          assetUrl: url ?? "",
+          status: layer.clip.status,
+          transform: layer.transform,
+          borderRadius: layer.borderRadius,
+          effects: layer.effects,
+          trackEffects: layer.trackEffects
+        });
+        if (!url) placeholders.push(placeholder);
+      } else if (url) {
+        videoSlots.push({
+          clipId: layer.clipId,
+          trackIndex: layer.trackIndex,
+          blendMode: layer.blendMode,
+          opacity: layer.opacity,
+          assetUrl: url,
+          transform: layer.transform,
+          borderRadius: layer.borderRadius,
+          effects: layer.effects,
+          trackEffects: layer.trackEffects
+        });
+      } else {
+        placeholders.push(placeholder);
       }
     }
 
@@ -476,7 +397,7 @@ export const PreviewCompositor: React.FC = memo(() => {
       activeImageLayers: imageLayers,
       placeholderLayers: placeholders
     };
-  }, [sortedTracks, clipsByTrackId, currentTimeMs, resolveUrl, urlCacheVersion]);
+  }, [tracks, clips, currentTimeMs, resolveUrl, urlCacheVersion]);
 
   // Source dims + transform for the single selected clip, but only while it is
   // actually rendered (active at the playhead) so the gizmo traces a visible
@@ -561,12 +482,7 @@ export const PreviewCompositor: React.FC = memo(() => {
       const rate = clip?.speedBaked
         ? 1
         : Math.max(0.0001, clip?.speedMultiplier ?? 1);
-      const intoClipTimelineSec =
-        (currentTimeMs - (clip?.startMs ?? 0)) / 1000;
-      const targetSec = Math.max(
-        0,
-        intoClipTimelineSec * rate + (clip?.inPointMs ?? 0) / 1000
-      );
+      const targetSec = clip ? clipSourceTimeSec(clip, currentTimeMs) : 0;
 
       // Setting currentTime before HAVE_METADATA is silently clamped to 0 and
       // a subsequent play() can reject with AbortError. Defer until the

--- a/web/src/components/timeline/preview/__tests__/sceneModel.test.ts
+++ b/web/src/components/timeline/preview/__tests__/sceneModel.test.ts
@@ -1,0 +1,172 @@
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+
+import {
+  clipSourceTimeSec,
+  computeActiveLayers,
+  effectiveAssetId,
+  isClipActive,
+  trackZ,
+  transitionOpacity,
+  LAYER_Z_BASE
+} from "../sceneModel";
+
+const clip = (overrides: Partial<TimelineClip>): TimelineClip =>
+  makeClip({
+    status: "generated",
+    currentAssetId: "asset-1",
+    mediaType: "video",
+    durationMs: 1000,
+    ...overrides
+  });
+
+const track = (overrides: Partial<TimelineTrack>): TimelineTrack =>
+  makeTrack({ type: "video", visible: true, ...overrides });
+
+describe("isClipActive", () => {
+  const c = clip({ startMs: 100, durationMs: 400 });
+  it("is active at start, inactive at end (half-open interval)", () => {
+    expect(isClipActive(c, 99)).toBe(false);
+    expect(isClipActive(c, 100)).toBe(true);
+    expect(isClipActive(c, 499)).toBe(true);
+    expect(isClipActive(c, 500)).toBe(false);
+  });
+});
+
+describe("transitionOpacity", () => {
+  it("returns 1 with no transition", () => {
+    expect(transitionOpacity(clip({ startMs: 0 }), 50)).toBe(1);
+  });
+  it("ramps 0→1 across the crossfade window", () => {
+    const c = clip({
+      startMs: 0,
+      transitionIn: { type: "crossfade", durationMs: 200 }
+    });
+    expect(transitionOpacity(c, 0)).toBe(0);
+    expect(transitionOpacity(c, 100)).toBeCloseTo(0.5);
+    expect(transitionOpacity(c, 200)).toBe(1);
+    expect(transitionOpacity(c, 500)).toBe(1);
+  });
+});
+
+describe("effectiveAssetId", () => {
+  it("returns currentAssetId for rendered statuses", () => {
+    for (const status of ["generated", "stale", "locked", "generating"] as const) {
+      expect(effectiveAssetId(clip({ status, currentAssetId: "a" }))).toBe("a");
+    }
+  });
+  it("returns undefined for draft/failed clips", () => {
+    expect(effectiveAssetId(clip({ status: "draft" }))).toBeUndefined();
+  });
+});
+
+describe("clipSourceTimeSec", () => {
+  it("offsets by in-point and timeline position", () => {
+    const c = clip({ startMs: 1000, inPointMs: 500 });
+    expect(clipSourceTimeSec(c, 1000)).toBeCloseTo(0.5);
+    expect(clipSourceTimeSec(c, 2000)).toBeCloseTo(1.5);
+  });
+  it("applies speed multiplier unless baked", () => {
+    const fast = clip({ startMs: 0, speedMultiplier: 2 });
+    expect(clipSourceTimeSec(fast, 1000)).toBeCloseTo(2);
+    const baked = clip({ startMs: 0, speedMultiplier: 2, speedBaked: true });
+    expect(clipSourceTimeSec(baked, 1000)).toBeCloseTo(1);
+  });
+});
+
+describe("trackZ", () => {
+  it("inverts the UI index so the top track composites last", () => {
+    expect(trackZ(0)).toBe(LAYER_Z_BASE);
+    expect(trackZ(2)).toBeLessThan(trackZ(0));
+  });
+});
+
+describe("computeActiveLayers", () => {
+  it("excludes audio clips, subtitle tracks, and hidden tracks", () => {
+    const tracks = [
+      track({ id: "v", index: 0, type: "video" }),
+      track({ id: "sub", index: 1, type: "subtitle" }),
+      track({ id: "hidden", index: 2, type: "video", visible: false })
+    ];
+    const clips = [
+      clip({ id: "vid", trackId: "v", startMs: 0, durationMs: 1000 }),
+      clip({ id: "aud", trackId: "v", startMs: 0, durationMs: 1000, mediaType: "audio" }),
+      clip({ id: "subc", trackId: "sub", startMs: 0, durationMs: 1000 }),
+      clip({ id: "hid", trackId: "hidden", startMs: 0, durationMs: 1000 })
+    ];
+    const layers = computeActiveLayers(tracks, clips, 100);
+    expect(layers.map((l) => l.clipId)).toEqual(["vid"]);
+  });
+
+  it("orders layers bottom track first (ascending track index)", () => {
+    const tracks = [
+      track({ id: "top", index: 0 }),
+      track({ id: "bottom", index: 1 })
+    ];
+    const clips = [
+      clip({ id: "topClip", trackId: "top", startMs: 0, durationMs: 1000 }),
+      clip({ id: "bottomClip", trackId: "bottom", startMs: 0, durationMs: 1000 })
+    ];
+    const layers = computeActiveLayers(tracks, clips, 100);
+    expect(layers.map((l) => l.clipId)).toEqual(["topClip", "bottomClip"]);
+    // The top UI track must blend last (highest z).
+    const top = layers.find((l) => l.clipId === "topClip")!;
+    const bottom = layers.find((l) => l.clipId === "bottomClip")!;
+    expect(trackZ(top.trackIndex)).toBeGreaterThan(trackZ(bottom.trackIndex));
+  });
+
+  it("classifies image vs video and folds in opacity + transition", () => {
+    const tracks = [track({ id: "v", index: 0 })];
+    const clips = [
+      clip({
+        id: "img",
+        trackId: "v",
+        startMs: 0,
+        durationMs: 1000,
+        mediaType: "image",
+        opacity: 0.5,
+        transitionIn: { type: "crossfade", durationMs: 200 }
+      })
+    ];
+    const layers = computeActiveLayers(tracks, clips, 100);
+    expect(layers).toHaveLength(1);
+    expect(layers[0].kind).toBe("image");
+    // base 0.5 * transition 0.5 (halfway through 200ms window) = 0.25
+    expect(layers[0].opacity).toBeCloseTo(0.25);
+  });
+
+  it("caps simultaneous video layers", () => {
+    const tracks = Array.from({ length: 12 }, (_, i) =>
+      track({ id: `t${i}`, index: i })
+    );
+    const clips = tracks.map((t) =>
+      clip({ id: `c-${t.id}`, trackId: t.id, startMs: 0, durationMs: 1000 })
+    );
+    expect(computeActiveLayers(tracks, clips, 100, { maxVideoLayers: 8 })).toHaveLength(8);
+  });
+
+  it("does not cap image layers", () => {
+    const tracks = Array.from({ length: 12 }, (_, i) =>
+      track({ id: `t${i}`, index: i })
+    );
+    const clips = tracks.map((t) =>
+      clip({
+        id: `c-${t.id}`,
+        trackId: t.id,
+        startMs: 0,
+        durationMs: 1000,
+        mediaType: "image"
+      })
+    );
+    expect(computeActiveLayers(tracks, clips, 100, { maxVideoLayers: 8 })).toHaveLength(12);
+  });
+
+  it("carries the unrendered assetId as undefined for draft clips", () => {
+    const tracks = [track({ id: "v", index: 0 })];
+    const clips = [
+      clip({ id: "draft", trackId: "v", startMs: 0, durationMs: 1000, status: "draft" })
+    ];
+    const layers = computeActiveLayers(tracks, clips, 100);
+    expect(layers[0].assetId).toBeUndefined();
+  });
+});

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -298,6 +298,15 @@ export class WebGPUCompositor {
     device.queue.submit([encoder.finish()]);
   }
 
+  /**
+   * Resolve once all submitted GPU work has completed. The offline renderer
+   * awaits this after {@link render} so the canvas pixels are final before a
+   * frame is captured for encoding.
+   */
+  async flush(): Promise<void> {
+    await this.device?.queue.onSubmittedWorkDone();
+  }
+
   dispose(): void {
     for (const entry of this.sourceTextures.values()) {
       entry.texture.destroy();

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -1,0 +1,190 @@
+/**
+ * sceneModel — the single source of truth for "what is on screen at time t".
+ *
+ * Both the live {@link PreviewCompositor} and the offline frame-by-frame
+ * {@link renderTimeline} renderer drive their GPU layer lists from
+ * {@link computeActiveLayers}, so an exported video is composited from the
+ * exact same scene description the user previewed — 1:1 with live.
+ *
+ * Everything here is pure (no DOM, no GPU, no store access) so it is trivially
+ * testable and reusable across the live and render paths.
+ */
+
+import type {
+  ClipEffect,
+  ClipTransform,
+  TimelineClip,
+  TimelineTrack,
+  TrackEffect
+} from "@nodetool-ai/timeline";
+import type { CompositorBlendMode } from "./gpu/types";
+
+/**
+ * Top-of-UI track (lowest `track.index`) renders on top in the composite —
+ * matches Premiere / Resolve / FCP. The compositor draws layers from low z to
+ * high z, so we invert the UI index. The constant offset keeps numbers
+ * positive for DOM placeholder z-indices too.
+ */
+export const LAYER_Z_BASE = 1000;
+export const trackZ = (uiIndex: number): number => LAYER_Z_BASE - uiIndex;
+
+/**
+ * Max simultaneous video layers. The live preview is bounded by its hot
+ * HTMLVideoElement pool; the renderer applies the same cap so the exported
+ * frame matches what the preview showed when many video clips overlap.
+ */
+export const MAX_VIDEO_LAYERS = 8;
+
+export function isClipActive(
+  clip: TimelineClip,
+  currentTimeMs: number
+): boolean {
+  return (
+    currentTimeMs >= clip.startMs &&
+    currentTimeMs < clip.startMs + clip.durationMs
+  );
+}
+
+/**
+ * Opacity multiplier for a clip given the playhead position. Implements the
+ * incoming `transitionIn` ramp (0→1 over `durationMs`). Returns 1 when no
+ * transition applies. Crossfade is the only type currently supported.
+ */
+export function transitionOpacity(
+  clip: TimelineClip,
+  currentTimeMs: number
+): number {
+  const t = clip.transitionIn;
+  if (!t || t.durationMs <= 0) return 1;
+  const intoClip = currentTimeMs - clip.startMs;
+  if (intoClip >= t.durationMs) return 1;
+  if (intoClip <= 0) return 0;
+  return intoClip / t.durationMs;
+}
+
+/** The asset id that should be drawn for a clip in its current status. */
+export function effectiveAssetId(clip: TimelineClip): string | undefined {
+  switch (clip.status) {
+    case "generated":
+    case "stale":
+    case "locked":
+    case "generating":
+      return clip.currentAssetId;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveBlendMode(
+  b: TimelineClip["blendMode"]
+): CompositorBlendMode {
+  return b ?? "normal";
+}
+
+/**
+ * The source-media time (seconds) a clip's video element should display at
+ * timeline position `currentTimeMs`. Honors the clip's in-point and speed
+ * (unless the speed change is already baked into the asset). Shared by the
+ * live preview's seek scheduling and the renderer's deterministic seeking so
+ * the same frame is shown in both.
+ */
+export function clipSourceTimeSec(
+  clip: TimelineClip,
+  currentTimeMs: number
+): number {
+  const rate = clip.speedBaked
+    ? 1
+    : Math.max(0.0001, clip.speedMultiplier ?? 1);
+  const intoClipTimelineSec = (currentTimeMs - clip.startMs) / 1000;
+  return Math.max(0, intoClipTimelineSec * rate + (clip.inPointMs ?? 0) / 1000);
+}
+
+/** A visual layer active at a point in time, in bottom-to-top composite order. */
+export interface ActiveLayer {
+  kind: "video" | "image";
+  clip: TimelineClip;
+  clipId: string;
+  trackIndex: number;
+  blendMode: CompositorBlendMode;
+  /** Final opacity including the clip base opacity and any transition ramp. */
+  opacity: number;
+  /** Asset to draw, or undefined when the clip has no usable render yet. */
+  assetId: string | undefined;
+  transform?: ClipTransform;
+  borderRadius?: number;
+  effects?: ClipEffect[];
+  trackEffects?: TrackEffect[];
+}
+
+export interface ComputeActiveLayersOptions {
+  /** Cap on simultaneous video layers. Defaults to {@link MAX_VIDEO_LAYERS}. */
+  maxVideoLayers?: number;
+}
+
+/**
+ * Resolve every visual layer active at `currentTimeMs`, in the order the
+ * compositor should blend them (bottom track first, top track last). Audio
+ * clips and subtitle tracks are excluded — they are not GPU layers.
+ *
+ * Video layers are capped to keep parity with the live preview's video pool;
+ * the cap is applied in composite order (top tracks win, matching the preview
+ * which fills slots while iterating top-to-bottom).
+ */
+export function computeActiveLayers(
+  tracks: TimelineTrack[],
+  clips: TimelineClip[],
+  currentTimeMs: number,
+  options: ComputeActiveLayersOptions = {}
+): ActiveLayer[] {
+  const maxVideoLayers = options.maxVideoLayers ?? MAX_VIDEO_LAYERS;
+
+  const sortedTracks = [...tracks].sort((a, b) => a.index - b.index);
+  const clipsByTrackId = new Map<string, TimelineClip[]>();
+  for (const c of clips) {
+    const arr = clipsByTrackId.get(c.trackId);
+    if (arr) arr.push(c);
+    else clipsByTrackId.set(c.trackId, [c]);
+  }
+
+  const layers: ActiveLayer[] = [];
+  let videoCount = 0;
+
+  for (const track of sortedTracks) {
+    if (!track.visible) continue;
+    if (track.type !== "video" && track.type !== "overlay") continue;
+
+    const activeClips = (clipsByTrackId.get(track.id) ?? [])
+      .filter((c) => isClipActive(c, currentTimeMs))
+      .sort((a, b) => a.startMs - b.startMs);
+
+    for (const clip of activeClips) {
+      if (clip.mediaType === "audio") continue;
+
+      const baseOpacity = clip.opacity ?? 1;
+      const opacity = baseOpacity * transitionOpacity(clip, currentTimeMs);
+      const common = {
+        clip,
+        clipId: clip.id,
+        trackIndex: track.index,
+        blendMode: resolveBlendMode(clip.blendMode),
+        opacity,
+        assetId: effectiveAssetId(clip),
+        transform: clip.transform,
+        borderRadius: clip.borderRadius,
+        effects: clip.effects,
+        trackEffects: track.effects
+      } satisfies Omit<ActiveLayer, "kind">;
+
+      if (clip.mediaType === "image") {
+        layers.push({ kind: "image", ...common });
+      } else {
+        // video | overlay
+        if (videoCount >= maxVideoLayers) continue;
+        videoCount += 1;
+        layers.push({ kind: "video", ...common });
+      }
+    }
+  }
+
+  return layers;
+}

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -179,8 +179,10 @@ export function computeActiveLayers(
         layers.push({ kind: "image", ...common });
       } else {
         // video | overlay
-        if (videoCount >= maxVideoLayers) continue;
-        videoCount += 1;
+        if (common.assetId) {
+          if (videoCount >= maxVideoLayers) continue;
+          videoCount += 1;
+        }
         layers.push({ kind: "video", ...common });
       }
     }

--- a/web/src/components/timeline/render/OffscreenVideoPool.ts
+++ b/web/src/components/timeline/render/OffscreenVideoPool.ts
@@ -1,0 +1,108 @@
+/**
+ * OffscreenVideoPool — deterministic, frame-accurate decoding of clip videos
+ * for offline rendering.
+ *
+ * Unlike the live preview (which plays elements in real time and uploads
+ * whatever frame happens to be decoded), the renderer seeks each video element
+ * to an exact source time and waits for the `seeked` event before handing the
+ * element to the compositor. That makes every exported frame reproducible and
+ * tearing-free, however slow the underlying decode is.
+ */
+
+const SEEK_EPSILON_SEC = 1 / 1000;
+
+interface PoolEntry {
+  el: HTMLVideoElement;
+  url: string;
+}
+
+export class OffscreenVideoPool {
+  private readonly container: HTMLDivElement;
+  private readonly entries = new Map<string, PoolEntry>();
+
+  constructor() {
+    this.container = document.createElement("div");
+    this.container.style.cssText =
+      "position:fixed;width:0;height:0;overflow:hidden;pointer-events:none;opacity:0;left:-9999px;top:-9999px;";
+    document.body.appendChild(this.container);
+  }
+
+  /**
+   * Return a video element decoded to `timeSec` of `url`. Resolves once the
+   * exact frame is available. Subsequent calls for the same url reuse the
+   * element. The returned element must be uploaded synchronously by the
+   * caller before the next `seek` on the same element.
+   */
+  async seek(url: string, timeSec: number): Promise<HTMLVideoElement> {
+    const el = this.ensureElement(url);
+    await this.whenMetadata(el);
+
+    const duration = Number.isFinite(el.duration) ? el.duration : Infinity;
+    const target = Math.max(
+      0,
+      Math.min(timeSec, Math.max(0, duration - SEEK_EPSILON_SEC))
+    );
+
+    // Already on the target frame — nothing to wait for.
+    if (Math.abs(el.currentTime - target) < SEEK_EPSILON_SEC) {
+      return el;
+    }
+
+    await new Promise<void>((resolve) => {
+      const onSeeked = () => {
+        el.removeEventListener("seeked", onSeeked);
+        resolve();
+      };
+      el.addEventListener("seeked", onSeeked);
+      el.currentTime = target;
+    });
+    return el;
+  }
+
+  private ensureElement(url: string): HTMLVideoElement {
+    const existing = this.entries.get(url);
+    if (existing) return existing.el;
+
+    const el = document.createElement("video");
+    el.preload = "auto";
+    el.muted = true;
+    el.playsInline = true;
+    el.crossOrigin = "anonymous";
+    el.src = url;
+    el.load();
+    this.container.appendChild(el);
+    this.entries.set(url, { el, url });
+    return el;
+  }
+
+  private whenMetadata(el: HTMLVideoElement): Promise<void> {
+    // readyState >= HAVE_METADATA means duration + dimensions are known.
+    if (el.readyState >= 1 && el.videoWidth > 0) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const onLoaded = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        reject(new Error(`Failed to load video: ${el.src}`));
+      };
+      const cleanup = () => {
+        el.removeEventListener("loadedmetadata", onLoaded);
+        el.removeEventListener("error", onError);
+      };
+      el.addEventListener("loadedmetadata", onLoaded);
+      el.addEventListener("error", onError);
+    });
+  }
+
+  dispose(): void {
+    for (const { el } of this.entries.values()) {
+      el.pause();
+      el.removeAttribute("src");
+      el.load();
+    }
+    this.entries.clear();
+    this.container.remove();
+  }
+}

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -1,0 +1,290 @@
+/**
+ * renderTimeline — offline, frame-by-frame export of a timeline to an MP4.
+ *
+ * The renderer drives the *same* {@link WebGPUCompositor} and the *same*
+ * {@link computeActiveLayers} scene description as the live preview, so the
+ * exported video is 1:1 with what playback showed. Instead of a real-time rAF
+ * loop it:
+ *
+ *   1. steps the playhead in exact `1 / fps` increments,
+ *   2. seeks each video element to the precise source frame (waiting for
+ *      `seeked`) so decoding is deterministic, not best-effort,
+ *   3. composites at full sequence resolution into an offscreen canvas,
+ *   4. encodes each frame with WebCodecs (via mediabunny) and muxes to MP4,
+ *   5. mixes the audio tracks down offline (see {@link renderTimelineAudio}).
+ */
+
+import type {
+  AudioBufferSource,
+  AudioCodec,
+  Quality,
+  VideoCodec
+} from "mediabunny";
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+
+import type { CompositeLayer } from "../preview/gpu/types";
+import {
+  clipSourceTimeSec,
+  computeActiveLayers,
+  trackZ
+} from "../preview/sceneModel";
+import { OffscreenVideoPool } from "./OffscreenVideoPool";
+import { renderTimelineAudio } from "./renderAudio";
+
+// mediabunny and the WebGPU compositor are imported dynamically inside
+// `renderTimeline` so they (and their top-level WebGPU/WebCodecs references)
+// are only loaded in the browser when an export actually runs — never at
+// module-eval time, which keeps the editor importable under jsdom.
+
+export type RenderPhase = "preparing" | "audio" | "video" | "finalizing";
+
+export interface RenderProgress {
+  phase: RenderPhase;
+  /** Frames encoded so far (video phase). */
+  frame: number;
+  totalFrames: number;
+  /** Overall completion ratio in [0, 1]. */
+  ratio: number;
+}
+
+export interface RenderTimelineOptions {
+  tracks: TimelineTrack[];
+  clips: TimelineClip[];
+  /** Sequence resolution in pixels. */
+  width: number;
+  height: number;
+  fps: number;
+  /** Total timeline length to render, in milliseconds. */
+  durationMs: number;
+  /** Resolve an asset id to a playable URL (or undefined when unavailable). */
+  resolveUrl: (assetId: string) => Promise<string | undefined>;
+  /** Video codec. Default `"avc"` (H.264). */
+  videoCodec?: VideoCodec;
+  /** Audio codec. Default `"aac"`. */
+  audioCodec?: AudioCodec;
+  /** Target video bitrate (bits/s) or a {@link Quality}. Default high. */
+  videoBitrate?: number | Quality;
+  /** Target audio bitrate (bits/s) or a {@link Quality}. Default medium. */
+  audioBitrate?: number | Quality;
+  signal?: AbortSignal;
+  onProgress?: (progress: RenderProgress) => void;
+}
+
+export interface RenderResult {
+  bytes: Uint8Array;
+  mimeType: string;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new DOMException("Render aborted", "AbortError");
+  }
+}
+
+/** Decode an image once and cache it for reuse across frames. */
+function makeImageLoader(): (url: string) => Promise<HTMLImageElement | null> {
+  const cache = new Map<string, HTMLImageElement>();
+  return async (url: string) => {
+    const cached = cache.get(url);
+    if (cached) return cached;
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.decoding = "async";
+    img.src = url;
+    try {
+      await img.decode();
+    } catch {
+      // Fall through; naturalWidth check below rejects unusable images.
+    }
+    if (img.naturalWidth > 0) {
+      cache.set(url, img);
+      return img;
+    }
+    return null;
+  };
+}
+
+/**
+ * Render the timeline and return the encoded MP4 bytes. Throws an
+ * `AbortError` if `signal` is aborted, or an `Error` if WebGPU is unavailable.
+ */
+export async function renderTimeline(
+  opts: RenderTimelineOptions
+): Promise<RenderResult> {
+  const {
+    tracks,
+    clips,
+    fps,
+    durationMs,
+    resolveUrl,
+    signal,
+    onProgress
+  } = opts;
+
+  if (fps <= 0) throw new Error("fps must be positive");
+  if (durationMs <= 0) throw new Error("durationMs must be positive");
+
+  // H.264/HEVC require even dimensions; clamp to keep the encoder happy.
+  const width = Math.max(2, Math.floor(opts.width / 2) * 2);
+  const height = Math.max(2, Math.floor(opts.height / 2) * 2);
+  const totalFrames = Math.max(1, Math.round((durationMs / 1000) * fps));
+
+  // Resolve each asset url at most once across the whole render.
+  const urlCache = new Map<string, string | undefined>();
+  const resolveCached = async (
+    assetId: string
+  ): Promise<string | undefined> => {
+    if (urlCache.has(assetId)) return urlCache.get(assetId);
+    const url = await resolveUrl(assetId);
+    urlCache.set(assetId, url);
+    return url;
+  };
+
+  onProgress?.({ phase: "preparing", frame: 0, totalFrames, ratio: 0 });
+  throwIfAborted(signal);
+
+  const [
+    {
+      BufferTarget,
+      CanvasSource,
+      Mp4OutputFormat,
+      Output,
+      QUALITY_HIGH,
+      QUALITY_MEDIUM,
+      AudioBufferSource: AudioBufferSourceCtor
+    },
+    { WebGPUCompositor }
+  ] = await Promise.all([
+    import("mediabunny"),
+    import("../preview/gpu/compositor")
+  ]);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const compositor = new WebGPUCompositor();
+  const videoPool = new OffscreenVideoPool();
+  const loadImage = makeImageLoader();
+
+  try {
+    const init = await compositor.init(canvas);
+    if (!init.ok) {
+      throw new Error(init.reason ?? "WebGPU compositor unavailable");
+    }
+    compositor.resize(width, height);
+
+    const output = new Output({
+      format: new Mp4OutputFormat(),
+      target: new BufferTarget()
+    });
+
+    const videoSource = new CanvasSource(canvas, {
+      codec: opts.videoCodec ?? "avc",
+      bitrate: opts.videoBitrate ?? QUALITY_HIGH
+    });
+    output.addVideoTrack(videoSource, { frameRate: fps });
+
+    // Mix the audio down before encoding video so the soundtrack is ready to
+    // hand to the muxer in one shot.
+    onProgress?.({ phase: "audio", frame: 0, totalFrames, ratio: 0 });
+    const audioBuffer = await renderTimelineAudio({
+      clips,
+      tracks,
+      durationMs,
+      resolveUrl: resolveCached
+    });
+    throwIfAborted(signal);
+
+    let audioSource: AudioBufferSource | null = null;
+    if (audioBuffer) {
+      audioSource = new AudioBufferSourceCtor({
+        codec: opts.audioCodec ?? "aac",
+        bitrate: opts.audioBitrate ?? QUALITY_MEDIUM
+      });
+      output.addAudioTrack(audioSource);
+    }
+
+    await output.start();
+
+    if (audioSource && audioBuffer) {
+      await audioSource.add(audioBuffer);
+      audioSource.close();
+    }
+
+    const frameDurationSec = 1 / fps;
+    for (let frame = 0; frame < totalFrames; frame++) {
+      throwIfAborted(signal);
+      const timeMs = (frame * 1000) / fps;
+
+      const layers = computeActiveLayers(tracks, clips, timeMs);
+      const composite: CompositeLayer[] = [];
+
+      for (const layer of layers) {
+        if (!layer.assetId) continue;
+        const url = await resolveCached(layer.assetId);
+        if (!url) continue;
+
+        if (layer.kind === "video") {
+          const el = await videoPool.seek(
+            url,
+            clipSourceTimeSec(layer.clip, timeMs)
+          );
+          if (el.videoWidth === 0) continue;
+          composite.push({
+            id: `v:${layer.clipId}`,
+            source: el,
+            opacity: layer.opacity,
+            blendMode: layer.blendMode,
+            zIndex: trackZ(layer.trackIndex),
+            transform: layer.transform,
+            borderRadius: layer.borderRadius,
+            effects: layer.effects,
+            trackEffects: layer.trackEffects
+          });
+        } else {
+          const img = await loadImage(url);
+          if (!img) continue;
+          composite.push({
+            id: `i:${layer.clipId}`,
+            source: img,
+            opacity: layer.opacity,
+            blendMode: layer.blendMode,
+            zIndex: trackZ(layer.trackIndex),
+            transform: layer.transform,
+            borderRadius: layer.borderRadius,
+            effects: layer.effects,
+            trackEffects: layer.trackEffects
+          });
+        }
+      }
+
+      compositor.setLayers(composite);
+      compositor.render();
+      await compositor.flush();
+
+      await videoSource.add(frame * frameDurationSec, frameDurationSec);
+
+      onProgress?.({
+        phase: "video",
+        frame: frame + 1,
+        totalFrames,
+        ratio: (frame + 1) / totalFrames
+      });
+    }
+
+    videoSource.close();
+
+    onProgress?.({ phase: "finalizing", frame: totalFrames, totalFrames, ratio: 1 });
+    await output.finalize();
+
+    const buffer = output.target.buffer;
+    if (!buffer) {
+      throw new Error("Encoding produced no output");
+    }
+    return { bytes: new Uint8Array(buffer), mimeType: "video/mp4" };
+  } finally {
+    compositor.dispose();
+    videoPool.dispose();
+  }
+}

--- a/web/src/components/timeline/render/renderAudio.ts
+++ b/web/src/components/timeline/render/renderAudio.ts
@@ -1,0 +1,73 @@
+/**
+ * renderTimelineAudio — offline mixdown of the timeline's audio tracks.
+ *
+ * Reuses {@link AudioGraph} (the same clip scheduling, fades, speed, per-clip
+ * gain, track mute/solo and DSP chain the live preview uses) but drives it with
+ * an `OfflineAudioContext`, so the exported soundtrack matches what playback
+ * produced — 1:1 with live.
+ */
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { AudioGraph, type ScheduledAudioClip } from "../preview/AudioGraph";
+
+export interface RenderAudioOptions {
+  clips: TimelineClip[];
+  tracks: TimelineTrack[];
+  /** Total timeline length to render, in milliseconds. */
+  durationMs: number;
+  /** Resolve an asset id to a playable URL (or undefined when unavailable). */
+  resolveUrl: (assetId: string) => Promise<string | undefined>;
+  /** Output sample rate. Defaults to 48 kHz. */
+  sampleRate?: number;
+}
+
+function isPlayableAudioClip(clip: TimelineClip): boolean {
+  return (
+    clip.mediaType === "audio" &&
+    !clip.muted &&
+    clip.currentAssetId != null &&
+    (clip.status === "generated" ||
+      clip.status === "stale" ||
+      clip.status === "locked") &&
+    clip.startMs + clip.durationMs > 0
+  );
+}
+
+/**
+ * Render every audible clip into a single stereo {@link AudioBuffer}, or
+ * `null` when the timeline has no usable audio.
+ */
+export async function renderTimelineAudio(
+  opts: RenderAudioOptions
+): Promise<AudioBuffer | null> {
+  const { clips, tracks, durationMs, resolveUrl } = opts;
+  const sampleRate = opts.sampleRate ?? 48_000;
+
+  if (durationMs <= 0) return null;
+
+  const audioClips = clips.filter(isPlayableAudioClip);
+  if (audioClips.length === 0) return null;
+
+  const resolved = await Promise.all(
+    audioClips.map(async (clip): Promise<ScheduledAudioClip | null> => {
+      const url = await resolveUrl(clip.currentAssetId!);
+      return url ? { clip, assetUrl: url } : null;
+    })
+  );
+  const validClips = resolved.filter(
+    (c): c is ScheduledAudioClip => c !== null
+  );
+  if (validClips.length === 0) return null;
+
+  const length = Math.max(1, Math.ceil((durationMs / 1000) * sampleRate));
+  const offline = new OfflineAudioContext(2, length, sampleRate);
+
+  // AudioGraph only ever calls BaseAudioContext members on its context, so the
+  // OfflineAudioContext stands in for the live AudioContext here.
+  const graph = new AudioGraph(offline as unknown as AudioContext);
+  // currentTimeMs = 0: the renderer always mixes the whole timeline from t=0,
+  // so each clip is scheduled at its absolute startMs on the offline clock.
+  await graph.scheduleClips(validClips, tracks, 0);
+
+  return offline.startRendering();
+}

--- a/web/src/components/timeline/render/renderAudio.ts
+++ b/web/src/components/timeline/render/renderAudio.ts
@@ -45,7 +45,16 @@ export async function renderTimelineAudio(
 
   if (durationMs <= 0) return null;
 
-  const audioClips = clips.filter(isPlayableAudioClip);
+  const audioTracks = tracks.filter((track) => track.type === "audio");
+  const hasSolo = audioTracks.some((track) => track.solo);
+  const audibleTrackIds = new Set(
+    audioTracks
+      .filter((track) => !track.muted && (!hasSolo || track.solo))
+      .map((track) => track.id)
+  );
+  const audioClips = clips.filter(
+    (clip) => isPlayableAudioClip(clip) && audibleTrackIds.has(clip.trackId)
+  );
   if (audioClips.length === 0) return null;
 
   const resolved = await Promise.all(

--- a/web/src/components/workspace/SketchSurface.tsx
+++ b/web/src/components/workspace/SketchSurface.tsx
@@ -1,0 +1,14 @@
+import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
+import StandaloneSketchEditor from "../sketch/StandaloneSketchEditor";
+
+interface SketchSurfaceProps {
+  refId: string;
+  mode: WorkspaceTabMode;
+  active: boolean;
+}
+
+const SketchSurface = ({ refId }: SketchSurfaceProps) => {
+  return <StandaloneSketchEditor documentId={refId} />;
+};
+
+export default SketchSurface;

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -2,6 +2,7 @@ import type { WorkspaceTab } from "../../stores/WorkspaceTabsStore";
 import WorkflowEditorSurface from "./WorkflowEditorSurface";
 import MiniAppPage from "../miniapps/MiniAppPage";
 import ImageSurface from "./ImageSurface";
+import SketchSurface from "./SketchSurface";
 import TextSurface from "./TextSurface";
 import Model3DSurface from "./Model3DSurface";
 import AudioSurface from "./AudioSurface";
@@ -28,6 +29,8 @@ const TabContent = ({ tab, active }: TabContentProps) => {
       );
     case "image":
       return <ImageSurface refId={tab.ref} mode={tab.mode} active={active} />;
+    case "sketch":
+      return <SketchSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "text":
       return <TextSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "model3d":

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -19,6 +19,7 @@ import OpenMenu from "./OpenMenu";
 const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   workflow: true,
   image: true,
+  sketch: false,
   timeline: true,
   model3d: true,
   text: true,
@@ -28,6 +29,7 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
 const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
   workflow: "⬡",
   image: "▦",
+  sketch: "✎",
   timeline: "▤",
   model3d: "◈",
   audio: "♪",
@@ -38,6 +40,7 @@ const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
 const TYPE_COLOR: Record<WorkspaceTabType, string> = {
   workflow: colorForType("any"),
   image: colorForType("image"),
+  sketch: colorForType("image"),
   timeline: colorForType("video"),
   model3d: colorForType("model_3d"),
   audio: colorForType("audio"),

--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -24,11 +24,13 @@ const meta = (
   }) as unknown as NodeMetadata;
 
 describe("quickAccessCategories", () => {
-  it("ships seven top-level views in order", () => {
+  it("ships nine top-level views in order", () => {
     const ids = LEFT_PANEL_TOP_LEVEL.map((c) => c.id);
     expect(ids).toEqual([
       "nodes",
       "workflows",
+      "sketches",
+      "timelines",
       "settings",
       "history",
       "favorites",

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -2,7 +2,7 @@
 /**
  * Left-panel sidebar (top-level) and node-browser sub-tabs.
  *
- *  - `LEFT_PANEL_TOP_LEVEL` (5 entries): one icon per top-level view shown in
+ *  - `LEFT_PANEL_TOP_LEVEL`: one icon per top-level view shown in
  *    the vertical rail.
  *  - `NODE_SUBCATEGORIES` (8 entries): tile-grid sub-tabs nested inside the
  *    "Nodes" view. Each filters MetadataStore down to a node family.
@@ -18,6 +18,7 @@ import StarIcon from "@mui/icons-material/Star";
 import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
 import ImageIcon from "@mui/icons-material/Image";
 import MovieIcon from "@mui/icons-material/Movie";
+import BrushOutlinedIcon from "@mui/icons-material/BrushOutlined";
 import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import ViewInArIcon from "@mui/icons-material/ViewInAr";
 import BuildIcon from "@mui/icons-material/Build";
@@ -118,6 +119,8 @@ const POPULAR_MODEL_RANK: ReadonlyMap<string, number> = new Map(
 export const LEFT_PANEL_TOP_LEVEL: readonly LeftPanelTopLevelCategory[] = [
   { id: "nodes", label: "Nodes", icon: <HubIcon /> },
   { id: "workflows", label: "Workflows", icon: <GridViewIcon /> },
+  { id: "sketches", label: "Sketches", icon: <BrushOutlinedIcon /> },
+  { id: "timelines", label: "Timelines", icon: <MovieIcon /> },
   { id: "settings", label: "Settings", icon: <SettingsIcon /> },
   { id: "history", label: "History", icon: <HistoryIcon /> },
   { id: "favorites", label: "Favorites", icon: <StarIcon /> },

--- a/web/src/hooks/sketch/useSaveSketchDocument.ts
+++ b/web/src/hooks/sketch/useSaveSketchDocument.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+import {
+  saveCurrentSketchDocument,
+  useSketchSessionStore
+} from "../../stores/sketch/SketchSessionStore";
+import { trpc } from "../../trpc/client";
+import { useNotificationStore } from "../../stores/NotificationStore";
+
+export function useSaveSketchDocument() {
+  const utils = trpc.useUtils();
+  const saveState = useSketchSessionStore((state) => state.saveState);
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(async () => {
+    const session = useSketchSessionStore.getState();
+    if (!session.documentId) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveCurrentSketchDocument((saved) => {
+        utils.sketch.get.setData({ id: saved.id }, saved);
+      });
+      useNotificationStore.getState().addNotification({
+        content: "Sketch saved.",
+        type: "success",
+        alert: false,
+        dedupeKey: `sketch-manual-save:${session.documentId}`,
+        replaceExisting: true
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [utils]);
+
+  return { save, saving: saving || saveState === "saving" };
+}

--- a/web/src/hooks/timeline/useTimelineExport.ts
+++ b/web/src/hooks/timeline/useTimelineExport.ts
@@ -49,6 +49,10 @@ function downloadBlob(bytes: Uint8Array, mimeType: string, filename: string): vo
   URL.revokeObjectURL(url);
 }
 
+function clipEndMs(clip: { startMs: number; durationMs: number }): number {
+  return clip.startMs + clip.durationMs;
+}
+
 export function useTimelineExport(): UseTimelineExportResult {
   const { tracks, clips, width, height, fps, durationMs } = useTimelineStore(
     useShallow((s) => ({
@@ -94,13 +98,22 @@ export function useTimelineExport(): UseTimelineExportResult {
       };
 
       try {
+        const clipsDurationMs = clips.reduce(
+          (max, clip) => Math.max(max, clipEndMs(clip)),
+          0
+        );
+        const exportDurationMs = Math.max(durationMs, clipsDurationMs);
+        if (exportDurationMs <= 0) {
+          throw new Error("Add a clip before exporting.");
+        }
+
         const { bytes, mimeType } = await renderTimeline({
           tracks,
           clips,
           width,
           height,
           fps,
-          durationMs,
+          durationMs: exportDurationMs,
           resolveUrl,
           signal: controller.signal,
           onProgress: setProgress

--- a/web/src/hooks/timeline/useTimelineExport.ts
+++ b/web/src/hooks/timeline/useTimelineExport.ts
@@ -1,0 +1,125 @@
+/**
+ * useTimelineExport — drives the offline {@link renderTimeline} export from the
+ * timeline editor and downloads the resulting MP4.
+ *
+ * Pulls the live document straight from {@link useTimelineStore} and resolves
+ * clip assets through {@link useAssetStore}, so the export renders exactly the
+ * sequence the user is editing.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+import {
+  renderTimeline,
+  type RenderProgress
+} from "../../components/timeline/render/TimelineRenderer";
+
+export interface UseTimelineExportResult {
+  /** Render + download the timeline as an MP4. Resolves when the file is saved. */
+  exportVideo: (filename?: string) => Promise<void>;
+  /** Abort an in-flight render. */
+  cancel: () => void;
+  /** Dismiss a surfaced error. */
+  clearError: () => void;
+  isExporting: boolean;
+  progress: RenderProgress | null;
+  error: string | null;
+}
+
+function sanitizeFilename(name: string): string {
+  const base = name.trim().replace(/[^\w.-]+/g, "_").replace(/^_+|_+$/g, "");
+  return base.length > 0 ? base : "timeline";
+}
+
+function downloadBlob(bytes: Uint8Array, mimeType: string, filename: string): void {
+  // `bytes` is always backed by a plain ArrayBuffer from the muxer; the cast
+  // satisfies the BlobPart typing under the current TS lib.
+  const blob = new Blob([bytes as BlobPart], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function useTimelineExport(): UseTimelineExportResult {
+  const { tracks, clips, width, height, fps, durationMs } = useTimelineStore(
+    useShallow((s) => ({
+      tracks: s.tracks,
+      clips: s.clips,
+      width: s.width,
+      height: s.height,
+      fps: s.fps,
+      durationMs: s.durationMs
+    }))
+  );
+  const getAsset = useAssetStore((s) => s.get);
+
+  const [isExporting, setIsExporting] = useState(false);
+  const [progress, setProgress] = useState<RenderProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const exportVideo = useCallback(
+    async (filename?: string) => {
+      if (abortRef.current) return; // already running
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setIsExporting(true);
+      setError(null);
+      setProgress({ phase: "preparing", frame: 0, totalFrames: 0, ratio: 0 });
+
+      const resolveUrl = async (
+        assetId: string
+      ): Promise<string | undefined> => {
+        try {
+          const asset = await getAsset(assetId);
+          return getAssetUrl(asset) ?? undefined;
+        } catch {
+          return undefined;
+        }
+      };
+
+      try {
+        const { bytes, mimeType } = await renderTimeline({
+          tracks,
+          clips,
+          width,
+          height,
+          fps,
+          durationMs,
+          resolveUrl,
+          signal: controller.signal,
+          onProgress: setProgress
+        });
+        downloadBlob(bytes, mimeType, `${sanitizeFilename(filename ?? "timeline")}.mp4`);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          // User cancelled — not an error.
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        abortRef.current = null;
+        setIsExporting(false);
+        setProgress(null);
+      }
+    },
+    [tracks, clips, width, height, fps, durationMs, getAsset]
+  );
+
+  return { exportVideo, cancel, clearError, isExporting, progress, error };
+}

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -12,6 +12,8 @@ import { persist } from "zustand/middleware";
  */
 export type LeftPanelView =
   | "workflows"
+  | "sketches"
+  | "timelines"
   | "settings"
   | "history"
   | "favorites"
@@ -63,6 +65,8 @@ const MAX_PANEL_SIZE = 800;
 
 const VALID_VIEWS: LeftPanelView[] = [
   "workflows",
+  "sketches",
+  "timelines",
   "settings",
   "history",
   "favorites",

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -17,6 +17,7 @@ import { persist } from "zustand/middleware";
 export type WorkspaceTabType =
   | "workflow"
   | "image"
+  | "sketch"
   | "timeline"
   | "model3d"
   | "audio"

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -790,6 +790,16 @@ async function saveSnapshot(
   }
 }
 
+export async function saveCurrentSketchDocument(
+  onSaved?: (response: SketchDocumentResponse) => void
+): Promise<void> {
+  const store = useSketchSessionStore.getState();
+  if (!store.documentId) {
+    return;
+  }
+  await saveSnapshot(store.documentId, store.name, onSaved);
+}
+
 export function useStandaloneSketchDocument(
   response: SketchDocumentResponse | undefined,
   enabled = true


### PR DESCRIPTION
Render the timeline to an MP4 entirely in the browser, reusing the exact
compositor and scene description as the live preview so exported frames
match playback frame-for-frame.

- sceneModel.ts: single source of truth for the active layers at time t
  (computeActiveLayers, clipSourceTimeSec, transitions, z-order). Both
  PreviewCompositor (live) and the renderer now drive their GPU layer
  lists from it, guaranteeing identical composition.
- render/TimelineRenderer.ts: steps the playhead in exact 1/fps
  increments, seeks each video element to the precise source frame
  (awaiting `seeked` for deterministic decoding), composites at full
  sequence resolution with the shared WebGPUCompositor, encodes each
  frame via WebCodecs and muxes to MP4 with mediabunny.
- render/OffscreenVideoPool.ts: frame-accurate, seek-and-wait decoding.
- render/renderAudio.ts: offline mixdown through the same AudioGraph
  (gain, fades, speed, mute/solo, DSP) driven by an OfflineAudioContext.
- AudioGraph accepts an injected context so the offline path reuses the
  live scheduling/DSP unchanged.
- WebGPUCompositor.flush() awaits GPU completion before frame capture.
- useTimelineExport hook + TopBar "Export" action + progress dialog.
- mediabunny and the WebGPU compositor are dynamically imported only
  when an export runs, keeping the editor importable under jsdom.
- Unit tests for the shared scene model.

https://claude.ai/code/session_01B71i2dJggcgPUFP8NKkjRF