### PR TITLE
fix(image-nodes): correct Contour kernel, LoadImageFolder path output, Fit/Crop bounds, and GPU cleanup

### DIFF
--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -147,7 +147,17 @@ function inferImageMime(uri: string | undefined, bytes: Uint8Array): string {
   if (bytes[0] === 0xff && bytes[1] === 0xd8) return "image/jpeg";
   if (bytes[0] === 0x47 && bytes[1] === 0x49) return "image/gif";
   if (bytes[0] === 0x42 && bytes[1] === 0x4d) return "image/bmp";
-  if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[8] === 0x57)
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // "R"
+    bytes[1] === 0x49 && // "I"
+    bytes[2] === 0x46 && // "F"
+    bytes[3] === 0x46 && // "F"
+    bytes[8] === 0x57 && // "W"
+    bytes[9] === 0x45 && // "E"
+    bytes[10] === 0x42 && // "B"
+    bytes[11] === 0x50 // "P"
+  )
     return "image/webp";
   if (
     bytes[0] === 0x89 &&
@@ -364,12 +374,14 @@ export class LoadImageFolderNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const collected: Record<string, unknown>[] = [];
+    let firstPath = "";
     for await (const item of this._loadImages()) {
+      if (collected.length === 0) firstPath = String(item.path ?? "");
       collected.push(item.image as Record<string, unknown>);
     }
     return {
       image: collected[0] ?? {},
-      name: "",
+      path: firstPath,
       images: collected
     };
   }
@@ -433,7 +445,7 @@ export class LoadImageFolderNode extends BaseNode {
           width: meta.width,
           height: meta.height
         }),
-        name: file.name
+        path: file.fullPath
       };
     }
   }
@@ -1044,16 +1056,7 @@ export class ScaleNode extends TransformImageNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const image = (this.image ?? {}) as ImageRefLike;
     const requestedScale = Number(this.scale ?? 0);
-    const targetWidth = 0;
-    const targetHeight = 0;
-    const scale =
-      requestedScale > 0
-        ? requestedScale
-        : targetWidth > 0 && (image.width ?? 0) > 0
-          ? targetWidth / Number(image.width)
-          : targetHeight > 0 && (image.height ?? 0) > 0
-            ? targetHeight / Number(image.height)
-            : 1;
+    const scale = requestedScale > 0 ? requestedScale : 1;
     const output = (await transformImage(image, (instance) => {
       const fallbackWidth = image.width ?? 1;
       const fallbackHeight = image.height ?? 1;
@@ -1063,17 +1066,13 @@ export class ScaleNode extends TransformImageNode {
       });
     }, context)) as Record<string, unknown>;
     const fallbackWidth =
-      targetWidth > 0
-        ? targetWidth
-        : image.width != null
-          ? Math.max(1, Math.round(Number(image.width) * scale))
-          : null;
+      image.width != null
+        ? Math.max(1, Math.round(Number(image.width) * scale))
+        : null;
     const fallbackHeight =
-      targetHeight > 0
-        ? targetHeight
-        : image.height != null
-          ? Math.max(1, Math.round(Number(image.height) * scale))
-          : null;
+      image.height != null
+        ? Math.max(1, Math.round(Number(image.height) * scale))
+        : null;
     return {
       output: {
         ...output,
@@ -1213,10 +1212,17 @@ export class CropNode extends TransformImageNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const image = (this.image ?? {}) as ImageRefLike;
+    const imgW = Number(image.width ?? 0);
+    const imgH = Number(image.height ?? 0);
     const left = Math.max(0, Number(this.left ?? 0));
     const top = Math.max(0, Number(this.top ?? 0));
-    const right = Number(this.right ?? image.width ?? 0);
-    const bottom = Number(this.bottom ?? image.height ?? 0);
+    // Clamp the crop box to the known image bounds. Without this an
+    // out-of-bounds region makes sharp.extract throw, which transformImage
+    // silently swallows and returns the full, uncropped image.
+    let right = Number(this.right ?? image.width ?? 0);
+    let bottom = Number(this.bottom ?? image.height ?? 0);
+    if (imgW > 0) right = Math.min(right, imgW);
+    if (imgH > 0) bottom = Math.min(bottom, imgH);
     const width = Math.max(1, right - left);
     const height = Math.max(1, bottom - top);
     const output = (await transformImage(image, (instance) =>
@@ -1282,7 +1288,7 @@ export class FitNode extends TransformImageNode {
     const width = Math.max(1, Number(this.width ?? image.width ?? 512));
     const height = Math.max(1, Number(this.height ?? image.height ?? 512));
     const output = (await transformImage(image, (instance) =>
-      instance.resize(width, height, { fit: "cover", position: "centre" })
+      instance.resize(width, height, { fit: "inside" })
     , context)) as Record<string, unknown>;
     return {
       output: {

--- a/packages/image-nodes/src/nodes/lib-image-color-grading.ts
+++ b/packages/image-nodes/src/nodes/lib-image-color-grading.ts
@@ -354,16 +354,16 @@ function createColorGradingNode(desc: Desc): NodeClass {
       // SplitToning
       if (t.endsWith(".SplitToning")) {
         const shadowHue = Number(
-          (this as any).shadow_hue ?? self.shadow_hue ?? 30
+          (this as any).shadow_hue ?? self.shadow_hue ?? 200
         );
         const shadowSat = Number(
-          (this as any).shadow_saturation ?? self.shadow_saturation ?? 0.5
+          (this as any).shadow_saturation ?? self.shadow_saturation ?? 0.3
         );
         const highlightHue = Number(
-          (this as any).highlight_hue ?? self.highlight_hue ?? 200
+          (this as any).highlight_hue ?? self.highlight_hue ?? 40
         );
         const highlightSat = Number(
-          (this as any).highlight_saturation ?? self.highlight_saturation ?? 0.5
+          (this as any).highlight_saturation ?? self.highlight_saturation ?? 0.3
         );
         const balance = Number((this as any).balance ?? self.balance ?? 0);
         const { data, width, height, alpha } = await toFloatRGB(baseBytes);

--- a/packages/image-nodes/src/nodes/lib-image-enhance.ts
+++ b/packages/image-nodes/src/nodes/lib-image-enhance.ts
@@ -475,7 +475,7 @@ const DESCRIPTORS: readonly Desc[] = [
           description:
             "Represents the percentage of pixels to ignore at both the darkest and lightest ends of the histogram. A cutoff value of 5 means ignoring the darkest 5% and the lightest 5% of pixels, enhancing overall contrast by stretching the remaining pixel values across the full brightness range.",
           min: 0,
-          max: 255
+          max: 49
         }
       }
     ]

--- a/packages/image-nodes/src/nodes/lib-image-filter.ts
+++ b/packages/image-nodes/src/nodes/lib-image-filter.ts
@@ -123,14 +123,15 @@ function createFilterNode(desc: Desc): NodeClass {
         return { output: toRef(Buffer.from(png), baseObj) };
       }
       if (t.endsWith(".Contour")) {
-        // Composite Prewitt-style edge detector. PIL's CONTOUR is a single
-        // 3×3 kernel; this approximates it with a centre-weighted Laplacian
-        // followed by inversion to give a white-background contour image.
+        // PIL CONTOUR: Laplacian kernel [-1×8, centre 8] (sum 0) with a
+        // full-white offset (255/255). Flat regions cancel to 0 → white
+        // background; edges survive as dark contour lines. A centre weight
+        // of 9 (sum 1) would sharpen and then blow out to white.
         const png = await runShaderOnPngBuffer(
           filtersConvolve3x3V1,
           {
             row0: d.vec4f(-1, -1, -1, 1),
-            row1: d.vec4f(-1, 9, -1, -1),
+            row1: d.vec4f(-1, 8, -1, 0),
             row2: d.vec4f(-1, -1, -1, 1)
           },
           new Uint8Array(baseBytes),

--- a/packages/image-nodes/src/nodes/lib-image-warp.ts
+++ b/packages/image-nodes/src/nodes/lib-image-warp.ts
@@ -193,13 +193,14 @@ class AffineNode extends BaseNode {
     const props = this.serialize() as Record<string, unknown>;
     const w = num(props.target_width, 0);
     const h = num(props.target_height, 0);
+    // Resolve each dimension independently so a single specified target
+    // (e.g. width only) is honored and combined with the source's other
+    // dimension, instead of being dropped unless BOTH are set.
     const src = w > 0 && h > 0 ? null : await imageDims(props.image, context);
+    const outputWidth = w > 0 ? w : src?.width;
+    const outputHeight = h > 0 ? h : src?.height;
     const opts: RunShaderOptions =
-      w > 0 && h > 0
-        ? { outputWidth: w, outputHeight: h }
-        : src
-        ? { outputWidth: src.width, outputHeight: src.height }
-        : {};
+      outputWidth && outputHeight ? { outputWidth, outputHeight } : {};
     const output = await runShaderNode(
       transformAffineV1,
       {

--- a/packages/image-nodes/src/nodes/lib-shader-utils.ts
+++ b/packages/image-nodes/src/nodes/lib-shader-utils.ts
@@ -148,25 +148,29 @@ async function readbackStraightAlpha(
     size: rowStride * height,
     usage: 0x09 /* COPY_DST | MAP_READ */
   });
-  const encoder = device.createCommandEncoder({ label: "shader-readback" });
-  encoder.copyTextureToBuffer(
-    { texture: texture.texture },
-    { buffer, bytesPerRow: rowStride, rowsPerImage: height },
-    { width, height }
-  );
-  device.queue.submit([encoder.finish()]);
-  await buffer.mapAsync(GPUMapMode.READ);
-  const mapped = new Uint8Array(buffer.getMappedRange());
-  const out = new Uint8Array(width * height * 4);
-  for (let row = 0; row < height; row++) {
-    out.set(
-      mapped.subarray(row * rowStride, row * rowStride + width * 4),
-      row * width * 4
+  try {
+    const encoder = device.createCommandEncoder({ label: "shader-readback" });
+    encoder.copyTextureToBuffer(
+      { texture: texture.texture },
+      { buffer, bytesPerRow: rowStride, rowsPerImage: height },
+      { width, height }
     );
+    device.queue.submit([encoder.finish()]);
+    await buffer.mapAsync(GPUMapMode.READ);
+    const mapped = new Uint8Array(buffer.getMappedRange());
+    const out = new Uint8Array(width * height * 4);
+    for (let row = 0; row < height; row++) {
+      out.set(
+        mapped.subarray(row * rowStride, row * rowStride + width * 4),
+        row * width * 4
+      );
+    }
+    buffer.unmap();
+    return unpremultiplyInPlace(out);
+  } finally {
+    // Destroy even if mapAsync rejects (device lost / validation error).
+    buffer.destroy();
   }
-  buffer.unmap();
-  buffer.destroy();
-  return unpremultiplyInPlace(out);
 }
 
 /** Options shared by both single-pass and recipe runners. */
@@ -254,51 +258,55 @@ export async function runShaderNode(
     }
   }
 
-  const dims = resolveOutputDims(module, source, opts);
-  const output = createLabeledTexture(device, {
-    label: `${module.id}-output`,
-    width: dims.width,
-    height: dims.height,
-    format: "rgba8unorm",
-    usage: module.kind === "compute" ? COMPUTE_OUTPUT_USAGE : OUTPUT_USAGE
-  });
+  let output: LabeledTexture | undefined;
+  try {
+    const dims = resolveOutputDims(module, source, opts);
+    output = createLabeledTexture(device, {
+      label: `${module.id}-output`,
+      width: dims.width,
+      height: dims.height,
+      format: "rgba8unorm",
+      usage: module.kind === "compute" ? COMPUTE_OUTPUT_USAGE : OUTPUT_USAGE
+    });
 
-  const encoder = device.createCommandEncoder({ label: `${module.id}-encode` });
-  if (module.kind === "compute") {
-    const [wx, wy] = module.workgroupSize;
-    cachedExecutor.encode({
-      ctx,
-      module,
-      encoder,
-      inputs,
-      output,
-      params: params as never,
-      dispatch: {
-        kind: "compute",
-        x: Math.ceil(dims.width / wx),
-        y: Math.ceil(dims.height / wy),
-        z: 1
-      }
-    });
-  } else {
-    cachedExecutor.encode({
-      ctx,
-      module,
-      encoder,
-      inputs,
-      output,
-      params: params as never,
-      dispatch: { kind: "fragment" }
-    });
+    const encoder = device.createCommandEncoder({ label: `${module.id}-encode` });
+    if (module.kind === "compute") {
+      const [wx, wy] = module.workgroupSize;
+      cachedExecutor.encode({
+        ctx,
+        module,
+        encoder,
+        inputs,
+        output,
+        params: params as never,
+        dispatch: {
+          kind: "compute",
+          x: Math.ceil(dims.width / wx),
+          y: Math.ceil(dims.height / wy),
+          z: 1
+        }
+      });
+    } else {
+      cachedExecutor.encode({
+        ctx,
+        module,
+        encoder,
+        inputs,
+        output,
+        params: params as never,
+        dispatch: { kind: "fragment" }
+      });
+    }
+    device.queue.submit([encoder.finish()]);
+
+    const rgba = await readbackStraightAlpha(device, output);
+    return rawRgbaImageRef(rgba, dims.width, dims.height);
+  } finally {
+    // Always release GPU textures, even if encode/submit/readback throws.
+    source?.texture.destroy();
+    for (const t of acquiredExtras) t.destroy();
+    output?.destroy();
   }
-  device.queue.submit([encoder.finish()]);
-
-  const rgba = await readbackStraightAlpha(device, output);
-  source?.texture.destroy();
-  for (const t of acquiredExtras) t.destroy();
-  output.destroy();
-
-  return rawRgbaImageRef(rgba, dims.width, dims.height);
 }
 
 /** Run a multi-pass {@link RecipeModule} (e.g. `filters.glow`, `mixer.dropShadow`). */
@@ -343,33 +351,37 @@ export async function runRecipeNode(
     }
   }
 
-  const dims = resolveOutputDims(recipe, source, opts);
-  const output = createLabeledTexture(device, {
-    label: `${recipe.id}-output`,
-    width: dims.width,
-    height: dims.height,
-    format: "rgba8unorm",
-    usage: OUTPUT_USAGE
-  });
+  let output: LabeledTexture | undefined;
+  try {
+    const dims = resolveOutputDims(recipe, source, opts);
+    output = createLabeledTexture(device, {
+      label: `${recipe.id}-output`,
+      width: dims.width,
+      height: dims.height,
+      format: "rgba8unorm",
+      usage: OUTPUT_USAGE
+    });
 
-  const encoder = device.createCommandEncoder({ label: `${recipe.id}-encode` });
-  cachedRecipeRunner.encode({
-    ctx,
-    module: recipe,
-    encoder,
-    inputs,
-    output,
-    params: params as never,
-    registry
-  });
-  device.queue.submit([encoder.finish()]);
+    const encoder = device.createCommandEncoder({ label: `${recipe.id}-encode` });
+    cachedRecipeRunner.encode({
+      ctx,
+      module: recipe,
+      encoder,
+      inputs,
+      output,
+      params: params as never,
+      registry
+    });
+    device.queue.submit([encoder.finish()]);
 
-  const rgba = await readbackStraightAlpha(device, output);
-  source.texture.destroy();
-  for (const t of acquiredExtras) t.destroy();
-  output.destroy();
-
-  return rawRgbaImageRef(rgba, dims.width, dims.height);
+    const rgba = await readbackStraightAlpha(device, output);
+    return rawRgbaImageRef(rgba, dims.width, dims.height);
+  } finally {
+    // Always release GPU textures, even if encode/submit/readback throws.
+    source.texture.destroy();
+    for (const t of acquiredExtras) t.destroy();
+    output?.destroy();
+  }
 }
 
 /**
@@ -545,7 +557,7 @@ export function colorValueToVec4(
       typeof r === "number" ? r : fallback[0],
       typeof g === "number" ? g : fallback[1],
       typeof b === "number" ? b : fallback[2],
-      typeof a === "number" ? a : 1
+      typeof a === "number" ? a : fallback[3]
     ];
     return out.some((v) => !Number.isFinite(v)) ? fallback : out;
   }
@@ -557,7 +569,14 @@ export function colorValueToVec4(
     if (typeof maybe === "string") value = maybe;
   }
   if (typeof value !== "string") return fallback;
-  const hex = value.startsWith("#") ? value.slice(1) : value;
+  let hex = value.startsWith("#") ? value.slice(1) : value;
+  // Expand 3-/4-digit shorthand (#fff, #fff8) by doubling each nibble.
+  if (hex.length === 3 || hex.length === 4) {
+    hex = hex
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
   const parseByte = (s: string): number => parseInt(s, 16) / 255;
   let parsed: [number, number, number, number] | null = null;
   if (hex.length === 6) {

--- a/packages/image-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/image-nodes/tests/regression-image-nodes.test.ts
@@ -152,7 +152,7 @@ describe("LoadImageFolderNode — include_subdirectories", () => {
     const allYields = await collectGen(node.genProcess());
     const results = allYields.filter((item) => "image" in item);
 
-    const names = results.map((r) => r.name);
+    const names = results.map((r) => path.basename(String(r.path)));
     expect(names).toContain("top.png");
     expect(names).toContain("nested.png");
     expect(results.length).toBe(2);
@@ -171,7 +171,7 @@ describe("LoadImageFolderNode — include_subdirectories", () => {
     const allYields = await collectGen(node.genProcess());
     const results = allYields.filter((item) => "image" in item);
 
-    const names = results.map((r) => r.name);
+    const names = results.map((r) => path.basename(String(r.path)));
     expect(names).toContain("top.png");
     expect(names).not.toContain("nested.png");
     expect(results.length).toBe(1);
@@ -195,7 +195,7 @@ describe("LoadImageFolderNode — extensions filter", () => {
     const allYields = await collectGen(node.genProcess());
     const results = allYields.filter((item) => "image" in item);
 
-    const names = results.map((r) => r.name);
+    const names = results.map((r) => path.basename(String(r.path)));
     expect(names).toContain("photo.png");
     expect(names).not.toContain("photo.bmp");
     expect(results.length).toBe(1);
@@ -212,7 +212,7 @@ describe("LoadImageFolderNode — extensions filter", () => {
     const allYields = await collectGen(node.genProcess());
     const results = allYields.filter((item) => "image" in item);
 
-    const names = results.map((r) => r.name);
+    const names = results.map((r) => path.basename(String(r.path)));
     expect(names).toContain("photo.png");
     expect(names).not.toContain("notes.txt");
   });
@@ -234,7 +234,7 @@ describe("LoadImageFolderNode — pattern matching", () => {
     const allYields = await collectGen(node.genProcess());
     const results = allYields.filter((item) => "image" in item);
 
-    const names = results.map((r) => r.name);
+    const names = results.map((r) => path.basename(String(r.path)));
     expect(names).toContain("cat.png");
     expect(names).not.toContain("dog.png");
     expect(results.length).toBe(1);


### PR DESCRIPTION
Bugs found and fixed across the image-nodes package:

- lib-image-filter Contour: kernel used centre weight 9 (a sharpen kernel,
  sum +1) with a full-white offset, blowing every flat region out to white.
  Use centre 8 (Laplacian, sum 0) matching PIL CONTOUR / the FindEdges kernel.

- image LoadImageFolder: declared a `path` output (also in the generated DSL
  outputs) but emitted an undeclared `name` instead, leaving `path` always
  empty. Emit the file path for both the buffered and streaming paths.

- image Fit: used sharp `fit: "cover"`, which fills and crops, contradicting
  the node's "fit within ... preserving aspect ratio" contract. Use `inside`.

- image Crop: clamp the crop box to the known image bounds so an oversized
  region no longer makes sharp.extract throw (silently swallowed, returning
  the full uncropped image).

- image inferImageMime: tighten WebP detection — require >=12 bytes and verify
  the full RIFF/WEBP fourcc instead of reading bytes[8] behind a <4 guard.

- image Scale: drop dead targetWidth/targetHeight=0 branches.

- lib-shader-utils: wrap GPU encode/readback in try/finally so output/input
  textures and the readback buffer are always destroyed on error (device loss,
  mapAsync rejection) instead of leaking.

- lib-shader-utils colorValueToVec4: expand 3-/4-digit hex shorthand (#fff)
  instead of falling back to the default colour; fix array-path alpha to fall
  back to fallback[3].

- lib-image-warp Affine: resolve target_width/target_height independently so a
  single specified dimension is honored instead of dropped unless both are set.

- lib-image-enhance AutoContrast: cap `cutoff` at 49 (it is a percentage) so
  values can no longer drive the channel to a silent no-op.

- lib-image-color-grading SplitToning: align stale inline fallback defaults
  with the descriptor defaults.

Regression tests for LoadImageFolder now assert against the declared `path`
output. typecheck, oxlint, and the package test suite pass.