### PR TITLE
Fix bugs in topaz-nodes API client

### DIFF
--- a/packages/topaz-nodes/src/topaz-base.ts
+++ b/packages/topaz-nodes/src/topaz-base.ts
@@ -119,20 +119,60 @@ function authHeaders(
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve a `Retry-After` header to milliseconds. The header may be either a
+ * delay in seconds or an HTTP date; an unparseable value falls back to the
+ * caller's backoff so we never end up with `sleep(NaN)` (≈ immediate retry).
+ */
+export function parseRetryAfterMs(
+  headerValue: string | null,
+  fallbackMs: number
+): number {
+  if (!headerValue) return fallbackMs;
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const dateMs = Date.parse(headerValue);
+  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
+  return fallbackMs;
+}
+
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT"]);
+
+/**
+ * Fetch with backoff on retryable statuses (and transient network errors).
+ *
+ * Only idempotent requests (GET/HEAD, and PUTs to presigned upload URLs) are
+ * retried — retrying a job-creating POST or a state-transitioning PATCH could
+ * duplicate work (e.g. submit two billable video jobs) when the server already
+ * acted before returning a 5xx, so those get a single attempt.
+ */
 async function fetchWithRetry(
   url: string,
   init: RequestInit = {},
   maxAttempts = 6
 ): Promise<Response> {
+  const method = (init.method ?? "GET").toUpperCase();
+  const attempts = IDEMPOTENT_METHODS.has(method) ? maxAttempts : 1;
   let delay = 1000;
   let last: Response | undefined;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const resp = await fetch(url, init);
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let resp: Response;
+    try {
+      resp = await fetch(url, init);
+    } catch (err) {
+      // Network-level failure (reset/timeout). Retry idempotent requests;
+      // surface immediately otherwise.
+      if (attempt === attempts) throw err;
+      await sleep(delay);
+      delay = Math.min(delay * 2, 30000);
+      continue;
+    }
     if (!RETRYABLE_STATUS.has(resp.status)) return resp;
     last = resp;
-    if (attempt === maxAttempts) break;
-    const retryAfter = resp.headers.get("Retry-After");
-    const wait = retryAfter ? Number(retryAfter) * 1000 : delay;
+    if (attempt === attempts) break;
+    const wait = parseRetryAfterMs(resp.headers.get("Retry-After"), delay);
+    // Drain the discarded body so the connection can be reused.
+    await resp.arrayBuffer().catch(() => undefined);
     await sleep(wait);
     delay = Math.min(delay * 2, 30000);
   }
@@ -164,7 +204,7 @@ async function pollUntilTerminal(
     if (FAILURE_STATES.has(status)) {
       throw new Error(`Topaz job failed: ${JSON.stringify(data)}`);
     }
-    await sleep(pollInterval);
+    if (attempt < maxAttempts - 1) await sleep(pollInterval);
   }
   throw new Error(
     `Topaz job did not complete within ${maxAttempts} poll attempts`
@@ -353,9 +393,15 @@ function detectImageMime(bytes: Uint8Array): string {
   }
   if (
     bytes.length >= 4 &&
-    bytes[0] === 0x49 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x2a
+    // TIFF little-endian (II*\0) or big-endian (MM\0*).
+    ((bytes[0] === 0x49 &&
+      bytes[1] === 0x49 &&
+      bytes[2] === 0x2a &&
+      bytes[3] === 0x00) ||
+      (bytes[0] === 0x4d &&
+        bytes[1] === 0x4d &&
+        bytes[2] === 0x00 &&
+        bytes[3] === 0x2a))
   ) {
     return "image/tiff";
   }
@@ -579,6 +625,9 @@ export async function topazExecuteVideoTask(
   }
   const acceptJson = (await accept.json()) as Record<string, unknown>;
   // Spec: { uploadId, urls[] }. Tolerate legacy shapes just in case.
+  const uploadId = (acceptJson.uploadId ?? acceptJson.upload_id) as
+    | string
+    | undefined;
   const uploadUrls = (acceptJson.urls ??
     acceptJson.uploadUrls ??
     (acceptJson.uploadUrl ? [acceptJson.uploadUrl] : [])) as string[];
@@ -588,14 +637,16 @@ export async function topazExecuteVideoTask(
 
   // 3. PUT bytes (single- or multi-part)
   const size = videoBytes.byteLength;
-  const partSize = Math.ceil(size / uploadUrls.length);
+  const partSize = Math.max(1, Math.ceil(size / uploadUrls.length));
   const uploadResults: Array<{ partNum: number; eTag: string }> = [];
   const uploadContentType = containerContentType(sourceMeta.container);
   for (let i = 0; i < uploadUrls.length; i++) {
-    const slice = videoBytes.slice(
-      i * partSize,
-      Math.min((i + 1) * partSize, size)
-    );
+    const start = i * partSize;
+    // Equal ceil-sized chunks can leave trailing presigned URLs with no bytes
+    // (e.g. 9 bytes across 4 URLs → parts 3/3/3/0). Stop once the source is
+    // fully consumed rather than PUT empty parts, which the API rejects.
+    if (start >= size) break;
+    const slice = videoBytes.slice(start, Math.min(start + partSize, size));
     const put = await fetchWithRetry(uploadUrls[i], {
       method: "PUT",
       headers: { "Content-Type": uploadContentType },
@@ -610,13 +661,15 @@ export async function topazExecuteVideoTask(
     });
   }
 
-  // 4. Complete upload
+  // 4. Complete upload. Echo back the uploadId from accept when present so the
+  // API can correlate the multipart upload it handed out.
+  const completeBody = uploadId ? { uploadId, uploadResults } : { uploadResults };
   const complete = await fetchWithRetry(
     spec.completeEndpoint.replace("{request_id}", requestId),
     {
       method: "PATCH",
       headers: authHeaders(apiKey, { "Content-Type": "application/json" }),
-      body: JSON.stringify({ uploadResults })
+      body: JSON.stringify(completeBody)
     }
   );
   if (!complete.ok) {

--- a/packages/topaz-nodes/tests/topaz-base.test.ts
+++ b/packages/topaz-nodes/tests/topaz-base.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   containerContentType,
   getApiKey,
+  parseRetryAfterMs,
   refToBytes,
   sourceContainerFromRef,
   topazExecuteImageTask,
@@ -206,6 +207,28 @@ describe("containerContentType", () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseRetryAfterMs
+// ---------------------------------------------------------------------------
+describe("parseRetryAfterMs", () => {
+  it("treats a numeric value as seconds", () => {
+    expect(parseRetryAfterMs("2", 5000)).toBe(2000);
+    expect(parseRetryAfterMs("0", 5000)).toBe(0);
+  });
+
+  it("treats an HTTP-date value as an absolute deadline", () => {
+    const ms = parseRetryAfterMs(new Date(Date.now() + 4000).toUTCString(), 9999);
+    // Allow a little slack for clock drift during the call.
+    expect(ms).toBeGreaterThan(2000);
+    expect(ms).toBeLessThanOrEqual(4000);
+  });
+
+  it("falls back (never NaN) for missing or unparseable values", () => {
+    expect(parseRetryAfterMs(null, 5000)).toBe(5000);
+    expect(parseRetryAfterMs("not-a-date", 5000)).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // topazExecuteVideoTask
 // ---------------------------------------------------------------------------
 describe("topazExecuteVideoTask", () => {
@@ -406,6 +429,103 @@ describe("topazExecuteVideoTask", () => {
       { ...sourceMeta, container: "weirdformat" }
     );
     expect(captured[0]).toBe("application/octet-stream");
+  });
+
+  it("skips empty trailing parts when accept returns more URLs than bytes", async () => {
+    const uploaded: Array<{ url: string; length: number }> = [];
+    let completeBody: { uploadResults: Array<{ partNum: number }> } | undefined;
+
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u === spec.submitEndpoint) {
+        return { ok: true, json: async () => ({ requestId: "r3" }) } as Response;
+      }
+      if (u.endsWith("/accept")) {
+        // 4 presigned URLs but only 3 source bytes — a ceil split leaves the
+        // 4th part empty (3/3/3/0 at partSize 1).
+        return {
+          ok: true,
+          json: async () => ({
+            uploadId: "up-3",
+            urls: [
+              "https://upload.topaz/p1",
+              "https://upload.topaz/p2",
+              "https://upload.topaz/p3",
+              "https://upload.topaz/p4"
+            ]
+          })
+        } as Response;
+      }
+      if (u.startsWith("https://upload.topaz/")) {
+        const body = init?.body as Uint8Array;
+        uploaded.push({ url: u, length: body.byteLength });
+        return {
+          ok: true,
+          headers: new Headers({ ETag: '"e"' })
+        } as unknown as Response;
+      }
+      if (u.endsWith("/complete-upload/")) {
+        completeBody = JSON.parse((init?.body as string) ?? "{}");
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      if (u.endsWith("/status")) {
+        return {
+          ok: true,
+          json: async () => ({
+            status: "complete",
+            download: { url: "https://cdn/v" }
+          })
+        } as Response;
+      }
+      if (u === "https://cdn/v") {
+        return {
+          ok: true,
+          arrayBuffer: async () => Uint8Array.from([1]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    await topazExecuteVideoTask(
+      "key",
+      spec,
+      { model: "prob-4" },
+      Uint8Array.from([1, 2, 3]),
+      sourceMeta
+    );
+
+    // Only 3 non-empty parts are uploaded; the 4th URL is left unused.
+    expect(uploaded.length).toBe(3);
+    expect(uploaded.every((p) => p.length > 0)).toBe(true);
+    expect(completeBody?.uploadResults.length).toBe(3);
+    expect(completeBody?.uploadResults.map((r) => r.partNum)).toEqual([1, 2, 3]);
+  });
+
+  it("does not retry the job-creating POST on a 5xx", async () => {
+    let createCalls = 0;
+    global.fetch = vi.fn(async (url: string | URL) => {
+      if (String(url) === spec.submitEndpoint) {
+        createCalls++;
+        return {
+          ok: false,
+          status: 503,
+          text: async () => "overloaded"
+        } as Response;
+      }
+      throw new Error(`unexpected: ${String(url)}`);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      topazExecuteVideoTask(
+        "key",
+        spec,
+        { model: "prob-4" },
+        Uint8Array.from([1, 2]),
+        sourceMeta
+      )
+    ).rejects.toThrow("Topaz create failed: 503");
+    // A retried POST could submit a second billable job — must be exactly one.
+    expect(createCalls).toBe(1);
   });
 });
 


### PR DESCRIPTION
Five fixes in the shared Topaz API utilities, with regression tests:

- Multipart video upload: an equal ceil-sized split across N presigned URLs
  could leave trailing zero-byte parts (e.g. 9 bytes / 4 URLs -> 3/3/3/0),
  producing empty PUTs and an empty-part entry in complete-upload that the
  API rejects. Stop once the source is fully consumed instead.
- Retry safety: fetchWithRetry now only retries idempotent requests
  (GET/HEAD and presigned PUTs). Retrying a job-creating POST or a
  state-transitioning PATCH on a 5xx could submit duplicate (billable)
  jobs when the server already acted before the error.
- Retry-After: handle the HTTP-date form. A date made Number(value) NaN,
  so wait=NaN and sleep(NaN) retried immediately with no backoff.
- detectImageMime: also recognize big-endian TIFF (MM\0*), a supported
  input format previously mis-tagged as application/octet-stream.
- complete-upload: echo back the uploadId returned by accept so the API
  can correlate the multipart upload.

Also: retry transient network errors on idempotent requests, drain
discarded response bodies before retrying, and drop a redundant trailing
sleep in the status poll loop.

https://claude.ai/code/session_01Uysmd384ESuk5FrsDhJKF7