### PR TITLE
fix(transformers-js): correctness fixes across nodes + provider

### DIFF
--- a/packages/transformers-js-nodes/src/index.ts
+++ b/packages/transformers-js-nodes/src/index.ts
@@ -36,6 +36,7 @@ export { TextToSpeechNode } from "./nodes/text-to-speech.js";
 
 export {
   clearPipelineCache,
+  decodeAudioBytesToSamples,
   extractRepoId,
   getPipeline,
   getTransformersJsCacheDir,

--- a/packages/transformers-js-nodes/src/transformers-base.ts
+++ b/packages/transformers-js-nodes/src/transformers-base.ts
@@ -257,7 +257,11 @@ export async function loadMediaBytes(
   context?: ProcessingContext
 ): Promise<Uint8Array> {
   if (!ref || typeof ref !== "object") return new Uint8Array();
-  if (ref.data) return decodeBase64Data(ref.data);
+  // A zero-length Uint8Array is still truthy, so check length explicitly —
+  // otherwise an empty inline buffer would shadow a perfectly good `uri`.
+  const hasInlineData =
+    ref.data instanceof Uint8Array ? ref.data.length > 0 : Boolean(ref.data);
+  if (hasInlineData) return decodeBase64Data(ref.data);
   const uri = typeof ref.uri === "string" ? ref.uri : "";
   if (!uri) return new Uint8Array();
 
@@ -349,7 +353,9 @@ function parseWavBytes(bytes: Uint8Array): {
       dataOffset += 8;
       break;
     }
-    dataOffset += 8 + chunkSize;
+    // RIFF chunks are word-aligned: an odd-sized chunk is followed by a pad
+    // byte that is not counted in chunkSize. Skip it so we stay aligned.
+    dataOffset += 8 + chunkSize + (chunkSize & 1);
   }
 
   const bytesPerSample = bitsPerSample / 8;
@@ -488,12 +494,10 @@ async function ffmpegToWav(
  *      avoids a second pass and gives much better quality than the linear
  *      resampler used for the in-process WAV path.
  */
-export async function loadAudioSamples(
-  ref: AudioRefLike | undefined,
-  samplingRate: number,
-  context?: ProcessingContext
+export async function decodeAudioBytesToSamples(
+  bytes: Uint8Array,
+  samplingRate: number
 ): Promise<Float32Array> {
-  const bytes = await loadMediaBytes(ref, context);
   if (!bytes.length) {
     throw new Error("Audio input is empty");
   }
@@ -511,6 +515,15 @@ export async function loadAudioSamples(
 
   const mono = mixToMono(wav.samples, wav.numChannels);
   return resampleLinear(mono, wav.sampleRate, samplingRate);
+}
+
+export async function loadAudioSamples(
+  ref: AudioRefLike | undefined,
+  samplingRate: number,
+  context?: ProcessingContext
+): Promise<Float32Array> {
+  const bytes = await loadMediaBytes(ref, context);
+  return decodeAudioBytesToSamples(bytes, samplingRate);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/transformers-js-nodes/src/wav.ts
+++ b/packages/transformers-js-nodes/src/wav.ts
@@ -98,7 +98,12 @@ export function decodeWav(bytes: Uint8Array): DecodedWav {
   }
 
   const bytesPerSample = bitsPerSample / 8;
-  const totalFrames = dataSize / (bytesPerSample * numChannels);
+  // Trust the smaller of the declared data size and the bytes actually present.
+  // Streaming/truncated WAVs often over-declare the data chunk (or write a
+  // placeholder size); reading past the buffer would throw a RangeError.
+  const available = Math.max(0, bytes.length - dataOffset);
+  const usableData = Math.min(dataSize, available);
+  const totalFrames = Math.floor(usableData / (bytesPerSample * numChannels));
   const out = new Float32Array(totalFrames);
   for (let i = 0; i < totalFrames; i++) {
     let sum = 0;
@@ -106,7 +111,10 @@ export function decodeWav(bytes: Uint8Array): DecodedWav {
       const sampleOffset = dataOffset + (i * numChannels + c) * bytesPerSample;
       let v: number;
       if (bitsPerSample === 16) {
-        v = view.getInt16(sampleOffset, true) / 0x8000;
+        // Match `encodeWav` (which scales by 0x7fff) and the canonical
+        // parseWavBytes so encode/decode round-trips at unit gain and the
+        // provider's ASR path normalizes identically to the node path.
+        v = view.getInt16(sampleOffset, true) / 0x7fff;
       } else if (bitsPerSample === 8) {
         v = (view.getUint8(sampleOffset) - 128) / 128;
       } else {

--- a/packages/transformers-js-nodes/tests/wav.test.ts
+++ b/packages/transformers-js-nodes/tests/wav.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { decodeWav, encodeWav } from "../src/wav.js";
+
+function bytesOf(buf: Buffer): Uint8Array {
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+describe("wav encode/decode", () => {
+  it("round-trips Float32 samples at unit gain", () => {
+    const input = new Float32Array([0, 0.5, -0.5, 1, -1, 0.25]);
+    const decoded = decodeWav(bytesOf(encodeWav(input, 16000)));
+
+    expect(decoded.sampleRate).toBe(16000);
+    expect(decoded.numChannels).toBe(1);
+    expect(decoded.samples.length).toBe(input.length);
+    for (let i = 0; i < input.length; i++) {
+      // encode scales by 0x7fff and decode divides by 0x7fff, so full-scale
+      // ±1 must round-trip without clipping past the [-1, 1] range.
+      expect(decoded.samples[i]).toBeCloseTo(input[i], 3);
+    }
+    expect(decoded.samples[3]).toBeCloseTo(1, 4);
+    expect(decoded.samples[4]).toBeCloseTo(-1, 4);
+  });
+
+  it("does not read past an over-declared data chunk", () => {
+    const input = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const bytes = bytesOf(encodeWav(input, 16000));
+    // Corrupt the declared data-chunk size (uint32 LE at byte 40) to a value
+    // far larger than the buffer — a streamed/truncated WAV pattern.
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(
+      40,
+      0xffffffff,
+      true
+    );
+
+    expect(() => decodeWav(bytes)).not.toThrow();
+    expect(decodeWav(bytes).samples.length).toBe(input.length);
+  });
+});

--- a/packages/transformers-js-provider/src/asr.ts
+++ b/packages/transformers-js-provider/src/asr.ts
@@ -1,4 +1,4 @@
-import { decodeWav, getPipeline, resampleLinear } from "@nodetool-ai/transformers-js-nodes";
+import { decodeAudioBytesToSamples, getPipeline } from "@nodetool-ai/transformers-js-nodes";
 import type { ASRResult } from "@nodetool-ai/runtime";
 
 const TARGET_SAMPLE_RATE = 16000;
@@ -7,6 +7,10 @@ interface AsrArgs {
   audio: Uint8Array;
   model: string;
   language?: string;
+  /** Accepted for provider-interface parity; transformers.js ASR has no
+   * initial-prompt parameter, so it is currently ignored. */
+  prompt?: string;
+  temperature?: number;
   word_timestamps?: boolean;
 }
 
@@ -23,12 +27,10 @@ type AsrPipelineFn = (
 export async function automaticSpeechRecognition(
   args: AsrArgs
 ): Promise<ASRResult> {
-  const decoded = decodeWav(args.audio);
-  const samples = resampleLinear(
-    decoded.samples,
-    decoded.sampleRate,
-    TARGET_SAMPLE_RATE
-  );
+  // Decode arbitrary audio (WAV in-process, everything else via ffmpeg) to
+  // mono Float32 at the model's expected 16 kHz — same path as the node side,
+  // so mp3/m4a/flac/etc. work instead of failing with "not a WAV file".
+  const samples = await decodeAudioBytesToSamples(args.audio, TARGET_SAMPLE_RATE);
 
   const pipeline = (await getPipeline({
     task: "automatic-speech-recognition",
@@ -37,6 +39,7 @@ export async function automaticSpeechRecognition(
 
   const opts: Record<string, unknown> = {};
   if (args.language) opts.language = args.language;
+  if (typeof args.temperature === "number") opts.temperature = args.temperature;
   if (args.word_timestamps) opts.return_timestamps = "word";
 
   const result = await pipeline(samples, opts);

--- a/packages/transformers-js-provider/src/chat.ts
+++ b/packages/transformers-js-provider/src/chat.ts
@@ -61,13 +61,11 @@ type ChatPipelineFn = (
 ) => Promise<PipelineOutput[]>;
 
 function warnIfTools(args: ChatArgs): void {
-  if ((args.tools && args.tools.length > 0) || args.tools === undefined) {
-    if (args.tools && args.tools.length > 0) {
-      log.warn(
-        "transformers_js: tool calls are not supported; ignoring tools",
-        { count: args.tools.length, model: args.model }
-      );
-    }
+  if (args.tools && args.tools.length > 0) {
+    log.warn("transformers_js: tool calls are not supported; ignoring tools", {
+      count: args.tools.length,
+      model: args.model
+    });
   }
 }
 
@@ -101,14 +99,21 @@ export async function generateMessage(args: ChatArgs): Promise<Message> {
   warnIfTools(args);
   if (args.signal?.aborted) throw makeAbortError();
 
+  const transformers = await loadTransformers();
   const pipeline = await getChatPipeline(args.model);
   const messages = normalizeMessages(args.messages);
   const opts = buildPipelineOpts(args);
 
-  const out = await pipeline(messages, opts);
-  if (args.signal?.aborted) throw makeAbortError();
+  const stopper = makeStopper(transformers, args.signal);
+  if (stopper.criteria) opts.stopping_criteria = stopper.criteria;
 
-  return { role: "assistant", content: extractAssistantText(out) };
+  try {
+    const out = await pipeline(messages, opts);
+    if (args.signal?.aborted) throw makeAbortError();
+    return { role: "assistant", content: extractAssistantText(out) };
+  } finally {
+    stopper.cleanup();
+  }
 }
 
 export async function* generateMessages(
@@ -137,7 +142,6 @@ export async function* generateMessages(
   const messages = normalizeMessages(args.messages);
   const opts = buildPipelineOpts(args);
 
-  const tokens: string[] = [];
   let resolveToken: ((value: string | null) => void) | null = null;
   const pending: Array<string | null> = [];
 
@@ -169,17 +173,17 @@ export async function* generateMessages(
   const streamer = new TextStreamerCtor(tokenizer, {
     skip_prompt: true,
     skip_special_tokens: true,
-    callback_function: (text: string) => {
-      tokens.push(text);
-      enqueue(text);
-    }
+    callback_function: (text: string) => enqueue(text)
   });
 
+  // Cooperative cancellation: interrupt the model loop when the signal aborts
+  // so an aborted stream stops generating instead of running to completion.
+  const stopper = makeStopper(transformers, args.signal);
+  const genOpts: Record<string, unknown> = { ...opts, streamer };
+  if (stopper.criteria) genOpts.stopping_criteria = stopper.criteria;
+
   // Kick off generation; resolve the iterator when complete.
-  const generation = pipeline(messages, {
-    ...opts,
-    streamer
-  })
+  const generation = pipeline(messages, genOpts)
     .then(() => enqueue(null))
     .catch((err) => {
       enqueue(null);
@@ -207,10 +211,17 @@ export async function* generateMessages(
       yield chunk;
     }
   } finally {
-    // Surface generation errors after the loop ends (or rethrow on abort).
-    await generation.catch((err) => {
-      throw err;
-    });
+    stopper.cleanup();
+    if (args.signal?.aborted) {
+      // Unwinding due to abort: the interrupt makes `generation` settle
+      // promptly; swallow its (expected) error so the AbortError surfaces.
+      await generation.catch(() => {});
+    } else {
+      // Surface any generation error after the loop ends.
+      await generation.catch((err) => {
+        throw err;
+      });
+    }
   }
 
   const final: Chunk = {
@@ -220,6 +231,39 @@ export async function* generateMessages(
     done: true
   };
   yield final;
+}
+
+type TransformersModule = Awaited<ReturnType<typeof loadTransformers>>;
+
+interface Stopper {
+  criteria?: { interrupt(): void };
+  cleanup(): void;
+}
+
+/**
+ * Build an `InterruptableStoppingCriteria` (when the runtime exposes one) and
+ * interrupt the model's generation loop the moment `signal` aborts. Without
+ * this, transformers.js runs the full generation regardless of the abort and
+ * the caller blocks until it finishes. Returns a no-op stopper when either the
+ * criteria class or the signal is unavailable.
+ */
+function makeStopper(
+  transformers: TransformersModule,
+  signal: AbortSignal | undefined
+): Stopper {
+  const Ctor = transformers.InterruptableStoppingCriteria;
+  if (!Ctor || !signal) return { cleanup: () => {} };
+  const criteria = new Ctor();
+  if (signal.aborted) {
+    criteria.interrupt();
+    return { criteria, cleanup: () => {} };
+  }
+  const onAbort = () => criteria.interrupt();
+  signal.addEventListener("abort", onAbort, { once: true });
+  return {
+    criteria,
+    cleanup: () => signal.removeEventListener("abort", onAbort)
+  };
 }
 
 function makeAbortError(): Error {

--- a/packages/transformers-js-provider/src/embeddings.ts
+++ b/packages/transformers-js-provider/src/embeddings.ts
@@ -52,6 +52,28 @@ function tensorToVectors(t: EmbeddingTensor): number[][] {
   throw new Error("Unrecognized embedding tensor shape");
 }
 
+/**
+ * Truncate each embedding to `dimensions` and re-normalize, mirroring the
+ * OpenAI `dimensions` parameter (Matryoshka-style). Re-normalizing keeps the
+ * vectors unit-length — the pipeline is invoked with `normalize: true`, and
+ * cosine similarity assumes that property. A no-op when `dimensions` is unset
+ * or already >= the model's hidden size.
+ */
+function truncateDimensions(
+  vectors: number[][],
+  dimensions?: number
+): number[][] {
+  if (!dimensions || dimensions <= 0) return vectors;
+  return vectors.map((v) => {
+    if (v.length <= dimensions) return v;
+    const sliced = v.slice(0, dimensions);
+    let norm = 0;
+    for (const x of sliced) norm += x * x;
+    norm = Math.sqrt(norm);
+    return norm > 0 ? sliced.map((x) => x / norm) : sliced;
+  });
+}
+
 export async function generateEmbedding(
   args: EmbedArgs
 ): Promise<number[][]> {
@@ -65,5 +87,5 @@ export async function generateEmbedding(
     normalize: true
   });
 
-  return tensorToVectors(result);
+  return truncateDimensions(tensorToVectors(result), args.dimensions);
 }

--- a/packages/transformers-js-provider/src/model-discovery.ts
+++ b/packages/transformers-js-provider/src/model-discovery.ts
@@ -4,8 +4,7 @@ import {
   isKokoroRepo,
   recommendedFor,
   scanTransformersJsCache,
-  type CachedTjsModel,
-  type TjsModelRef
+  type CachedTjsModel
 } from "@nodetool-ai/transformers-js-nodes";
 import type {
   ASRModel,
@@ -47,28 +46,18 @@ async function unionRecommendedAndCache(
     // Cache scan failures are non-fatal; we still surface recommended models.
   }
 
+  // We can only annotate recommended repos with their cached status: a cached
+  // repo that is not on any recommended list carries no task metadata on disk,
+  // so we cannot know which modality (text-gen vs ASR vs …) it belongs to and
+  // must not surface it under an arbitrary task.
   for (const c of cached) {
     const existing = recommended.get(c.repo_id);
     if (existing) {
       existing.cached = true;
-    } else if (matchesAny(c.repo_id, taskTypes)) {
-      // Off-list cached repos that happen to be recommended under one of the
-      // requested task types only — i.e. the same repo appears under another
-      // recommended task. Skip the rest; they belong to other modalities.
-      recommended.set(c.repo_id, { repo_id: c.repo_id, cached: true });
     }
   }
 
   return Array.from(recommended.values());
-}
-
-function matchesAny(repoId: string, taskTypes: string[]): boolean {
-  for (const t of taskTypes) {
-    if (recommendedFor(t).some((r: TjsModelRef) => r.repo_id === repoId)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 export async function discoverLanguageModels(): Promise<LanguageModel[]> {

--- a/packages/transformers-js-provider/tests/asr.test.ts
+++ b/packages/transformers-js-provider/tests/asr.test.ts
@@ -3,14 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 const asrPipelineFn = vi.fn();
 
 vi.mock("@nodetool-ai/transformers-js-nodes", () => ({
-  decodeWav: () => ({
-    samples: new Float32Array([0, 0.1, -0.1, 0]),
-    sampleRate: 8000,
-    numChannels: 1
-  }),
-  getPipeline: vi.fn(async () => asrPipelineFn),
-  resampleLinear: (s: Float32Array, from: number, to: number) =>
-    from === to ? s : new Float32Array([...s, ...s])
+  // Stub the combined decode+resample helper: yields 8 mono samples at 16kHz.
+  decodeAudioBytesToSamples: vi.fn(
+    async () => new Float32Array([0, 0.1, -0.1, 0, 0, 0.1, -0.1, 0])
+  ),
+  getPipeline: vi.fn(async () => asrPipelineFn)
 }));
 
 import { automaticSpeechRecognition } from "../src/asr.js";
@@ -26,8 +23,19 @@ describe("automaticSpeechRecognition", () => {
 
     expect(result).toEqual({ text: "hello world" });
     const samples = asrPipelineFn.mock.calls[0][0] as Float32Array;
-    // Stub resample doubles the length when from != to.
+    // Stub decoder yields 8 mono samples.
     expect(samples.length).toBe(8);
+  });
+
+  it("threads temperature into the pipeline options", async () => {
+    asrPipelineFn.mockResolvedValue({ text: "ok" });
+    await automaticSpeechRecognition({
+      audio: new Uint8Array([1, 2, 3]),
+      model: "onnx-community/whisper-base",
+      temperature: 0.4
+    });
+    const opts = asrPipelineFn.mock.calls.at(-1)?.[1];
+    expect(opts.temperature).toBe(0.4);
   });
 
   it("returns word-level chunks when word_timestamps is set", async () => {

--- a/packages/transformers-js-provider/tests/chat.test.ts
+++ b/packages/transformers-js-provider/tests/chat.test.ts
@@ -110,4 +110,59 @@ describe("generateMessages", () => {
     expect(chunks).toEqual(["Hello ", "world"]);
     expect(doneSeen).toBe(true);
   });
+
+  it("passes stopping_criteria and interrupts generation on abort", async () => {
+    let releaseGeneration: () => void = () => {};
+    const generationDone = new Promise<void>((resolve) => {
+      releaseGeneration = resolve;
+    });
+    const interrupt = vi.fn(() => releaseGeneration());
+
+    // Expose an InterruptableStoppingCriteria for this run only.
+    loadTransformers.mockImplementationOnce(async () => ({
+      TextStreamer: class {
+        cb?: (t: string) => void;
+        constructor(
+          _tokenizer: unknown,
+          opts: { callback_function?: (t: string) => void }
+        ) {
+          this.cb = opts.callback_function;
+        }
+      },
+      InterruptableStoppingCriteria: class {
+        interrupt = interrupt;
+      }
+    }));
+
+    fakePipeline.mockImplementation(
+      async (
+        _msgs: unknown,
+        opts: {
+          streamer?: { cb?: (t: string) => void };
+          stopping_criteria?: { interrupt(): void };
+        }
+      ) => {
+        expect(opts.stopping_criteria).toBeDefined();
+        opts.streamer?.cb?.("tok");
+        // Long-running generation that only ends once interrupted.
+        await generationDone;
+        return [{ generated_text: [{ role: "assistant", content: "tok" }] }];
+      }
+    );
+    Object.assign(fakePipeline, { tokenizer: {} });
+
+    const controller = new AbortController();
+    const gen = generateMessages({
+      messages: [{ role: "user", content: "hi" }],
+      model: "fake-model",
+      signal: controller.signal
+    });
+
+    const first = await gen.next();
+    expect(first.value).toMatchObject({ content: "tok", done: false });
+
+    controller.abort();
+    await expect(gen.next()).rejects.toThrow(/abort/i);
+    expect(interrupt).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/transformers-js-provider/tests/embeddings.test.ts
+++ b/packages/transformers-js-provider/tests/embeddings.test.ts
@@ -36,14 +36,25 @@ describe("generateEmbedding", () => {
     expect(out[1]).toEqual([4, 5, 6]);
   });
 
-  it("ignores the dimensions argument (no truncation supported)", async () => {
+  it("truncates and re-normalizes to the requested dimensions", async () => {
     embedPipelineFn.mockResolvedValue({ tolist: () => [[1, 2, 3, 4]] });
     const out = await generateEmbedding({
       text: "x",
       model: "fake",
       dimensions: 2
     });
-    // Length is unchanged because we do not honor `dimensions`.
-    expect(out[0]).toHaveLength(4);
+    expect(out[0]).toHaveLength(2);
+    // Truncated vector is re-normalized to unit length.
+    expect(Math.hypot(...out[0])).toBeCloseTo(1, 5);
+  });
+
+  it("leaves vectors untouched when dimensions >= hidden size", async () => {
+    embedPipelineFn.mockResolvedValue({ tolist: () => [[1, 2, 3, 4]] });
+    const out = await generateEmbedding({
+      text: "x",
+      model: "fake",
+      dimensions: 8
+    });
+    expect(out[0]).toEqual([1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
transformers-js-provider:
- chat: wire InterruptableStoppingCriteria so aborting a (streaming or
  non-streaming) generation actually stops the model loop instead of
  blocking the caller until it runs to completion; on abort the
  AbortError now surfaces (not the interrupt error). Simplify the
  redundant warnIfTools condition and drop the dead `tokens` accumulator.
- asr: decode arbitrary audio via the shared ffmpeg-capable decoder so
  mp3/m4a/flac/etc. work instead of failing with "not a WAV file", and
  thread `temperature` into the pipeline options.
- embeddings: honor `dimensions` by truncating + re-normalizing each
  vector (OpenAI/Matryoshka semantics) instead of silently ignoring it.
- model-discovery: remove the unreachable `matchesAny` branch (a cached
  repo matching a requested task is already seeded into the recommended
  map) and document why off-list cached repos can't be surfaced.

transformers-js-nodes:
- wav.decodeWav: divide 16-bit PCM by 0x7fff to match encodeWav and the
  canonical parseWavBytes (unit-gain round-trip, identical normalization
  on the provider's ASR path); clamp the declared data-chunk size to the
  bytes actually present so truncated/over-declared WAVs no longer throw
  a RangeError.
- transformers-base: extract decodeAudioBytesToSamples (reused by the
  provider's ASR), skip RIFF pad bytes when walking chunks, and don't let
  a zero-length inline `data` buffer shadow a valid `uri`.

Adds regression tests for WAV round-trip/clamping and streaming abort.