### PR TITLE
Add image and video generation support to Evolink provider

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -50,7 +50,7 @@ The capability system uses introspection to automatically detect which features 
 | Google Gemini | `gemini-provider.ts` | ✅ | ✅ | ✅ | File input via Blobs, Veo video |
 | xAI (Grok) | `xai-provider.ts` | ✅ | ✅ | — | Grok models; `XAI_API_KEY` |
 | DeepSeek | `deepseek-provider.ts` | ✅ | ✅ | — | DeepSeek-V3 and R1 reasoning; `DEEPSEEK_API_KEY` |
-| Evolink | `evolink-provider.ts` | ✅ | ✅ | model-dependent | OpenAI-compatible gateway (GPT, Claude, Gemini, DeepSeek); `EVOLINK_API_KEY` |
+| Evolink | `evolink-provider.ts` | ✅ | ✅ | model-dependent | OpenAI-compatible gateway (GPT, Claude, Gemini, DeepSeek). Also image (GPT Image, Nano Banana 2, Seedream) and video (Seedance, Wan, Veo, Sora, Grok) generation; `EVOLINK_API_KEY` |
 | Ollama | `ollama-provider.ts` | ✅ | model-dependent | Base64 | Local, no API key. `ollama pull` first |
 | vLLM | `vllm-provider.ts` | ✅ | model-dependent | ✅ | OpenAI-compatible, self-hosted |
 | HuggingFace | `huggingface-provider.ts` | ✅ | — | — | Hub models via FAL/Together/Replicate. See [HuggingFace Integration](huggingface.md) |
@@ -114,6 +114,8 @@ Use the HuggingFace 3D nodes (`HFTextTo3D`, `HFImageTo3D`) or the generic nodes 
 ### Multi-Provider Aggregators
 
 **kie.ai** — `KIE_API_KEY`. Unified access to multiple models via a single API. Recommended for providers without direct NodeTool API key support (ByteDance Seedance, Runway, Luma, xAI Grok Imagine, Alibaba Wan 2.6, Kling 3.0, FLUX.2, Nano Banana 2.0, Ideogram V3, Z-Image Turbo, Suno, and more).
+
+**Evolink** — `EVOLINK_API_KEY`. OpenAI/Anthropic-compatible gateway for chat (GPT, Claude, Gemini, DeepSeek) plus an asynchronous task API for image (GPT Image 2, Nano Banana 2, Seedream 5.0) and video (Seedance 2.0, Wan 2.6, Veo 3.1, Sora 2 Pro, Grok Imagine) generation behind one key.
 
 ## Generic Nodes: Provider-Agnostic Workflows
 

--- a/packages/runtime/src/providers/evolink-provider.ts
+++ b/packages/runtime/src/providers/evolink-provider.ts
@@ -1,8 +1,29 @@
 import OpenAI from "openai";
+import { createLogger } from "@nodetool-ai/config";
 import { OpenAIProvider } from "./openai-provider.js";
-import type { LanguageModel } from "./types.js";
+import type {
+  ASRModel,
+  EmbeddingModel,
+  ImageModel,
+  ImageToImageParams,
+  ImageToVideoParams,
+  LanguageModel,
+  TextToImageParams,
+  TextToVideoParams,
+  TTSModel,
+  VideoModel
+} from "./types.js";
 
-const EVOLINK_BASE_URL = "https://direct.evolink.ai/v1";
+const log = createLogger("nodetool.runtime.providers.evolink");
+
+// Evolink fronts two hosts: a synchronous OpenAI/Anthropic-compatible gateway
+// for text models, and an asynchronous, task-based gateway for media. The
+// chat path keeps using the OpenAI SDK against the gateway; image/video calls
+// submit a task and poll for the result on the media host.
+const EVOLINK_CHAT_BASE_URL = "https://direct.evolink.ai/v1";
+const EVOLINK_MEDIA_BASE_URL = "https://api.evolink.ai";
+const EVOLINK_FILE_UPLOAD_URL =
+  "https://files-api.evolink.ai/api/v1/files/upload/base64";
 
 interface EvolinkProviderOptions {
   client?: OpenAI;
@@ -10,10 +31,94 @@ interface EvolinkProviderOptions {
   fetchFn?: typeof fetch;
 }
 
+interface EvolinkTaskStatus {
+  status?: string;
+  progress?: number;
+  results?: string[];
+  error?: { code?: string; message?: string; type?: string } | string | null;
+}
+
+/**
+ * Image models reachable via `POST /v1/images/generations`. Every listed
+ * model also accepts an `image_urls` array, so each supports both
+ * text-to-image and image-to-image (editing).
+ */
+const EVOLINK_IMAGE_MODELS: ImageModel[] = [
+  { id: "gpt-image-2", name: "GPT Image 2" },
+  { id: "gpt-image-1.5", name: "GPT Image 1.5" },
+  { id: "gemini-3.1-flash-image-preview", name: "Nano Banana 2" },
+  { id: "doubao-seedream-5.0-lite", name: "Seedream 5.0 Lite" }
+].map((m) => ({
+  ...m,
+  provider: "evolink" as const,
+  supportedTasks: ["text_to_image", "image_to_image"]
+}));
+
+/**
+ * Video models reachable via `POST /v1/videos/generations`. Evolink uses
+ * distinct model ids per task for some families (e.g. Seedance, Wan), while
+ * others (Veo, Sora) switch task by the presence of `image_urls` — reflected
+ * in each model's `supportedTasks`.
+ */
+const EVOLINK_VIDEO_MODELS: VideoModel[] = [
+  {
+    id: "seedance-2.0-text-to-video",
+    name: "Seedance 2.0 (Text to Video)",
+    supportedTasks: ["text_to_video"],
+    resolutions: ["480p", "720p", "1080p"],
+    aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"]
+  },
+  {
+    id: "seedance-2.0-image-to-video",
+    name: "Seedance 2.0 (Image to Video)",
+    supportedTasks: ["image_to_video"],
+    resolutions: ["480p", "720p", "1080p"],
+    aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"]
+  },
+  {
+    id: "wan2.6-text-to-video",
+    name: "Wan 2.6 (Text to Video)",
+    supportedTasks: ["text_to_video"],
+    resolutions: ["720p", "1080p"],
+    aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4"]
+  },
+  {
+    id: "wan2.6-image-to-video",
+    name: "Wan 2.6 (Image to Video)",
+    supportedTasks: ["image_to_video"],
+    resolutions: ["720p", "1080p"],
+    aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4"]
+  },
+  {
+    id: "veo3.1-pro-beta",
+    name: "Veo 3.1 Pro",
+    supportedTasks: ["text_to_video", "image_to_video"],
+    resolutions: ["720p"],
+    aspectRatios: ["auto", "16:9", "9:16"]
+  },
+  {
+    id: "sora-2-pro-preview",
+    name: "Sora 2 Pro",
+    supportedTasks: ["text_to_video", "image_to_video"],
+    durations: [4, 8, 12],
+    resolutions: ["720p", "1080p"],
+    aspectRatios: ["16:9", "9:16"]
+  },
+  {
+    id: "grok-imagine-image-to-video-beta",
+    name: "Grok Imagine (Image to Video)",
+    supportedTasks: ["image_to_video"],
+    resolutions: ["480p", "720p"],
+    aspectRatios: ["16:9", "9:16", "1:1", "3:2", "2:3"]
+  }
+].map((m) => ({ ...m, provider: "evolink" as const }));
+
 /**
  * Evolink provider. Uses the OpenAI SDK against Evolink's
- * OpenAI-compatible gateway at https://direct.evolink.ai/v1, which fronts
- * GPT, Claude, Gemini, DeepSeek and other models behind a single API key.
+ * OpenAI-compatible gateway at https://direct.evolink.ai/v1 for chat (which
+ * fronts GPT, Claude, Gemini, DeepSeek and other models behind a single API
+ * key), and Evolink's asynchronous task API at https://api.evolink.ai for
+ * image and video generation.
  */
 export class EvolinkProvider extends OpenAIProvider {
   static override requiredSecrets(): string[] {
@@ -43,7 +148,7 @@ export class EvolinkProvider extends OpenAIProvider {
           ((key) =>
             new OpenAI({
               apiKey: key,
-              baseURL: EVOLINK_BASE_URL
+              baseURL: EVOLINK_CHAT_BASE_URL
             })),
         fetchFn
       }
@@ -57,14 +162,11 @@ export class EvolinkProvider extends OpenAIProvider {
   }
 
   override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
-    const response = await this._evolinkFetch(
-      `${EVOLINK_BASE_URL}/models`,
-      {
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`
-        }
+    const response = await this._evolinkFetch(`${EVOLINK_CHAT_BASE_URL}/models`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
       }
-    );
+    });
 
     if (!response.ok) {
       return [];
@@ -84,5 +186,278 @@ export class EvolinkProvider extends OpenAIProvider {
         name: row.name ?? row.id,
         provider: "evolink"
       }));
+  }
+
+  override async getAvailableImageModels(): Promise<ImageModel[]> {
+    return EVOLINK_IMAGE_MODELS;
+  }
+
+  override async getAvailableVideoModels(): Promise<VideoModel[]> {
+    return EVOLINK_VIDEO_MODELS;
+  }
+
+  // Evolink's media gateway has no speech-to-text, embedding, or built-in-voice
+  // TTS endpoints (Qwen TTS requires a pre-created custom voice). Override the
+  // OpenAIProvider lists so those OpenAI-only models don't surface under the
+  // evolink provider id.
+  override async getAvailableTTSModels(): Promise<TTSModel[]> {
+    return [];
+  }
+
+  override async getAvailableASRModels(): Promise<ASRModel[]> {
+    return [];
+  }
+
+  override async getAvailableEmbeddingModels(): Promise<EmbeddingModel[]> {
+    return [];
+  }
+
+  override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const body: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: this.withNegativePrompt(params.prompt, params.negativePrompt)
+    };
+
+    const size = this.resolveEvolinkImageSize(
+      params.aspectRatio,
+      params.width,
+      params.height
+    );
+    if (size) body.size = size;
+    if (params.resolution) body.resolution = params.resolution;
+    if (params.quality) body.quality = params.quality;
+
+    return this.runMediaTask("/v1/images/generations", body);
+  }
+
+  override async imageToImage(
+    image: Uint8Array,
+    params: ImageToImageParams
+  ): Promise<Uint8Array> {
+    if (!image || image.length === 0) {
+      throw new Error("image must not be empty.");
+    }
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const imageUrl = await this.uploadImage(image);
+    const body: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: this.withNegativePrompt(params.prompt, params.negativePrompt),
+      image_urls: [imageUrl]
+    };
+
+    const size = this.resolveEvolinkImageSize(
+      params.aspectRatio,
+      params.targetWidth ?? undefined,
+      params.targetHeight ?? undefined
+    );
+    if (size) body.size = size;
+    if (params.resolution) body.resolution = params.resolution;
+    if (params.quality) body.quality = params.quality;
+
+    return this.runMediaTask("/v1/images/generations", body);
+  }
+
+  override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const body: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: params.prompt
+    };
+    this.applyVideoParams(body, params);
+
+    return this.runMediaTask("/v1/videos/generations", body);
+  }
+
+  override async imageToVideo(
+    image: Uint8Array,
+    params: ImageToVideoParams
+  ): Promise<Uint8Array> {
+    if (!image || image.length === 0) {
+      throw new Error("The input image cannot be empty.");
+    }
+
+    const imageUrl = await this.uploadImage(image);
+    const body: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: params.prompt ?? "",
+      image_urls: [imageUrl]
+    };
+    this.applyVideoParams(body, params);
+
+    return this.runMediaTask("/v1/videos/generations", body);
+  }
+
+  private withNegativePrompt(
+    prompt: string,
+    negativePrompt?: string | null
+  ): string {
+    return negativePrompt
+      ? `${prompt.trim()}\n\nDo not include: ${negativePrompt.trim()}`
+      : prompt;
+  }
+
+  private resolveEvolinkImageSize(
+    aspectRatio?: string | null,
+    width?: number | null,
+    height?: number | null
+  ): string | undefined {
+    if (aspectRatio) return aspectRatio;
+    if (width && height) return `${width}x${height}`;
+    return undefined;
+  }
+
+  private applyVideoParams(
+    body: Record<string, unknown>,
+    params: TextToVideoParams | ImageToVideoParams
+  ): void {
+    const duration = this.resolveVideoDuration(params);
+    if (duration) body.duration = duration;
+    // Evolink expresses video resolution through the `quality` field
+    // (e.g. "720p", "1080p"), not a pixel size.
+    if (params.resolution) body.quality = params.resolution;
+    if (params.aspectRatio) body.aspect_ratio = params.aspectRatio;
+  }
+
+  private resolveVideoDuration(
+    params: TextToVideoParams | ImageToVideoParams
+  ): number | undefined {
+    if (params.durationSeconds && params.durationSeconds > 0) {
+      return Math.round(params.durationSeconds);
+    }
+    if (params.numFrames && params.numFrames > 0) {
+      return Math.max(1, Math.round(params.numFrames / 24));
+    }
+    return undefined;
+  }
+
+  private mediaHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  /** Upload raw image bytes and return a hosted URL Evolink can reference. */
+  private async uploadImage(
+    image: Uint8Array,
+    mimeType = "image/png"
+  ): Promise<string> {
+    const base64 = Buffer.from(image).toString("base64");
+    const response = await this._evolinkFetch(EVOLINK_FILE_UPLOAD_URL, {
+      method: "POST",
+      headers: this.mediaHeaders(),
+      body: JSON.stringify({
+        base64_data: `data:${mimeType};base64,${base64}`
+      })
+    });
+
+    const payload = (await response
+      .json()
+      .catch(() => ({}))) as {
+      success?: boolean;
+      data?: { file_url?: string };
+      msg?: string;
+    };
+
+    const fileUrl = payload.data?.file_url;
+    if (!response.ok || !payload.success || !fileUrl) {
+      throw new Error(
+        `Evolink file upload failed: ${response.status} ${payload.msg ?? ""}`.trim()
+      );
+    }
+    return fileUrl;
+  }
+
+  /** Submit a media task, poll until it completes, and download the result. */
+  private async runMediaTask(
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<Uint8Array> {
+    log.debug("Evolink media task", { path, model: body.model });
+    const taskId = await this.submitMediaTask(path, body);
+    const results = await this.pollMediaTask(taskId);
+    const url = results[0];
+    if (!url) {
+      throw new Error(`Evolink task ${taskId} returned no results`);
+    }
+    return this.downloadResult(url);
+  }
+
+  private async submitMediaTask(
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<string> {
+    const response = await this._evolinkFetch(`${EVOLINK_MEDIA_BASE_URL}${path}`, {
+      method: "POST",
+      headers: this.mediaHeaders(),
+      body: JSON.stringify(body)
+    });
+
+    const payload = (await response
+      .json()
+      .catch(() => ({}))) as { id?: string; error?: unknown };
+    if (!response.ok || !payload.id) {
+      throw new Error(
+        `Evolink task submit failed: ${response.status} ${JSON.stringify(
+          payload
+        )}`
+      );
+    }
+    return payload.id;
+  }
+
+  private async pollMediaTask(
+    taskId: string,
+    pollIntervalMs = 3000,
+    maxAttempts = 300
+  ): Promise<string[]> {
+    const url = `${EVOLINK_MEDIA_BASE_URL}/v1/tasks/${taskId}`;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const response = await this._evolinkFetch(url, {
+        headers: { Authorization: `Bearer ${this.apiKey}` }
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Evolink task query failed: ${response.status} (taskId: ${taskId})`
+        );
+      }
+
+      const data = (await response.json()) as EvolinkTaskStatus;
+      if (data.status === "completed") {
+        return data.results ?? [];
+      }
+      if (data.status === "failed") {
+        const message =
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message ?? "Unknown error";
+        throw new Error(`Evolink task failed: ${message} (taskId: ${taskId})`);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    const timeoutSeconds = (maxAttempts * pollIntervalMs) / 1000;
+    throw new Error(
+      `Evolink task timed out after ${timeoutSeconds}s (taskId: ${taskId})`
+    );
+  }
+
+  private async downloadResult(url: string): Promise<Uint8Array> {
+    const response = await this._evolinkFetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download Evolink result: ${response.status}`);
+    }
+    return new Uint8Array(await response.arrayBuffer());
   }
 }

--- a/packages/runtime/tests/providers/evolink-provider.test.ts
+++ b/packages/runtime/tests/providers/evolink-provider.test.ts
@@ -1,6 +1,50 @@
 import { describe, it, expect, vi } from "vitest";
 import { EvolinkProvider } from "../../src/providers/evolink-provider.js";
+import { providerCapabilities } from "../../src/providers/base-provider.js";
 import type { Message } from "../../src/providers/types.js";
+
+/**
+ * Route Evolink's media calls (file upload, task submit, task poll, result
+ * download) to canned responses keyed by URL.
+ */
+function makeMediaFetch(resultBytes: Uint8Array) {
+  return vi.fn(async (input: unknown, init?: { method?: string }) => {
+    const url = String(input);
+    if (url.includes("files-api.evolink.ai")) {
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { file_url: "https://files.evolink.ai/upload.png" }
+        })
+      };
+    }
+    if (
+      url.includes("/v1/images/generations") ||
+      url.includes("/v1/videos/generations")
+    ) {
+      expect(init?.method).toBe("POST");
+      return { ok: true, json: async () => ({ id: "task-1" }) };
+    }
+    if (url.includes("/v1/tasks/task-1")) {
+      return {
+        ok: true,
+        json: async () => ({
+          status: "completed",
+          progress: 100,
+          results: ["https://results.evolink.ai/out.bin"]
+        })
+      };
+    }
+    if (url.includes("results.evolink.ai/out.bin")) {
+      return {
+        ok: true,
+        arrayBuffer: async () => resultBytes.buffer
+      };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
 
 function makeAsyncIterable(items: unknown[]) {
   return {
@@ -165,5 +209,164 @@ describe("EvolinkProvider", () => {
     }
 
     expect(items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("advertises image and video capabilities", () => {
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    const caps = providerCapabilities(provider);
+    expect(caps).toContain("text_to_image");
+    expect(caps).toContain("image_to_image");
+    expect(caps).toContain("text_to_video");
+    expect(caps).toContain("image_to_video");
+  });
+
+  it("lists evolink image models tagged with the evolink provider", async () => {
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    const models = await provider.getAvailableImageModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every((m) => m.provider === "evolink")).toBe(true);
+    expect(models.map((m) => m.id)).toContain("gpt-image-2");
+    expect(
+      models.every((m) => m.supportedTasks?.includes("text_to_image"))
+    ).toBe(true);
+  });
+
+  it("lists evolink video models with per-task support", async () => {
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    const models = await provider.getAvailableVideoModels();
+    expect(models.every((m) => m.provider === "evolink")).toBe(true);
+    const t2v = models.find((m) => m.id === "seedance-2.0-text-to-video");
+    expect(t2v?.supportedTasks).toEqual(["text_to_video"]);
+    const i2v = models.find((m) => m.id === "seedance-2.0-image-to-video");
+    expect(i2v?.supportedTasks).toEqual(["image_to_video"]);
+  });
+
+  it("returns empty TTS/ASR/embedding lists (not OpenAI defaults)", async () => {
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(await provider.getAvailableTTSModels()).toEqual([]);
+    expect(await provider.getAvailableASRModels()).toEqual([]);
+    expect(await provider.getAvailableEmbeddingModels()).toEqual([]);
+  });
+
+  it("generates an image via the async media task API", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const mockFetch = makeMediaFetch(bytes);
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const result = await provider.textToImage({
+      model: { id: "gpt-image-2", name: "GPT Image 2", provider: "evolink" },
+      prompt: "a cat",
+      aspectRatio: "16:9"
+    });
+
+    expect(result).toEqual(bytes);
+    const submit = mockFetch.mock.calls.find((c) =>
+      String(c[0]).includes("/v1/images/generations")
+    );
+    const body = JSON.parse((submit?.[1] as any).body);
+    expect(body).toMatchObject({ model: "gpt-image-2", size: "16:9" });
+    expect(body.prompt).toBe("a cat");
+  });
+
+  it("uploads the input image before image-to-image generation", async () => {
+    const bytes = new Uint8Array([9, 8, 7]);
+    const mockFetch = makeMediaFetch(bytes);
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const result = await provider.imageToImage(new Uint8Array([1, 2, 3]), {
+      model: { id: "gpt-image-2", name: "GPT Image 2", provider: "evolink" },
+      prompt: "make it blue"
+    });
+
+    expect(result).toEqual(bytes);
+    expect(
+      mockFetch.mock.calls.some((c) =>
+        String(c[0]).includes("files-api.evolink.ai")
+      )
+    ).toBe(true);
+    const submit = mockFetch.mock.calls.find((c) =>
+      String(c[0]).includes("/v1/images/generations")
+    );
+    const body = JSON.parse((submit?.[1] as any).body);
+    expect(body.image_urls).toEqual(["https://files.evolink.ai/upload.png"]);
+  });
+
+  it("generates a video mapping resolution to quality", async () => {
+    const bytes = new Uint8Array([5, 6]);
+    const mockFetch = makeMediaFetch(bytes);
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const result = await provider.textToVideo({
+      model: {
+        id: "seedance-2.0-text-to-video",
+        name: "Seedance 2.0",
+        provider: "evolink"
+      },
+      prompt: "a dog running",
+      resolution: "720p",
+      aspectRatio: "16:9",
+      durationSeconds: 5
+    });
+
+    expect(result).toEqual(bytes);
+    const submit = mockFetch.mock.calls.find((c) =>
+      String(c[0]).includes("/v1/videos/generations")
+    );
+    const body = JSON.parse((submit?.[1] as any).body);
+    expect(body).toMatchObject({
+      model: "seedance-2.0-text-to-video",
+      prompt: "a dog running",
+      quality: "720p",
+      aspect_ratio: "16:9",
+      duration: 5
+    });
+  });
+
+  it("throws when a media task fails", async () => {
+    const mockFetch = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/v1/images/generations")) {
+        return { ok: true, json: async () => ({ id: "task-1" }) };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          status: "failed",
+          error: { message: "content policy" }
+        })
+      };
+    });
+    const provider = new EvolinkProvider(
+      { EVOLINK_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await expect(
+      provider.textToImage({
+        model: { id: "gpt-image-2", name: "GPT Image 2", provider: "evolink" },
+        prompt: "x"
+      })
+    ).rejects.toThrow("content policy");
   });
 });


### PR DESCRIPTION
## Summary

Extends the Evolink provider to support image and video generation tasks via Evolink's asynchronous media API, in addition to the existing chat/language model support through the OpenAI-compatible gateway.

## Key Changes

- **Dual API architecture**: Separates chat requests (using OpenAI SDK against `direct.evolink.ai/v1`) from media tasks (using async task API at `api.evolink.ai`)
- **Image generation**: Implements `textToImage()` and `imageToImage()` methods supporting multiple models (GPT Image, Gemini, Seedream, etc.)
- **Video generation**: Implements `textToVideo()` and `imageToVideo()` methods with per-task model support (Seedance, Wan, Veo, Sora, Grok Imagine)
- **Media task workflow**: Uploads images to file API, submits generation tasks, polls for completion, and downloads results
- **Model lists**: Adds static `EVOLINK_IMAGE_MODELS` and `EVOLINK_VIDEO_MODELS` with proper capability tagging and resolution/aspect ratio metadata
- **Capability overrides**: Returns empty lists for TTS, ASR, and embedding models (not available on Evolink) instead of inheriting OpenAI defaults
- **Comprehensive tests**: Adds test coverage for image/video generation, file upload, task polling, error handling, and capability advertisement

## Implementation Details

- Image size resolution supports both aspect ratios (e.g., "16:9") and explicit dimensions (e.g., "1920x1080")
- Negative prompts are appended to the main prompt with "Do not include:" prefix
- Video duration can be specified via `durationSeconds` or `numFrames` (converted to seconds at 24fps)
- Video resolution parameter is mapped to Evolink's `quality` field
- Task polling uses 3-second intervals with 300-attempt timeout (15 minutes max)
- File upload returns hosted URLs that Evolink can reference for image-to-image and image-to-video tasks
- Proper error handling for upload failures, task submission failures, task timeouts, and download failures

https://claude.ai/code/session_01KH6BSvFhLCdH6LVs95MQiQ