### PR TITLE
Improve video node error handling and add timeout support

### DIFF
--- a/packages/base-nodes/tests/audio-video-image-props.test.ts
+++ b/packages/base-nodes/tests/audio-video-image-props.test.ts
@@ -190,7 +190,7 @@ describe("TrimVideoNode — uses ffmpeg for trimming", () => {
 });
 
 describe("FrameToVideoNode — uses frame property (not frames)", () => {
-  it("combines frames into video", async () => {
+  it("reads frames from the frame property", async () => {
     const node = new FrameToVideoNode();
     node.assign({
       frame: [
@@ -198,10 +198,13 @@ describe("FrameToVideoNode — uses frame property (not frames)", () => {
         { data: Buffer.from([3, 4]).toString("base64") }
       ]
     });
-    const result = await node.process();
-    const output = result.output as { data: string };
-    const bytes = Buffer.from(output.data, "base64");
-    expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+    // Both frames are read from `frame` and written to disk, after which
+    // ffmpeg fails on the fake PNG bytes (or is missing) and the node
+    // throws. If the property were misread, the node would resolve with an
+    // empty video instead.
+    await expect(node.process()).rejects.toThrow(
+      "Combining frames into a video failed"
+    );
   });
 });
 

--- a/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
+++ b/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
@@ -1421,15 +1421,13 @@ describe("image nodes — full coverage", () => {
 // --------------- VIDEO NODES ---------------
 
 describe("video nodes — full coverage", () => {
-  it("ImageToVideoNode generates video from image", async () => {
+  it("ImageToVideoNode throws without a provider", async () => {
     const img = imageRef();
     const _n = new ImageToVideoNode();
     _n.assign({ image: img, prompt: "animate" });
-    const result = await _n.process();
-    const output = result.output as { type: string; data: string };
-    expect(output.type).toBe("video");
-    const outData = Buffer.from(output.data, "base64");
-    expect(outData.length).toBeGreaterThan(0);
+    await expect(_n.process()).rejects.toThrow(
+      "No provider available for image-to-video generation."
+    );
   });
 
   it("LoadVideoFileNode reads from file", async () => {
@@ -1453,7 +1451,7 @@ describe("video nodes — full coverage", () => {
     expect((result.output as { uri: string }).uri).toContain(filePath);
   });
 
-  it("SaveVideoFileVideoNode writes to file", async () => {
+  it("SaveVideoFileVideoNode writes to file and returns a video ref", async () => {
     const filePath = `${tmpDir}/save-video-file/out.mp4`;
     const ref = videoRef();
     const _n = new SaveVideoFileVideoNode();
@@ -1463,8 +1461,11 @@ describe("video nodes — full coverage", () => {
       filename: path.basename(filePath)
     });
     const result = await _n.process();
-    expect(path.normalize(String(result.output))).toBe(path.normalize(filePath));
-    const stat = await fs.stat(String(result.output));
+    const output = result.output as { type: string; uri: string; data: string };
+    expect(output.type).toBe("video");
+    expect(output.uri).toBe(`file://${path.normalize(filePath)}`);
+    expect(output.data.length).toBeGreaterThan(0);
+    const stat = await fs.stat(filePath);
     expect(stat.size).toBeGreaterThan(0);
   });
 
@@ -1543,17 +1544,16 @@ describe("video nodes — full coverage", () => {
     expect(result.output).toBe(0);
   });
 
-  it("FrameToVideoNode combines frames", async () => {
+  it("FrameToVideoNode throws when ffmpeg cannot encode the frames", async () => {
     const frameA = { data: Buffer.from([1, 2]).toString("base64") };
     const frameB = { data: Buffer.from([3, 4]).toString("base64") };
     const _n = new FrameToVideoNode();
     _n.assign({ frame: [frameA, frameB] });
-    const result = await _n.process();
-    const outData = Buffer.from(
-      (result.output as { data: string }).data,
-      "base64"
+    // The frames are not decodable PNGs (and ffmpeg may not even be
+    // installed) — the node must fail instead of emitting corrupt bytes.
+    await expect(_n.process()).rejects.toThrow(
+      "Combining frames into a video failed"
     );
-    expect(Array.from(outData)).toEqual([1, 2, 3, 4]);
   });
 
   it("FrameToVideoNode handles non-object frames", async () => {
@@ -1567,17 +1567,14 @@ describe("video nodes — full coverage", () => {
     expect(outData.length).toBe(0);
   });
 
-  it("ConcatVideoNode concatenates two videos", async () => {
+  it("ConcatVideoNode throws when ffmpeg cannot concatenate", async () => {
     const a = { data: Buffer.from([1, 2]).toString("base64") };
     const b = { data: Buffer.from([3, 4]).toString("base64") };
     const _n = new ConcatVideoNode();
     _n.assign({ video_1: a, video_2: b });
-    const result = await _n.process();
-    const outData = Buffer.from(
-      (result.output as { data: string }).data,
-      "base64"
-    );
-    expect(Array.from(outData)).toEqual([1, 2, 3, 4]);
+    // The inputs are not real videos (and ffmpeg may not even be
+    // installed) — the node must fail instead of emitting corrupt bytes.
+    await expect(_n.process()).rejects.toThrow("Concatenating videos failed");
   });
 
   it("TrimVideoNode falls back to original without ffmpeg", async () => {
@@ -1625,14 +1622,18 @@ describe("video nodes — full coverage", () => {
       overlay_video: ref
     });
     const overlay = await _n.process();
+    expect((overlay.output as { data: string }).data).toBeDefined();
+    // Transition reads both canonical inputs; with both non-empty it
+    // proceeds to ffmpeg, which fails on the fake bytes. Misread inputs
+    // would short-circuit to a pass-through instead.
     const _n2 = new TransitionVideoNode();
     _n2.assign({
       video_a: ref,
       video_b: ref
     });
-    const transition = await _n2.process();
-    expect((overlay.output as { data: string }).data).toBeDefined();
-    expect((transition.output as { data: string }).data).toBeDefined();
+    await expect(_n2.process()).rejects.toThrow(
+      "Creating the transition failed"
+    );
   });
 
   it("ReverseVideoNode falls back to original without ffmpeg", async () => {
@@ -1698,11 +1699,13 @@ describe("video nodes — full coverage", () => {
     const result = await _n.process();
     expect(typeof result.output).toBe("number");
 
-    // imageBytes in video module
+    // imageBytes in video module — null image is tolerated up to the
+    // provider check, which fails without a context
     const _n2 = new ImageToVideoNode();
     _n2.assign({ image: null, prompt: "" });
-    const imgResult = await _n2.process();
-    expect((imgResult.output as { data: string }).data).toBeDefined();
+    await expect(_n2.process()).rejects.toThrow(
+      "No provider available for image-to-video generation."
+    );
 
     // audioBytes in video module
     const _n3 = new AddAudioVideoNode();
@@ -1717,12 +1720,12 @@ describe("video nodes — full coverage", () => {
     _n.assign({
       frame: [{ data: uint8Data }]
     });
-    const result = await _n.process();
-    const outData = Buffer.from(
-      (result.output as { data: string }).data,
-      "base64"
+    // The Uint8Array frame is accepted (a frame file gets written), so the
+    // node proceeds to ffmpeg and fails there — an empty-bytes frame would
+    // instead resolve with an empty video before reaching ffmpeg.
+    await expect(_n.process()).rejects.toThrow(
+      "Combining frames into a video failed"
     );
-    expect(Array.from(outData)).toEqual([1, 2, 3]);
   });
 
   it("defaults() methods return expected structures", () => {
@@ -1797,14 +1800,12 @@ describe("video nodes — full coverage", () => {
     });
   });
 
-  it("TextToVideoNode generates video from text", async () => {
+  it("TextToVideoNode throws without a provider", async () => {
     const _n = new TextToVideoNode();
     _n.assign({ prompt: "hello-vid" });
-    const result = await _n.process();
-    const output = result.output as { type: string; data: string };
-    expect(output.type).toBe("video");
-    const outData = Buffer.from(output.data, "base64");
-    expect(outData.toString("utf8")).toBe("hello-vid");
+    await expect(_n.process()).rejects.toThrow(
+      "No provider available for text-to-video generation."
+    );
   });
 
   it("FrameToVideoNode handles non-array frames", async () => {

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -2216,7 +2216,8 @@ export class ProcessingContext {
           numFrames: params.num_frames as number | undefined,
           durationSeconds: params.duration_seconds as number | undefined,
           aspectRatio: params.aspect_ratio as string | undefined,
-          resolution: params.resolution as string | undefined
+          resolution: params.resolution as string | undefined,
+          timeoutSeconds: params.timeout_seconds as number | undefined
         });
       case "image_to_video":
         return provider.imageToVideo(coerceImageList(params), {
@@ -2226,7 +2227,8 @@ export class ProcessingContext {
           numFrames: params.num_frames as number | undefined,
           durationSeconds: params.duration_seconds as number | undefined,
           aspectRatio: params.aspect_ratio as string | undefined,
-          resolution: params.resolution as string | undefined
+          resolution: params.resolution as string | undefined,
+          timeoutSeconds: params.timeout_seconds as number | undefined
         });
       case "upscale_image":
         return provider.upscaleImage(params.image as Uint8Array, {

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -1183,7 +1183,10 @@ export class GeminiProvider extends BaseProvider {
     };
 
     // Poll for completion
-    const maxWait = 600_000; // 10 minutes
+    const maxWait =
+      params.timeoutSeconds && params.timeoutSeconds > 0
+        ? params.timeoutSeconds * 1000
+        : 600_000; // default 10 minutes
     const pollInterval = 10_000;
     let elapsed = 0;
     let current = operation;
@@ -1274,7 +1277,10 @@ export class GeminiProvider extends BaseProvider {
     };
 
     // Poll for completion
-    const maxWait = 600_000;
+    const maxWait =
+      params.timeoutSeconds && params.timeoutSeconds > 0
+        ? params.timeoutSeconds * 1000
+        : 600_000; // default 10 minutes
     const pollInterval = 10_000;
     let elapsed = 0;
     let current = operation;

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -197,6 +197,8 @@ export interface TextToVideoParams {
   guidanceScale?: number | null;
   numInferenceSteps?: number | null;
   seed?: number | null;
+  /** Per-call timeout. Providers translate this into a max polling window. */
+  timeoutSeconds?: number | null;
 }
 
 export interface ImageToVideoParams {
@@ -211,6 +213,8 @@ export interface ImageToVideoParams {
   guidanceScale?: number | null;
   numInferenceSteps?: number | null;
   seed?: number | null;
+  /** Per-call timeout. Providers translate this into a max polling window. */
+  timeoutSeconds?: number | null;
 }
 
 /**

--- a/packages/video-nodes/src/nodes/lib-video-download.ts
+++ b/packages/video-nodes/src/nodes/lib-video-download.ts
@@ -21,9 +21,12 @@ async function runCommand(
     let stderr = "";
     let timedOut = false;
 
+    let killTimer: NodeJS.Timeout | undefined;
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
+      // Escalate if the process ignores SIGTERM.
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5000);
     }, timeoutMs);
 
     child.stdout.on("data", (d) => {
@@ -34,10 +37,12 @@ async function runCommand(
     });
     child.on("error", (err) => {
       clearTimeout(timer);
+      clearTimeout(killTimer);
       reject(err);
     });
     child.on("close", (code) => {
       clearTimeout(timer);
+      clearTimeout(killTimer);
       if (timedOut) {
         resolve({
           stdout,
@@ -226,6 +231,9 @@ export class YtDlpDownloadLibNode extends BaseNode {
     const overwrite = Boolean(this.overwrite ?? false);
     const rateLimitKbps = Number(this.rate_limit_kbps ?? 0);
 
+    // One deadline for the whole node run: the metadata probe and the
+    // download share the budget instead of each getting the full timeout.
+    const deadline = Date.now() + timeoutMs;
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ytdlp-"));
 
     try {
@@ -304,7 +312,13 @@ export class YtDlpDownloadLibNode extends BaseNode {
         }
         dlArgs.push(url);
 
-        const dlRes = await runCommand("yt-dlp", dlArgs, timeoutMs);
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(
+            `yt-dlp timed out after ${Math.round(timeoutMs / 1000)}s before the download started`
+          );
+        }
+        const dlRes = await runCommand("yt-dlp", dlArgs, remainingMs);
         if (dlRes.exitCode !== 0) {
           throw new Error(
             `yt-dlp download failed: ${dlRes.stderr || dlRes.stdout}`

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -18,11 +18,6 @@ type VideoRefLike = { uri?: string; data?: Uint8Array | string };
 type ImageRefLike = { uri?: string; data?: Uint8Array | string };
 const execFile = promisify(execFileCb);
 
-function videoBytes(video: unknown): Uint8Array {
-  if (!video || typeof video !== "object") return new Uint8Array();
-  return toBytes((video as VideoRefLike).data);
-}
-
 async function videoBytesAsync(video: unknown, context?: ProcessingContext): Promise<Uint8Array> {
   if (!video || typeof video !== "object") return new Uint8Array();
   const bytes = await loadMediaRefBytes(video as VideoRefLike, context);
@@ -103,15 +98,19 @@ function dateName(name: string): string {
     .replaceAll("%S", pad(now.getSeconds()));
 }
 
-function bytesConcat(parts: Uint8Array[]): Uint8Array {
-  const total = parts.reduce((s, p) => s + p.length, 0);
-  const out = new Uint8Array(total);
-  let off = 0;
-  for (const p of parts) {
-    out.set(p, off);
-    off += p.length;
+/**
+ * Parse an ffprobe `r_frame_rate` value ("30000/1001" or "25") into a number.
+ * Returns 0 for malformed values or zero denominators instead of NaN/Infinity.
+ */
+function parseFrameRate(raw: string): number {
+  const parts = raw.trim().split("/");
+  if (parts.length === 2) {
+    const num = Number(parts[0]);
+    const den = Number(parts[1]);
+    return Number.isFinite(num) && den > 0 ? num / den : 0;
   }
-  return out;
+  const val = Number(parts[0]);
+  return Number.isFinite(val) && val > 0 ? val : 0;
 }
 
 async function ffprobeDuration(filePath: string): Promise<number> {
@@ -309,23 +308,23 @@ export class TextToVideoNode extends BaseNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const text = String(this.prompt ?? "");
     const { providerId, modelId } = modelConfig(this.serialize());
-    if (canUseProvider(context, providerId, modelId)) {
-      const output = (await context.runProviderPrediction({
-        provider: providerId,
-        capability: "text_to_video",
-        model: modelId,
-        params: {
-          prompt: text,
-          negative_prompt: this.negative_prompt,
-          duration_seconds: Number(this.duration ?? 0) || undefined,
-          aspect_ratio: this.aspect_ratio,
-          resolution: this.resolution
-        }
-      })) as Uint8Array;
-      return { output: videoRef(output) };
+    if (!canUseProvider(context, providerId, modelId)) {
+      throw new Error("No provider available for text-to-video generation.");
     }
-    const bytes = Uint8Array.from(Buffer.from(text, "utf8"));
-    return { output: videoRef(bytes) };
+    const output = (await context.runProviderPrediction({
+      provider: providerId,
+      capability: "text_to_video",
+      model: modelId,
+      params: {
+        prompt: text,
+        negative_prompt: this.negative_prompt,
+        duration_seconds: Number(this.duration ?? 0) || undefined,
+        aspect_ratio: this.aspect_ratio,
+        resolution: this.resolution,
+        timeout_seconds: Number(this.timeout_seconds ?? 0) || undefined
+      }
+    })) as Uint8Array;
+    return { output: videoRef(output) };
   }
 }
 
@@ -450,27 +449,24 @@ export class ImageToVideoNode extends BaseNode {
       await Promise.all(images.map((img) => imageBytesAsync(img, context)))
     ).filter((b) => b.length > 0);
     const { providerId, modelId } = modelConfig(this.serialize());
-    if (canUseProvider(context, providerId, modelId)) {
-      const output = (await context.runProviderPrediction({
-        provider: providerId,
-        capability: "image_to_video",
-        model: modelId,
-        params: {
-          images: bytesList,
-          prompt,
-          negative_prompt: this.negative_prompt,
-          duration_seconds: Number(this.duration ?? 0) || undefined,
-          aspect_ratio: this.aspect_ratio,
-          resolution: this.resolution
-        }
-      })) as Uint8Array;
-      return { output: videoRef(output) };
+    if (!canUseProvider(context, providerId, modelId)) {
+      throw new Error("No provider available for image-to-video generation.");
     }
-    return {
-      output: videoRef(
-        bytesConcat([...bytesList, Uint8Array.from(Buffer.from(prompt))])
-      )
-    };
+    const output = (await context.runProviderPrediction({
+      provider: providerId,
+      capability: "image_to_video",
+      model: modelId,
+      params: {
+        images: bytesList,
+        prompt,
+        negative_prompt: this.negative_prompt,
+        duration_seconds: Number(this.duration ?? 0) || undefined,
+        aspect_ratio: this.aspect_ratio,
+        resolution: this.resolution,
+        timeout_seconds: Number(this.timeout_seconds ?? 0) || undefined
+      }
+    })) as Uint8Array;
+    return { output: videoRef(output) };
   }
 }
 
@@ -494,7 +490,8 @@ export class LoadVideoFileNode extends BaseNode {
   declare path: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const p = filePath(String(this.path ?? ""));
+    const p = filePath(String(this.path ?? "").trim());
+    if (!p) throw new Error("No file path provided to Load Video File.");
     const data = new Uint8Array(await fs.readFile(p));
     return { output: videoRef(data, { uri: `file://${p}` }) };
   }
@@ -549,8 +546,9 @@ export class SaveVideoFileVideoNode extends BaseNode {
     const fname = dateName(String(this.filename || "video.mp4"));
     const p = path.resolve(folder, fname);
     await fs.mkdir(path.dirname(p), { recursive: true });
-    await fs.writeFile(p, await videoBytesAsync(this.video, context));
-    return { output: p };
+    const bytes = await videoBytesAsync(this.video, context);
+    await fs.writeFile(p, bytes);
+    return { output: videoRef(bytes, { uri: `file://${p}` }) };
   }
 }
 
@@ -757,7 +755,11 @@ export class ForEachFrameNode extends BaseNode {
   })
   declare end: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    // Buffered fallback: surface the first frame instead of nothing.
+    for await (const item of this.genProcess(context)) {
+      return item;
+    }
     return {};
   }
 
@@ -780,12 +782,8 @@ export class ForEachFrameNode extends BaseNode {
           "-of", "csv=p=0",
           inputFile.path
         ]);
-        const parts = stdout.trim().split("/");
-        if (parts.length === 2) {
-          fps = Number(parts[0]) / Number(parts[1]);
-        } else if (parts.length === 1 && Number(parts[0]) > 0) {
-          fps = Number(parts[0]);
-        }
+        const parsed = parseFrameRate(stdout);
+        if (parsed > 0) fps = parsed;
       } catch {
         // fall back to 24 fps
       }
@@ -880,14 +878,7 @@ export class FpsNode extends BaseNode {
         "-of", "csv=p=0",
         inputFile.path
       ]);
-      const parts = stdout.trim().split("/");
-      let fps = 0;
-      if (parts.length === 2) {
-        fps = Number(parts[0]) / Number(parts[1]);
-      } else if (parts.length === 1 && Number(parts[0]) > 0) {
-        fps = Number(parts[0]);
-      }
-      return { output: fps };
+      return { output: parseFrameRate(stdout) };
     } catch {
       return { output: 0 };
     } finally {
@@ -997,13 +988,12 @@ export class FrameToVideoNode extends BaseNode {
       );
       const result = new Uint8Array(await fs.readFile(outputPath));
       await outputs.emit("output", videoRef(result));
-    } catch {
-      // Fallback: concatenate raw frame bytes
-      const parts = frames.map((f) => {
-        if (!f || typeof f !== "object") return new Uint8Array();
-        return toBytes((f as { data?: Uint8Array | string }).data);
-      });
-      await outputs.emit("output", videoRef(bytesConcat(parts)));
+    } catch (error) {
+      throw new Error(
+        `Combining frames into a video failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     } finally {
       await fs.rm(inputDir, { recursive: true, force: true });
       await fs.rm(outputDir, { recursive: true, force: true });
@@ -1053,12 +1043,12 @@ export class FrameToVideoNode extends BaseNode {
       );
       const result = new Uint8Array(await fs.readFile(outputPath));
       return { output: videoRef(result) };
-    } catch {
-      const parts = frames.map((f) => {
-        if (!f || typeof f !== "object") return new Uint8Array();
-        return toBytes((f as { data?: Uint8Array | string }).data);
-      });
-      return { output: videoRef(bytesConcat(parts)) };
+    } catch (error) {
+      throw new Error(
+        `Combining frames into a video failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     } finally {
       await fs.rm(inputDir, { recursive: true, force: true });
       await fs.rm(outputDir, { recursive: true, force: true });
@@ -1123,8 +1113,12 @@ export class ConcatVideoNode extends BaseNode {
       );
       const result = new Uint8Array(await fs.readFile(outputPath));
       return { output: videoRef(result) };
-    } catch {
-      return { output: videoRef(bytesConcat(parts)) };
+    } catch (error) {
+      throw new Error(
+        `Concatenating videos failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     } finally {
       for (const input of inputs) {
         await input.cleanup();
@@ -1288,7 +1282,7 @@ export class RotateVideoNode extends VideoTransformNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
-    const angle = Number(this.angle ?? 90);
+    const angle = Number(this.angle ?? 0);
     const radians = (angle * Math.PI) / 180;
     const transformed =
       (await ffmpegTransform(bytes, [
@@ -1453,6 +1447,7 @@ export class OverlayVideoNode extends VideoTransformNode {
     const mainVideo = await videoBytesAsync(this.main_video, context);
     const overlayVideo = await videoBytesAsync(this.overlay_video, context);
     if (overlayVideo.length === 0) return { output: videoRef(mainVideo) };
+    if (mainVideo.length === 0) return { output: videoRef(overlayVideo) };
     const x = Number(this.x ?? 0);
     const y = Number(this.y ?? 0);
     const scale = Math.max(0.01, Number(this.scale ?? 1));
@@ -1771,7 +1766,8 @@ export class BlurVideoNode extends VideoTransformNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
-    const radius = Math.max(1, Number(this.strength ?? 2));
+    const radius = Number(this.strength ?? 5);
+    if (radius <= 0) return { output: videoRef(bytes) };
     const transformed =
       (await ffmpegTransform(bytes, [
         "-vf",
@@ -1820,7 +1816,7 @@ export class SaturationVideoNode extends VideoTransformNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
-    const saturation = Number(this.saturation ?? 1.2);
+    const saturation = Number(this.saturation ?? 1);
     const transformed =
       (await ffmpegTransform(bytes, [
         "-vf",
@@ -1916,8 +1912,10 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     const fontSize = Math.max(1, Number(this.font_size ?? 24));
     const fontColorObj = this.font_color as { value?: string } | undefined;
     const fontColor = String(fontColorObj?.value ?? "#FFFFFF").replace("#", "0x");
+    // `||` (not `??`): the default font ref has name "", which must also
+    // fall back rather than producing drawtext's font=''.
     const fontName = String(
-      (this.font as { name?: string } | undefined)?.name ?? "Sans"
+      (this.font as { name?: string } | undefined)?.name || "Sans"
     );
     const align = String(this.align ?? "bottom");
 
@@ -2127,6 +2125,7 @@ export class TransitionVideoNode extends VideoTransformNode {
     const a = await videoBytesAsync(this.video_a, context);
     const b = await videoBytesAsync(this.video_b, context);
     if (b.length === 0) return { output: videoRef(a) };
+    if (a.length === 0) return { output: videoRef(b) };
     const duration = Math.max(0.1, Number(this.duration ?? 1));
     const transitionType = String(this.transition_type ?? "fade");
 
@@ -2165,8 +2164,12 @@ export class TransitionVideoNode extends VideoTransformNode {
           `[0:v][1:v]xfade=transition=${transitionType}:duration=${duration}:offset=${offsetVal}`
         ],
         [{ suffix: ".mp4", bytes: b }]
-      )) ??
-      videoBytes({ data: Buffer.from(bytesConcat([a, b])).toString("base64") });
+      ));
+    if (transformed == null) {
+      throw new Error(
+        "Creating the transition failed: ffmpeg could not crossfade the two videos."
+      );
+    }
     return { output: videoRef(transformed) };
   }
 }
@@ -2249,49 +2252,52 @@ export class AddAudioVideoNode extends BaseNode {
       const volume = Math.max(0, Number(this.volume ?? 1));
       const mix = Boolean(this.mix);
 
-      const args: string[] = [
-        "-y",
-        "-i", videoInput.path,
-        "-i", audioInput.path
-      ];
-
-      if (mix) {
-        // Mix new audio with existing audio
-        args.push(
-          "-filter_complex",
-          `[1:a]volume=${volume}[newaud];[0:a][newaud]amix=inputs=2:duration=first[aout]`,
-          "-map", "0:v:0",
-          "-map", "[aout]",
-          "-c:v", "copy"
-        );
-      } else {
-        // Replace existing audio
-        args.push(
-          "-map", "0:v:0",
-          "-map", "1:a:0",
-          "-c:v", "copy",
-          "-c:a", "aac"
-        );
-        if (volume !== 1) {
-          // Insert volume filter before output
-          args.splice(args.length, 0);
-          // Re-build with filter
-          args.length = 0;
+      const buildArgs = (useMix: boolean): string[] => {
+        const args: string[] = [
+          "-y",
+          "-i", videoInput.path,
+          "-i", audioInput.path
+        ];
+        if (useMix) {
           args.push(
-            "-y",
-            "-i", videoInput.path,
-            "-i", audioInput.path,
+            "-filter_complex",
+            `[1:a]volume=${volume}[newaud];[0:a][newaud]amix=inputs=2:duration=first[aout]`,
+            "-map", "0:v:0",
+            "-map", "[aout]",
+            "-c:v", "copy"
+          );
+        } else if (volume !== 1) {
+          args.push(
             "-filter_complex", `[1:a]volume=${volume}[aout]`,
             "-map", "0:v:0",
             "-map", "[aout]",
             "-c:v", "copy",
             "-c:a", "aac"
           );
+        } else {
+          args.push(
+            "-map", "0:v:0",
+            "-map", "1:a:0",
+            "-c:v", "copy",
+            "-c:a", "aac"
+          );
         }
-      }
+        args.push(outputPath);
+        return args;
+      };
 
-      args.push(outputPath);
-      await execFile("ffmpeg", args, { maxBuffer: 50 * 1024 * 1024 });
+      try {
+        await execFile("ffmpeg", buildArgs(mix), {
+          maxBuffer: 50 * 1024 * 1024
+        });
+      } catch (error) {
+        // Mixing requires an existing audio stream ([0:a]); videos without
+        // one make ffmpeg fail. Fall back to plain replacement.
+        if (!mix) throw error;
+        await execFile("ffmpeg", buildArgs(false), {
+          maxBuffer: 50 * 1024 * 1024
+        });
+      }
       const result = new Uint8Array(await fs.readFile(outputPath));
       return { output: videoRef(result) };
     } catch {
@@ -2308,7 +2314,7 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ChromaKey";
   static readonly title = "Chroma Key";
   static readonly description =
-    "Apply chroma key (green screen) effect to a video.\n    video, chroma key, green screen, compositing";
+    "Apply chroma key (green screen) effect to a video. The MP4 output has no alpha channel, so the keyed-out area renders black — composite it over a background with the Overlay node.\n    video, chroma key, green screen, compositing";
   static readonly metadataOutputTypes = {
     output: "video"
   };
@@ -2406,7 +2412,17 @@ export class ExtractAudioVideoNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
-    if (bytes.length === 0) return { output: { data: null } };
+    if (bytes.length === 0) {
+      return {
+        output: {
+          type: "audio",
+          data: null,
+          uri: "",
+          asset_id: null,
+          metadata: null
+        }
+      };
+    }
 
     const input = await withTempFile(".mp4", bytes);
     const outputDir = await fs.mkdtemp(
@@ -2592,19 +2608,13 @@ export class GetVideoInfoNode extends BaseNode {
         (s) => s.codec_type === "audio"
       );
 
-      let fps = 0;
-      if (videoStream?.r_frame_rate) {
-        const parts = videoStream.r_frame_rate.split("/");
-        if (parts.length === 2) {
-          fps = Number(parts[0]) / Number(parts[1]);
-        } else if (parts.length === 1) {
-          fps = Number(parts[0]);
-        }
-      }
+      const fps = videoStream?.r_frame_rate
+        ? parseFrameRate(videoStream.r_frame_rate)
+        : 0;
 
-      const duration = Number(info.format?.duration ?? 0);
+      const duration = Number(info.format?.duration ?? 0) || 0;
       const frameCount = videoStream?.nb_frames
-        ? Number(videoStream.nb_frames)
+        ? Number(videoStream.nb_frames) || 0
         : Math.round(duration * fps);
 
       return {

--- a/packages/video-nodes/tests/regression-video.test.ts
+++ b/packages/video-nodes/tests/regression-video.test.ts
@@ -394,7 +394,9 @@ describe("TransitionVideoNode — uses transition_type, not hardcoded fade", () 
       transition_type: "wipeleft",
       duration: 1.0
     });
-    await node.process();
+    // The mocked ffmpeg always fails, so the node throws — the assertions
+    // below only inspect the captured ffmpeg arguments.
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("transition=wipeleft");
@@ -410,7 +412,7 @@ describe("TransitionVideoNode — uses transition_type, not hardcoded fade", () 
       transition_type: "fade",
       duration: 1.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     // The mock returns duration=10.5 for ffprobeDuration
     // offset should be 10.5 - 1.0 = 9.5
@@ -427,7 +429,7 @@ describe("TransitionVideoNode — uses transition_type, not hardcoded fade", () 
       transition_type: "dissolve",
       duration: 2.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     // Should have called ffprobe to get duration
     const probes = ffprobeCalls();
@@ -788,7 +790,11 @@ describe("FrameToVideoNode — numbers frames contiguously despite gaps", () => 
         frame: [img([1, 2, 3]), { type: "image", data: "" }, img([4, 5, 6])],
         fps: 24
       });
-      await node.process();
+      // The mocked ffmpeg always fails, so the node throws — the assertions
+      // below only inspect the frame files written beforehand.
+      await expect(node.process()).rejects.toThrow(
+        "Combining frames into a video failed"
+      );
 
       const frameWrites = writeSpy.mock.calls
         .map((c) => String(c[0]))


### PR DESCRIPTION
## Summary
This PR hardens video node error handling by replacing silent fallbacks with explicit errors, adds timeout support for text-to-video and image-to-video generation, and fixes several edge cases in video processing.

## Key Changes

### Error Handling & Validation
- **TextToVideoNode** and **ImageToVideoNode**: Now throw `"No provider available"` error instead of silently falling back to corrupted byte concatenation
- **FrameToVideoNode** and **ConcatVideoNode**: Throw descriptive errors on ffmpeg failure instead of emitting corrupt concatenated bytes
- **TransitionVideoNode**: Throw error when ffmpeg crossfade fails instead of falling back to byte concatenation
- **LoadVideoFileNode**: Validate file path is provided; throw error if empty after trim
- **SaveVideoFileVideoNode**: Now returns a proper video reference with URI instead of just a file path string

### Timeout Support
- Added `timeout_seconds` parameter to **TextToVideoNode** and **ImageToVideoNode** process methods
- Updated **GeminiProvider** to respect `timeoutSeconds` from params for both text-to-video and image-to-video operations (defaults to 10 minutes if not specified)
- Updated **ProcessingContext** to pass `timeout_seconds` through to provider calls
- Enhanced **YtDlpDownloadLibNode** to use a shared deadline across metadata probe and download phases instead of giving each operation the full timeout

### Code Quality & Refactoring
- Extracted `parseFrameRate()` helper function to centralize frame rate parsing logic (handles both "30000/1001" and "25" formats)
- Removed unused `videoBytes()` and `bytesConcat()` functions
- **ForEachFrameNode**: Added buffered fallback to return first frame instead of empty result
- **OverlayVideoNode** and **TransitionVideoNode**: Added early returns for empty video inputs
- **BlurVideoNode**: Changed default strength from 2 to 5; skip processing if radius ≤ 0
- **SaturationVideoNode**: Changed default saturation from 1.2 to 1
- **RotateVideoNode**: Changed default angle from 90 to 0
- **AddSubtitlesVideoNode**: Fixed font fallback to use `||` instead of `??` to properly handle empty font names
- **AddAudioVideoNode**: Refactored ffmpeg argument building; added fallback from mix mode to replace mode if mixing fails (handles videos without audio streams)
- **ExtractAudioVideoNode**: Return proper audio reference structure instead of `{ data: null }`
- **GetVideoInfoNode**: Simplified frame rate parsing using new `parseFrameRate()` helper; improved duration/frame count calculations
- **ChromaKeyVideoNode**: Updated description to clarify MP4 output has no alpha channel

### Process Improvements
- **lib-video-download.ts**: Enhanced timeout handling with SIGKILL escalation after 5 seconds if process ignores SIGTERM
- Improved error messages throughout to be more descriptive and actionable

## Test Updates
Updated test expectations to verify that nodes now throw errors on provider unavailability or ffmpeg failures instead of silently producing corrupt output. Tests for **FrameToVideoNode**, **ConcatVideoNode**, **TextToVideoNode**, and **ImageToVideoNode** now verify error throwing behavior.

## Breaking Changes
- **TextToVideoNode** and **ImageToVideoNode** now require a provider context; they throw instead of falling back
- **SaveVideoFileVideoNode** return type changed from string path to video reference object
- **FrameToVideoNode** and **ConcatVideoNode** now throw on ffmpeg failure instead of returning concatenated bytes

https://claude.ai/code/session_0187Nx5wTC8c54Wq8axZHoiB