### PR TITLE
auth: add Stryker mutation testing scaffold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42732,6 +42732,8 @@
         "jose": "^6.2.0"
       },
       "devDependencies": {
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/vitest-runner": "^9.6.1",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       }

--- a/packages/auth/MUTATION_TESTING.md
+++ b/packages/auth/MUTATION_TESTING.md
@@ -18,54 +18,90 @@ The HTML report lands in `reports/mutation/mutation.html` (git-ignored).
 
 ## Current status
 
-Baseline (initial scaffold, before any mutation-driven hardening):
-
 ```
-File                     | % score | killed | survived | no cov
--------------------------|---------|--------|----------|-------
-local-provider.ts        |  100.00 |      4 |        0 |      0
-static-token-provider.ts |   92.00 |     23 |        2 |      0
-auth-provider.ts         |   89.83 |     53 |        6 |      0
-multi-user-provider.ts   |   88.00 |     22 |        3 |      0
-middleware.ts            |   85.00 |     34 |        5 |      1
-supabase-provider.ts     |   84.78 |     78 |       13 |      1
-http-auth.ts             |   81.82 |     36 |        8 |      0
-user-manager.ts          |   75.00 |      9 |        3 |      0
-file-user-manager.ts     |   72.06 |     49 |        6 |     13
--------------------------|---------|--------|----------|-------
-All files                |   83.47 |    308 |       46 |     15
+File                     | % score | killed | survived
+-------------------------|---------|--------|---------
+auth-provider.ts         |  100.00 |      6 |        0
+file-user-manager.ts     |  100.00 |     66 |        0
+http-auth.ts             |  100.00 |     43 |        0
+middleware.ts            |  100.00 |     40 |        0
+user-manager.ts          |  100.00 |     12 |        0
+providers/local          |  100.00 |      4 |        0
+providers/static-token   |  100.00 |     23 |        0
+providers/multi-user     |  100.00 |     25 |        0
+providers/supabase       |  100.00 |     73 |        0
+-------------------------|---------|--------|---------
+All files                |  100.00 |    292 |        0
 ```
 
 The config gate (`stryker.config.json`) **breaks below 90%**, mirroring
-`packages/security`. The baseline is below that gate on purpose — it documents
-the quality target. The surviving mutants are a concrete hardening backlog, not
-noise.
+`packages/security`, so a regression in test quality fails fast.
 
-## Hardening backlog (surviving / uncovered mutants)
+## How the suite was hardened
 
-The survivors cluster into a few familiar shapes — each is a real test gap, not
-an equivalent mutant:
+Mutation testing surfaced gaps that line coverage hid. The tests added to close
+them pin *observable behaviour*, not implementation details (each test asserts
+one externally-meaningful property and reads as Arrange/Act/Assert):
 
-- **Unasserted error-message strings** (`user-manager.ts:43`,
-  `file-user-manager.ts:73/76/82`, `http-auth.ts:65-69`, `middleware.ts:54`):
-  tests assert *that* a throw/response happens but not *what* it says. Pin the
-  operator-facing message so a reworded/blanked error fails.
-- **Untested branch in `file-user-manager.ts:36-43`** (13 NoCoverage mutants):
-  an entire validation/parse path that no test exercises. Needs a test that
-  drives malformed/missing input through it.
-- **Token-parsing regexes** (`auth-provider.ts:42/54`, `http-auth.ts:25`): the
-  bearer/JWT shape checks. Feed malformed tokens (wrong segment count, bad
-  scheme, extra whitespace) so a loosened regex is caught.
-- **Boundary conditionals** (`static-token-provider.ts:35/40`,
-  `multi-user-provider.ts:31/38`, `supabase-provider.ts`,
-  `middleware.ts:48/63`): each needs the *other* side of the branch asserted.
-- **`supabase-provider.ts` claim mapping** (13 survivors around L56-133): assert
-  the exact shape/fields of the mapped user and the optional-chaining fallbacks.
+- **Operator-facing error messages** (`user-manager`, `middleware`, `http-auth`):
+  tests asserted *that* a throw/401 happened but not *what* it said, so blanking
+  or rerouting a message survived. They now pin the exact text — e.g. the
+  no-token middleware 401 must name `Authorization: Bearer <token>`, and a
+  provider's own rejection message must reach the caller (`error ?? default`).
+- **Token-parsing whitespace** (`auth-provider`, `http-auth`): `split(/\s+/)` is
+  exercised with a *run* of whitespace (`"Bearer  tok"`) so the `/\s+/` → `/\s/`
+  mutant, which would split a double space into three parts, is caught.
+- **Empty / non-string credential edge cases**: an empty `STATIC_AUTH_TOKEN`
+  must not become a credential that accepts the empty bearer token; a JWT with a
+  blank `sub` is rejected by the `|| !userId` arm; a *numeric* user-id claim is
+  rejected by the `typeof !== "string"` arm (each kills a different operand
+  mutant in the same guard).
+- **Default-value short-circuits**: a provider that returns `ok:true` with no
+  `tokenType` proves the `?? TokenType.STATIC` default; an accept-everything
+  provider proves `authenticateRequest`'s `if (!token) return null` runs *before*
+  `verifyToken`.
+- **401 wire format** (`http-auth`): the response body (`{ detail: … }`) and the
+  `Content-Type` / `WWW-Authenticate` challenge headers are asserted so the
+  object/string literals can't be emptied.
+- **Persistence & path resolution** (`file-user-manager`): the users file is
+  asserted to carry `version: "1.0"`; `resetToken` must preserve the stored
+  record's id/username/role; and a mocked `homedir()` pins the per-platform
+  default path (`~/.config/...`, `%APPDATA%/...`, `~/AppData/Roaming/...`) plus
+  the `USERS_FILE` override.
+- **Supabase cache & client** (`providers/supabase`): the TTL boundary is tested
+  at exactly `now === expiresAt` (kills `>=` → `>`); a null `data` response must
+  yield the domain error rather than a TypeError (`data?.user`); and a mocked
+  `@supabase/supabase-js` exercises the real lazy-client creation path, asserting
+  the client is created once and reused.
 
 ## Equivalent & non-behavioral mutants
 
-Where a mutant genuinely cannot change observable behaviour (e.g. diagnostic
-log text, encoding arguments that decode identically), suppress it at the source
-with a line-scoped `// Stryker disable` comment documenting *why*, so the
-headline score reflects the quality of tests over behavioural code — the same
-discipline applied in `packages/security`.
+Some mutants **cannot** be killed because they don't change observable behaviour.
+Chasing them is wasted effort, so they're suppressed at the source with a
+line-scoped `// Stryker disable` comment that documents *why*:
+
+- **`"utf-8"` encoding arguments** (`file-user-manager` read/write) — Node returns
+  a Buffer for an empty/invalid encoding and JSON.parse coerces it via the default
+  utf8 decoding, so `"utf8"` and `""` are byte-identical.
+- **`parts[1].trim()`** (`auth-provider`, `http-auth`) — `split(/\s+/)` already
+  yields tokens with no surrounding whitespace, so the trim is a no-op.
+- **Case-insensitive `Headers` fallback** (`auth-provider`) — `Headers.get` is
+  case-insensitive, so the capitalized fallback always resolves to the same value
+  as the primary lookup; every mutant on those two lines is equivalent.
+- **`STATIC_AUTH_TOKENS` parse guard** (`static-token`) — a falsy value makes
+  `JSON.parse` throw into the swallowing catch, so forcing the branch registers
+  no tokens either way.
+- **Supabase cache fast-paths** (`supabase-provider`) — the `cacheTtl<=0` /
+  `cacheMax<=0` guards are redundant with, respectively, the matching read gate in
+  `_getCachedUser` and the `size > cacheMax` eviction (an add-then-evict at
+  `max=0` leaves the cache unchanged); the `oldest !== undefined` check can never
+  be false because eviction only runs on a non-empty map.
+
+One redundant check was *removed* rather than suppressed: the `error !== null`
+clause in the Supabase error path was dead code (the enclosing `if (error)`
+already guarantees a truthy, non-null value), so deleting it both simplifies the
+code and eliminates the equivalent mutant.
+
+Each suppression is line-scoped and carries a reason, so the headline 100% score
+reflects the quality of the tests over *behavioural* code rather than being
+inflated by mutants no test could legitimately catch.

--- a/packages/auth/MUTATION_TESTING.md
+++ b/packages/auth/MUTATION_TESTING.md
@@ -1,0 +1,71 @@
+# Mutation Testing — `@nodetool-ai/auth`
+
+This package is security-critical (token verification, auth middleware, user
+roles), so its tests are verified with **mutation testing** in addition to
+ordinary coverage. Line coverage only proves code *ran*; mutation testing proves
+the tests would actually *fail* if the behaviour changed — exactly the property
+you want from an auth layer, where a silently-weakened check is a vulnerability.
+
+## Running it
+
+```bash
+npm run test:mutation --workspace=packages/auth
+# or, from packages/auth:
+npx stryker run
+```
+
+The HTML report lands in `reports/mutation/mutation.html` (git-ignored).
+
+## Current status
+
+Baseline (initial scaffold, before any mutation-driven hardening):
+
+```
+File                     | % score | killed | survived | no cov
+-------------------------|---------|--------|----------|-------
+local-provider.ts        |  100.00 |      4 |        0 |      0
+static-token-provider.ts |   92.00 |     23 |        2 |      0
+auth-provider.ts         |   89.83 |     53 |        6 |      0
+multi-user-provider.ts   |   88.00 |     22 |        3 |      0
+middleware.ts            |   85.00 |     34 |        5 |      1
+supabase-provider.ts     |   84.78 |     78 |       13 |      1
+http-auth.ts             |   81.82 |     36 |        8 |      0
+user-manager.ts          |   75.00 |      9 |        3 |      0
+file-user-manager.ts     |   72.06 |     49 |        6 |     13
+-------------------------|---------|--------|----------|-------
+All files                |   83.47 |    308 |       46 |     15
+```
+
+The config gate (`stryker.config.json`) **breaks below 90%**, mirroring
+`packages/security`. The baseline is below that gate on purpose — it documents
+the quality target. The surviving mutants are a concrete hardening backlog, not
+noise.
+
+## Hardening backlog (surviving / uncovered mutants)
+
+The survivors cluster into a few familiar shapes — each is a real test gap, not
+an equivalent mutant:
+
+- **Unasserted error-message strings** (`user-manager.ts:43`,
+  `file-user-manager.ts:73/76/82`, `http-auth.ts:65-69`, `middleware.ts:54`):
+  tests assert *that* a throw/response happens but not *what* it says. Pin the
+  operator-facing message so a reworded/blanked error fails.
+- **Untested branch in `file-user-manager.ts:36-43`** (13 NoCoverage mutants):
+  an entire validation/parse path that no test exercises. Needs a test that
+  drives malformed/missing input through it.
+- **Token-parsing regexes** (`auth-provider.ts:42/54`, `http-auth.ts:25`): the
+  bearer/JWT shape checks. Feed malformed tokens (wrong segment count, bad
+  scheme, extra whitespace) so a loosened regex is caught.
+- **Boundary conditionals** (`static-token-provider.ts:35/40`,
+  `multi-user-provider.ts:31/38`, `supabase-provider.ts`,
+  `middleware.ts:48/63`): each needs the *other* side of the branch asserted.
+- **`supabase-provider.ts` claim mapping** (13 survivors around L56-133): assert
+  the exact shape/fields of the mapped user and the optional-chaining fallbacks.
+
+## Equivalent & non-behavioral mutants
+
+Where a mutant genuinely cannot change observable behaviour (e.g. diagnostic
+log text, encoding arguments that decode identically), suppress it at the source
+with a line-scoped `// Stryker disable` comment documenting *why*, so the
+headline score reflects the quality of tests over behavioural code — the same
+discipline applied in `packages/security`.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node ../../scripts/build-typescript-workspace.mjs",
     "test": "vitest run",
+    "test:mutation": "stryker run",
     "lint": "tsc --noEmit"
   },
   "dependencies": {
@@ -14,6 +15,8 @@
     "jose": "^6.2.0"
   },
   "devDependencies": {
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   },

--- a/packages/auth/src/auth-provider.ts
+++ b/packages/auth/src/auth-provider.ts
@@ -37,9 +37,14 @@ export abstract class AuthProvider {
 
     let authHeader: string | null | undefined;
     if (headers instanceof Headers) {
+      // Stryker disable all: Headers.get is case-insensitive, so the capitalized
+      // fallback always resolves to the same value as the primary lookup. Every
+      // mutant on these two lines (`??`→`&&`, the regex, the callback) is
+      // therefore equivalent — no input produces an observable difference.
       authHeader =
         headers.get(headerName) ??
         headers.get(headerName.replace(/\b\w/g, (c) => c.toUpperCase()));
+      // Stryker restore all
     } else {
       authHeader =
         headers[headerName] ??
@@ -56,6 +61,8 @@ export abstract class AuthProvider {
       return null;
     }
 
+    // Stryker disable next-line MethodExpression: split(/\s+/) yields tokens with
+    // no surrounding whitespace, so trim() is a no-op here (equivalent mutant).
     const token = parts[1].trim();
     return token || null;
   }

--- a/packages/auth/src/file-user-manager.ts
+++ b/packages/auth/src/file-user-manager.ts
@@ -70,6 +70,9 @@ export class FileUserManager {
 
   private async load(): Promise<UsersFile> {
     try {
+      // Stryker disable next-line StringLiteral: an empty/invalid encoding yields a
+      // Buffer, which JSON.parse coerces via the default utf8 decoding, so "utf8"
+      // and "" are byte-identical here (equivalent mutant).
       const data = await readFile(this.usersFile, "utf8");
       return JSON.parse(data) as UsersFile;
     } catch {
@@ -79,6 +82,8 @@ export class FileUserManager {
 
   private async save(data: UsersFile): Promise<void> {
     await mkdir(dirname(this.usersFile), { recursive: true });
+    // Stryker disable next-line StringLiteral: writeFile encodes the string as utf8
+    // regardless of an empty encoding argument, so "utf8" vs "" are equivalent.
     await writeFile(this.usersFile, JSON.stringify(data, null, 2), "utf8");
   }
 

--- a/packages/auth/src/http-auth.ts
+++ b/packages/auth/src/http-auth.ts
@@ -25,6 +25,8 @@ export function extractBearerToken(request: Request): string | null {
   const parts = authHeader.split(/\s+/);
   if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") return null;
 
+  // Stryker disable next-line MethodExpression: split(/\s+/) yields tokens with
+  // no surrounding whitespace, so trim() is a no-op here (equivalent mutant).
   const token = parts[1].trim();
   return token || null;
 }

--- a/packages/auth/src/providers/static-token-provider.ts
+++ b/packages/auth/src/providers/static-token-provider.ts
@@ -37,6 +37,9 @@ export class StaticTokenProvider extends AuthProvider {
     }
 
     const multiTokens = process.env["STATIC_AUTH_TOKENS"];
+    // Stryker disable next-line ConditionalExpression: a falsy STATIC_AUTH_TOKENS
+    // ("" or unset) makes JSON.parse throw and be swallowed by the catch, so
+    // forcing the branch true registers no tokens either way (equivalent).
     if (multiTokens) {
       try {
         const parsed = JSON.parse(multiTokens) as Record<string, string>;

--- a/packages/auth/src/providers/supabase-provider.ts
+++ b/packages/auth/src/providers/supabase-provider.ts
@@ -66,6 +66,9 @@ export class SupabaseAuthProvider extends AuthProvider {
   }
 
   private _getCachedUser(token: string): string | null {
+    // Stryker disable next-line ConditionalExpression,EqualityOperator: redundant
+    // with _cacheUser's matching ttl gate — entries are never stored when
+    // cacheTtl<=0, so this guarded cache read is unreachable (equivalent).
     if (this.cacheTtl <= 0) return null;
 
     const key = this._makeCacheKey(token);
@@ -86,6 +89,10 @@ export class SupabaseAuthProvider extends AuthProvider {
   }
 
   private _cacheUser(token: string, userId: string): void {
+    // Stryker disable next-line all: redundant fast-path. cacheTtl<=0 entries are
+    // never read (gated in _getCachedUser), and cacheMax<=0 stores are immediately
+    // removed by the size>cacheMax eviction below, so every mutant here leaves the
+    // observable cache state unchanged (equivalent).
     if (this.cacheTtl <= 0 || this.cacheMax <= 0) return;
 
     const key = this._makeCacheKey(token);
@@ -98,6 +105,9 @@ export class SupabaseAuthProvider extends AuthProvider {
     // Evict oldest (first key) when over capacity
     if (this._cache.size > this.cacheMax) {
       const oldest = this._cache.keys().next().value;
+      // Stryker disable next-line ConditionalExpression: eviction only runs when
+      // size>cacheMax, so the map is non-empty and oldest is always defined here
+      // (the undefined guard can never be false — equivalent).
       if (oldest !== undefined) {
         this._cache.delete(oldest);
       }
@@ -123,8 +133,9 @@ export class SupabaseAuthProvider extends AuthProvider {
       const { data, error } = await client.auth.getUser(token);
 
       if (error) {
+        // `error` is truthy here, so it cannot be null — no null guard needed.
         const errMsg =
-          typeof error === "object" && error !== null && "message" in error
+          typeof error === "object" && "message" in error
             ? String((error as { message: string }).message)
             : String(error);
         return { ok: false, error: errMsg };

--- a/packages/auth/stryker.config.json
+++ b/packages/auth/stryker.config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "npm",
+  "testRunner": "vitest",
+  "reporters": ["html", "json", "clear-text", "progress"],
+  "jsonReporter": { "fileName": "reports/mutation/mutation.json" },
+  "coverageAnalysis": "perTest",
+  "mutate": ["src/**/*.ts", "!src/index.ts"],
+  "vitest": {
+    "configFile": "vitest.config.ts"
+  },
+  "thresholds": {
+    "high": 95,
+    "low": 85,
+    "break": 90
+  },
+  "timeoutMS": 60000,
+  "concurrency": 4
+}

--- a/packages/auth/tests/auth-provider.test.ts
+++ b/packages/auth/tests/auth-provider.test.ts
@@ -92,6 +92,14 @@ describe("AuthProvider.extractTokenFromHeaders", () => {
     });
     expect(token).toBe("capital");
   });
+
+  it("collapses runs of whitespace between scheme and token", () => {
+    // Two spaces: split(/\s+/) must treat the run as a single delimiter so the
+    // header still parses to exactly two parts (kills the /\s+/ → /\s/ mutant).
+    expect(
+      provider.extractTokenFromHeaders({ authorization: "Bearer  tok" })
+    ).toBe("tok");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -349,4 +357,3 @@ describe("AuthProvider.preferHeader", () => {
     expect(AuthProvider.preferHeader()).toBe("authorization");
   });
 });
-

--- a/packages/auth/tests/file-user-manager-paths.test.ts
+++ b/packages/auth/tests/file-user-manager-paths.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Path-resolution tests for FileUserManager's `defaultUsersFilePath()`.
+ *
+ * These exercise the platform/env branches that pick where users.json lives.
+ * `node:os` is mocked so `homedir()` points at a throwaway temp dir, letting us
+ * assert the exact computed path without touching the real home directory.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const path = await import("node:path");
+  const mockHome = path.join(actual.tmpdir(), "nodetool-auth-paths-home");
+  return { ...actual, homedir: () => mockHome };
+});
+
+// homedir() now resolves to the mocked path; capture it for assertions.
+import { homedir } from "node:os";
+import { FileUserManager } from "../src/file-user-manager.js";
+
+const MOCK_HOME = homedir();
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true
+  });
+}
+
+afterEach(async () => {
+  setPlatform(originalPlatform);
+  delete process.env["USERS_FILE"];
+  delete process.env["APPDATA"];
+  await rm(MOCK_HOME, { recursive: true, force: true });
+});
+
+describe("FileUserManager default path resolution", () => {
+  it("uses ~/.config/nodetool/users.json on non-Windows platforms", async () => {
+    delete process.env["USERS_FILE"];
+    setPlatform("linux");
+
+    const manager = new FileUserManager();
+    await manager.addUser("linux-user");
+
+    const expected = join(MOCK_HOME, ".config", "nodetool", "users.json");
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("uses %APPDATA%/nodetool/users.json on Windows when APPDATA is set", async () => {
+    delete process.env["USERS_FILE"];
+    const appdata = join(MOCK_HOME, "appdata-custom");
+    process.env["APPDATA"] = appdata;
+    setPlatform("win32");
+
+    const manager = new FileUserManager();
+    await manager.addUser("win-user");
+
+    const expected = join(appdata, "nodetool", "users.json");
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("falls back to ~/AppData/Roaming on Windows when APPDATA is unset", async () => {
+    delete process.env["USERS_FILE"];
+    delete process.env["APPDATA"];
+    setPlatform("win32");
+
+    const manager = new FileUserManager();
+    await manager.addUser("win-fallback-user");
+
+    const expected = join(
+      MOCK_HOME,
+      "AppData",
+      "Roaming",
+      "nodetool",
+      "users.json"
+    );
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("honours USERS_FILE over the computed default path", async () => {
+    const target = join(MOCK_HOME, "explicit", "users.json");
+    process.env["USERS_FILE"] = target;
+    setPlatform("linux");
+
+    const manager = new FileUserManager();
+    await manager.addUser("explicit-user");
+
+    // The file must land at USERS_FILE, not the platform default (kills the
+    // `if (envPath) return envPath` condition-removal mutants).
+    expect(existsSync(target)).toBe(true);
+  });
+});

--- a/packages/auth/tests/file-user-manager.test.ts
+++ b/packages/auth/tests/file-user-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { FileUserManager } from "../src/file-user-manager.js";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -58,6 +58,14 @@ describe("FileUserManager.addUser", () => {
     expect(user).not.toBeNull();
     expect(user!.username).toBe("dave");
   });
+
+  it("writes the users file with version '1.0'", async () => {
+    await manager.addUser("ver");
+    const raw = JSON.parse(await readFile(usersFilePath, "utf8")) as {
+      version: string;
+    };
+    expect(raw.version).toBe("1.0");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -107,6 +115,19 @@ describe("FileUserManager.resetToken", () => {
     // We cannot read back the raw token (only hash stored), but the userId must match.
     expect(stored).not.toBeNull();
     expect(newToken).toBeTruthy();
+  });
+
+  it("preserves the stored record's identity fields after reset", async () => {
+    // resetToken rebuilds the record via { ...existing, ... }; assert the spread
+    // is preserved so the stored user keeps its id/username/role (kills the
+    // ObjectLiteral-emptying mutant that would wipe everything but the token).
+    const created = await manager.addUser("iris", "admin");
+    await manager.resetToken("iris");
+    const stored = await manager.getUser("iris");
+    expect(stored).not.toBeNull();
+    expect(stored!.id).toBe(created.userId);
+    expect(stored!.username).toBe("iris");
+    expect(stored!.role).toBe("admin");
   });
 });
 

--- a/packages/auth/tests/http-auth.test.ts
+++ b/packages/auth/tests/http-auth.test.ts
@@ -19,6 +19,13 @@ class MockProvider extends AuthProvider {
   }
 }
 
+/** Accepts any token — used to prove the empty-token short-circuit matters. */
+class AcceptAllProvider extends AuthProvider {
+  async verifyToken(_token: string): Promise<AuthResult> {
+    return { ok: true, userId: "any", tokenType: TokenType.STATIC };
+  }
+}
+
 function makeRequest(
   headers: Record<string, string>,
   path: string = "/api/test"
@@ -58,6 +65,12 @@ describe("extractBearerToken", () => {
     const req = makeRequest({ authorization: "bearer tok" });
     expect(extractBearerToken(req)).toBe("tok");
   });
+
+  it("collapses a run of whitespace between scheme and token", () => {
+    // Two spaces must still split into exactly two parts (kills /\s+/ → /\s/).
+    const req = makeRequest({ authorization: "Bearer  abc123" });
+    expect(extractBearerToken(req)).toBe("abc123");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -81,6 +94,17 @@ describe("authenticateRequest", () => {
     const user = await authenticateRequest(req, defaultOptions());
     expect(user).toBeNull();
   });
+
+  it("returns null without consulting the provider when no token is present", async () => {
+    // Even a provider that accepts everything must not authenticate a request
+    // that carries no token — proving the `if (!token) return null` short-circuit
+    // runs before verifyToken (kills its condition-removal mutant).
+    const req = makeRequest({});
+    const user = await authenticateRequest(req, {
+      provider: new AcceptAllProvider()
+    });
+    expect(user).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -98,6 +122,19 @@ describe("requireAuth", () => {
     const response = await requireAuth(req, defaultOptions());
     expect(response).toBeInstanceOf(Response);
     expect(response!.status).toBe(401);
+  });
+
+  it("the 401 carries the JSON detail body and challenge headers", async () => {
+    // Pins the response payload and headers so the body/header object and string
+    // literals can't be blanked (kills the ObjectLiteral and StringLiteral mutants
+    // on the 401 Response).
+    const req = makeRequest({});
+    const response = await requireAuth(req, defaultOptions());
+    expect(await response!.json()).toEqual({
+      detail: "Authorization required"
+    });
+    expect(response!.headers.get("Content-Type")).toBe("application/json");
+    expect(response!.headers.get("WWW-Authenticate")).toBe("Bearer");
   });
 
   it("returns 401 Response when invalid token", async () => {

--- a/packages/auth/tests/middleware.test.ts
+++ b/packages/auth/tests/middleware.test.ts
@@ -28,6 +28,20 @@ class RejectProvider extends AuthProvider {
   }
 }
 
+/** Accepts but omits tokenType, exercising the `?? TokenType.STATIC` default. */
+class NoTypeAcceptProvider extends AuthProvider {
+  async verifyToken(_token: string): Promise<AuthResult> {
+    return { ok: true, userId: "no-type-user" };
+  }
+}
+
+/** Rejects without an error message, exercising the default-message fallback. */
+class NoErrorRejectProvider extends AuthProvider {
+  async verifyToken(_token: string): Promise<AuthResult> {
+    return { ok: false };
+  }
+}
+
 function makeRequest(
   headers: Record<string, string>,
   path = "/api/test"
@@ -165,6 +179,56 @@ describe("createAuthMiddleware", () => {
       expect(user.userId).toBe("1");
       expect(user.tokenType).toBe(TokenType.STATIC);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAuthMiddleware — error messages & tokenType defaults
+// ---------------------------------------------------------------------------
+describe("createAuthMiddleware error messages and tokenType defaults", () => {
+  it("the no-token 401 names the Authorization/Bearer requirement", async () => {
+    const middleware = createAuthMiddleware({
+      staticProvider: new RejectProvider(),
+      enforceAuth: true
+    });
+    // Pins the exact operator-facing message so the no-token branch can't be
+    // collapsed into the generic invalid-token path (kills the condition,
+    // block-removal and message-blanking mutants on the no-token guard).
+    await expect(middleware(makeRequest({}))).rejects.toThrow(
+      "Authorization header required. Use 'Authorization: Bearer <token>'."
+    );
+  });
+
+  it("defaults tokenType to STATIC when the static provider omits it", async () => {
+    const middleware = createAuthMiddleware({
+      staticProvider: new NoTypeAcceptProvider(),
+      enforceAuth: true
+    });
+    const user = await middleware(bearerRequest("tok"));
+    expect(user.userId).toBe("no-type-user");
+    expect(user.tokenType).toBe(TokenType.STATIC);
+  });
+
+  it("surfaces the static provider's error message on rejection", async () => {
+    const middleware = createAuthMiddleware({
+      staticProvider: new RejectProvider("bad static creds"),
+      enforceAuth: true
+    });
+    // `staticResult.error ?? default` must return the provider's error, not the
+    // generic fallback (kills the `??`→`&&` mutant).
+    await expect(middleware(bearerRequest("tok"))).rejects.toThrow(
+      "bad static creds"
+    );
+  });
+
+  it("falls back to the generic message when the provider gives no error", async () => {
+    const middleware = createAuthMiddleware({
+      staticProvider: new NoErrorRejectProvider(),
+      enforceAuth: true
+    });
+    await expect(middleware(bearerRequest("tok"))).rejects.toThrow(
+      "Invalid authentication token."
+    );
   });
 });
 

--- a/packages/auth/tests/multi-user-provider.test.ts
+++ b/packages/auth/tests/multi-user-provider.test.ts
@@ -83,6 +83,40 @@ describe("T-SEC-3: MultiUserAuthProvider", () => {
     expect(result.error).toContain("user");
   });
 
+  it("rejects an empty-string user_id claim", async () => {
+    // An empty sub is present-but-falsy: the `|| !userId` arm must reject it.
+    // (Kills the `||`→`&&` and the condition-removal mutants that would let a
+    // blank user id through.)
+    const provider = new MultiUserAuthProvider({ secret: TEST_SECRET });
+    const token = await createTestJwt({ sub: "" });
+    const result = await provider.verifyToken(token);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("sub");
+  });
+
+  it("rejects a non-string (numeric) user_id claim", async () => {
+    // A numeric claim is truthy, so only the `typeof !== "string"` arm rejects it.
+    // (Kills the mutant that drops that arm and would accept `userId: 12345`.)
+    const provider = new MultiUserAuthProvider({
+      secret: TEST_SECRET,
+      userIdClaim: "uid"
+    });
+    const token = await createTestJwt({ uid: 12345 });
+    const result = await provider.verifyToken(token);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("uid");
+  });
+
+  it("ignores a non-string role claim", async () => {
+    // role is only surfaced when it is a string; a numeric role must become
+    // undefined (kills the `typeof role === "string" ? …` → always-true mutant).
+    const provider = new MultiUserAuthProvider({ secret: TEST_SECRET });
+    const token = await createTestJwt({ sub: "user-42", role: 123 });
+    const result = await provider.verifyToken(token);
+    expect(result.ok).toBe(true);
+    expect(result.role).toBeUndefined();
+  });
+
   it("extracts role from JWT claims", async () => {
     const provider = new MultiUserAuthProvider({ secret: TEST_SECRET });
     const token = await createTestJwt({ sub: "user-42", role: "admin" });

--- a/packages/auth/tests/static-token-provider.test.ts
+++ b/packages/auth/tests/static-token-provider.test.ts
@@ -104,6 +104,21 @@ describe("StaticTokenProvider", () => {
     });
   });
 
+  describe("empty STATIC_AUTH_TOKEN env var", () => {
+    afterEach(() => {
+      delete process.env["STATIC_AUTH_TOKEN"];
+    });
+
+    it("does not register an empty token (rejects the empty string)", async () => {
+      // An empty STATIC_AUTH_TOKEN must NOT become a credential that accepts the
+      // empty bearer token — kills the `if (singleToken)` → always-true mutant.
+      process.env["STATIC_AUTH_TOKEN"] = "";
+      delete process.env["STATIC_AUTH_TOKENS"];
+      const provider = new StaticTokenProvider();
+      expect((await provider.verifyToken("")).ok).toBe(false);
+    });
+  });
+
   describe("malformed STATIC_AUTH_TOKENS env var", () => {
     beforeEach(() => {
       process.env["STATIC_AUTH_TOKENS"] = "not-valid-json";
@@ -133,5 +148,4 @@ describe("StaticTokenProvider", () => {
       delete process.env["STATIC_AUTH_TOKEN"];
     }
   });
-
 });

--- a/packages/auth/tests/supabase-client-init.test.ts
+++ b/packages/auth/tests/supabase-client-init.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for SupabaseAuthProvider's lazy client initialisation (`_getClient`).
+ *
+ * The main supabase-provider.test.ts injects a fake `_client` to avoid the real
+ * SDK. This file instead mocks `@supabase/supabase-js` so the `if (!this._client)`
+ * creation path is actually exercised — pinning that the client is created once
+ * and reused (kills the condition-removal / block-emptying mutants on L56).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClient } from "@supabase/supabase-js";
+import { SupabaseAuthProvider } from "../src/providers/supabase-provider.js";
+
+vi.mock("@supabase/supabase-js", () => {
+  const getUser = vi.fn(async () => ({
+    data: { user: { id: "lazy-client-user" } },
+    error: null
+  }));
+  return { createClient: vi.fn(() => ({ auth: { getUser } })) };
+});
+
+const mockedCreateClient = vi.mocked(createClient);
+
+describe("SupabaseAuthProvider lazy client initialisation", () => {
+  beforeEach(() => {
+    mockedCreateClient.mockClear();
+  });
+
+  it("creates the Supabase client and authenticates through it", async () => {
+    // cacheTtl: 0 keeps caching out of the way so every call goes through the
+    // client; the result proves _getClient returned a real (mocked) client
+    // rather than null (which a removed `if (!this._client)` assignment causes).
+    const provider = new SupabaseAuthProvider({
+      supabaseUrl: "https://test.supabase.co",
+      supabaseKey: "test-key",
+      cacheTtl: 0
+    });
+
+    const result = await provider.verifyToken("tok");
+    expect(result.ok).toBe(true);
+    expect(result.userId).toBe("lazy-client-user");
+    expect(mockedCreateClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the same client across calls instead of recreating it", async () => {
+    const provider = new SupabaseAuthProvider({
+      supabaseUrl: "https://test.supabase.co",
+      supabaseKey: "test-key",
+      cacheTtl: 0
+    });
+
+    await provider.verifyToken("tok-1");
+    await provider.verifyToken("tok-2");
+    expect(mockedCreateClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/auth/tests/supabase-provider.test.ts
+++ b/packages/auth/tests/supabase-provider.test.ts
@@ -92,6 +92,36 @@ describe("T-SEC-4: SupabaseAuthProvider", () => {
     expect(result.error).toBe("Invalid Supabase token");
   });
 
+  it("returns 'Invalid Supabase token' when the response data is null", async () => {
+    // `data?.user` must tolerate a null data object: optional chaining yields the
+    // domain error rather than throwing a TypeError (kills the `data?.user` →
+    // `data.user` mutant, which would surface a "Cannot read properties of null").
+    const provider = makeProvider({
+      getUser: async () =>
+        ({ data: null, error: null }) as unknown as {
+          data: { user: { id: string } | null };
+          error: unknown;
+        }
+    });
+    const result = await provider.verifyToken("null-data-token");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Invalid Supabase token");
+  });
+
+  it("stringifies a Supabase error object that has no message field", async () => {
+    // An object error without `message` falls to the String(error) branch
+    // (kills the `"message" in error` → always-true mutant).
+    const provider = makeProvider({
+      getUser: async () => ({
+        data: { user: null },
+        error: { code: 500 } as unknown
+      })
+    });
+    const result = await provider.verifyToken("obj-no-message");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("[object Object]");
+  });
+
   it("returns error when getUser throws", async () => {
     const provider = makeProvider({
       getUser: async () => {
@@ -217,6 +247,28 @@ describe("T-SEC-4: SupabaseAuthProvider", () => {
     const r2 = await provider.verifyToken("tok-ttl");
     expect(r2.ok).toBe(true);
     expect(r2.userId).toBe("ttl-user");
+    expect(getUser).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+  });
+
+  it("treats an entry as expired at the exact TTL boundary (>=)", async () => {
+    // The expiry check is `now >= expiresAt`. At now === expiresAt the entry must
+    // count as expired and trigger a refetch (kills the `>=` → `>` mutant, which
+    // would keep serving a just-expired token).
+    const getUser = vi.fn(async () => ({
+      data: { user: { id: "boundary-user" } },
+      error: null
+    }));
+    const provider = makeProvider({ getUser, cacheTtl: 10 });
+
+    const base = 1_000_000;
+    const nowSpy = vi.spyOn(performance, "now").mockReturnValue(base);
+    await provider.verifyToken("tok-boundary"); // cached, expiresAt = base + 10_000
+    expect(getUser).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(base + 10_000); // now === expiresAt exactly
+    await provider.verifyToken("tok-boundary");
     expect(getUser).toHaveBeenCalledTimes(2);
 
     vi.restoreAllMocks();

--- a/packages/auth/tests/user-manager.test.ts
+++ b/packages/auth/tests/user-manager.test.ts
@@ -60,8 +60,10 @@ describe("T-SEC-6: UserManager", () => {
     expect(found!.role).toBe("admin");
   });
 
-  it("setRole throws for unknown user", () => {
-    expect(() => manager.setRole("nonexistent", "admin")).toThrow();
+  it("setRole throws a 'User not found' error naming the missing user", () => {
+    expect(() => manager.setRole("nonexistent", "admin")).toThrow(
+      "User not found: nonexistent"
+    );
   });
 
   it("multiple users are independent", () => {


### PR DESCRIPTION
Mirror the security package's mutation-testing setup for @nodetool-ai/auth,
the other security-critical foundation package. Adds the test:mutation
script, stryker.config.json (vitest runner, 90% break gate), and
MUTATION_TESTING.md documenting the baseline.

Baseline: 83.47% mutation score (308 killed, 46 survived, 15 uncovered).
The doc captures the surviving-mutant backlog (unasserted error strings,
an untested file-user-manager branch, token-parsing regexes, boundary
conditionals, supabase claim mapping) as the path to the 90% gate.