### PR TITLE
Remove queue and workspace tabs from bottom panel

### DIFF
--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Drawer } from "@mui/material";
-import { Tooltip, Box } from "../ui_primitives";
+import { Tooltip } from "../ui_primitives";
 import { useResizeBottomPanel } from "../../hooks/handlers/useResizeBottomPanel";
 import {
   BOTTOM_PANEL_GROUPS,
@@ -15,11 +15,8 @@ import { useLocation } from "react-router-dom";
 import isEqual from "fast-deep-equal";
 import TracePanel from "./TracePanel";
 import LogPanel from "./LogPanel";
-import QueuePanel from "./jobs/QueuePanel";
 import SandboxesPanel from "../dashboard/SandboxesPanel";
-import WorkspaceTree from "../workspaces/WorkspaceTree";
 import { VersionHistoryPanel } from "../version";
-import PanelHeadline from "../ui/PanelHeadline";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { isProduction } from "../../lib/env";
@@ -32,7 +29,6 @@ import {
   Node as GraphNode,
   Edge as GraphEdge
 } from "../../stores/ApiTypes";
-import { useRunningJobs } from "../../hooks/useRunningJobs";
 import { useSystemStatsStore } from "../../stores/systemStatsHandler";
 import { globalWebSocketManager } from "../../lib/websocket/GlobalWebSocketManager";
 import { BASE_URL } from "../../stores/BASE_URL";
@@ -43,10 +39,7 @@ import TimelineIcon from "@mui/icons-material/Timeline";
 import ArticleIcon from "@mui/icons-material/Article";
 import DesktopWindowsIcon from "@mui/icons-material/DesktopWindows";
 import HistoryIcon from "@mui/icons-material/History";
-import FolderIcon from "@mui/icons-material/Folder";
-import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 
-const workspacesEnabled = !isProduction;
 const sandboxesEnabled = !isProduction;
 
 const HEADER_HEIGHT = 32;
@@ -119,12 +112,6 @@ interface ViewSpec {
 
 const VIEW_SPECS: Record<BottomPanelView, ViewSpec> = {
   logs: { id: "logs", label: "Logs", icon: <ArticleIcon />, enabled: true },
-  queue: {
-    id: "queue",
-    label: "Queue",
-    icon: <PlaylistPlayIcon />,
-    enabled: true
-  },
   sandboxes: {
     id: "sandboxes",
     label: "Sandboxes",
@@ -136,12 +123,6 @@ const VIEW_SPECS: Record<BottomPanelView, ViewSpec> = {
     label: "Versions",
     icon: <HistoryIcon />,
     enabled: true
-  },
-  workspace: {
-    id: "workspace",
-    label: "Workspace",
-    icon: <FolderIcon />,
-    enabled: workspacesEnabled
   },
   trace: {
     id: "trace",
@@ -356,14 +337,12 @@ const styles = (theme: Theme) =>
 interface TabButtonProps {
   spec: ViewSpec;
   active: boolean;
-  count?: number;
   onClick: () => void;
 }
 
 const TabButton = memo(function TabButton({
   spec,
   active,
-  count,
   onClick
 }: TabButtonProps) {
   return (
@@ -377,9 +356,6 @@ const TabButton = memo(function TabButton({
       >
         {spec.icon}
         <span>{spec.label}</span>
-        {count !== undefined && count > 0 && (
-          <span className="tab-count">{count}</span>
-        )}
       </button>
     </Tooltip>
   );
@@ -437,23 +413,6 @@ const PanelBodyContent = memo(function PanelBodyContent({
   switch (activeView) {
     case "logs":
       return <LogPanel />;
-    case "queue":
-      return (
-        <Box
-          className="queue-panel"
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            width: "100%",
-            height: "100%",
-            overflow: "hidden",
-            padding: "0 1em"
-          }}
-        >
-          <PanelHeadline title="Queue" />
-          <QueuePanel />
-        </Box>
-      );
     case "sandboxes":
       return sandboxesEnabled ? <SandboxesPanel /> : null;
     case "versions":
@@ -463,15 +422,6 @@ const PanelBodyContent = memo(function PanelBodyContent({
           onRestore={handleRestoreVersion}
           onClose={closeView}
         />
-      ) : null;
-    case "workspace":
-      return workspacesEnabled ? (
-        <Box
-          className="workspace-panel"
-          sx={{ width: "100%", height: "100%", overflow: "hidden" }}
-        >
-          <WorkspaceTree />
-        </Box>
       ) : null;
     case "trace":
       return <TracePanel />;
@@ -504,18 +454,14 @@ const PanelBottom: React.FC = () => {
     currentWorkflowId
   );
 
-  const { data: allJobs } = useRunningJobs();
-  const queuedCount =
-    allJobs?.filter((j) => j.status === "queued").length ?? 0;
-
   const systemStats = useSystemStatsStore((state) => state.stats);
 
   useCombo(["Control", "Shift", "T"], () => handlePanelToggle("trace"), false);
   useCombo(["l"], () => handlePanelToggle("logs"), false);
 
   // Production-disabled-view safeguard: if a previous session persisted a
-  // gated-off view (workspace/sandboxes), migrate the store to "logs" so the
-  // active view and the rendered body stay in sync.
+  // gated-off view (sandboxes), migrate the store to "logs" so the active
+  // view and the rendered body stay in sync.
   useEffect(() => {
     if (!VIEW_SPECS[activeView]?.enabled) {
       setActiveView("logs");
@@ -603,7 +549,6 @@ const PanelBottom: React.FC = () => {
                   key={view}
                   spec={VIEW_SPECS[view]}
                   active={isVisible && activeView === view}
-                  count={view === "queue" ? queuedCount : undefined}
                   onClick={() => handlePanelToggle(view)}
                 />
               ))}

--- a/web/src/stores/BottomPanelStore.ts
+++ b/web/src/stores/BottomPanelStore.ts
@@ -4,21 +4,16 @@ import { persist } from "zustand/middleware";
 /**
  * Bottom panel hosts secondary workflow tools that used to live in PanelRight.
  * Grouped into:
- *  - "run":      logs, jobs, sandboxes
- *  - "workflow": versions, workspace
+ *  - "run":      logs, sandboxes
+ *  - "workflow": versions
  *  - "debug":    trace
  *
  * Workflow settings and the agent panel now live in the left panel
  * (LeftPanelView "settings" / "agent"). The workflow assistant has been
- * removed entirely.
+ * removed entirely. The queue lives in the floating QueueOverlay and the
+ * workspace explorer in the left panel, so neither has a bottom-panel tab.
  */
-export type BottomPanelView =
-  | "logs"
-  | "queue"
-  | "sandboxes"
-  | "versions"
-  | "workspace"
-  | "trace";
+export type BottomPanelView = "logs" | "sandboxes" | "versions" | "trace";
 
 type BottomPanelGroup = "run" | "workflow" | "debug";
 
@@ -27,11 +22,11 @@ export const BOTTOM_PANEL_GROUPS: ReadonlyArray<{
   label: string;
   views: readonly BottomPanelView[];
 }> = [
-  { id: "run", label: "Run", views: ["logs", "queue", "sandboxes"] },
+  { id: "run", label: "Run", views: ["logs", "sandboxes"] },
   {
     id: "workflow",
     label: "Workflow",
-    views: ["versions", "workspace"]
+    views: ["versions"]
   },
   { id: "debug", label: "Debug", views: ["trace"] }
 ];


### PR DESCRIPTION
## Summary
Removes the "Queue" and "Workspace" tabs from the bottom panel. The queue functionality has been moved to a floating QueueOverlay, and the workspace explorer has been relocated to the left panel, so neither needs a dedicated bottom-panel tab.

## Changes
- **BottomPanelStore.ts**: Updated `BottomPanelView` type to remove `"queue"` and `"workspace"` views; updated `BOTTOM_PANEL_GROUPS` to remove these views from their respective groups
- **PanelBottom.tsx**:
  - Removed imports: `QueuePanel`, `WorkspaceTree`, `PanelHeadline`, `useRunningJobs`, `FolderIcon`, `PlaylistPlayIcon`, and `Box` (no longer needed)
  - Removed `workspacesEnabled` constant (workspace tab no longer exists)
  - Removed queue and workspace view specs from `VIEW_SPECS`
  - Removed `count` prop from `TabButton` component and its display logic
  - Removed queue and workspace cases from `PanelBodyContent` switch statement
  - Removed `useRunningJobs` hook call and `queuedCount` calculation
  - Updated production-disabled-view safeguard comment to reflect only sandboxes as a gated view
  - Removed `count` prop when rendering tab buttons

## Notes
- The queue functionality is now accessible via the floating QueueOverlay
- The workspace explorer is now in the left panel
- No functional changes to remaining bottom panel views (logs, sandboxes, versions, trace)

https://claude.ai/code/session_0138UTV92tpTfxzzkcawdoda