### PR TITLE
Fix video node ref handling and frame numbering

### DIFF
--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -10,7 +10,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
-  audioBytes,
   audioBytesAsync,
   toBytes
 } from "@nodetool-ai/audio-nodes";
@@ -62,6 +61,23 @@ function filePath(uriOrPath: string): string {
     }
   }
   return uriOrPath;
+}
+
+/**
+ * Resolve a folder value to a filesystem path. Accepts either a plain string
+ * path/URI or a folder ref object (`{ uri }`); returns "" when no usable path
+ * is present. Coercing the ref object with `String()` would yield
+ * "[object Object]", so callers must funnel folder props through here.
+ */
+function folderPath(raw: unknown): string {
+  if (typeof raw === "string") {
+    return raw.startsWith("file:") ? filePath(raw) : raw;
+  }
+  if (raw && typeof raw === "object") {
+    const uri = (raw as Record<string, unknown>).uri;
+    if (typeof uri === "string" && uri.length > 0) return filePath(uri);
+  }
+  return "";
 }
 
 function dateName(name: string): string {
@@ -511,8 +527,8 @@ export class SaveVideoFileVideoNode extends BaseNode {
   declare filename: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const folder = String(this.folder ?? ".");
-    const fname = dateName(String(this.filename ?? "video.mp4"));
+    const folder = folderPath(this.folder) || ".";
+    const fname = dateName(String(this.filename || "video.mp4"));
     const p = path.resolve(folder, fname);
     await fs.mkdir(path.dirname(p), { recursive: true });
     await fs.writeFile(p, await videoBytesAsync(this.video, context));
@@ -575,15 +591,7 @@ export class LoadVideoAssetsNode extends BaseNode {
     video: unknown;
     name: string;
   }> {
-    const raw = this.folder;
-    const folder =
-      typeof raw === "string" && raw.length > 0
-        ? raw.startsWith("file:")
-          ? filePath(raw)
-          : raw
-        : typeof raw === "object" && raw !== null && typeof (raw as Record<string, unknown>).uri === "string" && ((raw as Record<string, unknown>).uri as string).length > 0
-          ? filePath((raw as Record<string, unknown>).uri as string)
-          : "";
+    const folder = folderPath(this.folder);
     if (!folder) return;
     let entries;
     try {
@@ -669,8 +677,8 @@ export class SaveVideoNode extends BaseNode {
   declare name: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const folder = String(this.folder ?? ".");
-    const filename = dateName(String(this.name ?? "video.mp4"));
+    const folder = folderPath(this.folder) || ".";
+    const filename = dateName(String(this.name || "video.mp4"));
     const full = path.resolve(folder, filename);
     await fs.mkdir(path.dirname(full), { recursive: true });
     const bytes = await videoBytesAsync(this.video, context);
@@ -938,16 +946,23 @@ export class FrameToVideoNode extends BaseNode {
     );
     const outputPath = path.join(outputDir, "output.mp4");
     try {
-      // Write each frame as a numbered PNG file
-      for (let i = 0; i < frames.length; i++) {
-        const f = frames[i];
+      // Write each frame as a numbered PNG file. Use a contiguous counter
+      // (not the loop index) so skipped/empty frames don't leave gaps in the
+      // sequence — ffmpeg's image2 demuxer stops at the first missing number.
+      let written = 0;
+      for (const f of frames) {
         if (!f || typeof f !== "object") continue;
         const frameBytes = toBytes((f as { data?: Uint8Array | string }).data);
         if (frameBytes.length === 0) continue;
+        written += 1;
         await fs.writeFile(
-          path.join(inputDir, `frame_${String(i + 1).padStart(6, "0")}.png`),
+          path.join(inputDir, `frame_${String(written).padStart(6, "0")}.png`),
           frameBytes
         );
+      }
+      if (written === 0) {
+        await outputs.emit("output", videoRef(new Uint8Array()));
+        return;
       }
 
       await execFile(
@@ -990,16 +1005,20 @@ export class FrameToVideoNode extends BaseNode {
     );
     const outputPath = path.join(outputDir, "output.mp4");
     try {
-      for (let i = 0; i < frames.length; i++) {
-        const f = frames[i];
+      // Contiguous counter so skipped/empty frames don't leave gaps in the
+      // numbered sequence (ffmpeg's image2 demuxer stops at the first gap).
+      let written = 0;
+      for (const f of frames) {
         if (!f || typeof f !== "object") continue;
         const frameBytes = toBytes((f as { data?: Uint8Array | string }).data);
         if (frameBytes.length === 0) continue;
+        written += 1;
         await fs.writeFile(
-          path.join(inputDir, `frame_${String(i + 1).padStart(6, "0")}.png`),
+          path.join(inputDir, `frame_${String(written).padStart(6, "0")}.png`),
           frameBytes
         );
       }
+      if (written === 0) return { output: videoRef(new Uint8Array()) };
 
       const fps = Math.max(1, Number(this.fps ?? 30));
       await execFile(
@@ -2198,7 +2217,7 @@ export class AddAudioVideoNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const v = await videoBytesAsync(this.video, context);
-    const a = audioBytes(this.audio);
+    const a = await audioBytesAsync(this.audio, context);
     if (v.length === 0) return { output: videoRef(v) };
     if (a.length === 0) return { output: videoRef(v) };
 
@@ -2324,9 +2343,10 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
-    const color = String(this.key_color ?? "0x00FF00");
-    const similarity = Number(this.similarity ?? 0.1);
-    const blend = Number(this.blend ?? 0.0);
+    const keyColorObj = this.key_color as { value?: string } | undefined;
+    const color = String(keyColorObj?.value ?? "#00FF00").replace("#", "0x");
+    const similarity = Number(this.similarity ?? 0.3);
+    const blend = Number(this.blend ?? 0.1);
     const transformed =
       (await ffmpegTransform(bytes, [
         "-vf",

--- a/packages/video-nodes/tests/regression-video.test.ts
+++ b/packages/video-nodes/tests/regression-video.test.ts
@@ -7,6 +7,9 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 // Capture all execFile calls so we can inspect ffmpeg/ffprobe arguments
 let execFileCalls: Array<{ cmd: string; args: string[] }> = [];
@@ -122,7 +125,10 @@ const {
   FpsNode,
   GetVideoInfoNode,
   TrimVideoNode,
-  AddAudioVideoNode
+  AddAudioVideoNode,
+  ChromaKeyVideoNode,
+  SaveVideoNode,
+  FrameToVideoNode
 } = await import("@nodetool-ai/video-nodes");
 
 function videoRef(bytes: number[]) {
@@ -674,5 +680,124 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
 
     const args = ffmpegArgString();
     expect(args).not.toContain("amix");
+  });
+
+  it("loads audio from a file:// URI (async), not just inline data", async () => {
+    // Audio supplied as a URI ref with no inline `data` — the node must load
+    // it via the async loader. With the old synchronous `audioBytes`, the
+    // bytes would be empty and the node would return early WITHOUT calling
+    // ffmpeg. A real temp file backs the URI so audioBytesAsync can read it.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-aatest-"));
+    const wavPath = path.join(dir, "track.wav");
+    await fs.writeFile(wavPath, Buffer.from([10, 20, 30, 40, 50]));
+    try {
+      const node = new AddAudioVideoNode();
+      node.assign({
+        video: videoRef([1, 2, 3, 4]),
+        audio: { type: "audio", uri: `file://${wavPath}`, data: null },
+        volume: 1.0,
+        mix: false
+      });
+      await node.process();
+
+      // ffmpeg must have been invoked, proving the URI-backed audio loaded.
+      expect(ffmpegCalls().length).toBeGreaterThan(0);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── 11. ChromaKey ───────────────────────────────────────────────────────────
+
+describe("ChromaKeyVideoNode — uses the color ref value, not [object Object]", () => {
+  it("converts key_color.value (#RRGGBB) to ffmpeg's 0x form", async () => {
+    const node = new ChromaKeyVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      key_color: { type: "color", value: "#00FF00" },
+      similarity: 0.3,
+      blend: 0.1
+    });
+    await node.process();
+
+    const args = ffmpegArgString();
+    expect(args).toContain("colorkey=0x00FF00:0.3:0.1");
+    expect(args).not.toContain("[object Object]");
+  });
+
+  it("honors a non-default key color", async () => {
+    const node = new ChromaKeyVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      key_color: { type: "color", value: "#0000FF" },
+      similarity: 0.2,
+      blend: 0.05
+    });
+    await node.process();
+
+    const args = ffmpegArgString();
+    expect(args).toContain("colorkey=0x0000FF");
+  });
+});
+
+// ─── 12. SaveVideo (folder ref resolution) ───────────────────────────────────
+
+describe("SaveVideoNode — resolves a folder ref object to a path", () => {
+  it("writes under the folder ref's uri, not a [object Object] directory", async () => {
+    const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-savetest-"));
+    const writeSpy = vi.spyOn(fs, "writeFile").mockResolvedValue(undefined);
+    const mkdirSpy = vi
+      .spyOn(fs, "mkdir")
+      .mockResolvedValue(undefined as unknown as string);
+    try {
+      const node = new SaveVideoNode();
+      node.assign({
+        video: videoRef([1, 2, 3, 4]),
+        folder: { type: "folder", uri: `file://${targetDir}`, asset_id: null },
+        name: "clip.mp4"
+      });
+      await node.process();
+
+      expect(writeSpy).toHaveBeenCalled();
+      const writtenPath = String(writeSpy.mock.calls[0][0]);
+      expect(writtenPath).not.toContain("[object Object]");
+      expect(writtenPath).toBe(path.join(targetDir, "clip.mp4"));
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      await fs.rm(targetDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── 13. FrameToVideo (contiguous numbering) ─────────────────────────────────
+
+describe("FrameToVideoNode — numbers frames contiguously despite gaps", () => {
+  it("skips empty frames without leaving holes in the PNG sequence", async () => {
+    const writeSpy = vi.spyOn(fs, "writeFile").mockResolvedValue(undefined);
+    try {
+      const img = (bytes: number[]) => ({
+        type: "image",
+        data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+      });
+      const node = new FrameToVideoNode();
+      // Middle frame is empty (no data) and must be skipped, but the two valid
+      // frames should still be written as frame_000001 and frame_000002.
+      node.assign({
+        frame: [img([1, 2, 3]), { type: "image", data: "" }, img([4, 5, 6])],
+        fps: 24
+      });
+      await node.process();
+
+      const frameWrites = writeSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((p) => p.includes("frame_"))
+        .map((p) => path.basename(p))
+        .sort();
+      expect(frameWrites).toEqual(["frame_000001.png", "frame_000002.png"]);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
Fixes several bugs in video nodes where object references (folder, color, audio) were being coerced to strings incorrectly, resulting in "[object Object]" in file paths and ffmpeg arguments. Also fixes frame numbering in `FrameToVideoNode` to be contiguous despite gaps, and adds comprehensive regression tests.

## Key Changes

### Source Code (`packages/video-nodes/src/nodes/video.ts`)
- **AddAudioVideoNode**: Changed from synchronous `audioBytes()` to async `audioBytesAsync()` to properly load audio from file:// URIs instead of only inline data
- **ChromaKeyVideoNode**: Extract `.value` from color ref object and convert `#RRGGBB` to ffmpeg's `0x` format; fixed default similarity (0.1 → 0.3) and blend (0.0 → 0.1)
- **SaveVideoNode & SaveVideoFileVideoNode**: Added `folderPath()` helper to properly resolve folder ref objects to filesystem paths instead of coercing to "[object Object]"
- **LoadVideoAssetsNode**: Refactored to use new `folderPath()` helper, eliminating duplicated ref-resolution logic
- **FrameToVideoNode**: Fixed frame numbering to use a contiguous counter (`written`) instead of loop index, so skipped/empty frames don't leave gaps in the PNG sequence that would cause ffmpeg's image2 demuxer to stop prematurely; added early return when no frames are written

### Tests (`packages/video-nodes/tests/regression-video.test.ts`)
- Added test for `AddAudioVideoNode` loading audio from file:// URI (async loader)
- Added tests for `ChromaKeyVideoNode` color ref value extraction and hex-to-0x conversion
- Added test for `SaveVideoNode` folder ref resolution
- Added test for `FrameToVideoNode` contiguous numbering with gaps

## Implementation Details
- New `folderPath()` utility handles both string paths/URIs and folder ref objects with `.uri` property
- Frame numbering now uses a separate counter that only increments for non-empty frames, ensuring ffmpeg sees a contiguous sequence (frame_000001.png, frame_000002.png, etc.) even if input frames have gaps
- Color ref extraction follows the pattern: check for `.value` property on the ref object, then apply string transformations

https://claude.ai/code/session_01EBSBnuRtJvhx7nSL76UufR