### PR TITLE
Per-workflow concurrency cap + settings UI overhaul

### DIFF
--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -134,6 +134,11 @@ s(
   "Execution",
   "Maximum number of workflow runs a single client can execute at once (default: 4). Additional runs are queued and start automatically as running ones finish, preventing provider/API overload."
 );
+s(
+  "MAX_CONCURRENT_RUNS_PER_WORKFLOW",
+  "Execution",
+  "Maximum number of concurrent runs of the same workflow before additional runs queue (default: 4). Only applies to runs that opt into concurrency (e.g. timeline/sketch generation); canvas runs always stay sequential per workflow. Also bounded by MAX_CONCURRENT_JOBS."
+);
 
 // Provider endpoints
 s(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1168,9 +1168,12 @@ export class UnifiedWebSocketRunner {
 
   /** Default cap when `MAX_CONCURRENT_JOBS` is unset/invalid. */
   private static readonly DEFAULT_MAX_CONCURRENT_JOBS = 4;
-  /** How long a resolved MAX_CONCURRENT_JOBS value is reused before re-reading. */
+  /** Default per-workflow cap when `MAX_CONCURRENT_RUNS_PER_WORKFLOW` is unset/invalid. */
+  private static readonly DEFAULT_MAX_CONCURRENT_RUNS_PER_WORKFLOW = 4;
+  /** How long a resolved concurrency-setting value is reused before re-reading. */
   private static readonly MAX_CONCURRENT_JOBS_TTL_MS = 5000;
   private maxConcurrentJobsCache: { value: number; at: number } | null = null;
+  private maxRunsPerWorkflowCache: { value: number; at: number } | null = null;
 
   /**
    * Resolve the per-client concurrency cap from settings (>= 1), cached for a
@@ -1178,29 +1181,56 @@ export class UnifiedWebSocketRunner {
    * store every time. The setting changes rarely, so a short TTL is fine.
    */
   private async getMaxConcurrentJobs(): Promise<number> {
-    const now = Date.now();
     const cached = this.maxConcurrentJobsCache;
-    if (
-      cached &&
-      now - cached.at < UnifiedWebSocketRunner.MAX_CONCURRENT_JOBS_TTL_MS
-    ) {
-      return cached.value;
+    const value = await this.resolvePositiveIntSetting(
+      "MAX_CONCURRENT_JOBS",
+      UnifiedWebSocketRunner.DEFAULT_MAX_CONCURRENT_JOBS,
+      cached
+    );
+    this.maxConcurrentJobsCache = value;
+    return value.value;
+  }
+
+  /**
+   * Resolve the per-workflow concurrency cap (>= 1) for runs that opt into
+   * concurrency. When this many runs of the same workflow are already in
+   * flight, further opted-in runs queue. Cached like {@link getMaxConcurrentJobs}.
+   */
+  private async getMaxConcurrentRunsPerWorkflow(): Promise<number> {
+    const cached = this.maxRunsPerWorkflowCache;
+    const value = await this.resolvePositiveIntSetting(
+      "MAX_CONCURRENT_RUNS_PER_WORKFLOW",
+      UnifiedWebSocketRunner.DEFAULT_MAX_CONCURRENT_RUNS_PER_WORKFLOW,
+      cached
+    );
+    this.maxRunsPerWorkflowCache = value;
+    return value.value;
+  }
+
+  /**
+   * Read a positive-integer setting, reusing the cached value while it's still
+   * within the TTL. Falls back to `fallback` when the setting is unset/invalid
+   * or the settings store is unavailable (e.g. DB not initialized) rather than
+   * blocking the run, matching the runner's other best-effort DB access.
+   */
+  private async resolvePositiveIntSetting(
+    key: string,
+    fallback: number,
+    cached: { value: number; at: number } | null
+  ): Promise<{ value: number; at: number }> {
+    const now = Date.now();
+    if (cached && now - cached.at < UnifiedWebSocketRunner.MAX_CONCURRENT_JOBS_TTL_MS) {
+      return cached;
     }
     let raw: string | null = null;
     try {
-      raw = await getSetting("MAX_CONCURRENT_JOBS");
+      raw = await getSetting(key);
     } catch {
-      // Settings store unavailable (e.g. DB not initialized) — fall back to the
-      // default rather than blocking the run, matching the runner's other
-      // best-effort DB access.
+      // Settings store unavailable — fall back to the default.
     }
     const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-    const value =
-      Number.isFinite(parsed) && parsed > 0
-        ? parsed
-        : UnifiedWebSocketRunner.DEFAULT_MAX_CONCURRENT_JOBS;
-    this.maxConcurrentJobsCache = { value, at: now };
-    return value;
+    const value = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+    return { value, at: now };
   }
 
   /** Jobs occupying a concurrency slot: live + reserved-but-not-yet-registered. */
@@ -1209,24 +1239,37 @@ export class UnifiedWebSocketRunner {
   }
 
   /**
-   * Whether a run for this workflow is already executing. Used to keep
-   * same-workflow runs sequential (the next one stays queued until the current
-   * finishes) so their live node updates don't clobber each other in the
+   * Number of live (unfinished) runs currently executing for a workflow. Used
+   * to enforce the per-workflow concurrency limit so non-concurrent runs stay
+   * sequential and their live node updates don't clobber each other in the
    * editor. Safe to check against `activeJobs` alone: commands are processed
    * one-at-a-time and `startJobInner` registers the job before returning.
    */
-  private hasActiveJobForWorkflow(
+  private countActiveJobsForWorkflow(
     workflowId: string | null | undefined
-  ): boolean {
+  ): number {
     if (!workflowId) {
-      return false;
+      return 0;
     }
+    let count = 0;
     for (const job of this.activeJobs.values()) {
       if (job.workflowId === workflowId && !job.finished) {
-        return true;
+        count++;
       }
     }
-    return false;
+    return count;
+  }
+
+  /**
+   * The per-workflow concurrency limit a given run is subject to: concurrency
+   * opt-in runs share the configurable {@link getMaxConcurrentRunsPerWorkflow}
+   * cap; everything else stays strictly sequential (one run per workflow) so
+   * live node updates don't clobber the editor.
+   */
+  private perWorkflowLimitFor(req: { concurrent?: boolean }): Promise<number> {
+    return req.concurrent
+      ? this.getMaxConcurrentRunsPerWorkflow()
+      : Promise.resolve(1);
   }
 
   /**
@@ -1236,14 +1279,15 @@ export class UnifiedWebSocketRunner {
    */
   async runJob(req: RunJobRequest): Promise<void> {
     const max = await this.getMaxConcurrentJobs();
-    // Queue the run when over the global cap, or — unless this run opts into
-    // concurrency (req.concurrent) — when this workflow already has a run in
-    // flight (default: one run per workflow at a time). Reserve the slot
-    // synchronously (after the only await above) so two run_job commands can't
-    // both observe a free slot before either registers.
+    const perWorkflowMax = await this.perWorkflowLimitFor(req);
+    // Queue the run when over the global cap, or when this workflow already has
+    // its per-workflow limit of runs in flight — 1 for normal runs, or the
+    // configurable MAX_CONCURRENT_RUNS_PER_WORKFLOW for runs that opt into
+    // concurrency. Reserve the slot synchronously (after the awaits above) so
+    // two run_job commands can't both observe a free slot before either registers.
     if (
       this.inFlightJobCount >= max ||
-      (!req.concurrent && this.hasActiveJobForWorkflow(req.workflow_id))
+      this.countActiveJobsForWorkflow(req.workflow_id) >= perWorkflowMax
     ) {
       await this.enqueueJob(req);
       return;
@@ -1296,13 +1340,21 @@ export class UnifiedWebSocketRunner {
       const max = await this.getMaxConcurrentJobs().catch(
         () => UnifiedWebSocketRunner.DEFAULT_MAX_CONCURRENT_JOBS
       );
-      // Fill free slots with the first queued run whose workflow isn't already
-      // running (one run per workflow). startJob registers the job before it
-      // returns, so the next iteration sees it as in-flight.
+      const perWorkflowMax = await this.getMaxConcurrentRunsPerWorkflow().catch(
+        () => UnifiedWebSocketRunner.DEFAULT_MAX_CONCURRENT_RUNS_PER_WORKFLOW
+      );
+      // Fill free slots with the first queued run whose workflow is still under
+      // its per-workflow limit (1 for normal runs, perWorkflowMax for opted-in
+      // concurrent runs). startJob registers the job before it returns, so the
+      // next iteration sees it as in-flight.
       while (this.inFlightJobCount < max) {
         const candidate = this.jobQueue
           .positions()
-          .find((p) => p.concurrent || !this.hasActiveJobForWorkflow(p.workflowId));
+          .find(
+            (p) =>
+              this.countActiveJobsForWorkflow(p.workflowId) <
+              (p.concurrent ? perWorkflowMax : 1)
+          );
         if (!candidate) {
           break;
         }

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -651,6 +651,42 @@ describe("UnifiedWebSocketRunner", () => {
     await r.disconnect();
   });
 
+  it("queues opted-in runs past MAX_CONCURRENT_RUNS_PER_WORKFLOW", async () => {
+    await initTestDb();
+    const prev = process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW;
+    process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW = "2";
+    try {
+      let release!: () => void;
+      const gate = new Promise<void>((r2) => { release = r2; });
+      const r = new UnifiedWebSocketRunner({
+        resolveExecutor: () => ({ async process() { await gate; return {}; } })
+      });
+      await r.connect(ws);
+      const graph = { nodes: [{ id: "n1", type: "nodetool.constant.String", name: "nodetool.constant.String", properties: { value: "x" } }], edges: [] };
+
+      await r.runJob({ job_id: "A", workflow_id: "wf", graph, concurrent: true });
+      await r.runJob({ job_id: "B", workflow_id: "wf", graph, concurrent: true });
+      await r.runJob({ job_id: "C", workflow_id: "wf", graph, concurrent: true });
+      await new Promise((res) => setTimeout(res, 20));
+
+      const sent = ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+      // A and B fill the per-workflow cap of 2; C must queue.
+      expect(sent.some((m) => m.type === "job_update" && m.job_id === "B" && m.status === "running")).toBe(true);
+      expect(sent.some((m) => m.type === "job_update" && m.job_id === "C" && m.status === "queued")).toBe(true);
+      expect(sent.some((m) => m.type === "job_update" && m.job_id === "C" && m.status === "running")).toBe(false);
+
+      // As A/B finish, C drains and starts.
+      release();
+      await new Promise((res) => setTimeout(res, 20));
+      const after = ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+      expect(after.some((m) => m.type === "job_update" && m.job_id === "C" && m.status === "running")).toBe(true);
+      await r.disconnect();
+    } finally {
+      if (prev === undefined) delete process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW;
+      else process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW = prev;
+    }
+  });
+
   it("does not resurrect a job cancelled while it was queued", async () => {
     // A run can be cancelled via the DB-only cancel path (tRPC `jobs.cancel`)
     // while it is still sitting in the in-memory queue. drainQueue can then

--- a/web/src/components/menus/DefaultModelsMenu.tsx
+++ b/web/src/components/menus/DefaultModelsMenu.tsx
@@ -40,7 +40,7 @@ function DefaultModelsMenu() {
 
   return (
     <div>
-      <Text size="big" id="default-models" style={{ margin: 0 }}>
+      <Text size="big" id="default-models" className="settings-heading">
         Default Models
       </Text>
       <Text className="description" sx={{ mb: 2 }}>
@@ -48,17 +48,19 @@ function DefaultModelsMenu() {
         new nodes.
       </Text>
 
-      {MODEL_TYPE_CONFIG.map(({ type, label, Select }) => (
-        <DefaultModelRow
-          key={type}
-          modelType={type}
-          label={label}
-          Select={Select}
-          current={defaults[type]}
-          onSelect={setDefault}
-          onClear={clearDefault}
-        />
-      ))}
+      <div className="default-models-list">
+        {MODEL_TYPE_CONFIG.map(({ type, label, Select }) => (
+          <DefaultModelRow
+            key={type}
+            modelType={type}
+            label={label}
+            Select={Select}
+            current={defaults[type]}
+            onSelect={setDefault}
+            onClear={clearDefault}
+          />
+        ))}
+      </div>
     </div>
   );
 }
@@ -105,9 +107,9 @@ function DefaultModelRow({
   }, [modelType, onClear]);
 
   return (
-    <div className="settings-section" id={`default-model-${modelType}`}>
-      <Text size="big">{label}</Text>
-      <FlexRow align="center" gap={1} sx={{ mt: 1 }}>
+    <div className="default-model-row" id={`default-model-${modelType}`}>
+      <Text weight={600}>{label}</Text>
+      <FlexRow align="center" gap={1}>
         <Select onChange={handleChange} value={current?.id || ""} />
         {current && (
           <EditorButton size="small" onClick={handleClear}>
@@ -115,11 +117,6 @@ function DefaultModelRow({
           </EditorButton>
         )}
       </FlexRow>
-      {current && (
-        <Text size="small" sx={{ mt: 0.5, opacity: 0.7 }}>
-          {current.provider} / {current.name || current.id}
-        </Text>
-      )}
     </div>
   );
 }

--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -22,6 +22,48 @@ import {
 } from "../../stores/resourceChangeHandler";
 import { useTheme } from "@mui/material/styles";
 import { getSharedSettingsStyles } from "./sharedSettingsStyles";
+import { formatSettingLabel } from "./settingsLabel";
+
+/** Groups surfaced elsewhere (General tab, Folders panel) or via SearchProviderSection. */
+const HIDDEN_SETTING_GROUPS = new Set(["Folders", "Search", "Execution"]);
+/** Search-provider settings rendered by SearchProviderSection, not the generic list. */
+const SEARCH_RELATED_SETTINGS = new Set([
+  "SERP_PROVIDER",
+  "SERPAPI_API_KEY",
+  "DATA_FOR_SEO_LOGIN",
+  "DATA_FOR_SEO_PASSWORD",
+  "BRAVE_API_KEY",
+  "APIFY_API_KEY"
+]);
+
+/** Anchor id for a settings group heading (e.g. "vLLM" → "vllm"). */
+export const settingGroupSlug = (groupName: string): string =>
+  groupName.toLowerCase().replace(/\s+/g, "-");
+
+/**
+ * Ordered list of group names the generic settings list actually renders —
+ * used to build the Integrations sidebar so it mirrors the visible sections.
+ */
+export const getDisplayedSettingGroups = (
+  settings: SettingWithValue[]
+): string[] => {
+  const groups: string[] = [];
+  const seen = new Set<string>();
+  for (const setting of settings) {
+    if (
+      HIDDEN_SETTING_GROUPS.has(setting.group) ||
+      setting.is_secret ||
+      SEARCH_RELATED_SETTINGS.has(setting.env_var)
+    ) {
+      continue;
+    }
+    if (!seen.has(setting.group)) {
+      seen.add(setting.group);
+      groups.push(setting.group);
+    }
+  }
+  return groups;
+};
 import ExternalLink from "../common/ExternalLink";
 import { isElectron } from "../../lib/env";
 import { restFetch } from "../../lib/rest-fetch";
@@ -111,7 +153,7 @@ const SettingItem = memo(function SettingItem({
           <InputLabel
             id={`${setting.env_var.toLowerCase()}-label`}
           >
-            {setting.env_var.replace(/_/g, " ")}
+            {formatSettingLabel(setting.env_var)}
           </InputLabel>
           <Select
             labelId={`${setting.env_var.toLowerCase()}-label`}
@@ -132,7 +174,7 @@ const SettingItem = memo(function SettingItem({
           type={setting.is_secret ? "password" : "text"}
           autoComplete="off"
           id={`${setting.env_var.toLowerCase()}-input`}
-          label={setting.env_var.replace(/_/g, " ")}
+          label={formatSettingLabel(setting.env_var)}
           value={value || ""}
           onChange={handleChange}
           variant="standard"
@@ -283,23 +325,16 @@ const RemoteSettings = () => {
     }
 
     const filteredEntries: [string, SettingWithValue[]][] = [];
-    const searchRelatedSettings = new Set([
-      "SERP_PROVIDER",
-      "SERPAPI_API_KEY",
-      "DATA_FOR_SEO_LOGIN",
-      "DATA_FOR_SEO_PASSWORD",
-      "BRAVE_API_KEY",
-      "APIFY_API_KEY"
-    ]);
 
     settingsByGroup.forEach((groupSettings, groupName) => {
-      if (groupName === "Folders" || groupName === "Search") {
+      // Folders/Search/Execution are surfaced elsewhere — skip them here.
+      if (HIDDEN_SETTING_GROUPS.has(groupName)) {
         return;
       }
 
       const allowedSettings = groupSettings.filter(
         (setting) =>
-          !setting.is_secret && !searchRelatedSettings.has(setting.env_var)
+          !setting.is_secret && !SEARCH_RELATED_SETTINGS.has(setting.env_var)
       );
 
       if (allowedSettings.length > 0) {
@@ -415,13 +450,12 @@ const RemoteSettings = () => {
             css={getSharedSettingsStyles(theme)}
           >
             <div className="settings-main-content">
-              <Text size="giant">Settings</Text>
-
               {/* HuggingFace OAuth Section */}
               <div className="settings-section">
                 <Text
-                  size="bigger"
+                  size="big"
                   id="huggingface-oauth"
+                  className="settings-heading"
                 >
                   HuggingFace Authentication
                 </Text>
@@ -441,7 +475,7 @@ const RemoteSettings = () => {
                         <LoginIcon />
                       )
                     }
-                    sx={{ marginTop: "1em" }}
+                    sx={{ marginTop: "1em", alignSelf: "flex-start" }}
                   >
                     {isConnected
                       ? "Connected to HuggingFace"
@@ -466,8 +500,9 @@ const RemoteSettings = () => {
                 ([groupName, groupSettings]) => (
                   <div key={groupName} className="settings-section">
                     <Text
-                      size="bigger"
-                      id={groupName.toLowerCase().replace(/\s+/g, "-")}
+                      size="big"
+                      id={settingGroupSlug(groupName)}
+                      className="settings-heading"
                     >
                       {groupName}
                     </Text>

--- a/web/src/components/menus/SearchProviderSection.tsx
+++ b/web/src/components/menus/SearchProviderSection.tsx
@@ -8,6 +8,7 @@ import {
   Stack
 } from "@mui/material";
 import { FlexRow, Box, Chip } from "../ui_primitives";
+import { formatSettingLabel } from "./settingsLabel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import { TextInput, Text } from "../ui_primitives";
@@ -115,16 +116,14 @@ const SearchProviderSection = memo(function SearchProviderSection({
 
   return (
     <div className="settings-section">
-      <Text size="bigger" id="search-provider">
+      <Text size="big" id="search-provider" className="settings-heading">
         Search Provider
       </Text>
 
       {/* Provider Selector */}
       <div className="settings-item large">
         <FormControl variant="standard" fullWidth sx={{ marginBottom: "1.5em" }}>
-          <InputLabel id="provider-select-label">
-            Search Provider
-          </InputLabel>
+          <InputLabel id="provider-select-label">Provider</InputLabel>
           <Select
             labelId="provider-select-label"
             id="provider-select"
@@ -206,7 +205,7 @@ const SearchProviderSection = memo(function SearchProviderSection({
                     type="password"
                     autoComplete="off"
                     id={`${field.toLowerCase()}-input`}
-                    label={field.replace(/_/g, " ")}
+                    label={formatSettingLabel(field)}
                     value={value}
                     onChange={(e: unknown) => {
                       const target = e as { target: { value: string } };

--- a/web/src/components/menus/ServerNumberSetting.tsx
+++ b/web/src/components/menus/ServerNumberSetting.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { TextInput, Text } from "../ui_primitives";
+import useRemoteSettingsStore from "../../stores/RemoteSettingStore";
+
+export interface ServerNumberSettingProps {
+  /** Registry env var key (e.g. MAX_CONCURRENT_RUNS_PER_WORKFLOW). */
+  envVar: string;
+  label: string;
+  description: React.ReactNode;
+  defaultValue: number;
+  min?: number;
+  max?: number;
+  id?: string;
+}
+
+/**
+ * A numeric input backed by a server-side registry setting (read/written via
+ * tRPC `settings.list`/`settings.update`). Unlike the editor preferences in the
+ * General tab — which live in the local SettingsStore — these are persisted on
+ * the server because the runner reads them via `getSetting`.
+ */
+export const ServerNumberSetting = React.memo(function ServerNumberSetting({
+  envVar,
+  label,
+  description,
+  defaultValue,
+  min = 1,
+  max = 100,
+  id
+}: ServerNumberSettingProps) {
+  const fetchSettings = useRemoteSettingsStore((s) => s.fetchSettings);
+  const updateSettings = useRemoteSettingsStore((s) => s.updateSettings);
+  // Shared ["settings"] cache: dedupes with the API & Keys tab's own query.
+  useQuery({ queryKey: ["settings"], queryFn: fetchSettings });
+
+  const value = useRemoteSettingsStore(
+    (s) => s.settings.find((x) => x.env_var === envVar)?.value
+  );
+
+  const [local, setLocal] = useState<string>(String(defaultValue));
+  useEffect(() => {
+    setLocal(value != null && value !== "" ? String(value) : String(defaultValue));
+  }, [value, defaultValue]);
+
+  const commit = useCallback(() => {
+    const clamped = Math.max(min, Math.min(max, Number(local) || defaultValue));
+    setLocal(String(clamped));
+    if (String(clamped) !== (value ?? "")) {
+      void updateSettings({ [envVar]: String(clamped) });
+    }
+  }, [local, min, max, defaultValue, value, updateSettings, envVar]);
+
+  return (
+    <>
+      <TextInput
+        type="number"
+        autoComplete="off"
+        slotProps={{ htmlInput: { min, max } }}
+        id={id}
+        label={label}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        onBlur={commit}
+        variant="standard"
+        size="small"
+      />
+      <Text className="description">{description}</Text>
+    </>
+  );
+});
+
+export default ServerNumberSetting;

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -34,7 +34,12 @@ import {
   APIKeysRightSidebar,
   SecurityNotice
 } from "./APIKeysTab";
+import {
+  getDisplayedSettingGroups,
+  settingGroupSlug
+} from "./RemoteSettingsMenu";
 import SettingsIntroCard from "./SettingsIntroCard";
+import ServerNumberSetting from "./ServerNumberSetting";
 import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
 import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
 import ModelListIndex from "../hugging_face/model_list/ModelListIndex";
@@ -51,7 +56,15 @@ import useSecretsStore from "../../stores/SecretsStore";
 import { settingsStyles } from "./settingsMenuStyles";
 
 const workspacesEnabled = !isProduction;
-const aboutTabIndex = workspacesEnabled ? 5 : 4;
+
+// Tab indices. Workspaces is conditional, so About/Packages are derived.
+const TAB_GENERAL = 0;
+const TAB_API_KEYS = 1;
+const TAB_INTEGRATIONS = 2;
+const TAB_MODELS = 3;
+const TAB_COLLECTIONS = 4;
+const TAB_WORKSPACES = 5;
+const aboutTabIndex = workspacesEnabled ? 6 : 5;
 const packagesTabIndex = aboutTabIndex + 1;
 
 const UPDATE_CHANNEL_OPTIONS = [
@@ -119,6 +132,38 @@ const TabPanel = React.memo(function TabPanel(props: TabPanelProps) {
   );
 });
 
+interface SearchItemProps {
+  /** Lowercased, trimmed search term. Empty string shows everything. */
+  search: string;
+  /** Free-text the item matches against (label + description keywords). */
+  keywords: string;
+  id?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * A single settings row that hides itself when it doesn't match the current
+ * search. Returning null removes it from the DOM so the surrounding
+ * `.settings-section`/heading can collapse via CSS `:has()`.
+ */
+const SearchItem = React.memo(function SearchItem({
+  search,
+  keywords,
+  id,
+  className = "settings-item",
+  children
+}: SearchItemProps) {
+  if (search && !keywords.toLowerCase().includes(search)) {
+    return null;
+  }
+  return (
+    <div id={id} className={className}>
+      {children}
+    </div>
+  );
+});
+
 function SettingsPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -126,15 +171,17 @@ function SettingsPage() {
 
   const tabSubtitle = (tab: number): string => {
     switch (tab) {
-      case 0:
+      case TAB_GENERAL:
         return "Editor and workspace preferences.";
-      case 1:
-        return "Manage API keys, providers, and editor preferences.";
-      case 2:
+      case TAB_API_KEYS:
+        return "Provider API keys and credentials.";
+      case TAB_INTEGRATIONS:
+        return "Service endpoints, MCP servers, storage, and the Nodetool API.";
+      case TAB_MODELS:
         return "Manage local models and runtime preferences.";
-      case 3:
+      case TAB_COLLECTIONS:
         return "Vector store collections for retrieval and search.";
-      case 4:
+      case TAB_WORKSPACES:
         return "Workspaces and project organization.";
       default:
         if (tab === packagesTabIndex) {
@@ -148,7 +195,7 @@ function SettingsPage() {
     const raw = Number(searchParams.get("tab") ?? 0);
     if (Number.isNaN(raw)) return 0;
     const bounded = Math.min(packagesTabIndex, Math.max(0, raw));
-    if (!workspacesEnabled && bounded === 5) {
+    if (!workspacesEnabled && bounded === TAB_WORKSPACES) {
       return aboutTabIndex;
     }
     return bounded;
@@ -179,6 +226,15 @@ function SettingsPage() {
   const updateSettings = useSettingsStore((state) => state.updateSettings);
   const settings = useSettingsStore((state) => state.settings);
   const [apiSearchTerm, setApiSearchTerm] = useState("");
+  const [generalSearchTerm, setGeneralSearchTerm] = useState("");
+  const generalSearch = generalSearchTerm.toLowerCase().trim();
+  // Sections/components that aren't individual settings rows still need to hide
+  // when they don't match the search.
+  const generalMatches = useCallback(
+    (keywords: string) =>
+      !generalSearch || keywords.toLowerCase().includes(generalSearch),
+    [generalSearch]
+  );
 
   // Generate unique IDs for form controls
   const baseId = useId();
@@ -307,6 +363,7 @@ function SettingsPage() {
       next.set("tab", String(newValue));
       setSearchParams(next, { replace: true });
       setApiSearchTerm("");
+      setGeneralSearchTerm("");
     },
     [searchParams, setSearchParams]
   );
@@ -427,13 +484,12 @@ function SettingsPage() {
     });
   };
 
-  // Tab 0: General sidebar folders
+  // Tab 0: General sidebar folders — every section listed, in page order.
   const generalSidebarSections = [
     {
       category: "Workspace",
       items: [
         { id: "editor", label: "Editor" },
-        { id: "appearance", label: "Appearance" },
         ...(isElectron ? [{ id: "updates", label: "Updates" }] : [])
       ]
     },
@@ -451,46 +507,54 @@ function SettingsPage() {
     },
     {
       category: "History",
-      items: [{ id: "autosave", label: "Autosave" }]
-    }
-  ];
-
-  // Tab 1: API & Keys sidebar folders
-  const apiKeysSidebarSections = [
-    {
-      category: "Credentials",
       items: [
-        { id: "api-keys", label: "API Keys" },
-        ...(session?.access_token && !isLocalhost
-          ? [{ id: "nodetool-api-token", label: "Nodetool API Token" }]
-          : [])
+        { id: "autosave", label: "Autosave" },
+        { id: "appearance", label: "Appearance" }
       ]
-    },
-    {
-      category: "Configuration",
-      items: [{ id: "api-settings", label: "API Settings" }]
-    },
-    ...(isLocalhost
-      ? [
-          {
-            category: "Integrations",
-            items: [{ id: "mcp-integration", label: "MCP Servers" }]
-          }
-        ]
-      : []),
-    {
-      category: "Storage",
-      items: [{ id: "folders", label: "Folders" }]
     }
   ];
 
-  // Subscribe to store data for sidebar sections to enable memoization
+  // Subscribe to store data so the Integrations sidebar mirrors the live
+  // (registry-driven) list of setting groups rendered in the panel.
   const remoteSettings = useRemoteSettingsStore((state) => state.settings);
   const secrets = useSecretsStore((state) => state.secrets);
-
-  // Keep secrets sidebar sections for potential future use
-  void remoteSettings;
   void secrets;
+
+  // Tab 2: Integrations sidebar folders — Configuration lists every group the
+  // generic settings panel renders, so the sidebar shows all items.
+  const integrationsSidebarSections = useMemo(() => {
+    const configItems = [
+      { id: "api-settings", label: "API Settings" },
+      { id: "huggingface-oauth", label: "HuggingFace" },
+      { id: "search-provider", label: "Search Provider" },
+      ...getDisplayedSettingGroups(remoteSettings ?? []).map((group) => ({
+        id: settingGroupSlug(group),
+        label: group
+      }))
+    ];
+    return [
+      ...(session?.access_token && !isLocalhost
+        ? [
+            {
+              category: "Credentials",
+              items: [
+                { id: "nodetool-api-token", label: "Nodetool API Token" }
+              ]
+            }
+          ]
+        : []),
+      { category: "Configuration", items: configItems },
+      ...(isLocalhost
+        ? [
+            {
+              category: "Servers",
+              items: [{ id: "mcp-integration", label: "MCP Servers" }]
+            }
+          ]
+        : []),
+      { category: "Storage", items: [{ id: "folders", label: "Folders" }] }
+    ];
+  }, [remoteSettings, session?.access_token]);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -534,351 +598,471 @@ function SettingsPage() {
                 aria-label="settings tabs"
               >
                 <Tab label="General" id="settings-tab-0" />
-                <Tab label="API & Keys" id="settings-tab-1" />
-                <Tab label="Models" id="settings-tab-2" />
-                <Tab label="Collections" id="settings-tab-3" />
-                {workspacesEnabled && <Tab label="Workspaces" id="settings-tab-4" />}
+                <Tab label="API Keys" id="settings-tab-1" />
+                <Tab label="Integrations" id="settings-tab-2" />
+                <Tab label="Models" id="settings-tab-3" />
+                <Tab label="Collections" id="settings-tab-4" />
+                {workspacesEnabled && (
+                  <Tab label="Workspaces" id={`settings-tab-${TAB_WORKSPACES}`} />
+                )}
                 <Tab label="About" id={`settings-tab-${aboutTabIndex}`} />
                 <Tab label="Packages" id={`settings-tab-${packagesTabIndex}`} />
               </Tabs>
             </div>
 
-            <div className={`settings-container${settingsTab === 1 && !isMobile ? " settings-container--api-keys" : ""}`}>
-              {!isMobile && (settingsTab === 0 || settingsTab === 1 || settingsTab === aboutTabIndex) && (
-                <SettingsSidebar
-                  key={`sidebar-${settingsTab}`}
-                  activeSection={activeSection}
-                  sections={
-                    settingsTab === 0
-                      ? generalSidebarSections
-                      : settingsTab === 1
-                        ? apiKeysSidebarSections
-                        : settingsTab === aboutTabIndex
-                          ? getAboutSidebarSections()
-                          : []
-                  }
-                  onSectionClick={scrollToSection}
-                  footer={settingsTab === 1 ? <SecurityNotice /> : undefined}
-                />
-              )}
+            <div className={`settings-container${settingsTab === TAB_API_KEYS && !isMobile ? " settings-container--api-keys" : ""}`}>
+              {!isMobile &&
+                (settingsTab === TAB_GENERAL ||
+                  settingsTab === TAB_INTEGRATIONS ||
+                  settingsTab === aboutTabIndex) && (
+                  <SettingsSidebar
+                    key={`sidebar-${settingsTab}`}
+                    activeSection={activeSection}
+                    sections={
+                      settingsTab === TAB_GENERAL
+                        ? generalSidebarSections
+                        : settingsTab === TAB_INTEGRATIONS
+                          ? integrationsSidebarSections
+                          : settingsTab === aboutTabIndex
+                            ? getAboutSidebarSections()
+                            : []
+                    }
+                    onSectionClick={scrollToSection}
+                  />
+                )}
 
               <div
                 className={`settings-content${
-                  settingsTab === 2 ||
-                  settingsTab === 3 ||
-                  (settingsTab === 4 && workspacesEnabled) ||
+                  settingsTab === TAB_MODELS ||
+                  settingsTab === TAB_COLLECTIONS ||
+                  (settingsTab === TAB_WORKSPACES && workspacesEnabled) ||
                   settingsTab === packagesTabIndex
                     ? " settings-content--full"
                     : ""
-                }${settingsTab === 1 ? " settings-content--api-keys" : ""}`}
+                }${settingsTab === TAB_API_KEYS ? " settings-content--api-keys" : ""}`}
                 ref={settingsContentRef}
               >
                 {/* Tab 0: General */}
-                <TabPanel value={settingsTab} index={0}>
-                  <div id="editor" className="settings-section">
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Show Welcome Screen"
-                        checked={!!settings.showWelcomeOnStartup}
-                        onChange={handleShowWelcomeChange}
-                        description="Show the welcome screen when starting the application."
-                      />
-                    </div>
-
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Select Nodes On Drag"
-                        checked={!!settings.selectNodesOnDrag}
-                        onChange={handleSelectNodesOnDragChange}
-                      />
-                      <Text className="description">
-                        Mark nodes as selected after changing a node&apos;s
-                        position.
-                        <br />
-                        If disabled, nodes can still be selected by clicking on
-                        them.
+                <TabPanel value={settingsTab} index={TAB_GENERAL}>
+                  <div style={{ marginBottom: "1.5em" }}>
+                    <SearchInput
+                      placeholder="Search settings..."
+                      value={generalSearchTerm}
+                      onChange={setGeneralSearchTerm}
+                      size="small"
+                      showClear
+                    />
+                  </div>
+                  <div className="general-settings">
+                    <div className="settings-section">
+                      <Text size="big" id="editor" className="settings-heading">
+                        Editor
                       </Text>
-                    </div>
-
-                    {isElectron && (
-                      <div className="settings-item">
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="editor workspace show welcome screen startup"
+                      >
                         <LabeledSwitch
-                          label="Sound Notifications"
-                          checked={!!settings.soundNotifications}
-                          onChange={handleSoundNotificationsChange}
-                          description="Play a system beep sound when workflows complete, exports finish, or other important events occur."
+                          label="Show Welcome Screen"
+                          checked={!!settings.showWelcomeOnStartup}
+                          onChange={handleShowWelcomeChange}
+                          description="Show the welcome screen when starting the application."
                         />
-                      </div>
-                    )}
+                      </SearchItem>
 
-                    {supportsDesktopUpdateSettings && (
-                      <div className="settings-item">
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="editor workspace select nodes on drag selection"
+                      >
                         <LabeledSwitch
-                          label="Automatic Updates"
-                          checked={autoUpdatesEnabled}
-                          onChange={handleAutoUpdatesChange}
-                          description="Check for and download desktop app updates from the selected release channel."
-                        />
-                      </div>
-                    )}
-
-                    {supportsDesktopUpdateSettings && (
-                      <div id="updates" className="settings-item">
-                        <SelectField
-                          label="Update Channel"
-                          value={updateChannel}
-                          variant="standard"
-                          onChange={handleUpdateChannelChange}
-                          options={UPDATE_CHANNEL_OPTIONS}
+                          label="Select Nodes On Drag"
+                          checked={!!settings.selectNodesOnDrag}
+                          onChange={handleSelectNodesOnDragChange}
                         />
                         <Text className="description">
-                          Stable follows full releases. Nightly follows prerelease nightly builds.
-                          Nightly builds default to the Nightly channel.
+                          Mark nodes as selected after changing a node&apos;s
+                          position.
+                          <br />
+                          If disabled, nodes can still be selected by clicking on
+                          them.
                         </Text>
-                      </div>
+                      </SearchItem>
+
+                      {isElectron && (
+                        <SearchItem
+                          search={generalSearch}
+                          keywords="editor workspace sound notifications beep"
+                        >
+                          <LabeledSwitch
+                            label="Sound Notifications"
+                            checked={!!settings.soundNotifications}
+                            onChange={handleSoundNotificationsChange}
+                            description="Play a system beep sound when workflows complete, exports finish, or other important events occur."
+                          />
+                        </SearchItem>
+                      )}
+
+                      {supportsDesktopUpdateSettings && (
+                        <SearchItem
+                          search={generalSearch}
+                          keywords="editor workspace updates automatic desktop"
+                        >
+                          <LabeledSwitch
+                            label="Automatic Updates"
+                            checked={autoUpdatesEnabled}
+                            onChange={handleAutoUpdatesChange}
+                            description="Check for and download desktop app updates from the selected release channel."
+                          />
+                        </SearchItem>
+                      )}
+
+                      {supportsDesktopUpdateSettings && (
+                        <SearchItem
+                          search={generalSearch}
+                          id="updates"
+                          keywords="editor workspace update channel stable nightly"
+                        >
+                          <SelectField
+                            label="Update Channel"
+                            value={updateChannel}
+                            variant="standard"
+                            onChange={handleUpdateChannelChange}
+                            options={UPDATE_CHANNEL_OPTIONS}
+                          />
+                          <Text className="description">
+                            Stable follows full releases. Nightly follows prerelease nightly builds.
+                            Nightly builds default to the Nightly channel.
+                          </Text>
+                        </SearchItem>
+                      )}
+
+                      {isElectron && (
+                        <SearchItem
+                          search={generalSearch}
+                          keywords="editor workspace on close behavior quit background tray"
+                        >
+                          <SelectField
+                            label="On Close Behavior"
+                            value={closeBehavior}
+                            variant="standard"
+                            onChange={(v) =>
+                              handleCloseBehaviorChange(
+                                v as "ask" | "quit" | "background"
+                              )
+                            }
+                            options={CLOSE_BEHAVIOR_OPTIONS}
+                          />
+                          <Text className="description">
+                            Choose what happens when you close the main window.
+                            <br />
+                            <b>Ask Every Time:</b> Shows a dialog with options.
+                            <br />
+                            <b>Quit:</b> Closes the application completely.
+                            <br />
+                            <b>Background:</b> Keeps the app running in the system
+                            tray.
+                          </Text>
+                        </SearchItem>
+                      )}
+                    </div>
+
+                    <div className="settings-section">
+                      <Text
+                        size="big"
+                        id="execution"
+                        className="settings-heading"
+                      >
+                        Execution
+                      </Text>
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="execution warn before large runs confirmation"
+                      >
+                        <LabeledSwitch
+                          label="Warn Before Large Runs"
+                          checked={settings.confirmLargeRun ?? true}
+                          onChange={(checked) =>
+                            updateSettings({ confirmLargeRun: checked })
+                          }
+                          description="Running a workflow executes every node at once. Show a confirmation when a run would launch many model/provider nodes that could overload an API."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="execution large-run threshold"
+                      >
+                        <TextInput
+                          type="number"
+                          autoComplete="off"
+                          slotProps={{ htmlInput: { min: 1, max: 100 } }}
+                          id="large-run-threshold-input"
+                          label="Large-Run Threshold"
+                          value={settings.largeRunThreshold ?? 5}
+                          onChange={(e) =>
+                            updateSettings({
+                              largeRunThreshold: Math.max(
+                                1,
+                                Number(e.target.value) || 1
+                              )
+                            })
+                          }
+                          variant="standard"
+                          size="small"
+                          disabled={!(settings.confirmLargeRun ?? true)}
+                        />
+                        <Text className="description">
+                          Warn when a run would execute more than this many
+                          model/provider nodes (LLM, image, audio, API, etc.).
+                        </Text>
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="execution max concurrent jobs runs queue concurrency parallel"
+                      >
+                        <ServerNumberSetting
+                          envVar="MAX_CONCURRENT_JOBS"
+                          label="Max Concurrent Runs"
+                          defaultValue={4}
+                          min={1}
+                          max={64}
+                          description="Maximum number of workflow runs you can execute at once. Additional runs queue and start automatically as running ones finish."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="execution max concurrent runs per workflow same queue concurrency parallel"
+                      >
+                        <ServerNumberSetting
+                          envVar="MAX_CONCURRENT_RUNS_PER_WORKFLOW"
+                          label="Max Concurrent Runs per Workflow"
+                          defaultValue={4}
+                          min={1}
+                          max={64}
+                          description="How many runs of the same workflow may run at once before further runs queue. Applies to concurrent generation (timeline, sketch); canvas runs always stay sequential."
+                        />
+                      </SearchItem>
+                    </div>
+
+                    <div className="settings-section">
+                      <Text
+                        size="big"
+                        id="canvas-navigation"
+                        className="settings-heading"
+                      >
+                        Canvas & Navigation
+                      </Text>
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="canvas navigation pan controls mouse"
+                      >
+                        <SelectField
+                          label="Pan Controls"
+                          value={settings.panControls}
+                          variant="standard"
+                          onChange={handlePanControlsChange}
+                          options={PAN_CONTROLS_OPTIONS}
+                        />
+                        <div className="description">
+                          <Text>
+                            Move the canvas by dragging with the left or right
+                            mouse button.
+                          </Text>
+                          <Text>
+                            With RMB selected, you can also pan with the Middle
+                            Mouse Button.
+                          </Text>
+                        </div>
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="canvas navigation node selection mode full partial"
+                      >
+                        <SelectField
+                          label="Node Selection Mode"
+                          value={settings.selectionMode}
+                          variant="standard"
+                          onChange={handleSelectionModeChange}
+                          options={SELECTION_MODE_OPTIONS}
+                        />
+                        <Text className="description">
+                          When drawing a selection box for node selections:
+                          <br />
+                          <b>Full:</b> nodes have to be fully enclosed.
+                          <br />
+                          <b>Partial:</b> intersecting nodes will be selected.
+                        </Text>
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="canvas navigation grid snap precision"
+                      >
+                        <TextInput
+                          type="number"
+                          autoComplete="off"
+                          slotProps={{ htmlInput: { min: 1, max: 100 } }}
+                          id="grid-snap-input"
+                          label="Grid Snap Precision"
+                          value={settings.gridSnap}
+                          onChange={handleGridSnapChange}
+                          variant="standard"
+                          size="small"
+                        />
+                        <Text className="description">
+                          Snap precision for moving nodes on the canvas.
+                        </Text>
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="canvas navigation connection snap range"
+                      >
+                        <TextInput
+                          type="number"
+                          autoComplete="off"
+                          slotProps={{ htmlInput: { min: 5, max: 30 } }}
+                          id="connection-snap-input"
+                          label="Connection Snap Range"
+                          value={settings.connectionSnap}
+                          onChange={handleConnectionSnapChange}
+                          variant="standard"
+                          size="small"
+                        />
+                        <Text className="description">
+                          Snap distance for connecting nodes.
+                        </Text>
+                      </SearchItem>
+                    </div>
+
+                    {generalMatches("ai default models provider") && (
+                      <DefaultModelsMenu />
                     )}
 
-                    {isElectron && (
-                      <div className="settings-item">
+                    <div className="settings-section">
+                      <Text
+                        size="big"
+                        id="autosave"
+                        className="settings-heading"
+                      >
+                        Autosave & Version History
+                      </Text>
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="autosave version history enable"
+                      >
+                        <LabeledSwitch
+                          label="Enable Autosave"
+                          checked={settings.autosave?.enabled ?? true}
+                          onChange={(checked) =>
+                            updateAutosaveSettings({ enabled: checked })
+                          }
+                          description="Automatically save your workflow at regular intervals."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="autosave version history interval minutes"
+                      >
                         <SelectField
-                          label="On Close Behavior"
-                          value={closeBehavior}
+                          label="Autosave Interval (minutes)"
+                          value={settings.autosave?.intervalMinutes ?? 10}
                           variant="standard"
                           onChange={(v) =>
-                            handleCloseBehaviorChange(
-                              v as "ask" | "quit" | "background"
-                            )
+                            updateAutosaveSettings({
+                              intervalMinutes: Number(v)
+                            })
                           }
-                          options={CLOSE_BEHAVIOR_OPTIONS}
+                          options={AUTOSAVE_INTERVAL_OPTIONS}
+                          disabled={!settings.autosave?.enabled}
+                          description="How often to automatically save your workflow."
                         />
-                        <Text className="description">
-                          Choose what happens when you close the main window.
-                          <br />
-                          <b>Ask Every Time:</b> Shows a dialog with options.
-                          <br />
-                          <b>Quit:</b> Closes the application completely.
-                          <br />
-                          <b>Background:</b> Keeps the app running in the system
-                          tray.
-                        </Text>
-                      </div>
-                    )}
-                  </div>
+                      </SearchItem>
 
-                  <Text size="big" id="execution">
-                    Execution
-                  </Text>
-                  <div className="settings-section">
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Warn Before Large Runs"
-                        checked={settings.confirmLargeRun ?? true}
-                        onChange={(checked) =>
-                          updateSettings({ confirmLargeRun: checked })
-                        }
-                        description="Running a workflow executes every node at once. Show a confirmation when a run would launch many model/provider nodes that could overload an API."
-                      />
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="autosave version history save before running checkpoint"
+                      >
+                        <LabeledSwitch
+                          label="Save Before Running"
+                          checked={settings.autosave?.saveBeforeRun ?? true}
+                          onChange={(checked) =>
+                            updateAutosaveSettings({
+                              saveBeforeRun: checked
+                            })
+                          }
+                          description="Create a checkpoint version before executing workflow."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="autosave version history save on window close"
+                      >
+                        <LabeledSwitch
+                          label="Save on Window Close"
+                          checked={settings.autosave?.saveOnClose ?? true}
+                          onChange={(checked) =>
+                            updateAutosaveSettings({
+                              saveOnClose: checked
+                            })
+                          }
+                          description="Automatically save when closing the tab or window."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="autosave version history max versions per workflow"
+                      >
+                        <SelectField
+                          label="Max Versions per Workflow"
+                          value={
+                            settings.autosave?.maxVersionsPerWorkflow ?? 50
+                          }
+                          variant="standard"
+                          onChange={(v) =>
+                            updateAutosaveSettings({
+                              maxVersionsPerWorkflow: Number(v)
+                            })
+                          }
+                          options={MAX_VERSIONS_OPTIONS}
+                          description="Maximum number of versions to keep per workflow."
+                        />
+                      </SearchItem>
                     </div>
 
-                    <div className="settings-item">
-                      <TextInput
-                        type="number"
-                        autoComplete="off"
-                        slotProps={{ htmlInput: { min: 1, max: 100 } }}
-                        id="large-run-threshold-input"
-                        label="Large-Run Threshold"
-                        value={settings.largeRunThreshold ?? 5}
-                        onChange={(e) =>
-                          updateSettings({
-                            largeRunThreshold: Math.max(
-                              1,
-                              Number(e.target.value) || 1
-                            )
-                          })
-                        }
-                        variant="standard"
-                        size="small"
-                        disabled={!(settings.confirmLargeRun ?? true)}
-                      />
-                      <Text className="description">
-                        Warn when a run would execute more than this many
-                        model/provider nodes (LLM, image, audio, API, etc.).
+                    <div className="settings-section">
+                      <Text
+                        size="big"
+                        id="appearance"
+                        className="settings-heading"
+                      >
+                        Appearance
                       </Text>
-                    </div>
-                  </div>
-
-                  <Text size="big" id="canvas-navigation">
-                    Canvas & Navigation
-                  </Text>
-                  <div className="settings-section">
-                    <div className="settings-item">
-                      <SelectField
-                        label="Pan Controls"
-                        value={settings.panControls}
-                        variant="standard"
-                        onChange={handlePanControlsChange}
-                        options={PAN_CONTROLS_OPTIONS}
-                      />
-                      <div className="description">
-                        <Text>
-                          Move the canvas by dragging with the left or right
-                          mouse button.
-                        </Text>
-                        <Text>
-                          With RMB selected, you can also pan with the Middle
-                          Mouse Button.
-                        </Text>
-                      </div>
-                    </div>
-
-                    <div className="settings-item">
-                      <SelectField
-                        label="Node Selection Mode"
-                        value={settings.selectionMode}
-                        variant="standard"
-                        onChange={handleSelectionModeChange}
-                        options={SELECTION_MODE_OPTIONS}
-                      />
-                      <Text className="description">
-                        When drawing a selection box for node selections:
-                        <br />
-                        <b>Full:</b> nodes have to be fully enclosed.
-                        <br />
-                        <b>Partial:</b> intersecting nodes will be selected.
-                      </Text>
-                    </div>
-
-                    <div className="settings-item">
-                      <TextInput
-                        type="number"
-                        autoComplete="off"
-                        slotProps={{ htmlInput: { min: 1, max: 100 } }}
-                        id="grid-snap-input"
-                        label="Grid Snap Precision"
-                        value={settings.gridSnap}
-                        onChange={handleGridSnapChange}
-                        variant="standard"
-                        size="small"
-                      />
-                      <Text className="description">
-                        Snap precision for moving nodes on the canvas.
-                      </Text>
-                    </div>
-
-                    <div className="settings-item">
-                      <TextInput
-                        type="number"
-                        autoComplete="off"
-                        slotProps={{ htmlInput: { min: 5, max: 30 } }}
-                        id="connection-snap-input"
-                        label="Connection Snap Range"
-                        value={settings.connectionSnap}
-                        onChange={handleConnectionSnapChange}
-                        variant="standard"
-                        size="small"
-                      />
-                      <Text className="description">
-                        Snap distance for connecting nodes.
-                      </Text>
-                    </div>
-                  </div>
-
-                  <DefaultModelsMenu />
-
-                  <Text size="big" id="autosave">
-                    Autosave & Version History
-                  </Text>
-                  <div className="settings-section">
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Enable Autosave"
-                        checked={settings.autosave?.enabled ?? true}
-                        onChange={(checked) =>
-                          updateAutosaveSettings({ enabled: checked })
-                        }
-                        description="Automatically save your workflow at regular intervals."
-                      />
-                    </div>
-
-                    <div className="settings-item">
-                      <SelectField
-                        label="Autosave Interval (minutes)"
-                        value={settings.autosave?.intervalMinutes ?? 10}
-                        variant="standard"
-                        onChange={(v) =>
-                          updateAutosaveSettings({
-                            intervalMinutes: Number(v)
-                          })
-                        }
-                        options={AUTOSAVE_INTERVAL_OPTIONS}
-                        disabled={!settings.autosave?.enabled}
-                        description="How often to automatically save your workflow."
-                      />
-                    </div>
-
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Save Before Running"
-                        checked={settings.autosave?.saveBeforeRun ?? true}
-                        onChange={(checked) =>
-                          updateAutosaveSettings({
-                            saveBeforeRun: checked
-                          })
-                        }
-                        description="Create a checkpoint version before executing workflow."
-                      />
-                    </div>
-
-                    <div className="settings-item">
-                      <LabeledSwitch
-                        label="Save on Window Close"
-                        checked={settings.autosave?.saveOnClose ?? true}
-                        onChange={(checked) =>
-                          updateAutosaveSettings({
-                            saveOnClose: checked
-                          })
-                        }
-                        description="Automatically save when closing the tab or window."
-                      />
-                    </div>
-
-                    <div className="settings-item">
-                      <SelectField
-                        label="Max Versions per Workflow"
-                        value={
-                          settings.autosave?.maxVersionsPerWorkflow ?? 50
-                        }
-                        variant="standard"
-                        onChange={(v) =>
-                          updateAutosaveSettings({
-                            maxVersionsPerWorkflow: Number(v)
-                          })
-                        }
-                        options={MAX_VERSIONS_OPTIONS}
-                        description="Maximum number of versions to keep per workflow."
-                      />
-                    </div>
-                  </div>
-
-                  <Text size="big" id="appearance">
-                    Appearance
-                  </Text>
-                  <div className="settings-section">
-                    <div className="settings-item">
-                      <SelectField
-                        label="Time Format"
-                        value={settings.timeFormat}
-                        variant="standard"
-                        onChange={handleTimeFormatChange}
-                        options={TIME_FORMAT_OPTIONS}
-                        description="Display time in 12h or 24h format."
-                      />
+                      <SearchItem
+                        search={generalSearch}
+                        keywords="appearance time format 12h 24h"
+                      >
+                        <SelectField
+                          label="Time Format"
+                          value={settings.timeFormat}
+                          variant="standard"
+                          onChange={handleTimeFormatChange}
+                          options={TIME_FORMAT_OPTIONS}
+                          description="Display time in 12h or 24h format."
+                        />
+                      </SearchItem>
                     </div>
                   </div>
                 </TabPanel>
 
-                {/* Tab 1: API & Keys */}
-                <TabPanel value={settingsTab} index={1}>
+                {/* Tab 1: API Keys (provider credentials only) */}
+                <TabPanel value={settingsTab} index={TAB_API_KEYS}>
                   <div style={{ marginBottom: "1.5em" }}>
                     <SearchInput
                       placeholder="Search providers..."
@@ -889,10 +1073,21 @@ function SettingsPage() {
                     />
                   </div>
                   <APIKeysTabContent searchTerm={apiSearchTerm} />
+                  <Box sx={{ marginTop: "1.5em" }}>
+                    <SecurityNotice />
+                  </Box>
+                </TabPanel>
 
+                {/* Tab 2: Integrations (endpoints, MCP, storage, Nodetool API) */}
+                <TabPanel value={settingsTab} index={TAB_INTEGRATIONS}>
+                  <div className="integrations-settings">
                   {session?.access_token && !isLocalhost && (
                     <>
-                      <Text size="big" id="nodetool-api-token" sx={{ marginTop: "2em" }}>
+                      <Text
+                        size="big"
+                        id="nodetool-api-token"
+                        className="settings-heading"
+                      >
                         Nodetool API
                       </Text>
                       <Text
@@ -961,33 +1156,42 @@ function SettingsPage() {
                     </>
                   )}
 
-                  <Text size="big" id="api-settings" sx={{ marginTop: "2em" }}>
+                  <Text
+                    size="big"
+                    id="api-settings"
+                    className="settings-heading"
+                  >
                     API Settings
                   </Text>
                   <RemoteSettingsMenuComponent />
 
                   {isLocalhost && (
                     <>
-                      <Text size="big" id="mcp-integration" sx={{ marginTop: "2em" }}>
+                      <Text
+                        size="big"
+                        id="mcp-integration"
+                        className="settings-heading"
+                      >
                         MCP Integration
                       </Text>
                       <MCPSettingsMenu />
                     </>
                   )}
 
-                  <Text size="big" id="folders" sx={{ marginTop: "2em" }}>
+                  <Text size="big" id="folders" className="settings-heading">
                     Folders
                   </Text>
                   <FoldersSettings />
+                  </div>
                 </TabPanel>
 
-                {/* Tab 2: Models */}
-                <TabPanel value={settingsTab} index={2}>
+                {/* Tab 3: Models */}
+                <TabPanel value={settingsTab} index={TAB_MODELS}>
                   <ModelListIndex />
                 </TabPanel>
 
-                {/* Tab 3: Collections */}
-                <TabPanel value={settingsTab} index={3}>
+                {/* Tab 4: Collections */}
+                <TabPanel value={settingsTab} index={TAB_COLLECTIONS}>
                   <Box className="settings-panel-padded">
                     <SettingsIntroCard
                       icon={<LibraryBooksOutlinedIcon sx={{ fontSize: 22 }} />}
@@ -1004,9 +1208,9 @@ function SettingsPage() {
                   </Box>
                 </TabPanel>
 
-                {/* Tab 4: Workspaces */}
+                {/* Tab 5: Workspaces */}
                 {workspacesEnabled && (
-                  <TabPanel value={settingsTab} index={4}>
+                  <TabPanel value={settingsTab} index={TAB_WORKSPACES}>
                     <Box className="settings-panel-padded">
                       <SettingsIntroCard
                         icon={<FolderSpecialOutlinedIcon sx={{ fontSize: 22 }} />}
@@ -1035,7 +1239,7 @@ function SettingsPage() {
                 </TabPanel>
               </div>
 
-              {settingsTab === 1 && !isMobile && (
+              {settingsTab === TAB_API_KEYS && !isMobile && (
                 <APIKeysRightSidebar />
               )}
             </div>

--- a/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
+++ b/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
@@ -144,8 +144,8 @@ describe("RemoteSettingsMenu", () => {
       render(<RemoteSettingsMenuComponent />, { wrapper });
 
       await waitFor(() => {
-        // Non-secret setting should be visible
-        expect(screen.getByText("TIMEOUT")).toBeInTheDocument();
+        // Non-secret setting should be visible (label is title-cased)
+        expect(screen.getByText("Timeout")).toBeInTheDocument();
         expect(screen.getByText("Request timeout in seconds")).toBeInTheDocument();
 
         // Secret setting should NOT be visible
@@ -185,7 +185,7 @@ describe("RemoteSettingsMenu", () => {
       render(<RemoteSettingsMenuComponent />, { wrapper });
 
       await waitFor(() => {
-        expect(screen.getByText("TIMEOUT")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("30")).toBeInTheDocument();
       });
 
       // Update the non-secret setting

--- a/web/src/components/menus/settingsLabel.ts
+++ b/web/src/components/menus/settingsLabel.ts
@@ -1,0 +1,26 @@
+/** Acronyms that should stay upper-cased in setting labels. */
+const LABEL_ACRONYMS: Record<string, string> = {
+  api: "API",
+  url: "URL",
+  id: "ID",
+  js: "JS",
+  db: "DB",
+  hf: "HF",
+  serp: "SERP",
+  serpapi: "SerpAPI",
+  vllm: "vLLM",
+  llm: "LLM",
+  mcp: "MCP",
+  seo: "SEO"
+};
+
+/** "AUTOSAVE_INTERVAL_MINUTES" → "Autosave Interval Minutes" (acronyms kept). */
+export const formatSettingLabel = (envVar: string): string =>
+  envVar
+    .toLowerCase()
+    .split("_")
+    .map(
+      (word) =>
+        LABEL_ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join(" ");

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -243,32 +243,81 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
       padding: "1.25rem 1.75rem"
     }
   },
+  // When a search hides every row in a General section, collapse the whole
+  // section (its heading lives inside it) so only matching rows remain. Scoped
+  // to direct children so nested component sections (e.g. DefaultModelsMenu,
+  // whose rows have no `.settings-item`) aren't hidden.
+  ".general-settings > .settings-section:not(:has(.settings-item))": {
+    display: "none"
+  },
   ".settings-section": {
     backgroundColor: "transparent",
     borderRadius: 0,
     padding: 0,
-    margin: "1.5em 0",
+    margin: "0 0 1.5em",
     boxShadow: "none",
     border: "0 none",
 
     width: "100%",
     display: "flex",
     flexDirection: "column",
-    gap: ".5em",
+    gap: 0,
     "&:first-of-type": {
-      marginTop: "0.5em"
+      marginTop: "0.25em"
+    },
+    // Extra breathing room before each new group (a section that opens with a
+    // heading). The first section has no heading, so it isn't affected.
+    "&:has(.settings-heading)": {
+      marginTop: "2.5em"
+    }
+  },
+  // Section headers between groups (Execution, Canvas & Navigation, …). Lives as
+  // the first child of its section so an empty (search-filtered) section hides
+  // the heading too via `.settings-section:not(:has(.settings-item))`.
+  ".settings-heading": {
+    display: "block",
+    margin: "0 0 1em",
+    paddingTop: "2em",
+    borderTop: `1px solid ${theme.vars.palette.divider}`,
+    fontSize: theme.fontSizeBig,
+    fontWeight: 600,
+    letterSpacing: "0.01em",
+    lineHeight: 1.2,
+    color: theme.vars.palette.grey[0]
+  },
+  // No divider/extra space above the very first group heading in a tab.
+  ".integrations-settings > .settings-heading:first-child, .general-settings > .settings-section:first-child > .settings-heading":
+    {
+      borderTop: "none",
+      paddingTop: 0
+    },
+  ".general-settings > .settings-section:first-child": {
+    marginTop: "0.25em"
+  },
+  // Default Models rows (each: label, model select + clear, provider caption).
+  ".default-models-list": {
+    display: "flex",
+    flexDirection: "column"
+  },
+  ".default-model-row": {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.6em",
+    padding: "0.9em 0",
+    "&:last-child": {
+      paddingBottom: 0
     }
   },
   ".settings-item.large": {
     ".MuiInputBase-root": {
-      maxWidth: "unset !important"
+      // Cap "large" fields (endpoints, keys) to the same width as other fields
+      // instead of letting them span full width.
+      maxWidth: "34em !important"
     }
   },
   ".settings-item": {
-    padding: "0 0 .1em 0",
-    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    padding: "0.9em 0",
     "&:last-child": {
-      borderBottom: "none",
       paddingBottom: "0"
     },
     "&:first-of-type": {
@@ -277,7 +326,12 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     width: "100%",
     display: "flex",
     flexDirection: "column",
-    gap: ".8em",
+    gap: ".5em",
+    // SelectField wraps its control in a div with a hardcoded 24px bottom
+    // margin; neutralize it here so the row gap controls spacing consistently.
+    "& > div[style]": {
+      marginBottom: "0 !important"
+    },
     ".MuiInputBase-root": {
       maxWidth: "200px !important"
     },
@@ -290,7 +344,8 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
         position: "relative",
         transform: "none",
         marginBottom: theme.spacing(2),
-        fontWeight: 500,
+        fontWeight: 600,
+        letterSpacing: "0.01em",
         color: theme.vars.palette.grey[0],
         fontSize: theme.fontSizeNormal
       },
@@ -316,17 +371,28 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     },
     label: {
       color: theme.vars.palette.grey[0],
-      fontSize: theme.fontSizeBig,
-      fontWeight: 500,
-      padding: ".5em 0 .25em 0"
+      fontSize: theme.fontSizeNormal,
+      fontWeight: 600,
+      letterSpacing: "0.01em",
+      padding: "0"
+    },
+    // LabeledSwitch renders its description as MUI body2 (not `.description`).
+    "& .MuiTypography-body2": {
+      color: theme.vars.palette.grey[100],
+      opacity: 0.85,
+      fontSize: theme.fontSizeSmall,
+      lineHeight: "1.5",
+      marginTop: "0.4em",
+      maxWidth: "60ch"
     },
     ".description": {
-      color: theme.vars.palette.grey[50],
-      opacity: 0.5,
+      color: theme.vars.palette.grey[100],
+      opacity: 0.85,
       fontSize: theme.fontSizeSmall,
       margin: "0",
       padding: "0",
-      lineHeight: "1.6",
+      maxWidth: "60ch",
+      lineHeight: "1.5",
       a: {
         color: "var(--palette-primary-main)",
         backgroundColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.10)`,
@@ -411,7 +477,9 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
       boxShadow: "0 4px 8px rgba(0,0,0,0.2)"
     }
   },
-  ".MuiTypography-root": {
+  // Blanket body size for Typography, but leave section headings alone so they
+  // can use their larger heading size.
+  ".MuiTypography-root:not(.settings-heading)": {
     fontSize: theme.fontSizeNormal
   },
   ".MuiMenuItem-root": {

--- a/web/src/components/menus/sharedSettingsStyles.ts
+++ b/web/src/components/menus/sharedSettingsStyles.ts
@@ -62,9 +62,11 @@ export const getSharedSettingsStyles = (theme: Theme): SerializedStyles => {
 
     .description {
       margin-top: 0.25em;
-      opacity: 0.5;
-      font-size: 0.85em;
-      line-height: 1.4;
+      opacity: 0.85;
+      color: ${theme.vars.palette.grey[100]};
+      font-size: ${theme.fontSizeSmall};
+      line-height: 1.5;
+      max-width: 60ch;
     }
 
     a {
@@ -97,22 +99,38 @@ export const getSharedSettingsStyles = (theme: Theme): SerializedStyles => {
     .settings-item {
       display: flex;
       flex-direction: column;
-      gap: 0.4em;
-      padding: 0.5em 0;
-      border-bottom: 1px solid ${theme.vars.palette.divider};
+      gap: 0.5em;
+      padding: 0.9em 0;
 
-      &:last-child {
-        border-bottom: none;
+      /* Block-style label sitting above the field, matching the General tab. */
+      .MuiInputLabel-root {
+        position: relative;
+        transform: none;
+        margin-bottom: 0.4em;
+        font-size: ${theme.fontSizeNormal};
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        color: ${theme.vars.palette.grey[0]};
       }
 
       .MuiTextField-root {
         width: 100%;
+        max-width: 34em;
       }
 
       .MuiInputBase-root {
+        max-width: 34em;
+        background-color: ${theme.vars.palette.background.paper};
         border: 1px solid ${theme.vars.palette.divider};
         border-radius: 0.3em;
+        padding: 0.3em 1em;
+        font-size: ${theme.fontSizeNormal};
         transition: border-color 0.2s ease;
+
+        &::before,
+        &::after {
+          content: none;
+        }
 
         &:hover {
           border-color: ${theme.vars.palette.grey[300]};
@@ -125,7 +143,7 @@ export const getSharedSettingsStyles = (theme: Theme): SerializedStyles => {
     }
 
     .settings-item.large {
-      padding: 0.6em 0;
+      padding: 0.9em 0;
     }
 
     .settings-main-content {

--- a/web/src/components/workspaces/WorkspaceSelect.tsx
+++ b/web/src/components/workspaces/WorkspaceSelect.tsx
@@ -145,7 +145,7 @@ const WorkspaceSelect: React.FC<WorkspaceSelectProps> = memo(
       (event: { target: { value: string } }) => {
         const newValue = event.target.value;
         if (newValue === CREATE_NEW_VALUE) {
-          navigate("/settings?tab=4");
+          navigate("/settings?tab=5");
           return;
         }
         onChange(newValue === "" ? undefined : newValue);

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -520,7 +520,7 @@ const WorkspaceTree: React.FC = () => {
   }, [refetchFiles]);
 
   const handleManageWorkspace = useCallback(() => {
-    navigate("/settings?tab=4");
+    navigate("/settings?tab=5");
   }, [navigate]);
 
   // Handle double-click on tree container to find the specific tree item


### PR DESCRIPTION
## Summary

Started from "make the new same-workflow concurrency a settings param," then iterated into a broader settings cleanup.

### Concurrency
- New **`MAX_CONCURRENT_RUNS_PER_WORKFLOW`** setting (Execution group, default 4) caps how many *opt-in concurrent* runs of the same workflow run before further ones queue. Non-concurrent canvas runs stay strictly sequential (editor isolation). Wired through `UnifiedWebSocketRunner` admission (`runJob`) and `drainQueue`, with a cached settings getter mirroring `MAX_CONCURRENT_JOBS`.

### Settings UI
- **Concurrency controls are now discoverable**: both caps render in **General → Execution** via a new server-backed `ServerNumberSetting` (reads/writes the registry setting via tRPC). Removed the duplicate "Execution" group from the generic remote-settings list.
- **Split the "API & Keys" tab**: **API Keys** now contains only provider credentials; a new **Integrations** tab holds service endpoints, MCP servers, storage, and the Nodetool API. Tab indices are named constants; updated the two workspace deep-links (`tab=4` → `tab=5`).
- **General search**: the search box now filters every setting (per-row `SearchItem` + section collapse), not just providers.
- **Integrations sidebar** lists every group the panel actually renders (dynamic, registry-driven).
- **Aesthetics**: theme-var font sizes only; section headers exempted from the blanket `.MuiTypography-root` size rule so they read larger; consistent spacing; capped input widths; title-cased registry labels; horizontal dividers only between sections, not between fields.
- **Default Models**: de-crammed rows (proper spacing, no inter-field dividers) and dropped the redundant `provider / name` caption (the select already shows the model).

## Test plan
- `npm run typecheck` / `lint` pass for touched packages.
- Updated + passing: `packages/websocket/tests/unified-websocket-runner.test.ts` (new per-workflow-cap test) and `web/.../RemoteSettingsMenu.test.tsx`.
- Verified in-browser (headless Chrome): tab split, search/collapse, sidebar completeness, header sizing, dividers, Default Models layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)