### PR TITLE
feat: remote Python worker — bridge auth, CLI execution, RunPod Pod deploy

### DIFF
--- a/.claude/skills/companion-clis/SKILL.md
+++ b/.claude/skills/companion-clis/SKILL.md
@@ -1,0 +1,422 @@
+---
+name: companion-clis
+description: Companion CLIs for Runpod workflows — HuggingFace, GitHub, Docker, and AWS.
+allowed-tools: Bash(hf:*), Bash(gh:*), Bash(docker:*), Bash(aws:*), Bash(ssh-keygen:*), Bash(ssh-add:*), Bash(ssh-agent:*)
+compatibility: Linux, macOS, Windows
+metadata:
+  author: runpod
+  version: "1.0"
+license: Apache-2.0
+---
+
+# Companion CLIs
+
+Four CLIs commonly needed alongside Runpod: HuggingFace (`hf`), GitHub (`gh`), Docker (`docker`), and AWS (`aws`). Each requires credentials before use.
+
+## Windows: Install WSL2 First
+
+If you are on Windows, install WSL2 (Windows Subsystem for Linux) before proceeding. WSL2 gives you a native Linux environment on Windows, which all these CLIs are designed for. Run in PowerShell as Administrator, then restart:
+
+```powershell
+wsl --install
+```
+
+This installs WSL2 with Ubuntu by default. After restarting, open the Ubuntu app to complete setup (create a Linux username and password). From that point on, follow the **Linux** instructions throughout this skill.
+
+## HuggingFace CLI
+
+The HuggingFace CLI (`hf`) is used to download models from the Hub to your local machine so they are cached and available when you build and run the Docker container. For example, to deploy `meta-llama/Llama-3.1-8B` to a Runpod serverless endpoint: download the model locally first, build a Docker image that includes or mounts it, validate the container locally, then push the image to Docker Hub for Runpod to pull.
+
+### Install
+
+```bash
+# macOS / Linux (standalone installer — recommended)
+curl -LsSf https://hf.co/cli/install.sh | bash
+
+# macOS (Homebrew)
+brew install hf
+
+# Windows (WSL2): use the Linux standalone installer above
+```
+
+> **Note:** `pip install huggingface_hub` installs the older Python CLI (`huggingface-cli`), which uses different command syntax. The commands below are for the standalone `hf` CLI.
+
+### Credentials
+
+Get a token at https://huggingface.co/settings/tokens. Use **write** access for uploading; **read** access is sufficient for downloading public or gated models.
+
+```bash
+# Option 1: interactive login (saves token to ~/.cache/huggingface/token, optionally to git credential store)
+hf auth login
+
+# Option 2: non-interactive (pass token directly, useful in scripts and pod start commands)
+hf auth login --token $HF_TOKEN --add-to-git-credential
+
+# Option 3: environment variable (takes precedence over saved token; to revert, unset the variable)
+export HF_TOKEN=hf_...
+```
+
+```bash
+hf auth whoami      # confirm auth and org memberships
+hf auth logout      # delete all locally stored tokens
+```
+
+### Key Commands
+
+```bash
+# Download a model to a local directory (use --local-dir to control where it lands)
+hf download meta-llama/Llama-3.1-8B --local-dir ./models/llama-3.1-8b
+hf download TinyLlama/TinyLlama-1.1B-Chat-v1.0 --local-dir ./models/tinyllama
+
+# Download a single file from a model repo
+hf download meta-llama/Llama-3.1-8B config.json --local-dir ./models/llama-3.1-8b
+
+# Download with glob filters (e.g. only safetensors weights, skip fp16 variants)
+hf download stabilityai/stable-diffusion-xl-base-1.0 \
+  --include "*.safetensors" --exclude "*.fp16.*" \
+  --local-dir ./models/sdxl
+
+# Download a specific revision (commit hash, branch, or tag — append --revision REF)
+hf download meta-llama/Llama-3.1-8B --revision v1.0 --local-dir ./models/llama-3.1-8b
+```
+
+### Troubleshooting
+
+```bash
+# Increase download timeout on slow connections (default: 10s)
+export HF_HUB_DOWNLOAD_TIMEOUT=30
+```
+
+---
+
+## GitHub CLI
+
+The GitHub CLI (`gh`) is used to manage repositories for Runpod serverless workers. This includes cloning repos into local Docker containers for testing, versioning source code so changes can be tracked and shared with teammates or collaborators, and creating GitHub releases that publish listings to the Runpod Hub. The Hub indexes releases — not commits — so every deployment update requires a new release.
+
+### Install
+
+```bash
+# macOS
+brew install gh
+
+# Linux (Debian/Ubuntu)
+(type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
+  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+     | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt update && sudo apt install gh -y
+
+# Linux (Alpine)
+apk add github-cli
+
+# Windows (WSL2): use the Linux (Debian/Ubuntu) installer above
+```
+
+### SSH Keys
+
+An SSH key identifies your machine as authentic to remote services. Generate one key and register the public key with each service that requires it — GitHub (via `gh`) and HuggingFace (via browser).
+
+**Generate a key**
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+# Saves to ~/.ssh/id_ed25519 (private) and ~/.ssh/id_ed25519.pub (public)
+# Press Enter to accept the default path; set a passphrase or leave blank
+```
+
+**Add the key to the SSH agent**
+
+```bash
+# macOS
+eval "$(ssh-agent -s)"
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+
+# macOS — also add to ~/.ssh/config so the key loads automatically on login.
+# Create the file if it doesn't exist, and add these lines:
+#
+#   Host *
+#     AddKeysToAgent yes
+#     UseKeychain yes
+#     IdentityFile ~/.ssh/id_ed25519
+
+# Linux
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+
+# Windows (WSL2): use the Linux instructions above
+```
+
+### Credentials
+
+```bash
+# Interactive login — when prompted, select SSH as the git protocol
+gh auth login
+
+# Verify auth
+gh auth status
+```
+
+**Register the public key with each service**
+
+```bash
+# GitHub — upload via gh CLI (requires auth above to be completed first)
+gh ssh-key add ~/.ssh/id_ed25519.pub --title "my-machine"
+
+# HuggingFace — paste contents of public key manually in browser
+cat ~/.ssh/id_ed25519.pub   # copy this output
+# Then add at https://huggingface.co/settings/keys
+```
+
+### Key Commands
+
+```bash
+# Repositories
+gh repo create my-worker --public             # create a new public repo (required for Hub)
+gh repo clone owner/repo                      # clone a repository over SSH
+gh repo clone owner/repo -- --depth 1        # shallow clone
+gh repo view owner/repo                       # view repo details and URL
+
+# Releases — the Runpod Hub indexes releases, not commits
+# Every update to a Hub listing requires a new GitHub release
+gh release create v1.0.0 --title "v1.0.0" --notes "Initial release"   # create a release
+gh release create v1.0.1 --title "v1.0.1" --notes "Update model tag"  # update Hub listing
+gh release list                               # list all releases
+gh release view v1.0.0                        # view release details
+```
+
+#### Runpod Hub repository structure
+
+A Hub-compatible repository requires these files (in root or `.runpod/` directory):
+
+```
+handler.py        # serverless worker implementation
+Dockerfile        # container definition
+README.md         # documentation shown on Hub listing
+.runpod/
+  hub.json        # Hub metadata: title, description, category, GPU config, env vars
+  tests.json      # test cases run after each release
+```
+
+To publish: go to https://console.runpod.io → Hub → Add your repo → enter the GitHub repository URL.
+
+---
+
+## Docker
+
+Docker is used to build and validate container images locally before pushing to Docker Hub. Runpod uses Docker Hub as its default image registry — serverless endpoints, pods, and templates all reference images by their Docker Hub tag. Once an image is pushed, Runpod workers pull it automatically when the endpoint or pod is started.
+
+### Install
+
+**macOS:** Download Docker Desktop from https://docs.docker.com/desktop/setup/install/mac-install/
+- Choose the **Apple Silicon** installer for M-series Macs, or **Intel Chip** for older Macs
+- Open the DMG, drag Docker to Applications, and launch it
+
+**Windows:** Download Docker Desktop from https://docs.docker.com/desktop/setup/install/windows-install/
+- Requires WSL 2 — if you followed the WSL2 setup above, Docker Desktop will detect it automatically
+- After installation, `docker` commands work inside your WSL2 terminal without extra configuration
+- Run the installer and follow the setup wizard
+
+**Linux:** See https://docs.docker.com/engine/install/ for distro-specific instructions
+
+```bash
+# Linux convenience script (Ubuntu/Debian)
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER   # allow non-root usage (re-login after)
+```
+
+### Credentials
+
+Docker Hub authentication uses a personal access token (PAT), not your account password.
+
+1. Go to https://app.docker.com → Avatar (top right) → Account Settings → Personal Access Tokens
+2. Click **Generate new token** — give it a descriptive name, set an expiration, and choose **Read & Write** access
+3. Copy the token immediately — it is shown only once
+
+```bash
+docker login -u DOCKERHUB_USERNAME
+# When prompted for a password, paste your personal access token
+```
+
+Credentials are saved to `~/.docker/config.json` after a successful login.
+
+### Tagging
+
+> **Always use explicit semantic version tags. Never rely on `latest`.**
+
+The `latest` tag does not automatically point to the newest image — it only reflects the last build that was pushed without an explicit tag. If you push `v1.0.0` and then push `v1.0.1` with an explicit tag, `latest` still points to `v1.0.0`. Runpod workers pinned to `latest` will silently pull the wrong version.
+
+Use a tag that uniquely identifies the build: `v1.0.0`, `v1.0.1`, etc.
+
+```bash
+# Correct: explicit semantic version tag
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 .
+docker push myorg/myimage:v1.0.0
+
+# Wrong: latest tag is ambiguous and unreliable
+docker build -t myorg/myimage:latest .
+```
+
+### Docker Hub
+
+Docker Hub is the registry Runpod pulls images from. After pushing, images are visible at https://hub.docker.com/repositories/ and referenceable in Runpod as `username/image:tag`.
+
+Images on Docker Hub can be public (anyone can pull) or private (requires credentials). For private images, register your Docker Hub credentials in Runpod once and they become available to any template:
+
+1. Go to https://console.runpod.io/user/settings → **Container Registry Settings**
+2. Add your Docker Hub username and personal access token (the same PAT used for `docker login`)
+3. When creating or editing a template, select the saved credential from the dropdown
+
+> Runpod currently only supports `docker login` type credentials for container registry authentication.
+
+### Key Commands
+
+```bash
+# Build for Runpod (always --platform=linux/amd64 — pods run on x86 Linux)
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 .
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 -f Dockerfile.prod .  # specify Dockerfile
+
+# Tag an existing image before pushing (does not duplicate image data)
+docker tag myorg/myimage:v1.0.0 myorg/myimage:v1.0.1
+
+# Push to Docker Hub (image becomes available to Runpod as myorg/myimage:v1.0.0)
+docker push myorg/myimage:v1.0.0
+
+# Run locally for validation
+docker run --rm -it myorg/myimage:v1.0.0 bash
+docker run --rm --gpus all myorg/myimage:v1.0.0 bash   # with GPU (requires nvidia-container-toolkit)
+docker run --rm -p 8080:80 -e API_KEY=secret myorg/myimage:v1.0.0  # port mapping + env vars
+
+# Debug a running container
+docker exec -it CONTAINER_ID /bin/bash
+
+# Inspect
+docker images                          # list local images
+docker ps -a                           # list all containers (including stopped)
+docker logs CONTAINER_ID             # view container output
+docker logs -f CONTAINER_ID          # follow logs in real time
+
+# Cleanup
+docker rmi myorg/myimage:v1.0.0        # remove an image
+docker rm CONTAINER_ID               # remove a stopped container
+```
+
+---
+
+## AWS CLI
+
+The AWS CLI is used to access Runpod storage over the S3 protocol. Any Runpod product that can mount a Network Volume — pods, clusters, and serverless endpoints — can have its storage accessed this way. The bucket name is the network volume ID.
+
+### Install
+
+```bash
+# macOS
+brew install awscli
+
+# Linux
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip awscliv2.zip && sudo ./aws/install
+```
+
+### Credentials
+
+Runpod uses its own S3-compatible API, not AWS. You need a Runpod user ID and S3 API key — not an AWS account.
+
+- **Access key** (`AWS_ACCESS_KEY_ID`): your Runpod user ID — found in the console under Settings > S3 API Keys, in the key description (format: `user_...`)
+- **Secret key** (`AWS_SECRET_ACCESS_KEY`): an S3 API key — generate one at Settings > S3 API Keys > Create. Shown only once; save it immediately (format: `rps_...`)
+
+```bash
+# Option 1: interactive configure (writes ~/.aws/credentials and ~/.aws/config)
+# When prompted: enter user ID as access key, S3 API key as secret.
+# Press Enter to skip region and output format — region is always passed per-command, not stored in config.
+aws configure
+
+aws configure list    # verify stored credentials
+
+# Option 2: environment variables (override config files)
+export AWS_ACCESS_KEY_ID=user_...
+export AWS_SECRET_ACCESS_KEY=rps_...
+
+# To stop using env vars and fall back to config file:
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+```
+
+### Region and Endpoint
+
+The `--region` flag on every command is the Runpod datacenter ID where the network volume lives — not an AWS region. The `--endpoint-url` is derived from the same datacenter ID.
+
+Every command requires both flags:
+```
+--region DATACENTER --endpoint-url https://s3api-DATACENTER.runpod.io/
+```
+
+**Tip:** Each network volume on the storage page at https://console.runpod.io/user/storage/ shows a pre-filled example `aws s3 ls` command with the correct `--region` and `--endpoint-url` already substituted. Use this to confirm the exact values for a given volume.
+
+Datacenter IDs by region:
+
+| Region | Datacenter IDs |
+|--------|---------------|
+| EU | CZ-1, RO-1, IS-1, NO-1 |
+| US | CA-2, GA-2, IL-1, KS-2, MD-1, MO-1, MO-2, NC-1, NC-2, NE-1, WA-1 |
+
+### Key Commands
+
+Replace `DATACENTER` with the datacenter ID of your network volume (e.g. `CA-2`) and `NETWORK_VOLUME_ID` with the volume ID (used as the S3 bucket name).
+
+```bash
+# List files in a volume
+aws s3 ls \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/
+
+# List a subdirectory
+aws s3 ls \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/my-folder/
+
+# Upload a file
+aws s3 cp local-file.txt \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/
+
+# Download a file
+aws s3 cp \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-file.txt ./
+
+# Delete a file
+aws s3 rm \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-file.txt
+
+# Sync a local directory to a volume
+aws s3 sync local-dir/ \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-dir/
+```
+
+Path mapping: `/workspace/my-folder/file.txt` on a pod = `s3://NETWORK_VOLUME_ID/my-folder/file.txt` via S3.
+
+### Troubleshooting
+
+```bash
+# Retry on timeout (large transfers)
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=10
+
+# Extend read timeout for large files (seconds)
+aws s3 cp large-file.zip \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  --cli-read-timeout 7200 \
+  s3://NETWORK_VOLUME_ID/
+```

--- a/.claude/skills/flash/SKILL.md
+++ b/.claude/skills/flash/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: flash
+description: runpod-flash SDK and CLI for deploying AI workloads on Runpod serverless GPUs/CPUs.
+user-invocable: true
+---
+
+# Runpod Flash
+
+Write code locally, test with `flash run` (dev server at localhost:8888), and flash automatically provisions and deploys to remote GPUs/CPUs in the cloud. `Endpoint` handles everything.
+
+## Setup
+
+```bash
+pip install runpod-flash                 # requires Python >=3.10
+
+# auth option 1: browser-based login (saves token locally)
+flash login
+
+# auth option 2: API key via environment variable
+export RUNPOD_API_KEY=your_key
+
+flash init my-project                    # scaffold a new project in ./my-project
+```
+
+## CLI
+
+```bash
+flash run                                # start local dev server at localhost:8888
+flash run --auto-provision               # same, but pre-provision endpoints (no cold start)
+flash build                              # package artifact for deployment (500MB limit)
+flash build --exclude pkg1,pkg2          # exclude packages from build
+flash deploy                             # build + deploy (auto-selects env if only one)
+flash deploy --env staging               # build + deploy to "staging" environment
+flash deploy --app my-app --env prod     # deploy a specific app to an environment
+flash deploy --preview                   # build + launch local preview in Docker
+flash env list                           # list deployment environments
+flash env create staging                 # create "staging" environment
+flash env get staging                    # show environment details + resources
+flash env delete staging                 # delete environment + tear down resources
+flash undeploy list                      # list all active endpoints
+flash undeploy my-endpoint               # remove a specific endpoint
+```
+
+## Endpoint: Three Modes
+
+### Mode 1: Your Code (Queue-Based Decorator)
+
+One function = one endpoint with its own workers.
+
+```python
+from runpod_flash import Endpoint, GpuGroup
+
+@Endpoint(name="my-worker", gpu=GpuGroup.AMPERE_80, workers=5, dependencies=["torch"])
+async def compute(data):
+    import torch  # MUST import inside function (cloudpickle)
+    return {"sum": torch.tensor(data, device="cuda").sum().item()}
+
+result = await compute([1, 2, 3])
+```
+
+### Mode 2: Your Code (Load-Balanced Routes)
+
+Multiple HTTP routes share one pool of workers.
+
+```python
+from runpod_flash import Endpoint, GpuGroup
+
+api = Endpoint(name="my-api", gpu=GpuGroup.ADA_24, workers=(1, 5), dependencies=["torch"])
+
+@api.post("/predict")
+async def predict(data: list[float]):
+    import torch
+    return {"result": torch.tensor(data, device="cuda").sum().item()}
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+```
+
+### Mode 3: External Image (Client)
+
+Deploy a pre-built Docker image and call it via HTTP.
+
+```python
+from runpod_flash import Endpoint, GpuGroup, PodTemplate
+
+server = Endpoint(
+    name="my-server",
+    image="my-org/my-image:latest",
+    gpu=GpuGroup.AMPERE_80,
+    workers=1,
+    env={"HF_TOKEN": "xxx"},
+    template=PodTemplate(containerDiskInGb=100),
+)
+
+# LB-style
+result = await server.post("/v1/completions", {"prompt": "hello"})
+models = await server.get("/v1/models")
+
+# QB-style
+job = await server.run({"prompt": "hello"})
+await job.wait()
+print(job.output)
+```
+
+Connect to an existing endpoint by ID (no provisioning):
+
+```python
+ep = Endpoint(id="abc123")
+job = await ep.runsync({"input": "hello"})
+print(job.output)
+```
+
+## How Mode Is Determined
+
+| Parameters | Mode |
+|-----------|------|
+| `name=` only | Decorator (your code) |
+| `image=` set | Client (deploys image, then HTTP calls) |
+| `id=` set | Client (connects to existing, no provisioning) |
+
+## Endpoint Constructor
+
+```python
+Endpoint(
+    name="endpoint-name",                  # required (unless id= set)
+    id=None,                               # connect to existing endpoint
+    gpu=GpuGroup.AMPERE_80,               # single GPU type (default: ANY)
+    gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80],  # or list for auto-select by supply
+    cpu=CpuInstanceType.CPU5C_4_8,        # CPU type (mutually exclusive with gpu)
+    workers=5,                             # shorthand for (0, 5)
+    workers=(1, 5),                        # explicit (min, max)
+    idle_timeout=60,                       # seconds before scale-down (default: 60)
+    dependencies=["torch"],                # pip packages for remote exec
+    system_dependencies=["ffmpeg"],        # apt-get packages
+    image="org/image:tag",                 # pre-built Docker image (client mode)
+    env={"KEY": "val"},                    # environment variables
+    volume=NetworkVolume(...),             # persistent storage
+    gpu_count=1,                           # GPUs per worker
+    template=PodTemplate(containerDiskInGb=100),
+    flashboot=True,                        # fast cold starts
+    execution_timeout_ms=0,                # max execution time (0 = unlimited)
+)
+```
+
+- `gpu=` and `cpu=` are mutually exclusive
+- `workers=5` means `(0, 5)`. Default is `(0, 1)`
+- `idle_timeout` default is **60 seconds**
+- `flashboot=True` (default) -- enables fast cold starts via snapshot restore
+- `gpu_count` -- GPUs per worker (default 1), use >1 for multi-GPU models
+
+### NetworkVolume
+
+```python
+NetworkVolume(name="my-vol", size=100)  # size in GB, default 100
+```
+
+### PodTemplate
+
+```python
+PodTemplate(
+    containerDiskInGb=64,    # container disk size (default 64)
+    dockerArgs="",           # extra docker arguments
+    ports="",                # exposed ports
+    startScript="",          # script to run on start
+)
+```
+
+## EndpointJob
+
+Returned by `ep.run()` and `ep.runsync()` in client mode.
+
+```python
+job = await ep.run({"data": [1, 2, 3]})
+await job.wait(timeout=120)        # poll until done
+print(job.id, job.output, job.error, job.done)
+await job.cancel()
+```
+
+## GPU Types (GpuGroup)
+
+| Enum | GPU | VRAM |
+|------|-----|------|
+| `ANY` | any | varies |
+| `AMPERE_16` | RTX A4000 | 16GB |
+| `AMPERE_24` | RTX A5000/L4 | 24GB |
+| `AMPERE_48` | A40/A6000 | 48GB |
+| `AMPERE_80` | A100 | 80GB |
+| `ADA_24` | RTX 4090 | 24GB |
+| `ADA_32_PRO` | RTX 5090 | 32GB |
+| `ADA_48_PRO` | RTX 6000 Ada | 48GB |
+| `ADA_80_PRO` | H100 PCIe (80GB) / H100 HBM3 (80GB) / H100 NVL (94GB) | 80GB+ |
+| `HOPPER_141` | H200 | 141GB |
+
+## CPU Types (CpuInstanceType)
+
+| Enum | vCPU | RAM | Max Disk | Type |
+|------|------|-----|----------|------|
+| `CPU3G_1_4` | 1 | 4GB | 10GB | General |
+| `CPU3G_2_8` | 2 | 8GB | 20GB | General |
+| `CPU3G_4_16` | 4 | 16GB | 40GB | General |
+| `CPU3G_8_32` | 8 | 32GB | 80GB | General |
+| `CPU3C_1_2` | 1 | 2GB | 10GB | Compute |
+| `CPU3C_2_4` | 2 | 4GB | 20GB | Compute |
+| `CPU3C_4_8` | 4 | 8GB | 40GB | Compute |
+| `CPU3C_8_16` | 8 | 16GB | 80GB | Compute |
+| `CPU5C_1_2` | 1 | 2GB | 15GB | Compute (5th gen) |
+| `CPU5C_2_4` | 2 | 4GB | 30GB | Compute (5th gen) |
+| `CPU5C_4_8` | 4 | 8GB | 60GB | Compute (5th gen) |
+| `CPU5C_8_16` | 8 | 16GB | 120GB | Compute (5th gen) |
+
+```python
+from runpod_flash import Endpoint, CpuInstanceType
+
+@Endpoint(name="cpu-work", cpu=CpuInstanceType.CPU5C_4_8, workers=5, dependencies=["pandas"])
+async def process(data):
+    import pandas as pd
+    return pd.DataFrame(data).describe().to_dict()
+```
+
+## Common Patterns
+
+### CPU + GPU Pipeline
+
+```python
+from runpod_flash import Endpoint, GpuGroup, CpuInstanceType
+
+@Endpoint(name="preprocess", cpu=CpuInstanceType.CPU5C_4_8, workers=5, dependencies=["pandas"])
+async def preprocess(raw):
+    import pandas as pd
+    return pd.DataFrame(raw).to_dict("records")
+
+@Endpoint(name="infer", gpu=GpuGroup.AMPERE_80, workers=5, dependencies=["torch"])
+async def infer(clean):
+    import torch
+    t = torch.tensor([[v for v in r.values()] for r in clean], device="cuda")
+    return {"predictions": t.mean(dim=1).tolist()}
+
+async def pipeline(data):
+    return await infer(await preprocess(data))
+```
+
+### Parallel Execution
+
+```python
+import asyncio
+results = await asyncio.gather(compute(a), compute(b), compute(c))
+```
+
+## Gotchas
+
+1. **Imports outside function** -- most common error. Everything inside the decorated function.
+2. **Forgetting await** -- all decorated functions and client methods need `await`.
+3. **Missing dependencies** -- must list in `dependencies=[]`.
+4. **gpu/cpu are exclusive** -- pick one per Endpoint.
+5. **idle_timeout is seconds** -- default 60s, not minutes.
+6. **10MB payload limit** -- pass URLs, not large objects.
+7. **Client vs decorator** -- `image=`/`id=` = client. Otherwise = decorator.
+8. **Auto GPU switching requires workers >= 5** -- pass a list of GPU types (e.g. `gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80]`) and set `workers=5` or higher. The platform only auto-switches GPU types based on supply when max workers is at least 5.
+9. **`runsync` timeout is 60s** -- cold starts can exceed 60s. Use `ep.runsync(data, timeout=120)` for first requests or use `ep.run()` + `job.wait()` instead.

--- a/.claude/skills/runpodctl/SKILL.md
+++ b/.claude/skills/runpodctl/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: runpodctl
+description: Runpod CLI to manage your GPU workloads.
+allowed-tools: Bash(runpodctl:*)
+compatibility: Linux, macOS
+metadata:
+  author: runpod
+  version: "2.2"
+license: Apache-2.0
+---
+
+# Runpodctl
+
+Manage GPU pods, serverless endpoints, templates, volumes, and models.
+
+> **Spelling:** "Runpod" (capital R). Command is `runpodctl` (lowercase).
+
+## Install
+
+```bash
+# Any platform (official installer)
+curl -sSL https://cli.runpod.net | bash
+
+# macOS (Homebrew)
+brew install runpod/runpodctl/runpodctl
+
+# macOS (manual — universal binary)
+mkdir -p ~/.local/bin && curl -sL https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-darwin-all.tar.gz | tar xz -C ~/.local/bin
+
+# Linux
+mkdir -p ~/.local/bin && curl -sL https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-linux-amd64.tar.gz | tar xz -C ~/.local/bin
+
+# Windows (PowerShell)
+Invoke-WebRequest -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile runpodctl.zip; Expand-Archive runpodctl.zip -DestinationPath $env:LOCALAPPDATA\runpodctl; [Environment]::SetEnvironmentVariable('Path', $env:Path + ";$env:LOCALAPPDATA\runpodctl", 'User')
+```
+
+Ensure `~/.local/bin` is on your `PATH` (add `export PATH="$HOME/.local/bin:$PATH"` to `~/.bashrc` or `~/.zshrc`).
+
+## Quick start
+
+```bash
+runpodctl doctor                    # First time setup (API key + SSH)
+runpodctl gpu list                  # See available GPUs
+runpodctl hub search vllm           # Find a hub repo
+runpodctl serverless create --hub-id <id> --name "my-vllm"  # Deploy from hub
+runpodctl template search pytorch   # Find a template
+runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # Create from template
+runpodctl pod list                  # List your pods
+```
+
+API key: https://runpod.io/console/user/settings
+
+## Commands
+
+### Pods
+
+```bash
+runpodctl pod list                                    # List running pods (default, like docker ps)
+runpodctl pod list --all                              # List all pods including exited
+runpodctl pod list --status exited                    # Filter by status (RUNNING, EXITED, etc.)
+runpodctl pod list --since 24h                        # Pods created within last 24 hours
+runpodctl pod list --created-after 2025-01-15         # Pods created after date
+runpodctl pod get <pod-id>                            # Get pod details (includes SSH info)
+runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # Create from template
+runpodctl pod create --image "runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404" --gpu-id "NVIDIA GeForce RTX 4090"  # Create with image
+runpodctl pod create --compute-type cpu --image ubuntu:22.04  # Create CPU pod
+runpodctl pod start <pod-id>                          # Start stopped pod
+runpodctl pod stop <pod-id>                           # Stop running pod
+runpodctl pod restart <pod-id>                        # Restart pod
+runpodctl pod reset <pod-id>                          # Reset pod
+runpodctl pod update <pod-id> --name "new"            # Update pod
+runpodctl pod delete <pod-id>                         # Delete pod (aliases: rm, remove)
+```
+
+**List flags:** `--all` / `-a`, `--status`, `--since`, `--created-after`, `--name`, `--compute-type`
+**Get flags:** `--include-machine`, `--include-network-volume`
+
+**Create flags:** `--template-id` (required if no `--image`), `--image` (required if no `--template-id`), `--name`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--ssh` (default true), `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--network-volume-id`, `--ports`, `--env`, `--cloud-type`, `--data-center-ids`, `--global-networking`, `--public-ip`
+
+### Hub
+
+Browse and search the Runpod Hub — a curated marketplace of deployable repos.
+
+```bash
+runpodctl hub list                                    # Top 10 by stars
+runpodctl hub list --type SERVERLESS                  # Only serverless repos
+runpodctl hub list --type POD                         # Only pod repos
+runpodctl hub list --category ai --limit 20           # Filter by category
+runpodctl hub list --order-by deploys                 # Order by deploys
+runpodctl hub list --owner runpod-workers             # Filter by repo owner
+runpodctl hub search vllm                             # Search for "vllm"
+runpodctl hub search whisper --type SERVERLESS        # Search serverless repos
+runpodctl hub get <listing-id>                        # Get by listing id
+runpodctl hub get runpod-workers/worker-vllm          # Get by owner/name
+```
+
+**List/search flags:** `--type` (POD, SERVERLESS), `--category`, `--order-by` (stars, deploys, createdAt, updatedAt, releasedAt, views), `--order-dir` (asc, desc), `--limit`, `--offset`, `--owner`
+
+### Serverless (alias: sls)
+
+```bash
+runpodctl serverless list                             # List all endpoints
+runpodctl serverless get <endpoint-id>                # Get endpoint details
+runpodctl serverless create --name "x" --template-id "tpl_abc"  # Create from template
+runpodctl serverless create --name "x" --hub-id <listing-id>    # Create from hub repo
+runpodctl serverless create --hub-id <id> --env MODEL_NAME=my-model  # Override hub env defaults
+runpodctl serverless update <endpoint-id> --workers-max 5       # Update endpoint
+runpodctl serverless delete <endpoint-id>             # Delete endpoint
+```
+
+**Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
+
+**List flags:** `--include-template`, `--include-workers`
+**Update flags:** `--name`, `--workers-min`, `--workers-max`, `--idle-timeout`, `--scaler-type` (QUEUE_DELAY or REQUEST_COUNT), `--scaler-value`
+**Create flags:** `--name`, `--template-id` or `--hub-id` (one required), `--gpu-id`, `--gpu-count`, `--compute-type`, `--workers-min`, `--workers-max`, `--network-volume-id`, `--data-center-ids`, `--env`
+
+### Templates (alias: tpl)
+
+```bash
+runpodctl template list                               # Official + community (first 10)
+runpodctl template list --type official               # All official templates
+runpodctl template list --type community              # Community templates (first 10)
+runpodctl template list --type user                   # Your own templates
+runpodctl template list --all                         # Everything including user
+runpodctl template list --limit 50                    # Show 50 templates
+runpodctl template search pytorch                     # Search for "pytorch" templates
+runpodctl template search comfyui --limit 5           # Search, limit to 5 results
+runpodctl template search vllm --type official        # Search only official
+runpodctl template get <template-id>                  # Get template details (includes README, env, ports)
+runpodctl template create --name "x" --image "img"    # Create template
+runpodctl template create --name "x" --image "img" --serverless  # Create serverless template
+runpodctl template update <template-id> --name "new"  # Update template
+runpodctl template delete <template-id>               # Delete template
+```
+
+**List flags:** `--type` (official, community, user), `--limit`, `--offset`, `--all`
+**Create flags:** `--name`, `--image`, `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--ports`, `--env`, `--docker-start-cmd`, `--docker-entrypoint`, `--serverless`, `--readme`
+
+### Network Volumes (alias: nv)
+
+```bash
+runpodctl network-volume list                         # List all volumes
+runpodctl network-volume get <volume-id>              # Get volume details
+runpodctl network-volume create --name "x" --size 100 --data-center-id "US-GA-1"  # Create volume
+runpodctl network-volume update <volume-id> --name "new"  # Update volume
+runpodctl network-volume delete <volume-id>           # Delete volume
+```
+
+**Create flags:** `--name`, `--size`, `--data-center-id`
+
+### Models
+
+```bash
+runpodctl model list                                  # List your models
+runpodctl model list --all                            # List all models
+runpodctl model list --name "llama"                   # Filter by name
+runpodctl model list --provider "meta"                # Filter by provider
+runpodctl model add --name "my-model" --model-path ./model  # Add model
+runpodctl model remove --name "my-model"              # Remove model
+```
+
+### Registry (alias: reg)
+
+```bash
+runpodctl registry list                               # List registry auths
+runpodctl registry get <registry-id>                  # Get registry auth
+runpodctl registry create --name "x" --username "u" --password "p"  # Create registry auth
+runpodctl registry delete <registry-id>               # Delete registry auth
+```
+
+### Info
+
+```bash
+runpodctl user                                        # Account info and balance (alias: me)
+runpodctl gpu list                                    # List available GPUs
+runpodctl gpu list --include-unavailable              # Include unavailable GPUs
+runpodctl datacenter list                             # List datacenters (alias: dc)
+runpodctl billing pods                                # Pod billing history
+runpodctl billing serverless                          # Serverless billing history
+runpodctl billing network-volume                      # Volume billing history
+```
+
+### SSH
+
+```bash
+runpodctl ssh info <pod-id>                           # Get SSH info (command + key, does not connect)
+runpodctl ssh list-keys                               # List SSH keys
+runpodctl ssh add-key                                 # Add SSH key
+```
+
+**Agent note:** `ssh info` returns connection details, not an interactive session. If interactive SSH is not available, execute commands remotely via `ssh user@host "command"`.
+
+### File Transfer
+
+```bash
+runpodctl send <path>                                 # Send files (outputs code)
+runpodctl receive <code>                              # Receive files using code
+```
+
+### Utilities
+
+```bash
+runpodctl doctor                                      # Diagnose and fix CLI issues
+runpodctl update                                      # Update CLI
+runpodctl version                                     # Show version
+runpodctl completion                                  # Auto-detect shell and install completion
+```
+
+## URLs
+
+### Pod URLs
+
+Access exposed ports on your pod:
+
+```
+https://<pod-id>-<port>.proxy.runpod.net
+```
+
+Example: `https://abc123xyz-8888.proxy.runpod.net`
+
+### Serverless URLs
+
+```
+https://api.runpod.ai/v2/<endpoint-id>/run        # Async request
+https://api.runpod.ai/v2/<endpoint-id>/runsync    # Sync request
+https://api.runpod.ai/v2/<endpoint-id>/health     # Health check
+https://api.runpod.ai/v2/<endpoint-id>/status/<job-id>  # Job status
+```

--- a/docs/superpowers/specs/2026-06-08-hf-worker-docker-design.md
+++ b/docs/superpowers/specs/2026-06-08-hf-worker-docker-design.md
@@ -184,14 +184,14 @@ validation: the `.ts` DSL form documents the graph; the exported `.json` form is
 artifact loaded **into the running TS server** (UI import or the server's run API).
 Fallback node: `FillMask` / `distilbert-base-uncased`.
 
-**Critical wiring fact (verified):** the remote `WebsocketPythonBridge` is created and
-injected **only by the `websocket` server** (`server.ts` / `http-api.ts` /
-`mcp-server.ts`; the runner reads `options.pythonBridge`). The CLI/DSL local path
-(`nodetool run <file>` → `@nodetool-ai/dsl` `run()` → `ProcessingContext` /
-`WorkflowRunner`) does **not** create a Python bridge. Therefore the validation graph
-must execute **through a running server** that has `NODETOOL_WORKER_URL` set — not via
-`nodetool run`. (Adding remote-worker support to the CLI run path is a possible
-follow-up, out of scope here.)
+**Wiring note (updated):** originally the remote `WebsocketPythonBridge` was created
+**only by the `websocket` server**, so the CLI/DSL local path couldn't run Python nodes.
+That gap is now closed — `connectPythonBridgeForGraph` / `resolvePythonNodeExecutor` in
+`@nodetool-ai/runtime` wire the bridge into the in-process runners, so both
+`nodetool workflows run <graph.json>` and `nodetool run <file.ts>` execute Python (incl.
+HuggingFace worker) nodes: remote when `NODETOOL_WORKER_URL` is set, else a local stdio
+worker. The validation graph can therefore be driven by **either** a running server
+(web UI) **or** the CLI directly.
 
 ---
 
@@ -249,12 +249,12 @@ Performed end-to-end on macOS Docker (CPU):
 4. **Bridge attach** — start the TS server with
    `NODETOOL_WORKER_URL=ws://localhost:8787 NODETOOL_WORKER_TOKEN=secret npm run dev:server`;
    server logs a successful `discover` + `worker.status`; HF node metadata is present.
-5. **Graph run (through the server)** — with the smoke workflow loaded into the running
-   server (web UI editor, or the server's run API), execute it. The HF node runs **on the
+5. **Graph run** — execute the smoke workflow either via the CLI
+   (`NODETOOL_WORKER_URL=ws://localhost:8787 NODETOOL_WORKER_TOKEN=secret nodetool workflows run examples/hf-worker-smoke.json`)
+   or by loading it into the running server (web UI). The HF node runs **on the
    container** and returns an **embedding (`np_array`)** — `SentenceSimilarity` is a
    feature-extraction node (one embedding per input string), not a cross-string scorer,
-   so the smoke graph previews the embedding(s). This must go through the server, not
-   `nodetool run` (see §5.5 wiring fact). First run downloads the model into the
+   so the smoke graph previews the embedding(s). First run downloads the model into the
    `hf-cache` volume; subsequent runs reuse it.
 
 CUDA-only nodes (most diffusers/3D) are **expected to fail locally** and are deferred to
@@ -328,7 +328,7 @@ exposure/ops concerns that the deploy iteration must satisfy.
 | First-run model download latency | Healthcheck `start-period`; `hf-cache` volume persists models across restarts. |
 | Token mistakenly left unset in a cloud deploy | Document that unset = open; the cloud iteration must require it (and a tunnel/TLS). |
 | Bridge reconnects to a stale URL after instance change | Known gap; re-resolution is deploy-iteration work, recorded in §8.2. |
-| Validation assumed `nodetool run` would route to the worker (it won't — no bridge on the local CLI path) | Validate **through a running server** (§5.5, §7); CLI remote-worker support is a possible follow-up. |
+| ~~`nodetool run` couldn't route to the worker~~ (resolved) | The CLI/DSL runners now wire the Python bridge (`connectPythonBridgeForGraph`), so `nodetool workflows run` / `nodetool run` execute Python nodes against a remote (or local stdio) worker — §5.5. |
 
 ---
 

--- a/docs/superpowers/specs/2026-06-08-hf-worker-docker-design.md
+++ b/docs/superpowers/specs/2026-06-08-hf-worker-docker-design.md
@@ -1,0 +1,342 @@
+# HuggingFace Python Worker — Docker image, local run, and remote-worker wiring
+
+**Date:** 2026-06-08
+**Status:** Approved design, ready for implementation plan
+**Scope of this iteration:** Author a HuggingFace worker Docker image (layered on the
+existing `nodetool-core` image), provide local build/run ergonomics, add a minimal
+authentication handshake to the worker, and validate the full UI → TS server → remote
+worker path locally (CPU-only). Cloud/GPU deployment is **out of scope** here and is
+captured as recorded constraints for a follow-up iteration.
+
+---
+
+## 1. Background and problem
+
+NodeTool runs Python nodes through a worker process. Today the TypeScript server most
+commonly spawns a **local** worker over a stdio bridge (`PythonStdioBridge`,
+length-prefixed msgpack over stdin/stdout).
+
+There is a second, already-built topology: the worker can run as a **long-lived
+WebSocket server**, and the TS server attaches to it remotely. The pieces that already
+exist:
+
+- **`nodetool-core/Dockerfile`** builds a Python worker image (micromamba / Ubuntu
+  22.04 / Python 3.11) that installs `nodetool-core` from PyPI and runs
+  `python -m nodetool.worker --host 0.0.0.0 --port 7777` — a WebSocket server, with a
+  ws-handshake healthcheck. `EXPOSE 7777`, `CMD` (not `ENTRYPOINT`).
+- **`nodetool2` runtime**: `createPythonBridge()` returns a `WebsocketPythonBridge`
+  (reconnect + exponential backoff) whenever `NODETOOL_WORKER_URL=ws://host:port` is
+  set, instead of spawning a local worker. The TS server (`server.ts`, `http-api.ts`,
+  `mcp-server.ts`) calls `createPythonBridge()`, so setting that env var is sufficient
+  to switch the whole server onto a remote worker.
+
+What is **missing**, and what this iteration delivers:
+
+1. A **HuggingFace** worker image. HF nodes need a large ML stack (torch 2.9,
+   diffusers, transformers, accelerate, bitsandbytes, sam2, …) and, in production, a
+   GPU. No HF Dockerfile exists yet.
+2. **Local run ergonomics** to build the two layered images, run the worker, point the
+   server at it, and validate a graph end-to-end.
+3. **Authentication** on the worker. The WebSocket worker currently has **no auth**:
+   anyone who can reach the port can execute arbitrary nodes (remote code execution on
+   the GPU). A minimal token handshake is required before the image can ever be exposed
+   beyond localhost.
+
+This is a **packaging + wiring + auth** task. It is not a protocol change — the msgpack
+WebSocket protocol and the bridge already exist.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+- A `nodetool-huggingface` Docker image that layers on the core worker image and
+  installs the released `nodetool-huggingface` package from PyPI.
+- One-command local build/run (Makefile + compose) and a documented wire-up.
+- A minimal, opt-in `Authorization: Bearer` token handshake on the worker, honored by
+  the TS bridge on connect and reconnect.
+- A repeatable local validation (CPU-only) that proves: image health, auth gate, bridge
+  attach, and a real HF graph executing on the remote worker.
+- A written record of the RunPod / Vast.ai constraints that the cloud/GPU iteration must
+  satisfy.
+
+**Non-goals (this iteration)**
+- No changes to `packages/deploy` (no first-class deploy target for the worker).
+- No actual cloud/GPU deployment, and no GPU validation (macOS Docker is CPU-only).
+- No dynamic endpoint resolution or reconnect-with-re-resolution (recorded as a gap).
+- No TLS termination / tunnel automation.
+
+---
+
+## 3. Decisions (locked during brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Primary first target | **Local Docker** (CPU-only validation on macOS) |
+| What the iteration is about | **The HF worker image is the goal**; core is the stepping stone |
+| HF image base / CUDA strategy | **Layer on the core image + PyPI CUDA wheels** (torch wheel bundles CUDA; host needs only the NVIDIA driver + container runtime) |
+| "Done" boundary | **Dockerfile + local run + validation** (no `packages/deploy` changes) |
+| Package source | **Released PyPI packages** (version via build-arg) |
+| Worker auth | **Build `NODETOOL_WORKER_TOKEN` handshake now** (worker + bridge) |
+| Build wrappers | **Makefile** in `nodetool-huggingface` |
+| Validation | **Committed smoke DSL** (`SentenceSimilarity` / `all-MiniLM-L6-v2`) |
+
+---
+
+## 4. Architecture
+
+### 4.1 Image layering
+
+```
+mambaorg/micromamba:jammy
+        │  (nodetool-core/Dockerfile — exists)
+        ▼
+nodetool-core:local            FROM base; uv pip install nodetool-core==<NODETOOL_VERSION>
+   EXPOSE 7777 / HEALTHCHECK / CMD ["python","-m","nodetool.worker","--host","0.0.0.0","--port","7777"]
+        │  (nodetool-huggingface/Dockerfile — new)
+        ▼
+nodetool-hf:local              FROM ${CORE_IMAGE}; uv pip install nodetool-huggingface==<HF_VERSION>
+   (EXPOSE / HEALTHCHECK / CMD inherited from core; HF has no worker module of its own)
+```
+
+The HF image adds only Python packages on top of core. `python -m nodetool.worker`
+comes from the inherited `nodetool-core` dependency, so the HF image needs no new CMD.
+
+### 4.2 Runtime topology (local)
+
+```
+web UI ──ws──► TS server (host :7777) ──► createPythonBridge()
+                                              │  NODETOOL_WORKER_URL set?
+                                              ▼  yes → WebsocketPythonBridge
+                                          ws://localhost:8787  ──►  hf-worker container (:7777 internal)
+                                          Authorization: Bearer <NODETOOL_WORKER_TOKEN>
+```
+
+The TS dev server already binds host `7777`, so the worker container must publish on a
+**different host port**. This design uses **`8787`** → `NODETOOL_WORKER_URL=ws://localhost:8787`.
+
+---
+
+## 5. Artifacts
+
+All new files live in the **`nodetool-huggingface`** sibling repo, except the bridge
+change (`nodetool2`) and the worker auth change (`nodetool-core`).
+
+### 5.1 `nodetool-huggingface/Dockerfile` (new)
+
+```dockerfile
+# Layer the HuggingFace node stack on top of the core worker image.
+# CORE_IMAGE: locally-built `nodetool-core:local`, or a published
+#   ghcr.io/nodetool-ai/nodetool:<tag>. HF_VERSION pins the PyPI release.
+ARG CORE_IMAGE=nodetool-core:local
+FROM ${CORE_IMAGE}
+
+ARG HF_VERSION=0.7.1
+USER root
+
+# torch 2.9 + the rest pull CUDA-enabled wheels with a bundled CUDA runtime;
+# no nvidia/cuda base needed. The host supplies the NVIDIA driver at run time.
+RUN uv pip install --python $VIRTUAL_ENV --index-url https://pypi.org/simple \
+        "nodetool-huggingface==${HF_VERSION}" \
+    && rm -rf /root/.cache/uv /root/.cache/pip /tmp/* /var/tmp/*
+
+# EXPOSE 7777, HEALTHCHECK, CMD all inherited from the core image.
+```
+
+Notes:
+- Base HF dependencies only. Optional extras (`ocr`, `hunyuan3d`, `triposg`, …) are
+  **not** installed; if needed later they become additional build-args / image variants.
+- The image is large (multi-GB) by nature of the ML stack. Expected.
+
+### 5.2 `nodetool-huggingface/docker-compose.yaml` (new)
+
+- Service `hf-worker`:
+  - `build: { context: ., args: { CORE_IMAGE, HF_VERSION } }`
+  - `ports: ["8787:7777"]`
+  - `volumes: ["hf-cache:/app/huggingface"]` (named volume; `HF_HOME=/app/huggingface`)
+  - `environment`: pass through `NODETOOL_WORKER_TOKEN` (and any provider/runtime env
+    the worker needs).
+  - Healthcheck inherited from the image (or restated for clarity).
+- A **`gpu` compose profile** adds `deploy.resources.reservations.devices` (NVIDIA) /
+  `gpus: all`. Not activated on macOS — the default (CPU) service is used locally.
+- Named volume `hf-cache` declared at the bottom.
+
+### 5.3 `nodetool-huggingface/Makefile` (new)
+
+| Target | Action |
+| --- | --- |
+| `build-core` | `docker build -t nodetool-core:local ../nodetool-core` (or document pulling `ghcr.io/nodetool-ai/nodetool:<tag>`) |
+| `build-hf` | `docker build -t nodetool-hf:local --build-arg CORE_IMAGE=nodetool-core:local .` |
+| `up` | `docker compose up` (CPU) — runs the worker on `localhost:8787` |
+| `down` | `docker compose down` |
+
+### 5.4 `nodetool-huggingface/docs/worker-deployment.md` (new)
+
+Build → run → wire → validate steps; the cloud-constraints section (§8); the
+CPU-only-on-macOS and host-port-`8787` caveats; the `NODETOOL_WORKER_TOKEN` setup.
+
+### 5.5 `nodetool-huggingface/examples/hf-worker-smoke.{ts,json}` (new)
+
+A minimal workflow using the HuggingFace **SentenceSimilarity** node with
+`sentence-transformers/all-MiniLM-L6-v2` (~80 MB, CPU-fast) — a feature-extraction node
+that returns an `np_array` embedding per input string. Committed for repeatable
+validation: the `.ts` DSL form documents the graph; the exported `.json` form is the
+artifact loaded **into the running TS server** (UI import or the server's run API).
+Fallback node: `FillMask` / `distilbert-base-uncased`.
+
+**Critical wiring fact (verified):** the remote `WebsocketPythonBridge` is created and
+injected **only by the `websocket` server** (`server.ts` / `http-api.ts` /
+`mcp-server.ts`; the runner reads `options.pythonBridge`). The CLI/DSL local path
+(`nodetool run <file>` → `@nodetool-ai/dsl` `run()` → `ProcessingContext` /
+`WorkflowRunner`) does **not** create a Python bridge. Therefore the validation graph
+must execute **through a running server** that has `NODETOOL_WORKER_URL` set — not via
+`nodetool run`. (Adding remote-worker support to the CLI run path is a possible
+follow-up, out of scope here.)
+
+---
+
+## 6. Authentication (`NODETOOL_WORKER_TOKEN`)
+
+A shared-secret bearer token, opt-in, identical env name on both ends.
+
+### 6.1 Worker side — `nodetool-core`
+
+- In `start_server` (`server.py`), pass a `process_request` hook to
+  `websockets.asyncio.server.serve(...)`.
+- Behavior:
+  - Read the expected token from env `NODETOOL_WORKER_TOKEN`.
+  - **If unset/empty** → accept all connections (preserves local/stdio/dev behavior and
+    backward compatibility).
+  - **If set** → require request header `Authorization: Bearer <token>`. Compare with
+    `hmac.compare_digest` (constant time). On mismatch/absence, return an HTTP **401**
+    `Response` from `process_request`, which aborts the handshake before any frame.
+- Optionally make `--host` / `--port` default from env (`NODETOOL_WORKER_HOST`,
+  `NODETOOL_WORKER_PORT`) so the >70000 identity-port trick is possible on cloud hosts.
+  Optional; not required for local.
+
+### 6.2 Client side — `nodetool2` `python-websocket-bridge.ts`
+
+- The `ws` `WebSocket` constructor at the connect site already takes an options object
+  (`{ maxPayload }`). Add `headers: { Authorization: 'Bearer ' + token }` when a token
+  is configured.
+- Token source: `options.workerToken ?? process.env.NODETOOL_WORKER_TOKEN`, threaded
+  through `PythonBridgeOptions` and `createPythonBridge()` (alongside `wsUrl`).
+- The header must be applied on **both** the initial connect and every **reconnect**
+  (the reconnect path builds a fresh socket).
+- When no token is configured, behavior is unchanged (no header sent).
+
+### 6.3 Why a header (not first-message or subprotocol)
+
+- Both libraries support it directly (`ws` `headers` option; `websockets`
+  `process_request` + `request.headers`).
+- The handshake is rejected **before** any application frame, so an unauthenticated peer
+  never reaches the executor.
+- Headers survive both direct-TCP and HTTP-proxy paths.
+
+---
+
+## 7. Validation (local, CPU-only)
+
+Performed end-to-end on macOS Docker (CPU):
+
+1. **Image build** — `make build-core` then `make build-hf` succeed.
+2. **Image health** — `make up`; the container's ws-handshake healthcheck reports
+   healthy.
+3. **Auth gate** —
+   - Worker started with `NODETOOL_WORKER_TOKEN=secret`.
+   - Bridge with **no** / **wrong** token → handshake rejected (401), connect fails.
+   - Bridge with **matching** token → connects.
+4. **Bridge attach** — start the TS server with
+   `NODETOOL_WORKER_URL=ws://localhost:8787 NODETOOL_WORKER_TOKEN=secret npm run dev:server`;
+   server logs a successful `discover` + `worker.status`; HF node metadata is present.
+5. **Graph run (through the server)** — with the smoke workflow loaded into the running
+   server (web UI editor, or the server's run API), execute it. The HF node runs **on the
+   container** and returns an **embedding (`np_array`)** — `SentenceSimilarity` is a
+   feature-extraction node (one embedding per input string), not a cross-string scorer,
+   so the smoke graph previews the embedding(s). This must go through the server, not
+   `nodetool run` (see §5.5 wiring fact). First run downloads the model into the
+   `hf-cache` volume; subsequent runs reuse it.
+
+CUDA-only nodes (most diffusers/3D) are **expected to fail locally** and are deferred to
+the GPU iteration.
+
+---
+
+## 8. Cloud targets — recorded constraints (NEXT iteration, not built here)
+
+Validated against current (2026) RunPod and Vast.ai docs. The **image** design holds on
+both (PyPI CUDA wheels + host driver; `CMD` runs on boot). The deltas below are
+exposure/ops concerns that the deploy iteration must satisfy.
+
+### 8.1 Transport: direct TCP, never an HTTP proxy
+
+- **RunPod** HTTP proxy (`*.proxy.runpod.net`) is Cloudflare-fronted: **100 MB** body
+  cap, **100 s** timeout, WS disconnects observed at ~1.8 MiB. Unusable for large
+  binary frames. → Use **Expose TCP Ports** (direct, public IP, random external port).
+- **Vast.ai** raw `-p` is direct TCP passthrough (good). Their Caddy auth-proxy (when
+  external≠internal port) inserts an HTTP hop → use an **identity port map** (e.g. a
+  port >70000) for raw passthrough.
+- **Mitigation / preference:** offload large blobs to `ASSET_BUCKET` / S3 (the worker
+  already supports asset env) so WebSocket frames stay small. This both relieves the
+  frame-size limits and reduces egress. The 256 MB bridge frame ceiling should be
+  treated as a backstop, not a routine payload size.
+
+### 8.2 Dynamic endpoint resolution
+
+- Both platforms map internal `7777` to a **random external port** on a public IP, known
+  only **after** boot (RunPod: `RUNPOD_PUBLIC_IP` / `RUNPOD_TCP_PORT_*`; Vast: "IP Port
+  Info" / API). `NODETOOL_WORKER_URL` must therefore be resolved **at runtime from the
+  provider API**, not hardcoded.
+- **Gap:** the current `WebsocketPythonBridge` reconnects to a **fixed** URL. For cloud,
+  reconnect must **re-resolve** host:port (the instance/IP can change). This is
+  deploy-iteration work, explicitly out of scope now.
+
+### 8.3 Security
+
+- A raw, world-reachable port + no app auth = public RCE on the GPU. The
+  `NODETOOL_WORKER_TOKEN` handshake (built this iteration) is the app-level gate. For
+  public exposure it must be combined with **TLS (`wss`)** — terminated by you, since
+  neither platform's usable path gives free TLS at these frame sizes — or, preferably, a
+  **private tunnel** (Tailscale / WireGuard / SSH) with the worker bound to the tunnel
+  interface. Never expose the raw token-only port over plain `ws://` on the public
+  internet.
+
+### 8.4 GPU / host selection, persistence, cost
+
+- **CUDA host filter ≥ 12.x** for torch 2.9 (RunPod `allowedCudaVersions` / UI filter;
+  Vast `cuda_vers>=… driver_version>=…`), else the container can land on an old-driver
+  host and fail to use the GPU.
+- **Product/mode:** RunPod = **Pod** (not Serverless — serverless can't hold a
+  persistent client WebSocket). Vast = **entrypoint** launch mode (so the image `CMD`
+  runs as PID 1; SSH/Jupyter modes replace it → use `onstart`).
+- **Model cache:** RunPod Network Volume mounts at `/workspace` (set
+  `HF_HOME=/workspace/.cache/huggingface`); Vast Volume at `/data` (host-pinned, lost if
+  the host vanishes); Vast container disk is wiped on destroy. Treat the HF cache as a
+  rebuildable warm cache.
+- **Cost/reliability:** persistent GPU bills continuously (no scale-to-zero). Vast hosts
+  are heterogeneous/interruptible — prefer on-demand, high-reliability hosts; treat the
+  worker as ephemeral.
+
+---
+
+## 9. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| HF image is very large; slow first build | Expected; layer on core for cache reuse; document build time. |
+| macOS Docker can't exercise GPU paths | Validate CPU-capable nodes only; GPU validation deferred to the cloud iteration. |
+| First-run model download latency | Healthcheck `start-period`; `hf-cache` volume persists models across restarts. |
+| Token mistakenly left unset in a cloud deploy | Document that unset = open; the cloud iteration must require it (and a tunnel/TLS). |
+| Bridge reconnects to a stale URL after instance change | Known gap; re-resolution is deploy-iteration work, recorded in §8.2. |
+| Validation assumed `nodetool run` would route to the worker (it won't — no bridge on the local CLI path) | Validate **through a running server** (§5.5, §7); CLI remote-worker support is a possible follow-up. |
+
+---
+
+## 10. Out of scope / follow-up (the "cloud/GPU iteration")
+
+- First-class worker deploy target in `packages/deploy` (build → push → run → wire).
+- Provider integrations: RunPod **Pods** (direct TCP, network volume), Vast.ai
+  (entrypoint mode, identity port, volume), self-hosted GPU box (SSH).
+- Dynamic `NODETOOL_WORKER_URL` resolution + reconnect-with-re-resolution.
+- TLS / tunnel automation; large-blob S3 offload path.
+- Optional HF extras as image variants.

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -39,7 +39,9 @@ import { registerHuggingFaceNodes } from "@nodetool-ai/huggingface-nodes";
 import {
   ProcessingContext,
   FileStorageAdapter,
-  initTelemetry
+  initTelemetry,
+  connectPythonBridgeForGraph,
+  resolvePythonNodeExecutor
 } from "@nodetool-ai/runtime";
 import { registerPackageCommands } from "./commands/package.js";
 import {
@@ -522,12 +524,21 @@ workflows
           storage: new FileStorageAdapter(getDefaultAssetsPath())
         });
 
+        // Connect a Python worker bridge when the graph has non-TS (Python)
+        // nodes. Transport: NODETOOL_WORKER_URL (+ NODETOOL_WORKER_TOKEN) →
+        // remote worker; unset → local stdio worker. Pure-TS graphs get none.
+        const pythonBridge = await connectPythonBridgeForGraph(
+          graph.nodes,
+          (t) => registry.has(t)
+        );
+
         // Run workflow
         const runner = new WorkflowRunner(jobId, {
           resolveExecutor: (node: { id: string; type: string }) => {
-            if (!registry.has(node.type))
-              throw new Error(`Unknown node type: ${node.type}`);
-            return registry.resolve(node);
+            if (registry.has(node.type)) return registry.resolve(node);
+            const py = resolvePythonNodeExecutor(pythonBridge, node);
+            if (py) return py;
+            throw new Error(`Unknown node type: ${node.type}`);
           },
           executionContext: context
         });
@@ -536,10 +547,20 @@ workflows
           `Running workflow${workflowId ? ` ${workflowId}` : ""}...`
         );
 
-        const result = await runner.run(
-          { job_id: jobId, workflow_id: workflowId ?? undefined, params },
-          graph
-        );
+        const result = await (async () => {
+          try {
+            return await runner.run(
+              {
+                job_id: jobId,
+                workflow_id: workflowId ?? undefined,
+                params
+              },
+              graph
+            );
+          } finally {
+            pythonBridge?.close();
+          }
+        })();
 
         if (opts.json) {
           console.log(JSON.stringify(result, null, 2));

--- a/packages/deploy/scripts/runpod-worker.ts
+++ b/packages/deploy/scripts/runpod-worker.ts
@@ -1,0 +1,121 @@
+/**
+ * Deploy / manage a NodeTool worker as a RunPod Pod via the REST integration in
+ * the deploy module. The RunPod API key is read from the per-user secret store
+ * (nodetool_secrets), NOT process.env or runpodctl.
+ *
+ * Usage (via tsx):
+ *   tsx packages/deploy/scripts/runpod-worker.ts deploy --image <registry/img> [--token <t>] [--name <n>] [--exposure http|tcp]
+ *   tsx packages/deploy/scripts/runpod-worker.ts list
+ *   tsx packages/deploy/scripts/runpod-worker.ts destroy <podId>
+ */
+
+import { initDb, getSecret } from "@nodetool-ai/models";
+import { initMasterKey } from "@nodetool-ai/security";
+import { getDefaultDbPath } from "@nodetool-ai/config";
+
+import {
+  deployWorkerPod,
+  listPods,
+  deletePod,
+  getPod
+} from "../src/runpod-rest.js";
+
+const LOCAL_USER_ID = "1";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function loadApiKey(): Promise<string> {
+  // Primary source: the per-user secret store (nodetool_secrets).
+  try {
+    initDb(getDefaultDbPath());
+    await initMasterKey();
+    const key = await getSecret("RUNPOD_API_KEY", LOCAL_USER_ID);
+    if (key) return key;
+  } catch (err) {
+    console.error(
+      "[runpod-worker] secret-store read failed: " +
+        (err instanceof Error ? err.message : String(err))
+    );
+  }
+  // Fallback: environment (used when the keychain master key is unreachable,
+  // e.g. headless/sandboxed contexts). Secret store remains the primary path.
+  const envKey = process.env.RUNPOD_API_KEY;
+  if (envKey) {
+    console.error(
+      "[runpod-worker] using RUNPOD_API_KEY from environment (secret store unavailable)"
+    );
+    return envKey;
+  }
+  throw new Error(
+    "RUNPOD_API_KEY not found in the secret store or environment. Store it with: nodetool secrets store RUNPOD_API_KEY"
+  );
+}
+
+async function main(): Promise<void> {
+  const action = process.argv[2];
+  const apiKey = await loadApiKey();
+  console.error("[runpod-worker] RUNPOD_API_KEY loaded (len " + apiKey.length + ")");
+
+  if (action === "list") {
+    const pods = await listPods(apiKey);
+    console.log(JSON.stringify(pods.map((p) => ({ id: p.id, name: p.name, status: p.desiredStatus, image: p.image })), null, 2));
+    return;
+  }
+
+  if (action === "destroy") {
+    const id = process.argv[3];
+    if (!id) throw new Error("destroy requires a pod id");
+    await deletePod(apiKey, id);
+    console.log(`[runpod-worker] terminated pod ${id}`);
+    return;
+  }
+
+  if (action === "get") {
+    const id = process.argv[3];
+    const pod = await getPod(apiKey, id);
+    console.log(JSON.stringify(pod, null, 2));
+    return;
+  }
+
+  if (action === "deploy") {
+    const image = arg("image");
+    if (!image) throw new Error("deploy requires --image <registry/image:tag>");
+    const token = arg("token");
+    const name = arg("name") ?? "nodetool-worker-test";
+    const exposure = (arg("exposure") as "http" | "tcp" | undefined) ?? "http";
+
+    console.error(`[runpod-worker] creating CPU pod from ${image} (exposure=${exposure})...`);
+    const { podId, wsUrl, pod } = await deployWorkerPod(apiKey, {
+      name,
+      image,
+      workerToken: token,
+      exposure,
+      computeType: "CPU"
+    });
+    console.log(
+      JSON.stringify(
+        {
+          podId,
+          wsUrl,
+          token: token ?? null,
+          status: pod.desiredStatus,
+          publicIp: pod.publicIp ?? null,
+          portMappings: pod.portMappings ?? null
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  throw new Error(`Unknown action '${action}'. Use: deploy | list | get | destroy`);
+}
+
+main().catch((err) => {
+  console.error("[runpod-worker] error:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -18,6 +18,7 @@ export * from "./image-builder.js";
 export * from "./self-hosted.js";
 export * from "./runpod.js";
 export * from "./runpod-api.js";
+export * from "./runpod-rest.js";
 export * from "./deploy-to-runpod.js";
 export * from "./gcp.js";
 export * from "./google-cloud-run-api.js";

--- a/packages/deploy/src/runpod-rest.ts
+++ b/packages/deploy/src/runpod-rest.ts
@@ -1,0 +1,271 @@
+/**
+ * RunPod Pod management over the REST API (https://rest.runpod.io/v1).
+ *
+ * The serverless helpers in `runpod-api.ts` create templates/endpoints (the
+ * job/queue model) and read the API key from `process.env`. This module manages
+ * **persistent Pods** — the right shape for a long-lived NodeTool WebSocket
+ * worker the server/CLI attaches to — and takes the API key **explicitly** so it
+ * can be sourced from the per-user secret store (`getSecret`), never the
+ * environment.
+ *
+ * REST surface used: POST /v1/pods, GET /v1/pods/{id}, POST /v1/pods/{id}/stop,
+ * DELETE /v1/pods/{id}, GET /v1/pods.
+ */
+
+const RUNPOD_REST_BASE_URL = "https://rest.runpod.io/v1";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Request body for POST /v1/pods (subset we use; see the REST reference). */
+export interface RunpodPodSpec {
+  name: string;
+  imageName: string;
+  computeType?: "CPU" | "GPU";
+  // CPU pods
+  vcpuCount?: number;
+  cpuFlavorIds?: string[];
+  cpuFlavorPriority?: "availability" | "custom";
+  // GPU pods
+  gpuTypeIds?: string[];
+  gpuCount?: number;
+  // Common
+  ports?: string[]; // e.g. ["7777/http"] or ["7777/tcp"]
+  env?: Record<string, string>;
+  containerDiskInGb?: number;
+  volumeInGb?: number;
+  volumeMountPath?: string;
+  networkVolumeId?: string;
+  dockerEntrypoint?: string[];
+  dockerStartCmd?: string[];
+  supportPublicIp?: boolean;
+  globalNetworking?: boolean;
+  dataCenterIds?: string[];
+}
+
+/** Pod as returned by GET /v1/pods/{id} (fields we read). */
+export interface RunpodPod {
+  id: string;
+  name?: string;
+  desiredStatus?: "RUNNING" | "EXITED" | "TERMINATED" | string;
+  image?: string;
+  /** Public IPv4; empty/null while the Pod is initializing. */
+  publicIp?: string | null;
+  /** Internal→external port map, e.g. {"7777": 41021}. */
+  portMappings?: Record<string, number> | null;
+  ports?: string[];
+  [k: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// REST transport (explicit key — no process.env)
+// ---------------------------------------------------------------------------
+
+type HttpMethod = "GET" | "POST" | "DELETE";
+
+/**
+ * Call the RunPod REST API with an explicitly-supplied key.
+ *
+ * @param apiKey   RunPod API key (from the per-user secret store).
+ * @param endpoint Path under /v1, e.g. "pods" or "pods/<id>".
+ */
+async function runpodRest(
+  apiKey: string,
+  endpoint: string,
+  method: HttpMethod = "GET",
+  data?: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  if (!apiKey) throw new Error("RunPod API key is required");
+  const init: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    },
+    signal: AbortSignal.timeout(60_000)
+  };
+  if (data && method === "POST") init.body = JSON.stringify(data);
+
+  const response = await fetch(`${RUNPOD_REST_BASE_URL}/${endpoint}`, init);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `RunPod REST ${method} /${endpoint} failed (${response.status}): ${body}`
+    );
+  }
+  if (method === "DELETE" && response.status === 204) return {};
+  const text = await response.text();
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+// ---------------------------------------------------------------------------
+// Pod operations
+// ---------------------------------------------------------------------------
+
+/** Create (and deploy) a Pod. POST /v1/pods. */
+export async function createPod(
+  apiKey: string,
+  spec: RunpodPodSpec
+): Promise<RunpodPod> {
+  const pod = (await runpodRest(
+    apiKey,
+    "pods",
+    "POST",
+    spec as unknown as Record<string, unknown>
+  )) as RunpodPod;
+  if (!pod?.id) throw new Error("RunPod createPod returned no pod id");
+  return pod;
+}
+
+/** Get a Pod by id. GET /v1/pods/{id}. */
+export async function getPod(apiKey: string, id: string): Promise<RunpodPod> {
+  return (await runpodRest(apiKey, `pods/${id}`)) as RunpodPod;
+}
+
+/** List Pods. GET /v1/pods. */
+export async function listPods(apiKey: string): Promise<RunpodPod[]> {
+  const res = await runpodRest(apiKey, "pods");
+  if (Array.isArray(res)) return res as RunpodPod[];
+  const arr = (res as { pods?: unknown }).pods;
+  return Array.isArray(arr) ? (arr as RunpodPod[]) : [];
+}
+
+/** Stop a Pod (releases compute, keeps the volume). POST /v1/pods/{id}/stop. */
+export async function stopPod(apiKey: string, id: string): Promise<void> {
+  await runpodRest(apiKey, `pods/${id}/stop`, "POST");
+}
+
+/** Terminate a Pod (deletes it). DELETE /v1/pods/{id}. */
+export async function deletePod(apiKey: string, id: string): Promise<void> {
+  await runpodRest(apiKey, `pods/${id}`, "DELETE");
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Direct TCP WebSocket URL for an exposed `/tcp` port, or null while the Pod
+ * lacks a public IP / port mapping. Preferred for large frames (no HTTP proxy).
+ */
+export function podDirectWsUrl(
+  pod: RunpodPod,
+  internalPort: number
+): string | null {
+  const ext = pod.portMappings?.[String(internalPort)];
+  if (!pod.publicIp || !ext) return null;
+  return `ws://${pod.publicIp}:${ext}`;
+}
+
+/**
+ * RunPod HTTP-proxy WebSocket URL for an exposed `/http` port. TLS-terminated
+ * by RunPod; subject to the proxy's size/timeout limits (fine for small frames).
+ */
+export function podProxyWsUrl(podId: string, internalPort: number): string {
+  return `wss://${podId}-${internalPort}.proxy.runpod.net`;
+}
+
+// ---------------------------------------------------------------------------
+// High-level worker deploy
+// ---------------------------------------------------------------------------
+
+export interface DeployWorkerPodOptions {
+  /** Pod name. */
+  name: string;
+  /** Registry image RunPod pulls (must be reachable by RunPod). */
+  image: string;
+  /** Shared-secret passed as NODETOOL_WORKER_TOKEN (gates the ws handshake). */
+  workerToken?: string;
+  /** Internal port the worker serves on. Default 7777. */
+  internalPort?: number;
+  /** Expose via RunPod HTTP proxy ("http" → wss proxy) or direct TCP. */
+  exposure?: "http" | "tcp";
+  computeType?: "CPU" | "GPU";
+  vcpuCount?: number;
+  gpuTypeIds?: string[];
+  containerDiskInGb?: number;
+  /** Extra env merged into the container. */
+  env?: Record<string, string>;
+  /** Poll budget for the Pod to reach RUNNING + expose its endpoint. */
+  timeoutMs?: number;
+}
+
+export interface DeployedWorkerPod {
+  podId: string;
+  /** ws/wss URL to set as NODETOOL_WORKER_URL. */
+  wsUrl: string;
+  pod: RunpodPod;
+}
+
+/**
+ * Deploy a NodeTool worker image as a persistent RunPod Pod and wait until it is
+ * RUNNING with a resolvable WebSocket endpoint. Does NOT read process.env — pass
+ * `apiKey` (from the secret store) and `workerToken` explicitly.
+ *
+ * Reaching RUNNING + having an endpoint does not guarantee the worker process
+ * has finished loading nodes; the caller should connect with retry.
+ */
+export async function deployWorkerPod(
+  apiKey: string,
+  opts: DeployWorkerPodOptions
+): Promise<DeployedWorkerPod> {
+  const internalPort = opts.internalPort ?? 7777;
+  const exposure = opts.exposure ?? "http";
+  const env: Record<string, string> = { ...(opts.env ?? {}) };
+  if (opts.workerToken) env.NODETOOL_WORKER_TOKEN = opts.workerToken;
+
+  const spec: RunpodPodSpec = {
+    name: opts.name,
+    imageName: opts.image,
+    computeType: opts.computeType ?? "CPU",
+    vcpuCount: opts.computeType === "GPU" ? undefined : (opts.vcpuCount ?? 4),
+    gpuTypeIds: opts.gpuTypeIds,
+    ports: [`${internalPort}/${exposure}`],
+    env,
+    containerDiskInGb: opts.containerDiskInGb ?? 20
+  };
+
+  const created = await createPod(apiKey, spec);
+  const { pod, wsUrl } = await waitForPodEndpoint(apiKey, created.id, {
+    internalPort,
+    exposure,
+    timeoutMs: opts.timeoutMs ?? 240_000
+  });
+  return { podId: created.id, wsUrl, pod };
+}
+
+/** Poll GET /v1/pods/{id} until RUNNING with a resolvable endpoint. */
+export async function waitForPodEndpoint(
+  apiKey: string,
+  id: string,
+  opts: {
+    internalPort: number;
+    exposure: "http" | "tcp";
+    timeoutMs?: number;
+    intervalMs?: number;
+  }
+): Promise<{ pod: RunpodPod; wsUrl: string }> {
+  const deadline = Date.now() + (opts.timeoutMs ?? 240_000);
+  const intervalMs = opts.intervalMs ?? 5_000;
+  let last: RunpodPod | undefined;
+  while (Date.now() < deadline) {
+    const pod = await getPod(apiKey, id);
+    last = pod;
+    if (pod.desiredStatus === "TERMINATED" || pod.desiredStatus === "EXITED") {
+      throw new Error(`Pod ${id} reached terminal status ${pod.desiredStatus}`);
+    }
+    if (pod.desiredStatus === "RUNNING") {
+      if (opts.exposure === "http") {
+        return { pod, wsUrl: podProxyWsUrl(id, opts.internalPort) };
+      }
+      const direct = podDirectWsUrl(pod, opts.internalPort);
+      if (direct) return { pod, wsUrl: direct };
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `Pod ${id} did not become reachable within the timeout (last status: ${last?.desiredStatus ?? "unknown"})`
+  );
+}

--- a/packages/dsl/src/core.ts
+++ b/packages/dsl/src/core.ts
@@ -6,7 +6,12 @@
 
 import { WorkflowRunner } from "@nodetool-ai/kernel";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
-import { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  ProcessingContext,
+  connectPythonBridgeForGraph,
+  resolvePythonNodeExecutor,
+  type PythonBridgeOptions
+} from "@nodetool-ai/runtime";
 import type {
   NodeDescriptor as GraphNodeDescriptor,
   Edge,
@@ -330,6 +335,13 @@ export type RunOptions = {
    * secret is missing.
    */
   secretResolver?: SecretResolver;
+  /**
+   * Python worker bridge options forwarded to {@link createPythonBridge} when
+   * the graph contains Python nodes. Omit to rely on the environment
+   * (`NODETOOL_WORKER_URL` / `NODETOOL_WORKER_TOKEN`); set `wsUrl`/`workerToken`
+   * here to target a specific remote worker programmatically.
+   */
+  bridgeOptions?: PythonBridgeOptions;
 };
 
 export type WorkflowResult = Record<string, unknown>;
@@ -401,6 +413,21 @@ export async function run(
     // Some environments do not have the Reve node package in a runnable state.
   }
 
+  const hasTsExecutor = (type: string): boolean =>
+    Boolean(opts?.registry?.has(type)) ||
+    NodeRegistry.global.has(type) ||
+    builtinRegistry.has(type);
+
+  // Connect a Python worker bridge only when the graph has a node type no TS
+  // registry can resolve (a candidate Python node). Transport is chosen by
+  // NODETOOL_WORKER_URL (remote) vs unset (local stdio); see the helper. The
+  // bridge is closed in the finally below.
+  const pythonBridge = await connectPythonBridgeForGraph(
+    wf.nodes,
+    hasTsExecutor,
+    opts?.bridgeOptions
+  );
+
   const resolveExecutor = (node: { id: string; type: string }) => {
     if (opts?.registry?.has(node.type)) {
       return opts.registry.resolve(node);
@@ -411,6 +438,8 @@ export async function run(
     if (builtinRegistry.has(node.type)) {
       return builtinRegistry.resolve(node);
     }
+    const py = resolvePythonNodeExecutor(pythonBridge, node);
+    if (py) return py;
     throw new Error(`Unknown node type: ${node.type}`);
   };
 
@@ -419,7 +448,13 @@ export async function run(
     executionContext: context
   });
 
-  const result = await runner.run({ job_id: jobId }, { nodes, edges });
+  const result = await (async () => {
+    try {
+      return await runner.run({ job_id: jobId }, { nodes, edges });
+    } finally {
+      pythonBridge?.close();
+    }
+  })();
 
   if (result.status === "failed") {
     throw new Error(result.error ?? "Workflow execution failed");

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -87,6 +87,10 @@ export {
   encodeRawImageRef
 } from "./image-codec.js";
 export { PythonNodeExecutor } from "./python-node-executor.js";
+export {
+  connectPythonBridgeForGraph,
+  resolvePythonNodeExecutor
+} from "./python-graph-resolver.js";
 export { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 export {
   classifyAssetToken,

--- a/packages/runtime/src/python-bridge-factory.ts
+++ b/packages/runtime/src/python-bridge-factory.ts
@@ -18,6 +18,11 @@
  *
  * `options.wsUrl` takes precedence over the env var, so programmatic and test
  * callers can force the WebSocket transport without mutating the environment.
+ *
+ * Auth: the WebSocket bridge's shared-secret bearer token is sourced the same
+ * way — `options.workerToken ?? process.env.NODETOOL_WORKER_TOKEN`. When set,
+ * the bridge sends `Authorization: Bearer <token>` on connect and every
+ * reconnect; when unset/empty, no header is sent.
  */
 
 import { PythonStdioBridge } from "./python-stdio-bridge.js";
@@ -37,7 +42,13 @@ export function createPythonBridge(
 ): PythonBridgeBase {
   const wsUrl = options.wsUrl ?? process.env["NODETOOL_WORKER_URL"];
   if (wsUrl && wsUrl.trim()) {
-    return new WebsocketPythonBridge({ ...options, wsUrl: wsUrl.trim() });
+    const workerToken =
+      options.workerToken ?? process.env["NODETOOL_WORKER_TOKEN"];
+    return new WebsocketPythonBridge({
+      ...options,
+      wsUrl: wsUrl.trim(),
+      workerToken
+    });
   }
   return new PythonStdioBridge(options);
 }

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -38,6 +38,15 @@ export interface ProgressEvent {
 
 export interface PythonBridgeOptions {
   wsUrl?: string;
+  /**
+   * Shared-secret bearer token for the remote WebSocket worker. When set, the
+   * WebSocket bridge sends an `Authorization: Bearer <token>` header on every
+   * handshake (initial connect AND each reconnect); the worker rejects the
+   * handshake with HTTP 401 if it doesn't match. When unset/empty, no header is
+   * sent and the worker accepts all connections (local/dev backward compat).
+   * Threaded from `NODETOOL_WORKER_TOKEN` by {@link createPythonBridge}.
+   */
+  workerToken?: string;
   pythonPath?: string;
   workerArgs?: string[];
   autoRestart?: boolean;

--- a/packages/runtime/src/python-graph-resolver.ts
+++ b/packages/runtime/src/python-graph-resolver.ts
@@ -1,0 +1,118 @@
+/**
+ * Python-worker support for graphs executed OUTSIDE the websocket server.
+ *
+ * The websocket server wires the Python bridge into its own `resolveExecutor`
+ * (see packages/websocket/src/plugins/websocket.ts). In-process runners — the
+ * `nodetool run` / `nodetool workflows run` CLI commands and the DSL `run()` —
+ * had no such wiring, so any Python worker node failed with "Unknown node
+ * type". These helpers give those runners the same capability.
+ *
+ * Transport is chosen by {@link createPythonBridge}: when `NODETOOL_WORKER_URL`
+ * (optionally with `NODETOOL_WORKER_TOKEN`) is set, a remote WebSocket worker is
+ * used; otherwise a local stdio worker is spawned.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+
+import { createPythonBridge } from "./python-bridge-factory.js";
+import { PythonNodeExecutor } from "./python-node-executor.js";
+import type { PythonBridgeBase } from "./python-bridge-base.js";
+import type { PythonBridgeOptions } from "./python-bridge-types.js";
+
+const log = createLogger("nodetool.runtime.python-graph-resolver");
+
+/** Minimal graph-node shape the resolver needs. */
+interface GraphNodeLike {
+  id: string;
+  type: string;
+  properties?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Connect a Python worker bridge for a graph, but ONLY when the graph contains a
+ * node type the TS registry cannot resolve (a candidate Python node). Pure-TS
+ * graphs get no bridge — no worker spawned, no remote connection — preserving
+ * the prior behavior and cost for workflows that don't need Python.
+ *
+ * Failure handling depends on whether a remote worker was explicitly requested:
+ * - `NODETOOL_WORKER_URL` set → a connect failure is surfaced (the caller asked
+ *   for a specific remote worker, so a silent fallthrough would hide a real
+ *   misconfiguration).
+ * - unset (local stdio attempt) → a connect failure returns `null` and is
+ *   logged, so an unresolved node still reports the normal "Unknown node type"
+ *   error rather than a confusing worker-spawn error.
+ *
+ * The caller owns the returned bridge and MUST `close()` it after the run.
+ *
+ * @param nodes         The graph nodes (only `.type` is read).
+ * @param hasTsExecutor Predicate: can the in-process TS registry resolve a type?
+ * @param options       Bridge options forwarded to {@link createPythonBridge}.
+ * @returns The connected bridge, or `null` when no Python node is present (or a
+ *          local worker was unavailable).
+ */
+export async function connectPythonBridgeForGraph(
+  nodes: ReadonlyArray<{ type?: unknown }>,
+  hasTsExecutor: (nodeType: string) => boolean,
+  options?: PythonBridgeOptions
+): Promise<PythonBridgeBase | null> {
+  const needsPython = nodes.some(
+    (n) =>
+      typeof n.type === "string" && n.type.length > 0 && !hasTsExecutor(n.type)
+  );
+  if (!needsPython) return null;
+
+  const wsUrl = options?.wsUrl ?? process.env["NODETOOL_WORKER_URL"];
+  const bridge = createPythonBridge(options);
+  try {
+    await bridge.connect();
+    return bridge;
+  } catch (err) {
+    bridge.close();
+    if (wsUrl && wsUrl.trim()) {
+      // Remote worker explicitly requested — surface the failure.
+      throw err;
+    }
+    // No remote configured and a local worker isn't available here; fall
+    // through so unresolved node types report the normal error.
+    log.warn(
+      `Python worker bridge unavailable; Python nodes will be unresolved: ${String(
+        err
+      )}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Build a {@link PythonNodeExecutor} for a node when the bridge advertises its
+ * type, mirroring the websocket server's `resolveExecutor`. Returns `null` when
+ * there is no bridge or the bridge does not know the node type, so the caller
+ * can fall through to its own "unknown node type" error.
+ */
+export function resolvePythonNodeExecutor(
+  bridge: PythonBridgeBase | null,
+  node: GraphNodeLike
+): PythonNodeExecutor | null {
+  if (!bridge || !bridge.hasNodeType(node.type)) return null;
+
+  const meta = bridge
+    .getNodeMetadata()
+    .find((m) => m.node_type === node.type);
+  const props = (node.properties ?? node.data ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const outputTypes = Object.fromEntries(
+    (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
+  );
+
+  return new PythonNodeExecutor(
+    bridge,
+    node.type,
+    props,
+    outputTypes,
+    meta?.required_settings ?? [],
+    node.id
+  );
+}

--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -117,6 +117,7 @@ function crashSafeTerminate(ws: WebSocket): void {
 export class WebsocketPythonBridge extends PythonBridgeBase {
   private _ws: WebSocket | null = null;
   private readonly _wsUrl: string;
+  private readonly _workerToken: string | undefined;
   private readonly _maxReconnectDelayMs: number;
   private readonly _reconnectRpcTimeoutMs: number;
   private readonly _autoReconnect: boolean;
@@ -157,6 +158,10 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
       );
     }
     this._wsUrl = options.wsUrl;
+    // Shared-secret bearer token: when present, every handshake (connect AND
+    // reconnect, both via _openSocket) carries `Authorization: Bearer <token>`.
+    // An empty string is treated as unset (no header → worker accepts all).
+    this._workerToken = options.workerToken || undefined;
     this._maxReconnectDelayMs =
       options.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS;
     this._reconnectRpcTimeoutMs =
@@ -260,15 +265,29 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
 
   // ── Transport: open the remote socket ───────────────────────────────
 
+  /**
+   * Construct the `ws` WebSocket. The SINGLE place a socket is created — used by
+   * both the initial connect and every reconnect (both run through
+   * {@link _openTransport}), so the auth header is applied uniformly. When a
+   * worker token is configured, send `Authorization: Bearer <token>` on the
+   * handshake; otherwise send no header (worker accepts all).
+   */
+  private _openSocket(): WebSocket {
+    return new WebSocket(this._wsUrl, {
+      maxPayload: MAX_BRIDGE_FRAME_SIZE,
+      headers: this._workerToken
+        ? { Authorization: `Bearer ${this._workerToken}` }
+        : undefined
+    });
+  }
+
   protected override async _openTransport(): Promise<void> {
     const startupTimeoutMs =
       this._options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
-      const ws = new WebSocket(this._wsUrl, {
-        maxPayload: MAX_BRIDGE_FRAME_SIZE
-      });
+      const ws = this._openSocket();
       ws.binaryType = "nodebuffer";
 
       const startupTimer = setTimeout(() => {

--- a/packages/runtime/tests/python-bridge-factory.test.ts
+++ b/packages/runtime/tests/python-bridge-factory.test.ts
@@ -14,13 +14,17 @@ import { PythonStdioBridge } from "../src/python-stdio-bridge.js";
 import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
 
 const ENV_KEY = "NODETOOL_WORKER_URL";
+const TOKEN_ENV_KEY = "NODETOOL_WORKER_TOKEN";
 
 describe("createPythonBridge", () => {
   let savedWorkerUrl: string | undefined;
+  let savedWorkerToken: string | undefined;
 
   beforeEach(() => {
     savedWorkerUrl = process.env[ENV_KEY];
+    savedWorkerToken = process.env[TOKEN_ENV_KEY];
     delete process.env[ENV_KEY];
+    delete process.env[TOKEN_ENV_KEY];
   });
 
   afterEach(() => {
@@ -28,6 +32,11 @@ describe("createPythonBridge", () => {
       delete process.env[ENV_KEY];
     } else {
       process.env[ENV_KEY] = savedWorkerUrl;
+    }
+    if (savedWorkerToken === undefined) {
+      delete process.env[TOKEN_ENV_KEY];
+    } else {
+      process.env[TOKEN_ENV_KEY] = savedWorkerToken;
     }
   });
 

--- a/packages/runtime/tests/python-graph-resolver.test.ts
+++ b/packages/runtime/tests/python-graph-resolver.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  connectPythonBridgeForGraph,
+  resolvePythonNodeExecutor
+} from "../src/python-graph-resolver.js";
+import { PythonNodeExecutor } from "../src/python-node-executor.js";
+import type { PythonBridgeBase } from "../src/python-bridge-base.js";
+
+/**
+ * Minimal fake bridge exposing just the surface the resolver reads
+ * (hasNodeType + getNodeMetadata). Cast to PythonBridgeBase at the call site.
+ */
+function fakeBridge(
+  known: Record<
+    string,
+    { outputs?: Array<{ name: string; type: { type: string } }> }
+  >
+): PythonBridgeBase {
+  return {
+    hasNodeType: (t: string) => t in known,
+    getNodeMetadata: () =>
+      Object.entries(known).map(([node_type, meta]) => ({
+        node_type,
+        outputs: meta.outputs ?? [],
+        required_settings: []
+      })),
+    close: vi.fn()
+  } as unknown as PythonBridgeBase;
+}
+
+describe("connectPythonBridgeForGraph", () => {
+  it("returns null (no bridge) when every node resolves in the TS registry", async () => {
+    const bridge = await connectPythonBridgeForGraph(
+      [{ type: "a.B" }, { type: "c.D" }],
+      () => true
+    );
+    expect(bridge).toBeNull();
+  });
+
+  it("returns null for an empty graph (nothing needs Python)", async () => {
+    const bridge = await connectPythonBridgeForGraph([], () => false);
+    expect(bridge).toBeNull();
+  });
+
+  it("ignores nodes with a missing/blank type when deciding if Python is needed", async () => {
+    const bridge = await connectPythonBridgeForGraph(
+      [{ type: "" }, { type: undefined }, { type: "known.Ts" }],
+      (t) => t === "known.Ts"
+    );
+    expect(bridge).toBeNull();
+  });
+});
+
+describe("resolvePythonNodeExecutor", () => {
+  it("returns null when there is no bridge", () => {
+    expect(
+      resolvePythonNodeExecutor(null, { id: "1", type: "py.Node" })
+    ).toBeNull();
+  });
+
+  it("returns null when the bridge does not advertise the node type", () => {
+    const bridge = fakeBridge({ "py.Known": {} });
+    expect(
+      resolvePythonNodeExecutor(bridge, { id: "1", type: "py.Unknown" })
+    ).toBeNull();
+  });
+
+  it("builds a PythonNodeExecutor for a known Python node type", () => {
+    const bridge = fakeBridge({
+      "huggingface.sentence_similarity.SentenceSimilarity": {
+        outputs: [{ name: "output", type: { type: "np_array" } }]
+      }
+    });
+    const exec = resolvePythonNodeExecutor(bridge, {
+      id: "node-1",
+      type: "huggingface.sentence_similarity.SentenceSimilarity",
+      properties: { model: { type: "hf.sentence_similarity" } }
+    });
+    expect(exec).toBeInstanceOf(PythonNodeExecutor);
+  });
+});

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -12,6 +12,7 @@ import { AddressInfo } from "node:net";
 import * as msgpack from "@msgpack/msgpack";
 
 import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import { createPythonBridge } from "../src/python-bridge-factory.js";
 
 const FAKE_NODE = {
   node_type: "fake.TestNode",
@@ -47,6 +48,12 @@ interface FakeWorkerHandle {
   discoverCount: () => number;
   /** Total number of client connections accepted over the worker's lifetime. */
   connectionCount: () => number;
+  /**
+   * The `Authorization` header from each accepted handshake, in connection
+   * order. `undefined` when the client sent no such header. One entry per
+   * connection (so reconnects append further entries).
+   */
+  authHeaders: () => Array<string | undefined>;
   /** Currently connected sockets. */
   sockets: () => Set<WsServerSocket>;
   /** Mutate behavior at runtime (e.g. start answering discover after a drop). */
@@ -63,6 +70,7 @@ function startFakeWorker(
 ): Promise<FakeWorkerHandle> {
   const wss = new WebSocketServer({ port });
   const sockets = new Set<WsServerSocket>();
+  const authHeaders: Array<string | undefined> = [];
   let discovers = 0;
   let connections = 0;
   const opts: Required<FakeWorkerOptions> = {
@@ -72,8 +80,11 @@ function startFakeWorker(
     streamMode: initialOptions.streamMode ?? "chunks"
   };
 
-  wss.on("connection", (ws) => {
+  wss.on("connection", (ws, request) => {
     connections += 1;
+    // Record the handshake Authorization header (one entry per connection, so
+    // reconnects append). The header survives the WS upgrade on request.headers.
+    authHeaders.push(request.headers["authorization"]);
     sockets.add(ws);
     ws.binaryType = "nodebuffer";
     ws.on("close", () => sockets.delete(ws));
@@ -208,6 +219,7 @@ function startFakeWorker(
           }),
         discoverCount: () => discovers,
         connectionCount: () => connections,
+        authHeaders: () => authHeaders,
         sockets: () => sockets,
         setOptions: (next: FakeWorkerOptions) => {
           Object.assign(opts, next);
@@ -613,5 +625,91 @@ describe("WebsocketPythonBridge", () => {
       seen.push(chunk.content);
     }
     expect(seen).toEqual(["p-chunk-1", "p-chunk-2"]);
+  });
+
+  it("sends Authorization: Bearer on connect when a workerToken is set", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`,
+      workerToken: "s3cret-token"
+    });
+    await bridge.connect();
+
+    // Non-vacuous: assert the worker actually saw exactly one handshake and that
+    // it carried the bearer header. Guards against a header that is silently
+    // dropped (which would leave authHeaders[0] === undefined).
+    expect(worker.authHeaders()).toEqual(["Bearer s3cret-token"]);
+  });
+
+  it("re-sends Authorization: Bearer on every reconnect", async () => {
+    // The reconnect path builds a fresh socket; the header must be applied there
+    // too, not just on the initial connect.
+    worker = await startFakeWorker();
+    const port = worker.port;
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${port}`,
+      workerToken: "reconnect-token",
+      maxReconnectDelayMs: 50
+    });
+    await bridge.connect();
+    expect(worker.authHeaders()).toEqual(["Bearer reconnect-token"]);
+
+    let reconnected = false;
+    bridge.on("reconnected", () => {
+      reconnected = true;
+    });
+
+    // Drop the worker and bring it back on the same port; the bridge reconnects
+    // on its own, opening a second socket that must also carry the bearer header.
+    await worker.close();
+    worker = await startFakeWorker(port);
+
+    await waitFor(() => reconnected, 10000);
+    expect(bridge.isConnected).toBe(true);
+    // The fresh worker only saw the reconnect handshake — it too is authed.
+    expect(worker.authHeaders()).toEqual(["Bearer reconnect-token"]);
+  });
+
+  it("sends no Authorization header when no workerToken is configured", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    expect(worker.authHeaders()).toEqual([undefined]);
+  });
+
+  it("treats an empty-string workerToken as unset (no header)", async () => {
+    worker = await startFakeWorker();
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`,
+      workerToken: ""
+    });
+    await bridge.connect();
+
+    expect(worker.authHeaders()).toEqual([undefined]);
+  });
+
+  it("createPythonBridge threads NODETOOL_WORKER_TOKEN into the handshake", async () => {
+    // End-to-end through the factory: with only the env vars set, the bridge it
+    // builds must carry the bearer header on the handshake. Proves the factory
+    // sources the token from NODETOOL_WORKER_TOKEN (not just the constructor).
+    worker = await startFakeWorker();
+    const savedUrl = process.env["NODETOOL_WORKER_URL"];
+    const savedToken = process.env["NODETOOL_WORKER_TOKEN"];
+    process.env["NODETOOL_WORKER_URL"] = `ws://127.0.0.1:${worker.port}`;
+    process.env["NODETOOL_WORKER_TOKEN"] = "env-token";
+    try {
+      bridge = createPythonBridge() as WebsocketPythonBridge;
+      expect(bridge).toBeInstanceOf(WebsocketPythonBridge);
+      await bridge.connect();
+      expect(worker.authHeaders()).toEqual(["Bearer env-token"]);
+    } finally {
+      if (savedUrl === undefined) delete process.env["NODETOOL_WORKER_URL"];
+      else process.env["NODETOOL_WORKER_URL"] = savedUrl;
+      if (savedToken === undefined) delete process.env["NODETOOL_WORKER_TOKEN"];
+      else process.env["NODETOOL_WORKER_TOKEN"] = savedToken;
+    }
   });
 });

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "companion-clis": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "companion-clis/SKILL.md",
+      "computedHash": "5ed7e388eaa94501995edee5e8fb5b9028d0a2f8029b1f4ea531f7adf98ac6ce"
+    },
+    "flash": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "flash/SKILL.md",
+      "computedHash": "135a8c0a488aee2d1ca2170f5b8bf194febbf10bbb11c1ced3d123df0436847b"
+    },
+    "runpodctl": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "runpodctl/SKILL.md",
+      "computedHash": "fd7a47f981eefecfc7d96f80856074aae382e49cbe611a6fad4eee8ef3bed5c4"
+    }
+  }
+}


### PR DESCRIPTION
Enables running the NodeTool **Python worker as a remote service** that the TS server/CLI attaches to over WebSocket, plus a path to deploy it on RunPod.

## What's in here
- **`NODETOOL_WORKER_TOKEN` bridge auth** (`packages/runtime`): `WebsocketPythonBridge` sends `Authorization: Bearer <token>` on connect **and** reconnect (unset → open). Pairs with the worker-side `process_request` 401 gate in `nodetool-core` ≥ 0.7.3.
- **Run Python worker nodes from the CLI** (`cli`/`dsl`/`runtime`): `nodetool run` / `nodetool workflows run` now wire the Python bridge (`connectPythonBridgeForGraph` / `resolvePythonNodeExecutor`), so Python nodes execute against a remote (`NODETOOL_WORKER_URL`) or local stdio worker — previously they died with `Unknown node type` (only the websocket server wired the bridge).
- **RunPod Pod deploy over REST** (`packages/deploy/src/runpod-rest.ts` + `scripts/runpod-worker.ts`): `create/get/list/stop/delete` persistent RunPod **Pods** via `rest.runpod.io/v1`, API key passed explicitly (sourced from the per-user secret store, not `process.env`). Distinct from the existing serverless `RunPodDeployer`.
- **Design spec** for the HF worker Docker image (`docs/superpowers/specs/2026-06-08-hf-worker-docker-design.md`), incl. RunPod/Vast.ai constraints.
- Vendored RunPod skills (`.claude/skills/{companion-clis,flash,runpodctl}`).

## Verified
- `tsc` clean (runtime/dsl/cli/deploy); tests pass (runtime 26, dsl 138, cli 228).
- **End-to-end on RunPod**: built a CPU worker image (GHCR), deployed a pod via the REST module, ran a HuggingFace `SentenceSimilarity` workflow through the CLI bridge over `wss://` + token, got a **384-dim embedding** back from the pod, and tore it down.

## Notes / follow-ups
- Requires **nodetool-core ≥ 0.7.3** (worker auth gate + the 0.7.2 `python -m nodetool.worker` startup-crash fix this e2e surfaced).
- The pod deploy is currently a standalone module + driver script — **not yet a first-class `DeploymentManager` type** (would add a `RunPodPodDeployer` + pod schema). The REST transport could also be unified with `runpod-api.ts`'s `makeRunpodApiCall`.
- Branch bundles several threads (spec / bridge auth / CLI execution / deploy REST) — happy to split into focused PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)