### PR TITLE
fix(kernel): fix 19 correctness bugs found in kernel bug scan

### DIFF
--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -435,9 +435,9 @@ export class NodeActor {
   }
 
   private async _runCorrelatedImpl(analysis: NodeAnalysis): Promise<void> {
-    const dataHandles = [...this.inbox["_buffers"].keys()].filter(
-      (h) => h !== "__control__"
-    );
+    const dataHandles = this.inbox
+      .handles()
+      .filter((h) => h !== "__control__");
 
     if (dataHandles.length === 0) {
       // Source node: fire once with empty inputs at empty scope.
@@ -457,10 +457,18 @@ export class NodeActor {
       const scope = info?.scope ?? [];
       handleScope.set(h, scope);
       handleRepeats.set(h, info?.repeatsPerKey ?? false);
-      if (scope.length === 0) {
-        handleClass.set(h, "empty");
-      } else if (scope.length === invocationScope.length) {
+      // A repeating handle at the invocation scope is always "max" so the
+      // driver machinery fires once per envelope — including at root scope
+      // (both lengths 0, e.g. a chunk stream consumed at top level), where
+      // classifying it "empty" would make every chunk overwrite a single
+      // sticky slot and the node fire once with only the last chunk.
+      if (
+        scope.length === invocationScope.length &&
+        (scope.length > 0 || handleRepeats.get(h))
+      ) {
         handleClass.set(h, "max");
+      } else if (scope.length === 0) {
+        handleClass.set(h, "empty");
       } else {
         handleClass.set(h, "prefix");
       }
@@ -611,18 +619,31 @@ export class NodeActor {
 
     const tryFire = async (candidateKeys: Iterable<string>): Promise<void> => {
       for (const key of candidateKeys) {
-        if (fired.has(key) && driverHandle === null) {
-          // For non-repeating drivers each key fires at most once because
-          // bucket consumption strips it. The fired set protects against
-          // double-fire when the same key comes from multiple notifications.
-          continue;
+        if (driverHandle === null) {
+          if (fired.has(key)) {
+            // For non-repeating drivers each key fires at most once because
+            // bucket consumption strips it. The fired set protects against
+            // double-fire when the same key comes from multiple notifications.
+            continue;
+          }
+          if (!isReady(key)) continue;
+          const { values, envelopes } = collect(key);
+          // Set per-invocation envelopes so output routing can derive lineage.
+          this._lastEnvelopes = envelopes;
+          await this._executeWithInputs(values);
+          fired.add(key);
+        } else {
+          // Repeating driver: drain the whole backlog for this key, not just
+          // one envelope. Envelopes can pile up while a sticky input blocks
+          // readiness; firing once per notification would strand the rest in
+          // the actor-local bucket (silent data loss). collect() consumes one
+          // driver envelope per pass, so this loop terminates.
+          while (isReady(key)) {
+            const { values, envelopes } = collect(key);
+            this._lastEnvelopes = envelopes;
+            await this._executeWithInputs(values);
+          }
         }
-        if (!isReady(key)) continue;
-        const { values, envelopes } = collect(key);
-        // Set per-invocation envelopes so output routing can derive lineage.
-        this._lastEnvelopes = envelopes;
-        await this._executeWithInputs(values);
-        if (driverHandle === null) fired.add(key);
       }
     };
 
@@ -1153,9 +1174,9 @@ export class NodeActor {
    */
   private async _runControlled(): Promise<void> {
     // Identify data handles (non-control) that need to be populated
-    const dataHandles = [...this.inbox["_buffers"].keys()].filter(
-      (h) => h !== "__control__"
-    );
+    const dataHandles = this.inbox
+      .handles()
+      .filter((h) => h !== "__control__");
 
     // Wait for all data handles to have at least one value before
     // processing the first control event. This ensures that when an
@@ -1213,24 +1234,27 @@ export class NodeActor {
       return;
     }
 
-    // Drain items until all data handles have at least one value
-    for await (const [handle, item] of this.inbox.iterAny()) {
+    // Drain items until all data handles have at least one value.
+    // Control events that arrive first are held aside and re-queued after
+    // the wait: prepending them back while still iterating would make the
+    // very next tryPopAny() pop the same event again — an unbounded
+    // microtask spin that starves the event loop and blocks the upstream
+    // data put() forever.
+    const heldControlEvents: MessageEnvelope[] = [];
+    for await (const [handle, envelope] of this.inbox.iterAnyWithEnvelope()) {
       if (handle === "__control__") {
-        // Push control events back – they'll be consumed by iterInput later
-        this.inbox.prepend("__control__", {
-          data: item,
-          metadata: {},
-          timestamp: Date.now(),
-          event_id: "",
-          correlation_lineage: EMPTY_LINEAGE,
-          source_edge_id: ""
-        });
+        heldControlEvents.push(envelope);
         continue;
       }
       if (!this._cachedInputs) this._cachedInputs = {};
-      this._cachedInputs[handle] = item;
+      this._cachedInputs[handle] = envelope.data;
       pending.delete(handle);
       if (pending.size === 0) break;
+    }
+    // Re-queue held control events at the front, preserving arrival order,
+    // so iterInput("__control__") consumes them next.
+    for (let i = heldControlEvents.length - 1; i >= 0; i--) {
+      this.inbox.prepend("__control__", heldControlEvents[i]);
     }
   }
 
@@ -1240,18 +1264,15 @@ export class NodeActor {
    * arrived while waiting for the next control event.
    */
   private _cacheBufferedDataInputs(): void {
-    const buffers = this.inbox["_buffers"] as Map<
-      string,
-      Array<{ data: unknown }>
-    >;
-    for (const [handle, buf] of buffers) {
-      if (handle === "__control__" || buf.length === 0) continue;
-      // Use the latest buffered value for each data handle
-      while (buf.length > 0) {
-        const envelope = buf.shift()!;
-        if (!this._cachedInputs) this._cachedInputs = {};
-        this._cachedInputs[handle] = envelope.data;
-      }
+    for (const handle of this.inbox.handles()) {
+      if (handle === "__control__") continue;
+      // Use the latest buffered value for each data handle. drainHandle()
+      // (unlike popping the raw buffer) releases backpressure on producers
+      // blocked in put() and keeps the arrival queue consistent.
+      const drained = this.inbox.drainHandle(handle);
+      if (drained.length === 0) continue;
+      if (!this._cachedInputs) this._cachedInputs = {};
+      this._cachedInputs[handle] = drained[drained.length - 1].data;
     }
   }
 

--- a/packages/kernel/src/channel.ts
+++ b/packages/kernel/src/channel.ts
@@ -55,6 +55,8 @@ export interface ChannelStats {
 interface SubscriberQueue<T> {
   buffer: (T | typeof STOP_SIGNAL)[];
   waiters: Array<Deferred<void>>;
+  /** Items dropped because the buffer was at capacity. */
+  dropped: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,13 +68,15 @@ export class Channel<T = unknown> {
   private _subscribers = new Map<string, SubscriberQueue<T>>();
   private _closed = false;
   private _messageType?: new (...args: unknown[]) => T;
+  private _bufferLimit: number;
 
   constructor(
     name: string,
-    _bufferLimit = 100,
+    bufferLimit = 100,
     messageType?: new (...args: unknown[]) => T
   ) {
     this.name = name;
+    this._bufferLimit = bufferLimit;
     this._messageType = messageType;
   }
 
@@ -100,7 +104,22 @@ export class Channel<T = unknown> {
       );
     }
 
-    for (const sub of this._subscribers.values()) {
+    for (const [subscriberId, sub] of this._subscribers) {
+      // Bounded queue: a stalled subscriber must not grow its buffer without
+      // bound for the channel's lifetime. Drop the oldest item to make room
+      // (broadcast semantics — one slow consumer must not stall the others).
+      if (sub.buffer.length >= this._bufferLimit) {
+        sub.buffer.shift();
+        sub.dropped++;
+        if (sub.dropped === 1) {
+          // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+          log.warn("Subscriber buffer full — dropping oldest items", {
+            channel: this.name,
+            subscriberId,
+            bufferLimit: this._bufferLimit
+          });
+        }
+      }
       sub.buffer.push(item);
       // Wake any waiting consumer
       for (const w of sub.waiters.splice(0)) {
@@ -113,7 +132,16 @@ export class Channel<T = unknown> {
     // Stryker disable next-line ConditionalExpression: equivalent — without this early return the closed check at the wait branch yields the same empty result (the subscriber registers then immediately breaks)
     if (this._closed) return;
 
-    const sub: SubscriberQueue<T> = { buffer: [], waiters: [] };
+    // Replacing a live subscriber's queue would strand the old generator
+    // forever (publish/close never touch the evicted queue, so a consumer
+    // awaiting it never even receives the stop signal).
+    if (this._subscribers.has(subscriberId)) {
+      throw new Error(
+        `Channel '${this.name}' already has an active subscriber '${subscriberId}'`
+      );
+    }
+
+    const sub: SubscriberQueue<T> = { buffer: [], waiters: [], dropped: 0 };
     this._subscribers.set(subscriberId, sub);
 
     try {

--- a/packages/kernel/src/correlation-analysis.ts
+++ b/packages/kernel/src/correlation-analysis.ts
@@ -156,10 +156,18 @@ function topoSort(
     // Stryker disable next-line ArrayDeclaration: a non-empty seed is equivalent — a bogus target is not a real node and is dropped by the incoming-count logic
     outgoing.set(n.id, []);
   }
+  // A data edge from a node to itself is a one-node cycle. It must be
+  // reported like any other cycle: at runtime the self-edge counts as an
+  // upstream that is only marked done after the node's own actor completes,
+  // so the actor waits on itself and the whole run hangs.
+  const selfLoopNodes = new Set<string>();
   for (const edge of edges) {
     if (!isDataEdge(edge)) continue;
     if (!byId.has(edge.source) || !byId.has(edge.target)) continue;
-    if (edge.source === edge.target) continue; // self-loops ignored
+    if (edge.source === edge.target) {
+      selfLoopNodes.add(edge.source);
+      continue;
+    }
     outgoing.get(edge.source)!.push(edge.target);
     incoming.set(edge.target, (incoming.get(edge.target) ?? 0) + 1);
   }
@@ -187,9 +195,11 @@ function topoSort(
     }
   }
 
-  // Stryker disable next-line ConditionalExpression,EqualityOperator: the true/<= directions are equivalent — for a complete topo order `remaining` is empty, so the caller reports no cycle either way
-  if (order.length < nodes.length) {
+  if (order.length < nodes.length || selfLoopNodes.size > 0) {
     const remaining = nodes.filter((n) => !order.includes(n)).map((n) => n.id);
+    for (const id of selfLoopNodes) {
+      if (!remaining.includes(id)) remaining.push(id);
+    }
     return { order, cycle: remaining };
   }
   return { order, cycle: null };

--- a/packages/kernel/src/durable-inbox.ts
+++ b/packages/kernel/src/durable-inbox.ts
@@ -22,13 +22,21 @@ const log = createLogger("nodetool.kernel.durable-inbox");
  * a polyfill.
  */
 function fnv1a64Hex(input: string): string {
-  // 64-bit FNV-1a via two 32-bit halves.
+  // 64-bit hash via two independently seeded 32-bit FNV-1a streams. Both
+  // halves consume both bytes of every UTF-16 code unit; the differing
+  // offset bases keep the streams independent. (Feeding only the high byte
+  // to one half would make it depend solely on string length for ASCII
+  // input, collapsing this to an effectively 32-bit hash.)
   let h1 = 0x811c9dc5 | 0;
   let h2 = 0xcbf29ce4 | 0;
   for (let i = 0; i < input.length; i++) {
     const ch = input.charCodeAt(i);
-    h1 = Math.imul(h1 ^ (ch & 0xff), 16777619);
-    h2 = Math.imul(h2 ^ ((ch >>> 8) & 0xff), 16777619);
+    const lo = ch & 0xff;
+    const hi = (ch >>> 8) & 0xff;
+    h1 = Math.imul(h1 ^ lo, 16777619);
+    h1 = Math.imul(h1 ^ hi, 16777619);
+    h2 = Math.imul(h2 ^ lo, 16777619);
+    h2 = Math.imul(h2 ^ hi, 16777619);
   }
   const u1 = (h1 >>> 0).toString(16).padStart(8, "0");
   const u2 = (h2 >>> 0).toString(16).padStart(8, "0");
@@ -186,10 +194,34 @@ export class DurableInbox {
   }
 
   /**
+   * Chain serializing append() calls. getMaxSeq → findByMessageId → save is
+   * a read-modify-write; concurrent appends would otherwise both read the
+   * same maxSeq and persist duplicate seq/messageId rows (or silently drop
+   * one payload via the idempotency check).
+   */
+  private _appendChain: Promise<unknown> = Promise.resolve();
+
+  /**
    * Append a message to the inbox (idempotent).
    * If messageId already exists, returns existing without error.
+   * Appends on the same inbox are serialized.
    */
   async append(
+    handle: string,
+    payload: unknown,
+    messageId?: string,
+    payloadRef?: string
+  ): Promise<DurableMessage> {
+    const prev = this._appendChain;
+    const result = (async () => {
+      await prev.catch(() => undefined);
+      return this._appendImpl(handle, payload, messageId, payloadRef);
+    })();
+    this._appendChain = result.catch(() => undefined);
+    return result;
+  }
+
+  private async _appendImpl(
     handle: string,
     payload: unknown,
     messageId?: string,

--- a/packages/kernel/src/graph-utils.ts
+++ b/packages/kernel/src/graph-utils.ts
@@ -66,11 +66,18 @@ export function getDownstreamSubgraph(
   // Seed BFS with targets of initial edges
   // Stryker disable next-line ArrayDeclaration: a non-empty seed is equivalent — a bogus node id has no outgoing edges, so BFS adds nothing for it
   const queue: string[] = [];
+  const enqueued = new Set<string>();
   for (const e of initialEdges) {
     includedEdges.push(e);
     includedNodeIds.add(e.target);
     includedNodeIds.add(e.source);
-    queue.push(e.target);
+    // Two initial edges can share a target (one output feeding two handles
+    // of the same node); enqueueing it twice would duplicate all of its
+    // outgoing edges in the result.
+    if (!enqueued.has(e.target)) {
+      enqueued.add(e.target);
+      queue.push(e.target);
+    }
   }
 
   // BFS over outgoing edges

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -44,6 +44,13 @@ export interface GraphFromDictOptions {
   skipErrors?: boolean;
   allowUndefinedProperties?: boolean;
   validateNodeType?: (nodeType: string) => boolean;
+  /**
+   * When true (default), delete each node's saved property default for every
+   * handle fed by a surviving edge (the edge value wins at runtime).
+   * loadFromDict disables this and prunes itself after node-type resolution,
+   * since resolution can drop further nodes — and with them, edges.
+   */
+  pruneEdgeProperties?: boolean;
 }
 
 export interface ResolvedNodeType {
@@ -150,7 +157,8 @@ export class Graph {
     const {
       skipErrors = true,
       allowUndefinedProperties = true,
-      validateNodeType
+      validateNodeType,
+      pruneEdgeProperties = true
     } = options;
     if (!data || typeof data !== "object") {
       throw new GraphValidationError("Graph data must be an object");
@@ -166,25 +174,6 @@ export class Graph {
     }
     if (!Array.isArray(obj.edges)) {
       throw new GraphValidationError("'edges' must be an array");
-    }
-
-    const propertiesWithEdges = new Map<string, Set<string>>();
-    for (const edge of obj.edges) {
-      // Stryker disable next-line all: this pre-pass only collects edge-fed handles; non-object edges and non-string target/handle values yield no-op deletions, and the second edge pass below re-validates everything that matters
-      if (!edge || typeof edge !== "object") { if (skipErrors) continue; throw new GraphValidationError("Edge entries must be objects"); }
-      const edgeObj = edge as Record<string, unknown>;
-      // Stryker disable next-line all: equivalent — a non-string target/handle yields a no-op deletion later
-      const targetId = typeof edgeObj.target === "string" ? edgeObj.target : undefined;
-      // Stryker disable next-line all: equivalent — a non-string targetHandle yields a no-op deletion later
-      const targetHandle = typeof edgeObj.targetHandle === "string" ? edgeObj.targetHandle : undefined;
-      // Stryker disable next-line all: equivalent — an undefined target/handle only causes no-op deletions later
-      if (!targetId || !targetHandle) continue;
-      let handles = propertiesWithEdges.get(targetId);
-      if (!handles) {
-        handles = new Set<string>();
-        propertiesWithEdges.set(targetId, handles);
-      }
-      handles.add(targetHandle);
     }
 
     const validNodes: NodeDescriptor[] = [];
@@ -256,11 +245,6 @@ export class Graph {
         }
       }
 
-      // Stryker disable next-line ArrayDeclaration: defensive ?? fallback equivalent — a bogus handle deletes a non-existent property (no-op)
-      for (const handle of propertiesWithEdges.get(id) ?? []) {
-        delete rawProperties[handle];
-      }
-
       nodeObj.properties = rawProperties;
       delete nodeObj.data;
 
@@ -270,11 +254,8 @@ export class Graph {
 
     const validEdges: Edge[] = [];
     for (const edge of obj.edges) {
-      // Stryker disable next-line all: fully redundant with the identical check in the first edge pass above
       if (!edge || typeof edge !== "object") {
-        // Stryker disable next-line all: unreachable/redundant — the first edge pass already rejected non-object edges
         if (skipErrors) continue;
-        // Stryker disable next-line all: unreachable — the first edge pass already threw for non-object edges
         throw new GraphValidationError("Edge entries must be objects");
       }
 
@@ -304,7 +285,44 @@ export class Graph {
       validEdges.push(edgeObj as unknown as Edge);
     }
 
+    // Delete property defaults only for handles fed by edges that survived
+    // validation. Pruning from the raw edge list would strip a node's saved
+    // default for a malformed or dangling edge that is then dropped, leaving
+    // the node with neither its default nor an incoming value.
+    if (pruneEdgeProperties) {
+      Graph._pruneEdgeFedProperties(validNodes, validEdges);
+    }
+
     return new Graph({ nodes: validNodes, edges: validEdges });
+  }
+
+  /**
+   * Delete each node's saved property default for every handle that has an
+   * incoming edge — the runtime edge value wins, and stale defaults would
+   * shadow it in `_executeWithInputs`'s property merge.
+   */
+  private static _pruneEdgeFedProperties(
+    nodes: ReadonlyArray<NodeDescriptor>,
+    edges: ReadonlyArray<Edge>
+  ): void {
+    const handlesByTarget = new Map<string, Set<string>>();
+    for (const edge of edges) {
+      let handles = handlesByTarget.get(edge.target);
+      if (!handles) {
+        handles = new Set<string>();
+        handlesByTarget.set(edge.target, handles);
+      }
+      handles.add(edge.targetHandle);
+    }
+    for (const node of nodes) {
+      const handles = handlesByTarget.get(node.id);
+      if (!handles) continue;
+      const props = node.properties as Record<string, unknown> | undefined;
+      if (!props) continue;
+      for (const handle of handles) {
+        delete props[handle];
+      }
+    }
   }
 
   static async loadFromDict(
@@ -319,7 +337,11 @@ export class Graph {
     const normalized = Graph.fromDict(data, {
       skipErrors,
       // Stryker disable next-line BooleanLiteral: must stay true — property validation happens later against the RESOLVED types, not the saved cache (see comment in loadFromDict)
-      allowUndefinedProperties: true
+      allowUndefinedProperties: true,
+      // Resolution below can drop further nodes (unknown types) and their
+      // edges; prune edge-fed defaults only after the final edge set is known
+      // so a node downstream of a dropped node keeps its saved default.
+      pruneEdgeProperties: false
     });
 
     const resolvedNodes: NodeDescriptor[] = [];
@@ -401,6 +423,7 @@ export class Graph {
     const validEdges = normalized.edges.filter(
       (edge) => validNodeIds.has(edge.source) && validNodeIds.has(edge.target)
     );
+    Graph._pruneEdgeFedProperties(resolvedNodes, validEdges);
     return new Graph({ nodes: resolvedNodes, edges: validEdges });
   }
 
@@ -620,9 +643,15 @@ export class Graph {
     };
     const filteredNodes = this.nodes.filter(isInScope);
     const filteredNodeIds = new Set(filteredNodes.map((node) => node.id));
+    // Only data edges define the ordering (see docstring). Including control
+    // edges would turn a legal data-A→B + control-B→A controller feedback
+    // pattern into a mixed cycle, silently dropping both nodes from the
+    // returned levels.
     const filteredEdges = this.edges.filter(
       (edge) =>
-        filteredNodeIds.has(edge.source) && filteredNodeIds.has(edge.target)
+        isDataEdge(edge) &&
+        filteredNodeIds.has(edge.source) &&
+        filteredNodeIds.has(edge.target)
     );
 
     // In-degree count across filtered edges.

--- a/packages/kernel/src/inbox.ts
+++ b/packages/kernel/src/inbox.ts
@@ -472,6 +472,24 @@ export class NodeInbox {
   // State queries
   // -----------------------------------------------------------------------
 
+  /** All handle names registered on this inbox. */
+  handles(): string[] {
+    return [...this._buffers.keys()];
+  }
+
+  /**
+   * Drain and return every buffered envelope for a handle, releasing
+   * backpressure on blocked producers and clearing arrival entries.
+   */
+  drainHandle(handle: string): MessageEnvelope[] {
+    const buf = this._buffers.get(handle);
+    if (!buf || buf.length === 0) return [];
+    const drained = buf.splice(0);
+    this._arrival = this._arrival.filter((h) => h !== handle);
+    this._notifyPutWaiters();
+    return drained;
+  }
+
   /** Whether any handle has buffered data. */
   hasAny(): boolean {
     for (const buf of this._buffers.values()) {

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -217,14 +217,28 @@ export class WorkflowRunner {
   /** Cancellation flag. */
   private _cancelled = false;
 
-  /** Pending response resolvers for sendControlEvent. nodeId → resolver */
+  /**
+   * Pending response resolvers for sendControlEvent, FIFO per node. The
+   * controlled actor processes control events in order and emits outputs in
+   * order, so the oldest waiter matches the next output. A single slot per
+   * node would let a burst of concurrent control events (e.g. parallel agent
+   * tool calls) overwrite an earlier resolver, leaving its promise unsettled
+   * forever.
+   */
   private _pendingControlResponses = new Map<
     string,
-    {
+    Array<{
       resolve: (outputs: Record<string, unknown>) => void;
       reject: (err: Error) => void;
-    }
+    }>
   >();
+
+  /**
+   * Executor instance per node. Resolved once and reused so that the
+   * instance initialized in _initializeGraph is the same one that executes
+   * (NodeRegistry.resolve constructs a fresh instance per call).
+   */
+  private _executors = new Map<string, NodeExecutor>();
 
   /**
    * Nodes whose actor has finished running. A control event sent to such a
@@ -476,6 +490,8 @@ export class WorkflowRunner {
     this._messages = [];
     this._cancelled = false;
     this._pendingControlResponses = new Map();
+    this._completedNodes = new Set();
+    this._executors = new Map();
     this._correlation = undefined;
   }
 
@@ -579,11 +595,21 @@ export class WorkflowRunner {
 
   private async _initializeGraph(): Promise<void> {
     for (const node of this._graph.nodes) {
-      const executor = this._options.resolveExecutor(node);
+      const executor = this._resolveExecutor(node);
       if (executor.initialize) {
         await executor.initialize();
       }
     }
+  }
+
+  /** Resolve (and cache) the executor instance for a node. */
+  private _resolveExecutor(node: NodeDescriptor): NodeExecutor {
+    let executor = this._executors.get(node.id);
+    if (!executor) {
+      executor = this._options.resolveExecutor(node);
+      this._executors.set(node.id, executor);
+    }
+    return executor;
   }
 
   // -----------------------------------------------------------------------
@@ -776,7 +802,7 @@ export class WorkflowRunner {
       }
 
       const inbox = this._inboxes.get(node.id)!;
-      const executor = this._options.resolveExecutor(node);
+      const executor = this._resolveExecutor(node);
 
       // Build control context for controller nodes (Python parity:
       // _is_controller / _build_control_context). This tells the node
@@ -810,15 +836,17 @@ export class WorkflowRunner {
           // (the actor finished without producing the awaited output, e.g.
           // it errored mid-burst).
           this._completedNodes.add(node.id);
-          const pending = this._pendingControlResponses.get(node.id);
-          if (pending) {
+          const pendingQueue = this._pendingControlResponses.get(node.id);
+          if (pendingQueue) {
             this._pendingControlResponses.delete(node.id);
-            pending.reject(
-              new Error(
-                result.error ??
-                  `Controlled node ${node.id} completed without responding`
-              )
-            );
+            for (const pending of pendingQueue) {
+              pending.reject(
+                new Error(
+                  result.error ??
+                    `Controlled node ${node.id} completed without responding`
+                )
+              );
+            }
           }
 
           // If this is an output node, collect the result
@@ -1054,10 +1082,13 @@ export class WorkflowRunner {
       }
     }
 
-    // Resolve pending sendControlEvent promise if one exists for this node
-    const pending = this._pendingControlResponses.get(sourceNodeId);
-    if (pending) {
-      this._pendingControlResponses.delete(sourceNodeId);
+    // Resolve the oldest pending sendControlEvent promise for this node.
+    const pendingQueue = this._pendingControlResponses.get(sourceNodeId);
+    if (pendingQueue && pendingQueue.length > 0) {
+      const pending = pendingQueue.shift()!;
+      if (pendingQueue.length === 0) {
+        this._pendingControlResponses.delete(sourceNodeId);
+      }
       pending.resolve(outputs);
     }
   }
@@ -1069,6 +1100,11 @@ export class WorkflowRunner {
    */
   private async _sendEOS(nodeId: string): Promise<void> {
     const outgoing = this._graph.findOutgoingEdges(nodeId);
+    // _initializeInboxes counts one __control__ upstream per unique
+    // controller, so decrement once per target — not once per control edge.
+    // Parallel control edges to the same target would otherwise drive the
+    // count to zero while other controllers are still running.
+    const controlTargetsDone = new Set<string>();
     for (const edge of outgoing) {
       if (isControlEdge(edge)) {
         // Always mark __control__ source done when the controller finishes,
@@ -1076,6 +1112,8 @@ export class WorkflowRunner {
         // controlled nodes waiting on iterInput("__control__") regardless
         // of whether events were routed through the edge or via the manual
         // sendControlEvent() / dispatchControlEvent() APIs.
+        if (controlTargetsDone.has(edge.target)) continue;
+        controlTargetsDone.add(edge.target);
         const targetInbox = this._inboxes.get(edge.target);
         if (targetInbox) {
           targetInbox.markSourceDone("__control__");
@@ -1217,7 +1255,12 @@ export class WorkflowRunner {
     }
 
     const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingControlResponses.set(targetNodeId, { resolve, reject });
+      let queue = this._pendingControlResponses.get(targetNodeId);
+      if (!queue) {
+        queue = [];
+        this._pendingControlResponses.set(targetNodeId, queue);
+      }
+      queue.push({ resolve, reject });
     });
 
     const event: ControlEvent = {

--- a/packages/kernel/src/trigger-manager.ts
+++ b/packages/kernel/src/trigger-manager.ts
@@ -62,8 +62,19 @@ export class TriggerWorkflowManager {
   private static _instance: TriggerWorkflowManager | null = null;
 
   private _runningJobs = new Map<string, TriggerJob>();
+  /**
+   * In-flight start per workflow. startTriggerWorkflow's running-check and
+   * its _runningJobs.set are separated by awaits; without this, two
+   * concurrent starts (e.g. server-startup auto-start racing a user toggle)
+   * would both pass the check and leave one job running but untracked —
+   * unreachable by stop/shutdown.
+   */
+  private _pendingStarts = new Map<string, Promise<TriggerJob | null>>();
   private _watchdogTimer: ReturnType<typeof setInterval> | null = null;
   private _watchdogInterval: number;
+  /** Latest watchdog check, awaited by shutdown so a mid-flight restart cannot revive a job. */
+  private _watchdogCheckInFlight: Promise<void> | null = null;
+  private _shuttingDown = false;
   private _startJob: StartJobFn;
   private _hasTriggerNodes: HasTriggerNodesFn;
 
@@ -110,6 +121,31 @@ export class TriggerWorkflowManager {
       return existing;
     }
 
+    // A start for this workflow is already in flight — join it instead of
+    // starting a second job.
+    const pending = this._pendingStarts.get(workflowId);
+    if (pending) {
+      return pending;
+    }
+
+    const startPromise = this._startTriggerWorkflowImpl(
+      workflowId,
+      userId,
+      workflowName
+    );
+    this._pendingStarts.set(workflowId, startPromise);
+    try {
+      return await startPromise;
+    } finally {
+      this._pendingStarts.delete(workflowId);
+    }
+  }
+
+  private async _startTriggerWorkflowImpl(
+    workflowId: string,
+    userId: string,
+    workflowName?: string
+  ): Promise<TriggerJob | null> {
     // Check if workflow has trigger nodes
     const hasTriggers = await this._hasTriggerNodes(workflowId);
     if (!hasTriggers) {
@@ -246,7 +282,7 @@ export class TriggerWorkflowManager {
 
     this._watchdogTimer = setInterval(() => {
       // Stryker disable next-line BlockStatement: defensive error handler — _watchdogCheck swallows its own errors, so this catch only logs and is unreachable in practice
-      this._watchdogCheck().catch((err) => {
+      this._watchdogCheckInFlight = this._watchdogCheck().catch((err) => {
         // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
         log.error("Error in watchdog check", { error: String(err) });
       });
@@ -272,20 +308,33 @@ export class TriggerWorkflowManager {
   async shutdown(): Promise<void> {
     // Stryker disable next-line StringLiteral: diagnostic log message only
     log.info("Shutting down TriggerWorkflowManager");
-    this.stopWatchdog();
+    this._shuttingDown = true;
+    try {
+      this.stopWatchdog();
+      // A check fired from the interval may still be mid-restart; wait for
+      // it so it cannot re-insert a freshly started job after we snapshot
+      // the running set below.
+      if (this._watchdogCheckInFlight) {
+        await this._watchdogCheckInFlight;
+        this._watchdogCheckInFlight = null;
+      }
 
-    const workflowIds = [...this._runningJobs.keys()];
-    let stopped = 0;
-    for (const wfId of workflowIds) {
-      // Stryker disable next-line UpdateOperator: `stopped` is only used in the diagnostic log below
-      if (await this.stopTriggerWorkflow(wfId)) stopped++;
+      const workflowIds = [...this._runningJobs.keys()];
+      let stopped = 0;
+      for (const wfId of workflowIds) {
+        // Stryker disable next-line UpdateOperator: `stopped` is only used in the diagnostic log below
+        if (await this.stopTriggerWorkflow(wfId)) stopped++;
+      }
+
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+      log.info("TriggerWorkflowManager shutdown complete", { stopped });
+    } finally {
+      this._shuttingDown = false;
     }
-
-    // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
-    log.info("TriggerWorkflowManager shutdown complete", { stopped });
   }
 
   private async _watchdogCheck(): Promise<void> {
+    if (this._shuttingDown) return;
     // Stryker disable next-line ArrayDeclaration: a non-empty seed is equivalent — a bogus workflowId is skipped by the `if (!job) continue` guard below
     const toRestart: string[] = [];
 
@@ -302,14 +351,19 @@ export class TriggerWorkflowManager {
     }
 
     for (const workflowId of toRestart) {
+      if (this._shuttingDown) return;
       const job = this._runningJobs.get(workflowId);
       // Stryker disable next-line ConditionalExpression: equivalent — workflowId comes from toRestart built moments earlier from _runningJobs and nothing deletes in between, so job is always present; the guard is defensive
       if (!job) continue;
 
       // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.info("Attempting restart of trigger workflow", { workflowId });
-      this._runningJobs.delete(workflowId);
 
+      // Don't delete the entry first: startTriggerWorkflow restarts
+      // non-running jobs and overwrites the map on success. If the restart
+      // fails (transient startJob error → null) the failed entry must stay
+      // tracked so the next watchdog tick retries — deleting up-front would
+      // permanently drop the workflow after one failed restart.
       await this.startTriggerWorkflow(
         workflowId,
         job.metadata.userId,

--- a/packages/kernel/tests/bug-scan-regressions.test.ts
+++ b/packages/kernel/tests/bug-scan-regressions.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Regression tests for bugs found in the kernel bug scan.
+ *
+ * Each describe block pins the fixed behavior of one finding:
+ *  - controlled-mode livelock when a control event precedes data inputs
+ *  - sendControlEvent resolver overwrite on concurrent control events
+ *  - DurableInbox.append read-modify-write race
+ *  - correlated scheduler dropping queued repeating-driver envelopes
+ *  - root-scope chunk streams collapsing to "last value only"
+ *  - Channel bufferLimit ignored / duplicate subscriberId stranding
+ *  - Graph.fromDict deleting defaults for dropped edges
+ *  - Graph.topologicalSort ordering on control edges
+ *  - getDownstreamSubgraph duplicating edges for shared seed targets
+ *  - watchdog dropping a workflow after a failed restart
+ *  - runner initializing a different executor instance than the one that runs
+ *  - runner reuse rejecting control events for nodes completed in a prior run
+ *  - NodeInbox.drainHandle releasing producer backpressure
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NodeActor, type NodeExecutor } from "../src/actor.js";
+import { NodeInbox } from "../src/inbox.js";
+import { WorkflowRunner } from "../src/runner.js";
+import { DurableInbox } from "../src/durable-inbox.js";
+import { Channel } from "../src/channel.js";
+import { Graph } from "../src/graph.js";
+import { getDownstreamSubgraph } from "../src/graph-utils.js";
+import {
+  TriggerWorkflowManager,
+  type StartJobFn,
+  type HasTriggerNodesFn
+} from "../src/trigger-manager.js";
+import type { NodeAnalysis } from "../src/correlation-analysis.js";
+import type { NodeDescriptor, Edge } from "@nodetool-ai/protocol";
+
+const EMPTY_ANALYSIS: NodeAnalysis = {
+  invocationScope: [],
+  inputs: new Map(),
+  outputs: new Map()
+};
+
+function makeActor(
+  node: NodeDescriptor,
+  inbox: NodeInbox,
+  executor: NodeExecutor,
+  correlation: NodeAnalysis = EMPTY_ANALYSIS
+): { actor: NodeActor; sentOutputs: Array<Record<string, unknown>> } {
+  const sentOutputs: Array<Record<string, unknown>> = [];
+  const actor = new NodeActor({
+    node,
+    inbox,
+    executor,
+    correlation,
+    sendOutputs: async (_nodeId, outputs) => {
+      sentOutputs.push(outputs);
+    },
+    emitMessage: () => {}
+  });
+  return { actor, sentOutputs };
+}
+
+// ---------------------------------------------------------------------------
+// Controlled mode: control event arriving before data must not livelock
+// ---------------------------------------------------------------------------
+
+describe("controlled mode — control event before data inputs", () => {
+  it("processes the event once data arrives instead of spinning forever", async () => {
+    const node: NodeDescriptor = {
+      id: "worker",
+      type: "test.Worker",
+      is_controlled: true
+    };
+    const inbox = new NodeInbox();
+    inbox.addUpstream("x", 1);
+    inbox.addUpstream("__control__", 1);
+
+    const calls: Array<Record<string, unknown>> = [];
+    const executor: NodeExecutor = {
+      async process(inputs) {
+        calls.push(inputs);
+        return { result: (inputs.x as number) + 1 };
+      }
+    };
+    const { actor, sentOutputs } = makeActor(node, inbox, executor);
+
+    // Control event lands first; the data put only happens on a macrotask
+    // (like a real upstream LLM call). The old prepend-and-retry loop spun
+    // in microtasks and never let this timer fire.
+    await inbox.put("__control__", { event_type: "run", properties: {} });
+    setTimeout(() => {
+      void inbox.put("x", 41).then(() => {
+        inbox.markSourceDone("x");
+        inbox.markSourceDone("__control__");
+      });
+    }, 10);
+
+    const result = await actor.run();
+    expect(result.error).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].x).toBe(41);
+    expect(sentOutputs[0]).toEqual({ result: 42 });
+  }, 5000);
+});
+
+// ---------------------------------------------------------------------------
+// Correlated scheduler: repeating driver backlog must drain fully
+// ---------------------------------------------------------------------------
+
+describe("correlated scheduler — repeating driver", () => {
+  const input = (repeats: boolean) => ({
+    scope: [] as const,
+    repeatsPerKey: repeats,
+    isMultiEdge: false,
+    possibleChildRoots: new Set<string>()
+  });
+
+  it("fires once per chunk at root scope instead of only the last chunk", async () => {
+    const analysis: NodeAnalysis = {
+      invocationScope: [],
+      inputs: new Map([["chunk", input(true)]]),
+      outputs: new Map()
+    };
+    const inbox = new NodeInbox();
+    inbox.addUpstream("chunk", 1);
+
+    const calls: Array<Record<string, unknown>> = [];
+    const executor: NodeExecutor = {
+      async process(inputs) {
+        calls.push(inputs);
+        return {};
+      }
+    };
+    const { actor } = makeActor(
+      { id: "n", type: "test.Node" },
+      inbox,
+      executor,
+      analysis
+    );
+
+    const run = actor.run();
+    await inbox.put("chunk", "c1");
+    await inbox.put("chunk", "c2");
+    await inbox.put("chunk", "c3");
+    inbox.markSourceDone("chunk");
+    await run;
+
+    expect(calls.map((c) => c.chunk)).toEqual(["c1", "c2", "c3"]);
+  });
+
+  it("drains the whole backlog when a blocking sticky input arrives late", async () => {
+    const analysis: NodeAnalysis = {
+      invocationScope: [],
+      inputs: new Map([
+        ["chunk", input(true)],
+        ["config", input(false)]
+      ]),
+      outputs: new Map()
+    };
+    const inbox = new NodeInbox();
+    inbox.addUpstream("chunk", 1);
+    inbox.addUpstream("config", 1);
+
+    const calls: Array<Record<string, unknown>> = [];
+    const executor: NodeExecutor = {
+      async process(inputs) {
+        calls.push(inputs);
+        return {};
+      }
+    };
+    const { actor } = makeActor(
+      { id: "n", type: "test.Node" },
+      inbox,
+      executor,
+      analysis
+    );
+
+    const run = actor.run();
+    // Chunks pile up while the config input is still pending; let the actor
+    // consume them (none ready — config is open with no value yet).
+    await inbox.put("chunk", "c1");
+    await inbox.put("chunk", "c2");
+    await inbox.put("chunk", "c3");
+    await new Promise((r) => setTimeout(r, 0));
+    // The sticky arrival must release the entire backlog.
+    await inbox.put("config", "cfg");
+    await new Promise((r) => setTimeout(r, 0));
+    inbox.markSourceDone("chunk");
+    inbox.markSourceDone("config");
+    await run;
+
+    // Before the fix only one chunk fired per notification; the rest were
+    // stranded in the actor-local bucket and silently lost.
+    expect(calls.map((c) => c.chunk)).toEqual(["c1", "c2", "c3"]);
+    for (const c of calls) expect(c.config).toBe("cfg");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendControlEvent: concurrent events to the same node must all settle
+// ---------------------------------------------------------------------------
+
+describe("sendControlEvent — concurrent events to one node", () => {
+  it("resolves each caller with the matching output (FIFO)", async () => {
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "ctrl",
+        type: "test.Controller",
+        is_streaming_output: true,
+        outputs: { __control__: "control" }
+      },
+      {
+        id: "worker",
+        type: "test.Worker",
+        is_controlled: true,
+        outputs: { result: "int" }
+      }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "ce1",
+        source: "ctrl",
+        sourceHandle: "__control__",
+        target: "worker",
+        targetHandle: "__control__",
+        edge_type: "control"
+      }
+    ];
+
+    let resolveCtrl!: () => void;
+    const ctrlStarted = new Promise<void>((r) => {
+      resolveCtrl = r;
+    });
+    const cancelledRef = { cancelled: false };
+
+    const runner = new WorkflowRunner("job1", {
+      resolveExecutor: (node) => {
+        if (node.id === "ctrl") {
+          return {
+            async *genProcess() {
+              resolveCtrl();
+              while (!cancelledRef.cancelled) {
+                await new Promise((r) => setTimeout(r, 10));
+              }
+              yield { __control__: { event_type: "stop" } };
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        return {
+          process: async (inputs) => ({ result: (inputs.x as number) + 1 })
+        };
+      }
+    });
+
+    const runPromise = runner.run({ job_id: "job1" }, { nodes, edges });
+    await ctrlStarted;
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Burst: dispatch both before either response arrives. With the old
+    // single-slot resolver the first promise never settled.
+    const [out1, out2] = await Promise.all([
+      runner.sendControlEvent("worker", { x: 10 }),
+      runner.sendControlEvent("worker", { x: 20 })
+    ]);
+    expect(out1.result).toBe(11);
+    expect(out2.result).toBe(21);
+
+    cancelledRef.cancelled = true;
+    await runPromise;
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Runner: executor lifecycle and reuse
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner — executor lifecycle", () => {
+  it("runs process() on the same instance initialize() was called on", async () => {
+    const runner = new WorkflowRunner("job1", {
+      resolveExecutor: () => {
+        const state = { initialized: false };
+        return {
+          async initialize() {
+            state.initialized = true;
+          },
+          async process() {
+            return { ok: state.initialized };
+          }
+        };
+      }
+    });
+
+    const nodes: NodeDescriptor[] = [
+      { id: "n1", type: "test.Node", outputs: { ok: "bool" }, name: "out" }
+    ];
+    const result = await runner.run({ job_id: "j" }, { nodes, edges: [] });
+    expect(result.status).toBe("completed");
+    expect(result.outputs.out).toEqual([true]);
+  });
+
+  it("accepts control events on a reused runner for nodes completed in a prior run", async () => {
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "ctrl",
+        type: "test.Controller",
+        is_streaming_output: true,
+        outputs: { __control__: "control" }
+      },
+      {
+        id: "worker",
+        type: "test.Worker",
+        is_controlled: true,
+        outputs: { result: "int" }
+      }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "ce1",
+        source: "ctrl",
+        sourceHandle: "__control__",
+        target: "worker",
+        targetHandle: "__control__",
+        edge_type: "control"
+      }
+    ];
+
+    let resolveCtrl!: () => void;
+    let cancelledRef = { cancelled: false };
+    const runner = new WorkflowRunner("job1", {
+      resolveExecutor: (node) => {
+        if (node.id === "ctrl") {
+          const cancelled = cancelledRef;
+          return {
+            async *genProcess() {
+              resolveCtrl();
+              while (!cancelled.cancelled) {
+                await new Promise((r) => setTimeout(r, 10));
+              }
+              yield { __control__: { event_type: "stop" } };
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        return {
+          process: async (inputs) => ({ result: (inputs.x as number) + 1 })
+        };
+      }
+    });
+
+    // Run 1 to completion — marks "worker" completed.
+    let started = new Promise<void>((r) => {
+      resolveCtrl = r;
+    });
+    const run1 = runner.run({ job_id: "j1" }, { nodes, edges });
+    await started;
+    cancelledRef.cancelled = true;
+    await run1;
+
+    // Run 2 on the same runner: the stale completed-set must not block
+    // control events to the fresh actor.
+    cancelledRef = { cancelled: false };
+    started = new Promise<void>((r) => {
+      resolveCtrl = r;
+    });
+    const run2 = runner.run({ job_id: "j2" }, { nodes, edges });
+    await started;
+    await new Promise((r) => setTimeout(r, 30));
+
+    const out = await runner.sendControlEvent("worker", { x: 1 });
+    expect(out.result).toBe(2);
+
+    cancelledRef.cancelled = true;
+    await run2;
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// DurableInbox: concurrent appends
+// ---------------------------------------------------------------------------
+
+describe("DurableInbox — concurrent appends", () => {
+  it("assigns distinct seq and messageId to concurrent appends", async () => {
+    const inbox = new DurableInbox("run-1", "node-1");
+    const results = await Promise.all([
+      inbox.append("h", "a"),
+      inbox.append("h", "b"),
+      inbox.append("h", "c")
+    ]);
+
+    const seqs = results.map((m) => m.seq).sort();
+    expect(seqs).toEqual([1, 2, 3]);
+    expect(new Set(results.map((m) => m.messageId)).size).toBe(3);
+
+    const pending = await inbox.getPending("h");
+    expect(pending).toHaveLength(3);
+    expect(pending.map((m) => m.payload)).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel: bufferLimit and duplicate subscriber ids
+// ---------------------------------------------------------------------------
+
+describe("Channel — buffer limit and subscriber identity", () => {
+  it("bounds a stalled subscriber's buffer by dropping the oldest items", async () => {
+    const ch = new Channel<number>("c", 2);
+    const gen = ch.subscribe("slow");
+
+    // First next() registers the subscriber and waits for data.
+    const first = gen.next();
+    await ch.publish(1);
+    expect((await first).value).toBe(1);
+
+    // Subscriber stalls; publishes beyond the limit drop the oldest.
+    await ch.publish(2);
+    await ch.publish(3);
+    await ch.publish(4);
+    await ch.close();
+
+    const rest: number[] = [];
+    for await (const v of { [Symbol.asyncIterator]: () => gen }) {
+      rest.push(v);
+    }
+    expect(rest).toEqual([3, 4]);
+  });
+
+  it("rejects a second live subscriber with the same id", async () => {
+    const ch = new Channel<number>("c");
+    const gen1 = ch.subscribe("dup");
+    const first = gen1.next();
+    await ch.publish(1);
+    await first;
+
+    const gen2 = ch.subscribe("dup");
+    await expect(gen2.next()).rejects.toThrow(/already has an active subscriber/);
+
+    await ch.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graph.fromDict: edge-fed defaults survive when the edge is dropped
+// ---------------------------------------------------------------------------
+
+describe("Graph.fromDict — property defaults vs dropped edges", () => {
+  const nodeDict = (id: string, properties: Record<string, unknown> = {}) => ({
+    id,
+    type: "test.Node",
+    properties
+  });
+
+  it("keeps a node's default when its incoming edge is dangling", () => {
+    const graph = Graph.fromDict({
+      nodes: [nodeDict("b", { x: 5 })],
+      edges: [
+        { source: "ghost", sourceHandle: "out", target: "b", targetHandle: "x" }
+      ]
+    });
+    expect(graph.edges).toHaveLength(0);
+    expect(graph.findNode("b")!.properties).toEqual({ x: 5 });
+  });
+
+  it("still deletes the default when the edge survives", () => {
+    const graph = Graph.fromDict({
+      nodes: [nodeDict("a"), nodeDict("b", { x: 5 })],
+      edges: [
+        { source: "a", sourceHandle: "out", target: "b", targetHandle: "x" }
+      ]
+    });
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.findNode("b")!.properties).toEqual({});
+  });
+
+  it("loadFromDict keeps the default when the resolver drops the source node", async () => {
+    const graph = await Graph.loadFromDict(
+      {
+        nodes: [
+          { id: "a", type: "missing.Type", properties: {} },
+          nodeDict("b", { x: 5 })
+        ],
+        edges: [
+          { source: "a", sourceHandle: "out", target: "b", targetHandle: "x" }
+        ]
+      },
+      {
+        resolver: (nodeType: string) =>
+          nodeType === "test.Node" ? { nodeType } : null
+      }
+    );
+    expect(graph.findNode("a")).toBeUndefined();
+    expect(graph.edges).toHaveLength(0);
+    expect(graph.findNode("b")!.properties).toEqual({ x: 5 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graph.topologicalSort: control edges must not define the ordering
+// ---------------------------------------------------------------------------
+
+describe("Graph.topologicalSort — control edges excluded", () => {
+  it("keeps both nodes of a data-forward/control-back pair in the levels", () => {
+    const graph = new Graph({
+      nodes: [
+        { id: "a", type: "t" },
+        { id: "b", type: "t" }
+      ],
+      edges: [
+        { source: "a", sourceHandle: "out", target: "b", targetHandle: "in" },
+        {
+          source: "b",
+          sourceHandle: "__control__",
+          target: "a",
+          targetHandle: "__control__",
+          edge_type: "control"
+        }
+      ]
+    });
+    const levels = graph.topologicalSort();
+    expect(levels.map((l) => l.map((n) => n.id))).toEqual([["a"], ["b"]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDownstreamSubgraph: shared seed target must not duplicate edges
+// ---------------------------------------------------------------------------
+
+describe("getDownstreamSubgraph — shared seed target", () => {
+  it("includes downstream edges exactly once when two initial edges share a target", () => {
+    const graph = new Graph({
+      nodes: [
+        { id: "A", type: "t" },
+        { id: "B", type: "t" },
+        { id: "C", type: "t" }
+      ],
+      edges: [
+        { source: "A", sourceHandle: "out", target: "B", targetHandle: "in1" },
+        { source: "A", sourceHandle: "out", target: "B", targetHandle: "in2" },
+        { source: "B", sourceHandle: "out", target: "C", targetHandle: "in" }
+      ]
+    });
+    const result = getDownstreamSubgraph(graph, "A", "out");
+    const tailEdges = result.edges.filter((e) => e.source === "B");
+    expect(tailEdges).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Watchdog: failed restart must keep the workflow tracked for retry
+// ---------------------------------------------------------------------------
+
+describe("TriggerWorkflowManager — watchdog retry after failed restart", () => {
+  let startJob: ReturnType<typeof vi.fn<StartJobFn>>;
+  let hasTriggerNodes: ReturnType<typeof vi.fn<HasTriggerNodesFn>>;
+
+  beforeEach(() => {
+    TriggerWorkflowManager.resetInstance();
+    vi.useFakeTimers();
+    startJob = vi.fn(async () => ({
+      jobId: "job",
+      completion: new Promise<void>(() => {})
+    }));
+    hasTriggerNodes = vi.fn(async () => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TriggerWorkflowManager.resetInstance();
+  });
+
+  it("retries on the next tick instead of permanently dropping the workflow", async () => {
+    const mgr = TriggerWorkflowManager.getInstance({
+      startJob,
+      hasTriggerNodes,
+      watchdogInterval: 1000
+    });
+    const job = await mgr.startTriggerWorkflow("wf-1", "u");
+    job!.status = "failed";
+
+    // First restart attempt fails transiently.
+    startJob.mockRejectedValueOnce(new Error("transient"));
+    mgr.startWatchdog();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(startJob).toHaveBeenCalledTimes(2);
+    expect(mgr.getRunningWorkflow("wf-1")).toBeDefined();
+    expect(mgr.isWorkflowRunning("wf-1")).toBe(false);
+
+    // Next tick succeeds.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(startJob).toHaveBeenCalledTimes(3);
+    expect(mgr.isWorkflowRunning("wf-1")).toBe(true);
+    mgr.stopWatchdog();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NodeInbox.drainHandle: backpressure release
+// ---------------------------------------------------------------------------
+
+describe("NodeInbox.drainHandle — releases producer backpressure", () => {
+  it("wakes a producer blocked on a full buffer", async () => {
+    const inbox = new NodeInbox(1);
+    inbox.addUpstream("x", 1);
+
+    await inbox.put("x", 1);
+    let secondPutDone = false;
+    const secondPut = inbox.put("x", 2).then(() => {
+      secondPutDone = true;
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(secondPutDone).toBe(false);
+
+    const drained = inbox.drainHandle("x");
+    expect(drained.map((e) => e.data)).toEqual([1]);
+
+    await secondPut;
+    expect(secondPutDone).toBe(true);
+    expect(inbox.drainHandle("x").map((e) => e.data)).toEqual([2]);
+  });
+});

--- a/packages/kernel/tests/correlation-analysis-mutation.test.ts
+++ b/packages/kernel/tests/correlation-analysis-mutation.test.ts
@@ -124,11 +124,16 @@ describe("analyzeCorrelation – topological sort", () => {
     expect(issueWith(result, "Cycle detected")).toBeUndefined();
   });
 
-  it("ignores self-loops (no false cycle)", () => {
+  it("reports a self-loop data edge as a cycle", () => {
+    // A self-loop deadlocks at runtime: the node's inbox handle is only
+    // marked done after the node's own actor completes, so the actor waits
+    // on itself forever. It must be rejected like any other cycle.
     const nodes = [node("A", "t", { outputs: { value: "any" } })];
     const edges = [dataEdge("A", "value", "A", "in", "e1")];
     const result = analyzeCorrelation({ nodes, edges });
-    expect(issueWith(result, "Cycle detected")).toBeUndefined();
+    const issue = issueWith(result, "Cycle detected");
+    expect(issue).toBeDefined();
+    expect(issue!.message).toContain("A");
   });
 });
 

--- a/packages/kernel/tests/durable-inbox.test.ts
+++ b/packages/kernel/tests/durable-inbox.test.ts
@@ -140,20 +140,28 @@ describe("DurableInbox", () => {
 describe("DurableInbox.generateMessageId (FNV-1a)", () => {
   it("is a deterministic 16-hex hash of the addressing tuple", () => {
     expect(DurableInbox.generateMessageId("r1", "n1", "in", 1)).toBe(
-      "692af8c151832e04"
+      "c3cf6775d5843014"
     );
   });
 
   it("zero-pads the first 32-bit half to 8 hex digits", () => {
-    const id = DurableInbox.generateMessageId("r", "n", "h", 358);
-    expect(id).toBe("0001298d1115ec6c");
+    const id = DurableInbox.generateMessageId("r", "n", "h", 3);
+    expect(id).toBe("0b48aa687d6a54f1");
     expect(id).toHaveLength(16);
   });
 
   it("zero-pads the second 32-bit half to 8 hex digits", () => {
-    const id = DurableInbox.generateMessageId("run-1", "node-1", "input", 1000);
-    expect(id).toBe("e62a7d110c77be8c");
+    const id = DurableInbox.generateMessageId("run-1", "node-1", "input", 23);
+    expect(id).toBe("7b388159015a38d0");
     expect(id).toHaveLength(16);
+  });
+
+  it("equal-length keys produce distinct second halves (full 64-bit spread)", () => {
+    // The old hash fed only the high byte of each UTF-16 unit to the second
+    // half, making it depend solely on string length for ASCII keys.
+    const a = DurableInbox.generateMessageId("ra", "na", "ha", 1);
+    const b = DurableInbox.generateMessageId("rb", "nb", "hb", 2);
+    expect(a.slice(8)).not.toBe(b.slice(8));
   });
 });
 


### PR DESCRIPTION
High severity:
- actor: controlled-mode livelock when a control event arrives before
  data inputs — _waitForDataInputs re-prepended the event to the front
  of the arrival queue and immediately popped it again, spinning in
  microtasks at 100% CPU and starving the upstream data put() forever.
  Control events are now held aside and re-queued after the wait, and
  the original envelope (event id, lineage, metadata) is preserved.
- runner: sendControlEvent overwrote the pending resolver on concurrent
  control events to the same node, leaving the earlier caller's promise
  unsettled forever. Resolvers are now a FIFO queue per node.
- durable-inbox: append() had a read-modify-write race (getMaxSeq →
  findByMessageId → save) that produced duplicate seq/messageId rows or
  silently dropped payloads under concurrent appends. Appends on one
  inbox are now serialized.
- actor: the correlated scheduler fired each ready key at most once per
  notification, stranding backlogged repeats_per_key (chunk) envelopes
  in the actor-local bucket (silent data loss). Repeating drivers now
  drain the whole backlog.
- actor: a repeating stream consumed at root scope was classified as an
  empty-sticky input, so every chunk overwrote the previous one and the
  node fired once with only the last chunk. Repeating handles at the
  invocation scope are now always "max" (driver) handles.

Medium severity:
- graph: fromDict deleted node property defaults for handles fed by
  edges that were subsequently dropped (malformed/dangling edges, and
  resolver-dropped nodes in loadFromDict), leaving nodes with neither
  default nor input. Pruning now runs against the surviving edge set.
- correlation-analysis: self-loop data edges bypassed cycle detection
  and deadlocked the run at runtime; they are now reported as cycles.
- runner: initialize() ran on a different executor instance than the
  one that executed (resolveExecutor called twice). Instances are now
  cached per node.
- runner: _resetRunState didn't clear _completedNodes, so a reused
  runner rejected control events for nodes completed in a prior run.
- trigger-manager: startTriggerWorkflow had a check-then-act race that
  left a second concurrent start running but untracked; starts are now
  deduplicated via an in-flight map.
- trigger-manager: the watchdog deleted the job entry before awaiting
  the restart, permanently dropping the workflow if one restart attempt
  failed. The entry now stays tracked for retry on the next tick.
- channel: the bufferLimit constructor parameter was silently discarded
  (unbounded growth for stalled subscribers); it is now enforced with
  drop-oldest semantics.
- actor: _cacheBufferedDataInputs drained inbox buffers behind the
  inbox's back, never waking producers blocked on backpressure. Added
  NodeInbox.drainHandle() which releases put() waiters.

Low severity:
- runner: __control__ EOS decremented once per control edge while the
  upstream count used unique controllers; parallel control edges from
  one controller drove the count to zero early. EOS now dedupes by
  target.
- durable-inbox: the second half of fnv1a64Hex consumed only the high
  byte of each UTF-16 unit (always 0 for ASCII), collapsing the hash to
  32 effective bits; both halves now consume both bytes.
- channel: subscribing with a duplicate live subscriberId silently
  evicted (and stranded) the old queue; it now throws.
- graph-utils: getDownstreamSubgraph enqueued shared seed targets twice,
  duplicating their downstream edges in the result.
- graph: topologicalSort included control edges in the ordering despite
  its data-edges-only contract, silently dropping nodes in legal
  data-forward/control-back patterns.
- trigger-manager: shutdown() could race an in-flight watchdog check
  that re-inserted a restarted job after the shutdown snapshot; shutdown
  now awaits the in-flight check behind a _shuttingDown flag.

Adds regression tests for the fixed behaviors in
tests/bug-scan-regressions.test.ts.

https://claude.ai/code/session_01HhgKYZgDd5rRd5YGcej4P6