### PR TITLE
docs: add NodeTool Studio v1 PRD

### DIFF
--- a/docs/STUDIO_MVP_PROMPT.md
+++ b/docs/STUDIO_MVP_PROMPT.md
@@ -1,0 +1,99 @@
+# Studio MVP — Build Prompt
+
+> A self-contained prompt for an engineer or coding agent to build the first
+> end-to-end slice of NodeTool Studio. Scope is deliberately thin: prove the
+> thesis (script → voiced, captioned short-form video, edited as a document),
+> nothing more. See `docs/STUDIO_PRD.md` for the full vision.
+
+---
+
+## Prompt
+
+Build the **first MVP of NodeTool Studio**: a transcript-driven editor for
+short-form video, docked inside the existing `TimelineEditor`
+(`web/src/components/timeline/`). The MVP must prove one thing end-to-end —
+**you write a script, Studio turns each line into a voiced + captioned beat on the
+timeline, and editing the script edits the video** — then export an MP4.
+
+Do **not** build the assembly agent, research, b-roll generation, brand kits,
+auto-reframe, localization, or platform publishing yet. Those are out of scope for
+this MVP.
+
+### The one user story
+
+> I open Studio, paste or type a short script (a handful of lines). Each line
+> becomes a beat with generated voiceover and word-level captions, laid out on the
+> timeline in order. I press play and see/hear it. I delete a line and its clips
+> disappear and the timeline re-flows. I reword a line and its voiceover
+> regenerates. I export an MP4 that matches the preview.
+
+### Scope (build exactly this)
+
+1. **Transcript data model.** Add a `transcriptLine` type to
+   `packages/protocol/src/api-schemas/timeline.ts`:
+   `{ id, text, beatStartMs, clipIds[] }`, persisted inside the existing
+   `timelineDocument` so autosave and export inherit it for free.
+
+2. **Transcript store.** `web/src/stores/timeline/TimelineTranscriptStore.ts`,
+   beside `TimelineStore` / `TimelineGenerationStore`. Holds line↔clipId bindings
+   and these ops, each expressed as existing `TimelineStore` mutations:
+   - add line, edit line text, delete line, reorder lines;
+   - **delete line** → remove bound clips, re-flow `startMs`;
+   - **reorder** → recompute `startMs` across bound clips;
+   - **reword** → mark bound generated clips stale (existing `dependencyHash`
+     machinery) and trigger regenerate via the existing `TimelineGenerationStore`
+     path.
+
+3. **Beat generation.** For each line, generate:
+   - one **voiceover** clip via the existing `text-to-audio` clip generation;
+   - one **caption** layer with word-level timing
+     (`{ word, startMs, endMs }[]`) sourced from the existing transcription
+     nodes. A single fixed caption style is fine for the MVP.
+   The voiceover's duration determines the beat length; captions and `startMs`
+   follow from it.
+
+4. **Caption rendering.** Wire a caption layer into
+   `web/src/components/timeline/preview/sceneModel.ts` `computeActiveLayers` so
+   captions render identically in live preview and the WebCodecs MP4 export. One
+   code path, no export-specific rendering.
+
+5. **Transcript panel UI.** `web/src/components/timeline/TranscriptPanel.tsx`,
+   docked like `Inspector`:
+   - list of lines, inline text edit, add/delete/reorder;
+   - click a line → move playhead to its `beatStartMs` and select its clips;
+   - per-line "regenerate" button (reuses `ClipVersion` history).
+   Use `ui_primitives` only — no raw MUI imports (repo policy).
+
+6. **Export.** Reuse the existing in-browser WebCodecs MP4 export unchanged. It
+   must produce a file that matches the preview, captions included.
+
+### Constraints
+
+- Vertical 9:16 only for the MVP; the sequence already supports any
+  `width/height`, so don't hardcode — just default to vertical.
+- Output length is short-form by definition; no length cap logic needed.
+- TypeScript strict, no `any`, functional components, Zustand selectors (never
+  whole-store), `shallow` for multi-value selects.
+- Reuse the engine — do **not** reimplement sequence, generation, staleness,
+  versioning, the compositor, or export. The MVP is one data type, one store, one
+  panel, and a caption layer wired into code that already exists.
+
+### Definition of done
+
+- The one user story works start to finish against a running backend.
+- Reword → regenerate and delete → re-flow both work via the existing stores.
+- Captions match between preview and exported MP4.
+- `npm run check` is green (typecheck + lint + test), with tests for the store ops
+  (add/edit/delete/reorder/reword→stale) and the caption layer in
+  `computeActiveLayers`.
+
+### Before writing code
+
+The script→beat generation step is the one place that touches the assembly
+question from the PRD. For the MVP, keep it **deterministic** — a fixed per-line
+pipeline (line text → `text-to-audio` → caption timing), *not* an agent. Confirm
+this deterministic approach and surface any place the existing generation/staleness
+APIs don't fit the per-beat binding before building. List the specific
+existing functions/types you'll call (in `TimelineStore`, `TimelineGenerationStore`,
+the `text-to-audio` node, transcription nodes, and `computeActiveLayers`) so the
+integration points are explicit.

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -128,7 +128,7 @@ A creator opens Studio, types *"weekly update on our launch, punchy, 45 seconds,
 vertical."* Ninety seconds later there's a captioned, voiced, b-rolled vertical
 video on screen. They delete one sentence, reword the hook, swap the voice to
 their clone, hit a brand preset, and export — then generate the 16:9 cut for
-YouTube from the same project. Start to publish: under five minutes. That's the
+YouTube from the same project. Start to publish: under three minutes. That's the
 €50/month.
 
 ---

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -9,6 +9,26 @@ raw recording, or hand it a URL — Studio writes, voices, illustrates, captions
 cuts, and reframes a finished video you can publish. Then you edit it like a
 document: change the words, and the video changes with them.
 
+## Product focus: short-form, ≤3 minutes
+
+Studio is built for **short-form video, three minutes max** — Shorts, Reels,
+TikToks, ads, clips, micro-lessons, and explainers that fit the formats people
+actually watch and share. This is a deliberate constraint, not a limitation:
+
+- **It's where the demand and cadence are.** The €50/month creator publishes
+  short-form *often*; that volume is the whole business. Long-form is a different,
+  smaller, slower market.
+- **It makes the hard parts tractable.** Generation cost, render time, the
+  assembly agent's planning horizon, and the transcript-as-document editing model
+  are all far easier — and far better — bounded to a few minutes than to an hour.
+- **It sharpens every feature.** Captions, auto-reframe, hook-first pacing,
+  length variants (a 60s cut and a 15s teaser), and platform fan-out are all
+  short-form concerns. We optimize for them instead of compromising for the
+  long tail.
+
+Long-form *sources* are still first-class inputs — a 90-minute podcast or webinar
+goes in, but what comes out is short clips. The output is always ≤3 minutes.
+
 This is the thing creators currently assemble from five tools — a scriptwriter, a
 voice generator, a stock/b-roll library, a captioner, and a timeline editor.
 Studio collapses them into one surface where the **script is the timeline** and
@@ -140,21 +160,22 @@ because one person does all of them in one tool.
 
 ### 1. The faceless explainer channel
 
-**Who.** Solo creators running educational / niche YouTube and TikTok channels
-without showing their face — finance, history, science, "how X works," top-10
-lists. Often a side hustle scaling toward full-time. No editing skills, no on-
-camera presence, publishing 2–5 videos a week.
+**Who.** Solo creators running educational / niche short-form channels without
+showing their face — finance, history, science, "how X works," top-10 lists on
+TikTok, Reels, and Shorts. Often a side hustle scaling toward full-time. No
+editing skills, no on-camera presence, publishing daily.
 
-**Pain today.** A single 6-minute explainer is a day of work: write the script in
-one tool, generate voiceover in ElevenLabs, hunt stock b-roll, drag everything
-into a timeline, hand-time captions, render, then redo the whole thing as a
-vertical Short. The tool stack alone runs past €50/month and the workflow doesn't
-scale past a couple videos a week.
+**Pain today.** A single 60–90 second explainer Short is still hours of work:
+write the script in one tool, generate voiceover in ElevenLabs, hunt stock b-roll,
+drag everything into a timeline, hand-time captions, render, then redo the framing
+for each platform. The tool stack alone runs past €50/month and the workflow
+doesn't scale to a daily posting habit.
 
 **In Studio.** Type the topic. The assembly agent researches, writes, voices,
-fills b-roll per beat, and captions — out comes a bound sequence. They read the
-transcript, cut two weak sentences, reword the hook, reroll one b-roll shot, and
-export. Then one click for the 9:16 Short. A day becomes twenty minutes.
+fills b-roll per beat, and captions a tight ≤90s Short — out comes a bound
+sequence. They read the transcript, cut two weak sentences, reword the hook,
+reroll one b-roll shot, and export. Hours become minutes — fast enough to post
+every day.
 
 **Why they pay.** Studio is the difference between one video a week and one a day —
 it directly grows the channel that pays their rent.
@@ -201,15 +222,17 @@ hour the feature ships.
 2am the night before launch. The alternative costs ten times that and can't keep
 up.
 
-### 4. The course creator / educator
+### 4. The micro-lesson creator / educator
 
 **Who.** Online instructors, corporate L&D teams, bootcamps, and teachers building
-structured video lessons — module after module, in a consistent format.
+**bite-sized lessons** — a course delivered as a series of short, single-concept
+videos, plus the short "tip of the day" content they post to social to fill the
+top of their funnel.
 
-**Pain today.** Lesson video is repetitive production work: same intro, same lower-
-thirds, same caption style, every module. Updating a course when content changes
-means re-recording and re-editing. Keeping 40 lessons visually consistent by hand
-is error-prone and slow.
+**Pain today.** Short lesson video is repetitive production work: same intro, same
+lower-thirds, same caption style, every clip. Updating a course when content
+changes means re-recording and re-editing. Keeping 40 micro-lessons visually
+consistent by hand is error-prone and slow.
 
 **In Studio.** Each lesson is a transcript — write or paste it, Studio voices and
 illustrates it against a saved course template so every module matches. When the

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -1,111 +1,132 @@
-# NodeTool Studio — Product Requirements (v1)
+# NodeTool Studio — Product Vision
 
-> Status: Draft · Branch `claude/nodetool-video-creation-scope-Q7LQf` · Owner: matti
+> Status: Vision · Branch `claude/nodetool-video-creation-scope-Q7LQf` · Owner: matti
 
-## 1. Thesis
+## The pitch
 
-**Transcript-driven video editing, automated.** You write or generate a script;
-the script *is* the timeline. Editing the words edits the video. Think Descript's
-text-first editing model, but with AI clip generation wired in so beats can be
-filled (voiceover, b-roll, captions) instead of only cut.
+**You describe the video. Studio makes it.** Type a topic, paste a script, drop a
+raw recording, or hand it a URL — Studio writes, voices, illustrates, captions,
+cuts, and reframes a finished video you can publish. Then you edit it like a
+document: change the words, and the video changes with them.
 
-v1 proves the **editing model** — text ⇄ clips + word-level captions. The
-**auto-assembly agent** (script/topic → fully populated sequence) is explicitly
-v2; v1 builds the exact data model the agent will later emit, so v2 is "agent
-emits beats," not "agent invents a format."
+This is the thing creators currently assemble from five tools — a scriptwriter, a
+voice generator, a stock/b-roll library, a captioner, and a timeline editor.
+Studio collapses them into one surface where the **script is the timeline** and
+**AI fills every beat**. That bundle is what justifies a €50/month creator
+subscription: it replaces a stack that costs more than that and takes a day of
+work per video.
 
-## 2. Where it lives
+## Who pays €50/month
 
-A **transcript panel docked inside the existing `TimelineEditor`**
-(`web/src/components/timeline/`), alongside `Inspector` / `Tracks`. No new route,
-no new surface, no new export path. It rides the `TimelineSequence` engine that
-already ships in `main`:
+The solo creator, marketer, educator, and agency operator who ships short-form
+video *on a schedule* — weekly YouTube explainers, daily TikTok/Reels, course
+modules, product clips, ad variants. They don't want a node graph. They want to
+go from idea to publish-ready MP4 in minutes, then tweak by editing text. They'll
+pay because Studio is faster than hiring an editor and cheaper than the tool stack
+they're juggling today.
 
-- the sequence document (persisted, autosaved),
-- AI clip generation (`text-to-audio`, `text-to-video`),
-- clip version + staleness tracking (`dependencyHash`, `ClipVersion`),
-- the WebGPU compositor (`sceneModel.computeActiveLayers`),
-- browser WebCodecs MP4 export.
+## What makes it worth it
 
-v1 adds **one data type, one store, one panel, and a caption layer** — inside a
-component that already exists.
+The moat is that NodeTool already has the hard parts in `main` — a real sequence
+engine, AI clip generation, version/staleness tracking, a WebGPU compositor, and
+in-browser MP4 export. Studio is the **opinionated creator surface** on top of
+that engine. Competitors are either text-editors that bolt on AI (Descript) or AI
+generators with no real editor (the clip-farm tools). Studio is both: generative
+*and* editable, with the timeline as the substrate.
 
-## 3. Concepts
+---
 
-- **Beat** (`transcriptLine`): one line of script. Has text, a start time, and
-  the clip(s) bound to it. The beat is the unit the user edits.
-- **Binding**: a beat owns clips by id. A beat's clips are existing kinds —
-  `text-to-audio` (voiceover), `text-to-video` (b-roll), plus the new caption clip.
-- **Captions**: word-level timing on the existing `subtitle` track, rendered
-  identically in live preview and export.
+## The product
 
-## 4. v1 Scope
+### 1. Idea → finished video
 
-### 4.1 Transcript ⇄ clip binding (core IP)
+Every entry point lands on the same artifact — a transcript-bound sequence:
 
-- **Type** — add to `packages/protocol/src/api-schemas/timeline.ts`:
-  ```ts
-  transcriptLine {
-    id: string;
-    text: string;
-    beatStartMs: number;
-    clipIds: string[];          // clips bound to this beat
-  }
-  ```
-  Persisted inside the existing `timelineDocument`, so autosave and MP4 export
-  inherit it for free.
+- **Topic.** "5-minute explainer on how RAG works." Studio researches, writes a
+  script, picks a voice, generates voiceover, fills b-roll, captions it, and cuts
+  to the beat.
+- **Script.** Paste your own words; Studio voices and illustrates them.
+- **Raw footage / long video.** Upload a recording or talk; Studio transcribes,
+  finds the highlights, and assembles short clips — the "clip machine."
+- **URL / doc.** Turn a blog post, PDF, or product page into a video.
 
-- **Store** — `web/src/stores/timeline/TimelineTranscriptStore.ts`, beside
-  `TimelineStore` / `TimelineGenerationStore`. Holds line↔clipId bindings and the
-  edit ops. Every op is expressed as existing `TimelineStore` mutations:
-  - **Delete line** → remove bound clips, re-flow `startMs`.
-  - **Reorder lines** → recompute `startMs` across bound clips.
-  - **Reword line** → mark bound generated clips `stale` (existing
-    `dependencyHash` machinery) → offer regenerate (existing
-    `TimelineGenerationStore` path).
+The **assembly agent** is the headline. It doesn't just generate — it produces a
+fully bound sequence: beats → voiceover clips, b-roll clips, captions, music bed,
+transitions. Everything it emits is editable by hand afterward.
 
-### 4.2 Word-level captions (visible payoff)
+### 2. Edit like a document
 
-- **Content model** on the existing `subtitle` track: line →
-  `{ word, startMs, endMs }[]`, sourced from the transcription nodes already in
-  the repo.
-- **Render** — wire a caption layer into
-  `web/src/components/timeline/preview/sceneModel.ts`. `computeActiveLayers` is
-  the single source of truth for "what's on screen at *t*," so live preview and
-  the WebCodecs export render captions identically — no extra export work.
-- **Style knobs**: font, size, position, active-word highlight.
+The transcript panel *is* the editor. The script is a list of **beats**; each beat
+owns the clips that realize it.
 
-### 4.3 Transcript panel UI
+- **Delete a line** → its clips disappear and the timeline re-flows.
+- **Reorder lines** → the video reorders.
+- **Reword a line** → the bound voiceover/b-roll goes stale and regenerates.
+- **Click a line** → jumps the playhead and selects its clips.
+- **Reroll a beat** → new voice take, new b-roll, new phrasing — version history
+  keeps the old ones.
 
-- `web/src/components/timeline/TranscriptPanel.tsx`, docked like `Inspector`.
-- Click a line → selects its clips and moves the playhead.
-- Edit text inline.
-- Per-line **regenerate / reroll** (reuses `ClipVersion` history).
-- UI uses `ui_primitives` only (no raw MUI) per repo policy.
+No scrubbing, no razor tool, no keyframe hunting for the 90% case. Power users can
+still drop to the full timeline tracks when they want frame control.
 
-## 5. Out of scope (v2+)
+### 3. Voice, look, and brand
 
-- **Auto-assembly agent** — script/topic → fully populated sequence. v1's binding
-  model is its output target.
-- **STT → transcript ingestion** — the long-video "clip machine."
-- **Auto-reframe 16:9 → 9:16** — sequence `width/height` already support any
-  ratio; only subject-tracking is new.
+A video should sound and look like *you*:
 
-## 6. Milestone checklist
+- **Voices** — pick or clone a voice; consistent narrator across a series.
+- **Captions** — word-level, animated, on-brand. Styles are presets (font, size,
+  position, highlight, color) saved per brand.
+- **B-roll** — generated, stock, or your own library; auto-matched to each beat.
+- **Brand kit** — logo, fonts, colors, intro/outro, lower-thirds applied across
+  every project.
+- **Music & SFX** — auto-selected bed that ducks under voiceover.
 
-- [ ] `transcriptLine` type added to `timeline.ts` schema + persisted in document
-- [ ] `TimelineTranscriptStore` with binding state + delete/reorder/reword ops
-- [ ] Reword → stale → regenerate wired through `TimelineGenerationStore`
-- [ ] Caption content model on `subtitle` track (word-level timing)
-- [ ] Caption layer in `computeActiveLayers` (preview + export parity)
-- [ ] Caption style knobs (font/size/position/highlight)
-- [ ] `TranscriptPanel` docked in `TimelineEditor`, line→clip selection
-- [ ] Inline text edit + per-line regenerate/reroll
-- [ ] `npm run check` green (typecheck + lint + test)
+### 4. Multi-format, multi-platform
 
-## 7. Why this is low-risk
+One source, many outputs — this is where the subscription earns its keep for
+people publishing everywhere:
 
-Every hard part is already in `main`. The product bet — transcript-driven
-editing — gets validated before any agent or generation-quality risk is taken on.
-The agent (the headline feature) lands in v2 on top of a proven, persisted data
-model.
+- **Auto-reframe** 16:9 ↔ 9:16 ↔ 1:1 with subject tracking, so one edit ships to
+  YouTube, TikTok, Reels, and Shorts.
+- **Length variants** — a 60s cut and a 15s teaser from the same sequence.
+- **Localization** — translate the transcript, regenerate voice and captions in
+  another language; the timing re-flows automatically.
+- **Ad variants** — swap the hook line, get N versions for testing.
+
+### 5. Publish & iterate
+
+- Export publish-ready MP4 in any aspect ratio, in-browser.
+- Direct publish / scheduling to platforms.
+- Thumbnail generation from the best frame.
+- Reuse: save a finished video as a **template** — same structure, new script.
+
+---
+
+## How it sits on the engine
+
+Studio is a creator surface over NodeTool's existing infrastructure. The mapping:
+
+| Studio capability        | Engine it rides                                            |
+| ------------------------ | --------------------------------------------------------- |
+| Transcript-bound editing | `TimelineSequence` document (persisted, autosaved)        |
+| Voiceover & b-roll       | AI clip generation (`text-to-audio`, `text-to-video`)     |
+| Reword → regenerate      | `dependencyHash` staleness + `ClipVersion` history        |
+| Captions & overlays      | `sceneModel.computeActiveLayers` (preview/export parity)  |
+| Auto-reframe & variants  | sequence `width/height` (any ratio) + subject tracking    |
+| Export                   | in-browser WebCodecs MP4                                   |
+| Assembly agent           | NodeTool agent system (planner → steps → tools)           |
+
+The agent's output target is the transcript-bound sequence the manual editor
+produces — generation and hand-editing share one data model, so anything the
+agent makes, you can refine, and anything you build, the agent can extend.
+
+---
+
+## What "done" feels like
+
+A creator opens Studio, types *"weekly update on our launch, punchy, 45 seconds,
+vertical."* Ninety seconds later there's a captioned, voiced, b-rolled vertical
+video on screen. They delete one sentence, reword the hook, swap the voice to
+their clone, hit a brand preset, and export — then generate the 16:9 cut for
+YouTube from the same project. Start to publish: under five minutes. That's the
+€50/month.

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -130,3 +130,138 @@ video on screen. They delete one sentence, reword the hook, swap the voice to
 their clone, hit a brand preset, and export — then generate the 16:9 cut for
 YouTube from the same project. Start to publish: under five minutes. That's the
 €50/month.
+
+---
+
+## Hero use cases
+
+Six use cases that each, on their own, justify the subscription. Studio wins
+because one person does all of them in one tool.
+
+### 1. The faceless explainer channel
+
+**Who.** Solo creators running educational / niche YouTube and TikTok channels
+without showing their face — finance, history, science, "how X works," top-10
+lists. Often a side hustle scaling toward full-time. No editing skills, no on-
+camera presence, publishing 2–5 videos a week.
+
+**Pain today.** A single 6-minute explainer is a day of work: write the script in
+one tool, generate voiceover in ElevenLabs, hunt stock b-roll, drag everything
+into a timeline, hand-time captions, render, then redo the whole thing as a
+vertical Short. The tool stack alone runs past €50/month and the workflow doesn't
+scale past a couple videos a week.
+
+**In Studio.** Type the topic. The assembly agent researches, writes, voices,
+fills b-roll per beat, and captions — out comes a bound sequence. They read the
+transcript, cut two weak sentences, reword the hook, reroll one b-roll shot, and
+export. Then one click for the 9:16 Short. A day becomes twenty minutes.
+
+**Why they pay.** Studio is the difference between one video a week and one a day —
+it directly grows the channel that pays their rent.
+
+### 2. The podcast / long-form repurposer
+
+**Who.** Podcasters, interviewers, webinar hosts, and the agencies/VAs who manage
+their socials. They already have hours of long-form audio/video; their growth
+channel is short clips on TikTok, Reels, Shorts, and LinkedIn.
+
+**Pain today.** Finding the 30 clip-worthy moments in a 90-minute episode is
+manual and soul-crushing. Tools like Opus Clip find moments but give you no real
+editor; Descript edits but you're still scrubbing. Captioning and reframing each
+clip vertically is per-clip busywork. Output: maybe 5 clips per episode when 20
+are sitting in there.
+
+**In Studio.** Drop the episode. Studio transcribes, surfaces the high-retention
+moments as candidate clips, and assembles each as an editable transcript-bound
+sequence — already captioned and reframed to vertical with the speaker tracked.
+The editor trims by deleting words, tightens the hook, and ships. Twenty clips
+from one episode in the time it used to take to make five.
+
+**Why they pay.** Clip volume is reach, and reach is the whole reason they podcast.
+Studio multiplies the output of content they've already recorded.
+
+### 3. The founder / solo marketer
+
+**Who.** Early-stage founders, indie hackers, and one-person marketing teams who
+have to *be* the content department. Product launches, feature announcements,
+demo clips, "build in public" updates, founder POV videos for LinkedIn and X.
+
+**Pain today.** They have product knowledge but zero editing time. Hiring an editor
+is slow and expensive for the cadence they need; doing it themselves means a video
+ships once a month instead of weekly. Consistency across videos (brand, voice,
+captions) is nonexistent because each one is improvised.
+
+**In Studio.** Paste the changelog or a rough script. Studio turns it into a
+captioned, voiced, on-brand video using their saved brand kit — logo, colors,
+fonts, intro/outro baked in. Reword for tone, pick the cloned founder voice,
+export landscape for LinkedIn and vertical for Reels. Ship a launch video the same
+hour the feature ships.
+
+**Why they pay.** It's an editor + a brand designer for €50/month, available at
+2am the night before launch. The alternative costs ten times that and can't keep
+up.
+
+### 4. The course creator / educator
+
+**Who.** Online instructors, corporate L&D teams, bootcamps, and teachers building
+structured video lessons — module after module, in a consistent format.
+
+**Pain today.** Lesson video is repetitive production work: same intro, same lower-
+thirds, same caption style, every module. Updating a course when content changes
+means re-recording and re-editing. Keeping 40 lessons visually consistent by hand
+is error-prone and slow.
+
+**In Studio.** Each lesson is a transcript — write or paste it, Studio voices and
+illustrates it against a saved course template so every module matches. When the
+curriculum changes, edit the script line and regenerate just that beat instead of
+re-shooting. Templates make lesson #40 as fast as lesson #1.
+
+**Why they pay.** Course revenue depends on shipping the whole curriculum and
+keeping it current. Studio turns lesson production from a bottleneck into a
+text-editing task.
+
+### 5. The social agency / multi-brand manager
+
+**Who.** Social media agencies and in-house teams running many client or product
+brands at once. Their unit of work is "20 posts this week across 6 brands, each on
+3 platforms," and their margin is throughput.
+
+**Pain today.** Every brand needs its own look, voice, and caption style, and every
+platform needs its own aspect ratio. Multiplied across clients, that's a
+combinatorial explosion of manual reformatting. Maintaining brand consistency
+across a team of junior editors is a constant QA fire.
+
+**In Studio.** Brand kits enforce each client's voice, colors, fonts, and caption
+preset automatically. Build once per concept, then fan out: every platform's
+aspect ratio and a length variant from one source sequence. Templates standardize
+formats so a new team member produces on-brand output day one.
+
+**Why they pay.** This is pure margin — Studio cuts the per-deliverable cost across
+hundreds of deliverables a month. At agency volume, €50/month is a rounding error
+against the labor it removes.
+
+### 6. The global / localized publisher
+
+**Who.** Creators and brands expanding into multiple language markets — a YouTuber
+going from English to Spanish/Portuguese/Hindi, or a company localizing product
+and training videos for regional teams.
+
+**Pain today.** Localization means re-recording voiceover in each language, re-
+timing everything, and re-burning captions per language. It's so expensive that
+most creators simply don't do it and leave entire markets on the table.
+
+**In Studio.** Translate the transcript; Studio regenerates voiceover and captions
+in the target language and re-flows the timing automatically — same b-roll, same
+brand, new language. One source video becomes five market-ready videos without
+touching a timeline.
+
+**Why they pay.** Localization unlocks audiences worth far more than €50/month, and
+Studio makes it a button instead of a project.
+
+### The common thread
+
+Every hero user is **publishing on a cadence** and bottlenecked on production, not
+ideas. Studio attacks the bottleneck the same way for all of them: idea or source
+in, edit-by-text in the middle, many formats out. The transcript-bound sequence is
+the one model that serves the faceless creator, the repurposer, and the agency
+alike — which is why one subscription covers all six.

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -62,7 +62,7 @@ generators with no real editor (the clip-farm tools). Studio is both: generative
 
 Every entry point lands on the same artifact — a transcript-bound sequence:
 
-- **Topic.** "5-minute explainer on how RAG works." Studio researches, writes a
+- **Topic.** "90-second explainer on how RAG works." Studio researches, writes a
   script, picks a voice, generates voiceover, fills b-roll, captions it, and cuts
   to the beat.
 - **Script.** Paste your own words; Studio voices and illustrates them.
@@ -139,6 +139,49 @@ Studio is a creator surface over NodeTool's existing infrastructure. The mapping
 The agent's output target is the transcript-bound sequence the manual editor
 produces — generation and hand-editing share one data model, so anything the
 agent makes, you can refine, and anything you build, the agent can extend.
+
+### Simple surface, NodeTool engine underneath
+
+Studio's surface is deliberately simple — a transcript and a preview. But it is
+*not* a black box. **Underneath the surface is the full NodeTool engine**, and
+experts can look — and reach — under the hood:
+
+- The assembly that produced a video is a real NodeTool **workflow graph**.
+  Power users can open it, inspect every node, fork it, and rewire it.
+- Brand kits, voice choices, and the "fill this beat" steps are **reusable
+  workflow templates**, not hardcoded magic. A studio or agency can build a custom
+  pipeline once and run it behind the simple surface for every project.
+- This is the wedge no clip-farm competitor has: the easy surface *and* a
+  programmable engine. Casual users never see it; experts can take it as far as
+  NodeTool goes.
+
+### Open question: the agent harness + node workflows
+
+The biggest unsolved design problem — and the thing we need to figure out — is
+**how the assembly agent is harnessed and which node workflows it drives** to turn
+an idea into a bound sequence. This is the engineering heart of the product and is
+not yet specified. Open questions:
+
+- **Agent harness.** Is assembly one planning agent (TaskPlanner → steps), a fixed
+  pipeline of specialized SimpleAgents (researcher → scriptwriter → caster →
+  b-roll director → captioner), or a hybrid where a planner orchestrates
+  deterministic workflow sub-graphs? What does each beat's "fill" step look like
+  as an agent task, and how does it write back into the `TimelineSequence`?
+- **Node workflows.** What concrete graphs of existing/new nodes realize each
+  capability — script generation, voiceover (`text-to-audio`), b-roll
+  (`text-to-video` + stock search), transcription/highlight-finding for the clip
+  machine, caption timing, auto-reframe with subject tracking? Which already exist
+  in `base-nodes` and which must be built?
+- **Determinism vs. agency.** Where do we want a reliable, repeatable workflow
+  (so output is consistent and cheap) versus genuine agent reasoning (so it
+  handles open-ended topics)? Short-form's ≤3-min bound should make more of this
+  deterministic than a long-form tool could.
+- **Editability handoff.** How does agent output map cleanly onto the
+  transcript-bound model so every generated beat remains hand-editable and
+  re-runnable, with version history intact?
+
+Resolving this — designing the agent harness and the underlying node workflows —
+is the first real engineering milestone before any of the surface gets built.
 
 ---
 

--- a/docs/STUDIO_PRD.md
+++ b/docs/STUDIO_PRD.md
@@ -1,0 +1,111 @@
+# NodeTool Studio — Product Requirements (v1)
+
+> Status: Draft · Branch `claude/nodetool-video-creation-scope-Q7LQf` · Owner: matti
+
+## 1. Thesis
+
+**Transcript-driven video editing, automated.** You write or generate a script;
+the script *is* the timeline. Editing the words edits the video. Think Descript's
+text-first editing model, but with AI clip generation wired in so beats can be
+filled (voiceover, b-roll, captions) instead of only cut.
+
+v1 proves the **editing model** — text ⇄ clips + word-level captions. The
+**auto-assembly agent** (script/topic → fully populated sequence) is explicitly
+v2; v1 builds the exact data model the agent will later emit, so v2 is "agent
+emits beats," not "agent invents a format."
+
+## 2. Where it lives
+
+A **transcript panel docked inside the existing `TimelineEditor`**
+(`web/src/components/timeline/`), alongside `Inspector` / `Tracks`. No new route,
+no new surface, no new export path. It rides the `TimelineSequence` engine that
+already ships in `main`:
+
+- the sequence document (persisted, autosaved),
+- AI clip generation (`text-to-audio`, `text-to-video`),
+- clip version + staleness tracking (`dependencyHash`, `ClipVersion`),
+- the WebGPU compositor (`sceneModel.computeActiveLayers`),
+- browser WebCodecs MP4 export.
+
+v1 adds **one data type, one store, one panel, and a caption layer** — inside a
+component that already exists.
+
+## 3. Concepts
+
+- **Beat** (`transcriptLine`): one line of script. Has text, a start time, and
+  the clip(s) bound to it. The beat is the unit the user edits.
+- **Binding**: a beat owns clips by id. A beat's clips are existing kinds —
+  `text-to-audio` (voiceover), `text-to-video` (b-roll), plus the new caption clip.
+- **Captions**: word-level timing on the existing `subtitle` track, rendered
+  identically in live preview and export.
+
+## 4. v1 Scope
+
+### 4.1 Transcript ⇄ clip binding (core IP)
+
+- **Type** — add to `packages/protocol/src/api-schemas/timeline.ts`:
+  ```ts
+  transcriptLine {
+    id: string;
+    text: string;
+    beatStartMs: number;
+    clipIds: string[];          // clips bound to this beat
+  }
+  ```
+  Persisted inside the existing `timelineDocument`, so autosave and MP4 export
+  inherit it for free.
+
+- **Store** — `web/src/stores/timeline/TimelineTranscriptStore.ts`, beside
+  `TimelineStore` / `TimelineGenerationStore`. Holds line↔clipId bindings and the
+  edit ops. Every op is expressed as existing `TimelineStore` mutations:
+  - **Delete line** → remove bound clips, re-flow `startMs`.
+  - **Reorder lines** → recompute `startMs` across bound clips.
+  - **Reword line** → mark bound generated clips `stale` (existing
+    `dependencyHash` machinery) → offer regenerate (existing
+    `TimelineGenerationStore` path).
+
+### 4.2 Word-level captions (visible payoff)
+
+- **Content model** on the existing `subtitle` track: line →
+  `{ word, startMs, endMs }[]`, sourced from the transcription nodes already in
+  the repo.
+- **Render** — wire a caption layer into
+  `web/src/components/timeline/preview/sceneModel.ts`. `computeActiveLayers` is
+  the single source of truth for "what's on screen at *t*," so live preview and
+  the WebCodecs export render captions identically — no extra export work.
+- **Style knobs**: font, size, position, active-word highlight.
+
+### 4.3 Transcript panel UI
+
+- `web/src/components/timeline/TranscriptPanel.tsx`, docked like `Inspector`.
+- Click a line → selects its clips and moves the playhead.
+- Edit text inline.
+- Per-line **regenerate / reroll** (reuses `ClipVersion` history).
+- UI uses `ui_primitives` only (no raw MUI) per repo policy.
+
+## 5. Out of scope (v2+)
+
+- **Auto-assembly agent** — script/topic → fully populated sequence. v1's binding
+  model is its output target.
+- **STT → transcript ingestion** — the long-video "clip machine."
+- **Auto-reframe 16:9 → 9:16** — sequence `width/height` already support any
+  ratio; only subject-tracking is new.
+
+## 6. Milestone checklist
+
+- [ ] `transcriptLine` type added to `timeline.ts` schema + persisted in document
+- [ ] `TimelineTranscriptStore` with binding state + delete/reorder/reword ops
+- [ ] Reword → stale → regenerate wired through `TimelineGenerationStore`
+- [ ] Caption content model on `subtitle` track (word-level timing)
+- [ ] Caption layer in `computeActiveLayers` (preview + export parity)
+- [ ] Caption style knobs (font/size/position/highlight)
+- [ ] `TranscriptPanel` docked in `TimelineEditor`, line→clip selection
+- [ ] Inline text edit + per-line regenerate/reroll
+- [ ] `npm run check` green (typecheck + lint + test)
+
+## 7. Why this is low-risk
+
+Every hard part is already in `main`. The product bet — transcript-driven
+editing — gets validated before any agent or generation-quality risk is taken on.
+The agent (the headline feature) lands in v2 on top of a proven, persisted data
+model.


### PR DESCRIPTION
Transcript-driven video editing scoped as a panel inside the existing
TimelineEditor. v1 = transcript<->clip binding + word-level captions;
auto-assembly agent deferred to v2.