### PR TITLE
Add support for AtlasCloud, xAI, Together, and MiniMax providers

### DIFF
--- a/web/src/utils/__tests__/nodeProvider.test.ts
+++ b/web/src/utils/__tests__/nodeProvider.test.ts
@@ -87,6 +87,10 @@ describe("nodeProvider", () => {
       expect(getProviderKindForNamespace("anthropic")).toBe("api");
       expect(getProviderKindForNamespace("replicate")).toBe("api");
       expect(getProviderKindForNamespace("fal")).toBe("api");
+      expect(getProviderKindForNamespace("atlascloud")).toBe("api");
+      expect(getProviderKindForNamespace("xai")).toBe("api");
+      expect(getProviderKindForNamespace("together")).toBe("api");
+      expect(getProviderKindForNamespace("minimax")).toBe("api");
     });
 
     it('returns "local" for local-only namespaces', () => {

--- a/web/src/utils/nodeProvider.ts
+++ b/web/src/utils/nodeProvider.ts
@@ -25,7 +25,11 @@ const namespaceToSecretKey: Record<string, string> = {
   reve: "REVE_API_KEY",
   fal: "FAL_API_KEY",
   elevenlabs: "ELEVENLABS_API_KEY",
-  search: "SERPAPI_API_KEY"
+  search: "SERPAPI_API_KEY",
+  atlascloud: "ATLASCLOUD_API_KEY",
+  xai: "XAI_API_KEY",
+  together: "TOGETHER_API_KEY",
+  minimax: "MINIMAX_API_KEY"
 };
 
 // API-backed namespaces that currently do not require a dedicated key in this map.
@@ -57,7 +61,11 @@ const secretKeyToDisplayName: Record<string, string> = {
   REVE_API_KEY: "Reve API Key",
   FAL_API_KEY: "FAL API Key",
   ELEVENLABS_API_KEY: "ElevenLabs API Key",
-  SERPAPI_API_KEY: "SerpAPI Key"
+  SERPAPI_API_KEY: "SerpAPI Key",
+  ATLASCLOUD_API_KEY: "AtlasCloud API Key",
+  XAI_API_KEY: "xAI API Key",
+  TOGETHER_API_KEY: "Together API Key",
+  MINIMAX_API_KEY: "MiniMax API Key"
 };
 
 export const getRootNamespace = (namespace: string): string =>


### PR DESCRIPTION
## Summary
Adds configuration support for four new API providers: AtlasCloud, xAI, Together, and MiniMax. These providers are registered in the node provider utility and can now be used as API-backed namespaces with their respective API keys.

## Changes
- **`web/src/utils/nodeProvider.ts`**:
  - Added four new namespace-to-secret-key mappings:
    - `atlascloud` → `ATLASCLOUD_API_KEY`
    - `xai` → `XAI_API_KEY`
    - `together` → `TOGETHER_API_KEY`
    - `minimax` → `MINIMAX_API_KEY`
  - Added corresponding display name mappings in `secretKeyToDisplayName` for UI presentation

- **`web/src/utils/__tests__/nodeProvider.test.ts`**:
  - Added test assertions confirming all four new providers return `"api"` as their provider kind

## Implementation Details
These providers follow the existing pattern for API-backed namespaces and do not require dedicated entries in the `apiBackedNamespacesWithoutKey` map, meaning they will use the standard API key authentication flow.

https://claude.ai/code/session_015rZg5FghkYQ9aBpsBUPGxz