### PR TITLE
fix(providers): resolve asset:// refs in media node uploaders

### DIFF
--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -103,6 +103,12 @@ type StorageLike = {
 
 type ProcessContext = Parameters<BaseNode["process"]>[0] & {
   storage?: StorageLike | null;
+  // Canonical asset resolver on ProcessingContext. Resolves asset://<id> and
+  // package://<pkg>/<path> reference URIs that storage adapters return null for.
+  // SSRF-safe — it performs no unguarded outbound fetches.
+  resolveAssetBytes?: (
+    uri: string
+  ) => Promise<{ bytes: Uint8Array | null }>;
 };
 
 function looksLikePublicUrl(s: unknown): s is string {
@@ -286,6 +292,25 @@ export async function resolveAssetForAtlas(
   }
   if (r.data instanceof Uint8Array && r.data.byteLength > 0) {
     return bytesToDataUri(r.data, guessMime(r, defaultMimeFor(fieldType)));
+  }
+
+  // Reference URIs (asset://<id>, package://<pkg>/<path>) that storage adapters
+  // return null for — resolve them via the canonical, SSRF-safe context helper.
+  // Read uri fresh from ref: the looksLikePublicUrl predicate above narrowed
+  // r.uri away, so a typeof check re-establishes the string type here.
+  const uri = (ref as AssetRef).uri;
+  if (
+    typeof uri === "string" &&
+    (uri.startsWith("asset://") || uri.startsWith("package://")) &&
+    context?.resolveAssetBytes
+  ) {
+    const { bytes } = await context.resolveAssetBytes(uri);
+    if (bytes && bytes.byteLength > 0) {
+      return bytesToDataUri(
+        new Uint8Array(bytes),
+        guessMime(r, defaultMimeFor(fieldType))
+      );
+    }
   }
 
   if (r.uri && context?.storage) {

--- a/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
@@ -60,6 +60,28 @@ describe("resolveAssetForAtlas", () => {
     expect(out).toBe("data:image/png;base64,AQID");
   });
 
+  // Storage adapters return null for asset://<id> reference URIs (they only
+  // know memory://, /api/storage/..., file paths). The canonical resolver
+  // context.resolveAssetBytes handles asset:// (and package://) refs, so the
+  // resolver must consult it before falling through to fetch/throw.
+  it("uses context.resolveAssetBytes for asset:// refs storage can't materialize", async () => {
+    const retrieve = vi.fn().mockResolvedValue(null);
+    const resolveAssetBytes = vi
+      .fn()
+      .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) });
+    const out = await resolveAssetForAtlas(
+      { type: "image", uri: "asset://asset-123" },
+      { storage: { retrieve }, resolveAssetBytes } as unknown as never,
+      "image"
+    );
+    expect(resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect(out).toBe(
+      `data:image/png;base64,${Buffer.from(
+        Uint8Array.from([137, 80, 78, 71])
+      ).toString("base64")}`
+    );
+  });
+
   // SSRF defense: refs whose URIs point at the runtime's own host, RFC1918
   // private space, or cloud-metadata endpoints are never fetched. With no
   // alternative resolution path, resolveAssetForAtlas throws.

--- a/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
+++ b/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
@@ -97,7 +97,9 @@ export class SpeechToTextNode extends BaseNode {
   })
   declare file_format: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const apiKey = getElevenLabsApiKey(this._secrets);
 
     const audio = this.audio as Record<string, unknown> | undefined;
@@ -117,7 +119,8 @@ export class SpeechToTextNode extends BaseNode {
     const diarize = Boolean(this.diarize ?? this.diarize ?? false);
     const fileFormat = String(this.file_format ?? this.file_format ?? "other");
 
-    // Get audio bytes from data URI or fetch from URI
+    // Get audio bytes from inline data, an asset/package ref resolved via the
+    // processing context, or a direct HTTP(S) fetch as a fallback.
     let audioBytes: Buffer;
     if (audio.data && typeof audio.data === "string") {
       const match = (audio.data as string).match(/^data:[^;]+;base64,(.+)$/);
@@ -127,10 +130,21 @@ export class SpeechToTextNode extends BaseNode {
         throw new Error("Invalid audio data URI");
       }
     } else if (audio.uri && typeof audio.uri === "string") {
-      const resp = await fetch(audio.uri as string);
-      if (!resp.ok)
-        throw new Error(`Failed to fetch audio: ${resp.statusText}`);
-      audioBytes = Buffer.from(await resp.arrayBuffer());
+      const uri = audio.uri;
+      if (/^https?:\/\//i.test(uri)) {
+        const resp = await fetch(uri);
+        if (!resp.ok)
+          throw new Error(`Failed to fetch audio: ${resp.statusText}`);
+        audioBytes = Buffer.from(await resp.arrayBuffer());
+      } else {
+        // asset://, package://, or any storage/relative URI — must be resolved
+        // through the processing context, not fetched directly.
+        const resolved = await context?.resolveAssetBytes?.(uri);
+        if (!resolved?.bytes) {
+          throw new Error(`Failed to resolve audio reference: ${uri}`);
+        }
+        audioBytes = Buffer.from(resolved.bytes);
+      }
     } else {
       throw new Error("Audio must have a data URI or uri field");
     }

--- a/packages/elevenlabs-nodes/tests/speech-to-text.test.ts
+++ b/packages/elevenlabs-nodes/tests/speech-to-text.test.ts
@@ -125,6 +125,32 @@ describe("SpeechToTextNode", () => {
     expect(result.text).toBe("fetched audio");
   });
 
+  it("resolves an asset:// uri via the processing context", async () => {
+    // Only the STT API call should hit fetch; the audio bytes come from the
+    // context resolver, not from fetch("asset://...").
+    const resolvedBytes = new Uint8Array(
+      Buffer.from(WAV_BASE64, "base64")
+    );
+    const resolveAssetBytes = vi.fn(async () => ({
+      bytes: resolvedBytes,
+      attempts: []
+    }));
+    const context = { resolveAssetBytes } as unknown as Parameters<
+      SpeechToTextNode["process"]
+    >[0];
+
+    const node = makeNode({ audio: { type: "audio", uri: "asset://asset-123" } });
+    const result = await node.process(context);
+
+    expect(resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    // fetch is used ONLY for the ElevenLabs API, never for the asset:// ref.
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://api.elevenlabs.io/v1/speech-to-text"
+    );
+    expect(result.text).toBe("Hello world");
+  });
+
   it("throws when ElevenLabs API returns an error", async () => {
     mockFetch.mockResolvedValue({
       ok: false,

--- a/packages/fal-nodes/src/fal-base.ts
+++ b/packages/fal-nodes/src/fal-base.ts
@@ -97,6 +97,9 @@ interface UploadContext {
   storage?: {
     retrieve(uri: string): Promise<Uint8Array | null | undefined>;
   } | null;
+  resolveAssetBytes?: (
+    uri: string
+  ) => Promise<{ bytes: Uint8Array | null }>;
 }
 
 export async function assetToFalUrl(
@@ -115,6 +118,19 @@ export async function assetToFalUrl(
   }
   // For non-HTTPS URIs (http://, file://, relative paths, etc.), try to fetch and upload
   if (uri) {
+    // Asset/package reference URIs are resolved via the context's canonical
+    // resolver — storage adapters only understand their own schemes and return
+    // null for `asset://<id>` / `package://<pkg>/<path>` references.
+    if (
+      (uri.startsWith("asset://") || uri.startsWith("package://")) &&
+      context?.resolveAssetBytes
+    ) {
+      const { bytes } = await context.resolveAssetBytes(uri);
+      if (bytes) {
+        return falUpload(apiKey, bytes, inferContentType(ref.type as string));
+      }
+    }
+
     const bytes = await context?.storage?.retrieve(uri);
     if (bytes) {
       return falUpload(apiKey, bytes, inferContentType(ref.type as string));

--- a/packages/fal-nodes/tests/fal-base.test.ts
+++ b/packages/fal-nodes/tests/fal-base.test.ts
@@ -326,6 +326,31 @@ describe("assetToFalUrl", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("resolves asset:// ref via context.resolveAssetBytes and uploads", async () => {
+    const context = {
+      storage: {
+        retrieve: vi.fn(async () => null)
+      },
+      resolveAssetBytes: vi.fn(async () => ({
+        bytes: Uint8Array.from([137, 80, 78, 71])
+      }))
+    };
+    mockStorageUpload.mockResolvedValueOnce(
+      "https://v3.fal.media/files/asset-resolved.png"
+    );
+
+    const url = await assetToFalUrl(
+      apiKey,
+      { type: "image", uri: "asset://asset-123" },
+      context
+    );
+
+    expect(url).toBe("https://v3.fal.media/files/asset-resolved.png");
+    expect(context.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect(mockStorageUpload).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("returns null when no uri and no data", async () => {
     const url = await assetToFalUrl(apiKey, { type: "image" });
     expect(url).toBeNull();

--- a/packages/huggingface-nodes/src/huggingface-base.ts
+++ b/packages/huggingface-nodes/src/huggingface-base.ts
@@ -49,8 +49,22 @@ export function isRefSet(ref: MediaRef | undefined | null): ref is MediaRef {
   return !!ref && (!!ref.uri || !!ref.data);
 }
 
+/**
+ * Minimal structural view of the ProcessingContext that a node's `process()`
+ * receives. We only need `resolveAssetBytes` here, which resolves NodeTool's
+ * own reference schemes (`asset://<id>`, `package://<pkg>/<path>`, storage
+ * URIs). Typed structurally to keep this package free of a `@nodetool-ai/runtime`
+ * dependency.
+ */
+export type AssetResolveContext =
+  | { resolveAssetBytes?: (uri: string) => Promise<{ bytes: Uint8Array | null }> }
+  | undefined;
+
 /** Read the raw bytes behind an image/audio/video ref (data URI, base64, or URL). */
-export async function refToBytes(ref: MediaRef): Promise<Uint8Array> {
+export async function refToBytes(
+  ref: MediaRef,
+  context?: AssetResolveContext
+): Promise<Uint8Array> {
   const data = ref.data;
   if (data instanceof Uint8Array) {
     return data;
@@ -67,18 +81,33 @@ export async function refToBytes(ref: MediaRef): Promise<Uint8Array> {
       const base64 = uri.slice(uri.indexOf(",") + 1);
       return new Uint8Array(Buffer.from(base64, "base64"));
     }
-    const res = await fetch(uri);
-    if (!res.ok) {
-      throw new Error(`Failed to fetch media from ${uri}: ${res.status}`);
+    const isHttp = uri.startsWith("http://") || uri.startsWith("https://");
+    // NodeTool reference schemes (asset://, package://) and storage URIs are
+    // not fetchable directly — resolve them through the ProcessingContext.
+    if (!isHttp && context?.resolveAssetBytes) {
+      const { bytes } = await context.resolveAssetBytes(uri);
+      if (bytes) {
+        return bytes;
+      }
+      throw new Error(`Failed to resolve media from ${uri}`);
     }
-    return new Uint8Array(await res.arrayBuffer());
+    if (isHttp) {
+      const res = await fetch(uri);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch media from ${uri}: ${res.status}`);
+      }
+      return new Uint8Array(await res.arrayBuffer());
+    }
   }
   throw new Error("Media input is empty — provide an image/audio/video.");
 }
 
 /** Read a media ref as a base64 string (no `data:` prefix), as the API expects. */
-export async function refToBase64(ref: MediaRef): Promise<string> {
-  const bytes = await refToBytes(ref);
+export async function refToBase64(
+  ref: MediaRef,
+  context?: AssetResolveContext
+): Promise<string> {
+  const bytes = await refToBytes(ref, context);
   return Buffer.from(bytes).toString("base64");
 }
 

--- a/packages/huggingface-nodes/src/nodes/audio.ts
+++ b/packages/huggingface-nodes/src/nodes/audio.ts
@@ -58,14 +58,16 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
   })
   declare return_timestamps: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const audio = this.audio as MediaRef | undefined;
     if (!audio || (!audio.uri && !audio.data)) {
       throw new Error("Input audio is required");
     }
 
-    const base64 = await refToBase64(audio);
+    const base64 = await refToBase64(audio, context);
     const returnTimestamps = Boolean(this.return_timestamps ?? false);
 
     const result = await hfPipelineJson<{
@@ -128,14 +130,16 @@ export class AudioClassificationNode extends BaseNode {
   })
   declare top_k: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const audio = this.audio as MediaRef | undefined;
     if (!audio || (!audio.uri && !audio.data)) {
       throw new Error("Input audio is required");
     }
 
-    const base64 = await refToBase64(audio);
+    const base64 = await refToBase64(audio, context);
     const result = await hfPipelineJson<
       Array<{ label?: string; score?: number }>
     >(token, String(this.model ?? "superb/hubert-base-superb-er"), {

--- a/packages/huggingface-nodes/src/nodes/image.ts
+++ b/packages/huggingface-nodes/src/nodes/image.ts
@@ -220,14 +220,16 @@ export class ImageToImageNode extends BaseNode {
   })
   declare num_inference_steps: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
       throw new Error("Input image is required");
     }
 
-    const base64 = await refToBase64(image);
+    const base64 = await refToBase64(image, context);
     const guidance = Number(this.guidance_scale ?? 0);
     const steps = Number(this.num_inference_steps ?? 0);
 
@@ -294,14 +296,16 @@ export class ImageClassificationNode extends BaseNode {
   })
   declare top_k: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
       throw new Error("Input image is required");
     }
 
-    const base64 = await refToBase64(image);
+    const base64 = await refToBase64(image, context);
     const result = await hfPipelineJson<
       Array<{ label?: string; score?: number }>
     >(token, String(this.model ?? "google/vit-base-patch16-224"), {
@@ -347,14 +351,16 @@ export class ImageSegmentationNode extends BaseNode {
   })
   declare image: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
       throw new Error("Input image is required");
     }
 
-    const base64 = await refToBase64(image);
+    const base64 = await refToBase64(image, context);
     const result = await hfPipelineJson<
       Array<{ label?: string; score?: number; mask?: string }>
     >(token, String(this.model ?? "nvidia/segformer-b0-finetuned-ade-512-512"), {
@@ -415,14 +421,16 @@ export class ObjectDetectionNode extends BaseNode {
   })
   declare threshold: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(
+    context?: Parameters<BaseNode["process"]>[0]
+  ): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
       throw new Error("Input image is required");
     }
 
-    const base64 = await refToBase64(image);
+    const base64 = await refToBase64(image, context);
     const result = await hfPipelineJson<
       Array<{
         label?: string;

--- a/packages/huggingface-nodes/tests/huggingface-base.test.ts
+++ b/packages/huggingface-nodes/tests/huggingface-base.test.ts
@@ -68,6 +68,31 @@ describe("media ref helpers", () => {
   it("refToBytes throws on empty ref", async () => {
     await expect(refToBytes({})).rejects.toThrow(/empty/);
   });
+
+  it("refToBytes resolves an asset:// uri via context, not fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const ctx = {
+      resolveAssetBytes: vi
+        .fn()
+        .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) })
+    };
+    const bytes = await refToBytes({ type: "image", uri: "asset://asset-123" }, ctx);
+    expect(Array.from(bytes)).toEqual([137, 80, 78, 71]);
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refToBase64 resolves an asset:// uri via context", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const ctx = {
+      resolveAssetBytes: vi
+        .fn()
+        .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) })
+    };
+    const b64 = await refToBase64({ type: "image", uri: "asset://asset-123" }, ctx);
+    expect(Buffer.from(b64, "base64")).toEqual(Buffer.from([137, 80, 78, 71]));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("output ref builders", () => {

--- a/packages/kie-nodes/src/kie-base.ts
+++ b/packages/kie-nodes/src/kie-base.ts
@@ -3,14 +3,11 @@
  * Uses native fetch (Node 18+).
  */
 
+import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import type { MediaRefValue, ProcessingContext } from "@nodetool-ai/runtime";
+
 const KIE_API_BASE = "https://api.kie.ai";
 const KIE_UPLOAD_URL = "https://kieai.redpandaai.co/api/file-stream-upload";
-
-type UploadContext = {
-  storage?: {
-    retrieve: (uri: string) => Promise<Uint8Array | null> | Uint8Array | null;
-  } | null;
-};
 
 function headers(apiKey: string): Record<string, string> {
   return {
@@ -164,45 +161,28 @@ function isLocalHttpUrl(uri: string): boolean {
   );
 }
 
+/**
+ * Resolve an asset ref to raw bytes for upload. Delegates to the canonical
+ * {@link loadMediaRefBytes}, which handles inline `data`, `data:` URIs,
+ * `asset://<id>` references (via `context.resolveAssetBytes`), package asset
+ * URIs, opaque storage URIs (plus `asset_id` → `/api/storage/<id>.<ext>`
+ * candidates), local file paths, and local http(s) URLs. KIE's earlier bespoke
+ * resolver only handled `data`/`data:`/`storage.retrieve(uri)`, so `asset://`
+ * refs — the format this package's own field descriptions recommend — failed
+ * with "Image has no data or URI".
+ */
 async function resolveUploadBytes(
   ref: Record<string, unknown>,
-  context?: UploadContext
+  context?: ProcessingContext
 ): Promise<Buffer | null> {
-  const data = ref.data as string | undefined;
-  if (data) {
-    return Buffer.from(data, "base64");
-  }
-
-  const uri = ref.uri as string | undefined;
-  if (!uri) return null;
-
-  if (uri.startsWith("data:")) {
-    const commaIndex = uri.indexOf(",");
-    if (commaIndex !== -1) {
-      const encoded = uri.slice(commaIndex + 1);
-      return Buffer.from(encoded, "base64");
-    }
-  }
-
-  const bytes = await context?.storage?.retrieve(uri);
-  if (bytes) {
-    return Buffer.from(bytes);
-  }
-
-  if (isRemoteHttpUrl(uri) && isLocalHttpUrl(uri)) {
-    const response = await fetch(uri);
-    if (response.ok) {
-      return Buffer.from(await response.arrayBuffer());
-    }
-  }
-
-  return null;
+  const bytes = await loadMediaRefBytes(ref as MediaRefValue, context);
+  return bytes ? Buffer.from(bytes) : null;
 }
 
 export async function uploadImageInput(
   apiKey: string,
   image: unknown,
-  context?: UploadContext
+  context?: ProcessingContext
 ): Promise<string> {
   if (!image || typeof image !== "object") throw new Error("Image is required");
   const img = image as Record<string, unknown>;
@@ -223,7 +203,7 @@ export async function uploadImageInput(
 export async function uploadAudioInput(
   apiKey: string,
   audio: unknown,
-  context?: UploadContext
+  context?: ProcessingContext
 ): Promise<string> {
   if (!audio || typeof audio !== "object") throw new Error("Audio is required");
   const a = audio as Record<string, unknown>;
@@ -244,7 +224,7 @@ export async function uploadAudioInput(
 export async function uploadVideoInput(
   apiKey: string,
   video: unknown,
-  context?: UploadContext
+  context?: ProcessingContext
 ): Promise<string> {
   if (!video || typeof video !== "object") throw new Error("Video is required");
   const v = video as Record<string, unknown>;

--- a/packages/kie-nodes/tests/kie-base.test.ts
+++ b/packages/kie-nodes/tests/kie-base.test.ts
@@ -131,6 +131,42 @@ describe("uploadImageInput", () => {
     expect(result).toBe("https://kie.example/uploaded.png");
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
+
+  it("uploads bytes for asset:// refs via resolveAssetBytes", async () => {
+    const storage = { retrieve: vi.fn().mockResolvedValue(null) };
+    const resolveAssetBytes = vi
+      .fn()
+      .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) });
+
+    const result = await uploadImageInput(
+      "test-api-key",
+      { type: "image", uri: "asset://asset-123" },
+      { storage, resolveAssetBytes } as any
+    );
+
+    expect(resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect(result).toBe("https://kie.example/uploaded.png");
+  });
+
+  it("uploads bytes via asset_id storage candidates when the uri misses", async () => {
+    const storage = {
+      retrieve: vi
+        .fn()
+        .mockImplementation(async (key: string) =>
+          key === "/api/storage/asset-123.png"
+            ? Uint8Array.from([137, 80, 78, 71])
+            : null
+        )
+    };
+
+    const result = await uploadImageInput(
+      "test-api-key",
+      { type: "image", uri: "/api/storage/stale.png", asset_id: "asset-123" },
+      { storage } as any
+    );
+
+    expect(result).toBe("https://kie.example/uploaded.png");
+  });
 });
 
 describe("kieExecuteOmniDirect", () => {

--- a/packages/replicate-nodes/src/replicate-base.ts
+++ b/packages/replicate-nodes/src/replicate-base.ts
@@ -62,6 +62,9 @@ interface UploadContext {
   storage?: {
     retrieve(uri: string): Promise<Uint8Array | null | undefined>;
   } | null;
+  resolveAssetBytes?: (
+    uri: string
+  ) => Promise<{ bytes: Uint8Array | null }>;
 }
 
 /**
@@ -95,6 +98,24 @@ export async function assetToUrl(
         return await uploadToReplicate(apiKey, uri);
       } catch {
         return uri;
+      }
+    }
+    // Asset/package references: resolve to bytes via the context and upload.
+    // Storage adapters only understand their own URI schemes, so these refs
+    // must go through resolveAssetBytes (asset://<id>, package://<pkg>/<path>).
+    if (
+      apiKey &&
+      context?.resolveAssetBytes &&
+      (uri.startsWith("asset://") || uri.startsWith("package://"))
+    ) {
+      const { bytes } = await context.resolveAssetBytes(uri);
+      if (bytes) {
+        return uploadBytesToReplicate(
+          apiKey,
+          bytes,
+          inferMime(ref),
+          filenameForMime(inferMime(ref))
+        );
       }
     }
     // Local/relative paths: resolve via local server and upload

--- a/packages/replicate-nodes/tests/replicate-base.test.ts
+++ b/packages/replicate-nodes/tests/replicate-base.test.ts
@@ -1,4 +1,13 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const mockFilesCreate = vi.fn();
+
+vi.mock("replicate", () => ({
+  default: class {
+    files = { create: mockFilesCreate };
+  }
+}));
+
 import {
   getReplicateApiKey,
   removeNulls,
@@ -171,6 +180,29 @@ describe("assetToUrl", () => {
   it("passes through data URIs", async () => {
     const dataUri = "data:image/png;base64,abc123";
     expect(await assetToUrl({ uri: dataUri })).toBe(dataUri);
+  });
+
+  it("resolves asset:// refs via context.resolveAssetBytes and uploads them", async () => {
+    mockFilesCreate.mockResolvedValueOnce({
+      urls: { get: "https://replicate.delivery/uploaded/asset-123.png" }
+    });
+
+    const ctx = {
+      storage: { retrieve: vi.fn().mockResolvedValue(null) },
+      resolveAssetBytes: vi
+        .fn()
+        .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) })
+    };
+
+    const result = await assetToUrl(
+      { type: "image", uri: "asset://asset-123" },
+      "api-key",
+      ctx
+    );
+
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect(result).toBe("https://replicate.delivery/uploaded/asset-123.png");
+    expect(result).not.toBe("asset://asset-123");
   });
 });
 

--- a/packages/reve-nodes/src/reve-base.ts
+++ b/packages/reve-nodes/src/reve-base.ts
@@ -61,7 +61,14 @@ type StorageLike = {
   retrieve: (uri: string) => Promise<Uint8Array | null> | Uint8Array | null;
 } | null;
 
-type AssetContext = { storage?: StorageLike } | undefined;
+type AssetContext =
+  | {
+      storage?: StorageLike;
+      resolveAssetBytes?: (
+        uri: string
+      ) => Promise<{ bytes: Uint8Array | null }>;
+    }
+  | undefined;
 
 // ---------------------------------------------------------------------------
 // API key
@@ -110,6 +117,14 @@ export async function refToBytes(
   const dataUriMatch = uri.match(/^data:[^;]*;base64,(.+)$/s);
   if (dataUriMatch) {
     return new Uint8Array(Buffer.from(dataUriMatch[1], "base64"));
+  }
+
+  if (
+    (uri.startsWith("asset://") || uri.startsWith("package://")) &&
+    context?.resolveAssetBytes
+  ) {
+    const { bytes } = await context.resolveAssetBytes(uri);
+    if (bytes) return new Uint8Array(bytes);
   }
 
   if (context?.storage) {

--- a/packages/reve-nodes/tests/reve-base.test.ts
+++ b/packages/reve-nodes/tests/reve-base.test.ts
@@ -56,6 +56,21 @@ describe("refToBytes / refToBase64", () => {
     expect(storage.retrieve).toHaveBeenCalledWith("asset://x");
   });
 
+  it("resolves an asset:// ref via context.resolveAssetBytes when storage returns null", async () => {
+    const ctx = {
+      storage: { retrieve: vi.fn().mockResolvedValue(null) },
+      resolveAssetBytes: vi
+        .fn()
+        .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) })
+    };
+    const bytes = await refToBytes(
+      { type: "image", uri: "asset://asset-123" },
+      ctx
+    );
+    expect([...bytes]).toEqual([137, 80, 78, 71]);
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+  });
+
   it("throws without data or uri", async () => {
     await expect(refToBytes({})).rejects.toThrow("Image has no data or URI");
   });

--- a/packages/storage/src/supabase-storage-adapter.ts
+++ b/packages/storage/src/supabase-storage-adapter.ts
@@ -5,6 +5,7 @@ import type {
   StorageListResult,
   StorageStat
 } from "./storage-adapter.js";
+import { normalizeStorageKey } from "./storage-keys.js";
 
 export interface SupabaseStorageAdapterOptions {
   url: string;
@@ -125,7 +126,24 @@ export class SupabaseStorageAdapter implements StorageAdapter {
     // flat mode we'd have to walk recursively — implement hierarchical only
     // for now and fall back to a single-level listing without commonPrefixes
     // for flat mode (callers wanting recursion should walk themselves).
-    const dir = prefix.replace(/\/+$/, "");
+    // Normalize the (possibly caller-supplied) prefix the way the file and S3
+    // adapters do. normalizeStorageKey rejects path-traversal keys and uses no
+    // polynomial regex, avoiding the ReDoS that `prefix.replace(/\/+$/, "")`
+    // suffered on long `/`-runs reachable from asset refs (CWE-1333). Invalid
+    // keys yield an empty listing rather than escaping the bucket.
+    let dir = "";
+    if (prefix && prefix !== "/") {
+      try {
+        dir = normalizeStorageKey(prefix);
+      } catch {
+        return { entries: [], commonPrefixes: [] };
+      }
+    }
+    // path.normalize can leave a single trailing slash (e.g. "a/"); strip it so
+    // childKey construction below never produces "dir//name".
+    if (dir.endsWith("/")) {
+      dir = dir.slice(0, -1);
+    }
     const { data, error } = await this.getClient()
       .storage.from(this.bucket)
       .list(dir, { limit: 1000 });

--- a/packages/storage/tests/storage-adapters.test.ts
+++ b/packages/storage/tests/storage-adapters.test.ts
@@ -177,6 +177,41 @@ describe("SupabaseStorageAdapter", () => {
     expect(storage.getPublicUrl("file:///tmp/x")).toBeNull();
   });
 
+  // A fake client exposing a single stable `list` spy (the shared fakeClient's
+  // `from()` returns a fresh object per call, so its spy can't be asserted on).
+  function clientWithListSpy() {
+    const list = vi.fn(async () => ({ data: [], error: null }));
+    const bucket = { list };
+    return { client: { storage: { from: () => bucket } } as any, list };
+  }
+
+  it("list() strips trailing slashes without a polynomial regex", async () => {
+    const { client, list } = clientWithListSpy();
+    const storage = new SupabaseStorageAdapter({
+      url: "https://x.supabase.co",
+      apiKey: "k",
+      bucket: "uploads",
+      client
+    });
+    // A long run of trailing slashes is the ReDoS trigger for /\/+$/; the
+    // normalized prefix must collapse to "foo" and complete promptly.
+    await storage.list(`foo${"/".repeat(50000)}`);
+    expect(list).toHaveBeenCalledWith("foo", expect.anything());
+  });
+
+  it("list() rejects path-traversal prefixes with an empty result", async () => {
+    const { client, list } = clientWithListSpy();
+    const storage = new SupabaseStorageAdapter({
+      url: "https://x.supabase.co",
+      apiKey: "k",
+      bucket: "uploads",
+      client
+    });
+    const result = await storage.list("../../etc");
+    expect(result).toEqual({ entries: [], commonPrefixes: [] });
+    expect(list).not.toHaveBeenCalled();
+  });
+
   it("requires url/serviceKey/bucket", () => {
     expect(
       () =>

--- a/packages/together-nodes/src/together-base.ts
+++ b/packages/together-nodes/src/together-base.ts
@@ -164,6 +164,15 @@ export interface AssetStorageLike {
 
 export interface AssetResolveContext {
   storage?: AssetStorageLike | null;
+  /**
+   * Canonical ProcessingContext resolver for reference URIs (`asset://<id>`,
+   * `package://<pkg>/<path>`). Storage adapters return null for these, so this
+   * is the only path that resolves them. SSRF-safe (resolves from storage / the
+   * configured server, never an attacker-controlled host).
+   */
+  resolveAssetBytes?: (
+    uri: string
+  ) => Promise<{ bytes: Uint8Array | null }>;
 }
 
 function decodeBase64(data: string): Uint8Array {
@@ -208,6 +217,16 @@ export async function resolveAssetBytes(
   // Empty placeholder ref (no uri, no data) → treat as "no asset provided" so
   // the caller can surface a clear "<field> is required" error instead.
   if (uri.length === 0) return null;
+
+  // Reference URIs (`asset://<id>`, `package://<pkg>/<path>`) are not known to
+  // storage adapters — only the ProcessingContext resolver handles them.
+  if (
+    (uri.startsWith("asset://") || uri.startsWith("package://")) &&
+    context?.resolveAssetBytes
+  ) {
+    const { bytes } = await context.resolveAssetBytes(uri);
+    if (bytes) return new Uint8Array(bytes);
+  }
 
   if (context?.storage) {
     try {

--- a/packages/together-nodes/tests/together-base.test.ts
+++ b/packages/together-nodes/tests/together-base.test.ts
@@ -70,6 +70,19 @@ describe("resolveAssetBytes", () => {
     expect(Array.from(out!)).toEqual([9, 9]);
   });
 
+  it("resolves an asset:// uri via context.resolveAssetBytes", async () => {
+    const pngBytes = Uint8Array.from([137, 80, 78, 71]);
+    const storage = { retrieve: vi.fn().mockResolvedValue(null) };
+    const resolve = vi.fn().mockResolvedValue({ bytes: pngBytes });
+    const out = await resolveAssetBytes(
+      { type: "image", uri: "asset://asset-123" },
+      { storage, resolveAssetBytes: resolve } as never,
+      "image"
+    );
+    expect(resolve).toHaveBeenCalledWith("asset://asset-123");
+    expect(Array.from(out!)).toEqual([137, 80, 78, 71]);
+  });
+
   it("fetches a public https url ref", async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,

--- a/packages/topaz-nodes/src/topaz-base.ts
+++ b/packages/topaz-nodes/src/topaz-base.ts
@@ -96,7 +96,14 @@ type StorageLike = {
   retrieve: (uri: string) => Promise<Uint8Array | null> | Uint8Array | null;
 } | null;
 
-type AssetContext = { storage?: StorageLike } | undefined;
+type AssetContext =
+  | {
+      storage?: StorageLike;
+      resolveAssetBytes?: (
+        uri: string
+      ) => Promise<{ bytes: Uint8Array | null }>;
+    }
+  | undefined;
 
 // ---------------------------------------------------------------------------
 // API key
@@ -245,6 +252,14 @@ export async function refToBytes(
   const dataUriMatch = uri.match(/^data:[^;]*;base64,(.+)$/s);
   if (dataUriMatch) {
     return new Uint8Array(Buffer.from(dataUriMatch[1], "base64"));
+  }
+
+  if (
+    (uri.startsWith("asset://") || uri.startsWith("package://")) &&
+    context?.resolveAssetBytes
+  ) {
+    const { bytes } = await context.resolveAssetBytes(uri);
+    if (bytes) return new Uint8Array(bytes);
   }
 
   if (context?.storage) {

--- a/packages/topaz-nodes/tests/topaz-base.test.ts
+++ b/packages/topaz-nodes/tests/topaz-base.test.ts
@@ -79,6 +79,20 @@ describe("refToBytes", () => {
     expect([...bytes]).toEqual([9, 8, 7]);
   });
 
+  it("resolves an asset:// ref via context.resolveAssetBytes", async () => {
+    const png = Uint8Array.from([137, 80, 78, 71]);
+    const ctx = {
+      storage: { retrieve: vi.fn().mockResolvedValue(null) },
+      resolveAssetBytes: vi.fn().mockResolvedValue({ bytes: png })
+    };
+    const bytes = await refToBytes(
+      { type: "image", uri: "asset://asset-123" },
+      ctx as never
+    );
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
+    expect([...bytes]).toEqual([137, 80, 78, 71]);
+  });
+
   it("throws when neither data nor uri is set", async () => {
     await expect(refToBytes({})).rejects.toThrow("Asset has no data or URI");
   });


### PR DESCRIPTION
## Problem

Running a KIE video node with an image-list input failed with **`Image has no data or URI`**. Root cause: provider node packages resolve user media refs (`{ type, uri, data, asset_id }`) with bespoke logic that calls `context.storage.retrieve(uri)` (or a raw `fetch(uri)`) directly. Storage adapters only understand their own URI schemes (`memory://`, `/api/storage/...`, file paths) and return `null` for **`asset://<id>`** reference URIs — which is the format the nodes' own field descriptions recommend (`asset://{assetId}`), and what flows in from image-list inputs, saved workflows, and node-to-node connections.

Auditing the other providers showed the **same class of bug in 8 packages**, with severity ranging from a thrown error, to silently dropping the image, to handing the remote model a bogus `asset://` URL.

## Fix

Route reference URIs (`asset://`, `package://`) through the canonical, SSRF-safe `ProcessingContext.resolveAssetBytes()` before each provider's storage fallback — the same call `loadMediaRefBytes` makes internally. All existing provider-URL passthroughs and SSRF guards are preserved.

| Package | Was | Fix |
|---|---|---|
| `kie-nodes` | threw `Image has no data or URI` | `resolveUploadBytes` delegates to canonical `loadMediaRefBytes` |
| `fal-nodes` | returned `null` → image dropped | `asset://` → `resolveAssetBytes` → `falUpload` |
| `replicate-nodes` | passed `asset://` as a bogus URL | → `resolveAssetBytes` → `uploadBytesToReplicate` |
| `reve-nodes` | threw `Cannot resolve image URI` | surgical `asset://` branch in `refToBytes` |
| `topaz-nodes` | threw `Cannot resolve asset URI` | surgical `asset://` branch in `refToBytes` |
| `together-nodes` | threw `not a fetchable URL` | `asset://` branch **before** the SSRF-guarded fetch (guard kept) |
| `atlascloud-nodes` | fell through / failed | `asset://` → data-URI (SSRF guard kept) |
| `elevenlabs-nodes` | `fetch("asset://…")` threw; no storage at all | threaded `context` into `SpeechToTextNode.process`, resolve via context |
| `huggingface-nodes` | `fetch("asset://…")` threw; no storage at all | threaded `context` through `refToBytes`/`refToBase64` into 6 nodes (image ×4, audio ×2) |

Already correct (use `loadMediaRefBytes`): `image-nodes`, `video-nodes`, `integration-nodes`, `minimax-nodes`.

Notes: ElevenLabs realtime/TTS nodes were audited and don't read media inputs; `huggingface` `TextToImageNode` has no media input. `reve`/`topaz`/`huggingface` get no new `@nodetool-ai/runtime` dependency — they call the context method via structural types.

## Verification

- `npm run build:packages` — all 54 packages typecheck ✅
- Test suites for all 9 changed packages: **498 passed, 0 failed** ✅ (each fix is TDD'd — failing test confirmed first, then green)
- `oxlint` clean across all 9 changed `src` dirs ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: ReDoS in Supabase storage adapter (CodeQL #209, high)

While reviewing the data flow above, CodeQL flagged `js/polynomial-redos` at `packages/storage/src/supabase-storage-adapter.ts:128`: `prefix.replace(/\/+$/, "")` is a polynomial regex, and the `prefix` is tainted by the very asset-resolution flow this PR widens (`loadMediaRefBytes` → `resolveAssetBytes` → `storage.list`). A crafted `asset://` ref with a long run of `/` could backtrack quadratically → DoS.

Fix: normalize the prefix with `normalizeStorageKey()` exactly like the file and S3 adapters already do — no polynomial regex, and it rejects path-traversal keys (the Supabase adapter was the only one not normalizing). A single trailing slash left by `path.normalize` is stripped without a regex. Covered by two new tests (50k-slash input resolves in ~2ms; `../../etc` returns empty without hitting the backend).
