### PR TITLE
Persist text generations so Agent nodes load history in the UI

### DIFF
--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1228,6 +1228,9 @@ const GEMMA_3_4B_IT_GGUF_BASE = {
 export class SummarizerNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Summarizer";
   static readonly body = "content_card";
+  // Persist the primary text output as a generation so the node gets a
+  // reload-surviving, browsable history like generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly title = "Summarizer";
   static readonly description =
     "Generate concise summaries of text content using LLM providers with streaming output.\n    text, summarization, nlp, content, streaming\n\n    Specialized for creating high-quality summaries with real-time streaming:\n    - Condensing long documents into key points\n    - Creating executive summaries with live output\n    - Extracting main ideas from text as they're generated\n    - Maintaining factual accuracy while reducing length";
@@ -1667,6 +1670,9 @@ export class ExtractorNode extends BaseNode {
 export class ClassifierNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Classifier";
   static readonly body = "content_card";
+  // Persist the primary text output as a generation so the node gets a
+  // reload-surviving, browsable history like generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly title = "Classifier";
   static readonly description =
     "Classify text into predefined or dynamic categories using LLM.\n    classification, nlp, categorization\n\n    Use cases:\n    - Sentiment analysis\n    - Topic classification\n    - Intent detection\n    - Content categorization";
@@ -1874,6 +1880,9 @@ export class ClassifierNode extends BaseNode {
 export class AgentNode extends BaseNode {
   static readonly nodeType: string = "nodetool.agents.Agent";
   static readonly body = "content_card";
+  // Persist the primary text output as a generation so the node gets a
+  // reload-surviving, browsable history like generative media nodes.
+  static readonly autoSaveAsset = true;
   static readonly title: string = "Agent";
   static readonly description: string =
     "Generate natural language responses using LLM providers and streams output.\n    llm, text-generation, chatbot, question-answering, streaming\n\n    Dynamic properties are substituted as {{variable}} (or {variable})\n    placeholders in both the prompt and system text. Add a property named\n    `subject` and write `Classify: {{subject}}` in the prompt — the wired\n    value replaces the placeholder at run time. Jinja-style filters are\n    supported: {{subject|upper}}, {{text|truncate(100)}}, etc. Unknown\n    placeholders are left intact.";

--- a/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
+++ b/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
@@ -29,6 +29,23 @@ function expectMetadataDefaults(NodeCls: any) {
   expect(new NodeCls().serialize()).toEqual(metadataDefaults(NodeCls));
 }
 
+describe("text agents persist generations", () => {
+  // These text content-card nodes opt into auto_save_asset so their primary
+  // text output is saved as a generation (text/plain asset) on job completion,
+  // giving them a reload-surviving, browsable history like media nodes.
+  it.each([
+    [SummarizerNode, "text"],
+    [ClassifierNode, "output"],
+    [AgentNode, "text"]
+  ])("%p saves its primary str output as a generation", (NodeCls, primary) => {
+    const meta = getNodeMetadata(NodeCls as any);
+    expect(meta.auto_save_asset).toBe(true);
+    // The backend only persists text generations when the primary output is str.
+    expect(meta.outputs[0]?.name).toBe(primary);
+    expect((meta.outputs[0]?.type as { type?: string })?.type).toBe("str");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // agents.ts
 // ---------------------------------------------------------------------------

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -247,12 +247,7 @@ function extractCloudKey(uri: string): string | null {
 
 const ASSET_MEDIA_TYPES = new Set(["image", "audio", "video"]);
 
-/**
- * Cap on the inline-preview text stored in a text generation's asset metadata.
- * The full text is always in the asset bytes; this just bounds the row size so a
- * very large generation doesn't bloat the assets table. ~200 KB comfortably
- * covers normal agent/summarizer output.
- */
+/** Byte cap for inline-preview text stored in a text generation's asset metadata. */
 const TEXT_GENERATION_PREVIEW_CAP = 200_000;
 
 /**

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -247,6 +247,37 @@ function extractCloudKey(uri: string): string | null {
 
 const ASSET_MEDIA_TYPES = new Set(["image", "audio", "video"]);
 
+/**
+ * Cap on the inline-preview text stored in a text generation's asset metadata.
+ * The full text is always in the asset bytes; this just bounds the row size so a
+ * very large generation doesn't bloat the assets table. ~200 KB comfortably
+ * covers normal agent/summarizer output.
+ */
+const TEXT_GENERATION_PREVIEW_CAP = 200_000;
+
+/**
+ * Resolve a node's primary output name when it is a text/str type, so its value
+ * can be persisted as a text generation. Mirrors the frontend's
+ * `getPrimaryOutput` (honor `primary_output`, else first output). Returns
+ * undefined for non-text primaries (media, structured data, …).
+ */
+export function primaryTextOutputName(
+  meta:
+    | {
+        outputs?: Array<{ name: string; type?: { type?: string } }>;
+        primary_output?: string;
+      }
+    | undefined
+): string | undefined {
+  const outputs = meta?.outputs ?? [];
+  if (outputs.length === 0) return undefined;
+  const named = meta?.primary_output;
+  const primary =
+    (named && outputs.find((o) => o.name === named)) || outputs[0];
+  const t = primary?.type?.type;
+  return t === "str" || t === "text" ? primary.name : undefined;
+}
+
 const ASSET_TYPE_MIME: Record<string, string> = {
   image: "image/png",
   audio: "audio/wav",
@@ -322,6 +353,14 @@ async function autoSaveAssets(
     workflowId: string | null;
     jobId: string;
     nodeId: string;
+    /**
+     * Name of the node's primary output when it is a text/str type. When set and
+     * the result carries a non-empty string there, it is persisted as a
+     * `text/plain` asset so text content-card nodes (Agent, Summarizer,
+     * Classifier) get the same reload-surviving, browsable generation history as
+     * media nodes.
+     */
+    textOutputName?: string;
   }
 ): Promise<void> {
   const queue: Record<string, unknown>[] = [];
@@ -412,6 +451,39 @@ async function autoSaveAssets(
         nodeId: opts.nodeId,
         error: String(err)
       });
+    }
+  }
+
+  // Persist the primary text output as a generation (a text/plain asset), so
+  // text content-card nodes get the same reload-surviving, browsable generation
+  // history as media nodes. The text is stored both as the asset bytes and
+  // (capped) inline in metadata so the UI can preview it without a fetch.
+  const textKey = opts.textOutputName;
+  if (textKey) {
+    const textVal = result[textKey];
+    if (typeof textVal === "string" && textVal.length > 0) {
+      const bytes = new TextEncoder().encode(textVal);
+      const asset = new Asset({
+        user_id: opts.userId,
+        workflow_id: opts.workflowId ?? null,
+        node_id: opts.nodeId,
+        job_id: opts.jobId,
+        name: `text_${opts.nodeId.slice(0, 8)}`,
+        content_type: "text/plain",
+        parent_id: null
+      });
+      asset.metadata = { text: textVal.slice(0, TEXT_GENERATION_PREVIEW_CAP) };
+      const fileName = `${asset.id}.txt`;
+      try {
+        await storeAssetWithThumbnail(asset.id, fileName, bytes, "text/plain");
+        asset.size = bytes.length;
+        await asset.save();
+      } catch (err) {
+        log.warn("Auto-save text generation failed", {
+          nodeId: opts.nodeId,
+          error: String(err)
+        });
+      }
     }
   }
 }
@@ -1686,6 +1758,7 @@ export class UnifiedWebSocketRunner {
                     workflowId: active.workflowId,
                     jobId: active.jobId,
                     nodeId: String(outbound.node_id ?? ""),
+                    textOutputName: primaryTextOutputName(meta)
                   }
                 );
               } catch (err) {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -458,6 +458,9 @@ async function autoSaveAssets(
     const textVal = result[textKey];
     if (typeof textVal === "string" && textVal.length > 0) {
       const bytes = new TextEncoder().encode(textVal);
+      const previewText = new TextDecoder().decode(
+        bytes.slice(0, TEXT_GENERATION_PREVIEW_CAP)
+      );
       const asset = new Asset({
         user_id: opts.userId,
         workflow_id: opts.workflowId ?? null,
@@ -467,7 +470,7 @@ async function autoSaveAssets(
         content_type: "text/plain",
         parent_id: null
       });
-      asset.metadata = { text: textVal.slice(0, TEXT_GENERATION_PREVIEW_CAP) };
+      asset.metadata = { text: previewText };
       const fileName = `${asset.id}.txt`;
       try {
         await storeAssetWithThumbnail(asset.id, fileName, bytes, "text/plain");

--- a/packages/websocket/tests/primary-text-output.test.ts
+++ b/packages/websocket/tests/primary-text-output.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { primaryTextOutputName } from "../src/unified-websocket-runner.js";
+
+describe("primaryTextOutputName", () => {
+  it("returns the first output name when its type is str", () => {
+    expect(
+      primaryTextOutputName({
+        outputs: [
+          { name: "text", type: { type: "str" } },
+          { name: "audio", type: { type: "audio" } }
+        ]
+      })
+    ).toBe("text");
+  });
+
+  it("honors primary_output when set to a str output", () => {
+    expect(
+      primaryTextOutputName({
+        primary_output: "summary",
+        outputs: [
+          { name: "raw", type: { type: "image" } },
+          { name: "summary", type: { type: "str" } }
+        ]
+      })
+    ).toBe("summary");
+  });
+
+  it("returns undefined when the primary output is not text", () => {
+    expect(
+      primaryTextOutputName({
+        outputs: [{ name: "image", type: { type: "image" } }]
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for missing/empty metadata", () => {
+    expect(primaryTextOutputName(undefined)).toBeUndefined();
+    expect(primaryTextOutputName({ outputs: [] })).toBeUndefined();
+  });
+});

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -263,10 +263,14 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     setMode((m) => (m === "single" ? "multi" : "single"));
   }, []);
 
+  // The fullscreen AssetViewer only renders media; text generations use the
+  // inline preview only.
+  const canOpenViewer =
+    !!currentAsset && !showingLive && isMediaAsset(currentAsset);
   const handleOpenViewer = useCallback(() => {
-    if (!currentAsset || showingLive) return;
+    if (!canOpenViewer) return;
     setViewerOpen(true);
-  }, [currentAsset, showingLive]);
+  }, [canOpenViewer]);
 
   // Children (ImageView) render under this context: it suppresses their own
   // overlay/viewer and routes "open" here, so the viewer's gallery reflects the
@@ -448,7 +452,7 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
             title="Open in viewer"
             size="small"
             onClick={handleOpenViewer}
-            disabled={!currentAsset || showingLive}
+            disabled={!canOpenViewer}
             className="overlay-icon-btn"
             aria-label="Open in viewer"
           >
@@ -480,7 +484,7 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
         </div>
       ) : null}
 
-      {currentAsset && currentAsset.get_url ? (
+      {currentAsset && currentAsset.get_url && isMediaAsset(currentAsset) ? (
         <AssetViewer
           asset={currentAsset}
           sortedAssets={mediaAssets}

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -622,6 +622,10 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
   }, [result, liveResolvedResult, lastJobAssets]);
 
   const isMediaVariant = MEDIA_VARIANTS.includes(variant);
+  // Text generations are persisted as text/plain assets (autoSaveAsset on
+  // Agent/Summarizer/Classifier), so the text card gets the same browsable,
+  // reload-surviving history navigator as media variants.
+  const usesHistoryNavigator = isMediaVariant || variant === "text";
 
   const isDynamic = !!nodeMetadata.supports_dynamic_inputs;
   const hasDynamicProps =
@@ -698,7 +702,7 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
       data-content-card-variant={variant}
     >
       <div className="preview-area">
-        {isMediaVariant ? (
+        {usesHistoryNavigator ? (
           <NodeHistoryViewer
             workflowId={workflowId}
             nodeId={id}

--- a/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
+++ b/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
@@ -269,6 +269,40 @@ describe("ContentCardBody results", () => {
     const container = screen.getByLabelText("Generated text");
     expect(container).toHaveTextContent("first second");
   });
+
+  it("shows a history navigator over persisted text generations", () => {
+    const textAsset = (
+      id: string,
+      jobId: string,
+      text: string,
+      createdAt: string
+    ): Asset =>
+      ({
+        id,
+        content_type: "text/plain",
+        name: id,
+        get_url: `http://localhost/api/storage/${id}.txt`,
+        metadata: { text },
+        created_at: createdAt,
+        node_id: nodeId,
+        job_id: jobId
+      }) as unknown as Asset;
+    const assets = [
+      textAsset("t1", "job-1", "first gen", "2026-01-01T00:00:00Z"),
+      textAsset("t2", "job-2", "second gen", "2026-01-02T00:00:00Z")
+    ];
+    seedAssets(assets);
+    mockAssetHistory = assets;
+
+    renderContentCard(metadataForOutput("str"));
+
+    // The text card now gets the same navigator as media: pagination over the
+    // persisted generations, defaulting to the latest, rendering its inline text.
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    expect(screen.getByLabelText("Generated text")).toHaveTextContent(
+      "second gen"
+    );
+  });
 });
 
 describe("ContentCardBody dynamic inputs", () => {

--- a/web/src/utils/__tests__/nodeGenerations.test.ts
+++ b/web/src/utils/__tests__/nodeGenerations.test.ts
@@ -1,5 +1,6 @@
 import {
   outputOf,
+  assetToOutputValue,
   assetToGeneration,
   mergeGenerations,
   getCurrentGeneration,
@@ -39,6 +40,44 @@ describe("outputOf", () => {
   });
   it("returns undefined outputs as undefined", () => {
     expect(outputOf(gen({}), "x")).toBeUndefined();
+  });
+});
+
+describe("assetToOutputValue", () => {
+  it("maps an image asset to an image value", () => {
+    expect(assetToOutputValue(asset("a1", "j1", "2026-01-01T00:00:00Z"))).toEqual(
+      { type: "image", uri: "http://x/a1.png" }
+    );
+  });
+
+  it("maps a text/plain asset to a text value using inline metadata", () => {
+    const textAsset = {
+      id: "t1",
+      job_id: "j1",
+      node_id: "n1",
+      content_type: "text/plain",
+      get_url: "http://x/t1.txt",
+      metadata: { text: "hello world" },
+      created_at: "2026-01-01T00:00:00Z"
+    } as unknown as Asset;
+    expect(assetToOutputValue(textAsset)).toEqual({
+      type: "text",
+      text: "hello world",
+      uri: "http://x/t1.txt"
+    });
+  });
+
+  it("returns empty text when a text asset has no inline metadata", () => {
+    const textAsset = {
+      id: "t2",
+      content_type: "text/plain",
+      get_url: "http://x/t2.txt"
+    } as unknown as Asset;
+    expect(assetToOutputValue(textAsset)).toEqual({
+      type: "text",
+      text: "",
+      uri: "http://x/t2.txt"
+    });
   });
 });
 

--- a/web/src/utils/nodeGenerations.ts
+++ b/web/src/utils/nodeGenerations.ts
@@ -10,6 +10,16 @@ export const assetToOutputValue = (asset: Asset): Record<string, unknown> => {
   if (ct.startsWith("image/")) return { type: "image", uri };
   if (ct.startsWith("video/")) return { type: "video", uri };
   if (ct.startsWith("audio/")) return { type: "audio", uri };
+  if (ct.startsWith("text/")) {
+    // Text generations carry the (capped) text inline in metadata so the
+    // preview renders without a fetch; the full text lives in the asset bytes.
+    const meta = asset.metadata as { text?: unknown } | null | undefined;
+    return {
+      type: "text",
+      text: typeof meta?.text === "string" ? meta.text : "",
+      uri
+    };
+  }
   if (ct.includes("model") || asset.name?.toLowerCase().endsWith(".glb")) {
     return { type: "model_3d", uri, name: asset.name ?? undefined };
   }


### PR DESCRIPTION
## Problem

The Agent node (and other text content-card nodes: Summarizer, Classifier) didn't load generations in the UI and lost their output on reload. Two compounding reasons:

- **Generations are asset-backed** (`useNodeResultHistory` → `assets.list({node_id})`), but these nodes' text output was never persisted (text isn't asset-like, and they weren't `auto_save_asset`).
- **`ContentCardBody` only rendered the history navigator (`NodeHistoryViewer`) for media variants** — the `text` variant got a single live-value preview with no history.

So even in-session there was no navigator, and after reload there was nothing to load. This is uniform across all text content-card nodes, not agent-specific.

## Fix — full parity with media generations

**Backend (`packages/websocket`)**
- `autoSaveAssets` now persists a node's **primary text output** (when it's a `str`/`text` output) as a `text/plain` asset tagged `node_id` + `job_id` — the same generation store media nodes use. Full text in the asset bytes; a capped (~200 KB) copy stored inline in `asset.metadata.text` so the UI previews it without a fetch.
- New `primaryTextOutputName(meta)` resolves the primary output name iff it's `str`/`text` (mirrors the frontend's `getPrimaryOutput`); wired into the save call.

**Nodes (`packages/llm-nodes`)**
- `Agent`, `Summarizer`, `Classifier` set `autoSaveAsset = true` (each has a `str` primary output). `Extractor` is excluded — it outputs structured data, not text.

**Frontend (`web`)**
- `assetToOutputValue` maps `text/plain` assets to `{ type: "text", text }` from the inline metadata.
- `ContentCardBody` renders `NodeHistoryViewer` for the `text` variant too → browsable, reload-surviving generation history with the existing `TextPreview` renderer.
- `NodeHistoryViewer` guards the fullscreen `AssetViewer` to media assets only (text generations use the inline preview).

## Consequences (inherent to matching media behavior)
- **Every run** of these agents is saved to the assets table, so they also appear in the global asset library (agents run often).
- Making them `auto_save_asset` means an **uncached instance blocks partial runs** ("Run X first"), like fal/replicate nodes.

Both follow directly from reusing the media generation pipeline. Flagging in case you'd prefer a dedicated text-generation store that doesn't surface in the asset library — that'd be a larger change.

## Verification
- New tests: `primaryTextOutputName` unit test; `llm-nodes` assert the three nodes persist their `str` primary; `assetToOutputValue` text mapping; `ContentCardBody` text-history navigator.
- `websocket` (719) + `llm-nodes` + touched `web` suites green; `web` typecheck + lint clean; `build:packages` clean.

Branched off `main`, independent of #3556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)