### PR TITLE
fix(atlascloud-nodes): retry paid downloads, harden SSRF guard, and 4 more bugs

### DIFF
--- a/packages/atlascloud-nodes/src/atlascloud-base.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-base.ts
@@ -58,7 +58,23 @@ function authHeaders(apiKey: string): Record<string, string> {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
-async function fetchWithRetry(
+/**
+ * Resolve a `Retry-After` header to a millisecond delay. The header is allowed
+ * to be either delay-seconds (`"120"`) or an HTTP-date
+ * (`"Wed, 21 Oct 2025 07:28:00 GMT"`); a date used to parse to `NaN`, and
+ * `setTimeout(_, NaN)` fires immediately — defeating the backoff. Fall back to
+ * the caller's exponential delay when the header is absent or unparseable.
+ */
+export function retryAfterMs(header: string | null, fallback: number): number {
+  if (!header) return fallback;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const when = Date.parse(header);
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now());
+  return fallback;
+}
+
+export async function fetchWithRetry(
   url: string,
   init: RequestInit = {},
   maxAttempts = 6
@@ -70,12 +86,26 @@ async function fetchWithRetry(
     if (!RETRYABLE_STATUS.has(resp.status)) return resp;
     last = resp;
     if (attempt === maxAttempts) break;
-    const retryAfter = resp.headers.get("Retry-After");
-    const wait = retryAfter ? Number(retryAfter) * 1000 : delay;
+    const wait = retryAfterMs(resp.headers.get("Retry-After"), delay);
     await sleep(wait);
     delay = Math.min(delay * 2, 30000);
   }
   return last as Response;
+}
+
+/**
+ * Download a finished prediction's output bytes. Retries 429/5xx with backoff:
+ * by the time we reach the download the job is already generated and billed,
+ * so a transient CDN blip must not throw the paid-for result away.
+ */
+export async function atlasDownload(url: string): Promise<Uint8Array> {
+  const res = await fetchWithRetry(url);
+  if (!res.ok) {
+    throw new Error(
+      `AtlasCloud download failed: HTTP ${res.status} fetching ${url}`
+    );
+  }
+  return new Uint8Array(await res.arrayBuffer());
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +153,18 @@ interface AtlasPollResult {
   error?: string;
 }
 
+// AtlasCloud has not committed to a single status vocabulary across models, so
+// accept the synonyms its image and video workers have been observed to emit
+// rather than time out on a terminal-but-unrecognized word.
+const SUCCESS_STATUS = new Set([
+  "completed",
+  "complete",
+  "succeeded",
+  "success",
+  "done"
+]);
+const FAILURE_STATUS = new Set(["failed", "error", "canceled", "cancelled"]);
+
 export async function atlasPoll(
   apiKey: string,
   predictionId: string,
@@ -147,10 +189,10 @@ export async function atlasPoll(
     const d = data?.data ?? {};
     const status = String(d.status ?? "").toLowerCase();
 
-    if (status === "completed" || status === "succeeded" || status === "success") {
+    if (SUCCESS_STATUS.has(status)) {
       return d;
     }
-    if (status === "failed" || status === "error") {
+    if (FAILURE_STATUS.has(status)) {
       const msg = d.error || data?.message || text.slice(0, 500);
       throw new Error(
         `AtlasCloud job failed: ${msg} (predictionId: ${predictionId})`

--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -23,6 +23,7 @@ import type {
   PromptAssetTextField
 } from "@nodetool-ai/runtime";
 import {
+  atlasDownload,
   atlasPoll,
   atlasSubmit,
   getApiKey,
@@ -87,7 +88,12 @@ const LIST_ASSET_RE = /^list\[(image|video|audio)\]$/;
 type AssetRef = {
   uri?: string;
   data?: string | Uint8Array;
+  // Native NodeTool refs use snake_case `mime_type`; the refs that
+  // `mapPromptAssetsToInputs` injects for @-mentioned assets (InjectedAssetRef)
+  // use camelCase `mimeType`. Accept both so a mentioned asset whose URI has no
+  // usable extension isn't silently mislabeled with the type default.
   mime_type?: string;
+  mimeType?: string;
   metadata?: { mime_type?: string };
 };
 
@@ -120,7 +126,10 @@ function looksLikePublicUrl(s: unknown): s is string {
  * bypassed by a public DNS name that resolves to a private IP (DNS rebinding).
  * That's a known limitation — fixing it properly requires resolving DNS in
  * the same socket dance as the eventual fetch(). The string check is what
- * the canonical fal/replicate/topaz providers use today.
+ * the canonical fal/replicate/topaz providers use today, hardened here against
+ * the inet_aton-style numeric encodings (decimal/hex/octal, short-form) and
+ * IPv4-mapped IPv6 that the OS resolver still accepts but a naive dotted-quad
+ * regex misses.
  */
 function isSafeHttpUrl(uri: string): boolean {
   let u: URL;
@@ -133,29 +142,91 @@ function isSafeHttpUrl(uri: string): boolean {
   return !isPrivateOrLocalHost(u.hostname);
 }
 
+/** Parse a single inet_aton component: decimal, 0x-hex, or 0-prefixed octal. */
+function parseIpComponent(part: string): number | null {
+  if (/^0x[0-9a-f]+$/i.test(part)) return parseInt(part.slice(2), 16);
+  if (/^0[0-7]+$/.test(part)) return parseInt(part, 8);
+  if (/^[0-9]+$/.test(part)) return parseInt(part, 10);
+  return null;
+}
+
+/**
+ * Parse `host` as IPv4 using inet_aton semantics, which `getaddrinfo` (and thus
+ * `fetch`) honors: `a.b.c.d`, the short forms `a.b.c` / `a.b` / `a`, and each
+ * component in decimal, hex (`0x7f`), or octal (`0177`). Returns the four
+ * octets, or null when the host isn't a numeric IPv4 in any of these forms.
+ */
+function ipv4ToOctets(host: string): [number, number, number, number] | null {
+  const parts = host.split(".");
+  if (parts.length === 0 || parts.length > 4) return null;
+  const nums: number[] = [];
+  for (const part of parts) {
+    const n = parseIpComponent(part);
+    if (n === null || n < 0) return null;
+    nums.push(n);
+  }
+  // Every component but the last must fit in one octet; the final component
+  // absorbs all remaining low-order octets (e.g. "127.1" → 127.0.0.1).
+  const n = nums.length;
+  for (let i = 0; i < n - 1; i++) {
+    if (nums[i] > 0xff) return null;
+  }
+  const tailOctets = 4 - (n - 1);
+  const tail = nums[n - 1];
+  if (tail < 0 || tail > 0xffffffff || tail >= 2 ** (tailOctets * 8)) return null;
+  let value = tail;
+  for (let i = 0; i < n - 1; i++) {
+    value += nums[i] * 256 ** (3 - i);
+  }
+  return [
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff
+  ];
+}
+
+/** Extract the embedded IPv4 from an IPv4-mapped / -compatible IPv6 address. */
+function mappedIpv4ToOctets(
+  host: string
+): [number, number, number, number] | null {
+  // Dotted tail: ::ffff:127.0.0.1 or the deprecated compat form ::127.0.0.1
+  const dotted = /^::(?:ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(host);
+  if (dotted) return ipv4ToOctets(dotted[1]);
+  // Hex tail: ::ffff:7f00:1
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(host);
+  if (hex) {
+    const hi = parseInt(hex[1], 16);
+    const lo = parseInt(hex[2], 16);
+    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff];
+  }
+  return null;
+}
+
+function isPrivateV4(octets: [number, number, number, number]): boolean {
+  const [o1, o2] = octets;
+  if (o1 === 0) return true; // 0.0.0.0/8 — "this network"
+  if (o1 === 10) return true; // RFC1918
+  if (o1 === 127) return true; // loopback
+  if (o1 === 169 && o2 === 254) return true; // link-local incl. cloud metadata
+  if (o1 === 172 && o2 >= 16 && o2 <= 31) return true; // RFC1918
+  if (o1 === 192 && o2 === 168) return true; // RFC1918
+  if (o1 === 100 && o2 >= 64 && o2 <= 127) return true; // CGNAT
+  return false;
+}
+
 function isPrivateOrLocalHost(hostname: string): boolean {
   // URL.hostname returns IPv6 wrapped in brackets ("[::1]") on Node — strip
   // before pattern matching so the v6 cases below work on the bare form.
   let h = hostname.toLowerCase();
   if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
-  if (h === "" || h === "localhost") return true;
+  if (h === "" || h === "localhost" || h.endsWith(".localhost")) return true;
 
-  // IPv4 dotted quad
-  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
-  if (v4) {
-    const o1 = Number(v4[1]);
-    const o2 = Number(v4[2]);
-    if (o1 === 0) return true; // 0.0.0.0/8 — "this network"
-    if (o1 === 10) return true; // RFC1918
-    if (o1 === 127) return true; // loopback
-    if (o1 === 169 && o2 === 254) return true; // link-local incl. cloud metadata
-    if (o1 === 172 && o2 >= 16 && o2 <= 31) return true; // RFC1918
-    if (o1 === 192 && o2 === 168) return true; // RFC1918
-    if (o1 === 100 && o2 >= 64 && o2 <= 127) return true; // CGNAT
-    return false;
-  }
+  // IPv4 in any inet_aton-accepted spelling, or embedded in a mapped IPv6.
+  const octets = ipv4ToOctets(h) ?? mappedIpv4ToOctets(h);
+  if (octets) return isPrivateV4(octets);
 
-  // IPv6 — URL.hostname returns bracket-stripped form (e.g. "::1", "fe80::1")
+  // Pure IPv6 — URL.hostname returns bracket-stripped form ("::1", "fe80::1").
   if (h === "::1" || h === "::") return true;
   if (h.startsWith("fe80:") || h.startsWith("fe80::")) return true; // link-local
   // ULA range fc00::/7 — first nibble is f, second is c or d
@@ -169,6 +240,7 @@ function bytesToDataUri(bytes: Uint8Array, mime: string): string {
 
 function guessMime(ref: AssetRef | undefined, fallback: string): string {
   if (ref?.mime_type) return ref.mime_type;
+  if (ref?.mimeType) return ref.mimeType;
   if (ref?.metadata?.mime_type) return ref.metadata.mime_type;
   const uri = ref?.uri ?? "";
   if (/\.jpe?g(?:[?#]|$)/i.test(uri)) return "image/jpeg";
@@ -434,13 +506,9 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
       });
       const url = pickOutputUrl(result);
 
-      const dl = await fetch(url);
-      if (!dl.ok) {
-        throw new Error(
-          `AtlasCloud download failed: HTTP ${dl.status} fetching ${url}`
-        );
-      }
-      const bytes = new Uint8Array(await dl.arrayBuffer());
+      // Retries 429/5xx — the job is already generated and billed by now, so a
+      // transient CDN blip must not throw the paid-for result away.
+      const bytes = await atlasDownload(url);
 
       // Preferred path: hand bytes to NodeTool storage so the result becomes a
       // proper local asset. Falls back to base64 embed if storage is missing

--- a/packages/atlascloud-nodes/src/atlascloud-manifest.json
+++ b/packages/atlascloud-nodes/src/atlascloud-manifest.json
@@ -89,13 +89,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame",
-        "description": "Also return the last frame as a separate image."
       }
     ]
   },
@@ -204,13 +197,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame",
-        "description": "Also return the last frame as a separate image."
       }
     ]
   },
@@ -303,13 +289,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame",
-        "description": "Also return the last frame as a separate image."
       }
     ]
   },
@@ -417,13 +396,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame",
-        "description": "Also return the last frame as a separate image."
       }
     ]
   },
@@ -516,11 +488,10 @@
       },
       {
         "name": "images",
-        "type": "image",
-        "array": true,
+        "type": "list[image]",
         "default": null,
-        "title": "Image",
-        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
         "required": true
       },
       {
@@ -690,11 +661,10 @@
       },
       {
         "name": "images",
-        "type": "image",
-        "array": true,
+        "type": "list[image]",
         "default": null,
-        "title": "Image",
-        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
         "required": true
       },
       {
@@ -880,12 +850,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame"
       }
     ]
   },
@@ -990,12 +954,6 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
-      },
-      {
-        "name": "return_last_frame",
-        "type": "bool",
-        "default": false,
-        "title": "Return Last Frame"
       }
     ]
   },
@@ -1097,11 +1055,10 @@
       },
       {
         "name": "images",
-        "type": "image",
-        "array": true,
+        "type": "list[image]",
         "default": null,
-        "title": "Image",
-        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
         "required": true
       },
       {
@@ -1242,11 +1199,10 @@
       },
       {
         "name": "images",
-        "type": "image",
-        "array": true,
+        "type": "list[image]",
         "default": null,
-        "title": "Image",
-        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
         "required": true
       },
       {

--- a/packages/atlascloud-nodes/src/index.ts
+++ b/packages/atlascloud-nodes/src/index.ts
@@ -20,6 +20,7 @@ export type {
 export {
   ATLAS_BASE,
   SUBMIT_PATH,
+  atlasDownload,
   atlasPoll,
   atlasSubmit,
   getApiKey,

--- a/packages/atlascloud-nodes/tests/atlascloud-base.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-base.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
+  atlasDownload,
   atlasPoll,
   atlasSubmit,
+  fetchWithRetry,
   getApiKey,
-  pickOutputUrl
+  pickOutputUrl,
+  retryAfterMs
 } from "../src/atlascloud-base.js";
 
 // ---------------------------------------------------------------------------
@@ -75,6 +78,127 @@ describe("pickOutputUrl", () => {
 
   it("throws when no URL is present", () => {
     expect(() => pickOutputUrl({})).toThrow("No output URL in result");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retryAfterMs
+// ---------------------------------------------------------------------------
+describe("retryAfterMs", () => {
+  it("returns the fallback when the header is absent", () => {
+    expect(retryAfterMs(null, 1234)).toBe(1234);
+  });
+
+  it("parses delay-seconds into milliseconds", () => {
+    expect(retryAfterMs("2", 1000)).toBe(2000);
+  });
+
+  it("parses an HTTP-date relative to now instead of yielding NaN", () => {
+    const future = new Date(Date.now() + 5000).toUTCString();
+    const ms = retryAfterMs(future, 1000);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(5000);
+  });
+
+  it("clamps a past HTTP-date to zero (no negative sleep)", () => {
+    const past = new Date(Date.now() - 5000).toUTCString();
+    expect(retryAfterMs(past, 1000)).toBe(0);
+  });
+
+  it("falls back when the header is neither seconds nor a date", () => {
+    expect(retryAfterMs("soon", 777)).toBe(777);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWithRetry
+// ---------------------------------------------------------------------------
+describe("fetchWithRetry", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("retries retryable statuses then returns the first non-retryable response", async () => {
+    let calls = 0;
+    global.fetch = vi.fn(async () => {
+      calls++;
+      if (calls < 3) {
+        return {
+          ok: false,
+          status: 503,
+          headers: new Headers({ "Retry-After": "0" })
+        } as Response;
+      }
+      return { ok: true, status: 200, headers: new Headers() } as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await fetchWithRetry("https://x");
+    expect(res.status).toBe(200);
+    expect(calls).toBe(3);
+  });
+
+  it("does not retry a non-retryable status", async () => {
+    const fn = vi.fn(
+      async () =>
+        ({ ok: false, status: 400, headers: new Headers() }) as Response
+    );
+    global.fetch = fn as unknown as typeof fetch;
+
+    const res = await fetchWithRetry("https://x");
+    expect(res.status).toBe(400);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// atlasDownload
+// ---------------------------------------------------------------------------
+describe("atlasDownload", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("retries a transient 5xx and returns the bytes — the job is already billed", async () => {
+    let calls = 0;
+    global.fetch = vi.fn(async () => {
+      calls++;
+      if (calls === 1) {
+        return {
+          ok: false,
+          status: 503,
+          headers: new Headers({ "Retry-After": "0" })
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    const bytes = await atlasDownload("https://cdn/out.png");
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    expect(calls).toBe(2);
+  });
+
+  it("throws a descriptive error once retries are exhausted", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      headers: new Headers({ "Retry-After": "0" }),
+      text: async () => ""
+    })) as unknown as typeof fetch;
+
+    await expect(atlasDownload("https://cdn/out.png")).rejects.toThrow(
+      "AtlasCloud download failed: HTTP 500"
+    );
   });
 });
 
@@ -237,6 +361,38 @@ describe("atlasPoll", () => {
     const out = await atlasPoll("k", "p", { pollInterval: 0, maxAttempts: 10 });
     expect(out.status).toBe("succeeded");
     expect(calls).toBe(3);
+  });
+
+  it("recognizes alternative terminal success words (complete / done)", async () => {
+    for (const status of ["complete", "done"]) {
+      global.fetch = vi.fn(async () => {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({ data: { status, outputs: ["u"] } })
+        } as Response;
+      }) as unknown as typeof fetch;
+
+      const out = await atlasPoll("k", "p", { pollInterval: 0, maxAttempts: 2 });
+      expect(out.status).toBe(status);
+    }
+  });
+
+  it("treats a 'canceled' status as a job failure rather than looping to timeout", async () => {
+    global.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: async () => JSON.stringify({ data: { status: "canceled" } })
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    await expect(
+      atlasPoll("k", "p", { pollInterval: 0, maxAttempts: 2 })
+    ).rejects.toThrow("AtlasCloud job failed");
   });
 
   it("throws on a structured failure body with the error message", async () => {

--- a/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   createAtlasNodeClass,
   resolveAssetForAtlas,
@@ -34,6 +37,17 @@ describe("resolveAssetForAtlas", () => {
     expect(out).toBe("data:image/jpeg;base64,aGVsbG8=");
   });
 
+  it("honors a camelCase mimeType (as injected by prompt @-mentions) when the URI has no extension", async () => {
+    // mapPromptAssetsToInputs injects InjectedAssetRef shaped { uri, mimeType,
+    // data } — camelCase mimeType, and an asset:// URI with no file extension.
+    const out = await resolveAssetForAtlas(
+      { uri: "asset://abc123", data: "aGVsbG8=", mimeType: "image/webp" },
+      undefined,
+      "image"
+    );
+    expect(out).toBe("data:image/webp;base64,aGVsbG8=");
+  });
+
   it("uses context.storage to materialize internal URIs", async () => {
     const bytes = Uint8Array.from([1, 2, 3]);
     const storage = { retrieve: vi.fn().mockResolvedValue(bytes) };
@@ -52,6 +66,7 @@ describe("resolveAssetForAtlas", () => {
   describe("SSRF guard — rejects private / loopback / metadata hosts", () => {
     const blocked = [
       "http://localhost:7777/a.png",
+      "http://sub.localhost/a.png",
       "http://127.0.0.1/a.png",
       "http://0.0.0.0/a.png",
       "http://10.0.0.5/a.png",
@@ -62,7 +77,17 @@ describe("resolveAssetForAtlas", () => {
       "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
       "http://[::1]/a.png",
       "http://[fe80::1]/a.png",
-      "http://[fc00::1]/a.png"
+      "http://[fc00::1]/a.png",
+      // inet_aton numeric encodings of 127.0.0.1 the OS resolver still accepts
+      "http://2130706433/a.png", // decimal
+      "http://0x7f000001/a.png", // hex
+      "http://0177.0.0.1/a.png", // octal first octet
+      "http://127.1/a.png", // short form
+      // decimal encoding of 169.254.169.254 (cloud metadata)
+      "http://2852039166/latest/meta-data/",
+      // IPv4-mapped IPv6 loopback (dotted + hex tail)
+      "http://[::ffff:127.0.0.1]/a.png",
+      "http://[::ffff:7f00:1]/a.png"
     ];
     for (const uri of blocked) {
       it(`refuses to fetch ${uri}`, async () => {
@@ -544,5 +569,100 @@ describe("createAtlasNodeClass.process", () => {
     await expect(node.process({ storage: null })).rejects.toThrow(
       "AtlasCloud job failed: moderation flagged"
     );
+  });
+
+  it("retries a transient 5xx on the (already-billed) output download", async () => {
+    let dlAttempts = 0;
+    global.fetch = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith("/generateImage")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "pid-1" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/pid-1")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.png"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.png") {
+        dlAttempts++;
+        if (dlAttempts === 1) {
+          return {
+            ok: false,
+            status: 503,
+            headers: new Headers({ "Retry-After": "0" })
+          } as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          arrayBuffer: async () => Uint8Array.from([0x89, 0x50]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const Cls = createAtlasNodeClass(makeSpec()) as unknown as new () => {
+      prompt: string;
+      size: string;
+      steps: number;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "a cat";
+    node.size = "1024x1024";
+    node.steps = 1;
+
+    const storage = { store: vi.fn().mockResolvedValue("memory://x.png") };
+    const out = await node.process({ storage });
+
+    // The CDN 503 was retried rather than throwing away the paid-for result.
+    expect(dlAttempts).toBe(2);
+    expect(storage.store).toHaveBeenCalledTimes(1);
+    expect(out).toEqual({ output: { type: "image", uri: "memory://x.png" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manifest invariants
+// ---------------------------------------------------------------------------
+describe("atlascloud-manifest", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../src/atlascloud-manifest.json"),
+      "utf8"
+    )
+  ) as AtlasManifestEntry[];
+
+  it("no longer exposes the unsurfaced return_last_frame option", () => {
+    const offenders = manifest
+      .filter((e) => e.fields.some((f) => f.name === "return_last_frame"))
+      .map((e) => e.className);
+    expect(offenders).toEqual([]);
+  });
+
+  it("models multi-image edit inputs as list[image], not a single wrapped image", () => {
+    const edits = manifest.filter((e) =>
+      e.fields.some((f) => f.name === "images")
+    );
+    expect(edits.length).toBeGreaterThan(0);
+    for (const e of edits) {
+      const images = e.fields.find((f) => f.name === "images");
+      expect(images?.type).toBe("list[image]");
+      // the single-wrap `array` flag must be gone now that it's a real list
+      expect((images as { array?: boolean }).array).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
Fixes the bugs found while reviewing packages/atlascloud-nodes:

- Output download now retries 429/5xx. The module spec promised retry on
  "polls/downloads" but the result download used a plain fetch, so a single
  transient CDN blip threw away an already-generated, already-billed result.
  Adds atlasDownload() (built on fetchWithRetry) and routes the factory
  through it; mirrors topaz-nodes.

- SSRF guard now blocks the inet_aton numeric IP encodings (decimal/hex/octal
  and short forms) and IPv4-mapped IPv6 that getaddrinfo still resolves but the
  old dotted-quad regex missed (e.g. http://2130706433/, http://0x7f000001/,
  http://[::ffff:127.0.0.1]/ all reaching loopback/metadata). Also blocks
  *.localhost.

- guessMime now reads camelCase `mimeType` (the shape mapPromptAssetsToInputs
  injects for @-mentioned assets), not just snake_case `mime_type`, so a
  mentioned asset whose URI has no file extension isn't mislabeled.

- Retry-After parsing handles HTTP-date as well as delay-seconds; a date used
  to parse to NaN and setTimeout(_, NaN) fires immediately, defeating backoff.

- Edit nodes (GPT Image 2 / Nano Banana 2 / Pro / Pro Ultra) model `images` as
  list[image] instead of a single image wrapped via `array:true`, matching the
  plural field name and the advertised "up to 14 input images".

- Removed the `return_last_frame` option from the Seedance nodes: the node
  surfaces a single output and pickOutputUrl only returns outputs[0], so the
  extra last-frame image was silently discarded.

- Poll accepts a few more terminal status synonyms (complete/done, canceled)
  so a terminal-but-unrecognized status doesn't loop to a full timeout.

Adds tests for each fix.