### PR TITLE
Implement streaming for SummarizerNode and fix agent output routing

### DIFF
--- a/packages/code-nodes/src/nodes/tool-agents.ts
+++ b/packages/code-nodes/src/nodes/tool-agents.ts
@@ -10,7 +10,7 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { ToolLike } from "@nodetool-ai/llm-nodes";
-import { runAgentLoop } from "@nodetool-ai/llm-nodes";
+import { runAgentLoop, resolveBuiltinAgentTool } from "@nodetool-ai/llm-nodes";
 import { exec } from "node:child_process";
 import { access, mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -235,13 +235,23 @@ async function buildAssetContentParts(
   return parts;
 }
 
+/** Cap a string at `maxChars`, appending a marker noting how much was dropped. */
+function truncateText(text: string, maxChars: number): string {
+  if (maxChars <= 0 || text.length <= maxChars) return text;
+  return (
+    text.slice(0, maxChars) +
+    `\n…[truncated ${text.length - maxChars} chars]`
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tool factories for skill agent loop
 // ---------------------------------------------------------------------------
 
 export function makeExecuteBashTool(
   workspaceDir: string,
-  timeoutMs = 120_000
+  timeoutMs = 120_000,
+  maxChars = 200_000
 ): ToolLike {
   return {
     name: "execute_bash",
@@ -267,8 +277,8 @@ export function makeExecuteBashTool(
           (error, stdout, stderr) => {
             resolve({
               success: !error,
-              stdout: stdout ?? "",
-              stderr: stderr ?? "",
+              stdout: truncateText(stdout ?? "", maxChars),
+              stderr: truncateText(stderr ?? "", maxChars),
               ...(error ? { error: error.message } : {})
             });
           }
@@ -333,18 +343,51 @@ class ToolAgentNode extends BaseNode {
   /** Override in subclasses to declare output sinks. Keys are output handle names, values are tool names. */
   static readonly _outputSinkConfig: Record<string, string> = {};
 
+  /** Names of builtin agent tools (from @nodetool-ai/agents) to expose to the loop. */
+  static readonly _builtinToolNames: readonly string[] = [];
+
+  /** Whether the execute_bash tool is included in the loop. */
+  static readonly _includeBash: boolean = true;
+
   /** Transient storage for output paths set during agent loop. */
   private _outputSinks: Record<string, string[]> = {};
 
-  /** Build tools for the agent loop. Includes execute_bash + any output sink tools. */
+  /** Resolved max serialized output chars, clamped to a positive value. */
+  protected _maxOutputChars(): number {
+    const v = Number((this as any).max_output_chars ?? 200_000);
+    return Number.isFinite(v) && v > 0 ? v : 200_000;
+  }
+
+  /**
+   * Extra context appended to the user prompt. Override in subclasses to
+   * inject node-specific fields (e.g. a URL or output directory) that are
+   * declared as props but would otherwise never reach the agent.
+   */
+  protected promptContext(): string {
+    return "";
+  }
+
+  /**
+   * Build tools for the agent loop: execute_bash (unless disabled), any
+   * builtin agent tools named by the subclass, and the declared output sinks.
+   */
   getTools(workspaceDir: string): ToolLike[] {
-    const tools: ToolLike[] = [
-      makeExecuteBashTool(
-        workspaceDir,
-        ((this as any).timeout_seconds ?? 120) * 1000
-      )
-    ];
-    const config = (this.constructor as typeof ToolAgentNode)._outputSinkConfig;
+    const ctor = this.constructor as typeof ToolAgentNode;
+    const tools: ToolLike[] = [];
+    if (ctor._includeBash) {
+      tools.push(
+        makeExecuteBashTool(
+          workspaceDir,
+          ((this as any).timeout_seconds ?? 120) * 1000,
+          this._maxOutputChars()
+        )
+      );
+    }
+    for (const name of ctor._builtinToolNames) {
+      const builtin = resolveBuiltinAgentTool(name);
+      if (builtin) tools.push(builtin as unknown as ToolLike);
+    }
+    const config = ctor._outputSinkConfig;
     this._outputSinks = {};
     for (const [outputName, toolName] of Object.entries(config)) {
       const sink: string[] = [];
@@ -448,6 +491,10 @@ class ToolAgentNode extends BaseNode {
     if (workspaceFiles.length > 0) {
       augmentedPrompt += `\n\nInput files available in the workspace directory:\n${workspaceFiles.map((f) => `- ${f}`).join("\n")}`;
     }
+    const extraContext = this.promptContext();
+    if (extraContext) {
+      augmentedPrompt += `\n\n${extraContext}`;
+    }
 
     const systemPrompt = (this.constructor as typeof ToolAgentNode)
       ._systemPrompt;
@@ -463,7 +510,10 @@ class ToolAgentNode extends BaseNode {
       maxIterations: 10
     });
 
-    return { text, ...(await this.readOutputSinks(workspaceDir)) };
+    return {
+      text: truncateText(text, this._maxOutputChars()),
+      ...(await this.readOutputSinks(workspaceDir))
+    };
   }
 }
 
@@ -542,11 +592,12 @@ export class BrowserAgentNode extends ToolAgentNode {
   static readonly metadataOutputTypes = {
     text: "str"
   };
+  static readonly _builtinToolNames = ["browser", "take_screenshot"];
   static readonly _systemPrompt =
     "You are a browser automation and extraction agent using Playwright-backed browser tools. " +
-    "Use `browser` to fetch page content and metadata, `take_screenshot` for screenshots, " +
-    "and DOM tools (`dom_examine`, `dom_search`, `dom_extract`) for structured inspection. " +
+    "Use `browser` to fetch page content and metadata, and `take_screenshot` for screenshots. " +
     "The `browser` tool returns JSON fields like `success`, `url`, `content`, `metadata`, or `error`. " +
+    "Use `execute_bash` for local processing of fetched content (parsing, filtering, saving files). " +
     "Do not browse search engine result pages directly; explain that direct SERP browsing is disabled.";
   @prop({
     type: "language_model",
@@ -1295,6 +1346,8 @@ export class HttpApiAgentNode extends ToolAgentNode {
   static readonly metadataOutputTypes = {
     text: "str"
   };
+  static readonly _builtinToolNames = ["http_request"];
+  static readonly _includeBash = false;
   static readonly _systemPrompt =
     "You are an HTTP API integration specialist. " +
     "You can use exactly one tool: `http_request`. " +
@@ -1979,6 +2032,16 @@ export class YtDlpDownloaderAgentNode extends ToolAgentNode {
     max: 2000000
   })
   declare max_output_chars: any;
+
+  protected promptContext(): string {
+    const url = String((this as any).url ?? "").trim();
+    const outputDir = String((this as any).output_dir ?? "").trim();
+    const lines: string[] = [];
+    if (url) lines.push(`Video URL: ${url}`);
+    if (outputDir)
+      lines.push(`Output directory (workspace-relative): ${outputDir}`);
+    return lines.join("\n");
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dsl/src/generated/nodetool.agents.ts
+++ b/packages/dsl/src/generated/nodetool.agents.ts
@@ -10,6 +10,7 @@ export interface SummarizerInputs {
   text?: Connectable<string>;
   image?: Connectable<ImageRef>;
   audio?: Connectable<AudioRef>;
+  max_sentences?: Connectable<number>;
 }
 
 export interface SummarizerOutputs {

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1895,9 +1895,9 @@ export class AgentNode extends BaseNode {
     },
     {
       id: "deepseek-r1:8b",
-      type: "mistral_model",
+      type: "llama_model",
       name: "Deepseek R1 - 8B",
-      repo_id: "deepseek-r1:8",
+      repo_id: "deepseek-r1:8b",
       description:
         "DeepSeek R1 8B balances reasoning with precise function calls for iterative agents.",
       size_on_disk: 5583457484
@@ -2845,6 +2845,7 @@ export class AgentNode extends BaseNode {
       dynamicVars
     );
     const rawTools: ToolLike[] = await this.buildTools(context);
+    const structuredSchema = getStructuredOutputSchema(this);
 
     // Build control tools
     const controlContext = this.getDynamic<Record<string, unknown>>("_control_context");
@@ -2866,7 +2867,7 @@ export class AgentNode extends BaseNode {
       tools: agentTools,
       systemPrompt: system,
       maxTokenLimit: Number(this.max_tokens ?? 8192),
-      outputSchema: getStructuredOutputSchema(this) ?? undefined,
+      outputSchema: structuredSchema ?? undefined,
       planningModel: modelId,
       maxSteps: 10,
       maxStepIterations: 5
@@ -2971,22 +2972,29 @@ export class AgentNode extends BaseNode {
       }
     }
 
+    const finalResults = agent.getResults();
     const resultText =
       lastText ||
-      (agent.getResults() != null
-        ? typeof agent.getResults() === "string"
-          ? (agent.getResults() as string)
-          : JSON.stringify(agent.getResults())
+      (finalResults != null
+        ? typeof finalResults === "string"
+          ? finalResults
+          : JSON.stringify(finalResults)
         : "");
 
     yield { chunk: null, thinking: null, text: resultText, audio: null };
-    return {
-      text: resultText,
-      output: resultText,
-      chunk: null,
-      thinking: null,
-      audio: null
-    };
+
+    // When the node declares dynamic outputs, surface the agent's structured
+    // result as a bare object so process()/the kernel route it to those output
+    // handles — mirroring loop mode's `yield structuredResult`. Without this,
+    // plan mode only ever emits `text` and dynamic outputs stay empty.
+    if (
+      structuredSchema &&
+      finalResults &&
+      typeof finalResults === "object" &&
+      !Array.isArray(finalResults)
+    ) {
+      yield finalResults as Record<string, unknown>;
+    }
   }
 }
 

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1233,14 +1233,11 @@ export class SummarizerNode extends BaseNode {
   };
   static readonly inlineFields = ["text"];
   static readonly inputFields = ["image", "audio", "system_prompt"];
-  // TODO: process() awaits the full provider response and only returns
-  // `text` — `chunk` is never emitted. To actually stream, convert to
-  // `genProcess` and yield each provider piece as a `chunk`, then flip
-  // `chunk` to `iteration`. Keeping `single` so metadata reflects current
-  // behavior.
+  // Streamed output: each provider piece is emitted as a `chunk` iteration,
+  // and the final aggregated summary is the `text` single output.
   static readonly outputCorrelation: Record<string, OutputCorrelation> = {
     text: { kind: "single", source: "__execution__" },
-    chunk: { kind: "single", source: "__execution__" }
+    chunk: { kind: "iteration", source: "__execution__", group: "stream" }
   };
   static readonly recommendedModels = [
     {
@@ -1303,7 +1300,7 @@ export class SummarizerNode extends BaseNode {
   @prop({
     type: "str",
     default:
-      "\n        You are an expert summarizer. Your task is to create clear, accurate, and concise summaries using Markdown for structuring.\n        Follow these guidelines:\n        1. Identify and include only the most important information.\n        2. Maintain factual accuracy - do not add or modify information.\n        3. Use clear, direct language.\n        4. Aim for approximately {self.max_tokens} tokens.\n        ",
+      "\n        You are an expert summarizer. Your task is to create clear, accurate, and concise summaries using Markdown for structuring.\n        Follow these guidelines:\n        1. Identify and include only the most important information.\n        2. Maintain factual accuracy - do not add or modify information.\n        3. Use clear, direct language.\n        4. Keep the summary brief and to the point.\n        ",
     title: "System Prompt",
     description: "The system prompt for the summarizer"
   })
@@ -1360,32 +1357,84 @@ export class SummarizerNode extends BaseNode {
   })
   declare audio: AudioRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const text = asText(this.text ?? this.text ?? "");
-    const maxSentences = Number((this as any).max_sentences ?? 3);
+  @prop({
+    type: "int",
+    default: 3,
+    title: "Max Sentences",
+    description: "Approximate number of sentences for the summary.",
+    min: 1,
+    max: 100
+  })
+  declare max_sentences: number;
+
+  private _maxSentences(): number {
+    const raw = Number(this.max_sentences ?? 3);
+    return Number.isFinite(raw) ? Math.max(1, raw) : 3;
+  }
+
+  async *genProcess(
+    context?: ProcessingContext
+  ): AsyncGenerator<Record<string, unknown>> {
+    const text = asText(this.text ?? "");
+    const maxSentences = this._maxSentences();
+    const systemPrompt =
+      asText(this.system_prompt ?? "").trim() || SUMMARIZER_SYSTEM_PROMPT;
     const { providerId, modelId } = getModelConfig(this.serialize());
+
     if (hasProviderSupport(context, providerId, modelId)) {
       const provider = await context.getProvider(providerId);
-      const result = await generateProviderMessage(provider, {
-        model: modelId,
-        maxTokens: Number.isFinite(maxSentences)
-          ? Math.max(64, maxSentences * 128)
-          : 384,
+      let full = "";
+      for await (const item of streamProviderMessages(provider, {
         messages: [
-          { role: "system", content: SUMMARIZER_SYSTEM_PROMPT },
+          { role: "system", content: systemPrompt },
           {
             role: "user",
-            content: `Summarize the following text in about ${Math.max(1, maxSentences)} sentence(s):\n\n${text}`
+            content: `Summarize the following text in about ${maxSentences} sentence(s):\n\n${text}`
           }
-        ]
-      });
-      return { text: result, output: result };
+        ],
+        model: modelId,
+        maxTokens: Math.max(64, maxSentences * 128)
+      })) {
+        if (isChunkItem(item) && !item.thinking) {
+          const piece = item.content ?? "";
+          if (piece) {
+            full += piece;
+            yield {
+              chunk: {
+                type: "chunk",
+                content: piece,
+                content_type: "text",
+                done: false
+              },
+              text: null
+            };
+          }
+        }
+      }
+      const summary = full.trim();
+      yield { chunk: null, text: summary, output: summary };
+      return;
     }
-    const result = summarize(
-      text,
-      Number.isFinite(maxSentences) ? maxSentences : 3
-    );
-    return { text: result, output: result };
+
+    const summary = summarize(text, maxSentences);
+    yield {
+      chunk: {
+        type: "chunk",
+        content: summary,
+        content_type: "text",
+        done: true
+      },
+      text: summary,
+      output: summary
+    };
+  }
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    let text = "";
+    for await (const item of this.genProcess(context)) {
+      if (typeof item.text === "string") text = item.text;
+    }
+    return { text, output: text };
   }
 }
 
@@ -1418,12 +1467,12 @@ export class CreateThreadNode extends BaseNode {
   declare thread_id: string;
 
   async process(): Promise<Record<string, unknown>> {
-    const requested = String(this.thread_id ?? this.thread_id ?? "").trim();
+    const requested = String(this.thread_id ?? "").trim();
     if (requested) {
       if (!THREAD_STORE.has(requested)) {
         THREAD_STORE.set(requested, {
           id: requested,
-          title: String(this.title ?? this.title ?? "Agent Conversation"),
+          title: String(this.title ?? "Agent Conversation"),
           messages: []
         });
       }
@@ -1433,7 +1482,7 @@ export class CreateThreadNode extends BaseNode {
     const id = makeThreadId();
     THREAD_STORE.set(id, {
       id,
-      title: String(this.title ?? this.title ?? "Agent Conversation"),
+      title: String(this.title ?? "Agent Conversation"),
       messages: []
     });
     return { thread_id: id };
@@ -1568,7 +1617,7 @@ export class ExtractorNode extends BaseNode {
   declare audio: AudioRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const text = asText(this.text ?? this.text ?? "");
+    const text = asText(this.text ?? "");
     const { providerId, modelId } = getModelConfig(this.serialize());
     if (hasProviderSupport(context, providerId, modelId)) {
       const provider = await context.getProvider(providerId);
@@ -1582,7 +1631,11 @@ export class ExtractorNode extends BaseNode {
         model: modelId,
         maxTokens: Number((this as any).max_tokens ?? 1024),
         messages: [
-          { role: "system", content: EXTRACTOR_SYSTEM_PROMPT },
+          {
+            role: "system",
+            content:
+              asText(this.system_prompt ?? "").trim() || EXTRACTOR_SYSTEM_PROMPT
+          },
           { role: "user", content: text }
         ],
         toolName: "extraction_result",
@@ -1736,8 +1789,8 @@ export class ClassifierNode extends BaseNode {
   declare categories: string[];
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const text = asText(this.text ?? this.text ?? "");
-    const categories = getCategories(this.categories ?? this.categories);
+    const text = asText(this.text ?? "");
+    const categories = getCategories(this.categories);
     if (categories.length < 2) {
       throw new Error("At least 2 categories are required");
     }
@@ -1749,7 +1802,11 @@ export class ClassifierNode extends BaseNode {
         model: modelId,
         maxTokens: Number((this as any).max_tokens ?? 256),
         messages: [
-          { role: "system", content: CLASSIFIER_SYSTEM_PROMPT },
+          {
+            role: "system",
+            content:
+              asText(this.system_prompt ?? "").trim() || CLASSIFIER_SYSTEM_PROMPT
+          },
           {
             role: "user",
             content: `Allowed categories: ${categories.join(", ")}\n\nText: ${text}`
@@ -2422,16 +2479,16 @@ export class AgentNode extends BaseNode {
       asText(this.system ?? DEFAULT_SYSTEM_PROMPT),
       dynamicVars
     );
-    const image = this.image ?? this.image;
-    const audio = this.audio ?? this.audio;
-    const historyInput = this.history ?? this.history;
+    const image = this.image;
+    const audio = this.audio;
+    const historyInput = this.history;
     const history = Array.isArray(historyInput)
       ? historyInput
           .map((item) => normalizeMessage(item))
           .filter((item): item is Message => item !== null)
       : [];
-    const threadId = String(this.thread_id ?? this.thread_id ?? "").trim();
-    const maxTokens = Number(this.max_tokens ?? this.max_tokens ?? 8192);
+    const threadId = String(this.thread_id ?? "").trim();
+    const maxTokens = Number(this.max_tokens ?? 8192);
     const maxTurns = Math.max(1, Number(this.max_turns ?? 100));
     const tools: ToolLike[] = await this.buildTools(context);
 

--- a/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
+++ b/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
@@ -218,11 +218,11 @@ describe("SummarizerNode", () => {
     expect(result.text).toBe("A. B. C.");
   });
 
-  it("uses assigned defaults when inputs are missing", async () => {
+  it("respects assigned max_sentences", async () => {
     const n = new (SummarizerNode as any)();
     n.assign({ text: "From props. Second.", max_sentences: 1 });
     const result = await n.process();
-    expect(result.text).toBe("From props. Second.");
+    expect(result.text).toBe("From props.");
   });
 });
 


### PR DESCRIPTION
## Summary

This PR implements streaming support for `SummarizerNode` by converting it from a single-response `process()` method to an async generator `genProcess()` that yields chunks as they arrive from the LLM provider. It also fixes several bugs in agent output handling, removes redundant null-coalescing operators, and improves tool configuration for agent subclasses.

## Key Changes

### SummarizerNode Streaming
- Converted `process()` to `genProcess()` async generator that yields individual chunks from the provider stream
- Updated `outputCorrelation` to mark `chunk` as `kind: "iteration"` with `group: "stream"` instead of `kind: "single"`
- Kept `process()` as a wrapper that consumes the generator for backward compatibility
- Added `max_sentences` as a proper `@prop()` field with validation via `_maxSentences()` helper
- Updated system prompt default to remove token count reference (now uses brief guideline instead)
- Improved chunk emission to include proper metadata (`type`, `content_type`, `done` flags)

### Agent Output Routing (Plan Mode)
- Fixed plan mode to surface structured results to dynamic output handles by yielding the agent's final result object when `structuredSchema` is defined
- This mirrors loop mode behavior and ensures dynamic outputs receive data instead of staying empty
- Cached `getResults()` call to avoid multiple invocations

### Tool Agent Infrastructure
- Added `_builtinToolNames` static field to declare builtin agent tools (e.g., `["browser", "take_screenshot"]`)
- Added `_includeBash` static field to control whether `execute_bash` is included (defaults to `true`)
- Added `_maxOutputChars()` method to resolve and validate max output character limit
- Added `promptContext()` protected method for subclasses to inject node-specific context into prompts
- Implemented `truncateText()` utility to cap output with a marker showing dropped character count
- Updated `makeExecuteBashTool()` to accept `maxChars` parameter and truncate stdout/stderr

### Specific Subclass Updates
- **BrowserAgentNode**: Declared `_builtinToolNames = ["browser", "take_screenshot"]`, updated system prompt
- **HttpApiAgentNode**: Declared `_builtinToolNames = ["http_request"]`, disabled bash with `_includeBash = false`
- **YtDlpDownloaderAgentNode**: Implemented `promptContext()` to inject URL and output directory into prompts

### Code Cleanup
- Removed redundant null-coalescing operators (e.g., `x ?? x` → `x`) throughout `AgentNode`, `CreateThreadNode`, `ExtractorNode`, `ClassifierNode`
- Fixed `ExtractorNode` and `ClassifierNode` to respect custom `system_prompt` input instead of always using defaults
- Fixed deepseek-r1:8b model config: corrected `type` from `"mistral_model"` to `"llama_model"` and `repo_id` from `"deepseek-r1:8"` to `"deepseek-r1:8b"`

### Test Updates
- Updated `SummarizerNode` test to verify that `max_sentences` parameter is actually respected (was previously not being used)

## Notable Implementation Details

- Streaming chunks are yielded with `text: null` to avoid duplicate output, then the final aggregated summary is yielded with `chunk: null` and the full `text`
- Fallback to local `summarize()` function still works when provider is unavailable, yielding a single chunk with `done: true`
- Agent plan mode now checks if `structuredSchema` exists and the result is a plain object before yielding it as dynamic output
- Tool truncation preserves the original output up to the limit and appends a marker like `\n…[truncated 50000 chars]` for transparency

https://claude.ai/code/session_01BUAVcZZQGVfwo31t72Xo1T