### PR TITLE
Document node authoring patterns & API wrapper rules in AGENTS.md

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -173,6 +173,162 @@ Backend-specific standards (full detail in `DEVELOPMENT_STANDARDS.md`):
 
 `packages/*` currently has `@typescript-eslint/no-explicit-any` disabled (transitional). **target**: zero `any` in `packages/protocol`, `packages/kernel`, `packages/runtime`, `packages/agents`, `packages/node-sdk`. New code must use `unknown` + narrowing or proper generics.
 
+## Node Authoring — Bug Patterns to Avoid
+
+Most `*-nodes` packages have **no** AGENTS.md of their own, so these
+cross-cutting rules — distilled from shipped bug fixes — apply to **every** node
+you write or edit. Package-specific overlays (e.g. `audio-nodes`, `image-nodes`,
+`llm-nodes`) add to, not replace, this list.
+
+### Output contract
+
+- **Every key your `process()`/`genProcess()` returns must be a declared output
+  slot** in `metadataOutputTypes`. The graph editor only exposes declared slots
+  as connectable handles, so a returned key that isn't declared (a stray `name`,
+  `output`, `row_id`, …) is **unreachable downstream** — the data silently
+  vanishes. This bit automation-, image-, and audio-nodes.
+- **Test that each declared output port is actually populated, and never test a
+  node only as a terminal sink** — sinks collect every returned value regardless
+  of slot name, so they hide slot-name mismatches. Assert the invariant
+  "every returned key is a declared slot" (see
+  `automation-nodes/tests/output-slots-and-fixes.test.ts`).
+- **A streaming output handle (`chunk`) must be produced by an `async *genProcess`
+  generator**, and `outputCorrelation` must match: `iteration` for streamed
+  chunks, `single` for the final aggregate. Declaring a `chunk` output on a node
+  whose `process()` only returns a final value leaves it permanently empty.
+- **Implement every prop you declare.** A declared-but-unwired prop (filter
+  `extensions`, `include_subdirectories`, `timeout_seconds`, `gain_db`) is a
+  silent no-op. If you delegate to a shared loader, make sure it honors those props.
+
+### Media refs (ImageRef / VideoRef / AudioRef / Model3DRef)
+
+- **`data` carries RAW base64 or a `Uint8Array` — never a `data:` URI.** The hot
+  consumers (`decodeAssetBytes` in websocket, `asUint8Array` in openai-provider)
+  do `Buffer.from(data, "base64")` with no prefix stripping, so a
+  `data:image/png;base64,` prefix corrupts every saved/forwarded asset. Put the
+  MIME type in `content_type`, not inline in `data`.
+- **Always include the `type` discriminator** (`"image"`/`"audio"`/`"video"`/
+  `"model3d"`) on every ref you emit — `isAssetLikeValue`, asset auto-save, and
+  downstream type detection all key off it. A bare `Uint8Array` output is an
+  untyped value; wrap it as `{ type, data }`.
+- **Use your package's `*Ref`/`*RefFromBytes` helper** (`imageRef`/`videoRef`,
+  `audioRefFromBytes`/`audioRefFromWav`, the minimax `*RefFromBytes`) instead of
+  hand-rolling the object literal — the helper sets `type` and raw-base64 `data`
+  correctly.
+- **Read input media bytes with the async, context-aware resolver**
+  (`loadMediaRefBytes(value, context)` in runtime, or `audioBytesAsync` /
+  `videoBytesAsync`). The sync readers (`audioBytes`) see only inline `data` and
+  return empty for `asset://`/`file://`/`http`/storage refs — a node that uses
+  them silently drops media supplied as an asset or URL.
+- **Choosing inline `data` vs `uri`: check `.length > 0`, never bare
+  truthiness.** A zero-length `Uint8Array` is truthy, so `if (ref.data)` shadows
+  a perfectly good `uri`. Guard `data.length > 0` and fall through to URI/asset
+  resolution.
+
+### Indices, bounds, and numeric guards
+
+- **No `if (end < 0) end = length` catch-all.** Pick exactly one documented
+  sentinel (e.g. `-1` = "through the end") and count *other* negatives from the
+  end Python-style (`len + end`). Always clamp indices and crop/extract boxes to
+  the valid range before slicing — downstream libs (sharp) throw on out-of-range,
+  and wrappers may swallow the error and silently return the un-cropped input.
+- **Never write `Number(x) !== null` / `Number(x) !== undefined`.** `Number()`
+  returns a number or `NaN`, never null — the guard is always true and the branch
+  is dead. Use `Number.isFinite(x)`, or treat the prop default (usually `0`) as
+  "unset". Test *both* branches of every bound check.
+- **Evaluate any divisor derived from a prop at the prop's declared `min` and
+  `max`.** If it can reach `0` or non-finite (e.g. `2^(bitDepth-1)-1` at
+  `bitDepth=1`), floor/clamp it. Test the boundary values, not just the default.
+- **Generate evenly-spaced float series as `i * step`, not repeated `+= step`** —
+  accumulation drifts for fractional steps (frame ticks at `1000/30`).
+- **Track "did X happen" with an explicit boolean set at the decision point**, not
+  by inferring `result !== input` — that's wrong when the result legitimately
+  equals the input (a snap landing exactly on the cursor).
+
+### Defaults, dead code, and parsing
+
+- **Apply defaults as `{ ...options, key: options?.key ?? DEFAULT }` — spread
+  first, default last.** Spreading `...options` *after* a default lets an explicit
+  `key: undefined` clobber it (an explicit `undefined` is a present key).
+- **A prop default lives in exactly one place (the descriptor).** Inline
+  `?? literal` fallbacks must reference that same value, never a hardcoded copy
+  that drifts. Collapse any `a ?? a`. A default filename's extension must match
+  the bytes actually written.
+- **Treat a logically-unreachable branch as a bug, not dead weight** — it almost
+  always means the intended behavior was silently never executed (e.g. a dead
+  `else if` inside an outer truthy `if` dropped conditional fields). When a
+  runtime factory mirrors a codegen reference, keep the branch structure identical.
+- **Parse structured binary/markup by structure, not fixed offsets.** Walk RIFF
+  chunks honoring word-alignment padding (`offset += 8 + size + (size & 1)`);
+  validate the full magic signature *and* minimum byte length before indexing;
+  check both byte orders for endian-sensitive formats (TIFF `II*`/`MM\0*`); never
+  trust a declared length field from external/streamed data — clamp to bytes
+  present. Read feed fields by element/attribute, not RSS-only assumptions.
+- **Treat empty-string and whitespace-only input as a valid empty case**, not just
+  `null`/`undefined` — `.trim()` before `JSON.parse`/`new RegExp`/numeric parse.
+- **Never build an expression evaluator with `new Function`/`with` or naive
+  substring `.replace()` of keywords** (it corrupts string literals and makes
+  chained comparisons always-true). Tokenize and parse; throw on invalid input
+  instead of silently returning an empty result.
+- **Release native/GPU handles in a `finally` block, never on the trailing happy
+  path.** Allocate as `let h: T | undefined`, `h?.destroy()` in `finally`, so a
+  throw during encode/submit/`mapAsync` can't leak the handle.
+
+## External-API Wrapper Nodes
+
+Packages that wrap third-party AI APIs (`atlascloud-nodes`, `topaz-nodes`,
+`replicate-nodes`, `kie-nodes`, `fal-nodes`, `minimax-nodes`, …) share a billing
+and transport surface where transient errors cost real money. Rules from shipped
+fixes:
+
+- **Never retry a non-idempotent request (job-creating `POST`, state-transition
+  `PATCH`) on 5xx** — the server may have already acted (and billed) before the
+  error. Retry only `GET`/`HEAD` and idempotent `PUT`s (presigned uploads).
+- **Always retry the *download* of a billed result** (429/5xx with backoff) — once
+  a job is submitted and billed, a transient CDN blip must not discard the
+  paid-for output. Also retry *thrown* network errors (ECONNRESET/timeout) for
+  idempotent requests, and drain a discarded response body before retrying so the
+  keep-alive connection is reusable.
+- **Parse `Retry-After` as either delay-seconds *or* an HTTP-date**, clamp to
+  `>= 0`, and fall back to exponential backoff when unparseable. Never feed a raw
+  `Number(header)` into `sleep` — an HTTP-date yields `NaN` and fires immediately.
+- **Centralize terminal poll states in shared SUCCESS/FAILURE sets covering all
+  synonyms** (`fail`/`failed`, `cancel`/`canceled`/`cancelled`,
+  `complete`/`completed`/`done`/`succeeded`). A terminal status a poll loop
+  doesn't recognize must never silently degrade into a timeout. Don't sleep after
+  the final poll attempt.
+- **Harden SSRF checks on every URL you download**: normalize the host to numeric
+  octets using full `inet_aton` semantics (decimal `2130706433`, hex `0x7f...`,
+  octal, short-form `127.1`) and unwrap IPv4-mapped IPv6 (`[::ffff:127.0.0.1]`)
+  *before* range-checking private/loopback/link-local/metadata; block `localhost`
+  and `*.localhost`. A dotted-quad regex is not enough (the
+  `169.254.169.254` metadata IP has many encodings). `atlascloud-base.ts` has the
+  hardened reference.
+- **Extract output URLs by recursively scanning** string / `FileOutput`
+  (`.url()`/`.url`) / array / named-key-object shapes; accept a *nested* string
+  only if it matches `^(https?:|data:)`. Don't assume the URL sits under a fixed
+  key. Don't advertise an API option that produces an extra output the node's
+  single-output extractor can't surface.
+- **Detect all-numeric enums and register numeric values + numeric default**, and
+  coerce the API arg back to a number — a `String()` cast sends `"768"` and fails
+  the model's integer schema.
+- **Prune empty args by stripping only top-level `null`/`undefined`/`""` keys** —
+  never recurse into user-supplied `dict[...]` inputs (you'd mutate their intended
+  shape) and never strip `0`/`false`. Return `null` (so arg-cleanup drops it) for
+  an asset that can't be turned into a publicly reachable URL — never hand a remote
+  API a local/relative path.
+- **AssetRefs**: read both snake_case `mime_type` *and* camelCase `mimeType` (prompt
+  @-mention injection uses camelCase); model a multi-asset input as
+  `list[image]`/`list[video]`/`list[audio]`, not a single asset type with
+  `array: true`.
+- **Multipart upload**: stop chunking once the source is fully consumed (no
+  zero-byte trailing parts) and echo correlation IDs (`uploadId`) from the
+  accept/initiate step into the complete call.
+- **Wire `AbortSignal` into the runtime's cooperative cancellation hook** (e.g.
+  transformers.js `InterruptableStoppingCriteria`), not just a post-hoc
+  `signal.aborted` check, and surface `AbortError` (not the internal interrupt
+  error). Clean up the listener.
+
 ## Adding a New Package
 
 1. Create directory under `packages/<name>/` with `package.json`, `tsconfig.json`, `src/index.ts`.

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -429,3 +429,21 @@ NODETOOL_AGENT_AUTO_SKILLS=0                # Disable auto-matching (default: en
 6. **Restrict tools**: Per-step `tools` arrays limit which tools a step can call
 7. **Observe**: Enable tracing (`OTEL_TRACES_EXPORTER=console`) to see every LLM call
 8. **Iterate on skills**: Add domain-specific SKILL.md files to improve agent behavior
+
+## Authoring Agent Nodes — Pitfalls
+
+When building a node that wraps an agent (e.g. the `code-nodes` tool-agents, or
+`llm-nodes` `AgentNode`):
+
+- **Every tool named in an agent's system prompt must actually be registered in
+  its toolset.** `BrowserAgent`/`HttpApiAgent` prompts instructed the model to call
+  `browser`/`take_screenshot`/`http_request` tools that were never registered (only
+  `execute_bash` was) — a prompt-referenced-but-unregistered tool is a silent
+  no-op. Resolve real builtin tools (`resolveBuiltinAgentTool`) and don't reference
+  tools you didn't wire.
+- **Every declared prop must be consumed by `process()` or injected into the
+  prompt.** A declared-but-unwired prop (`max_output_chars`, `url`, `output_dir`)
+  does nothing — inject node props via a `promptContext()` hook.
+- **`yield` structured results so the kernel routes them to dynamic output
+  handles; don't `return` them from a generator** (`yield*` discards the return
+  value). Keep structured-output emission consistent across modes (loop vs plan).

--- a/packages/atlascloud-nodes/AGENTS.md
+++ b/packages/atlascloud-nodes/AGENTS.md
@@ -1,0 +1,31 @@
+# atlascloud-nodes — AtlasCloud API Wrapper
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **atlascloud-nodes**
+
+> Read [packages/AGENTS.md § External-API Wrapper Nodes](../AGENTS.md#external-api-wrapper-nodes) first — those billing/SSRF/poll/retry rules are the bulk of what matters here. This overlay notes the AtlasCloud specifics.
+
+`atlascloud-base.ts` holds the **hardened SSRF reference** for the monorepo:
+`isPrivateOrLocalHost` normalizes a host to numeric octets via full `inet_aton`
+semantics (decimal/hex/octal + short forms), unwraps IPv4-mapped IPv6, blocks
+`localhost`/`*.localhost`, and is tested against the decimal metadata IP
+`2852039166` (169.254.169.254). Other wrapper packages should adopt it.
+
+Package specifics from shipped fixes:
+
+- **Download billed results through `atlasDownload` (`fetchWithRetry`)**, not a
+  plain `fetch` — a transient 429/5xx on the CDN otherwise discards an
+  already-billed result.
+- **Latent gap to respect**: `fetchWithRetry` here does **not** yet distinguish
+  idempotent methods, so do **not** route job-creating `POST`s through a retrying
+  path — a 5xx after the server billed would double-submit. (See the `topaz-nodes`
+  `IDEMPOTENT_METHODS` pattern.)
+- **Recognize all terminal poll states** via the `SUCCESS_STATUS` /
+  `FAILURE_STATUS` synonym sets (`complete`/`done`/`succeeded`, `canceled`) — an
+  unrecognized terminal status must not poll to timeout.
+- **`guessMime` reads both `mime_type` and `mimeType`** — prompt @-mention
+  injection (`InjectedAssetRef`) uses camelCase; don't rely on extension sniffing
+  for extension-less / `asset://` URIs.
+- **Model multi-image inputs as `list[image]`**, not a single `image` with
+  `array: true`.
+- **Don't expose an API option that yields an extra output** the single-output
+  node can't surface (the `return_last_frame` Seedance option was dropped).

--- a/packages/audio-nodes/AGENTS.md
+++ b/packages/audio-nodes/AGENTS.md
@@ -1,0 +1,48 @@
+# audio-nodes — Audio Editing & DSP
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **audio-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first (output-contract, media-ref, bounds, and divisor rules apply). This overlay covers audio-specific correctness.
+
+## Decode before you edit — operate in sample space
+
+- **Never slice, trim, fade, concat, overlay, or measure audio on encoded
+  container bytes.** Doing so corrupts the 44-byte WAV header into the signal.
+  Decode WAV → operate on PCM sample frames → re-encode. Keep a raw-byte fallback
+  for non-WAV input.
+- **Time-valued props are *seconds*, never byte offsets.** Convert with
+  `frame = round(seconds * sampleRate)`. (Slice/Trim once treated seconds as byte
+  counts and used the broken `if (end < 0) end = data.length` sentinel — see the
+  bounds rules in [packages/AGENTS.md](../AGENTS.md#indices-bounds-and-numeric-guards).)
+- **Joining/overlaying two clips is only valid when their `sampleRate` and
+  `numChannels` match — assert it** before mixing in sample space.
+- **`CreateSilence` must emit a real WAV** (`encodeWav(new Float32Array(frames), sampleRate, 1)`),
+  not `new Uint8Array(length)` zero bytes with `duration` as a byte count.
+
+## Parse WAV by structure, not fixed offsets
+
+- **Walk RIFF chunks honoring word-alignment padding**
+  (`offset = body + chunkSize + (chunkSize & 1)`) and read `fmt `/`data` fields
+  relative to each chunk body — never fixed offsets like 22/24/34/36. Files with
+  `LIST`/`JUNK` chunks or `WAVE_FORMAT_EXTENSIBLE` break fixed-offset readers.
+  Clamp `dataSize` to the bytes actually present. `readWavHeader` is the reference.
+- **Use one shared 16-bit PCM normalization constant across encode/decode/parse**
+  (`0x7fff`) so round-trips are unit-gain.
+
+## DSP controls
+
+- **Wire every declared DSP control through to the effect.** `PeakFilter` once
+  hardcoded `gain = 0` (no-op) with no `gain_db` prop; `NoiseGate` smoothed with
+  the release coefficient in both directions, so `attack_ms` was dead. When a node
+  computes two coefficients (attack vs release, in vs out), assert each is used in
+  its intended branch. A "node does nothing" smoke test catches no-ops.
+- **Floor parameter-derived divisors.** `Bitcrush` `levels = 2^(bitDepth-1)-1` is
+  `0` at the minimum `bitDepth`, producing NaN samples — use
+  `max(1, 2^bitDepth - 1)`.
+
+## Output ports
+
+- **Return the declared port keys** — `TextToSpeech` returns `{ audio }` (not
+  `{ output }`); `LoadAudioFolder` yields `path` (not `name`) and must implement
+  its own `extensions`/`include_subdirectories` props rather than delegating to a
+  loader that ignores them.

--- a/packages/automation-nodes/AGENTS.md
+++ b/packages/automation-nodes/AGENTS.md
@@ -1,0 +1,48 @@
+# automation-nodes — Triggers, Filesystem, SQLite, OS
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **automation-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first — the output-slot contract bit this package hardest. This overlay covers automation-specific correctness.
+
+## Output-slot contract (the headline bug)
+
+- **Every key a node returns must be a declared `metadataOutputTypes` slot.**
+  `Insert`/`Update`/`Delete`/`ExecuteSQL`/`SplitPath`/`SplitExtension` declared a
+  single `output` slot but returned `row_id`/`rows_affected`/`dirname`/… — keys
+  the editor never exposed as handles, so the data was unreachable downstream. The
+  `assertKeysDeclared` invariant in `tests/output-slots-and-fixes.test.ts` pins
+  this; **never test a node only as a terminal sink** (sinks hide the mismatch).
+- **`SaveImageFile`/`SaveVideoFile` outputs need the `type` discriminator**
+  (`type: "image"`/`"video"`).
+
+## Dependencies
+
+- **Every imported runtime module must be a declared dependency in this package's
+  own `package.json`** — `cheerio`/`turndown`/`sharp` were imported but resolved
+  only via monorepo hoisting, which breaks on standalone install.
+
+## Filesystem & SQLite
+
+- **Don't overload `fs.mkdir`'s `recursive` flag to express "error if exists".**
+  `recursive` means parents-plus-idempotent, so passing `exist_ok` as `recursive`
+  also disables parent creation. Always `mkdir({ recursive: true })` and check
+  existence separately.
+- **Validate dynamic SQL has at least one column/value before string-building** —
+  empty `data`/`columns` otherwise emits syntactically invalid SQL. Throw a clear
+  message.
+- **A glob-to-regex converter must translate every metacharacter the contract
+  promises** — `*` → `.*` **and** `?` → `.` — not just `*`.
+
+## Triggers & timeouts
+
+- **In a drift-compensated scheduler, the first tick lands one full interval after
+  the initial delay unless an on-start emission consumed that slot.** Offset by
+  whether the start tick fired (`driftOffset = emitOnStart ? 0 : 1`); otherwise the
+  first tick fires immediately when `emit_on_start = false`.
+- **Never swallow a setup failure that leaves an async generator blocked
+  forever.** If `fs.watch` fails for every path (zero watchers), throw with the
+  underlying message instead of hanging on `queue.get()`.
+- **A declared timeout option must actually bound the wait** — implement
+  `timeout_seconds` with `Promise.race([iterator.next(), timeoutPromise])` (a
+  `unique symbol` sentinel so TS narrows the result), clearing the timer each
+  iteration.

--- a/packages/code-runners/AGENTS.md
+++ b/packages/code-runners/AGENTS.md
@@ -1,0 +1,45 @@
+# code-runners — Secure Code Execution
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **code-runners**
+
+> Read [packages/AGENTS.md](../AGENTS.md) and [DEVELOPMENT_STANDARDS §16 Security](../../docs/DEVELOPMENT_STANDARDS.md#16-security) first. This package runs untrusted code in Docker/subprocess sandboxes — correctness here is a security boundary.
+
+## Resource lifecycle (containers, child processes, sockets)
+
+- **Register every external handle on the shared base field the moment it's
+  created, and null it in `finally`.** `ServerDockerRunner` overrode `stream()`
+  to create its own container but never set `_activeContainerId`, so the inherited
+  `stop()` couldn't kill it — it leaked until timeout. Keep lifecycle fields
+  `protected` (not `private`) so subclasses that own creation can clean up.
+- **Honor the stop/cancel flag inside *every* polling and streaming loop**
+  (`if (this._stopped) break`) — readiness waits and log pumps included.
+- **Distinguish a timeout-kill from a genuine non-zero exit, and check both
+  `exitCode` and `signalCode`** (a signal kill leaves `exitCode === null`).
+  Surface captured child output when readiness fails — never throw a bare
+  "did not become ready".
+
+## Stream decoding
+
+- **Never `buffer.toString("utf-8")` on a streamed/chunked byte slice** — a
+  multibyte UTF-8 character split across a frame boundary decodes to `U+FFFD`. Use
+  a per-stream `new StringDecoder("utf8")` (separate for stdout/stderr),
+  accumulate via `decoder.write(payload)`, and flush `decoder.end()` on close.
+
+## Filesystem / archive safety
+
+- **Zip Slip: validate entry names against the destination prefix *before*
+  extracting anything** (`unzip -Z1` to list, reject escapes), then after
+  extraction walk with `lstatSync` (does **not** follow symlinks) and remove any
+  symlink whose `realpathSync` target escapes `destDir`. A post-hoc `statSync`
+  walk follows symlinks and misses the attack.
+- **Pass absolute, pre-created host paths to Docker bind mounts** (via
+  `getWorkspaceHostPath`) — Docker rejects relative, non-existent bind sources.
+
+## Caching & defaults
+
+- **Derive a cache key from every input that changes the artifact** (URL, version,
+  args) — `binaryCacheName` hashes the URL into the filename. Keying on a constant
+  label (`"server"`) made different `binaryUrl`s reuse the first cached binary.
+- **Apply option defaults as `{ ...options, image: options?.image ?? DEFAULT }`** —
+  spread first, default last. Spreading `...options` after the default lets an
+  explicit `image: undefined` clobber the computed language default.

--- a/packages/data-nodes/AGENTS.md
+++ b/packages/data-nodes/AGENTS.md
@@ -1,0 +1,39 @@
+# data-nodes — Dataframes, Filtering, Feeds & Charts
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **data-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first (bounds, empty-input, and parsing rules apply). This overlay covers data-specific correctness.
+
+## Dataframe shapes
+
+- **Any dataframe consumer must accept BOTH shapes data nodes emit** — row-records
+  `{ rows }` and the canonical column matrix `{ columns, data }` — by normalizing
+  through the shared `asRows` helper. The chart reader and the web
+  `DataframeRenderer` once understood only `{ columns, data }` and threw / rendered
+  empty for `{ rows }`.
+
+## Filter / query evaluation
+
+- **Never evaluate filter expressions with `new Function`/`with(row)` or naive
+  substring `.replace()` of `and`/`or`/`not`.** Substring replacement corrupts
+  string literals (`'Research and Development'`); `with`+`new Function` makes
+  chained comparisons (`100 <= price <= 200`) always-true and uses JS `in`
+  (property check) for membership. Use the recursive-descent parser that supports
+  Python-style chained comparisons and array `in`, and respects string literals.
+- **Throw on an unparseable condition — never silently swallow to an empty
+  result.** A silently-empty filter looks like "no matches" and hides the bug.
+
+## Slicing & empty input
+
+- **Negative slice indices**: `-1` is the only "through the end" sentinel; other
+  negatives count back from the end (`max(0, len + end)`); guard non-finite via
+  `Number.isFinite`. (See [packages/AGENTS.md § bounds](../AGENTS.md#indices-bounds-and-numeric-guards).)
+- **Empty/whitespace input is a valid empty case** — `String(text ?? "").trim()`,
+  then `text === "" ? [] : JSON.parse(text)`. Don't let `"   "` reach `JSON.parse`.
+
+## Feed parsing
+
+- **Read feed fields by element/attribute, not RSS-only assumptions.** Atom links
+  come from `<link href=...>` (not `<id>`), and the author name is the `<name>`
+  inside `<author>` — don't return the literal `<author><name>…</name></author>`
+  markup.

--- a/packages/huggingface-nodes/src/huggingface-base.ts
+++ b/packages/huggingface-nodes/src/huggingface-base.ts
@@ -82,25 +82,34 @@ export async function refToBase64(ref: MediaRef): Promise<string> {
   return Buffer.from(bytes).toString("base64");
 }
 
-/** Wrap generated image bytes into an ImageRef-shaped output. */
+/**
+ * Wrap generated image bytes into an ImageRef-shaped output.
+ *
+ * `data` is RAW base64 (no `data:` prefix); the MIME type goes in
+ * `content_type`. Asset-saving (`decodeAssetBytes`) and provider forwarding
+ * (`asUint8Array`) decode `data` directly with `Buffer.from(data, "base64")`,
+ * so a `data:` prefix would corrupt the bytes.
+ */
 export function imageRefFromBytes(
   bytes: Uint8Array,
   mimeType = "image/png"
 ): Record<string, unknown> {
   return {
     type: "image",
-    data: `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`
+    data: Buffer.from(bytes).toString("base64"),
+    content_type: mimeType
   };
 }
 
-/** Wrap generated video bytes into a VideoRef-shaped output. */
+/** Wrap generated video bytes into a VideoRef-shaped output (raw base64 `data`). */
 export function videoRefFromBytes(
   bytes: Uint8Array,
   mimeType = "video/mp4"
 ): Record<string, unknown> {
   return {
     type: "video",
-    data: `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`,
+    data: Buffer.from(bytes).toString("base64"),
+    content_type: mimeType,
     format: mimeType.split("/")[1] ?? "mp4"
   };
 }
@@ -113,7 +122,7 @@ export function imageRefFromBase64(
   const clean = base64.startsWith("data:")
     ? base64.slice(base64.indexOf(",") + 1)
     : base64;
-  return { type: "image", data: `data:${mimeType};base64,${clean}` };
+  return { type: "image", data: clean, content_type: mimeType };
 }
 
 function authHeaders(token: string): Record<string, string> {

--- a/packages/huggingface-nodes/tests/huggingface-base.test.ts
+++ b/packages/huggingface-nodes/tests/huggingface-base.test.ts
@@ -71,21 +71,27 @@ describe("media ref helpers", () => {
 });
 
 describe("output ref builders", () => {
-  it("imageRefFromBytes builds a data URI", () => {
+  it("imageRefFromBytes emits raw base64 with content_type (no data: prefix)", () => {
     const ref = imageRefFromBytes(new Uint8Array([1, 2, 3]), "image/jpeg");
     expect(ref.type).toBe("image");
-    expect(String(ref.data)).toMatch(/^data:image\/jpeg;base64,/);
+    expect(ref.content_type).toBe("image/jpeg");
+    expect(String(ref.data)).not.toMatch(/^data:/);
+    expect(ref.data).toBe(Buffer.from([1, 2, 3]).toString("base64"));
   });
 
-  it("videoRefFromBytes sets a format", () => {
+  it("videoRefFromBytes emits raw base64 with content_type and format", () => {
     const ref = videoRefFromBytes(new Uint8Array([1]), "video/webm");
     expect(ref.type).toBe("video");
+    expect(ref.content_type).toBe("video/webm");
     expect(ref.format).toBe("webm");
+    expect(String(ref.data)).not.toMatch(/^data:/);
+    expect(ref.data).toBe(Buffer.from([1]).toString("base64"));
   });
 
-  it("imageRefFromBase64 strips an existing data prefix", () => {
+  it("imageRefFromBase64 strips an existing data prefix and stores raw base64", () => {
     const ref = imageRefFromBase64("data:image/png;base64,QUJD");
-    expect(ref.data).toBe("data:image/png;base64,QUJD");
+    expect(ref.data).toBe("QUJD");
+    expect(ref.content_type).toBe("image/png");
   });
 });
 

--- a/packages/huggingface-nodes/tests/nodes.test.ts
+++ b/packages/huggingface-nodes/tests/nodes.test.ts
@@ -149,10 +149,11 @@ describe("TextToImageNode", () => {
     );
     const node = withSecrets(new TextToImageNode({ prompt: "a cat" }));
     const out = await node.process();
-    expect((out.output as Record<string, unknown>).type).toBe("image");
-    expect(String((out.output as Record<string, unknown>).data)).toMatch(
-      /^data:image\/png;base64,/
-    );
+    const ref = out.output as Record<string, unknown>;
+    expect(ref.type).toBe("image");
+    expect(ref.content_type).toBe("image/png");
+    expect(String(ref.data)).not.toMatch(/^data:/);
+    expect(ref.data).toBe(Buffer.from(png).toString("base64"));
   });
 
   it("throws on empty prompt", async () => {

--- a/packages/image-nodes/AGENTS.md
+++ b/packages/image-nodes/AGENTS.md
@@ -1,0 +1,45 @@
+# image-nodes — Image Processing & Shaders
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **image-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first (output-contract, bounds, defaults, and `finally`-cleanup rules apply). This overlay covers image-specific correctness.
+
+## Bounds & silent-swallow
+
+- **Clamp crop/extract boxes to image bounds before calling `sharp.extract`.** An
+  oversized region makes sharp throw, and `transformImage` swallows the error and
+  returns the **full uncropped image** — a silent wrong result. Clamp
+  `right = min(right, imgW)`, `width = max(1, right - left)`.
+- **Resolve paired optional dimensions independently** — `Affine`/`Scale` once set
+  output dims only when *both* `target_width` and `target_height` were `> 0`, so
+  specifying just one was dropped. Use `w > 0 ? w : src.width` per dimension.
+
+## GPU / native handle cleanup
+
+- **Release every acquired GPU texture, buffer, and readback buffer in a
+  `finally` block** (`let h: T | undefined; … h?.destroy()` in `finally`) — a
+  throw during encode/submit/`mapAsync` (device loss, validation error) otherwise
+  leaks GPU memory. Don't put `.destroy()` on the trailing happy path.
+
+## Kernel & format correctness
+
+- **Verify a convolution kernel's sum matches its intent**: edge/Laplacian sum
+  `0`, blur sum `1`, sharpen sum `1`. `Contour` used a sharpen kernel (center `9`,
+  sum `+1`) with a white offset and blew flat regions to white; the fix is the
+  Laplacian (center `8`, sum `0`) matching PIL `CONTOUR`/the `FindEdges` kernel.
+  Cross-check against PIL and sibling kernels in the same file.
+- **Validate the full magic signature *and* minimum byte length before
+  indexing.** `inferImageMime` read `bytes[8]` behind a `< 4` guard; WebP needs
+  `bytes.length >= 12` and all of `R I F F` (0–3) + `W E B P` (8–11).
+- **Handle 3-/4-digit hex shorthand** in color parsing (`#fff`) by doubling each
+  nibble — don't fall back to the default color.
+- **Percentage props that cut from both ends must cap below 50** — `AutoContrast`
+  `cutoff` at `max: 255` let `>= 50` silently zero the channel; `max: 49`.
+
+## Output ports
+
+- **Return declared port keys** — `LoadImageFolder` declares `path` but once
+  emitted `name`, leaving `path` empty on both buffered and streaming paths.
+- **Inline `?? default` fallbacks must match the descriptor defaults** —
+  `SplitToning`'s inline `?? 30/200/0.5` disagreed with the descriptor's
+  `200/40/0.3`.

--- a/packages/kie-nodes/CLAUDE.md
+++ b/packages/kie-nodes/CLAUDE.md
@@ -54,3 +54,18 @@ All nodes correctly use `metadataOutputTypes` set from `spec.outputType`.
 - Suno music nodes use separate `kieExecuteSunoTask()` API path
 - Validation rules (not_empty) checked before API calls
 - Conditional fields (gte_zero, truthy, not_default) for optional parameters
+
+## Bug-Prevention Notes
+
+- **Conditional-field inclusion must mirror the codegen reference
+  (`packages/kie-codegen/.../node-generator.ts`) exactly.** Structure
+  `buildParams()` as `if (condition === "gte_zero") … else if (condition === "truthy") … else (include unconditionally)`.
+  A `not_default`/unknown condition is included unconditionally — it must have a
+  reachable `else` branch. The old `else if (!conditional)` nested inside
+  `if (conditional)` was dead code and silently dropped those fields. Add a test
+  per condition type.
+- **Poll loops must accept every spelling of a terminal state.** `pollCustom`
+  treated only `state === "fail"` as failure and missed `"failed"`, so a
+  Veo/Runway task reporting `"failed"` polled to timeout. Accept `fail`/`failed`
+  (and `complete`/`completed`/`done`/`succeeded`) — keep all loops
+  (`pollStatus`/`pollUntilDone`/`pollCustom`) consistent.

--- a/packages/llm-nodes/AGENTS.md
+++ b/packages/llm-nodes/AGENTS.md
@@ -1,0 +1,48 @@
+# llm-nodes — LLM, Image, TTS & Agent Nodes
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **llm-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first — media-ref and output-contract rules apply. This overlay covers nodes that call provider REST endpoints directly and the agent/streaming nodes.
+
+## Provider-direct nodes (Gemini Imagen/Veo, OpenAI images, TTS)
+
+- **Mirror the request/response shape of the matching `packages/runtime`
+  provider — never the vendor JS/Python SDK shape.** The SDK wraps a different
+  wire envelope. Gemini's `:predict`/`:generateImages`/`:generateVideos` REST
+  endpoints need `{ instances: [{ prompt, image: { bytesBase64Encoded, mimeType } }], parameters: {...} }`,
+  not the SDK's `{ prompt, config }`; image bytes go under `bytesBase64Encoded`,
+  not `imageBytes`.
+- **Parse every documented response variant.** Try REST/Vertex
+  `predictions[].bytesBase64Encoded` *and* SDK `generatedImages[].image.imageBytes`;
+  handle large media (Veo video) delivered as a download **`uri`** (fetch with the
+  API key appended, then base64) in addition to inline bytes.
+- **Gate model-specific request params on the target model.** `gpt-image-1`
+  rejects `response_format` (valid only for dall-e-2/3) and always returns base64.
+  Don't send a param a newer model rejects.
+- **Guard response array access and throw a descriptive error** — `data.data?.[0]`
+  with an explicit `"No image data in response"`, never a bare `data.data[0]` that
+  throws an opaque `undefined`.
+- **Emit media output refs with `type` + raw base64** via the `imageRefFromB64` /
+  `audioRefFromB64` helpers (the Gemini TTS ref once omitted `type: "audio"`, so
+  auto-save skipped it). See [packages/AGENTS.md § Media refs](../AGENTS.md#media-refs-imageref--videoref--audioref--model3dref).
+
+## Streaming & thinking blocks
+
+- **A declared `chunk` output must be produced by `async *genProcess`** — the
+  Summarizer node declared `chunk` but only returned `text` from `process()`, so
+  the stream output was dead. Match `outputCorrelation` (`iteration` for chunks).
+- **Keep the streaming thinking-tag splitter in sync with the non-streaming
+  `extractThinkTags`.** Recognize the canonical `</redacted_thinking>` close tag;
+  a string-concat typo once produced two identical `</think>` entries and never
+  matched the real close tag.
+
+## Agent output routing
+
+- **`yield` an agent's structured results so the kernel routes them to dynamic
+  output handles — don't `return` them from the generator** (`yield*` discards a
+  `return` value). Plan mode must yield `agent.getResults()` when an `outputSchema`
+  is present, mirroring loop mode, or dynamic outputs stay empty.
+- **Every tool named in an agent's system prompt must be registered in its
+  toolset, and every declared prop must be consumed or injected into the prompt.**
+  A prompt referencing an unregistered tool, or a declared-but-unwired prop, is a
+  silent no-op (see the `code-nodes` browser/http agent fix).

--- a/packages/minimax-nodes/src/minimax-base.ts
+++ b/packages/minimax-nodes/src/minimax-base.ts
@@ -81,15 +81,22 @@ export const AUDIO_FORMAT_MIME: Record<string, string> = {
   pcm: "audio/pcm"
 };
 
-/** Build an inline AudioRef from raw bytes for the given format. */
+/**
+ * Build an inline AudioRef from raw bytes for the given format.
+ *
+ * `data` is RAW base64 (no `data:` prefix); the MIME type goes in
+ * `content_type`. Asset-saving (`decodeAssetBytes`) and provider forwarding
+ * (`asUint8Array`) decode `data` directly with `Buffer.from(data, "base64")`,
+ * so a `data:` prefix would corrupt the bytes.
+ */
 export function audioRefFromBytes(
   bytes: Uint8Array,
   format: string
-): { type: "audio"; data: string } {
-  const mime = AUDIO_FORMAT_MIME[format] ?? "audio/mpeg";
+): { type: "audio"; data: string; content_type: string } {
   return {
     type: "audio",
-    data: `data:${mime};base64,${bytesToBase64(bytes)}`
+    data: bytesToBase64(bytes),
+    content_type: AUDIO_FORMAT_MIME[format] ?? "audio/mpeg"
   };
 }
 

--- a/packages/minimax-nodes/tests/music.test.ts
+++ b/packages/minimax-nodes/tests/music.test.ts
@@ -40,8 +40,12 @@ describe("MinimaxMusicNode", () => {
 
     expect(result.output).toMatchObject({
       type: "audio",
-      data: expect.stringContaining("data:audio/mpeg;base64,")
+      content_type: "audio/mpeg",
+      data: Buffer.from("fake-song").toString("base64")
     });
+    expect(
+      String((result.output as Record<string, unknown>).data)
+    ).not.toMatch(/^data:/);
   });
 
   it("requires a prompt", async () => {

--- a/packages/minimax-nodes/tests/text-to-speech.test.ts
+++ b/packages/minimax-nodes/tests/text-to-speech.test.ts
@@ -59,8 +59,12 @@ describe("MinimaxTextToSpeechNode", () => {
 
     expect(result.output).toMatchObject({
       type: "audio",
-      data: expect.stringContaining("data:audio/mpeg;base64,")
+      content_type: "audio/mpeg",
+      data: Buffer.from("fake-audio").toString("base64")
     });
+    expect(
+      String((result.output as Record<string, unknown>).data)
+    ).not.toMatch(/^data:/);
   });
 
   it("reads the API key from injected secrets", async () => {

--- a/packages/node-sdk/AGENTS.md
+++ b/packages/node-sdk/AGENTS.md
@@ -1,0 +1,36 @@
+# node-sdk — BaseNode, NodeRegistry, Type System
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **node-sdk**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first — the **Node Authoring — Bug Patterns to Avoid** section there is the contract every node must satisfy (output slots, media refs, bounds, defaults). This overlay covers the `BaseNode` internals that enforce it.
+
+## Framework-injected internals vs. user dynamic props
+
+The framework injects internals into a node before `process()` runs — resolved
+`_secrets` (API keys), `_control_context`, `__node_id`, `__node_name`. These must
+**never** mix with user-supplied dynamic inputs:
+
+- **Route every reserved `_`-prefixed key to the private `_internalProps` map**
+  (in `assign`/`setDynamic`/`getDynamic`), not `dynamicProps`. If they land in
+  `dynamicProps` they leak three ways: `serialize()` persists API keys into graph
+  state; `Object.fromEntries(this.dynamicProps)` pulls secrets into prompt-template
+  variables; and per-node arg builders forward them to provider requests.
+- **Gate on the `_` prefix, not a hardcoded skip-list.** The old guard
+  (`["__node_id", "__node_name", "_secrets"]`) omitted `_control_context` and
+  needed a per-package `SKIP_KEYS` workaround. Prefix-gating covers any new
+  internal automatically.
+- **Regression-test the boundary**: assert `serialize()` excludes internals and
+  that prompt-variable iteration (`dynamicProps`) doesn't see `_secrets` /
+  `_control_context`.
+
+## Node output & streaming contract
+
+These are defined here (in `BaseNode`/the registry) and enforced for every node —
+see [packages/AGENTS.md § Output contract](../AGENTS.md#output-contract):
+
+- Every key returned from `process()`/`genProcess()` must be a declared
+  `metadataOutputTypes` slot, or it's unreachable in the editor.
+- A `chunk` (streaming) output requires an `async *genProcess` generator with
+  `outputCorrelation` set to `iteration` (chunks) / `single` (aggregate).
+- `yield` structured results so the kernel routes them to dynamic output handles;
+  a value `return`ed from a generator is discarded by `yield*`.

--- a/packages/replicate-nodes/CLAUDE.md
+++ b/packages/replicate-nodes/CLAUDE.md
@@ -47,6 +47,8 @@ All nodes correctly use `metadataOutputTypes` for output type declarations. Dict
 ## Common Pitfalls
 
 - Never default asset inputs to `""` - always use proper AssetRef objects
-- Replicate output can be string, array, FileOutput (with .url() method), or object (asset wrapped under a named key) - `extractUrl()` handles all cases
+- `dict[...]` props default to `null`, **not** `""` (an empty string is an invalid empty default for a dict).
+- Replicate output can be string, array, FileOutput (with .url() method), or object (asset wrapped under a named key) - `extractUrl()` handles all cases. It recursively scans object/array shapes but only accepts a **nested** string when it matches `URL_LIKE = /^(https?:|data:)/` — a bare top-level string is still returned verbatim (model contract). Don't assume the URL sits under a fixed key.
+- `assetToUrl()` returns `null` for an asset it can't turn into a publicly reachable URL or data URI (e.g. an upload failure leaving only a relative path). Returning the original relative `uri` hands Replicate a path it can't fetch; returning `null` lets `removeNulls()` drop the arg.
 - The `removeNulls()` function strips only **top-level** `null`/`undefined`/empty-string keys. It does NOT recurse (so pass-through `dict[...]` inputs keep their shape) and does NOT strip `0`/`false`.
 - Numeric enums (e.g. SD `width`/`height`): the manifest stores enum values as strings, so the factory detects all-numeric enums and registers numeric `values`/`default` and coerces the API arg back to a number. A plain `String()` cast would send `"768"` and fail the model's integer schema.

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -1,0 +1,63 @@
+# Runtime — ProcessingContext & LLM Providers
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **runtime**
+
+> Read [packages/AGENTS.md](../AGENTS.md) and [docs/DEVELOPMENT_STANDARDS.md](../../docs/DEVELOPMENT_STANDARDS.md) first. This overlay covers the LLM provider adapters in `src/providers/` and the shared media-ref resolver.
+
+LLM providers must present an **identical contract** to callers regardless of the
+underlying vendor API. The bugs below all came from one provider diverging.
+
+## Cost / token accounting (`cost-calculator.ts`, providers)
+
+- **`UsageInfo.inputTokens` is the *full* prompt total, inclusive of cached and
+  cache-write subsets.** When a vendor reports the *uncached* portion separately
+  (Anthropic: `usage.input_tokens` excludes cache read/write), add cache-read +
+  cache-write back in before calling `trackUsage` — `@pydantic/genai-prices`
+  re-subtracts `cachedTokens`, so passing the raw uncached count double-counts the
+  discount and never bills cache creation.
+- **Every `PRICING_TIERS` entry needs a source comment citing the vendor's
+  published rate.** A fabricated rate (the old `gpt-4o-mini-tts` tier) is a silent
+  mispricing; provenance lets the number be re-verified when prices change.
+
+## Streaming
+
+- **Emit exactly one terminal `{ done: true }` chunk for every stream-termination
+  reason** (`stop`, `tool_calls`, `length`, `content_filter`), in all providers.
+  The OpenAI provider used to emit it only on `finish_reason === "stop"`, so
+  tool-call/length finishes left consumers waiting forever. The end-of-stream
+  contract must be reason-independent and identical across providers.
+
+## Tool-call ↔ tool-result pairing
+
+- **Pair tool results to calls using the key the provider correlates on**: Gemini
+  matches `functionResponse` to `functionCall` by **function name** (build an
+  id→name map from the preceding assistant `toolCalls`); OpenAI/Anthropic match by
+  call **id**. Never assume our internal `toolCallId` is the vendor's identifier.
+- **For providers that require strict role alternation (Gemini), merge parallel
+  tool results into a single turn** rather than emitting consecutive same-role
+  turns.
+- **Mint emulated tool-call ids as `timestamp + per-call counter`**, never a
+  timestamp alone — same-millisecond calls collide. Use `replaceAll`, not
+  `replace`, when stripping call text that can recur.
+
+## Request / response shape (provider-direct & message conversion)
+
+- **Map roles the target provider lacks into one it accepts** — a stray Anthropic
+  `system` message folds into a `user` message; don't mislabel it `assistant`.
+- **Never `String(content)` on a message whose content may be a structured-block
+  array** — it stringifies to `"[object Object]"`. Filter text blocks
+  (`isTextContent`) and join.
+- **Guard provider response array access (`data?.[0]`) and throw a descriptive
+  error** when an expected payload is absent — never assume a documented array
+  field is present and non-empty.
+
+## Shared media-ref resolver (`media-ref-bytes.ts`, `python-node-executor.ts`)
+
+- **Guard `data.length > 0` on *every* inline branch** (string base64 **and**
+  `Uint8Array`) before returning, so an empty inline buffer falls through to
+  `uri`/`asset_id`/storage resolution instead of short-circuiting to empty bytes.
+- **Never emit raw bytes as a node output** — wrap media in a typed ref
+  `{ type, data }` (the Python node executor must do this even when no storage
+  adapter is available) so downstream type detection and asset-saving work.
+
+See [packages/AGENTS.md § Media refs](../AGENTS.md#media-refs-imageref--videoref--audioref--model3dref) for the raw-base64 / `type`-discriminator rules that apply to every ref.

--- a/packages/security/AGENTS.md
+++ b/packages/security/AGENTS.md
@@ -1,0 +1,31 @@
+# security — Secret Storage & Encryption
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **security**
+
+> Read [packages/AGENTS.md](../AGENTS.md) and [DEVELOPMENT_STANDARDS §16 Security](../../docs/DEVELOPMENT_STANDARDS.md#16-security) first. Bugs here silently orphan or corrupt user secrets, so every change needs a test that pins the exact behavior.
+
+## Cross-runtime crypto correctness
+
+- **Keep base64 padding on tokens consumed cross-runtime.** `encryptFernet`
+  stripped `=` padding, but Python's `cryptography.Fernet` uses
+  `base64.urlsafe_b64decode`, which rejects unpadded input → `InvalidToken`. Only
+  translate the alphabet (`+`→`-`, `/`→`_`); keep the padding.
+- **A TS-only round-trip test is not a cross-runtime compatibility test.** Assert
+  the exact wire format the other runtime expects (`token.length % 4 === 0`, no
+  `+`/`/`), not just that TS can decode what TS encoded.
+
+## Master-key resolution
+
+- **A failure or empty result from an *authoritative* configured key source is
+  fatal — never fall back to generating a new key.** When
+  `AWS_SECRETS_MASTER_KEY_NAME` is set, an AWS error or empty secret must throw;
+  silently falling through to keychain key-generation makes every
+  previously-encrypted secret undecryptable. Don't swallow errors in the layer the
+  precedence logic depends on (`getFromAwsSecrets` must not try/catch-to-null).
+- **Single-flight lazy init.** Guard generate-and-persist initialization
+  (`initMasterKey`) with an in-flight promise so concurrent first-run callers share
+  one key instead of each generating a different one and racing to persist.
+- **Health/startup checks must use the same full async resolution path as
+  production reads** (`await initMasterKey()`), never a partial sync getter
+  (`getMasterKey()` sees only env + cache) — otherwise the check disagrees with
+  real behavior and reports false failures for keychain/AWS-resident keys.

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -1,0 +1,40 @@
+# timeline — Clip Editing Math
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **timeline**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first (the bounds/float-math rules apply here). This package is pure functions over clips; the web store `web/src/stores/timeline/TimelineStore.ts` calls them, so forward and inverse ops must stay consistent.
+
+## Timeline-space vs. source-space
+
+- **Never conflate timeline duration with source duration.** A clip with an
+  unbaked `speedMultiplier` consumes `rate` source-ms per timeline-ms. Convert
+  through one shared `sourceRate(clip)` helper
+  (`speedBaked ? 1 : max(0.0001, speedMultiplier ?? 1)`, guarding zero/negative)
+  used by split, trim, merge, **and** the preview compositor — so they can't
+  diverge. Source points scale (`inPointMs + leftDurationMs * rate`); timeline
+  duration uses the raw delta.
+- **An inverse op must use the same rate-aware quantity the forward op wrote.**
+  Merge undoing split compares `outPointMs ?? (inPointMs + durationMs)` for
+  contiguity — the `+ durationMs` reconstruction is only correct at 1× speed.
+
+## Splitting / cloning entities
+
+- **When you split or clone by spreading `...clip`, explicitly clear the
+  properties that belong only to the original outer boundary** — `delete
+  leftClip.fadeOutMs`, `delete rightClip.fadeInMs`/`transitionIn`. A full spread
+  duplicates boundary fades/crossfades onto the new interior hard cut.
+- **Partition time-positioned children, don't copy them to both halves.**
+  `splitClip` must assign each caption word to exactly one side (clamping the
+  straddling word) and **rebase** the moved side's local timings
+  (`startMs - splitMs`), not copy the whole `words` array to both.
+
+## Snapping & placement
+
+- **Generate snap-point ticks as `i * interval`, never `t += interval`** —
+  fractional intervals (`1000/30`) drift under accumulation and stop deduping
+  against integer boundaries.
+- **Track `snapped` as an explicit boolean set when a within-threshold candidate
+  is adopted**, not `closest !== timeMs` — the latter is wrong when the snap target
+  lands exactly on the input.
+- **Exclude the moving entity's own footprint from overlap/collision checks**
+  (`excludeClipIds`) — otherwise a dragged clip reports overlapping itself.

--- a/packages/topaz-nodes/AGENTS.md
+++ b/packages/topaz-nodes/AGENTS.md
@@ -1,0 +1,31 @@
+# topaz-nodes — Topaz API Wrapper
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **topaz-nodes**
+
+> Read [packages/AGENTS.md § External-API Wrapper Nodes](../AGENTS.md#external-api-wrapper-nodes) first. This overlay notes the Topaz specifics from shipped fixes.
+
+`topaz-base.ts` holds the reference **idempotent-retry** logic:
+
+- **`IDEMPOTENT_METHODS = {GET, HEAD, PUT}` — non-idempotent methods get a single
+  attempt.** A job-creating `POST`/state-transitioning `PATCH` must not be retried
+  on 5xx; the server may have already acted (and billed). Presigned-URL `PUT`
+  uploads are safe to retry.
+- **Retry thrown network errors (ECONNRESET/timeout) for idempotent requests**,
+  not only retryable status codes, and **drain the discarded response body**
+  (`await resp.arrayBuffer().catch(() => undefined)`) before sleeping so the
+  keep-alive connection is reusable.
+- **`parseRetryAfterMs` handles both delay-seconds and HTTP-date**, clamps `>= 0`,
+  and falls back to exponential backoff — never `Number(header)` straight into
+  `sleep`.
+- **Don't sleep after the final poll attempt** — guard the inter-poll delay with
+  `if (attempt < maxAttempts - 1)`.
+
+Multipart upload & format detection:
+
+- **Stop chunking once the source is fully consumed** — `partSize = max(1, ceil(size/N))`
+  with `if (start >= size) break`, so a small file across many presigned URLs
+  doesn't emit zero-byte trailing parts the API rejects.
+- **Echo the `uploadId`** (tolerating `uploadId`/`upload_id`) from the accept step
+  into the complete-upload call.
+- **Detect both TIFF byte orders** in `detectImageMime` — little-endian `49 49 2A 00`
+  (`II*`) *and* big-endian `4D 4D 00 2A` (`MM\0*`).

--- a/packages/transformers-js-nodes/AGENTS.md
+++ b/packages/transformers-js-nodes/AGENTS.md
@@ -1,0 +1,33 @@
+# transformers-js-nodes — Local transformers.js Inference
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **transformers-js-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first. This overlay covers the nodes here **and** the paired `transformers-js-provider` package (no separate doc) — they share decode paths and must stay consistent.
+
+## Audio decoding (node ↔ provider parity)
+
+- **Route audio through the shared ffmpeg-capable decoder
+  (`decodeAudioBytesToSamples`), never a WAV-only `decodeWav`.** ASR once called
+  `decodeWav` directly and rejected mp3/m4a/flac with "not a WAV file". Share the
+  *exact* decode path between node and provider so behavior can't diverge, and
+  thread documented model params (e.g. `temperature`) through.
+
+## WAV correctness
+
+- **One shared 16-bit PCM normalization constant across encode/decode/parse**
+  (`0x7fff`). `decodeWav` divided by `0x8000` while `encodeWav`/`parseWavBytes`
+  used `0x7fff`, breaking unit-gain round-trips.
+- **Never trust the declared data-chunk size** — clamp to bytes present
+  (`usableData = min(dataSize, bytes.length - dataOffset)`, `Math.floor` frames) or
+  a truncated/streaming WAV throws `RangeError`.
+- **Honor the RIFF odd-chunk pad byte** when walking chunks
+  (`offset += 8 + chunkSize + (chunkSize & 1)`).
+- **Choosing inline `data` vs `uri`: check `.length > 0`** — `if (ref.data)` treats
+  a zero-length `Uint8Array` as truthy and shadows a valid `uri`.
+
+## Cancellation
+
+- **Wire the `AbortSignal` into transformers.js's cooperative stopping hook**
+  (`InterruptableStoppingCriteria`), not just a post-hoc `signal.aborted` check —
+  otherwise generation runs to completion regardless of abort. Clean up the
+  listener and surface `AbortError` (not the internal interrupt error).

--- a/packages/video-nodes/AGENTS.md
+++ b/packages/video-nodes/AGENTS.md
@@ -1,0 +1,26 @@
+# video-nodes — Video Editing & Assembly
+
+**Navigation**: [packages/AGENTS.md](../AGENTS.md) → **video-nodes**
+
+> Read [packages/AGENTS.md](../AGENTS.md) first (media-ref rules apply). This overlay covers video-specific correctness.
+
+## Reading input media
+
+- **Read input audio/video bytes with the async, context-aware resolver**
+  (`await audioBytesAsync(this.audio, context)` / `videoBytesAsync`), never the
+  sync `audioBytes`. `AddAudio` used the sync inline-only reader, so audio supplied
+  as an asset/`file://`/`http` URI yielded empty bytes and the node silently
+  returned the video with no audio.
+
+## ffmpeg numbered sequences
+
+- **Number frame files with a contiguous counter incremented only on a successful
+  write — never the loop index.** When a frame is skipped, a filename based on
+  `i + 1` leaves a gap, and ffmpeg's `image2` demuxer stops at the first missing
+  number, dropping every frame after the gap. Keep a separate `written` counter
+  (`frame_000001.png`, `frame_000002.png`, …).
+- **Handle the zero-frames case explicitly** — emit an empty
+  `videoRef(new Uint8Array())` rather than invoking ffmpeg on nothing.
+
+Construct outputs with the `videoRef` helper (raw base64 `data`, `type: "video"`)
+— see [packages/AGENTS.md § Media refs](../AGENTS.md#media-refs-imageref--videoref--audioref--model3dref).

--- a/web/src/components/AGENTS.md
+++ b/web/src/components/AGENTS.md
@@ -79,6 +79,24 @@ If no existing primitive fits your use case:
 - Don't create new inline objects/functions in JSX when passing to memoized children.
 - Co-locate tests in `__tests__/` subdirectories next to source files.
 
+## Node editor pitfalls
+
+From shipped fixes in `node_editor/`, `node/`, and the Inspector:
+
+- **Per-type handle/edge colors are generated CSS scoped to the canvas wrapper,
+  not inherited globally.** When you move or rename the component hosting the
+  ReactFlow canvas, carry the `css={generateCSS}` injection onto the new wrapper
+  — drop it and every handle falls back to grey.
+- **A property whose value is driven by a connected input edge must be rendered
+  inert and dimmed — never editable.** Plumb `isConnected` into `PropertyInput`
+  and use the `inert` attribute (not just `disabled`/`pointer-events`) so the
+  field also leaves the tab order; editing a connection-driven value is a no-op
+  that confuses users.
+- **Don't write `x !== null` after a truthiness guard (`x && …`).** The truthy
+  check already excludes `null`/`undefined`; the extra comparison is dead code
+  and gets flagged by CodeQL ("comparison between inconvertible types"). This bit
+  several node-status guards in `BaseNode`/`Dynamic*Node`.
+
 ## Styling
 
 - Use `sx` prop on primitives for one-off style overrides.

--- a/web/src/hooks/AGENTS.md
+++ b/web/src/hooks/AGENTS.md
@@ -55,6 +55,30 @@ const selectedNodes = useNodeStore(state => state.nodes.filter(n => n.selected))
 const store = useNodeStore();
 ```
 
+## Run-driving hooks: concurrency
+
+Hooks that launch and track workflow runs (`sketch/useGenerateLayer`,
+`timeline/useGenerateClip`, `useRegenerateStaleLayers`, miniapp runners, node
+exec-state hooks) must assume **multiple runs of the same workflow execute at
+once**. Lessons from shipped fixes:
+
+- **Resolve a job's output/error from that job's own messages, not a shared
+  store.** Capture each job's `output_update` value and node errors into per-job
+  maps keyed by `jobId` from the live stream; on completion read
+  `extractAssetId(jobOutputs.get(jobId))`. Resolving via
+  `resolveOutputAssetId(workflowId, nodeId)` against the shared `ResultsStore`
+  lets concurrent runs read each other's results.
+- **Use `jobId` returned from `run()`** — don't read `runnerStore.job_id` after
+  starting a run (it may point at a different, still-active job).
+- **Guard shared-slot resets on `store.job_id === jobId`** before clearing
+  per-workflow runner state from a terminal `job_update`.
+- **Per-node status is the source of truth for "running now", not the coarse
+  run-level `RunState`** — run-level state lags per-node updates (a run can
+  execute nodes while still `queued`). Use run-level state only as a negative
+  filter (skip `TERMINAL_RUN_STATES`), as `useNodeActiveRunCount` does.
+- **Regression test with two concurrent same-workflow jobs** driven through the
+  real handler (see `*.concurrency.test.ts`, `ambientLiveness.repro.test.ts`).
+
 ## Testing
 
 ```bash

--- a/web/src/lib/AGENTS.md
+++ b/web/src/lib/AGENTS.md
@@ -20,6 +20,12 @@ This directory contains integrations with external libraries (WebSocket, Supabas
 - Always subscribe to updates and return the unsubscribe function.
 - Clean up subscriptions in `useEffect` cleanup.
 - Validate all incoming messages before processing.
+- **Every run-submission path must set `concurrent: true` on the `run_job`
+  payload.** Without it the backend serializes the run behind any in-flight
+  same-workflow run. When you add a new way to launch a run (e.g.
+  `runInlineGraphJob` for Run-from-here / node context-menu), match the flag the
+  other paths use — an unset flag silently queues the run instead of running it
+  alongside the others.
 
 ### Supabase
 

--- a/web/src/stores/AGENTS.md
+++ b/web/src/stores/AGENTS.md
@@ -34,6 +34,36 @@ const { selectedAssets, searchTerm } = useAssetGridStore(
 );
 ```
 
+## Concurrent runs — state must be keyed by `jobId`
+
+A single workflow can have **multiple runs in flight at once**. Every piece of
+run-related state must be scoped to the `jobId` it belongs to, or concurrent
+runs will clobber each other. These rules come straight from shipped bug fixes:
+
+- **Return the id from whatever starts an async run — never re-read a global
+  afterward.** `WorkflowRunner.run()` returns the `job_id` it actually started
+  (it may queue a fresh job while `runnerStore.job_id` still points at the
+  active one). Callers must use the returned id; reading `runnerStore.job_id`
+  right after `run()` subscribes to the wrong job.
+- **Capture a job's outputs/errors from the live message stream into a per-job
+  `Map` keyed by `jobId`** — don't resolve a finished run's result by reading a
+  workflow- or node-keyed shared store (`ResultsStore`/`ErrorStore`) at
+  completion time. A sibling run will have overwritten that slot. Clean the map
+  up on unsubscribe.
+- **Guard every shared-slot reset/clear on ownership.** Before resetting
+  per-workflow run state from a terminal `job_update`, check the slot still
+  belongs to this job (`store.job_id === jobId`). A terminal event from one job
+  must never reset another's state.
+- **Don't clear shared state at workflow scope to "reset" one run.**
+  `clearErrors(workflowId)` wipes every concurrent run's errors. Job-keyed state
+  is already empty for a fresh `jobId`, so clear at the narrowest key (`jobId`)
+  or not at all.
+- **An async/background task that resolves later must not call a focus-grabbing,
+  latest-run-wins action unconditionally.** `recordRun` auto-focuses the latest
+  run; result hydration writes under `HYDRATED_JOB_ID` always but only
+  `recordRun`s when no real run exists (`getRuns(workflowId)` shows none),
+  otherwise it steals focus from a live run.
+
 ## Testing
 
 ```bash
@@ -44,3 +74,6 @@ npm test -- --testPathPattern=stores  # Store tests only
 - Place tests in `__tests__/` subdirectories.
 - Test actions and derived state, not internal implementation.
 - Mock API calls and external dependencies.
+- **Regression-test run-state code with two concurrent same-workflow jobs**
+  driven through the real reducer/handler (see `WorkflowRunner.test.ts`,
+  `workflowResultHydration.focus.test.ts`). Single-job tests miss every bug above.


### PR DESCRIPTION
## Summary

Adds comprehensive bug-prevention documentation to `packages/AGENTS.md` and creates package-specific overlays in 13 new `AGENTS.md` files. These distill patterns from shipped bug fixes across node authoring, LLM providers, external API wrappers, and web state management. Also fixes media-ref helpers in `huggingface-nodes` and `minimax-nodes` to emit raw base64 instead of `data:` URIs, and updates tests accordingly.

## Key Changes

### Documentation (packages/AGENTS.md & package overlays)

- **Node Authoring — Bug Patterns to Avoid** (new section in `packages/AGENTS.md`):
  - Output contract: every returned key must be a declared slot; test non-terminal nodes; streaming outputs require `async *genProcess`; implement every declared prop
  - Media refs: `data` carries raw base64 (no `data:` prefix); always include `type` discriminator; use package helpers; read with async resolver; guard `data.length > 0`
  - Indices & bounds: no catch-all `if (end < 0)` sentinels; use `Number.isFinite`; clamp divisors; generate float series as `i * step`; track state with explicit booleans
  - Defaults & parsing: spread first, default last; one source of truth per default; treat unreachable branches as bugs; parse by structure not offsets; guard empty input; never use `new Function` for expressions; release handles in `finally`

- **External-API Wrapper Nodes** (new section in `packages/AGENTS.md`):
  - Never retry non-idempotent requests on 5xx (server may have already billed)
  - Always retry downloads of billed results with backoff
  - Parse `Retry-After` as delay-seconds or HTTP-date; clamp and fall back to exponential backoff
  - Centralize terminal poll states in SUCCESS/FAILURE sets
  - Harden SSRF checks on every URL

- **Package-specific overlays** (new files):
  - `packages/runtime/AGENTS.md`: Cost accounting (cache-inclusive token counts), streaming (emit terminal chunks for all reasons), tool-call pairing, request/response shape mapping, media-ref resolver guards
  - `packages/audio-nodes/AGENTS.md`: Decode before edit, time in seconds not bytes, sample-rate/channel matching, WAV structure parsing, DSP control wiring, output port keys
  - `packages/automation-nodes/AGENTS.md`: Output-slot contract (headline bug), dependency declarations, filesystem/SQLite validation, glob-to-regex completeness, trigger/timeout correctness
  - `packages/llm-nodes/AGENTS.md`: Provider-direct request/response shape, response variant parsing, model-specific param gating, streaming thinking blocks, agent output routing
  - `packages/code-runners/AGENTS.md`: Resource lifecycle (containers, processes), stream decoding (StringDecoder), Zip Slip validation, caching & defaults
  - `packages/image-nodes/AGENTS.md`: Bounds clamping before sharp, paired optional dimensions, GPU handle cleanup, kernel/format correctness, output port keys
  - `packages/timeline/AGENTS.md`: Timeline vs. source-space rate tracking, inverse op consistency, split/clone boundary fades, snap-point generation, snapping state tracking
  - `packages/data-nodes/AGENTS.md`: Dataframe shape normalization, filter expression parsing (no `new Function`), slice indices, feed field reading
  - `packages/node-sdk/AGENTS.md`: Framework internals vs. user props (prefix-gating `_`), output contract enforcement
  - `packages/transformers-js-nodes/AGENTS.md`: Audio decode path parity, WAV normalization constant, data-chunk size clamping, RIFF padding, cancellation via AbortSignal
  - `packages/atlascloud-nodes/AGENTS.md`: SSRF reference implementation, retry through `atlasDownload`, terminal poll states
  - `packages/security/AGENTS.md`: Base64 padding for cross-runtime crypto, master-key resolution (no fallback on authoritative source failure

https://claude.ai/code/session_01PJ49YS6vGgXk6F2eaG7vu3