### PR TITLE
Add MiniMax AI node pack with TTS, music, image, and video generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Before submitting a PR, review for:
 
 ## Common Pitfalls
 
-- **Decorator packages load from `dist/`**: `base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, `elevenlabs-nodes` use decorators. After changing these, run `npm run build:packages` before running `npm run dev`.
+- **Decorator packages load from `dist/`**: `base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, `elevenlabs-nodes`, `minimax-nodes` use decorators. After changing these, run `npm run build:packages` before running `npm run dev`.
 - **Package build order matters**: Always use `npm run build:packages` (builds in dependency order). Don't build individual packages with unbuilt dependencies.
 - **Mobile typecheck needs protocol**: Run `cd packages/protocol && npm run build` before `npm run typecheck:mobile`.
 - **WebSocket uses MsgPack, not JSON**: Use existing serialization helpers. Don't serialize WebSocket messages as JSON.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,8 @@ nodetool/
 │   ├── replicate-codegen/  #   Code generator for Replicate nodes
 │   ├── fal-nodes/          #   FAL AI integration nodes
 │   ├── fal-codegen/        #   Code generator for FAL nodes
-│   └── elevenlabs-nodes/   #   ElevenLabs voice synthesis nodes
+│   ├── elevenlabs-nodes/   #   ElevenLabs voice synthesis nodes
+│   └── minimax-nodes/      #   MiniMax TTS, music, image, and video nodes
 ├── web/                    # React web application (Vite + MUI)
 ├── electron/               # Electron desktop shell
 ├── mobile/                 # React Native mobile app (Expo)
@@ -156,6 +157,7 @@ Feature Layer
   ├── dsl ───────────────────────────────── Workflow DSL
   ├── replicate-nodes, fal-nodes ────────── Provider integrations
   ├── elevenlabs-nodes ──────────────────── Voice synthesis
+  ├── minimax-nodes ─────────────────────── Speech, music, image, video
   ├── huggingface ───────────────────────── Model discovery
   └── chat ──────────────────────────────── Chat protocol
 
@@ -236,7 +238,7 @@ Node implementations and provider integrations.
 
 **`chat`** — Chat protocol and runtime integration for conversational AI interactions.
 
-**`replicate-nodes`**, **`fal-nodes`**, **`elevenlabs-nodes`** — Provider-specific node packs for Replicate AI, FAL AI, and ElevenLabs voice synthesis. Each extends `BaseNode` from node-sdk.
+**`replicate-nodes`**, **`fal-nodes`**, **`elevenlabs-nodes`**, **`minimax-nodes`** — Provider-specific node packs for Replicate AI, FAL AI, ElevenLabs voice synthesis, and MiniMax (speech, music, image, video). Each extends `BaseNode` from node-sdk.
 
 **`huggingface`** — HuggingFace model discovery, cache scanning, and artifact inspection for local model management.
 
@@ -792,7 +794,7 @@ Packages must be built in dependency order. The root `build:packages` script han
 protocol → config → security → storage → auth → code-runners
     → runtime → vectorstore → models → kernel → node-sdk
     → agents → base-nodes → dsl → chat → huggingface
-    → replicate-nodes → fal-nodes → elevenlabs-nodes
+    → replicate-nodes → fal-nodes → elevenlabs-nodes → minimax-nodes
     → websocket → cli → deploy
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY packages/fal-nodes/package.json packages/fal-nodes/
 COPY packages/replicate-codegen/package.json packages/replicate-codegen/
 COPY packages/replicate-nodes/package.json packages/replicate-nodes/
 COPY packages/elevenlabs-nodes/package.json packages/elevenlabs-nodes/
+COPY packages/minimax-nodes/package.json packages/minimax-nodes/
 COPY packages/kie-codegen/package.json packages/kie-codegen/
 COPY packages/kie-nodes/package.json packages/kie-nodes/
 COPY packages/agents/package.json packages/agents/

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -6591,6 +6591,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11046,9 +11047,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {
@@ -11511,18 +11512,18 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
-      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
+      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.7",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.7"
       }
     },
     "node_modules/redent": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -71,6 +71,6 @@
     "minimatch": ">=3.1.4",
     "flatted": ">=3.4.2",
     "ajv": ">=6.14.0",
-    "react-test-renderer": "19.2.3"
+    "react-test-renderer": "19.2.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "packages/replicate-codegen",
         "packages/replicate-nodes",
         "packages/elevenlabs-nodes",
+        "packages/minimax-nodes",
         "packages/transformers-js-nodes",
         "packages/transformers-js-provider",
         "packages/websocket",
@@ -10513,6 +10514,10 @@
     },
     "node_modules/@nodetool-ai/llm-nodes": {
       "resolved": "packages/llm-nodes",
+      "link": true
+    },
+    "node_modules/@nodetool-ai/minimax-nodes": {
+      "resolved": "packages/minimax-nodes",
       "link": true
     },
     "node_modules/@nodetool-ai/models": {
@@ -41882,6 +41887,7 @@
         "@nodetool-ai/fal-nodes": "*",
         "@nodetool-ai/huggingface": "*",
         "@nodetool-ai/kernel": "*",
+        "@nodetool-ai/minimax-nodes": "*",
         "@nodetool-ai/models": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/protocol": "*",
@@ -42075,6 +42081,7 @@
         "@nodetool-ai/base-nodes": "*",
         "@nodetool-ai/elevenlabs-nodes": "*",
         "@nodetool-ai/kernel": "*",
+        "@nodetool-ai/minimax-nodes": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/runtime": "*",
@@ -42269,6 +42276,20 @@
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",
+        "@nodetool-ai/runtime": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      }
+    },
+    "packages/minimax-nodes": {
+      "name": "@nodetool-ai/minimax-nodes",
+      "version": "0.7.0-rc.23",
+      "license": "MIT",
+      "dependencies": {
+        "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/runtime": "*"
       },
       "devDependencies": {
@@ -42702,6 +42723,7 @@
         "@nodetool-ai/image-editor": "*",
         "@nodetool-ai/kernel": "*",
         "@nodetool-ai/kie-nodes": "*",
+        "@nodetool-ai/minimax-nodes": "*",
         "@nodetool-ai/models": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/protocol": "*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "packages/replicate-codegen",
     "packages/replicate-nodes",
     "packages/elevenlabs-nodes",
+    "packages/minimax-nodes",
     "packages/transformers-js-nodes",
     "packages/transformers-js-provider",
     "packages/websocket",

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -26,6 +26,7 @@ The `packages/` directory contains the TypeScript backend — a set of npm works
 | `@nodetool-ai/fal-codegen` | Code generator for FAL AI node definitions |
 | `@nodetool-ai/replicate-nodes` | Replicate integration nodes |
 | `@nodetool-ai/elevenlabs-nodes` | ElevenLabs TTS integration nodes |
+| `@nodetool-ai/minimax-nodes` | MiniMax TTS, music, image, and video nodes |
 | `@nodetool-ai/code-runners` | Secure code execution (Docker + subprocess sandboxing) |
 | `@nodetool-ai/huggingface` | HuggingFace model discovery and downloads |
 | `@nodetool-ai/vectorstore` | SQLite-vec vector store for RAG |
@@ -61,7 +62,7 @@ npm run dev:watch:server
 npm run dev:server
 ```
 
-**Important**: The dev server uses `tsx --watch` which runs TypeScript directly. However, `base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, and `elevenlabs-nodes` use decorators and load from `dist/`. If you change these packages, run `npm run build:packages` first.
+**Important**: The dev server uses `tsx --watch` which runs TypeScript directly. However, `base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, `elevenlabs-nodes`, and `minimax-nodes` use decorators and load from `dist/`. If you change these packages, run `npm run build:packages` first.
 
 ## Testing
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "@trpc/server": "^11.0.0",
     "@nodetool-ai/base-nodes": "*",
     "@nodetool-ai/elevenlabs-nodes": "*",
+    "@nodetool-ai/minimax-nodes": "*",
     "@nodetool-ai/transformers-js-nodes": "*",
     "@nodetool-ai/dsl": "*",
     "@nodetool-ai/fal-nodes": "*",

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -30,6 +30,7 @@ import { WorkflowRunner } from "@nodetool-ai/kernel";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
+import { registerMinimaxNodes } from "@nodetool-ai/minimax-nodes";
 import { registerTransformersJsNodes } from "@nodetool-ai/transformers-js-nodes";
 import { registerFalNodes } from "@nodetool-ai/fal-nodes";
 import { registerReplicateNodes } from "@nodetool-ai/replicate-nodes";
@@ -450,6 +451,7 @@ workflows
         const registry = new NodeRegistry();
         registerBaseNodes(registry);
         registerElevenLabsNodes(registry);
+        registerMinimaxNodes(registry);
         registerTransformersJsNodes(registry);
         registerFalNodes(registry);
         registerReplicateNodes(registry);

--- a/packages/cli/tests/__stubs__/nodetool.ts
+++ b/packages/cli/tests/__stubs__/nodetool.ts
@@ -279,6 +279,7 @@ export class NodeRegistry {
 // base-nodes / fal-nodes / replicate-nodes / elevenlabs-nodes / transformers-js-nodes
 export const registerBaseNodes = (_reg?: unknown) => {};
 export const registerElevenLabsNodes = (_reg?: unknown) => {};
+export const registerMinimaxNodes = (_reg?: unknown) => {};
 export const registerTransformersJsNodes = (_reg?: unknown) => {};
 export const registerFalNodes = (_reg?: unknown) => {};
 export const registerReplicateNodes = (_reg?: unknown) => {};

--- a/packages/cli/tests/nodetool.test.ts
+++ b/packages/cli/tests/nodetool.test.ts
@@ -60,6 +60,10 @@ vi.mock("@nodetool-ai/elevenlabs-nodes", () => ({
   registerElevenLabsNodes: vi.fn()
 }));
 
+vi.mock("@nodetool-ai/minimax-nodes", () => ({
+  registerMinimaxNodes: vi.fn()
+}));
+
 vi.mock("@nodetool-ai/transformers-js-nodes", () => ({
   registerTransformersJsNodes: vi.fn()
 }));

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -38,6 +38,9 @@
       "path": "../elevenlabs-nodes"
     },
     {
+      "path": "../minimax-nodes"
+    },
+    {
       "path": "../transformers-js-nodes"
     },
     {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -25,6 +25,7 @@ function nodetoolStubPlugin(): Plugin {
     "@nodetool-ai/node-sdk",
     "@nodetool-ai/base-nodes",
     "@nodetool-ai/elevenlabs-nodes",
+    "@nodetool-ai/minimax-nodes",
     "@nodetool-ai/transformers-js-nodes",
     "@nodetool-ai/fal-nodes",
     "@nodetool-ai/replicate-nodes",

--- a/packages/dsl/src/core.ts
+++ b/packages/dsl/src/core.ts
@@ -373,6 +373,12 @@ export async function run(
     // Some environments do not have the ElevenLabs node package in a runnable state.
   }
   try {
+    const { registerMinimaxNodes } = await import("@nodetool-ai/minimax-nodes");
+    registerMinimaxNodes(builtinRegistry);
+  } catch {
+    // Some environments do not have the MiniMax node package in a runnable state.
+  }
+  try {
     const { registerTransformersJsNodes } = await import(
       "@nodetool-ai/transformers-js-nodes"
     );

--- a/packages/dsl/tsconfig.json
+++ b/packages/dsl/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../elevenlabs-nodes"
     },
     {
+      "path": "../minimax-nodes"
+    },
+    {
       "path": "../transformers-js-nodes"
     },
     {

--- a/packages/dsl/vitest.config.ts
+++ b/packages/dsl/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
         __dirname,
         "../elevenlabs-nodes/src/index.ts"
       ),
+      "@nodetool-ai/minimax-nodes": resolve(
+        __dirname,
+        "../minimax-nodes/src/index.ts"
+      ),
       "@nodetool-ai/transformers-js-nodes": resolve(
         __dirname,
         "../transformers-js-nodes/src/index.ts"

--- a/packages/minimax-nodes/README.md
+++ b/packages/minimax-nodes/README.md
@@ -1,0 +1,27 @@
+# @nodetool-ai/minimax-nodes
+
+MiniMax AI nodes for [NodeTool](https://nodetool.ai).
+
+These nodes call the [MiniMax API](https://platform.minimax.io/docs/api-reference/api-overview)
+directly so they can expose MiniMax-specific controls that the generic provider
+nodes don't carry.
+
+## Nodes
+
+| Node | Type | Description |
+| --- | --- | --- |
+| MiniMax Voice | `minimax.Voice` | Pick a MiniMax system voice and output its voice ID. |
+| MiniMax Text to Speech | `minimax.TextToSpeech` | Synthesize speech with emotion, volume, pitch, speed, and language boost. |
+| MiniMax Music Generation | `minimax.MusicGeneration` | Generate a full song with vocals from a style prompt and lyrics. |
+| MiniMax Text to Image | `minimax.TextToImage` | Generate images with image-01 at a chosen aspect ratio. |
+| MiniMax Text to Video | `minimax.TextToVideo` | Generate video from text with Hailuo / Director models. |
+| MiniMax Image to Video | `minimax.ImageToVideo` | Animate a still image into a video. |
+
+## Configuration
+
+Set `MINIMAX_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an
+environment variable.
+
+> MiniMax chat models and the generic Text to Image / Text to Video / Text to
+> Speech nodes also work through the built-in MiniMax provider; this pack adds
+> dedicated, discoverable nodes with the full set of MiniMax options.

--- a/packages/minimax-nodes/package.json
+++ b/packages/minimax-nodes/package.json
@@ -1,47 +1,37 @@
 {
-  "name": "@nodetool-ai/dsl",
+  "name": "@nodetool-ai/minimax-nodes",
   "type": "module",
   "version": "0.7.0-rc.23",
-  "description": "Type-safe TypeScript DSL for defining NodeTool workflows",
+  "description": "MiniMax AI nodes for nodetool",
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "nodetool-dev": "./src/index.ts",
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
   "scripts": {
     "build": "node ../../scripts/build-typescript-workspace.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit",
-    "codegen": "tsx scripts/codegen.ts"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@nodetool-ai/base-nodes": "*",
-    "@nodetool-ai/elevenlabs-nodes": "*",
-    "@nodetool-ai/minimax-nodes": "*",
-    "@nodetool-ai/transformers-js-nodes": "*",
-    "@nodetool-ai/protocol": "*",
-    "@nodetool-ai/kernel": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/runtime": "*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "tsx": "^4.0.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/nodetool-ai/nodetool.git",
-    "directory": "packages/dsl"
+    "directory": "packages/minimax-nodes"
   },
   "homepage": "https://nodetool.ai",
   "bugs": {

--- a/packages/minimax-nodes/src/index.ts
+++ b/packages/minimax-nodes/src/index.ts
@@ -1,0 +1,31 @@
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import { VOICE_NODES } from "./nodes/voice.js";
+import { TEXT_TO_SPEECH_NODES } from "./nodes/text-to-speech.js";
+import { MUSIC_NODES } from "./nodes/music.js";
+import { TEXT_TO_IMAGE_NODES } from "./nodes/text-to-image.js";
+import { TEXT_TO_VIDEO_NODES } from "./nodes/text-to-video.js";
+import { IMAGE_TO_VIDEO_NODES } from "./nodes/image-to-video.js";
+
+export { MinimaxVoiceNode } from "./nodes/voice.js";
+export { MinimaxTextToSpeechNode } from "./nodes/text-to-speech.js";
+export { MinimaxMusicNode } from "./nodes/music.js";
+export { MinimaxTextToImageNode } from "./nodes/text-to-image.js";
+export { MinimaxTextToVideoNode } from "./nodes/text-to-video.js";
+export { MinimaxImageToVideoNode } from "./nodes/image-to-video.js";
+
+export const MINIMAX_NODES: readonly NodeClass[] = [
+  ...VOICE_NODES,
+  ...TEXT_TO_SPEECH_NODES,
+  ...MUSIC_NODES,
+  ...TEXT_TO_IMAGE_NODES,
+  ...TEXT_TO_VIDEO_NODES,
+  ...IMAGE_TO_VIDEO_NODES
+];
+
+export function registerMinimaxNodes(registry: {
+  register: (nodeClass: NodeClass) => void;
+}): void {
+  for (const nodeClass of MINIMAX_NODES) {
+    registry.register(nodeClass);
+  }
+}

--- a/packages/minimax-nodes/src/minimax-base.ts
+++ b/packages/minimax-nodes/src/minimax-base.ts
@@ -1,0 +1,369 @@
+/**
+ * Shared helpers and constants for the MiniMax node pack.
+ *
+ * Nodes talk to MiniMax's REST API directly (mirroring the elevenlabs-nodes
+ * pattern) rather than going through the runtime provider. That lets each node
+ * expose MiniMax-specific knobs — emotion, volume, pitch, lyrics, camera
+ * direction — that the generic provider interface does not carry. All network
+ * access goes through the global `fetch` so tests can stub it.
+ *
+ * Docs: https://platform.minimax.io/docs/api-reference/api-overview
+ */
+
+export const MINIMAX_BASE_URL = "https://api.minimax.io";
+
+/** Resolve the MiniMax API key from injected secrets or the environment. */
+export function getMinimaxApiKey(secrets: Record<string, string>): string {
+  const key = secrets?.MINIMAX_API_KEY || process.env.MINIMAX_API_KEY || "";
+  if (!key) throw new Error("MINIMAX_API_KEY is not configured");
+  return key;
+}
+
+export function minimaxHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json"
+  };
+}
+
+interface MinimaxBaseResp {
+  status_code?: number;
+  status_msg?: string;
+}
+
+/** MiniMax embeds a `base_resp` on most responses; surface failures as errors. */
+export function assertBaseResp(
+  data: Record<string, unknown>,
+  context: string
+): void {
+  const baseResp = data.base_resp as MinimaxBaseResp | undefined;
+  if (baseResp && baseResp.status_code && baseResp.status_code !== 0) {
+    throw new Error(
+      `MiniMax ${context} failed: ${baseResp.status_msg ?? "unknown error"} (code ${baseResp.status_code})`
+    );
+  }
+}
+
+/** Decode MiniMax's hex-encoded audio payloads to raw bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const len = Math.floor(clean.length / 2);
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+/**
+ * MiniMax audio endpoints return either hex-encoded bytes or, when configured,
+ * a download URL. Normalise both to raw bytes.
+ */
+export async function resolveAudioPayload(audio: string): Promise<Uint8Array> {
+  if (/^https?:\/\//i.test(audio)) {
+    const dl = await fetch(audio);
+    if (!dl.ok) {
+      throw new Error(`Failed to download MiniMax audio from ${audio}`);
+    }
+    return new Uint8Array(await dl.arrayBuffer());
+  }
+  return hexToBytes(audio);
+}
+
+export const AUDIO_FORMAT_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  flac: "audio/flac",
+  pcm: "audio/pcm"
+};
+
+/** Build an inline AudioRef from raw bytes for the given format. */
+export function audioRefFromBytes(
+  bytes: Uint8Array,
+  format: string
+): { type: "audio"; data: string } {
+  const mime = AUDIO_FORMAT_MIME[format] ?? "audio/mpeg";
+  return {
+    type: "audio",
+    data: `data:${mime};base64,${bytesToBase64(bytes)}`
+  };
+}
+
+/** Guess an image MIME type from magic bytes; defaults to PNG. */
+export function inferImageMime(bytes: Uint8Array): string {
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) return "image/jpeg";
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[8] === 0x57) {
+    return "image/webp";
+  }
+  return "image/png";
+}
+
+export function imageRefFromBytes(
+  bytes: Uint8Array
+): { type: "image"; data: string; mimeType: string } {
+  return {
+    type: "image",
+    data: bytesToBase64(bytes),
+    mimeType: inferImageMime(bytes)
+  };
+}
+
+export function videoRefFromBytes(
+  bytes: Uint8Array
+): { type: "video"; data: string } {
+  return { type: "video", data: bytesToBase64(bytes) };
+}
+
+// ---------------------------------------------------------------------------
+// Catalogues
+// ---------------------------------------------------------------------------
+
+/**
+ * Curated subset of MiniMax's 300+ system voices — enough for a UI picker.
+ * Any MiniMax voice_id (including cloned voices) can still be passed directly
+ * to the Text to Speech node.
+ */
+export const MINIMAX_VOICES: string[] = [
+  "English_Trustworth_Man",
+  "English_CalmWoman",
+  "English_UpsetGirl",
+  "English_Gentle-voiced_man",
+  "English_Whispering_girl_v3",
+  "English_Diligent_Man",
+  "English_Graceful_Lady",
+  "English_ReservedYoungMan",
+  "English_PlayfulGirl",
+  "English_ManWithDeepVoice",
+  "English_GentleTeacher",
+  "English_MaturePartner",
+  "English_FriendlyPerson",
+  "English_MatureBoss",
+  "English_Debator",
+  "English_LovelyGirl",
+  "English_Steadymentor",
+  "English_Deep-VoicedGentleman",
+  "English_DecentYoungMan",
+  "English_SentimentalLady",
+  "English_ImposingManner",
+  "English_SadTeen",
+  "English_Wiselady",
+  "English_CaptivatingStoryteller",
+  "English_AttractiveGirl",
+  "English_DescendPriest",
+  "English_ConfidentWoman",
+  "English_CuteElf",
+  "English_radiant_girl",
+  "English_Insightful_Speaker",
+  "Chinese (Mandarin)_Warm_Bestie",
+  "Chinese (Mandarin)_Gentleman",
+  "Chinese (Mandarin)_Kind-hearted_Antie",
+  "Chinese (Mandarin)_Lyrical_Voice",
+  "Chinese (Mandarin)_Straightforward_Boy",
+  "Chinese (Mandarin)_Stubborn_Friend",
+  "Chinese (Mandarin)_Sweet_Girl_2",
+  "Chinese (Mandarin)_Gentle_Youth",
+  "Chinese (Mandarin)_Warm_Girl",
+  "Chinese (Mandarin)_Male_Announcer"
+];
+
+export const DEFAULT_VOICE = "English_Trustworth_Man";
+
+export const MINIMAX_TTS_MODELS: string[] = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo"
+];
+
+/** "auto" is a node-only sentinel meaning "omit emotion from the request". */
+export const MINIMAX_EMOTIONS: string[] = [
+  "auto",
+  "neutral",
+  "happy",
+  "sad",
+  "angry",
+  "fearful",
+  "disgusted",
+  "surprised"
+];
+
+/** "auto" is a node-only sentinel meaning "let MiniMax autodetect the language". */
+export const MINIMAX_LANGUAGE_BOOST: string[] = [
+  "auto",
+  "English",
+  "Chinese",
+  "Chinese,Yue",
+  "Japanese",
+  "Korean",
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Portuguese",
+  "Russian",
+  "Arabic",
+  "Turkish",
+  "Dutch",
+  "Ukrainian",
+  "Vietnamese",
+  "Indonesian",
+  "Thai",
+  "Polish"
+];
+
+export const MINIMAX_MUSIC_MODELS: string[] = ["music-1.5", "music-01"];
+
+export const MINIMAX_IMAGE_ASPECTS: string[] = [
+  "1:1",
+  "16:9",
+  "4:3",
+  "3:2",
+  "2:3",
+  "3:4",
+  "9:16",
+  "21:9"
+];
+
+export const MINIMAX_T2V_MODELS: string[] = [
+  "MiniMax-Hailuo-2.3",
+  "MiniMax-Hailuo-2.3-Fast",
+  "MiniMax-Hailuo-02",
+  "T2V-01-Director"
+];
+
+export const MINIMAX_I2V_MODELS: string[] = [
+  "MiniMax-Hailuo-2.3",
+  "MiniMax-Hailuo-2.3-Fast",
+  "MiniMax-Hailuo-02",
+  "I2V-01-Director",
+  "S2V-01"
+];
+
+export const MINIMAX_VIDEO_RESOLUTIONS: string[] = ["512P", "768P", "1080P"];
+export const MINIMAX_VIDEO_DURATIONS: number[] = [6, 10];
+
+// ---------------------------------------------------------------------------
+// Async video generation (submit → poll → download)
+// ---------------------------------------------------------------------------
+
+export interface VideoTaskOptions {
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+}
+
+/**
+ * Submit a video generation task, poll until it succeeds, and download the
+ * resulting file. Mirrors the runtime provider's flow so the node behaves
+ * identically while exposing MiniMax-specific request fields.
+ */
+export async function generateVideo(
+  apiKey: string,
+  body: Record<string, unknown>,
+  options: VideoTaskOptions = {}
+): Promise<Uint8Array> {
+  const submit = await fetch(`${MINIMAX_BASE_URL}/v1/video_generation`, {
+    method: "POST",
+    headers: minimaxHeaders(apiKey),
+    body: JSON.stringify(body)
+  });
+  if (!submit.ok) {
+    throw new Error(
+      `MiniMax video_generation submit failed: ${submit.status} ${await submit.text()}`
+    );
+  }
+  const submitData = (await submit.json()) as Record<string, unknown>;
+  assertBaseResp(submitData, "video_generation submit");
+
+  const taskId = submitData.task_id as string | undefined;
+  if (!taskId) {
+    throw new Error(
+      `MiniMax video_generation returned no task_id: ${JSON.stringify(submitData)}`
+    );
+  }
+
+  const fileId = await pollVideoTask(apiKey, taskId, options);
+  return downloadFile(apiKey, fileId);
+}
+
+async function pollVideoTask(
+  apiKey: string,
+  taskId: string,
+  options: VideoTaskOptions = {}
+): Promise<string> {
+  const pollIntervalMs = options.pollIntervalMs ?? 5000;
+  const maxAttempts = options.maxAttempts ?? 360;
+  const url = `${MINIMAX_BASE_URL}/v1/query/video_generation?task_id=${encodeURIComponent(
+    taskId
+  )}`;
+  for (let i = 0; i < maxAttempts; i++) {
+    const res = await fetch(url, { headers: minimaxHeaders(apiKey) });
+    if (!res.ok) {
+      throw new Error(
+        `MiniMax video status failed: ${res.status} ${await res.text()}`
+      );
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    const status = String(data.status ?? "").toLowerCase();
+    if (status === "success") {
+      const fileId = data.file_id as string | undefined;
+      if (!fileId) {
+        throw new Error("MiniMax video task succeeded but returned no file_id");
+      }
+      return fileId;
+    }
+    if (status === "fail" || status === "failed") {
+      throw new Error(
+        `MiniMax video task failed: ${JSON.stringify(data.base_resp ?? data)}`
+      );
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(
+    `MiniMax video task timed out after ${maxAttempts * pollIntervalMs}ms`
+  );
+}
+
+async function downloadFile(
+  apiKey: string,
+  fileId: string
+): Promise<Uint8Array> {
+  const url = `${MINIMAX_BASE_URL}/v1/files/retrieve?file_id=${encodeURIComponent(
+    fileId
+  )}`;
+  const res = await fetch(url, { headers: minimaxHeaders(apiKey) });
+  if (!res.ok) {
+    throw new Error(
+      `MiniMax files/retrieve failed: ${res.status} ${await res.text()}`
+    );
+  }
+  const data = (await res.json()) as Record<string, unknown>;
+  assertBaseResp(data, "files/retrieve");
+  const file = data.file as Record<string, unknown> | undefined;
+  const downloadUrl = (file?.download_url ?? file?.downloadURL) as
+    | string
+    | undefined;
+  if (!downloadUrl) {
+    throw new Error(
+      `MiniMax files/retrieve returned no download_url: ${JSON.stringify(data)}`
+    );
+  }
+  const dl = await fetch(downloadUrl);
+  if (!dl.ok) {
+    throw new Error(`Failed to download MiniMax file from ${downloadUrl}`);
+  }
+  return new Uint8Array(await dl.arrayBuffer());
+}

--- a/packages/minimax-nodes/src/minimax-base.ts
+++ b/packages/minimax-nodes/src/minimax-base.ts
@@ -225,7 +225,11 @@ export const MINIMAX_LANGUAGE_BOOST: string[] = [
   "Polish"
 ];
 
-export const MINIMAX_MUSIC_MODELS: string[] = ["music-1.5", "music-01"];
+export const MINIMAX_MUSIC_MODELS: string[] = [
+  "music-2.6",
+  "music-1.5",
+  "music-01"
+];
 
 export const MINIMAX_IMAGE_ASPECTS: string[] = [
   "1:1",

--- a/packages/minimax-nodes/src/nodes/image-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/image-to-video.ts
@@ -1,0 +1,104 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import {
+  bytesToBase64,
+  generateVideo,
+  getMinimaxApiKey,
+  inferImageMime,
+  MINIMAX_I2V_MODELS,
+  MINIMAX_VIDEO_DURATIONS,
+  MINIMAX_VIDEO_RESOLUTIONS,
+  videoRefFromBytes
+} from "../minimax-base.js";
+
+export class MinimaxImageToVideoNode extends BaseNode {
+  static readonly nodeType = "minimax.ImageToVideo";
+  static readonly body = "content_card";
+  static readonly title = "MiniMax Image to Video";
+  static readonly description =
+    "Animate a still image into a video using MiniMax Hailuo and Director " +
+    "models. The image becomes the first frame.\n" +
+    "video, generation, image-to-video, i2v, hailuo, minimax\n\n" +
+    "Use cases:\n" +
+    "- Bring a photo or render to life\n" +
+    "- Add motion to product or character art\n" +
+    "- Create animated intros from a key frame";
+  static readonly metadataOutputTypes = { output: "video" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["image", "prompt"];
+  static readonly requiredSettings = ["MINIMAX_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "enum",
+    default: "MiniMax-Hailuo-02",
+    title: "Model",
+    description: "The MiniMax video model to use.",
+    values: MINIMAX_I2V_MODELS
+  })
+  declare model: any;
+
+  @prop({
+    type: "image",
+    default: { type: "image", uri: "", asset_id: null, data: null },
+    title: "Image",
+    description: "The image to use as the first frame of the video."
+  })
+  declare image: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Prompt",
+    description:
+      "Optional text prompt guiding the motion. Director models support camera " +
+      "moves like [Push in], [Pan left], [Truck left]."
+  })
+  declare prompt: any;
+
+  @prop({
+    type: "int",
+    default: 6,
+    title: "Duration",
+    description: "Video duration in seconds.",
+    values: MINIMAX_VIDEO_DURATIONS
+  })
+  declare duration: any;
+
+  @prop({
+    type: "enum",
+    default: "768P",
+    title: "Resolution",
+    description: "Output resolution.",
+    values: MINIMAX_VIDEO_RESOLUTIONS
+  })
+  declare resolution: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const apiKey = getMinimaxApiKey(this._secrets);
+
+    const imageBytes = await loadMediaRefBytes(this.image, context);
+    if (!imageBytes || imageBytes.length === 0) {
+      throw new Error("An input image is required");
+    }
+    const mime = inferImageMime(imageBytes);
+
+    const body: Record<string, unknown> = {
+      model: String(this.model ?? "MiniMax-Hailuo-02"),
+      first_frame_image: `data:${mime};base64,${bytesToBase64(imageBytes)}`,
+      duration: Number(this.duration ?? 6),
+      resolution: String(this.resolution ?? "768P")
+    };
+    const prompt = String(this.prompt ?? "");
+    if (prompt) body.prompt = prompt;
+
+    const bytes = await generateVideo(apiKey, body);
+    return { output: videoRefFromBytes(bytes) };
+  }
+}
+
+export const IMAGE_TO_VIDEO_NODES: readonly NodeClass[] = [
+  MinimaxImageToVideoNode
+];

--- a/packages/minimax-nodes/src/nodes/music.ts
+++ b/packages/minimax-nodes/src/nodes/music.ts
@@ -1,0 +1,122 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import {
+  audioRefFromBytes,
+  assertBaseResp,
+  getMinimaxApiKey,
+  MINIMAX_BASE_URL,
+  MINIMAX_MUSIC_MODELS,
+  minimaxHeaders,
+  resolveAudioPayload
+} from "../minimax-base.js";
+
+const MUSIC_FORMATS = ["mp3", "wav"];
+
+export class MinimaxMusicNode extends BaseNode {
+  static readonly nodeType = "minimax.MusicGeneration";
+  static readonly body = "content_card";
+  static readonly title = "MiniMax Music Generation";
+  static readonly description =
+    "Generate a full song with vocals from a style description and lyrics " +
+    "using MiniMax music models.\n" +
+    "audio, music, song, generation, lyrics, vocals, minimax\n\n" +
+    "Use cases:\n" +
+    "- Turn lyrics into a finished song\n" +
+    "- Prototype melodies and arrangements\n" +
+    "- Create background music for videos\n" +
+    "- Produce jingles and theme songs";
+  static readonly metadataOutputTypes = { output: "audio" };
+  static readonly inlineFields: string[] = ["prompt", "lyrics"];
+  static readonly inputFields: string[] = ["prompt", "lyrics"];
+  static readonly requiredSettings = ["MINIMAX_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "str",
+    default: "An upbeat pop song with bright synths and a catchy chorus",
+    title: "Prompt",
+    description:
+      "Describe the style, mood, genre, and instrumentation of the music."
+  })
+  declare prompt: any;
+
+  @prop({
+    type: "str",
+    default:
+      "[Verse]\nWalking down the city street\n[Chorus]\nThis is our moment, shining bright",
+    title: "Lyrics",
+    description:
+      "Song lyrics. Use newlines between lines and structure tags like " +
+      "[Intro], [Verse], [Chorus], [Bridge], [Outro]."
+  })
+  declare lyrics: any;
+
+  @prop({
+    type: "enum",
+    default: "music-1.5",
+    title: "Model",
+    description: "The MiniMax music model to use.",
+    values: MINIMAX_MUSIC_MODELS
+  })
+  declare model: any;
+
+  @prop({
+    type: "enum",
+    default: "mp3",
+    title: "Format",
+    description: "Output audio format.",
+    values: MUSIC_FORMATS
+  })
+  declare format: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const apiKey = getMinimaxApiKey(this._secrets);
+
+    const prompt = String(this.prompt ?? "");
+    if (!prompt) throw new Error("Prompt is required");
+
+    const lyrics = String(this.lyrics ?? "");
+    if (!lyrics) throw new Error("Lyrics are required");
+
+    const model = String(this.model ?? "music-1.5");
+    const format = String(this.format ?? "mp3");
+
+    const body: Record<string, unknown> = {
+      model,
+      prompt,
+      lyrics,
+      audio_setting: {
+        sample_rate: 44100,
+        bitrate: 256000,
+        format
+      },
+      output_format: "hex"
+    };
+
+    const res = await fetch(`${MINIMAX_BASE_URL}/v1/music_generation`, {
+      method: "POST",
+      headers: minimaxHeaders(apiKey),
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) {
+      throw new Error(
+        `MiniMax music_generation failed: ${res.status} ${await res.text()}`
+      );
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    assertBaseResp(data, "music_generation");
+
+    const payload = data.data as Record<string, unknown> | undefined;
+    const audio = payload?.audio as string | undefined;
+    if (!audio) {
+      throw new Error(
+        `MiniMax music_generation returned no audio data: ${JSON.stringify(data)}`
+      );
+    }
+
+    const bytes = await resolveAudioPayload(audio);
+    return { output: audioRefFromBytes(bytes, format) };
+  }
+}
+
+export const MUSIC_NODES: readonly NodeClass[] = [MinimaxMusicNode];

--- a/packages/minimax-nodes/src/nodes/music.ts
+++ b/packages/minimax-nodes/src/nodes/music.ts
@@ -53,7 +53,7 @@ export class MinimaxMusicNode extends BaseNode {
 
   @prop({
     type: "enum",
-    default: "music-1.5",
+    default: "music-2.6",
     title: "Model",
     description: "The MiniMax music model to use.",
     values: MINIMAX_MUSIC_MODELS
@@ -78,7 +78,7 @@ export class MinimaxMusicNode extends BaseNode {
     const lyrics = String(this.lyrics ?? "");
     if (!lyrics) throw new Error("Lyrics are required");
 
-    const model = String(this.model ?? "music-1.5");
+    const model = String(this.model ?? "music-2.6");
     const format = String(this.format ?? "mp3");
 
     const body: Record<string, unknown> = {

--- a/packages/minimax-nodes/src/nodes/text-to-image.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-image.ts
@@ -1,0 +1,127 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import {
+  assertBaseResp,
+  getMinimaxApiKey,
+  imageRefFromBytes,
+  MINIMAX_BASE_URL,
+  MINIMAX_IMAGE_ASPECTS,
+  minimaxHeaders
+} from "../minimax-base.js";
+
+export class MinimaxTextToImageNode extends BaseNode {
+  static readonly nodeType = "minimax.TextToImage";
+  static readonly body = "content_card";
+  static readonly title = "MiniMax Text to Image";
+  static readonly description =
+    "Generate images from text prompts using MiniMax image-01.\n" +
+    "image, generation, text-to-image, t2i, minimax\n\n" +
+    "Use cases:\n" +
+    "- Create illustrations and concept art\n" +
+    "- Generate marketing visuals\n" +
+    "- Produce images at a chosen aspect ratio";
+  static readonly metadataOutputTypes = { output: "image" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["prompt"];
+  static readonly requiredSettings = ["MINIMAX_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "str",
+    default: "image-01",
+    title: "Model",
+    description: "The MiniMax image model to use.",
+    values: ["image-01"]
+  })
+  declare model: any;
+
+  @prop({
+    type: "str",
+    default: "A cat holding a sign that says hello world",
+    title: "Prompt",
+    description: "Text prompt describing the desired image."
+  })
+  declare prompt: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Negative Prompt",
+    description: "Describe what to avoid in the image."
+  })
+  declare negative_prompt: any;
+
+  @prop({
+    type: "enum",
+    default: "1:1",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the generated image.",
+    values: MINIMAX_IMAGE_ASPECTS
+  })
+  declare aspect_ratio: any;
+
+  @prop({
+    type: "bool",
+    default: true,
+    title: "Prompt Optimizer",
+    description: "Let MiniMax automatically refine the prompt before generating."
+  })
+  declare prompt_optimizer: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const apiKey = getMinimaxApiKey(this._secrets);
+
+    const basePrompt = String(this.prompt ?? "");
+    if (!basePrompt) throw new Error("Prompt is required");
+
+    const negative = String(this.negative_prompt ?? "").trim();
+    const prompt = negative
+      ? `${basePrompt.trim()}\n\nDo not include: ${negative}`
+      : basePrompt;
+
+    const body: Record<string, unknown> = {
+      model: String(this.model ?? "image-01") || "image-01",
+      prompt,
+      aspect_ratio: String(this.aspect_ratio ?? "1:1"),
+      n: 1,
+      response_format: "base64",
+      prompt_optimizer: Boolean(this.prompt_optimizer ?? true)
+    };
+
+    const res = await fetch(`${MINIMAX_BASE_URL}/v1/image_generation`, {
+      method: "POST",
+      headers: minimaxHeaders(apiKey),
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) {
+      throw new Error(
+        `MiniMax image_generation failed: ${res.status} ${await res.text()}`
+      );
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    assertBaseResp(data, "image_generation");
+
+    const payload = data.data as Record<string, unknown> | undefined;
+    const b64List = payload?.image_base64 as string[] | undefined;
+    if (b64List && b64List.length > 0) {
+      const bytes = new Uint8Array(Buffer.from(b64List[0], "base64"));
+      return { output: imageRefFromBytes(bytes) };
+    }
+
+    const urls = payload?.image_urls as string[] | undefined;
+    if (urls && urls.length > 0) {
+      const dl = await fetch(urls[0]);
+      if (!dl.ok) {
+        throw new Error(`Failed to download MiniMax image from ${urls[0]}`);
+      }
+      const bytes = new Uint8Array(await dl.arrayBuffer());
+      return { output: imageRefFromBytes(bytes) };
+    }
+
+    throw new Error("MiniMax image_generation returned no image data");
+  }
+}
+
+export const TEXT_TO_IMAGE_NODES: readonly NodeClass[] = [
+  MinimaxTextToImageNode
+];

--- a/packages/minimax-nodes/src/nodes/text-to-speech.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-speech.ts
@@ -1,0 +1,191 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import {
+  audioRefFromBytes,
+  assertBaseResp,
+  DEFAULT_VOICE,
+  getMinimaxApiKey,
+  MINIMAX_BASE_URL,
+  MINIMAX_EMOTIONS,
+  MINIMAX_LANGUAGE_BOOST,
+  MINIMAX_TTS_MODELS,
+  MINIMAX_VOICES,
+  minimaxHeaders,
+  resolveAudioPayload
+} from "../minimax-base.js";
+
+const TTS_FORMATS = ["mp3", "wav", "flac"];
+
+export class MinimaxTextToSpeechNode extends BaseNode {
+  static readonly nodeType = "minimax.TextToSpeech";
+  static readonly body = "content_card";
+  static readonly title = "MiniMax Text to Speech";
+  static readonly description =
+    "Generate natural-sounding speech with MiniMax T2A, including emotion and " +
+    "fine voice control.\n" +
+    "audio, tts, speech, synthesis, voice, emotion, minimax\n\n" +
+    "Use cases:\n" +
+    "- Create expressive voiceovers with emotion control\n" +
+    "- Produce multilingual narration\n" +
+    "- Generate character voices\n" +
+    "- Build audiobooks and podcasts";
+  static readonly metadataOutputTypes = { output: "audio" };
+  static readonly inlineFields: string[] = ["text"];
+  static readonly inputFields: string[] = ["voice_id"];
+  static readonly requiredSettings = ["MINIMAX_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "str",
+    default: "Hello, how are you?",
+    title: "Text",
+    description: "The text to convert to speech (up to 10,000 characters)."
+  })
+  declare text: any;
+
+  @prop({
+    type: "str",
+    default: DEFAULT_VOICE,
+    title: "Voice ID",
+    description:
+      "MiniMax voice ID. Connect a MiniMax Voice node, pick from the list, or " +
+      "provide a custom/cloned voice ID.",
+    values: MINIMAX_VOICES
+  })
+  declare voice_id: any;
+
+  @prop({
+    type: "enum",
+    default: "speech-2.6-hd",
+    title: "Model",
+    description: "The MiniMax speech model to use.",
+    values: MINIMAX_TTS_MODELS
+  })
+  declare model: any;
+
+  @prop({
+    type: "enum",
+    default: "auto",
+    title: "Emotion",
+    description:
+      "Emotional tone of the speech. 'auto' lets the model decide from the text.",
+    values: MINIMAX_EMOTIONS
+  })
+  declare emotion: any;
+
+  @prop({
+    type: "float",
+    default: 1.0,
+    title: "Speed",
+    description: "Speech speed multiplier.",
+    min: 0.5,
+    max: 2.0
+  })
+  declare speed: any;
+
+  @prop({
+    type: "float",
+    default: 1.0,
+    title: "Volume",
+    description: "Output volume.",
+    min: 0.1,
+    max: 10.0
+  })
+  declare volume: any;
+
+  @prop({
+    type: "int",
+    default: 0,
+    title: "Pitch",
+    description: "Pitch shift in semitones.",
+    min: -12,
+    max: 12
+  })
+  declare pitch: any;
+
+  @prop({
+    type: "enum",
+    default: "auto",
+    title: "Language Boost",
+    description:
+      "Bias pronunciation toward a language. 'auto' autodetects from the text.",
+    values: MINIMAX_LANGUAGE_BOOST
+  })
+  declare language_boost: any;
+
+  @prop({
+    type: "enum",
+    default: "mp3",
+    title: "Format",
+    description: "Output audio format.",
+    values: TTS_FORMATS
+  })
+  declare format: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const apiKey = getMinimaxApiKey(this._secrets);
+
+    const text = String(this.text ?? "");
+    if (!text) throw new Error("Text is required");
+
+    const voiceId = String(this.voice_id ?? DEFAULT_VOICE);
+    if (!voiceId) throw new Error("voice_id is required");
+
+    const model = String(this.model ?? "speech-2.6-hd");
+    const emotion = String(this.emotion ?? "auto");
+    const languageBoost = String(this.language_boost ?? "auto");
+    const format = String(this.format ?? "mp3");
+
+    const voiceSetting: Record<string, unknown> = {
+      voice_id: voiceId,
+      speed: Math.max(0.5, Math.min(2.0, Number(this.speed ?? 1.0))),
+      vol: Math.max(0.1, Math.min(10.0, Number(this.volume ?? 1.0))),
+      pitch: Math.max(-12, Math.min(12, Math.trunc(Number(this.pitch ?? 0))))
+    };
+    if (emotion && emotion !== "auto") {
+      voiceSetting.emotion = emotion;
+    }
+
+    const body: Record<string, unknown> = {
+      model,
+      text,
+      stream: false,
+      voice_setting: voiceSetting,
+      audio_setting: {
+        sample_rate: 32000,
+        bitrate: 128000,
+        format,
+        channel: 1
+      }
+    };
+    if (languageBoost && languageBoost !== "auto") {
+      body.language_boost = languageBoost;
+    }
+
+    const res = await fetch(`${MINIMAX_BASE_URL}/v1/t2a_v2`, {
+      method: "POST",
+      headers: minimaxHeaders(apiKey),
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) {
+      throw new Error(`MiniMax t2a_v2 failed: ${res.status} ${await res.text()}`);
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    assertBaseResp(data, "t2a_v2");
+
+    const payload = data.data as Record<string, unknown> | undefined;
+    const audio = payload?.audio as string | undefined;
+    if (!audio) {
+      throw new Error(
+        `MiniMax t2a_v2 returned no audio data: ${JSON.stringify(data)}`
+      );
+    }
+
+    const bytes = await resolveAudioPayload(audio);
+    return { output: audioRefFromBytes(bytes, format) };
+  }
+}
+
+export const TEXT_TO_SPEECH_NODES: readonly NodeClass[] = [
+  MinimaxTextToSpeechNode
+];

--- a/packages/minimax-nodes/src/nodes/text-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-video.ts
@@ -1,0 +1,87 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import {
+  generateVideo,
+  getMinimaxApiKey,
+  MINIMAX_T2V_MODELS,
+  MINIMAX_VIDEO_DURATIONS,
+  MINIMAX_VIDEO_RESOLUTIONS,
+  videoRefFromBytes
+} from "../minimax-base.js";
+
+export class MinimaxTextToVideoNode extends BaseNode {
+  static readonly nodeType = "minimax.TextToVideo";
+  static readonly body = "content_card";
+  static readonly title = "MiniMax Text to Video";
+  static readonly description =
+    "Generate video from a text prompt using MiniMax Hailuo and Director " +
+    "models.\n" +
+    "video, generation, text-to-video, t2v, hailuo, minimax\n\n" +
+    "Use cases:\n" +
+    "- Create short cinematic clips from a description\n" +
+    "- Prototype motion concepts\n" +
+    "- Generate B-roll and social content";
+  static readonly metadataOutputTypes = { output: "video" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["prompt"];
+  static readonly requiredSettings = ["MINIMAX_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "enum",
+    default: "MiniMax-Hailuo-02",
+    title: "Model",
+    description: "The MiniMax video model to use.",
+    values: MINIMAX_T2V_MODELS
+  })
+  declare model: any;
+
+  @prop({
+    type: "str",
+    default: "A cat playing with a ball of yarn",
+    title: "Prompt",
+    description:
+      "Text prompt describing the video. Director models support camera " +
+      "moves like [Push in], [Pan left], [Truck left]."
+  })
+  declare prompt: any;
+
+  @prop({
+    type: "int",
+    default: 6,
+    title: "Duration",
+    description: "Video duration in seconds.",
+    values: MINIMAX_VIDEO_DURATIONS
+  })
+  declare duration: any;
+
+  @prop({
+    type: "enum",
+    default: "768P",
+    title: "Resolution",
+    description: "Output resolution.",
+    values: MINIMAX_VIDEO_RESOLUTIONS
+  })
+  declare resolution: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const apiKey = getMinimaxApiKey(this._secrets);
+
+    const prompt = String(this.prompt ?? "");
+    if (!prompt) throw new Error("Prompt is required");
+
+    const body: Record<string, unknown> = {
+      model: String(this.model ?? "MiniMax-Hailuo-02"),
+      prompt,
+      duration: Number(this.duration ?? 6),
+      resolution: String(this.resolution ?? "768P")
+    };
+
+    const bytes = await generateVideo(apiKey, body);
+    return { output: videoRefFromBytes(bytes) };
+  }
+}
+
+export const TEXT_TO_VIDEO_NODES: readonly NodeClass[] = [
+  MinimaxTextToVideoNode
+];

--- a/packages/minimax-nodes/src/nodes/voice.ts
+++ b/packages/minimax-nodes/src/nodes/voice.ts
@@ -1,0 +1,35 @@
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import { DEFAULT_VOICE, MINIMAX_VOICES } from "../minimax-base.js";
+
+export class MinimaxVoiceNode extends BaseNode {
+  static readonly nodeType = "minimax.Voice";
+  static readonly body = "small";
+  static readonly title = "MiniMax Voice";
+  static readonly description =
+    "Select a MiniMax system voice and output its voice ID.\n" +
+    "audio, tts, speech, voice, voice-id, minimax\n\n" +
+    "Use cases:\n" +
+    "- Pick a built-in MiniMax voice by name\n" +
+    "- Feed a voice ID into the MiniMax Text to Speech node\n" +
+    "- Reuse the same voice across a workflow";
+  static readonly metadataOutputTypes = { voice_id: "str" };
+  static readonly inlineFields: string[] = ["voice"];
+  static readonly inputFields: string[] = [];
+
+  @prop({
+    type: "enum",
+    default: DEFAULT_VOICE,
+    title: "Voice",
+    description: "MiniMax system voice to use.",
+    values: MINIMAX_VOICES
+  })
+  declare voice: any;
+
+  async process(): Promise<Record<string, unknown>> {
+    const voice = String(this.voice ?? DEFAULT_VOICE);
+    return { voice_id: voice };
+  }
+}
+
+export const VOICE_NODES: readonly NodeClass[] = [MinimaxVoiceNode];

--- a/packages/minimax-nodes/tests/music.test.ts
+++ b/packages/minimax-nodes/tests/music.test.ts
@@ -36,7 +36,7 @@ describe("MinimaxMusicNode", () => {
     const body = JSON.parse(options.body as string) as Record<string, unknown>;
     expect(body.prompt).toBe("lo-fi beat");
     expect(body.lyrics).toBe("[Verse]\nhello");
-    expect(body.model).toBe("music-1.5");
+    expect(body.model).toBe("music-2.6");
 
     expect(result.output).toMatchObject({
       type: "audio",

--- a/packages/minimax-nodes/tests/music.test.ts
+++ b/packages/minimax-nodes/tests/music.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MinimaxMusicNode } from "../src/nodes/music.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const audioHex = Buffer.from("fake-song").toString("hex");
+
+function makeNode(props: Record<string, unknown> = {}): MinimaxMusicNode {
+  return new MinimaxMusicNode(props);
+}
+
+describe("MinimaxMusicNode", () => {
+  beforeEach(() => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { audio: audioHex },
+        base_resp: { status_code: 0, status_msg: "success" }
+      })
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    mockFetch.mockReset();
+  });
+
+  it("posts prompt and lyrics to the music_generation endpoint", async () => {
+    const node = makeNode({ prompt: "lo-fi beat", lyrics: "[Verse]\nhello" });
+    const result = await node.process();
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/v1/music_generation");
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body.prompt).toBe("lo-fi beat");
+    expect(body.lyrics).toBe("[Verse]\nhello");
+    expect(body.model).toBe("music-1.5");
+
+    expect(result.output).toMatchObject({
+      type: "audio",
+      data: expect.stringContaining("data:audio/mpeg;base64,")
+    });
+  });
+
+  it("requires a prompt", async () => {
+    await expect(
+      makeNode({ prompt: "", lyrics: "x" }).process()
+    ).rejects.toThrow("Prompt is required");
+  });
+
+  it("requires lyrics", async () => {
+    await expect(
+      makeNode({ prompt: "x", lyrics: "" }).process()
+    ).rejects.toThrow("Lyrics are required");
+  });
+
+  it("surfaces MiniMax base_resp errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        base_resp: { status_code: 2013, status_msg: "invalid params" }
+      })
+    });
+    await expect(
+      makeNode({ prompt: "x", lyrics: "y" }).process()
+    ).rejects.toThrow("invalid params");
+  });
+});

--- a/packages/minimax-nodes/tests/registration.test.ts
+++ b/packages/minimax-nodes/tests/registration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { MINIMAX_NODES, registerMinimaxNodes } from "../src/index.js";
+
+describe("registerMinimaxNodes", () => {
+  it("registers the MiniMax node pack", () => {
+    const registry = new NodeRegistry();
+    registerMinimaxNodes(registry);
+
+    expect(registry.has("minimax.Voice")).toBe(true);
+    expect(registry.has("minimax.TextToSpeech")).toBe(true);
+    expect(registry.has("minimax.MusicGeneration")).toBe(true);
+    expect(registry.has("minimax.TextToImage")).toBe(true);
+    expect(registry.has("minimax.TextToVideo")).toBe(true);
+    expect(registry.has("minimax.ImageToVideo")).toBe(true);
+  });
+
+  it("exposes every node through MINIMAX_NODES", () => {
+    const types = MINIMAX_NODES.map(
+      (n) => (n as unknown as { nodeType: string }).nodeType
+    );
+    expect(types).toEqual([
+      "minimax.Voice",
+      "minimax.TextToSpeech",
+      "minimax.MusicGeneration",
+      "minimax.TextToImage",
+      "minimax.TextToVideo",
+      "minimax.ImageToVideo"
+    ]);
+  });
+});

--- a/packages/minimax-nodes/tests/text-to-image.test.ts
+++ b/packages/minimax-nodes/tests/text-to-image.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MinimaxTextToImageNode } from "../src/nodes/text-to-image.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// 1x1 PNG so inferImageMime resolves to image/png.
+const pngBytes = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
+]);
+const pngB64 = Buffer.from(pngBytes).toString("base64");
+
+function makeNode(
+  props: Record<string, unknown> = {}
+): MinimaxTextToImageNode {
+  return new MinimaxTextToImageNode(props);
+}
+
+describe("MinimaxTextToImageNode", () => {
+  beforeEach(() => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { image_base64: [pngB64] },
+        base_resp: { status_code: 0, status_msg: "success" }
+      })
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    mockFetch.mockReset();
+  });
+
+  it("posts to image_generation and returns a base64 image ref", async () => {
+    const node = makeNode({ prompt: "a fox", aspect_ratio: "16:9" });
+    const result = await node.process();
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/v1/image_generation");
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body.model).toBe("image-01");
+    expect(body.prompt).toBe("a fox");
+    expect(body.aspect_ratio).toBe("16:9");
+
+    expect(result.output).toMatchObject({
+      type: "image",
+      mimeType: "image/png",
+      data: pngB64
+    });
+  });
+
+  it("appends the negative prompt into the prompt text", async () => {
+    await makeNode({ prompt: "a fox", negative_prompt: "blurry" }).process();
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(String(body.prompt)).toContain("Do not include: blurry");
+  });
+
+  it("requires a prompt", async () => {
+    await expect(makeNode({ prompt: "" }).process()).rejects.toThrow(
+      "Prompt is required"
+    );
+  });
+
+  it("downloads from image_urls when no base64 is returned", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { image_urls: ["https://cdn.minimax.io/img.png"] },
+          base_resp: { status_code: 0 }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () =>
+          pngBytes.buffer.slice(
+            pngBytes.byteOffset,
+            pngBytes.byteOffset + pngBytes.byteLength
+          )
+      });
+
+    const result = await makeNode({ prompt: "a fox" }).process();
+    expect(mockFetch.mock.calls[1][0]).toBe("https://cdn.minimax.io/img.png");
+    expect(result.output).toMatchObject({ type: "image", data: pngB64 });
+  });
+});

--- a/packages/minimax-nodes/tests/text-to-speech.test.ts
+++ b/packages/minimax-nodes/tests/text-to-speech.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MinimaxTextToSpeechNode } from "../src/nodes/text-to-speech.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const audioHex = Buffer.from("fake-audio").toString("hex");
+
+function makeNode(
+  props: Record<string, unknown> = {}
+): MinimaxTextToSpeechNode {
+  return new MinimaxTextToSpeechNode(props);
+}
+
+function bodyOf(call: number): Record<string, unknown> {
+  const [, options] = mockFetch.mock.calls[call] as [string, RequestInit];
+  return JSON.parse(options.body as string) as Record<string, unknown>;
+}
+
+describe("MinimaxTextToSpeechNode", () => {
+  const originalApiKey = process.env.MINIMAX_API_KEY;
+
+  beforeEach(() => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { audio: audioHex },
+        base_resp: { status_code: 0, status_msg: "success" }
+      })
+    });
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.MINIMAX_API_KEY;
+    } else {
+      process.env.MINIMAX_API_KEY = originalApiKey;
+    }
+    mockFetch.mockReset();
+  });
+
+  it("posts to the t2a_v2 endpoint with a bearer token", async () => {
+    const node = makeNode({ text: "Hello world" });
+    const result = await node.process();
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/v1/t2a_v2");
+    expect(options.method).toBe("POST");
+    expect((options.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-key"
+    );
+
+    const body = bodyOf(0);
+    expect(body.text).toBe("Hello world");
+    expect((body.voice_setting as Record<string, unknown>).voice_id).toBe(
+      "English_Trustworth_Man"
+    );
+
+    expect(result.output).toMatchObject({
+      type: "audio",
+      data: expect.stringContaining("data:audio/mpeg;base64,")
+    });
+  });
+
+  it("reads the API key from injected secrets", async () => {
+    delete process.env.MINIMAX_API_KEY;
+    const node = makeNode({ text: "Hi" });
+    node.setDynamic("_secrets", { MINIMAX_API_KEY: "from-secrets" });
+    await node.process();
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBe(
+      "Bearer from-secrets"
+    );
+  });
+
+  it("throws when the API key is missing", async () => {
+    delete process.env.MINIMAX_API_KEY;
+    const node = makeNode({ text: "Hi" });
+    await expect(node.process()).rejects.toThrow("MINIMAX_API_KEY");
+  });
+
+  it("throws when the text is empty", async () => {
+    const node = makeNode({ text: "" });
+    await expect(node.process()).rejects.toThrow("Text is required");
+  });
+
+  it("omits emotion when set to auto", async () => {
+    await makeNode({ text: "Hi", emotion: "auto" }).process();
+    const voiceSetting = bodyOf(0).voice_setting as Record<string, unknown>;
+    expect(voiceSetting.emotion).toBeUndefined();
+  });
+
+  it("includes emotion when explicitly chosen", async () => {
+    await makeNode({ text: "Hi", emotion: "happy" }).process();
+    const voiceSetting = bodyOf(0).voice_setting as Record<string, unknown>;
+    expect(voiceSetting.emotion).toBe("happy");
+  });
+
+  it("omits language_boost when set to auto and includes it otherwise", async () => {
+    await makeNode({ text: "Hi", language_boost: "auto" }).process();
+    expect(bodyOf(0).language_boost).toBeUndefined();
+
+    mockFetch.mockClear();
+    await makeNode({ text: "Hi", language_boost: "English" }).process();
+    expect(bodyOf(0).language_boost).toBe("English");
+  });
+
+  it("clamps the speed into the supported range", async () => {
+    await makeNode({ text: "Hi", speed: 9 }).process();
+    const voiceSetting = bodyOf(0).voice_setting as Record<string, unknown>;
+    expect(voiceSetting.speed).toBe(2.0);
+  });
+
+  it("passes the selected format through to audio_setting", async () => {
+    await makeNode({ text: "Hi", format: "wav" }).process();
+    const audioSetting = bodyOf(0).audio_setting as Record<string, unknown>;
+    expect(audioSetting.format).toBe("wav");
+  });
+
+  it("surfaces MiniMax base_resp errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        base_resp: { status_code: 1004, status_msg: "invalid api key" }
+      })
+    });
+    await expect(makeNode({ text: "Hi" }).process()).rejects.toThrow(
+      "invalid api key"
+    );
+  });
+
+  it("surfaces HTTP errors", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401, text: async () => "no" });
+    await expect(makeNode({ text: "Hi" }).process()).rejects.toThrow(
+      "t2a_v2 failed"
+    );
+  });
+});

--- a/packages/minimax-nodes/tests/video.test.ts
+++ b/packages/minimax-nodes/tests/video.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MinimaxTextToVideoNode } from "../src/nodes/text-to-video.js";
+import { MinimaxImageToVideoNode } from "../src/nodes/image-to-video.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const videoBytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+const videoB64 = Buffer.from(videoBytes).toString("base64");
+
+/** Queue the submit → poll → retrieve → download responses for a video job. */
+function queueVideoSuccess(): void {
+  mockFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ task_id: "task-1", base_resp: { status_code: 0 } })
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "Success", file_id: "file-1" })
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        file: { download_url: "https://cdn.minimax.io/video.mp4" },
+        base_resp: { status_code: 0 }
+      })
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: async () =>
+        videoBytes.buffer.slice(
+          videoBytes.byteOffset,
+          videoBytes.byteOffset + videoBytes.byteLength
+        )
+    });
+}
+
+describe("MinimaxTextToVideoNode", () => {
+  beforeEach(() => {
+    process.env.MINIMAX_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    mockFetch.mockReset();
+  });
+
+  it("submits, polls, downloads and returns a video ref", async () => {
+    queueVideoSuccess();
+    const node = new MinimaxTextToVideoNode({
+      prompt: "a sunset",
+      duration: 6,
+      resolution: "768P"
+    });
+    const result = await node.process();
+
+    const [submitUrl, submitOpts] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit
+    ];
+    expect(submitUrl).toContain("/v1/video_generation");
+    const body = JSON.parse(submitOpts.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body.prompt).toBe("a sunset");
+    expect(body.model).toBe("MiniMax-Hailuo-02");
+
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(result.output).toMatchObject({ type: "video", data: videoB64 });
+  });
+
+  it("requires a prompt", async () => {
+    await expect(
+      new MinimaxTextToVideoNode({ prompt: "" }).process()
+    ).rejects.toThrow("Prompt is required");
+  });
+
+  it("throws when the task fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ task_id: "task-1", base_resp: { status_code: 0 } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "Fail", base_resp: { status_msg: "nope" } })
+      });
+    await expect(
+      new MinimaxTextToVideoNode({ prompt: "x" }).process()
+    ).rejects.toThrow("video task failed");
+  });
+});
+
+describe("MinimaxImageToVideoNode", () => {
+  beforeEach(() => {
+    process.env.MINIMAX_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    mockFetch.mockReset();
+  });
+
+  it("sends the input image as the first frame", async () => {
+    queueVideoSuccess();
+    const imageB64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    const node = new MinimaxImageToVideoNode({
+      image: { type: "image", data: imageB64 },
+      prompt: "[Push in] zoom"
+    });
+    const result = await node.process();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as RequestInit).body as string
+    ) as Record<string, unknown>;
+    expect(String(body.first_frame_image)).toContain("base64,");
+    expect(body.prompt).toBe("[Push in] zoom");
+    expect(result.output).toMatchObject({ type: "video", data: videoB64 });
+  });
+
+  it("throws when no input image is provided", async () => {
+    const node = new MinimaxImageToVideoNode({
+      image: { type: "image", data: null, uri: "" }
+    });
+    await expect(node.process()).rejects.toThrow("input image is required");
+  });
+});

--- a/packages/minimax-nodes/tests/voice.test.ts
+++ b/packages/minimax-nodes/tests/voice.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { MinimaxVoiceNode } from "../src/nodes/voice.js";
+import { DEFAULT_VOICE, MINIMAX_VOICES } from "../src/minimax-base.js";
+
+function makeNode(props: Record<string, unknown> = {}): MinimaxVoiceNode {
+  return new MinimaxVoiceNode(props);
+}
+
+describe("MinimaxVoiceNode", () => {
+  it("outputs the selected voice ID", async () => {
+    const node = makeNode({ voice: "English_CalmWoman" });
+    const result = await node.process();
+    expect(result.voice_id).toBe("English_CalmWoman");
+  });
+
+  it("defaults to the trustworthy man voice", async () => {
+    const result = await makeNode().process();
+    expect(result.voice_id).toBe(DEFAULT_VOICE);
+  });
+
+  it("exposes every system voice as an enum option", () => {
+    const voiceProp = MinimaxVoiceNode.getDeclaredProperties().find(
+      (p) => p.name === "voice"
+    );
+    expect(voiceProp?.options.values).toEqual(MINIMAX_VOICES);
+  });
+
+  it("declares a string voice_id output", () => {
+    expect(MinimaxVoiceNode.metadataOutputTypes).toEqual({ voice_id: "str" });
+  });
+});

--- a/packages/minimax-nodes/tsconfig.json
+++ b/packages/minimax-nodes/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "tests",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../node-sdk"
+    }
+  ]
+}

--- a/packages/minimax-nodes/vitest.config.ts
+++ b/packages/minimax-nodes/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -214,6 +214,7 @@ export class MinimaxProvider extends OpenAIProvider {
 
   override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
     return [
+      { id: "MiniMax-M3", name: "MiniMax M3", provider: "minimax" },
       { id: "MiniMax-M2.7", name: "MiniMax M2.7", provider: "minimax" },
       {
         id: "MiniMax-M2.7-highspeed",

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -30,6 +30,7 @@
     "@nodetool-ai/dsl": "*",
     "@nodetool-ai/image-editor": "*",
     "@nodetool-ai/elevenlabs-nodes": "*",
+    "@nodetool-ai/minimax-nodes": "*",
     "@nodetool-ai/transformers-js-nodes": "*",
     "@nodetool-ai/transformers-js-provider": "*",
     "@nodetool-ai/fal-nodes": "*",

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -16,6 +16,7 @@ import {
 import { setPackSnapshot } from "./pack-snapshot.js";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
+import { registerMinimaxNodes } from "@nodetool-ai/minimax-nodes";
 import { registerTransformersJsNodes } from "@nodetool-ai/transformers-js-nodes";
 import { registerFalNodes } from "@nodetool-ai/fal-nodes";
 import { registerKieNodes } from "@nodetool-ai/kie-nodes";
@@ -54,6 +55,7 @@ function isProduction(): boolean {
 export function registerBuiltInNodes(registry: NodeRegistry): void {
   registerBaseNodes(registry);
   registerElevenLabsNodes(registry);
+  registerMinimaxNodes(registry);
   if (!isProduction()) {
     registerTransformersJsNodes(registry);
   }

--- a/packages/websocket/tsconfig.json
+++ b/packages/websocket/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../elevenlabs-nodes"
     },
     {
+      "path": "../minimax-nodes"
+    },
+    {
       "path": "../transformers-js-nodes"
     },
     {

--- a/scripts/run-workflow.mjs
+++ b/scripts/run-workflow.mjs
@@ -288,6 +288,7 @@ async function main() {
   let NodeRegistry;
   let registerBaseNodes;
   let registerElevenLabsNodes;
+  let registerMinimaxNodes;
   let registerFalNodes;
   let ProcessingContext;
   let OpenAIProvider;
@@ -305,6 +306,7 @@ async function main() {
     const nodeSdkPath = path.resolve(tsRoot, "packages/node-sdk/dist/index.js");
     const baseNodesPath = path.resolve(tsRoot, "packages/base-nodes/dist/index.js");
     const elevenLabsNodesPath = path.resolve(tsRoot, "packages/elevenlabs-nodes/dist/index.js");
+    const minimaxNodesPath = path.resolve(tsRoot, "packages/minimax-nodes/dist/index.js");
     const runtimePath = path.resolve(tsRoot, "packages/runtime/dist/index.js");
     const falNodesPath = path.resolve(tsRoot, "packages/fal-nodes/dist/index.js");
     const modelsPath = path.resolve(tsRoot, "packages/models/dist/index.js");
@@ -313,6 +315,11 @@ async function main() {
     ({ NodeRegistry } = await import(pathToFileURL(nodeSdkPath).href));
     ({ registerBaseNodes } = await import(pathToFileURL(baseNodesPath).href));
     ({ registerElevenLabsNodes } = await import(pathToFileURL(elevenLabsNodesPath).href));
+    try {
+      ({ registerMinimaxNodes } = await import(pathToFileURL(minimaxNodesPath).href));
+    } catch {
+      // MiniMax nodes package not built — skip
+    }
     ({
       ProcessingContext,
       OpenAIProvider,
@@ -349,6 +356,7 @@ async function main() {
   const registry = new NodeRegistry();
   registerBaseNodes(registry);
   registerElevenLabsNodes(registry);
+  if (registerMinimaxNodes) registerMinimaxNodes(registry);
   if (registerFalNodes) registerFalNodes(registry);
 
   // Check if any node in the graph needs Python execution

--- a/scripts/websocket-workspaces.mjs
+++ b/scripts/websocket-workspaces.mjs
@@ -14,6 +14,7 @@ export const websocketWorkspaces = [
   "@nodetool-ai/fal-nodes",
   "@nodetool-ai/replicate-nodes",
   "@nodetool-ai/elevenlabs-nodes",
+  "@nodetool-ai/minimax-nodes",
   "@nodetool-ai/agents",
   "@nodetool-ai/kie-nodes",
   "@nodetool-ai/base-nodes",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -21,6 +21,7 @@
     { "path": "packages/replicate-codegen" },
     { "path": "packages/replicate-nodes" },
     { "path": "packages/elevenlabs-nodes" },
+    { "path": "packages/minimax-nodes" },
     { "path": "packages/transformers-js-nodes" },
     { "path": "packages/transformers-js-provider" },
     { "path": "packages/kie-codegen" },


### PR DESCRIPTION
## Summary

Adds a new `@nodetool-ai/minimax-nodes` package that integrates MiniMax AI's REST API directly into NodeTool workflows. This follows the same pattern as the existing ElevenLabs node pack, exposing MiniMax-specific controls (emotion, volume, pitch, language boost, camera direction) that the generic provider interface doesn't carry.

## Key Changes

- **New package**: `packages/minimax-nodes/` with 6 node types:
  - `MinimaxVoiceNode` — voice ID selector
  - `MinimaxTextToSpeechNode` — speech synthesis with emotion, speed, volume, pitch, language boost
  - `MinimaxMusicNode` — music generation from prompt + lyrics
  - `MinimaxTextToImageNode` — image generation with aspect ratio control
  - `MinimaxTextToVideoNode` — text-to-video with Hailuo and Director models
  - `MinimaxImageToVideoNode` — image-to-video animation

- **Shared utilities** (`minimax-base.ts`):
  - API key resolution from secrets or environment
  - Response validation with `assertBaseResp()`
  - Audio/image/video payload handling (hex decoding, base64 encoding, MIME type inference)
  - Async video generation workflow (submit → poll → download)
  - Curated voice, model, emotion, language, aspect ratio, and resolution catalogues

- **Comprehensive tests**: Unit tests for all nodes covering happy paths, error cases, API key resolution, and parameter validation

- **Integration**: Registered in all relevant workspace configs (CLI, DSL, WebSocket, Docker) and TypeScript references

## Implementation Details

- Nodes call MiniMax's REST API directly (not through the runtime provider) to expose MiniMax-specific knobs
- All network access goes through global `fetch` for testability
- Video generation uses async task polling with configurable intervals and max attempts
- Audio/image payloads support both hex-encoded bytes and download URLs
- Image MIME types inferred from magic bytes (JPEG, PNG, WebP detection)
- Follows existing node SDK patterns: `@prop` decorators, `BaseNode` extension, metadata output types

https://claude.ai/code/session_01UhZmmK2HRJptTjCg3bvErP