### PR TITLE
Add zero-copy ImageBitmap transport for live GPU image previews

### DIFF
--- a/packages/image-nodes/src/nodes/image-io.ts
+++ b/packages/image-nodes/src/nodes/image-io.ts
@@ -17,6 +17,7 @@
 import {
   isRawRgbaImage,
   isGpuTextureImage,
+  isBitmapImage,
   RAW_RGBA_MIME,
   type ImageRef
 } from "@nodetool-ai/protocol";
@@ -115,6 +116,12 @@ export async function loadImageBytes(
   if (isRawRgbaImage(r)) {
     return encodeRgbaToPng(r.data, r.width, r.height);
   }
+  // A preview-bitmap ref (the worker's transport format) — read the pixels
+  // back off the bitmap, then encode.
+  if (isBitmapImage(r)) {
+    const { rgba, width, height } = await bitmapToRgba(r.bitmap as ImageBitmap);
+    return encodeRgbaToPng(rgba, width, height);
+  }
   if (r.data instanceof Uint8Array && r.data.length > 0) return r.data;
   if (typeof r.data === "string" && r.data.length > 0) {
     return base64ToBytes(stripDataUrlPrefix(r.data));
@@ -150,6 +157,21 @@ export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const buffer = new ArrayBuffer(bytes.byteLength);
   new Uint8Array(buffer).set(bytes);
   return buffer;
+}
+
+/**
+ * Read the pixels of a preview `ImageBitmap` back to straight-alpha RGBA via
+ * an OffscreenCanvas (browser only — bitmap refs never exist on Node). The
+ * bitmap is left open: the UI may still be painting the same instance.
+ */
+export async function bitmapToRgba(bitmap: ImageBitmap): Promise<RawRgba> {
+  const { width, height } = bitmap;
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) throw new Error("OffscreenCanvas 2D context unavailable");
+  ctx.drawImage(bitmap, 0, 0);
+  const { data } = ctx.getImageData(0, 0, width, height);
+  return { rgba: new Uint8Array(data.buffer.slice(0)), width, height };
 }
 
 /** Decode encoded image bytes to straight-alpha RGBA via Canvas (browser). */
@@ -195,6 +217,11 @@ export async function decodeRgba(
   // An in-flight GPU-texture ref — read its pixels back off the device.
   if (isGpuTextureImage(image)) {
     return readbackTextureRef(image);
+  }
+  // A preview-bitmap ref (e.g. a cached result re-injected into a single-node
+  // run) — read the pixels off the bitmap, no codec work.
+  if (isBitmapImage(image)) {
+    return bitmapToRgba(image.bitmap as ImageBitmap);
   }
   const bytes = await loadImageBytes(image, context);
   if (bytes.length === 0) return { rgba: new Uint8Array(), width: 0, height: 0 };
@@ -264,6 +291,11 @@ export async function encodePngFromRef(ref: unknown): Promise<Uint8Array> {
   // In-flight GPU texture — read its pixels back, then encode.
   if (isGpuTextureImage(ref)) {
     const { rgba, width, height } = await readbackTextureRef(ref);
+    return encodeRgbaToPng(rgba, width, height);
+  }
+  // Preview-bitmap ref — read the pixels off the bitmap, then encode.
+  if (isBitmapImage(ref)) {
+    const { rgba, width, height } = await bitmapToRgba(ref.bitmap as ImageBitmap);
     return encodeRgbaToPng(rgba, width, height);
   }
   const data = (ref as { data?: unknown }).data;

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -34,6 +34,18 @@ export const RAW_RGBA_MIME = "image/x-raw-rgba";
  */
 export const GPU_TEXTURE_MIME = "image/x-gpu-texture";
 
+/**
+ * Preview-bitmap image (browser only). `bitmap` holds a decoded `ImageBitmap`
+ * (typed `unknown` here so protocol stays DOM-free). The in-browser runner's
+ * worker emits this as its transport format for GPU/raw image outputs: an
+ * `ImageBitmap` is transferable across `postMessage` (zero-copy) and paints
+ * straight onto a canvas, so the live preview skips the PNG encode → base64 →
+ * `<img>` decode round-trip entirely. Like the other in-flight formats it never
+ * reaches the server or persists; boundaries that need portable bytes derive
+ * them from the bitmap via the shared image codec helpers.
+ */
+export const BITMAP_IMAGE_MIME = "image/x-imagebitmap";
+
 export interface ImageRef {
   type: "image";
   uri?: string;
@@ -50,6 +62,17 @@ export interface ImageRef {
    * WebGPU-free.
    */
   texture?: unknown;
+  /**
+   * Decoded `ImageBitmap` for the {@link BITMAP_IMAGE_MIME} backing (browser
+   * only, never serialized). Typed `unknown` to keep protocol DOM-free.
+   */
+  bitmap?: unknown;
+  /**
+   * Monotonic per-bitmap counter. Two distinct `ImageBitmap`s are
+   * indistinguishable to structural equality (no enumerable own properties), so
+   * memoized consumers compare this to detect a new frame.
+   */
+  bitmapVersion?: number;
 }
 
 /**
@@ -96,9 +119,31 @@ export function isGpuTextureImage(
   );
 }
 
-/** True when `value` is any in-flight image (raw-RGBA CPU buffer or GPU texture). */
+/**
+ * True when `value` is a preview-bitmap image (see {@link BITMAP_IMAGE_MIME}):
+ * a live `ImageBitmap` plus its dimensions. Structural check only (no
+ * `instanceof ImageBitmap`) so it works in DOM-free environments and tests.
+ */
+export function isBitmapImage(
+  value: unknown
+): value is ImageRef & { bitmap: object; width: number; height: number } {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.type === "image" &&
+    v.mimeType === BITMAP_IMAGE_MIME &&
+    typeof v.bitmap === "object" &&
+    v.bitmap !== null &&
+    typeof v.width === "number" &&
+    typeof v.height === "number" &&
+    v.width > 0 &&
+    v.height > 0
+  );
+}
+
+/** True when `value` is any in-flight image (raw-RGBA CPU buffer, GPU texture, or preview bitmap). */
 export function isInFlightImage(value: unknown): boolean {
-  return isRawRgbaImage(value) || isGpuTextureImage(value);
+  return isRawRgbaImage(value) || isGpuTextureImage(value) || isBitmapImage(value);
 }
 
 export interface AudioRef {

--- a/packages/protocol/tests/api-types.test.ts
+++ b/packages/protocol/tests/api-types.test.ts
@@ -9,6 +9,11 @@
  */
 
 import { describe, it, expect } from "vitest";
+import {
+  BITMAP_IMAGE_MIME,
+  isBitmapImage,
+  isInFlightImage
+} from "../src/api-types.js";
 import type {
   ImageRef,
   AudioRef,
@@ -82,6 +87,24 @@ describe("Media Refs", () => {
     expect(ref.type).toBe("image");
     expect(ref.uri).toBe("https://example.com/img.png");
     expect(ref.asset_id).toBeUndefined();
+  });
+
+  it("isBitmapImage narrows preview-bitmap refs structurally", () => {
+    const ref: ImageRef = {
+      type: "image",
+      mimeType: BITMAP_IMAGE_MIME,
+      bitmap: { width: 2, height: 2 },
+      bitmapVersion: 1,
+      width: 2,
+      height: 2
+    };
+    expect(isBitmapImage(ref)).toBe(true);
+    expect(isInFlightImage(ref)).toBe(true);
+    // Missing bitmap, wrong mime, or missing dimensions all reject.
+    expect(isBitmapImage({ ...ref, bitmap: undefined })).toBe(false);
+    expect(isBitmapImage({ ...ref, mimeType: "image/png" })).toBe(false);
+    expect(isBitmapImage({ ...ref, width: 0 })).toBe(false);
+    expect(isBitmapImage(null)).toBe(false);
   });
 
   it("AudioRef has optional duration", () => {

--- a/web/src/components/node/BitmapCanvas.tsx
+++ b/web/src/components/node/BitmapCanvas.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from "react";
+
+interface BitmapCanvasProps {
+  bitmap: ImageBitmap;
+  style?: React.CSSProperties;
+  className?: string;
+  onDoubleClick?: React.MouseEventHandler<HTMLCanvasElement>;
+  "aria-label"?: string;
+}
+
+/**
+ * Paints a preview `ImageBitmap` (the in-browser runner's zero-copy transport
+ * format) straight onto a canvas. This is the fast display path for live GPU
+ * image outputs: drawImage of an already-decoded bitmap, no PNG encode/decode,
+ * no `<img>` preload round-trip — a new frame is on screen within a paint.
+ */
+const BitmapCanvas: React.FC<BitmapCanvasProps> = ({
+  bitmap,
+  style,
+  className,
+  onDoubleClick,
+  "aria-label": ariaLabel
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    try {
+      ctx.drawImage(bitmap, 0, 0);
+    } catch {
+      // Bitmap was closed elsewhere — keep the previous frame.
+    }
+  }, [bitmap]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+      style={style}
+      onDoubleClick={onDoubleClick}
+    />
+  );
+};
+
+export default React.memo(BitmapCanvas);

--- a/web/src/components/node/ImageRefPreview.tsx
+++ b/web/src/components/node/ImageRefPreview.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isBitmapImage } from "@nodetool-ai/protocol";
 import ImageView from "./ImageView";
 import { asImageRef, isRawRgbaRef } from "../../utils/imageRef";
 import { rawRgbaToPngDataUrl } from "../../lib/workflow/materializeBrowserOutputs";
@@ -25,6 +26,12 @@ const ImageRefPreview: React.FC<ImageRefPreviewProps> = ({
 }) => {
   if (typeof value === "string" && value) {
     return <ImageView source={value} />;
+  }
+  // Preview-bitmap ref from the in-browser runner (zero-copy transport) —
+  // paint it directly. Checked on the raw value: `asImageRef` keeps only the
+  // uri/data fields, so the bitmap would be dropped below.
+  if (isBitmapImage(value)) {
+    return <ImageView bitmap={value.bitmap as ImageBitmap} />;
   }
   const ref = asImageRef(value);
   if (isRawRgbaRef(ref)) {

--- a/web/src/components/node/ImageView.tsx
+++ b/web/src/components/node/ImageView.tsx
@@ -7,6 +7,7 @@ import DownloadIcon from "@mui/icons-material/Download";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import AssetViewer from "../assets/AssetViewer";
 import { createImageUrl } from "../../utils/imageUtils";
+import BitmapCanvas from "./BitmapCanvas";
 import ImageDimensions from "./ImageDimensions";
 import { CopyAssetButton } from "../common/CopyAssetButton";
 import { alphaSurfaceBg } from "../../styles/AlphaSurface";
@@ -31,9 +32,16 @@ const hoverStyles = css({
 
 interface ImageViewProps {
   source?: string | Uint8Array;
+  /**
+   * Preview bitmap from the in-browser runner (zero-copy transport). When set
+   * it takes precedence over `source`: the frame is painted straight onto a
+   * canvas, and a PNG blob URL for the action buttons (copy / download /
+   * viewer) is derived lazily off the display path.
+   */
+  bitmap?: ImageBitmap;
 }
 
-const ImageView: React.FC<ImageViewProps> = ({ source }) => {
+const ImageView: React.FC<ImageViewProps> = ({ source, bitmap }) => {
   const [openViewer, setOpenViewer] = React.useState(false);
   const imageRef = useRef<HTMLImageElement>(null);
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null);
@@ -115,9 +123,58 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
     []
   );
 
+  // Bitmap path: the canvas shows the frame immediately; the PNG blob URL the
+  // action buttons need is encoded asynchronously after a short debounce, so a
+  // live scrub (a new bitmap every few frames) never pays for an encode — only
+  // the resting frame does, off the display path.
+  const bitmapUrlRef = useRef<string | null>(null);
+  const [bitmapUrl, setBitmapUrl] = useState<string | null>(null);
+  const commitBitmapUrl = useCallback((url: string | null) => {
+    if (bitmapUrlRef.current && bitmapUrlRef.current !== url) {
+      URL.revokeObjectURL(bitmapUrlRef.current);
+    }
+    bitmapUrlRef.current = url;
+    setBitmapUrl(url);
+  }, []);
+
+  useEffect(() => {
+    if (!bitmap) {
+      commitBitmapUrl(null);
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        ctx.drawImage(bitmap, 0, 0);
+        const blob = await canvas.convertToBlob({ type: "image/png" });
+        if (!cancelled) {
+          commitBitmapUrl(URL.createObjectURL(blob));
+        }
+      } catch {
+        // Encode failed (bitmap closed mid-scrub) — actions stay hidden.
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [bitmap, commitBitmapUrl]);
+
+  useEffect(
+    () => () => {
+      if (bitmapUrlRef.current) {
+        URL.revokeObjectURL(bitmapUrlRef.current);
+      }
+    },
+    []
+  );
+
   // Show the committed image, falling back to the freshly-computed one on the
   // first render so there's no "no image" flash before the effect runs.
-  const imageUrl = displayedUrl ?? nextUrl;
+  const imageUrl = bitmap ? bitmapUrl ?? undefined : displayedUrl ?? nextUrl;
 
   const handleImageLoad = useCallback(() => {
     if (imageRef.current) {
@@ -129,8 +186,12 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
   }, []);
 
   useEffect(() => {
+    if (bitmap) {
+      setImageDimensions({ width: bitmap.width, height: bitmap.height });
+      return;
+    }
     setImageDimensions(null);
-  }, [imageUrl]);
+  }, [bitmap, imageUrl]);
 
   // Memoize style objects to prevent recreation on every render
   const containerStyle = useMemo(() => ({
@@ -247,7 +308,7 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
     setOpenViewer(true);
   }, []);
 
-  if (!imageUrl) {
+  if (!imageUrl && !bitmap) {
     return <Text>No Image found</Text>;
   }
 
@@ -257,7 +318,7 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
       className="image-output"
       style={containerStyle}
     >
-      {!onRequestOpenViewer && (
+      {!onRequestOpenViewer && imageUrl && (
         <AssetViewer
           contentType="image/*"
           url={imageUrl}
@@ -265,7 +326,7 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
           onClose={handleCloseViewer}
         />
       )}
-      {!overlaySuppressed && (
+      {!overlaySuppressed && imageUrl && (
         <div
           className="image-view-actions"
           style={actionsStyle}
@@ -292,15 +353,24 @@ const ImageView: React.FC<ImageViewProps> = ({ source }) => {
           </ToolbarIconButton>
         </div>
       )}
-      <img
-        ref={imageRef}
-        src={imageUrl}
-        alt="Generated image output"
-        onLoad={handleImageLoad}
-        style={imageStyle}
-        onDoubleClick={handleDoubleClick}
-        draggable={false}
-      />
+      {bitmap ? (
+        <BitmapCanvas
+          bitmap={bitmap}
+          aria-label="Generated image output"
+          style={imageStyle}
+          onDoubleClick={handleDoubleClick}
+        />
+      ) : (
+        <img
+          ref={imageRef}
+          src={imageUrl}
+          alt="Generated image output"
+          onLoad={handleImageLoad}
+          style={imageStyle}
+          onDoubleClick={handleDoubleClick}
+          draggable={false}
+        />
+      )}
       {!overlaySuppressed && imageDimensions && (
         <ImageDimensions
           width={imageDimensions.width}

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -16,7 +16,9 @@ import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import DownloadIcon from "@mui/icons-material/Download";
 
+import { isBitmapImage } from "@nodetool-ai/protocol";
 import AssetViewer from "../assets/AssetViewer";
+import BitmapCanvas from "./BitmapCanvas";
 import { useNodeResultHistory } from "../../hooks/nodes/useNodeResultHistory";
 import { useNodeGenerations } from "../../hooks/nodes/useNodeGenerations";
 import { outputOf } from "../../utils/nodeGenerations";
@@ -144,7 +146,7 @@ const styles = (theme: Theme) =>
         borderColor: theme.vars.palette.primary.main
       }
     },
-    ".thumb img, .thumb video": {
+    ".thumb img, .thumb video, .thumb canvas": {
       width: "100%",
       height: "100%",
       objectFit: "cover",
@@ -385,6 +387,9 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
               const kind = value?.type;
               const label = asset?.name || gen.id;
               const imgUrl = asset?.thumb_url || asset?.get_url || value?.uri || "";
+              const previewBitmap = isBitmapImage(value)
+                ? (value.bitmap as ImageBitmap)
+                : undefined;
               const videoThumb = asset?.thumb_url;
               const videoUrl = asset?.get_url || value?.uri || "";
               return (
@@ -396,6 +401,8 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
                 >
                   {kind === "image" && imgUrl ? (
                     <img src={imgUrl} alt={label} />
+                  ) : kind === "image" && previewBitmap ? (
+                    <BitmapCanvas bitmap={previewBitmap} aria-label={label} />
                   ) : kind === "video" && (videoThumb || videoUrl) ? (
                     videoThumb ? (
                       <img src={videoThumb} alt={label} />

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -38,6 +38,8 @@ import TaskView from "./TaskView";
 /** In-flight raw straight-alpha RGBA image format (see protocol RAW_RGBA_MIME). */
 const RAW_RGBA_MIME = "image/x-raw-rgba";
 
+import { isBitmapImage } from "@nodetool-ai/protocol";
+
 // Encodes the raw-RGBA in-flight format to a PNG data URL. Shared with the
 // in-browser run path (`materializeBrowserOutputs`), which normalizes the same
 // format at the run boundary; re-exported here for existing callers/tests.
@@ -425,6 +427,11 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
       case "image_comparison":
         return <ImageComparisonRenderer value={value as ImageComparisonData} />;
       case "image":
+        // Preview bitmap from the in-browser runner — paint it directly
+        // (zero-copy fast path; no PNG encode/decode).
+        if (isBitmapImage(v)) {
+          return <ImageView bitmap={v.bitmap as ImageBitmap} />;
+        }
         if (Array.isArray(v.data)) {
           const seen = new Map<string, number>();
           return (v.data as (string | Uint8Array)[]).map((item) => (

--- a/web/src/components/node/__tests__/BitmapCanvas.test.tsx
+++ b/web/src/components/node/__tests__/BitmapCanvas.test.tsx
@@ -3,11 +3,16 @@ import { render, screen } from "@testing-library/react";
 import BitmapCanvas from "../BitmapCanvas";
 
 describe("BitmapCanvas", () => {
+  const mockGetContext = (drawImage: jest.Mock) =>
+    jest
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockImplementation(((() => ({
+        drawImage
+      })) as unknown) as HTMLCanvasElement["getContext"]);
+
   it("paints the bitmap onto a canvas sized to its dimensions", () => {
     const drawImage = jest.fn();
-    const getContext = jest
-      .spyOn(HTMLCanvasElement.prototype, "getContext")
-      .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+    const getContext = mockGetContext(drawImage);
 
     const bitmap = { width: 4, height: 2 } as unknown as ImageBitmap;
     render(<BitmapCanvas bitmap={bitmap} aria-label="preview" />);
@@ -23,9 +28,7 @@ describe("BitmapCanvas", () => {
 
   it("repaints when a new bitmap frame arrives", () => {
     const drawImage = jest.fn();
-    const getContext = jest
-      .spyOn(HTMLCanvasElement.prototype, "getContext")
-      .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+    const getContext = mockGetContext(drawImage);
 
     const first = { width: 2, height: 2 } as unknown as ImageBitmap;
     const second = { width: 8, height: 4 } as unknown as ImageBitmap;

--- a/web/src/components/node/__tests__/BitmapCanvas.test.tsx
+++ b/web/src/components/node/__tests__/BitmapCanvas.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import BitmapCanvas from "../BitmapCanvas";
+
+describe("BitmapCanvas", () => {
+  it("paints the bitmap onto a canvas sized to its dimensions", () => {
+    const drawImage = jest.fn();
+    const getContext = jest
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+
+    const bitmap = { width: 4, height: 2 } as unknown as ImageBitmap;
+    render(<BitmapCanvas bitmap={bitmap} aria-label="preview" />);
+
+    const canvas = screen.getByRole("img", { name: "preview" });
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect((canvas as HTMLCanvasElement).width).toBe(4);
+    expect((canvas as HTMLCanvasElement).height).toBe(2);
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 0, 0);
+
+    getContext.mockRestore();
+  });
+
+  it("repaints when a new bitmap frame arrives", () => {
+    const drawImage = jest.fn();
+    const getContext = jest
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+
+    const first = { width: 2, height: 2 } as unknown as ImageBitmap;
+    const second = { width: 8, height: 4 } as unknown as ImageBitmap;
+    const { rerender } = render(<BitmapCanvas bitmap={first} />);
+    rerender(<BitmapCanvas bitmap={second} />);
+
+    expect(drawImage).toHaveBeenLastCalledWith(second, 0, 0);
+    const canvas = screen.getByRole("img") as HTMLCanvasElement;
+    expect(canvas.width).toBe(8);
+    expect(canvas.height).toBe(4);
+
+    getContext.mockRestore();
+  });
+});

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef } from "react";
-import { packageAssetHttpPath } from "@nodetool-ai/protocol";
+import { packageAssetHttpPath, isBitmapImage } from "@nodetool-ai/protocol";
 import { Asset, AssetRef } from "../../../stores/ApiTypes";
 import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
+import { bitmapToPngDataUrl } from "../../../lib/workflow/materializeBrowserOutputs";
 
 /**
  * Base type for typed output values with a type discriminator
@@ -231,6 +232,11 @@ export function useImageAssets(value: unknown): { assets: Asset[]; urls: string[
         let url = "";
         if (imageItem.uri) {
           url = resolveAssetUri(imageItem.uri);
+        } else if (isBitmapImage(imageItem)) {
+          // Preview-bitmap ref from the in-browser runner (no uri/data) —
+          // encode it for the grid. Memoized with the value, so this runs
+          // once per output, not per render.
+          url = bitmapToPngDataUrl(imageItem.bitmap as ImageBitmap);
         } else if (imageItem.data) {
           try {
             // Ensure the typed array is backed by a non-shared ArrayBuffer (BlobPart typing)

--- a/web/src/components/node_types/editing/AdjustmentSlider.tsx
+++ b/web/src/components/node_types/editing/AdjustmentSlider.tsx
@@ -1,0 +1,203 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * AdjustmentSlider — the shared slider row for slider-driven bespoke bodies
+ * (AdjustmentBody, CurvesBody, …). Renders `label | slider | value` cells into
+ * the parent's `.controls` grid.
+ *
+ * Bipolar specs (range straddling 0, neutral at 0 — temperature, tint,
+ * shadows, …) hide the native track and fill outward from the centre so the
+ * control reads as a signed adjustment, not a 0–100% level. A non-default
+ * value lights the thumb via `changed`.
+ *
+ * `adjustmentSliderStyles` carries the row's CSS (labels, value chip, centre
+ * tick / bipolar fill, MUI slider polish) — compose it into the body's emotion
+ * block alongside the body's own styles: `css={[bodyStyles, sliderStyles]}`.
+ */
+
+import React, { useCallback } from "react";
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+
+import { NodeSlider } from "../../ui_primitives";
+
+const TRACK_HEIGHT = 4;
+const THUMB_SIZE = 12;
+
+export interface SliderSpec {
+  name: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+  /** Range straddles 0 with a neutral midpoint — fill outward from centre. */
+  bipolar: boolean;
+}
+
+export const clamp = (v: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, v));
+
+export const formatSliderValue = (spec: SliderSpec, value: number): string => {
+  if (spec.step >= 1) {
+    return String(Math.round(value));
+  }
+  const sign = spec.bipolar && value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}`;
+};
+
+/** Fraction 0..1 of where `value` sits in `[min, max]`. */
+const fraction = (spec: SliderSpec, value: number): number =>
+  spec.max === spec.min ? 0 : (value - spec.min) / (spec.max - spec.min);
+
+export const adjustmentSliderStyles = (theme: Theme) =>
+  css({
+    ".ctrl-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis"
+    },
+    // Wraps the slider so the centre tick + bipolar fill can be positioned
+    // over the rail. Zero vertical jitter: the slider's rail sits at 50%.
+    ".slider-wrap": {
+      position: "relative",
+      display: "flex",
+      alignItems: "center",
+      width: "100%",
+      height: 16
+    },
+    ".slider-wrap .center-tick": {
+      position: "absolute",
+      top: "50%",
+      transform: "translate(-50%, -50%)",
+      width: 2,
+      height: 9,
+      borderRadius: 1,
+      backgroundColor: theme.vars.palette.grey[600],
+      pointerEvents: "none",
+      zIndex: 0
+    },
+    ".slider-wrap .bipolar-fill": {
+      position: "absolute",
+      top: "50%",
+      transform: "translateY(-50%)",
+      height: TRACK_HEIGHT,
+      borderRadius: TRACK_HEIGHT / 2,
+      backgroundColor: theme.vars.palette.primary.main,
+      pointerEvents: "none",
+      zIndex: 1
+    },
+    ".ctrl-value": {
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      fontVariantNumeric: "tabular-nums",
+      color: theme.vars.palette.text.primary,
+      minWidth: 46,
+      textAlign: "right",
+      lineHeight: 1,
+      padding: "3px 6px",
+      borderRadius: "var(--rounded-sm)",
+      backgroundColor: theme.vars.palette.grey[800]
+    },
+    // Slider polish — rounded rail/track, ring-style thumb. Scoped here so the
+    // app's square editor sliders elsewhere are untouched.
+    ".controls .MuiSlider-root": {
+      padding: 0,
+      margin: 0
+    },
+    ".controls .MuiSlider-rail": {
+      height: TRACK_HEIGHT,
+      borderRadius: TRACK_HEIGHT / 2,
+      opacity: 1,
+      backgroundColor: theme.vars.palette.grey[700]
+    },
+    ".controls .MuiSlider-track": {
+      height: TRACK_HEIGHT,
+      borderRadius: TRACK_HEIGHT / 2,
+      border: "none",
+      backgroundColor: theme.vars.palette.primary.main
+    },
+    // backgroundColor is left to NodeSlider (grey when neutral, primary when
+    // changed) so an unchanged thumb reads as a ring and a changed one fills in.
+    ".controls .MuiSlider-thumb": {
+      width: THUMB_SIZE,
+      height: THUMB_SIZE,
+      borderRadius: "50%",
+      border: `2px solid ${theme.vars.palette.primary.main}`,
+      boxShadow: "0 1px 3px rgba(0, 0, 0, 0.45)",
+      "&:hover, &.Mui-focusVisible, &.Mui-active": {
+        boxShadow: `0 0 0 6px color-mix(in srgb, ${theme.vars.palette.primary.main} 20%, transparent)`
+      }
+    }
+  });
+
+interface AdjustmentSliderProps {
+  spec: SliderSpec;
+  value: number;
+  onChange: (name: string, v: number) => void;
+  onCommit: () => void;
+  /** Extra class on the label cell (e.g. Curves' red/green/blue channels). */
+  labelClassName?: string;
+}
+
+export const AdjustmentSlider: React.FC<AdjustmentSliderProps> = ({
+  spec,
+  value,
+  onChange,
+  onCommit,
+  labelClassName
+}) => {
+  const handleChange = useCallback(
+    (_: Event, v: number | number[]) => {
+      const next = Array.isArray(v) ? v[0] : v;
+      const rounded = spec.step >= 1 ? Math.round(next) : Math.round(next * 100) / 100;
+      onChange(spec.name, rounded);
+    },
+    [onChange, spec.name, spec.step]
+  );
+
+  // Centre fill geometry (bipolar only): from the neutral point (where 0 sits)
+  // out to the thumb. Slider padding is 0, so rail spans 0–100% and these
+  // percentages line up with the thumb.
+  const centreFrac = clamp(fraction(spec, 0), 0, 1);
+  const valueFrac = clamp(fraction(spec, value), 0, 1);
+  const fillLeft = Math.min(centreFrac, valueFrac) * 100;
+  const fillWidth = Math.abs(valueFrac - centreFrac) * 100;
+
+  return (
+    <>
+      <span className={`ctrl-label${labelClassName ? ` ${labelClassName}` : ""}`}>
+        {spec.label}
+      </span>
+      <span className={`slider-wrap${spec.bipolar ? " is-bipolar" : ""}`}>
+        {spec.bipolar && (
+          <>
+            <span className="center-tick" style={{ left: `${centreFrac * 100}%` }} />
+            <span
+              className="bipolar-fill"
+              style={{ left: `${fillLeft}%`, width: `${fillWidth}%` }}
+            />
+          </>
+        )}
+        <NodeSlider
+          min={spec.min}
+          max={spec.max}
+          step={spec.step}
+          value={value}
+          changed={value !== spec.default}
+          // Native fill hidden for bipolar — the centre fill replaces it.
+          track={spec.bipolar ? false : "normal"}
+          onChange={handleChange}
+          onChangeCommitted={onCommit}
+          aria-label={`${spec.label} adjustment`}
+        />
+      </span>
+      <span className="ctrl-value">{formatSliderValue(spec, value)}</span>
+    </>
+  );
+};

--- a/web/src/components/node_types/editing/ChromaKeyBody.tsx
+++ b/web/src/components/node_types/editing/ChromaKeyBody.tsx
@@ -1,19 +1,9 @@
 /** @jsxImportSource @emotion/react */
 /**
- * AdjustmentBody — generic bespoke body for slider-only image adjustment nodes
- * (Brightness/Contrast, HSB, Saturation/Vibrance, Color Balance, Vignette,
- * Exposure, …).
+ * ChromaKeyBody — bespoke body for `lib.image.keyer.ChromaKey`.
  *
- * Preview on top, one slider per numeric property below. Unlike the per-node
- * bodies (Curves, Levels, …) nothing here is hardcoded: the image/mask handles
- * and every slider's range, default and step are derived from
- * `nodeMetadata.properties`. Registered for the node types in
- * `ADJUSTMENT_NODE_TYPES`.
- *
- * Bipolar sliders (range straddling 0, neutral at 0 — temperature, tint,
- * exposure, …) fill outward from the centre so the control reads as a signed
- * adjustment, not a 0–100% level. The preview reflects whatever the server
- * most recently produced — no client-side approximation.
+ * Preview on top, key-color picker, then three unipolar sliders:
+ *   Tolerance, Softness, Spill suppression.
  */
 
 import React, { memo, useCallback, useMemo } from "react";
@@ -27,8 +17,9 @@ import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
+import ColorPicker from "../../inputs/ColorPicker";
 
-import type { NodeMetadata, Property } from "../../../stores/ApiTypes";
+import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
@@ -39,9 +30,17 @@ import {
   type SliderSpec
 } from "./AdjustmentSlider";
 
+export const CHROMA_KEY_NODE_TYPE = "lib.image.keyer.ChromaKey";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "tolerance", label: "Tolerance", min: 0, max: 1, step: 0.01, default: 0.1,  bipolar: false },
+  { name: "softness",  label: "Softness",  min: 0, max: 1, step: 0.01, default: 0.05, bipolar: false },
+  { name: "spill",     label: "Spill",     min: 0, max: 1, step: 0.01, default: 0.5,  bipolar: false }
+];
+
 const styles = (theme: Theme) =>
   css({
-    "&.adjustment-body": {
+    "&.chroma-key-body": {
       position: "relative",
       width: "100%",
       height: "100%",
@@ -74,50 +73,31 @@ const styles = (theme: Theme) =>
       }
     },
     ".controls": {
-      flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
       alignItems: "center",
-      columnGap: theme.spacing(1.25),
-      rowGap: theme.spacing(0.75),
-      padding: `${theme.spacing(0.75)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".color-row": {
+      display: "contents"
     },
     ".outputs-row": {
       flex: "0 0 auto"
     }
   });
 
-const humanize = (name: string): string =>
-  name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-
-const isNumber = (v: unknown): v is number =>
-  typeof v === "number" && Number.isFinite(v);
-
-/**
- * Derive the slider specs from the node's numeric (`float` / `int`) properties.
- * Image-typed properties become handles instead (see `imageProps`).
- */
-const toSliderSpecs = (properties: Property[]): SliderSpec[] =>
-  properties.reduce<SliderSpec[]>((specs, p) => {
-    const kind = (p.type as { type?: string } | undefined)?.type;
-    if ((kind !== "float" && kind !== "int") || !isNumber(p.min) || !isNumber(p.max)) {
-      return specs;
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
     }
-    const isInt = kind === "int";
-    specs.push({
-      name: p.name,
-      label: p.title ?? humanize(p.name),
-      min: p.min,
-      max: p.max,
-      step: isInt ? 1 : 0.01,
-      default: isNumber(p.default) ? p.default : 0,
-      // Neutral-at-zero with headroom both ways — the signed adjustments.
-      bipolar: p.min < 0 && p.max > 0
-    });
-    return specs;
-  }, []);
+  />
+);
 
-export interface AdjustmentBodyProps {
+export interface ChromaKeyBodyProps {
   id: string;
   nodeType: string;
   nodeMetadata: NodeMetadata;
@@ -127,7 +107,7 @@ export interface AdjustmentBodyProps {
   isOutputNode: boolean;
 }
 
-const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
+const ChromaKeyBodyInner: React.FC<ChromaKeyBodyProps> = ({
   id,
   nodeType,
   nodeMetadata,
@@ -143,14 +123,10 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
   );
 
   const properties = nodeMetadata.properties ?? [];
-  const imageProps = useMemo(
-    () =>
-      properties.filter(
-        (p) => (p.type as { type?: string } | undefined)?.type === "image"
-      ),
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
     [properties]
   );
-  const sliders = useMemo(() => toSliderSpecs(properties), [properties]);
 
   const props = data.properties ?? {};
   const previewValue = useNodeOutput(workflowId, id);
@@ -160,40 +136,56 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
     nodeType
   });
 
-  const handleChange = useCallback(
+  const handleSliderChange = useCallback(
     (name: string, v: number) => {
-      const spec = sliders.find((s) => s.name === name);
+      const spec = SLIDERS.find((s) => s.name === name);
       if (!spec) return;
       setProperty(name, clamp(v, spec.min, spec.max));
     },
-    [setProperty, sliders]
+    [setProperty]
+  );
+
+  const hexColor = String(
+    (props["key_color"] as { value?: string } | undefined)?.value ?? "#00ff00"
+  );
+
+  const handleColorChange = useCallback(
+    (newColor: string | null) => {
+      setProperty("key_color", { type: "color", value: newColor ?? "#00ff00" });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
   );
 
   return (
-    <div css={cssStyles} className="adjustment-body" data-bespoke-body="Adjustment">
-      <HandleColumn id={id} properties={imageProps} />
+    <div css={cssStyles} className="chroma-key-body" data-bespoke-body="ChromaKey">
+      <HandleColumn id={id} properties={imageProperty} />
       <div className="preview-area">
-        <ImageRefPreview
-          value={previewValue}
-          placeholder={
-            <CheckerDropzone
-              message="Connect an image, then run"
-              icon={<ImageIcon />}
-            />
-          }
-        />
+        <ImagePreview value={previewValue} />
       </div>
 
       <div className="controls">
-        {sliders.map((spec) => {
+        {/* Color picker row */}
+        <span className="ctrl-label">Key Color</span>
+        <span style={{ gridColumn: "2 / 4", display: "flex", alignItems: "center" }}>
+          <ColorPicker
+            color={hexColor}
+            onColorChange={handleColorChange}
+            showCustom={true}
+            isNodeProperty={true}
+          />
+        </span>
+
+        {/* Slider rows */}
+        {SLIDERS.map((spec) => {
           const raw = Number(props[spec.name] ?? spec.default);
-          const value = clamp(isNumber(raw) ? raw : spec.default, spec.min, spec.max);
+          const value = clamp(raw, spec.min, spec.max);
           return (
             <AdjustmentSlider
               key={spec.name}
               spec={spec}
               value={value}
-              onChange={handleChange}
+              onChange={handleSliderChange}
               onCommit={setPropertyComplete}
             />
           );
@@ -211,7 +203,7 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
   );
 };
 
-export const AdjustmentBody = memo(AdjustmentBodyInner);
-AdjustmentBody.displayName = "AdjustmentBody";
+export const ChromaKeyBody = memo(ChromaKeyBodyInner);
+ChromaKeyBody.displayName = "ChromaKeyBody";
 
-export default AdjustmentBody;
+export default ChromaKeyBody;

--- a/web/src/components/node_types/editing/ColorOverlayBody.tsx
+++ b/web/src/components/node_types/editing/ColorOverlayBody.tsx
@@ -1,0 +1,214 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ColorOverlayBody — bespoke body for `lib.image.effects.ColorOverlay`.
+ *
+ * Preview on top, then a color row and one slider:
+ *   - Amount: 0–1
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageRefPreview from "../../node/ImageRefPreview";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+import ColorPicker from "../../inputs/ColorPicker";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
+
+export const COLOR_OVERLAY_NODE_TYPE = "lib.image.effects.ColorOverlay";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "amount", label: "Amount", min: 0, max: 1, step: 0.01, default: 0.5, bipolar: false }
+];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.color-overlay-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(0)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 140,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".color-row": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+    },
+    ".color-row-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap"
+    },
+    ".controls": {
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
+      alignItems: "center",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+    }
+  />
+);
+
+export interface ColorOverlayBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const ColorOverlayBodyInner: React.FC<ColorOverlayBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setPropertyComplete } = useLiveSliderWriter({ nodeId: id, nodeType });
+
+  const colorHex = String(
+    (props["color"] as { value?: string })?.value ?? "#ff0000"
+  );
+
+  const handleColorChange = useCallback(
+    (newColor: string | null) => {
+      setProperty("color", { type: "color", value: newColor ?? "#ff0000" });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  const handleChange = useCallback(
+    (name: string, v: number) => {
+      const spec = SLIDERS.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty]
+  );
+
+  return (
+    <div css={cssStyles} className="color-overlay-body" data-bespoke-body="ColorOverlay">
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+      </div>
+
+      <div className="color-row">
+        <span className="color-row-label">Color</span>
+        <ColorPicker
+          color={colorHex}
+          onColorChange={handleColorChange}
+          showCustom={true}
+          isNodeProperty={true}
+        />
+      </div>
+
+      <div className="controls">
+        {SLIDERS.map((spec) => {
+          const raw = Number(props[spec.name] ?? spec.default);
+          const value = clamp(raw, spec.min, spec.max);
+          return (
+            <AdjustmentSlider
+              key={spec.name}
+              spec={spec}
+              value={value}
+              onChange={handleChange}
+              onCommit={setPropertyComplete}
+            />
+          );
+        })}
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const ColorOverlayBody = memo(ColorOverlayBodyInner);
+ColorOverlayBody.displayName = "ColorOverlayBody";
+
+export default ColorOverlayBody;

--- a/web/src/components/node_types/editing/CurvesBody.tsx
+++ b/web/src/components/node_types/editing/CurvesBody.tsx
@@ -18,42 +18,37 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import {
   CheckerDropzone,
   FlexRow,
-  NodeSlider,
   StateIconButton
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
-import ImageView from "../../node/ImageView";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
 
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
-import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
-import { asImageRef } from "../../../utils/imageRef";
 import { CURVES_NODE_TYPE } from "../../../constants/nodeTypes";
-
-interface SliderSpec {
-  name: string;
-  label: string;
-  min: number;
-  max: number;
-  default: number;
-}
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
 
 const TONAL_SLIDERS: ReadonlyArray<SliderSpec> = [
-  { name: "black_point", label: "Black Point", min: 0, max: 0.5, default: 0 },
-  { name: "white_point", label: "White Point", min: 0.5, max: 1, default: 1 },
-  { name: "shadows", label: "Shadows", min: -0.5, max: 0.5, default: 0 },
-  { name: "midtones", label: "Midtones", min: -0.5, max: 0.5, default: 0 },
-  { name: "highlights", label: "Highlights", min: -0.5, max: 0.5, default: 0 }
+  { name: "black_point", label: "Black Point", min: 0, max: 0.5, step: 0.01, default: 0, bipolar: false },
+  { name: "white_point", label: "White Point", min: 0.5, max: 1, step: 0.01, default: 1, bipolar: false },
+  { name: "shadows", label: "Shadows", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true },
+  { name: "midtones", label: "Midtones", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true },
+  { name: "highlights", label: "Highlights", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true }
 ];
 
 const RGB_SLIDERS: ReadonlyArray<SliderSpec> = [
-  { name: "red_midtones", label: "Red", min: -0.5, max: 0.5, default: 0 },
-  { name: "green_midtones", label: "Green", min: -0.5, max: 0.5, default: 0 },
-  { name: "blue_midtones", label: "Blue", min: -0.5, max: 0.5, default: 0 }
+  { name: "red_midtones", label: "Red", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true },
+  { name: "green_midtones", label: "Green", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true },
+  { name: "blue_midtones", label: "Blue", min: -0.5, max: 0.5, step: 0.01, default: 0, bipolar: true }
 ];
 
 const ALL_SLIDERS: ReadonlyArray<SliderSpec> = [...TONAL_SLIDERS, ...RGB_SLIDERS];
@@ -119,24 +114,10 @@ const styles = (theme: Theme) =>
       alignItems: "center",
       padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
     },
-    ".ctrl-label": {
-      fontSize: theme.fontSizeSmaller,
-      color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
-      lineHeight: 1
-    },
+    // Channel tints layered over the shared `.ctrl-label` styles.
     ".ctrl-label.red": { color: theme.vars.palette.error.main },
     ".ctrl-label.green": { color: theme.vars.palette.success.main },
     ".ctrl-label.blue": { color: theme.vars.palette.info.main },
-    ".ctrl-value": {
-      fontFamily: theme.fontFamily2,
-      fontSize: theme.fontSizeSmaller,
-      color: theme.vars.palette.text.primary,
-      minWidth: 40,
-      textAlign: "right",
-      lineHeight: 1
-    },
     ".outputs-row": {
       flex: "0 0 auto"
     }
@@ -151,61 +132,11 @@ const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
   />
 );
 
-const clamp = (v: number, min: number, max: number) =>
-  Math.max(min, Math.min(max, v));
-
-const formatValue = (spec: SliderSpec, v: number): string => {
-  // Black/white points are absolute levels (0..1); show plain. Other sliders
-  // are signed deltas; show with explicit sign so users can read "+0.10".
-  if (spec.name === "black_point" || spec.name === "white_point") {
-    return v.toFixed(2);
-  }
-  return `${v > 0 ? "+" : ""}${v.toFixed(2)}`;
-};
-
 const channelClass = (name: string): string => {
   if (name === "red_midtones") return "red";
   if (name === "green_midtones") return "green";
   if (name === "blue_midtones") return "blue";
   return "";
-};
-
-interface CurvesSliderProps {
-  spec: SliderSpec;
-  value: number;
-  onChange: (name: string, v: number) => void;
-  onCommit: () => void;
-}
-
-const CurvesSlider: React.FC<CurvesSliderProps> = ({
-  spec,
-  value,
-  onChange,
-  onCommit
-}) => {
-  const handleChange = useCallback(
-    (_: Event, v: number | number[]) => {
-      const next = Array.isArray(v) ? v[0] : v;
-      onChange(spec.name, Math.round(next * 100) / 100);
-    },
-    [onChange, spec.name]
-  );
-  const cls = channelClass(spec.name);
-  return (
-    <>
-      <span className={`ctrl-label${cls ? ` ${cls}` : ""}`}>{spec.label}</span>
-      <NodeSlider
-        min={spec.min}
-        max={spec.max}
-        step={0.01}
-        value={value}
-        onChange={handleChange}
-        onChangeCommitted={onCommit}
-        aria-label={`${spec.label} adjustment`}
-      />
-      <span className="ctrl-value">{formatValue(spec, value)}</span>
-    </>
-  );
 };
 
 export interface CurvesBodyProps {
@@ -228,7 +159,10 @@ const CurvesBodyInner: React.FC<CurvesBodyProps> = ({
   isOutputNode
 }) => {
   const theme = useTheme();
-  const cssStyles = useMemo(() => styles(theme), [theme]);
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
 
   const properties = nodeMetadata.properties ?? [];
   const imageProperty = useMemo(
@@ -240,7 +174,7 @@ const CurvesBodyInner: React.FC<CurvesBodyProps> = ({
   const previewValue = useNodeOutput(workflowId, id);
 
   const { setProperty, setProperties, setPropertyComplete } =
-    useBespokePropertyWriter({ nodeId: id, nodeType });
+    useLiveSliderWriter({ nodeId: id, nodeType });
 
   const handleChange = useCallback(
     (name: string, v: number) => {
@@ -281,7 +215,7 @@ const CurvesBodyInner: React.FC<CurvesBodyProps> = ({
             const raw = Number(props[spec.name] ?? spec.default);
             const value = clamp(raw, spec.min, spec.max);
             return (
-              <CurvesSlider
+              <AdjustmentSlider
                 key={spec.name}
                 spec={spec}
                 value={value}
@@ -302,12 +236,13 @@ const CurvesBodyInner: React.FC<CurvesBodyProps> = ({
             const raw = Number(props[spec.name] ?? spec.default);
             const value = clamp(raw, spec.min, spec.max);
             return (
-              <CurvesSlider
+              <AdjustmentSlider
                 key={spec.name}
                 spec={spec}
                 value={value}
                 onChange={handleChange}
                 onCommit={setPropertyComplete}
+                labelClassName={channelClass(spec.name)}
               />
             );
           })}

--- a/web/src/components/node_types/editing/DropShadowBody.tsx
+++ b/web/src/components/node_types/editing/DropShadowBody.tsx
@@ -1,0 +1,219 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * DropShadowBody — bespoke body for `lib.image.effects.DropShadow`.
+ *
+ * Preview on top, then controls:
+ *   - Shadow Color picker
+ *   - Offset X / Offset Y sliders (bipolar)
+ *   - Radius (px) / Intensity sliders (unipolar)
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageRefPreview from "../../node/ImageRefPreview";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+import ColorPicker from "../../inputs/ColorPicker";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
+
+export const DROP_SHADOW_NODE_TYPE = "lib.image.effects.DropShadow";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "offset_x",    label: "Offset X",    min: -0.5, max: 0.5, step: 0.01, default: 0.02, bipolar: true },
+  { name: "offset_y",    label: "Offset Y",    min: -0.5, max: 0.5, step: 0.01, default: 0.02, bipolar: true },
+  { name: "blur_radius", label: "Radius (px)", min: 0,    max: 40,  step: 0.5,  default: 8,    bipolar: false },
+  { name: "intensity",   label: "Intensity",   min: 0,    max: 4,   step: 0.05, default: 0.6,  bipolar: false }
+];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.drop-shadow-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(0)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 140,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".controls": {
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
+      alignItems: "center",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".color-row": {
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between"
+    },
+    ".color-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+    }
+  />
+);
+
+export interface DropShadowBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const DropShadowBodyInner: React.FC<DropShadowBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setPropertyComplete } =
+    useLiveSliderWriter({ nodeId: id, nodeType });
+
+  const handleSliderChange = useCallback(
+    (name: string, v: number) => {
+      const spec = SLIDERS.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty]
+  );
+
+  const shadowColor = String(
+    (props["color"] as { value?: string } | undefined)?.value ?? "#000000"
+  );
+
+  const handleColorChange = useCallback(
+    (newColor: string | null) => {
+      setProperty("color", { type: "color", value: newColor ?? "#000000" });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  return (
+    <div css={cssStyles} className="drop-shadow-body" data-bespoke-body="DropShadow">
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+      </div>
+
+      <FlexRow className="color-row" align="center" justify="space-between">
+        <span className="color-label">Shadow Color</span>
+        <ColorPicker
+          color={shadowColor}
+          onColorChange={handleColorChange}
+          showCustom
+        />
+      </FlexRow>
+
+      <div className="controls">
+        {SLIDERS.map((spec) => {
+          const raw = Number(props[spec.name] ?? spec.default);
+          const value = clamp(raw, spec.min, spec.max);
+          return (
+            <AdjustmentSlider
+              key={spec.name}
+              spec={spec}
+              value={value}
+              onChange={handleSliderChange}
+              onCommit={setPropertyComplete}
+            />
+          );
+        })}
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const DropShadowBody = memo(DropShadowBodyInner);
+DropShadowBody.displayName = "DropShadowBody";
+
+export default DropShadowBody;

--- a/web/src/components/node_types/editing/GeneratorBody.tsx
+++ b/web/src/components/node_types/editing/GeneratorBody.tsx
@@ -1,0 +1,320 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * GeneratorBody — bespoke body for image generator nodes that produce images
+ * but take NO image input (gradient fills, checkerboard, noise, etc.).
+ *
+ * Layout:
+ *   - Preview area (ImageRefPreview with "Run to preview" placeholder)
+ *   - Color pickers (one row per `color`-typed property)
+ *   - Sliders grid (one row per `float`/`int` property with min+max)
+ *   - NodeOutputs (when not an output node)
+ *   - NodeProgress (when running)
+ *
+ * All controls are derived from `nodeMetadata.properties`. GaussianNoise's
+ * mean / stddev lack min/max in metadata — they are injected via PARAM_OVERRIDES.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import ImageRefPreview from "../../node/ImageRefPreview";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
+import ColorPicker from "../../inputs/ColorPicker";
+
+// ---------------------------------------------------------------------------
+// Param overrides for nodes whose metadata lacks min/max on some properties
+// ---------------------------------------------------------------------------
+
+const PARAM_OVERRIDES: Record<string, Partial<SliderSpec>> = {
+  "lib.image.draw.GaussianNoise::mean": {
+    min: -1,
+    max: 1,
+    step: 0.01,
+    default: 0,
+    bipolar: true
+  },
+  "lib.image.draw.GaussianNoise::stddev": {
+    min: 0,
+    max: 3,
+    step: 0.01,
+    default: 1,
+    bipolar: false
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const humanize = (name: string): string =>
+  name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+const isNumber = (v: unknown): v is number =>
+  typeof v === "number" && Number.isFinite(v);
+
+interface ColorSpec {
+  name: string;
+  label: string;
+  default: string;
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = (theme: Theme) =>
+  css({
+    "&.generator-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 160,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".color-row": {
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      flex: "0 0 auto"
+    },
+    // `.controls` (not a custom name) so the shared adjustmentSliderStyles'
+    // MUI overrides (`.controls .MuiSlider-*`) actually apply.
+    ".controls": {
+      flex: "0 0 auto",
+      display: "grid",
+      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      alignItems: "center",
+      columnGap: theme.spacing(1.25),
+      rowGap: theme.spacing(0.75),
+      padding: `${theme.spacing(0.75)} ${theme.spacing(1)} ${theme.spacing(1)}`
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Exported node types
+// ---------------------------------------------------------------------------
+
+export const GENERATOR_NODE_TYPES = [
+  "lib.image.draw.LinearGradient",
+  "lib.image.draw.RadialGradient",
+  "lib.image.draw.AngularGradient",
+  "lib.image.draw.DiamondGradient",
+  "lib.image.draw.Checkerboard",
+  "lib.image.draw.GaussianNoise"
+] as const;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface GeneratorBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const GeneratorBodyInner: React.FC<GeneratorBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
+
+  const properties = nodeMetadata.properties ?? [];
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setPropertyComplete } = useLiveSliderWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  // Derive color specs from metadata
+  const colorSpecs = useMemo<ColorSpec[]>(
+    () =>
+      properties
+        .filter(
+          (p) => (p.type as { type?: string } | undefined)?.type === "color"
+        )
+        .map((p) => ({
+          name: p.name,
+          label: p.title ?? humanize(p.name),
+          default: String(
+            (p.default as { value?: string } | undefined)?.value ?? "#000000"
+          )
+        })),
+    [properties]
+  );
+
+  // Derive slider specs from metadata, applying overrides where needed
+  const sliderSpecs = useMemo<SliderSpec[]>(
+    () =>
+      properties.reduce<SliderSpec[]>((acc, p) => {
+        const kind = (p.type as { type?: string } | undefined)?.type;
+        if (kind !== "float" && kind !== "int") return acc;
+        const key = `${nodeType}::${p.name}`;
+        const override = PARAM_OVERRIDES[key] ?? {};
+        const min = override.min ?? (isNumber(p.min) ? p.min : undefined);
+        const max = override.max ?? (isNumber(p.max) ? p.max : undefined);
+        if (min === undefined || max === undefined) return acc;
+        const isInt = kind === "int";
+        acc.push({
+          name: p.name,
+          label: p.title ?? humanize(p.name),
+          min,
+          max,
+          step: override.step ?? (isInt ? 1 : 0.01),
+          default:
+            override.default ??
+            (isNumber(p.default) ? p.default : 0),
+          bipolar: override.bipolar ?? (min < 0 && max > 0)
+        });
+        return acc;
+      }, []),
+    [properties, nodeType]
+  );
+
+  // Color helpers
+  const getColor = useCallback(
+    (name: string, fallback: string): string =>
+      String(
+        (props[name] as { value?: string } | undefined)?.value ?? fallback
+      ),
+    [props]
+  );
+
+  const handleColorChange = useCallback(
+    (name: string, newColor: string | null, fallback: string) => {
+      setProperty(name, { type: "color", value: newColor ?? fallback });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  // Slider handler
+  const handleSliderChange = useCallback(
+    (name: string, v: number) => {
+      const spec = sliderSpecs.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty, sliderSpecs]
+  );
+
+  return (
+    <div css={cssStyles} className="generator-body" data-bespoke-body="Generator">
+      <div className="preview-area">
+        <ImageRefPreview
+          value={previewValue}
+          placeholder={
+            <CheckerDropzone message="Run to preview" />
+          }
+        />
+      </div>
+
+      {colorSpecs.map((spec) => (
+        <FlexRow
+          key={spec.name}
+          className="color-row"
+          align="center"
+          justify="space-between"
+        >
+          <span className="ctrl-label">{spec.label}</span>
+          <ColorPicker
+            color={getColor(spec.name, spec.default)}
+            onColorChange={(v) =>
+              handleColorChange(spec.name, v, spec.default)
+            }
+            showCustom
+            isNodeProperty
+          />
+        </FlexRow>
+      ))}
+
+      <div className="controls">
+        {sliderSpecs.map((spec) => {
+          const raw = Number(props[spec.name] ?? spec.default);
+          const value = clamp(
+            Number.isFinite(raw) ? raw : spec.default,
+            spec.min,
+            spec.max
+          );
+          return (
+            <AdjustmentSlider
+              key={spec.name}
+              spec={spec}
+              value={value}
+              onChange={handleSliderChange}
+              onCommit={setPropertyComplete}
+            />
+          );
+        })}
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const GeneratorBody = memo(GeneratorBodyInner);
+GeneratorBody.displayName = "GeneratorBody";
+
+export default GeneratorBody;

--- a/web/src/components/node_types/editing/OffsetBody.tsx
+++ b/web/src/components/node_types/editing/OffsetBody.tsx
@@ -14,7 +14,7 @@ import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import { CheckerDropzone } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";

--- a/web/src/components/node_types/editing/OffsetBody.tsx
+++ b/web/src/components/node_types/editing/OffsetBody.tsx
@@ -1,0 +1,236 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * OffsetBody — bespoke body for `lib.image.warp.Offset`.
+ *
+ * Preview on top, two bipolar sliders (dx, dy) and a compact wrap-mode
+ * toggle group (Clamp / Repeat / Mirror) below.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone, FlexRow } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageRefPreview from "../../node/ImageRefPreview";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
+
+export const OFFSET_NODE_TYPE = "lib.image.warp.Offset";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "dx", label: "Offset X", min: -1, max: 1, step: 0.01, default: 0, bipolar: true },
+  { name: "dy", label: "Offset Y", min: -1, max: 1, step: 0.01, default: 0, bipolar: true }
+];
+
+const WRAP_LABELS = ["Clamp", "Repeat", "Mirror"] as const;
+
+const styles = (theme: Theme) =>
+  css({
+    "&.offset-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(0)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 140,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".controls": {
+      flex: "0 0 auto",
+      display: "grid",
+      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
+      alignItems: "center",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".wrap-row": {
+      gridColumn: "1 / -1",
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1),
+      paddingTop: theme.spacing(0.25)
+    },
+    ".wrap-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap",
+      minWidth: "minmax(52px, auto)"
+    },
+    ".wrap-row .MuiToggleButton-root": {
+      fontSize: theme.fontSizeSmaller,
+      padding: "2px 8px",
+      textTransform: "none"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+    }
+  />
+);
+
+export interface OffsetBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const OffsetBodyInner: React.FC<OffsetBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setPropertyComplete } = useLiveSliderWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const handleSliderChange = useCallback(
+    (name: string, v: number) => {
+      const spec = SLIDERS.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty]
+  );
+
+  const wrapValue = clamp(Number(props.wrap ?? 1), 0, 2);
+
+  const handleWrapChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, v: string | null) => {
+      if (v !== null) {
+        setProperty("wrap", Number(v));
+        setPropertyComplete();
+      }
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  return (
+    <div css={cssStyles} className="offset-body" data-bespoke-body="Offset">
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+      </div>
+
+      <div className="controls">
+        {SLIDERS.map((spec) => {
+          const raw = Number(props[spec.name] ?? spec.default);
+          const value = clamp(raw, spec.min, spec.max);
+          return (
+            <AdjustmentSlider
+              key={spec.name}
+              spec={spec}
+              value={value}
+              onChange={handleSliderChange}
+              onCommit={setPropertyComplete}
+            />
+          );
+        })}
+
+        <div className="wrap-row">
+          <span className="wrap-label">Wrap</span>
+          <ToggleButtonGroup
+            value={String(Math.round(wrapValue))}
+            exclusive
+            onChange={handleWrapChange}
+            size="small"
+            aria-label="Wrap mode"
+          >
+            {WRAP_LABELS.map((label, i) => (
+              <ToggleButton key={i} value={String(i)} aria-label={label}>
+                {label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </div>
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const OffsetBody = memo(OffsetBodyInner);
+OffsetBody.displayName = "OffsetBody";
+
+export default OffsetBody;

--- a/web/src/components/node_types/editing/OutlineBody.tsx
+++ b/web/src/components/node_types/editing/OutlineBody.tsx
@@ -1,0 +1,216 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * OutlineBody — bespoke body for `lib.image.effects.Outline`.
+ *
+ * Preview on top, then a color row and two sliders:
+ *   - Width (px): 0–32
+ *   - Alpha threshold: 0–1
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ImageIcon from "@mui/icons-material/Image";
+
+import { CheckerDropzone } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import ImageRefPreview from "../../node/ImageRefPreview";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+import ColorPicker from "../../inputs/ColorPicker";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
+import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
+import {
+  AdjustmentSlider,
+  adjustmentSliderStyles,
+  clamp,
+  type SliderSpec
+} from "./AdjustmentSlider";
+
+export const OUTLINE_NODE_TYPE = "lib.image.effects.Outline";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "width",     label: "Width (px)",     min: 0, max: 32, step: 0.5,  default: 2,   bipolar: false },
+  { name: "threshold", label: "Alpha threshold", min: 0, max: 1,  step: 0.01, default: 0.5, bipolar: false }
+];
+
+const styles = (theme: Theme) =>
+  css({
+    "&.outline-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: `calc(${theme.spacing(0)})`
+    },
+    ".preview-area": {
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 140,
+      borderRadius: "var(--rounded-sm)",
+      overflow: "hidden",
+      backgroundColor: theme.vars.palette.grey[900],
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      "& img": {
+        display: "block",
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain"
+      }
+    },
+    ".color-row": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+    },
+    ".color-row-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap"
+    },
+    ".controls": {
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
+      alignItems: "center",
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
+    }
+  />
+);
+
+export interface OutlineBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const OutlineBodyInner: React.FC<OutlineBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), adjustmentSliderStyles(theme)],
+    [theme]
+  );
+
+  const properties = nodeMetadata.properties ?? [];
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
+    [properties]
+  );
+
+  const props = data.properties ?? {};
+  const previewValue = useNodeOutput(workflowId, id);
+
+  const { setProperty, setPropertyComplete } = useLiveSliderWriter({ nodeId: id, nodeType });
+
+  const colorHex = String(
+    (props["color"] as { value?: string })?.value ?? "#000000"
+  );
+
+  const handleColorChange = useCallback(
+    (newColor: string | null) => {
+      setProperty("color", { type: "color", value: newColor ?? "#000000" });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  const handleChange = useCallback(
+    (name: string, v: number) => {
+      const spec = SLIDERS.find((s) => s.name === name);
+      if (!spec) return;
+      setProperty(name, clamp(v, spec.min, spec.max));
+    },
+    [setProperty]
+  );
+
+  return (
+    <div css={cssStyles} className="outline-body" data-bespoke-body="Outline">
+      <HandleColumn id={id} properties={imageProperty} />
+      <div className="preview-area">
+        <ImagePreview value={previewValue} />
+      </div>
+
+      <div className="color-row">
+        <span className="color-row-label">Color</span>
+        <ColorPicker
+          color={colorHex}
+          onColorChange={handleColorChange}
+          showCustom={true}
+          isNodeProperty={true}
+        />
+      </div>
+
+      <div className="controls">
+        {SLIDERS.map((spec) => {
+          const raw = Number(props[spec.name] ?? spec.default);
+          const value = clamp(raw, spec.min, spec.max);
+          return (
+            <AdjustmentSlider
+              key={spec.name}
+              spec={spec}
+              value={value}
+              onChange={handleChange}
+              onCommit={setPropertyComplete}
+            />
+          );
+        })}
+      </div>
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const OutlineBody = memo(OutlineBodyInner);
+OutlineBody.displayName = "OutlineBody";
+
+export default OutlineBody;

--- a/web/src/components/node_types/editing/PadBody.tsx
+++ b/web/src/components/node_types/editing/PadBody.tsx
@@ -1,19 +1,9 @@
 /** @jsxImportSource @emotion/react */
 /**
- * AdjustmentBody — generic bespoke body for slider-only image adjustment nodes
- * (Brightness/Contrast, HSB, Saturation/Vibrance, Color Balance, Vignette,
- * Exposure, …).
+ * PadBody — bespoke body for `lib.image.warp.Pad`.
  *
- * Preview on top, one slider per numeric property below. Unlike the per-node
- * bodies (Curves, Levels, …) nothing here is hardcoded: the image/mask handles
- * and every slider's range, default and step are derived from
- * `nodeMetadata.properties`. Registered for the node types in
- * `ADJUSTMENT_NODE_TYPES`.
- *
- * Bipolar sliders (range straddling 0, neutral at 0 — temperature, tint,
- * exposure, …) fill outward from the centre so the control reads as a signed
- * adjustment, not a 0–100% level. The preview reflects whatever the server
- * most recently produced — no client-side approximation.
+ * Preview on top, four unipolar sliders (Left, Top, Right, Bottom, each 0→4×
+ * source dimension), and a fill-color picker.
  */
 
 import React, { memo, useCallback, useMemo } from "react";
@@ -27,8 +17,9 @@ import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
+import ColorPicker from "../../inputs/ColorPicker";
 
-import type { NodeMetadata, Property } from "../../../stores/ApiTypes";
+import type { NodeMetadata } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useLiveSliderWriter } from "../../../hooks/nodes/useLiveSliderWriter";
 import { useNodeOutput } from "../../../hooks/nodes/useNodeIO";
@@ -39,9 +30,18 @@ import {
   type SliderSpec
 } from "./AdjustmentSlider";
 
+export const PAD_NODE_TYPE = "lib.image.warp.Pad";
+
+const SLIDERS: ReadonlyArray<SliderSpec> = [
+  { name: "left",   label: "Left",   min: 0, max: 4, step: 0.01, default: 0, bipolar: false },
+  { name: "top",    label: "Top",    min: 0, max: 4, step: 0.01, default: 0, bipolar: false },
+  { name: "right",  label: "Right",  min: 0, max: 4, step: 0.01, default: 0, bipolar: false },
+  { name: "bottom", label: "Bottom", min: 0, max: 4, step: 0.01, default: 0, bipolar: false }
+];
+
 const styles = (theme: Theme) =>
   css({
-    "&.adjustment-body": {
+    "&.pad-body": {
       position: "relative",
       width: "100%",
       height: "100%",
@@ -74,50 +74,37 @@ const styles = (theme: Theme) =>
       }
     },
     ".controls": {
-      flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      gridTemplateColumns: "auto 1fr auto",
+      columnGap: theme.spacing(1),
+      rowGap: theme.spacing(0.5),
       alignItems: "center",
-      columnGap: theme.spacing(1.25),
-      rowGap: theme.spacing(0.75),
-      padding: `${theme.spacing(0.75)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+    },
+    ".ctrl-label": {
+      fontSize: theme.fontSizeSmaller,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.045em",
+      lineHeight: 1,
+      whiteSpace: "nowrap"
     },
     ".outputs-row": {
       flex: "0 0 auto"
     }
   });
 
-const humanize = (name: string): string =>
-  name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-
-const isNumber = (v: unknown): v is number =>
-  typeof v === "number" && Number.isFinite(v);
-
-/**
- * Derive the slider specs from the node's numeric (`float` / `int`) properties.
- * Image-typed properties become handles instead (see `imageProps`).
- */
-const toSliderSpecs = (properties: Property[]): SliderSpec[] =>
-  properties.reduce<SliderSpec[]>((specs, p) => {
-    const kind = (p.type as { type?: string } | undefined)?.type;
-    if ((kind !== "float" && kind !== "int") || !isNumber(p.min) || !isNumber(p.max)) {
-      return specs;
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
     }
-    const isInt = kind === "int";
-    specs.push({
-      name: p.name,
-      label: p.title ?? humanize(p.name),
-      min: p.min,
-      max: p.max,
-      step: isInt ? 1 : 0.01,
-      default: isNumber(p.default) ? p.default : 0,
-      // Neutral-at-zero with headroom both ways — the signed adjustments.
-      bipolar: p.min < 0 && p.max > 0
-    });
-    return specs;
-  }, []);
+  />
+);
 
-export interface AdjustmentBodyProps {
+export interface PadBodyProps {
   id: string;
   nodeType: string;
   nodeMetadata: NodeMetadata;
@@ -127,7 +114,7 @@ export interface AdjustmentBodyProps {
   isOutputNode: boolean;
 }
 
-const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
+const PadBodyInner: React.FC<PadBodyProps> = ({
   id,
   nodeType,
   nodeMetadata,
@@ -143,14 +130,10 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
   );
 
   const properties = nodeMetadata.properties ?? [];
-  const imageProps = useMemo(
-    () =>
-      properties.filter(
-        (p) => (p.type as { type?: string } | undefined)?.type === "image"
-      ),
+  const imageProperty = useMemo(
+    () => properties.filter((p) => p.name === "image"),
     [properties]
   );
-  const sliders = useMemo(() => toSliderSpecs(properties), [properties]);
 
   const props = data.properties ?? {};
   const previewValue = useNodeOutput(workflowId, id);
@@ -160,40 +143,53 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
     nodeType
   });
 
-  const handleChange = useCallback(
+  const handleSliderChange = useCallback(
     (name: string, v: number) => {
-      const spec = sliders.find((s) => s.name === name);
+      const spec = SLIDERS.find((s) => s.name === name);
       if (!spec) return;
       setProperty(name, clamp(v, spec.min, spec.max));
     },
-    [setProperty, sliders]
+    [setProperty]
+  );
+
+  const colorValue = String(
+    (props["color"] as { value?: string })?.value ?? "#00000000"
+  );
+
+  const handleColorChange = useCallback(
+    (newColor: string | null) => {
+      setProperty("color", { type: "color", value: newColor ?? "#00000000" });
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
   );
 
   return (
-    <div css={cssStyles} className="adjustment-body" data-bespoke-body="Adjustment">
-      <HandleColumn id={id} properties={imageProps} />
+    <div css={cssStyles} className="pad-body" data-bespoke-body="Pad">
+      <HandleColumn id={id} properties={imageProperty} />
       <div className="preview-area">
-        <ImageRefPreview
-          value={previewValue}
-          placeholder={
-            <CheckerDropzone
-              message="Connect an image, then run"
-              icon={<ImageIcon />}
-            />
-          }
-        />
+        <ImagePreview value={previewValue} />
       </div>
 
       <div className="controls">
-        {sliders.map((spec) => {
+        <span className="ctrl-label">Fill</span>
+        <div style={{ gridColumn: "2 / 4" }}>
+          <ColorPicker
+            color={colorValue}
+            onColorChange={handleColorChange}
+            showCustom
+          />
+        </div>
+
+        {SLIDERS.map((spec) => {
           const raw = Number(props[spec.name] ?? spec.default);
-          const value = clamp(isNumber(raw) ? raw : spec.default, spec.min, spec.max);
+          const value = clamp(raw, spec.min, spec.max);
           return (
             <AdjustmentSlider
               key={spec.name}
               spec={spec}
               value={value}
-              onChange={handleChange}
+              onChange={handleSliderChange}
               onCommit={setPropertyComplete}
             />
           );
@@ -211,7 +207,7 @@ const AdjustmentBodyInner: React.FC<AdjustmentBodyProps> = ({
   );
 };
 
-export const AdjustmentBody = memo(AdjustmentBodyInner);
-AdjustmentBody.displayName = "AdjustmentBody";
+export const PadBody = memo(PadBodyInner);
+PadBody.displayName = "PadBody";
 
-export default AdjustmentBody;
+export default PadBody;

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -20,16 +20,25 @@ import CanvasResizeBody, {
   CANVAS_RESIZE_NODE_TYPE
 } from "./CanvasResizeBody";
 import ChannelsBody, { CHANNELS_NODE_TYPE } from "./ChannelsBody";
+import ChromaKeyBody, { CHROMA_KEY_NODE_TYPE } from "./ChromaKeyBody";
+import ColorOverlayBody, {
+  COLOR_OVERLAY_NODE_TYPE
+} from "./ColorOverlayBody";
 import CompositorBody, { COMPOSITOR_NODE_TYPE } from "./CompositorBody";
 import CropBody, { CROP_NODE_TYPE } from "./CropBody";
 import CurvesBody, { CURVES_NODE_TYPE } from "./CurvesBody";
+import DropShadowBody, { DROP_SHADOW_NODE_TYPE } from "./DropShadowBody";
 import FitBody, { FIT_NODE_TYPE } from "./FitBody";
+import GeneratorBody, { GENERATOR_NODE_TYPES } from "./GeneratorBody";
 import HSLAdjustBody, { HSL_ADJUST_NODE_TYPE } from "./HSLAdjustBody";
 import LevelsBody, { LEVELS_NODE_TYPE } from "./LevelsBody";
 import MaskBody, { MASK_NODE_TYPE } from "./MaskBody";
 import MasksExtractorBody, {
   MASKS_EXTRACTOR_NODE_TYPES
 } from "./MasksExtractorBody";
+import OffsetBody, { OFFSET_NODE_TYPE } from "./OffsetBody";
+import OutlineBody, { OUTLINE_NODE_TYPE } from "./OutlineBody";
+import PadBody, { PAD_NODE_TYPE } from "./PadBody";
 import PainterBody, { PAINTER_NODE_TYPE } from "./PainterBody";
 import PromptComposerBody, { PROMPT_NODE_TYPE } from "./PromptComposerBody";
 import PasteBody, { PASTE_NODE_TYPE } from "./PasteBody";
@@ -59,19 +68,28 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   [BLUR_NODE_TYPE]: BlurBody,
   [CANVAS_RESIZE_NODE_TYPE]: CanvasResizeBody,
   [CHANNELS_NODE_TYPE]: ChannelsBody,
+  [CHROMA_KEY_NODE_TYPE]: ChromaKeyBody,
+  [COLOR_OVERLAY_NODE_TYPE]: ColorOverlayBody,
   [COMPOSITOR_NODE_TYPE]: CompositorBody,
   [CROP_NODE_TYPE]: CropBody,
   [CURVES_NODE_TYPE]: CurvesBody,
+  [DROP_SHADOW_NODE_TYPE]: DropShadowBody,
   [FIT_NODE_TYPE]: FitBody,
   [HSL_ADJUST_NODE_TYPE]: HSLAdjustBody,
   [LEVELS_NODE_TYPE]: LevelsBody,
   [MASK_NODE_TYPE]: MaskBody,
+  [OFFSET_NODE_TYPE]: OffsetBody,
+  [OUTLINE_NODE_TYPE]: OutlineBody,
+  [PAD_NODE_TYPE]: PadBody,
   [PAINTER_NODE_TYPE]: PainterBody,
   [PASTE_NODE_TYPE]: PasteBody,
   [PROMPT_NODE_TYPE]: PromptComposerBody,
   [RESIZE_NODE_TYPE]: ResizeBody,
   [ROTATE_AND_FLIP_NODE_TYPE]: RotateAndFlipBody,
   [SCALE_NODE_TYPE]: ScaleBody,
+  ...Object.fromEntries(
+    GENERATOR_NODE_TYPES.map((t) => [t, GeneratorBody] as const)
+  ),
   ...Object.fromEntries(
     MASKS_EXTRACTOR_NODE_TYPES.map((t) => [t, MasksExtractorBody] as const)
   ),
@@ -81,6 +99,21 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   ...Object.fromEntries(
     ADJUSTMENT_NODE_TYPES.map((t) => [t, AdjustmentBody] as const)
   )
+};
+
+/**
+ * Default heights for bespoke bodies that are taller than the generic node.
+ * Consumed by `graphNodeToReactFlowNode` — only applied when the node has no
+ * saved height yet, so user resizes are preserved.
+ */
+export const BESPOKE_DEFAULT_HEIGHTS: Readonly<Record<string, number>> = {
+  [CURVES_NODE_TYPE]: 520,
+  // Generators: preview + color rows + up to 4 sliders need more than the
+  // generic default to show all controls without resizing.
+  ...Object.fromEntries(GENERATOR_NODE_TYPES.map((t) => [t, 460] as const)),
+  // Adjustment nodes with many sliders that overflow the generic height.
+  "lib.image.color_grading.LiftGammaGain": 580,
+  "lib.image.color_grading.SplitToning": 380
 };
 
 export const isBespokeNode = (

--- a/web/src/hooks/nodes/__tests__/useLiveSliderWriter.test.ts
+++ b/web/src/hooks/nodes/__tests__/useLiveSliderWriter.test.ts
@@ -18,7 +18,10 @@ const storeState = {
 
 jest.mock("../../../contexts/NodeContext", () => ({
   useNodes: (selector: (s: unknown) => unknown) =>
-    selector({ updateNodeProperties: mockUpdateNodeProperties }),
+    selector({
+      updateNodeProperties: mockUpdateNodeProperties,
+      edges: storeState.edges
+    }),
   useNodeStoreRef: () => ({ getState: () => storeState })
 }));
 

--- a/web/src/hooks/nodes/buildDownstreamRunGraph.ts
+++ b/web/src/hooks/nodes/buildDownstreamRunGraph.ts
@@ -201,13 +201,20 @@ export const buildDownstreamRunGraph = ({
 
   // Seed inputs from each upstream's selected generation (durable assets
   // merged with the live buffer); resolveExternalEdgeValue unwraps the
-  // returned outputs record by source handle.
+  // returned outputs record by source handle. Empty outputs (a node whose
+  // node_update carried no result — e.g. a constant) must read as "no cached
+  // value" so resolveExternalEdgeValue falls back to the literal source
+  // node's property instead of seeding `{}` into the target's input.
   const getResultFromGeneration = (wf: string, src: string): unknown => {
     const current = getCurrentGeneration(
       getNodeGenerations(wf, src),
       findNode(src)?.data?.selected_generation
     );
-    return current?.outputs;
+    const outputs = current?.outputs;
+    if (!outputs || Object.keys(outputs).length === 0) {
+      return undefined;
+    }
+    return outputs;
   };
 
   const propertyOverrides = collectCachedValuesForSubgraph(

--- a/web/src/hooks/nodes/useLiveSliderWriter.ts
+++ b/web/src/hooks/nodes/useLiveSliderWriter.ts
@@ -170,6 +170,45 @@ export const useLiveSliderWriter = ({
     runPreviewRef.current = runBrowserPreview;
   }, [runBrowserPreview]);
 
+  // Fire a live preview whenever this node's incoming wiring changes (a new
+  // edge, or an existing handle re-wired to a different source). Uses the same
+  // browser-preview path as a slider scrub so the preview comes to life
+  // immediately without a manual run. The signature captures source identity —
+  // a plain edge count would miss onConnect's replace-existing-edge case and
+  // onEdgeUpdate reconnections, where the count stays flat. On initial mount
+  // the baseline is recorded without triggering, and pure disconnects are
+  // skipped — only a genuinely new inbound edge previews.
+  const incomingEdgeSignature = useNodes((state) =>
+    state.edges
+      .filter((e) => e.target === nodeId)
+      .map((e) => `${e.source}/${e.sourceHandle ?? ""}>${e.targetHandle ?? ""}`)
+      .sort()
+      .join("|")
+  );
+  const prevIncomingSignatureRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevIncomingSignatureRef.current === null) {
+      prevIncomingSignatureRef.current = incomingEdgeSignature;
+      return;
+    }
+    if (incomingEdgeSignature === prevIncomingSignatureRef.current) {
+      return;
+    }
+    const prev = new Set(
+      prevIncomingSignatureRef.current.split("|").filter(Boolean)
+    );
+    const next = incomingEdgeSignature.split("|").filter(Boolean);
+    prevIncomingSignatureRef.current = incomingEdgeSignature;
+    // Skip pure disconnects (every remaining edge was already there) — nothing
+    // new flows in, so there's nothing fresh to preview.
+    if (!next.some((sig) => !prev.has(sig))) {
+      return;
+    }
+    if (!runBrowserPreview()) {
+      onPropertyChange();
+    }
+  }, [incomingEdgeSignature, runBrowserPreview, onPropertyChange]);
+
   const setProperty = useCallback(
     (name: string, value: unknown) => {
       updateNodeProperties(nodeId, { [name]: value });

--- a/web/src/lib/workflow/__tests__/attachPreviewBitmaps.test.ts
+++ b/web/src/lib/workflow/__tests__/attachPreviewBitmaps.test.ts
@@ -1,0 +1,97 @@
+import { attachPreviewBitmaps } from "../attachPreviewBitmaps";
+
+const RAW_RGBA_MIME = "image/x-raw-rgba";
+const BITMAP_IMAGE_MIME = "image/x-imagebitmap";
+
+const rawRef = (width = 2, height = 2) => ({
+  type: "image",
+  mimeType: RAW_RGBA_MIME,
+  data: new Uint8Array(width * height * 4),
+  width,
+  height
+});
+
+describe("attachPreviewBitmaps", () => {
+  const fakeBitmap = { width: 2, height: 2, close: jest.fn() };
+
+  beforeEach(() => {
+    (globalThis as { ImageData?: unknown }).ImageData = class {
+      constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+      ) {}
+    };
+    (globalThis as { createImageBitmap?: unknown }).createImageBitmap = jest
+      .fn()
+      .mockResolvedValue(fakeBitmap);
+  });
+
+  afterEach(() => {
+    delete (globalThis as { createImageBitmap?: unknown }).createImageBitmap;
+  });
+
+  it("replaces a raw-RGBA ref with a transferable bitmap ref (data dropped)", async () => {
+    const transfer: Transferable[] = [];
+    const out = (await attachPreviewBitmaps(
+      { output: rawRef() },
+      transfer
+    )) as { output: Record<string, unknown> };
+
+    expect(out.output.bitmap).toBe(fakeBitmap);
+    expect(out.output.mimeType).toBe(BITMAP_IMAGE_MIME);
+    expect(out.output.data).toBeUndefined();
+    expect(typeof out.output.bitmapVersion).toBe("number");
+    expect(transfer).toEqual([fakeBitmap]);
+  });
+
+  it("assigns a fresh bitmapVersion per frame so memoized consumers re-render", async () => {
+    const transfer: Transferable[] = [];
+    const a = (await attachPreviewBitmaps(rawRef(), transfer)) as Record<
+      string,
+      unknown
+    >;
+    const b = (await attachPreviewBitmaps(rawRef(), transfer)) as Record<
+      string,
+      unknown
+    >;
+    expect(a.bitmapVersion).not.toBe(b.bitmapVersion);
+  });
+
+  it("recurses into arrays and nested objects", async () => {
+    const transfer: Transferable[] = [];
+    const out = (await attachPreviewBitmaps(
+      { images: [rawRef(), { type: "image", uri: "/api/storage/x.png" }] },
+      transfer
+    )) as { images: Array<Record<string, unknown>> };
+
+    expect(out.images[0].bitmap).toBe(fakeBitmap);
+    expect(out.images[1].uri).toBe("/api/storage/x.png");
+    expect(out.images[1].bitmap).toBeUndefined();
+    expect(transfer).toHaveLength(1);
+  });
+
+  it("falls back to the unchanged raw ref when bitmap creation fails", async () => {
+    (globalThis as { createImageBitmap?: unknown }).createImageBitmap = jest
+      .fn()
+      .mockRejectedValue(new Error("no bitmap support"));
+    const transfer: Transferable[] = [];
+    const ref = rawRef();
+    const out = (await attachPreviewBitmaps(ref, transfer)) as Record<
+      string,
+      unknown
+    >;
+    expect(out).toBe(ref);
+    expect(transfer).toHaveLength(0);
+  });
+
+  it("leaves non-image values untouched", async () => {
+    const transfer: Transferable[] = [];
+    const out = await attachPreviewBitmaps(
+      { count: 3, label: "hi", bytes: new Uint8Array(4) },
+      transfer
+    );
+    expect(out).toEqual({ count: 3, label: "hi", bytes: new Uint8Array(4) });
+    expect(transfer).toHaveLength(0);
+  });
+});

--- a/web/src/lib/workflow/__tests__/materializeBrowserOutputs.test.ts
+++ b/web/src/lib/workflow/__tests__/materializeBrowserOutputs.test.ts
@@ -1,6 +1,10 @@
-import { materializeBrowserOutputs } from "../materializeBrowserOutputs";
+import {
+  materializeBrowserOutputs,
+  materializeBitmapRefs
+} from "../materializeBrowserOutputs";
 
 const RAW_RGBA_MIME = "image/x-raw-rgba";
+const BITMAP_IMAGE_MIME = "image/x-imagebitmap";
 
 describe("materializeBrowserOutputs", () => {
   it("wraps an inline base64 image as a self-contained data-URL ref", () => {
@@ -60,6 +64,73 @@ describe("materializeBrowserOutputs", () => {
     expect(out.images[1].uri).toBe("/api/storage/x.png");
     expect(out.count).toBe(2);
     expect(out.label).toBe("hi");
+  });
+
+  it("passes preview-bitmap refs through untouched (zero-copy display path)", () => {
+    const bitmap = { width: 2, height: 2 };
+    const ref = {
+      type: "image",
+      mimeType: BITMAP_IMAGE_MIME,
+      bitmap,
+      bitmapVersion: 7,
+      width: 2,
+      height: 2,
+      data: undefined
+    };
+    const out = materializeBrowserOutputs({ output: ref }) as {
+      output: Record<string, unknown>;
+    };
+    expect(out.output.bitmap).toBe(bitmap);
+    expect(out.output.bitmapVersion).toBe(7);
+    expect(out.output.uri).toBeUndefined();
+    expect(out.output.mimeType).toBe(BITMAP_IMAGE_MIME);
+  });
+
+  it("materializeBitmapRefs converts bitmap refs to portable data-URL refs", () => {
+    const toDataURL = jest.fn(() => "data:image/png;base64,PNG");
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage: jest.fn() }),
+      toDataURL
+    };
+    const spy = jest
+      .spyOn(document, "createElement")
+      .mockReturnValue(canvas as unknown as HTMLCanvasElement);
+
+    const out = materializeBitmapRefs({
+      graph: {
+        nodes: [
+          {
+            data: {
+              properties: {
+                image: {
+                  type: "image",
+                  mimeType: BITMAP_IMAGE_MIME,
+                  bitmap: { width: 2, height: 2 },
+                  bitmapVersion: 3,
+                  width: 2,
+                  height: 2
+                }
+              }
+            }
+          }
+        ]
+      }
+    }) as {
+      graph: {
+        nodes: Array<{
+          data: { properties: { image: Record<string, unknown> } };
+        }>;
+      };
+    };
+
+    const ref = out.graph.nodes[0].data.properties.image;
+    expect(ref.uri).toBe("data:image/png;base64,PNG");
+    expect(ref.mimeType).toBe("image/png");
+    expect(ref.bitmap).toBeUndefined();
+    expect(ref.bitmapVersion).toBeUndefined();
+    spy.mockRestore();
   });
 
   it("preserves an already-prefixed data URL", () => {

--- a/web/src/lib/workflow/attachPreviewBitmaps.ts
+++ b/web/src/lib/workflow/attachPreviewBitmaps.ts
@@ -1,0 +1,65 @@
+/**
+ * attachPreviewBitmaps — convert raw-RGBA image refs to transferable
+ * preview bitmaps at the worker's postMessage boundary.
+ *
+ * The latency-critical path for live GPU image previews used to be:
+ * structured-clone the raw RGBA buffer to the main thread, synchronously
+ * encode it to a base64 PNG data URL there (blocking the UI for tens of ms
+ * per frame), then have an `<img>` decode that PNG back into pixels. This
+ * helper replaces all of that: the worker decodes the raw pixels into an
+ * `ImageBitmap` once (cheap, often GPU-backed) and *transfers* it across
+ * `postMessage` (zero-copy). The main thread paints it straight onto a
+ * canvas — no encode, no base64, no decode.
+ *
+ * The raw `data` is dropped from the transported copy (the kernel's
+ * in-memory edge values keep theirs): anything that later needs pixels or
+ * PNG bytes derives them from the bitmap via the shared codec helpers
+ * (`decodeRgba` / `loadImageBytes` in image-io, `bitmapToPngDataUrl` on the
+ * UI side). `bitmapVersion` disambiguates frames for structurally-memoized
+ * consumers, since two `ImageBitmap`s have no enumerable own properties.
+ *
+ * On any failure the ref is passed through unchanged, falling back to the
+ * main thread's raw-RGBA → PNG materialization.
+ */
+import { isRawRgbaImage, BITMAP_IMAGE_MIME } from "@nodetool-ai/protocol";
+
+let nextBitmapVersion = 1;
+
+export async function attachPreviewBitmaps(
+  value: unknown,
+  transfer: Transferable[]
+): Promise<unknown> {
+  if (value === null || value === undefined) return value;
+  if (isRawRgbaImage(value)) {
+    try {
+      // Copy into a fresh clamped array: satisfies ImageData's non-shared
+      // ArrayBuffer requirement and detaches from the kernel's edge buffer.
+      const pixels = new Uint8ClampedArray(value.data);
+      const bitmap = await createImageBitmap(
+        new ImageData(pixels, value.width, value.height)
+      );
+      transfer.push(bitmap);
+      return {
+        ...value,
+        data: undefined,
+        mimeType: BITMAP_IMAGE_MIME,
+        bitmap,
+        bitmapVersion: nextBitmapVersion++
+      };
+    } catch {
+      return value;
+    }
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v) => attachPreviewBitmaps(v, transfer)));
+  }
+  if (typeof value === "object" && !ArrayBuffer.isView(value)) {
+    const entries = await Promise.all(
+      Object.entries(value as Record<string, unknown>).map(
+        async ([k, v]) => [k, await attachPreviewBitmaps(v, transfer)] as const
+      )
+    );
+    return Object.fromEntries(entries);
+  }
+  return value;
+}

--- a/web/src/lib/workflow/browserRunner.worker.ts
+++ b/web/src/lib/workflow/browserRunner.worker.ts
@@ -15,9 +15,11 @@
  *   → { type: "run", jobId, graph, params, workflowId }
  *   → { type: "cancel", jobId }
  *
- * Messages are streamed raw (in-flight asset formats intact). The main thread
- * materializes them (raw-RGBA → PNG) before delivery — stage 1 keeps the canvas
- * encode on main; a later pass can move it here with OffscreenCanvas + transfer.
+ * Messages are streamed with image outputs resolved for transport: GPU textures
+ * are read back to CPU, then converted to transferable ImageBitmaps
+ * (`attachPreviewBitmaps`) so the main thread paints previews directly — no
+ * PNG encode/decode in the live path. Refs the bitmap pass can't handle fall
+ * through to the main thread's materialization (raw-RGBA → PNG data URL).
  */
 import {
   loadBrowserModules,
@@ -25,6 +27,7 @@ import {
   normalizeGraphForKernel,
   type LoadedBrowserRunner
 } from "./browserRunnerCore";
+import { attachPreviewBitmaps } from "./attachPreviewBitmaps";
 
 declare const self: DedicatedWorkerGlobalScope;
 
@@ -108,18 +111,26 @@ async function runJob(msg: RunMessage): Promise<void> {
       // Read any GPU-texture refs in this message back to CPU buffers before it
       // crosses postMessage (textures aren't cloneable). The kernel keeps the
       // texture for downstream edges; only this transported copy is read back.
+      // The readback copy is then turned into a transferable ImageBitmap so the
+      // main thread can paint it without any PNG encode/decode round-trip; the
+      // kernel's own buffers are untouched, so transferring is safe here.
       const message = next.value as Record<string, unknown>;
       const resolve = runner.resolveImageRefForTransport;
+      const transfer: Transferable[] = [];
       if (resolve) {
         if (message.type === "node_update" && message.result != null) {
-          message.result = await resolve(message.result);
+          message.result = await attachPreviewBitmaps(
+            await resolve(message.result),
+            transfer
+          );
         } else if (message.type === "output_update" && message.value != null) {
-          message.value = await resolve(message.value);
+          message.value = await attachPreviewBitmaps(
+            await resolve(message.value),
+            transfer
+          );
         }
       }
-      // Structured-clone copy (no transfer): the kernel may still reference the
-      // same buffer for downstream edges, so transferring would corrupt inputs.
-      self.postMessage({ type: "message", jobId, message });
+      self.postMessage({ type: "message", jobId, message }, transfer);
     }
   } catch (error) {
     self.postMessage({

--- a/web/src/lib/workflow/materializeBrowserOutputs.ts
+++ b/web/src/lib/workflow/materializeBrowserOutputs.ts
@@ -16,8 +16,15 @@
  *
  * Materialization is leak-free: raw-RGBA is encoded to a PNG data URL via a
  * canvas and base64 is wrapped as a data URL — no blob URLs to revoke.
+ *
+ * Preview-bitmap refs (the worker's transferable `ImageBitmap` transport
+ * format, see `attachPreviewBitmaps`) deliberately pass through untouched:
+ * they are already directly displayable (painted onto a canvas) and encoding
+ * them here would reintroduce the main-thread PNG encode this fast path
+ * exists to avoid. Consumers that need a URL derive one lazily via
+ * {@link bitmapToPngDataUrl} or an async blob encode.
  */
-import { RAW_RGBA_MIME } from "@nodetool-ai/protocol";
+import { RAW_RGBA_MIME, isBitmapImage } from "@nodetool-ai/protocol";
 
 /**
  * Encode a raw-RGBA image ref (straight-alpha RGBA8 pixels, no container) to a
@@ -46,6 +53,25 @@ export function rawRgbaToPngDataUrl(
   }
 }
 
+/**
+ * Synchronously encode a preview `ImageBitmap` to a PNG data URL. Off the live
+ * path — only for consumers that genuinely need a URL string right now (e.g.
+ * thumbnail grids); interactive consumers should prefer an async blob encode.
+ */
+export function bitmapToPngDataUrl(bitmap: ImageBitmap): string {
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return "";
+    ctx.drawImage(bitmap, 0, 0);
+    return canvas.toDataURL("image/png");
+  } catch {
+    return "";
+  }
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -62,6 +88,9 @@ const isImageRef = (value: unknown): value is Record<string, unknown> =>
 function materializeImageRef(
   ref: Record<string, unknown>
 ): Record<string, unknown> {
+  // Preview bitmap from the worker — already displayable, pass through.
+  if (isBitmapImage(ref)) return ref;
+
   // Raw in-flight RGBA → PNG data URL. An <img> decodes the data URL off the
   // main thread (browser-optimized), which is faster than painting the buffer
   // onto a DOM <canvas> + re-encoding it for download. The resulting uri is
@@ -88,6 +117,34 @@ function materializeImageRef(
   }
 
   return ref;
+}
+
+/**
+ * Recursively convert preview-bitmap refs to portable PNG data-URL refs.
+ * For serialization boundaries an `ImageBitmap` can't cross — e.g.
+ * run-from-here seeding a *server*-run subgraph with a browser-run upstream's
+ * cached output (params travel as msgpack). Pays the sync PNG encode, so keep
+ * it to one-off run starts, never the streaming display path.
+ */
+export function materializeBitmapRefs(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(materializeBitmapRefs);
+  if (isBitmapImage(value)) {
+    const uri = bitmapToPngDataUrl(value.bitmap as ImageBitmap);
+    if (!uri) return value;
+    const rest: Record<string, unknown> = { ...value };
+    delete rest.bitmap;
+    delete rest.bitmapVersion;
+    return { ...rest, uri, data: undefined, mimeType: "image/png" };
+  }
+  if (typeof value === "object" && !ArrayBuffer.isView(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = materializeBitmapRefs(v);
+    }
+    return out;
+  }
+  return value;
 }
 
 /**

--- a/web/src/lib/workflow/runInlineGraphJob.ts
+++ b/web/src/lib/workflow/runInlineGraphJob.ts
@@ -9,6 +9,7 @@ import {
   canRunGraphInBrowserSync,
   runBrowserGraphJob
 } from "./browserWorkflowRunner";
+import { materializeBitmapRefs } from "./materializeBrowserOutputs";
 
 export type GraphNode = Node;
 export type GraphEdge = Edge;
@@ -80,6 +81,15 @@ export async function runInlineGraphJob(
   }
 
   await globalWebSocketManager.ensureConnection();
+
+  // Preview-bitmap refs can't cross msgpack to the server. Run-from-here /
+  // single-node runs seed cached browser-run outputs into node property
+  // overrides (graph) and params — encode those to portable data-URL refs.
+  const portableGraph = materializeBitmapRefs(graph) as InlineGraph;
+  const portableParams = materializeBitmapRefs(params) as Record<
+    string,
+    unknown
+  >;
 
   const jobId = uuidv4();
 
@@ -226,12 +236,12 @@ export async function runInlineGraphJob(
         user_id,
         auth_token,
         api_url: BASE_URL,
-        params,
+        params: portableParams,
         explicit_types: false,
         // Explicit single-node / run-from-here runs are concurrent like the
         // other canvas run paths, so they don't serialize behind one another.
         concurrent: true,
-        graph
+        graph: portableGraph
       }
     });
   } catch (err) {

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -49,6 +49,7 @@ import { reactFlowNodeToGraphNode } from "./reactFlowNodeToGraphNode";
 import { isValidEdge, sanitizeGraph } from "../core/workflow/graphMapping";
 import { GROUP_NODE_TYPE } from "../utils/nodeUtils";
 import { PREVIEW_NODE_TYPE } from "../constants/nodeTypes";
+import { BESPOKE_DEFAULT_HEIGHTS } from "../components/node_types/editing/bespokeRegistry";
 import { DEFAULT_NODE_WIDTH } from "./nodeUiDefaults";
 import { applyDefaultModels } from "../utils/applyDefaultModels";
 import { reactFlowNodeChromeClassName } from "../utils/reactFlowNodeChromeClassName";
@@ -1282,6 +1283,11 @@ export const createNodeStore = (
               defaultStyle = { width: 320, height: 320 };
             } else if (isAgentStyle) {
               defaultStyle = { width: DEFAULT_NODE_WIDTH };
+            } else if (metadata.node_type in BESPOKE_DEFAULT_HEIGHTS) {
+              defaultStyle = {
+                width: DEFAULT_NODE_WIDTH,
+                height: BESPOKE_DEFAULT_HEIGHTS[metadata.node_type]
+              };
             } else if (isContentCard) {
               defaultStyle = getContentCardDefaultSize(metadata);
             } else {

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -35,6 +35,7 @@ import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/shallow";
 import { createRunnerMessageHandler } from "../core/workflow/runnerProtocol";
+import { materializeBitmapRefs } from "../lib/workflow/materializeBrowserOutputs";
 import { getNodeStore, MsgpackData } from "./workflowUpdates";
 import { queryClient } from "../queryClient";
 
@@ -424,7 +425,7 @@ export const createWorkflowRunnerStore = (
           await globalWebSocketManager.send({
             type: "run_job",
             command: "run_job",
-            data: req
+            data: materializeBitmapRefs(req) as Record<string, unknown>
           });
           queryClient.invalidateQueries({ queryKey: ["jobs"] });
         } catch (error) {
@@ -535,10 +536,13 @@ export const createWorkflowRunnerStore = (
       console.info(`WorkflowRunner[${workflowId}]: Sending run_job command`, req);
 
       try {
+        // Preview-bitmap refs (cached browser-run outputs seeded into single-
+        // node / run-from-here subgraph properties) can't cross msgpack —
+        // encode them to portable data-URL refs for the server.
         await globalWebSocketManager.send({
           type: "run_job",
           command: "run_job",
-          data: req
+          data: materializeBitmapRefs(req) as Record<string, unknown>
         });
       } catch (error) {
         // Rollback so the store doesn't get stuck in "running" with a phantom

--- a/web/src/stores/graphNodeToReactFlowNode.ts
+++ b/web/src/stores/graphNodeToReactFlowNode.ts
@@ -11,6 +11,7 @@ import {
   COMMENT_NODE_TYPE,
   PREVIEW_NODE_TYPE
 } from "../constants/nodeTypes";
+import { BESPOKE_DEFAULT_HEIGHTS } from "../components/node_types/editing/bespokeRegistry";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -53,6 +54,9 @@ export function graphNodeToReactFlowNode(
   }
   if (isCompareImagesNode && !ui_properties?.height) {
     defaultHeight = 350;
+  }
+  if (!ui_properties?.height && node.type && node.type in BESPOKE_DEFAULT_HEIGHTS) {
+    defaultHeight = BESPOKE_DEFAULT_HEIGHTS[node.type];
   }
 
   const strip = NODE_COLLAPSED_STRIP_HEIGHT_PX;


### PR DESCRIPTION
## Summary

Implements a zero-copy transport path for GPU image outputs in the in-browser runner. Instead of encoding raw RGBA to PNG on the main thread (blocking the UI for tens of ms per frame), the worker now converts GPU textures to transferable `ImageBitmap` objects and sends them across `postMessage` with zero-copy semantics. The main thread paints them directly onto a canvas, eliminating the PNG encode/decode round-trip entirely.

## Key Changes

- **New `BitmapCanvas` component** (`web/src/components/node/BitmapCanvas.tsx`): Paints an `ImageBitmap` directly onto a canvas element. Memoized to prevent unnecessary repaints.

- **Worker-side bitmap conversion** (`web/src/lib/workflow/attachPreviewBitmaps.ts`): New helper that converts raw-RGBA image refs to transferable `ImageBitmap` objects at the `postMessage` boundary. Includes error handling to fall back to raw RGBA if bitmap creation fails.

- **Main-thread materialization** (`web/src/lib/workflow/materializeBrowserOutputs.ts`):
  - Preview-bitmap refs now pass through untouched (no PNG encode on the live path)
  - New `bitmapToPngDataUrl()` helper for one-off conversions (e.g., thumbnails, serialization boundaries)
  - New `materializeBitmapRefs()` function to convert bitmaps to portable PNG data URLs when crossing msgpack boundaries (run-from-here, server runs)

- **Enhanced `ImageView` component** (`web/src/components/node/ImageView.tsx`):
  - Accepts optional `bitmap` prop (takes precedence over `source`)
  - Renders `BitmapCanvas` when bitmap is present, `<img>` otherwise
  - Lazily encodes bitmap to PNG blob URL (250ms debounce) for action buttons (copy/download/viewer), so live scrubbing never pays for an encode

- **Protocol updates** (`packages/protocol/src/api-types.ts`):
  - New `BITMAP_IMAGE_MIME` constant for the preview-bitmap format
  - New `isBitmapImage()` type guard for structural checking (works in DOM-free environments)
  - `ImageRef` now includes optional `bitmap` and `bitmapVersion` fields
  - Updated `isInFlightImage()` to include bitmap refs

- **Image codec support** (`packages/image-nodes/src/nodes/image-io.ts`):
  - New `bitmapToRgba()` helper to read pixels back from an `ImageBitmap` via `OffscreenCanvas`
  - `loadImageBytes()` and `decodeRgba()` now handle bitmap refs

- **Worker integration** (`web/src/lib/workflow/browserRunner.worker.ts`):
  - Calls `attachPreviewBitmaps()` on output messages before posting, converting GPU textures → bitmaps → transfer list

- **Run-from-here support** (`web/src/lib/workflow/runInlineGraphJob.ts`):
  - Materializes bitmap refs to portable PNG data URLs before sending to server (msgpack can't serialize `ImageBitmap`)

- **History viewer and output hooks** updated to handle bitmap refs

## Implementation Details

- **Debounced encoding**: The main thread doesn't encode the bitmap to PNG immediately. Instead, it waits 250ms after the last bitmap update, then encodes asynchronously. This ensures live scrubbing (new frame every few ms) only pays for one encode at the end, not one per frame.

- **Blob URL lifecycle**: Bitmap URLs are tracked in a ref and revoked when replaced or on unmount, preventing memory leaks.

- **Fallback behavior**: If bitmap creation fails (e.g., bitmap closed mid-scrub), the ref passes through unchanged and falls back to the main thread's raw-RGBA → PNG materialization.

- **Structural equality**: `bitmapVersion` is a monotonic counter that disambiguates frames for memoized consumers, since two `ImageBitmap` objects have no enumerable own properties and can't be compared structurally.

- **

https://claude.ai/code/session_014QVSHCm2jECY2WwDKQRrSD