### PR TITLE
Fix keyboard shortcut stacking for overlapping combo registrations

### DIFF
--- a/web/src/hooks/__tests__/useNodeEditorShortcuts.test.tsx
+++ b/web/src/hooks/__tests__/useNodeEditorShortcuts.test.tsx
@@ -8,7 +8,8 @@ import {
 const mockOpenNodeMenu = jest.fn();
 
 jest.mock("../../stores/KeyPressedStore", () => ({
-  registerComboCallback: jest.fn(),
+  // registerComboCallback returns a disposer; hand back a no-op so cleanup works
+  registerComboCallback: jest.fn(() => jest.fn()),
   unregisterComboCallback: jest.fn()
 }));
 

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  registerComboCallback,
-  unregisterComboCallback
-} from "../stores/KeyPressedStore";
+import { registerComboCallback } from "../stores/KeyPressedStore";
 import { NODE_EDITOR_SHORTCUTS } from "../config/shortcuts";
 import { getIsElectronDetails, isTextInputActive } from "../utils/browser";
 import { getMousePosition } from "../utils/MousePosition";
@@ -696,7 +693,7 @@ export const useNodeEditorShortcuts = (
       return;
     }
 
-    const registered: string[] = [];
+    const disposers: Array<() => void> = [];
 
     NODE_EDITOR_SHORTCUTS.forEach((sc) => {
       if (!sc.registerCombo) {
@@ -721,17 +718,18 @@ export const useNodeEditorShortcuts = (
           .map((k) => k.toLowerCase())
           .sort()
           .join("+");
-        registerComboCallback(normalized, {
-          callback: meta.callback,
-          preventDefault: meta.preventDefault ?? true,
-          active: meta.active ?? true
-        });
-        registered.push(normalized);
+        disposers.push(
+          registerComboCallback(normalized, {
+            callback: meta.callback,
+            preventDefault: meta.preventDefault ?? true,
+            active: meta.active ?? true
+          })
+        );
       });
     });
 
     return () => {
-      registered.forEach((combo) => unregisterComboCallback(combo));
+      disposers.forEach((dispose) => dispose());
     };
     // selectedNodeCount affects active flags for align shortcuts
   }, [active, selectedNodeCount, electronDetails, shortcutMeta]);

--- a/web/src/stores/KeyPressedStore.ts
+++ b/web/src/stores/KeyPressedStore.ts
@@ -11,7 +11,7 @@
  */
 
 import { create } from "zustand";
-import { useMemo, useEffect, useContext } from "react";
+import { useMemo, useEffect, useContext, useRef } from "react";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/shallow";
 import { KeyboardContext } from "../components/KeyboardProvider";
@@ -48,7 +48,16 @@ interface ComboOptions {
 }
 
 // Module-level variables and functions
-const comboCallbacks = new Map<string, ComboOptions>();
+type ComboRegistration = ComboOptions & { token: symbol };
+
+// Each combo maps to a STACK of registrations rather than a single slot.
+// Multiple components routinely bind the same combo (e.g. several modals, the
+// node menu, and the toolbar all bind "escape"). With a single slot the last
+// mount overwrote the earlier binding and the first UNMOUNT deleted the binding
+// for everyone — so shortcuts intermittently stopped working. A stack lets the
+// most-recently-registered active binding win (a focused modal shadows the
+// background editor) while unmounting one binding leaves the others intact.
+const comboCallbacks = new Map<string, ComboRegistration[]>();
 let lastPointerDownWasCanvas = false;
 
 const isWorkflowEditorElement = (node: Element | null | undefined): boolean =>
@@ -57,15 +66,74 @@ const isWorkflowEditorElement = (node: Element | null | undefined): boolean =>
     node.closest(".react-flow__renderer") !== null ||
     node.closest("[data-workflow-editor]") !== null);
 
-const registerComboCallback = (combo: string, options: ComboOptions = {}) => {
+/**
+ * Registers a combo handler and returns a disposer that removes exactly that
+ * handler (by identity), regardless of what else registered the same combo in
+ * the meantime. Prefer the returned disposer over {@link unregisterComboCallback}.
+ */
+const registerComboCallback = (
+  combo: string,
+  options: ComboOptions = {}
+): (() => void) => {
   // Normalize 'ctrl' to 'control' for consistency
   const normalizedCombo = combo.replace(/\bctrl\b/g, "control");
-  comboCallbacks.set(normalizedCombo, options);
+  const registration: ComboRegistration = {
+    ...options,
+    token: Symbol(normalizedCombo)
+  };
+  const stack = comboCallbacks.get(normalizedCombo);
+  if (stack) {
+    stack.push(registration);
+  } else {
+    comboCallbacks.set(normalizedCombo, [registration]);
+  }
+
+  return () => {
+    const current = comboCallbacks.get(normalizedCombo);
+    if (!current) {
+      return;
+    }
+    const index = current.findIndex((r) => r.token === registration.token);
+    if (index !== -1) {
+      current.splice(index, 1);
+    }
+    if (current.length === 0) {
+      comboCallbacks.delete(normalizedCombo);
+    }
+  };
 };
 
 const unregisterComboCallback = (combo: string) => {
+  // Back-compat helper: pops the most-recently-registered binding for the
+  // combo. Precise removal should use the disposer from registerComboCallback.
   const normalizedCombo = combo.replace(/\bctrl\b/g, "control");
-  comboCallbacks.delete(normalizedCombo);
+  const stack = comboCallbacks.get(normalizedCombo);
+  if (!stack) {
+    return;
+  }
+  stack.pop();
+  if (stack.length === 0) {
+    comboCallbacks.delete(normalizedCombo);
+  }
+};
+
+// Resolve which binding handles a combo: the topmost (most recently registered)
+// registration that is active and has a callback. Returns undefined when no
+// binding should fire, letting default browser behavior proceed.
+const resolveComboRegistration = (
+  combo: string
+): ComboRegistration | undefined => {
+  const stack = comboCallbacks.get(combo);
+  if (!stack) {
+    return undefined;
+  }
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const registration = stack[i];
+    if (registration.callback && registration.active !== false) {
+      return registration;
+    }
+  }
+  return undefined;
 };
 
 const executeComboCallbacks = (
@@ -77,9 +145,9 @@ const executeComboCallbacks = (
   }
   const pressedKeysString = Array.from(pressedKeys).sort().join("+");
   const activeElement = document.activeElement;
-  const options = comboCallbacks.get(pressedKeysString);
+  const options = resolveComboRegistration(pressedKeysString);
 
-  if (!options?.callback || options.active === false) {
+  if (!options) {
     // No active callback for this combo, or combo is inactive.
     // Default browser behavior (e.g., typing a character) will occur.
     return;
@@ -168,7 +236,7 @@ const executeComboCallbacks = (
   }
   
   // Execute the callback
-  options.callback();
+  options.callback?.();
   
   // After executing a combo, clear non-modifier keys to prevent stuck keys
   // This is important because keyup events may not fire reliably, especially on macOS
@@ -269,13 +337,28 @@ const useKeyPressedStore = create<KeyPressedState>()((set, get) => ({
   }
 }));
 
-// Add this near the top of the file, with other module-level variables
-let listenersInitialized = false;
+// Ref-counted global key listeners. Multiple consumers call initKeyListeners
+// (app bootstrap + every KeyboardProvider). A plain boolean guard let whichever
+// consumer happened to "own" the listeners tear them down on unmount while other
+// live consumers still needed them — globally killing keyboard handling. Ref-
+// counting attaches on the first consumer and detaches only once the last one
+// releases.
+let listenerRefCount = 0;
+let detachKeyListeners: (() => void) | null = null;
+
+const releaseKeyListeners = () => {
+  listenerRefCount = Math.max(0, listenerRefCount - 1);
+  if (listenerRefCount === 0 && detachKeyListeners) {
+    detachKeyListeners();
+    detachKeyListeners = null;
+  }
+};
 
 const initKeyListeners = () => {
-  // Check if listeners are already initialized
-  if (listenersInitialized) {
-    return () => {}; // Return a no-op cleanup function
+  listenerRefCount += 1;
+  // Listeners already attached for an earlier consumer — just hold a reference.
+  if (detachKeyListeners) {
+    return releaseKeyListeners;
   }
 
   const handleKeyChange = (event: KeyboardEvent, isPressed: boolean) => {
@@ -378,19 +461,17 @@ const initKeyListeners = () => {
   window.addEventListener("blur", clearAllKeys);
   window.addEventListener("focus", clearAllKeys);
 
-  // Set the flag to true after adding listeners
-  listenersInitialized = true;
-
-  // Return a cleanup function
-  return () => {
+  detachKeyListeners = () => {
     window.removeEventListener("keydown", handleKeyDown);
     window.removeEventListener("keyup", handleKeyUp);
     window.removeEventListener("pointerdown", handlePointerDown, true);
     window.removeEventListener("blur", clearAllKeys);
     window.removeEventListener("focus", clearAllKeys);
     lastPointerDownWasCanvas = false;
-    listenersInitialized = false;
   };
+
+  // Return a cleanup function that releases this consumer's reference.
+  return releaseKeyListeners;
 };
 
 export const useKeyPressed = <T>(selector: (state: KeyPressedState) => T) =>
@@ -415,18 +496,24 @@ const useCombo = (
     [combo]
   );
 
+  // Keep the latest callback in a ref so an unstable (inline) callback does not
+  // force re-registration on every render. The effect below registers once per
+  // combo/active/scope change and always invokes the current callback.
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
   useEffect(() => {
     // Only register if both the keyboard context and the hook's active prop are true
-    if (keyboardActive && active) {
-      registerComboCallback(memoizedCombo, {
-        callback,
-        preventDefault,
-        active,
-        scope
-      });
-      return () => unregisterComboCallback(memoizedCombo);
+    if (!(keyboardActive && active)) {
+      return;
     }
-  }, [memoizedCombo, callback, preventDefault, active, keyboardActive, scope]);
+    return registerComboCallback(memoizedCombo, {
+      callback: () => callbackRef.current(),
+      preventDefault,
+      active,
+      scope
+    });
+  }, [memoizedCombo, preventDefault, active, keyboardActive, scope]);
 };
 
 const agentCallback = () => {

--- a/web/src/stores/__tests__/KeyPressedStore.test.ts
+++ b/web/src/stores/__tests__/KeyPressedStore.test.ts
@@ -535,6 +535,96 @@ describe("KeyPressedStore", () => {
     });
   });
 
+  describe("stacked combo registrations (scoping)", () => {
+    // These cover the regression where a single shared slot per combo meant the
+    // last mount overwrote earlier bindings and the first unmount deleted the
+    // binding for every still-mounted component (e.g. several modals + the
+    // toolbar all bind "escape"), so shortcuts intermittently stopped working.
+
+    const pressEscape = () => {
+      (document.body as HTMLElement).focus();
+      const { setKeysPressed } = useKeyPressedStore.getState();
+      act(() => {
+        setKeysPressed(
+          { escape: true },
+          new KeyboardEvent("keydown", { key: "Escape" })
+        );
+        setKeysPressed({ escape: false });
+      });
+    };
+
+    it("fires the most recently registered binding for a shared combo", () => {
+      const first = jest.fn();
+      const second = jest.fn();
+      const disposeFirst = registerComboCallback("escape", { callback: first });
+      const disposeSecond = registerComboCallback("escape", {
+        callback: second
+      });
+
+      pressEscape();
+
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(first).not.toHaveBeenCalled();
+
+      disposeFirst();
+      disposeSecond();
+    });
+
+    it("keeps other bindings for the same combo when one is disposed", () => {
+      const toolbar = jest.fn();
+      const modal = jest.fn();
+      const disposeToolbar = registerComboCallback("escape", {
+        callback: toolbar
+      });
+      const disposeModal = registerComboCallback("escape", { callback: modal });
+
+      // Modal (registered last) unmounts — the toolbar binding must survive.
+      disposeModal();
+      pressEscape();
+
+      expect(toolbar).toHaveBeenCalledTimes(1);
+      expect(modal).not.toHaveBeenCalled();
+
+      disposeToolbar();
+    });
+
+    it("disposes the exact binding by identity, not the newest", () => {
+      const a = jest.fn();
+      const b = jest.fn();
+      const disposeA = registerComboCallback("escape", { callback: a });
+      const disposeB = registerComboCallback("escape", { callback: b });
+
+      // Dispose the FIRST registration; the second (topmost) must still win.
+      disposeA();
+      pressEscape();
+
+      expect(b).toHaveBeenCalledTimes(1);
+      expect(a).not.toHaveBeenCalled();
+
+      disposeB();
+    });
+
+    it("falls through to an active binding when the topmost is inactive", () => {
+      const background = jest.fn();
+      const foreground = jest.fn();
+      const disposeBg = registerComboCallback("escape", {
+        callback: background
+      });
+      const disposeFg = registerComboCallback("escape", {
+        callback: foreground,
+        active: false
+      });
+
+      pressEscape();
+
+      expect(background).toHaveBeenCalledTimes(1);
+      expect(foreground).not.toHaveBeenCalled();
+
+      disposeBg();
+      disposeFg();
+    });
+  });
+
   describe("helper functions", () => {
     it("isKeyPressed returns correct value", () => {
       const { setKeysPressed, isKeyPressed } = useKeyPressedStore.getState();


### PR DESCRIPTION
## Summary

Fixes a critical bug where keyboard shortcuts would intermittently stop working when multiple components registered the same combo (e.g., several modals, the node menu, and toolbar all binding "escape"). The issue was that a single shared slot per combo meant the last mount would overwrite earlier bindings, and the first unmount would delete the binding for all still-mounted components.

## Key Changes

- **Stacked combo registrations**: Changed `comboCallbacks` from a `Map<string, ComboOptions>` to a `Map<string, ComboRegistration[]>` to maintain a stack of registrations per combo. The most recently registered (topmost) active binding wins, allowing focused modals to shadow background editor bindings.

- **Precise disposal by identity**: `registerComboCallback()` now returns a disposer function that removes exactly that handler by a unique `symbol` token, regardless of what else registered the same combo in the meantime. This replaces the imprecise `unregisterComboCallback()` which only popped the most recent binding.

- **Resolution logic**: Added `resolveComboRegistration()` to walk the stack from top to bottom, returning the first active registration with a callback. Falls through to lower-priority bindings when the topmost is inactive.

- **Ref-counted global listeners**: Fixed a separate bug where multiple consumers of `initKeyListeners()` (app bootstrap + every `KeyboardProvider`) could tear down listeners prematurely. Replaced the boolean `listenersInitialized` flag with `listenerRefCount` and `detachKeyListeners` callback, ensuring listeners attach on the first consumer and detach only once the last one releases.

- **Callback stability in `useCombo`**: Added `useRef` to hold the latest callback, allowing the effect to register once per combo/active/scope change without re-registering on every render when an inline callback is passed. The effect now uses the disposer returned by `registerComboCallback()` instead of calling `unregisterComboCallback()`.

- **Updated `useNodeEditorShortcuts`**: Changed from tracking registered combo strings and calling `unregisterComboCallback()` to collecting disposer functions and calling them in cleanup, ensuring precise removal of each registered binding.

## Testing

Added comprehensive test suite covering:
- Most recently registered binding fires for a shared combo
- Other bindings survive when one is disposed
- Exact binding disposed by identity, not just the newest
- Fall-through to active binding when topmost is inactive

https://claude.ai/code/session_01E5c96Rf1WhfXS73BAUdhV1