### PR TITLE
Add portable workflow bundle codec and package asset system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,14 @@ npm run dev:nodetool -- workflows run <id> --json               # JSON output
 npm run dev:nodetool -- workflows export-dsl <workflow_id>
 npm run dev:nodetool -- workflows export-dsl <id> -o output.ts  # Write to file
 npm run dev:nodetool -- workflows export-dsl workflow.json       # From JSON file
+
+# Export workflow as a shipped template: materialize its referenced assets into
+# the package's constant asset dir (rewriting refs to package://<pkg>/<file>)
+# and write the example JSON. The assets ship with the build and resolve on any
+# install via /api/assets/packages/<pkg>/<file>.
+npm run dev:nodetool -- workflows export-example <workflow_id>
+npm run dev:nodetool -- workflows export-example <id> --package nodetool-base
+npm run dev:nodetool -- workflows export-example workflow.json -o example.json
 ```
 
 ### nodetool jobs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,11 +224,14 @@ npm run dev:nodetool -- workflows export-example <workflow_id>
 npm run dev:nodetool -- workflows export-example <id> --package nodetool-base
 npm run dev:nodetool -- workflows export-example workflow.json -o example.json
 
-# Export/import a portable .nodetool bundle (zip): the workflow graph plus the
-# bytes of every asset it references, sharable as a single self-contained file
-# (refs become bundle://<file> inside, rewritten back to asset:// on import).
-npm run dev:nodetool -- workflows export-bundle <workflow_id> -o my-workflow.nodetool
-npm run dev:nodetool -- workflows import-bundle my-workflow.nodetool   # → local library
+# Export/import a portable .nodetool bundle (zip): one or more workflow graphs
+# plus the bytes of every asset they reference, sharable as a single file (refs
+# become bundle://<file> inside, rewritten back to asset:// on import). Also
+# exposed over the API (GET /api/workflows/:id/export-bundle, POST
+# /api/workflows/export-bundle {workflow_ids}, POST /api/workflows/import-bundle)
+# and in the editor command menu (Export/Import Workflow as Bundle).
+npm run dev:nodetool -- workflows export-bundle <id> [<id2> ...] -o my-pack.nodetool
+npm run dev:nodetool -- workflows import-bundle my-pack.nodetool   # → local library
 ```
 
 ### nodetool jobs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,12 @@ npm run dev:nodetool -- workflows export-dsl workflow.json       # From JSON fil
 npm run dev:nodetool -- workflows export-example <workflow_id>
 npm run dev:nodetool -- workflows export-example <id> --package nodetool-base
 npm run dev:nodetool -- workflows export-example workflow.json -o example.json
+
+# Export/import a portable .nodetool bundle (zip): the workflow graph plus the
+# bytes of every asset it references, sharable as a single self-contained file
+# (refs become bundle://<file> inside, rewritten back to asset:// on import).
+npm run dev:nodetool -- workflows export-bundle <workflow_id> -o my-workflow.nodetool
+npm run dev:nodetool -- workflows import-bundle my-workflow.nodetool   # → local library
 ```
 
 ### nodetool jobs

--- a/electron/scripts/bundle-backend.mjs
+++ b/electron/scripts/bundle-backend.mjs
@@ -431,12 +431,14 @@ async function main() {
   }
   console.log(`  Total: ${stagedManifests.size} manifest(s) staged`);
 
-  // --- Copy example workflows and thumbnail assets ---
+  // --- Copy example workflows and package assets ---
   // server.ts resolves examples relative to import.meta.url, so in the
   // packaged app (resources/backend/server.mjs) it looks for:
   //   resources/backend/examples/nodetool-base/   (workflow JSONs)
-  //   resources/backend/assets/nodetool-base/     (thumbnail JPGs)
-  console.log("\nCopying example workflows and thumbnail assets...");
+  //   resources/backend/assets/nodetool-base/     (thumbnail JPGs + constant
+  //                                                 `package://` assets served
+  //                                                 at /api/assets/packages/...)
+  console.log("\nCopying example workflows and package assets...");
   const BASE_NODES_NODETOOL_DIR = path.join(
     ROOT_DIR,
     "packages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42578,6 +42578,7 @@
         "@sinclair/typebox": "^0.34.0",
         "@trpc/server": "^11.0.0",
         "fastify": "^5.8.5",
+        "fflate": "^0.8.2",
         "msgpackr": "^1.11.2",
         "sharp": "^0.34.5",
         "superjson": "^2.2.2",

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -757,10 +757,10 @@ workflows
   );
 
 workflows
-  .command("export-bundle <workflow_id_or_file>")
+  .command("export-bundle <workflow_id_or_file...>")
   .description(
-    "Export a workflow as a portable .nodetool bundle (zip): the graph plus the " +
-      "bytes of every asset it references, sharable as a single file"
+    "Export one or more workflows as a portable .nodetool bundle (zip): the " +
+      "graphs plus the bytes of every asset they reference, in a single file"
   )
   .option(
     "--api-url <url>",
@@ -774,15 +774,15 @@ workflows
   )
   .action(
     async (
-      idOrFile: string,
+      idsOrFiles: string[],
       opts: { apiUrl: string; output?: string; includeRemote?: boolean }
     ) => {
       try {
         const { readFileSync } = await import("node:fs");
         const { writeFile } = await import("node:fs/promises");
-        const { packWorkflowBundle } = await import("@nodetool-ai/websocket");
+        const { packWorkflowsBundle } = await import("@nodetool-ai/websocket");
 
-        let workflow: {
+        type BundleWf = {
           name: string;
           description?: string;
           tags?: string[];
@@ -791,60 +791,48 @@ workflows
           graph: { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] };
         };
 
-        const isFile =
-          idOrFile.endsWith(".json") ||
-          idOrFile.includes("/") ||
-          idOrFile.includes("\\");
-
-        if (isFile) {
-          const raw = JSON.parse(readFileSync(idOrFile, "utf8")) as Record<
-            string,
-            unknown
-          >;
-          workflow = {
-            name: typeof raw.name === "string" ? raw.name : "workflow",
-            description:
-              typeof raw.description === "string" ? raw.description : "",
-            tags: Array.isArray(raw.tags)
-              ? raw.tags.filter((t): t is string => typeof t === "string")
-              : [],
-            run_mode: (raw.run_mode as string | null | undefined) ?? null,
-            settings: (raw.settings as Record<string, unknown> | null) ?? null,
-            graph: (raw.graph ?? raw) as typeof workflow.graph
-          };
-        } else {
-          const wf = (await createApiClient(opts.apiUrl).workflows.get.query({
-            id: idOrFile
-          })) as Record<string, unknown>;
-          workflow = {
-            name: typeof wf.name === "string" ? wf.name : "workflow",
-            description:
-              typeof wf.description === "string" ? wf.description : "",
-            tags: Array.isArray(wf.tags)
-              ? wf.tags.filter((t): t is string => typeof t === "string")
-              : [],
-            run_mode: (wf.run_mode as string | null | undefined) ?? null,
-            settings: (wf.settings as Record<string, unknown> | null) ?? null,
-            graph: wf.graph as typeof workflow.graph
-          };
-        }
-
-        if (!workflow.graph?.nodes) {
-          throw new Error("Workflow has no graph to export");
-        }
+        const toBundleWf = (raw: Record<string, unknown>): BundleWf => ({
+          name: typeof raw.name === "string" ? raw.name : "workflow",
+          description: typeof raw.description === "string" ? raw.description : "",
+          tags: Array.isArray(raw.tags)
+            ? raw.tags.filter((t): t is string => typeof t === "string")
+            : [],
+          run_mode: (raw.run_mode as string | null | undefined) ?? null,
+          settings: (raw.settings as Record<string, unknown> | null) ?? null,
+          graph: (raw.graph ?? raw) as BundleWf["graph"]
+        });
 
         const apiUrl = opts.apiUrl.replace(/\/+$/, "");
-        const fetchAssetBytes = makeAssetFetcher(apiUrl);
+        const workflowsToPack: BundleWf[] = [];
+        for (const idOrFile of idsOrFiles) {
+          const isFile =
+            idOrFile.endsWith(".json") ||
+            idOrFile.includes("/") ||
+            idOrFile.includes("\\");
+          const raw = isFile
+            ? (JSON.parse(readFileSync(idOrFile, "utf8")) as Record<string, unknown>)
+            : ((await createApiClient(apiUrl).workflows.get.query({
+                id: idOrFile
+              })) as Record<string, unknown>);
+          const wf = toBundleWf(raw);
+          if (!wf.graph?.nodes) {
+            throw new Error(`Workflow '${idOrFile}' has no graph to export`);
+          }
+          workflowsToPack.push(wf);
+        }
 
-        const { bytes, manifest, skipped } = await packWorkflowBundle({
-          workflow,
-          fetchAssetBytes,
+        const { bytes, manifest, skipped } = await packWorkflowsBundle({
+          workflows: workflowsToPack,
+          fetchAssetBytes: makeAssetFetcher(apiUrl),
           nodetoolVersion: cliVersion(),
           ...(opts.includeRemote ? { includeRemote: true } : {})
         });
 
-        const safeName = workflow.name.replace(/[^A-Za-z0-9._-]+/g, "_");
-        const outPath = opts.output ?? `${safeName}.nodetool`;
+        const defaultBase =
+          workflowsToPack.length === 1
+            ? workflowsToPack[0]!.name.replace(/[^A-Za-z0-9._-]+/g, "_")
+            : `${workflowsToPack.length}-workflows`;
+        const outPath = opts.output ?? `${defaultBase}.nodetool`;
         await writeFile(outPath, bytes);
 
         for (const a of manifest.assets) {
@@ -853,6 +841,9 @@ workflows
         for (const s of skipped) {
           console.error(`  warning: could not resolve asset ${s} (left as-is)`);
         }
+        console.error(
+          `  bundled ${manifest.workflows.length} workflow(s), ${manifest.assets.length} asset(s)`
+        );
         console.log(outPath);
       } catch (e) {
         console.error(String(e));
@@ -865,9 +856,9 @@ workflows
   .command("import-bundle <bundle_file>")
   .description(
     "Import a .nodetool bundle into the local library: store its assets and " +
-      "create the workflow with refs rewritten to the imported assets"
+      "create the workflows with refs rewritten to the imported assets"
   )
-  .option("--json", "Output the created workflow as JSON")
+  .option("--json", "Output the created workflows as JSON")
   .action(async (bundleFile: string, opts: { json?: boolean }) => {
     try {
       const { readFileSync } = await import("node:fs");
@@ -888,17 +879,21 @@ workflows
         }
       });
 
-      const wf = result.workflow;
-      const created = (await Workflow.create({
-        user_id: "1",
-        name: wf.name,
-        description: wf.description ?? "",
-        tags: wf.tags ?? [],
-        access: "private",
-        graph: wf.graph,
-        run_mode: wf.run_mode ?? "workflow",
-        settings: wf.settings ?? null
-      })) as unknown as Record<string, unknown>;
+      const created: Record<string, unknown>[] = [];
+      for (const wf of result.workflows) {
+        created.push(
+          (await Workflow.create({
+            user_id: "1",
+            name: wf.name,
+            description: wf.description ?? "",
+            tags: wf.tags ?? [],
+            access: "private",
+            graph: wf.graph,
+            run_mode: wf.run_mode ?? "workflow",
+            settings: wf.settings ?? null
+          })) as unknown as Record<string, unknown>
+        );
+      }
 
       for (const s of result.missing) {
         console.error(`  warning: bundle asset ${s} was missing from the archive`);
@@ -907,13 +902,15 @@ workflows
         console.error(`  warning: ${m}`);
       }
       console.error(
-        `  imported ${result.imported.length} asset(s) into local storage`
+        `  imported ${created.length} workflow(s) and ${result.imported.length} asset(s) into local storage`
       );
 
       if (opts.json) {
         asJson(created);
       } else {
-        console.log(String(created["id"]));
+        for (const c of created) {
+          console.log(String(c["id"]));
+        }
       }
     } catch (e) {
       console.error(String(e));

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -722,11 +722,12 @@ workflows
           ...(opts.includeRemote ? { includeRemote: true } : {})
         });
 
+        const slug = name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
         const example = {
-          id: name
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/^-+|-+$/g, ""),
+          id: slug || "workflow",
           access: "public",
           name,
           description,
@@ -735,8 +736,13 @@ workflows
           graph: result.graph
         };
 
+        // Sanitize the on-disk filename separately from the display name so
+        // names with path separators can't escape the examples directory.
+        const safeFileName =
+          name.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+/, "") ||
+          "workflow";
         const outPath =
-          opts.output ?? join(examplesDir, opts.package, `${name}.json`);
+          opts.output ?? join(examplesDir, opts.package, `${safeFileName}.json`);
         await mkdir(dirname(outPath), { recursive: true });
         await writeFile(outPath, JSON.stringify(example, null, 2) + "\n", "utf8");
 

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -570,6 +570,177 @@ workflows
     }
   );
 
+workflows
+  .command("export-example <workflow_id_or_file>")
+  .description(
+    "Export a workflow as a shipped template: materialize its assets into the " +
+      "package's constant asset dir (package:// refs) and write the example JSON"
+  )
+  .option(
+    "--api-url <url>",
+    "API base URL (used to fetch the workflow and asset bytes by id)",
+    process.env["NODETOOL_API_URL"] ?? "http://localhost:7777"
+  )
+  .option("--package <name>", "Owning package", "nodetool-base")
+  .option(
+    "--assets-dir <dir>",
+    "Root holding <package>/<file> constant assets (defaults to the monorepo base-nodes assets dir)"
+  )
+  .option(
+    "--examples-dir <dir>",
+    "Directory the example JSON is written under, as <dir>/<package>/<name>.json"
+  )
+  .option("-o, --output <file>", "Write the example JSON to this exact path")
+  .option(
+    "--include-remote",
+    "Also materialize http(s) and local-file refs (off by default)"
+  )
+  .action(
+    async (
+      idOrFile: string,
+      opts: {
+        apiUrl: string;
+        package: string;
+        assetsDir?: string;
+        examplesDir?: string;
+        output?: string;
+        includeRemote?: boolean;
+      }
+    ) => {
+      try {
+        const { readFileSync } = await import("node:fs");
+        const { mkdir, writeFile } = await import("node:fs/promises");
+        const { join } = await import("node:path");
+        const { materializeWorkflowConstantAssets } = await import(
+          "@nodetool-ai/websocket"
+        );
+
+        let name = "";
+        let description = "";
+        let tags: string[] = [];
+        let graph: { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] };
+
+        const isFile =
+          idOrFile.endsWith(".json") ||
+          idOrFile.includes("/") ||
+          idOrFile.includes("\\");
+
+        if (isFile) {
+          const raw = JSON.parse(readFileSync(idOrFile, "utf8")) as Record<
+            string,
+            unknown
+          >;
+          name = typeof raw.name === "string" ? raw.name : "workflow";
+          description = typeof raw.description === "string" ? raw.description : "";
+          tags = Array.isArray(raw.tags)
+            ? raw.tags.filter((t): t is string => typeof t === "string")
+            : [];
+          graph = (raw.graph ?? raw) as typeof graph;
+        } else {
+          const client = createApiClient(opts.apiUrl);
+          const wf = (await client.workflows.get.query({
+            id: idOrFile
+          })) as Record<string, unknown>;
+          name = typeof wf.name === "string" ? wf.name : "workflow";
+          description = typeof wf.description === "string" ? wf.description : "";
+          tags = Array.isArray(wf.tags)
+            ? wf.tags.filter((t): t is string => typeof t === "string")
+            : [];
+          graph = wf.graph as typeof graph;
+        }
+
+        if (!graph?.nodes) {
+          throw new Error("Workflow has no graph to export");
+        }
+
+        const repoRoot = resolve(__dirname, "..", "..", "..");
+        const baseNodesDir = join(
+          repoRoot,
+          "packages",
+          "base-nodes",
+          "nodetool"
+        );
+        const assetsRoot = opts.assetsDir ?? join(baseNodesDir, "assets");
+        const examplesDir = opts.examplesDir ?? join(baseNodesDir, "examples");
+
+        const apiUrl = opts.apiUrl.replace(/\/+$/, "");
+        const fetchAssetBytes = async (
+          ref: string
+        ): Promise<Uint8Array | null> => {
+          let url: string | null = null;
+          if (ref.startsWith("asset://")) {
+            const id = ref.slice("asset://".length);
+            const bareId = id.replace(/\.[^.]+$/, "");
+            try {
+              const meta = await fetch(
+                `${apiUrl}/api/assets/${encodeURIComponent(bareId)}`
+              );
+              if (meta.ok) {
+                const j = (await meta.json()) as { get_url?: string };
+                if (j.get_url) {
+                  url = j.get_url.startsWith("/")
+                    ? `${apiUrl}${j.get_url}`
+                    : j.get_url;
+                }
+              }
+            } catch {
+              // fall back to the storage route below
+            }
+            url ??= `${apiUrl}/api/storage/${encodeURIComponent(id)}`;
+          } else if (ref.includes("/api/storage/")) {
+            url = /^https?:\/\//.test(ref)
+              ? ref
+              : `${apiUrl}${ref.startsWith("/") ? ref : `/${ref}`}`;
+          } else if (/^https?:\/\//.test(ref)) {
+            url = ref;
+          }
+          if (!url) return null;
+          const res = await fetch(url);
+          if (!res.ok) return null;
+          return new Uint8Array(await res.arrayBuffer());
+        };
+
+        const result = await materializeWorkflowConstantAssets(graph, {
+          packageName: opts.package,
+          assetsRoot,
+          fetchAssetBytes,
+          ...(opts.includeRemote ? { includeRemote: true } : {})
+        });
+
+        const example = {
+          id: name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, ""),
+          access: "public",
+          name,
+          description,
+          tags,
+          package_name: opts.package,
+          graph: result.graph
+        };
+
+        const outPath =
+          opts.output ?? join(examplesDir, opts.package, `${name}.json`);
+        await mkdir(dirname(outPath), { recursive: true });
+        await writeFile(outPath, JSON.stringify(example, null, 2) + "\n", "utf8");
+
+        for (const a of result.exported) {
+          console.error(
+            `  asset ${a.source} → ${a.packageUri} (${a.byteLength} bytes)`
+          );
+        }
+        for (const s of result.skipped) {
+          console.error(`  warning: could not resolve asset ${s} (left as-is)`);
+        }
+        console.log(outPath);
+      } catch (e) {
+        console.error(String(e));
+        process.exit(1);
+      }
+    }
+  );
+
 // ---------------------------------------------------------------------------
 // jobs
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -99,6 +99,55 @@ async function apiGetText(apiUrl: string, path: string): Promise<string> {
   return res.text();
 }
 
+// This CLI's package version, stamped into exported bundle manifests.
+function cliVersion(): string | undefined {
+  try {
+    const req = createRequire(import.meta.url);
+    return (req("../package.json") as { version?: string }).version;
+  } catch {
+    // Version is best-effort metadata; omit it if the file can't be read.
+    return undefined;
+  }
+}
+
+// Download asset bytes from a running server, used by the export commands to
+// resolve `asset://` / `/api/storage/` (and optionally http) refs into bytes.
+function makeAssetFetcher(
+  apiUrl: string
+): (ref: string) => Promise<Uint8Array | null> {
+  return async (ref: string): Promise<Uint8Array | null> => {
+    let url: string | null = null;
+    if (ref.startsWith("asset://")) {
+      const id = ref.slice("asset://".length);
+      const bareId = id.replace(/\.[^.]+$/, "");
+      try {
+        const meta = await fetch(
+          `${apiUrl}/api/assets/${encodeURIComponent(bareId)}`
+        );
+        if (meta.ok) {
+          const j = (await meta.json()) as { get_url?: string };
+          if (j.get_url) {
+            url = j.get_url.startsWith("/") ? `${apiUrl}${j.get_url}` : j.get_url;
+          }
+        }
+      } catch {
+        // Metadata lookup failed — fall back to the storage route below.
+      }
+      url ??= `${apiUrl}/api/storage/${encodeURIComponent(id)}`;
+    } else if (ref.includes("/api/storage/")) {
+      url = /^https?:\/\//.test(ref)
+        ? ref
+        : `${apiUrl}${ref.startsWith("/") ? ref : `/${ref}`}`;
+    } else if (/^https?:\/\//.test(ref)) {
+      url = ref;
+    }
+    if (!url) return null;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Table printer
 // ---------------------------------------------------------------------------
@@ -664,41 +713,7 @@ workflows
         const examplesDir = opts.examplesDir ?? join(baseNodesDir, "examples");
 
         const apiUrl = opts.apiUrl.replace(/\/+$/, "");
-        const fetchAssetBytes = async (
-          ref: string
-        ): Promise<Uint8Array | null> => {
-          let url: string | null = null;
-          if (ref.startsWith("asset://")) {
-            const id = ref.slice("asset://".length);
-            const bareId = id.replace(/\.[^.]+$/, "");
-            try {
-              const meta = await fetch(
-                `${apiUrl}/api/assets/${encodeURIComponent(bareId)}`
-              );
-              if (meta.ok) {
-                const j = (await meta.json()) as { get_url?: string };
-                if (j.get_url) {
-                  url = j.get_url.startsWith("/")
-                    ? `${apiUrl}${j.get_url}`
-                    : j.get_url;
-                }
-              }
-            } catch {
-              // fall back to the storage route below
-            }
-            url ??= `${apiUrl}/api/storage/${encodeURIComponent(id)}`;
-          } else if (ref.includes("/api/storage/")) {
-            url = /^https?:\/\//.test(ref)
-              ? ref
-              : `${apiUrl}${ref.startsWith("/") ? ref : `/${ref}`}`;
-          } else if (/^https?:\/\//.test(ref)) {
-            url = ref;
-          }
-          if (!url) return null;
-          const res = await fetch(url);
-          if (!res.ok) return null;
-          return new Uint8Array(await res.arrayBuffer());
-        };
+        const fetchAssetBytes = makeAssetFetcher(apiUrl);
 
         const result = await materializeWorkflowConstantAssets(graph, {
           packageName: opts.package,
@@ -740,6 +755,171 @@ workflows
       }
     }
   );
+
+workflows
+  .command("export-bundle <workflow_id_or_file>")
+  .description(
+    "Export a workflow as a portable .nodetool bundle (zip): the graph plus the " +
+      "bytes of every asset it references, sharable as a single file"
+  )
+  .option(
+    "--api-url <url>",
+    "API base URL (used to fetch the workflow and asset bytes by id)",
+    process.env["NODETOOL_API_URL"] ?? "http://localhost:7777"
+  )
+  .option("-o, --output <file>", "Output path (default: <name>.nodetool)")
+  .option(
+    "--include-remote",
+    "Also embed http(s) and local-file refs (off by default)"
+  )
+  .action(
+    async (
+      idOrFile: string,
+      opts: { apiUrl: string; output?: string; includeRemote?: boolean }
+    ) => {
+      try {
+        const { readFileSync } = await import("node:fs");
+        const { writeFile } = await import("node:fs/promises");
+        const { packWorkflowBundle } = await import("@nodetool-ai/websocket");
+
+        let workflow: {
+          name: string;
+          description?: string;
+          tags?: string[];
+          run_mode?: string | null;
+          settings?: Record<string, unknown> | null;
+          graph: { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] };
+        };
+
+        const isFile =
+          idOrFile.endsWith(".json") ||
+          idOrFile.includes("/") ||
+          idOrFile.includes("\\");
+
+        if (isFile) {
+          const raw = JSON.parse(readFileSync(idOrFile, "utf8")) as Record<
+            string,
+            unknown
+          >;
+          workflow = {
+            name: typeof raw.name === "string" ? raw.name : "workflow",
+            description:
+              typeof raw.description === "string" ? raw.description : "",
+            tags: Array.isArray(raw.tags)
+              ? raw.tags.filter((t): t is string => typeof t === "string")
+              : [],
+            run_mode: (raw.run_mode as string | null | undefined) ?? null,
+            settings: (raw.settings as Record<string, unknown> | null) ?? null,
+            graph: (raw.graph ?? raw) as typeof workflow.graph
+          };
+        } else {
+          const wf = (await createApiClient(opts.apiUrl).workflows.get.query({
+            id: idOrFile
+          })) as Record<string, unknown>;
+          workflow = {
+            name: typeof wf.name === "string" ? wf.name : "workflow",
+            description:
+              typeof wf.description === "string" ? wf.description : "",
+            tags: Array.isArray(wf.tags)
+              ? wf.tags.filter((t): t is string => typeof t === "string")
+              : [],
+            run_mode: (wf.run_mode as string | null | undefined) ?? null,
+            settings: (wf.settings as Record<string, unknown> | null) ?? null,
+            graph: wf.graph as typeof workflow.graph
+          };
+        }
+
+        if (!workflow.graph?.nodes) {
+          throw new Error("Workflow has no graph to export");
+        }
+
+        const apiUrl = opts.apiUrl.replace(/\/+$/, "");
+        const fetchAssetBytes = makeAssetFetcher(apiUrl);
+
+        const { bytes, manifest, skipped } = await packWorkflowBundle({
+          workflow,
+          fetchAssetBytes,
+          nodetoolVersion: cliVersion(),
+          ...(opts.includeRemote ? { includeRemote: true } : {})
+        });
+
+        const safeName = workflow.name.replace(/[^A-Za-z0-9._-]+/g, "_");
+        const outPath = opts.output ?? `${safeName}.nodetool`;
+        await writeFile(outPath, bytes);
+
+        for (const a of manifest.assets) {
+          console.error(`  embedded ${a.file} (${a.bytes} bytes)`);
+        }
+        for (const s of skipped) {
+          console.error(`  warning: could not resolve asset ${s} (left as-is)`);
+        }
+        console.log(outPath);
+      } catch (e) {
+        console.error(String(e));
+        process.exit(1);
+      }
+    }
+  );
+
+workflows
+  .command("import-bundle <bundle_file>")
+  .description(
+    "Import a .nodetool bundle into the local library: store its assets and " +
+      "create the workflow with refs rewritten to the imported assets"
+  )
+  .option("--json", "Output the created workflow as JSON")
+  .action(async (bundleFile: string, opts: { json?: boolean }) => {
+    try {
+      const { readFileSync } = await import("node:fs");
+      const { randomUUID } = await import("node:crypto");
+      const { extname } = await import("node:path");
+      const { importWorkflowBundle } = await import("@nodetool-ai/websocket");
+
+      await setupDb();
+      const storage = new FileStorageAdapter(getDefaultAssetsPath());
+
+      const zip = new Uint8Array(readFileSync(bundleFile));
+      const result = await importWorkflowBundle(zip, {
+        storeAsset: async ({ bytes, fileName, contentType }) => {
+          const id = randomUUID();
+          const key = `${id}${extname(fileName)}`;
+          await storage.store(key, bytes, contentType);
+          return { uri: `asset://${key}`, assetId: id };
+        }
+      });
+
+      const wf = result.workflow;
+      const created = (await Workflow.create({
+        user_id: "1",
+        name: wf.name,
+        description: wf.description ?? "",
+        tags: wf.tags ?? [],
+        access: "private",
+        graph: wf.graph,
+        run_mode: wf.run_mode ?? "workflow",
+        settings: wf.settings ?? null
+      })) as unknown as Record<string, unknown>;
+
+      for (const s of result.missing) {
+        console.error(`  warning: bundle asset ${s} was missing from the archive`);
+      }
+      for (const m of result.checksumMismatches) {
+        console.error(`  warning: ${m}`);
+      }
+      console.error(
+        `  imported ${result.imported.length} asset(s) into local storage`
+      );
+
+      if (opts.json) {
+        asJson(created);
+      } else {
+        console.log(String(created["id"]));
+      }
+    } catch (e) {
+      console.error(String(e));
+      process.exit(1);
+    }
+  });
 
 // ---------------------------------------------------------------------------
 // jobs

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,6 +5,7 @@
 export * from "./messages.js";
 export * from "./graph.js";
 export * from "./api-types.js";
+export * from "./package-assets.js";
 export { TypeMetadata } from "./type-metadata.js";
 export { validateType, type ValidationResult } from "./typecheck.js";
 export {

--- a/packages/protocol/src/package-assets.ts
+++ b/packages/protocol/src/package-assets.ts
@@ -1,0 +1,79 @@
+/**
+ * Constant "package" assets — files that ship with a node package (and the
+ * Electron build) and are referenced by example workflows and templates.
+ *
+ * Scheme: `package://<package-name>/<relative-path>`
+ *   e.g. `package://nodetool-base/audio/sample-loop.mp3`
+ *
+ * Unlike user assets (`asset://<id>`, `/api/storage/<key>`), package assets have
+ * stable, machine-independent URIs: the same URI resolves on every install
+ * because the bytes are bundled with the package rather than stored per-user.
+ * The backend serves them at
+ * `/api/assets/packages/<package-name>/<relative-path>`.
+ *
+ * This is what makes a workflow portable as a template — referenced inputs
+ * (sample images, audio, documents) can be materialized into the package's
+ * asset directory and the refs rewritten to `package://` URIs.
+ */
+
+export const PACKAGE_ASSET_SCHEME = "package://";
+
+/** HTTP route prefix the backend serves package assets from. */
+export const PACKAGE_ASSET_HTTP_PREFIX = "/api/assets/packages/";
+
+export interface PackageAssetRef {
+  /** Owning package, e.g. `nodetool-base`. */
+  packageName: string;
+  /** Path of the file within the package's asset directory. */
+  path: string;
+}
+
+export function isPackageAssetUri(uri: string | null | undefined): uri is string {
+  return typeof uri === "string" && uri.startsWith(PACKAGE_ASSET_SCHEME);
+}
+
+/**
+ * Parse `package://<pkg>/<path>` into its parts. Returns null when the URI is
+ * not a package asset URI or is missing a package/path segment.
+ */
+export function parsePackageAssetUri(
+  uri: string | null | undefined
+): PackageAssetRef | null {
+  if (!isPackageAssetUri(uri)) {
+    return null;
+  }
+  const rest = uri.slice(PACKAGE_ASSET_SCHEME.length);
+  const slash = rest.indexOf("/");
+  if (slash <= 0) {
+    return null;
+  }
+  const packageName = rest.slice(0, slash);
+  const path = rest.slice(slash + 1).replace(/^\/+/, "");
+  if (!packageName || !path) {
+    return null;
+  }
+  return { packageName, path };
+}
+
+export function buildPackageAssetUri(packageName: string, path: string): string {
+  const cleanPath = path.replace(/\\/g, "/").replace(/^\/+/, "");
+  return `${PACKAGE_ASSET_SCHEME}${packageName}/${cleanPath}`;
+}
+
+/**
+ * Map a package asset URI to the backend HTTP path that serves it
+ * (`/api/assets/packages/<pkg>/<path>`). Returns null for non-package URIs.
+ */
+export function packageAssetHttpPath(
+  uri: string | null | undefined
+): string | null {
+  const ref = parsePackageAssetUri(uri);
+  if (!ref) {
+    return null;
+  }
+  const encodedPath = ref.path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `${PACKAGE_ASSET_HTTP_PREFIX}${encodeURIComponent(ref.packageName)}/${encodedPath}`;
+}

--- a/packages/protocol/tests/package-assets.test.ts
+++ b/packages/protocol/tests/package-assets.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  PACKAGE_ASSET_HTTP_PREFIX,
+  PACKAGE_ASSET_SCHEME,
+  buildPackageAssetUri,
+  isPackageAssetUri,
+  packageAssetHttpPath,
+  parsePackageAssetUri
+} from "../src/package-assets.js";
+
+describe("package-assets", () => {
+  describe("isPackageAssetUri", () => {
+    it("recognizes package URIs", () => {
+      expect(isPackageAssetUri("package://nodetool-base/sample.png")).toBe(true);
+    });
+    it("rejects other schemes and empties", () => {
+      expect(isPackageAssetUri("asset://abc")).toBe(false);
+      expect(isPackageAssetUri("/api/storage/x.png")).toBe(false);
+      expect(isPackageAssetUri("")).toBe(false);
+      expect(isPackageAssetUri(null)).toBe(false);
+      expect(isPackageAssetUri(undefined)).toBe(false);
+    });
+  });
+
+  describe("parsePackageAssetUri", () => {
+    it("splits package and path", () => {
+      expect(parsePackageAssetUri("package://nodetool-base/audio/loop.mp3")).toEqual(
+        { packageName: "nodetool-base", path: "audio/loop.mp3" }
+      );
+    });
+    it("strips leading slashes from the path", () => {
+      expect(parsePackageAssetUri("package://pkg//nested/file.bin")).toEqual({
+        packageName: "pkg",
+        path: "nested/file.bin"
+      });
+    });
+    it("returns null when malformed", () => {
+      expect(parsePackageAssetUri("package://only-package")).toBeNull();
+      expect(parsePackageAssetUri("package:///no-package")).toBeNull();
+      expect(parsePackageAssetUri("package://pkg/")).toBeNull();
+      expect(parsePackageAssetUri("asset://abc")).toBeNull();
+    });
+  });
+
+  describe("buildPackageAssetUri", () => {
+    it("round-trips with parse", () => {
+      const uri = buildPackageAssetUri("nodetool-base", "img/cat.png");
+      expect(uri).toBe(`${PACKAGE_ASSET_SCHEME}nodetool-base/img/cat.png`);
+      expect(parsePackageAssetUri(uri)).toEqual({
+        packageName: "nodetool-base",
+        path: "img/cat.png"
+      });
+    });
+    it("normalizes backslashes and leading slashes", () => {
+      expect(buildPackageAssetUri("pkg", "/a\\b\\c.png")).toBe(
+        "package://pkg/a/b/c.png"
+      );
+    });
+  });
+
+  describe("packageAssetHttpPath", () => {
+    it("maps to the served HTTP path with encoding", () => {
+      expect(packageAssetHttpPath("package://nodetool-base/a b/c.png")).toBe(
+        `${PACKAGE_ASSET_HTTP_PREFIX}nodetool-base/a%20b/c.png`
+      );
+    });
+    it("returns null for non-package URIs", () => {
+      expect(packageAssetHttpPath("asset://abc")).toBeNull();
+    });
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -11,6 +11,7 @@
  */
 
 import type { AssetRef, ProcessingMessage, ProviderCost } from "@nodetool-ai/protocol";
+import { packageAssetHttpPath, parsePackageAssetUri } from "@nodetool-ai/protocol";
 import { AgentMemory } from "./agent-memory.js";
 import { encodeRawImageRef } from "./image-codec.js";
 import { inlineTextAssetRefs } from "./prompt-asset-refs.js";
@@ -1728,6 +1729,60 @@ export class ProcessingContext {
       }
       return null;
     };
+
+    // Constant package assets (`package://<pkg>/<path>`) ship with the install
+    // — they have stable URIs and don't live in per-user storage. Resolve from
+    // the bundled package-assets dir when configured, else over HTTP from the
+    // server's package-asset route.
+    const packageRef = parsePackageAssetUri(trimmed);
+    if (packageRef) {
+      const root =
+        this.environment.NODETOOL_PACKAGE_ASSETS_DIR ??
+        process.env.NODETOOL_PACKAGE_ASSETS_DIR;
+      if (root) {
+        const segments = `${packageRef.packageName}/${packageRef.path}`
+          .split("/")
+          .filter((s) => s && s !== ".");
+        if (!segments.some((s) => s === "..")) {
+          const filePath = resolve(join(root, ...segments));
+          const within = !relative(resolve(root), filePath).startsWith("..");
+          if (within) {
+            try {
+              const bytes = (await readFile(filePath)) as Uint8Array;
+              attempts.push(`package asset: ${filePath}`);
+              return { bytes, attempts };
+            } catch (error) {
+              attempts.push(
+                `package asset miss: ${filePath} (${error instanceof Error ? error.message : String(error)})`
+              );
+            }
+          }
+        }
+      }
+      const httpPath = packageAssetHttpPath(trimmed);
+      if (httpPath) {
+        let pkgBaseUrl =
+          this.environment.NODETOOL_API_URL ??
+          process.env.NODETOOL_API_URL ??
+          "http://localhost:7777";
+        while (pkgBaseUrl.endsWith("/")) {
+          pkgBaseUrl = pkgBaseUrl.slice(0, -1);
+        }
+        const url = `${pkgBaseUrl}${httpPath}`;
+        try {
+          const bytes = await this.downloadFile(url, {
+            retry: { maxRetries: 1, backoffMs: 200 }
+          });
+          attempts.push(`downloaded: ${url}`);
+          return { bytes, attempts };
+        } catch (error) {
+          attempts.push(
+            `package asset http miss: ${url} (${error instanceof Error ? error.message : String(error)})`
+          );
+        }
+      }
+      return { bytes: null, attempts };
+    }
 
     // A concrete storage URI / http URL handed in directly.
     if (trimmed.includes("://") && !trimmed.startsWith("asset://")) {

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -1,4 +1,4 @@
-import { isRawRgbaImage } from "@nodetool-ai/protocol";
+import { isPackageAssetUri, isRawRgbaImage } from "@nodetool-ai/protocol";
 import { importNodeBuiltin } from "@nodetool-ai/config";
 import type { ProcessingContext } from "./context.js";
 import { encodeRawRgbaToPng } from "./image-codec.js";
@@ -100,7 +100,7 @@ export async function loadMediaRefBytes(
     return null;
   }
 
-  if (uri.startsWith("asset://") && context) {
+  if ((uri.startsWith("asset://") || isPackageAssetUri(uri)) && context) {
     const { bytes } = await context.resolveAssetBytes(uri);
     if (bytes) {
       return bytes;

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -722,6 +722,68 @@ describe("ProcessingContext.resolveAssetBytes", () => {
       expect.objectContaining({ method: "GET" })
     );
   });
+
+  it("resolves a package:// asset from the configured package assets dir", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nodetool-pkg-assets-"));
+    try {
+      await mkdir(join(root, "nodetool-base", "audio"), { recursive: true });
+      await writeFile(
+        join(root, "nodetool-base", "audio", "loop.bin"),
+        new Uint8Array([1, 2, 3, 4])
+      );
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        environment: { NODETOOL_PACKAGE_ASSETS_DIR: root }
+      });
+      const { bytes } = await ctx.resolveAssetBytes(
+        "package://nodetool-base/audio/loop.bin"
+      );
+      expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([1, 2, 3, 4]));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses path traversal in package:// asset paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nodetool-pkg-assets-"));
+    try {
+      await writeFile(join(root, "secret.bin"), new Uint8Array([9, 9]));
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        environment: { NODETOOL_PACKAGE_ASSETS_DIR: join(root, "pkg") }
+      });
+      const { bytes } = await ctx.resolveAssetBytes(
+        "package://pkg/..%2Fsecret.bin"
+      );
+      // The encoded segment is not decoded into a traversal, and the literal
+      // path does not exist, so nothing is leaked.
+      expect(bytes).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the package-asset HTTP route when no dir is configured", async () => {
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      environment: { NODETOOL_API_URL: "http://server.test" }
+    });
+    const payload = new Uint8Array([5, 6, 7]);
+    const fetchSpy = vi
+      .spyOn(ctx as unknown as { _fetch: typeof fetch }, "_fetch")
+      .mockResolvedValue(
+        new Response(payload, { status: 200 }) as unknown as Response
+      );
+
+    const { bytes } = await ctx.resolveAssetBytes(
+      "package://nodetool-base/img/cat.png"
+    );
+    expect(Uint8Array.from(bytes ?? [])).toEqual(payload);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://server.test/api/assets/packages/nodetool-base/img/cat.png",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
 });
 
 describe("ProcessingContext – asset helper methods", () => {

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -55,6 +55,7 @@
     "@mariozechner/pi-coding-agent": "^0.72.1",
     "@sinclair/typebox": "^0.34.0",
     "fastify": "^5.8.5",
+    "fflate": "^0.8.2",
     "@trpc/server": "^11.0.0",
     "@hyzyla/pdfium": "^2.1.12",
     "msgpackr": "^1.11.2",

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -89,6 +89,17 @@ export interface HttpApiOptions {
    */
   examplesDir?: string;
   examplesAssetsFallbackDir?: string;
+  /**
+   * Root directories that hold per-package constant assets, laid out as
+   * `<root>/<package-name>/<file>`. Served (read-only, public) at
+   * `/api/assets/packages/<package-name>/<file>` and referenced from workflows
+   * via the `package://<package-name>/<file>` scheme.
+   *
+   * These ship with the Electron build (bundled next to `server.mjs`) so the
+   * route resolves without a Python installation. When set, the route checks
+   * these roots before falling back to Python package metadata.
+   */
+  packageAssetsRoots?: string[];
 }
 
 // Lazily created storage handler — recreated if options change

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -49,6 +49,12 @@ import {
 } from "./storage-api.js";
 import { handleFileRequest } from "./file-api.js";
 import { storeAssetWithThumbnail, thumbnailKey } from "./lib/thumbnail.js";
+import { getAssetAdapter } from "./lib/storage.js";
+import {
+  packWorkflowsBundle,
+  importWorkflowBundle,
+  type BundledWorkflow
+} from "./lib/workflow-bundle.js";
 
 const log = createLogger("nodetool.websocket.http");
 
@@ -1161,6 +1167,216 @@ export async function handleWorkflowDslExport(
   }
 }
 
+// ── Workflow bundle export/import (.nodetool) ──────────────────────────
+
+/** Resolve asset bytes for a ref during export, via the asset storage adapter. */
+async function resolveAssetBytesForExport(
+  ref: string
+): Promise<Uint8Array | null> {
+  try {
+    if (ref.startsWith("asset://")) {
+      const rest = ref.slice("asset://".length).split("?")[0].split("#")[0];
+      let key = rest;
+      if (!nodePath.extname(rest)) {
+        const asset = (await Asset.get(rest)) as Asset | null;
+        if (!asset) return null;
+        key = getAssetFileName(asset.id, asset.content_type);
+      }
+      const adapter = getAssetAdapter();
+      return await adapter.retrieve(adapter.uriForKey(key));
+    }
+    if (ref.includes("/api/storage/")) {
+      const key = decodeURIComponent(
+        ref.slice(ref.indexOf("/api/storage/") + "/api/storage/".length).split("?")[0]
+      );
+      const adapter = getAssetAdapter();
+      return await adapter.retrieve(adapter.uriForKey(key));
+    }
+    if (/^https?:\/\//.test(ref)) {
+      const res = await fetch(ref);
+      if (!res.ok) return null;
+      return new Uint8Array(await res.arrayBuffer());
+    }
+  } catch {
+    // Unresolved — the ref is left as-is in the bundle.
+  }
+  return null;
+}
+
+async function loadBundledWorkflow(
+  workflowId: string,
+  userId: string
+): Promise<BundledWorkflow | { error: Response }> {
+  const workflow = (await Workflow.get(workflowId)) as Workflow | null;
+  if (!workflow) {
+    return { error: errorResponse(404, `Workflow not found: ${workflowId}`) };
+  }
+  if (workflow.access !== "public" && workflow.user_id !== userId) {
+    return { error: errorResponse(404, `Workflow not found: ${workflowId}`) };
+  }
+  if (!workflow.graph) {
+    return { error: errorResponse(400, "Workflow has no graph to export") };
+  }
+  return {
+    id: workflow.id,
+    name: workflow.name,
+    description: workflow.description ?? "",
+    tags: workflow.tags ?? [],
+    run_mode: workflow.run_mode ?? null,
+    settings: workflow.settings ?? null,
+    graph: workflow.graph as unknown as BundledWorkflow["graph"]
+  };
+}
+
+function bundleResponse(bytes: Uint8Array, name: string): Response {
+  const safe = name.replace(/[^A-Za-z0-9._-]+/g, "_") || "workflows";
+  // Copy into an ArrayBuffer-backed view so it satisfies BodyInit.
+  const body = new Uint8Array(bytes);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "application/zip",
+      "content-length": String(bytes.byteLength),
+      "content-disposition": `attachment; filename="${safe}.nodetool"`,
+      "cache-control": "no-store"
+    }
+  });
+}
+
+/** GET /api/workflows/:id/export-bundle — single workflow as a .nodetool zip. */
+export async function handleWorkflowExportBundle(
+  request: Request,
+  workflowId: string,
+  options: HttpApiOptions
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return errorResponse(405, "Method not allowed");
+  }
+  const userId = getUserId(request, options.userIdHeader ?? "x-user-id");
+  const loaded = await loadBundledWorkflow(workflowId, userId);
+  if ("error" in loaded) {
+    return loaded.error;
+  }
+  const { bytes } = await packWorkflowsBundle({
+    workflows: [loaded],
+    fetchAssetBytes: resolveAssetBytesForExport
+  });
+  return bundleResponse(bytes, loaded.name);
+}
+
+/** POST /api/workflows/export-bundle {workflow_ids} — multiple workflows. */
+export async function handleWorkflowsExportBundle(
+  request: Request,
+  options: HttpApiOptions
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return errorResponse(405, "Method not allowed");
+  }
+  const userId = getUserId(request, options.userIdHeader ?? "x-user-id");
+  const body = await parseJsonBody<{ workflow_ids?: unknown }>(request);
+  const ids = Array.isArray(body?.workflow_ids)
+    ? body.workflow_ids.filter((v): v is string => typeof v === "string")
+    : [];
+  if (ids.length === 0) {
+    return errorResponse(400, "workflow_ids (non-empty array) is required");
+  }
+  const workflows: BundledWorkflow[] = [];
+  for (const id of ids) {
+    const loaded = await loadBundledWorkflow(id, userId);
+    if ("error" in loaded) {
+      return loaded.error;
+    }
+    workflows.push(loaded);
+  }
+  const { bytes } = await packWorkflowsBundle({
+    workflows,
+    fetchAssetBytes: resolveAssetBytesForExport
+  });
+  const name =
+    workflows.length === 1 ? workflows[0].name : `${workflows.length}-workflows`;
+  return bundleResponse(bytes, name);
+}
+
+/** POST /api/workflows/import-bundle — multipart .nodetool upload. */
+export async function handleWorkflowImportBundle(
+  request: Request,
+  options: HttpApiOptions
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return errorResponse(405, "Method not allowed");
+  }
+  const userId = getUserId(request, options.userIdHeader ?? "x-user-id");
+
+  let zipBytes: Uint8Array | null = null;
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("multipart/form-data")) {
+    try {
+      const fd = await request.formData();
+      const file = fd.get("file") as File | null;
+      if (file) {
+        zipBytes = new Uint8Array(await file.arrayBuffer());
+      }
+    } catch {
+      return errorResponse(400, "Invalid multipart form data");
+    }
+  } else {
+    const buf = await request.arrayBuffer();
+    if (buf.byteLength > 0) {
+      zipBytes = new Uint8Array(buf);
+    }
+  }
+  if (!zipBytes) {
+    return errorResponse(400, "A .nodetool bundle file is required");
+  }
+
+  let result: Awaited<ReturnType<typeof importWorkflowBundle>>;
+  try {
+    result = await importWorkflowBundle(zipBytes, {
+      storeAsset: async ({ bytes, fileName, contentType: assetType }) => {
+        const asset = (await Asset.create({
+          user_id: userId,
+          name: fileName,
+          content_type: assetType,
+          parent_id: userId,
+          size: bytes.byteLength
+        })) as Asset;
+        const storedName = getAssetFileName(asset.id, asset.content_type);
+        await storeAssetWithThumbnail(asset.id, storedName, bytes, asset.content_type);
+        return { uri: `asset://${storedName}`, assetId: asset.id };
+      }
+    });
+  } catch (error) {
+    return errorResponse(
+      400,
+      `Invalid bundle: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const created: JsonObject[] = [];
+  for (const wf of result.workflows) {
+    const workflow = await createWorkflow(
+      {
+        name: wf.name,
+        description: wf.description ?? "",
+        tags: wf.tags ?? [],
+        access: "private",
+        graph: wf.graph as unknown as WorkflowRequestBody["graph"],
+        settings: wf.settings ?? null,
+        run_mode: wf.run_mode ?? "workflow"
+      },
+      userId
+    );
+    created.push(toWorkflowResponse(workflow));
+  }
+
+  return jsonResponse({
+    workflows: created,
+    imported: result.imported.length,
+    missing: result.missing,
+    checksum_mismatches: result.checksumMismatches
+  });
+}
+
 // ── Workflow Gradio export (stub) ──────────────────────────────────────
 
 export async function handleWorkflowGradioExport(
@@ -1726,6 +1942,14 @@ export async function handleApiRequest(
     return handleWorkflowTools(request, options);
   }
 
+  if (pathname === "/api/workflows/export-bundle") {
+    return handleWorkflowsExportBundle(request, options);
+  }
+
+  if (pathname === "/api/workflows/import-bundle") {
+    return handleWorkflowImportBundle(request, options);
+  }
+
   if (pathname === "/api/workflows/examples") {
     return handleWorkflowExamples(request, options);
   }
@@ -1779,6 +2003,9 @@ export async function handleApiRequest(
       }
       if (subPath === "dsl-export") {
         return handleWorkflowDslExport(request, workflowId, options);
+      }
+      if (subPath === "export-bundle") {
+        return handleWorkflowExportBundle(request, workflowId, options);
       }
       if (subPath === "gradio-export") {
         return handleWorkflowGradioExport(request, workflowId, options);

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -30,3 +30,10 @@ export {
   handleMcpHttpRequest,
   type McpServerOptions
 } from "./mcp-server.js";
+export {
+  materializeWorkflowConstantAssets,
+  type WorkflowGraphLike,
+  type MaterializeOptions,
+  type MaterializeResult,
+  type ExportedAsset
+} from "./lib/package-asset-export.js";

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -44,6 +44,7 @@ export {
 } from "./lib/package-asset-export.js";
 export {
   packWorkflowBundle,
+  packWorkflowsBundle,
   unpackWorkflowBundle,
   importWorkflowBundle,
   verifyBundleChecksums,
@@ -53,6 +54,7 @@ export {
   type WorkflowBundleManifest,
   type BundledWorkflow,
   type PackBundleOptions,
+  type PackWorkflowsBundleOptions,
   type PackBundleResult,
   type UnpackedBundle,
   type ImportBundleOptions,

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -32,8 +32,30 @@ export {
 } from "./mcp-server.js";
 export {
   materializeWorkflowConstantAssets,
+  collectWorkflowAssets,
+  transformMediaRefs,
   type WorkflowGraphLike,
   type MaterializeOptions,
   type MaterializeResult,
-  type ExportedAsset
+  type ExportedAsset,
+  type CollectOptions,
+  type CollectResult,
+  type CollectedAsset
 } from "./lib/package-asset-export.js";
+export {
+  packWorkflowBundle,
+  unpackWorkflowBundle,
+  importWorkflowBundle,
+  verifyBundleChecksums,
+  WORKFLOW_BUNDLE_SCHEME,
+  WORKFLOW_BUNDLE_FORMAT,
+  WORKFLOW_BUNDLE_VERSION,
+  type WorkflowBundleManifest,
+  type BundledWorkflow,
+  type PackBundleOptions,
+  type PackBundleResult,
+  type UnpackedBundle,
+  type ImportBundleOptions,
+  type ImportBundleResult,
+  type StoreAssetInput
+} from "./lib/workflow-bundle.js";

--- a/packages/websocket/src/lib/package-asset-export.ts
+++ b/packages/websocket/src/lib/package-asset-export.ts
@@ -11,6 +11,9 @@
  * `package://<packageName>/<file>` (clearing the stale `asset_id`/`temp_id`/
  * inline `data`). The result resolves identically on every install via the
  * `/api/assets/packages/...` route.
+ *
+ * The lower-level {@link transformMediaRefs} / {@link collectWorkflowAssets}
+ * primitives are shared with the `.nodetool` bundle codec (`workflow-bundle`).
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
@@ -19,6 +22,231 @@ import { buildPackageAssetUri } from "@nodetool-ai/protocol";
 export interface WorkflowGraphLike {
   nodes: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
+}
+
+const MEDIA_TYPE_EXTENSIONS: Record<string, string> = {
+  image: ".png",
+  audio: ".mp3",
+  video: ".mp4",
+  document: ".bin",
+  model3d: ".glb"
+};
+
+/** True for refs that must be materialized to ship (per-install identifiers). */
+export function isLocalAssetUri(uri: string): boolean {
+  if (uri.startsWith("package://")) {
+    return false;
+  }
+  if (uri.startsWith("asset://")) {
+    return true;
+  }
+  return uri.includes("/api/storage/");
+}
+
+export function isRemoteOrFileUri(uri: string): boolean {
+  return (
+    /^https?:\/\//.test(uri) ||
+    uri.startsWith("file://") ||
+    uri.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(uri)
+  );
+}
+
+/** Best-effort extension for an asset, from the source URI then the ref type. */
+export function mediaExtension(source: string, refType: unknown): string {
+  let raw = source;
+  if (raw.startsWith("asset://")) {
+    raw = raw.slice("asset://".length);
+  } else if (raw.includes("/api/storage/")) {
+    raw = raw.slice(raw.indexOf("/api/storage/") + "/api/storage/".length);
+  }
+  raw = raw.split("?")[0].split("#")[0];
+  const ext = extname(basename(raw));
+  if (ext) {
+    return ext;
+  }
+  if (typeof refType === "string") {
+    return MEDIA_TYPE_EXTENSIONS[refType] ?? ".bin";
+  }
+  return ".bin";
+}
+
+/** Strip query/fragment and return a safe flat file name for the asset. */
+function deriveFileName(source: string, refType: unknown): string {
+  let raw = source;
+  if (raw.startsWith("asset://")) {
+    raw = raw.slice("asset://".length);
+  } else if (raw.includes("/api/storage/")) {
+    raw = raw.slice(raw.indexOf("/api/storage/") + "/api/storage/".length);
+  }
+  raw = raw.split("?")[0].split("#")[0];
+  let name = basename(raw) || raw;
+  // Collapse anything that isn't a safe flat filename character.
+  name = name.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+/, "");
+  if (!name) {
+    name = "asset";
+  }
+  if (!extname(name)) {
+    name = `${name}${mediaExtension(source, refType)}`;
+  }
+  return name;
+}
+
+/**
+ * A media ref is a plain object carrying at least one asset locator
+ * (`uri`/`asset_id`/`temp_id`). We rewrite these in place.
+ */
+function asMediaRef(value: unknown): Record<string, unknown> | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Uint8Array
+  ) {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+  const hasLocator =
+    typeof obj.uri === "string" ||
+    typeof obj.asset_id === "string" ||
+    typeof obj.temp_id === "string";
+  return hasLocator ? obj : null;
+}
+
+/**
+ * Clone `graph` and invoke `visit` on every media ref found under each node's
+ * `data` / `dynamic_properties`. The visitor mutates refs in place on the
+ * clone; the input graph is never modified. Returns the rewritten clone.
+ */
+export async function transformMediaRefs(
+  graph: WorkflowGraphLike,
+  visit: (ref: Record<string, unknown>) => Promise<void> | void
+): Promise<WorkflowGraphLike> {
+  const clone = structuredClone(graph) as WorkflowGraphLike;
+
+  const walk = async (value: unknown): Promise<void> => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        await walk(item);
+      }
+      return;
+    }
+    const ref = asMediaRef(value);
+    if (ref) {
+      await visit(ref);
+    }
+    if (typeof value === "object" && value !== null) {
+      for (const child of Object.values(value as Record<string, unknown>)) {
+        await walk(child);
+      }
+    }
+  };
+
+  for (const node of clone.nodes) {
+    if (node.data !== undefined) {
+      await walk(node.data);
+    }
+    if (node.dynamic_properties !== undefined) {
+      await walk(node.dynamic_properties);
+    }
+  }
+
+  return clone;
+}
+
+/** The locator to feed `fetchAssetBytes`, or null when not materializable. */
+function materializableSource(
+  ref: Record<string, unknown>,
+  includeRemote: boolean
+): string | null {
+  const uri = typeof ref.uri === "string" ? ref.uri : "";
+  if (uri && isLocalAssetUri(uri)) {
+    return uri;
+  }
+  if (uri && includeRemote && isRemoteOrFileUri(uri)) {
+    return uri;
+  }
+  // No usable uri — fall back to an asset id (resolved by the fetcher).
+  if (!uri || uri.length === 0) {
+    if (typeof ref.asset_id === "string" && ref.asset_id) {
+      return `asset://${ref.asset_id}`;
+    }
+  }
+  return null;
+}
+
+export interface CollectedAsset {
+  /** The ref that was rewritten. */
+  source: string;
+  fileName: string;
+  /** The rewritten ref uri. */
+  uri: string;
+  bytes: Uint8Array;
+}
+
+export interface CollectOptions {
+  fetchAssetBytes: (ref: string) => Promise<Uint8Array | null>;
+  includeRemote?: boolean;
+  /** Choose a file name for a resolved asset. */
+  fileNameFor: (input: {
+    source: string;
+    bytes: Uint8Array;
+    refType: unknown;
+  }) => string;
+  /** Build the rewritten ref uri from the chosen file name. */
+  uriFor: (fileName: string) => string;
+}
+
+export interface CollectResult {
+  graph: WorkflowGraphLike;
+  /** Unique assets (deduped by source). */
+  assets: CollectedAsset[];
+  /** Sources that looked materializable but could not be resolved. */
+  skipped: string[];
+}
+
+/**
+ * Walk a graph, resolve each materializable asset ref to bytes, and rewrite the
+ * ref's `uri` (clearing `asset_id`/`temp_id`/`data`). The caller decides where
+ * the collected bytes are persisted. Identical sources are resolved once.
+ */
+export async function collectWorkflowAssets(
+  graph: WorkflowGraphLike,
+  options: CollectOptions
+): Promise<CollectResult> {
+  const includeRemote = options.includeRemote ?? false;
+  const assets: CollectedAsset[] = [];
+  const skipped: string[] = [];
+  const resolved = new Map<string, string>();
+
+  const outGraph = await transformMediaRefs(graph, async (ref) => {
+    const source = materializableSource(ref, includeRemote);
+    if (!source) {
+      return;
+    }
+    let uri = resolved.get(source);
+    if (!uri) {
+      const bytes = await options.fetchAssetBytes(source);
+      if (!bytes) {
+        skipped.push(source);
+        return;
+      }
+      const fileName = options.fileNameFor({
+        source,
+        bytes,
+        refType: ref.type
+      });
+      uri = options.uriFor(fileName);
+      resolved.set(source, uri);
+      assets.push({ source, fileName, uri, bytes });
+    }
+    ref.uri = uri;
+    delete ref.asset_id;
+    delete ref.temp_id;
+    delete ref.data;
+  });
+
+  return { graph: outGraph, assets, skipped };
 }
 
 export interface MaterializeOptions {
@@ -57,174 +285,34 @@ export interface MaterializeResult {
   skipped: string[];
 }
 
-const MEDIA_TYPE_EXTENSIONS: Record<string, string> = {
-  image: ".png",
-  audio: ".mp3",
-  video: ".mp4",
-  document: ".bin",
-  model3d: ".glb"
-};
-
-/** True for refs that must be materialized to ship (per-install identifiers). */
-function isLocalAssetUri(uri: string): boolean {
-  if (uri.startsWith("package://")) {
-    return false;
-  }
-  if (uri.startsWith("asset://")) {
-    return true;
-  }
-  return uri.includes("/api/storage/");
-}
-
-function isRemoteOrFileUri(uri: string): boolean {
-  return (
-    /^https?:\/\//.test(uri) ||
-    uri.startsWith("file://") ||
-    uri.startsWith("/") ||
-    /^[A-Za-z]:[\\/]/.test(uri)
-  );
-}
-
-/** Strip query/fragment and return a safe flat file name for the asset. */
-function deriveFileName(source: string, refType: unknown): string {
-  let raw = source;
-  if (raw.startsWith("asset://")) {
-    raw = raw.slice("asset://".length);
-  } else if (raw.includes("/api/storage/")) {
-    raw = raw.slice(raw.indexOf("/api/storage/") + "/api/storage/".length);
-  }
-  raw = raw.split("?")[0].split("#")[0];
-  let name = basename(raw) || raw;
-  // Collapse anything that isn't a safe flat filename character.
-  name = name.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+/, "");
-  if (!name) {
-    name = "asset";
-  }
-  if (!extname(name)) {
-    const ext =
-      typeof refType === "string"
-        ? MEDIA_TYPE_EXTENSIONS[refType] ?? ".bin"
-        : ".bin";
-    name = `${name}${ext}`;
-  }
-  return name;
-}
-
-/**
- * A media ref is a plain object carrying at least one asset locator
- * (`uri`/`asset_id`/`temp_id`). We rewrite these in place.
- */
-function asMediaRef(value: unknown): Record<string, unknown> | null {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value) ||
-    value instanceof Uint8Array
-  ) {
-    return null;
-  }
-  const obj = value as Record<string, unknown>;
-  const hasLocator =
-    typeof obj.uri === "string" ||
-    typeof obj.asset_id === "string" ||
-    typeof obj.temp_id === "string";
-  return hasLocator ? obj : null;
-}
-
-/** The locator to feed `fetchAssetBytes`, or null when not materializable. */
-function materializableSource(
-  ref: Record<string, unknown>,
-  includeRemote: boolean
-): string | null {
-  const uri = typeof ref.uri === "string" ? ref.uri : "";
-  if (uri && isLocalAssetUri(uri)) {
-    return uri;
-  }
-  if (uri && includeRemote && isRemoteOrFileUri(uri)) {
-    return uri;
-  }
-  // No usable uri — fall back to an asset id (resolved by the fetcher).
-  if (!uri || uri.length === 0) {
-    if (typeof ref.asset_id === "string" && ref.asset_id) {
-      return `asset://${ref.asset_id}`;
-    }
-  }
-  return null;
-}
-
 export async function materializeWorkflowConstantAssets(
   graph: WorkflowGraphLike,
   options: MaterializeOptions
 ): Promise<MaterializeResult> {
-  const clone = structuredClone(graph) as WorkflowGraphLike;
-  const exported: ExportedAsset[] = [];
-  const skipped: string[] = [];
-  // Dedupe identical sources so the same asset is written and named once.
-  const resolved = new Map<string, string>();
+  const { graph: outGraph, assets, skipped } = await collectWorkflowAssets(
+    graph,
+    {
+      fetchAssetBytes: options.fetchAssetBytes,
+      ...(options.includeRemote ? { includeRemote: true } : {}),
+      fileNameFor: ({ source, refType }) => deriveFileName(source, refType),
+      uriFor: (fileName) => buildPackageAssetUri(options.packageName, fileName)
+    }
+  );
+
   const targetDir = join(options.assetsRoot, options.packageName);
-  let ensuredDir = false;
-
-  const processRef = async (ref: Record<string, unknown>): Promise<void> => {
-    const source = materializableSource(ref, options.includeRemote ?? false);
-    if (!source) {
-      return;
-    }
-
-    let packageUri = resolved.get(source);
-    if (!packageUri) {
-      const bytes = await options.fetchAssetBytes(source);
-      if (!bytes) {
-        skipped.push(source);
-        return;
-      }
-      const fileName = deriveFileName(source, ref.type);
-      if (!ensuredDir) {
-        await mkdir(targetDir, { recursive: true });
-        ensuredDir = true;
-      }
-      await writeFile(join(targetDir, fileName), bytes);
-      packageUri = buildPackageAssetUri(options.packageName, fileName);
-      resolved.set(source, packageUri);
-      exported.push({
-        source,
-        packageUri,
-        fileName,
-        byteLength: bytes.byteLength
-      });
-    }
-
-    ref.uri = packageUri;
-    delete ref.asset_id;
-    delete ref.temp_id;
-    delete ref.data;
-  };
-
-  const walk = async (value: unknown): Promise<void> => {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        await walk(item);
-      }
-      return;
-    }
-    const ref = asMediaRef(value);
-    if (ref) {
-      await processRef(ref);
-    }
-    if (typeof value === "object" && value !== null) {
-      for (const child of Object.values(value as Record<string, unknown>)) {
-        await walk(child);
-      }
-    }
-  };
-
-  for (const node of clone.nodes) {
-    if (node.data !== undefined) {
-      await walk(node.data);
-    }
-    if (node.dynamic_properties !== undefined) {
-      await walk(node.dynamic_properties);
-    }
+  if (assets.length > 0) {
+    await mkdir(targetDir, { recursive: true });
+  }
+  const exported: ExportedAsset[] = [];
+  for (const asset of assets) {
+    await writeFile(join(targetDir, asset.fileName), asset.bytes);
+    exported.push({
+      source: asset.source,
+      packageUri: asset.uri,
+      fileName: asset.fileName,
+      byteLength: asset.bytes.byteLength
+    });
   }
 
-  return { graph: clone, exported, skipped };
+  return { graph: outGraph, exported, skipped };
 }

--- a/packages/websocket/src/lib/package-asset-export.ts
+++ b/packages/websocket/src/lib/package-asset-export.ts
@@ -1,0 +1,230 @@
+/**
+ * Convert a workflow into a portable template by materializing the user-local
+ * assets it references (uploaded inputs, generated samples) into constant
+ * package assets that ship with the build.
+ *
+ * User assets are addressed by per-install identifiers — `asset://<id>` or
+ * `/api/storage/<key>` — that resolve only on the machine that created them.
+ * For a workflow to work as a shipped example, those bytes must travel with it.
+ * This walks the graph, writes each referenced asset as a flat file under
+ * `<assetsRoot>/<packageName>/<file>`, and rewrites the ref's `uri` to
+ * `package://<packageName>/<file>` (clearing the stale `asset_id`/`temp_id`/
+ * inline `data`). The result resolves identically on every install via the
+ * `/api/assets/packages/...` route.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { buildPackageAssetUri } from "@nodetool-ai/protocol";
+
+export interface WorkflowGraphLike {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}
+
+export interface MaterializeOptions {
+  /** Package the assets belong to, e.g. `nodetool-base`. */
+  packageName: string;
+  /** Root holding `<packageName>/<file>` constant assets on disk. */
+  assetsRoot: string;
+  /**
+   * Resolve the raw bytes for a referenced asset. `ref` is the original
+   * `uri` (or `asset://<id>` synthesized from an `asset_id`). Return `null`
+   * when the asset can't be resolved — the ref is then left untouched.
+   */
+  fetchAssetBytes: (ref: string) => Promise<Uint8Array | null>;
+  /**
+   * Also materialize remote (`http`/`https`) and local-file (`file://`,
+   * absolute path) references. Off by default — remote URLs are already
+   * portable and local paths are usually intentional. `asset://` and
+   * `/api/storage/` refs are always materialized.
+   */
+  includeRemote?: boolean;
+}
+
+export interface ExportedAsset {
+  /** The ref that was rewritten. */
+  source: string;
+  /** The `package://` URI it now points to. */
+  packageUri: string;
+  fileName: string;
+  byteLength: number;
+}
+
+export interface MaterializeResult {
+  graph: WorkflowGraphLike;
+  exported: ExportedAsset[];
+  /** Refs that looked materializable but could not be resolved. */
+  skipped: string[];
+}
+
+const MEDIA_TYPE_EXTENSIONS: Record<string, string> = {
+  image: ".png",
+  audio: ".mp3",
+  video: ".mp4",
+  document: ".bin",
+  model3d: ".glb"
+};
+
+/** True for refs that must be materialized to ship (per-install identifiers). */
+function isLocalAssetUri(uri: string): boolean {
+  if (uri.startsWith("package://")) {
+    return false;
+  }
+  if (uri.startsWith("asset://")) {
+    return true;
+  }
+  return uri.includes("/api/storage/");
+}
+
+function isRemoteOrFileUri(uri: string): boolean {
+  return (
+    /^https?:\/\//.test(uri) ||
+    uri.startsWith("file://") ||
+    uri.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(uri)
+  );
+}
+
+/** Strip query/fragment and return a safe flat file name for the asset. */
+function deriveFileName(source: string, refType: unknown): string {
+  let raw = source;
+  if (raw.startsWith("asset://")) {
+    raw = raw.slice("asset://".length);
+  } else if (raw.includes("/api/storage/")) {
+    raw = raw.slice(raw.indexOf("/api/storage/") + "/api/storage/".length);
+  }
+  raw = raw.split("?")[0].split("#")[0];
+  let name = basename(raw) || raw;
+  // Collapse anything that isn't a safe flat filename character.
+  name = name.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+/, "");
+  if (!name) {
+    name = "asset";
+  }
+  if (!extname(name)) {
+    const ext =
+      typeof refType === "string"
+        ? MEDIA_TYPE_EXTENSIONS[refType] ?? ".bin"
+        : ".bin";
+    name = `${name}${ext}`;
+  }
+  return name;
+}
+
+/**
+ * A media ref is a plain object carrying at least one asset locator
+ * (`uri`/`asset_id`/`temp_id`). We rewrite these in place.
+ */
+function asMediaRef(value: unknown): Record<string, unknown> | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Uint8Array
+  ) {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+  const hasLocator =
+    typeof obj.uri === "string" ||
+    typeof obj.asset_id === "string" ||
+    typeof obj.temp_id === "string";
+  return hasLocator ? obj : null;
+}
+
+/** The locator to feed `fetchAssetBytes`, or null when not materializable. */
+function materializableSource(
+  ref: Record<string, unknown>,
+  includeRemote: boolean
+): string | null {
+  const uri = typeof ref.uri === "string" ? ref.uri : "";
+  if (uri && isLocalAssetUri(uri)) {
+    return uri;
+  }
+  if (uri && includeRemote && isRemoteOrFileUri(uri)) {
+    return uri;
+  }
+  // No usable uri — fall back to an asset id (resolved by the fetcher).
+  if (!uri || uri.length === 0) {
+    if (typeof ref.asset_id === "string" && ref.asset_id) {
+      return `asset://${ref.asset_id}`;
+    }
+  }
+  return null;
+}
+
+export async function materializeWorkflowConstantAssets(
+  graph: WorkflowGraphLike,
+  options: MaterializeOptions
+): Promise<MaterializeResult> {
+  const clone = structuredClone(graph) as WorkflowGraphLike;
+  const exported: ExportedAsset[] = [];
+  const skipped: string[] = [];
+  // Dedupe identical sources so the same asset is written and named once.
+  const resolved = new Map<string, string>();
+  const targetDir = join(options.assetsRoot, options.packageName);
+  let ensuredDir = false;
+
+  const processRef = async (ref: Record<string, unknown>): Promise<void> => {
+    const source = materializableSource(ref, options.includeRemote ?? false);
+    if (!source) {
+      return;
+    }
+
+    let packageUri = resolved.get(source);
+    if (!packageUri) {
+      const bytes = await options.fetchAssetBytes(source);
+      if (!bytes) {
+        skipped.push(source);
+        return;
+      }
+      const fileName = deriveFileName(source, ref.type);
+      if (!ensuredDir) {
+        await mkdir(targetDir, { recursive: true });
+        ensuredDir = true;
+      }
+      await writeFile(join(targetDir, fileName), bytes);
+      packageUri = buildPackageAssetUri(options.packageName, fileName);
+      resolved.set(source, packageUri);
+      exported.push({
+        source,
+        packageUri,
+        fileName,
+        byteLength: bytes.byteLength
+      });
+    }
+
+    ref.uri = packageUri;
+    delete ref.asset_id;
+    delete ref.temp_id;
+    delete ref.data;
+  };
+
+  const walk = async (value: unknown): Promise<void> => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        await walk(item);
+      }
+      return;
+    }
+    const ref = asMediaRef(value);
+    if (ref) {
+      await processRef(ref);
+    }
+    if (typeof value === "object" && value !== null) {
+      for (const child of Object.values(value as Record<string, unknown>)) {
+        await walk(child);
+      }
+    }
+  };
+
+  for (const node of clone.nodes) {
+    if (node.data !== undefined) {
+      await walk(node.data);
+    }
+    if (node.dynamic_properties !== undefined) {
+      await walk(node.dynamic_properties);
+    }
+  }
+
+  return { graph: clone, exported, skipped };
+}

--- a/packages/websocket/src/lib/workflow-bundle.ts
+++ b/packages/websocket/src/lib/workflow-bundle.ts
@@ -1,13 +1,18 @@
 /**
- * `.nodetool` workflow bundle codec — a self-contained, portable archive of a
- * workflow plus the asset bytes it references, for sharing a workflow as a
- * template (offline file, import-by-URL, or upload to a hosted catalog).
+ * `.nodetool` workflow bundle codec — a self-contained, portable archive of one
+ * or more workflows plus the asset bytes they reference, for sharing workflows
+ * as templates (offline file, import-by-URL, or upload to a hosted catalog).
  *
  * Layout (a zip):
- *   manifest.json   — bundle format/version, nodetool version, asset checksums
- *   workflow.json   — the workflow (graph refs rewritten to `bundle://<file>`)
- *   assets/<file>   — content-addressed asset bytes (sha256 + ext)
- *   thumbnail.jpg   — optional preview
+ *   manifest.json        — format/version, nodetool version, workflow list,
+ *                          asset checksums
+ *   workflows/<file>.json — one per workflow (graph refs → `bundle://<file>`)
+ *   assets/<file>        — content-addressed asset bytes (sha256 + ext), shared
+ *                          and deduped across all workflows in the bundle
+ *   thumbnail.jpg        — optional preview
+ *
+ * (v1 bundles used a single top-level `workflow.json`; `unpackWorkflowBundle`
+ * still reads those.)
  *
  * Export rewrites per-install refs (`asset://`, `/api/storage/`) into
  * `bundle://<file>` and packs the bytes. Import resolves each `bundle://` ref
@@ -27,19 +32,21 @@ import {
 
 export const WORKFLOW_BUNDLE_SCHEME = "bundle://";
 export const WORKFLOW_BUNDLE_FORMAT = "nodetool-workflow-bundle";
-export const WORKFLOW_BUNDLE_VERSION = 1;
+export const WORKFLOW_BUNDLE_VERSION = 2;
 
 export interface WorkflowBundleManifest {
   format: typeof WORKFLOW_BUNDLE_FORMAT;
   version: number;
   nodetool_version?: string;
   created_at: string;
+  workflows: Array<{ file: string; name: string }>;
   assets: Array<{ file: string; bytes: number; sha256: string }>;
   thumbnail?: string | null;
 }
 
 /** The workflow payload carried in a bundle (no per-user/db fields). */
 export interface BundledWorkflow {
+  id?: string;
   name: string;
   description?: string;
   tags?: string[];
@@ -48,11 +55,19 @@ export interface BundledWorkflow {
   graph: WorkflowGraphLike;
 }
 
-export interface PackBundleOptions {
-  workflow: BundledWorkflow;
+export interface PackWorkflowsBundleOptions {
+  workflows: BundledWorkflow[];
   /** Resolve bytes for a referenced asset (`asset://`/`/api/storage/` uri). */
   fetchAssetBytes: (ref: string) => Promise<Uint8Array | null>;
   /** Also embed http(s) and local-file refs. Off by default. */
+  includeRemote?: boolean;
+  nodetoolVersion?: string;
+  thumbnail?: Uint8Array | null;
+}
+
+export interface PackBundleOptions {
+  workflow: BundledWorkflow;
+  fetchAssetBytes: (ref: string) => Promise<Uint8Array | null>;
   includeRemote?: boolean;
   nodetoolVersion?: string;
   thumbnail?: Uint8Array | null;
@@ -69,36 +84,85 @@ function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-/** Build a `.nodetool` zip from a workflow, embedding its referenced assets. */
-export async function packWorkflowBundle(
-  options: PackBundleOptions
+function sanitizeFileBase(value: string): string {
+  const cleaned = value.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+/, "");
+  return cleaned || "workflow";
+}
+
+/** A unique `workflows/<file>.json` name, disambiguated against `used`. */
+function uniqueWorkflowFile(
+  workflow: BundledWorkflow,
+  index: number,
+  used: Set<string>
+): string {
+  const base = sanitizeFileBase(workflow.id || workflow.name || `workflow-${index + 1}`);
+  let candidate = `${base}.json`;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}-${n}.json`;
+    n += 1;
+  }
+  return candidate;
+}
+
+/** Build a `.nodetool` zip from one or more workflows, embedding their assets. */
+export async function packWorkflowsBundle(
+  options: PackWorkflowsBundleOptions
 ): Promise<PackBundleResult> {
-  const { graph, assets, skipped } = await collectWorkflowAssets(
-    options.workflow.graph,
-    {
-      fetchAssetBytes: options.fetchAssetBytes,
-      ...(options.includeRemote ? { includeRemote: true } : {}),
-      fileNameFor: ({ source, bytes, refType }) =>
-        `${sha256Hex(bytes)}${mediaExtension(source, refType)}`,
-      uriFor: (fileName) => `${WORKFLOW_BUNDLE_SCHEME}${fileName}`
+  // Resolve each source at most once, even when shared across workflows.
+  const memo = new Map<string, Promise<Uint8Array | null>>();
+  const fetchAssetBytes = (ref: string): Promise<Uint8Array | null> => {
+    let pending = memo.get(ref);
+    if (!pending) {
+      pending = options.fetchAssetBytes(ref);
+      memo.set(ref, pending);
     }
-  );
+    return pending;
+  };
 
   const files: Record<string, Uint8Array> = {};
   const manifestAssets: WorkflowBundleManifest["assets"] = [];
-  const seen = new Set<string>();
-  for (const asset of assets) {
-    if (seen.has(asset.fileName)) {
-      continue; // identical content already packed
+  const manifestWorkflows: WorkflowBundleManifest["workflows"] = [];
+  const seenAssetFiles = new Set<string>();
+  const usedWorkflowFiles = new Set<string>();
+  const skipped = new Set<string>();
+
+  let index = 0;
+  for (const workflow of options.workflows) {
+    const { graph, assets, skipped: workflowSkipped } = await collectWorkflowAssets(
+      workflow.graph,
+      {
+        fetchAssetBytes,
+        ...(options.includeRemote ? { includeRemote: true } : {}),
+        fileNameFor: ({ source, bytes, refType }) =>
+          `${sha256Hex(bytes)}${mediaExtension(source, refType)}`,
+        uriFor: (fileName) => `${WORKFLOW_BUNDLE_SCHEME}${fileName}`
+      }
+    );
+
+    for (const s of workflowSkipped) {
+      skipped.add(s);
     }
-    seen.add(asset.fileName);
-    const zipPath = `assets/${asset.fileName}`;
-    files[zipPath] = asset.bytes;
-    manifestAssets.push({
-      file: zipPath,
-      bytes: asset.bytes.byteLength,
-      sha256: sha256Hex(asset.bytes)
-    });
+    for (const asset of assets) {
+      if (seenAssetFiles.has(asset.fileName)) {
+        continue; // identical content already packed
+      }
+      seenAssetFiles.add(asset.fileName);
+      const zipPath = `assets/${asset.fileName}`;
+      files[zipPath] = asset.bytes;
+      manifestAssets.push({
+        file: zipPath,
+        bytes: asset.bytes.byteLength,
+        sha256: sha256Hex(asset.bytes)
+      });
+    }
+
+    const wfFile = uniqueWorkflowFile(workflow, index, usedWorkflowFiles);
+    usedWorkflowFiles.add(wfFile);
+    const bundled: BundledWorkflow = { ...workflow, graph };
+    files[`workflows/${wfFile}`] = strToU8(JSON.stringify(bundled, null, 2));
+    manifestWorkflows.push({ file: `workflows/${wfFile}`, name: workflow.name });
+    index += 1;
   }
 
   const manifest: WorkflowBundleManifest = {
@@ -108,24 +172,30 @@ export async function packWorkflowBundle(
       ? { nodetool_version: options.nodetoolVersion }
       : {}),
     created_at: new Date().toISOString(),
+    workflows: manifestWorkflows,
     assets: manifestAssets,
     thumbnail: options.thumbnail ? "thumbnail.jpg" : null
   };
 
-  const bundledWorkflow: BundledWorkflow = { ...options.workflow, graph };
-
   files["manifest.json"] = strToU8(JSON.stringify(manifest, null, 2));
-  files["workflow.json"] = strToU8(JSON.stringify(bundledWorkflow, null, 2));
   if (options.thumbnail) {
     files["thumbnail.jpg"] = options.thumbnail;
   }
 
-  return { bytes: zipSync(files), manifest, skipped };
+  return { bytes: zipSync(files), manifest, skipped: [...skipped] };
+}
+
+/** Convenience wrapper to bundle a single workflow. */
+export async function packWorkflowBundle(
+  options: PackBundleOptions
+): Promise<PackBundleResult> {
+  const { workflow, ...rest } = options;
+  return packWorkflowsBundle({ ...rest, workflows: [workflow] });
 }
 
 export interface UnpackedBundle {
   manifest: WorkflowBundleManifest;
-  workflow: BundledWorkflow;
+  workflows: BundledWorkflow[];
   /** file name (without the `assets/` prefix) → bytes. */
   assets: Map<string, Uint8Array>;
   thumbnail: Uint8Array | null;
@@ -135,11 +205,9 @@ export function unpackWorkflowBundle(zipBytes: Uint8Array): UnpackedBundle {
   const entries = unzipSync(zipBytes);
 
   const manifestEntry = entries["manifest.json"];
-  const workflowEntry = entries["workflow.json"];
-  if (!manifestEntry || !workflowEntry) {
-    throw new Error("Invalid bundle: missing manifest.json or workflow.json");
+  if (!manifestEntry) {
+    throw new Error("Invalid bundle: missing manifest.json");
   }
-
   const manifest = JSON.parse(strFromU8(manifestEntry)) as WorkflowBundleManifest;
   if (manifest.format !== WORKFLOW_BUNDLE_FORMAT) {
     throw new Error(`Unrecognized bundle format: ${String(manifest.format)}`);
@@ -150,9 +218,39 @@ export function unpackWorkflowBundle(zipBytes: Uint8Array): UnpackedBundle {
     );
   }
 
-  const workflow = JSON.parse(strFromU8(workflowEntry)) as BundledWorkflow;
-  if (!workflow.graph?.nodes) {
-    throw new Error("Invalid bundle: workflow has no graph");
+  const parseWorkflow = (path: string): BundledWorkflow => {
+    const wf = JSON.parse(strFromU8(entries[path])) as BundledWorkflow;
+    if (!wf.graph?.nodes) {
+      throw new Error(`Invalid bundle: ${path} has no graph`);
+    }
+    return wf;
+  };
+
+  const workflows: BundledWorkflow[] = [];
+  const workflowPaths = Object.keys(entries).filter(
+    (p) => p.startsWith("workflows/") && p.endsWith(".json")
+  );
+  if (workflowPaths.length > 0) {
+    // Preserve manifest order, then append any entries the manifest omitted.
+    const seen = new Set<string>();
+    const ordered = (manifest.workflows ?? [])
+      .map((w) => w.file)
+      .filter((f) => entries[f]);
+    for (const path of ordered) {
+      workflows.push(parseWorkflow(path));
+      seen.add(path);
+    }
+    for (const path of workflowPaths.sort()) {
+      if (!seen.has(path)) {
+        workflows.push(parseWorkflow(path));
+      }
+    }
+  } else if (entries["workflow.json"]) {
+    // v1 single-workflow bundle.
+    workflows.push(parseWorkflow("workflow.json"));
+  }
+  if (workflows.length === 0) {
+    throw new Error("Invalid bundle: no workflows found");
   }
 
   const assets = new Map<string, Uint8Array>();
@@ -163,7 +261,7 @@ export function unpackWorkflowBundle(zipBytes: Uint8Array): UnpackedBundle {
   }
   const thumbnail = entries["thumbnail.jpg"] ?? null;
 
-  return { manifest, workflow, assets, thumbnail };
+  return { manifest, workflows, assets, thumbnail };
 }
 
 /** Verify each asset's bytes against the manifest sha256. Returns mismatches. */
@@ -204,7 +302,7 @@ export interface ImportBundleOptions {
 }
 
 export interface ImportBundleResult {
-  workflow: BundledWorkflow;
+  workflows: BundledWorkflow[];
   imported: Array<{ file: string; uri: string }>;
   /** `bundle://` refs whose bytes were missing from the archive. */
   missing: string[];
@@ -237,8 +335,9 @@ function mimeForFile(fileName: string): string {
 }
 
 /**
- * Resolve a bundle's `bundle://` refs into concrete stored assets and return a
- * workflow ready to create. `storeAsset` decides where the bytes land.
+ * Resolve a bundle's `bundle://` refs into concrete stored assets and return
+ * workflows ready to create. `storeAsset` decides where the bytes land; assets
+ * shared across workflows are stored once.
  */
 export async function importWorkflowBundle(
   zipBytes: Uint8Array,
@@ -253,10 +352,10 @@ export async function importWorkflowBundle(
   }
 
   const imported: Array<{ file: string; uri: string }> = [];
-  const missing: string[] = [];
+  const missing = new Set<string>();
   const resolvedByFile = new Map<string, { uri: string; assetId?: string }>();
 
-  const graph = await transformMediaRefs(bundle.workflow.graph, async (ref) => {
+  const rewriteRef = async (ref: Record<string, unknown>): Promise<void> => {
     const uri = typeof ref.uri === "string" ? ref.uri : "";
     if (!uri.startsWith(WORKFLOW_BUNDLE_SCHEME)) {
       return;
@@ -264,10 +363,9 @@ export async function importWorkflowBundle(
     const fileName = uri.slice(WORKFLOW_BUNDLE_SCHEME.length);
     const bytes = bundle.assets.get(fileName);
     if (!bytes) {
-      missing.push(fileName);
+      missing.add(fileName);
       return;
     }
-
     let stored = resolvedByFile.get(fileName);
     if (!stored) {
       const result = await options.storeAsset({
@@ -276,11 +374,13 @@ export async function importWorkflowBundle(
         contentType: mimeForFile(fileName),
         refType: ref.type
       });
-      stored = { uri: result.uri, ...(result.assetId ? { assetId: result.assetId } : {}) };
+      stored = {
+        uri: result.uri,
+        ...(result.assetId ? { assetId: result.assetId } : {})
+      };
       resolvedByFile.set(fileName, stored);
       imported.push({ file: fileName, uri: stored.uri });
     }
-
     ref.uri = stored.uri;
     delete ref.temp_id;
     delete ref.data;
@@ -289,12 +389,18 @@ export async function importWorkflowBundle(
     } else {
       delete ref.asset_id;
     }
-  });
+  };
+
+  const workflows: BundledWorkflow[] = [];
+  for (const workflow of bundle.workflows) {
+    const graph = await transformMediaRefs(workflow.graph, rewriteRef);
+    workflows.push({ ...workflow, graph });
+  }
 
   return {
-    workflow: { ...bundle.workflow, graph },
+    workflows,
     imported,
-    missing,
+    missing: [...missing],
     checksumMismatches
   };
 }

--- a/packages/websocket/src/lib/workflow-bundle.ts
+++ b/packages/websocket/src/lib/workflow-bundle.ts
@@ -1,0 +1,300 @@
+/**
+ * `.nodetool` workflow bundle codec — a self-contained, portable archive of a
+ * workflow plus the asset bytes it references, for sharing a workflow as a
+ * template (offline file, import-by-URL, or upload to a hosted catalog).
+ *
+ * Layout (a zip):
+ *   manifest.json   — bundle format/version, nodetool version, asset checksums
+ *   workflow.json   — the workflow (graph refs rewritten to `bundle://<file>`)
+ *   assets/<file>   — content-addressed asset bytes (sha256 + ext)
+ *   thumbnail.jpg   — optional preview
+ *
+ * Export rewrites per-install refs (`asset://`, `/api/storage/`) into
+ * `bundle://<file>` and packs the bytes. Import resolves each `bundle://` ref
+ * back to a concrete asset via a caller-supplied `storeAsset` (which decides
+ * where the bytes land — user storage, a workspace, etc.) and rewrites the ref
+ * to the returned uri. The codec itself is storage-agnostic and dependency-light
+ * (fflate + node:crypto) so it can be reused server-side and, later, in the UI.
+ */
+import { createHash } from "node:crypto";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import {
+  collectWorkflowAssets,
+  mediaExtension,
+  transformMediaRefs,
+  type WorkflowGraphLike
+} from "./package-asset-export.js";
+
+export const WORKFLOW_BUNDLE_SCHEME = "bundle://";
+export const WORKFLOW_BUNDLE_FORMAT = "nodetool-workflow-bundle";
+export const WORKFLOW_BUNDLE_VERSION = 1;
+
+export interface WorkflowBundleManifest {
+  format: typeof WORKFLOW_BUNDLE_FORMAT;
+  version: number;
+  nodetool_version?: string;
+  created_at: string;
+  assets: Array<{ file: string; bytes: number; sha256: string }>;
+  thumbnail?: string | null;
+}
+
+/** The workflow payload carried in a bundle (no per-user/db fields). */
+export interface BundledWorkflow {
+  name: string;
+  description?: string;
+  tags?: string[];
+  run_mode?: string | null;
+  settings?: Record<string, unknown> | null;
+  graph: WorkflowGraphLike;
+}
+
+export interface PackBundleOptions {
+  workflow: BundledWorkflow;
+  /** Resolve bytes for a referenced asset (`asset://`/`/api/storage/` uri). */
+  fetchAssetBytes: (ref: string) => Promise<Uint8Array | null>;
+  /** Also embed http(s) and local-file refs. Off by default. */
+  includeRemote?: boolean;
+  nodetoolVersion?: string;
+  thumbnail?: Uint8Array | null;
+}
+
+export interface PackBundleResult {
+  bytes: Uint8Array;
+  manifest: WorkflowBundleManifest;
+  /** Refs that looked embeddable but could not be resolved (left as-is). */
+  skipped: string[];
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Build a `.nodetool` zip from a workflow, embedding its referenced assets. */
+export async function packWorkflowBundle(
+  options: PackBundleOptions
+): Promise<PackBundleResult> {
+  const { graph, assets, skipped } = await collectWorkflowAssets(
+    options.workflow.graph,
+    {
+      fetchAssetBytes: options.fetchAssetBytes,
+      ...(options.includeRemote ? { includeRemote: true } : {}),
+      fileNameFor: ({ source, bytes, refType }) =>
+        `${sha256Hex(bytes)}${mediaExtension(source, refType)}`,
+      uriFor: (fileName) => `${WORKFLOW_BUNDLE_SCHEME}${fileName}`
+    }
+  );
+
+  const files: Record<string, Uint8Array> = {};
+  const manifestAssets: WorkflowBundleManifest["assets"] = [];
+  const seen = new Set<string>();
+  for (const asset of assets) {
+    if (seen.has(asset.fileName)) {
+      continue; // identical content already packed
+    }
+    seen.add(asset.fileName);
+    const zipPath = `assets/${asset.fileName}`;
+    files[zipPath] = asset.bytes;
+    manifestAssets.push({
+      file: zipPath,
+      bytes: asset.bytes.byteLength,
+      sha256: sha256Hex(asset.bytes)
+    });
+  }
+
+  const manifest: WorkflowBundleManifest = {
+    format: WORKFLOW_BUNDLE_FORMAT,
+    version: WORKFLOW_BUNDLE_VERSION,
+    ...(options.nodetoolVersion
+      ? { nodetool_version: options.nodetoolVersion }
+      : {}),
+    created_at: new Date().toISOString(),
+    assets: manifestAssets,
+    thumbnail: options.thumbnail ? "thumbnail.jpg" : null
+  };
+
+  const bundledWorkflow: BundledWorkflow = { ...options.workflow, graph };
+
+  files["manifest.json"] = strToU8(JSON.stringify(manifest, null, 2));
+  files["workflow.json"] = strToU8(JSON.stringify(bundledWorkflow, null, 2));
+  if (options.thumbnail) {
+    files["thumbnail.jpg"] = options.thumbnail;
+  }
+
+  return { bytes: zipSync(files), manifest, skipped };
+}
+
+export interface UnpackedBundle {
+  manifest: WorkflowBundleManifest;
+  workflow: BundledWorkflow;
+  /** file name (without the `assets/` prefix) → bytes. */
+  assets: Map<string, Uint8Array>;
+  thumbnail: Uint8Array | null;
+}
+
+export function unpackWorkflowBundle(zipBytes: Uint8Array): UnpackedBundle {
+  const entries = unzipSync(zipBytes);
+
+  const manifestEntry = entries["manifest.json"];
+  const workflowEntry = entries["workflow.json"];
+  if (!manifestEntry || !workflowEntry) {
+    throw new Error("Invalid bundle: missing manifest.json or workflow.json");
+  }
+
+  const manifest = JSON.parse(strFromU8(manifestEntry)) as WorkflowBundleManifest;
+  if (manifest.format !== WORKFLOW_BUNDLE_FORMAT) {
+    throw new Error(`Unrecognized bundle format: ${String(manifest.format)}`);
+  }
+  if (manifest.version > WORKFLOW_BUNDLE_VERSION) {
+    throw new Error(
+      `Bundle version ${manifest.version} is newer than supported (${WORKFLOW_BUNDLE_VERSION})`
+    );
+  }
+
+  const workflow = JSON.parse(strFromU8(workflowEntry)) as BundledWorkflow;
+  if (!workflow.graph?.nodes) {
+    throw new Error("Invalid bundle: workflow has no graph");
+  }
+
+  const assets = new Map<string, Uint8Array>();
+  for (const [path, bytes] of Object.entries(entries)) {
+    if (path.startsWith("assets/")) {
+      assets.set(path.slice("assets/".length), bytes);
+    }
+  }
+  const thumbnail = entries["thumbnail.jpg"] ?? null;
+
+  return { manifest, workflow, assets, thumbnail };
+}
+
+/** Verify each asset's bytes against the manifest sha256. Returns mismatches. */
+export function verifyBundleChecksums(bundle: UnpackedBundle): string[] {
+  const mismatches: string[] = [];
+  for (const entry of bundle.manifest.assets) {
+    const fileName = entry.file.startsWith("assets/")
+      ? entry.file.slice("assets/".length)
+      : entry.file;
+    const bytes = bundle.assets.get(fileName);
+    if (!bytes) {
+      mismatches.push(`${entry.file} (missing)`);
+      continue;
+    }
+    if (entry.sha256 && sha256Hex(bytes) !== entry.sha256) {
+      mismatches.push(`${entry.file} (checksum)`);
+    }
+  }
+  return mismatches;
+}
+
+export interface StoreAssetInput {
+  bytes: Uint8Array;
+  fileName: string;
+  contentType: string;
+  refType?: unknown;
+}
+
+export interface ImportBundleOptions {
+  /**
+   * Persist a bundled asset and return the ref it should be addressed by
+   * (e.g. `asset://<id>`). `assetId`, when provided, is written back onto the
+   * ref so it round-trips through the asset system.
+   */
+  storeAsset: (input: StoreAssetInput) => Promise<{ uri: string; assetId?: string }>;
+  /** Throw if any asset fails its manifest checksum. Default: false (warn). */
+  verifyChecksums?: boolean;
+}
+
+export interface ImportBundleResult {
+  workflow: BundledWorkflow;
+  imported: Array<{ file: string; uri: string }>;
+  /** `bundle://` refs whose bytes were missing from the archive. */
+  missing: string[];
+  checksumMismatches: string[];
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".flac": "audio/flac",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".glb": "model/gltf-binary",
+  ".pdf": "application/pdf",
+  ".json": "application/json",
+  ".txt": "text/plain"
+};
+
+function mimeForFile(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  const ext = dot >= 0 ? fileName.slice(dot).toLowerCase() : "";
+  return MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Resolve a bundle's `bundle://` refs into concrete stored assets and return a
+ * workflow ready to create. `storeAsset` decides where the bytes land.
+ */
+export async function importWorkflowBundle(
+  zipBytes: Uint8Array,
+  options: ImportBundleOptions
+): Promise<ImportBundleResult> {
+  const bundle = unpackWorkflowBundle(zipBytes);
+  const checksumMismatches = verifyBundleChecksums(bundle);
+  if (options.verifyChecksums && checksumMismatches.length > 0) {
+    throw new Error(
+      `Bundle checksum verification failed: ${checksumMismatches.join(", ")}`
+    );
+  }
+
+  const imported: Array<{ file: string; uri: string }> = [];
+  const missing: string[] = [];
+  const resolvedByFile = new Map<string, { uri: string; assetId?: string }>();
+
+  const graph = await transformMediaRefs(bundle.workflow.graph, async (ref) => {
+    const uri = typeof ref.uri === "string" ? ref.uri : "";
+    if (!uri.startsWith(WORKFLOW_BUNDLE_SCHEME)) {
+      return;
+    }
+    const fileName = uri.slice(WORKFLOW_BUNDLE_SCHEME.length);
+    const bytes = bundle.assets.get(fileName);
+    if (!bytes) {
+      missing.push(fileName);
+      return;
+    }
+
+    let stored = resolvedByFile.get(fileName);
+    if (!stored) {
+      const result = await options.storeAsset({
+        bytes,
+        fileName,
+        contentType: mimeForFile(fileName),
+        refType: ref.type
+      });
+      stored = { uri: result.uri, ...(result.assetId ? { assetId: result.assetId } : {}) };
+      resolvedByFile.set(fileName, stored);
+      imported.push({ file: fileName, uri: stored.uri });
+    }
+
+    ref.uri = stored.uri;
+    delete ref.temp_id;
+    delete ref.data;
+    if (stored.assetId) {
+      ref.asset_id = stored.assetId;
+    } else {
+      delete ref.asset_id;
+    }
+  });
+
+  return {
+    workflow: { ...bundle.workflow, graph },
+    imported,
+    missing,
+    checksumMismatches
+  };
+}

--- a/packages/websocket/src/routes/assets.ts
+++ b/packages/websocket/src/routes/assets.ts
@@ -88,22 +88,6 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
             }
           );
         }
-        const loaded = loadPythonPackageMetadata({
-          roots: apiOptions.metadataRoots,
-          maxDepth: apiOptions.metadataMaxDepth
-        });
-        const pkg = loaded.packages.find((p) => p.name === pkgName);
-        if (!pkg || !pkg.sourceFolder) {
-          return new Response(
-            JSON.stringify(
-              apiError(ApiErrorCode.NOT_FOUND, `Package '${pkgName}' not found`)
-            ),
-            {
-              status: 404,
-              headers: { "content-type": "application/json" }
-            }
-          );
-        }
         const { createReadStream, statSync } = await import("node:fs");
         const { extname, resolve } = await import("node:path");
         const mimeTypes: Record<string, string> = {
@@ -114,29 +98,58 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
           ".webp": "image/webp",
           ".svg": "image/svg+xml",
           ".mp3": "audio/mpeg",
+          ".wav": "audio/wav",
           ".mp4": "video/mp4",
           ".webm": "video/webm",
           ".json": "application/json",
           ".txt": "text/plain"
         };
-        const baseDir = resolve(
-          `${pkg.sourceFolder}/nodetool/assets/${pkgName}`
-        );
-        const assetPath = resolve(baseDir, aName);
-        // Prevent path traversal.
-        if (!assetPath.startsWith(baseDir + "/") && assetPath !== baseDir) {
+
+        // Candidate base dirs holding this package's constant assets. Bundled
+        // roots (shipped with the Electron build) are checked first so the
+        // route resolves without a Python installation; Python package
+        // metadata is the fallback for source/dev layouts.
+        const baseDirs: string[] = [];
+        for (const root of apiOptions.packageAssetsRoots ?? []) {
+          baseDirs.push(resolve(root, pkgName));
+        }
+        const loaded = loadPythonPackageMetadata({
+          roots: apiOptions.metadataRoots,
+          maxDepth: apiOptions.metadataMaxDepth
+        });
+        const pkg = loaded.packages.find((p) => p.name === pkgName);
+        if (pkg?.sourceFolder) {
+          baseDirs.push(resolve(`${pkg.sourceFolder}/nodetool/assets/${pkgName}`));
+        }
+        if (baseDirs.length === 0) {
           return new Response(
-            JSON.stringify(apiError(ApiErrorCode.ASSET_NOT_FOUND, "Not found")),
+            JSON.stringify(
+              apiError(ApiErrorCode.NOT_FOUND, `Package '${pkgName}' not found`)
+            ),
             {
               status: 404,
               headers: { "content-type": "application/json" }
             }
           );
         }
-        let fileStat: { size: number; mtimeMs: number };
-        try {
-          fileStat = statSync(assetPath);
-        } catch {
+
+        let assetPath: string | null = null;
+        let fileStat: { size: number; mtimeMs: number } | null = null;
+        for (const baseDir of baseDirs) {
+          const candidate = resolve(baseDir, aName);
+          // Prevent path traversal.
+          if (!candidate.startsWith(baseDir + "/") && candidate !== baseDir) {
+            continue;
+          }
+          try {
+            fileStat = statSync(candidate);
+            assetPath = candidate;
+            break;
+          } catch {
+            // Try the next candidate base dir.
+          }
+        }
+        if (!assetPath || !fileStat) {
           return new Response(
             JSON.stringify(
               apiError(

--- a/packages/websocket/src/routes/assets.ts
+++ b/packages/websocket/src/routes/assets.ts
@@ -47,18 +47,15 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
   });
 
   app.get(
-    "/api/assets/packages/:packageName/:assetName",
+    "/api/assets/packages/:packageName/*",
     async (req, reply) => {
-      const { packageName, assetName } = req.params as {
-        packageName: string;
-        assetName: string;
-      };
+      const params = req.params as { packageName: string; "*": string };
       await bridge(req, reply, async (_request) => {
         let pkgName: string;
         let aName: string;
         try {
-          pkgName = decodeURIComponent(packageName);
-          aName = decodeURIComponent(assetName);
+          pkgName = decodeURIComponent(params.packageName);
+          aName = decodeURIComponent(params["*"] ?? "");
         } catch {
           return new Response(
             JSON.stringify(
@@ -70,15 +67,18 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
             }
           );
         }
+        // `aName` may be a nested path (e.g. `audio/loop.mp3`). Reject empty,
+        // backslash, and traversal segments; `..` is checked per-segment.
+        const segments = aName.split("/");
         if (
           !pkgName ||
           !aName ||
-          pkgName.includes("..") ||
-          aName.includes("..") ||
+          pkgName === "." ||
+          pkgName === ".." ||
           pkgName.includes("/") ||
-          aName.includes("/") ||
           pkgName.includes("\\") ||
-          aName.includes("\\")
+          aName.includes("\\") ||
+          segments.some((s) => s === "" || s === "." || s === "..")
         ) {
           return new Response(
             JSON.stringify(apiError(ApiErrorCode.ASSET_NOT_FOUND, "Not found")),
@@ -89,7 +89,9 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
           );
         }
         const { createReadStream, statSync } = await import("node:fs");
-        const { extname, resolve } = await import("node:path");
+        const { extname, resolve, relative, isAbsolute } = await import(
+          "node:path"
+        );
         const mimeTypes: Record<string, string> = {
           ".jpg": "image/jpeg",
           ".jpeg": "image/jpeg",
@@ -105,51 +107,47 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
           ".txt": "text/plain"
         };
 
-        // Candidate base dirs holding this package's constant assets. Bundled
-        // roots (shipped with the Electron build) are checked first so the
-        // route resolves without a Python installation; Python package
-        // metadata is the fallback for source/dev layouts.
-        const baseDirs: string[] = [];
-        for (const root of apiOptions.packageAssetsRoots ?? []) {
-          baseDirs.push(resolve(root, pkgName));
-        }
-        const loaded = loadPythonPackageMetadata({
-          roots: apiOptions.metadataRoots,
-          maxDepth: apiOptions.metadataMaxDepth
-        });
-        const pkg = loaded.packages.find((p) => p.name === pkgName);
-        if (pkg?.sourceFolder) {
-          baseDirs.push(resolve(`${pkg.sourceFolder}/nodetool/assets/${pkgName}`));
-        }
-        if (baseDirs.length === 0) {
-          return new Response(
-            JSON.stringify(
-              apiError(ApiErrorCode.NOT_FOUND, `Package '${pkgName}' not found`)
-            ),
-            {
-              status: 404,
-              headers: { "content-type": "application/json" }
-            }
-          );
-        }
-
-        let assetPath: string | null = null;
-        let fileStat: { size: number; mtimeMs: number } | null = null;
-        for (const baseDir of baseDirs) {
-          const candidate = resolve(baseDir, aName);
-          // Prevent path traversal.
-          if (!candidate.startsWith(baseDir + "/") && candidate !== baseDir) {
-            continue;
+        // Resolve `<baseDir>/<segments...>` with a separator-agnostic
+        // containment guard (works on Windows, where startsWith(baseDir + "/")
+        // would not).
+        const tryServe = (
+          baseDir: string
+        ): { path: string; size: number; mtimeMs: number } | null => {
+          const candidate = resolve(baseDir, ...segments);
+          const rel = relative(baseDir, candidate);
+          if (rel.startsWith("..") || isAbsolute(rel)) {
+            return null;
           }
           try {
-            fileStat = statSync(candidate);
-            assetPath = candidate;
-            break;
+            const st = statSync(candidate);
+            if (!st.isFile()) return null;
+            return { path: candidate, size: st.size, mtimeMs: st.mtimeMs };
           } catch {
-            // Try the next candidate base dir.
+            return null;
+          }
+        };
+
+        // Configured bundled roots first (no Python needed). Only fall back to
+        // Python package metadata — which walks the filesystem — when the asset
+        // isn't found in a configured root, keeping the hot path cheap.
+        let hit: { path: string; size: number; mtimeMs: number } | null = null;
+        for (const root of apiOptions.packageAssetsRoots ?? []) {
+          hit = tryServe(resolve(root, pkgName));
+          if (hit) break;
+        }
+        if (!hit) {
+          const loaded = loadPythonPackageMetadata({
+            roots: apiOptions.metadataRoots,
+            maxDepth: apiOptions.metadataMaxDepth
+          });
+          const pkg = loaded.packages.find((p) => p.name === pkgName);
+          if (pkg?.sourceFolder) {
+            hit = tryServe(
+              resolve(`${pkg.sourceFolder}/nodetool/assets/${pkgName}`)
+            );
           }
         }
-        if (!assetPath || !fileStat) {
+        if (!hit) {
           return new Response(
             JSON.stringify(
               apiError(
@@ -163,6 +161,8 @@ const assetsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
             }
           );
         }
+        const assetPath = hit.path;
+        const fileStat = { size: hit.size, mtimeMs: hit.mtimeMs };
         const contentType =
           mimeTypes[extname(aName).toLowerCase()] ?? "application/octet-stream";
         const stream = createReadStream(assetPath);

--- a/packages/websocket/src/routes/workflows.ts
+++ b/packages/websocket/src/routes/workflows.ts
@@ -14,6 +14,9 @@ import { getUserId, type HttpApiOptions } from "../http-api.js";
 import {
   handleWorkflowById,
   handleWorkflowDslExport,
+  handleWorkflowExportBundle,
+  handleWorkflowsExportBundle,
+  handleWorkflowImportBundle,
   handleWorkflowExamples,
   handleWorkflowExamplesSearch,
   handleWorkflowGradioExport,
@@ -85,6 +88,20 @@ const workflowsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
     );
   });
 
+  // Bundle export/import (.nodetool). Static paths registered before
+  // `/api/workflows/:id` so they aren't captured as a workflow id.
+  app.post("/api/workflows/export-bundle", async (req, reply) => {
+    await bridge(req, reply, (request) =>
+      handleWorkflowsExportBundle(request, apiOptions)
+    );
+  });
+
+  app.post("/api/workflows/import-bundle", async (req, reply) => {
+    await bridge(req, reply, (request) =>
+      handleWorkflowImportBundle(request, apiOptions)
+    );
+  });
+
   app.get("/api/workflows/public/:workflowId", async (req, reply) => {
     const { workflowId } = req.params as { workflowId: string };
     await bridge(req, reply, (request) =>
@@ -107,6 +124,13 @@ const workflowsRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
     const { id } = req.params as { id: string };
     await bridge(req, reply, (request) =>
       handleWorkflowDslExport(request, id, apiOptions)
+    );
+  });
+
+  app.get("/api/workflows/:id/export-bundle", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    await bridge(req, reply, (request) =>
+      handleWorkflowExportBundle(request, id, apiOptions)
     );
   });
 

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -669,6 +669,35 @@ if (_resolvedExamplesDir) {
     apiOptions.examplesAssetsFallbackDir = _bundledAssetsDir;
   }
 }
+
+// Constant package assets (`package://<pkg>/<file>`) are served read-only at
+// `/api/assets/packages/<pkg>/<file>` from `<root>/<pkg>/<file>`. The bundled
+// root sits next to server.mjs (no Python needed); the monorepo root is used
+// in dev/dist runs.
+const _bundledPackageAssetsRoot = resolve(_serverDir, "assets");
+const _monoPackageAssetsRoot = resolve(
+  _serverDir,
+  "..",
+  "..",
+  "..",
+  "packages",
+  "base-nodes",
+  "nodetool",
+  "assets"
+);
+const _packageAssetsRoots = [
+  existsSync(_bundledPackageAssetsRoot) ? _bundledPackageAssetsRoot : null,
+  existsSync(_monoPackageAssetsRoot) ? _monoPackageAssetsRoot : null
+].filter((d): d is string => Boolean(d));
+if (_packageAssetsRoots.length > 0) {
+  apiOptions.packageAssetsRoots = _packageAssetsRoots;
+  // Let in-process workflow execution resolve `package://` refs straight from
+  // disk instead of guessing the loopback port for an HTTP round-trip.
+  if (!process.env["NODETOOL_PACKAGE_ASSETS_DIR"]) {
+    process.env["NODETOOL_PACKAGE_ASSETS_DIR"] = _packageAssetsRoots[0];
+  }
+}
+
 const staticFolder = process.env["STATIC_FOLDER"];
 const hasStaticApp = Boolean(staticFolder && existsSync(staticFolder));
 

--- a/packages/websocket/tests/package-asset-export.test.ts
+++ b/packages/websocket/tests/package-asset-export.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for materializeWorkflowConstantAssets — converting a workflow's
+ * per-install asset refs into shipped constant `package://` assets.
+ *
+ * Run with:
+ *   npm run test --workspace=packages/websocket -- package-asset-export
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  materializeWorkflowConstantAssets,
+  type WorkflowGraphLike
+} from "../src/lib/package-asset-export.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "nodetool-export-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function audioInputGraph(): WorkflowGraphLike {
+  return {
+    nodes: [
+      {
+        id: "1",
+        type: "nodetool.input.AudioInput",
+        data: {
+          name: "description",
+          value: {
+            asset_id: "6cba4e9efc884854a3939f62007fd9bf",
+            uri: "/api/storage/6cba4e9efc884854a3939f62007fd9bf.bin",
+            type: "audio"
+          }
+        }
+      }
+    ],
+    edges: []
+  };
+}
+
+describe("materializeWorkflowConstantAssets", () => {
+  it("rewrites a /api/storage ref to package:// and writes the bytes", async () => {
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([9, 8, 7]));
+    const result = await materializeWorkflowConstantAssets(audioInputGraph(), {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+
+    expect(fetchAssetBytes).toHaveBeenCalledWith(
+      "/api/storage/6cba4e9efc884854a3939f62007fd9bf.bin"
+    );
+    expect(result.exported).toHaveLength(1);
+    const ex = result.exported[0];
+    expect(ex.fileName).toBe("6cba4e9efc884854a3939f62007fd9bf.bin");
+    expect(ex.packageUri).toBe(
+      "package://nodetool-base/6cba4e9efc884854a3939f62007fd9bf.bin"
+    );
+
+    const ref = (result.graph.nodes[0].data as Record<string, any>).value;
+    expect(ref.uri).toBe(
+      "package://nodetool-base/6cba4e9efc884854a3939f62007fd9bf.bin"
+    );
+    expect(ref.asset_id).toBeUndefined();
+    expect(ref.type).toBe("audio");
+
+    const written = await readFile(
+      join(root, "nodetool-base", "6cba4e9efc884854a3939f62007fd9bf.bin")
+    );
+    expect(Array.from(written)).toEqual([9, 8, 7]);
+  });
+
+  it("does not mutate the input graph", async () => {
+    const input = audioInputGraph();
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([1]));
+    await materializeWorkflowConstantAssets(input, {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+    const ref = (input.nodes[0].data as Record<string, any>).value;
+    expect(ref.uri).toBe(
+      "/api/storage/6cba4e9efc884854a3939f62007fd9bf.bin"
+    );
+    expect(ref.asset_id).toBe("6cba4e9efc884854a3939f62007fd9bf");
+  });
+
+  it("resolves asset:// refs via a synthesized id and adds an extension by type", async () => {
+    const graph: WorkflowGraphLike = {
+      nodes: [
+        {
+          id: "1",
+          type: "nodetool.constant.Image",
+          data: { value: { asset_id: "abc123", type: "image" } }
+        }
+      ],
+      edges: []
+    };
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([2, 2]));
+    const result = await materializeWorkflowConstantAssets(graph, {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+    expect(fetchAssetBytes).toHaveBeenCalledWith("asset://abc123");
+    expect(result.exported[0].fileName).toBe("abc123.png");
+  });
+
+  it("leaves remote and package refs untouched by default", async () => {
+    const graph: WorkflowGraphLike = {
+      nodes: [
+        {
+          id: "1",
+          type: "x",
+          data: {
+            a: { uri: "https://example.com/i.png", type: "image" },
+            b: { uri: "package://nodetool-base/already.png", type: "image" }
+          }
+        }
+      ],
+      edges: []
+    };
+    const fetchAssetBytes = vi.fn();
+    const result = await materializeWorkflowConstantAssets(graph, {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+    expect(fetchAssetBytes).not.toHaveBeenCalled();
+    expect(result.exported).toHaveLength(0);
+    const data = result.graph.nodes[0].data as Record<string, any>;
+    expect(data.a.uri).toBe("https://example.com/i.png");
+    expect(data.b.uri).toBe("package://nodetool-base/already.png");
+  });
+
+  it("dedupes identical sources to a single file", async () => {
+    const graph: WorkflowGraphLike = {
+      nodes: [
+        { id: "1", type: "x", data: { v: { uri: "/api/storage/dup.png", type: "image" } } },
+        { id: "2", type: "x", data: { v: { uri: "/api/storage/dup.png", type: "image" } } }
+      ],
+      edges: []
+    };
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([5]));
+    const result = await materializeWorkflowConstantAssets(graph, {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+    expect(fetchAssetBytes).toHaveBeenCalledTimes(1);
+    expect(result.exported).toHaveLength(1);
+  });
+
+  it("records refs that fail to resolve in skipped and leaves them unchanged", async () => {
+    const fetchAssetBytes = vi.fn().mockResolvedValue(null);
+    const result = await materializeWorkflowConstantAssets(audioInputGraph(), {
+      packageName: "nodetool-base",
+      assetsRoot: root,
+      fetchAssetBytes
+    });
+    expect(result.skipped).toEqual([
+      "/api/storage/6cba4e9efc884854a3939f62007fd9bf.bin"
+    ]);
+    expect(result.exported).toHaveLength(0);
+    const ref = (result.graph.nodes[0].data as Record<string, any>).value;
+    expect(ref.uri).toBe(
+      "/api/storage/6cba4e9efc884854a3939f62007fd9bf.bin"
+    );
+  });
+});

--- a/packages/websocket/tests/package-assets-route.test.ts
+++ b/packages/websocket/tests/package-assets-route.test.ts
@@ -15,17 +15,23 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import assetsRoutes from "../src/routes/assets.js";
 
-describe("GET /api/assets/packages/:packageName/:assetName", () => {
+describe("GET /api/assets/packages/:packageName/*", () => {
   let app: FastifyInstance;
   let root: string;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "nodetool-pkg-route-"));
-    await mkdir(join(root, "nodetool-base"), { recursive: true });
+    await mkdir(join(root, "nodetool-base", "audio"), { recursive: true });
     await writeFile(
       join(root, "nodetool-base", "cat.png"),
       Buffer.from([1, 2, 3, 4])
     );
+    await writeFile(
+      join(root, "nodetool-base", "audio", "loop.mp3"),
+      Buffer.from([5, 6, 7])
+    );
+    // A file that lives outside the package dir, used for traversal checks.
+    await writeFile(join(root, "secret.txt"), Buffer.from([9, 9, 9]));
     app = Fastify({ logger: false });
     await app.register(assetsRoutes, {
       apiOptions: { packageAssetsRoots: [root] }
@@ -48,6 +54,16 @@ describe("GET /api/assets/packages/:packageName/:assetName", () => {
     expect(Array.from(res.rawPayload)).toEqual([1, 2, 3, 4]);
   });
 
+  it("serves a nested package asset path", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/assets/packages/nodetool-base/audio/loop.mp3"
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("audio/mpeg");
+    expect(Array.from(res.rawPayload)).toEqual([5, 6, 7]);
+  });
+
   it("404s for a missing asset in a known package", async () => {
     const res = await app.inject({
       method: "GET",
@@ -64,11 +80,12 @@ describe("GET /api/assets/packages/:packageName/:assetName", () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it("rejects path traversal in the asset name", async () => {
+  it("rejects path traversal out of the package dir", async () => {
     const res = await app.inject({
       method: "GET",
-      url: "/api/assets/packages/nodetool-base/weird..name.png"
+      url: "/api/assets/packages/nodetool-base/%2e%2e%2fsecret.txt"
     });
     expect(res.statusCode).toBe(404);
+    expect(res.rawPayload.includes(9)).toBe(false);
   });
 });

--- a/packages/websocket/tests/package-assets-route.test.ts
+++ b/packages/websocket/tests/package-assets-route.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration tests for constant package-asset serving:
+ *   GET /api/assets/packages/<package-name>/<file>
+ *
+ * Verifies that assets resolve from a configured bundled root (the path the
+ * Electron build ships next to server.mjs) without a Python installation.
+ *
+ * Run with:
+ *   npm run test --workspace=packages/websocket -- package-assets-route
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import assetsRoutes from "../src/routes/assets.js";
+
+describe("GET /api/assets/packages/:packageName/:assetName", () => {
+  let app: FastifyInstance;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "nodetool-pkg-route-"));
+    await mkdir(join(root, "nodetool-base"), { recursive: true });
+    await writeFile(
+      join(root, "nodetool-base", "cat.png"),
+      Buffer.from([1, 2, 3, 4])
+    );
+    app = Fastify({ logger: false });
+    await app.register(assetsRoutes, {
+      apiOptions: { packageAssetsRoots: [root] }
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("serves a constant package asset from a configured root", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/assets/packages/nodetool-base/cat.png"
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/png");
+    expect(Array.from(res.rawPayload)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("404s for a missing asset in a known package", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/assets/packages/nodetool-base/missing.png"
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s for an unknown package with no configured root", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/assets/packages/no-such-pkg/x.png"
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects path traversal in the asset name", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/assets/packages/nodetool-base/weird..name.png"
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/websocket/tests/workflow-bundle.test.ts
+++ b/packages/websocket/tests/workflow-bundle.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the .nodetool workflow bundle codec — packing a workflow + its
+ * referenced assets into a portable zip and importing it back.
+ *
+ * Run with:
+ *   npm run test --workspace=packages/websocket -- workflow-bundle
+ */
+import { describe, it, expect, vi } from "vitest";
+import { strToU8, zipSync } from "fflate";
+import {
+  packWorkflowBundle,
+  unpackWorkflowBundle,
+  importWorkflowBundle,
+  verifyBundleChecksums,
+  WORKFLOW_BUNDLE_FORMAT,
+  WORKFLOW_BUNDLE_SCHEME,
+  WORKFLOW_BUNDLE_VERSION,
+  type BundledWorkflow
+} from "../src/lib/workflow-bundle.js";
+
+/** Build a raw .nodetool zip from a workflow graph + named asset entries. */
+function makeZip(
+  graph: BundledWorkflow["graph"],
+  assets: Record<string, Uint8Array>,
+  manifestAssets: { file: string; bytes: number; sha256: string }[]
+): Uint8Array {
+  const files: Record<string, Uint8Array> = {
+    "manifest.json": strToU8(
+      JSON.stringify({
+        format: WORKFLOW_BUNDLE_FORMAT,
+        version: WORKFLOW_BUNDLE_VERSION,
+        created_at: new Date().toISOString(),
+        assets: manifestAssets,
+        thumbnail: null
+      })
+    ),
+    "workflow.json": strToU8(JSON.stringify({ name: "raw", graph }))
+  };
+  for (const [name, bytes] of Object.entries(assets)) {
+    files[`assets/${name}`] = bytes;
+  }
+  return zipSync(files);
+}
+
+function audioWorkflow(): BundledWorkflow {
+  return {
+    name: "Audio To Image",
+    description: "demo",
+    tags: ["audio"],
+    run_mode: "workflow",
+    settings: null,
+    graph: {
+      nodes: [
+        {
+          id: "1",
+          type: "nodetool.input.AudioInput",
+          data: {
+            name: "clip",
+            value: {
+              asset_id: "6cba4e9e",
+              uri: "/api/storage/6cba4e9e.mp3",
+              type: "audio"
+            }
+          }
+        }
+      ],
+      edges: []
+    }
+  };
+}
+
+describe("packWorkflowBundle / unpackWorkflowBundle", () => {
+  it("embeds referenced assets and rewrites refs to bundle://", async () => {
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const { bytes, manifest } = await packWorkflowBundle({
+      workflow: audioWorkflow(),
+      fetchAssetBytes,
+      nodetoolVersion: "9.9.9"
+    });
+
+    expect(fetchAssetBytes).toHaveBeenCalledWith("/api/storage/6cba4e9e.mp3");
+    expect(manifest.format).toBe(WORKFLOW_BUNDLE_FORMAT);
+    expect(manifest.nodetool_version).toBe("9.9.9");
+    expect(manifest.assets).toHaveLength(1);
+    expect(manifest.assets[0].file).toMatch(/^assets\/[0-9a-f]{64}\.mp3$/);
+    expect(manifest.assets[0].bytes).toBe(3);
+
+    const unpacked = unpackWorkflowBundle(bytes);
+    const ref = (unpacked.workflow.graph.nodes[0].data as Record<string, any>)
+      .value;
+    expect(ref.uri.startsWith(WORKFLOW_BUNDLE_SCHEME)).toBe(true);
+    expect(ref.asset_id).toBeUndefined();
+    expect(unpacked.assets.size).toBe(1);
+    expect(verifyBundleChecksums(unpacked)).toEqual([]);
+  });
+
+  it("does not mutate the input workflow graph", async () => {
+    const wf = audioWorkflow();
+    await packWorkflowBundle({
+      workflow: wf,
+      fetchAssetBytes: vi.fn().mockResolvedValue(new Uint8Array([1]))
+    });
+    const ref = (wf.graph.nodes[0].data as Record<string, any>).value;
+    expect(ref.uri).toBe("/api/storage/6cba4e9e.mp3");
+  });
+
+  it("dedupes identical asset bytes to a single archive entry", async () => {
+    const wf: BundledWorkflow = {
+      name: "two refs",
+      graph: {
+        nodes: [
+          { id: "1", type: "x", data: { v: { uri: "/api/storage/a.png", type: "image" } } },
+          { id: "2", type: "x", data: { v: { uri: "/api/storage/b.png", type: "image" } } }
+        ],
+        edges: []
+      }
+    };
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([7, 7, 7]));
+    const { manifest } = await packWorkflowBundle({ workflow: wf, fetchAssetBytes });
+    // Two distinct sources, identical bytes → one content-addressed file.
+    expect(fetchAssetBytes).toHaveBeenCalledTimes(2);
+    expect(manifest.assets).toHaveLength(1);
+  });
+
+  it("rejects an unrecognized format on unpack", () => {
+    // Pack a valid bundle, then feed unrelated bytes.
+    expect(() => unpackWorkflowBundle(new Uint8Array([0, 1, 2]))).toThrow();
+  });
+});
+
+describe("importWorkflowBundle", () => {
+  it("round-trips: export then import rewrites refs via storeAsset", async () => {
+    const { bytes } = await packWorkflowBundle({
+      workflow: audioWorkflow(),
+      fetchAssetBytes: vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6]))
+    });
+
+    const stored: Array<{ fileName: string; contentType: string }> = [];
+    const result = await importWorkflowBundle(bytes, {
+      storeAsset: async ({ fileName, contentType }) => {
+        stored.push({ fileName, contentType });
+        return { uri: `asset://imported-${stored.length}.mp3`, assetId: `imported-${stored.length}` };
+      }
+    });
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0].contentType).toBe("audio/mpeg");
+    expect(result.missing).toEqual([]);
+    expect(result.imported).toHaveLength(1);
+
+    const ref = (result.workflow.graph.nodes[0].data as Record<string, any>)
+      .value;
+    expect(ref.uri).toBe("asset://imported-1.mp3");
+    expect(ref.asset_id).toBe("imported-1");
+    expect(result.workflow.name).toBe("Audio To Image");
+  });
+
+  it("reports bundle:// refs whose bytes are missing from the archive", async () => {
+    const zip = makeZip(
+      {
+        nodes: [
+          { id: "1", type: "x", data: { v: { uri: `${WORKFLOW_BUNDLE_SCHEME}ghost.png`, type: "image" } } }
+        ],
+        edges: []
+      },
+      {},
+      []
+    );
+    const storeAsset = vi.fn();
+    const result = await importWorkflowBundle(zip, { storeAsset });
+    expect(storeAsset).not.toHaveBeenCalled();
+    expect(result.missing).toEqual(["ghost.png"]);
+  });
+
+  it("throws on checksum mismatch when verifyChecksums is set", async () => {
+    const zip = makeZip(
+      {
+        nodes: [
+          { id: "1", type: "x", data: { v: { uri: `${WORKFLOW_BUNDLE_SCHEME}real.png`, type: "image" } } }
+        ],
+        edges: []
+      },
+      { "real.png": new Uint8Array([1, 2, 3]) },
+      [{ file: "assets/real.png", bytes: 3, sha256: "deadbeef" }]
+    );
+    await expect(
+      importWorkflowBundle(zip, {
+        storeAsset: async () => ({ uri: "asset://x", assetId: "x" }),
+        verifyChecksums: true
+      })
+    ).rejects.toThrow(/checksum/i);
+  });
+
+  it("imports despite a checksum mismatch when verification is off", async () => {
+    const zip = makeZip(
+      {
+        nodes: [
+          { id: "1", type: "x", data: { v: { uri: `${WORKFLOW_BUNDLE_SCHEME}real.png`, type: "image" } } }
+        ],
+        edges: []
+      },
+      { "real.png": new Uint8Array([1, 2, 3]) },
+      [{ file: "assets/real.png", bytes: 3, sha256: "deadbeef" }]
+    );
+    const result = await importWorkflowBundle(zip, {
+      storeAsset: async () => ({ uri: "asset://x", assetId: "x" })
+    });
+    expect(result.checksumMismatches).toEqual(["assets/real.png (checksum)"]);
+    expect(result.imported).toHaveLength(1);
+  });
+});
+
+describe("verifyBundleChecksums", () => {
+  it("flags missing and mismatched assets", () => {
+    const mismatches = verifyBundleChecksums({
+      manifest: {
+        format: WORKFLOW_BUNDLE_FORMAT,
+        version: WORKFLOW_BUNDLE_VERSION,
+        created_at: "",
+        assets: [
+          { file: "assets/a.png", bytes: 1, sha256: "wrong" },
+          { file: "assets/b.png", bytes: 1, sha256: "x" }
+        ],
+        thumbnail: null
+      },
+      workflow: { name: "w", graph: { nodes: [], edges: [] } },
+      assets: new Map([["a.png", new Uint8Array([1])]]),
+      thumbnail: null
+    });
+    expect(mismatches).toEqual([
+      "assets/a.png (checksum)",
+      "assets/b.png (missing)"
+    ]);
+  });
+});

--- a/packages/websocket/tests/workflow-bundle.test.ts
+++ b/packages/websocket/tests/workflow-bundle.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from "vitest";
 import { strToU8, zipSync } from "fflate";
 import {
   packWorkflowBundle,
+  packWorkflowsBundle,
   unpackWorkflowBundle,
   importWorkflowBundle,
   verifyBundleChecksums,
@@ -86,7 +87,9 @@ describe("packWorkflowBundle / unpackWorkflowBundle", () => {
     expect(manifest.assets[0].bytes).toBe(3);
 
     const unpacked = unpackWorkflowBundle(bytes);
-    const ref = (unpacked.workflow.graph.nodes[0].data as Record<string, any>)
+    expect(unpacked.workflows).toHaveLength(1);
+    expect(unpacked.manifest.workflows[0].name).toBe("Audio To Image");
+    const ref = (unpacked.workflows[0].graph.nodes[0].data as Record<string, any>)
       .value;
     expect(ref.uri.startsWith(WORKFLOW_BUNDLE_SCHEME)).toBe(true);
     expect(ref.asset_id).toBeUndefined();
@@ -148,11 +151,12 @@ describe("importWorkflowBundle", () => {
     expect(result.missing).toEqual([]);
     expect(result.imported).toHaveLength(1);
 
-    const ref = (result.workflow.graph.nodes[0].data as Record<string, any>)
+    expect(result.workflows).toHaveLength(1);
+    const ref = (result.workflows[0].graph.nodes[0].data as Record<string, any>)
       .value;
     expect(ref.uri).toBe("asset://imported-1.mp3");
     expect(ref.asset_id).toBe("imported-1");
-    expect(result.workflow.name).toBe("Audio To Image");
+    expect(result.workflows[0].name).toBe("Audio To Image");
   });
 
   it("reports bundle:// refs whose bytes are missing from the archive", async () => {
@@ -217,13 +221,14 @@ describe("verifyBundleChecksums", () => {
         format: WORKFLOW_BUNDLE_FORMAT,
         version: WORKFLOW_BUNDLE_VERSION,
         created_at: "",
+        workflows: [],
         assets: [
           { file: "assets/a.png", bytes: 1, sha256: "wrong" },
           { file: "assets/b.png", bytes: 1, sha256: "x" }
         ],
         thumbnail: null
       },
-      workflow: { name: "w", graph: { nodes: [], edges: [] } },
+      workflows: [{ name: "w", graph: { nodes: [], edges: [] } }],
       assets: new Map([["a.png", new Uint8Array([1])]]),
       thumbnail: null
     });
@@ -231,5 +236,81 @@ describe("verifyBundleChecksums", () => {
       "assets/a.png (checksum)",
       "assets/b.png (missing)"
     ]);
+  });
+});
+
+describe("multi-workflow bundles", () => {
+  it("packs several workflows, sharing identical assets, and imports them all", async () => {
+    const shared = { uri: "/api/storage/shared.png", type: "image" };
+    const workflows: BundledWorkflow[] = [
+      {
+        name: "First",
+        graph: { nodes: [{ id: "1", type: "x", data: { v: { ...shared } } }], edges: [] }
+      },
+      {
+        name: "Second",
+        graph: { nodes: [{ id: "2", type: "x", data: { v: { ...shared } } }], edges: [] }
+      }
+    ];
+    // Same source across workflows → resolved once (memoized).
+    const fetchAssetBytes = vi.fn().mockResolvedValue(new Uint8Array([1, 1, 1]));
+
+    const { bytes, manifest } = await packWorkflowsBundle({
+      workflows,
+      fetchAssetBytes
+    });
+    expect(fetchAssetBytes).toHaveBeenCalledTimes(1);
+    expect(manifest.workflows.map((w) => w.name)).toEqual(["First", "Second"]);
+    expect(manifest.assets).toHaveLength(1); // shared, deduped
+
+    const unpacked = unpackWorkflowBundle(bytes);
+    expect(unpacked.workflows).toHaveLength(2);
+
+    let storeCalls = 0;
+    const result = await importWorkflowBundle(bytes, {
+      storeAsset: async () => {
+        storeCalls += 1;
+        return { uri: "asset://shared-imported.png", assetId: "shared-imported" };
+      }
+    });
+    // Shared asset stored once across both workflows.
+    expect(storeCalls).toBe(1);
+    expect(result.workflows).toHaveLength(2);
+    for (const wf of result.workflows) {
+      expect((wf.graph.nodes[0].data as Record<string, any>).v.uri).toBe(
+        "asset://shared-imported.png"
+      );
+    }
+  });
+
+  it("disambiguates workflow file names when names collide", async () => {
+    const { manifest } = await packWorkflowsBundle({
+      workflows: [
+        { name: "Same", graph: { nodes: [], edges: [] } },
+        { name: "Same", graph: { nodes: [], edges: [] } }
+      ],
+      fetchAssetBytes: vi.fn()
+    });
+    const files = manifest.workflows.map((w) => w.file);
+    expect(new Set(files).size).toBe(2);
+  });
+
+  it("reads a legacy v1 single-workflow bundle (workflow.json)", async () => {
+    const v1 = zipSync({
+      "manifest.json": strToU8(
+        JSON.stringify({
+          format: WORKFLOW_BUNDLE_FORMAT,
+          version: 1,
+          created_at: "",
+          assets: []
+        })
+      ),
+      "workflow.json": strToU8(
+        JSON.stringify({ name: "Legacy", graph: { nodes: [], edges: [] } })
+      )
+    });
+    const unpacked = unpackWorkflowBundle(v1);
+    expect(unpacked.workflows).toHaveLength(1);
+    expect(unpacked.workflows[0].name).toBe("Legacy");
   });
 });

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -12,8 +12,12 @@ import { useNotificationStore } from "../../stores/NotificationStore";
 import isEqual from "fast-deep-equal";
 import React from "react";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import {
+  exportWorkflowBundle,
+  importWorkflowBundle
+} from "../../utils/workflowBundle";
 import { useNodes } from "../../contexts/NodeContext";
 import { create } from "zustand";
 import { shallow } from "zustand/shallow";
@@ -41,6 +45,7 @@ import AutoFixHighRoundedIcon from "@mui/icons-material/AutoFixHighRounded";
 import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import FolderZipRoundedIcon from "@mui/icons-material/FolderZipRounded";
 
 // Icons — Edit
 import UndoRoundedIcon from "@mui/icons-material/UndoRounded";
@@ -125,6 +130,7 @@ const WorkflowCommands = memo(function WorkflowCommands() {
     (state) => state.addNotification
   );
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const saveWorkflow = useWorkflowManager((state) => state.saveWorkflow);
   const saveExample = useWorkflowManager((state) => state.saveExample);
@@ -134,6 +140,7 @@ const WorkflowCommands = memo(function WorkflowCommands() {
   const openWorkflows = useWorkflowManager((state) => state.openWorkflows);
   const createWorkflow = useWorkflowManager((state) => state.create);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const bundleInputRef = useRef<HTMLInputElement>(null);
 
   const runWorkflow = useCallback(() => {
     run({}, currentWorkflow, nodes, edges);
@@ -234,6 +241,51 @@ const WorkflowCommands = memo(function WorkflowCommands() {
     [createWorkflow, navigate, addNotification]
   );
 
+  const exportBundle = useCallback(async () => {
+    if (!currentWorkflow?.id) return;
+    try {
+      await exportWorkflowBundle(currentWorkflow.id, currentWorkflow.name);
+    } catch (error) {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Failed to export bundle: ${error instanceof Error ? error.message : "Unknown error"}`
+      });
+    }
+  }, [currentWorkflow, addNotification]);
+
+  const handleImportBundle = useCallback(() => {
+    bundleInputRef.current?.click();
+  }, []);
+
+  const handleBundleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      try {
+        const result = await importWorkflowBundle(file);
+        await queryClient.invalidateQueries({ queryKey: ["workflows"] });
+        const first = result.workflows[0];
+        if (first) {
+          navigate(`/editor/${first.id}`);
+        }
+        addNotification({
+          type: "success",
+          alert: true,
+          content: `Imported ${result.workflows.length} workflow(s) from bundle`
+        });
+      } catch (error) {
+        addNotification({
+          type: "error",
+          alert: true,
+          content: `Failed to import bundle: ${error instanceof Error ? error.message : "Unknown error"}`
+        });
+      }
+      if (bundleInputRef.current) bundleInputRef.current.value = "";
+    },
+    [queryClient, navigate, addNotification]
+  );
+
   return (
     <>
       <input
@@ -243,6 +295,14 @@ const WorkflowCommands = memo(function WorkflowCommands() {
         aria-label="Import workflow file"
         style={{ display: "none" }}
         onChange={handleImportFileChange}
+      />
+      <input
+        ref={bundleInputRef}
+        type="file"
+        accept=".nodetool,application/zip"
+        aria-label="Import workflow bundle file"
+        style={{ display: "none" }}
+        onChange={handleBundleFileChange}
       />
     <Command.Group heading="Workflow">
       <Command.Item onSelect={() => executeAndClose(runWorkflow)}>
@@ -262,6 +322,12 @@ const WorkflowCommands = memo(function WorkflowCommands() {
       </Command.Item>
       <Command.Item onSelect={() => executeAndClose(handleImportWorkflow)}>
         <FileUploadRoundedIcon /> Import Workflow from JSON
+      </Command.Item>
+      <Command.Item onSelect={() => executeAndClose(exportBundle)}>
+        <FolderZipRoundedIcon /> Export Workflow as Bundle (.nodetool)
+      </Command.Item>
+      <Command.Item onSelect={() => executeAndClose(handleImportBundle)}>
+        <FolderZipRoundedIcon /> Import Workflow from Bundle (.nodetool)
       </Command.Item>
       <Command.Item onSelect={() => executeAndClose(copyWorkflow)}>
         <ContentCopyRoundedIcon /> Copy Workflow as JSON

--- a/web/src/components/node/output/__tests__/hooks.test.ts
+++ b/web/src/components/node/output/__tests__/hooks.test.ts
@@ -35,6 +35,12 @@ describe("output/hooks", () => {
       );
     });
 
+    it("converts package:// URIs to the packages route", () => {
+      expect(resolveAssetUri("package://nodetool-base/audio/loop.mp3")).toBe(
+        "http://localhost:7777/api/assets/packages/nodetool-base/audio/loop.mp3"
+      );
+    });
+
     it("passes through absolute http URLs unchanged", () => {
       expect(resolveAssetUri("http://example.com/image.jpg")).toBe(
         "http://example.com/image.jpg"

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
+import { packageAssetHttpPath } from "@nodetool-ai/protocol";
 import { Asset, AssetRef } from "../../../stores/ApiTypes";
 import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
@@ -81,8 +82,8 @@ function extractStorageKey(uri: string | null | undefined): string | null {
 
 /**
  * Resolves asset URIs to their actual URLs.
- * Converts asset:// URIs to /api/storage/ URLs.
- * Passes through other URI schemes unchanged.
+ * Converts asset:// URIs to /api/storage/ URLs and package:// URIs to the
+ * /api/assets/packages/ route. Passes through other URI schemes unchanged.
  */
 export function resolveAssetUri(uri: string | undefined | null): string {
   if (!uri) {
@@ -93,6 +94,12 @@ export function resolveAssetUri(uri: string | undefined | null): string {
   if (uri.startsWith("asset://")) {
     const assetId = uri.slice("asset://".length);
     return `${BASE_URL}/api/storage/${assetId}`;
+  }
+
+  // Handle package:// scheme - constant assets shipped with a package
+  const pkgPath = packageAssetHttpPath(uri);
+  if (pkgPath) {
+    return `${BASE_URL}${pkgPath}`;
   }
 
   // Handle /api/storage/ relative URLs — prefix with BASE_URL for Electron

--- a/web/src/utils/__tests__/imageUtils.test.ts
+++ b/web/src/utils/__tests__/imageUtils.test.ts
@@ -107,6 +107,24 @@ describe("imageUtils", () => {
       expect(result.blobUrl).toBeNull();
     });
 
+    it("resolves package:// URI on ImageSource to the packages route", () => {
+      const source: ImageSource = { uri: "package://nodetool-base/cat.png" };
+      const result = createImageUrl(source, null);
+      expect(result.url).toBe(
+        "http://localhost:7777/api/assets/packages/nodetool-base/cat.png"
+      );
+      expect(result.blobUrl).toBeNull();
+    });
+
+    it("resolves raw package:// string to the packages route", () => {
+      const source: ImageData = "package://nodetool-base/cat.png";
+      const result = createImageUrl(source, null);
+      expect(result.url).toBe(
+        "http://localhost:7777/api/assets/packages/nodetool-base/cat.png"
+      );
+      expect(result.blobUrl).toBeNull();
+    });
+
     it("converts plain base64 string to data URI", () => {
       const source: ImageData = "abc123";
       const result = createImageUrl(source, null);

--- a/web/src/utils/__tests__/workflowBundle.test.ts
+++ b/web/src/utils/__tests__/workflowBundle.test.ts
@@ -1,0 +1,153 @@
+import { restFetch } from "../../lib/rest-fetch";
+import {
+  exportWorkflowBundle,
+  exportWorkflowsBundle,
+  importWorkflowBundle
+} from "../workflowBundle";
+
+jest.mock("../../lib/rest-fetch", () => ({
+  restFetch: jest.fn()
+}));
+jest.mock("../../stores/BASE_URL", () => ({
+  BASE_URL: "",
+  withApiBase: (u: string) => u
+}));
+
+const mockRestFetch = restFetch as jest.Mock;
+
+function fakeResponse(opts: {
+  ok: boolean;
+  status?: number;
+  blob?: Blob;
+  json?: unknown;
+  text?: string;
+  disposition?: string;
+}): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status ?? (opts.ok ? 200 : 400),
+    blob: async () => opts.blob ?? new Blob([new Uint8Array([1, 2, 3])]),
+    json: async () => opts.json ?? null,
+    text: async () => opts.text ?? "",
+    headers: {
+      get: (k: string) =>
+        k.toLowerCase() === "content-disposition" ? opts.disposition ?? null : null
+    }
+  } as unknown as Response;
+}
+
+let lastAnchor: HTMLAnchorElement | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  lastAnchor = null;
+  Object.defineProperty(global.URL, "createObjectURL", {
+    configurable: true,
+    value: jest.fn(() => "blob:mock")
+  });
+  Object.defineProperty(global.URL, "revokeObjectURL", {
+    configurable: true,
+    value: jest.fn()
+  });
+  jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  const origCreate = document.createElement.bind(document);
+  jest
+    .spyOn(document, "createElement")
+    .mockImplementation((tag: string, ...rest: unknown[]) => {
+      const el = origCreate(tag as never, ...(rest as []));
+      if (tag === "a") {
+        lastAnchor = el as HTMLAnchorElement;
+      }
+      return el;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("exportWorkflowBundle", () => {
+  it("fetches the single-workflow export route and downloads the file", async () => {
+    mockRestFetch.mockResolvedValue(
+      fakeResponse({
+        ok: true,
+        disposition: 'attachment; filename="My Flow.nodetool"'
+      })
+    );
+
+    await exportWorkflowBundle("wf-1", "My Flow");
+
+    expect(mockRestFetch).toHaveBeenCalledWith(
+      "/api/workflows/wf-1/export-bundle",
+      { method: "GET" }
+    );
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+    expect(lastAnchor?.download).toBe("My Flow.nodetool");
+  });
+
+  it("falls back to a sanitized name when no content-disposition is present", async () => {
+    mockRestFetch.mockResolvedValue(fakeResponse({ ok: true }));
+    await exportWorkflowBundle("wf-2", "Has Spaces!");
+    expect(lastAnchor?.download).toBe("Has_Spaces_.nodetool");
+  });
+
+  it("throws when the server responds with an error", async () => {
+    mockRestFetch.mockResolvedValue(
+      fakeResponse({ ok: false, status: 404, text: "Workflow not found" })
+    );
+    await expect(exportWorkflowBundle("missing", "x")).rejects.toThrow(
+      "Workflow not found"
+    );
+  });
+});
+
+describe("exportWorkflowsBundle", () => {
+  it("POSTs workflow_ids to the multi-workflow export route", async () => {
+    mockRestFetch.mockResolvedValue(fakeResponse({ ok: true }));
+    await exportWorkflowsBundle(["a", "b"], "pack");
+    expect(mockRestFetch).toHaveBeenCalledWith(
+      "/api/workflows/export-bundle",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ workflow_ids: ["a", "b"] })
+      })
+    );
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("importWorkflowBundle", () => {
+  it("uploads the file as multipart and returns the created workflows", async () => {
+    mockRestFetch.mockResolvedValue(
+      fakeResponse({
+        ok: true,
+        json: {
+          workflows: [{ id: "new-1", name: "Imported" }],
+          imported: 2,
+          missing: [],
+          checksum_mismatches: []
+        }
+      })
+    );
+
+    const file = new File([new Uint8Array([1])], "x.nodetool");
+    const result = await importWorkflowBundle(file);
+
+    const [url, init] = mockRestFetch.mock.calls[0];
+    expect(url).toBe("/api/workflows/import-bundle");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("file")).toBe(file);
+    expect(result.workflows[0]).toEqual({ id: "new-1", name: "Imported" });
+    expect(result.imported).toBe(2);
+  });
+
+  it("throws the server-provided detail on failure", async () => {
+    mockRestFetch.mockResolvedValue(
+      fakeResponse({ ok: false, status: 400, json: { detail: "Invalid bundle: boom" } })
+    );
+    await expect(
+      importWorkflowBundle(new File([], "bad.nodetool"))
+    ).rejects.toThrow("Invalid bundle: boom");
+  });
+});

--- a/web/src/utils/imageUtils.ts
+++ b/web/src/utils/imageUtils.ts
@@ -2,6 +2,7 @@
  * Image utility functions for converting various image data formats to displayable URLs.
  */
 
+import { packageAssetHttpPath } from "@nodetool-ai/protocol";
 import { BASE_URL } from "../stores/BASE_URL";
 
 export type ImageData = string | Uint8Array | number[];
@@ -14,6 +15,7 @@ export interface ImageSource {
 /**
  * Resolve a URI string to a fetchable URL.
  * - `asset://{id}` → `${BASE_URL}/api/storage/{id}`.
+ * - `package://{pkg}/{path}` → `${BASE_URL}/api/assets/packages/{pkg}/{path}`.
  * - `/api/...` → prefixed with `BASE_URL`.
  * - Other absolute URIs (`data:`, `blob:`, `http:`, `https:`) returned as-is.
  */
@@ -21,6 +23,10 @@ const resolveUri = (uri: string): string => {
   if (uri.startsWith("asset://")) {
     const assetId = uri.slice("asset://".length);
     return `${BASE_URL}/api/storage/${assetId}`;
+  }
+  const pkgPath = packageAssetHttpPath(uri);
+  if (pkgPath) {
+    return `${BASE_URL}${pkgPath}`;
   }
   if (uri.startsWith("/api/")) {
     return `${BASE_URL}${uri}`;
@@ -83,7 +89,8 @@ export const createImageUrl = (
       data.startsWith("data:") ||
       data.startsWith("blob:") ||
       data.startsWith("http") ||
-      data.startsWith("asset://")
+      data.startsWith("asset://") ||
+      data.startsWith("package://")
     ) {
       return { url: resolveUri(data), blobUrl: null };
     }

--- a/web/src/utils/workflowBundle.ts
+++ b/web/src/utils/workflowBundle.ts
@@ -1,0 +1,111 @@
+/**
+ * Client helpers for the portable `.nodetool` workflow bundle endpoints:
+ *   GET  /api/workflows/:id/export-bundle   → download a single workflow + assets
+ *   POST /api/workflows/export-bundle        → download multiple workflows + assets
+ *   POST /api/workflows/import-bundle        → import a bundle into the library
+ */
+import { restFetch } from "../lib/rest-fetch";
+
+export interface ImportedBundleWorkflow {
+  id: string;
+  name: string;
+}
+
+export interface ImportBundleResponse {
+  workflows: ImportedBundleWorkflow[];
+  imported: number;
+  missing: string[];
+  checksum_mismatches: string[];
+}
+
+function filenameFromDisposition(
+  header: string | null,
+  fallback: string
+): string {
+  if (header) {
+    const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(header);
+    if (match?.[1]) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+  return fallback;
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function sanitizeBundleName(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]+/g, "_") || "workflow";
+}
+
+/** Download one workflow as a `.nodetool` bundle. */
+export async function exportWorkflowBundle(
+  workflowId: string,
+  fallbackName: string
+): Promise<void> {
+  const res = await restFetch(
+    `/api/workflows/${encodeURIComponent(workflowId)}/export-bundle`,
+    { method: "GET" }
+  );
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(detail || `Export failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const filename = filenameFromDisposition(
+    res.headers.get("content-disposition"),
+    `${sanitizeBundleName(fallbackName)}.nodetool`
+  );
+  triggerDownload(blob, filename);
+}
+
+/** Download several workflows together as a single `.nodetool` bundle. */
+export async function exportWorkflowsBundle(
+  workflowIds: string[],
+  fallbackName = "workflows"
+): Promise<void> {
+  const res = await restFetch("/api/workflows/export-bundle", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ workflow_ids: workflowIds })
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(detail || `Export failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const filename = filenameFromDisposition(
+    res.headers.get("content-disposition"),
+    `${sanitizeBundleName(fallbackName)}.nodetool`
+  );
+  triggerDownload(blob, filename);
+}
+
+/** Upload a `.nodetool` bundle; the server stores its assets and creates the workflows. */
+export async function importWorkflowBundle(
+  file: File
+): Promise<ImportBundleResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await restFetch("/api/workflows/import-bundle", {
+    method: "POST",
+    body: formData
+  });
+  const data: unknown = await res.json().catch(() => null);
+  if (!res.ok) {
+    const detail =
+      data && typeof data === "object" && "detail" in data
+        ? String((data as { detail: unknown }).detail)
+        : `Import failed (${res.status})`;
+    throw new Error(detail);
+  }
+  return data as ImportBundleResponse;
+}


### PR DESCRIPTION
## Summary

Introduces a complete system for creating portable, shareable workflow templates via `.nodetool` bundle files (zip archives) and a new `package://` asset scheme for constant, machine-independent asset references. This enables workflows to be exported with their referenced assets embedded, imported into any installation, and shipped as examples with the build.

## Key Changes

### Workflow Bundle Codec (`packages/websocket/src/lib/workflow-bundle.ts`)
- **`packWorkflowBundle` / `packWorkflowsBundle`**: Exports one or more workflows as a `.nodetool` zip file
  - Collects all referenced assets (`asset://`, `/api/storage/`, optionally http/file refs)
  - Content-addresses assets by SHA256 hash to deduplicate identical bytes across workflows
  - Rewrites asset refs from per-install identifiers to `bundle://<file>` URIs
  - Includes manifest with format version, workflow list, asset checksums, optional thumbnail
- **`unpackWorkflowBundle` / `importWorkflowBundle`**: Imports bundles back into the system
  - Unpacks the zip and verifies asset checksums
  - Resolves each `bundle://` ref via a caller-supplied `storeAsset` callback (decides where bytes land)
  - Rewrites refs to concrete URIs (e.g., `asset://imported-id`)
  - Supports v1 (single `workflow.json`) and v2 (multiple `workflows/` files) formats
- **`verifyBundleChecksums`**: Validates bundle integrity

### Package Asset System
- **New `package://` URI scheme** (`packages/protocol/src/package-assets.ts`):
  - Format: `package://<package-name>/<relative-path>` (e.g., `package://nodetool-base/audio/sample.mp3`)
  - Stable, machine-independent URIs — same bytes on every install
  - Served at `/api/assets/packages/<package-name>/<file>` (read-only, public)
  - Resolves from bundled root (next to `server.mjs` in Electron) or monorepo in dev
- **`materializeWorkflowConstantAssets`** (`packages/websocket/src/lib/package-asset-export.ts`):
  - Converts a workflow's per-install asset refs into shipped `package://` assets
  - Walks the graph, fetches bytes for each `asset://` / `/api/storage/` ref
  - Writes materialized assets to `<assetsRoot>/<packageName>/<file>`
  - Rewrites refs to `package://` URIs, clears stale `asset_id`/`temp_id`/inline `data`
  - Used by CLI `export-example` command and UI export flows

### HTTP API & Routes
- **`GET /api/workflows/:id/export-bundle`**: Download single workflow as `.nodetool` zip
- **`POST /api/workflows/export-bundle`**: Download multiple workflows as `.nodetool` zip
- **`POST /api/workflows/import-bundle`**: Import a `.nodetool` bundle into the library
- **`GET /api/assets/packages/:packageName/:assetName`**: Serve constant package assets
  - Checks configured `packageAssetsRoots` first (bundled assets, no Python needed)
  - Falls back to Python package metadata if configured

### CLI Commands
- **`workflows export-example <workflow_id_or_file>`**: Export workflow as shipped template
  - Materializes assets into package's constant asset dir
  - Writes example JSON with `package://` refs
  - Options: `--package`, `--assets-dir`, `--examples-dir`, `--include-remote`

### Web UI
- **`exportWorkflowBundle` / `exportWorkflowsBundle`**: Client helpers for bundle export endpoints
- **`importWorkflowBundle`**: Client helper for bundle import endpoint
- **Command menu integration**: "Export as Bundle" and "Import Bundle" commands
- **Asset URI resolution**: Updated `imageUtils.ts`, `hooks.ts` to resolve `package://` URIs to HTTP routes

### Runtime & Processing

https://claude.ai/code/session_01ADcYifh2naxDcqhpWFyzPx