### PR TITLE
Multi-asset list inputs + fix partial-run list aggregation

### DIFF
--- a/packages/code-nodes/src/nodes/tool-agents.ts
+++ b/packages/code-nodes/src/nodes/tool-agents.ts
@@ -1012,6 +1012,9 @@ export class EmailAgentNode extends ToolAgentNode {
 
 export class FfmpegAgentNode extends ToolAgentNode {
   static readonly nodeType = "nodetool.agents.FfmpegAgent";
+  // Produces real audio/video assets via set_output_audio/video; persist them
+  // on job completion like other generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly requiredRuntimes = ["ffmpeg"];
   static readonly title = "FFmpeg Agent";
   static readonly inlineFields = [];
@@ -1072,32 +1075,20 @@ export class FfmpegAgentNode extends ToolAgentNode {
   declare model: any;
 
   @prop({
-    type: "audio",
-    default: {
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
+    type: "list[audio]",
+    default: [],
     title: "Audio",
-    description: "Optional audio input for media reasoning tasks."
+    description:
+      "Optional audio inputs for media reasoning tasks. Accepts a list, or a single Audio (auto-wrapped)."
   })
   declare audio: any;
 
   @prop({
-    type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    type: "list[video]",
+    default: [],
     title: "Video",
-    description: "Optional video input for media reasoning tasks."
+    description:
+      "Optional video inputs for media reasoning tasks. Accepts a list, or a single Video (auto-wrapped)."
   })
   declare video: any;
 
@@ -1411,6 +1402,10 @@ export class HttpApiAgentNode extends ToolAgentNode {
 
 export class ImageAgentNode extends ToolAgentNode {
   static readonly nodeType = "nodetool.agents.ImageAgent";
+  // Produces a real image asset via set_output_image; persist it on job
+  // completion (assets table, tagged node_id+job_id) like other generative
+  // media nodes, so it survives reload and appears in node history.
+  static readonly autoSaveAsset = true;
   static readonly title = "Image Agent";
   static readonly inlineFields = [];
   static readonly inputFields = ["prompt", "image"];
@@ -1441,16 +1436,11 @@ export class ImageAgentNode extends ToolAgentNode {
   declare model: any;
 
   @prop({
-    type: "image",
-    default: {
-      type: "image",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
-    title: "Image",
-    description: "Optional image input for image reasoning tasks."
+    type: "list[image]",
+    default: [],
+    title: "Images",
+    description:
+      "Optional image inputs for image reasoning tasks. Accepts a list, or a single Image (auto-wrapped)."
   })
   declare image: any;
 
@@ -1489,6 +1479,9 @@ export class ImageAgentNode extends ToolAgentNode {
 
 export class MediaAgentNode extends ToolAgentNode {
   static readonly nodeType = "nodetool.agents.MediaAgent";
+  // Produces real audio/video assets via set_output_audio/video; persist them
+  // on job completion like other generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly title = "Media Agent";
   static readonly inlineFields = [];
   static readonly inputFields = ["prompt", "audio", "video"];
@@ -1525,32 +1518,20 @@ export class MediaAgentNode extends ToolAgentNode {
   declare model: any;
 
   @prop({
-    type: "audio",
-    default: {
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
+    type: "list[audio]",
+    default: [],
     title: "Audio",
-    description: "Optional audio input for media reasoning tasks."
+    description:
+      "Optional audio inputs for media reasoning tasks. Accepts a list, or a single Audio (auto-wrapped)."
   })
   declare audio: any;
 
   @prop({
-    type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    type: "list[video]",
+    default: [],
     title: "Video",
-    description: "Optional video input for media reasoning tasks."
+    description:
+      "Optional video inputs for media reasoning tasks. Accepts a list, or a single Video (auto-wrapped)."
   })
   declare video: any;
 
@@ -1942,6 +1923,9 @@ export class VectorStoreAgentNode extends ToolAgentNode {
 
 export class YtDlpDownloaderAgentNode extends ToolAgentNode {
   static readonly nodeType = "nodetool.agents.YtDlpDownloaderAgent";
+  // Produces a real downloaded video asset via set_output_video; persist it on
+  // job completion like other generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly title = "yt-dlp Downloader Agent";
   static readonly inlineFields = ["url"];
   static readonly inputFields: string[] = ["prompt"];

--- a/packages/code-nodes/tests/tool-agents.test.ts
+++ b/packages/code-nodes/tests/tool-agents.test.ts
@@ -167,17 +167,17 @@ describe("Agent-specific defaults", () => {
     expect(d.allow_mutation).toBe(false);
   });
 
-  it("FfmpegAgentNode has audio/video refs", () => {
+  it("FfmpegAgentNode has audio/video list inputs", () => {
     const node = new FfmpegAgentNode();
     const d = node.serialize();
-    expect(d.audio).toHaveProperty("type", "audio");
-    expect(d.video).toHaveProperty("type", "video");
+    expect(d.audio).toEqual([]);
+    expect(d.video).toEqual([]);
   });
 
-  it("ImageAgentNode has image ref and timeout 90", () => {
+  it("ImageAgentNode has image list input and timeout 90", () => {
     const node = new ImageAgentNode();
     const d = node.serialize();
-    expect(d.image).toHaveProperty("type", "image");
+    expect(d.image).toEqual([]);
     expect(d.timeout_seconds).toBe(90);
   });
 
@@ -193,6 +193,15 @@ describe("Agent-specific defaults", () => {
     const node = new PdfLibAgentNode();
     const d = node.serialize();
     expect(d.document).toHaveProperty("type", "document");
+  });
+
+  it("media-producing agents auto-save their asset outputs", () => {
+    // Image/audio/video agents persist their generated assets on job completion
+    // (assets table) like other generative media nodes.
+    expect(ImageAgentNode.autoSaveAsset).toBe(true);
+    expect(MediaAgentNode.autoSaveAsset).toBe(true);
+    expect(FfmpegAgentNode.autoSaveAsset).toBe(true);
+    expect(YtDlpDownloaderAgentNode.autoSaveAsset).toBe(true);
   });
 
   it("DocxAgentNode has timeout 300", () => {

--- a/packages/dsl/src/generated/nodetool.agents.ts
+++ b/packages/dsl/src/generated/nodetool.agents.ts
@@ -77,8 +77,8 @@ export interface AgentInputs {
   system?: Connectable<string>;
   prompt?: Connectable<string>;
   tools?: Connectable<unknown[]>;
-  image?: Connectable<ImageRef>;
-  audio?: Connectable<AudioRef>;
+  image?: Connectable<ImageRef[]>;
+  audio?: Connectable<AudioRef[]>;
   history?: Connectable<unknown[]>;
   thread_id?: Connectable<string>;
   max_tokens?: Connectable<number>;
@@ -235,8 +235,8 @@ export function emailAgent(inputs: EmailAgentInputs): DslNode<EmailAgentOutputs,
 // FFmpeg Agent — nodetool.agents.FfmpegAgent
 export interface FfmpegAgentInputs {
   model?: Connectable<unknown>;
-  audio?: Connectable<AudioRef>;
-  video?: Connectable<VideoRef>;
+  audio?: Connectable<AudioRef[]>;
+  video?: Connectable<VideoRef[]>;
   prompt?: Connectable<string>;
   timeout_seconds?: Connectable<number>;
   max_output_chars?: Connectable<number>;
@@ -320,7 +320,7 @@ export function httpApiAgent(inputs: HttpApiAgentInputs): DslNode<HttpApiAgentOu
 // Image Agent — nodetool.agents.ImageAgent
 export interface ImageAgentInputs {
   model?: Connectable<unknown>;
-  image?: Connectable<ImageRef>;
+  image?: Connectable<ImageRef[]>;
   prompt?: Connectable<string>;
   timeout_seconds?: Connectable<number>;
   max_output_chars?: Connectable<number>;
@@ -338,8 +338,8 @@ export function imageAgent(inputs: ImageAgentInputs): DslNode<ImageAgentOutputs>
 // Media Agent — nodetool.agents.MediaAgent
 export interface MediaAgentInputs {
   model?: Connectable<unknown>;
-  audio?: Connectable<AudioRef>;
-  video?: Connectable<VideoRef>;
+  audio?: Connectable<AudioRef[]>;
+  video?: Connectable<VideoRef[]>;
   prompt?: Connectable<string>;
   timeout_seconds?: Connectable<number>;
   max_output_chars?: Connectable<number>;

--- a/packages/dsl/src/generated/nodetool.generators.ts
+++ b/packages/dsl/src/generated/nodetool.generators.ts
@@ -10,8 +10,8 @@ export interface StructuredOutputGeneratorInputs {
   instructions?: Connectable<string>;
   context?: Connectable<string>;
   max_tokens?: Connectable<number>;
-  image?: Connectable<ImageRef>;
-  audio?: Connectable<AudioRef>;
+  image?: Connectable<ImageRef[]>;
+  audio?: Connectable<AudioRef[]>;
 }
 
 export interface StructuredOutputGeneratorOutputs {
@@ -77,8 +77,8 @@ export function chartGenerator(inputs: ChartGeneratorInputs): DslNode<ChartGener
 export interface SVGGeneratorInputs {
   model?: Connectable<unknown>;
   prompt?: Connectable<string>;
-  image?: Connectable<ImageRef>;
-  audio?: Connectable<AudioRef>;
+  image?: Connectable<ImageRef[]>;
+  audio?: Connectable<AudioRef[]>;
   max_tokens?: Connectable<number>;
 }
 

--- a/packages/integration-nodes/tests/kie-tool-agents.test.ts
+++ b/packages/integration-nodes/tests/kie-tool-agents.test.ts
@@ -119,25 +119,11 @@ describe("Tool agent node defaults", () => {
     expect(node.serialize().timeout_seconds).toBe(180);
   });
 
-  it("FfmpegAgentNode has audio and video", () => {
+  it("FfmpegAgentNode has audio/video list inputs", () => {
     const node = new FfmpegAgentNode();
     const d = node.serialize();
-    expect(d.audio).toEqual({
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    });
-    expect(d.video).toEqual({
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    });
+    expect(d.audio).toEqual([]);
+    expect(d.video).toEqual([]);
   });
 
   it("FilesystemAgentNode base defaults", () => {
@@ -160,39 +146,19 @@ describe("Tool agent node defaults", () => {
     expect(node.serialize().timeout_seconds).toBe(180);
   });
 
-  it("ImageAgentNode has image, timeout, max_output_chars", () => {
+  it("ImageAgentNode has image list input, timeout, max_output_chars", () => {
     const node = new ImageAgentNode();
     const d = node.serialize();
-    expect(d.image).toEqual({
-      type: "image",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    });
+    expect(d.image).toEqual([]);
     expect(d.timeout_seconds).toBe(90);
     expect(d.max_output_chars).toBe(120000);
   });
 
-  it("MediaAgentNode has audio and video", () => {
+  it("MediaAgentNode has audio/video list inputs", () => {
     const node = new MediaAgentNode();
     const d = node.serialize();
-    expect(d.audio).toEqual({
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    });
-    expect(d.video).toEqual({
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    });
+    expect(d.audio).toEqual([]);
+    expect(d.video).toEqual([]);
   });
 
   it("PdfLibAgentNode has document and custom timeout", () => {

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -510,19 +510,34 @@ export function expandAssetReferences(prompt: string): MessageContent[] {
   return parts.length > 0 ? parts : [{ type: "text", text: prompt }];
 }
 
+/**
+ * Normalize a list-typed media input to an array. Accepts an array (the
+ * declared `list[image]`/`list[audio]` shape), a lone ref (defensive, in case
+ * coercion didn't run), or null/undefined.
+ */
+function toRefArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined) return [];
+  return [value];
+}
+
 function buildUserMessage(
   prompt: string,
-  image: unknown,
-  audio: unknown
+  images: unknown,
+  audios: unknown
 ): Message {
   const content: MessageContent[] = expandAssetReferences(prompt);
-  const imageRef = normalizeBinaryRef(image);
-  if (imageRef) {
-    content.push({ type: "image_url", image: imageRef });
+  for (const image of toRefArray(images)) {
+    const imageRef = normalizeBinaryRef(image);
+    if (imageRef) {
+      content.push({ type: "image_url", image: imageRef });
+    }
   }
-  const audioRef = normalizeBinaryRef(audio);
-  if (audioRef) {
-    content.push({ type: "audio", audio: audioRef });
+  for (const audio of toRefArray(audios)) {
+    const audioRef = normalizeBinaryRef(audio);
+    if (audioRef) {
+      content.push({ type: "audio", audio: audioRef });
+    }
   }
   return { role: "user", content };
 }
@@ -2376,32 +2391,22 @@ export class AgentNode extends BaseNode {
   declare tools: string[];
 
   @prop({
-    type: "image",
-    default: {
-      type: "image",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
-    title: "Image",
-    description: "The image to analyze"
+    type: "list[image]",
+    default: [],
+    title: "Images",
+    description:
+      "Images to attach to the prompt. Wire a list[image] source to send several at once, or a single Image (auto-wrapped into a one-item list). Each image becomes a separate block in the user message sent to the provider."
   })
-  declare image: ImageRef;
+  declare image: ImageRef[];
 
   @prop({
-    type: "audio",
-    default: {
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
+    type: "list[audio]",
+    default: [],
     title: "Audio",
-    description: "The audio to analyze"
+    description:
+      "Audio clips to attach to the prompt. Wire a list[audio] source to send several at once, or a single Audio (auto-wrapped into a one-item list). Each clip becomes a separate block in the user message sent to the provider."
   })
-  declare audio: AudioRef;
+  declare audio: AudioRef[];
 
   @prop({
     type: "list[message]",
@@ -2503,8 +2508,8 @@ export class AgentNode extends BaseNode {
       asText(this.system ?? DEFAULT_SYSTEM_PROMPT),
       dynamicVars
     );
-    const image = this.image;
-    const audio = this.audio;
+    const images = this.image;
+    const audios = this.audio;
     const historyInput = this.history;
     const history = Array.isArray(historyInput)
       ? historyInput
@@ -2556,7 +2561,7 @@ export class AgentNode extends BaseNode {
       { role: "system", content: system },
       ...(await loadThreadMessages(context, threadId)),
       ...history,
-      buildUserMessage(prompt, image, audio)
+      buildUserMessage(prompt, images, audios)
     ];
     log.info("AgentNode prepared messages", {
       nodeId: this.__node_id ?? null,

--- a/packages/llm-nodes/src/nodes/generators.ts
+++ b/packages/llm-nodes/src/nodes/generators.ts
@@ -149,17 +149,32 @@ function normalizeBinaryRef(value: unknown): BinaryRef | null {
   return out.uri || out.data ? out : null;
 }
 
+/**
+ * Normalize a list-typed media input to an array. Accepts an array (the
+ * declared `list[image]`/`list[audio]` shape), a lone ref (defensive, in case
+ * coercion didn't run), or null/undefined.
+ */
+function toRefArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined) return [];
+  return [value];
+}
+
 function buildMessageContent(
   text: string,
-  image: unknown,
-  audio: unknown
+  images: unknown,
+  audios: unknown
 ): string | MessageContent[] {
-  const imageRef = normalizeBinaryRef(image);
-  const audioRef = normalizeBinaryRef(audio);
-  if (!imageRef && !audioRef) return text;
+  const imageRefs = toRefArray(images)
+    .map(normalizeBinaryRef)
+    .filter((ref): ref is BinaryRef => ref !== null);
+  const audioRefs = toRefArray(audios)
+    .map(normalizeBinaryRef)
+    .filter((ref): ref is BinaryRef => ref !== null);
+  if (imageRefs.length === 0 && audioRefs.length === 0) return text;
   const parts: MessageContent[] = [{ type: "text", text }];
-  if (imageRef) parts.push({ type: "image", image: imageRef });
-  if (audioRef) parts.push({ type: "audio", audio: audioRef });
+  for (const image of imageRefs) parts.push({ type: "image", image });
+  for (const audio of audioRefs) parts.push({ type: "audio", audio });
   return parts;
 }
 
@@ -439,30 +454,20 @@ export class StructuredOutputGeneratorNode extends BaseNode {
   declare max_tokens: any;
 
   @prop({
-    type: "image",
-    default: {
-      type: "image",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
-    title: "Image",
-    description: "Optional image to include in the generation request."
+    type: "list[image]",
+    default: [],
+    title: "Images",
+    description:
+      "Optional images to include in the generation request. Accepts a list, or a single Image (auto-wrapped). Each becomes a separate block in the message sent to the provider."
   })
   declare image: any;
 
   @prop({
-    type: "audio",
-    default: {
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
+    type: "list[audio]",
+    default: [],
     title: "Audio",
-    description: "Optional audio to include in the generation request."
+    description:
+      "Optional audio to include in the generation request. Accepts a list, or a single Audio (auto-wrapped). Each becomes a separate block in the message sent to the provider."
   })
   declare audio: any;
 
@@ -1026,30 +1031,20 @@ export class SVGGeneratorNode extends BaseNode {
   declare prompt: any;
 
   @prop({
-    type: "image",
-    default: {
-      type: "image",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
-    title: "Image",
-    description: "Image to use for generation"
+    type: "list[image]",
+    default: [],
+    title: "Images",
+    description:
+      "Images to use for generation. Accepts a list, or a single Image (auto-wrapped). Each becomes a separate block in the message sent to the provider."
   })
   declare image: any;
 
   @prop({
-    type: "audio",
-    default: {
-      type: "audio",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null
-    },
+    type: "list[audio]",
+    default: [],
     title: "Audio",
-    description: "Audio to use for generation"
+    description:
+      "Audio to use for generation. Accepts a list, or a single Audio (auto-wrapped). Each becomes a separate block in the message sent to the provider."
   })
   declare audio: any;
 

--- a/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
+++ b/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
@@ -616,6 +616,44 @@ describe("AgentNode", () => {
     );
   });
 
+  it("attaches a list of images and audio as separate content blocks", async () => {
+    const n = new (AgentNode as any)();
+    let capturedMessages: any[] = [];
+    const mockProvider = {
+      async *generateMessages({
+        messages
+      }: any): AsyncGenerator<Record<string, unknown>> {
+        capturedMessages = messages;
+        yield {
+          type: "chunk",
+          content: "ok",
+          content_type: "text",
+          done: true
+        };
+      }
+    };
+    n.assign({
+      prompt: "Describe these",
+      image: [{ uri: "file://a.png" }, { uri: "file://b.png" }],
+      audio: [{ data: "YXVkaW8x" }, { data: "YXVkaW8y" }],
+      model: { provider: "test", id: "m1" }
+    });
+    await n.process({ getProvider: async () => mockProvider } as any);
+    const lastUser = capturedMessages[capturedMessages.length - 1];
+    expect(lastUser.role).toBe("user");
+    expect(lastUser.content[0].text).toBe("Describe these");
+    const images = lastUser.content.filter((p: any) => p.type === "image_url");
+    const audios = lastUser.content.filter((p: any) => p.type === "audio");
+    expect(images.map((p: any) => p.image.uri)).toEqual([
+      "file://a.png",
+      "file://b.png"
+    ]);
+    expect(audios.map((p: any) => p.audio.data)).toEqual([
+      "YXVkaW8x",
+      "YXVkaW8y"
+    ]);
+  });
+
   it("persists the user and assistant messages through context thread APIs", async () => {
     const n = new (AgentNode as any)();
     const created: any[] = [];
@@ -1673,6 +1711,33 @@ describe("SVGGeneratorNode", () => {
     const result = await n.process();
     const svg = (result.output as any[])[0].content;
     expect(svg).toContain(">SVG</text>");
+  });
+
+  it("attaches a list of images as separate content blocks", async () => {
+    let captured: any[] = [];
+    const mockContext = {
+      getProvider: async () => ({}),
+      // eslint-disable-next-line require-yield
+      async *streamProviderPrediction() {},
+      runProviderPrediction: async ({ params }: any) => {
+        captured = params.messages;
+        return { content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>' };
+      }
+    };
+    const n = new (SVGGeneratorNode as any)();
+    n.assign({
+      prompt: "draw from these",
+      image: [{ uri: "file://a.png" }, { uri: "file://b.png" }],
+      model: { provider: "test", id: "m1" }
+    });
+    await n.process(mockContext as any);
+    const user = captured[captured.length - 1];
+    expect(user.role).toBe("user");
+    const images = user.content.filter((p: any) => p.type === "image");
+    expect(images.map((p: any) => p.image.uri)).toEqual([
+      "file://a.png",
+      "file://b.png"
+    ]);
   });
 
   it("defaults width/height to 512 when given 0 or NaN", async () => {

--- a/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
@@ -19,8 +19,23 @@ jest.mock("../../../stores/NotificationStore", () => ({
   useNotificationStore: jest.fn()
 }));
 
+jest.mock("../../../stores/MetadataStore", () => ({
+  __esModule: true,
+  default: { getState: jest.fn(() => ({ getMetadata: () => undefined })) }
+}));
+
+jest.mock("../../../utils/edgeValue", () => ({
+  resolveExternalEdgeValue: jest.fn(() => ({
+    value: undefined,
+    hasValue: false,
+    isFallback: false
+  }))
+}));
+
 
 import { useNodeStoreRef } from "../../../contexts/NodeContext";
+import useMetadataStore from "../../../stores/MetadataStore";
+import { resolveExternalEdgeValue } from "../../../utils/edgeValue";
 import {
   useWebsocketRunner,
   getWorkflowRunnerStore
@@ -33,6 +48,8 @@ const mockUseWebsocketRunner = useWebsocketRunner as jest.Mock;
 const mockGetWorkflowRunnerStore = getWorkflowRunnerStore as jest.Mock;
 const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
 const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
+const mockMetadataGetState = (useMetadataStore as unknown as { getState: jest.Mock }).getState;
+const mockResolveExternalEdgeValue = resolveExternalEdgeValue as jest.Mock;
 
 type RunnerState = {
   state: "idle" | "running" | "error" | "cancelled" | "connecting";
@@ -311,6 +328,80 @@ describe("useRunSelectedNodes", () => {
 
     // Only the first run was dispatched; the sequence broke on error.
     expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("aggregates multiple external edges into a list[image] handle instead of last-write-wins", async () => {
+    const falNode = {
+      id: "node-f",
+      type: "fal.image_to_image.IdeogramV3Edit",
+      data: { properties: { images: [] } },
+      selected: true
+    };
+    const img1 = {
+      id: "img-1",
+      type: "nodetool.constant.Image",
+      data: { properties: {} },
+      selected: false
+    };
+    const img2 = {
+      id: "img-2",
+      type: "nodetool.constant.Image",
+      data: { properties: {} },
+      selected: false
+    };
+    const edges = [
+      { id: "ei1", source: "img-1", target: "node-f", sourceHandle: "output", targetHandle: "images" },
+      { id: "ei2", source: "img-2", target: "node-f", sourceHandle: "output", targetHandle: "images" }
+    ];
+
+    mockGetSelectedNodes.mockReturnValue([falNode]);
+    mockFindNode.mockImplementation((id: string) =>
+      [falNode, img1, img2].find((n) => n.id === id)
+    );
+    mockUseNodeStoreRef.mockReturnValue({
+      getState: () => ({
+        nodes: [falNode, img1, img2],
+        edges,
+        workflow: defaultWorkflow,
+        findNode: mockFindNode,
+        getSelectedNodes: mockGetSelectedNodes
+      })
+    });
+
+    // Each upstream edge resolves to a distinct image ref.
+    mockResolveExternalEdgeValue.mockImplementation((edge: { source: string }) => ({
+      value: { type: "image", uri: edge.source === "img-1" ? "a.png" : "b.png" },
+      hasValue: true,
+      isFallback: false
+    }));
+
+    // `images` is a list[image] (collect) handle.
+    mockMetadataGetState.mockReturnValue({
+      getMetadata: (type: string) =>
+        type === "fal.image_to_image.IdeogramV3Edit"
+          ? {
+              properties: [
+                {
+                  name: "images",
+                  type: { type: "list", type_args: [{ type: "image", type_args: [] }] }
+                }
+              ]
+            }
+          : undefined
+    });
+
+    const { result } = renderHook(() => useRunSelectedNodes());
+    await act(async () => {
+      await result.current.runSelectedNodes();
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const nodesPassedToRun = mockRun.mock.calls[0][2];
+    const fal = nodesPassedToRun.find((n: { id: string }) => n.id === "node-f");
+    expect(fal.data.properties.images).toEqual([
+      { type: "image", uri: "a.png" },
+      { type: "image", uri: "b.png" }
+    ]);
   });
 
   it("clamps runs to the supported range [1, 32]", async () => {

--- a/web/src/hooks/nodes/useRunSelectedNodes.ts
+++ b/web/src/hooks/nodes/useRunSelectedNodes.ts
@@ -10,6 +10,11 @@ import { resolveExternalEdgeValue } from "../../utils/edgeValue";
 import { getNodeGenerations } from "../../stores/nodeGenerationAccessor";
 import { getCurrentGeneration } from "../../utils/nodeGenerations";
 import { useNodeStoreRef } from "../../contexts/NodeContext";
+import useMetadataStore from "../../stores/MetadataStore";
+import {
+  EdgeOverrideCollector,
+  applyNodeOverrides
+} from "../../utils/edgeOverrides";
 
 export const MIN_RUNS = 1;
 export const MAX_RUNS = 32;
@@ -91,19 +96,18 @@ export function useRunSelectedNodes(): UseRunSelectedNodesReturn {
         return current?.outputs;
       };
 
-      const nodePropertyOverrides = new Map<string, Record<string, unknown>>();
-
+      // Seed each selected node's inputs from its external (non-selected)
+      // upstreams. The collector aggregates multiple edges into one list/collect
+      // handle — see EdgeOverrideCollector — so two images wired to a single
+      // list[image] handle aren't collapsed to one (last-write-wins).
+      const collector = new EdgeOverrideCollector();
       for (const edge of externalInputEdges) {
-        const sourceNodeId = edge.source;
-        const sourceHandle = edge.sourceHandle;
-        const targetNodeId = edge.target;
         const targetHandle = edge.targetHandle;
-
         if (!targetHandle) {
           continue;
         }
 
-        const { value, hasValue, isFallback } = resolveExternalEdgeValue(
+        const { value, hasValue } = resolveExternalEdgeValue(
           edge,
           workflow.id,
           getResultForFocusedJob,
@@ -113,50 +117,17 @@ export function useRunSelectedNodes(): UseRunSelectedNodesReturn {
           continue;
         }
 
-        const existing = nodePropertyOverrides.get(targetNodeId) || {};
-        existing[targetHandle] = value;
-        nodePropertyOverrides.set(targetNodeId, existing);
-
-        console.info(
-          `Run selected nodes: Caching property ${targetHandle} on node ${targetNodeId} from upstream node ${sourceNodeId}`,
-          {
-            sourceHandle,
-            valueSource: isFallback ? "node" : "cached_result"
-          }
-        );
+        collector.add(edge.target, targetHandle, value);
       }
 
-      const nodesWithCachedValues = selectedNodes.map((n: Node<NodeData>) => {
-        const overrides = nodePropertyOverrides.get(n.id);
-        if (overrides && Object.keys(overrides).length > 0) {
-          const dynamicProps = n.data?.dynamic_properties || {};
-          const staticProps = n.data?.properties || {};
-          const updatedDynamicProps = { ...dynamicProps };
-          const updatedStaticProps = { ...staticProps };
+      const nodePropertyOverrides = collector.resolve(
+        findNode,
+        useMetadataStore.getState().getMetadata
+      );
 
-          for (const [key, value] of Object.entries(overrides)) {
-            if (Object.prototype.hasOwnProperty.call(dynamicProps, key)) {
-              updatedDynamicProps[key] = value;
-            } else {
-              updatedStaticProps[key] = value;
-            }
-          }
-
-          return {
-            ...n,
-            data: {
-              ...n.data,
-              properties: {
-                ...updatedStaticProps
-              },
-              dynamic_properties: {
-                ...updatedDynamicProps
-              }
-            }
-          };
-        }
-        return n;
-      });
+      const nodesWithCachedValues = selectedNodes.map((n: Node<NodeData>) =>
+        applyNodeOverrides(n, nodePropertyOverrides.get(n.id))
+      );
 
       console.info(
         `Running workflow from ${selectedNodes.length} selected node(s) × ${totalRuns} run(s)`,

--- a/web/src/stores/__tests__/NodeStore.test.ts
+++ b/web/src/stores/__tests__/NodeStore.test.ts
@@ -394,6 +394,96 @@ describe("Edge Validation", () => {
     expect(target?.data.exposedInputs).toEqual(["input1"]);
   });
 
+  test("onConnect allows multiple edges into a list[image] collect handle (fal node)", () => {
+    restoreAddEdge();
+    const imageType = {
+      type: "image",
+      optional: false,
+      values: null,
+      type_args: [],
+      type_name: null
+    };
+    const listImageType = {
+      type: "list",
+      optional: false,
+      values: null,
+      type_args: [imageType],
+      type_name: null
+    };
+    useMetadataStore.setState(
+      {
+        ...useMetadataStore.getState(),
+        metadata: {
+          ...mockMetadata,
+          img_source: {
+            node_type: "img_source",
+            title: "Img",
+            description: "",
+            namespace: "test",
+            layout: "default",
+            outputs: [{ name: "image", type: imageType, stream: false }],
+            properties: [],
+            supports_dynamic_inputs: false,
+            supports_dynamic_outputs: false,
+            recommended_models: [],
+            is_streaming_output: false,
+            required_settings: []
+          } as unknown as NodeMetadata,
+          fal_test: {
+            node_type: "fal_test",
+            title: "Fal",
+            description: "",
+            namespace: "fal",
+            layout: "default",
+            outputs: [{ name: "output", type: imageType, stream: false }],
+            properties: [
+              {
+                name: "images",
+                type: listImageType,
+                default: [],
+                title: "Images",
+                description: "",
+                required: false
+              }
+            ],
+            input_fields: ["images"],
+            supports_dynamic_inputs: false,
+            supports_dynamic_outputs: false,
+            recommended_models: [],
+            is_streaming_output: false,
+            required_settings: []
+          } as unknown as NodeMetadata
+        }
+      },
+      true
+    );
+
+    const src1 = makeNode("s1", store.getState().workflow.id, "img_source");
+    const src2 = makeNode("s2", store.getState().workflow.id, "img_source");
+    const fal = makeNode("f", store.getState().workflow.id, "fal_test");
+    store.getState().addNode(src1);
+    store.getState().addNode(src2);
+    store.getState().addNode(fal);
+
+    store.getState().onConnect({
+      source: "s1",
+      target: "f",
+      sourceHandle: "image",
+      targetHandle: "images"
+    });
+    store.getState().onConnect({
+      source: "s2",
+      target: "f",
+      sourceHandle: "image",
+      targetHandle: "images"
+    });
+
+    const imagesEdges = store
+      .getState()
+      .edges.filter((e) => e.target === "f" && e.targetHandle === "images");
+    expect(imagesEdges).toHaveLength(2);
+  });
+
   test("onConnect does not promote when target is already a metadata-defined input handle", () => {
     restoreAddEdge();
     // Declare input1 in input_fields so its handle is already metadata-driven.

--- a/web/src/utils/__tests__/edgeOverrides.test.ts
+++ b/web/src/utils/__tests__/edgeOverrides.test.ts
@@ -1,0 +1,94 @@
+import { Node } from "@xyflow/react";
+import { EdgeOverrideCollector, applyNodeOverrides } from "../edgeOverrides";
+import { NodeData } from "../../stores/NodeData";
+import { NodeMetadata } from "../../stores/ApiTypes";
+
+const node = (
+  id: string,
+  type: string,
+  data: Partial<NodeData> = {}
+): Node<NodeData> => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: {
+    properties: {},
+    dynamic_properties: {},
+    selectable: true,
+    workflow_id: "wf",
+    ...data
+  } as NodeData
+});
+
+// `target.list` is a collect (list[image]) handle; everything else is scalar.
+const getMetadata = (type: string): NodeMetadata =>
+  ({
+    title: type,
+    properties: [
+      {
+        name: "list",
+        type: { type: "list", type_args: [{ type: "image", type_args: [] }] }
+      },
+      { name: "scalar", type: { type: "image", type_args: [] } }
+    ]
+  }) as unknown as NodeMetadata;
+
+describe("EdgeOverrideCollector", () => {
+  const findNode = (nodes: Node<NodeData>[]) => (id: string) =>
+    nodes.find((n) => n.id === id);
+
+  it("passes a single edge's value through unchanged (no list wrapping)", () => {
+    const n = node("t", "T");
+    const c = new EdgeOverrideCollector();
+    c.add("t", "list", { uri: "a.png" });
+    const overrides = c.resolve(findNode([n]), getMetadata);
+    expect(overrides.get("t")).toEqual({ list: { uri: "a.png" } });
+  });
+
+  it("aggregates 2+ edges into a list when the handle is a collect type", () => {
+    const n = node("t", "T");
+    const c = new EdgeOverrideCollector();
+    c.add("t", "list", { uri: "a.png" });
+    c.add("t", "list", { uri: "b.png" });
+    const overrides = c.resolve(findNode([n]), getMetadata);
+    expect(overrides.get("t")).toEqual({
+      list: [{ uri: "a.png" }, { uri: "b.png" }]
+    });
+  });
+
+  it("keeps last-write-wins for 2+ edges into a non-collect handle", () => {
+    const n = node("t", "T");
+    const c = new EdgeOverrideCollector();
+    c.add("t", "scalar", { uri: "a.png" });
+    c.add("t", "scalar", { uri: "b.png" });
+    const overrides = c.resolve(findNode([n]), getMetadata);
+    expect(overrides.get("t")).toEqual({ scalar: { uri: "b.png" } });
+  });
+
+  it("does not aggregate when metadata is missing for the handle", () => {
+    const n = node("t", "T");
+    const c = new EdgeOverrideCollector();
+    c.add("t", "unknown", { uri: "a.png" });
+    c.add("t", "unknown", { uri: "b.png" });
+    const overrides = c.resolve(findNode([n]), getMetadata);
+    expect(overrides.get("t")).toEqual({ unknown: { uri: "b.png" } });
+  });
+});
+
+describe("applyNodeOverrides", () => {
+  it("returns the node unchanged when there are no overrides", () => {
+    const n = node("t", "T");
+    expect(applyNodeOverrides(n, undefined)).toBe(n);
+    expect(applyNodeOverrides(n, {})).toBe(n);
+  });
+
+  it("routes keys to dynamic_properties when present there, else static", () => {
+    const n = node("t", "T", {
+      properties: { a: 1 },
+      dynamic_properties: { b: 2 }
+    });
+    const result = applyNodeOverrides(n, { a: 10, b: 20, c: 30 });
+    expect(result.data.properties).toEqual({ a: 10, c: 30 });
+    expect(result.data.dynamic_properties).toEqual({ b: 20 });
+  });
+});

--- a/web/src/utils/__tests__/runSubgraph.test.ts
+++ b/web/src/utils/__tests__/runSubgraph.test.ts
@@ -1,6 +1,7 @@
 import { Edge, Node } from "@xyflow/react";
 import { buildRunSubgraph } from "../runSubgraph";
 import { NodeData } from "../../stores/NodeData";
+import { NodeMetadata } from "../../stores/ApiTypes";
 
 const WF = "wf1";
 
@@ -29,8 +30,12 @@ const edge = (
 ): Edge => ({ id, source, target, sourceHandle, targetHandle, type: "default" });
 
 // Generative nodes are the ones flagged auto_save_asset.
-const getMetadata = (type: string) =>
-  type.startsWith("gen.") ? { auto_save_asset: true, title: type } : { title: type };
+const getMetadata = (type: string): NodeMetadata =>
+  ({
+    auto_save_asset: type.startsWith("gen."),
+    title: type,
+    properties: []
+  }) as unknown as NodeMetadata;
 
 const noResults = () => undefined;
 
@@ -154,6 +159,59 @@ describe("buildRunSubgraph", () => {
     });
     expect(sub.nodeIds).toEqual(new Set(["t", "m"]));
     expect(sub.blocked).toEqual([{ nodeId: "g", title: "gen.Audio" }]);
+  });
+
+  it("aggregates two edges into a list[image] handle instead of last-write-wins", () => {
+    const target = node("grid", "lib.grid.CombineImageGrid");
+    const genA = node("a", "gen.Image");
+    const genB = node("b", "gen.Image");
+
+    // Both upstreams have cached results, so they're inlined as overrides.
+    const getResult = (_wf: string, src: string) =>
+      src === "a"
+        ? { output: { uri: "a.png", type: "image" } }
+        : src === "b"
+          ? { output: { uri: "b.png", type: "image" } }
+          : undefined;
+
+    // The grid's `tiles` handle is list[image] → a collect type.
+    const getMetadataWithList = (type: string): NodeMetadata =>
+      ({
+        auto_save_asset: type.startsWith("gen."),
+        title: type,
+        properties:
+          type === "lib.grid.CombineImageGrid"
+            ? [
+                {
+                  name: "tiles",
+                  type: {
+                    type: "list",
+                    type_args: [{ type: "image", type_args: [] }]
+                  }
+                }
+              ]
+            : []
+      }) as unknown as NodeMetadata;
+
+    const sub = buildRunSubgraph({
+      targetId: "grid",
+      nodes: [target, genA, genB],
+      edges: [
+        edge("e1", "a", "grid", "tiles"),
+        edge("e2", "b", "grid", "tiles")
+      ],
+      workflowId: WF,
+      getResult,
+      getMetadata: getMetadataWithList
+    });
+
+    expect(sub.blocked).toEqual([]);
+    expect(sub.nodeIds).toEqual(new Set(["grid"]));
+    const submitted = sub.nodes.find((n) => n.id === "grid")!;
+    expect(submitted.data.properties.tiles).toEqual([
+      { uri: "a.png", type: "image" },
+      { uri: "b.png", type: "image" }
+    ]);
   });
 
   it("deduplicates a generative upstream feeding two inputs", () => {

--- a/web/src/utils/edgeOverrides.ts
+++ b/web/src/utils/edgeOverrides.ts
@@ -1,0 +1,103 @@
+import { Node } from "@xyflow/react";
+import { NodeData } from "../stores/NodeData";
+import { NodeMetadata } from "../stores/ApiTypes";
+import { findInputHandle } from "./handleUtils";
+import { isCollectType } from "./TypeHandler";
+
+type FindNode = (id: string) => Node<NodeData> | undefined;
+type GetMetadata = (nodeType: string) => NodeMetadata | undefined;
+
+/**
+ * Shared builder for the property overrides that the partial-run paths inject in
+ * place of edges they don't submit (single-node "Run Node"/"Run from here" via
+ * {@link buildRunSubgraph}, and "run selected nodes"). Both seed a target node's
+ * inputs from upstream values that won't run as part of the partial graph.
+ *
+ * Accumulates every external upstream value per (targetNode, targetHandle) in
+ * the order it's added, then resolves: a handle fed by 2+ upstreams aggregates
+ * into a list when the handle is a list/collect type — mirroring the kernel's
+ * multi-edge list aggregation. Without this, two edges wired into one
+ * `list[image]` handle collapse to a single image (last-write-wins).
+ */
+export class EdgeOverrideCollector {
+  private readonly byNode = new Map<string, Map<string, unknown[]>>();
+
+  /** Record one resolved upstream value for a target node's input handle. */
+  add(nodeId: string, handle: string, value: unknown): void {
+    let handles = this.byNode.get(nodeId);
+    if (!handles) {
+      handles = new Map();
+      this.byNode.set(nodeId, handles);
+    }
+    const values = handles.get(handle) ?? [];
+    values.push(value);
+    handles.set(handle, values);
+  }
+
+  /**
+   * Resolve accumulated values into final per-node override records. A single
+   * edge passes its value through unchanged (so an edge already carrying a list
+   * isn't double-wrapped); only when 2+ edges feed one handle do we consult
+   * metadata to decide whether to aggregate into a list.
+   */
+  resolve(
+    findNode: FindNode,
+    getMetadata: GetMetadata
+  ): Map<string, Record<string, unknown>> {
+    const overrides = new Map<string, Record<string, unknown>>();
+    for (const [nodeId, handles] of this.byNode) {
+      const node = findNode(nodeId);
+      const meta = node?.type ? getMetadata(node.type) : undefined;
+      const resolved: Record<string, unknown> = {};
+      for (const [handle, values] of handles) {
+        if (values.length <= 1) {
+          resolved[handle] = values[0];
+          continue;
+        }
+        let isCollect = false;
+        if (node && meta) {
+          const inputHandle = findInputHandle(node, handle, meta);
+          isCollect = inputHandle?.type
+            ? isCollectType(inputHandle.type)
+            : false;
+        }
+        resolved[handle] = isCollect ? values : values[values.length - 1];
+      }
+      overrides.set(nodeId, resolved);
+    }
+    return overrides;
+  }
+}
+
+/**
+ * Merge override values into a node's properties, routing each key to
+ * `dynamic_properties` when the node already carries it there, otherwise to
+ * static `properties`. Returns the node unchanged when there are no overrides.
+ */
+export function applyNodeOverrides(
+  node: Node<NodeData>,
+  overrides: Record<string, unknown> | undefined
+): Node<NodeData> {
+  if (!overrides || Object.keys(overrides).length === 0) {
+    return node;
+  }
+  const dynamicProps = node.data?.dynamic_properties || {};
+  const staticProps = node.data?.properties || {};
+  const updatedDynamicProps = { ...dynamicProps };
+  const updatedStaticProps = { ...staticProps };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (Object.prototype.hasOwnProperty.call(dynamicProps, key)) {
+      updatedDynamicProps[key] = value;
+    } else {
+      updatedStaticProps[key] = value;
+    }
+  }
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      properties: updatedStaticProps,
+      dynamic_properties: updatedDynamicProps
+    }
+  };
+}

--- a/web/src/utils/runSubgraph.ts
+++ b/web/src/utils/runSubgraph.ts
@@ -1,11 +1,11 @@
 import { Edge, Node } from "@xyflow/react";
 import { NodeData } from "../stores/NodeData";
+import { NodeMetadata } from "../stores/ApiTypes";
 import { resolveExternalEdgeValue } from "./edgeValue";
+import { EdgeOverrideCollector, applyNodeOverrides } from "./edgeOverrides";
 
 type GetResult = (_workflowId: string, _nodeId: string) => unknown;
-type GetMetadata = (
-  _nodeType: string
-) => { auto_save_asset?: boolean; title?: string } | undefined;
+type GetMetadata = (_nodeType: string) => NodeMetadata | undefined;
 
 export interface BlockedUpstream {
   nodeId: string;
@@ -21,34 +21,6 @@ export interface RunSubgraph {
   /** Uncached generative upstreams that must be executed before this run. */
   blocked: BlockedUpstream[];
 }
-
-const applyOverrides = (
-  node: Node<NodeData>,
-  overrides: Record<string, unknown> | undefined
-): Node<NodeData> => {
-  if (!overrides || Object.keys(overrides).length === 0) {
-    return node;
-  }
-  const dynamicProps = node.data?.dynamic_properties || {};
-  const staticProps = node.data?.properties || {};
-  const updatedDynamicProps = { ...dynamicProps };
-  const updatedStaticProps = { ...staticProps };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (Object.prototype.hasOwnProperty.call(dynamicProps, key)) {
-      updatedDynamicProps[key] = value;
-    } else {
-      updatedStaticProps[key] = value;
-    }
-  }
-  return {
-    ...node,
-    data: {
-      ...node.data,
-      properties: updatedStaticProps,
-      dynamic_properties: updatedDynamicProps
-    }
-  };
-};
 
 const nodeTitle = (node: Node<NodeData>, getMetadata: GetMetadata): string => {
   const dataTitle = (node.data as { title?: unknown } | undefined)?.title;
@@ -96,15 +68,9 @@ export const buildRunSubgraph = ({
   }
 
   const included = new Set<string>([targetId]);
-  const overrides = new Map<string, Record<string, unknown>>();
+  const collector = new EdgeOverrideCollector();
   const blocked: BlockedUpstream[] = [];
   const blockedSeen = new Set<string>();
-
-  const setOverride = (nodeId: string, handle: string, value: unknown) => {
-    const existing = overrides.get(nodeId) ?? {};
-    existing[handle] = value;
-    overrides.set(nodeId, existing);
-  };
 
   const stack: string[] = [targetId];
   while (stack.length) {
@@ -122,7 +88,7 @@ export const buildRunSubgraph = ({
         findNode
       );
       if (hasValue) {
-        setOverride(currentId, edge.targetHandle, value);
+        collector.add(currentId, edge.targetHandle, value);
         continue;
       }
 
@@ -150,10 +116,12 @@ export const buildRunSubgraph = ({
     }
   }
 
+  const overrides = collector.resolve(findNode, getMetadata);
+
   const subgraphNodes = [...included]
     .map((id) => findNode(id))
     .filter((n): n is Node<NodeData> => Boolean(n))
-    .map((n) => applyOverrides(n, overrides.get(n.id)));
+    .map((n) => applyNodeOverrides(n, overrides.get(n.id)));
 
   const subgraphEdges = edges.filter(
     (e) => included.has(e.source) && included.has(e.target)


### PR DESCRIPTION
## Summary

Three related changes around feeding **multiple media assets** into AI/agent nodes:

1. **List inputs on AI/agent nodes.** Several nodes that took a single image/audio/video now take a list. Single values still auto-wrap to a 1-element list, so existing graphs keep working.
   - `AgentNode`: `image → list[image]`, `audio → list[audio]`
   - `StructuredOutputGenerator`, `SVGGenerator`: `image/audio → list[image]/list[audio]`
   - `ImageAgent`: `image → list[image]`
   - `MediaAgent`, `FfmpegAgent`: `audio/video → list[audio]/list[video]`
   - DSL input types regenerated to match.

2. **Partial-run list aggregation fix.** When you run a single node ("Run Node" / "Run from here") or "run selected nodes", upstream values that aren't part of the partial graph are injected as property overrides. Two edges wired into one `list[image]` handle were collapsed to a single image (**last-write-wins**). They now aggregate into a list when the handle is a list/collect type — mirroring the kernel's existing multi-edge list aggregation for full runs.

   The two partial-run paths (`useRunSelectedNodes` and `buildRunSubgraph`) had **independently duplicated** the override-building, the list-aggregation decision, and the static/dynamic property merge — which is why the same bug had to be fixed twice. Consolidated all of it into a shared `EdgeOverrideCollector` + `applyNodeOverrides` in `web/src/utils/edgeOverrides.ts`.

3. **Persist agent-generated media.** `ImageAgent`, `MediaAgent`, `FfmpegAgent`, and `YtDlpDownloaderAgent` produce real image/audio/video assets but were session-only. They now set `autoSaveAsset = true`, so their outputs are written to the assets table (survive reload, appear in node history, reusable as cached upstreams) like other generative media nodes.

## Behavioral note

Marking those agents as generative also reclassifies them in `buildRunSubgraph`: an **uncached** instance feeding a downstream partial run now **blocks** with "Run X first" instead of being silently re-executed — consistent with how fal/replicate nodes behave, and preferable for expensive LLM+tool agents.

## Verification

- `code-nodes` (96) and `llm-nodes` (451) suites pass.
- New `web` unit tests: `edgeOverrides.test.ts`; regression tests added to `runSubgraph.test.ts` and `useRunSelectedNodes.test.ts`.
- `web` typecheck + lint clean; `build:packages` (tsc per package) clean.
- Manually verified a real FAL multi-image edit endpoint (`qwen-image-edit-2509`) accepts a 2-element `image_urls` array end-to-end through the package's upload/submit path.

## Out of scope (follow-ups)
- Surfacing FAL's 422 validation `detail` (the generic "Unprocessable Entity" hides the real cause, e.g. `image_too_small`) — useful, but kept separate to keep this PR focused.
- A reported content-card display issue for a fal edit node after partial runs is still under investigation and is unrelated to this PR's display path (verified sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)