### PR TITLE
Filter cloud API models from Models Manager

### DIFF
--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -113,7 +113,7 @@ function dedupeModels(models: UnifiedModel[]): UnifiedModel[] {
   const seen = new Set<string>();
   const deduped: UnifiedModel[] = [];
   for (const model of models) {
-    const key = `${model.repo_id ?? ""}::${model.path ?? ""}`;
+    const key = `${model.provider ?? ""}::${model.repo_id ?? model.id ?? ""}::${model.path ?? ""}`;
     if (!seen.has(key)) {
       seen.add(key);
       deduped.push(model);
@@ -246,7 +246,7 @@ function toUnifiedLanguageModel(model: LanguageModel): UnifiedModel {
     type: "language_model",
     name: model.name,
     repo_id: null,
-    path: model.id,
+    path: null,
     downloaded: model.provider === "ollama" || model.provider === "llama_cpp",
     tags: [model.provider]
   };
@@ -267,7 +267,7 @@ function toUnifiedModel(
     type,
     name: model.name,
     repo_id: null,
-    path: model.id,
+    path: null,
     downloaded: model.provider === "ollama" || model.provider === "llama_cpp",
     tags: [model.provider]
   };

--- a/packages/websocket/src/trpc/routers/models.ts
+++ b/packages/websocket/src/trpc/routers/models.ts
@@ -225,7 +225,7 @@ function dedupeModels(models: UnifiedModel[]): UnifiedModel[] {
   const seen = new Set<string>();
   const deduped: UnifiedModel[] = [];
   for (const model of models) {
-    const key = `${model.repo_id ?? ""}::${model.path ?? ""}`;
+    const key = `${model.provider ?? ""}::${model.repo_id ?? model.id ?? ""}::${model.path ?? ""}`;
     if (!seen.has(key)) {
       seen.add(key);
       deduped.push(model);
@@ -612,7 +612,7 @@ function toUnifiedLanguageModel(
     name: model.name,
     provider: model.provider,
     repo_id: null,
-    path: model.id,
+    path: null,
     downloaded: model.provider === "ollama" || model.provider === "llama_cpp",
     tags: [model.provider],
     supports_tools: supportsTools ?? null
@@ -638,7 +638,7 @@ function toUnifiedModel(
     name: model.name,
     provider: model.provider,
     repo_id: null,
-    path: model.id,
+    path: null,
     downloaded: model.provider === "ollama" || model.provider === "llama_cpp",
     tags: [model.provider],
     voices: model.voices ?? null,

--- a/web/src/components/hugging_face/model_list/__tests__/isManageableModel.test.ts
+++ b/web/src/components/hugging_face/model_list/__tests__/isManageableModel.test.ts
@@ -1,0 +1,47 @@
+import { UnifiedModel } from "../../../../stores/ApiTypes";
+import { isManageableModel } from "../useModels";
+
+const model = (overrides: Partial<UnifiedModel>): UnifiedModel =>
+  ({
+    id: "m",
+    name: "m",
+    type: "language_model",
+    repo_id: null,
+    path: null,
+    ...overrides
+  }) as UnifiedModel;
+
+describe("isManageableModel", () => {
+  it("keeps HuggingFace models", () => {
+    expect(isManageableModel(model({ type: "hf.text_generation" }))).toBe(true);
+  });
+
+  it("keeps HuggingFace models identified by path", () => {
+    expect(
+      isManageableModel(model({ type: "language_model", path: "model.gguf" }))
+    ).toBe(true);
+  });
+
+  it("keeps transformers.js cached models", () => {
+    expect(
+      isManageableModel(model({ type: "tjs.text_generation", provider: "transformers_js" }))
+    ).toBe(true);
+  });
+
+  it("keeps Ollama models", () => {
+    expect(isManageableModel(model({ type: "llama_model", provider: "ollama" }))).toBe(true);
+  });
+
+  it("keeps local-runtime provider models", () => {
+    expect(isManageableModel(model({ provider: "ollama" }))).toBe(true);
+    expect(isManageableModel(model({ provider: "llama_cpp" }))).toBe(true);
+    expect(isManageableModel(model({ provider: "huggingface" }))).toBe(true);
+  });
+
+  it("drops cloud API provider models", () => {
+    expect(isManageableModel(model({ provider: "openai" }))).toBe(false);
+    expect(isManageableModel(model({ provider: "anthropic" }))).toBe(false);
+    expect(isManageableModel(model({ provider: "gemini" }))).toBe(false);
+    expect(isManageableModel(model({ provider: "groq" }))).toBe(false);
+  });
+});

--- a/web/src/components/hugging_face/model_list/useModels.ts
+++ b/web/src/components/hugging_face/model_list/useModels.ts
@@ -11,7 +11,25 @@ import type { ModelSortField, ModelSortDirection } from "../../../stores/ModelMa
 import { useQuery } from "@tanstack/react-query";
 import { openInExplorer, openOllamaPath } from "../../../utils/fileExplorer";
 import { useHfCacheStatusStore } from "../../../stores/HfCacheStatusStore";
-import { getHfCacheKey } from "../../../utils/hfCache";
+import { getHfCacheKey, isHfModel } from "../../../utils/hfCache";
+import { isLocalProvider } from "../../../utils/providerDisplay";
+
+/**
+ * The Models Manager only lists models that live on disk: downloadable
+ * HuggingFace / transformers.js repos and local runtimes (Ollama, llama.cpp,
+ * MLX). Cloud API models (OpenAI, Anthropic, …) are configured via API keys
+ * rather than downloaded, so they don't belong here.
+ */
+export const isManageableModel = (model: UnifiedModel): boolean => {
+  if (isHfModel(model)) {
+    return true;
+  }
+  const type = model.type ?? "";
+  if (type === "llama_model" || type.startsWith("tjs")) {
+    return true;
+  }
+  return isLocalProvider(model.provider ?? undefined);
+};
 
 const sortModels = (
   models: UnifiedModel[],
@@ -64,7 +82,7 @@ export const useModels = (): UseModelsResult => {
   const cacheStatuses = useHfCacheStatusStore((state) => state.statuses);
 
   const {
-    data: allModels,
+    data: rawModels,
     isLoading,
     isFetching,
     error
@@ -73,6 +91,11 @@ export const useModels = (): UseModelsResult => {
     queryFn: () => trpc.models.all.query(),
     refetchOnWindowFocus: false
   });
+
+  const allModels = useMemo(
+    () => rawModels?.filter(isManageableModel),
+    [rawModels]
+  );
 
   const groupedModels = useMemo(
     () => groupModelsByType(allModels || []),


### PR DESCRIPTION
## Summary
The Models Manager now only displays models that live on disk (HuggingFace repos, transformers.js cached models, and local runtimes like Ollama and llama.cpp). Cloud API provider models (OpenAI, Anthropic, Gemini, Groq) are filtered out since they're configured via API keys rather than downloaded.

## Key Changes

- **Added `isManageableModel()` function** in `useModels.ts` to determine which models should appear in the Models Manager. Models are kept if they:
  - Are HuggingFace models (via `isHfModel()` check)
  - Have type `llama_model` or start with `tjs` (transformers.js)
  - Use local runtime providers (Ollama, llama.cpp, HuggingFace)
  
  Cloud API providers (OpenAI, Anthropic, Gemini, Groq) are filtered out.

- **Updated `useModels()` hook** to filter raw models through `isManageableModel()` before grouping and sorting, ensuring only manageable models are displayed.

- **Fixed model deduplication logic** in both `packages/websocket/src/models-api.ts` and `packages/websocket/src/trpc/routers/models.ts` to include `provider` in the deduplication key, preventing duplicate models from different providers.

- **Corrected `path` field mapping** for non-HuggingFace models: changed from `path: model.id` to `path: null` in `toUnifiedLanguageModel()` and `toUnifiedModel()` functions. The `id` field is now properly used for deduplication instead of being conflated with file paths.

- **Added comprehensive test suite** (`isManageableModel.test.ts`) covering:
  - HuggingFace model detection
  - transformers.js cached models
  - Ollama and local runtime models
  - Filtering of cloud API providers

## Implementation Details

The filtering happens at the query level in `useModels()` using `useMemo()` to avoid unnecessary re-filtering. This ensures the Models Manager UI only shows models that users can actually manage (download, delete, etc.) while keeping cloud API models available elsewhere in the application for configuration via API keys.

https://claude.ai/code/session_01QQqmn286Z9yLXTnV3NHKwN