### PR TITLE
Remove timeout_seconds and roundness parameters from image nodes

### DIFF
--- a/packages/dsl/src/generated/lib.image.color_grading.ts
+++ b/packages/dsl/src/generated/lib.image.color_grading.ts
@@ -176,7 +176,6 @@ export interface VignetteInputs {
   image?: Connectable<ImageRef>;
   amount?: Connectable<number>;
   midpoint?: Connectable<number>;
-  roundness?: Connectable<number>;
   feather?: Connectable<number>;
 }
 

--- a/packages/dsl/src/generated/nodetool.image.ts
+++ b/packages/dsl/src/generated/nodetool.image.ts
@@ -273,7 +273,6 @@ export interface TextToImageInputs {
   negative_prompt?: Connectable<string>;
   aspect_ratio?: Connectable<string>;
   resolution?: Connectable<string>;
-  timeout_seconds?: Connectable<number>;
 }
 
 export interface TextToImageOutputs {
@@ -294,7 +293,6 @@ export interface ImageToImageInputs {
   aspect_ratio?: Connectable<string>;
   resolution?: Connectable<string>;
   scheduler?: Connectable<string>;
-  timeout_seconds?: Connectable<number>;
 }
 
 export interface ImageToImageOutputs {

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -1515,16 +1515,6 @@ export class TextToImageNode extends BaseNode {
   })
   declare resolution: any;
 
-  @prop({
-    type: "int",
-    default: 0,
-    title: "Timeout Seconds",
-    description: "Timeout in seconds for API calls (0 = use provider default)",
-    min: 0,
-    max: 3600
-  })
-  declare timeout_seconds: any;
-
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const prompt = String(this.prompt ?? "");
     const aspectRatio = String(this.aspect_ratio ?? "1:1");
@@ -1649,16 +1639,6 @@ export class ImageToImageNode extends BaseNode {
     description: "Scheduler to use (provider-specific)"
   })
   declare scheduler: any;
-
-  @prop({
-    type: "int",
-    default: 0,
-    title: "Timeout Seconds",
-    description: "Timeout in seconds for API calls (0 = use provider default)",
-    min: 0,
-    max: 3600
-  })
-  declare timeout_seconds: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     let images = normalizeImageList(this.image);

--- a/packages/image-nodes/src/nodes/lib-image-color-grading.ts
+++ b/packages/image-nodes/src/nodes/lib-image-color-grading.ts
@@ -295,7 +295,7 @@ function createColorGradingNode(desc: Desc): NodeClass {
       // onto the shader's `radius` (where the vignette begins) and `softness`.
       if (t.endsWith(".Vignette")) {
         const midpoint = num(props.midpoint, 0.5);
-        const feather = Math.max(0.01, num(props.feather, 0.4));
+        const feather = Math.max(0.01, num(props.feather, 0.5));
         return emit(
           await runShaderNode(
             vignetteV1,
@@ -1211,18 +1211,6 @@ const DESCRIPTORS: readonly Desc[] = [
           description:
             "Distance from center where vignette begins (0=center, 1=edges).",
           min: 0,
-          max: 1
-        }
-      },
-      {
-        name: "roundness",
-        options: {
-          type: "float",
-          default: 0,
-          title: "Roundness",
-          description:
-            "Shape of vignette. 0=oval matching image aspect, 1=circular, -1=rectangular.",
-          min: -1,
           max: 1
         }
       },

--- a/packages/image-nodes/src/nodes/lib-image-enhance.ts
+++ b/packages/image-nodes/src/nodes/lib-image-enhance.ts
@@ -458,8 +458,9 @@ const DESCRIPTORS: readonly Desc[] = [
           type: "int",
           default: 3,
           title: "Rank",
-          description: "Rank filter rank.",
-          min: 1,
+          description:
+            "Index into the sorted neighbourhood (0 = minimum, size*size-1 = maximum).",
+          min: 0,
           max: 512
         }
       }

--- a/packages/image-nodes/tests/lib-image-processing.test.ts
+++ b/packages/image-nodes/tests/lib-image-processing.test.ts
@@ -315,7 +315,6 @@ describe("lib-image-color-grading nodes", () => {
       image: img,
       amount: 0.8,
       midpoint: 0.3,
-      roundness: 0,
       feather: 0.5
     });
     assertValidImage(output);


### PR DESCRIPTION
## Summary
Removes the `timeout_seconds` parameter from text-to-image and image-to-image nodes, and removes the `roundness` parameter from the vignette color grading node. Also updates related documentation and test files.

## Changes

### Image Generation Nodes
- Removed `timeout_seconds` property decorator from `TextToImageNode` and `ImageToImageNode` in `packages/image-nodes/src/nodes/image.ts`
- Updated generated TypeScript interfaces in `packages/dsl/src/generated/nodetool.image.ts` to remove `timeout_seconds` from `TextToImageInputs` and `ImageToImageInputs`

### Color Grading (Vignette)
- Removed `roundness` parameter from vignette node descriptor in `packages/image-nodes/src/nodes/lib-image-color-grading.ts`
- Updated default feather value from `0.4` to `0.5` for vignette effect
- Removed `roundness` from generated vignette interface in `packages/dsl/src/generated/lib.image.color_grading.ts`
- Updated test to remove `roundness` parameter from vignette node invocation

### Image Enhancement
- Updated rank filter parameter description in `packages/image-nodes/src/nodes/lib-image-enhance.ts` to clarify it represents an index into sorted neighborhood
- Changed minimum rank value from `1` to `0` to allow full range of neighborhood values

## Implementation Details
These changes simplify the node interfaces by removing parameters that were either unused or superseded by other configuration options. The vignette feather default adjustment provides a more balanced default appearance.

https://claude.ai/code/session_016wxDbX8Au7Vi9wk5BCiVN9