### PR TITLE
Add LLM/agent execution tracing to debug panel

### DIFF
--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -35,6 +35,7 @@ import {
   JobUpdate,
   LanguageModel,
   LlamaModel,
+  LLMCallUpdate,
   LogUpdate,
   Message as ProtocolMessage,
   MessageAudioContent,
@@ -140,6 +141,7 @@ export type { JobResponse };
 export type { JobUpdate };
 export type { LanguageModel };
 export type { LlamaModel };
+export type { LLMCallUpdate };
 export type { LogUpdate };
 /**
  * Chat permission mode (per-thread). Sent on every outgoing chat message.

--- a/web/src/stores/__tests__/workflowUpdates.trace.test.ts
+++ b/web/src/stores/__tests__/workflowUpdates.trace.test.ts
@@ -1,0 +1,121 @@
+import type { WorkflowAttributes } from "../ApiTypes";
+import useTraceStore from "../TraceStore";
+import { handleUpdate } from "../workflowUpdates";
+
+const mockWorkflow = {
+  id: "workflow-1",
+  name: "Workflow 1"
+} as WorkflowAttributes;
+
+const makeRunner = (jobId: string | null, state = "running") => ({
+  getState: () => ({
+    job_id: jobId,
+    state,
+    queuePosition: null,
+    addNotification: jest.fn(),
+    dequeueNextPendingRun: jest.fn()
+  }),
+  setState: jest.fn(),
+  subscribe: jest.fn()
+});
+
+beforeEach(() => {
+  useTraceStore.getState().clear();
+});
+
+describe("handleUpdate → TraceStore wiring", () => {
+  it("starts a fresh trace run on the runner's own job_update(running)", () => {
+    const runner = makeRunner("trace-job-1");
+    handleUpdate(
+      mockWorkflow,
+      { type: "job_update", status: "running", job_id: "trace-job-1" } as never,
+      runner as never,
+      () => undefined
+    );
+    expect(useTraceStore.getState().isRecording).toBe(true);
+  });
+
+  it("records llm_call, tool_call and tool_result events while recording", () => {
+    useTraceStore.getState().startRun(new Date().toISOString());
+    const runner = makeRunner("job-1");
+
+    handleUpdate(
+      mockWorkflow,
+      {
+        type: "llm_call",
+        node_id: "agent-1",
+        node_name: "Agent",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+        response: "hello",
+        tokens_input: 10,
+        tokens_output: 5,
+        duration_ms: 123,
+        timestamp: new Date().toISOString()
+      } as never,
+      runner as never,
+      () => undefined
+    );
+
+    handleUpdate(
+      mockWorkflow,
+      {
+        type: "tool_call_update",
+        node_id: "agent-1",
+        name: "search",
+        args: {},
+        job_id: "job-1"
+      } as never,
+      runner as never,
+      () => undefined
+    );
+
+    handleUpdate(
+      mockWorkflow,
+      {
+        type: "tool_result_update",
+        node_id: "agent-1",
+        name: "search",
+        result: { ok: true },
+        is_error: false,
+        job_id: "job-1"
+      } as never,
+      runner as never,
+      () => undefined
+    );
+
+    const events = useTraceStore.getState().events;
+    expect(events.map((e) => e.type)).toEqual([
+      "llm_call",
+      "tool_call",
+      "tool_result"
+    ]);
+    expect(events[0].summary).toContain("anthropic/claude-sonnet-4-6");
+    expect(events[0].detail).toMatchObject({
+      tokens_input: 10,
+      tokens_output: 5
+    });
+  });
+
+  it("does not record events when no run is active", () => {
+    // store cleared in beforeEach → isRecording is false
+    const runner = makeRunner("job-1");
+    handleUpdate(
+      mockWorkflow,
+      {
+        type: "llm_call",
+        node_id: "agent-1",
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        messages: [],
+        response: "",
+        duration_ms: 1,
+        timestamp: new Date().toISOString()
+      } as never,
+      runner as never,
+      () => undefined
+    );
+    expect(useTraceStore.getState().events).toHaveLength(0);
+  });
+});

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -11,10 +11,13 @@ import {
   OutputUpdate,
   EdgeUpdate,
   LogUpdate,
+  LLMCallUpdate,
   StepResult,
   Message,
   Chunk
 } from "./ApiTypes";
+import useTraceStore, { traceEventId } from "./TraceStore";
+import type { TraceEvent, TraceEventType } from "./TraceStore";
 import useWorkflowRunsStore, { RunState } from "./WorkflowRunsStore";
 import useResultsStore from "./ResultsStore";
 import useStatusStore from "./StatusStore";
@@ -64,6 +67,38 @@ type WorkflowSubscription = {
 };
 
 const workflowSubscriptions = new Map<string, WorkflowSubscription>();
+
+// The job_id whose run is currently being recorded into the TraceStore. Used to
+// call startRun() exactly once per run (startRun clears prior events), so the
+// trace panel shows a fresh timeline per execution rather than accumulating.
+let traceRunJobId: string | null = null;
+
+/**
+ * Append one event to the global TraceStore (the LLM/agent debug timeline shown
+ * in the bottom "Debug" → Trace panel). No-ops unless a run is being recorded.
+ * relativeMs is measured from the run's start so events line up on a shared axis.
+ */
+const appendTrace = (
+  type: TraceEventType,
+  summary: string,
+  detail: unknown,
+  meta?: Pick<TraceEvent, "nodeId" | "nodeName" | "nodeType">
+): void => {
+  const store = useTraceStore.getState();
+  if (!store.isRecording || !store.runStartTime) {
+    return;
+  }
+  const now = Date.now();
+  store.append({
+    id: traceEventId(),
+    timestamp: new Date(now).toISOString(),
+    relativeMs: now - new Date(store.runStartTime).getTime(),
+    type,
+    summary,
+    detail,
+    ...meta
+  });
+};
 
 export const mergeNodeUpdateProperties = ({
   updateProperties,
@@ -227,6 +262,7 @@ export type MsgpackData =
   | OutputUpdate
   | StepResult
   | EdgeUpdate
+  | LLMCallUpdate
   | Notification;
 
 export const handleUpdate = (
@@ -309,6 +345,9 @@ export const handleUpdate = (
     if (data.node_id && messageJobId) {
       setToolCall(workflow.id, messageJobId, data.node_id, data);
     }
+    appendTrace("tool_call", data.message || `Tool: ${data.name}`, data, {
+      nodeId: data.node_id ?? undefined
+    });
   }
 
   if (data.type === "tool_result_update") {
@@ -318,6 +357,12 @@ export const handleUpdate = (
     if (data.node_id && messageJobId) {
       appendToolResult(workflow.id, messageJobId, data.node_id, data.result);
     }
+    appendTrace(
+      "tool_result",
+      `${data.name ?? "Tool"} result${data.is_error ? " (error)" : ""}`,
+      data,
+      { nodeId: data.node_id ?? undefined }
+    );
   }
 
   if (data.type === "task_update") {
@@ -326,6 +371,21 @@ export const handleUpdate = (
     } else if (!data.node_id) {
       console.error("TaskUpdate has no node_id");
     }
+  }
+
+  if (data.type === "llm_call") {
+    const tokensIn = data.tokens_input ?? 0;
+    const tokensOut = data.tokens_output ?? 0;
+    const duration =
+      data.duration_ms != null ? ` (${data.duration_ms}ms)` : "";
+    appendTrace(
+      "llm_call",
+      `${data.provider}/${data.model}: ${tokensIn}→${tokensOut} tok${duration}${
+        data.error ? " — error" : ""
+      }`,
+      data,
+      { nodeId: data.node_id, nodeName: data.node_name ?? undefined }
+    );
   }
 
   if (data.type === "output_update") {
@@ -349,6 +409,13 @@ export const handleUpdate = (
       severity: "info",
       timestamp: Date.now()
     });
+
+    appendTrace(
+      "output",
+      `${data.node_name || data.node_id} → ${data.output_name}`,
+      data,
+      { nodeId: data.node_id, nodeName: data.node_name }
+    );
   }
 
   if (data.type === "chunk") {
@@ -396,6 +463,13 @@ export const handleUpdate = (
       // A new run starts: clear any prior pre-flight validation highlights
       // so stale red outlines don't linger after the user fixes them.
       usePropertyValidationStore.getState().clearWorkflow(workflow.id);
+      // Begin a fresh LLM/agent trace timeline for the runner's own run. Guarded
+      // by job_id so startRun (which clears prior events) fires once per run, not
+      // on every running/queued heartbeat.
+      if (isRunnerJob && job.job_id !== traceRunJobId) {
+        traceRunJobId = job.job_id ?? null;
+        useTraceStore.getState().startRun(new Date().toISOString());
+      }
     } else if (job.status === "suspended") {
       newState = "suspended";
     } else if (job.status === "paused") {
@@ -652,6 +726,16 @@ export const handleUpdate = (
         severity: "error",
         timestamp: Date.now()
       });
+      appendTrace(
+        "node_error",
+        `${update.node_name || update.node_id} error`,
+        update,
+        {
+          nodeId: update.node_id,
+          nodeName: update.node_name,
+          nodeType: update.node_type
+        }
+      );
     } else {
       runnerStore.setState({
         statusMessage: `${update.node_name} ${update.status}`
@@ -674,6 +758,16 @@ export const handleUpdate = (
           previousStatus !== "booting"
         ) {
           startExecution(workflow.id, jobId, update.node_id);
+          appendTrace(
+            "node_start",
+            `${update.node_name || update.node_id}`,
+            update,
+            {
+              nodeId: update.node_id,
+              nodeName: update.node_name,
+              nodeType: update.node_type
+            }
+          );
         } else if (isFinishing) {
           endExecution(workflow.id, jobId, update.node_id);
         }
@@ -713,6 +807,16 @@ export const handleUpdate = (
             outputs,
             cost: update.provider_cost ?? undefined
           });
+          appendTrace(
+            "node_complete",
+            `${update.node_name || update.node_id}`,
+            update,
+            {
+              nodeId: update.node_id,
+              nodeName: update.node_name,
+              nodeType: update.node_type
+            }
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary
Integrates workflow execution events (LLM calls, tool calls, node lifecycle) into the TraceStore, enabling a real-time debug timeline in the bottom "Debug" → Trace panel. Events are recorded only when a run is active and include summaries, detailed metadata, and relative timestamps for visual alignment.

## Key Changes

- **TraceStore wiring in `handleUpdate`**: Added `appendTrace()` helper that records events to the global TraceStore when a run is recording. Events include type, summary, detail, and optional node metadata (id, name, type).

- **Run lifecycle tracking**: When a `job_update` with status "running" arrives for the runner's own job, `startRun()` is called exactly once (guarded by `traceRunJobId`) to begin a fresh trace timeline and clear prior events.

- **Event types captured**:
  - `llm_call`: Provider/model, token counts, duration, error status
  - `tool_call`: Tool name and arguments
  - `tool_result`: Result data and error flag
  - `output`: Output node emissions
  - `node_start`, `node_complete`, `node_error`: Node lifecycle events

- **Type exports**: Added `LLMCallUpdate` to `ApiTypes.ts` exports and updated `MsgpackData` union to include it.

- **Test coverage**: Added comprehensive test suite (`workflowUpdates.trace.test.ts`) verifying:
  - Fresh trace run starts on runner's own job_update(running)
  - Events are recorded while recording is active
  - Events are ignored when no run is active

## Implementation Details

- Events are timestamped in ISO format and include `relativeMs` (milliseconds from run start) for timeline alignment
- Each event gets a unique `traceEventId()` 
- `appendTrace()` is a no-op if `isRecording` is false or `runStartTime` is not set, preventing event leakage between runs
- Node metadata (id, name, type) is optionally attached to events for filtering/grouping in the UI

https://claude.ai/code/session_01WYV9vjUV7HCkSy5GBqv7Fr