### PR TITLE
Fix text node bugs and add regex replacement template support

### DIFF
--- a/packages/text-nodes/src/nodes/lib-html-parse.ts
+++ b/packages/text-nodes/src/nodes/lib-html-parse.ts
@@ -75,7 +75,7 @@ export class ExtractLinksLibNode extends BaseNode {
       const href = $(el).attr("href") ?? "";
       const text = $(el).text().trim();
       const linkType =
-        href.startsWith(baseUrl) || href.startsWith("/")
+        (baseUrl && href.startsWith(baseUrl)) || href.startsWith("/")
           ? "internal"
           : "external";
       results.push({ href, text, type: linkType });
@@ -407,7 +407,7 @@ export class WebsiteContentExtractorLibNode extends BaseNode {
 
     // Fallback: strip tags manually like the Python version
     const $ = cheerio.load(htmlContent);
-    $("script, style, nav, sidebar, footer, header").remove();
+    $("script, style, nav, aside, footer, header").remove();
 
     const main =
       $("article").first().text() ||

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -29,6 +29,53 @@ function toTitleCase(value: string): string {
   );
 }
 
+// Expands a replacement template against a single match the same way
+// String.prototype.replace does ($$, $&, $`, $', $n, $nn, $<name>), so the
+// count-limited path stays consistent with the unlimited native replace.
+function applyReplacement(template: string, match: RegExpExecArray): string {
+  const groupCount = match.length - 1;
+  return template.replace(
+    /\$(\$|&|`|'|<([^>]*)>|\d{1,2})/g,
+    (whole: string, token: string, name?: string): string => {
+      if (token === "$") return "$";
+      if (token === "&") return match[0];
+      if (token === "`") return match.input.slice(0, match.index);
+      if (token === "'") {
+        return match.input.slice(match.index + match[0].length);
+      }
+      if (name !== undefined) {
+        return match.groups?.[name] ?? "";
+      }
+      if (token.length === 2) {
+        const two = Number(token);
+        if (two >= 1 && two <= groupCount) return match[two] ?? "";
+        const one = Number(token[0]);
+        if (one >= 1 && one <= groupCount) {
+          return (match[one] ?? "") + token[1];
+        }
+        return whole;
+      }
+      const one = Number(token);
+      if (one >= 1 && one <= groupCount) return match[one] ?? "";
+      return whole;
+    }
+  );
+}
+
+// Expands strftime-style date tokens (%Y %m %d %H %M %S) so the documented
+// filename variables produce unique names instead of a literal "%Y-...".
+function formatFilename(name: string): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return name
+    .replace(/%Y/g, String(now.getFullYear()))
+    .replace(/%m/g, pad(now.getMonth() + 1))
+    .replace(/%d/g, pad(now.getDate()))
+    .replace(/%H/g, pad(now.getHours()))
+    .replace(/%M/g, pad(now.getMinutes()))
+    .replace(/%S/g, pad(now.getSeconds()));
+}
+
 function folderPath(value: unknown): string {
   if (typeof value === "string") return value;
   if (!value || typeof value !== "object") return "";
@@ -142,7 +189,7 @@ export class ChunkTextNode extends BaseNode {
     const words = text.split(separator);
     const chunks: string[] = [];
     for (let i = 0; i < words.length; i += step) {
-      chunks.push(words.slice(i, i + length).join(" "));
+      chunks.push(words.slice(i, i + length).join(separator));
     }
     return { output: chunks };
   }
@@ -429,7 +476,7 @@ export class RegexReplaceNode extends BaseNode {
   declare count: any;
 
   async process(): Promise<Record<string, unknown>> {
-    let text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? this.text ?? "");
     const pattern = String(this.pattern ?? this.pattern ?? "");
     const replacement = String(this.replacement ?? this.replacement ?? "");
     const count = Number(this.count ?? this.count ?? 0);
@@ -439,15 +486,23 @@ export class RegexReplaceNode extends BaseNode {
     }
 
     const regex = new RegExp(pattern, "g");
+    let result = "";
+    let lastIndex = 0;
     let replaced = 0;
-    text = text.replace(regex, (match) => {
-      if (replaced >= count) {
-        return match;
-      }
+    while (replaced < count) {
+      const match = regex.exec(text);
+      if (match === null) break;
+      result += text.slice(lastIndex, match.index);
+      result += applyReplacement(replacement, match);
+      lastIndex = match.index + match[0].length;
       replaced += 1;
-      return replacement;
-    });
-    return { output: text };
+      // Advance past zero-width matches to avoid an infinite loop.
+      if (match[0].length === 0) {
+        regex.lastIndex += 1;
+      }
+    }
+    result += text.slice(lastIndex);
+    return { output: result };
   }
 }
 
@@ -772,11 +827,11 @@ export class SliceTextNode extends BaseNode {
     const chars = [...text];
     const result: string[] = [];
     const len = chars.length;
-    const normStart = start < 0 ? len + start : start;
-    const effectiveStop = stop === 0 ? len : stop;
-    const normStop = effectiveStop < 0 ? len + effectiveStop : effectiveStop;
 
     if (step > 0) {
+      const normStart = start < 0 ? len + start : start;
+      const effectiveStop = stop === 0 ? len : stop;
+      const normStop = effectiveStop < 0 ? len + effectiveStop : effectiveStop;
       for (
         let i = Math.max(0, normStart);
         i < Math.min(len, normStop);
@@ -785,6 +840,12 @@ export class SliceTextNode extends BaseNode {
         result.push(chars[i]);
       }
     } else {
+      // For a negative step, an unset start (0) begins at the last character
+      // and an unset stop (0) walks down to and including index 0 — so a bare
+      // step=-1 reverses the text, matching Python's s[::-1].
+      const normStart =
+        start === 0 ? len - 1 : start < 0 ? len + start : start;
+      const normStop = stop === 0 ? -1 : stop < 0 ? len + stop : stop;
       for (
         let i = Math.min(len - 1, normStart);
         i > Math.max(-1, normStop);
@@ -1073,7 +1134,6 @@ export class RemovePunctuationNode extends BaseNode {
     const replacement = String(this.replacement ?? this.replacement ?? "");
     const punctuation = String(
       this.punctuation ??
-        this.punctuation ??
         `!"#$%&'()*+,\\-./:;<=>?@[\\]^_{|}~`
     );
 
@@ -1202,13 +1262,14 @@ export class HasLengthTextNode extends BaseNode {
 
     const length = text.length;
 
-    if (exactLength !== null) {
+    // A length of 0 means the bound is unset (props default to 0).
+    if (exactLength > 0) {
       return { output: length === exactLength };
     }
-    if (minLength !== null && length < minLength) {
+    if (minLength > 0 && length < minLength) {
       return { output: false };
     }
-    if (maxLength !== null && length > maxLength) {
+    if (maxLength > 0 && length > maxLength) {
       return { output: false };
     }
     return { output: true };
@@ -1864,7 +1925,7 @@ export class SaveTextFileNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const text = String(this.text ?? this.text ?? "");
     const folder = String(this.folder ?? this.folder ?? "");
-    const name = String(this.name ?? this.name ?? "output.txt");
+    const name = formatFilename(String(this.name ?? this.name ?? "output.txt"));
     if (!folder) {
       throw new Error("folder cannot be empty");
     }
@@ -1920,10 +1981,17 @@ export class SaveTextNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const text = String(this.text ?? this.text ?? "");
-    const name = String(this.name ?? this.name ?? "output.txt");
+    const name = formatFilename(String(this.name ?? this.name ?? "output.txt"));
+    const folder = folderPath(this.folder ?? "");
     const fs = await loadNodeFsPromises();
-    await fs.writeFile(name, text, "utf-8");
-    return { output: { uri: name, data: text } };
+    const path = await loadNodePath();
+    const fsPath = folder ? path.join(folder, name) : name;
+    if (folder) {
+      await fs.mkdir(folder, { recursive: true });
+    }
+    await fs.writeFile(fsPath, text, "utf-8");
+    const uri = fsPath.replace(/\\/g, "/");
+    return { output: { uri, data: text } };
   }
 }
 

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -476,10 +476,10 @@ export class RegexReplaceNode extends BaseNode {
   declare count: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.pattern ?? this.pattern ?? "");
-    const replacement = String(this.replacement ?? this.replacement ?? "");
-    const count = Number(this.count ?? this.count ?? 0);
+    const text = String(this.text ?? "");
+    const pattern = String(this.pattern ?? "");
+    const replacement = String(this.replacement ?? "");
+    const count = Number(this.count ?? 0);
 
     if (count <= 0) {
       return { output: text.replace(new RegExp(pattern, "g"), replacement) };
@@ -1923,9 +1923,9 @@ export class SaveTextFileNode extends BaseNode {
   declare name: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const folder = String(this.folder ?? this.folder ?? "");
-    const name = formatFilename(String(this.name ?? this.name ?? "output.txt"));
+    const text = String(this.text ?? "");
+    const folder = String(this.folder ?? "");
+    const name = formatFilename(String(this.name ?? "output.txt"));
     if (!folder) {
       throw new Error("folder cannot be empty");
     }
@@ -1980,8 +1980,8 @@ export class SaveTextNode extends BaseNode {
   declare name: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const name = formatFilename(String(this.name ?? this.name ?? "output.txt"));
+    const text = String(this.text ?? "");
+    const name = formatFilename(String(this.name ?? "output.txt"));
     const folder = folderPath(this.folder ?? "");
     const fs = await loadNodeFsPromises();
     const path = await loadNodePath();

--- a/packages/text-nodes/tests/lib-html-parse.test.ts
+++ b/packages/text-nodes/tests/lib-html-parse.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { ExtractLinksLibNode } from "@nodetool-ai/text-nodes";
+
+const HTML = [
+  '<a href="https://site.com/page">Page</a>',
+  '<a href="/local">Local</a>',
+  '<a href="https://other.com">Other</a>'
+].join("");
+
+describe("ExtractLinksLibNode", () => {
+  it("classifies internal vs external links against a base URL", async () => {
+    const node = new ExtractLinksLibNode();
+    node.assign({ html: HTML, base_url: "https://site.com" });
+    const links = (await node.process()).links as Array<{ type: string }>;
+    expect(links.map((l) => l.type)).toEqual([
+      "internal",
+      "internal",
+      "external"
+    ]);
+  });
+
+  it("does not mark every link internal when base_url is empty", async () => {
+    const node = new ExtractLinksLibNode();
+    node.assign({ html: HTML, base_url: "" });
+    const links = (await node.process()).links as Array<{ type: string }>;
+    // Only root-relative links are internal without a base URL.
+    expect(links.map((l) => l.type)).toEqual([
+      "external",
+      "internal",
+      "external"
+    ]);
+  });
+});

--- a/packages/text-nodes/tests/text-extra.test.ts
+++ b/packages/text-nodes/tests/text-extra.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HasLengthTextNode,
+  SliceTextNode,
+  ChunkTextNode,
+  RegexReplaceNode
+} from "@nodetool-ai/text-nodes";
+
+describe("HasLengthTextNode", () => {
+  it("honors min_length", async () => {
+    const pass = new HasLengthTextNode();
+    pass.assign({ text: "hello", min_length: 3 });
+    expect((await pass.process()).output).toBe(true);
+
+    const fail = new HasLengthTextNode();
+    fail.assign({ text: "hi", min_length: 3 });
+    expect((await fail.process()).output).toBe(false);
+  });
+
+  it("honors max_length", async () => {
+    const fail = new HasLengthTextNode();
+    fail.assign({ text: "hello", max_length: 3 });
+    expect((await fail.process()).output).toBe(false);
+
+    const pass = new HasLengthTextNode();
+    pass.assign({ text: "hello", max_length: 10 });
+    expect((await pass.process()).output).toBe(true);
+  });
+
+  it("honors exact_length", async () => {
+    const pass = new HasLengthTextNode();
+    pass.assign({ text: "hello", exact_length: 5 });
+    expect((await pass.process()).output).toBe(true);
+
+    const fail = new HasLengthTextNode();
+    fail.assign({ text: "hello", exact_length: 4 });
+    expect((await fail.process()).output).toBe(false);
+  });
+
+  it("passes any non-empty text when no bounds are set", async () => {
+    const node = new HasLengthTextNode();
+    node.assign({ text: "hello" });
+    expect((await node.process()).output).toBe(true);
+  });
+});
+
+describe("SliceTextNode", () => {
+  it("reverses text with step=-1 and default start/stop", async () => {
+    const node = new SliceTextNode();
+    node.assign({ text: "hello", step: -1 });
+    expect((await node.process()).output).toBe("olleh");
+  });
+
+  it("takes every second character with step=2", async () => {
+    const node = new SliceTextNode();
+    node.assign({ text: "abcdef", step: 2 });
+    expect((await node.process()).output).toBe("ace");
+  });
+
+  it("reverses every second character with step=-2", async () => {
+    const node = new SliceTextNode();
+    node.assign({ text: "abcdef", step: -2 });
+    expect((await node.process()).output).toBe("fdb");
+  });
+
+  it("slices a range with step=1", async () => {
+    const node = new SliceTextNode();
+    node.assign({ text: "hello", start: 1, stop: 4 });
+    expect((await node.process()).output).toBe("ell");
+  });
+});
+
+describe("ChunkTextNode", () => {
+  it("rejoins chunks with the original separator", async () => {
+    const node = new ChunkTextNode();
+    node.assign({ text: "a,b,c,d", delimiter: ",", separator: ",", length: 2 });
+    expect((await node.process()).output).toEqual(["a,b", "c,d"]);
+  });
+});
+
+describe("RegexReplaceNode", () => {
+  it("limits replacements via count", async () => {
+    const node = new RegexReplaceNode();
+    node.assign({ text: "aaa", pattern: "a", replacement: "b", count: 2 });
+    expect((await node.process()).output).toBe("bba");
+  });
+
+  it("honors backreferences in the count-limited path", async () => {
+    const node = new RegexReplaceNode();
+    node.assign({
+      text: "John Smith",
+      pattern: "(\\w+) (\\w+)",
+      replacement: "$2 $1",
+      count: 1
+    });
+    expect((await node.process()).output).toBe("Smith John");
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes several bugs in text processing nodes and adds proper template expansion support for regex replacements, enabling backreferences and special tokens like `$&`, `$1`, etc. to work correctly in the count-limited replacement path.

## Key Changes

- **RegexReplaceNode**: Rewrote the count-limited replacement logic to properly expand replacement templates using the same syntax as `String.prototype.replace()` (supports `$$`, `$&`, `` $` ``, `$'`, `$n`, `$nn`, `$<name>`). Previously, literal replacement strings were used, breaking backreferences.

- **New helper functions**:
  - `applyReplacement()`: Expands replacement templates against regex matches, matching native `String.replace()` behavior
  - `formatFilename()`: Expands strftime-style date tokens (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) in filenames for unique output names

- **SaveTextNode & SaveTextFileNode**: Now support folder paths and apply filename formatting. SaveTextNode creates parent directories if needed and normalizes paths to forward slashes for URIs.

- **SliceTextNode**: Fixed negative step handling. When `step < 0` with default `start=0` and `stop=0`, now correctly reverses text (matching Python's `s[::-1]`). Previously, the normalization logic didn't account for the different semantics of unset bounds in reverse mode.

- **ChunkTextNode**: Fixed separator handling — now rejoins chunks with the original `separator` parameter instead of hardcoded space.

- **HasLengthTextNode**: Fixed bound checking to treat `0` as "unset" (props default to 0), allowing exact length checks and proper min/max validation.

- **RemovePunctuationNode**: Removed duplicate `this.punctuation ??` fallback.

- **RegexReplaceNode**: Changed `let text` to `const text` for immutability.

- **ExtractLinksLibNode**: Fixed internal link classification to only mark links as internal when `baseUrl` is non-empty and the href starts with it (was incorrectly marking all links as internal when baseUrl was empty).

- **WebsiteContentExtractorLibNode**: Changed selector from `sidebar` to `aside` (correct HTML5 semantic element).

## Tests Added

- `text-extra.test.ts`: Comprehensive tests for HasLengthTextNode, SliceTextNode, ChunkTextNode, and RegexReplaceNode covering edge cases like negative steps, count-limited replacements, and backreferences.
- `lib-html-parse.test.ts`: Tests for ExtractLinksLibNode verifying correct classification of internal vs external links with and without base URLs.

## Implementation Details

The `applyReplacement()` function handles all standard regex replacement tokens:
- `$$` → literal `$`
- `$&` → entire match
- `` $` `` → text before match
- `$'` → text after match
- `$n` / `$nn` → numbered capture groups
- `$<name>` → named capture groups

The count-limited path now uses a manual loop with `RegExp.exec()` instead of `String.replace()` to respect the count limit while still expanding templates correctly. Zero-width matches are handled by advancing `lastIndex` to prevent infinite loops.

https://claude.ai/code/session_019DTU83M3nbhgWcibwqojc7