### PR TITLE
feat(timeline): standalone player view surface + manual save button

### DIFF
--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -54,6 +54,7 @@ import { useWorkflowFreshnessCheck } from "../../hooks/timeline/useWorkflowFresh
 import { useTimelineGenerationSubscriptions } from "../../hooks/timeline/useGenerateClip";
 import { useLoadTimelineIntoStore } from "../../hooks/timeline/useLoadTimelineIntoStore";
 import { useTimelineAutosave } from "../../hooks/timeline/useTimelineAutosave";
+import { useTimelineSave } from "../../hooks/timeline/useTimelineSave";
 import { useTimelineExport } from "../../hooks/timeline/useTimelineExport";
 
 // ── Drag-handle constants ──────────────────────────────────────────────────
@@ -271,6 +272,9 @@ const TimelineEditorBody: React.FC<Omit<TimelineEditorProps, "active">> = memo((
   // Persist subsequent edits back via trpc.timeline.update (debounced).
   useTimelineAutosave();
 
+  // Imperative save for the Save button (forces an immediate PATCH).
+  const { save: handleSave, isSaving } = useTimelineSave();
+
   // Reconcile clips against current workflow state on mount.
   useWorkflowFreshnessCheck(sequenceId ?? null);
   useTimelineGenerationSubscriptions();
@@ -432,6 +436,8 @@ const TimelineEditorBody: React.FC<Omit<TimelineEditorProps, "active">> = memo((
         }
         onExportVideo={sequenceUnavailable ? undefined : handleExportVideo}
         isExporting={isExporting}
+        onSave={sequenceUnavailable ? undefined : handleSave}
+        isSaving={isSaving}
         activitySlot={<ActivityIndicator />}
       />
 

--- a/web/src/components/timeline/TimelinePlayer.tsx
+++ b/web/src/components/timeline/TimelinePlayer.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * TimelinePlayer — standalone, self-loading timeline viewer.
+ *
+ * Wraps {@link PreviewArea} (the viewport compositor + transport controls) in
+ * its own {@link TimelineProvider} instance and loads the requested sequence
+ * into that instance's stores. Unlike {@link TimelineEditor} it renders no
+ * tracks, inspector, or top bar — just the player, full-bleed.
+ *
+ * Self-contained: pass a `sequenceId` and it fetches + plays. Use it as the
+ * View-mode surface of a timeline tab, or embed it anywhere a read-only preview
+ * of a sequence is needed.
+ */
+
+import React, { memo } from "react";
+import { useTheme } from "@mui/material/styles";
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+
+import { EmptyState, FlexColumn, LoadingSpinner } from "../ui_primitives";
+
+import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
+import { useTimeline } from "../../hooks/useTimelineSequence";
+import { useLoadTimelineIntoStore } from "../../hooks/timeline/useLoadTimelineIntoStore";
+import { PreviewArea } from "./preview/PreviewArea";
+
+const containerStyles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+    backgroundColor: theme.vars.palette.background.default,
+    alignItems: "center",
+    justifyContent: "center"
+  });
+
+export interface TimelinePlayerProps {
+  /** Sequence id to load and play. */
+  sequenceId?: string;
+  /**
+   * Whether this surface is the focused/visible one. Drives which instance
+   * receives imperative playback actions. Defaults to `true`.
+   */
+  active?: boolean;
+}
+
+const TimelinePlayerBody: React.FC<Omit<TimelinePlayerProps, "active">> = memo(
+  ({ sequenceId }) => {
+    const theme = useTheme();
+    const { data: sequence, isLoading, isError } = useTimeline(sequenceId);
+
+    // Mirror the fetched sequence into this instance's TimelineStore so the
+    // store-bound PreviewArea renders its content.
+    useLoadTimelineIntoStore(sequence);
+
+    const unavailable = !isLoading && (isError || !sequence);
+
+    return (
+      <FlexColumn fullWidth fullHeight css={containerStyles(theme)}>
+        {isLoading ? (
+          <LoadingSpinner text="Loading sequence…" />
+        ) : unavailable ? (
+          <EmptyState
+            variant="error"
+            title="Sequence not found"
+            description="The timeline sequence you requested does not exist or you do not have access to it."
+          />
+        ) : (
+          <PreviewArea
+            fps={sequence?.fps ?? 30}
+            sequenceWidth={sequence?.width ?? 1920}
+            sequenceHeight={sequence?.height ?? 1080}
+          />
+        )}
+      </FlexColumn>
+    );
+  }
+);
+
+TimelinePlayerBody.displayName = "TimelinePlayerBody";
+
+/**
+ * Wraps the player body in a {@link TimelineProvider} so each instance gets its
+ * own isolated stores (document, playback, UI) — letting a viewer coexist with
+ * an editor of the same or a different sequence.
+ */
+export const TimelinePlayer: React.FC<TimelinePlayerProps> = ({
+  active = true,
+  ...bodyProps
+}) => (
+  <TimelineProvider active={active}>
+    <TimelinePlayerBody {...bodyProps} />
+  </TimelineProvider>
+);
+
+TimelinePlayer.displayName = "TimelinePlayer";
+
+export default TimelinePlayer;

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -18,6 +18,7 @@ import {
 } from "../ui_primitives";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import SaveIcon from "@mui/icons-material/Save";
 
 import { TopBarPrompt } from "./TopBarPrompt";
 
@@ -58,6 +59,10 @@ export interface TopBarProps {
   onExportVideo?: () => void;
   /** True while an export render is in progress. */
   isExporting?: boolean;
+  /** Called when the user clicks Save (force-persists the current document) */
+  onSave?: () => void;
+  /** True while a manual save is in flight. */
+  isSaving?: boolean;
   /** Optional slot for an activity indicator (NOD-311) */
   activitySlot?: React.ReactNode;
 }
@@ -69,6 +74,8 @@ export const TopBar: React.FC<TopBarProps> = memo(
     onProjectNameClick,
     onExportVideo,
     isExporting = false,
+    onSave,
+    isSaving = false,
     activitySlot
   }) => {
     const theme = useTheme();
@@ -114,6 +121,18 @@ export const TopBar: React.FC<TopBarProps> = memo(
         <FlexRow gap={1} align="center">
           {/* Activity indicator slot — filled by NOD-311 */}
           {activitySlot}
+
+          {onSave && (
+            <EditorButton
+              variant="outlined"
+              onClick={onSave}
+              disabled={isSaving}
+              startIcon={<SaveIcon />}
+              size="small"
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </EditorButton>
+          )}
 
           {onExportVideo && (
             <EditorButton

--- a/web/src/components/workspace/TimelineSurface.tsx
+++ b/web/src/components/workspace/TimelineSurface.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
 import TimelineEditor from "../timeline/TimelineEditor";
+import TimelinePlayer from "../timeline/TimelinePlayer";
 
 interface TimelineSurfaceProps {
   refId: string;
@@ -11,15 +12,17 @@ interface TimelineSurfaceProps {
 /**
  * Workspace surface for a timeline tab. `refId` is the sequenceId.
  *
- * The timeline document, playback clock, and UI state live in per-instance
- * Zustand stores provided by `TimelineProvider` (wired inside TimelineEditor),
- * so multiple timeline tabs can be edited in parallel. There is no
- * self-contained read-only preview that loads its own sequence, so we render
- * the full TimelineEditor for both view and edit modes for now. The editor
- * shows its own LoadingSpinner in the preview region while the sequence loads.
+ * View mode renders the standalone {@link TimelinePlayer} (read-only viewer);
+ * Edit mode renders the full {@link TimelineEditor}. Each wraps its own
+ * `TimelineProvider`, so the document, playback clock, and UI state live in
+ * per-instance Zustand stores and multiple timeline tabs stay isolated.
  */
-const TimelineSurface = ({ refId, active }: TimelineSurfaceProps) => {
-  return <TimelineEditor sequenceId={refId} active={active} />;
+const TimelineSurface = ({ refId, mode, active }: TimelineSurfaceProps) => {
+  return mode === "view" ? (
+    <TimelinePlayer sequenceId={refId} active={active} />
+  ) : (
+    <TimelineEditor sequenceId={refId} active={active} />
+  );
 };
 
 export default TimelineSurface;

--- a/web/src/hooks/timeline/useTimelineSave.ts
+++ b/web/src/hooks/timeline/useTimelineSave.ts
@@ -1,0 +1,59 @@
+/**
+ * useTimelineSave — imperative "Save now" for the timeline editor.
+ *
+ * Autosave ({@link useTimelineAutosave}) covers the common case, but the Save
+ * button lets the user force an immediate PATCH of the current document and see
+ * explicit feedback. Reads the live snapshot straight from the TimelineStore
+ * and rolls `baseUpdatedAt` forward from the response, same as autosave.
+ */
+import { useCallback, useState } from "react";
+
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { trpcClient } from "../../trpc/client";
+
+export interface UseTimelineSaveResult {
+  /** PATCH the current document immediately. Resolves when the save settles. */
+  save: () => Promise<void>;
+  isSaving: boolean;
+}
+
+export function useTimelineSave(): UseTimelineSaveResult {
+  const store = useTimelineStoreApi();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const save = useCallback(async () => {
+    const state = store.getState();
+    if (!state.sequenceId) return;
+    setIsSaving(true);
+    try {
+      const response = await trpcClient.timeline.update.mutate({
+        id: state.sequenceId,
+        baseUpdatedAt: state.baseUpdatedAt ?? undefined,
+        document: {
+          tracks: state.tracks,
+          clips: state.clips,
+          markers: state.markers
+        }
+      });
+      const updatedAt = (response as { updatedAt?: unknown } | undefined)
+        ?.updatedAt;
+      if (typeof updatedAt === "string") {
+        store.getState().setBaseUpdatedAt(updatedAt);
+      }
+    } catch (error) {
+      console.error("Timeline save failed:", error);
+      useNotificationStore.getState().addNotification({
+        content: "Could not save the timeline — please try again.",
+        type: "error",
+        alert: true,
+        dedupeKey: "timeline-save-failed",
+        replaceExisting: true
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [store]);
+
+  return { save, isSaving };
+}


### PR DESCRIPTION
## Summary

Two timeline editor improvements:

1. **Standalone `TimelinePlayer` as the View-mode surface.** The timeline tab's View/Edit toggle previously rendered the full `TimelineEditor` for *both* modes, so switching did nothing. View mode now renders a new standalone `TimelinePlayer` — the existing `PreviewArea` (viewport compositor + transport controls) wrapped in its own `TimelineProvider` instance, self-loading the sequence via `useTimeline` + `useLoadTimelineIntoStore`. No tracks, inspector, or top bar — just the player, full-bleed. It's self-contained (`sequenceId` in → loads + plays) so it's reusable anywhere a read-only sequence preview is needed.

2. **Manual Save button.** Added `useTimelineSave` and a Save button in the timeline `TopBar`, next to Export. Autosave (`useTimelineAutosave`) still covers the common case; the button forces an immediate PATCH with visible feedback ("Saving…") and surfaces an error notification on failure.

## Changes

- `web/src/components/timeline/TimelinePlayer.tsx` (new) — standalone viewer.
- `web/src/components/workspace/TimelineSurface.tsx` — branch on mode: View → `TimelinePlayer`, Edit → `TimelineEditor`.
- `web/src/hooks/timeline/useTimelineSave.ts` (new) — imperative save.
- `web/src/components/timeline/TopBar.tsx` — Save button + `onSave`/`isSaving` props.
- `web/src/components/timeline/TimelineEditor.tsx` — wire up `useTimelineSave`.

## Testing

- `npm run typecheck` — passes.
- `eslint` on all touched files — clean.
- Verified live via Chrome DevTools against the dev server with a real sequence: View renders only the player (`[data-testid="preview-area"]`, no editing chrome); Edit adds the top bar, tracks panel, and inspector. Toggle swaps surfaces instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)