### PR TITLE
Fix bugs in automation-nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41810,16 +41810,20 @@
         "@tensorflow-models/qna": "^1.0.2",
         "@tensorflow/tfjs": "^4.22.0",
         "better-sqlite3": "^12.8.0",
+        "cheerio": "^1.2.0",
         "chrome-launcher": "^1.2.0",
         "chrome-remote-interface": "^0.34.0",
         "exceljs": "^4.4.0",
+        "sharp": "^0.34.5",
         "tesseract.js": "^7.0.0",
+        "turndown": "^7.2.2",
         "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/chrome-remote-interface": "^0.33.0",
         "@types/node": "^22.0.0",
+        "@types/turndown": "^5.0.6",
         "@types/ws": "^8.5.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"

--- a/packages/automation-nodes/package.json
+++ b/packages/automation-nodes/package.json
@@ -26,16 +26,20 @@
     "@tensorflow-models/qna": "^1.0.2",
     "@tensorflow/tfjs": "^4.22.0",
     "better-sqlite3": "^12.8.0",
+    "cheerio": "^1.2.0",
     "chrome-launcher": "^1.2.0",
     "chrome-remote-interface": "^0.34.0",
     "exceljs": "^4.4.0",
+    "sharp": "^0.34.5",
     "tesseract.js": "^7.0.0",
+    "turndown": "^7.2.2",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/chrome-remote-interface": "^0.33.0",
     "@types/node": "^22.0.0",
+    "@types/turndown": "^5.0.6",
     "@types/ws": "^8.5.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"

--- a/packages/automation-nodes/src/nodes/lib-os.ts
+++ b/packages/automation-nodes/src/nodes/lib-os.ts
@@ -295,7 +295,15 @@ export class CreateDirectoryLibNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const p = expandUser(String(this.path ?? ""));
     if (!p) throw new Error("'path' field cannot be empty");
-    await fs.mkdir(p, { recursive: Boolean(this.exist_ok ?? true) });
+    const existOk = Boolean(this.exist_ok ?? true);
+    // `recursive` in fs.mkdir controls BOTH parent creation and
+    // suppress-error-on-exists. Parent directories should always be created;
+    // `exist_ok` should only govern whether an existing leaf is an error, so
+    // handle that check separately rather than tying it to `recursive`.
+    if (!existOk && existsSync(p)) {
+      throw new Error(`Directory already exists: ${p}`);
+    }
+    await fs.mkdir(p, { recursive: true });
     return {};
   }
 }
@@ -800,7 +808,8 @@ export class SplitPathLibNode extends BaseNode {
   static readonly description =
     "Split a path into directory and file components.\n    files, path, split\n\n    Use cases:\n    - Separate directory from filename\n    - Process path components separately\n    - Extract path parts";
   static readonly metadataOutputTypes = {
-    output: "dict"
+    dirname: "str",
+    basename: "str"
   };
 
   @prop({
@@ -823,7 +832,8 @@ export class SplitExtensionLibNode extends BaseNode {
   static readonly description =
     "Split a path into root and extension components.\n    files, path, extension, split\n\n    Use cases:\n    - Extract file extension\n    - Process filename without extension\n    - Handle file types";
   static readonly metadataOutputTypes = {
-    output: "dict"
+    root: "str",
+    extension: "str"
   };
 
   @prop({

--- a/packages/automation-nodes/src/nodes/lib-sqlite.ts
+++ b/packages/automation-nodes/src/nodes/lib-sqlite.ts
@@ -140,6 +140,12 @@ export class CreateTableLibNode extends BaseNode {
         };
       }
 
+      if (columns.length === 0) {
+        throw new Error(
+          "Cannot create a table with no columns — define at least one column"
+        );
+      }
+
       const columnDefs: string[] = [];
       for (let i = 0; i < columns.length; i++) {
         const col = columns[i];
@@ -179,7 +185,9 @@ export class InsertLibNode extends BaseNode {
   static readonly description =
     "Insert a record into a SQLite table.\n    sqlite, database, insert, add, record\n\n    Use cases:\n    - Add new flashcards to database\n    - Store agent observations\n    - Persist workflow results";
   static readonly metadataOutputTypes = {
-    output: "dict[str, any]"
+    row_id: "int",
+    rows_affected: "int",
+    message: "str"
   };
 
   @prop({
@@ -218,6 +226,11 @@ export class InsertLibNode extends BaseNode {
 
     try {
       const keys = Object.keys(data);
+      if (keys.length === 0) {
+        throw new Error(
+          "Insert data cannot be empty — provide at least one column/value pair"
+        );
+      }
       const columnsPart = keys.map((k) => quoteIdentifier(k)).join(", ");
       const placeholders = keys.map(() => "?").join(", ");
       const quotedTableName = quoteIdentifier(tableName);
@@ -355,7 +368,8 @@ export class UpdateLibNode extends BaseNode {
   static readonly description =
     "Update records in a SQLite table.\n    sqlite, database, update, modify, change\n\n    Use cases:\n    - Update flashcard content\n    - Modify stored records\n    - Change agent memory";
   static readonly metadataOutputTypes = {
-    output: "dict[str, any]"
+    rows_affected: "int",
+    message: "str"
   };
 
   @prop({
@@ -434,7 +448,8 @@ export class DeleteLibNode extends BaseNode {
   static readonly description =
     "Delete records from a SQLite table.\n    sqlite, database, delete, remove, drop\n\n    Use cases:\n    - Remove flashcards\n    - Delete agent memory\n    - Clean up old data";
   static readonly metadataOutputTypes = {
-    output: "dict[str, any]"
+    rows_affected: "int",
+    message: "str"
   };
 
   @prop({
@@ -499,8 +514,15 @@ export class ExecuteSQLLibNode extends BaseNode {
   static readonly inputFields = ["parameters"];
   static readonly description =
     "Execute arbitrary SQL statements for advanced operations.\n    sqlite, database, sql, execute, custom\n\n    Use cases:\n    - Complex queries with joins\n    - Aggregate functions (COUNT, SUM, AVG)\n    - Custom SQL operations";
+  // Modifying statements emit rows_affected/last_row_id/message; queries emit
+  // rows/count/message. Both shapes are declared so either set of handles can
+  // be wired downstream — unused slots are simply not emitted.
   static readonly metadataOutputTypes = {
-    output: "dict[str, any]"
+    rows_affected: "int",
+    last_row_id: "int",
+    message: "str",
+    rows: "list[dict[str, any]]",
+    count: "int"
   };
 
   @prop({

--- a/packages/automation-nodes/src/nodes/triggers.ts
+++ b/packages/automation-nodes/src/nodes/triggers.ts
@@ -71,19 +71,15 @@ export class WaitNode extends BaseNode {
   static readonly nodeType = "nodetool.triggers.Wait";
   static readonly title = "Wait";
   static readonly description =
-    "Node that suspends workflow execution until externally resumed.\n\n" +
-    "    This node pauses the workflow at this point and waits for an external\n" +
-    "    signal (via API call) to continue. When resumed, it outputs the input\n" +
-    "    data merged with any data provided during the resume call.\n\n" +
+    "Pause workflow execution for a fixed amount of time, then pass the input\n" +
+    "    through to the output.\n\n" +
     "    Use cases:\n" +
-    "    - Human-in-the-loop workflows requiring approval\n" +
-    "    - Waiting for external processes to complete\n" +
-    "    - Pausing workflows for manual data entry\n" +
-    "    - Synchronization points in multi-step processes\n" +
-    "    - Interactive chatbot-style workflows\n\n" +
-    "    The workflow is suspended (not running) while waiting, so it doesn't\n" +
-    "    consume resources. State is persisted and the workflow can be resumed\n" +
-    "    even after server restarts.";
+    "    - Rate-limiting or throttling between steps\n" +
+    "    - Waiting a fixed delay before continuing\n" +
+    "    - Spacing out polling or retry attempts\n\n" +
+    "    The input data is forwarded unchanged once the wait completes, along\n" +
+    "    with the resume timestamp and the actual number of seconds waited. A\n" +
+    "    timeout of 0 means no wait — the input passes through immediately.";
   static readonly inlineFields = [];
   static readonly inputFields = ["input"];
   static readonly metadataOutputTypes = {
@@ -96,7 +92,7 @@ export class WaitNode extends BaseNode {
     type: "int",
     default: 0,
     title: "Timeout Seconds",
-    description: "Optional timeout in seconds (0 = wait indefinitely)",
+    description: "Seconds to wait before continuing (0 = no wait)",
     min: 0
   })
   declare timeout_seconds: any;
@@ -105,7 +101,7 @@ export class WaitNode extends BaseNode {
     type: "any",
     default: "",
     title: "Input",
-    description: "Input data to pass through to the output when resumed"
+    description: "Input data to pass through to the output after waiting"
   })
   declare input: any;
 
@@ -194,14 +190,35 @@ export class ManualTriggerNode extends BaseNode {
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
     const maxEvents = Number(this.max_events ?? 0);
     const triggerName = String(this.name ?? "manual_trigger");
+    const timeoutSeconds = Number(this.timeout_seconds ?? 0) || 0;
+    const timeoutMs = timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0;
     let eventsProcessed = 0;
 
-    for await (const [handle, item] of inputs.any()) {
+    const iterator = inputs.any()[Symbol.asyncIterator]();
+    // `unique symbol` so the `=== TIMEOUT` check below narrows the race result.
+    const TIMEOUT: unique symbol = Symbol("timeout");
+    while (true) {
+      let result: IteratorResult<[string, unknown]>;
+      if (timeoutMs > 0) {
+        // Stop waiting if no event arrives within the configured timeout.
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<typeof TIMEOUT>((resolve) => {
+          timer = setTimeout(() => resolve(TIMEOUT), timeoutMs);
+        });
+        const next = await Promise.race([iterator.next(), timeoutPromise]);
+        clearTimeout(timer);
+        if (next === TIMEOUT) break;
+        result = next;
+      } else {
+        result = await iterator.next();
+      }
+      if (result.done) break;
+
+      const [handle, item] = result.value;
       if (handle === "__control__") continue;
 
-      const data = item;
       const event = {
-        data,
+        data: item,
         timestamp: new Date().toISOString(),
         source: triggerName,
         event_type: "manual"
@@ -319,11 +336,18 @@ export class IntervalTriggerNode extends BaseNode {
       if (maxEvents > 0 && tickCount >= maxEvents) return;
     }
 
-    // Main loop
+    // Main loop. When `emit_on_start` fired, the on-start emission already
+    // consumed the first slot (tickCount === 1) so `tickCount` whole intervals
+    // should have elapsed by the next scheduled tick. When it did not, the next
+    // tick is the very first one and must still land a full interval after the
+    // initial delay — hence the +1 offset. Without it, drift compensation makes
+    // the first tick fire immediately, defeating `emit_on_start = false`.
+    const driftOffset = emitOnStart ? 0 : 1;
     while (true) {
       if (driftCompensation) {
         // Calculate next tick time based on start time
-        const nextTickMs = tickCount * intervalMs + initialDelayMs;
+        const intervalsElapsed = tickCount + driftOffset;
+        const nextTickMs = intervalsElapsed * intervalMs + initialDelayMs;
         const elapsed = Date.now() - startTime;
         const waitMs = Math.max(MIN_WAIT_SECONDS * 1000, nextTickMs - elapsed);
         await new Promise((r) => setTimeout(r, waitMs));
@@ -720,6 +744,7 @@ export class FileWatchTriggerNode extends BaseNode {
 
     // Use fs.watch for filesystem monitoring
     const watchers: fs.FSWatcher[] = [];
+    let watchError: unknown = null;
 
     const watchDir = (dir: string) => {
       try {
@@ -745,12 +770,23 @@ export class FileWatchTriggerNode extends BaseNode {
           }
         );
         watchers.push(watcher);
-      } catch (_err) {
-        // Some paths may not be watchable
+      } catch (err) {
+        // Record the failure so it can be surfaced if no watcher starts at all
+        // (e.g. recursive watch unsupported on this platform). Swallowing it
+        // silently would leave the generator blocked on queue.get() forever
+        // with no diagnostic.
+        watchError = err;
       }
     };
 
     watchDir(watchPath);
+
+    if (watchers.length === 0) {
+      throw new Error(
+        `Failed to watch path: ${watchPath}` +
+          (watchError instanceof Error ? ` (${watchError.message})` : "")
+      );
+    }
 
     let eventsProcessed = 0;
     try {

--- a/packages/automation-nodes/src/nodes/workspace.ts
+++ b/packages/automation-nodes/src/nodes/workspace.ts
@@ -74,7 +74,9 @@ function formatTimestampedName(name: string): string {
 
 function wildcardToRegExp(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escaped.replaceAll("*", ".*")}$`);
+  // `*` matches any run of characters, `?` matches exactly one. `?` is not in
+  // the escaped set above, so it survives as a literal until rewritten here.
+  return new RegExp(`^${escaped.replaceAll("*", ".*").replaceAll("?", ".")}$`);
 }
 
 async function walk(dir: string, recursive: boolean): Promise<string[]> {
@@ -800,6 +802,7 @@ export class SaveImageFileNode extends BaseNode {
     await fs.writeFile(full, bytes);
     return {
       output: {
+        type: "image",
         uri: fileUri(full),
         data: Buffer.from(bytes).toString("base64")
       }
@@ -898,6 +901,7 @@ export class SaveVideoFileNode extends BaseNode {
     await fs.writeFile(full, bytes);
     return {
       output: {
+        type: "video",
         uri: fileUri(full),
         data: Buffer.from(bytes).toString("base64")
       }

--- a/packages/automation-nodes/tests/output-slots-and-fixes.test.ts
+++ b/packages/automation-nodes/tests/output-slots-and-fixes.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for the automation-nodes bug fixes.
+ *
+ * The headline issue: several nodes declared a single `output` slot in
+ * `metadataOutputTypes` but `process()` returned different, flattened keys.
+ * The graph editor only exposes declared slots as connectable handles, so the
+ * real data was unreachable downstream. The existing e2e suite missed this
+ * because it used these nodes as terminal sinks (which collect every returned
+ * value regardless of slot name).
+ *
+ * The invariant asserted here — every key a node returns must be a declared
+ * output slot — catches that whole class of bug.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  CreateTableLibNode,
+  InsertLibNode,
+  UpdateLibNode,
+  DeleteLibNode,
+  ExecuteSQLLibNode,
+  SplitPathLibNode,
+  SplitExtensionLibNode,
+  WaitNode,
+  IntervalTriggerNode
+} from "@nodetool-ai/automation-nodes";
+
+type NodeClassLike = {
+  nodeType: string;
+  metadataOutputTypes?: Record<string, string>;
+};
+
+function assertKeysDeclared(
+  NodeClass: NodeClassLike,
+  result: Record<string, unknown>
+): void {
+  const declared = Object.keys(NodeClass.metadataOutputTypes ?? {});
+  for (const key of Object.keys(result)) {
+    expect(
+      declared,
+      `${NodeClass.nodeType} returned undeclared output slot "${key}" — ` +
+        `declared slots are [${declared.join(", ")}]`
+    ).toContain(key);
+  }
+}
+
+describe("SQLite nodes — returned keys match declared output slots", () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "an-slots-sqlite-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+  const ctx = (): ProcessingContext =>
+    ({ workspaceDir: tmpDir }) as unknown as ProcessingContext;
+
+  const COLUMNS = {
+    columns: [
+      { name: "id", data_type: "int" },
+      { name: "name", data_type: "string" }
+    ]
+  };
+
+  it("Insert / Update / Delete / Query / ExecuteSQL only emit declared slots", async () => {
+    const create = new CreateTableLibNode();
+    create.assign({
+      database_name: "t.db",
+      table_name: "items",
+      columns: COLUMNS
+    });
+    assertKeysDeclared(CreateTableLibNode, await create.process(ctx()));
+
+    const insert = new InsertLibNode();
+    insert.assign({
+      database_name: "t.db",
+      table_name: "items",
+      data: { name: "alice" }
+    });
+    const insRes = await insert.process(ctx());
+    assertKeysDeclared(InsertLibNode, insRes);
+    expect(insRes.rows_affected).toBe(1);
+    expect(insRes.row_id).toBe(1);
+
+    const update = new UpdateLibNode();
+    update.assign({
+      database_name: "t.db",
+      table_name: "items",
+      data: { name: "bob" },
+      where: "id = 1"
+    });
+    const updRes = await update.process(ctx());
+    assertKeysDeclared(UpdateLibNode, updRes);
+    expect(updRes.rows_affected).toBe(1);
+
+    const query = new ExecuteSQLLibNode();
+    query.assign({ database_name: "t.db", sql: "SELECT * FROM items" });
+    assertKeysDeclared(ExecuteSQLLibNode, await query.process(ctx()));
+
+    const dml = new ExecuteSQLLibNode();
+    dml.assign({
+      database_name: "t.db",
+      sql: "INSERT INTO items (name) VALUES (?)",
+      parameters: ["carol"]
+    });
+    assertKeysDeclared(ExecuteSQLLibNode, await dml.process(ctx()));
+
+    const del = new DeleteLibNode();
+    del.assign({ database_name: "t.db", table_name: "items", where: "id = 1" });
+    const delRes = await del.process(ctx());
+    assertKeysDeclared(DeleteLibNode, delRes);
+    expect(delRes.rows_affected).toBe(1);
+  });
+
+  it("Insert rejects empty data instead of building invalid SQL", async () => {
+    const insert = new InsertLibNode();
+    insert.assign({ database_name: "t.db", table_name: "items", data: {} });
+    await expect(insert.process(ctx())).rejects.toThrow(/cannot be empty/i);
+  });
+
+  it("CreateTable rejects an empty column list", async () => {
+    const create = new CreateTableLibNode();
+    create.assign({
+      database_name: "t.db",
+      table_name: "empty",
+      columns: { columns: [] }
+    });
+    await expect(create.process(ctx())).rejects.toThrow(/no columns/i);
+  });
+});
+
+describe("Path split nodes — returned keys match declared output slots", () => {
+  it("SplitPath emits dirname + basename", async () => {
+    const node = new SplitPathLibNode();
+    node.assign({ path: "/foo/bar/file.txt" });
+    const result = await node.process();
+    assertKeysDeclared(SplitPathLibNode, result);
+    expect(result).toEqual({ dirname: "/foo/bar", basename: "file.txt" });
+  });
+
+  it("SplitExtension emits root + extension", async () => {
+    const node = new SplitExtensionLibNode();
+    node.assign({ path: "/foo/bar/file.txt" });
+    const result = await node.process();
+    assertKeysDeclared(SplitExtensionLibNode, result);
+    expect(result).toEqual({ root: "/foo/bar/file", extension: ".txt" });
+  });
+});
+
+describe("WaitNode — timeout 0 passes through without waiting", () => {
+  it("returns the input immediately when timeout is 0", async () => {
+    const node = new WaitNode();
+    node.assign({ timeout_seconds: 0, input: "hello" });
+    const start = Date.now();
+    const result = await node.process();
+    expect(Date.now() - start).toBeLessThan(500);
+    expect(result.data).toBe("hello");
+    expect(result.waited_seconds as number).toBeLessThan(0.5);
+  });
+});
+
+describe("IntervalTrigger — emit_on_start=false respects the interval under drift compensation", () => {
+  it("waits a full interval before the first tick rather than firing immediately", async () => {
+    const node = new IntervalTriggerNode();
+    node.assign({
+      interval_seconds: 0.2,
+      initial_delay_seconds: 0,
+      emit_on_start: false,
+      include_drift_compensation: true,
+      max_events: 1
+    });
+    const start = Date.now();
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of node.genProcess()) {
+      events.push(event);
+    }
+    const elapsed = Date.now() - start;
+    expect(events).toHaveLength(1);
+    expect(events[0].tick).toBe(1);
+    // Pre-fix the first tick fired in ~1ms; it must now wait ~one interval.
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+  });
+});


### PR DESCRIPTION
Output-slot contract mismatches (the headline): several nodes declared a
single `output` slot in metadataOutputTypes but process() returned different,
flattened keys. The graph editor only exposes declared slots as connectable
handles, so the real data was unreachable downstream. Declare the actual
returned slots instead:
  - lib.sqlite.Insert    -> row_id, rows_affected, message
  - lib.sqlite.Update    -> rows_affected, message
  - lib.sqlite.Delete    -> rows_affected, message
  - lib.sqlite.ExecuteSQL -> rows_affected, last_row_id, message, rows, count
  - lib.os.SplitPath     -> dirname, basename
  - lib.os.SplitExtension -> root, extension

Missing runtime dependencies: cheerio, turndown and sharp were imported but
not declared in package.json (only resolved via monorepo hoisting). Added
them plus @types/turndown.

Other fixes:
  - WaitNode: docs claimed "0 = wait indefinitely" but timeout 0 returns
    immediately. Aligned description/prop with the implemented timed-delay
    behavior.
  - IntervalTrigger: with emit_on_start=false, drift compensation made the
    first tick fire immediately instead of after a full interval. Added the
    interval offset so the first tick is correctly delayed.
  - FileWatchTrigger: a failed fs.watch was swallowed silently, leaving the
    generator blocked forever with no diagnostic. Now surfaces the error when
    no watcher can be created.
  - CreateDirectory: exist_ok was wired to fs.mkdir's `recursive` flag, which
    also disabled parent creation. Always create parents; check exist_ok
    separately.
  - SQLite Insert/CreateTable: validate empty data/columns instead of emitting
    invalid SQL.
  - ManualTrigger: implemented the previously-ignored timeout_seconds.
  - workspace glob: handle `?` wildcards (was only handling `*`).
  - SaveImageFile/SaveVideoFile: include the `type` discriminator in output.

Added regression tests asserting every returned key is a declared output slot.

https://claude.ai/code/session_01TnRNELuCBAyQNhnaAvmrkS