### PR TITLE
feat(runtime): WebsocketPythonBridge + NODETOOL_WORKER_URL selector

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -61,6 +61,19 @@ export {
   type PythonWorkerLoadError,
   type PythonWorkerStatus
 } from "./python-stdio-bridge.js";
+import { PythonBridgeBase } from "./python-bridge-base.js";
+export { PythonBridgeBase };
+export {
+  WebsocketPythonBridge,
+  type WebsocketPythonBridgeOptions
+} from "./python-websocket-bridge.js";
+export { createPythonBridge } from "./python-bridge-factory.js";
+/**
+ * Transport-agnostic public handle for a Python worker bridge. Consumers that
+ * only use the shared interface should type against this rather than the
+ * concrete stdio implementation, so a future WebSocket transport drops in.
+ */
+export type PythonBridge = PythonBridgeBase;
 // Public API re-export — the source of truth lives in @nodetool-ai/protocol
 // so the Electron main bundle (which can't pull in the runtime barrel) and
 // any other thin consumer can read these constants without dragging the

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -23,27 +23,27 @@ import type {
   ToolCall
 } from "./types.js";
 import type { Chunk } from "@nodetool-ai/protocol";
-import type { PythonStdioBridge } from "../python-stdio-bridge.js";
+import type { PythonBridgeBase } from "../python-bridge-base.js";
 
 type PythonProviderOptions = Record<string, unknown> & {
   _id: string;
-  _bridge: PythonStdioBridge;
+  _bridge: PythonBridgeBase;
 };
 
 export class PythonProvider extends BaseProvider {
-  private _bridge: PythonStdioBridge;
+  private _bridge: PythonBridgeBase;
   private _pythonProviderId: string;
   private _secrets: Record<string, string>;
 
   constructor(
     providerId: string,
-    bridge: PythonStdioBridge,
+    bridge: PythonBridgeBase,
     secrets?: Record<string, string>
   );
   constructor(options: PythonProviderOptions);
   constructor(
     providerIdOrOptions: string | PythonProviderOptions,
-    bridge?: PythonStdioBridge,
+    bridge?: PythonBridgeBase,
     secrets: Record<string, string> = {}
   ) {
     if (typeof providerIdOrOptions === "string") {

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -1,0 +1,790 @@
+/**
+ * Transport-agnostic Python worker bridge base class.
+ *
+ * Holds all the protocol logic that is independent of how bytes move
+ * between the JS runtime and the Python worker — pending-request bookkeeping,
+ * message dispatch, discover/execute/cancel, provider RPC, and the shared
+ * connection lifecycle. Concrete transports (stdio, WebSocket) subclass this
+ * and implement the small set of transport hooks below.
+ *
+ * The wire protocol itself (msgpack-encoded `{type, request_id, data}` frames)
+ * is shared; only framing/transport differs per subclass.
+ */
+
+import { importNodeBuiltin } from "@nodetool-ai/config";
+
+// The base only needs crypto (request IDs) and events (EventEmitter).
+// Lazy-load so the module *graph* loads off-Node; instantiating a concrete
+// bridge there throws at construction. Notably the base does NOT require
+// child_process — that belongs to the stdio subclass only.
+const nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
+  "node:crypto"
+);
+const nodeEvents = await importNodeBuiltin<typeof import("node:events")>(
+  "node:events"
+);
+
+function notOnNode(api: string): never {
+  throw new Error(`${api} requires Node — PythonBridgeBase is Node-only`);
+}
+const randomUUID =
+  nodeCrypto?.randomUUID ??
+  ((): string => notOnNode("node:crypto.randomUUID"));
+// Re-export the EventEmitter type/class — falls back to a no-op so the
+// module evaluates off-Node; consumers that instantiate the bridge will
+// fail at construction time, not at module load.
+class FallbackEmitter {
+  on(_: string, __: (...args: unknown[]) => void): this {
+    notOnNode("node:events.EventEmitter");
+  }
+  emit(_: string, ...__: unknown[]): boolean {
+    notOnNode("node:events.EventEmitter");
+  }
+  removeAllListeners(): this {
+    notOnNode("node:events.EventEmitter");
+  }
+}
+const EventEmitter = (nodeEvents?.EventEmitter ??
+  FallbackEmitter) as unknown as typeof import("node:events").EventEmitter;
+
+import { createLogger } from "@nodetool-ai/config";
+
+import {
+  BRIDGE_PROTOCOL_VERSION,
+  MIN_NODETOOL_CORE_VERSION
+} from "@nodetool-ai/protocol/bridge-protocol";
+
+const log = createLogger("nodetool.runtime.python-bridge-base");
+import type {
+  PythonNodeMetadata,
+  ExecuteResult,
+  ExecuteInputBlobs,
+  ProgressEvent,
+  StreamCallback,
+  PythonProviderInfo,
+  PythonBridgeOptions,
+  PythonWorkerLoadError,
+  PythonWorkerStatus
+} from "./python-bridge-types.js";
+
+interface PendingRequest {
+  resolve: (value: ExecuteResult) => void;
+  reject: (error: Error) => void;
+  onProgress?: (event: ProgressEvent) => void;
+}
+
+interface PendingStreamRequest {
+  resolve: (value: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+  onChunk: StreamCallback;
+}
+
+const DEFAULT_EXECUTE_TIMEOUT_MS = Number(
+  process.env["NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS"] ?? 12 * 60 * 1000
+);
+const DEFAULT_STATUS_TIMEOUT_MS = Number(
+  process.env["NODETOOL_PYTHON_STATUS_TIMEOUT_MS"] ?? 10000
+);
+
+/**
+ * Transport-agnostic Python bridge. Subclasses provide the transport via
+ * {@link _openTransport} and {@link _send}, plus {@link close}. The optional
+ * {@link _assertCanConnect} hook lets a transport refuse to connect (e.g. in
+ * production).
+ */
+export abstract class PythonBridgeBase extends EventEmitter {
+  protected _nodeMetadata: PythonNodeMetadata[] = [];
+  protected _loadErrors: PythonWorkerLoadError[] = [];
+  protected _workerStatus: PythonWorkerStatus | null = null;
+  protected _pending = new Map<string, PendingRequest>();
+  protected _pendingStream = new Map<string, PendingStreamRequest>();
+  protected _options: PythonBridgeOptions;
+  protected _connected = false;
+  private _connectPromise: Promise<void> | null = null;
+
+  constructor(options: PythonBridgeOptions = {}) {
+    super();
+    this._options = options;
+  }
+
+  // ── Transport hooks (implemented by subclasses) ─────────────────────
+
+  /** Open the underlying transport and become connected. */
+  protected abstract _openTransport(): Promise<void>;
+
+  /** Encode + send a single protocol message over the transport. */
+  protected abstract _send(msg: Record<string, unknown>): void;
+
+  /** Tear down the transport and reject any pending requests. */
+  abstract close(): void;
+
+  /**
+   * Optional guard invoked at the start of connect(). Throw to refuse.
+   * Default is a no-op.
+   */
+  protected _assertCanConnect(): void {}
+
+  // ── Connection lifecycle ───────────────────────────────────────────
+
+  async connect(): Promise<void> {
+    this._assertCanConnect();
+    await this._openTransport();
+    await this._discover();
+    try {
+      await this._getWorkerStatusWithTimeout();
+    } catch (err) {
+      log.warn(
+        "Failed to fetch initial Python worker status; load_errors will be unavailable until next status fetch",
+        err
+      );
+    }
+  }
+
+  ensureConnected(): Promise<void> {
+    if (this._connected) return Promise.resolve();
+    if (!this._connectPromise) {
+      this._connectPromise = this.connect().then(
+        () => {
+          this._connectPromise = null;
+        },
+        (err) => {
+          this._connectPromise = null;
+          throw err;
+        }
+      );
+    }
+    return this._connectPromise;
+  }
+
+  // ── Message dispatch ────────────────────────────────────────────────
+
+  protected _handleMessage(msg: Record<string, unknown>): void {
+    const type = msg.type as string;
+    const requestId = msg.request_id as string | null;
+
+    if (type === "discover" && requestId) {
+      const pending = this._pending.get(requestId);
+      if (pending) {
+        const data = msg.data as {
+          nodes: PythonNodeMetadata[];
+          protocol_version?: number;
+          load_errors?: PythonWorkerLoadError[];
+        };
+        // Reject the discover promise if the worker's protocol is older
+        // than what this build of the JS runtime requires. Workers that
+        // pre-date the protocol_version field are treated as version 1
+        // (the initial protocol release) — they speak the same wire
+        // format as v1, they just don't announce it.
+        const workerVersion =
+          typeof data.protocol_version === "number"
+            ? data.protocol_version
+            : 1;
+        if (workerVersion < BRIDGE_PROTOCOL_VERSION) {
+          this._pending.delete(requestId);
+          pending.reject(
+            new Error(
+              `The installed nodetool-core speaks bridge protocol v${workerVersion}, ` +
+                `but this Nodetool build requires v${BRIDGE_PROTOCOL_VERSION}. ` +
+                `Please reinstall the Python environment from Settings → Packages ` +
+                `(Reinstall environment) — it will fetch nodetool-core>=${MIN_NODETOOL_CORE_VERSION}.`
+            )
+          );
+          return;
+        }
+        if (workerVersion > BRIDGE_PROTOCOL_VERSION) {
+          // Forward-compat: a newer worker is expected to keep speaking
+          // older protocols, so we proceed with a warning.
+          this.emit(
+            "stderr",
+            `[python-bridge] Worker protocol v${workerVersion} is newer than ` +
+              `JS runtime v${BRIDGE_PROTOCOL_VERSION}; assuming backward compatibility.\n`
+          );
+        }
+        this._nodeMetadata = data.nodes;
+        this._loadErrors = data.load_errors ?? [];
+        pending.resolve({ outputs: {}, blobs: {} });
+      }
+    } else if (type === "result" && requestId) {
+      const streamReq = this._pendingStream.get(requestId);
+      if (streamReq) {
+        this._pendingStream.delete(requestId);
+        streamReq.resolve(msg.data as Record<string, unknown>);
+        return;
+      }
+      const pending = this._pending.get(requestId);
+      if (pending) {
+        this._pending.delete(requestId);
+        const data = msg.data as {
+          outputs: Record<string, unknown>;
+          blobs: Record<string, Uint8Array>;
+        };
+        pending.resolve({ outputs: data.outputs, blobs: data.blobs ?? {} });
+      }
+    } else if (type === "error" && requestId) {
+      const streamReq = this._pendingStream.get(requestId);
+      if (streamReq) {
+        this._pendingStream.delete(requestId);
+        const data = msg.data as { error: string; traceback?: string };
+        const err = new Error(data.error);
+        (err as unknown as Record<string, unknown>).traceback = data.traceback;
+        streamReq.reject(err);
+        return;
+      }
+      const pending = this._pending.get(requestId);
+      if (pending) {
+        this._pending.delete(requestId);
+        const data = msg.data as { error: string; traceback?: string };
+        const err = new Error(data.error);
+        (err as unknown as Record<string, unknown>).traceback = data.traceback;
+        pending.reject(err);
+      }
+    } else if (type === "chunk" && requestId) {
+      const streamReq = this._pendingStream.get(requestId);
+      if (streamReq) {
+        streamReq.onChunk(msg.data as Record<string, unknown>);
+      }
+    } else if (type === "progress" && requestId) {
+      const pending = this._pending.get(requestId);
+      if (pending?.onProgress) {
+        const data = msg.data as { progress: number; total: number };
+        pending.onProgress({ request_id: requestId, ...data });
+      }
+      this.emit("progress", msg.data);
+    }
+  }
+
+  protected _rejectAllPending(error: Error): void {
+    for (const [, req] of this._pending) {
+      req.reject(error);
+    }
+    this._pending.clear();
+    for (const [, req] of this._pendingStream) {
+      req.reject(error);
+    }
+    this._pendingStream.clear();
+  }
+
+  // ── Discover ───────────────────────────────────────────────────────
+
+  protected async _discover(): Promise<void> {
+    const requestId = randomUUID();
+    return new Promise<void>((resolve, reject) => {
+      this._pending.set(requestId, {
+        resolve: () => {
+          this._pending.delete(requestId);
+          resolve();
+        },
+        reject: (err) => {
+          this._pending.delete(requestId);
+          reject(err);
+        }
+      });
+      this._send({ type: "discover", request_id: requestId, data: {} });
+    });
+  }
+
+  // ── Node execution ─────────────────────────────────────────────────
+
+  async execute(
+    nodeType: string,
+    fields: Record<string, unknown>,
+    secrets: Record<string, string>,
+    blobs: ExecuteInputBlobs,
+    onProgress?: (event: ProgressEvent) => void
+  ): Promise<ExecuteResult> {
+    const requestId = randomUUID();
+    const timeoutMs =
+      this._options.executeTimeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS;
+
+    log.debug("Python bridge execute dispatched", { nodeType, requestId });
+
+    const executePromise = new Promise<ExecuteResult>((resolve, reject) => {
+      this._pending.set(requestId, { resolve, reject, onProgress });
+      try {
+        this._send({
+          type: "execute",
+          request_id: requestId,
+          data: { node_type: nodeType, fields, secrets, blobs }
+        });
+      } catch (err) {
+        this._pending.delete(requestId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+
+    if (timeoutMs <= 0) {
+      return executePromise;
+    }
+
+    let timer: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<ExecuteResult>((_, reject) => {
+      timer = setTimeout(() => {
+        if (!this._pending.has(requestId)) {
+          return;
+        }
+        this._pending.delete(requestId);
+        try {
+          this.cancel(requestId);
+        } catch {
+          // Worker may already be gone; cancel is best-effort.
+        }
+        const stderrHint = this.getRecentStderrSummary(4);
+        reject(
+          new Error(
+            `Python node "${nodeType}" timed out after ${timeoutMs}ms waiting for the worker.` +
+              (stderrHint ? ` Recent stderr: ${stderrHint}` : "")
+          )
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([executePromise, timeoutPromise]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  async *executeStream(
+    nodeType: string,
+    fields: Record<string, unknown>,
+    secrets: Record<string, string>,
+    blobs: ExecuteInputBlobs,
+    onProgress?: (event: ProgressEvent) => void
+  ): AsyncGenerator<ExecuteResult> {
+    const requestId = randomUUID();
+    const chunks: ExecuteResult[] = [];
+    let done = false;
+    let error: Error | null = null;
+    let finalResult: ExecuteResult | null = null;
+    let emittedCount = 0;
+    let resolveWait: (() => void) | null = null;
+
+    if (onProgress) {
+      this._pending.set(requestId, {
+        resolve: () => undefined,
+        reject: () => undefined,
+        onProgress
+      });
+    }
+
+    const onChunk = (chunk: Record<string, unknown>) => {
+      chunks.push({
+        outputs: (chunk.outputs as Record<string, unknown>) ?? {},
+        blobs: (chunk.blobs as Record<string, Uint8Array>) ?? {}
+      });
+      if (resolveWait) {
+        resolveWait();
+        resolveWait = null;
+      }
+    };
+
+    const streamPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
+      this._pendingStream.set(requestId, { resolve, reject, onChunk });
+    });
+
+    streamPromise
+      .then((result) => {
+        finalResult = {
+          outputs: (result.outputs as Record<string, unknown>) ?? {},
+          blobs: (result.blobs as Record<string, Uint8Array>) ?? {}
+        };
+        done = true;
+        this._pending.delete(requestId);
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      })
+      .catch((err) => {
+        error = err;
+        done = true;
+        this._pending.delete(requestId);
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      });
+
+    this._send({
+      type: "execute.stream",
+      request_id: requestId,
+      data: { node_type: nodeType, fields, secrets, blobs }
+    });
+
+    while (true) {
+      while (chunks.length > 0) {
+        emittedCount += 1;
+        yield chunks.shift()!;
+      }
+      if (done) break;
+      if (error) throw error;
+      await new Promise<void>((resolve) => {
+        resolveWait = resolve;
+      });
+    }
+    if (error) throw error;
+    if (emittedCount === 0 && finalResult) {
+      yield finalResult;
+    }
+  }
+
+  cancel(requestId: string): void {
+    this._send({ type: "cancel", request_id: requestId, data: {} });
+  }
+
+  getNodeMetadata(): PythonNodeMetadata[] {
+    return this._nodeMetadata;
+  }
+
+  getLoadErrors() {
+    return this._loadErrors;
+  }
+
+  async getWorkerStatus() {
+    const requestId = randomUUID();
+    const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      this._pendingStream.set(requestId, {
+        resolve,
+        reject,
+        onChunk: () => {}
+      });
+      this._send({ type: "worker.status", request_id: requestId, data: {} });
+    });
+    this._workerStatus =
+      result as unknown as PythonWorkerStatus;
+    this._loadErrors = this._workerStatus.load_errors ?? this._loadErrors;
+    return this._workerStatus;
+  }
+
+  /**
+   * getWorkerStatus() guarded by a timeout so a silent worker cannot hang
+   * connect() forever. On timeout we reject this single call and clean up its
+   * pending entry + timer; connect()'s catch then logs and proceeds.
+   *
+   * Protected so transports that override connect() (e.g. the WebSocket
+   * bridge, which wraps the whole RPC phase in its own timeout) can still
+   * honor statusTimeoutMs for the status sub-call.
+   */
+  protected async _getWorkerStatusWithTimeout(): Promise<PythonWorkerStatus> {
+    const timeoutMs =
+      this._options.statusTimeoutMs ?? DEFAULT_STATUS_TIMEOUT_MS;
+    if (timeoutMs <= 0) {
+      return this.getWorkerStatus();
+    }
+
+    const requestId = randomUUID();
+    let timer: NodeJS.Timeout | undefined;
+
+    const statusPromise = new Promise<Record<string, unknown>>(
+      (resolve, reject) => {
+        this._pendingStream.set(requestId, {
+          resolve,
+          reject,
+          onChunk: () => {}
+        });
+        try {
+          this._send({
+            type: "worker.status",
+            request_id: requestId,
+            data: {}
+          });
+        } catch (err) {
+          this._pendingStream.delete(requestId);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    );
+
+    const timeoutPromise = new Promise<Record<string, unknown>>((_, reject) => {
+      timer = setTimeout(() => {
+        // Reject only this single call and drop its pending entry so a late
+        // response is ignored rather than resolving a dead promise.
+        this._pendingStream.delete(requestId);
+        reject(
+          new Error(
+            `Python worker status timed out after ${timeoutMs}ms.`
+          )
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      const result = await Promise.race([statusPromise, timeoutPromise]);
+      this._workerStatus = result as unknown as PythonWorkerStatus;
+      this._loadErrors = this._workerStatus.load_errors ?? this._loadErrors;
+      return this._workerStatus;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  hasNodeType(nodeType: string): boolean {
+    return this._nodeMetadata.some((n) => n.node_type === nodeType);
+  }
+
+  get isConnected(): boolean {
+    return this._connected;
+  }
+
+  /**
+   * Whether this bridge has a worker it can attempt to connect to. Gates
+   * boot-time auto-connect — the server only eagerly calls ensureConnected()
+   * when this returns true. The base default is true (a WebSocket bridge always
+   * has a configured URL); the stdio subclass overrides it to report whether a
+   * local Python interpreter was found.
+   */
+  isAvailable(): boolean {
+    return true;
+  }
+
+  // ── Provider bridge methods ────────────────────────────────────────
+
+  async listProviders(): Promise<PythonProviderInfo[]> {
+    const result = await this._providerCall("provider.list", {});
+    return (result as { providers: PythonProviderInfo[] }).providers;
+  }
+
+  async getProviderModels(
+    providerId: string,
+    modelType: string,
+    secrets?: Record<string, string>
+  ): Promise<Record<string, unknown>[]> {
+    const result = await this._providerCall("provider.models", {
+      provider: providerId,
+      model_type: modelType,
+      secrets: secrets ?? {}
+    });
+    return (result as { models: Record<string, unknown>[] }).models;
+  }
+
+  async providerGenerate(
+    providerId: string,
+    messages: Record<string, unknown>[],
+    model: string,
+    options?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const result = await this._providerCall("provider.generate", {
+      provider: providerId,
+      messages,
+      model,
+      ...options
+    });
+    return (result as { message: Record<string, unknown> }).message;
+  }
+
+  async *providerStream(
+    providerId: string,
+    messages: Record<string, unknown>[],
+    model: string,
+    options?: Record<string, unknown>
+  ): AsyncGenerator<Record<string, unknown>> {
+    const requestId = randomUUID();
+    const chunks: Record<string, unknown>[] = [];
+    let done = false;
+    let error: Error | null = null;
+    let resolveWait: (() => void) | null = null;
+
+    const onChunk = (chunk: Record<string, unknown>) => {
+      chunks.push(chunk);
+      if (resolveWait) {
+        resolveWait();
+        resolveWait = null;
+      }
+    };
+
+    const streamPromise = new Promise<Record<string, unknown>>(
+      (resolve, reject) => {
+        this._pendingStream.set(requestId, { resolve, reject, onChunk });
+      }
+    );
+
+    streamPromise
+      .then(() => {
+        done = true;
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      })
+      .catch((err) => {
+        error = err;
+        done = true;
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      });
+
+    this._send({
+      type: "provider.stream",
+      request_id: requestId,
+      data: { provider: providerId, messages, model, ...options }
+    });
+
+    while (true) {
+      while (chunks.length > 0) yield chunks.shift()!;
+      if (done) break;
+      if (error) throw error;
+      await new Promise<void>((resolve) => {
+        resolveWait = resolve;
+      });
+    }
+    if (error) throw error;
+  }
+
+  async providerTextToImage(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    const result = await this._providerCall("provider.text_to_image", {
+      provider: providerId,
+      params,
+      secrets: secrets ?? {}
+    });
+    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
+  }
+
+  async providerImageToImage(
+    providerId: string,
+    image: Uint8Array,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    const result = await this._providerCall("provider.image_to_image", {
+      provider: providerId,
+      image,
+      params,
+      secrets: secrets ?? {}
+    });
+    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
+  }
+
+  async *providerTTS(
+    providerId: string,
+    text: string,
+    model: string,
+    options?: Record<string, unknown>
+  ): AsyncGenerator<Uint8Array> {
+    const requestId = randomUUID();
+    const chunks: Uint8Array[] = [];
+    let done = false;
+    let error: Error | null = null;
+    let resolveWait: (() => void) | null = null;
+
+    const onChunk = (chunk: Record<string, unknown>) => {
+      const blobs = chunk.blobs as Record<string, Uint8Array> | undefined;
+      if (blobs?.audio) chunks.push(blobs.audio);
+      if (resolveWait) {
+        resolveWait();
+        resolveWait = null;
+      }
+    };
+
+    const streamPromise = new Promise<Record<string, unknown>>(
+      (resolve, reject) => {
+        this._pendingStream.set(requestId, { resolve, reject, onChunk });
+      }
+    );
+
+    streamPromise
+      .then(() => {
+        done = true;
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      })
+      .catch((err) => {
+        error = err;
+        done = true;
+        if (resolveWait) {
+          resolveWait();
+          resolveWait = null;
+        }
+      });
+
+    this._send({
+      type: "provider.tts",
+      request_id: requestId,
+      data: { provider: providerId, text, model, ...options }
+    });
+
+    while (true) {
+      while (chunks.length > 0) yield chunks.shift()!;
+      if (done) break;
+      if (error) throw error;
+      await new Promise<void>((resolve) => {
+        resolveWait = resolve;
+      });
+    }
+    if (error) throw error;
+  }
+
+  async providerASR(
+    providerId: string,
+    audio: Uint8Array,
+    model: string,
+    options?: Record<string, unknown>
+  ): Promise<import("./providers/types.js").ASRResult> {
+    const result = await this._providerCall("provider.asr", {
+      provider: providerId,
+      audio,
+      model,
+      ...options
+    });
+    const r = result as {
+      text: string;
+      chunks?: Array<{ timestamp: [number, number]; text: string }>;
+    };
+    return {
+      text: r.text,
+      chunks: r.chunks
+    };
+  }
+
+  async providerEmbedding(
+    providerId: string,
+    text: string | string[],
+    model: string,
+    dimensions?: number
+  ): Promise<number[][]> {
+    const result = await this._providerCall("provider.embedding", {
+      provider: providerId,
+      text,
+      model,
+      dimensions
+    });
+    return (result as { embeddings: number[][] }).embeddings;
+  }
+
+  protected async _providerCall(
+    type: string,
+    data: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const requestId = randomUUID();
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      this._pendingStream.set(requestId, {
+        resolve,
+        reject,
+        onChunk: () => {}
+      });
+      this._send({ type, request_id: requestId, data });
+    });
+  }
+
+  // ── Diagnostics ────────────────────────────────────────────────────
+
+  /**
+   * Recent worker stderr summary used to enrich timeout errors. Transports
+   * that capture stderr (stdio) override this; the base returns null.
+   */
+  getRecentStderrSummary(_limit = 12): string | null {
+    return null;
+  }
+}

--- a/packages/runtime/src/python-bridge-factory.ts
+++ b/packages/runtime/src/python-bridge-factory.ts
@@ -1,0 +1,43 @@
+/**
+ * Factory that selects the right Python worker bridge transport.
+ *
+ * Centralizes the one decision every server entry point would otherwise
+ * duplicate: spawn a local Python subprocess, or attach to an already-running
+ * remote worker over WebSocket?
+ *
+ * The selector is the `NODETOOL_WORKER_URL` environment variable:
+ *
+ * - When set, it must be the full WebSocket URL of a running worker — a
+ *   `ws://` or `wss://` address (e.g. the Docker container's port, such as
+ *   `ws://127.0.0.1:7777`). The remote {@link WebsocketPythonBridge} is used.
+ *   That bridge never spawns a process and is allowed to connect in production,
+ *   unlike the local stdio bridge.
+ * - When unset (or blank), the local {@link PythonStdioBridge} is used — it
+ *   spawns `python -m nodetool.worker` as a subprocess and is gated to
+ *   non-production environments (unless explicitly overridden).
+ *
+ * `options.wsUrl` takes precedence over the env var, so programmatic and test
+ * callers can force the WebSocket transport without mutating the environment.
+ */
+
+import { PythonStdioBridge } from "./python-stdio-bridge.js";
+import { WebsocketPythonBridge } from "./python-websocket-bridge.js";
+import type { PythonBridgeBase } from "./python-bridge-base.js";
+import type { PythonBridgeOptions } from "./python-bridge-types.js";
+
+/**
+ * Create the appropriate Python worker bridge for the current environment.
+ *
+ * Returns a {@link WebsocketPythonBridge} when a WebSocket URL is supplied via
+ * `options.wsUrl` or the `NODETOOL_WORKER_URL` env var; otherwise returns a
+ * local {@link PythonStdioBridge}. See the module doc for the full contract.
+ */
+export function createPythonBridge(
+  options: PythonBridgeOptions = {}
+): PythonBridgeBase {
+  const wsUrl = options.wsUrl ?? process.env["NODETOOL_WORKER_URL"];
+  if (wsUrl && wsUrl.trim()) {
+    return new WebsocketPythonBridge({ ...options, wsUrl: wsUrl.trim() });
+  }
+  return new PythonStdioBridge(options);
+}

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -44,6 +44,20 @@ export interface PythonBridgeOptions {
   startupTimeoutMs?: number;
   /** Max time to wait for a single node execute (0 = no timeout). */
   executeTimeoutMs?: number;
+  /**
+   * Max time to wait for the initial worker.status fetch during connect()
+   * (0 = no timeout). Guards against a silent worker hanging connect()
+   * forever. Default ~10000ms.
+   */
+  statusTimeoutMs?: number;
+  /**
+   * Max time to wait for the post-open RPC phase (discover + worker.status)
+   * during connect() and reconnect on the WebSocket bridge (0 = no timeout).
+   * The startup timeout only covers the TCP/WS handshake, not the RPC phase,
+   * so a worker that accepts the socket but never answers discover would
+   * otherwise wedge the reconnect loop forever. Default ~20000ms.
+   */
+  reconnectRpcTimeoutMs?: number;
 }
 
 export type StreamCallback = (chunk: Record<string, unknown>) => void;

--- a/packages/runtime/src/python-stdio-bridge.ts
+++ b/packages/runtime/src/python-stdio-bridge.ts
@@ -8,6 +8,9 @@
  * Protocol: [4 bytes big-endian length][msgpack payload]
  * Readiness: "NODETOOL_STDIO_READY" on stderr
  * Logs: all Python output goes to stderr
+ *
+ * Transport-agnostic protocol logic lives in PythonBridgeBase; this subclass
+ * supplies the stdio transport (subprocess spawn + length-prefixed framing).
  */
 
 import * as msgpack from "@msgpack/msgpack";
@@ -16,14 +19,8 @@ import { importNodeBuiltin } from "@nodetool-ai/config";
 // Python bridge is fundamentally Node-only (subprocess + raw FDs).
 // Lazy-load the builtins so the module *graph* loads off-Node;
 // instantiating PythonStdioBridge there throws at construction.
-const nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
-  "node:crypto"
-);
 const nodeCp = await importNodeBuiltin<typeof import("node:child_process")>(
   "node:child_process"
-);
-const nodeEvents = await importNodeBuiltin<typeof import("node:events")>(
-  "node:events"
 );
 const nodeFs = await importNodeBuiltin<typeof import("node:fs")>("node:fs");
 const nodeOs = await importNodeBuiltin<typeof import("node:os")>("node:os");
@@ -34,9 +31,6 @@ const nodePath = await importNodeBuiltin<typeof import("node:path")>(
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonStdioBridge is Node-only`);
 }
-const randomUUID =
-  nodeCrypto?.randomUUID ??
-  ((): string => notOnNode("node:crypto.randomUUID"));
 type ChildProcess = ReturnType<typeof import("node:child_process").spawn>;
 const spawn = (
   ...args: Parameters<typeof import("node:child_process").spawn>
@@ -49,29 +43,10 @@ const basename = (p: string): string =>
   nodePath ? nodePath.basename(p) : notOnNode("node:path.basename");
 const join = (...parts: string[]): string =>
   nodePath ? nodePath.join(...parts) : notOnNode("node:path.join");
-// Re-export the EventEmitter type/class — falls back to a no-op so the
-// module evaluates off-Node; consumers that instantiate the bridge will
-// fail at construction time, not at module load.
-class FallbackEmitter {
-  on(_: string, __: (...args: unknown[]) => void): this {
-    notOnNode("node:events.EventEmitter");
-  }
-  emit(_: string, ...__: unknown[]): boolean {
-    notOnNode("node:events.EventEmitter");
-  }
-  removeAllListeners(): this {
-    notOnNode("node:events.EventEmitter");
-  }
-}
-const EventEmitter = (nodeEvents?.EventEmitter ??
-  FallbackEmitter) as unknown as typeof import("node:events").EventEmitter;
 
 import { createLogger } from "@nodetool-ai/config";
 
-import {
-  BRIDGE_PROTOCOL_VERSION,
-  MIN_NODETOOL_CORE_VERSION
-} from "@nodetool-ai/protocol/bridge-protocol";
+import { PythonBridgeBase } from "./python-bridge-base.js";
 
 const log = createLogger("nodetool.runtime.python-stdio-bridge");
 import type {
@@ -98,18 +73,6 @@ export type {
   PythonWorkerStatus
 };
 
-interface PendingRequest {
-  resolve: (value: ExecuteResult) => void;
-  reject: (error: Error) => void;
-  onProgress?: (event: ProgressEvent) => void;
-}
-
-interface PendingStreamRequest {
-  resolve: (value: Record<string, unknown>) => void;
-  reject: (error: Error) => void;
-  onChunk: StreamCallback;
-}
-
 type PythonLaunchCandidate = {
   command: string;
   argsPrefix?: string[];
@@ -121,73 +84,35 @@ const MAX_BRIDGE_FRAME_SIZE = Number(
 );
 const PYTHON_BRIDGE_ALLOWED_IN_PRODUCTION =
   process.env["NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION"] === "1";
-const DEFAULT_EXECUTE_TIMEOUT_MS = Number(
-  process.env["NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS"] ?? 12 * 60 * 1000
-);
 
 function isProductionMode(): boolean {
   return process.env["NODETOOL_ENV"] === "production";
 }
 
-export class PythonStdioBridge extends EventEmitter {
+export class PythonStdioBridge extends PythonBridgeBase {
   private _process: ChildProcess | null = null;
-  private _nodeMetadata: PythonNodeMetadata[] = [];
-  private _loadErrors: PythonWorkerLoadError[] = [];
-  private _workerStatus: PythonWorkerStatus | null = null;
-  private _pending = new Map<string, PendingRequest>();
-  private _pendingStream = new Map<string, PendingStreamRequest>();
-  private _options: PythonBridgeOptions;
-  private _connected = false;
-  private _connectPromise: Promise<void> | null = null;
   /** Buffered stdout data waiting to be parsed into frames. */
   private _readBuffer = Buffer.alloc(0);
   /** Recent stderr lines from the worker for diagnostics. */
   private _recentStderr: string[] = [];
 
   constructor(options: PythonBridgeOptions = {}) {
-    super();
-    this._options = options;
+    super(options);
   }
 
-  // ── Connection lifecycle ───────────────────────────────────────────
+  // ── Connection guard ───────────────────────────────────────────────
 
-  async connect(): Promise<void> {
+  protected override _assertCanConnect(): void {
     if (isProductionMode() && !PYTHON_BRIDGE_ALLOWED_IN_PRODUCTION) {
       throw new Error(
         "Python bridge is disabled in production. Python workers are a local-only feature."
       );
     }
-    await this._spawnAndConnect();
-    await this._discover();
-    try {
-      await this.getWorkerStatus();
-    } catch (err) {
-      log.warn(
-        "Failed to fetch initial Python worker status; load_errors will be unavailable until next status fetch",
-        err
-      );
-    }
   }
 
-  ensureConnected(): Promise<void> {
-    if (this._connected) return Promise.resolve();
-    if (!this._connectPromise) {
-      this._connectPromise = this.connect().then(
-        () => {
-          this._connectPromise = null;
-        },
-        (err) => {
-          this._connectPromise = null;
-          throw err;
-        }
-      );
-    }
-    return this._connectPromise;
-  }
+  // ── Transport: spawn & stdio setup ─────────────────────────────────
 
-  // ── Spawn & stdio setup ────────────────────────────────────────────
-
-  private async _spawnAndConnect(): Promise<void> {
+  protected override async _openTransport(): Promise<void> {
     const candidates = this._getPythonLaunchCandidates();
     let lastError: Error | null = null;
 
@@ -364,17 +289,6 @@ export class PythonStdioBridge extends EventEmitter {
     }
   }
 
-  private _rejectAllPending(error: Error): void {
-    for (const [, req] of this._pending) {
-      req.reject(error);
-    }
-    this._pending.clear();
-    for (const [, req] of this._pendingStream) {
-      req.reject(error);
-    }
-    this._pendingStream.clear();
-  }
-
   private _failProtocol(error: Error): void {
     log.error(error.message);
     this._rejectAllPending(error);
@@ -383,7 +297,7 @@ export class PythonStdioBridge extends EventEmitter {
 
   // ── Send ───────────────────────────────────────────────────────────
 
-  private _send(msg: Record<string, unknown>): void {
+  protected override _send(msg: Record<string, unknown>): void {
     if (!this._process?.stdin || !this._connected) {
       throw new Error("Not connected to Python worker");
     }
@@ -399,545 +313,9 @@ export class PythonStdioBridge extends EventEmitter {
     this._process.stdin.write(payload);
   }
 
-  // ── Message dispatch ────────────────────────────────────────────────
-
-  private _handleMessage(msg: Record<string, unknown>): void {
-    const type = msg.type as string;
-    const requestId = msg.request_id as string | null;
-
-    if (type === "discover" && requestId) {
-      const pending = this._pending.get(requestId);
-      if (pending) {
-        const data = msg.data as {
-          nodes: PythonNodeMetadata[];
-          protocol_version?: number;
-          load_errors?: PythonWorkerLoadError[];
-        };
-        // Reject the discover promise if the worker's protocol is older
-        // than what this build of the JS runtime requires. Workers that
-        // pre-date the protocol_version field are treated as version 1
-        // (the initial protocol release) — they speak the same wire
-        // format as v1, they just don't announce it.
-        const workerVersion =
-          typeof data.protocol_version === "number"
-            ? data.protocol_version
-            : 1;
-        if (workerVersion < BRIDGE_PROTOCOL_VERSION) {
-          this._pending.delete(requestId);
-          pending.reject(
-            new Error(
-              `The installed nodetool-core speaks bridge protocol v${workerVersion}, ` +
-                `but this Nodetool build requires v${BRIDGE_PROTOCOL_VERSION}. ` +
-                `Please reinstall the Python environment from Settings → Packages ` +
-                `(Reinstall environment) — it will fetch nodetool-core>=${MIN_NODETOOL_CORE_VERSION}.`
-            )
-          );
-          return;
-        }
-        if (workerVersion > BRIDGE_PROTOCOL_VERSION) {
-          // Forward-compat: a newer worker is expected to keep speaking
-          // older protocols, so we proceed with a warning.
-          this.emit(
-            "stderr",
-            `[python-bridge] Worker protocol v${workerVersion} is newer than ` +
-              `JS runtime v${BRIDGE_PROTOCOL_VERSION}; assuming backward compatibility.\n`
-          );
-        }
-        this._nodeMetadata = data.nodes;
-        this._loadErrors = data.load_errors ?? [];
-        pending.resolve({ outputs: {}, blobs: {} });
-      }
-    } else if (type === "result" && requestId) {
-      const streamReq = this._pendingStream.get(requestId);
-      if (streamReq) {
-        this._pendingStream.delete(requestId);
-        streamReq.resolve(msg.data as Record<string, unknown>);
-        return;
-      }
-      const pending = this._pending.get(requestId);
-      if (pending) {
-        this._pending.delete(requestId);
-        const data = msg.data as {
-          outputs: Record<string, unknown>;
-          blobs: Record<string, Uint8Array>;
-        };
-        pending.resolve({ outputs: data.outputs, blobs: data.blobs ?? {} });
-      }
-    } else if (type === "error" && requestId) {
-      const streamReq = this._pendingStream.get(requestId);
-      if (streamReq) {
-        this._pendingStream.delete(requestId);
-        const data = msg.data as { error: string; traceback?: string };
-        const err = new Error(data.error);
-        (err as unknown as Record<string, unknown>).traceback = data.traceback;
-        streamReq.reject(err);
-        return;
-      }
-      const pending = this._pending.get(requestId);
-      if (pending) {
-        this._pending.delete(requestId);
-        const data = msg.data as { error: string; traceback?: string };
-        const err = new Error(data.error);
-        (err as unknown as Record<string, unknown>).traceback = data.traceback;
-        pending.reject(err);
-      }
-    } else if (type === "chunk" && requestId) {
-      const streamReq = this._pendingStream.get(requestId);
-      if (streamReq) {
-        streamReq.onChunk(msg.data as Record<string, unknown>);
-      }
-    } else if (type === "progress" && requestId) {
-      const pending = this._pending.get(requestId);
-      if (pending?.onProgress) {
-        const data = msg.data as { progress: number; total: number };
-        pending.onProgress({ request_id: requestId, ...data });
-      }
-      this.emit("progress", msg.data);
-    }
-  }
-
-  // ── Discover ───────────────────────────────────────────────────────
-
-  private async _discover(): Promise<void> {
-    const requestId = randomUUID();
-    return new Promise<void>((resolve, reject) => {
-      this._pending.set(requestId, {
-        resolve: () => {
-          this._pending.delete(requestId);
-          resolve();
-        },
-        reject: (err) => {
-          this._pending.delete(requestId);
-          reject(err);
-        }
-      });
-      this._send({ type: "discover", request_id: requestId, data: {} });
-    });
-  }
-
-  // ── Node execution ─────────────────────────────────────────────────
-
-  async execute(
-    nodeType: string,
-    fields: Record<string, unknown>,
-    secrets: Record<string, string>,
-    blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
-  ): Promise<ExecuteResult> {
-    const requestId = randomUUID();
-    const timeoutMs =
-      this._options.executeTimeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS;
-
-    log.debug("Python bridge execute dispatched", { nodeType, requestId });
-
-    const executePromise = new Promise<ExecuteResult>((resolve, reject) => {
-      this._pending.set(requestId, { resolve, reject, onProgress });
-      try {
-        this._send({
-          type: "execute",
-          request_id: requestId,
-          data: { node_type: nodeType, fields, secrets, blobs }
-        });
-      } catch (err) {
-        this._pending.delete(requestId);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
-    });
-
-    if (timeoutMs <= 0) {
-      return executePromise;
-    }
-
-    let timer: NodeJS.Timeout | undefined;
-    const timeoutPromise = new Promise<ExecuteResult>((_, reject) => {
-      timer = setTimeout(() => {
-        if (!this._pending.has(requestId)) {
-          return;
-        }
-        this._pending.delete(requestId);
-        try {
-          this.cancel(requestId);
-        } catch {
-          // Worker may already be gone; cancel is best-effort.
-        }
-        const stderrHint = this.getRecentStderrSummary(4);
-        reject(
-          new Error(
-            `Python node "${nodeType}" timed out after ${timeoutMs}ms waiting for the worker.` +
-              (stderrHint ? ` Recent stderr: ${stderrHint}` : "")
-          )
-        );
-      }, timeoutMs);
-    });
-
-    try {
-      return await Promise.race([executePromise, timeoutPromise]);
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    }
-  }
-
-  async *executeStream(
-    nodeType: string,
-    fields: Record<string, unknown>,
-    secrets: Record<string, string>,
-    blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
-  ): AsyncGenerator<ExecuteResult> {
-    const requestId = randomUUID();
-    const chunks: ExecuteResult[] = [];
-    let done = false;
-    let error: Error | null = null;
-    let finalResult: ExecuteResult | null = null;
-    let emittedCount = 0;
-    let resolveWait: (() => void) | null = null;
-
-    if (onProgress) {
-      this._pending.set(requestId, {
-        resolve: () => undefined,
-        reject: () => undefined,
-        onProgress
-      });
-    }
-
-    const onChunk = (chunk: Record<string, unknown>) => {
-      chunks.push({
-        outputs: (chunk.outputs as Record<string, unknown>) ?? {},
-        blobs: (chunk.blobs as Record<string, Uint8Array>) ?? {}
-      });
-      if (resolveWait) {
-        resolveWait();
-        resolveWait = null;
-      }
-    };
-
-    const streamPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingStream.set(requestId, { resolve, reject, onChunk });
-    });
-
-    streamPromise
-      .then((result) => {
-        finalResult = {
-          outputs: (result.outputs as Record<string, unknown>) ?? {},
-          blobs: (result.blobs as Record<string, Uint8Array>) ?? {}
-        };
-        done = true;
-        this._pending.delete(requestId);
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      })
-      .catch((err) => {
-        error = err;
-        done = true;
-        this._pending.delete(requestId);
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      });
-
-    this._send({
-      type: "execute.stream",
-      request_id: requestId,
-      data: { node_type: nodeType, fields, secrets, blobs }
-    });
-
-    while (true) {
-      while (chunks.length > 0) {
-        emittedCount += 1;
-        yield chunks.shift()!;
-      }
-      if (done) break;
-      if (error) throw error;
-      await new Promise<void>((resolve) => {
-        resolveWait = resolve;
-      });
-    }
-    if (error) throw error;
-    if (emittedCount === 0 && finalResult) {
-      yield finalResult;
-    }
-  }
-
-  cancel(requestId: string): void {
-    this._send({ type: "cancel", request_id: requestId, data: {} });
-  }
-
-  getNodeMetadata(): PythonNodeMetadata[] {
-    return this._nodeMetadata;
-  }
-
-  getLoadErrors() {
-    return this._loadErrors;
-  }
-
-  async getWorkerStatus() {
-    const requestId = randomUUID();
-    const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingStream.set(requestId, {
-        resolve,
-        reject,
-        onChunk: () => {}
-      });
-      this._send({ type: "worker.status", request_id: requestId, data: {} });
-    });
-    this._workerStatus =
-      result as unknown as PythonWorkerStatus;
-    this._loadErrors = this._workerStatus.load_errors ?? this._loadErrors;
-    return this._workerStatus;
-  }
-
-  hasNodeType(nodeType: string): boolean {
-    return this._nodeMetadata.some((n) => n.node_type === nodeType);
-  }
-
-  get isConnected(): boolean {
-    return this._connected;
-  }
-
-  // ── Provider bridge methods ────────────────────────────────────────
-
-  async listProviders(): Promise<PythonProviderInfo[]> {
-    const result = await this._providerCall("provider.list", {});
-    return (result as { providers: PythonProviderInfo[] }).providers;
-  }
-
-  async getProviderModels(
-    providerId: string,
-    modelType: string,
-    secrets?: Record<string, string>
-  ): Promise<Record<string, unknown>[]> {
-    const result = await this._providerCall("provider.models", {
-      provider: providerId,
-      model_type: modelType,
-      secrets: secrets ?? {}
-    });
-    return (result as { models: Record<string, unknown>[] }).models;
-  }
-
-  async providerGenerate(
-    providerId: string,
-    messages: Record<string, unknown>[],
-    model: string,
-    options?: Record<string, unknown>
-  ): Promise<Record<string, unknown>> {
-    const result = await this._providerCall("provider.generate", {
-      provider: providerId,
-      messages,
-      model,
-      ...options
-    });
-    return (result as { message: Record<string, unknown> }).message;
-  }
-
-  async *providerStream(
-    providerId: string,
-    messages: Record<string, unknown>[],
-    model: string,
-    options?: Record<string, unknown>
-  ): AsyncGenerator<Record<string, unknown>> {
-    const requestId = randomUUID();
-    const chunks: Record<string, unknown>[] = [];
-    let done = false;
-    let error: Error | null = null;
-    let resolveWait: (() => void) | null = null;
-
-    const onChunk = (chunk: Record<string, unknown>) => {
-      chunks.push(chunk);
-      if (resolveWait) {
-        resolveWait();
-        resolveWait = null;
-      }
-    };
-
-    const streamPromise = new Promise<Record<string, unknown>>(
-      (resolve, reject) => {
-        this._pendingStream.set(requestId, { resolve, reject, onChunk });
-      }
-    );
-
-    streamPromise
-      .then(() => {
-        done = true;
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      })
-      .catch((err) => {
-        error = err;
-        done = true;
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      });
-
-    this._send({
-      type: "provider.stream",
-      request_id: requestId,
-      data: { provider: providerId, messages, model, ...options }
-    });
-
-    while (true) {
-      while (chunks.length > 0) yield chunks.shift()!;
-      if (done) break;
-      if (error) throw error;
-      await new Promise<void>((resolve) => {
-        resolveWait = resolve;
-      });
-    }
-    if (error) throw error;
-  }
-
-  async providerTextToImage(
-    providerId: string,
-    params: Record<string, unknown>,
-    secrets?: Record<string, string>
-  ): Promise<Uint8Array> {
-    const result = await this._providerCall("provider.text_to_image", {
-      provider: providerId,
-      params,
-      secrets: secrets ?? {}
-    });
-    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
-  }
-
-  async providerImageToImage(
-    providerId: string,
-    image: Uint8Array,
-    params: Record<string, unknown>,
-    secrets?: Record<string, string>
-  ): Promise<Uint8Array> {
-    const result = await this._providerCall("provider.image_to_image", {
-      provider: providerId,
-      image,
-      params,
-      secrets: secrets ?? {}
-    });
-    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
-  }
-
-  async *providerTTS(
-    providerId: string,
-    text: string,
-    model: string,
-    options?: Record<string, unknown>
-  ): AsyncGenerator<Uint8Array> {
-    const requestId = randomUUID();
-    const chunks: Uint8Array[] = [];
-    let done = false;
-    let error: Error | null = null;
-    let resolveWait: (() => void) | null = null;
-
-    const onChunk = (chunk: Record<string, unknown>) => {
-      const blobs = chunk.blobs as Record<string, Uint8Array> | undefined;
-      if (blobs?.audio) chunks.push(blobs.audio);
-      if (resolveWait) {
-        resolveWait();
-        resolveWait = null;
-      }
-    };
-
-    const streamPromise = new Promise<Record<string, unknown>>(
-      (resolve, reject) => {
-        this._pendingStream.set(requestId, { resolve, reject, onChunk });
-      }
-    );
-
-    streamPromise
-      .then(() => {
-        done = true;
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      })
-      .catch((err) => {
-        error = err;
-        done = true;
-        if (resolveWait) {
-          resolveWait();
-          resolveWait = null;
-        }
-      });
-
-    this._send({
-      type: "provider.tts",
-      request_id: requestId,
-      data: { provider: providerId, text, model, ...options }
-    });
-
-    while (true) {
-      while (chunks.length > 0) yield chunks.shift()!;
-      if (done) break;
-      if (error) throw error;
-      await new Promise<void>((resolve) => {
-        resolveWait = resolve;
-      });
-    }
-    if (error) throw error;
-  }
-
-  async providerASR(
-    providerId: string,
-    audio: Uint8Array,
-    model: string,
-    options?: Record<string, unknown>
-  ): Promise<import("./providers/types.js").ASRResult> {
-    const result = await this._providerCall("provider.asr", {
-      provider: providerId,
-      audio,
-      model,
-      ...options
-    });
-    const r = result as {
-      text: string;
-      chunks?: Array<{ timestamp: [number, number]; text: string }>;
-    };
-    return {
-      text: r.text,
-      chunks: r.chunks
-    };
-  }
-
-  async providerEmbedding(
-    providerId: string,
-    text: string | string[],
-    model: string,
-    dimensions?: number
-  ): Promise<number[][]> {
-    const result = await this._providerCall("provider.embedding", {
-      provider: providerId,
-      text,
-      model,
-      dimensions
-    });
-    return (result as { embeddings: number[][] }).embeddings;
-  }
-
-  private async _providerCall(
-    type: string,
-    data: Record<string, unknown>
-  ): Promise<Record<string, unknown>> {
-    const requestId = randomUUID();
-    return new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingStream.set(requestId, {
-        resolve,
-        reject,
-        onChunk: () => {}
-      });
-      this._send({ type, request_id: requestId, data });
-    });
-  }
-
   // ── Shutdown ───────────────────────────────────────────────────────
 
-  close(): void {
+  override close(): void {
     if (this._pending.size > 0 || this._pendingStream.size > 0) {
       this._rejectAllPending(new Error("Python bridge closed"));
     }
@@ -958,11 +336,20 @@ export class PythonStdioBridge extends EventEmitter {
     return this._getPythonLaunchCandidates().length > 0;
   }
 
+  /**
+   * For the stdio transport, availability means a local Python interpreter was
+   * found (and the bridge is permitted to run in this environment). Delegates to
+   * {@link hasPython}.
+   */
+  override isAvailable(): boolean {
+    return this.hasPython();
+  }
+
   getRecentStderrLines(limit = 12): string[] {
     return this._recentStderr.slice(-limit);
   }
 
-  getRecentStderrSummary(limit = 12): string | null {
+  override getRecentStderrSummary(limit = 12): string | null {
     const lines = this.getRecentStderrLines(limit)
       .map((line) => line.trim())
       .filter(Boolean)

--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -1,0 +1,543 @@
+/**
+ * Python worker bridge using a remote WebSocket transport.
+ *
+ * Unlike {@link PythonStdioBridge}, this bridge NEVER spawns a process — it
+ * connects to an already-running worker (Docker, remote host, sidecar) by URL.
+ * The worker lifecycle is owned externally; this bridge only owns the socket.
+ *
+ * Wire protocol: one WS BINARY message == exactly one msgpack frame. There is
+ * NO 4-byte length prefix (that framing belongs to the stdio transport). The
+ * worker sends frames via `ws.send(msgpack.packb(msg))`; we decode every
+ * incoming binary message with msgpack.decode and feed it to the shared
+ * {@link PythonBridgeBase._handleMessage}.
+ *
+ * Resilience: if the socket drops unexpectedly (worker restart, network blip),
+ * the bridge rejects all in-flight requests, emits "exit", and then reconnects
+ * with exponential backoff (1s, 2s, 4s, … capped at maxReconnectDelayMs).
+ * After a successful reconnect it re-runs discover + worker.status and emits
+ * "reconnected". An explicit {@link close} disables reconnect.
+ */
+
+import * as msgpack from "@msgpack/msgpack";
+
+import WebSocket from "ws";
+
+import { createLogger } from "@nodetool-ai/config";
+
+import { PythonBridgeBase } from "./python-bridge-base.js";
+
+const log = createLogger("nodetool.runtime.python-websocket-bridge");
+
+import type {
+  PythonNodeMetadata,
+  ExecuteResult,
+  ExecuteInputBlobs,
+  ProgressEvent,
+  StreamCallback,
+  PythonProviderInfo,
+  PythonBridgeOptions,
+  PythonWorkerLoadError,
+  PythonWorkerStatus
+} from "./python-bridge-types.js";
+
+export type {
+  PythonNodeMetadata,
+  ExecuteResult,
+  ExecuteInputBlobs,
+  ProgressEvent,
+  StreamCallback,
+  PythonProviderInfo,
+  PythonBridgeOptions,
+  PythonWorkerLoadError,
+  PythonWorkerStatus
+};
+
+/** Mirror of the stdio bridge's frame ceiling, used here for `maxPayload`. */
+const MAX_BRIDGE_FRAME_SIZE = Number(
+  process.env["NODETOOL_BRIDGE_MAX_FRAME_SIZE"] ?? 256 * 1024 * 1024
+);
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 20000;
+const DEFAULT_RECONNECT_RPC_TIMEOUT_MS = 20000;
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 30000;
+const INITIAL_RECONNECT_DELAY_MS = 1000;
+
+export interface WebsocketPythonBridgeOptions extends PythonBridgeOptions {
+  /**
+   * Upper bound on the exponential reconnect backoff (ms). The delay starts at
+   * 1s and doubles each attempt up to this cap. Default 30000.
+   */
+  maxReconnectDelayMs?: number;
+}
+
+/**
+ * Attach permanent no-op 'error' sinks to a socket so a late 'error' event
+ * cannot crash the host process.
+ *
+ * When a WebSocket is still CONNECTING, tearing it down (close/terminate)
+ * makes it asynchronously emit a late 'error' ("WebSocket was closed before
+ * the connection was established"), and the underlying TCP socket may emit its
+ * own error too. If the only 'error' listener has been detached, Node
+ * escalates an unhandled 'error' on the EventEmitter into a process crash.
+ * Sinks on both the WebSocket and (if reachable) its TCP socket swallow them.
+ */
+function attachErrorSinks(ws: WebSocket): void {
+  try {
+    ws.on("error", () => {});
+  } catch {
+    /* best-effort */
+  }
+  // The raw TCP socket can emit its own error during a CONNECTING teardown.
+  const rawSocket = (
+    ws as unknown as { _socket?: { on?: (e: string, l: () => void) => void } }
+  )._socket;
+  if (rawSocket && typeof rawSocket.on === "function") {
+    try {
+      rawSocket.on("error", () => {});
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Terminate a socket crash-safely: attach error sinks (see
+ * {@link attachErrorSinks}) before terminating so any late CONNECTING-state
+ * error is swallowed rather than crashing the process.
+ */
+function crashSafeTerminate(ws: WebSocket): void {
+  attachErrorSinks(ws);
+  try {
+    ws.terminate();
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+export class WebsocketPythonBridge extends PythonBridgeBase {
+  private _ws: WebSocket | null = null;
+  private readonly _wsUrl: string;
+  private readonly _maxReconnectDelayMs: number;
+  private readonly _reconnectRpcTimeoutMs: number;
+  private readonly _autoReconnect: boolean;
+
+  /** Set once close() is called — permanently disables reconnect. */
+  private _explicitlyClosed = false;
+  /** Timer for a pending reconnect attempt, if any. */
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True while a reconnect attempt is in flight (guards overlap). */
+  private _reconnecting = false;
+  /**
+   * True once a connection has been fully established and announced (initial
+   * connect() resolved, or a reconnect emitted "reconnected"). Gates the
+   * "exit" emission so a socket that drops mid-reconnect — before any
+   * "reconnected" was emitted for it — does not produce a duplicate "exit"
+   * for consumers pairing exit/reconnected.
+   */
+  private _announcedConnected = false;
+  /** Current backoff delay; doubles each failed attempt. */
+  private _reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+  /**
+   * Set while an _openTransport handshake is in flight; invoking it rejects the
+   * handshake and crash-safely tears down the CONNECTING socket. Lets close()
+   * abort a connect that is still mid-handshake instead of waiting out the full
+   * startup timeout.
+   */
+  private _abortHandshake: ((err: Error) => void) | null = null;
+  /** Bound listeners for the active socket, removed before replacing it. */
+  private _messageListener: ((data: WebSocket.RawData) => void) | null = null;
+  private _closeListener: (() => void) | null = null;
+  private _errorListener: ((err: Error) => void) | null = null;
+
+  constructor(options: WebsocketPythonBridgeOptions = {}) {
+    super(options);
+    if (!options.wsUrl) {
+      throw new Error(
+        "WebsocketPythonBridge requires options.wsUrl — the remote worker WebSocket URL"
+      );
+    }
+    this._wsUrl = options.wsUrl;
+    this._maxReconnectDelayMs =
+      options.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS;
+    this._reconnectRpcTimeoutMs =
+      options.reconnectRpcTimeoutMs ?? DEFAULT_RECONNECT_RPC_TIMEOUT_MS;
+    // WebSocket transport reconnects by default — the worker lives elsewhere
+    // and may restart independently. Set autoRestart: false to opt out.
+    this._autoReconnect = options.autoRestart ?? true;
+  }
+
+  /** The remote worker WebSocket URL this bridge connects to. */
+  get wsUrl(): string {
+    return this._wsUrl;
+  }
+
+  // ── Connection lifecycle ────────────────────────────────────────────
+
+  /**
+   * Connect to the remote worker. Overrides the base flow so the post-open RPC
+   * phase (discover + worker.status) is bounded by a timeout: the startup
+   * timeout only covers the TCP/WS handshake, so a worker that accepts the
+   * socket but never answers discover would otherwise hang connect() forever.
+   * On RPC timeout we tear down the half-open socket (crash-safe) and reject.
+   */
+  override async connect(): Promise<void> {
+    this._assertCanConnect();
+    await this._openTransport();
+    try {
+      await this._withRpcTimeout(this._runPostOpenRpc());
+    } catch (err) {
+      this._teardownSocket(
+        err instanceof Error ? err.message : "Python worker connect failed"
+      );
+      throw err;
+    }
+    this._announcedConnected = true;
+  }
+
+  /**
+   * Run discover + worker.status against the freshly-opened socket. discover
+   * failures propagate (they mean the worker is unusable); a status failure is
+   * tolerated — load_errors will simply be unavailable until the next fetch.
+   */
+  private async _runPostOpenRpc(): Promise<void> {
+    await this._discover();
+    try {
+      // Use the status call bounded by statusTimeoutMs so a worker that
+      // answers discover but hangs on status does not stall the RPC phase up
+      // to the (larger) reconnectRpcTimeoutMs.
+      await this._getWorkerStatusWithTimeout();
+    } catch (err) {
+      log.warn(
+        "Failed to fetch worker status; load_errors will be unavailable until the next status fetch",
+        err
+      );
+    }
+  }
+
+  /**
+   * Race a post-open RPC promise against the configured RPC timeout. A worker
+   * that accepts the socket but never answers (half-open: port up before
+   * handlers are registered during a restart) is rejected rather than allowed
+   * to hang. A timeout of 0 disables the bound.
+   */
+  private async _withRpcTimeout<T>(promise: Promise<T>): Promise<T> {
+    const timeoutMs = this._reconnectRpcTimeoutMs;
+    if (timeoutMs <= 0) {
+      return promise;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Python worker did not answer discover/status within ${timeoutMs}ms (${this._wsUrl}).`
+          )
+        );
+      }, timeoutMs);
+    });
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Detach long-lived listeners, crash-safely terminate the current socket,
+   * clear connection state, and reject any requests left in flight (e.g. the
+   * discover/status RPCs that timed out, or a user execute that slipped in
+   * while the socket was briefly open). Idempotent and safe to call twice.
+   */
+  private _teardownSocket(reason: string): void {
+    if (this._ws) {
+      this._detachLongLivedListeners(this._ws);
+      crashSafeTerminate(this._ws);
+      this._ws = null;
+    }
+    this._connected = false;
+    this._rejectAllPending(new Error(reason));
+  }
+
+  // ── Transport: open the remote socket ───────────────────────────────
+
+  protected override async _openTransport(): Promise<void> {
+    const startupTimeoutMs =
+      this._options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const ws = new WebSocket(this._wsUrl, {
+        maxPayload: MAX_BRIDGE_FRAME_SIZE
+      });
+      ws.binaryType = "nodebuffer";
+
+      const startupTimer = setTimeout(() => {
+        finishError(
+          new Error(
+            `Python worker WebSocket did not open within ${startupTimeoutMs}ms (${this._wsUrl}).`
+          )
+        );
+      }, startupTimeoutMs);
+
+      // Listeners used only during the open handshake; replaced with the
+      // long-lived listeners on success.
+      const onOpen = () => finishSuccess();
+      const onPreOpenError = (err: Error) => finishError(err);
+      const onPreOpenClose = () =>
+        finishError(
+          new Error(
+            `Python worker WebSocket closed before opening (${this._wsUrl}).`
+          )
+        );
+
+      const cleanupHandshake = () => {
+        clearTimeout(startupTimer);
+        this._abortHandshake = null;
+        ws.removeListener("open", onOpen);
+        ws.removeListener("error", onPreOpenError);
+        ws.removeListener("close", onPreOpenClose);
+      };
+
+      const finishError = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanupHandshake();
+        // cleanupHandshake just removed the only 'error' listener. The socket
+        // may still be CONNECTING, in which case terminate() emits a late
+        // 'error' that would otherwise crash the process — terminate
+        // crash-safely.
+        crashSafeTerminate(ws);
+        reject(err);
+      };
+
+      const finishSuccess = () => {
+        if (settled) return;
+        settled = true;
+        cleanupHandshake();
+        this._ws = ws;
+        this._connected = true;
+        this._attachLongLivedListeners(ws);
+        resolve();
+      };
+
+      // Let close() abort this handshake mid-flight instead of waiting out the
+      // full startup timeout.
+      this._abortHandshake = finishError;
+
+      // close() may have already fired before we registered the aborter.
+      if (this._explicitlyClosed) {
+        finishError(
+          new Error(`Python worker WebSocket closed before opening (${this._wsUrl}).`)
+        );
+        return;
+      }
+
+      ws.on("open", onOpen);
+      ws.on("error", onPreOpenError);
+      ws.on("close", onPreOpenClose);
+    });
+  }
+
+  /**
+   * Wire up the message/close/error handlers for an opened socket. Removed via
+   * {@link _detachLongLivedListeners} before any reconnect so listeners never
+   * leak across sockets.
+   */
+  private _attachLongLivedListeners(ws: WebSocket): void {
+    this._messageListener = (data: WebSocket.RawData) => {
+      try {
+        const buf = this._toUint8Array(data);
+        const msg = msgpack.decode(buf) as Record<string, unknown>;
+        this._handleMessage(msg);
+      } catch (err) {
+        log.error(`Failed to decode WebSocket frame: ${err}`);
+      }
+    };
+    this._closeListener = () => this._onUnexpectedClose();
+    this._errorListener = (err: Error) => {
+      log.warn(`Python worker WebSocket error: ${err.message}`);
+      this._onUnexpectedClose();
+    };
+
+    ws.on("message", this._messageListener);
+    ws.on("close", this._closeListener);
+    ws.on("error", this._errorListener);
+  }
+
+  private _detachLongLivedListeners(ws: WebSocket): void {
+    if (this._messageListener) ws.removeListener("message", this._messageListener);
+    if (this._closeListener) ws.removeListener("close", this._closeListener);
+    if (this._errorListener) ws.removeListener("error", this._errorListener);
+    this._messageListener = null;
+    this._closeListener = null;
+    this._errorListener = null;
+  }
+
+  /** Normalize the various ws RawData shapes into a single Uint8Array. */
+  private _toUint8Array(data: WebSocket.RawData): Uint8Array {
+    if (data instanceof ArrayBuffer) return new Uint8Array(data);
+    if (Array.isArray(data)) return Buffer.concat(data);
+    // Buffer is a Uint8Array subclass; msgpack.decode accepts it directly.
+    return data as Uint8Array;
+  }
+
+  // ── Send ────────────────────────────────────────────────────────────
+
+  protected override _send(msg: Record<string, unknown>): void {
+    if (!this._ws || !this._connected) {
+      throw new Error("Not connected to Python worker");
+    }
+    const payload = msgpack.encode(msg);
+    if (payload.length > MAX_BRIDGE_FRAME_SIZE) {
+      throw new Error(
+        `Outgoing Python bridge frame exceeds max size (${payload.length} > ${MAX_BRIDGE_FRAME_SIZE})`
+      );
+    }
+    // Send as a single binary frame — no length prefix on WebSocket.
+    this._ws.send(payload, { binary: true });
+  }
+
+  // ── Unexpected close → reject + reconnect ───────────────────────────
+
+  private _onUnexpectedClose(): void {
+    if (this._explicitlyClosed) return;
+    // Guard re-entrancy: both 'close' and 'error' can fire for one drop.
+    if (!this._connected) return;
+
+    const reconnecting = this._reconnecting;
+    this._connected = false;
+
+    if (this._ws) {
+      this._detachLongLivedListeners(this._ws);
+      crashSafeTerminate(this._ws);
+      this._ws = null;
+    }
+
+    // Reject in-flight requests in both cases. When this drop happens during
+    // an in-flight reconnect (a fresh socket opened, then dropped while
+    // discover/status were running), rejecting the pending discover promise is
+    // what kicks _attemptReconnect's catch into owning teardown + backoff +
+    // reschedule — so we deliberately do NOT reschedule here, avoiding a race
+    // where two paths both grow/skip backoff non-deterministically.
+    this._rejectAllPending(
+      new Error("Python worker WebSocket closed unexpectedly")
+    );
+
+    if (reconnecting) {
+      // The reconnect attempt owns re-announcement and the next backoff step.
+      // Emitting "exit" here would produce a duplicate exit for a connection
+      // that was never announced as reconnected.
+      return;
+    }
+
+    // Only announce "exit" for the drop of a fully-established connection.
+    if (this._announcedConnected) {
+      this.emit("exit", null);
+    }
+
+    if (!this._autoReconnect) return;
+    this._scheduleReconnect();
+  }
+
+  private _scheduleReconnect(): void {
+    if (this._explicitlyClosed || !this._autoReconnect) return;
+    if (this._reconnectTimer || this._reconnecting) return;
+
+    const delay = Math.min(this._reconnectDelayMs, this._maxReconnectDelayMs);
+    log.info(
+      `Scheduling Python worker WebSocket reconnect in ${delay}ms (${this._wsUrl}).`
+    );
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      void this._attemptReconnect();
+    }, delay);
+  }
+
+  private async _attemptReconnect(): Promise<void> {
+    if (this._explicitlyClosed || this._reconnecting) return;
+    this._reconnecting = true;
+    try {
+      await this._openTransport();
+      // Re-run discovery + status against the (possibly new) worker so node
+      // metadata and load errors reflect the current process. Bound the RPC
+      // phase by a timeout: _openTransport only covers the handshake, so a
+      // half-open worker (port up before handlers are registered during a
+      // restart) that never answers discover would otherwise wedge the
+      // reconnect loop forever with _reconnecting stuck true.
+      await this._withRpcTimeout(this._runPostOpenRpc());
+      // Success: reset backoff and announce.
+      this._reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+      this._reconnecting = false;
+      this._announcedConnected = true;
+      log.info(`Python worker WebSocket reconnected (${this._wsUrl}).`);
+      this.emit("reconnected");
+    } catch (err) {
+      // This catch is the single owner of teardown + backoff growth +
+      // reschedule for a failed reconnect. _onUnexpectedClose deliberately
+      // does NOT reschedule while _reconnecting is true, so backoff timing is
+      // deterministic regardless of which event observed the drop first.
+      this._reconnecting = false;
+      log.warn(
+        `Python worker WebSocket reconnect failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      // Tear down any half-open socket crash-safely (it may still be
+      // CONNECTING, or open-but-silent on discover/status).
+      this._teardownSocket(
+        err instanceof Error ? err.message : "Python worker reconnect failed"
+      );
+      if (this._explicitlyClosed || !this._autoReconnect) return;
+      this._reconnectDelayMs = Math.min(
+        this._reconnectDelayMs * 2,
+        this._maxReconnectDelayMs
+      );
+      this._scheduleReconnect();
+    }
+  }
+
+  // ── Shutdown ────────────────────────────────────────────────────────
+
+  override close(): void {
+    this._explicitlyClosed = true;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    this._reconnecting = false;
+    this._announcedConnected = false;
+    // Abort an in-flight handshake (CONNECTING socket) so a pending connect()
+    // rejects immediately instead of waiting out the startup timeout. The
+    // aborter crash-safely terminates the CONNECTING socket.
+    if (this._abortHandshake) {
+      const abort = this._abortHandshake;
+      this._abortHandshake = null;
+      abort(
+        new Error(`Python worker WebSocket closed before opening (${this._wsUrl}).`)
+      );
+    }
+    if (this._ws) {
+      this._detachLongLivedListeners(this._ws);
+      // Detaching removed the error listener; close()/terminate() on a socket
+      // that is still CONNECTING emits a late 'error' that would crash the
+      // process. Attach permanent no-op error sinks first.
+      const ws = this._ws;
+      attachErrorSinks(ws);
+      try {
+        ws.close();
+      } catch {
+        /* best-effort cleanup */
+      }
+      try {
+        ws.terminate();
+      } catch {
+        /* best-effort cleanup */
+      }
+      this._ws = null;
+    }
+    this._connected = false;
+    if (this._pending.size > 0 || this._pendingStream.size > 0) {
+      this._rejectAllPending(new Error("Python bridge closed"));
+    }
+  }
+}

--- a/packages/runtime/tests/python-bridge-factory.test.ts
+++ b/packages/runtime/tests/python-bridge-factory.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for createPythonBridge — the transport selector that picks the local
+ * stdio bridge or the remote WebSocket bridge based on options.wsUrl and the
+ * NODETOOL_WORKER_URL environment variable.
+ *
+ * These tests only assert which concrete bridge is constructed; they never call
+ * connect() (there is no real worker behind the URLs used here).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { createPythonBridge } from "../src/python-bridge-factory.js";
+import { PythonStdioBridge } from "../src/python-stdio-bridge.js";
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+
+const ENV_KEY = "NODETOOL_WORKER_URL";
+
+describe("createPythonBridge", () => {
+  let savedWorkerUrl: string | undefined;
+
+  beforeEach(() => {
+    savedWorkerUrl = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedWorkerUrl === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = savedWorkerUrl;
+    }
+  });
+
+  it("returns a stdio bridge with no env var and no options", () => {
+    const bridge = createPythonBridge();
+    expect(bridge).toBeInstanceOf(PythonStdioBridge);
+  });
+
+  it("returns a WebSocket bridge when options.wsUrl is set", () => {
+    const bridge = createPythonBridge({ wsUrl: "ws://127.0.0.1:7777" });
+    expect(bridge).toBeInstanceOf(WebsocketPythonBridge);
+    expect(bridge.isAvailable()).toBe(true);
+  });
+
+  it("returns a WebSocket bridge when NODETOOL_WORKER_URL is set", () => {
+    process.env[ENV_KEY] = "ws://127.0.0.1:7777";
+    const bridge = createPythonBridge();
+    expect(bridge).toBeInstanceOf(WebsocketPythonBridge);
+    expect(bridge.isAvailable()).toBe(true);
+    expect((bridge as WebsocketPythonBridge).wsUrl).toBe("ws://127.0.0.1:7777");
+  });
+
+  it("lets options.wsUrl override the env var", () => {
+    process.env[ENV_KEY] = "ws://from-env:7777";
+    const bridge = createPythonBridge({ wsUrl: "ws://from-option:7777" });
+    expect(bridge).toBeInstanceOf(WebsocketPythonBridge);
+    // Assert the chosen URL, not just the type — guards against a reversed
+    // coalesce (process.env ?? options.wsUrl) that a type-only check misses.
+    expect((bridge as WebsocketPythonBridge).wsUrl).toBe("ws://from-option:7777");
+  });
+
+  it("falls back to stdio when the env var is whitespace-only", () => {
+    process.env[ENV_KEY] = "   ";
+    const bridge = createPythonBridge();
+    expect(bridge).toBeInstanceOf(PythonStdioBridge);
+  });
+
+  it("falls back to stdio when the env var is empty", () => {
+    process.env[ENV_KEY] = "";
+    const bridge = createPythonBridge();
+    expect(bridge).toBeInstanceOf(PythonStdioBridge);
+  });
+});

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Tests for WebsocketPythonBridge — the connect-to-remote-URL Python worker
+ * bridge with auto-reconnect. Stands up an in-process fake worker that speaks
+ * the msgpack-over-WebSocket protocol (one WS binary message == one msgpack
+ * frame, no length prefix).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocketServer, type WebSocket as WsServerSocket } from "ws";
+import * as net from "node:net";
+import { AddressInfo } from "node:net";
+import * as msgpack from "@msgpack/msgpack";
+
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+
+const FAKE_NODE = {
+  node_type: "fake.TestNode",
+  title: "Fake Test Node",
+  description: "A fake node for testing",
+  properties: [],
+  outputs: [{ name: "out", type: { type: "string" } }],
+  required_settings: []
+};
+
+interface FakeWorkerOptions {
+  /** When false, discover requests are silently ignored (no reply). */
+  answerDiscover?: boolean;
+  /** When false, worker.status requests are silently ignored (no reply). */
+  answerStatus?: boolean;
+  /** When false, execute requests are silently ignored (no reply). */
+  answerExecute?: boolean;
+  /**
+   * execute.stream behavior:
+   *  - "chunks": emit two chunks then the empty result terminator (default)
+   *  - "empty": emit only the empty result terminator (zero chunks)
+   */
+  streamMode?: "chunks" | "empty";
+}
+
+interface FakeWorkerHandle {
+  port: number;
+  /** Forcibly drop all currently-connected client sockets. */
+  dropConnections: () => void;
+  /** Close the server entirely. */
+  close: () => Promise<void>;
+  /** Number of discover requests the worker has answered. */
+  discoverCount: () => number;
+  /** Total number of client connections accepted over the worker's lifetime. */
+  connectionCount: () => number;
+  /** Currently connected sockets. */
+  sockets: () => Set<WsServerSocket>;
+  /** Mutate behavior at runtime (e.g. start answering discover after a drop). */
+  setOptions: (opts: FakeWorkerOptions) => void;
+}
+
+/**
+ * Start a fake worker on a specific port (or ephemeral when port === 0).
+ * Returns once the server is listening.
+ */
+function startFakeWorker(
+  port = 0,
+  initialOptions: FakeWorkerOptions = {}
+): Promise<FakeWorkerHandle> {
+  const wss = new WebSocketServer({ port });
+  const sockets = new Set<WsServerSocket>();
+  let discovers = 0;
+  let connections = 0;
+  const opts: Required<FakeWorkerOptions> = {
+    answerDiscover: initialOptions.answerDiscover ?? true,
+    answerStatus: initialOptions.answerStatus ?? true,
+    answerExecute: initialOptions.answerExecute ?? true,
+    streamMode: initialOptions.streamMode ?? "chunks"
+  };
+
+  wss.on("connection", (ws) => {
+    connections += 1;
+    sockets.add(ws);
+    ws.binaryType = "nodebuffer";
+    ws.on("close", () => sockets.delete(ws));
+    ws.on("message", (raw: Buffer) => {
+      const msg = msgpack.decode(raw as Uint8Array) as Record<string, unknown>;
+      const type = msg.type as string;
+      const requestId = msg.request_id as string;
+      const send = (m: Record<string, unknown>) => {
+        ws.send(msgpack.encode(m));
+      };
+
+      switch (type) {
+        case "discover":
+          if (!opts.answerDiscover) break;
+          discovers += 1;
+          send({
+            type: "discover",
+            request_id: requestId,
+            data: {
+              nodes: [FAKE_NODE],
+              protocol_version: 1,
+              load_errors: []
+            }
+          });
+          break;
+        case "worker.status":
+          if (!opts.answerStatus) break;
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              transport: "websocket",
+              protocol_version: 1,
+              node_count: 1,
+              provider_count: 1,
+              namespaces: ["fake"],
+              load_errors: [],
+              max_frame_size: 256 * 1024 * 1024
+            }
+          });
+          break;
+        case "execute": {
+          if (!opts.answerExecute) break;
+          const data = msg.data as { fields?: Record<string, unknown> };
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              outputs: { out: (data.fields?.value as string) ?? "executed" },
+              blobs: {}
+            }
+          });
+          break;
+        }
+        case "execute.stream": {
+          if (opts.streamMode === "chunks") {
+            send({
+              type: "chunk",
+              request_id: requestId,
+              data: { outputs: { out: "chunk-1" }, blobs: {} }
+            });
+            send({
+              type: "chunk",
+              request_id: requestId,
+              data: { outputs: { out: "chunk-2" }, blobs: {} }
+            });
+          }
+          // Real worker contract: the stream terminates with an empty result
+          // frame ({outputs:{}, blobs:{}}), not a payload-bearing one.
+          send({
+            type: "result",
+            request_id: requestId,
+            data: { outputs: {}, blobs: {} }
+          });
+          break;
+        }
+        case "provider.list":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              providers: [
+                { id: "fake-provider", capabilities: ["chat"], required_secrets: [] }
+              ]
+            }
+          });
+          break;
+        case "provider.stream": {
+          send({
+            type: "chunk",
+            request_id: requestId,
+            data: { content: "p-chunk-1" }
+          });
+          send({
+            type: "chunk",
+            request_id: requestId,
+            data: { content: "p-chunk-2" }
+          });
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {}
+          });
+          break;
+        }
+        case "cancel":
+          // no-op
+          break;
+        default:
+          break;
+      }
+    });
+  });
+
+  return new Promise<FakeWorkerHandle>((resolve) => {
+    wss.on("listening", () => {
+      const addr = wss.address() as AddressInfo;
+      resolve({
+        port: addr.port,
+        dropConnections: () => {
+          for (const ws of sockets) {
+            // terminate() abruptly drops the TCP connection.
+            ws.terminate();
+          }
+          sockets.clear();
+        },
+        close: () =>
+          new Promise<void>((res) => {
+            for (const ws of sockets) ws.terminate();
+            sockets.clear();
+            wss.close(() => res());
+          }),
+        discoverCount: () => discovers,
+        connectionCount: () => connections,
+        sockets: () => sockets,
+        setOptions: (next: FakeWorkerOptions) => {
+          Object.assign(opts, next);
+        }
+      });
+    });
+  });
+}
+
+/**
+ * Start a raw TCP server that accepts the connection but never performs the
+ * WebSocket upgrade handshake — simulating a half-open port that stalls the WS
+ * upgrade. Used to reproduce the CONNECTING-state teardown crash.
+ */
+function startStallingTcpServer(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    // Intentionally read nothing and never reply — the WS upgrade stalls.
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({
+        port: addr.port,
+        close: () =>
+          new Promise<void>((res) => {
+            for (const s of sockets) s.destroy();
+            sockets.clear();
+            server.close(() => res());
+          })
+      });
+    });
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+  intervalMs = 10
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+describe("WebsocketPythonBridge", () => {
+  let worker: FakeWorkerHandle | null = null;
+  let bridge: WebsocketPythonBridge | null = null;
+
+  afterEach(async () => {
+    if (bridge) {
+      bridge.close();
+      bridge = null;
+    }
+    if (worker) {
+      await worker.close();
+      worker = null;
+    }
+  });
+
+  it("requires a wsUrl", () => {
+    expect(() => new WebsocketPythonBridge({})).toThrow(/wsUrl/i);
+  });
+
+  it("connect() populates node metadata", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+
+    await bridge.connect();
+
+    const meta = bridge.getNodeMetadata();
+    expect(meta).toHaveLength(1);
+    expect(meta[0]!.node_type).toBe("fake.TestNode");
+    expect(bridge.isConnected).toBe(true);
+  });
+
+  it("execute() round-trips outputs", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const result = await bridge.execute(
+      "fake.TestNode",
+      { value: "hello" },
+      {},
+      {}
+    );
+    expect(result.outputs).toEqual({ out: "hello" });
+    expect(result.blobs).toEqual({});
+  });
+
+  it("executeStream() yields streamed chunks", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const seen: unknown[] = [];
+    for await (const chunk of bridge.executeStream(
+      "fake.TestNode",
+      {},
+      {},
+      {}
+    )) {
+      seen.push(chunk.outputs);
+    }
+    expect(seen).toEqual([{ out: "chunk-1" }, { out: "chunk-2" }]);
+  });
+
+  it("a provider call works", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const providers = await bridge.listProviders();
+    expect(providers).toHaveLength(1);
+    expect(providers[0]!.id).toBe("fake-provider");
+  });
+
+  it("getWorkerStatus() reports transport websocket", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const status = await bridge.getWorkerStatus();
+    expect(status.transport).toBe("websocket");
+    expect(status.protocol_version).toBe(1);
+  });
+
+  it("_send throws when not connected", () => {
+    bridge = new WebsocketPythonBridge({ wsUrl: "ws://127.0.0.1:1" });
+    expect(() => bridge!.cancel("nope")).toThrow(/not connected/i);
+  });
+
+  it("auto-reconnects after the socket is dropped server-side", async () => {
+    // Worker answers connect (discover/status) but deliberately never answers
+    // execute, so the in-flight request is still pending when we drop the LIVE
+    // socket. This proves _rejectAllPending — the request must reject with the
+    // unexpected-close error, NOT bounce off the _send "Not connected" guard.
+    worker = await startFakeWorker(0, { answerExecute: false });
+    const port = worker.port;
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${port}`,
+      // keep reconnect fast for the test
+      maxReconnectDelayMs: 50
+    });
+    await bridge.connect();
+    expect(worker.discoverCount()).toBe(1);
+
+    let exited = false;
+    let reconnected = false;
+    bridge.on("exit", () => {
+      exited = true;
+    });
+    bridge.on("reconnected", () => {
+      reconnected = true;
+    });
+
+    // Issue an execute while fully connected; the worker never replies, so the
+    // pending entry is live in the bridge.
+    let inflightError: Error | null = null;
+    const inflight = bridge
+      .execute("fake.TestNode", { value: "x" }, {}, {})
+      .catch((err: Error) => {
+        inflightError = err;
+      });
+
+    // Let the execute frame reach the worker (which ignores it) so the request
+    // is genuinely in flight before we tear the socket down.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Drop the live socket from the server side — this is the unexpected close.
+    await worker.close();
+
+    await waitFor(() => exited, 5000);
+    await inflight;
+    expect(inflightError).not.toBeNull();
+    // Must be the close-path rejection, not the send-guard path.
+    expect((inflightError as unknown as Error).message).toContain(
+      "closed unexpectedly"
+    );
+    expect((inflightError as unknown as Error).message).not.toContain(
+      "Not connected"
+    );
+
+    // Bring the worker back up on the same port (now answering execute too).
+    worker = await startFakeWorker(port);
+
+    // Bridge should reconnect on its own (re-running discover) and emit
+    // "reconnected".
+    await waitFor(() => reconnected, 10000);
+    expect(bridge.isConnected).toBe(true);
+    expect(worker.discoverCount()).toBe(1); // fresh server, discover re-run
+
+    // A subsequent execute should now succeed against the new worker.
+    const result = await bridge.execute(
+      "fake.TestNode",
+      { value: "again" },
+      {},
+      {}
+    );
+    expect(result.outputs).toEqual({ out: "again" });
+  });
+
+  it("does NOT reconnect after explicit close()", async () => {
+    worker = await startFakeWorker();
+    const port = worker.port;
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${port}`,
+      maxReconnectDelayMs: 50
+    });
+    await bridge.connect();
+
+    let reconnected = false;
+    bridge.on("reconnected", () => {
+      reconnected = true;
+    });
+
+    bridge.close();
+    expect(bridge.isConnected).toBe(false);
+
+    // Drop and bring back the worker; bridge must stay closed.
+    await worker.close();
+    worker = await startFakeWorker(port);
+
+    // Give it ample time to (incorrectly) reconnect.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(reconnected).toBe(false);
+    expect(bridge.isConnected).toBe(false);
+  });
+
+  it("does not crash when the WS upgrade stalls past the startup timeout", async () => {
+    // CRASH REPRO: a raw TCP server accepts the connection but never performs
+    // the WS upgrade. The handshake startup timer fires and tears down a still-
+    // CONNECTING socket. Before the fix this terminated a socket whose error
+    // listener had just been removed, so Node escalated the late
+    // "WebSocket was closed before the connection was established" error into an
+    // uncaught exception and crashed the process. The test merely completing
+    // (no unhandledRejection / uncaughtException) is the proof.
+    const stall = await startStallingTcpServer();
+    try {
+      bridge = new WebsocketPythonBridge({
+        wsUrl: `ws://127.0.0.1:${stall.port}`,
+        startupTimeoutMs: 100,
+        autoRestart: false
+      });
+
+      let rejected = false;
+      await bridge.connect().catch(() => {
+        rejected = true;
+      });
+      expect(rejected).toBe(true);
+
+      // Give any late CONNECTING-state error a chance to surface; if the sink
+      // were missing the process would have already crashed.
+      await new Promise((r) => setTimeout(r, 150));
+      bridge.close();
+      bridge = null;
+    } finally {
+      await stall.close();
+    }
+  });
+
+  it("does not crash when close() is called before the socket opens", async () => {
+    // close-before-open variant: connect() is racing the handshake; we close
+    // the bridge while the socket is still CONNECTING. close() detaches the
+    // error listener then terminates, which would crash without the no-op sink.
+    const stall = await startStallingTcpServer();
+    try {
+      bridge = new WebsocketPythonBridge({
+        wsUrl: `ws://127.0.0.1:${stall.port}`,
+        startupTimeoutMs: 5000,
+        autoRestart: false
+      });
+
+      const connectPromise = bridge.connect().catch(() => {
+        /* expected: closed before open */
+      });
+      // Tear down mid-handshake.
+      await new Promise((r) => setTimeout(r, 20));
+      bridge.close();
+      await connectPromise;
+
+      // Let any late CONNECTING-state error fire.
+      await new Promise((r) => setTimeout(r, 100));
+      bridge = null;
+    } finally {
+      await stall.close();
+    }
+  });
+
+  it("times out a half-open reconnect and keeps retrying", async () => {
+    // RECONNECT RPC TIMEOUT: after a drop, the worker accepts the new socket
+    // but never answers discover. Without an RPC-phase timeout the reconnect
+    // would await forever with _reconnecting stuck true, wedging self-healing.
+    worker = await startFakeWorker();
+    const port = worker.port;
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${port}`,
+      maxReconnectDelayMs: 50,
+      reconnectRpcTimeoutMs: 150
+    });
+    await bridge.connect();
+
+    let reconnected = false;
+    bridge.on("reconnected", () => {
+      reconnected = true;
+    });
+
+    // Bring the worker back up on the same port but as a half-open worker that
+    // accepts sockets yet never answers discover.
+    await worker.close();
+    worker = await startFakeWorker(port, { answerDiscover: false });
+
+    // Give the bridge several reconnect cycles. Each accepts the socket, hangs
+    // on discover, times out, tears down, and retries — it must NOT wedge. With
+    // discover unanswered it can never finish a reconnect, so "reconnected"
+    // must not fire. (isConnected is intentionally not asserted here: the socket
+    // is briefly open during each RPC window, so that flag races the cycle.)
+    await new Promise((r) => setTimeout(r, 600));
+    expect(reconnected).toBe(false);
+    // Multiple half-open cycles must have been attempted (the worker has seen
+    // more than one connection), proving the loop is alive, not stuck.
+    expect(worker.connectionCount()).toBeGreaterThan(1);
+
+    // Now let the worker answer discover again; the next reconnect cycle must
+    // succeed — proving the loop never got stuck with reconnect disabled.
+    worker.setOptions({ answerDiscover: true });
+    await waitFor(() => reconnected, 10000);
+    expect(bridge.isConnected).toBe(true);
+
+    const result = await bridge.execute(
+      "fake.TestNode",
+      { value: "healed" },
+      {},
+      {}
+    );
+    expect(result.outputs).toEqual({ out: "healed" });
+  });
+
+  it("connect() resolves even if worker.status never answers", async () => {
+    // STATUS TIMEOUT: discover succeeds but worker.status hangs. connect()
+    // tolerates a status timeout (load_errors simply unavailable) and resolves.
+    worker = await startFakeWorker(0, { answerStatus: false });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`,
+      statusTimeoutMs: 150,
+      // Keep the overall RPC bound comfortably above the status timeout so the
+      // status timeout (not the RPC timeout) is what we exercise.
+      reconnectRpcTimeoutMs: 5000
+    });
+
+    await bridge.connect();
+    expect(bridge.isConnected).toBe(true);
+    expect(bridge.getNodeMetadata()).toHaveLength(1);
+  });
+
+  it("executeStream() yields the single final result for a zero-chunk stream", async () => {
+    // EMPTY-TERMINATOR PARITY: the worker emits only the empty result
+    // terminator ({outputs:{}, blobs:{}}) and no chunks. The bridge's
+    // emittedCount===0 && finalResult branch must yield exactly that one frame.
+    worker = await startFakeWorker(0, { streamMode: "empty" });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    const seen: Array<{ outputs: Record<string, unknown> }> = [];
+    for await (const chunk of bridge.executeStream(
+      "fake.TestNode",
+      {},
+      {},
+      {}
+    )) {
+      seen.push(chunk);
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.outputs).toEqual({});
+  });
+
+  it("providerStream() yields chunks in order then terminates", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    const seen: unknown[] = [];
+    for await (const chunk of bridge.providerStream(
+      "fake-provider",
+      [{ role: "user", content: "hi" }],
+      "fake-model"
+    )) {
+      seen.push(chunk.content);
+    }
+    expect(seen).toEqual(["p-chunk-1", "p-chunk-2"]);
+  });
+});

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -35,9 +35,10 @@ import {
 import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   PythonNodeExecutor,
-  PythonStdioBridge,
+  createPythonBridge,
   logPythonWorkerStderr,
-  type NodeExecutor
+  type NodeExecutor,
+  type PythonBridge
 } from "@nodetool-ai/runtime";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
 import { handleOpenAIRequest, type OpenAIApiOptions } from "./openai-api.js";
@@ -108,7 +109,7 @@ function getStorageHandler(
 
 type WorkflowRuntimeEnvironment = {
   registry: NodeRegistry;
-  pythonBridge: PythonStdioBridge;
+  pythonBridge: PythonBridge;
   ensurePythonBridge: () => Promise<void>;
   resolveExecutor: (node: {
     id: string;
@@ -132,7 +133,7 @@ async function getWorkflowRuntimeEnvironment(
           log
         }));
 
-      const pythonBridge = new PythonStdioBridge({
+      const pythonBridge = createPythonBridge({
         workerArgs: process.env["NODETOOL_WORKER_NAMESPACES"]
           ? ["--namespaces", process.env["NODETOOL_WORKER_NAMESPACES"]]
           : []

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -25,9 +25,10 @@ import {
 import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   PythonNodeExecutor,
-  PythonStdioBridge,
+  createPythonBridge,
   logPythonWorkerStderr,
-  type NodeExecutor
+  type NodeExecutor,
+  type PythonBridge
 } from "@nodetool-ai/runtime";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
 import type { AgentTransport } from "./agent/transport.js";
@@ -61,7 +62,7 @@ async function getUnifiedNodeMetadata(
 
 type RuntimeEnvironment = {
   registry: NodeRegistry;
-  pythonBridge: PythonStdioBridge;
+  pythonBridge: PythonBridge;
   ensurePythonBridge: () => Promise<void>;
   resolveExecutor: (node: {
     id: string;
@@ -83,7 +84,7 @@ function getRuntimeEnvironment(
         log
       });
 
-      const pythonBridge = new PythonStdioBridge({
+      const pythonBridge = createPythonBridge({
         workerArgs: process.env["NODETOOL_WORKER_NAMESPACES"]
           ? ["--namespaces", process.env["NODETOOL_WORKER_NAMESPACES"]]
           : []

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -21,7 +21,7 @@ import {
   type VideoModel
 } from "@nodetool-ai/runtime";
 import type { BaseProvider } from "@nodetool-ai/runtime";
-import type { PythonStdioBridge } from "@nodetool-ai/runtime";
+import type { PythonBridge } from "@nodetool-ai/runtime";
 import {
   readCachedHfModels,
   searchCachedHfModels,
@@ -298,7 +298,7 @@ import { PythonProvider, registerProvider } from "@nodetool-ai/runtime";
  * via the Python stdio bridge. Call after the bridge has connected.
  */
 export async function registerPythonProviders(
-  bridge: PythonStdioBridge
+  bridge: PythonBridge
 ): Promise<string[]> {
   const providers = await bridge.listProviders();
   const registered: string[] = [];

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -3,7 +3,7 @@ import { createLogger } from "@nodetool-ai/config";
 import { WsAdapter } from "../ws-adapter.js";
 import { UnifiedWebSocketRunner } from "../unified-websocket-runner.js";
 import { createGraphNodeTypeResolver, type NodeRegistry } from "@nodetool-ai/node-sdk";
-import type { PythonStdioBridge } from "@nodetool-ai/runtime";
+import type { PythonBridge } from "@nodetool-ai/runtime";
 import { PythonNodeExecutor, getProvider } from "@nodetool-ai/runtime";
 import { getSecret as getStoredSecret } from "@nodetool-ai/models";
 import type { HttpApiOptions } from "../http-api.js";
@@ -12,7 +12,7 @@ const log = createLogger("nodetool.websocket.ws");
 
 export interface WebSocketPluginOptions {
   registry: NodeRegistry;
-  pythonBridge: PythonStdioBridge;
+  pythonBridge: PythonBridge;
   getPythonBridgeReady: () => boolean;
   ensurePythonBridge: () => Promise<void>;
   /** Forwarded to the runner for read-only RPC commands (list_workflows, …). */

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -25,8 +25,9 @@ import { registerTransformersJsProvider } from "@nodetool-ai/transformers-js-pro
 import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   initTelemetry,
-  PythonStdioBridge,
-  logPythonWorkerStderr
+  createPythonBridge,
+  logPythonWorkerStderr,
+  type PythonBridge
 } from "@nodetool-ai/runtime";
 import { initMasterKey } from "@nodetool-ai/security";
 import {
@@ -162,7 +163,7 @@ async function broadcastResourceChange(
 
 async function notifyPythonBridgeResourceChanges(
   app: FastifyInstance,
-  pythonBridge: PythonStdioBridge
+  pythonBridge: PythonBridge
 ): Promise<void> {
   await broadcastResourceChange(app, {
     event: "updated",
@@ -384,7 +385,7 @@ if (process.env["NODETOOL_ENV"] !== "production") {
 // Python bridge
 // ---------------------------------------------------------------------------
 
-const pythonBridge = new PythonStdioBridge({
+const pythonBridge = createPythonBridge({
   workerArgs: process.env["NODETOOL_WORKER_NAMESPACES"]
     ? ["--namespaces", process.env["NODETOOL_WORKER_NAMESPACES"]]
     : []
@@ -981,8 +982,8 @@ if (process.platform === "win32") {
   process.on("SIGBREAK", () => void shutdown("SIGBREAK"));
 }
 
-// Start Python bridge eagerly if Python is installed.
-if (pythonBridge.hasPython()) {
+// Start Python bridge eagerly if a worker is available.
+if (pythonBridge.isAvailable()) {
   log.info(`Starting Python bridge eagerly [${startupMs()}]`);
   pythonBridge
     .ensureConnected()

--- a/packages/websocket/src/trpc/context.ts
+++ b/packages/websocket/src/trpc/context.ts
@@ -1,20 +1,20 @@
 import type { FastifyRequest } from "fastify";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
-import type { PythonStdioBridge } from "@nodetool-ai/runtime";
+import type { PythonBridge } from "@nodetool-ai/runtime";
 import type { HttpApiOptions } from "../http-api.js";
 
 export interface Context {
   userId: string | null;
   registry: NodeRegistry;
   apiOptions: HttpApiOptions;
-  pythonBridge: PythonStdioBridge;
+  pythonBridge: PythonBridge;
   getPythonBridgeReady: () => boolean;
 }
 
 export interface ContextFactoryInput {
   registry: NodeRegistry;
   apiOptions: HttpApiOptions;
-  pythonBridge: PythonStdioBridge;
+  pythonBridge: PythonBridge;
   getPythonBridgeReady: () => boolean;
 }
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -85,7 +85,7 @@ import {
 } from "@nodetool-ai/agents";
 import { RunNodeTool } from "./agent/run-node-tool.js";
 import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
-import type { PythonStdioBridge } from "@nodetool-ai/runtime";
+import type { PythonBridge } from "@nodetool-ai/runtime";
 import { appRouter } from "./trpc/router.js";
 import { createCallerFactory } from "./trpc/index.js";
 import type { HttpApiOptions } from "./http-api.js";
@@ -741,7 +741,7 @@ export interface UnifiedWebSocketRunnerOptions {
    * accept the bridge in their context. Plain workflow execution and chat
    * keep working without it.
    */
-  pythonBridge?: PythonStdioBridge;
+  pythonBridge?: PythonBridge;
   /** Whether the Python bridge has finished hydrating. Same wiring as the tRPC HTTP context. */
   getPythonBridgeReady?: () => boolean;
   /** API options forwarded into the tRPC context (metadata roots, registry, etc.). */
@@ -765,7 +765,7 @@ export class UnifiedWebSocketRunner {
   private getNodeMetadata?: UnifiedWebSocketRunnerOptions["getNodeMetadata"];
   private validateNode?: UnifiedWebSocketRunnerOptions["validateNode"];
   private nodeRegistry?: NodeRegistry;
-  private pythonBridge?: PythonStdioBridge;
+  private pythonBridge?: PythonBridge;
   private getPythonBridgeReady?: () => boolean;
   private apiOptions?: HttpApiOptions;
   private configuredProvidersCache: Map<string, Record<string, BaseProvider>> =


### PR DESCRIPTION
## What

Adds a second Python-worker transport: a **WebSocket** bridge for a remote/Dockerized worker, alongside the existing local stdio bridge.

- **`PythonBridgeBase`** (new abstract class): all transport-agnostic logic extracted from `PythonStdioBridge` (message dispatch, request correlation, `execute`/`executeStream`, every `provider.*` method, metadata/status). `PythonStdioBridge` now extends it (−657 lines of duplication).
- **`WebsocketPythonBridge`** (new): connect-to-`wsUrl` bridge over `ws://`/`wss://` with exponential-backoff **auto-reconnect** (re-discovers on reconnect). One WS binary message == one msgpack frame (no length prefix).
- **`createPythonBridge()`** factory + **`NODETOOL_WORKER_URL`** selector: returns the WebSocket bridge when `NODETOOL_WORKER_URL` (or `options.wsUrl`) is set, else the local stdio subprocess bridge. The boot-time auto-connect gate generalizes from stdio-only `hasPython()` to a transport-agnostic `isAvailable()`.
- Consumers retyped `PythonStdioBridge` → `PythonBridge` (the base); production construction unchanged when the env var is unset.

## Why

Enables running the Python node-runner as a remote/containerized worker (e.g. the Docker image on `:7777`) instead of only a local subprocess — usable in production, unlike the local-only stdio bridge. Pairs with **nodetool-ai/nodetool-core#918** (the server-side WS protocol parity).

## Usage

```
NODETOOL_WORKER_URL=ws://127.0.0.1:7777   # -> WebsocketPythonBridge (remote/Docker)
# unset                                   # -> PythonStdioBridge (local subprocess)
```

## Review caught + fixed (adversarial review with reproductions)

- 🔴 **CRITICAL**: terminating a CONNECTING socket after its error listener was removed crashed the host process — fixed with error sinks at every teardown site; proven by a mutation test.
- 🟠 **HIGH**: reconnect could wedge forever (unbounded discover/status RPCs) — fixed with `reconnectRpcTimeoutMs`; proven by an empirical reconnect-cycle test.

## Test plan

- New `python-websocket-bridge.test.ts` (in-process fake `ws` worker): connect/discover, execute, `executeStream`, `provider.stream`, `worker.status`, in-flight rejection on drop, full reconnect cycle, crash-repro (stalled upgrade), half-open RPC timeout, status-timeout-still-resolves.
- New `python-bridge-factory.test.ts`: selector precedence (asserts the chosen URL, not just type).
- `tsc --noEmit` clean (runtime + websocket); full runtime suite green (1019); stdio bridge tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)