### PR TITLE
fix(runtime): correct provider cost accounting, streaming, and media handling bugs

### DIFF
--- a/packages/runtime/src/comfy-executor.ts
+++ b/packages/runtime/src/comfy-executor.ts
@@ -216,11 +216,15 @@ export function executeComfy(
     }
 
     // Reconcile from history: cached nodes (and any not captured live) don't
-    // emit `executed`, so fetch them now — skipping those already streamed.
+    // emit `executed`, so fetch them now — skipping only nodes whose live
+    // download actually succeeded. A node added to `emitted` but whose live
+    // download failed or yielded nothing is intentionally NOT skipped, so it
+    // gets a second chance from history rather than being lost. (All in-flight
+    // downloads have settled by now: `settle()` drains them before resolving.)
     const fromHistory = await fetchOutputs(
       base,
       promptId,
-      streamState.emitted
+      new Set(Object.keys(streamState.collected))
     );
     for (const [nodeId, outputs] of Object.entries(fromHistory)) {
       streamState.collected[nodeId] = outputs;

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -91,7 +91,7 @@ export async function loadMediaRefBytes(
     const b64 = comma >= 0 ? data.slice(comma + 1) : data;
     return new Uint8Array(Buffer.from(b64, "base64"));
   }
-  if (data instanceof Uint8Array) {
+  if (data instanceof Uint8Array && data.length > 0) {
     return data;
   }
 

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -287,13 +287,19 @@ export class AnthropicProvider extends BaseProvider {
     }
 
     if (message.role === "system") {
-      return {
-        role: "assistant",
-        content:
-          typeof message.content === "string"
-            ? message.content
-            : String(message.content ?? "")
-      };
+      // Anthropic has no `system` role in the messages array (the system prompt
+      // is a top-level param). The main generate paths strip system messages
+      // before conversion; if one still reaches here, fold it into a user
+      // message rather than mislabeling it as assistant text (and avoid
+      // String(array) producing "[object Object]").
+      const text =
+        typeof message.content === "string"
+          ? message.content
+          : (message.content ?? [])
+              .filter(isTextContent)
+              .map((c) => c.text)
+              .join("\n");
+      return { role: "user", content: text };
     }
 
     if (message.role === "user") {
@@ -517,6 +523,7 @@ export class AnthropicProvider extends BaseProvider {
     let streamInputTokens = 0;
     let streamOutputTokens = 0;
     let streamCachedTokens = 0;
+    let streamCacheWriteTokens = 0;
 
     // Track in-flight tool_use blocks: index → { id, name, accumulated partial_json }
     const activeToolBlocks = new Map<
@@ -529,6 +536,7 @@ export class AnthropicProvider extends BaseProvider {
         const usage = event.message.usage;
         streamInputTokens += usage.input_tokens ?? 0;
         streamCachedTokens += usage.cache_read_input_tokens ?? 0;
+        streamCacheWriteTokens += usage.cache_creation_input_tokens ?? 0;
       }
 
       if (event.type === "message_delta") {
@@ -536,10 +544,15 @@ export class AnthropicProvider extends BaseProvider {
       }
 
       if (event.type === "message_stop") {
+        // Anthropic's `input_tokens` is the uncached portion only; cache
+        // read/write tokens are reported separately. genai-prices expects
+        // `inputTokens` to be the full prompt total (see UsageInfo docs).
         this.trackUsage(args.model, {
-          inputTokens: streamInputTokens,
+          inputTokens:
+            streamInputTokens + streamCachedTokens + streamCacheWriteTokens,
           outputTokens: streamOutputTokens,
-          cachedTokens: streamCachedTokens
+          cachedTokens: streamCachedTokens,
+          cacheWriteTokens: streamCacheWriteTokens
         });
       }
 
@@ -691,10 +704,16 @@ export class AnthropicProvider extends BaseProvider {
     );
 
     if (response.usage) {
+      // Anthropic's `input_tokens` is the uncached portion only; cache
+      // read/write tokens are reported separately. genai-prices expects
+      // `inputTokens` to be the full prompt total (see UsageInfo docs).
+      const cacheRead = response.usage.cache_read_input_tokens ?? 0;
+      const cacheWrite = response.usage.cache_creation_input_tokens ?? 0;
       this.trackUsage(args.model, {
-        inputTokens: response.usage.input_tokens ?? 0,
+        inputTokens: (response.usage.input_tokens ?? 0) + cacheRead + cacheWrite,
         outputTokens: response.usage.output_tokens ?? 0,
-        cachedTokens: response.usage.cache_read_input_tokens ?? 0
+        cachedTokens: cacheRead,
+        cacheWriteTokens: cacheWrite
       });
     }
 

--- a/packages/runtime/src/providers/cost-calculator.ts
+++ b/packages/runtime/src/providers/cost-calculator.ts
@@ -61,9 +61,13 @@ export const PRICING_TIERS: Record<string, PricingTier> = {
   whisperStandard: { costType: CostType.DURATION_BASED, perMinute: 0.006 },
   whisperLowCost: { costType: CostType.DURATION_BASED, perMinute: 0.003 },
   // TTS / Text-to-Speech — per 1000 characters.
-  ttsStandard: { costType: CostType.CHARACTER_BASED, per1kChars: 0.0006 },
+  // tts-1 = $15/1M chars ($0.015/1k); tts-1-hd = $30/1M chars ($0.03/1k).
   ttsHd: { costType: CostType.CHARACTER_BASED, per1kChars: 0.015 },
   ttsUltraHd: { costType: CostType.CHARACTER_BASED, per1kChars: 0.03 },
+  // gpt-4o-mini-tts is natively token-based (text in + audio out); OpenAI's
+  // own estimate is ~$0.015/min of audio. Approximated here per-1k-chars
+  // (~1 min ≈ 900–1000 chars) since the TTS call meters characters, not tokens.
+  ttsGpt4oMini: { costType: CostType.CHARACTER_BASED, per1kChars: 0.015 },
 
   // --- 3D generation (TASK_BASED) — USD per task ---
   // Pricing sources (verify on each pricing change):
@@ -92,7 +96,7 @@ export const MODEL_TO_TIER: Record<string, string> = {
   "openai:gpt-4o-transcribe": "whisperStandard",
   "openai:gpt-4o-mini-transcribe": "whisperLowCost",
   // TTS / Text-to-Speech
-  "openai:gpt-4o-mini-tts": "ttsStandard",
+  "openai:gpt-4o-mini-tts": "ttsGpt4oMini",
   "openai:tts-1": "ttsHd",
   "openai:tts-1-hd": "ttsUltraHd",
   // Meshy 3D generation — text tier is textured (preview + refine); image is single-step
@@ -109,9 +113,20 @@ export const MODEL_TO_TIER: Record<string, string> = {
 };
 
 export interface UsageInfo {
+  /**
+   * Total prompt/input tokens, **inclusive** of `cachedTokens` and
+   * `cacheWriteTokens`. This matches the `@pydantic/genai-prices` contract,
+   * which derives the full-price text input as
+   * `inputTokens - cachedTokens - cacheWriteTokens`. Providers whose API
+   * reports the uncached portion separately (e.g. Anthropic) must add the
+   * cache read/write counts back in before populating this field.
+   */
   inputTokens?: number;
   outputTokens?: number;
+  /** Cache-read (hit) tokens — a subset of {@link inputTokens}, priced at a discount. */
   cachedTokens?: number;
+  /** Cache-write (creation) tokens — a subset of {@link inputTokens}, priced at a premium. */
+  cacheWriteTokens?: number;
   reasoningTokens?: number;
   inputCharacters?: number;
   durationSeconds?: number;
@@ -167,6 +182,9 @@ function calcTokenPriceUsd(
   };
   if (usage.cachedTokens && usage.cachedTokens > 0) {
     gpUsage.cache_read_tokens = usage.cachedTokens;
+  }
+  if (usage.cacheWriteTokens && usage.cacheWriteTokens > 0) {
+    gpUsage.cache_write_tokens = usage.cacheWriteTokens;
   }
 
   const providerId = GENAI_PROVIDER_MAP[providerLower];

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -271,6 +271,19 @@ export class GeminiProvider extends BaseProvider {
     let systemInstruction: string | undefined;
     const contents: GeminiContent[] = [];
 
+    // Gemini correlates a tool result to its call by the function *name*, not
+    // by id (and our tool-call ids are synthesized — never valid Gemini
+    // function names). Map each tool-call id back to its function name so the
+    // `functionResponse.name` below matches the earlier `functionCall.name`.
+    const toolCallNames = new Map<string, string>();
+    for (const m of messages) {
+      if (m.role === "assistant" && m.toolCalls) {
+        for (const tc of m.toolCalls) {
+          if (tc.id) toolCallNames.set(tc.id, tc.name);
+        }
+      }
+    }
+
     for (const msg of messages) {
       if (msg.role === "system") {
         systemInstruction =
@@ -290,12 +303,19 @@ export class GeminiProvider extends BaseProvider {
             ? msg.content
             : JSON.stringify(msg.content);
 
+        const functionName =
+          (msg.toolCallId
+            ? toolCallNames.get(msg.toolCallId)
+            : undefined) ??
+          msg.toolCallId ??
+          "unknown";
+
         contents.push({
           role: "user",
           parts: [
             {
               functionResponse: {
-                name: msg.toolCallId ?? "unknown",
+                name: functionName,
                 response: { result: responseText }
               }
             }

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -180,6 +180,7 @@ export class OllamaProvider extends BaseProvider {
     // or [func_name(key=value)]
     const funcPattern = /\[?\b(\w+)\(([^)]*)\)\]?/g;
     let match: RegExpExecArray | null;
+    let callIndex = 0;
 
     while ((match = funcPattern.exec(content)) !== null) {
       const [fullMatch, name, argsStr] = match;
@@ -200,8 +201,17 @@ export class OllamaProvider extends BaseProvider {
         else args[key] = value;
       }
 
-      calls.push({ id: `emulated-${name}-${Date.now()}`, name, args });
-      cleaned = cleaned.replace(fullMatch, "").trim();
+      // Include a per-call index so repeated calls to the same tool within one
+      // response (same Date.now() millisecond) get distinct ids.
+      calls.push({
+        id: `emulated-${name}-${Date.now()}-${callIndex}`,
+        name,
+        args
+      });
+      callIndex += 1;
+      // replaceAll (not replace) so every occurrence of this call text is
+      // stripped, not just the first.
+      cleaned = cleaned.replaceAll(fullMatch, "").trim();
     }
 
     return [calls, cleaned];

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -791,6 +791,16 @@ export class OpenAIProvider extends BaseProvider {
           }
           deltaToolCalls.clear();
         }
+
+        // Always emit a terminal `done: true` chunk when the completion
+        // finishes, regardless of reason. "stop" already emits one above; for
+        // every other terminal reason (tool_calls, length, content_filter)
+        // emit one here so consumers get a consistent end-of-stream marker
+        // (matching the Anthropic and Gemini providers).
+        if (choice.finish_reason && choice.finish_reason !== "stop") {
+          const doneChunk: Chunk = { type: "chunk", content: "", done: true };
+          yield doneChunk;
+        }
       }
     } finally {
       if (typeof stream.close === "function") {

--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -92,8 +92,31 @@ export class PythonNodeExecutor {
     private nodeType: string,
     _properties: Record<string, unknown>,
     private outputTypes: Record<string, string>,
-    private requiredSettings: string[]
+    private requiredSettings: string[],
+    /** Graph node id, used to surface Python worker progress as node_progress. */
+    private nodeId?: string
   ) {}
+
+  /**
+   * Build an onProgress sink that forwards the Python worker's progress events
+   * to the context message stream as `node_progress`. Returns undefined when we
+   * lack the context or node id needed to address the message.
+   */
+  private progressHandler(
+    context?: ProcessingContext
+  ): ((event: ProgressEvent) => void) | undefined {
+    const nodeId = this.nodeId;
+    if (!context || !nodeId) return undefined;
+    return (event: ProgressEvent) => {
+      context.postMessage({
+        type: "node_progress",
+        node_id: nodeId,
+        progress: event.progress,
+        total: event.total,
+        workflow_id: context.workflowId
+      });
+    };
+  }
 
   private async prepareExecution(
     inputs: Record<string, unknown>,
@@ -185,6 +208,11 @@ export class PythonNodeExecutor {
           contentType
         );
         outputs[name] = { uri, type: mediaType };
+      } else if (mediaType) {
+        // No storage adapter available: keep the bytes inline but preserve the
+        // media kind so downstream nodes receive a typed ref (e.g. ImageRef),
+        // not a bare Uint8Array.
+        outputs[name] = { type: mediaType, data: blobData };
       } else {
         outputs[name] = blobData;
       }
@@ -203,7 +231,7 @@ export class PythonNodeExecutor {
       fields,
       secrets,
       blobs,
-      undefined
+      this.progressHandler(context)
     );
     return this.materializeOutputs(result, context);
   }
@@ -223,7 +251,7 @@ export class PythonNodeExecutor {
       fields,
       secrets,
       blobs,
-      undefined
+      this.progressHandler(context)
     )) {
       yield await this.materializeOutputs(partial, context);
     }

--- a/packages/runtime/src/trace-exporters.ts
+++ b/packages/runtime/src/trace-exporters.ts
@@ -262,7 +262,9 @@ function colorize(s: string, color: keyof typeof COLOR): string {
 }
 
 function formatPretty(r: TraceRecord): string {
-  const dur = `${r.duration_ms.toFixed(1)}ms`;
+  // duration_ms is already integer-rounded by hrTimeToMs, so toFixed(1) only
+  // ever appended a meaningless ".0".
+  const dur = `${r.duration_ms}ms`;
   const statusColor: keyof typeof COLOR =
     r.status.code === "ERROR"
       ? "red"

--- a/packages/runtime/tests/providers/anthropic-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/anthropic-provider-coverage.test.ts
@@ -47,12 +47,14 @@ describe("AnthropicProvider – convertMessage branches", () => {
     { client: {} as any }
   );
 
-  it("converts system message to assistant role", async () => {
+  it("folds a stray system message into a user message", async () => {
+    // Anthropic has no `system` role in the messages array; a system message
+    // reaching convertMessage is folded into a user message (not assistant).
     const result = await provider.convertMessage({
       role: "system",
       content: "You are helpful"
     });
-    expect(result).toEqual({ role: "assistant", content: "You are helpful" });
+    expect(result).toEqual({ role: "user", content: "You are helpful" });
   });
 
   it("handles system message with non-string content", async () => {
@@ -60,7 +62,7 @@ describe("AnthropicProvider – convertMessage branches", () => {
       role: "system",
       content: null
     });
-    expect(result).toEqual({ role: "assistant", content: "" });
+    expect(result).toEqual({ role: "user", content: "" });
   });
 
   it("converts user text message", async () => {

--- a/packages/runtime/tests/providers/cost-calculator.test.ts
+++ b/packages/runtime/tests/providers/cost-calculator.test.ts
@@ -135,7 +135,7 @@ describe("CostCalculator.calculate – local non-token modalities (USD)", () => 
       { inputCharacters: 5000 },
       "openai"
     );
-    expect(cost).toBeCloseTo((5000 / 1000) * PRICING_TIERS.ttsStandard.per1kChars!);
+    expect(cost).toBeCloseTo((5000 / 1000) * PRICING_TIERS.ttsGpt4oMini.per1kChars!);
   });
 
   it("calculates task-based cost (3D)", () => {

--- a/packages/runtime/tests/providers/openai-provider.test.ts
+++ b/packages/runtime/tests/providers/openai-provider.test.ts
@@ -159,9 +159,6 @@ describe("OpenAIProvider", () => {
             finish_reason: "tool_calls"
           }
         ]
-      },
-      {
-        choices: [{ delta: { content: "" }, finish_reason: "stop" }]
       }
     ]);
 

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -244,7 +244,8 @@ async function getWorkflowRuntimeEnvironment(
             Object.fromEntries(
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
-            meta?.required_settings ?? []
+            meta?.required_settings ?? [],
+            node.id
           );
         }
         if (registry.getMetadata(node.type) && !registry.has(node.type)) {

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -196,7 +196,8 @@ function getRuntimeEnvironment(
             Object.fromEntries(
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
-            meta?.required_settings ?? []
+            meta?.required_settings ?? [],
+            node.id
           );
         }
         if (registry.getMetadata(node.type) && !registry.has(node.type)) {

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -172,7 +172,8 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
             Object.fromEntries(
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
-            meta?.required_settings ?? []
+            meta?.required_settings ?? [],
+            node.id
           );
         }
         if (registry.getMetadata(node.type) && !registry.has(node.type)) {

--- a/packages/websocket/src/trpc/routers/workflows.ts
+++ b/packages/websocket/src/trpc/routers/workflows.ts
@@ -634,7 +634,8 @@ export const workflowsRouter = router({
             Object.fromEntries(
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
-            meta?.required_settings ?? []
+            meta?.required_settings ?? [],
+            node.id
           );
         }
         return registry.resolve(node as Parameters<typeof registry.resolve>[0]);


### PR DESCRIPTION
Fixes a set of correctness bugs found while reviewing packages/runtime:

- Anthropic cost undercount (critical): Anthropic's `input_tokens` is the
  uncached portion only, but it was passed to genai-prices as if inclusive of
  cache reads, double-subtracting cached tokens (and clamping to zero on large
  cached prompts). Cache-write tokens were never billed at all. `inputTokens`
  is now documented as inclusive; Anthropic adds cache read+write back in and
  passes a new `cacheWriteTokens` field. Also fixes the undercounted
  `gen_ai.usage.total_tokens` span attribute.

- ComfyUI output loss: nodes were added to the `emitted` set before their live
  download finished, so a failed/empty download left the node skipped by the
  history reconciliation pass and its output was lost. Reconciliation now skips
  only successfully-collected nodes.

- Gemini tool-result naming: tool results were sent with `functionResponse.name`
  set to the synthetic tool-call id instead of the function name, so Gemini
  couldn't correlate results to calls in multi-turn tool conversations. The name
  is now recovered from the originating function call.

- OpenAI streaming: a terminal `done: true` chunk was emitted only on
  `finish_reason === "stop"`, never for tool-call/length finishes. Now always
  emits one terminal chunk, matching the Anthropic and Gemini providers.

- media-ref-bytes: an empty `Uint8Array` data buffer returned 0 bytes instead
  of falling through to resolve the uri/asset_id (string path already guarded
  length; Uint8Array path now does too).

- python-node-executor: media blobs are no longer emitted as bare Uint8Arrays
  when no storage adapter is present (wrapped as a typed inline ref), and Python
  worker progress is now surfaced as node_progress messages (node id threaded
  from the websocket resolvers).

- gpt-4o-mini-tts mispricing: replaced a fabricated $0.0006/1k-char rate with a
  documented ~$0.015/1k-char approximation of OpenAI's per-minute estimate.

- Ollama emulated tool calls: per-call index added to ids to avoid same-ms
  collisions; replaceAll used to strip all occurrences of the call text.

- Anthropic convertMessage: a stray system message is folded into a user message
  instead of being mislabeled as assistant text / stringified to "[object Object]".

- trace-exporters: dropped the always-".0" toFixed(1) on integer durations.