### PR TITLE
Extract Models, Collections, Workspaces to full-screen manager pages

### DIFF
--- a/web/src/components/collections/CollectionList.tsx
+++ b/web/src/components/collections/CollectionList.tsx
@@ -19,8 +19,7 @@ import {
   ListGroup,
   ListItemRow,
   Surface,
-  Text,
-  Box
+  Text
 } from "../ui_primitives";
 import { CollectionResponse } from "../../stores/ApiTypes";
 
@@ -126,14 +125,9 @@ const CollectionList = () => {
               mt: 1
             }}
           >
-            <Box>
-              <Text size="big" weight={600}>
-                Collections
-              </Text>
-              <Text size="small" color="secondary">
-                {totalCount} {totalCount === 1 ? "collection" : "collections"}
-              </Text>
-            </Box>
+            <Text size="small" color="secondary">
+              {totalCount} {totalCount === 1 ? "collection" : "collections"}
+            </Text>
             <CreateFab
               onClick={handleShowForm}
               label="Create Collection"

--- a/web/src/components/collections/CollectionsExplorer.tsx
+++ b/web/src/components/collections/CollectionsExplorer.tsx
@@ -1,55 +1,23 @@
-/** @jsxImportSource @emotion/react */
-import { css } from "@emotion/react";
-import React from "react";
-import { Box } from "../ui_primitives";
-import { useTheme } from "@mui/material/styles";
-import type { Theme } from "@mui/material/styles";
-import AppHeader from "../panels/AppHeader";
+import React, { memo } from "react";
+import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
+import ManagerPageLayout from "../panels/ManagerPageLayout";
 import CollectionList from "./CollectionList";
-import PanelHeadline from "../ui/PanelHeadline";
 
-const styles = (theme: Theme) =>
-  css({
-    "&": {
-      position: "relative",
-      display: "flex",
-      width: "100%",
-      height: "100%",
-      top: "0",
-      left: "0",
-      padding: "0",
-      backgroundColor: theme.vars.palette.c_editor_bg_color
-    },
-    ".collections-explorer": {
-      position: "relative",
-      width: "100%",
-      top: "64px",
-      padding: "0 24px"
-    }
-  });
+/**
+ * Full-screen Collections page. Reachable from the logo menu; wraps the
+ * collection list in the shared manager chrome (header + back button).
+ */
+const CollectionsExplorer: React.FC = () => (
+  <ManagerPageLayout
+    icon={<LibraryBooksOutlinedIcon sx={{ fontSize: 22 }} />}
+    title="Collections"
+    subtitle="Searchable document collections for RAG workflows — drop in PDFs, Markdown, HTML, or transcripts."
+    docsUrl="https://docs.nodetool.ai/collections.html"
+  >
+    <CollectionList />
+  </ManagerPageLayout>
+);
 
-const CollectionsExplorer: React.FC = () => {
-  const theme = useTheme();
-  return (
-    <Box css={styles(theme)}>
-      <Box
-        className="actions-container"
-        sx={{
-          position: "absolute",
-          top: "32px",
-          left: 0,
-          right: 0,
-          zIndex: 1000
-        }}
-      >
-        <AppHeader />
-      </Box>
-      <Box className="collections-explorer">
-        <PanelHeadline title="Collections" />
-        <CollectionList />
-      </Box>
-    </Box>
-  );
-};
+CollectionsExplorer.displayName = "CollectionsExplorer";
 
-export default CollectionsExplorer;
+export default memo(CollectionsExplorer);

--- a/web/src/components/hugging_face/model_list/ModelsPage.tsx
+++ b/web/src/components/hugging_face/model_list/ModelsPage.tsx
@@ -1,0 +1,24 @@
+import React, { memo } from "react";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import ManagerPageLayout from "../../panels/ManagerPageLayout";
+import ModelListIndex from "./ModelListIndex";
+
+/**
+ * Full-screen Model Manager page. Reachable from the logo menu; wraps the
+ * model list in the shared manager chrome (header + back button).
+ */
+const ModelsPage: React.FC = () => (
+  <ManagerPageLayout
+    icon={<ViewInArOutlinedIcon sx={{ fontSize: 22 }} />}
+    title="Model Manager"
+    subtitle="Browse, download, and manage local AI models."
+    docsUrl="https://docs.nodetool.ai/models.html"
+    padded={false}
+  >
+    <ModelListIndex />
+  </ManagerPageLayout>
+);
+
+ModelsPage.displayName = "ModelsPage";
+
+export default memo(ModelsPage);

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -24,7 +24,7 @@ import {
 } from "../ui_primitives";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import { isLocalhost, isElectron, isProduction } from "../../lib/env";
+import { isLocalhost, isElectron } from "../../lib/env";
 import RemoteSettingsMenuComponent from "./RemoteSettingsMenu";
 import useRemoteSettingsStore from "../../stores/RemoteSettingStore";
 import FoldersSettings from "./FoldersSettingsMenu";
@@ -38,13 +38,7 @@ import {
   getDisplayedSettingGroups,
   settingGroupSlug
 } from "./RemoteSettingsMenu";
-import SettingsIntroCard from "./SettingsIntroCard";
 import ServerNumberSetting from "./ServerNumberSetting";
-import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
-import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
-import ModelListIndex from "../hugging_face/model_list/ModelListIndex";
-import CollectionList from "../collections/CollectionList";
-import WorkspacesManager from "../workspaces/WorkspacesManager";
 import { getAboutSidebarSections } from "./aboutSidebarUtils";
 import DefaultModelsMenu from "./DefaultModelsMenu";
 import MCPSettingsMenu from "./MCPSettingsMenu";
@@ -55,17 +49,13 @@ import SettingsSidebar from "./SettingsSidebar";
 import useSecretsStore from "../../stores/SecretsStore";
 import { settingsStyles } from "./settingsMenuStyles";
 
-const workspacesEnabled = !isProduction;
-
-// Tab indices. Workspaces is conditional, so About/Packages are derived.
+// Tab indices. Models, Collections, and Workspaces now live as standalone
+// full-screen pages reachable from the logo menu.
 const TAB_GENERAL = 0;
 const TAB_API_KEYS = 1;
 const TAB_INTEGRATIONS = 2;
-const TAB_MODELS = 3;
-const TAB_COLLECTIONS = 4;
-const TAB_WORKSPACES = 5;
-const aboutTabIndex = workspacesEnabled ? 6 : 5;
-const packagesTabIndex = aboutTabIndex + 1;
+const aboutTabIndex = 3;
+const packagesTabIndex = 4;
 
 const UPDATE_CHANNEL_OPTIONS = [
   { value: "latest", label: "Stable" },
@@ -177,12 +167,6 @@ function SettingsPage() {
         return "Provider API keys and credentials.";
       case TAB_INTEGRATIONS:
         return "Service endpoints, MCP servers, storage, and the Nodetool API.";
-      case TAB_MODELS:
-        return "Manage local models and runtime preferences.";
-      case TAB_COLLECTIONS:
-        return "Vector store collections for retrieval and search.";
-      case TAB_WORKSPACES:
-        return "Workspaces and project organization.";
       default:
         if (tab === packagesTabIndex) {
           return "Discover, trust, and install third-party node packs.";
@@ -194,11 +178,7 @@ function SettingsPage() {
   const settingsTab = useMemo(() => {
     const raw = Number(searchParams.get("tab") ?? 0);
     if (Number.isNaN(raw)) return 0;
-    const bounded = Math.min(packagesTabIndex, Math.max(0, raw));
-    if (!workspacesEnabled && bounded === TAB_WORKSPACES) {
-      return aboutTabIndex;
-    }
-    return bounded;
+    return Math.min(packagesTabIndex, Math.max(0, raw));
   }, [searchParams]);
 
   const setGridSnap = useSettingsStore((state) => state.setGridSnap);
@@ -600,11 +580,6 @@ function SettingsPage() {
                 <Tab label="General" id="settings-tab-0" />
                 <Tab label="API Keys" id="settings-tab-1" />
                 <Tab label="Integrations" id="settings-tab-2" />
-                <Tab label="Models" id="settings-tab-3" />
-                <Tab label="Collections" id="settings-tab-4" />
-                {workspacesEnabled && (
-                  <Tab label="Workspaces" id={`settings-tab-${TAB_WORKSPACES}`} />
-                )}
                 <Tab label="About" id={`settings-tab-${aboutTabIndex}`} />
                 <Tab label="Packages" id={`settings-tab-${packagesTabIndex}`} />
               </Tabs>
@@ -633,9 +608,6 @@ function SettingsPage() {
 
               <div
                 className={`settings-content${
-                  settingsTab === TAB_MODELS ||
-                  settingsTab === TAB_COLLECTIONS ||
-                  (settingsTab === TAB_WORKSPACES && workspacesEnabled) ||
                   settingsTab === packagesTabIndex
                     ? " settings-content--full"
                     : ""
@@ -1184,49 +1156,6 @@ function SettingsPage() {
                   <FoldersSettings />
                   </div>
                 </TabPanel>
-
-                {/* Tab 3: Models */}
-                <TabPanel value={settingsTab} index={TAB_MODELS}>
-                  <ModelListIndex />
-                </TabPanel>
-
-                {/* Tab 4: Collections */}
-                <TabPanel value={settingsTab} index={TAB_COLLECTIONS}>
-                  <Box className="settings-panel-padded">
-                    <SettingsIntroCard
-                      icon={<LibraryBooksOutlinedIcon sx={{ fontSize: 22 }} />}
-                      title="Collections"
-                      description="Group documents into searchable collections for RAG workflows. Drop in PDFs, Markdown, HTML, or transcripts and any index node can query them."
-                      docsUrl="https://docs.nodetool.ai/collections.html"
-                      highlights={[
-                        { label: "Vector search" },
-                        { label: "Embedding-backed" },
-                        { label: "Workflow-ready" }
-                      ]}
-                    />
-                    <CollectionList />
-                  </Box>
-                </TabPanel>
-
-                {/* Tab 5: Workspaces */}
-                {workspacesEnabled && (
-                  <TabPanel value={settingsTab} index={TAB_WORKSPACES}>
-                    <Box className="settings-panel-padded">
-                      <SettingsIntroCard
-                        icon={<FolderSpecialOutlinedIcon sx={{ fontSize: 22 }} />}
-                        title="Workspaces"
-                        description="Define directory roots that agents and workflows can read, write, and organize files in. Each workspace is a sandboxed folder available to chat tools and node runs."
-                        docsUrl="https://docs.nodetool.ai/workspaces.html"
-                        highlights={[
-                          { label: "Sandboxed folders" },
-                          { label: "Agent-accessible" },
-                          { label: "Per-project" }
-                        ]}
-                      />
-                      <WorkspacesManager />
-                    </Box>
-                  </TabPanel>
-                )}
 
                 {/* About */}
                 <TabPanel value={settingsTab} index={aboutTabIndex}>

--- a/web/src/components/panels/ManagerPageLayout.tsx
+++ b/web/src/components/panels/ManagerPageLayout.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import React, { memo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import AppHeader from "./AppHeader";
+import { Box, EditorButton, FlexColumn, FlexRow, Text } from "../ui_primitives";
+import { HEADER_HEIGHT } from "../../config/constants";
+
+interface ManagerPageLayoutProps {
+  /** Icon shown in the tinted chip beside the title. */
+  icon?: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  /** Optional docs link rendered as a button in the hero's action row. */
+  docsUrl?: string;
+  docsLabel?: string;
+  /** Extra controls rendered on the right of the hero header. */
+  actions?: React.ReactNode;
+  /**
+   * Pad and scroll the content area. Disable for full-bleed managers (e.g. the
+   * model list) that own their own layout, sidebars, and scrolling.
+   */
+  padded?: boolean;
+  children: React.ReactNode;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    "&": {
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+      height: "100%",
+      paddingTop: `${HEADER_HEIGHT}px`,
+      backgroundColor: theme.vars.palette.background.default
+    },
+    ".manager-page-hero": {
+      flexShrink: 0,
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(2),
+      padding: theme.spacing(2.5, 4),
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      background: `linear-gradient(180deg, ${theme.vars.palette.background.paper} 0%, ${theme.vars.palette.background.default} 100%)`
+    },
+    ".manager-page-back": {
+      flexShrink: 0
+    },
+    ".manager-page-icon": {
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: 44,
+      height: 44,
+      minWidth: 44,
+      flexShrink: 0,
+      borderRadius: "var(--rounded-lg)",
+      background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+      color: theme.vars.palette.primary.main
+    },
+    ".manager-page-titles": {
+      minWidth: 0
+    },
+    ".manager-page-title": {
+      margin: 0,
+      fontSize: "var(--fontSizeBig)",
+      fontWeight: 600,
+      lineHeight: 1.2,
+      letterSpacing: "-0.01em",
+      color: theme.vars.palette.text.primary
+    },
+    ".manager-page-subtitle": {
+      margin: 0,
+      marginTop: "2px",
+      fontSize: theme.fontSizeSmall,
+      lineHeight: 1.4,
+      color: theme.vars.palette.text.secondary
+    },
+    ".manager-page-actions": {
+      marginLeft: "auto",
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1),
+      flexShrink: 0
+    },
+    ".manager-page-content": {
+      flex: 1,
+      minHeight: 0,
+      display: "flex",
+      flexDirection: "column",
+      overflow: "hidden"
+    },
+    ".manager-page-content--padded": {
+      overflowY: "auto",
+      padding: theme.spacing(3, 4)
+    }
+  });
+
+/**
+ * Full-screen page chrome for the global managers (Models, Collections,
+ * Workspaces). Renders the fixed AppHeader, a hero strip with a back button,
+ * icon, title/subtitle, and optional actions, then hands the rest of the
+ * viewport to its children.
+ */
+const ManagerPageLayout: React.FC<ManagerPageLayoutProps> = ({
+  icon,
+  title,
+  subtitle,
+  docsUrl,
+  docsLabel = "Documentation",
+  actions,
+  padded = true,
+  children
+}) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const handleBack = useCallback(() => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate("/dashboard");
+    }
+  }, [navigate]);
+
+  return (
+    <Box css={styles(theme)} className="manager-page">
+      <AppHeader />
+      <header className="manager-page-hero">
+        <EditorButton
+          className="manager-page-back"
+          density="normal"
+          onClick={handleBack}
+          startIcon={<ArrowBackRoundedIcon sx={{ fontSize: 16 }} />}
+          aria-label="Go back"
+        >
+          Back
+        </EditorButton>
+        {icon && <span className="manager-page-icon">{icon}</span>}
+        <FlexColumn className="manager-page-titles" gap={0}>
+          <h1 className="manager-page-title">{title}</h1>
+          {subtitle && <p className="manager-page-subtitle">{subtitle}</p>}
+        </FlexColumn>
+        {(docsUrl || actions) && (
+          <FlexRow className="manager-page-actions">
+            {actions}
+            {docsUrl && (
+              <EditorButton
+                variant="outlined"
+                density="normal"
+                endIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                onClick={() =>
+                  window.open(docsUrl, "_blank", "noopener,noreferrer")
+                }
+              >
+                {docsLabel}
+              </EditorButton>
+            )}
+          </FlexRow>
+        )}
+      </header>
+      <Box
+        className={`manager-page-content${
+          padded ? " manager-page-content--padded" : ""
+        }`}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+ManagerPageLayout.displayName = "ManagerPageLayout";
+
+export default memo(ManagerPageLayout);

--- a/web/src/components/panels/ManagerPageLayout.tsx
+++ b/web/src/components/panels/ManagerPageLayout.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import AppHeader from "./AppHeader";
-import { Box, EditorButton, FlexColumn, FlexRow, Text } from "../ui_primitives";
+import { Box, EditorButton, FlexColumn, FlexRow } from "../ui_primitives";
 import { HEADER_HEIGHT } from "../../config/constants";
 
 interface ManagerPageLayoutProps {

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -10,13 +10,19 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import DownloadIcon from "@mui/icons-material/Download";
 import SpaceDashboardOutlinedIcon from "@mui/icons-material/SpaceDashboardOutlined";
 import PaidOutlinedIcon from "@mui/icons-material/PaidOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
+import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
 
+import { isProduction } from "../../lib/env";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { useAppHeaderStore } from "../../stores/AppHeaderStore";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
 import Help from "../content/Help/Help";
 import Logo from "../Logo";
 import { Popover, MenuItemPrimitive, Tooltip } from "../ui_primitives";
+
+const workspacesEnabled = !isProduction;
 
 const logoButtonStyles = (theme: Theme) =>
   css({
@@ -88,6 +94,21 @@ const RailAppMenu: React.FC = () => {
 
   const goCosts = useCallback(() => {
     navigate("/costs");
+    close();
+  }, [navigate, close]);
+
+  const goModels = useCallback(() => {
+    navigate("/models");
+    close();
+  }, [navigate, close]);
+
+  const goCollections = useCallback(() => {
+    navigate("/collections");
+    close();
+  }, [navigate, close]);
+
+  const goWorkspaces = useCallback(() => {
+    navigate("/workspaces");
     close();
   }, [navigate, close]);
 
@@ -165,6 +186,25 @@ const RailAppMenu: React.FC = () => {
             onClick={goCosts}
             dividerAfter
           />
+          <MenuItemPrimitive
+            label="Model Manager"
+            icon={<ViewInArOutlinedIcon />}
+            onClick={goModels}
+          />
+          <MenuItemPrimitive
+            label="Collections"
+            icon={<LibraryBooksOutlinedIcon />}
+            onClick={goCollections}
+            dividerAfter={!workspacesEnabled}
+          />
+          {workspacesEnabled && (
+            <MenuItemPrimitive
+              label="Workspaces"
+              icon={<FolderSpecialOutlinedIcon />}
+              onClick={goWorkspaces}
+              dividerAfter
+            />
+          )}
           <MenuItemPrimitive
             label="Settings"
             icon={<SettingsIcon />}

--- a/web/src/components/workspaces/WorkspacesPage.tsx
+++ b/web/src/components/workspaces/WorkspacesPage.tsx
@@ -1,0 +1,23 @@
+import React, { memo } from "react";
+import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
+import ManagerPageLayout from "../panels/ManagerPageLayout";
+import WorkspacesManager from "./WorkspacesManager";
+
+/**
+ * Full-screen Workspaces page. Reachable from the logo menu; wraps the
+ * workspace manager in the shared manager chrome (header + back button).
+ */
+const WorkspacesPage: React.FC = () => (
+  <ManagerPageLayout
+    icon={<FolderSpecialOutlinedIcon sx={{ fontSize: 22 }} />}
+    title="Workspaces"
+    subtitle="Sandboxed folders that agents and workflows can read, write, and organize files in."
+    docsUrl="https://docs.nodetool.ai/workspaces.html"
+  >
+    <WorkspacesManager />
+  </ManagerPageLayout>
+);
+
+WorkspacesPage.displayName = "WorkspacesPage";
+
+export default memo(WorkspacesPage);

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -75,8 +75,11 @@ const GlobalChat = React.lazy(
 const StandaloneMiniApp = React.lazy(
   () => import("./components/miniapps/StandaloneMiniApp")
 );
-const ModelListIndex = React.lazy(
-  () => import("./components/hugging_face/model_list/ModelListIndex")
+const ModelsPage = React.lazy(
+  () => import("./components/hugging_face/model_list/ModelsPage")
+);
+const WorkspacesPage = React.lazy(
+  () => import("./components/workspaces/WorkspacesPage")
 );
 const WorkflowGraphView = React.lazy(
   () => import("./components/graph_view/WorkflowGraphView")
@@ -330,7 +333,15 @@ function getRoutes() {
       path: "models",
       element: (
         <ProtectedRoute>
-          <ModelListIndex />
+          <ModelsPage />
+        </ProtectedRoute>
+      )
+    },
+    {
+      path: "workspaces",
+      element: (
+        <ProtectedRoute>
+          <WorkspacesPage />
         </ProtectedRoute>
       )
     },


### PR DESCRIPTION
## Summary

Refactors the Models, Collections, and Workspaces managers out of the Settings modal into dedicated full-screen pages, accessible from the logo menu. Introduces a new `ManagerPageLayout` component that provides consistent chrome (AppHeader, back button, hero section with icon/title/subtitle/actions) for these global managers.

## Key Changes

- **New `ManagerPageLayout` component** (`web/src/components/panels/ManagerPageLayout.tsx`): Reusable full-screen page wrapper with fixed AppHeader, hero strip (back button, icon, title, subtitle, optional docs link and custom actions), and scrollable content area. Supports both padded and full-bleed layouts.

- **New dedicated manager pages**:
  - `ModelsPage.tsx`: Wraps `ModelListIndex` in `ManagerPageLayout`
  - `WorkspacesPage.tsx`: Wraps `WorkspacesManager` in `ManagerPageLayout`
  - `CollectionsExplorer.tsx`: Refactored to use `ManagerPageLayout` instead of custom header/layout logic

- **Updated Settings modal** (`SettingsMenu.tsx`):
  - Removed Models, Collections, and Workspaces tabs
  - Removed associated tab indices and conditional logic
  - Removed `isProduction` import (no longer needed for workspaces gating in settings)
  - Cleaned up tab panel rendering

- **Updated logo menu** (`RailAppMenu.tsx`):
  - Added navigation items for Model Manager, Collections, and Workspaces
  - Workspaces item conditionally rendered based on `!isProduction`
  - Each menu item navigates to its respective full-screen page

- **Updated routing** (`index.tsx`):
  - Added `/models` route pointing to `ModelsPage`
  - Added `/workspaces` route pointing to `WorkspacesPage`
  - Lazy-loaded both new pages

- **Minor cleanup** (`CollectionList.tsx`): Removed redundant title/count display from the list header (now provided by `ManagerPageLayout`)

## Implementation Details

- `ManagerPageLayout` uses Emotion CSS for styling with theme integration, matching the existing design system
- Back button intelligently navigates to previous page or dashboard fallback
- All three managers now have consistent UX: same header chrome, navigation patterns, and visual hierarchy
- Workspaces feature gating (`!isProduction`) preserved in the logo menu

https://claude.ai/code/session_01DNPf8SJE66RNww4Gfabcni