### PR TITLE
fix(node-menu): clamp search result descriptions to a single line

### DIFF
--- a/web/src/components/node_menu/SearchResultItem.tsx
+++ b/web/src/components/node_menu/SearchResultItem.tsx
@@ -35,8 +35,6 @@ interface SearchResultItemProps {
   compact?: boolean;
 }
 
-const MAX_DESCRIPTION_LENGTH = 120;
-
 const searchResultStyles = (theme: Theme, compact: boolean) =>
   css({
     "&.search-result-item": {
@@ -111,6 +109,9 @@ const searchResultStyles = (theme: Theme, compact: boolean) =>
         color: theme.vars.palette.text.secondary,
         lineHeight: 1.4,
         marginTop: theme.spacing(1),
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
         "& .highlight": {
           color: "var(--palette-primary-main)"
         }
@@ -265,15 +266,6 @@ const SearchResultItem = memo(
         const searchLower = searchTerm.toLowerCase();
         return tags.filter((tag) => tag.toLowerCase().includes(searchLower));
       }, [searchTerm, tags]);
-
-      // Truncate description if too long - memoize
-      const truncatedDescription = useMemo(
-        () =>
-          description.length > MAX_DESCRIPTION_LENGTH
-            ? description.substring(0, MAX_DESCRIPTION_LENGTH) + "..."
-            : description,
-        [description]
-      );
 
       const [isExpanded, setIsExpanded] = useState(false);
 
@@ -473,10 +465,10 @@ const SearchResultItem = memo(
             </div>
           </div>
 
-          {truncatedDescription && (
+          {description && (
             <Text className="result-description" component="div">
               <HighlightText
-                text={truncatedDescription}
+                text={description}
                 query={searchTerm}
                 matchStyle="primary"
               />


### PR DESCRIPTION
## Problem

In the node menu search results, long node descriptions wrapped to multiple lines, crowding the next result row and making the list look cramped (see e.g. the Claude model nodes where descriptions spilled onto a second line).

## Fix

In `SearchResultItem.tsx`:
- `.result-description` now clamps to a **single line** with `white-space: nowrap` + `overflow: hidden` + `text-overflow: ellipsis`. The ellipsis is responsive to the actual column width — short descriptions show in full, long ones clip cleanly at the right edge, and every row has a uniform height.
- Removed the fixed `MAX_DESCRIPTION_LENGTH = 120` JS truncation (and `truncatedDescription`). It cut at a hard character count regardless of available width and could double up with the CSS ellipsis. The full description goes to the DOM and CSS handles the visual clamp; `HighlightText` still highlights matches within the full text.

Compact mode (left sidebar) was already single-line title-only, so it's unaffected.

## Verification
- `npm run typecheck` ✅
- `eslint` on the changed file ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)