### PR TITLE
Fix correctness bugs across web Zustand stores

### DIFF
--- a/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
+++ b/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
@@ -140,7 +140,8 @@ export const WorkflowLoader: React.FC<WorkflowLoaderProps> = memo(
         setLoading(true);
         try {
           const workflow =
-            getWorkflow(option.id) ?? (await fetchWorkflow(option.id));
+            getWorkflow(option.id) ??
+            (await fetchWorkflow(option.id, { makeCurrent: false }));
           if (!workflow) {
             throw new Error("Failed to load workflow");
           }
@@ -167,7 +168,7 @@ export const WorkflowLoader: React.FC<WorkflowLoaderProps> = memo(
         const currentWorkflow =
           selectedWorkflowStore?.getState().getWorkflow() ??
           getWorkflow(selectedWorkflowId) ??
-          (await fetchWorkflow(selectedWorkflowId));
+          (await fetchWorkflow(selectedWorkflowId, { makeCurrent: false }));
 
         if (!currentWorkflow || isCancelled) {
           return;

--- a/web/src/components/sketch/Inspector/GeneratedLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/GeneratedLayerPanel.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 /** Inspector panel for generated sketch layers — header, inputs form, actions, and version history. */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -111,6 +111,15 @@ export const GeneratedLayerPanel: React.FC<GeneratedLayerPanelProps> = memo(
       }
       return createNodeStore(workflow);
     }, [managerNodeStore, workflow]);
+    // Release the transient store's metadata subscription when it is
+    // replaced (workflow refetch) or the panel unmounts — otherwise every
+    // refetch leaks a NodeStore. cleanup() is idempotent.
+    useEffect(() => {
+      if (!transientNodeStore) {
+        return undefined;
+      }
+      return () => transientNodeStore.getState().cleanup();
+    }, [transientNodeStore]);
     const nodeStoreForForm = managerNodeStore ?? transientNodeStore;
 
     const jobState = useSketchGenerationStore(

--- a/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
@@ -8,7 +8,7 @@
  * "Open in Node Editor" from the actions row.
  */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -96,6 +96,15 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
       }
       return createNodeStore(workflow);
     }, [managerNodeStore, workflow]);
+    // Release the transient store's metadata subscription when it is
+    // replaced (workflow refetch) or the panel unmounts — otherwise every
+    // refetch leaks a NodeStore. cleanup() is idempotent.
+    useEffect(() => {
+      if (!transientNodeStore) {
+        return undefined;
+      }
+      return () => transientNodeStore.getState().cleanup();
+    }, [transientNodeStore]);
     const nodeStoreForForm = managerNodeStore ?? transientNodeStore;
 
     const inputDefinitions = useMemo<MiniAppInputDefinition[]>(() => {

--- a/web/src/contexts/WorkflowManagerContext.tsx
+++ b/web/src/contexts/WorkflowManagerContext.tsx
@@ -122,10 +122,13 @@ export const WorkflowManagerProvider: FC<{
   });
 
   useEffect(() => {
-    // Restore workflows that were previously open from localStorage
+    // Restore workflows that were previously open from localStorage.
+    // makeCurrent: false — the store already restored `currentWorkflowId`
+    // from localStorage at creation; letting these parallel fetches each set
+    // it would make the last-resolved fetch win and scramble the active tab.
     const openWorkflows = getOpenWorkflowsFromStorage();
     openWorkflows.forEach((workflowId: string) => {
-      store.getState().fetchWorkflow(workflowId);
+      store.getState().fetchWorkflow(workflowId, { makeCurrent: false });
     });
   }, [store]);
 

--- a/web/src/stores/AssetGridStore.ts
+++ b/web/src/stores/AssetGridStore.ts
@@ -101,7 +101,11 @@ export const useAssetGridStore = create<AssetGridState>()(
   selectedFolderIds: [],
   setAssetItemSize: (size) => set({ assetItemSize: size }),
   setCurrentFolder: (folder) =>
-    set({ currentFolder: folder, currentFolderId: folder?.id }),
+    set({
+      currentFolder: folder,
+      currentFolderId: folder?.id ?? null,
+      parentFolder: null
+    }),
   setCurrentFolderId: (folderId) =>
     set({ currentFolderId: folderId, currentFolder: null, parentFolder: null }),
   setDeleteDialogOpen: (open) => set({ deleteDialogOpen: open }),
@@ -127,12 +131,34 @@ export const useAssetGridStore = create<AssetGridState>()(
 
   handleSelectAllAssets: () => {
     const { filteredAssets } = get();
-    set({ selectedAssetIds: filteredAssets.map((asset) => asset.id) });
+    set({
+      selectedAssetIds: filteredAssets.map((asset) => asset.id),
+      selectedAssets: filteredAssets
+    });
   },
 
-  handleDeselectAssets: () => set({ selectedAssetIds: [] }),
+  handleDeselectAssets: () => set({ selectedAssetIds: [], selectedAssets: [] }),
   setSelectedAssetIds: (ids) => {
-    set({ selectedAssetIds: ids });
+    // Keep `selectedAssets` in sync so the two can't desync: resolve each id
+    // against the asset lists available in the store, falling back to the
+    // previous selection for ids whose assets aren't in the current view.
+    const { filteredAssets, globalSearchResults, selectedAssets } = get();
+    const byId = new Map<string, Asset>();
+    for (const asset of selectedAssets) {
+      byId.set(asset.id, asset);
+    }
+    for (const asset of globalSearchResults) {
+      byId.set(asset.id, asset);
+    }
+    for (const asset of filteredAssets) {
+      byId.set(asset.id, asset);
+    }
+    set({
+      selectedAssetIds: ids,
+      selectedAssets: ids
+        .map((id) => byId.get(id))
+        .filter((asset): asset is Asset => asset !== undefined)
+    });
   },
   setSelectedAssets: (assets) => {
     set({ selectedAssets: assets });

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -105,8 +105,11 @@ const uploadAsset = async (
   }
 };
 
+// Note: the tRPC `assets.list` procedure takes no cursor — it returns up to
+// `page_size` (default 10000) assets in one page, so there is no client-side
+// cursor pagination. Recursive listing goes through the separate
+// `assets.recursive` procedure (see `load`).
 type AssetQuery = {
-  cursor?: string;
   workflow_id?: string | null;
   parent_id?: string | null;
   content_type?: string | null;
@@ -148,7 +151,7 @@ export interface AssetStore {
   ) => Promise<Asset>;
   load: (query: AssetQuery) => Promise<AssetList>;
   loadFolderTree: (sortBy?: string) => Promise<FolderTree>;
-  loadCurrentFolder: (cursor?: string) => Promise<AssetList>;
+  loadCurrentFolder: () => Promise<AssetList>;
   search: (query: AssetSearchQuery) => Promise<AssetSearchResult>;
   update: (asset: AssetUpdate) => Promise<Asset>;
   delete: (id: string) => Promise<string[]>;
@@ -255,11 +258,27 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   /**
    * Load assets from the server.
    *
+   * Recursive queries are served by the dedicated `assets.recursive`
+   * procedure (the `assets.list` procedure has no recursive flag) and
+   * require a `parent_id` to recurse from.
+   *
    * @param query The asset query to use to load assets.
    * @returns A promise that resolves to the loaded assets.
    */
-  // Adjusting the load function to correctly handle the query
   load: async (query: AssetQuery) => {
+    if (query.recursive) {
+      if (!query.parent_id) {
+        throw new Error("Recursive asset queries require a parent_id");
+      }
+      const data = await trpcClient.assets.recursive.query({
+        id: query.parent_id
+      });
+      const normalized = normalizeAssetList(data.assets ?? []);
+      for (const asset of normalized) {
+        get().add(asset);
+      }
+      return { next: null, assets: normalized };
+    }
     const data = await trpcClient.assets.list.query({
       ...(query.parent_id !== undefined && query.parent_id !== null
         ? { parent_id: query.parent_id }
@@ -292,7 +311,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   /**
    * Load the current folder and its parent folder.
    */
-  loadCurrentFolder: async (cursor?: string) => {
+  loadCurrentFolder: async () => {
     const currentFolderId = useAssetGridStore.getState().currentFolderId;
     const setCurrentFolder = useAssetGridStore.getState().setCurrentFolder;
     const setParentFolder = useAssetGridStore.getState().setParentFolder;
@@ -319,7 +338,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
           });
       }
     }
-    return get().load({ parent_id: requestedFolderId, cursor: cursor || "" });
+    return get().load({ parent_id: requestedFolderId });
   },
 
   /**

--- a/web/src/stores/AudioQueueStore.ts
+++ b/web/src/stores/AudioQueueStore.ts
@@ -8,6 +8,9 @@ interface AudioQueueItem {
 
 interface AudioQueueState {
   currentPlayingId: string | null;
+  // The item that is currently playing. It is removed from `queue` when it
+  // starts playing, so we keep a reference here to be able to stop it later.
+  currentItem: AudioQueueItem | null;
   queue: AudioQueueItem[];
 
   // Register an audio output for playback
@@ -35,6 +38,7 @@ interface AudioQueueState {
  */
 export const useAudioQueue = create<AudioQueueState>((set, get) => ({
   currentPlayingId: null,
+  currentItem: null,
   queue: [],
 
   enqueue: (item: AudioQueueItem) => {
@@ -45,7 +49,7 @@ export const useAudioQueue = create<AudioQueueState>((set, get) => ({
 
     // If nothing is playing, start immediately
     if (!state.currentPlayingId) {
-      set({ currentPlayingId: item.id, queue: filtered });
+      set({ currentPlayingId: item.id, currentItem: item, queue: filtered });
       item.onPlay();
     } else {
       // Add to queue
@@ -56,10 +60,21 @@ export const useAudioQueue = create<AudioQueueState>((set, get) => ({
   dequeue: (id: string) => {
     const state = get();
 
-    // If it's currently playing, stop it and move to next
     if (state.currentPlayingId === id) {
-      // Don't call finishCurrent here - just clear current
-      set({ currentPlayingId: null, queue: state.queue });
+      // The playing item is being removed — promote the next queued item so
+      // the queue doesn't stall (callers stop their own audio before
+      // dequeueing, so we don't call onStop here).
+      const nextItem = state.queue[0];
+      if (nextItem) {
+        set({
+          currentPlayingId: nextItem.id,
+          currentItem: nextItem,
+          queue: state.queue.slice(1)
+        });
+        nextItem.onPlay();
+      } else {
+        set({ currentPlayingId: null, currentItem: null });
+      }
     } else {
       // Just remove from queue
       set({ queue: state.queue.filter((q) => q.id !== id) });
@@ -74,12 +89,13 @@ export const useAudioQueue = create<AudioQueueState>((set, get) => ({
       // Play next in queue
       set({
         currentPlayingId: nextItem.id,
+        currentItem: nextItem,
         queue: state.queue.slice(1)
       });
       nextItem.onPlay();
     } else {
       // Nothing left to play
-      set({ currentPlayingId: null });
+      set({ currentPlayingId: null, currentItem: null });
     }
   },
 
@@ -87,15 +103,12 @@ export const useAudioQueue = create<AudioQueueState>((set, get) => ({
     const state = get();
 
     // Stop current if playing
-    if (state.currentPlayingId) {
-      const current = state.queue.find((q) => q.id === state.currentPlayingId);
-      if (current) {
-        current.onStop();
-      }
+    if (state.currentItem) {
+      state.currentItem.onStop();
     }
 
     // Clear everything
-    set({ currentPlayingId: null, queue: [] });
+    set({ currentPlayingId: null, currentItem: null, queue: [] });
   },
 
   isPlaying: (id: string) => {

--- a/web/src/stores/CollectionStore.ts
+++ b/web/src/stores/CollectionStore.ts
@@ -54,6 +54,12 @@ interface CollectionStore {
   handleDrop: (collectionName: string) => (event: React.DragEvent<HTMLDivElement>) => Promise<void>;
 }
 
+// Monotonic token identifying the latest drop. Overlapping drops each capture
+// their own token; only the latest drop is allowed to write the shared
+// indexProgress/indexErrors state, so an older in-flight drop can't clobber
+// the progress UI of a newer one.
+let dropCounter = 0;
+
 export const useCollectionStore = create<CollectionStore>()(
   devtools(
     (set, get) => ({
@@ -126,12 +132,16 @@ export const useCollectionStore = create<CollectionStore>()(
 
       handleDrop: (collectionName: string) => async (event: React.DragEvent<HTMLDivElement>) => {
         event.preventDefault();
-        set({ dragOverCollection: null, indexErrors: [] });
+        set({ dragOverCollection: null });
 
         const files = Array.from(event.dataTransfer.files);
         if (files.length === 0) {return;}
 
+        const dropId = ++dropCounter;
+        const isLatestDrop = () => dropId === dropCounter;
+
         set({
+          indexErrors: [],
           indexProgress: {
             collection: collectionName,
             current: 0,
@@ -178,21 +188,25 @@ export const useCollectionStore = create<CollectionStore>()(
             });
           } finally {
             completed++;
-            set((state) => ({
-              indexProgress: state.indexProgress
-                ? {
-                    ...state.indexProgress,
-                    current: completed
-                  }
-                : null
-            }));
+            if (isLatestDrop()) {
+              set((state) => ({
+                indexProgress: state.indexProgress
+                  ? {
+                      ...state.indexProgress,
+                      current: completed
+                    }
+                  : null
+              }));
+            }
           }
         }
 
         await get().fetchCollections();
         // Indexing changes the collection's document count; refresh consumers.
         queryClient.invalidateQueries({ queryKey: ["collections"] });
-        set({ indexProgress: null, indexErrors: errors });
+        if (isLatestDrop()) {
+          set({ indexProgress: null, indexErrors: errors });
+        }
       }
     }),
     {

--- a/web/src/stores/ColorPickerStore.ts
+++ b/web/src/stores/ColorPickerStore.ts
@@ -198,7 +198,9 @@ export const useColorPickerStore = create<ColorPickerState>()(
  * Convert gradient to CSS string
  */
 export function gradientToCss(gradient: GradientValue): string {
-  const stopsStr = gradient.stops
+  // Copy before sorting — `.sort()` mutates in place and `gradient` may be a
+  // persisted store object that must not be modified.
+  const stopsStr = [...gradient.stops]
     .sort((a, b) => a.position - b.position)
     .map((stop) => `${stop.color} ${stop.position}%`)
     .join(", ");

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -257,6 +257,17 @@ function extractMessageText(message: Message | ChatOutgoingMessage): string {
   return "";
 }
 
+// Concurrency guards (module-level so they never end up in persisted state):
+// - `connectPromise` dedupes overlapping connect() calls; without it each call
+//   registers its own event handlers on the GlobalWebSocketManager singleton
+//   and later `set({ wsEventUnsubscribes })` calls overwrite earlier arrays,
+//   leaking handlers. Cleared in `finally` so a failed connect can be retried.
+let connectPromise: Promise<void> | null = null;
+// - `inFlightMessageLoads` dedupes loadMessages() per thread: concurrent calls
+//   for the SAME thread await one request, while loads for different threads
+//   proceed independently.
+const inFlightMessageLoads = new Map<string, Promise<Message[]>>();
+
 const useGlobalChatStore = create<GlobalChatState>()(
   persist<GlobalChatState>(
     (set, get) => ({
@@ -386,6 +397,13 @@ const useGlobalChatStore = create<GlobalChatState>()(
       loadMessagesTimeoutId: null,
 
       connect: async () => {
+        // Overlapping connect() calls share one in-flight attempt; otherwise
+        // each call would register its own event handlers on the singleton
+        // manager and the loser's unsubscribe handles would be lost.
+        if (connectPromise) {
+          return connectPromise;
+        }
+        connectPromise = (async () => {
         console.info("Connecting to global chat");
 
         const state = get();
@@ -394,6 +412,10 @@ const useGlobalChatStore = create<GlobalChatState>()(
         Object.values(state.wsThreadSubscriptions).forEach((unsubscribe) =>
           unsubscribe()
         );
+        // Drop the now-dead handles immediately: if anything below throws,
+        // state must not keep truthy-but-unsubscribed entries, or sendMessage
+        // would skip re-subscribing and streamed replies would have no handler.
+        set({ wsEventUnsubscribes: [], wsThreadSubscriptions: {} });
 
         // Load threads if not already loaded
         if (!state.threadsLoaded) {
@@ -531,6 +553,14 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // Connection is automatic via globalWebSocketManager
         // Subscriptions will trigger connection if not already connected
         console.info("Global chat subscriptions set up");
+        })();
+        try {
+          await connectPromise;
+        } finally {
+          // Always clear the guard — a FAILED connect must not block the
+          // retry button from starting a fresh attempt.
+          connectPromise = null;
+        }
       },
 
       disconnect: () => {
@@ -697,7 +727,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
         try {
           await globalWebSocketManager.send(commandMessage);
 
-          // Safety timeout - reset status if no response after 60 seconds
+          // Safety timeout - reset status if no response after 5 minutes
           const timeoutId = setTimeout(() => {
             const currentState = get();
             if (
@@ -755,7 +785,14 @@ const useGlobalChatStore = create<GlobalChatState>()(
             threadsRecord[thread.id] = thread;
           });
 
-          set({ threads: threadsRecord, threadsLoaded: true, error: null });
+          // Merge with existing threads so locally-created/optimistic threads
+          // that haven't reached the server yet don't get wiped (the server
+          // response wins for ids present in both).
+          set((state) => ({
+            threads: { ...state.threads, ...threadsRecord },
+            threadsLoaded: true,
+            error: null
+          }));
         } catch (error) {
           console.error("Failed to fetch threads:", error);
           set({
@@ -979,60 +1016,70 @@ const useGlobalChatStore = create<GlobalChatState>()(
       },
 
       loadMessages: async (threadId: string, cursor?: string) => {
-        const { messageCache, isLoadingMessages } = get();
-
-        if (isLoadingMessages) {
-          return messageCache[threadId] || [];
+        // Dedupe per thread: concurrent calls for the SAME thread await the
+        // one in-flight request, while loads for other threads proceed
+        // independently (a store-wide guard used to silently drop them).
+        const inFlight = inFlightMessageLoads.get(threadId);
+        if (inFlight) {
+          return inFlight;
         }
 
+        const load = (async (): Promise<Message[]> => {
+          try {
+            const data = await trpcClient.messages.list.query({
+              thread_id: threadId,
+              ...(cursor ? { cursor } : {}),
+              limit: 100
+            });
+
+            // The tRPC response shape is a strict subset of the web-side
+            // `Message` openapi type (which includes agent-specific fields
+            // that this endpoint never emits). Cast to the broader type so
+            // downstream store operations compile.
+            const messages = (data.messages ?? []) as unknown as Message[];
+            const nextCursor = data.next;
+
+            set((state) => {
+              const existingMessages = state.messageCache[threadId] || [];
+              const updatedMessages = cursor
+                ? [...existingMessages, ...messages]
+                : messages;
+
+              return {
+                messageCache: {
+                  ...state.messageCache,
+                  [threadId]: updatedMessages
+                },
+                messageCursors: {
+                  ...state.messageCursors,
+                  [threadId]: nextCursor
+                }
+              };
+            });
+
+            return get().messageCache[threadId] || [];
+          } catch (error) {
+            console.error("Failed to load messages:", error);
+            set({
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to load messages"
+            });
+            return get().messageCache[threadId] || [];
+          }
+        })();
+
+        // `isLoadingMessages` stays a store-wide "any load in flight" flag.
+        inFlightMessageLoads.set(threadId, load);
         set({ isLoadingMessages: true, error: null });
-
         try {
-          const data = await trpcClient.messages.list.query({
-            thread_id: threadId,
-            ...(cursor ? { cursor } : {}),
-            limit: 100
-          });
-
-          // The tRPC response shape is a strict subset of the web-side
-          // `Message` openapi type (which includes agent-specific fields
-          // that this endpoint never emits). Cast to the broader type so
-          // downstream store operations compile.
-          const messages = (data.messages ?? []) as unknown as Message[];
-          const nextCursor = data.next;
-
-          set((state) => {
-            const existingMessages = state.messageCache[threadId] || [];
-            const updatedMessages = cursor
-              ? [...existingMessages, ...messages]
-              : messages;
-
-            return {
-              messageCache: {
-                ...state.messageCache,
-                [threadId]: updatedMessages
-              },
-              messageCursors: {
-                ...state.messageCursors,
-                [threadId]: nextCursor
-              },
-              isLoadingMessages: false
-            };
-          });
-
-          return cursor
-            ? [...(messageCache[threadId] || []), ...messages]
-            : messages;
-        } catch (error) {
-          console.error("Failed to load messages:", error);
-          set({
-            error:
-              error instanceof Error
-                ? error.message
-                : "Failed to load messages",
-            isLoadingMessages: false
-          });
-          return messageCache[threadId] || [];
+          return await load;
+        } finally {
+          inFlightMessageLoads.delete(threadId);
+          if (inFlightMessageLoads.size === 0) {
+            set({ isLoadingMessages: false });
+          }
         }
       },
 

--- a/web/src/stores/KeyPressedStore.ts
+++ b/web/src/stores/KeyPressedStore.ts
@@ -179,8 +179,10 @@ const executeComboCallbacks = (
 
     // 1. Always allow "shift+enter", "control+enter", and "meta+enter" to proceed to execution.
     //    These are commonly used for multiline input and running actions.
+    //    Note: pressedKeysString is sorted alphabetically, so the literals
+    //    below must be in sorted form (e.g. "enter+shift", not "shift+enter").
     if (
-      pressedKeysString === "shift+enter" ||
+      pressedKeysString === "enter+shift" ||
       pressedKeysString === "control+enter" ||
       pressedKeysString === "enter+meta"
     ) {

--- a/web/src/stores/ModelDownloadStore.ts
+++ b/web/src/stores/ModelDownloadStore.ts
@@ -264,6 +264,18 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
               });
             }
           }
+        } else if (data.status === "error") {
+          // Server-side failure before the download manager attached a
+          // repo_id (e.g. the manager failed to start). There's nothing to
+          // attribute it to, so fail every entry still awaiting its first
+          // progress message so rows don't spin forever.
+          const message = data.error || data.message || "Download failed";
+          console.error("[ModelDownloadStore] Server error:", message);
+          Object.entries(get().downloads).forEach(([id, download]) => {
+            if (download.status === "pending") {
+              get().updateDownload(id, { status: "error", message });
+            }
+          });
         }
       };
 
@@ -427,17 +439,31 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
         get().updateDownload(id, { status: "error" });
       }
     } else {
-      const ws = await get().connectWebSocket();
-      ws.send(
-        JSON.stringify({
-          command: "start_download",
-          repo_id: repoId,
-          path: path,
-          allow_patterns: allowPatterns,
-          ignore_patterns: ignorePatterns,
-          model_type: modelType
-        })
-      );
+      try {
+        const ws = await get().connectWebSocket();
+        ws.send(
+          JSON.stringify({
+            command: "start_download",
+            repo_id: repoId,
+            path: path,
+            allow_patterns: allowPatterns,
+            ignore_patterns: ignorePatterns,
+            model_type: modelType
+          })
+        );
+      } catch (error) {
+        console.error(
+          "[ModelDownloadStore] Failed to connect for download:",
+          error
+        );
+        get().updateDownload(id, {
+          status: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to connect to download service"
+        });
+      }
     }
   },
 
@@ -449,9 +475,23 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
       return;
     }
 
-    const ws = await get().connectWebSocket();
-    ws.send(JSON.stringify({ command: "cancel_download", id: id }));
-    get().updateDownload(id, { status: "cancelled" });
+    try {
+      const ws = await get().connectWebSocket();
+      ws.send(JSON.stringify({ command: "cancel_download", id: id }));
+      get().updateDownload(id, { status: "cancelled" });
+    } catch (error) {
+      console.error(
+        "[ModelDownloadStore] Failed to connect for cancel:",
+        error
+      );
+      // We couldn't reach the server to cancel, but the user asked for the
+      // row to stop — mark it cancelled locally ("cancelled" is not an
+      // active status in hasActiveDownloads, so the spinner stops).
+      get().updateDownload(id, {
+        status: "cancelled",
+        message: "Could not reach server to cancel; download may still be running on server."
+      });
+    }
   },
 
   isDialogOpen: false,

--- a/web/src/stores/ModelPreferencesStore.ts
+++ b/web/src/stores/ModelPreferencesStore.ts
@@ -109,7 +109,7 @@ export const useModelPreferencesStore = create<ModelPreferencesState>()(
         const fallback = {
           favorites: [] as FavoriteKey[],
           recents: [] as RecentEntry[],
-          onlyAvailable: true,
+          onlyAvailable: false,
           enabledProviders: {} as Record<string, boolean>,
           defaults: {} as Record<
             string,

--- a/web/src/stores/NodeMenuStore.ts
+++ b/web/src/stores/NodeMenuStore.ts
@@ -435,6 +435,18 @@ export const createNodeMenuStore = () =>
             set({ dragToCreate: false });
             return;
           }
+          // Clear pending timers so a late fire doesn't repopulate
+          // searchResults/hover state after the menu has closed.
+          if (searchTimeout) {
+            clearTimeout(searchTimeout);
+            searchTimeout = null;
+          }
+          if (hoveredNodeTimeout !== null) {
+            clearTimeout(hoveredNodeTimeout);
+            hoveredNodeTimeout = null;
+          }
+          // Invalidate any in-flight debounced search so it no-ops.
+          pendingSearchId++;
           set({
             searchTerm: "",
             dropType: "",
@@ -451,7 +463,8 @@ export const createNodeMenuStore = () =>
             selectedProviderType: "all",
             showDocumentation: false,
             selectedNodeType: null,
-            selectedIndex: -1
+            selectedIndex: -1,
+            hoveredNode: null
           });
         }
       },

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -546,8 +546,26 @@ export const createNodeStore = (
             }
           },
           onEdgeUpdate: (oldEdge: Edge, newConnection: Connection): void => {
+            // A reconnect onto a handle was attempted — mark it successful
+            // immediately (canonical xyflow pattern) so onEdgeUpdateEnd never
+            // deletes the edge. If validation fails below, the original edge
+            // is left unchanged.
+            get().setEdgeUpdateSuccessful(true);
             const edge = get().edges.find((e) => e.id === oldEdge.id);
             if (edge) {
+              const isUnchanged =
+                edge.source === newConnection.source &&
+                edge.target === newConnection.target &&
+                (edge.sourceHandle ?? null) ===
+                  (newConnection.sourceHandle ?? null) &&
+                (edge.targetHandle ?? null) ===
+                  (newConnection.targetHandle ?? null);
+              if (isUnchanged) {
+                // Dropped back on the original handle — successful no-op.
+                // (validateConnection would reject it as a duplicate since
+                // the dragged edge itself is still in the edges array.)
+                return;
+              }
               const srcNode = get().findNode(newConnection.source);
               const targetNode = get().findNode(newConnection.target);
               if (
@@ -703,9 +721,14 @@ export const createNodeStore = (
               console.warn(`Node with id ${node.id} already exists`);
               return;
             }
-            node.expandParent = true;
-            node.data.workflow_id = get().workflow.id;
-            set({ nodes: [...get().nodes, syncReactFlowNodeChromeClass(node)] });
+            const newNode = {
+              ...node,
+              expandParent: true,
+              data: { ...node.data, workflow_id: get().workflow.id }
+            };
+            set({
+              nodes: [...get().nodes, syncReactFlowNodeChromeClass(newNode)]
+            });
             get().setWorkflowDirty(true);
           },
           updateNode: (
@@ -780,6 +803,7 @@ export const createNodeStore = (
               };
               return { ...state, nodes };
             });
+            get().setWorkflowDirty(true);
           },
           updateNodeProperties: (
             id: string,
@@ -827,15 +851,10 @@ export const createNodeStore = (
               return;
             }
 
-            const focusedElement = document.activeElement;
-            if (
-              focusedElement instanceof HTMLElement &&
-              (focusedElement.classList.contains("MuiInput-input") ||
-                focusedElement.tagName === "TEXTAREA")
-            ) {
-              return;
-            }
-
+            // Note: the Delete/Backspace-while-typing guard lives in the
+            // keyboard layer (KeyPressedStore suppresses those combos when an
+            // editable element is focused), so programmatic callers (ui tools,
+            // context menus, grouping) always work here.
             const foundIdSet = new Set(foundIds);
             const nodes: Node<NodeData>[] = [];
 
@@ -1034,7 +1053,10 @@ export const createNodeStore = (
               layoutedNodes.map((n) => [n.id, n])
             );
 
-            const updatedNodes = allNodes.map((node) => {
+            // Re-read nodes after the await: merge only layout-computed
+            // positions into the current state so concurrent edits (added,
+            // removed, or changed nodes) are preserved.
+            const updatedNodes = get().nodes.map((node) => {
               const layoutedNode = layoutedNodeMap.get(node.id);
               if (layoutedNode) {
                 return {

--- a/web/src/stores/PacksStore.ts
+++ b/web/src/stores/PacksStore.ts
@@ -53,6 +53,16 @@ interface PacksStore {
   reload: () => Promise<void>;
 }
 
+/**
+ * Serializes trust mutations. `setTrusted` does a read-modify-write of the
+ * allowlist; if two rapid toggles each read the pre-await state, the second
+ * overwrites the first server-side. Each mutation is chained onto this
+ * promise and reads `get().trust` only once the previous one has settled.
+ * Tasks never reject (errors are captured into store state), so plain
+ * `.then` chaining is safe.
+ */
+let trustMutation: Promise<unknown> = Promise.resolve();
+
 const usePacksStore = create<PacksStore>((set, get) => ({
   packs: [],
   trust: { allowlist: [], allowUnlisted: false },
@@ -75,33 +85,47 @@ const usePacksStore = create<PacksStore>((set, get) => ({
     }
   },
 
-  setTrusted: async (packName, trusted) => {
-    const { trust } = get();
-    const current = new Set(trust.allowlist);
-    if (trusted) current.add(packName);
-    else current.delete(packName);
-    const allowlist = [...current];
-    try {
-      const next = await trpcClient.packs.setTrust.mutate({ allowlist });
-      set({ trust: next });
-      const refreshed = await trpcClient.packs.reload.mutate();
-      set({ packs: refreshed.packs });
-    } catch (err: unknown) {
-      set({ error: createErrorMessage(err, "Failed to update pack trust").message });
-    }
+  setTrusted: (packName, trusted) => {
+    const task = async (): Promise<void> => {
+      // Read trust INSIDE the chained task so it sees the previous
+      // mutation's result instead of a stale pre-await snapshot.
+      const { trust } = get();
+      const current = new Set(trust.allowlist);
+      if (trusted) current.add(packName);
+      else current.delete(packName);
+      const allowlist = [...current];
+      try {
+        const next = await trpcClient.packs.setTrust.mutate({ allowlist });
+        set({ trust: next });
+        const refreshed = await trpcClient.packs.reload.mutate();
+        set({ packs: refreshed.packs });
+      } catch (err: unknown) {
+        set({ error: createErrorMessage(err, "Failed to update pack trust").message });
+      }
+    };
+    const run = trustMutation.then(task);
+    trustMutation = run;
+    return run;
   },
 
-  setAllowUnlisted: async (allowUnlisted) => {
-    try {
-      const next = await trpcClient.packs.setTrust.mutate({ allowUnlisted });
-      set({ trust: next });
-      const refreshed = await trpcClient.packs.reload.mutate();
-      set({ packs: refreshed.packs });
-    } catch (err: unknown) {
-      set({
-        error: createErrorMessage(err, "Failed to update allowUnlisted setting").message
-      });
-    }
+  setAllowUnlisted: (allowUnlisted) => {
+    const task = async (): Promise<void> => {
+      try {
+        const next = await trpcClient.packs.setTrust.mutate({ allowUnlisted });
+        set({ trust: next });
+        const refreshed = await trpcClient.packs.reload.mutate();
+        set({ packs: refreshed.packs });
+      } catch (err: unknown) {
+        set({
+          error: createErrorMessage(err, "Failed to update allowUnlisted setting").message
+        });
+      }
+    };
+    // Chained on the same queue so allowUnlisted updates don't interleave
+    // with allowlist read-modify-writes on the shared trust object.
+    const run = trustMutation.then(task);
+    trustMutation = run;
+    return run;
   },
 
   reload: async () => {

--- a/web/src/stores/RemoteSettingStore.ts
+++ b/web/src/stores/RemoteSettingStore.ts
@@ -26,6 +26,7 @@ const useRemoteSettingsStore = create<RemoteSettingsStore>((set, get) => ({
   error: null,
 
   fetchSettings: async () => {
+    set({ isLoading: true, error: null });
     try {
       const data = await trpcClient.settings.list.query();
       const settings = data.settings as SettingWithValue[];
@@ -43,13 +44,16 @@ const useRemoteSettingsStore = create<RemoteSettingsStore>((set, get) => ({
       set({
         settings,
         settingsByGroup,
-        isLoading: false
+        isLoading: false,
+        error: null
       });
 
       return settings;
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
-      throw createErrorMessage(error, "Failed to load settings");
+      const message = createErrorMessage(error, "Failed to load settings");
+      set({ isLoading: false, error: message.message });
+      throw message;
     }
   },
 

--- a/web/src/stores/ResultsStore.ts
+++ b/web/src/stores/ResultsStore.ts
@@ -325,13 +325,23 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
     return get().tasks[nodeKey(workflowId, jobId, nodeId)];
   },
   /**
-   * Clear the provider costs for a workflow.
+   * Clear all per-node results for a workflow (or for specific nodes of it):
+   * provider costs, live generations, tool results, output results, progress,
+   * chunks, tasks, tool calls and planning updates. Edge status is keyed by
+   * edge id, not node id, so it is cleared separately via `clearEdges`.
    */
   clearResults: (workflowId: string, nodeIds?: Set<string>) => {
     set((state) => ({
       providerCosts: filterRecord(state.providerCosts, workflowId, nodeIds),
       liveGenerations: filterRecord(state.liveGenerations, workflowId, nodeIds),
-      toolResults: filterRecord(state.toolResults, workflowId, nodeIds)
+      toolResults: filterRecord(state.toolResults, workflowId, nodeIds),
+      outputResults: filterRecord(state.outputResults, workflowId, nodeIds),
+      progress: filterRecord(state.progress, workflowId, nodeIds),
+      chunks: filterRecord(state.chunks, workflowId, nodeIds),
+      tasks: filterRecord(state.tasks, workflowId, nodeIds),
+      toolCalls: filterRecord(state.toolCalls, workflowId, nodeIds),
+      planningUpdates: filterRecord(state.planningUpdates, workflowId, nodeIds),
+      resultsVersion: state.resultsVersion + 1
     }));
   },
   clearOutputResults: (workflowId: string, nodeIds?: Set<string>) => {

--- a/web/src/stores/RightPanelStore.ts
+++ b/web/src/stores/RightPanelStore.ts
@@ -93,7 +93,17 @@ export const useRightPanelStore = create<ResizePanelState>()(
 
       setVisibility: (isVisible: boolean) =>
         set((state: ResizePanelState) => ({
-          panel: { ...state.panel, isVisible }
+          panel: {
+            ...state.panel,
+            isVisible,
+            // A drag-collapse can persist a sliver-sized panel (MIN_DRAG_SIZE).
+            // When reopening, restore at least the usable minimum so the panel
+            // doesn't come back as a 60px sliver.
+            panelSize:
+              isVisible && state.panel.panelSize < MIN_PANEL_SIZE
+                ? MIN_PANEL_SIZE
+                : state.panel.panelSize
+          }
         })),
 
       handleViewChange: (view: RightPanelView) => {

--- a/web/src/stores/SubgraphTabsStore.ts
+++ b/web/src/stores/SubgraphTabsStore.ts
@@ -32,6 +32,15 @@ interface SubgraphTabsState {
 
 const tabKey = (workflowId: string, nodeId: string) => `${workflowId}:${nodeId}`;
 
+/** Release the tab's NodeStore resources (metadata subscription). */
+const cleanupTabStore = (tab: SubgraphTab): void => {
+  try {
+    tab.store.getState().cleanup();
+  } catch (err) {
+    console.warn(`[SubgraphTabs] NodeStore cleanup failed for ${tab.key}`, err);
+  }
+};
+
 const buildSubgraphWorkflow = (
   key: string,
   label: string,
@@ -73,6 +82,11 @@ export const useSubgraphTabsStore = create<SubgraphTabsState>()((set, get) => ({
     const { tabs, activeKey } = get();
     const idx = tabs.findIndex((t) => t.key === key);
     if (idx === -1) return;
+    // Tear down the tab's NodeStore (releases its MetadataStore
+    // subscription) before dropping the reference — mirrors
+    // WorkflowManagerStore.removeWorkflow; without this the store leaks
+    // forever.
+    cleanupTabStore(tabs[idx]);
     const newTabs = tabs.filter((t) => t.key !== key);
     let newActive = activeKey;
     if (activeKey === key) {
@@ -85,13 +99,15 @@ export const useSubgraphTabsStore = create<SubgraphTabsState>()((set, get) => ({
   setActive: (key) => set({ activeKey: key }),
 
   closeForWorkflow: (workflowId) => {
-    set((state) => {
-      const remaining = state.tabs.filter((t) => t.workflowId !== workflowId);
-      const stillActive = remaining.some((t) => t.key === state.activeKey);
-      return {
-        tabs: remaining,
-        activeKey: stillActive ? state.activeKey : null
-      };
+    const { tabs, activeKey } = get();
+    const removed = tabs.filter((t) => t.workflowId === workflowId);
+    if (removed.length === 0) return;
+    removed.forEach(cleanupTabStore);
+    const remaining = tabs.filter((t) => t.workflowId !== workflowId);
+    const stillActive = remaining.some((t) => t.key === activeKey);
+    set({
+      tabs: remaining,
+      activeKey: stillActive ? activeKey : null
     });
   },
 

--- a/web/src/stores/VibeCodingStore.ts
+++ b/web/src/stores/VibeCodingStore.ts
@@ -62,17 +62,42 @@ export const useVibeCodingStore = create<VibeCodingState>()(
       },
 
       initSession: (workflowId, savedHtml) => {
-        set((state) => ({
-          sessions: {
-            ...state.sessions,
-            [workflowId]: {
-              ...defaultSession,
-              workflowId,
-              savedHtml,
-              currentHtml: savedHtml
-            }
+        set((state) => {
+          const existing = state.sessions[workflowId];
+          if (existing) {
+            // Preserve the session (rehydrated unsaved work, chat history)
+            // instead of resetting on every panel mount / html_app change.
+            // Sync savedHtml from the workflow; only follow it with
+            // currentHtml when there are no unsaved edits. After a save,
+            // html_app === currentHtml, so syncing savedHtml while keeping
+            // messages intact is exactly right. Stale transient status/error
+            // (e.g. a persisted "streaming") is reset.
+            const hasUnsaved = existing.currentHtml !== existing.savedHtml;
+            return {
+              sessions: {
+                ...state.sessions,
+                [workflowId]: {
+                  ...existing,
+                  savedHtml,
+                  currentHtml: hasUnsaved ? existing.currentHtml : savedHtml,
+                  status: "idle" as const,
+                  error: null
+                }
+              }
+            };
           }
-        }));
+          return {
+            sessions: {
+              ...state.sessions,
+              [workflowId]: {
+                ...defaultSession,
+                workflowId,
+                savedHtml,
+                currentHtml: savedHtml
+              }
+            }
+          };
+        });
       },
 
       clearSession: (workflowId) => {

--- a/web/src/stores/WorkflowManagerStore.ts
+++ b/web/src/stores/WorkflowManagerStore.ts
@@ -32,8 +32,10 @@ import useErrorStore from "./ErrorStore";
 import useStatusStore from "./StatusStore";
 import useExecutionTimeStore from "./ExecutionTimeStore";
 import usePropertyValidationStore from "./PropertyValidationStore";
+import useWorkflowRunsStore from "./WorkflowRunsStore";
 import { useFavoriteWorkflowsStore } from "./FavoriteWorkflowsStore";
 import { useWorkflowAssetStore } from "./WorkflowAssetStore";
+import { useSubgraphTabsStore } from "./SubgraphTabsStore";
 import { useCurrentWorkspaceStore } from "./CurrentWorkspaceStore";
 
 const isWorkflowNotFoundError = (err: unknown): boolean => {
@@ -166,7 +168,10 @@ export type WorkflowManagerState = {
   saveWorkflow: (workflow: Workflow) => Promise<void>;
   getCurrentWorkflow: () => Workflow | undefined;
   setCurrentWorkflowId: (workflowId: string) => void;
-  fetchWorkflow: (workflowId: string) => Promise<Workflow | undefined>;
+  fetchWorkflow: (
+    workflowId: string,
+    options?: { makeCurrent?: boolean }
+  ) => Promise<Workflow | undefined>;
   newWorkflow: () => Workflow;
   createNew: () => Promise<Workflow>;
   create: (
@@ -236,6 +241,30 @@ const pruneStaleWorkflowReference = (
   });
 };
 
+// Per-workflow MetadataStore subscriptions waiting for metadata to load so
+// live fal/kie pricing can be fetched. Tracked so removeWorkflow can release
+// them if metadata never loads while the workflow is open.
+const pricingMetadataUnsubs = new Map<string, Array<() => void>>();
+
+const registerPricingUnsub = (
+  workflowId: string,
+  unsub: () => void
+): void => {
+  const list = pricingMetadataUnsubs.get(workflowId) ?? [];
+  list.push(unsub);
+  pricingMetadataUnsubs.set(workflowId, list);
+};
+
+const releasePricingUnsubs = (workflowId: string): void => {
+  const list = pricingMetadataUnsubs.get(workflowId);
+  if (list) {
+    for (const unsub of list) {
+      unsub();
+    }
+    pricingMetadataUnsubs.delete(workflowId);
+  }
+};
+
 // -----------------------------------------------------------------
 // ZUSTAND STORE CREATION
 // -----------------------------------------------------------------
@@ -297,6 +326,12 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
          * @throws {Error} If the save operation fails
          */
         saveWorkflow: async (workflow: Workflow) => {
+          // Snapshot the node store's state references before the awaited
+          // mutation. Every NodeStore mutation produces new `nodes`/`edges`/
+          // `workflow` references, so reference equality after the await tells
+          // us whether the user edited the graph while the save was in flight.
+          const nodeStoreBefore = get().nodeStores[workflow.id];
+          const stateBefore = nodeStoreBefore?.getState();
 
           let data: Workflow;
           try {
@@ -347,10 +382,23 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
           set((state) => {
             const nodeStore = state.nodeStores[persistedWorkflow.id];
             if (nodeStore) {
-              nodeStore.setState({
-                workflow: persistedWorkflow
-              });
-              nodeStore.getState().setWorkflowDirty(false);
+              const current = nodeStore.getState();
+              const editedDuringSave =
+                nodeStore !== nodeStoreBefore ||
+                !stateBefore ||
+                current.nodes !== stateBefore.nodes ||
+                current.edges !== stateBefore.edges ||
+                current.workflow !== stateBefore.workflow;
+              // Only mark the store clean (and adopt the server's workflow
+              // attributes) when nothing changed during the save. If the user
+              // edited meanwhile, keep the dirty flag and their attribute
+              // edits — the next autosave persists them.
+              if (!editedDuringSave) {
+                nodeStore.setState({
+                  workflow: persistedWorkflow
+                });
+                nodeStore.getState().setWorkflowDirty(false);
+              }
             }
 
             const index = state.openWorkflows.findIndex((w) => w.id === persistedWorkflow.id);
@@ -649,21 +697,40 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
         ].filter((t) => t.startsWith("fal."));
 
         if (falNodeTypes.length > 0) {
+          // Returns true once metadata has loaded (the map is populated in one
+          // bulk setMetadata), whether or not any pricing was found — so the
+          // fallback subscription below always terminates after one real
+          // attempt instead of living forever when pricing never appears.
           const doFetch = (): boolean => {
             const meta = useMetadataStore.getState().metadata;
+            if (Object.keys(meta).length === 0) return false;
             const endpointIds = falNodeTypes
               .map((t) => meta[t]?.fal_unit_pricing?.endpoint_id)
               .filter((id): id is string => Boolean(id));
-            if (endpointIds.length === 0) return false;
-            fetchLiveFalPricing(meta, endpointIds)
-              .then((updated) => {
-                if (updated) {
-                  useMetadataStore.getState().setMetadata({ ...meta });
-                }
-              })
-              .catch(() => {
-                // surfaced as console.error inside fetchLiveFalPricing
-              });
+            if (endpointIds.length > 0) {
+              fetchLiveFalPricing(meta, endpointIds)
+                .then((updatedPricing) => {
+                  if (!updatedPricing) return;
+                  // Re-read the live map — metadata may have been reloaded
+                  // while the fetch was in flight; merge the fresh pricing
+                  // into cloned entries so per-node selectors re-render.
+                  const store = useMetadataStore.getState();
+                  const merged = { ...store.metadata };
+                  let changed = false;
+                  for (const [nodeType, pricing] of Object.entries(
+                    updatedPricing
+                  )) {
+                    const base = merged[nodeType];
+                    if (!base) continue;
+                    merged[nodeType] = { ...base, fal_unit_pricing: pricing };
+                    changed = true;
+                  }
+                  if (changed) store.setMetadata(merged);
+                })
+                .catch(() => {
+                  // surfaced as console.error inside fetchLiveFalPricing
+                });
+            }
             return true;
           };
 
@@ -671,6 +738,7 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
             const unsub = useMetadataStore.subscribe(() => {
               if (doFetch()) unsub();
             });
+            registerPricingUnsub(workflow.id, unsub);
           }
         }
 
@@ -681,23 +749,37 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
         ].filter((t) => t.startsWith("kie."));
 
         if (kieNodeTypes.length > 0) {
+          // Same termination contract as the FAL block above: true once
+          // metadata is loaded, regardless of whether pricing was found.
           const doFetchKie = (): boolean => {
             const meta = useMetadataStore.getState().metadata;
+            if (Object.keys(meta).length === 0) {
+              return false;
+            }
             const modelIds = kieNodeTypes
               .map((t) => meta[t]?.kie_unit_pricing?.model_id)
               .filter((id): id is string => Boolean(id));
-            if (modelIds.length === 0) {
-              return false;
+            if (modelIds.length > 0) {
+              fetchLiveKiePricing(meta, modelIds)
+                .then((updatedPricing) => {
+                  if (!updatedPricing) return;
+                  const store = useMetadataStore.getState();
+                  const merged = { ...store.metadata };
+                  let changed = false;
+                  for (const [nodeType, pricing] of Object.entries(
+                    updatedPricing
+                  )) {
+                    const base = merged[nodeType];
+                    if (!base) continue;
+                    merged[nodeType] = { ...base, kie_unit_pricing: pricing };
+                    changed = true;
+                  }
+                  if (changed) store.setMetadata(merged);
+                })
+                .catch(() => {
+                  // surfaced as console.error inside fetchLiveKiePricing
+                });
             }
-            fetchLiveKiePricing(meta, modelIds)
-              .then((updated) => {
-                if (updated) {
-                  useMetadataStore.getState().setMetadata({ ...meta });
-                }
-              })
-              .catch(() => {
-                // surfaced as console.error inside fetchLiveKiePricing
-              });
             return true;
           };
 
@@ -705,6 +787,7 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
             const unsub = useMetadataStore.subscribe(() => {
               if (doFetchKie()) unsub();
             });
+            registerPricingUnsub(workflow.id, unsub);
           }
         }
       },
@@ -715,6 +798,7 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
         */
        removeWorkflow: (workflowId: string) => {
          unsubscribeFromWorkflowUpdates(workflowId);
+         releasePricingUnsubs(workflowId);
 
          const { nodeStores, openWorkflows, currentWorkflowId, notifiedAutosaveVersions } = get();
 
@@ -748,12 +832,22 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
          useStatusStore.getState().clearStatuses(workflowId);
          useExecutionTimeStore.getState().clearTimings(workflowId);
          usePropertyValidationStore.getState().clearWorkflow(workflowId);
+         useWorkflowRunsStore.getState().clearWorkflow(workflowId);
+         useWorkflowAssetStore.getState().clearWorkflowAssets(workflowId);
+         // Close the workflow's subgraph tabs (cleans up their NodeStores).
+         useSubgraphTabsStore.getState().closeForWorkflow(workflowId);
 
          const newOpenWorkflows = openWorkflows.filter(
            (w) => w.id !== workflowId
          );
          const newStores = { ...nodeStores };
          delete newStores[workflowId];
+         // Subgraph tab stores are registered under `${workflowId}:${nodeId}`.
+         for (const key of Object.keys(newStores)) {
+           if (key.startsWith(`${workflowId}:`)) {
+             delete newStores[key];
+           }
+         }
 
          const newNotified = { ...notifiedAutosaveVersions };
          delete newNotified[workflowId];
@@ -851,7 +945,27 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
       },
 
       // Fetches the workflow data by its ID, using QueryClient cache and adds the workflow store.
-      fetchWorkflow: async (workflowId: string) => {
+      // Pass { makeCurrent: false } for background loads (startup tab restore,
+      // sub-workflow lookups) so parallel fetches can't race to scramble the
+      // active tab.
+      fetchWorkflow: async (
+        workflowId: string,
+        options?: { makeCurrent?: boolean }
+      ) => {
+        const makeCurrent = options?.makeCurrent ?? true;
+        // Assets are non-critical to opening the workflow: log and continue
+        // instead of misreporting an asset failure as a workflow-load failure.
+        const loadAssetsNonFatal = async (id: string): Promise<void> => {
+          try {
+            await useWorkflowAssetStore.getState().loadWorkflowAssets(id);
+          } catch (err) {
+            console.warn(
+              `[WorkflowManager] Failed to load assets for workflow ${id}`,
+              err
+            );
+          }
+        };
+
         // If already have a NodeStore, just set current and ensure query cache is populated.
         const existing = get().getWorkflow(workflowId);
         if (existing) {
@@ -859,7 +973,9 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
             workflowQueryKey(workflowId),
             existing
           );
-          get().setCurrentWorkflowId(workflowId);
+          if (makeCurrent) {
+            get().setCurrentWorkflowId(workflowId);
+          }
           return existing;
         }
 
@@ -869,8 +985,10 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
         );
         if (cached) {
           get().addWorkflow(cached);
-          get().setCurrentWorkflowId(workflowId);
-          await useWorkflowAssetStore.getState().loadWorkflowAssets(workflowId);
+          if (makeCurrent) {
+            get().setCurrentWorkflowId(workflowId);
+          }
+          await loadAssetsNonFatal(workflowId);
           return cached;
         }
 
@@ -887,8 +1005,10 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
             return undefined;
           }
           get().addWorkflow(data);
-          get().setCurrentWorkflowId(data.id);
-          await useWorkflowAssetStore.getState().loadWorkflowAssets(data.id);
+          if (makeCurrent) {
+            get().setCurrentWorkflowId(data.id);
+          }
+          await loadAssetsNonFatal(data.id);
           return data;
         } catch (e: unknown) {
           if (isWorkflowNotFoundError(e)) {

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -130,6 +130,13 @@ export type WorkflowRunner = {
   edges: Edge[];
   job_id: string | null;
   /**
+   * True while the active run executes in-browser (kernel runner) rather than
+   * on the server. Browser runs don't hold a WebSocket connection, so the
+   * stuck-state recovery heuristic must not treat a closed socket as a sign
+   * the run died.
+   */
+  isBrowserRun: boolean;
+  /**
    * 1-based position in the backend's run queue while a run waits for a
    * concurrency slot, or null when not queued. Queued runs reuse the "running"
    * state (so existing busy/disabled logic applies); this field lets the UI
@@ -197,6 +204,7 @@ export const createWorkflowRunnerStore = (
     nodes: [],
     edges: [],
     job_id: null,
+    isBrowserRun: false,
     queuePosition: null,
     unsubscribe: null,
     state: "idle",
@@ -236,6 +244,7 @@ export const createWorkflowRunnerStore = (
         unsubscribe: null,
         state: "idle",
         job_id: null,
+        isBrowserRun: false,
         queuePosition: null,
         statusMessage: null,
         notifications: [],
@@ -380,24 +389,73 @@ export const createWorkflowRunnerStore = (
       // never received a terminal job_update (e.g. WS dropped, worker crashed).
       // Reset so the user can retry instead of getting permanently blocked.
       // "connecting" is mid-handshake, not stuck — only treat the
-      // post-handshake states as stuck candidates.
+      // post-handshake states as stuck candidates. Pure in-browser runs never
+      // hold a WS connection, so a closed socket is only a stuck signal for
+      // server runs.
       const stuck =
         busy &&
         currentState !== "connecting" &&
-        (!currentJobId || !wsConnected);
+        (!currentJobId || (!wsConnected && !get().isBrowserRun));
 
-      // Resolve auth once; both the active run and a queued submission need it.
+      const jobId = uuidv4();
+      const queueRun = busy && !stuck;
+
+      if (!queueRun) {
+        if (stuck) {
+          console.warn(
+            `WorkflowRunner[${workflowId}]: Recovering from stuck state`,
+            { currentState, currentJobId, wsConnected }
+          );
+        }
+
+        console.info(`WorkflowRunner[${workflowId}]: Starting workflow run`);
+
+        // Claim the run synchronously — before any `await` (auth/session
+        // resolution included) — so a concurrent run() sees us as busy (and
+        // queues), and the UI reflects the start immediately. Per-run state is
+        // keyed by jobId, so a fresh run starts on an empty slice; don't clear
+        // prior runs' node state (per-job keys mean a clear would erase a
+        // concurrently running sibling of this workflow).
+        set({
+          workflow,
+          nodes,
+          edges,
+          job_id: jobId,
+          isBrowserRun: false,
+          queuePosition: null,
+          statusMessage: "Workflow starting...",
+          notifications: [],
+          state: "connecting"
+        });
+      }
+
+      // Resolve auth after the claim; both the active run and a queued
+      // submission need it. On failure, release the claim so the runner
+      // doesn't stay stuck in "connecting" with a phantom job_id.
       let auth_token = "local_token";
       let user = "1";
       if (!isLocalhost) {
-        const {
-          data: { session }
-        } = await supabase.auth.getSession();
-        auth_token = session?.access_token || "";
-        user = session?.user?.id || "";
+        try {
+          const {
+            data: { session }
+          } = await supabase.auth.getSession();
+          auth_token = session?.access_token || "";
+          user = session?.user?.id || "";
+        } catch (error) {
+          if (!queueRun) {
+            set({
+              state: "error",
+              job_id: null,
+              statusMessage:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to resolve auth session"
+            });
+          }
+          throw error instanceof Error ? error : new Error(String(error));
+        }
       }
 
-      const jobId = uuidv4();
       const req = buildRunJobData({
         jobId,
         jobName: deriveJobTitle(workflow, nodes, subgraphNodeIds),
@@ -411,7 +469,7 @@ export const createWorkflowRunnerStore = (
         concurrent
       });
 
-      if (busy && !stuck) {
+      if (queueRun) {
         // A run is already in progress for this workflow. Submit this one to
         // the backend, which persists it as a "queued" job and starts it when
         // the current run finishes (one run per workflow). Leave the active
@@ -438,31 +496,6 @@ export const createWorkflowRunnerStore = (
         }
         return jobId;
       }
-      if (stuck) {
-        console.warn(
-          `WorkflowRunner[${workflowId}]: Recovering from stuck state`,
-          { currentState, currentJobId, wsConnected }
-        );
-        set({ state: "idle", job_id: null });
-      }
-
-      console.info(`WorkflowRunner[${workflowId}]: Starting workflow run`);
-
-      // Claim the run synchronously — before any `await` — so a concurrent
-      // run() sees us as busy (and queues), and the UI reflects the start
-      // immediately. Per-run state is keyed by jobId, so a fresh run starts on
-      // an empty slice; don't clear prior runs' node state (per-job keys mean a
-      // clear would erase a concurrently running sibling of this workflow).
-      set({
-        workflow,
-        nodes,
-        edges,
-        job_id: jobId,
-        queuePosition: null,
-        statusMessage: "Workflow starting...",
-        notifications: [],
-        state: "connecting"
-      });
 
       // Pure-browser graphs (every node declares browser-platform support) run
       // client-side with the kernel runner — no server round-trip. Their
@@ -506,7 +539,7 @@ export const createWorkflowRunnerStore = (
       }
 
       if (runsInBrowser) {
-        set({ state: "running" });
+        set({ state: "running", isBrowserRun: true });
         console.info(
           `WorkflowRunner[${workflowId}]: Running graph in-browser`,
           { jobId }
@@ -712,6 +745,7 @@ const defaultWorkflowRunner: WorkflowRunner = {
   nodes: [],
   edges: [],
   job_id: null,
+  isBrowserRun: false,
   queuePosition: null,
   unsubscribe: null,
   state: "idle",

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -38,7 +38,10 @@ export interface WorkspaceTab {
 export interface OpenTabInput {
   type: WorkspaceTabType;
   ref: string;
-  /** Defaults to "edit". */
+  /**
+   * New tabs default to "edit". For an existing tab the mode is only
+   * updated when one is explicitly given.
+   */
   mode?: WorkspaceTabMode;
   title?: string;
 }
@@ -143,7 +146,7 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
     (set, get) => ({
       ...seedTabsFromLegacy(),
 
-      openTab: ({ type, ref, mode = "edit", title }) => {
+      openTab: ({ type, ref, mode, title }) => {
         const id = tabId(type, ref);
         const existing = get().tabs.find((t) => t.id === id);
         if (existing) {
@@ -151,7 +154,7 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
             activeTabId: id,
             tabs: state.tabs.map((t) =>
               t.id === id
-                ? { ...t, mode, title: title ?? t.title }
+                ? { ...t, mode: mode ?? t.mode, title: title ?? t.title }
                 : t
             )
           }));
@@ -161,7 +164,7 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
           id,
           type,
           ref,
-          mode,
+          mode: mode ?? "edit",
           title: title ?? "Untitled"
         };
         set((state) => ({

--- a/web/src/stores/__tests__/AssetGridStore.test.ts
+++ b/web/src/stores/__tests__/AssetGridStore.test.ts
@@ -134,7 +134,7 @@ describe("AssetGridStore", () => {
       expect(useAssetGridStore.getState().selectedAssets).toEqual(assets);
     });
 
-    it("selects all filtered assets", () => {
+    it("selects all filtered assets and keeps selectedAssets in sync", () => {
       const assets = [
         createMockAsset("1"),
         createMockAsset("2"),
@@ -147,15 +147,51 @@ describe("AssetGridStore", () => {
       });
 
       expect(useAssetGridStore.getState().selectedAssetIds).toEqual(["1", "2", "3"]);
+      expect(useAssetGridStore.getState().selectedAssets).toEqual(assets);
     });
 
-    it("deselects all assets", () => {
+    it("deselects all assets and clears selectedAssets", () => {
+      const assets = [createMockAsset("1"), createMockAsset("2")];
+
       act(() => {
-        useAssetGridStore.getState().setSelectedAssetIds(["1", "2", "3"]);
+        useAssetGridStore.getState().setFilteredAssets(assets);
+        useAssetGridStore.getState().handleSelectAllAssets();
         useAssetGridStore.getState().handleDeselectAssets();
       });
 
       expect(useAssetGridStore.getState().selectedAssetIds).toEqual([]);
+      expect(useAssetGridStore.getState().selectedAssets).toEqual([]);
+    });
+
+    it("derives selectedAssets from filteredAssets in setSelectedAssetIds", () => {
+      const assets = [
+        createMockAsset("1"),
+        createMockAsset("2"),
+        createMockAsset("3")
+      ];
+
+      act(() => {
+        useAssetGridStore.getState().setFilteredAssets(assets);
+        useAssetGridStore.getState().setSelectedAssetIds(["1", "3"]);
+      });
+
+      expect(useAssetGridStore.getState().selectedAssets).toEqual([
+        assets[0],
+        assets[2]
+      ]);
+    });
+
+    it("clears selectedAssets when setSelectedAssetIds receives an empty list", () => {
+      const assets = [createMockAsset("1")];
+
+      act(() => {
+        useAssetGridStore.getState().setFilteredAssets(assets);
+        useAssetGridStore.getState().setSelectedAssetIds(["1"]);
+        useAssetGridStore.getState().setSelectedAssetIds([]);
+      });
+
+      expect(useAssetGridStore.getState().selectedAssetIds).toEqual([]);
+      expect(useAssetGridStore.getState().selectedAssets).toEqual([]);
     });
   });
 
@@ -180,7 +216,8 @@ describe("AssetGridStore", () => {
 
       const state = useAssetGridStore.getState();
       expect(state.currentFolder).toBeNull();
-      expect(state.currentFolderId).toBeUndefined();
+      expect(state.currentFolderId).toBeNull();
+      expect(state.parentFolder).toBeNull();
     });
 
     it("sets current folder by ID", () => {

--- a/web/src/stores/__tests__/AssetStore.test.ts
+++ b/web/src/stores/__tests__/AssetStore.test.ts
@@ -379,12 +379,46 @@ describe("AssetStore", () => {
 
       const { load } = useAssetStore.getState();
       const result = await load({
-        workflow_id: "test-workflow",
-        cursor: "test-cursor"
+        workflow_id: "test-workflow"
       });
 
       expect(listQuery).toHaveBeenCalledWith({ workflow_id: "test-workflow" });
       expect(result).toEqual(mockAssetList);
+    });
+
+    it("should route recursive queries to the recursive tRPC procedure", async () => {
+      const mockAssets = [
+        {
+          id: "asset1",
+          name: "nested.jpg",
+          content_type: "image/jpeg",
+          size: 1024,
+          created_at: "2023-01-01T00:00:00Z",
+          parent_id: "folder1",
+          user_id: "test-user",
+          get_url: "/assets/asset1",
+          workflow_id: null,
+          thumb_url: null,
+          metadata: {}
+        }
+      ];
+      recursiveQuery.mockResolvedValueOnce({ assets: mockAssets });
+
+      const { load } = useAssetStore.getState();
+      const result = await load({ parent_id: "folder1", recursive: true });
+
+      expect(recursiveQuery).toHaveBeenCalledWith({ id: "folder1" });
+      expect(listQuery).not.toHaveBeenCalled();
+      expect(result).toEqual({ next: null, assets: mockAssets });
+    });
+
+    it("should reject recursive queries without a parent_id", async () => {
+      const { load } = useAssetStore.getState();
+      await expect(load({ recursive: true })).rejects.toThrow(
+        "Recursive asset queries require a parent_id"
+      );
+      expect(recursiveQuery).not.toHaveBeenCalled();
+      expect(listQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/stores/__tests__/AudioQueueStore.test.ts
+++ b/web/src/stores/__tests__/AudioQueueStore.test.ts
@@ -82,7 +82,7 @@ describe("AudioQueueStore", () => {
   });
 
   describe("dequeue", () => {
-    it("clears current playing item without auto-playing next", () => {
+    it("promotes the next queued item when the playing item is dequeued", () => {
       const onPlay1 = jest.fn();
       const onStop1 = jest.fn();
       const item1 = { id: "audio1", onPlay: onPlay1, onStop: onStop1 };
@@ -97,11 +97,26 @@ describe("AudioQueueStore", () => {
         useAudioQueue.getState().dequeue("audio1");
       });
 
-      // Dequeue clears current without auto-playing next
+      // The next queued item is promoted and starts playing
+      expect(onPlay2).toHaveBeenCalledTimes(1);
+      expect(useAudioQueue.getState().currentPlayingId).toBe("audio2");
+      expect(useAudioQueue.getState().currentItem?.id).toBe("audio2");
+      expect(useAudioQueue.getState().queue).toHaveLength(0);
+    });
+
+    it("clears current playback when dequeueing the playing item with empty queue", () => {
+      const onPlay1 = jest.fn();
+      const onStop1 = jest.fn();
+      const item1 = { id: "audio1", onPlay: onPlay1, onStop: onStop1 };
+
+      act(() => {
+        useAudioQueue.getState().enqueue(item1);
+        useAudioQueue.getState().dequeue("audio1");
+      });
+
       expect(useAudioQueue.getState().currentPlayingId).toBeNull();
-      // The queue still contains the next item
-      expect(useAudioQueue.getState().queue).toHaveLength(1);
-      expect(useAudioQueue.getState().queue[0].id).toBe("audio2");
+      expect(useAudioQueue.getState().currentItem).toBeNull();
+      expect(useAudioQueue.getState().queue).toHaveLength(0);
     });
 
     it("removes item from queue without affecting current playback", () => {
@@ -182,7 +197,12 @@ describe("AudioQueueStore", () => {
         useAudioQueue.getState().stopAll();
       });
 
+      // The currently playing item is actually stopped
+      expect(onStop1).toHaveBeenCalledTimes(1);
+      // Queued (never-played) items don't get onStop
+      expect(onStop2).not.toHaveBeenCalled();
       expect(useAudioQueue.getState().currentPlayingId).toBeNull();
+      expect(useAudioQueue.getState().currentItem).toBeNull();
       expect(useAudioQueue.getState().queue).toHaveLength(0);
     });
 

--- a/web/src/stores/__tests__/CollectionStore.test.ts
+++ b/web/src/stores/__tests__/CollectionStore.test.ts
@@ -316,6 +316,54 @@ describe("CollectionStore", () => {
       ]);
     });
 
+    it("stale overlapping drop does not clobber the newer drop's progress", async () => {
+      const eventA = {
+        preventDefault: jest.fn(),
+        dataTransfer: {
+          files: [new File(["a"], "a.txt", { type: "text/plain" })]
+        }
+      } as unknown as React.DragEvent<HTMLDivElement>;
+      const eventB = {
+        preventDefault: jest.fn(),
+        dataTransfer: {
+          files: [new File(["b"], "b.txt", { type: "text/plain" })]
+        }
+      } as unknown as React.DragEvent<HTMLDivElement>;
+
+      const okResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({ path: "/ok" })
+      };
+      let resolveUploadA: (value: typeof okResponse) => void = () => {};
+      mockRestFetch
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveUploadA = resolve;
+            })
+        )
+        .mockResolvedValue(okResponse);
+      listQuery.mockResolvedValue({ collections: [], count: 0 });
+
+      // Drop A starts and hangs on its upload.
+      const dropA = useCollectionStore.getState().handleDrop("colA")(eventA);
+      // Drop B starts later and finishes first — it owns the progress state.
+      await act(async () => {
+        await useCollectionStore.getState().handleDrop("colB")(eventB);
+      });
+
+      expect(useCollectionStore.getState().indexProgress).toBeNull();
+
+      // The stale drop A finishes afterwards; it must not write progress.
+      await act(async () => {
+        resolveUploadA(okResponse);
+        await dropA;
+      });
+
+      expect(useCollectionStore.getState().indexProgress).toBeNull();
+      expect(useCollectionStore.getState().indexErrors).toEqual([]);
+    });
+
     it("returns early when no files dropped", async () => {
       const event = {
         preventDefault: jest.fn(),

--- a/web/src/stores/__tests__/ColorPickerStore.test.ts
+++ b/web/src/stores/__tests__/ColorPickerStore.test.ts
@@ -234,6 +234,24 @@ describe("gradientToCss", () => {
     const css = gradientToCss(gradient);
     expect(css).toBe("linear-gradient(90deg, #ff0000 0%, #0000ff 100%)");
   });
+
+  it("does not mutate the input gradient's stops", () => {
+    const gradient: GradientValue = {
+      type: "linear",
+      angle: 90,
+      stops: [
+        { color: "#0000ff", position: 100 },
+        { color: "#ff0000", position: 0 }
+      ]
+    };
+
+    gradientToCss(gradient);
+
+    expect(gradient.stops).toEqual([
+      { color: "#0000ff", position: 100 },
+      { color: "#ff0000", position: 0 }
+    ]);
+  });
 });
 
 describe("PRESET_PALETTES", () => {

--- a/web/src/stores/__tests__/ResultsStore.test.ts
+++ b/web/src/stores/__tests__/ResultsStore.test.ts
@@ -317,5 +317,54 @@ describe("ResultsStore", () => {
       expect(useResultsStore.getState().getProviderCost(workflowId1, jobId1, nodeId2)).toBeUndefined();
       expect(useResultsStore.getState().getProviderCost(workflowId1, jobId1, "node-3")).toEqual(cost("c"));
     });
+
+    it("clearResults purges every per-node map for the node", () => {
+      const store = useResultsStore.getState();
+      const task: Task = {
+        type: "task",
+        id: "t1",
+        title: "task",
+        description: "",
+        steps: []
+      };
+      const toolCall: ToolCallUpdate = {
+        type: "tool_call_update",
+        name: "tool",
+        args: {},
+        message: "calling"
+      };
+      const planningUpdate: PlanningUpdate = {
+        type: "planning_update",
+        phase: "planning",
+        status: "in_progress",
+        content: "plan"
+      };
+
+      store.setProviderCost(workflowId1, jobId1, nodeId1, cost("a"));
+      store.setOutputResult(workflowId1, jobId1, nodeId1, "out");
+      store.setProgress(workflowId1, jobId1, nodeId1, 50, 100);
+      store.addChunk(workflowId1, jobId1, nodeId1, "chunk");
+      store.setTask(workflowId1, jobId1, nodeId1, task);
+      store.setToolCall(workflowId1, jobId1, nodeId1, toolCall);
+      store.appendToolResult(workflowId1, jobId1, nodeId1, "tool-out");
+      store.setPlanningUpdate(workflowId1, jobId1, nodeId1, planningUpdate);
+      store.upsertLiveGeneration(workflowId1, nodeId1, jobId1, { status: "running" });
+      // Same node id in another workflow must survive.
+      store.setOutputResult(workflowId2, jobId1, nodeId1, "other-out");
+
+      useResultsStore.getState().clearResults(workflowId1, new Set([nodeId1]));
+
+      const state = useResultsStore.getState();
+      expect(state.getProviderCost(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getOutputResult(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getProgress(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getChunk(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getTask(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getToolCall(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getToolResults(workflowId1, jobId1, nodeId1)).toEqual([]);
+      expect(state.getPlanningUpdate(workflowId1, jobId1, nodeId1)).toBeUndefined();
+      expect(state.getLiveGenerations(workflowId1, nodeId1)).toEqual([]);
+      expect(state.getOutputResult(workflowId2, jobId1, nodeId1)).toBe("other-out");
+    });
   });
 });

--- a/web/src/stores/__tests__/RightPanelStore.test.ts
+++ b/web/src/stores/__tests__/RightPanelStore.test.ts
@@ -108,6 +108,49 @@ describe("RightPanelStore", () => {
     });
   });
 
+  describe("setVisibility", () => {
+    it("restores the panel to the usable minimum when reopening from a collapsed sliver", () => {
+      const { closePanel, setVisibility } = useRightPanelStore.getState();
+
+      act(() => {
+        // Drag-collapse persists panelSize: 60 (MIN_DRAG_SIZE) and hides.
+        closePanel();
+        setVisibility(true);
+      });
+
+      const { panel } = useRightPanelStore.getState();
+      expect(panel.isVisible).toBe(true);
+      expect(panel.panelSize).toBe(250);
+    });
+
+    it("keeps the current size when reopening with a usable size", () => {
+      const { setSize, setVisibility } = useRightPanelStore.getState();
+
+      act(() => {
+        setSize(400);
+        setVisibility(false);
+        setVisibility(true);
+      });
+
+      const { panel } = useRightPanelStore.getState();
+      expect(panel.isVisible).toBe(true);
+      expect(panel.panelSize).toBe(400);
+    });
+
+    it("does not resize when hiding the panel", () => {
+      const { setSize, setVisibility } = useRightPanelStore.getState();
+
+      act(() => {
+        setSize(60);
+        setVisibility(false);
+      });
+
+      const { panel } = useRightPanelStore.getState();
+      expect(panel.isVisible).toBe(false);
+      expect(panel.panelSize).toBe(60);
+    });
+  });
+
   describe("closePanel", () => {
     it("closes panel and sets size to minimum", () => {
       const { closePanel, setVisibility, setSize } = useRightPanelStore.getState();

--- a/web/src/stores/__tests__/VibeCodingStore.test.ts
+++ b/web/src/stores/__tests__/VibeCodingStore.test.ts
@@ -67,6 +67,81 @@ describe("VibeCodingStore", () => {
       expect(session.savedHtml).toBeNull();
       expect(session.currentHtml).toBeNull();
     });
+
+    it("preserves unsaved currentHtml and messages on re-init (rehydrated session)", () => {
+      const message: Message = {
+        type: "message",
+        role: "user",
+        name: "",
+        content: [{ type: "text", text: "Make it blue" }],
+        created_at: new Date().toISOString()
+      };
+
+      act(() => {
+        useVibeCodingStore.getState().initSession("workflow1", "<html>saved</html>");
+        useVibeCodingStore.getState().addMessage("workflow1", message);
+        useVibeCodingStore.getState().setCurrentHtml("workflow1", "<html>unsaved</html>");
+        // Panel remounts and re-inits with the workflow's html_app.
+        useVibeCodingStore.getState().initSession("workflow1", "<html>saved</html>");
+      });
+
+      const session = useVibeCodingStore.getState().getSession("workflow1");
+      expect(session.currentHtml).toBe("<html>unsaved</html>");
+      expect(session.savedHtml).toBe("<html>saved</html>");
+      expect(session.messages).toHaveLength(1);
+      expect(useVibeCodingStore.getState().isDirty("workflow1")).toBe(true);
+    });
+
+    it("keeps chat history after a save (html_app catches up to currentHtml)", () => {
+      const message: Message = {
+        type: "message",
+        role: "assistant",
+        name: "",
+        content: [{ type: "text", text: "Done" }],
+        created_at: new Date().toISOString()
+      };
+
+      act(() => {
+        useVibeCodingStore.getState().initSession("workflow1", "<html>v1</html>");
+        useVibeCodingStore.getState().addMessage("workflow1", message);
+        useVibeCodingStore.getState().setCurrentHtml("workflow1", "<html>v2</html>");
+        // Save: setSavedHtml syncs both, then the workflow refetch triggers
+        // initSession with the new html_app.
+        useVibeCodingStore.getState().setSavedHtml("workflow1", "<html>v2</html>");
+        useVibeCodingStore.getState().initSession("workflow1", "<html>v2</html>");
+      });
+
+      const session = useVibeCodingStore.getState().getSession("workflow1");
+      expect(session.messages).toHaveLength(1);
+      expect(session.currentHtml).toBe("<html>v2</html>");
+      expect(session.savedHtml).toBe("<html>v2</html>");
+      expect(useVibeCodingStore.getState().isDirty("workflow1")).toBe(false);
+    });
+
+    it("syncs currentHtml to a changed savedHtml when the session is clean", () => {
+      act(() => {
+        useVibeCodingStore.getState().initSession("workflow1", "<html>old</html>");
+        // html_app changed externally; no local edits.
+        useVibeCodingStore.getState().initSession("workflow1", "<html>new</html>");
+      });
+
+      const session = useVibeCodingStore.getState().getSession("workflow1");
+      expect(session.savedHtml).toBe("<html>new</html>");
+      expect(session.currentHtml).toBe("<html>new</html>");
+    });
+
+    it("resets stale transient status/error on re-init", () => {
+      act(() => {
+        useVibeCodingStore.getState().initSession("workflow1", "<html>v1</html>");
+        useVibeCodingStore.getState().setStatus("workflow1", "streaming");
+        useVibeCodingStore.getState().setError("workflow1", "boom");
+        useVibeCodingStore.getState().initSession("workflow1", "<html>v1</html>");
+      });
+
+      const session = useVibeCodingStore.getState().getSession("workflow1");
+      expect(session.status).toBe("idle");
+      expect(session.error).toBeNull();
+    });
   });
 
   describe("clearSession", () => {

--- a/web/src/stores/__tests__/WorkflowRunner.test.ts
+++ b/web/src/stores/__tests__/WorkflowRunner.test.ts
@@ -357,6 +357,50 @@ describe("WorkflowRunner", () => {
       );
     });
 
+    it("claims the run synchronously so an immediate second run() queues", () => {
+      // The claim (job_id + state "connecting") must land before any await so
+      // a concurrent run() can't also see "idle" and clobber the first claim.
+      const promise = store.getState().run({}, testWorkflow, [], []);
+      expect(store.getState().state).toBe("connecting");
+      expect(store.getState().job_id).toBe("test-job-id-123");
+      return promise;
+    });
+
+    it("does not treat a live in-browser run as stuck when the socket is closed", async () => {
+      (globalWebSocketManager.isConnectionOpen as jest.Mock).mockReturnValueOnce(
+        false
+      );
+      store.setState({
+        state: "running",
+        job_id: "job-browser",
+        isBrowserRun: true
+      });
+
+      await store.getState().run({}, testWorkflow, [], []);
+
+      // The new run is queued behind the browser run instead of hijacking it.
+      expect(store.getState().job_id).toBe("job-browser");
+      expect(store.getState().state).toBe("running");
+      expect(globalWebSocketManager.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers a stuck server run when the socket is closed", async () => {
+      (globalWebSocketManager.isConnectionOpen as jest.Mock).mockReturnValueOnce(
+        false
+      );
+      store.setState({
+        state: "running",
+        job_id: "job-server",
+        isBrowserRun: false
+      });
+      (uuidv4 as jest.Mock).mockReturnValueOnce("job-recovered");
+
+      const jobId = await store.getState().run({}, testWorkflow, [], []);
+
+      expect(jobId).toBe("job-recovered");
+      expect(store.getState().job_id).toBe("job-recovered");
+    });
+
     it("allows starting a new run after state returns to idle", async () => {
       await store.getState().run({}, testWorkflow, [], []);
       expect(globalWebSocketManager.send).toHaveBeenCalledTimes(1);

--- a/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
+++ b/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
@@ -82,6 +82,18 @@ describe("openTab", () => {
       title: "Flow 1" // preserved when reopened without a title
     });
   });
+
+  it("preserves an existing tab's mode when reopened without a mode", () => {
+    const store = useWorkspaceTabsStore.getState();
+    store.openTab({ type: "workflow", ref: "wf1", mode: "view" });
+    store.openTab({ type: "image", ref: "img1" });
+    // Refocus without specifying a mode — must NOT flip back to "edit".
+    store.openTab({ type: "workflow", ref: "wf1" });
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.activeTabId).toBe("workflow:wf1");
+    expect(state.getActiveTab()).toMatchObject({ mode: "view" });
+  });
 });
 
 describe("mode", () => {

--- a/web/src/stores/__tests__/workflowUpdates.trace.test.ts
+++ b/web/src/stores/__tests__/workflowUpdates.trace.test.ts
@@ -98,6 +98,43 @@ describe("handleUpdate → TraceStore wiring", () => {
     });
   });
 
+  it("tracks trace runs per workflow so concurrent runs don't restart each other's trace", () => {
+    const wfA = { id: "wf-a", name: "A" } as WorkflowAttributes;
+    const wfB = { id: "wf-b", name: "B" } as WorkflowAttributes;
+    const runnerA = makeRunner("job-a");
+    const runnerB = makeRunner("job-b");
+
+    const runningUpdate = (jobId: string) =>
+      ({ type: "job_update", status: "running", job_id: jobId }) as never;
+
+    handleUpdate(wfA, runningUpdate("job-a"), runnerA as never, () => undefined);
+    handleUpdate(wfB, runningUpdate("job-b"), runnerB as never, () => undefined);
+
+    // Record an event, then deliver more running heartbeats for both jobs.
+    // With a shared (non-per-workflow) trace job id, each alternating
+    // heartbeat would call startRun again and wipe the recorded events.
+    handleUpdate(
+      wfA,
+      {
+        type: "llm_call",
+        node_id: "agent-1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        messages: [],
+        response: "",
+        duration_ms: 1,
+        timestamp: new Date().toISOString()
+      } as never,
+      runnerA as never,
+      () => undefined
+    );
+    handleUpdate(wfA, runningUpdate("job-a"), runnerA as never, () => undefined);
+    handleUpdate(wfB, runningUpdate("job-b"), runnerB as never, () => undefined);
+
+    expect(useTraceStore.getState().events).toHaveLength(1);
+    expect(useTraceStore.getState().isRecording).toBe(true);
+  });
+
   it("does not record events when no run is active", () => {
     // store cleared in beforeEach → isRecording is false
     const runner = makeRunner("job-1");

--- a/web/src/stores/customEquality.ts
+++ b/web/src/stores/customEquality.ts
@@ -19,7 +19,10 @@ function compareNode(a: Node<NodeData>, b: Node<NodeData>): boolean {
     a.type === b.type &&
     a.data.collapsed === b.data.collapsed &&
     a.data.bypassed === b.data.bypassed &&
+    a.data.title === b.data.title &&
     shallow(a.data.properties, b.data.properties) &&
+    shallow(a.data.dynamic_properties, b.data.dynamic_properties) &&
+    shallow(a.data.dynamic_outputs, b.data.dynamic_outputs) &&
     a.position.x === b.position.x &&
     a.position.y === b.position.y
   );

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -70,10 +70,13 @@ type WorkflowSubscription = {
 
 const workflowSubscriptions = new Map<string, WorkflowSubscription>();
 
-// The job_id whose run is currently being recorded into the TraceStore. Used to
-// call startRun() exactly once per run (startRun clears prior events), so the
-// trace panel shows a fresh timeline per execution rather than accumulating.
-let traceRunJobId: string | null = null;
+// Per-workflow job_id whose run is currently being recorded into the
+// TraceStore. Used to call startRun() exactly once per run (startRun clears
+// prior events), so the trace panel shows a fresh timeline per execution
+// rather than accumulating. Keyed by workflow id so concurrent runs of
+// different workflows don't ping-pong a shared id and repeatedly wipe the
+// trace timeline.
+const traceRunJobIds = new Map<string, string | null>();
 
 /**
  * Append one event to the global TraceStore (the LLM/agent debug timeline shown
@@ -230,6 +233,7 @@ export const subscribeToWorkflowUpdates = (
         unsubscribeJob = null;
       }
       workflowSubscriptions.delete(workflowId);
+      traceRunJobIds.delete(workflowId);
     }
   });
 
@@ -481,8 +485,12 @@ export const handleUpdate = (
       // Begin a fresh LLM/agent trace timeline for the runner's own run. Guarded
       // by job_id so startRun (which clears prior events) fires once per run, not
       // on every running/queued heartbeat.
-      if (isRunnerJob && job.job_id !== traceRunJobId) {
-        traceRunJobId = job.job_id ?? null;
+      const incomingTraceJobId = job.job_id ?? null;
+      if (
+        isRunnerJob &&
+        incomingTraceJobId !== traceRunJobIds.get(workflow.id)
+      ) {
+        traceRunJobIds.set(workflow.id, incomingTraceJobId);
         useTraceStore.getState().startRun(new Date().toISOString());
       }
     } else if (job.status === "suspended") {

--- a/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
+++ b/web/src/utils/__tests__/fetchLiveFalPricing.test.ts
@@ -8,16 +8,17 @@ beforeEach(() => {
 });
 
 describe("fetchLiveFalPricing", () => {
-  it("returns false for empty endpointIds", async () => {
+  it("returns null for empty endpointIds", async () => {
     const result = await fetchLiveFalPricing({}, []);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("fetches with correct URL and updates metadata", async () => {
+  it("fetches with correct URL and returns updated pricing without mutating input", async () => {
+    const originalPricing = { endpoint_id: "fal-ai/fast-sdxl" };
     const metadataByType: Record<string, any> = {
       "fal.FastSDXL": {
-        fal_unit_pricing: { endpoint_id: "fal-ai/fast-sdxl" }
+        fal_unit_pricing: originalPricing
       }
     };
 
@@ -41,21 +42,30 @@ describe("fetchLiveFalPricing", () => {
       "fal-ai/fast-sdxl"
     ]);
 
-    expect(result).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
       `${window.location.origin}/api/fal/pricing?endpoint_id=fal-ai%2Ffast-sdxl`
     );
+    expect(result).toEqual({
+      "fal.FastSDXL": {
+        endpoint_id: "fal-ai/fast-sdxl",
+        unit_price: 0.02,
+        billing_unit: "image",
+        currency: "usd",
+        source: "live",
+        checked_at: "2026-01-20T00:00:00Z"
+      }
+    });
+    // The input metadata is left untouched — callers merge the returned
+    // pricing into NEW metadata objects so per-node selectors re-render.
+    expect(metadataByType["fal.FastSDXL"].fal_unit_pricing).toBe(
+      originalPricing
+    );
     expect(metadataByType["fal.FastSDXL"].fal_unit_pricing).toEqual({
-      endpoint_id: "fal-ai/fast-sdxl",
-      unit_price: 0.02,
-      billing_unit: "image",
-      currency: "usd",
-      source: "live",
-      checked_at: "2026-01-20T00:00:00Z"
+      endpoint_id: "fal-ai/fast-sdxl"
     });
   });
 
-  it("returns false when no matching entries", async () => {
+  it("returns null when no matching entries", async () => {
     const metadataByType: Record<string, any> = {
       "fal.FastSDXL": {
         fal_unit_pricing: { endpoint_id: "fal-ai/fast-sdxl" }
@@ -81,33 +91,33 @@ describe("fetchLiveFalPricing", () => {
     const result = await fetchLiveFalPricing(metadataByType, [
       "fal-ai/fast-sdxl"
     ]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returns false on fetch error", async () => {
+  it("returns null on fetch error", async () => {
     mockFetch.mockRejectedValue(new Error("Network error"));
 
     const result = await fetchLiveFalPricing({}, ["fal-ai/fast-sdxl"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returns false on non-ok response", async () => {
+  it("returns null on non-ok response", async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 500
     });
 
     const result = await fetchLiveFalPricing({}, ["fal-ai/fast-sdxl"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returns false on 204 response", async () => {
+  it("returns null on 204 response", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 204
     });
 
     const result = await fetchLiveFalPricing({}, ["fal-ai/fast-sdxl"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 });

--- a/web/src/utils/__tests__/fetchLiveKiePricing.test.ts
+++ b/web/src/utils/__tests__/fetchLiveKiePricing.test.ts
@@ -8,16 +8,17 @@ beforeEach(() => {
 });
 
 describe("fetchLiveKiePricing", () => {
-  it("returns false for empty modelIds", async () => {
+  it("returns null for empty modelIds", async () => {
     const result = await fetchLiveKiePricing({}, []);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("fetches with correct URL and updates metadata", async () => {
+  it("fetches with correct URL and returns updated pricing without mutating input", async () => {
+    const originalPricing = { model_id: "kie-ai/fast-gen" };
     const metadataByType: Record<string, any> = {
       "kie.FastGen": {
-        kie_unit_pricing: { model_id: "kie-ai/fast-gen" }
+        kie_unit_pricing: originalPricing
       }
     };
 
@@ -44,24 +45,33 @@ describe("fetchLiveKiePricing", () => {
       "kie-ai/fast-gen"
     ]);
 
-    expect(result).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
       `${window.location.origin}/api/kie/pricing?model_id=kie-ai%2Ffast-gen`
     );
+    expect(result).toEqual({
+      "kie.FastGen": {
+        model_id: "kie-ai/fast-gen",
+        unit_price: 8,
+        billing_unit: "image",
+        currency: "credits",
+        usd_price: 0.08,
+        tier_count: 3,
+        pricing_url: "https://kie.ai/pricing",
+        source: "live",
+        checked_at: "2026-02-20T00:00:00Z"
+      }
+    });
+    // The input metadata is left untouched — callers merge the returned
+    // pricing into NEW metadata objects so per-node selectors re-render.
+    expect(metadataByType["kie.FastGen"].kie_unit_pricing).toBe(
+      originalPricing
+    );
     expect(metadataByType["kie.FastGen"].kie_unit_pricing).toEqual({
-      model_id: "kie-ai/fast-gen",
-      unit_price: 8,
-      billing_unit: "image",
-      currency: "credits",
-      usd_price: 0.08,
-      tier_count: 3,
-      pricing_url: "https://kie.ai/pricing",
-      source: "live",
-      checked_at: "2026-02-20T00:00:00Z"
+      model_id: "kie-ai/fast-gen"
     });
   });
 
-  it("returns false when no matching entries in response", async () => {
+  it("returns null when no matching entries in response", async () => {
     const metadataByType: Record<string, any> = {
       "kie.FastGen": {
         kie_unit_pricing: { model_id: "kie-ai/fast-gen" }
@@ -87,36 +97,36 @@ describe("fetchLiveKiePricing", () => {
     const result = await fetchLiveKiePricing(metadataByType, [
       "kie-ai/fast-gen"
     ]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returns false on fetch error", async () => {
+  it("returns null on fetch error", async () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     mockFetch.mockRejectedValue(new Error("Network error"));
 
     const result = await fetchLiveKiePricing({}, ["kie-ai/fast-gen"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     spy.mockRestore();
   });
 
-  it("returns false on non-ok response", async () => {
+  it("returns null on non-ok response", async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 500
     });
 
     const result = await fetchLiveKiePricing({}, ["kie-ai/fast-gen"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returns false when response has no byModelId", async () => {
+  it("returns null when response has no byModelId", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ fetched_at: "2026-02-20T00:00:00Z" })
     });
 
     const result = await fetchLiveKiePricing({}, ["kie-ai/fast-gen"]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
   it("skips metadata entries without existing kie_unit_pricing", async () => {
@@ -143,7 +153,7 @@ describe("fetchLiveKiePricing", () => {
     const result = await fetchLiveKiePricing(metadataByType, [
       "kie-ai/fast-gen"
     ]);
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     expect(metadataByType["kie.NoPricing"].kie_unit_pricing).toBeUndefined();
   });
 

--- a/web/src/utils/fetchLiveFalPricing.ts
+++ b/web/src/utils/fetchLiveFalPricing.ts
@@ -1,4 +1,4 @@
-import type { NodeMetadata } from "../stores/ApiTypes";
+import type { FalUnitPricing, NodeMetadata } from "../stores/ApiTypes";
 
 interface LivePricingResponse {
   byEndpointId: Record<string, { unit_price: number; billing_unit: string; currency: string }>;
@@ -7,14 +7,16 @@ interface LivePricingResponse {
 
 /**
  * Fetches live FAL unit prices for a specific set of endpoint IDs.
- * Merges results into metadataByType in place, marking them source: "live".
- * Returns true if any entries were updated (caller should re-set store state).
+ * Does NOT mutate `metadataByType`; instead returns a map of node type →
+ * fresh `fal_unit_pricing` (marked source: "live") for the entries that were
+ * updated, or null when nothing changed. The caller merges these into new
+ * metadata objects so per-node selectors re-render.
  */
 export async function fetchLiveFalPricing(
   metadataByType: Record<string, NodeMetadata>,
   endpointIds: string[],
-): Promise<boolean> {
-  if (endpointIds.length === 0) return false;
+): Promise<Record<string, FalUnitPricing> | null> {
+  if (endpointIds.length === 0) return null;
 
   const url = new URL("/api/fal/pricing", window.location.origin);
   for (const id of endpointIds) url.searchParams.append("endpoint_id", id);
@@ -22,21 +24,22 @@ export async function fetchLiveFalPricing(
   let data: LivePricingResponse;
   try {
     const res = await fetch(url.toString());
-    if (!res.ok || res.status === 204) return false;
+    if (!res.ok || res.status === 204) return null;
     data = (await res.json()) as LivePricingResponse;
-    if (!data.byEndpointId) return false;
+    if (!data.byEndpointId) return null;
   } catch (err) {
     console.error("[fal-pricing] fetch error:", err);
-    return false;
+    return null;
   }
 
-  let updated = 0;
-  for (const md of Object.values(metadataByType)) {
+  const updated: Record<string, FalUnitPricing> = {};
+  let updatedCount = 0;
+  for (const [nodeType, md] of Object.entries(metadataByType)) {
     const existing = md.fal_unit_pricing;
     if (!existing) continue;
     const fresh = data.byEndpointId[existing.endpoint_id];
     if (!fresh) continue;
-    md.fal_unit_pricing = {
+    updated[nodeType] = {
       endpoint_id: existing.endpoint_id,
       unit_price: fresh.unit_price,
       billing_unit: fresh.billing_unit,
@@ -44,7 +47,7 @@ export async function fetchLiveFalPricing(
       source: "live",
       checked_at: data.fetched_at,
     };
-    updated++;
+    updatedCount++;
   }
-  return updated > 0;
+  return updatedCount > 0 ? updated : null;
 }

--- a/web/src/utils/fetchLiveKiePricing.ts
+++ b/web/src/utils/fetchLiveKiePricing.ts
@@ -1,4 +1,4 @@
-import type { NodeMetadata } from "../stores/ApiTypes";
+import type { KieUnitPricing, NodeMetadata } from "../stores/ApiTypes";
 
 interface LiveKiePricingResponse {
   byModelId: Record<
@@ -17,14 +17,18 @@ interface LiveKiePricingResponse {
 }
 
 /**
- * Fetches live kie.ai list prices for specific model IDs and merges into metadata.
+ * Fetches live kie.ai list prices for specific model IDs.
+ * Does NOT mutate `metadataByType`; instead returns a map of node type →
+ * fresh `kie_unit_pricing` (marked source: "live") for the entries that were
+ * updated, or null when nothing changed. The caller merges these into new
+ * metadata objects so per-node selectors re-render.
  */
 export async function fetchLiveKiePricing(
   metadataByType: Record<string, NodeMetadata>,
   modelIds: string[],
-): Promise<boolean> {
+): Promise<Record<string, KieUnitPricing> | null> {
   if (modelIds.length === 0) {
-    return false;
+    return null;
   }
 
   const url = new URL("/api/kie/pricing", window.location.origin);
@@ -36,19 +40,20 @@ export async function fetchLiveKiePricing(
   try {
     const res = await fetch(url.toString());
     if (!res.ok) {
-      return false;
+      return null;
     }
     data = (await res.json()) as LiveKiePricingResponse;
     if (!data.byModelId) {
-      return false;
+      return null;
     }
   } catch (err) {
     console.error("[kie-pricing] fetch error:", err);
-    return false;
+    return null;
   }
 
-  let updated = 0;
-  for (const md of Object.values(metadataByType)) {
+  const updated: Record<string, KieUnitPricing> = {};
+  let updatedCount = 0;
+  for (const [nodeType, md] of Object.entries(metadataByType)) {
     const existing = md.kie_unit_pricing;
     if (!existing) {
       continue;
@@ -57,7 +62,7 @@ export async function fetchLiveKiePricing(
     if (!fresh) {
       continue;
     }
-    md.kie_unit_pricing = {
+    updated[nodeType] = {
       model_id: fresh.model_id,
       unit_price: fresh.unit_price,
       billing_unit: fresh.billing_unit,
@@ -68,7 +73,7 @@ export async function fetchLiveKiePricing(
       source: "live",
       checked_at: data.fetched_at,
     };
-    updated++;
+    updatedCount++;
   }
-  return updated > 0;
+  return updatedCount > 0 ? updated : null;
 }


### PR DESCRIPTION
Editor graph (NodeStore, customEquality):
- onEdgeUpdate never set edgeUpdateSuccessful, so every edge
  reconnection drag was deleted by onEdgeUpdateEnd; also treat dropping
  an edge back on its original handle as a no-op instead of a delete
- updateNodeData now marks the workflow dirty (renames, comments,
  dynamic properties were skipped by autosave and unload saves)
- compareNode now compares title, dynamic_properties and
  dynamic_outputs so those edits create undo snapshots
- deleteNodes no longer checks DOM focus (the keyboard path already
  guards via KeyPressedStore), unblocking ui_delete_node and
  group-into-subgraph while inputs are focused
- autoLayout merges positions into current state instead of restoring a
  pre-await snapshot; addNode no longer mutates the caller's node

Workflow lifecycle (WorkflowManagerStore, WorkflowRunner,
workflowUpdates, WorkspaceTabsStore, VibeCodingStore):
- saveWorkflow only clears the dirty flag and overwrites workflow
  attributes when nothing changed during the in-flight save
- removeWorkflow now clears WorkflowRunsStore, WorkflowAssetStore,
  subgraph tabs (with NodeStore cleanup) and their nodeStores entries
- fal/kie pricing: re-read metadata after fetch instead of clobbering
  with a stale snapshot, clone entries instead of mutating in place,
  and release the fallback metadata subscription
- fetchWorkflow accepts makeCurrent so startup restore and sub-workflow
  loads don't race to steal the active tab; asset load failures no
  longer abort or misreport workflow loads
- WorkflowRunner.run claims the run synchronously before the auth
  await; browser runs are no longer misdetected as stuck
- traceRunJobId is per-workflow so concurrent runs stop wiping traces
- openTab only updates an existing tab's mode when one is given
- VibeCoding initSession preserves existing sessions so persisted
  unsaved work and chat history survive panel remounts and saves

Chat (GlobalChatStore):
- per-thread in-flight load dedupe (rapid thread switches no longer
  show stale/empty conversations)
- fetchThreads merges server threads instead of wiping optimistic local
  threads whose streamed chunks were then dropped
- connect() is concurrency-guarded and clears dead WS handler arrays so
  failed connects can't strand threads without stream handlers

Assets/audio/misc:
- AudioQueueStore tracks the playing item: stopAll actually stops it
  and dequeue promotes the next item instead of stalling the queue
- AssetStore routes recursive queries to assets.recursive and drops the
  never-forwarded cursor param; AssetGrid selection ids/objects stay in
  sync; CollectionStore drop progress is token-guarded against
  overlapping drops; gradientToCss no longer sorts stops in place
- ResultsStore.clearResults purges all per-node maps, not 3 of 9
- RightPanel setVisibility restores a usable width after drag-collapse
- RemoteSettingStore sets isLoading/error so required-setting warnings
  don't flash during load; ModelDownloadStore error paths no longer
  leave rows pending forever; PacksStore trust mutations are serialized
  against lost updates; NodeMenu close cancels pending search/hover
  timers; KeyPressedStore shift+enter allowlist uses the sorted key
  form; ModelPreferences migrate fallback matches the onlyAvailable
  default; transient inspector NodeStores release their metadata
  subscriptions

https://claude.ai/code/session_01KLr71qAwjSfhtLGr3jT6hz