### PR TITLE
Fix media ref format: use raw base64 instead of data URIs

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -6591,6 +6591,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11046,9 +11047,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {
@@ -11511,18 +11512,18 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
-      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
+      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.7",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.7"
       }
     },
     "node_modules/redent": {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -25,7 +25,7 @@
         "expo-document-picker": "~56.0.4",
         "expo-image-picker": "~56.0.15",
         "expo-status-bar": "~56.0.4",
-        "react": "19.2.7",
+        "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-get-random-values": "~1.11.0",
         "react-native-markdown-display": "^7.0.2",
@@ -11016,9 +11016,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11512,18 +11512,18 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
-      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "react-is": "^19.2.7",
+        "react-is": "^19.2.3",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.3"
       }
     },
     "node_modules/redent": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -71,6 +71,6 @@
     "minimatch": ">=3.1.4",
     "flatted": ">=3.4.2",
     "ajv": ">=6.14.0",
-    "react-test-renderer": "19.2.3"
+    "react-test-renderer": "19.2.7"
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,7 +34,7 @@
     "expo-document-picker": "~56.0.4",
     "expo-image-picker": "~56.0.15",
     "expo-status-bar": "~56.0.4",
-    "react": "19.2.7",
+    "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-get-random-values": "~1.11.0",
     "react-native-markdown-display": "^7.0.2",
@@ -71,6 +71,6 @@
     "minimatch": ">=3.1.4",
     "flatted": ">=3.4.2",
     "ajv": ">=6.14.0",
-    "react-test-renderer": "19.2.7"
+    "react-test-renderer": "19.2.3"
   }
 }

--- a/packages/llm-nodes/src/nodes/openai.ts
+++ b/packages/llm-nodes/src/nodes/openai.ts
@@ -309,7 +309,7 @@ export class CreateImageNode extends BaseNode {
 
     const item = data.data[0];
     if (item.b64_json) {
-      return { output: { type: "image", data: `data:image/png;base64,${item.b64_json}` } };
+      return { output: imageRefFromB64(item.b64_json) };
     } else if (item.url) {
       return { output: { type: "image", uri: item.url } };
     }
@@ -413,12 +413,13 @@ export class EditImageNode extends BaseNode {
     const quality = String(this.quality ?? "high");
 
     // Build multipart form data
+    // Note: gpt-image-1 always returns base64 and rejects `response_format`,
+    // so it must not be sent (unlike the legacy dall-e-2 edits endpoint).
     const formData = new FormData();
     formData.append("prompt", prompt);
     formData.append("model", model);
     formData.append("size", size);
     formData.append("quality", quality);
-    formData.append("response_format", "b64_json");
 
     // Convert image ref to blob
     const imageBlob = await refToBlob(image);
@@ -446,12 +447,109 @@ export class EditImageNode extends BaseNode {
 
     const item = data.data[0];
     if (item.b64_json) {
-      return { output: { type: "image", data: `data:image/png;base64,${item.b64_json}` } };
+      return { output: imageRefFromB64(item.b64_json) };
     } else if (item.url) {
       return { output: { type: "image", uri: item.url } };
     }
     throw new Error("No image data in response");
   }
+}
+
+// ---------------------------------------------------------------------------
+// 5b. ImageVariation
+// ---------------------------------------------------------------------------
+export class ImageVariationNode extends BaseNode {
+  static readonly nodeType = "openai.image.ImageVariation";
+  static readonly body = "content_card";
+  static readonly title = "Image Variation";
+  static readonly inlineFields = [];
+  static readonly inputFields = ["image"];
+  static readonly description =
+    "Generate variations of an input image using OpenAI's image variations API.\n    image, variation, remix, generate, alternative, dall-e\n\n    Takes a square PNG image and produces a new image that is a variation of it.\n    No text prompt is used — the model riffs on the source image directly.";
+  static readonly metadataOutputTypes = {
+    output: "image"
+  };
+  static readonly requiredSettings = ["OPENAI_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "image",
+    default: {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
+    title: "Image",
+    description: "The source image to generate variations from (square PNG)."
+  })
+  declare image: any;
+
+  @prop({
+    type: "enum",
+    default: "1024x1024",
+    title: "Size",
+    description: "The size of the generated image.",
+    values: ["256x256", "512x512", "1024x1024"]
+  })
+  declare size: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const apiKey = getApiKey(this._secrets);
+    const image = this.image as Record<string, unknown> | undefined;
+    if (!image || (!image.data && !image.uri)) {
+      throw new Error("Input image is required");
+    }
+    const size = String(this.size ?? "1024x1024");
+
+    // The variations endpoint only supports dall-e-2, which requires the
+    // `response_format` to request base64 output.
+    const formData = new FormData();
+    formData.append("model", "dall-e-2");
+    formData.append("n", "1");
+    formData.append("size", size);
+    formData.append("response_format", "b64_json");
+
+    const imageBlob = await refToBlob(image);
+    formData.append("image", imageBlob, "image.png");
+
+    const res = await fetch(`${OPENAI_API_BASE}/images/variations`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: formData
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`OpenAI ImageVariation API error ${res.status}: ${err}`);
+    }
+    const data = (await res.json()) as {
+      data: Array<{ b64_json?: string; url?: string }>;
+    };
+
+    const item = data.data[0];
+    if (item.b64_json) {
+      return { output: imageRefFromB64(item.b64_json) };
+    } else if (item.url) {
+      return { output: { type: "image", uri: item.url } };
+    }
+    throw new Error("No image data in response");
+  }
+}
+
+/**
+ * Build an image ref from raw base64. NodeTool's media refs carry **raw**
+ * base64 in `data` (matching `audioRefFromBytes` and the Gemini nodes); the
+ * asset-saving path (`decodeAssetBytes`) and downstream providers decode the
+ * field directly, so a `data:` prefix would corrupt the bytes.
+ */
+function imageRefFromB64(b64: string): Record<string, unknown> {
+  return { type: "image", data: b64, content_type: "image/png" };
+}
+
+/** Build an audio ref from raw base64 with an explicit mime type. */
+function audioRefFromB64(b64: string, contentType: string): Record<string, unknown> {
+  return { type: "audio", data: b64, content_type: contentType };
 }
 
 /** Convert an image/audio ref object to a Blob for multipart upload. */
@@ -527,23 +625,44 @@ export class TextToSpeechNode extends BaseNode {
   @prop({ type: "float", default: 1, title: "Speed", min: 0.25, max: 4 })
   declare speed: any;
 
+  @prop({
+    type: "str",
+    default: "",
+    title: "Instructions",
+    description:
+      "Steer the voice's tone, emotion, and delivery (gpt-4o-mini-tts only)."
+  })
+  declare instructions: any;
+
   async process(): Promise<Record<string, unknown>> {
     const apiKey = getApiKey(this._secrets);
     const text = String(this.input ?? "");
+    if (!text) throw new Error("Input text cannot be empty");
     const model = String(this.model ?? "tts-1");
     const voice = String(this.voice ?? "alloy");
     const speed = Number(this.speed ?? 1.0);
+    const instructions = String(this.instructions ?? "");
+
+    const isMiniTts = model === "gpt-4o-mini-tts";
+    const body: Record<string, unknown> = {
+      model,
+      input: text,
+      voice,
+      response_format: "mp3"
+    };
+    // `speed` is supported by tts-1 / tts-1-hd but not gpt-4o-mini-tts, while
+    // `instructions` is the inverse — only honored by gpt-4o-mini-tts. Sending
+    // the wrong one to a model returns a 400.
+    if (isMiniTts) {
+      if (instructions) body.instructions = instructions;
+    } else {
+      body.speed = speed;
+    }
 
     const res = await fetch(`${OPENAI_API_BASE}/audio/speech`, {
       method: "POST",
       headers: authHeaders(apiKey),
-      body: JSON.stringify({
-        model,
-        input: text,
-        voice,
-        speed,
-        response_format: "mp3"
-      })
+      body: JSON.stringify(body)
     });
     if (!res.ok) {
       const err = await res.text();
@@ -552,7 +671,7 @@ export class TextToSpeechNode extends BaseNode {
 
     const arrayBuf = await res.arrayBuffer();
     const b64 = Buffer.from(arrayBuf).toString("base64");
-    return { output: { type: "audio", data: `data:audio/mp3;base64,${b64}` } };
+    return { output: audioRefFromB64(b64, "audio/mpeg") };
   }
 }
 
@@ -1409,6 +1528,7 @@ export const OPENAI_NODES = tagAsServer([
   ModerationNode,
   CreateImageNode,
   EditImageNode,
+  ImageVariationNode,
   TextToSpeechNode,
   TranslateNode,
   TranscribeNode,

--- a/packages/llm-nodes/tests/kie-openai.test.ts
+++ b/packages/llm-nodes/tests/kie-openai.test.ts
@@ -294,7 +294,8 @@ describe("CreateImageNode", () => {
     const result = await node.process();
     expect(result.output).toEqual({
       type: "image",
-      data: "data:image/png;base64,abc123"
+      data: "abc123",
+      content_type: "image/png"
     });
   });
 
@@ -372,7 +373,8 @@ describe("EditImageNode", () => {
     const result = await node.process();
     expect(result.output).toEqual({
       type: "image",
-      data: "data:image/png;base64,edited123"
+      data: "edited123",
+      content_type: "image/png"
     });
   });
 
@@ -409,7 +411,8 @@ describe("EditImageNode", () => {
     const result = await node.process();
     expect(result.output).toEqual({
       type: "image",
-      data: "data:image/png;base64,result"
+      data: "result",
+      content_type: "image/png"
     });
   });
 
@@ -437,7 +440,8 @@ describe("EditImageNode", () => {
     const result = await node.process();
     expect(result.output).toEqual({
       type: "image",
-      data: "data:image/png;base64,masked"
+      data: "masked",
+      content_type: "image/png"
     });
   });
 
@@ -539,7 +543,9 @@ describe("TextToSpeechNode", () => {
     node.setDynamic("_secrets", secrets._secrets);
     const result = await node.process();
     const output = result.output as Record<string, string>;
-    expect(output.data).toMatch(/^data:audio\/mp3;base64,/);
+    expect(output.data).toBe(Buffer.from([10, 20, 30]).toString("base64"));
+    expect(output.data.startsWith("data:")).toBe(false);
+    expect(output.content_type).toBe("audio/mpeg");
   });
 
   it("throws on API error", async () => {

--- a/packages/llm-nodes/tests/openai-nodes.test.ts
+++ b/packages/llm-nodes/tests/openai-nodes.test.ts
@@ -5,6 +5,7 @@ import {
   ModerationNode,
   CreateImageNode,
   EditImageNode,
+  ImageVariationNode,
   TextToSpeechNode,
   TranslateNode,
   TranscribeNode,
@@ -150,7 +151,7 @@ describe("ModerationNode", () => {
 // ── CreateImageNode ───────────────────────────────────────────────────────
 
 describe("CreateImageNode", () => {
-  it("returns base64 image", async () => {
+  it("returns raw base64 image without a data URI prefix", async () => {
     const node = new CreateImageNode();
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ data: [{ b64_json: "imgdata" }] })
@@ -159,7 +160,11 @@ describe("CreateImageNode", () => {
     node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
     const result = await node.process();
     const output = result.output as Record<string, string>;
-    expect(output.data).toContain("imgdata");
+    // Media refs must carry RAW base64 in `data` — a `data:` prefix corrupts
+    // asset saving (decodeAssetBytes) and downstream provider consumption.
+    expect(output.data).toBe("imgdata");
+    expect(output.data.startsWith("data:")).toBe(false);
+    expect(output.content_type).toBe("image/png");
   });
 
   it("returns URL image", async () => {
@@ -210,7 +215,7 @@ describe("EditImageNode", () => {
     await expect(node.process()).rejects.toThrow("Edit prompt cannot be empty");
   });
 
-  it("sends multipart with image", async () => {
+  it("sends multipart with image and returns raw base64", async () => {
     const node = new EditImageNode();
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ data: [{ b64_json: "edited" }] })
@@ -222,21 +227,104 @@ describe("EditImageNode", () => {
     node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
     const result = await node.process();
     const output = result.output as Record<string, string>;
-    expect(output.data).toContain("edited");
+    expect(output.data).toBe("edited");
+    expect(output.data.startsWith("data:")).toBe(false);
+  });
+
+  it("does not send response_format (rejected by gpt-image-1)", async () => {
+    const node = new EditImageNode();
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [{ b64_json: "edited" }] })
+    );
+    node.assign({
+      prompt: "make blue",
+      image: { data: "base64data" }
+    });
+    node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    await node.process();
+    const body = mockFetch.mock.calls[0][1].body as FormData;
+    expect(body.has("response_format")).toBe(false);
+  });
+});
+
+// ── ImageVariationNode ────────────────────────────────────────────────────
+
+describe("ImageVariationNode", () => {
+  it("throws when image missing", async () => {
+    const node = new ImageVariationNode();
+    node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    await expect(node.process()).rejects.toThrow("Input image is required");
+  });
+
+  it("returns a variation image", async () => {
+    const node = new ImageVariationNode();
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [{ b64_json: "varied" }] })
+    );
+    node.assign({ image: { data: "base64data" } });
+    node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    const result = await node.process();
+    const output = result.output as Record<string, string>;
+    expect(output.data).toBe("varied");
+    expect(output.content_type).toBe("image/png");
+    const body = mockFetch.mock.calls[0][1].body as FormData;
+    expect(body.get("model")).toBe("dall-e-2");
   });
 });
 
 // ── TextToSpeechNode ──────────────────────────────────────────────────────
 
 describe("TextToSpeechNode (OpenAI)", () => {
-  it("returns audio data", async () => {
+  it("returns raw base64 audio with content type", async () => {
     const node = new TextToSpeechNode();
     mockFetch.mockResolvedValueOnce(jsonResponse({}));
     node.assign({ input: "Hello" });
     node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
     const result = await node.process();
     const output = result.output as Record<string, string>;
-    expect(output.data).toContain("base64");
+    expect(typeof output.data).toBe("string");
+    expect(output.data.length).toBeGreaterThan(0);
+    expect(output.data.startsWith("data:")).toBe(false);
+    expect(output.content_type).toBe("audio/mpeg");
+  });
+
+  it("throws on empty input", async () => {
+    const node = new TextToSpeechNode();
+    node.assign({ input: "" });
+    node.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    await expect(node.process()).rejects.toThrow("Input text cannot be empty");
+  });
+
+  it("gates speed/instructions to the model that supports each", async () => {
+    // tts-1: speed supported, instructions rejected → only speed sent.
+    const ttsOne = new TextToSpeechNode();
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    ttsOne.assign({
+      input: "Hi",
+      model: "tts-1",
+      speed: 1.5,
+      instructions: "cheerful"
+    });
+    ttsOne.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    await ttsOne.process();
+    const body1 = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body1.instructions).toBeUndefined();
+    expect(body1.speed).toBe(1.5);
+
+    // gpt-4o-mini-tts: instructions supported, speed rejected → only instructions.
+    const ttsMini = new TextToSpeechNode();
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    ttsMini.assign({
+      input: "Hi",
+      model: "gpt-4o-mini-tts",
+      speed: 1.5,
+      instructions: "cheerful"
+    });
+    ttsMini.setDynamic("_secrets", { OPENAI_API_KEY: "test-key" });
+    await ttsMini.process();
+    const body2 = JSON.parse(mockFetch.mock.calls[1][1].body as string);
+    expect(body2.instructions).toBe("cheerful");
+    expect(body2.speed).toBeUndefined();
   });
 
   it("throws on API error", async () => {

--- a/packages/llm-nodes/tests/openai.test.ts
+++ b/packages/llm-nodes/tests/openai.test.ts
@@ -251,7 +251,9 @@ describe("CreateImageNode", () => {
     const [url] = mockFetch.mock.calls[0];
     expect(url).toBe("https://api.openai.com/v1/images/generations");
     const output = result.output as Record<string, unknown>;
-    expect(output.data).toContain("data:image/png;base64,imgbase64data");
+    // Media refs carry RAW base64 in `data` (no `data:` prefix).
+    expect(output.data).toBe("imgbase64data");
+    expect(output.content_type).toBe("image/png");
   });
 
   it("returns url when no b64_json", async () => {
@@ -333,8 +335,11 @@ describe("EditImageNode", () => {
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toBe("https://api.openai.com/v1/images/edits");
     expect(opts.body).toBeInstanceOf(FormData);
+    // gpt-image-1 rejects `response_format`, so it must not be sent.
+    expect((opts.body as FormData).has("response_format")).toBe(false);
     const output = result.output as Record<string, unknown>;
-    expect(output.data).toContain("editedimg");
+    expect(output.data).toBe("editedimg");
+    expect((output.data as string).startsWith("data:")).toBe(false);
   });
 });
 
@@ -373,9 +378,10 @@ describe("TextToSpeechNode", () => {
     const [url] = mockFetch.mock.calls[0];
     expect(url).toBe("https://api.openai.com/v1/audio/speech");
     const output = result.output as Record<string, unknown>;
-    expect((output.data as string).startsWith("data:audio/mp3;base64,")).toBe(
-      true
-    );
+    // RAW base64 (no `data:` prefix), with an explicit mime type.
+    expect(output.data).toBe(Buffer.from([1, 2, 3, 4]).toString("base64"));
+    expect((output.data as string).startsWith("data:")).toBe(false);
+    expect(output.content_type).toBe("audio/mpeg");
   });
 });
 
@@ -536,14 +542,15 @@ describe("RealtimeTranscriptionNode", () => {
 // OPENAI_NODES export
 // ---------------------------------------------------------------------------
 describe("OPENAI_NODES", () => {
-  it("exports all 10 nodes", () => {
-    expect(OPENAI_NODES).toHaveLength(10);
+  it("exports all 11 nodes", () => {
+    expect(OPENAI_NODES).toHaveLength(11);
     const types = OPENAI_NODES.map((n) => n.nodeType);
     expect(types).toContain("openai.text.Embedding");
     expect(types).toContain("openai.text.WebSearch");
     expect(types).toContain("openai.text.Moderation");
     expect(types).toContain("openai.image.CreateImage");
     expect(types).toContain("openai.image.EditImage");
+    expect(types).toContain("openai.image.ImageVariation");
     expect(types).toContain("openai.audio.TextToSpeech");
     expect(types).toContain("openai.audio.Translate");
     expect(types).toContain("openai.audio.Transcribe");


### PR DESCRIPTION
## Summary

Adds missing OpenAI integrations as nodes and fixes integration bugs in the existing OpenAI nodes. Media references produced by the OpenAI image/audio nodes now store **raw base64** in the `data` field (matching `audioRefFromBytes` and the Gemini nodes) instead of `data:` URIs, which fixes asset saving and downstream provider decoding.

## OpenAI node changes (`packages/llm-nodes`)

- **Image nodes (CreateImage, EditImage)**: emit raw base64 in `data` with explicit `content_type: "image/png"` (previously `data:image/png;base64,{b64}`).
- **Audio node (TextToSpeech)**: emits raw base64 with `content_type: "audio/mpeg"` (previously `data:audio/mp3;base64,{b64}`).
- **New `ImageVariationNode`** (`openai.image.ImageVariation`): wraps the `/images/variations` endpoint (dall-e-2, `response_format=b64_json`), completing the image suite (Create / Edit / Variation). `OPENAI_NODES` count goes 10 → 11.
- **EditImage bug fix**: removed the `response_format` parameter that `gpt-image-1` rejects (the provider's own `imageToImage` already omits it).
- **TextToSpeech**: added empty-input validation, an `instructions` field (steerable voice), and model-aware param gating — `speed` for tts-1/tts-1-hd, `instructions` for gpt-4o-mini-tts — to avoid 400s.
- Extracted `imageRefFromB64()` / `audioRefFromB64()` helpers; tests updated to assert raw base64 + `content_type` and the corrected request params.

### Why raw base64

`decodeAssetBytes` (auto-save path) and the providers' `asUint8Array` decode the `data` field directly as base64, so a `data:` prefix corrupts the stored/forwarded bytes. These nodes set `autoSaveAsset = true`, so the corruption triggered in practice.

## Mobile CI fix (required to make this PR's Quality Gate green)

The `Quality Gate (npm run check)` job was failing on the mobile app tests — **not** on anything in this PR — because of a pre-existing dependency mismatch on `main`: a dependabot bump set `react` to `19.2.7` in `mobile/`, but React Native 0.85.3 bundles `react-native-renderer@19.2.3` and requires `react` to match it **exactly** (the `^19.2.3` peer range is misleading). This crashed every mobile test that exercised a native Animated component.

Fix: pin `react` (and `react-test-renderer`) back to `19.2.3` in `mobile/` so `react`, `react-test-renderer`, and `react-native-renderer` all align. Net change vs `main` is `react` 19.2.7 → 19.2.3 plus the matching lockfile entries. Full mobile suite passes (19/19 suites, 351 tests). This was included here (rather than a separate PR) to unblock this branch's CI.

https://claude.ai/code/session_017bf2wB4TPD5KHAgv3jPkko