### PR TITLE
Improve FAL asset output mapping for flexible endpoint schemas

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -25,7 +25,7 @@
         "expo-document-picker": "~56.0.4",
         "expo-image-picker": "~56.0.15",
         "expo-status-bar": "~56.0.4",
-        "react": "19.2.7",
+        "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-get-random-values": "~1.11.0",
         "react-native-markdown-display": "^7.0.2",
@@ -6591,6 +6591,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11015,9 +11016,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11046,9 +11047,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,7 +34,7 @@
     "expo-document-picker": "~56.0.4",
     "expo-image-picker": "~56.0.15",
     "expo-status-bar": "~56.0.4",
-    "react": "19.2.7",
+    "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-get-random-values": "~1.11.0",
     "react-native-markdown-display": "^7.0.2",

--- a/packages/fal-nodes/src/fal-dynamic.ts
+++ b/packages/fal-nodes/src/fal-dynamic.ts
@@ -357,9 +357,13 @@ async function coerceInputValue(
   if (value && typeof value === "object" && !Array.isArray(value)) {
     const ref = value as Record<string, unknown>;
     if (ref.uri !== undefined || ref.data !== undefined) {
-      // Try data URI for images, CDN upload otherwise
-      const dataUrl = await imageToDataUrl(ref);
-      if (dataUrl) return dataUrl;
+      // Inline images as data URIs. Only images — `imageToDataUrl` always tags
+      // the payload with an image MIME type, so routing video/audio through it
+      // would mislabel them (e.g. an MP4 sent as `data:image/png`).
+      if (ref.type === "image") {
+        const dataUrl = await imageToDataUrl(ref);
+        if (dataUrl) return dataUrl;
+      }
       const uri = ref.uri as string | undefined;
       if (uri?.startsWith("https://") && !uri.includes("localhost")) return uri;
       const data = ref.data as string | undefined;

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -28,6 +28,7 @@ import {
   assetToFalUrl,
   imageToDataUrl
 } from "./fal-base.js";
+import type { FalImageResult } from "./fal-base.js";
 import { reportFalCost } from "./fal-cost.js";
 
 export interface FalManifestEntry {
@@ -280,6 +281,57 @@ function coerceAssetRef(
   return value;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Pull a usable asset URL out of a FAL response value. FAL endpoints return the
+ * asset variously as a File object (`{ url }`), a bare URL string, or an array
+ * of either, so handle all three uniformly.
+ */
+function extractAssetUri(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const u = extractAssetUri(item);
+      if (u) return u;
+    }
+    return "";
+  }
+  const rec = asRecord(value);
+  if (rec && typeof rec.url === "string") return rec.url;
+  return "";
+}
+
+/**
+ * Resolve the URL for a single-asset output. Checks well-known response keys
+ * first (e.g. `video`, `video_url`), then falls back to whatever asset field
+ * the endpoint's schema declared — covering endpoints that return `video_url`,
+ * `audio_file`, etc. instead of the canonical singular key.
+ */
+function resolveAssetUri(
+  spec: FalManifestEntry,
+  res: Record<string, unknown>,
+  preferredKeys: string[]
+): string {
+  for (const key of preferredKeys) {
+    if (key in res) {
+      const u = extractAssetUri(res[key]);
+      if (u) return u;
+    }
+  }
+  for (const f of spec.outputFields) {
+    if (f.name in res) {
+      const u = extractAssetUri(res[f.name]);
+      if (u) return u;
+    }
+  }
+  return "";
+}
+
 function mapOutput(
   spec: FalManifestEntry,
   res: Record<string, unknown>
@@ -289,29 +341,45 @@ function mapOutput(
       return {
         output: {
           type: "video",
-          uri: (res.video as Record<string, unknown>)?.url ?? ""
+          uri: resolveAssetUri(spec, res, [
+            "video",
+            "videos",
+            "video_url",
+            "video_file"
+          ])
         }
       };
     case "audio":
       return {
         output: {
           type: "audio",
-          uri: (res.audio as Record<string, unknown>)?.url ?? ""
+          uri: resolveAssetUri(spec, res, [
+            "audio",
+            "audios",
+            "audio_url",
+            "audio_file"
+          ])
         }
       };
-    case "model_3d": {
-      const ref =
-        (res as Record<string, unknown>).model_glb ??
-        (res as Record<string, unknown>).model_mesh;
+    case "model_3d":
       return {
         output: {
           type: "model_3d",
-          uri: (ref as Record<string, unknown>)?.url ?? ""
+          uri: resolveAssetUri(spec, res, [
+            "model_glb",
+            "model_mesh",
+            "model",
+            "model_url"
+          ])
         }
       };
+    case "str": {
+      // The text lives under the endpoint's declared field name (e.g.
+      // `results`, `voice_id`), which is not always `output`.
+      const name = spec.outputFields[0]?.name;
+      const value = name && name in res ? res[name] : res.output;
+      return { output: value ?? "" };
     }
-    case "str":
-      return { output: (res as Record<string, unknown>).output ?? "" };
     default:
       if (spec.outputFields.length > 0) {
         const out: Record<string, unknown> = {};
@@ -374,6 +442,15 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
           | undefined;
         if (images?.length) {
           return { output: falImageToRef(images[0]) };
+        }
+        // Many endpoints return a single `image` object instead of an `images`
+        // array; map it onto the canonical `output` slot too.
+        const single = res.image;
+        if (asRecord(single)?.url) {
+          return { output: falImageToRef(single as FalImageResult) };
+        }
+        if (typeof single === "string" && single) {
+          return { output: { type: "image", uri: single } };
         }
         return mapOutput(specRef, res);
       }

--- a/packages/fal-nodes/tests/fal-dynamic.test.ts
+++ b/packages/fal-nodes/tests/fal-dynamic.test.ts
@@ -522,6 +522,79 @@ describe("FalDynamicNode.process — asset ref coercion", () => {
     expect(typeof opts.input.image_url).toBe("string");
     expect((opts.input.image_url as string).startsWith("data:")).toBe(true);
   });
+
+  it("uploads a video data ref with a video MIME type (not as image)", async () => {
+    const openApiWithVideo = {
+      info: { "x-fal-metadata": { endpointId: "fal-ai/vid" } },
+      paths: {
+        "/fal-ai/vid": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { video_url: { type: "string" } },
+                    required: ["video_url"]
+                  }
+                }
+              }
+            }
+          },
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { type: "object", properties: {} }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).endsWith("llms.txt")) {
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              `**Model ID**: \`fal-ai/vid\`\n` +
+                `https://fal.ai/api/openapi/queue/openapi.json?endpoint_id=fal-ai/vid`
+            )
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(openApiWithVideo)
+      });
+    });
+
+    mockStorageUpload.mockResolvedValue("https://fal.media/uploaded.mp4");
+    mockSubscribe.mockResolvedValue({ data: { result: "done" } });
+
+    const node = new FalDynamicNode();
+    const executor = node.toExecutor();
+    await executor.process({
+      _secrets: { FAL_API_KEY: "k" },
+      model_info: "fal-ai/vid",
+      video_url: { type: "video", data: "aGVsbG8=" } // no uri → must upload
+    });
+
+    // The uploaded blob must carry a video content type, never image/*.
+    expect(mockStorageUpload).toHaveBeenCalledOnce();
+    const blob = mockStorageUpload.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("video/mp4");
+
+    const [, opts] = mockSubscribe.mock.calls[0] as [
+      string,
+      { input: Record<string, unknown> }
+    ];
+    expect(opts.input.video_url).toBe("https://fal.media/uploaded.mp4");
+  });
 });
 
 /* ================================================================== */

--- a/packages/fal-nodes/tests/fal-factory.test.ts
+++ b/packages/fal-nodes/tests/fal-factory.test.ts
@@ -176,6 +176,79 @@ describe("FAL factory argument building", () => {
     });
   });
 
+  const makeNode = (overrides: Partial<Parameters<typeof createFalNodeClass>[0]>) =>
+    createFalNodeClass({
+      endpointId: "fal-ai/test",
+      className: "OutModel",
+      moduleName: "x",
+      docstring: "test",
+      tags: [],
+      useCases: [],
+      outputType: "str",
+      outputFields: [],
+      enums: [],
+      inputFields: [],
+      ...overrides
+    });
+
+  it("maps a singular `image` object output onto the `output` slot", async () => {
+    falSubmit.mockResolvedValueOnce({
+      image: { url: "https://fal.media/out.png", width: 64, height: 32 }
+    });
+    const NodeClass = makeNode({
+      outputType: "image",
+      outputFields: [
+        { name: "image", propType: "image", tsType: "image", default: null, description: "", fieldType: "output", required: true }
+      ]
+    });
+    const result = await new NodeClass({}).process();
+    expect(result).toEqual({
+      output: { type: "image", uri: "https://fal.media/out.png" }
+    });
+  });
+
+  it("maps a `video_url` string output onto the `output` slot", async () => {
+    falSubmit.mockResolvedValueOnce({ video_url: "https://fal.media/clip.mp4" });
+    const NodeClass = makeNode({
+      outputType: "video",
+      outputFields: [
+        { name: "video_url", propType: "video", tsType: "video", default: null, description: "", fieldType: "output", required: true }
+      ]
+    });
+    const result = await new NodeClass({}).process();
+    expect(result).toEqual({
+      output: { type: "video", uri: "https://fal.media/clip.mp4" }
+    });
+  });
+
+  it("maps an `audio_file` object output onto the `output` slot", async () => {
+    falSubmit.mockResolvedValueOnce({
+      audio_file: { url: "https://fal.media/sound.wav" }
+    });
+    const NodeClass = makeNode({
+      outputType: "audio",
+      outputFields: [
+        { name: "audio_file", propType: "str", tsType: "string", default: null, description: "", fieldType: "output", required: true }
+      ]
+    });
+    const result = await new NodeClass({}).process();
+    expect(result).toEqual({
+      output: { type: "audio", uri: "https://fal.media/sound.wav" }
+    });
+  });
+
+  it("reads a `str` output from its declared field name (not `output`)", async () => {
+    falSubmit.mockResolvedValueOnce({ voice_id: "abc-123" });
+    const NodeClass = makeNode({
+      outputType: "str",
+      outputFields: [
+        { name: "voice_id", propType: "str", tsType: "string", default: "", description: "", fieldType: "output", required: true }
+      ]
+    });
+    const result = await new NodeClass({}).process();
+    expect(result).toEqual({ output: "abc-123" });
+  });
+
   it("forwards ProcessingContext to asset upload resolution", async () => {
     const NodeClass = createFalNodeClass({
       endpointId: "fal-ai/test",


### PR DESCRIPTION
## Summary

Enhance FAL node output handling to robustly map asset fields (image, video, audio, model_3d) and string outputs across endpoints with varying response schemas. Many FAL endpoints return assets under non-canonical field names (e.g., `video_url`, `audio_file`, `model_glb`) or as singular objects instead of arrays, causing output mapping to fail silently.

## Key Changes

- **New helper functions** (`asRecord`, `extractAssetUri`, `resolveAssetUri`):
  - `asRecord()`: Type-safe object validation
  - `extractAssetUri()`: Recursively extract URLs from File objects, bare strings, or arrays
  - `resolveAssetUri()`: Check preferred field names first, then fall back to schema-declared output fields

- **Improved asset output mapping** in `mapOutput()`:
  - Video, audio, and model_3d outputs now use `resolveAssetUri()` with multiple fallback keys (e.g., `video`, `videos`, `video_url`, `video_file`)
  - Handles both File objects (`{ url: "..." }`) and bare URL strings uniformly

- **String output handling**:
  - `str` type outputs now read from the endpoint's declared field name (e.g., `voice_id`, `results`) instead of always expecting `output`
  - Preserves backward compatibility with endpoints that do use `output`

- **Singular image object support**:
  - Image endpoints returning a single `image` object (instead of `images` array) now map correctly to the output slot
  - Handles both File objects and bare URL strings

- **Video/audio data ref upload fix** in `coerceInputValue()`:
  - Only inline images as data URIs; video and audio refs are now uploaded to CDN
  - Prevents mislabeling video/audio payloads with image MIME types

## Testing

- Added test cases for singular `image` object, `video_url` string, `audio_file` object, and custom `str` field name outputs
- Added test for video data ref upload with correct `video/mp4` MIME type

https://claude.ai/code/session_01TTZPzySMJo8PVUattrhsWi