### PR TITLE
Fix error handling and tool result management in agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43149,6 +43149,7 @@
       "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
+        "@nodetool-ai/config": "*",
         "@nodetool-ai/gpu": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
@@ -43396,8 +43397,6 @@
         "ws": "^8.19.0"
       },
       "devDependencies": {
-        "@stryker-mutator/core": "^9.6.1",
-        "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "typescript": "^5.7.2",

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -334,6 +334,7 @@ async function* mergeAsyncGenerators<T>(
   let activeCount = generators.length;
   let resolve: (() => void) | null = null;
   let firstError: unknown = undefined;
+  let hasError = false;
 
   function notify() {
     if (resolve) {
@@ -350,7 +351,10 @@ async function* mergeAsyncGenerators<T>(
         notify();
       }
     } catch (e) {
-      if (firstError === undefined) firstError = e;
+      if (!hasError) {
+        hasError = true;
+        firstError = e;
+      }
     } finally {
       activeCount--;
       notify();
@@ -374,7 +378,9 @@ async function* mergeAsyncGenerators<T>(
 
   await Promise.allSettled(tasks);
 
-  if (firstError !== undefined) {
-    throw firstError;
+  if (hasError) {
+    throw firstError instanceof Error
+      ? firstError
+      : new Error(String(firstError));
   }
 }

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -579,15 +579,19 @@ export class StepExecutor {
    */
   private evictOldToolResultsIfOverBudget(): void {
     while (this.estimateTokens() > this.maxTokenLimit * 0.9) {
+      // Evict the oldest assistant tool-call turn together with ALL of its
+      // tool results. Removing a tool result on its own leaves the assistant
+      // message with a dangling tool call, which providers reject.
       const idx = this.history.findIndex(
-        (m, i) => i > 0 && m.role === "tool"
+        (m, i) =>
+          i > 0 && m.role === "assistant" && (m.toolCalls?.length ?? 0) > 0
       );
       if (idx === -1) return;
-      this.history.splice(idx, 1);
-      const prev = this.history[idx - 1];
-      if (prev?.role === "assistant" && prev.toolCalls?.length === 1) {
-        this.history.splice(idx - 1, 1);
+      let end = idx + 1;
+      while (end < this.history.length && this.history[end].role === "tool") {
+        end++;
       }
+      this.history.splice(idx, end - idx);
     }
   }
 
@@ -984,6 +988,20 @@ export class StepExecutor {
             args: finishStepCall.args,
             message: this.generateToolCallMessage(finishStepCall)
           } satisfies ToolCallUpdate;
+
+          // Every tool call in the assistant message needs a tool result —
+          // even the siblings we don't execute. If finish_step validation
+          // fails below and the loop continues, a dangling tool call makes
+          // the provider reject the next request.
+          for (const tc of filteredToolCalls) {
+            if (tc === finishStepCall) continue;
+            this.history.push({
+              role: "tool",
+              toolCallId: tc.id,
+              content:
+                '{"status": "skipped", "reason": "finish_step was called in the same turn"}'
+            });
+          }
 
           // Extract and validate result
           const resultPayload =

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -420,6 +420,7 @@ async function* mergeAsyncGenerators<T>(
   let activeCount = generators.length;
   let resolve: (() => void) | null = null;
   let firstError: unknown = undefined;
+  let hasError = false;
 
   function notify() {
     if (resolve) {
@@ -437,7 +438,10 @@ async function* mergeAsyncGenerators<T>(
         notify();
       }
     } catch (e) {
-      if (firstError === undefined) firstError = e;
+      if (!hasError) {
+        hasError = true;
+        firstError = e;
+      }
     } finally {
       activeCount--;
       notify();
@@ -467,7 +471,9 @@ async function* mergeAsyncGenerators<T>(
   // Wait for all producer promises to settle
   await Promise.allSettled(tasks);
 
-  if (firstError !== undefined) {
-    throw firstError;
+  if (hasError) {
+    throw firstError instanceof Error
+      ? firstError
+      : new Error(String(firstError));
   }
 }

--- a/packages/agents/src/tools/dataseo-tools.ts
+++ b/packages/agents/src/tools/dataseo-tools.ts
@@ -96,7 +96,9 @@ async function dataForSEORequest(
     }
     return (await res.json()) as DataForSEOResponse;
   } catch (e: unknown) {
-    return { error: `DataForSEO request failed: ${(e as Error).message}` };
+    return {
+      error: `DataForSEO request failed: ${e instanceof Error ? e.message : String(e)}`
+    };
   }
 }
 
@@ -162,7 +164,7 @@ export class DataForSEOSearchTool extends Tool {
     try {
       creds = await getDataForSEOCredentials(context);
     } catch (e: unknown) {
-      return { error: (e as Error).message };
+      return { error: e instanceof Error ? e.message : String(e) };
     }
     const auth = makeAuthHeader(creds.login, creds.password);
 
@@ -248,7 +250,7 @@ export class DataForSEONewsTool extends Tool {
     try {
       creds = await getDataForSEOCredentials(context);
     } catch (e: unknown) {
-      return { error: (e as Error).message };
+      return { error: e instanceof Error ? e.message : String(e) };
     }
     const auth = makeAuthHeader(creds.login, creds.password);
 
@@ -351,7 +353,7 @@ export class DataForSEOImagesTool extends Tool {
     try {
       creds = await getDataForSEOCredentials(context);
     } catch (e: unknown) {
-      return { error: (e as Error).message };
+      return { error: e instanceof Error ? e.message : String(e) };
     }
     const auth = makeAuthHeader(creds.login, creds.password);
 

--- a/packages/agents/src/tools/http-tools.ts
+++ b/packages/agents/src/tools/http-tools.ts
@@ -90,7 +90,8 @@ export class DownloadFileTool extends Tool {
 
       const contentType = response.headers.get("Content-Type") ?? "unknown";
       const contentLength = response.headers.get("Content-Length");
-      const fileSizeBytes = contentLength ? parseInt(contentLength, 10) : null;
+      const parsedLength = contentLength ? parseInt(contentLength, 10) : NaN;
+      const fileSizeBytes = Number.isFinite(parsedLength) ? parsedLength : null;
 
       const bytes = new Uint8Array(await response.arrayBuffer());
       const persisted = await persistBinaryOutput(context, bytes, {

--- a/packages/agents/src/tools/vector-tools.ts
+++ b/packages/agents/src/tools/vector-tools.ts
@@ -241,7 +241,8 @@ export class VecHybridSearchTool extends Tool {
       const combined: Record<string, { doc: string; score: number }> = {};
       const fuse = (matches: VectorMatch[]) => {
         matches.forEach((m, rank) => {
-          const score = 1 / (rank + kConstant);
+          // RRF uses 1-based ranks: first result scores 1/(k+1).
+          const score = 1 / (rank + 1 + kConstant);
           if (m.document == null) return;
           if (combined[m.id]) combined[m.id].score += score;
           else combined[m.id] = { doc: m.document, score };


### PR DESCRIPTION
## Summary
This PR fixes several critical issues in the agent execution system related to error handling, tool result management, and ranking calculations. The changes ensure proper cleanup of tool results during token budget eviction, correct error propagation in async generators, and accurate reciprocal rank fusion scoring.

## Key Changes

### StepExecutor: Fix tool result eviction logic
- **Changed**: `evictOldToolResultsIfOverBudget()` now evicts an entire assistant tool-call turn together with ALL of its tool results, rather than individual tool results
- **Why**: Removing a tool result on its own leaves the assistant message with a dangling tool call, which providers reject. The new logic finds the oldest assistant message with tool calls and removes it along with all subsequent tool results in one operation
- **Added**: When `finish_step` is called, sibling tool calls that aren't executed now receive explicit "skipped" tool results, preventing dangling tool calls that would cause provider rejection on the next request

### Error handling in async generators
- **Fixed**: `mergeAsyncGenerators()` in both `task-executor.ts` and `parallel-task-executor.ts` now properly tracks error state with a `hasError` flag
- **Why**: The previous logic using `firstError === undefined` could fail if the first error was `undefined` itself, causing the error to not be thrown
- **Added**: Error wrapping ensures non-Error objects are converted to Error instances before throwing

### DataForSEO tools: Safer error message extraction
- **Changed**: All error handling now uses `e instanceof Error ? e.message : String(e)` instead of unsafe type assertions
- **Why**: Prevents runtime errors when caught exceptions aren't Error objects

### HTTP tools: Safer Content-Length parsing
- **Fixed**: `DownloadFileTool` now validates parsed Content-Length with `Number.isFinite()` before using it
- **Why**: `parseInt()` can return `NaN` for invalid input, which should be treated as missing length

### Vector tools: Correct RRF scoring
- **Fixed**: `VecHybridSearchTool` reciprocal rank fusion now uses `1 / (rank + 1 + kConstant)` instead of `1 / (rank + kConstant)`
- **Why**: RRF standard uses 1-based ranks where the first result scores `1/(k+1)`, not `1/k`

https://claude.ai/code/session_019pK6eJiLEP7LCiX963oKyQ