### PR TITLE
Fix clip generation, timeline state management, and preview rendering

### DIFF
--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -18,6 +18,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
 import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
 import ImageModelSelect from "../../properties/ImageModelSelect";
 import VideoModelSelect from "../../properties/VideoModelSelect";
@@ -76,6 +77,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     (s) => s.setClipDirectGenModel
   );
   const patchClipBinding = useTimelineStore((s) => s.patchClipBinding);
+  const addNotification = useNotificationStore((s) => s.addNotification);
 
   const {
     generateClip,
@@ -159,12 +161,19 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   );
 
   const handleGenerateClick = useCallback(() => {
-    if (isActive) {
-      void cancelClipGeneration();
-    } else {
-      void generateClip();
-    }
-  }, [isActive, cancelClipGeneration, generateClip]);
+    const action = isActive ? cancelClipGeneration() : generateClip();
+    action.catch((err: unknown) => {
+      addNotification({
+        content: `Clip generation failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        type: "error",
+        alert: true,
+        dedupeKey: "timeline-clip-generate-failed",
+        replaceExisting: true
+      });
+    });
+  }, [isActive, cancelClipGeneration, generateClip, addNotification]);
 
   if (!clip) {
     return null;

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -23,7 +23,11 @@ import type { Theme } from "@mui/material/styles";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 
 import type { TimelineClip, TimelineTrack, ClipStatus } from "@nodetool-ai/timeline";
-import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  useTimelineStoreApi,
+  timelineTemporalOf
+} from "../../../stores/timeline/TimelineStore";
 import {
   useTimelineUIStore,
   useIsClipSelected
@@ -374,7 +378,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
 
   const isSelected = useIsClipSelected(clipId);
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
-  const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
 
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const addToSelection = useTimelineUIStore((s) => s.addToSelection);
@@ -470,6 +473,36 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     }
     return deriveClipStatus(clip, generationState, errorState, true);
   }, [clip, generationState, errorState]);
+
+  // ── Undo batching ───────────────────────────────────────────────────────
+  //
+  // Drag/trim gestures mutate the store on every pointermove. To collapse a
+  // whole gesture into a single undo entry we let the *first* mutation of the
+  // gesture be recorded normally (zundo pushes the pre-gesture state onto the
+  // undo stack inside that set call), then pause history tracking for the
+  // rest of the gesture and resume on gesture end. While paused, zundo
+  // records nothing — so one undo step reverts the entire drag.
+
+  const timelineStoreApi = useTimelineStoreApi();
+  const historyPausedRef = useRef(false);
+
+  const pauseHistoryAfterFirstMutation = useCallback(() => {
+    if (!historyPausedRef.current) {
+      timelineTemporalOf(timelineStoreApi).pause();
+      historyPausedRef.current = true;
+    }
+  }, [timelineStoreApi]);
+
+  const resumeHistory = useCallback(() => {
+    if (historyPausedRef.current) {
+      historyPausedRef.current = false;
+      timelineTemporalOf(timelineStoreApi).resume();
+    }
+  }, [timelineStoreApi]);
+
+  // Safety net: never leave history tracking paused if the clip unmounts
+  // mid-gesture (e.g. the store changes underneath us).
+  useEffect(() => resumeHistory, [resumeHistory]);
 
   // ── Drag (move) ─────────────────────────────────────────────────────────
 
@@ -596,12 +629,15 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
             disableSnap
           );
         }
+        // First mutation recorded the pre-drag state; batch the rest.
+        pauseHistoryAfterFirstMutation();
       };
 
       const onUpOrCancel = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUpOrCancel);
         window.removeEventListener("pointercancel", onUpOrCancel);
+        resumeHistory();
         // Defer dragging flag reset so the synthetic click that follows
         // pointerup is still suppressed by handleClick.
         const wasDragging = isDraggingRef.current;
@@ -625,7 +661,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       splitClipAtTime,
       clipId,
       moveClip,
-      moveSelectedClips
+      moveSelectedClips,
+      pauseHistoryAfterFirstMutation,
+      resumeHistory
     ]
   );
 
@@ -660,6 +698,13 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
 
   // ── Trim start ──────────────────────────────────────────────────────────
 
+  // Gesture-ownership flags: each trim handle's move handler only runs when
+  // *its own* pointerdown started the gesture. Without this, dragging another
+  // clip across the handle (with the primary button held) would fire the move
+  // handler and corrupt this clip's geometry.
+  const isTrimmingStartRef = useRef(false);
+  const isTrimmingEndRef = useRef(false);
+
   const trimStartRef = useRef({ startX: 0, startMs: 0 });
 
   const handleTrimStartPointerDown = useCallback(
@@ -675,13 +720,19 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       e.stopPropagation();
       e.currentTarget.setPointerCapture(e.pointerId);
       trimStartRef.current = { startX: e.clientX, startMs: clip.startMs };
+      isTrimmingStartRef.current = true;
     },
     [clip, activeTool]
   );
 
   const handleTrimStartPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!clip || clip.locked || e.buttons !== 1) {
+      if (
+        !isTrimmingStartRef.current ||
+        !clip ||
+        clip.locked ||
+        e.buttons !== 1
+      ) {
         return;
       }
       // Stop bubbling so the parent clip body's drag-pointermove handler
@@ -696,9 +747,10 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       // So: pointer moving right (+deltaPx) should shrink the clip from the start.
       // We negate so that dragging the handle right correctly shrinks the clip start.
       trimClipStart(clip.id, -deltaMs);
+      pauseHistoryAfterFirstMutation();
       trimStartRef.current.startX = e.clientX;
     },
-    [clip, msPerPx, trimClipStart]
+    [clip, msPerPx, trimClipStart, pauseHistoryAfterFirstMutation]
   );
 
   // ── Trim end ────────────────────────────────────────────────────────────
@@ -722,13 +774,19 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         startMs: clip.startMs,
         startDuration: clip.durationMs
       };
+      isTrimmingEndRef.current = true;
     },
     [clip, activeTool]
   );
 
   const handleTrimEndPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!clip || clip.locked || e.buttons !== 1) {
+      if (
+        !isTrimmingEndRef.current ||
+        !clip ||
+        clip.locked ||
+        e.buttons !== 1
+      ) {
         return;
       }
       // Stop bubbling so the parent clip body's drag-pointermove handler
@@ -738,16 +796,27 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       const deltaPx = e.clientX - trimEndRef.current.startX;
       const deltaMs = deltaPx * msPerPx;
       trimClipEnd(clip.id, deltaMs, audioSourceDurationMs);
+      pauseHistoryAfterFirstMutation();
       trimEndRef.current.startX = e.clientX;
     },
-    [clip, msPerPx, trimClipEnd, audioSourceDurationMs]
+    [clip, msPerPx, trimClipEnd, audioSourceDurationMs, pauseHistoryAfterFirstMutation]
   );
+
+  // Shared end-of-trim handler (pointerup AND pointercancel): release the
+  // gesture flags and resume undo tracking.
+  const handleTrimPointerEnd = useCallback(() => {
+    isTrimmingStartRef.current = false;
+    isTrimmingEndRef.current = false;
+    resumeHistory();
+  }, [resumeHistory]);
 
   if (!clip) {
     return null;
   }
 
-  const leftPx = clip.startMs / msPerPx - scrollLeftPx;
+  // The clip renders inside the natively scrolling lanes container, so
+  // lane-local coordinates are already content-space — no scroll offset.
+  const leftPx = clip.startMs / msPerPx;
   const widthPx = Math.max(MIN_CLIP_WIDTH_PX, clip.durationMs / msPerPx);
 
   const statusInfo = CLIP_STATUS_MAP[derivedStatus];
@@ -767,6 +836,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       handleTrimStartPointerMove={handleTrimStartPointerMove}
       handleTrimEndPointerDown={handleTrimEndPointerDown}
       handleTrimEndPointerMove={handleTrimEndPointerMove}
+      handleTrimPointerEnd={handleTrimPointerEnd}
       cutMode={activeTool === "cut"}
     />
   );
@@ -786,6 +856,7 @@ interface ClipBodyProps {
   handleTrimStartPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
   handleTrimEndPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
   handleTrimEndPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimPointerEnd: () => void;
   cutMode: boolean;
 }
 
@@ -803,6 +874,7 @@ const ClipBody: React.FC<ClipBodyProps> = ({
   handleTrimStartPointerMove,
   handleTrimEndPointerDown,
   handleTrimEndPointerMove,
+  handleTrimPointerEnd,
   cutMode
 }) => {
   const theme = useTheme();
@@ -967,6 +1039,8 @@ const ClipBody: React.FC<ClipBodyProps> = ({
         css={trimHandleStyles(theme, "start", clip.locked)}
         onPointerDown={handleTrimStartPointerDown}
         onPointerMove={handleTrimStartPointerMove}
+        onPointerUp={handleTrimPointerEnd}
+        onPointerCancel={handleTrimPointerEnd}
         aria-label="Trim clip start"
         data-testid={`clip-trim-start-${clipId}`}
       />
@@ -975,6 +1049,8 @@ const ClipBody: React.FC<ClipBodyProps> = ({
         css={trimHandleStyles(theme, "end", clip.locked)}
         onPointerDown={handleTrimEndPointerDown}
         onPointerMove={handleTrimEndPointerMove}
+        onPointerUp={handleTrimPointerEnd}
+        onPointerCancel={handleTrimPointerEnd}
         aria-label="Trim clip end"
         data-testid={`clip-trim-end-${clipId}`}
       />

--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -139,6 +139,9 @@ export const Playhead: React.FC<PlayheadProps> = memo(
 
     const handlePointerMove = useCallback(
       (e: React.PointerEvent<HTMLDivElement>) => {
+        // Only react while this playhead owns the gesture — otherwise a clip
+        // dragged across the hit area (buttons === 1) would scrub the playhead.
+        if (!dragging) return;
         if (e.buttons !== 1) return;
         const deltaPx = e.clientX - dragStartXRef.current;
         const deltaMs = deltaPx * msPerPx;
@@ -147,7 +150,7 @@ export const Playhead: React.FC<PlayheadProps> = memo(
           Math.max(0, Math.min(cap, dragStartMsRef.current + deltaMs))
         );
       },
-      [msPerPx, durationMs, setCurrentTimeMs]
+      [dragging, msPerPx, durationMs, setCurrentTimeMs]
     );
 
     const handlePointerUp = useCallback(() => {

--- a/web/src/components/timeline/Tracks/TimeRuler.tsx
+++ b/web/src/components/timeline/Tracks/TimeRuler.tsx
@@ -13,7 +13,8 @@ import React, {
   memo,
   useCallback,
   useEffect,
-  useRef
+  useRef,
+  useState
 } from "react";
 import { css } from "@emotion/react";
 import { useColorScheme, useTheme } from "@mui/material/styles";
@@ -183,6 +184,23 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
     const markers = useTimelineStore((s) => s.markers);
     const removeScene = useTimelineStore((s) => s.removeScene);
 
+    // ── Resize → redraw ─────────────────────────────────────────────────────
+    //
+    // The canvas backing store is sized from offsetWidth/offsetHeight inside
+    // the draw effect; bump a tick on container resize so the effect reruns
+    // and the ruler redraws at the new size.
+
+    const [resizeTick, setResizeTick] = useState(0);
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+      const ro = new ResizeObserver(() => setResizeTick((t) => t + 1));
+      ro.observe(canvas);
+      return () => ro.disconnect();
+    }, []);
+
     // ── Draw ────────────────────────────────────────────────────────────────
 
     useEffect(() => {
@@ -273,7 +291,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
         ctx.lineTo(px + 0.5, h);
         ctx.stroke();
       }
-    }, [msPerPx, scrollLeftPx, totalWidthPx, theme, headerWidthPx, activeMode, markers]);
+    }, [msPerPx, scrollLeftPx, totalWidthPx, theme, headerWidthPx, activeMode, markers, resizeTick]);
 
     // ── Pointer interaction ─────────────────────────────────────────────────
 

--- a/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
@@ -11,7 +11,14 @@
  * Only enabled effects are wired into the live audio graph.
  */
 
-import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -575,9 +582,14 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
     [dragBand]
   );
 
-  // Scroll-wheel on mid handle adjusts Q.
-  const handleMidWheel = useCallback(
-    (e: React.WheelEvent<SVGElement>) => {
+  // Scroll-wheel on mid handle adjusts Q. Attached as a native non-passive
+  // listener: React's onWheel is passive, so preventDefault() there can't
+  // stop the page from scrolling.
+  const midHandleRef = useRef<SVGCircleElement | null>(null);
+  useEffect(() => {
+    const el = midHandleRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
       if (disabled) return;
       e.preventDefault();
       const next = clamp(
@@ -586,9 +598,10 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
         10
       );
       onPatch({ midQ: parseFloat(next.toFixed(2)) });
-    },
-    [effect.midQ, onPatch, disabled]
-  );
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [effect.midQ, onPatch, disabled]);
 
   // Static grid: log decade lines + dB lines.
   const gridFreqs = [50, 100, 200, 500, 1000, 2000, 5000, 10000];
@@ -712,7 +725,7 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
               strokeWidth={2}
               style={{ cursor: disabled ? "default" : "grab" }}
               onPointerDown={handlePointerDown(band)}
-              onWheel={isMid ? handleMidWheel : undefined}
+              ref={isMid ? midHandleRef : undefined}
             />
             <text
               x={x}
@@ -1049,9 +1062,13 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
     [drag]
   );
 
-  // Threshold-line wheel changes knee width.
-  const onThreshWheel = useCallback(
-    (e: React.WheelEvent<SVGElement>) => {
+  // Threshold-line wheel changes knee width. Native non-passive listener so
+  // preventDefault() actually blocks scrolling (React's onWheel is passive).
+  const threshHandleRef = useRef<SVGCircleElement | null>(null);
+  useEffect(() => {
+    const el = threshHandleRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
       if (disabled) return;
       e.preventDefault();
       const next = clamp(
@@ -1060,9 +1077,10 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
         40
       );
       onPatch({ kneeDb: parseFloat(next.toFixed(1)) });
-    },
-    [effect.kneeDb, onPatch, disabled]
-  );
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [effect.kneeDb, onPatch, disabled]);
 
   const gridDbs = [-48, -36, -24, -12];
   const gridColor = theme.vars.palette.divider;
@@ -1175,7 +1193,7 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
         strokeWidth={2}
         style={{ cursor: disabled ? "default" : "ew-resize" }}
         onPointerDown={onDown("threshold")}
-        onWheel={onThreshWheel}
+        ref={threshHandleRef}
       />
       <text
         x={thrX}

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -8,7 +8,7 @@
  *   - Height resize handle at the bottom edge
  */
 
-import React, { memo, useCallback, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -22,7 +22,11 @@ import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined
 import GraphicEqOutlinedIcon from "@mui/icons-material/GraphicEqOutlined";
 
 import type { TimelineTrack } from "@nodetool-ai/timeline";
-import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  useTimelineStoreApi,
+  timelineTemporalOf
+} from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { Tooltip } from "../../ui_primitives";
 import {
@@ -226,11 +230,16 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
   }, [track.name]);
 
   const commitName = useCallback(() => {
+    // Blur fires even when the input is read-only (not in edit mode) — don't
+    // commit the stale localName from a previous edit session in that case.
+    if (!editingName) {
+      return;
+    }
     setEditingName(false);
     if (localName.trim()) {
       setTrackName(track.id, localName.trim());
     }
-  }, [localName, setTrackName, track.id]);
+  }, [editingName, localName, setTrackName, track.id]);
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -249,6 +258,24 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
 
   const dragStartYRef = useRef(0);
   const dragStartHeightRef = useRef(heightPx);
+  // Gesture-ownership flag: the move handler only runs when this handle's
+  // pointerdown started the gesture (not when another drag passes over it).
+  const isResizingRef = useRef(false);
+
+  // Undo batching: record the pre-resize state with the first mutation, then
+  // pause history so the whole resize collapses into one undo entry.
+  const timelineStoreApi = useTimelineStoreApi();
+  const historyPausedRef = useRef(false);
+
+  const resumeHistory = useCallback(() => {
+    if (historyPausedRef.current) {
+      historyPausedRef.current = false;
+      timelineTemporalOf(timelineStoreApi).resume();
+    }
+  }, [timelineStoreApi]);
+
+  // Safety net: never leave history paused if the header unmounts mid-resize.
+  useEffect(() => resumeHistory, [resumeHistory]);
 
   const handleResizePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
@@ -257,13 +284,14 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
       e.currentTarget.setPointerCapture(e.pointerId);
       dragStartYRef.current = e.clientY;
       dragStartHeightRef.current = heightPx;
+      isResizingRef.current = true;
     },
     [heightPx]
   );
 
   const handleResizePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (e.buttons !== 1) {
+      if (!isResizingRef.current || e.buttons !== 1) {
         return;
       }
       const deltaY = e.clientY - dragStartYRef.current;
@@ -272,9 +300,19 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
         Math.max(MIN_TRACK_HEIGHT_PX, dragStartHeightRef.current + deltaY)
       );
       setTrackHeight(track.id, newHeight);
+      // First mutation recorded the pre-resize state; batch the rest.
+      if (!historyPausedRef.current) {
+        timelineTemporalOf(timelineStoreApi).pause();
+        historyPausedRef.current = true;
+      }
     },
-    [setTrackHeight, track.id]
+    [setTrackHeight, track.id, timelineStoreApi]
   );
+
+  const handleResizePointerEnd = useCallback(() => {
+    isResizingRef.current = false;
+    resumeHistory();
+  }, [resumeHistory]);
 
   const isAudioTrack = track.type === "audio";
   const supportsEffects =
@@ -440,6 +478,8 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
         css={resizeHandleStyles(theme)}
         onPointerDown={handleResizePointerDown}
         onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerEnd}
+        onPointerCancel={handleResizePointerEnd}
         aria-label="Resize track height"
         role="separator"
         aria-orientation="horizontal"

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -122,7 +122,6 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   );
 
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
-  const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
   const clearSelection = useTimelineUIStore((s) => s.clearSelection);
   const seek = useTimelinePlaybackStore((s) => s.seek);
   const setSelection = useTimelineUIStore((s) => s.setSelection);
@@ -134,6 +133,8 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   const isRubberBandingRef = useRef(false);
   const rbStartRef = useRef({ x: 0, y: 0 });
+  /** Selection snapshot taken at pointerdown when Shift is held (union mode). */
+  const rbBaseSelectionRef = useRef<Set<string> | null>(null);
   const [rubberBand, setRubberBand] = React.useState<RubberBandRect | null>(
     null
   );
@@ -272,10 +273,11 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         return;
       }
 
-      // Compute start time from drop position + scroll offset
+      // The lane lives inside the scrolling lanes container, so lane-local
+      // coordinates are already content-space — no scroll offset needed.
       const rect = e.currentTarget.getBoundingClientRect();
       const dropX = e.clientX - rect.left;
-      const startMs = Math.max(0, Math.round((dropX + scrollLeftPx) * msPerPx));
+      const startMs = Math.max(0, Math.round(dropX * msPerPx));
 
       addImportedClip(asset, track.id, startMs);
     },
@@ -283,7 +285,6 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       isAssetDrag,
       track.type,
       track.id,
-      scrollLeftPx,
       msPerPx,
       addImportedClip,
       showWarning
@@ -302,6 +303,13 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
       if (!e.shiftKey) {
         clearSelection();
+        rbBaseSelectionRef.current = null;
+      } else {
+        // Shift+band: remember the existing selection so the band's contents
+        // can be unioned with it instead of replacing it.
+        rbBaseSelectionRef.current = new Set(
+          useTimelineUIStore.getState().selectedClipIds
+        );
       }
 
       e.currentTarget.setPointerCapture(e.pointerId);
@@ -313,11 +321,12 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       };
       isRubberBandingRef.current = true;
 
-      // Move the playhead to the clicked position.
-      const timeMs = Math.round((localX + scrollLeftPx) * msPerPx);
+      // Move the playhead to the clicked position. The lane is inside the
+      // scrolling container, so localX is already content-space.
+      const timeMs = Math.round(localX * msPerPx);
       seek(timeMs);
     },
-    [clearSelection, scrollLeftPx, msPerPx, seek]
+    [clearSelection, msPerPx, seek]
   );
 
   const handleLanePointerMove = useCallback(
@@ -336,10 +345,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
       setRubberBand({ left, top, width, height });
 
-      // Compute which clips overlap the rubber-band. The lane itself is not
-      // the scroll container — TracksRegion is — so e.currentTarget.scrollLeft
-      // is always 0. Use the UI store's tracked scroll offset instead.
-      const rbStartMs = (left + scrollLeftPx) * msPerPx;
+      // Compute which clips overlap the rubber-band. The lane renders inside
+      // the scrolling lanes container, so lane-local coordinates are already
+      // content-space — no scroll offset.
+      const rbStartMs = left * msPerPx;
       const rbEndMs = rbStartMs + width * msPerPx;
 
       // Read clips lazily to avoid subscribing to the full array in render
@@ -354,13 +363,17 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         })
         .map((c) => c.id);
 
-      setSelection(selected);
+      // Shift+band unions with the selection snapshotted at pointerdown;
+      // a plain band replaces the selection.
+      const base = rbBaseSelectionRef.current;
+      setSelection(base ? [...new Set([...base, ...selected])] : selected);
     },
-    [msPerPx, scrollLeftPx, track.id, setSelection]
+    [msPerPx, track.id, setSelection]
   );
 
   const handleLanePointerUp = useCallback(() => {
     isRubberBandingRef.current = false;
+    rbBaseSelectionRef.current = null;
     setRubberBand(null);
   }, []);
 
@@ -378,13 +391,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       e.preventDefault();
       const rect = e.currentTarget.getBoundingClientRect();
       const dropX = e.clientX - rect.left;
-      const startMs = Math.max(
-        0,
-        Math.round((dropX + scrollLeftPx) * msPerPx)
-      );
+      const startMs = Math.max(0, Math.round(dropX * msPerPx));
       setContextMenuPos({ x: e.clientX, y: e.clientY, startMs });
     },
-    [track.locked, scrollLeftPx, msPerPx]
+    [track.locked, msPerPx]
   );
 
   const handleAddClipFromMenu = useCallback(() => {
@@ -411,6 +421,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       onPointerDown={handleLanePointerDown}
       onPointerMove={handleLanePointerMove}
       onPointerUp={handleLanePointerUp}
+      onPointerCancel={handleLanePointerUp}
       onDragOver={handleAssetDragOver}
       onDragLeave={handleAssetDragLeave}
       onDrop={handleAssetDrop}

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -245,17 +245,23 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     );
 
     // ── Zoom (wheel) ────────────────────────────────────────────────────────
+    //
+    // Attached as a native non-passive listener: React's onWheel is passive,
+    // so preventDefault() inside it can't stop the browser's pinch-zoom.
 
-    const handleWheel = useCallback(
-      (e: React.WheelEvent<HTMLDivElement>) => {
+    useEffect(() => {
+      const el = scrollableRef.current;
+      if (!el) return;
+      const onWheel = (e: WheelEvent) => {
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
           const factor = 1 + e.deltaY * ZOOM_SENSITIVITY;
           setZoom(msPerPx * factor);
         }
-      },
-      [msPerPx, setZoom]
-    );
+      };
+      el.addEventListener("wheel", onWheel, { passive: false });
+      return () => el.removeEventListener("wheel", onWheel);
+    }, [msPerPx, setZoom]);
 
     // ── Keyboard shortcuts ─────────────────────────────────────────────────
     //
@@ -457,7 +463,6 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             ref={scrollableRef}
             css={scrollableAreaStyles}
             onScroll={handleScroll}
-            onWheel={handleWheel}
           >
             <div
               css={lanesContainerStyles}

--- a/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
+++ b/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * TrackLane / Clip coordinate-math tests.
+ *
+ * The lanes render INSIDE the natively scrolling container (TracksRegion's
+ * overflowX: auto panel whose content width is the full timeline width), so
+ * lane-local pixel coordinates are already content-space. These tests pin
+ * that invariant: a non-zero UI-store scrollLeftPx must NOT shift clip
+ * positions or px→ms conversions (seek, rubber-band).
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+// Polyfill PointerEvent for jsdom (which doesn't support it natively).
+// PointerEvent extends MouseEvent so clientX/clientY/button work correctly.
+if (typeof window !== "undefined" && !window.PointerEvent) {
+  (window as unknown as Record<string, unknown>).PointerEvent =
+    class PointerEvent extends MouseEvent {
+      readonly pointerId: number;
+      readonly pointerType: string;
+      readonly isPrimary: boolean;
+
+      constructor(type: string, params: PointerEventInit & MouseEventInit = {}) {
+        super(type, params);
+        this.pointerId = params.pointerId ?? 0;
+        this.pointerType = params.pointerType ?? "";
+        this.isPrimary = params.isPrimary ?? false;
+      }
+    };
+}
+
+// ── Heavy media hooks → no-op mocks ─────────────────────────────────────────
+
+jest.mock("../Tracks/useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../Tracks/useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+
+// ── Stores that pull in network/api dependencies → light mocks ─────────────
+
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: (sel: (s: { get: () => Promise<null> }) => unknown) =>
+    sel({ get: () => Promise.resolve(null) })
+}));
+jest.mock("../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: (sel: (s: { focusedJob: Record<string, string> }) => unknown) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: (sel: (s: { errors: Record<string, unknown> }) => unknown) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: (
+    sel: (s: { clipJobs: Record<string, unknown> }) => unknown
+  ) => sel({ clipJobs: {} })
+}));
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { TrackLane } from "../Tracks/TrackLane";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+
+// jsdom does not implement pointer capture.
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = jest.fn();
+  HTMLElement.prototype.releasePointerCapture = jest.fn();
+});
+
+const track: TimelineTrack = {
+  id: "t1",
+  name: "Video 1",
+  type: "video",
+  index: 0,
+  visible: true,
+  locked: false
+};
+
+const makeClip = (
+  id: string,
+  startMs: number,
+  durationMs: number
+): TimelineClip => ({
+  id,
+  trackId: track.id,
+  name: id,
+  startMs,
+  durationMs,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked: false,
+  versions: []
+});
+
+const MS_PER_PX = 10;
+const SCROLL_LEFT_PX = 300;
+
+const renderLane = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <TrackLane track={track} />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  useTimelineStore.setState({
+    tracks: [track],
+    clips: [makeClip("c1", 2000, 1000), makeClip("c2", 3000, 1000)],
+    durationMs: 10_000
+  });
+  useTimelineUIStore.setState({
+    msPerPx: MS_PER_PX,
+    scrollLeftPx: SCROLL_LEFT_PX,
+    selectedClipIds: new Set<string>()
+  });
+  useTimelinePlaybackStore.setState({ currentTimeMs: 0 });
+});
+
+describe("TrackLane content-space coordinate math", () => {
+  it("positions clips at startMs / msPerPx regardless of scrollLeftPx", () => {
+    renderLane();
+    // 2000 ms / 10 ms-per-px = 200 px. A double-counted scroll offset would
+    // yield 200 - 300 = -100 px.
+    expect(screen.getByTestId("clip-c1").style.left).toBe("200px");
+    expect(screen.getByTestId("clip-c2").style.left).toBe("300px");
+  });
+
+  it("seeks using lane-local x without adding scrollLeftPx", () => {
+    renderLane();
+    const lane = screen.getByTestId("track-lane-t1");
+    // jsdom rects are all-zero, so clientX === lane-local x.
+    fireEvent.pointerDown(lane, { button: 0, clientX: 120, pointerId: 1 });
+    expect(useTimelinePlaybackStore.getState().currentTimeMs).toBe(
+      120 * MS_PER_PX
+    );
+  });
+
+  it("rubber-band selects clips by content-space range", () => {
+    renderLane();
+    const lane = screen.getByTestId("track-lane-t1");
+    // Band from x=150 (1500 ms) to x=250 (2500 ms) → only c1 (2000–3000 ms).
+    fireEvent.pointerDown(lane, { button: 0, clientX: 150, pointerId: 1 });
+    fireEvent.pointerMove(lane, { buttons: 1, clientX: 250, pointerId: 1 });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect([...selected]).toEqual(["c1"]);
+  });
+
+  it("shift+rubber-band unions the band with the prior selection", () => {
+    useTimelineUIStore.setState({ selectedClipIds: new Set(["c2"]) });
+    renderLane();
+    const lane = screen.getByTestId("track-lane-t1");
+    fireEvent.pointerDown(lane, {
+      button: 0,
+      clientX: 150,
+      pointerId: 1,
+      shiftKey: true
+    });
+    fireEvent.pointerMove(lane, {
+      buttons: 1,
+      clientX: 250,
+      pointerId: 1,
+      shiftKey: true
+    });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect(selected.has("c1")).toBe(true);
+    expect(selected.has("c2")).toBe(true);
+    expect(selected.size).toBe(2);
+  });
+
+  it("clears the rubber band on pointercancel", () => {
+    renderLane();
+    const lane = screen.getByTestId("track-lane-t1");
+    fireEvent.pointerDown(lane, { button: 0, clientX: 150, pointerId: 1 });
+    fireEvent.pointerMove(lane, { buttons: 1, clientX: 250, pointerId: 1 });
+    fireEvent.pointerCancel(lane, { pointerId: 1 });
+    // Further moves must not extend a stale band selection.
+    fireEvent.pointerMove(lane, { buttons: 1, clientX: 450, pointerId: 1 });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect([...selected]).toEqual(["c1"]);
+  });
+});

--- a/web/src/components/timeline/preview/AudioGraph.ts
+++ b/web/src/components/timeline/preview/AudioGraph.ts
@@ -324,11 +324,39 @@ export class AudioGraph {
     prevOutput.connect(this.masterGain!);
   }
 
+  /**
+   * Tear down chains for tracks not in `trackIds`, releasing their audio
+   * nodes. Called whenever the authoritative track list flows through
+   * `updateTracks` so deleted tracks don't leak GainNodes/effect chains.
+   */
+  retainTracks(trackIds: Iterable<string>): void {
+    const keep = new Set(trackIds);
+    for (const [id, chain] of this.trackChains) {
+      if (keep.has(id)) continue;
+      try {
+        chain.trackGain.disconnect();
+      } catch {
+        /* not connected */
+      }
+      for (const unit of chain.units) {
+        for (const n of unit.nodes) {
+          try {
+            n.disconnect();
+          } catch {
+            /* not connected */
+          }
+        }
+      }
+      this.trackChains.delete(id);
+    }
+  }
+
   /** Solo rule: if any audio track is soloed, non-solo tracks are silenced. */
   updateTracks(tracks: TimelineTrack[]): void {
     if (!this.ctx) {
       return;
     }
+    this.retainTracks(tracks.map((t) => t.id));
     const audioTracks = tracks.filter((t) => t.type === "audio");
     const hasSolo = audioTracks.some((t) => t.solo);
     const now = this.ctx.currentTime;
@@ -345,7 +373,8 @@ export class AudioGraph {
   async scheduleClips(
     clips: ScheduledAudioClip[],
     tracks: TimelineTrack[],
-    currentTimeMs: number
+    currentTimeMs: number,
+    shouldCancel?: () => boolean
   ): Promise<void> {
     const ctx = this.getContext();
     const activeIds = new Set(clips.map((c) => c.clip.id));
@@ -356,6 +385,12 @@ export class AudioGraph {
           src.stop();
         } catch {
           // source may already have stopped at its natural end
+        }
+        const gain = this.clipGains.get(id);
+        try {
+          gain?.disconnect();
+        } catch {
+          /* not connected */
         }
         this.clipSources.delete(id);
         this.clipGains.delete(id);
@@ -373,6 +408,11 @@ export class AudioGraph {
     });
 
     const loadedBuffers = await Promise.all(bufferPromises);
+    // A newer play/pause/seek gesture superseded this call while buffers were
+    // loading — registering now would schedule audio at a stale offset.
+    if (shouldCancel?.()) {
+      return;
+    }
     const bufferMap = new Map(loadedBuffers.map((b) => [b.clipId, b.buffer]));
 
     for (const { clip, assetUrl } of clips) {
@@ -466,6 +506,18 @@ export class AudioGraph {
         src.stop();
       } catch {
         // already stopped
+      }
+      try {
+        src.disconnect();
+      } catch {
+        /* not connected */
+      }
+    }
+    for (const [, gain] of this.clipGains) {
+      try {
+        gain.disconnect();
+      } catch {
+        /* not connected */
       }
     }
     this.clipSources.clear();

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -40,9 +40,12 @@ import { getAssetUrl } from "../../../utils/assetHelpers";
 import { useCombo } from "../../../stores/KeyPressedStore";
 
 function formatTimecode(timeMs: number, fps: number): string {
+  // Integer frame math: fractional rates (29.97, 23.976) would otherwise
+  // leak fractions into the frame field. Non-drop-frame timecode.
+  const fpsInt = Math.max(1, Math.round(fps));
   const totalFrames = Math.floor((timeMs / 1000) * fps);
-  const framePart = totalFrames % fps;
-  const totalSeconds = Math.floor(totalFrames / fps);
+  const framePart = totalFrames % fpsInt;
+  const totalSeconds = Math.floor(totalFrames / fpsInt);
   const seconds = totalSeconds % 60;
   const totalMinutes = Math.floor(totalSeconds / 60);
   const minutes = totalMinutes % 60;
@@ -162,6 +165,10 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
     const clockRef = useRef<PlaybackClock>(new PlaybackClock());
     const graphRef = useRef<AudioGraph>(new AudioGraph());
+    /** Bumped by every play/pause/stop/seek gesture. Async continuations in
+     *  handlePlay compare against their captured value and bail when a later
+     *  gesture has superseded them, so stale audio is never scheduled. */
+    const playGenRef = useRef(0);
 
     useEffect(() => {
       const clock = clockRef.current;
@@ -181,15 +188,25 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
     }, [tracks]);
 
     const handlePlay = useCallback(async () => {
-      play();
+      const generation = ++playGenRef.current;
+      const isStale = () => playGenRef.current !== generation;
+
       const graph = graphRef.current;
       const clock = clockRef.current;
 
       // Read fresh to avoid stale closure when the user scrubs before pressing play.
-      const startMs = useTimelinePlaybackStore.getState().currentTimeMs;
+      let startMs = useTimelinePlaybackStore.getState().currentTimeMs;
+      // Pressing Play while parked at the end restarts from the top.
+      if (durationMs > 0 && startMs >= durationMs - frameDeltaMs(fps)) {
+        startMs = 0;
+        setCurrentTimeMs(0);
+      }
+
+      play();
 
       const ctx = graph.getContext();
       await ctx.resume();
+      if (isStale()) return;
 
       const activeAudioClips = clips.filter(
         (c) =>
@@ -220,8 +237,13 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       const validClips = scheduledClips.filter(
         (c): c is NonNullable<typeof c> => c !== null
       );
+      if (isStale()) return;
 
-      await graph.scheduleClips(validClips, tracks, startMs);
+      // Clear any sources an older gesture registered, right before
+      // scheduling the new ones — so the latest gesture always wins.
+      graph.stopAll();
+      await graph.scheduleClips(validClips, tracks, startMs, isStale);
+      if (isStale()) return;
 
       clock.start(
         startMs,
@@ -229,9 +251,10 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         validClips.length > 0 ? ctx : null,
         durationMs || Infinity
       );
-    }, [play, clips, tracks, durationMs, getAsset]);
+    }, [play, clips, tracks, durationMs, fps, getAsset, setCurrentTimeMs]);
 
     const handlePause = useCallback(() => {
+      playGenRef.current++;
       pause();
       clockRef.current.stop();
       graphRef.current.stopAll();
@@ -239,11 +262,23 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
     }, [pause]);
 
     const handleStop = useCallback(() => {
+      playGenRef.current++;
       stop();
       clockRef.current.stop();
       graphRef.current.stopAll();
       graphRef.current.suspend();
     }, [stop]);
+
+    // The clock auto-pauses via the store when it hits the timeline end —
+    // a path that bypasses handlePause. Mirror its teardown here so audio
+    // sources are released and the AudioContext suspends.
+    useEffect(() => {
+      if (isPlaying) return;
+      playGenRef.current++;
+      clockRef.current.stop();
+      graphRef.current.stopAll();
+      graphRef.current.suspend();
+    }, [isPlaying]);
 
     // On external seek while playing, restart audio scheduling + clock at the
     // new position so audio re-aligns with the playhead. We key on seekNonce

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -136,6 +136,11 @@ interface ActiveImageLayer {
   trackEffects?: TrackEffect[];
 }
 
+type AssetUrlEntry =
+  | { status: "pending" }
+  | { status: "resolved"; url: string }
+  | { status: "failed" };
+
 interface ActiveCaptionLayer {
   clipId: string;
   trackIndex: number;
@@ -172,7 +177,7 @@ export const PreviewCompositor: React.FC = memo(() => {
     s.selectedClipIds.size === 1 ? [...s.selectedClipIds][0] : null
   );
 
-  const assetUrlCache = useRef<Map<string, string>>(new Map());
+  const assetUrlCache = useRef<Map<string, AssetUrlEntry>>(new Map());
   const [urlCacheVersion, setUrlCacheVersion] = useState(0);
   const getAsset = useAssetStore((s) => s.get);
 
@@ -181,19 +186,27 @@ export const PreviewCompositor: React.FC = memo(() => {
       if (!assetId) {
         return undefined;
       }
-      if (assetUrlCache.current.has(assetId)) {
-        return assetUrlCache.current.get(assetId);
+      const cached = assetUrlCache.current.get(assetId);
+      if (cached) {
+        // pending → fetch already in flight; failed → don't retry every tick
+        // (the cache ref survives until remount, when a fresh attempt is made).
+        return cached.status === "resolved" ? cached.url : undefined;
       }
+      assetUrlCache.current.set(assetId, { status: "pending" });
       getAsset(assetId)
         .then((asset) => {
           const url = getAssetUrl(asset);
           if (url) {
-            assetUrlCache.current.set(assetId, url);
+            assetUrlCache.current.set(assetId, { status: "resolved", url });
             setUrlCacheVersion((v) => v + 1);
+          } else {
+            assetUrlCache.current.set(assetId, { status: "failed" });
           }
         })
         .catch(() => {
-          // Asset unavailable — leave cache empty; placeholder will render.
+          // Asset unavailable — mark failed so the placeholder renders
+          // without re-issuing the fetch on every render tick.
+          assetUrlCache.current.set(assetId, { status: "failed" });
         });
       return undefined;
     },
@@ -227,10 +240,9 @@ export const PreviewCompositor: React.FC = memo(() => {
   const [gpuReady, setGpuReady] = useState(false);
   const [gpuFailed, setGpuFailed] = useState(false);
 
-  // Frame element CSS size and canvas backing size, mirrored into state so the
-  // transform gizmo overlay can map clip space → screen pixels.
+  // Frame element CSS size, mirrored into state so the transform gizmo
+  // overlay can map clip space → screen pixels.
   const [frameSize, setFrameSize] = useState({ w: 0, h: 0 });
-  const [canvasSize, setCanvasSize] = useState({ w: 0, h: 0 });
 
   useLayoutEffect(() => {
     const container = poolContainerRef.current;
@@ -340,15 +352,19 @@ export const PreviewCompositor: React.FC = memo(() => {
         canvas.height = h;
         compositorRef.current?.resize(w, h);
       }
-      setCanvasSize((prev) =>
-        prev.w === w && prev.h === h ? prev : { w, h }
-      );
     };
     apply();
     const ro = new ResizeObserver(apply);
     ro.observe(container);
     return () => ro.disconnect();
   }, [sequenceWidth, sequenceHeight]);
+
+  // transform.position is stored in sequence pixels; tell the compositor the
+  // sequence resolution so placement doesn't depend on viewport size / DPR.
+  useEffect(() => {
+    if (!gpuReady) return;
+    compositorRef.current?.setReferenceSize(sequenceWidth, sequenceHeight);
+  }, [gpuReady, sequenceWidth, sequenceHeight]);
 
   const clipById = useMemo(
     () => new Map(clips.map((c) => [c.id, c])),
@@ -778,8 +794,8 @@ export const PreviewCompositor: React.FC = memo(() => {
             transform={selectedGizmo.transform}
             sourceWidth={selectedGizmo.sourceWidth}
             sourceHeight={selectedGizmo.sourceHeight}
-            canvasWidth={canvasSize.w}
-            canvasHeight={canvasSize.h}
+            sequenceWidth={sequenceWidth}
+            sequenceHeight={sequenceHeight}
             frameWidth={frameSize.w}
             frameHeight={frameSize.h}
             onChange={(id, next) => patchClip(id, { transform: next })}

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -80,10 +80,10 @@ export interface TransformGizmoOverlayProps {
   sourceWidth: number;
   /** Source pixel height of the clip's decoded media. */
   sourceHeight: number;
-  /** GPU canvas backing width (px) — matches the compositor. */
-  canvasWidth: number;
-  /** GPU canvas backing height (px) — matches the compositor. */
-  canvasHeight: number;
+  /** Sequence pixel width — `transform.position` is stored in this space. */
+  sequenceWidth: number;
+  /** Sequence pixel height — `transform.position` is stored in this space. */
+  sequenceHeight: number;
   /** Frame element CSS width (px). */
   frameWidth: number;
   /** Frame element CSS height (px). */
@@ -114,13 +114,13 @@ function computeGeometry(
   t: ClipTransform,
   srcW: number,
   srcH: number,
-  canvasW: number,
-  canvasH: number,
+  seqW: number,
+  seqH: number,
   frameW: number,
   frameH: number
 ): BoxGeometry {
-  const base = containBaseScale(srcW, srcH, canvasW, canvasH);
-  const m = buildTransformMatrix(t, base, canvasW, canvasH);
+  const base = containBaseScale(srcW, srcH, seqW, seqH);
+  const m = buildTransformMatrix(t, base, seqW, seqH);
   const at = (qx: number, qy: number): Point =>
     clipToCss(
       m[0] * qx + m[4] * qy + m[12],
@@ -227,8 +227,8 @@ export function TransformGizmoOverlay({
   transform,
   sourceWidth,
   sourceHeight,
-  canvasWidth,
-  canvasHeight,
+  sequenceWidth,
+  sequenceHeight,
   frameWidth,
   frameHeight,
   onChange
@@ -239,8 +239,8 @@ export function TransformGizmoOverlay({
   if (
     sourceWidth <= 0 ||
     sourceHeight <= 0 ||
-    canvasWidth <= 0 ||
-    canvasHeight <= 0 ||
+    sequenceWidth <= 0 ||
+    sequenceHeight <= 0 ||
     frameWidth <= 0 ||
     frameHeight <= 0
   ) {
@@ -252,8 +252,8 @@ export function TransformGizmoOverlay({
     t,
     sourceWidth,
     sourceHeight,
-    canvasWidth,
-    canvasHeight,
+    sequenceWidth,
+    sequenceHeight,
     frameWidth,
     frameHeight
   );
@@ -271,10 +271,11 @@ export function TransformGizmoOverlay({
     y: topMid.y + outward.y * ROTATION_HANDLE_OFFSET
   };
 
-  /** CSS px → position px delta along each canvas axis. */
-  const cssToPosX = (dxCss: number): number => (dxCss * canvasWidth) / frameWidth;
+  /** CSS px → sequence-px position delta along each axis. */
+  const cssToPosX = (dxCss: number): number =>
+    (dxCss * sequenceWidth) / frameWidth;
   const cssToPosY = (dyCss: number): number =>
-    (dyCss * canvasHeight) / frameHeight;
+    (dyCss * sequenceHeight) / frameHeight;
 
   const fixedPointFor = (target: ScaleHandle): Point => {
     switch (target) {
@@ -486,8 +487,8 @@ export function TransformGizmoOverlay({
       candidate,
       sourceWidth,
       sourceHeight,
-      canvasWidth,
-      canvasHeight,
+      sequenceWidth,
+      sequenceHeight,
       frameWidth,
       frameHeight
     );
@@ -514,8 +515,8 @@ export function TransformGizmoOverlay({
       candidate,
       sourceWidth,
       sourceHeight,
-      canvasWidth,
-      canvasHeight,
+      sequenceWidth,
+      sequenceHeight,
       frameWidth,
       frameHeight
     );

--- a/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
@@ -21,15 +21,15 @@ Element.prototype.setPointerCapture = () => {};
 Element.prototype.releasePointerCapture = () => {};
 Element.prototype.hasPointerCapture = () => false;
 
-// Square source on a 2:1 canvas/frame. containBaseScale → {x:0.5, y:1}, so the
-// identity box spans x 50..150, y 0..100 with center (100,50).
+// Square source on a 2:1 sequence/frame. containBaseScale → {x:0.5, y:1}, so
+// the identity box spans x 50..150, y 0..100 with center (100,50).
 const baseProps = {
   clipId: "clip-1",
   transform: undefined as ClipTransform | undefined,
   sourceWidth: 100,
   sourceHeight: 100,
-  canvasWidth: 200,
-  canvasHeight: 100,
+  sequenceWidth: 200,
+  sequenceHeight: 100,
   frameWidth: 200,
   frameHeight: 100
 };
@@ -69,7 +69,7 @@ describe("TransformGizmoOverlay", () => {
 
     expect(onChange).toHaveBeenCalled();
     const [, next] = onChange.mock.calls.at(-1)!;
-    // canvas/frame are equal so 1 CSS px == 1 position px here.
+    // sequence/frame are equal so 1 CSS px == 1 position px here.
     expect(next.position.x).toBeCloseTo(30, 3);
     expect(next.position.y).toBeCloseTo(20, 3);
   });

--- a/web/src/components/timeline/preview/gpu/__tests__/transform.test.ts
+++ b/web/src/components/timeline/preview/gpu/__tests__/transform.test.ts
@@ -108,4 +108,86 @@ describe("buildTransformMatrix", () => {
       expect(Number.isNaN(m[i])).toBe(false);
     }
   });
+
+  describe("aspect-corrected rotation", () => {
+    /** Map a quad corner through the matrix and convert NDC → pixels. */
+    const cornerPx = (
+      m: Float32Array,
+      qx: number,
+      qy: number,
+      w: number,
+      h: number
+    ) => ({
+      x: (m[0] * qx + m[4] * qy + m[12]) * (w / 2),
+      y: (m[1] * qx + m[5] * qy + m[13]) * (h / 2),
+    });
+
+    it("keeps a square clip square under 90° rotation on a 16:9 canvas", () => {
+      const W = 1920;
+      const H = 1080;
+      // Square source contain-fit on 16:9: 540px half-extent on both axes.
+      const base = containBaseScale(1080, 1080, W, H);
+      const transform: ClipTransform = {
+        ...IDENTITY_TRANSFORM,
+        rotation: Math.PI / 2,
+      };
+      const m = buildTransformMatrix(transform, base, W, H);
+      const c = cornerPx(m, 1, 1, W, H);
+      // 90° rotation in pixel space: (540, 540) → (-540, 540).
+      expect(Math.abs(c.x)).toBeCloseTo(540, 3);
+      expect(Math.abs(c.y)).toBeCloseTo(540, 3);
+    });
+
+    it("swaps pixel extents of a non-square clip under 90° rotation", () => {
+      const W = 1920;
+      const H = 1080;
+      // Full-frame 16:9 source: base scale {1,1} → half-extents (960, 540).
+      const transform: ClipTransform = {
+        ...IDENTITY_TRANSFORM,
+        rotation: Math.PI / 2,
+      };
+      const m = buildTransformMatrix(transform, { x: 1, y: 1 }, W, H);
+      const right = cornerPx(m, 1, 0, W, H);
+      const top = cornerPx(m, 0, 1, W, H);
+      // The 960px half-width now spans 960px vertically, and vice versa.
+      expect(Math.hypot(right.x, right.y)).toBeCloseTo(960, 3);
+      expect(Math.abs(right.y)).toBeCloseTo(960, 3);
+      expect(Math.hypot(top.x, top.y)).toBeCloseTo(540, 3);
+      expect(Math.abs(top.x)).toBeCloseTo(540, 3);
+    });
+
+    it("normalizes position by the provided reference resolution", () => {
+      const transform: ClipTransform = {
+        ...IDENTITY_TRANSFORM,
+        position: { x: 960, y: -540 },
+      };
+      const m = buildTransformMatrix(transform, { x: 1, y: 1 }, 1920, 1080);
+      expect(m[12]).toBeCloseTo(1.0);
+      expect(m[13]).toBeCloseTo(1.0);
+    });
+
+    it("keeps the anchor point fixed under rotation on a non-square canvas", () => {
+      const W = 1920;
+      const H = 1080;
+      const anchor = { x: 0.25, y: 0.75 };
+      const ax = (anchor.x - 0.5) * 2;
+      const ay = (anchor.y - 0.5) * 2;
+      const still = buildTransformMatrix(
+        { ...IDENTITY_TRANSFORM, anchor },
+        { x: 1, y: 1 },
+        W,
+        H
+      );
+      const rotated = buildTransformMatrix(
+        { ...IDENTITY_TRANSFORM, anchor, rotation: 0.7 },
+        { x: 1, y: 1 },
+        W,
+        H
+      );
+      const before = cornerPx(still, ax, ay, W, H);
+      const after = cornerPx(rotated, ax, ay, W, H);
+      expect(after.x).toBeCloseTo(before.x, 3);
+      expect(after.y).toBeCloseTo(before.y, 3);
+    });
+  });
 });

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -54,7 +54,12 @@ function sourceDimensions(source: CompositeSource): {
 
 function uploadKey(source: CompositeSource): string {
   if (source instanceof HTMLVideoElement) {
-    return `v:${source.currentTime}:${source.videoWidth}x${source.videoHeight}`;
+    // `currentTime` updates as soon as a seek starts, before the target frame
+    // is decoded. Stamping the new time while `seeking` is true would mark a
+    // stale frame as current and skip the real upload on `seeked` — so use a
+    // distinct key during the seek; the post-`seeked` render re-uploads.
+    const time = source.seeking ? "seeking" : String(source.currentTime);
+    return `v:${time}:${source.videoWidth}x${source.videoHeight}`;
   }
   if (source instanceof HTMLImageElement) {
     return `i:${source.src}:${source.naturalWidth}x${source.naturalHeight}`;
@@ -81,6 +86,11 @@ export class WebGPUCompositor {
 
   private canvasWidth = 0;
   private canvasHeight = 0;
+  /** Reference (sequence) resolution that `transform.position` is stored in.
+   *  Falls back to the canvas size when unset — the offline renderer's canvas
+   *  is the sequence resolution, so it never needs to set this explicitly. */
+  private refWidth = 0;
+  private refHeight = 0;
 
   private sourceTextures = new Map<string, SourceTexture>();
   private layers: CompositeLayer[] = [];
@@ -124,6 +134,16 @@ export class WebGPUCompositor {
     this.effects = new WebGPUEffectsProcessor(device);
 
     return { ok: true };
+  }
+
+  /**
+   * Set the sequence resolution used to interpret `transform.position` (and
+   * rotation aspect). The live preview calls this because its canvas backing
+   * size tracks the viewport/DPR, not the sequence.
+   */
+  setReferenceSize(width: number, height: number): void {
+    this.refWidth = width;
+    this.refHeight = height;
   }
 
   resize(width: number, height: number): void {
@@ -258,8 +278,8 @@ export class WebGPUCompositor {
       const matrix = buildTransformMatrix(
         transform,
         base,
-        this.canvasWidth,
-        this.canvasHeight
+        this.refWidth || this.canvasWidth,
+        this.refHeight || this.canvasHeight
       );
       const invAffine = forwardClipMatrixToInverseAffine(
         matrix,

--- a/web/src/components/timeline/preview/gpu/transform.ts
+++ b/web/src/components/timeline/preview/gpu/transform.ts
@@ -40,25 +40,39 @@ export function containBaseScale(
  * contain-fit base scale, then the user-supplied scale / rotation /
  * position / anchor on top.
  *
- * Position is in canvas pixels relative to the canvas center.
+ * `width` / `height` are the *reference* resolution — the sequence's pixel
+ * dimensions, not the (DPR-scaled) preview canvas backing size — so a stored
+ * `transform.position` means the same thing in the preview, the gizmo and
+ * the offline export. Rotation is applied in pixel-aspect space (sandwich
+ * A⁻¹ · R · A where A maps NDC to aspect-corrected space) so rotating a clip
+ * on a non-square sequence does not shear: a square stays square under 90°.
+ *
+ * Position is in sequence pixels relative to the canvas center.
  * Anchor is normalized [0,1] (0.5 = quad center).
  */
 export function buildTransformMatrix(
   transform: ClipTransform,
   base: { x: number; y: number },
-  canvasWidth: number,
-  canvasHeight: number
+  width: number,
+  height: number
 ): Float32Array {
   const sx = base.x * transform.scale.x;
   const sy = base.y * transform.scale.y;
   const cos = Math.cos(transform.rotation);
   const sin = Math.sin(transform.rotation);
 
+  // Aspect-corrected rotation: R' = A⁻¹ · R · A with A = diag(W/2, H/2)
+  // (NDC → pixels). Collapses to plain R when the canvas is square.
+  const aspect = width > 0 && height > 0 ? width / height : 1;
+  const r00 = cos;
+  const r01 = -sin / aspect;
+  const r10 = sin * aspect;
+  const r11 = cos;
+
   // Position in clip space: x = px / (W/2), y = -py / (H/2). Y is flipped
   // because canvas Y grows downward but clip-space Y grows upward.
-  const tx = canvasWidth === 0 ? 0 : (transform.position.x / canvasWidth) * 2;
-  const ty =
-    canvasHeight === 0 ? 0 : -(transform.position.y / canvasHeight) * 2;
+  const tx = width === 0 ? 0 : (transform.position.x / width) * 2;
+  const ty = height === 0 ? 0 : -(transform.position.y / height) * 2;
 
   // Anchor offset in clip space (-1..1). Default 0.5 → 0 offset.
   const ax = (transform.anchor.x - 0.5) * 2;
@@ -66,13 +80,13 @@ export function buildTransformMatrix(
 
   const m = new Float32Array(16);
   // Column 0
-  m[0] = sx * cos;
-  m[1] = sx * sin;
+  m[0] = r00 * sx;
+  m[1] = r10 * sx;
   m[2] = 0;
   m[3] = 0;
   // Column 1
-  m[4] = -sy * sin;
-  m[5] = sy * cos;
+  m[4] = r01 * sy;
+  m[5] = r11 * sy;
   m[6] = 0;
   m[7] = 0;
   // Column 2
@@ -80,9 +94,10 @@ export function buildTransformMatrix(
   m[9] = 0;
   m[10] = 1;
   m[11] = 0;
-  // Column 3 (translation, anchor-corrected)
-  m[12] = tx + ax * (1 - sx * cos) + ay * sy * sin;
-  m[13] = ty + ay * (1 - sy * cos) - ax * sx * sin;
+  // Column 3 (translation, anchor-corrected: the anchor point stays fixed
+  // at its untransformed clip-space location, offset by the position).
+  m[12] = tx + ax - (m[0] * ax + m[4] * ay);
+  m[13] = ty + ay - (m[1] * ax + m[5] * ay);
   m[14] = 0;
   m[15] = 1;
   return m;

--- a/web/src/components/timeline/render/OffscreenVideoPool.ts
+++ b/web/src/components/timeline/render/OffscreenVideoPool.ts
@@ -16,8 +16,16 @@ interface PoolEntry {
   url: string;
 }
 
+function abortError(): DOMException {
+  return new DOMException("Video seek aborted", "AbortError");
+}
+
 export class OffscreenVideoPool {
   private readonly container: HTMLDivElement;
+  /** Keyed by clip id — two clips of the same asset must hold separate
+   *  elements, since the export loop seeks every layer of a frame before any
+   *  upload happens (a shared element would show the last-seeked time on all
+   *  layers). Elements are still reused across frames for the same clip. */
   private readonly entries = new Map<string, PoolEntry>();
 
   constructor() {
@@ -28,14 +36,21 @@ export class OffscreenVideoPool {
   }
 
   /**
-   * Return a video element decoded to `timeSec` of `url`. Resolves once the
-   * exact frame is available. Subsequent calls for the same url reuse the
+   * Return a video element for `clipId` decoded to `timeSec` of `url`.
+   * Resolves once the exact frame is available; rejects on media error or
+   * when `signal` aborts. Subsequent calls for the same clip reuse the
    * element. The returned element must be uploaded synchronously by the
-   * caller before the next `seek` on the same element.
+   * caller before the next `seek` for the same clip.
    */
-  async seek(url: string, timeSec: number): Promise<HTMLVideoElement> {
-    const el = this.ensureElement(url);
-    await this.whenMetadata(el);
+  async seek(
+    clipId: string,
+    url: string,
+    timeSec: number,
+    signal?: AbortSignal
+  ): Promise<HTMLVideoElement> {
+    if (signal?.aborted) throw abortError();
+    const el = this.ensureElement(clipId, url);
+    await this.whenMetadata(el, signal);
 
     const duration = Number.isFinite(el.duration) ? el.duration : Infinity;
     const target = Math.max(
@@ -48,20 +63,42 @@ export class OffscreenVideoPool {
       return el;
     }
 
-    await new Promise<void>((resolve) => {
-      const onSeeked = () => {
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
         el.removeEventListener("seeked", onSeeked);
+        el.removeEventListener("error", onError);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const onSeeked = () => {
+        cleanup();
         resolve();
       };
+      const onError = () => {
+        cleanup();
+        reject(new Error(`Video error while seeking: ${el.src}`));
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(abortError());
+      };
       el.addEventListener("seeked", onSeeked);
+      el.addEventListener("error", onError);
+      signal?.addEventListener("abort", onAbort);
       el.currentTime = target;
     });
     return el;
   }
 
-  private ensureElement(url: string): HTMLVideoElement {
-    const existing = this.entries.get(url);
-    if (existing) return existing.el;
+  private ensureElement(clipId: string, url: string): HTMLVideoElement {
+    const existing = this.entries.get(clipId);
+    if (existing) {
+      if (existing.url === url) return existing.el;
+      // Clip resolved to a new asset mid-render — point the element at it.
+      existing.el.src = url;
+      existing.el.load();
+      existing.url = url;
+      return existing.el;
+    }
 
     const el = document.createElement("video");
     el.preload = "auto";
@@ -71,11 +108,14 @@ export class OffscreenVideoPool {
     el.src = url;
     el.load();
     this.container.appendChild(el);
-    this.entries.set(url, { el, url });
+    this.entries.set(clipId, { el, url });
     return el;
   }
 
-  private whenMetadata(el: HTMLVideoElement): Promise<void> {
+  private whenMetadata(
+    el: HTMLVideoElement,
+    signal?: AbortSignal
+  ): Promise<void> {
     // readyState >= HAVE_METADATA means duration + dimensions are known.
     if (el.readyState >= 1 && el.videoWidth > 0) return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
@@ -87,12 +127,18 @@ export class OffscreenVideoPool {
         cleanup();
         reject(new Error(`Failed to load video: ${el.src}`));
       };
+      const onAbort = () => {
+        cleanup();
+        reject(abortError());
+      };
       const cleanup = () => {
         el.removeEventListener("loadedmetadata", onLoaded);
         el.removeEventListener("error", onError);
+        signal?.removeEventListener("abort", onAbort);
       };
       el.addEventListener("loadedmetadata", onLoaded);
       el.addEventListener("error", onError);
+      signal?.addEventListener("abort", onAbort);
     });
   }
 

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -247,8 +247,10 @@ export async function renderTimeline(
 
         if (layer.kind === "video") {
           const el = await videoPool.seek(
+            layer.clipId,
             url,
-            clipSourceTimeSec(layer.clip, timeMs)
+            clipSourceTimeSec(layer.clip, timeMs),
+            signal
           );
           if (el.videoWidth === 0) continue;
           composite.push({

--- a/web/src/hooks/timeline/__tests__/useGenerateClip.concurrency.test.ts
+++ b/web/src/hooks/timeline/__tests__/useGenerateClip.concurrency.test.ts
@@ -4,14 +4,36 @@ import {
   handleJobMessage
 } from "../useGenerateClip";
 import { useTimelineGenerationStore } from "../../../stores/timeline/TimelineGenerationStore";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+
+const makeClip = (id: string) => ({
+  id,
+  trackId: "track-1",
+  name: id,
+  startMs: 0,
+  durationMs: 1000,
+  mediaType: "video" as const,
+  workflowId: "wf",
+  sourceType: "generated" as const,
+  status: "generating" as const,
+  selectedOutputNodeId: "out",
+  locked: false,
+  versions: []
+});
 
 describe("useGenerateClip concurrent resolution", () => {
   beforeEach(() => {
     __resetGenerateClipSubscriptionsForTests();
     useTimelineGenerationStore.setState({ clipJobs: {}, jobToClip: {} });
+    useTimelineStore.setState({
+      sequenceId: "seq-1",
+      tracks: [{ id: "track-1", name: "Track", type: "video", index: 0, visible: true, locked: false }],
+      clips: [makeClip("clip1"), makeClip("clip2")],
+      markers: []
+    });
   });
 
-  it("resolves each concurrent job's own output asset", async () => {
+  it("resolves each concurrent job's own output asset and applies it to the clip", async () => {
     const store = useTimelineGenerationStore.getState();
     store.registerJob("clip1", "A", "wf");
     store.registerJob("clip2", "B", "wf");
@@ -27,5 +49,16 @@ describe("useGenerateClip concurrent resolution", () => {
 
     expect(spy).toHaveBeenCalledWith("A", "completed", { assetId: "assetA" });
     expect(spy).toHaveBeenCalledWith("B", "completed", { assetId: "assetB" });
+
+    // The clips actually received their assets (version + currentAssetId).
+    const clips = useTimelineStore.getState().clips;
+    const clip1 = clips.find((c) => c.id === "clip1");
+    const clip2 = clips.find((c) => c.id === "clip2");
+    expect(clip1?.currentAssetId).toBe("assetA");
+    expect(clip1?.status).toBe("generated");
+    expect(clip1?.versions).toHaveLength(1);
+    expect(clip2?.currentAssetId).toBe("assetB");
+    expect(clip2?.status).toBe("generated");
+    expect(clip2?.versions).toHaveLength(1);
   });
 });

--- a/web/src/hooks/timeline/__tests__/useGenerateClip.test.ts
+++ b/web/src/hooks/timeline/__tests__/useGenerateClip.test.ts
@@ -184,6 +184,244 @@ describe("useGenerateClip", () => {
     fetchQuerySpy.mockRestore();
   });
 
+  it("applies the completed job's output asset to the clip", async () => {
+    const clip = {
+      id: "clip-done",
+      trackId: "track-1",
+      name: "Clip",
+      startMs: 0,
+      durationMs: 1000,
+      mediaType: "video" as const,
+      workflowId: "wf-1",
+      sourceType: "generated" as const,
+      status: "draft" as const,
+      selectedOutputNodeId: "output-1",
+      dependencyHash: "hash-1",
+      paramOverrides: { prompt: "hello" },
+      locked: false,
+      versions: []
+    };
+    useTimelineStore.setState({
+      sequenceId: "seq-1",
+      tracks: [{ id: "track-1", name: "Track", type: "video", index: 0, visible: true, locked: false }],
+      clips: [clip],
+      markers: []
+    });
+
+    const fetchQuerySpy = jest
+      .spyOn(queryClient, "fetchQuery")
+      .mockResolvedValue({
+        id: "wf-1",
+        name: "WF",
+        access: "private",
+        graph: { nodes: [], edges: [] }
+      } as never);
+    getWorkflowRunnerStoreMock.mockReturnValue({
+      getState: () => ({ run: jest.fn(async () => "job-done") })
+    });
+    subscribeMock.mockImplementation(
+      ((jobId: string, handler: (message: Record<string, unknown>) => void) => {
+        jobHandlers.set(jobId, handler);
+        return () => {
+          jobHandlers.delete(jobId);
+        };
+      }) as any
+    );
+
+    const { result } = renderHook(() => useGenerateClip(clip.id));
+
+    await act(async () => {
+      await result.current.generateClip();
+    });
+
+    await act(async () => {
+      jobHandlers.get("job-done")?.({
+        type: "output_update",
+        node_id: "output-1",
+        value: { asset_id: "asset-99" },
+        job_id: "job-done"
+      });
+      jobHandlers.get("job-done")?.({
+        type: "job_update",
+        status: "completed",
+        job_id: "job-done"
+      });
+    });
+
+    const updated = useTimelineStore
+      .getState()
+      .clips.find((c) => c.id === clip.id);
+    expect(updated?.currentAssetId).toBe("asset-99");
+    expect(updated?.status).toBe("generated");
+    expect(updated?.lastGeneratedHash).toBe("hash-1");
+    expect(updated?.versions).toHaveLength(1);
+    expect(updated?.versions?.[0]).toMatchObject({
+      jobId: "job-done",
+      assetId: "asset-99",
+      dependencyHash: "hash-1",
+      paramOverridesSnapshot: { prompt: "hello" }
+    });
+    // Job entry is cleared once the asset is applied.
+    expect(
+      useTimelineGenerationStore.getState().clipJobs[clip.id]
+    ).toBeUndefined();
+
+    fetchQuerySpy.mockRestore();
+  });
+
+  it("treats a completed job without an output asset as a failure", async () => {
+    const clip = {
+      id: "clip-noasset",
+      trackId: "track-1",
+      name: "Clip",
+      startMs: 0,
+      durationMs: 1000,
+      mediaType: "video" as const,
+      workflowId: "wf-1",
+      sourceType: "generated" as const,
+      status: "draft" as const,
+      selectedOutputNodeId: "output-1",
+      locked: false,
+      versions: []
+    };
+    useTimelineStore.setState({
+      sequenceId: "seq-1",
+      tracks: [{ id: "track-1", name: "Track", type: "video", index: 0, visible: true, locked: false }],
+      clips: [clip],
+      markers: []
+    });
+    useTimelineGenerationStore
+      .getState()
+      .registerJob(clip.id, "job-noasset", "wf-1");
+
+    subscribeMock.mockImplementation(
+      ((jobId: string, handler: (message: Record<string, unknown>) => void) => {
+        jobHandlers.set(jobId, handler);
+        return () => {
+          jobHandlers.delete(jobId);
+        };
+      }) as any
+    );
+
+    renderHook(() => useGenerateClip(clip.id));
+
+    // No output_update arrives before the terminal job_update.
+    const { handleJobMessage, __setJobContextForTests } = await import(
+      "../useGenerateClip"
+    );
+    __setJobContextForTests("job-noasset", {
+      clipId: clip.id,
+      workflowId: "wf-1",
+      selectedOutputNodeId: "output-1"
+    });
+    await act(async () => {
+      await handleJobMessage("job-noasset", {
+        type: "job_update",
+        status: "completed",
+        job_id: "job-noasset"
+      } as never);
+    });
+
+    expect(
+      useTimelineGenerationStore.getState().clipJobs[clip.id]?.status
+    ).toBe("failed");
+    expect(
+      useTimelineStore.getState().clips.find((c) => c.id === clip.id)?.status
+    ).toBe("failed");
+    expect(
+      useErrorStore.getState().getError("wf-1", "job-noasset", "output-1")
+    ).toBeTruthy();
+  });
+
+  it("starts only one job for a rapid double-click (async start window)", async () => {
+    const clip = {
+      id: "clip-double",
+      trackId: "track-1",
+      name: "Clip",
+      startMs: 0,
+      durationMs: 1000,
+      mediaType: "video" as const,
+      workflowId: "wf-1",
+      sourceType: "generated" as const,
+      status: "draft" as const,
+      locked: false,
+      versions: []
+    };
+    useTimelineStore.setState({
+      sequenceId: "seq-1",
+      tracks: [{ id: "track-1", name: "Track", type: "video", index: 0, visible: true, locked: false }],
+      clips: [clip],
+      markers: []
+    });
+
+    const fetchQuerySpy = jest
+      .spyOn(queryClient, "fetchQuery")
+      .mockResolvedValue({
+        id: "wf-1",
+        name: "WF",
+        access: "private",
+        graph: { nodes: [], edges: [] }
+      } as never);
+    const run = jest.fn(async () => "job-double");
+    getWorkflowRunnerStoreMock.mockReturnValue({ getState: () => ({ run }) });
+    subscribeMock.mockImplementation((() => () => {}) as any);
+
+    const { result } = renderHook(() => useGenerateClip(clip.id));
+
+    await act(async () => {
+      // Fire twice without awaiting in between — the second call lands while
+      // the first is still inside its pre-registerJob awaits.
+      await Promise.all([
+        result.current.generateClip(),
+        result.current.generateClip()
+      ]);
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+
+    fetchQuerySpy.mockRestore();
+  });
+
+  it("rolls back the optimistic queued status when the start fails", async () => {
+    const clip = {
+      id: "clip-failstart",
+      trackId: "track-1",
+      name: "Clip",
+      startMs: 0,
+      durationMs: 1000,
+      mediaType: "video" as const,
+      workflowId: "wf-1",
+      sourceType: "generated" as const,
+      status: "draft" as const,
+      locked: false,
+      versions: []
+    };
+    useTimelineStore.setState({
+      sequenceId: "seq-1",
+      tracks: [{ id: "track-1", name: "Track", type: "video", index: 0, visible: true, locked: false }],
+      clips: [clip],
+      markers: []
+    });
+
+    const fetchQuerySpy = jest
+      .spyOn(queryClient, "fetchQuery")
+      .mockRejectedValue(new Error("fetch failed"));
+
+    const { result } = renderHook(() => useGenerateClip(clip.id));
+
+    await act(async () => {
+      await expect(result.current.generateClip()).rejects.toThrow(
+        "fetch failed"
+      );
+    });
+
+    expect(
+      useTimelineStore.getState().clips.find((c) => c.id === clip.id)?.status
+    ).toBe("draft");
+
+    fetchQuerySpy.mockRestore();
+  });
+
   it("cancels an active clip generation job", async () => {
     const clip = {
       id: "clip-2",

--- a/web/src/hooks/timeline/__tests__/useLoadTimelineIntoStore.test.ts
+++ b/web/src/hooks/timeline/__tests__/useLoadTimelineIntoStore.test.ts
@@ -43,6 +43,26 @@ describe("useLoadTimelineIntoStore", () => {
     expect(state.durationMs).toBe(5000);
   });
 
+  it("does NOT reload on a same-id refetch (preserves local edits)", () => {
+    const seq = makeSeq();
+    const { rerender } = renderHook(
+      ({ s }: { s: TimelineSequence | undefined }) =>
+        useLoadTimelineIntoStore(s),
+      { initialProps: { s: seq as TimelineSequence | undefined } }
+    );
+    expect(useTimelineStore.getState().sequenceId).toBe("seq-1");
+
+    // Local edit after load.
+    useTimelineStore.getState().addTrack("video");
+    expect(useTimelineStore.getState().tracks).toHaveLength(1);
+
+    // Background refetch: a fresh object for the same sequence id.
+    rerender({ s: makeSeq() });
+
+    // The local edit survives — the store was not reloaded.
+    expect(useTimelineStore.getState().tracks).toHaveLength(1);
+  });
+
   it("reloads when the sequence id changes", () => {
     const a = makeSeq({ id: "a", durationMs: 1000 });
     const b = makeSeq({ id: "b", durationMs: 2000 });

--- a/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
+++ b/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, beforeEach, jest } from "@jest/globals";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
-import { useTimelineAutosave } from "../useTimelineAutosave";
+import {
+  useTimelineAutosave,
+  markTimelineLoadMigrated
+} from "../useTimelineAutosave";
 import { trpcClient } from "../../../__mocks__/trpcClientMock";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 
@@ -265,6 +268,121 @@ describe("useTimelineAutosave", () => {
 
     // The second save fires without waiting for the debounce timer.
     await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(2));
+  });
+
+  it("sends the freshest baseUpdatedAt for a save queued behind an in-flight one", async () => {
+    seedSequence();
+    let resolveFirst: (v: unknown) => void = () => {};
+    (updateMutate as any).mockImplementationOnce(
+      () =>
+        new Promise((resolve: (v: unknown) => void) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    renderHook(() => useTimelineAutosave({ debounceMs: 50 }));
+
+    act(() => {
+      useTimelineStore.getState().addTrack("video");
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+
+    // An edit captured while the first save is still in flight snapshots the
+    // PRE-response token — the follow-up save must not send it.
+    act(() => {
+      useTimelineStore.getState().addTrack("audio");
+    });
+    await act(async () => {
+      resolveFirst({
+        id: "seq-1",
+        updatedAt: "2026-01-01T00:10:00Z"
+      });
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(2));
+
+    expect(
+      (updateMutate.mock.calls[1][0] as { baseUpdatedAt?: string })
+        .baseUpdatedAt
+    ).toBe("2026-01-01T00:10:00Z");
+  });
+
+  it("retries a failed save on the unmount flush", async () => {
+    seedSequence();
+    (updateMutate as any).mockRejectedValueOnce(new Error("boom"));
+    const { unmount } = renderHook(() =>
+      useTimelineAutosave({ debounceMs: 50 })
+    );
+
+    act(() => {
+      useTimelineStore.getState().addTrack("video");
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    // Wait for the failure handler to restore the snapshot.
+    await waitFor(() => {
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications.some((n) => n.content.includes("autosave"))).toBe(
+        true
+      );
+    });
+
+    // No hot retry loop while idle.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+
+    // The unmount flush retries the restored snapshot.
+    unmount();
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(2));
+    const retryArg = updateMutate.mock.calls[1][0] as {
+      document: { tracks: unknown[] };
+    };
+    expect(retryArg.document.tracks).toHaveLength(1);
+  });
+
+  it("does not schedule a save when a sequence is loaded after mount", async () => {
+    renderHook(() => useTimelineAutosave({ debounceMs: 50 }));
+
+    act(() => {
+      seedSequence();
+    });
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(updateMutate).not.toHaveBeenCalled();
+
+    // A real edit after the load still saves.
+    act(() => {
+      useTimelineStore.getState().addTrack("video");
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+  });
+
+  it("persists a load that migrated a legacy transcript exactly once", async () => {
+    renderHook(() => useTimelineAutosave({ debounceMs: 50 }));
+
+    act(() => {
+      markTimelineLoadMigrated("seq-1");
+      seedSequence();
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(updateMutate).toHaveBeenCalledTimes(1);
   });
 
   it("notifies on save failure", async () => {

--- a/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
+++ b/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
@@ -323,10 +323,11 @@ describe("useWorkflowFreshnessCheck", () => {
       return React.createElement(React.Fragment, null, children);
     };
     const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
-      React.createElement(TimelineProvider, {
-        active: false,
-        children: React.createElement(Capture, null, children)
-      });
+      React.createElement(
+        TimelineProvider,
+        { active: false },
+        React.createElement(Capture, null, children)
+      );
 
     mockWorkflowsGet.mockResolvedValue(
       buildWorkflow({ id: "wf-1", updatedAt: NEWER_UPDATED_AT })

--- a/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
+++ b/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.ts
@@ -6,12 +6,18 @@
  */
 
 import { describe, it, expect, beforeEach } from "@jest/globals";
+import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
 import { makeTrack, makeClip } from "@nodetool-ai/timeline";
 import { mockWorkflowsGet } from "../../../__mocks__/trpcClientMock";
 
-import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  useTimelineStoreApi
+} from "../../../stores/timeline/TimelineStore";
+import type { TimelineStoreApi } from "../../../stores/timeline/TimelineStore";
+import { TimelineProvider } from "../../../stores/timeline/TimelineInstance";
 import { useWorkflowFreshnessCheck } from "../useWorkflowFreshnessCheck";
 
 const BASE_UPDATED_AT = "2026-01-01T10:00:00.000Z";
@@ -302,6 +308,59 @@ describe("useWorkflowFreshnessCheck", () => {
         .clips.find((c) => c.id === clip.id);
       expect(current?.status).toBe("stale");
     });
+  });
+
+  it("subscribes to the surrounding provider's instance, not the active/static one", async () => {
+    // A provider with active={false} never pushes its instance onto the
+    // activation stack, so the static `useTimelineStore.getState()` keeps
+    // resolving the default instance. The hook must still observe the
+    // provider's instance via context.
+    const apiRef: { current: TimelineStoreApi | null } = { current: null };
+    const Capture: React.FC<{ children?: React.ReactNode }> = ({
+      children
+    }) => {
+      apiRef.current = useTimelineStoreApi();
+      return React.createElement(React.Fragment, null, children);
+    };
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+      React.createElement(TimelineProvider, {
+        active: false,
+        children: React.createElement(Capture, null, children)
+      });
+
+    mockWorkflowsGet.mockResolvedValue(
+      buildWorkflow({ id: "wf-1", updatedAt: NEWER_UPDATED_AT })
+    );
+
+    renderHook(() => useWorkflowFreshnessCheck("seq-1"), { wrapper });
+    expect(apiRef.current).not.toBeNull();
+
+    // Populate the PROVIDER instance (async, like useLoadTimelineIntoStore).
+    const track = makeTrack({ type: "video" });
+    const clip = makeClip({
+      trackId: track.id,
+      workflowId: "wf-1",
+      sourceType: "generated",
+      status: "generated",
+      versions: [makeSuccessVersion(BASE_UPDATED_AT)]
+    });
+    act(() => {
+      apiRef.current?.setState({
+        sequenceId: "seq-1",
+        tracks: [track],
+        clips: [clip]
+      });
+    });
+
+    await waitFor(() => {
+      const current = apiRef.current
+        ?.getState()
+        .clips.find((c) => c.id === clip.id);
+      expect(current?.status).toBe("stale");
+    });
+
+    // The default/static instance was never touched.
+    expect(useTimelineStore.getState().clips).toHaveLength(0);
   });
 
   it("auto-resolves a missing selectedOutputNodeId to the first available output and marks the clip stale", async () => {

--- a/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.tsx
+++ b/web/src/hooks/timeline/__tests__/useWorkflowFreshnessCheck.test.tsx
@@ -320,14 +320,15 @@ describe("useWorkflowFreshnessCheck", () => {
       children
     }) => {
       apiRef.current = useTimelineStoreApi();
-      return React.createElement(React.Fragment, null, children);
+      return <>{children}</>;
     };
-    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
-      React.createElement(
-        TimelineProvider,
-        { active: false },
-        React.createElement(Capture, null, children)
-      );
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({
+      children
+    }) => (
+      <TimelineProvider active={false}>
+        <Capture>{children}</Capture>
+      </TimelineProvider>
+    );
 
     mockWorkflowsGet.mockResolvedValue(
       buildWorkflow({ id: "wf-1", updatedAt: NEWER_UPDATED_AT })

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -43,9 +43,20 @@ interface TimelineClipLike {
 const jobSubscriptions = new Map<string, () => void>();
 const jobContexts = new Map<string, JobSubscriptionContext>();
 const jobOutputs = new Map<string, unknown>();
+// Clips whose generateClip() is past the single-flight guard but hasn't
+// registered its job yet (the start path awaits a workflow fetch and the
+// runner before registerJob). A synchronous marker closes the double-click
+// hole where two calls both pass the store-based guard.
+const startingClips = new Set<string>();
 
 const isActiveStatus = (status: string): boolean =>
   status === "queued" || status === "running";
+
+const isDirectGenKind = (kind: string | undefined): boolean =>
+  kind === "text-to-image" ||
+  kind === "image-to-image" ||
+  kind === "text-to-video" ||
+  kind === "text-to-audio";
 
 /**
  * Compute the non-generating clip status from current clip fields. Used by
@@ -88,6 +99,7 @@ export const __resetGenerateClipSubscriptionsForTests = (): void => {
   jobSubscriptions.clear();
   jobContexts.clear();
   jobOutputs.clear();
+  startingClips.clear();
 };
 
 export const __setJobContextForTests = (
@@ -217,17 +229,30 @@ export const handleJobMessage = async (jobId: string, message: WebSocketMessage)
       ? extractAssetId(jobOutputs.get(jobId))
       : undefined;
 
+    // A run can report "completed" without producing the selected output
+    // asset (e.g. a node errored mid-flight). Surface that as a failure
+    // instead of silently reverting the clip to draft.
+    if (!assetId) {
+      const errorMessage =
+        "Workflow finished without producing an output asset.";
+      useErrorStore
+        .getState()
+        .setError(
+          context.workflowId,
+          jobId,
+          context.selectedOutputNodeId ?? "__job__",
+          errorMessage
+        );
+      generationStore.updateJobStatus(jobId, "failed", { errorMessage });
+      unsubscribeJob(jobId);
+      return;
+    }
+
+    // The store's completed handler applies the asset to the clip: it
+    // appends a ClipVersion, sets currentAssetId / lastGeneratedHash
+    // (unless locked) and settles clip.status.
     generationStore.updateJobStatus(jobId, "completed", { assetId });
     generationStore.clearJob(context.clipId);
-
-    const clip = useTimelineStore
-      .getState()
-      .clips.find((candidate) => candidate.id === context.clipId);
-    if (clip) {
-      useTimelineStore
-        .getState()
-        .patchClip(context.clipId, { status: deriveIdleClipStatus(clip) });
-    }
     unsubscribeJob(jobId);
     return;
   }
@@ -352,10 +377,9 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
 
   // Direct-gen clips skip the workflow runner and `TimelineGenerationStore`
   // entirely — status is driven straight from the RPC response and reflected
-  // on `clip.status`.
-  const isDirectGen =
-    clip?.bindingKind === "text-to-image" ||
-    clip?.bindingKind === "image-to-image";
+  // on `clip.status` (which also covers jobs started elsewhere, e.g. the
+  // AddClipMenu, since they patch the same clip status).
+  const isDirectGen = isDirectGenKind(clip?.bindingKind);
   const isDirectGenActive =
     isDirectGen && (clip?.status === "queued" || clip?.status === "generating");
   const isDirectGenFailed = isDirectGen && clip?.status === "failed";
@@ -365,10 +389,7 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
       throw new Error("Clip not found");
     }
 
-    if (
-      clip.bindingKind === "text-to-image" ||
-      clip.bindingKind === "image-to-image"
-    ) {
+    if (isDirectGenKind(clip.bindingKind)) {
       await directGen.start(clip.id);
       return;
     }
@@ -382,48 +403,65 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
     // clip, do nothing. Without this guard a rapid double-click registers a
     // second job that overwrites the first in the store, orphans the local
     // subscription, and leaves the original job running on the server.
+    // `startingClips` covers the async window before registerJob runs.
+    if (startingClips.has(clip.id)) {
+      return;
+    }
     const existing = useTimelineGenerationStore.getState().clipJobs[clip.id];
     if (existing && (existing.status === "queued" || existing.status === "running")) {
       return;
     }
 
-    const workflow = await queryClient.fetchQuery({
-      queryKey: workflowQueryKey(workflowId),
-      queryFn: () => fetchWorkflowById(workflowId),
-      staleTime: 0
-    });
+    startingClips.add(clip.id);
+    patchClip(clip.id, { status: "queued" });
+    try {
+      const workflow = await queryClient.fetchQuery({
+        queryKey: workflowQueryKey(workflowId),
+        queryFn: () => fetchWorkflowById(workflowId),
+        staleTime: 0
+      });
 
-    const graphNodes = workflow.graph?.nodes ?? [];
-    const graphEdges = workflow.graph?.edges ?? [];
-    const nodes = graphNodes.map((node: WorkflowGraphNode) =>
-      graphNodeToReactFlowNode(workflow, node)
-    );
-    const edges = graphEdges.map(graphEdgeToReactFlowEdge);
+      const graphNodes = workflow.graph?.nodes ?? [];
+      const graphEdges = workflow.graph?.edges ?? [];
+      const nodes = graphNodes.map((node: WorkflowGraphNode) =>
+        graphNodeToReactFlowNode(workflow, node)
+      );
+      const edges = graphEdges.map(graphEdgeToReactFlowEdge);
 
-    const runnerStore = getWorkflowRunnerStore(workflowId);
-    // Use the id run() returns, not runnerStore.job_id: when the runner is
-    // already busy the run is queued under a fresh id while the store keeps
-    // pointing at the active run, so reading it back would subscribe this
-    // clip to the wrong job and strand its updates.
-    const jobId = await runnerStore
-      .getState()
-      .run(clip.paramOverrides ?? {}, workflow, nodes, edges, undefined, undefined, true);
+      const runnerStore = getWorkflowRunnerStore(workflowId);
+      // Use the id run() returns, not runnerStore.job_id: when the runner is
+      // already busy the run is queued under a fresh id while the store keeps
+      // pointing at the active run, so reading it back would subscribe this
+      // clip to the wrong job and strand its updates.
+      const jobId = await runnerStore
+        .getState()
+        .run(clip.paramOverrides ?? {}, workflow, nodes, edges, undefined, undefined, true);
 
-    if (!jobId) {
-      throw new Error("Workflow runner did not return a job id");
+      if (!jobId) {
+        throw new Error("Workflow runner did not return a job id");
+      }
+
+      registerJob(clip.id, jobId, workflowId);
+      await subscribeJob(
+        jobId,
+        {
+          clipId: clip.id,
+          workflowId,
+          selectedOutputNodeId: clip.selectedOutputNodeId
+        },
+        false
+      );
+    } catch (error) {
+      // Roll back the optimistic "queued" status unless a job actually got
+      // registered (then its own lifecycle owns the status).
+      if (!useTimelineGenerationStore.getState().clipJobs[clip.id]) {
+        patchClip(clip.id, { status: deriveIdleClipStatus(clip) });
+      }
+      throw error;
+    } finally {
+      startingClips.delete(clip.id);
     }
-
-    registerJob(clip.id, jobId, workflowId);
-    await subscribeJob(
-      jobId,
-      {
-        clipId: clip.id,
-        workflowId,
-        selectedOutputNodeId: clip.selectedOutputNodeId
-      },
-      false
-    );
-  }, [clip, registerJob, directGen]);
+  }, [clip, registerJob, directGen, patchClip]);
 
   const cancelClipGeneration = useCallback(async () => {
     if (isDirectGen) {

--- a/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
+++ b/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
@@ -11,6 +11,7 @@ import {
   useTimelineStoreApi,
   timelineTemporalOf
 } from "../../stores/timeline/TimelineStore";
+import { markTimelineLoadMigrated } from "./useTimelineAutosave";
 
 import type { TimelineSequence } from "@nodetool-ai/timeline";
 
@@ -22,6 +23,17 @@ export function useLoadTimelineIntoStore(
   useEffect(() => {
     if (!sequence) {
       return;
+    }
+    // Background refetches (e.g. on window focus) produce a fresh `sequence`
+    // object for the same id; reloading would clobber local edits and wipe
+    // the undo history. Only (re)load when a different sequence arrives.
+    if (store.getState().sequenceId === sequence.id) {
+      return;
+    }
+    if ((sequence.transcript?.length ?? 0) > 0) {
+      // loadSequence folds a legacy transcript onto clips; tell autosave to
+      // persist that migrated document once.
+      markTimelineLoadMigrated(sequence.id);
     }
     store.getState().loadSequence(sequence);
     // The load is a tracked `set`; clear history so the first Ctrl+Z can't

--- a/web/src/hooks/timeline/useTimelineAutosave.ts
+++ b/web/src/hooks/timeline/useTimelineAutosave.ts
@@ -3,18 +3,23 @@
  *
  * Subscribes to the document slice of `TimelineStore` and PATCHes the
  * persisted sequence via `trpc.timeline.update` whenever the user mutates
- * tracks / clips / markers / durationMs.
+ * tracks / clips / markers / transcript.
  *
  * Robustness:
  *   - Debounces saves so a burst of edits coalesces into one PATCH.
  *   - Single-flight: while a save is in flight, additional edits accumulate
  *     in `pendingRef` and a follow-up save fires once the in-flight one
  *     resolves.
- *   - Optimistic concurrency: sends `baseUpdatedAt` (sourced from the
- *     TimelineStore) so the server can reject stale writes; rolls it
- *     forward from each successful response.
- *   - Failures surface a deduped notification and leave `pendingRef`
- *     intact so the next edit retries automatically.
+ *   - Optimistic concurrency: sends `baseUpdatedAt` (read from the
+ *     TimelineStore at SEND time, so an edit captured during an in-flight
+ *     save can't self-conflict with that save's own response token) and
+ *     rolls it forward from each successful response — but only while the
+ *     store still holds the saved sequence.
+ *   - Failures surface a deduped notification and restore the snapshot to
+ *     `pendingRef` so the next edit or the unmount flush retries.
+ *   - Loading a sequence re-baselines the subscriber instead of scheduling a
+ *     save; the one exception is a load that migrated a legacy transcript,
+ *     which is persisted once (see `markTimelineLoadMigrated`).
  *   - Pending edits are flushed on unmount.
  */
 import { useEffect, useRef } from "react";
@@ -34,18 +39,36 @@ interface DocumentSnapshot {
   clips: TimelineStoreState["clips"];
   markers: TimelineStoreState["markers"];
   transcript: TimelineStoreState["transcript"];
-  durationMs: number;
 }
 
+// `durationMs` is intentionally NOT tracked: the PATCH schema has no
+// durationMs field, so treating it as a dirty-trigger would schedule saves
+// that can never persist it. It is recomputed client-side from the clips.
 const pickSnapshot = (state: TimelineStoreState): DocumentSnapshot => ({
   sequenceId: state.sequenceId,
   baseUpdatedAt: state.baseUpdatedAt,
   tracks: state.tracks,
   clips: state.clips,
   markers: state.markers,
-  transcript: state.transcript,
-  durationMs: state.durationMs
+  transcript: state.transcript
 });
+
+// Sequence ids whose load migrated a legacy transcript onto clips. The
+// migrated document differs from what the server holds, so it must be
+// persisted once even though a plain load is not an edit.
+const migratedLoads = new Set<string>();
+
+/**
+ * Called by `useLoadTimelineIntoStore` just before `loadSequence` when the
+ * fetched document carries a legacy `TranscriptLine[]` transcript that the
+ * load folds onto clips. Autosave then persists that one load.
+ */
+export function markTimelineLoadMigrated(sequenceId: string): void {
+  migratedLoads.add(sequenceId);
+}
+
+const consumeMigratedLoad = (sequenceId: string): boolean =>
+  migratedLoads.delete(sequenceId);
 
 export interface UseTimelineAutosaveOptions {
   debounceMs?: number;
@@ -72,10 +95,21 @@ export function useTimelineAutosave(
     const runSave = async (snapshot: DocumentSnapshot) => {
       if (!snapshot.sequenceId) return;
       inFlightRef.current = true;
+      let succeeded = false;
       try {
+        // Read the concurrency token at send time: a snapshot captured while
+        // a previous save was in flight still carries that save's
+        // pre-response token and would 409 against our own write. Fall back
+        // to the snapshot token if the store has since loaded a different
+        // sequence (its live token belongs to the new one).
+        const live = store.getState();
+        const baseUpdatedAt =
+          live.sequenceId === snapshot.sequenceId
+            ? live.baseUpdatedAt
+            : snapshot.baseUpdatedAt;
         const response = await trpcClient.timeline.update.mutate({
           id: snapshot.sequenceId,
-          baseUpdatedAt: snapshot.baseUpdatedAt ?? undefined,
+          baseUpdatedAt: baseUpdatedAt ?? undefined,
           document: {
             tracks: snapshot.tracks,
             clips: snapshot.clips,
@@ -85,9 +119,15 @@ export function useTimelineAutosave(
         });
         const updatedAt = (response as { updatedAt?: unknown } | undefined)
           ?.updatedAt;
-        if (typeof updatedAt === "string") {
+        // Only roll the token forward while the store still holds the saved
+        // sequence — otherwise we'd poison a newly loaded sequence's token.
+        if (
+          typeof updatedAt === "string" &&
+          store.getState().sequenceId === snapshot.sequenceId
+        ) {
           store.getState().setBaseUpdatedAt(updatedAt);
         }
+        succeeded = true;
       } catch (error) {
         console.error("Timeline autosave failed:", error);
         useNotificationStore.getState().addNotification({
@@ -98,10 +138,20 @@ export function useTimelineAutosave(
           dedupeKey: "timeline-autosave-failed",
           replaceExisting: true
         });
-        // Leave pendingRef intact so the next edit triggers a retry.
+        // Restore the snapshot (unless a newer edit replaced it) so the next
+        // edit or the unmount flush retries the save.
+        if (!pendingRef.current) {
+          pendingRef.current = snapshot;
+        }
       } finally {
         inFlightRef.current = false;
-        if (pendingRef.current) {
+        // Follow up on a pending snapshot — but not the failed one we just
+        // restored, which would otherwise retry in a hot loop. It waits for
+        // the next edit or the unmount flush instead.
+        if (
+          pendingRef.current &&
+          (succeeded || pendingRef.current !== snapshot)
+        ) {
           if (flushImmediatelyOnComplete) {
             flush();
           } else {
@@ -134,12 +184,22 @@ export function useTimelineAutosave(
     // Skip subscriber updates that don't change persisted document fields.
     // Otherwise the server's `setBaseUpdatedAt` write after each save loops
     // back into the subscriber and triggers an infinite save→response cycle.
-    let lastSequenceId: string | null = null;
-    let lastTracks: TimelineStoreState["tracks"] | null = null;
-    let lastClips: TimelineStoreState["clips"] | null = null;
-    let lastMarkers: TimelineStoreState["markers"] | null = null;
-    let lastTranscript: TimelineStoreState["transcript"] | null = null;
-    let lastDurationMs: number | null = null;
+    // Baseline from the current state so a remount mid-session doesn't
+    // mistake the next edit for a sequence load.
+    const initial = store.getState();
+    let lastSequenceId: string | null = initial.sequenceId;
+    let lastTracks: TimelineStoreState["tracks"] | null = initial.tracks;
+    let lastClips: TimelineStoreState["clips"] | null = initial.clips;
+    let lastMarkers: TimelineStoreState["markers"] | null = initial.markers;
+    let lastTranscript: TimelineStoreState["transcript"] | null =
+      initial.transcript;
+
+    // A sequence loaded before this hook subscribed may still owe its
+    // one-time migration save.
+    if (initial.sequenceId && consumeMigratedLoad(initial.sequenceId)) {
+      pendingRef.current = pickSnapshot(initial);
+      schedule();
+    }
 
     const unsubscribe = store.subscribe((state) => {
       if (!state.sequenceId) return;
@@ -148,15 +208,19 @@ export function useTimelineAutosave(
         state.tracks === lastTracks &&
         state.clips === lastClips &&
         state.markers === lastMarkers &&
-        state.transcript === lastTranscript &&
-        state.durationMs === lastDurationMs;
+        state.transcript === lastTranscript;
       if (docUnchanged) return;
+      const isLoad = state.sequenceId !== lastSequenceId;
       lastSequenceId = state.sequenceId;
       lastTracks = state.tracks;
       lastClips = state.clips;
       lastMarkers = state.markers;
       lastTranscript = state.transcript;
-      lastDurationMs = state.durationMs;
+      if (isLoad && !consumeMigratedLoad(state.sequenceId)) {
+        // Loading a sequence is not an edit: re-baseline without scheduling
+        // a redundant PATCH of the document we just fetched.
+        return;
+      }
       pendingRef.current = pickSnapshot(state);
       schedule();
     });

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -14,7 +14,8 @@ import {
   globalWebSocketManager,
   type WebSocketMessage
 } from "../../lib/websocket/GlobalWebSocketManager";
-import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import type { TimelineStoreApi } from "../../stores/timeline/TimelineStore";
 import { makeClipVersion } from "@nodetool-ai/timeline";
 import type { TimelineClip } from "@nodetool-ai/timeline";
 import { deriveIdleClipStatus } from "./useGenerateClip";
@@ -53,13 +54,18 @@ const clearInFlight = (clipId: string): void => {
   }
 };
 
-function fail(clipId: string): void {
-  useTimelineStore.getState().patchClip(clipId, { status: "failed" });
+function fail(timeline: TimelineStoreApi, clipId: string): void {
+  timeline.getState().patchClip(clipId, { status: "failed" });
 }
 
 export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
+  // Capture the surrounding instance's document store once; all reads and
+  // writes in the async flow below go through this same handle so a focus
+  // switch to another timeline instance mid-generation can't redirect them.
+  const timeline = useTimelineStoreApi();
+
   const start = useCallback(async (clipId: string): Promise<string | null> => {
-    const clip = useTimelineStore
+    const clip = timeline
       .getState()
       .clips.find((c) => c.id === clipId);
     if (!clip) return null;
@@ -76,12 +82,12 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
       return null;
     }
     if (!clip.provider || !clip.model) {
-      fail(clipId);
+      fail(timeline, clipId);
       return null;
     }
     const prompt = (clip.prompt ?? "").trim();
     if (!prompt) {
-      fail(clipId);
+      fail(timeline, clipId);
       return null;
     }
 
@@ -89,14 +95,14 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
     let sourceAssetId: string | undefined;
     if (kind === "image-to-image") {
       if (!clip.sourceClipId) {
-        fail(clipId);
+        fail(timeline, clipId);
         return null;
       }
-      const sourceClip = useTimelineStore
+      const sourceClip = timeline
         .getState()
         .clips.find((c) => c.id === clip.sourceClipId);
       if (!sourceClip?.currentAssetId) {
-        fail(clipId);
+        fail(timeline, clipId);
         return null;
       }
       sourceAssetId = sourceClip.currentAssetId;
@@ -106,7 +112,7 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
     clearInFlight(clipId);
 
     const requestId = randomId();
-    useTimelineStore.getState().patchClip(clipId, { status: "generating" });
+    timeline.getState().patchClip(clipId, { status: "generating" });
 
     let unsubscribe: (() => void) | undefined;
     const cleanup = () => {
@@ -119,7 +125,7 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
 
     const settle = (msg: DirectGenRpcResponse) => {
       cleanup();
-      const store = useTimelineStore.getState();
+      const store = timeline.getState();
       if (msg.error) {
         store.patchClip(clipId, { status: "failed" });
         return;
@@ -200,12 +206,12 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
       });
     } catch {
       cleanup();
-      fail(clipId);
+      fail(timeline, clipId);
       return null;
     }
 
     return requestId;
-  }, []);
+  }, [timeline]);
 
   const cancel = useCallback((clipId: string) => {
     clearInFlight(clipId);
@@ -213,14 +219,14 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
     // generated/stale clip should not regress to "Draft" just because the
     // user cancelled a re-roll. `deriveIdleClipStatus` produces draft only
     // when the clip has no rendered asset.
-    const clip = useTimelineStore
+    const clip = timeline
       .getState()
       .clips.find((c) => c.id === clipId);
     if (!clip) return;
-    useTimelineStore
+    timeline
       .getState()
       .patchClip(clipId, { status: deriveIdleClipStatus(clip) });
-  }, []);
+  }, [timeline]);
 
   return { start, cancel };
 }

--- a/web/src/hooks/timeline/useTimelineSave.ts
+++ b/web/src/hooks/timeline/useTimelineSave.ts
@@ -38,7 +38,12 @@ export function useTimelineSave(): UseTimelineSaveResult {
       });
       const updatedAt = (response as { updatedAt?: unknown } | undefined)
         ?.updatedAt;
-      if (typeof updatedAt === "string") {
+      // Only roll the token forward while the store still holds the saved
+      // sequence — otherwise we'd poison a newly loaded sequence's token.
+      if (
+        typeof updatedAt === "string" &&
+        store.getState().sequenceId === state.sequenceId
+      ) {
         store.getState().setBaseUpdatedAt(updatedAt);
       }
     } catch (error) {

--- a/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
+++ b/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
@@ -12,7 +12,10 @@
 
 import { useEffect, useRef, useCallback } from "react";
 import { trpcClient } from "../../trpc/client";
-import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  useTimelineStoreApi
+} from "../../stores/timeline/TimelineStore";
 
 interface ClipVersion {
   id: string;
@@ -47,6 +50,11 @@ function latestSuccessfulWorkflowUpdatedAt(
 export function useWorkflowFreshnessCheck(
   sequenceId: string | null | undefined
 ): void {
+  // Resolve the surrounding instance's store via context rather than the
+  // active-instance statics: this hook's effect runs before the parent
+  // TimelineProvider pushes its instance (child effects run first), so the
+  // statics would subscribe to whichever instance was active previously.
+  const store = useTimelineStoreApi();
   const markClipsStaleForWorkflow = useTimelineStore(
     (s) => s.markClipsStaleForWorkflow
   );
@@ -58,7 +66,7 @@ export function useWorkflowFreshnessCheck(
   const runCheck = useCallback(async () => {
     if (!sequenceId) return;
 
-    const clips = useTimelineStore.getState().clips;
+    const clips = store.getState().clips;
 
     const workflowIds = new Set<string>();
     for (const clip of clips) {
@@ -150,6 +158,7 @@ export function useWorkflowFreshnessCheck(
     );
   }, [
     sequenceId,
+    store,
     markClipsStaleForWorkflow,
     applyInputDrift,
     setClipsOutputNode
@@ -164,7 +173,7 @@ export function useWorkflowFreshnessCheck(
     // `lastCheckedSequenceId` against an empty store.
     const tryRun = (): boolean => {
       if (lastCheckedSequenceId.current === sequenceId) return true;
-      const state = useTimelineStore.getState();
+      const state = store.getState();
       if (state.sequenceId !== sequenceId) return false;
       if (state.clips.length === 0) return false;
       lastCheckedSequenceId.current = sequenceId;
@@ -174,11 +183,11 @@ export function useWorkflowFreshnessCheck(
 
     if (tryRun()) return;
 
-    const unsubscribe = useTimelineStore.subscribe(() => {
+    const unsubscribe = store.subscribe(() => {
       if (tryRun()) {
         unsubscribe();
       }
     });
     return unsubscribe;
-  }, [sequenceId, runCheck]);
+  }, [sequenceId, store, runCheck]);
 }

--- a/web/src/stores/timeline/TimelineGenerationStore.ts
+++ b/web/src/stores/timeline/TimelineGenerationStore.ts
@@ -19,6 +19,8 @@
 
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
+import { makeClipVersion } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "./TimelineStore";
 import useResultsStore from "../ResultsStore";
 import { extractAssetId } from "../outputAssetId";
@@ -170,9 +172,16 @@ export const useTimelineGenerationStore =
         set((state) => {
           const nextClipJobs = { ...state.clipJobs, [clipId]: jobState };
           persistClipJobs(nextClipJobs);
+          const nextJobToClip = { ...state.jobToClip, [jobId]: clipId };
+          // Drop the previous job's reverse mapping: a replayed event for the
+          // superseded job must not mutate the new job's state.
+          const previous = state.clipJobs[clipId];
+          if (previous && previous.jobId !== jobId) {
+            delete nextJobToClip[previous.jobId];
+          }
           return {
             clipJobs: nextClipJobs,
-            jobToClip: { ...state.jobToClip, [jobId]: clipId }
+            jobToClip: nextJobToClip
           };
         });
 
@@ -192,7 +201,25 @@ export const useTimelineGenerationStore =
           return;
         }
 
-        const updated: ClipJobState = { ...existing, status, ...extra };
+        // The documented "completed" contract requires an output asset;
+        // a job that completes without one is surfaced as a failure
+        // (mirrors the sketch editor's useGenerateLayer).
+        const completedWithoutAsset = status === "completed" && !extra?.assetId;
+        const effectiveStatus: ClipGenerationStatus = completedWithoutAsset
+          ? "failed"
+          : status;
+        const updated: ClipJobState = {
+          ...existing,
+          status: effectiveStatus,
+          ...extra,
+          ...(completedWithoutAsset
+            ? {
+                errorMessage:
+                  extra?.errorMessage ??
+                  "Job completed without producing an output asset."
+              }
+            : {})
+        };
 
         set((state) => {
           const nextClipJobs = { ...state.clipJobs, [clipId]: updated };
@@ -204,13 +231,46 @@ export const useTimelineGenerationStore =
 
         // ── Mirror status into TimelineStore ──────────────────────────────
 
-        if (status === "running") {
+        if (effectiveStatus === "running") {
           useTimelineStore.getState().patchClip(clipId, { status: "generating" });
           return;
         }
 
-        if (status === "failed") {
+        if (effectiveStatus === "failed") {
           useTimelineStore.getState().patchClip(clipId, { status: "failed" });
+          return;
+        }
+
+        if (effectiveStatus === "completed" && extra?.assetId) {
+          const assetId = extra.assetId;
+          const timeline = useTimelineStore.getState();
+          const clip = timeline.clips.find(
+            (candidate) => candidate.id === clipId
+          );
+          if (!clip) {
+            return;
+          }
+          // Apply the completed contract: append a ClipVersion, set
+          // currentAssetId and lastGeneratedHash (unless the clip is locked),
+          // and settle the clip's status.
+          const patch: Partial<TimelineClip> = {
+            status: "generated",
+            versions: [
+              ...(clip.versions ?? []),
+              makeClipVersion({
+                jobId,
+                assetId,
+                workflowUpdatedAt: new Date().toISOString(),
+                dependencyHash: clip.dependencyHash ?? "",
+                paramOverridesSnapshot: clip.paramOverrides ?? {}
+              })
+            ]
+          };
+          if (!clip.locked) {
+            patch.currentAssetId = assetId;
+            patch.lastGeneratedHash = clip.dependencyHash;
+          }
+          timeline.patchClip(clipId, patch);
         }
       },
 

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -9,8 +9,10 @@
  *     (tracks + clips + markers).
  *   - Exposes pure-reducer actions: move, trim, split, duplicate, delete,
  *     addTrack, removeTrack, reorderTracks, setTrackHeight.
- *   - Each drag operation is a single zundo entry (pauseTracking /
- *     resumeTracking wrapping fine-grained moves).
+ *   - Undo granularity: the temporal `equality` option dedupes no-op sets so
+ *     guard-returns never create history entries, and drag handlers (e.g. in
+ *     Clip.tsx) call zundo's `pause()` / `resume()` from the outside so each
+ *     drag gesture collapses into a single undo entry.
  *
  * Usage:
  *   // Subscribe to a single clip's geometry only:
@@ -373,6 +375,58 @@ type PartializedState = Pick<
   "tracks" | "clips" | "markers" | "durationMs" | "transcript"
 >;
 
+// ── Temporal equality (dedupe no-op sets) ───────────────────────────────────
+
+/** Shallow per-key equality for plain records (one level of `Object.is`). */
+function shallowRecordEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  const recA = a as Record<string, unknown>;
+  const recB = b as Record<string, unknown>;
+  const keysA = Object.keys(recA);
+  const keysB = Object.keys(recB);
+  return (
+    keysA.length === keysB.length &&
+    keysA.every((k) => Object.is(recA[k], recB[k]))
+  );
+}
+
+/** Element-wise array equality, comparing items shallowly. */
+function shallowArrayEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  return (
+    a === b ||
+    (a.length === b.length &&
+      a.every((item, i) => shallowRecordEqual(item, b[i])))
+  );
+}
+
+/**
+ * zundo `equality`: returns true when two partialized snapshots are
+ * equivalent, so no-op sets (guard-returns, `{}` patches, value-identical
+ * remaps) don't push duplicate undo entries.
+ */
+function partializedEqual(
+  pastState: PartializedState,
+  currentState: PartializedState
+): boolean {
+  return (
+    pastState.durationMs === currentState.durationMs &&
+    shallowArrayEqual(pastState.tracks, currentState.tracks) &&
+    shallowArrayEqual(pastState.clips, currentState.clips) &&
+    shallowArrayEqual(pastState.markers, currentState.markers) &&
+    shallowArrayEqual(pastState.transcript, currentState.transcript)
+  );
+}
+
 // ── Scene split/merge helpers (pure) ───────────────────────────────────────
 
 /** Split every clip that strictly contains `timeMs` into two halves. */
@@ -734,6 +788,14 @@ export const createTimelineStore = (
               snappedDelta = snappedStart - primary.startMs;
             }
 
+            // Clamp the delta ONCE for the whole group so relative spacing is
+            // preserved when the selection is dragged against t=0.
+            const minStartMs = state.clips.reduce(
+              (min, c) => (selectedIds.has(c.id) ? Math.min(min, c.startMs) : min),
+              primary.startMs
+            );
+            const effectiveDelta = Math.max(snappedDelta, -minStartMs);
+
             return {
               clips: state.clips.map((c) => {
                 if (!selectedIds.has(c.id)) {
@@ -742,13 +804,13 @@ export const createTimelineStore = (
                 if (c.id === primaryClipId) {
                   return {
                     ...c,
-                    startMs: Math.max(0, c.startMs + snappedDelta),
+                    startMs: c.startMs + effectiveDelta,
                     trackId: toTrackId ?? c.trackId
                   };
                 }
                 return {
                   ...c,
-                  startMs: Math.max(0, c.startMs + snappedDelta)
+                  startMs: c.startMs + effectiveDelta
                 };
               })
             };
@@ -780,15 +842,15 @@ export const createTimelineStore = (
               return state;
             }
             try {
-              // Clamp deltaMs so that outPointMs cannot exceed source duration.
+              // Clamp grow deltas so that outPointMs cannot exceed source
+              // duration. Never clamp a shrink — an over-extended clip
+              // (outPointMs already past source end) must still shrink.
               let clampedDelta = deltaMs;
-              if (maxSourceDurationMs !== undefined) {
+              if (maxSourceDurationMs !== undefined && deltaMs > 0) {
                 const currentOutPointMs =
                   clip.outPointMs ?? (clip.inPointMs ?? 0) + clip.durationMs;
                 const maxGrow = maxSourceDurationMs - currentOutPointMs;
-                if (clampedDelta > maxGrow) {
-                  clampedDelta = Math.max(0, maxGrow);
-                }
+                clampedDelta = Math.min(deltaMs, Math.max(0, maxGrow));
               }
               const trimmed = trimClip(clip, "end", clampedDelta);
               return {
@@ -1196,6 +1258,7 @@ export const createTimelineStore = (
       }),
       {
         limit: 100,
+        equality: partializedEqual,
         partialize: (state): PartializedState => ({
           tracks: state.tracks,
           clips: state.clips,

--- a/web/src/stores/timeline/TimelineTranscriptStore.ts
+++ b/web/src/stores/timeline/TimelineTranscriptStore.ts
@@ -26,6 +26,7 @@ import { makeClip, makeClipVersion, createTimeOrderedUuid } from "@nodetool-ai/t
 import type { CaptionWord, TimelineClip } from "@nodetool-ai/timeline";
 
 import { useTimelineStore } from "./TimelineStore";
+import type { TimelineStoreState } from "./TimelineStore";
 import { useTimelinePlaybackStore } from "./TimelinePlaybackStore";
 import * as ops from "./transcriptOps";
 import type { TokenRef } from "./transcriptOps";
@@ -150,6 +151,29 @@ function parseCaptionWords(result: Record<string, unknown>): CaptionWord[] {
     }
   }
   return words;
+}
+
+// ── Active-instance pinning ──────────────────────────────────────────────────
+
+interface PinnedTimelineStore {
+  getState: () => TimelineStoreState;
+  release: () => void;
+}
+
+/**
+ * Pin the *currently active* timeline instance's document store for the
+ * duration of an async flow. `useTimelineStore.getState()` re-resolves the
+ * active instance on every call, so a flow that awaits in between would write
+ * into whichever timeline gained focus meanwhile. The pin captures the
+ * instance once (via `subscribe`, which binds at call time) and serves
+ * consistent reads/writes until released.
+ */
+function pinActiveTimelineStore(): PinnedTimelineStore {
+  let latest = useTimelineStore.getState();
+  const release = useTimelineStore.subscribe((state: TimelineStoreState) => {
+    latest = state;
+  });
+  return { getState: () => latest, release };
 }
 
 // ── Track helpers ────────────────────────────────────────────────────────────
@@ -369,9 +393,13 @@ export const useTimelineTranscriptStore = create<TimelineTranscriptStoreState>(
 
       generateBeat: async (clipId) => {
         const { config } = get();
+        // Pin the instance whose beat is being voiced: every read/write in
+        // this multi-await flow must target the same timeline document even
+        // if another instance becomes active mid-generation.
+        const timeline = pinActiveTimelineStore();
         setClipStatus(clipId, "generating");
         try {
-          const clip = useTimelineStore
+          const clip = timeline
             .getState()
             .clips.find((c) => c.id === clipId);
           if (!clip) throw new Error(`Transcript beat ${clipId} not found`);
@@ -394,8 +422,8 @@ export const useTimelineTranscriptStore = create<TimelineTranscriptStoreState>(
           const audioAssetId = assetIds[0];
           if (!audioAssetId) throw new Error("No audio asset produced");
 
-          const patchClip = useTimelineStore.getState().patchClip;
-          const existing = useTimelineStore
+          const patchClip = timeline.getState().patchClip;
+          const existing = timeline
             .getState()
             .clips.find((c) => c.id === clipId);
           patchClip(clipId, {
@@ -437,13 +465,21 @@ export const useTimelineTranscriptStore = create<TimelineTranscriptStoreState>(
           patchClip(clipId, { caption: { words } });
 
           // 4. Re-flow so the real durations lay the beats out end-to-end.
-          const after = useTimelineStore.getState();
+          //    Bail if the clip was deleted while generation was in flight —
+          //    re-flowing then would reshuffle unrelated clips for nothing.
+          const after = timeline.getState();
+          if (!after.clips.some((c) => c.id === clipId)) {
+            setClipStatus(clipId, "idle");
+            return;
+          }
           after.setTranscriptAndClips(ops.reflowGenerated(after.clips));
 
           setClipStatus(clipId, "idle");
         } catch (err) {
           setClipStatus(clipId, "failed");
           throw err instanceof Error ? err : new Error(String(err));
+        } finally {
+          timeline.release();
         }
       },
 
@@ -452,35 +488,43 @@ export const useTimelineTranscriptStore = create<TimelineTranscriptStoreState>(
         if (mediaType !== "audio" && mediaType !== "video") {
           throw new Error("Only audio or video can be transcribed");
         }
-        const trackId =
-          mediaType === "audio" ? ensureVoiceoverTrack() : ensureVideoTrack();
-
-        // An empty caption marks the clip as a (recorded) transcript clip up
-        // front, so it shows a "transcribing…" paragraph before words arrive.
-        const base = assetToClip(asset, trackId, timelineEndMs());
-        const clip = {
-          ...base,
-          paragraphId: base.id,
-          caption: { words: [] as CaptionWord[] }
-        };
-        useTimelineStore.getState().addClip(clip);
-
-        setClipStatus(clip.id, "generating");
+        // Pin the instance receiving the import so the post-transcription
+        // caption write can't land in another timeline that gained focus
+        // while the RPC was in flight.
+        const timeline = pinActiveTimelineStore();
         try {
-          const { config } = get();
-          const asrResult = await rpcRequest("transcribe_audio", {
-            provider: config.asrProvider,
-            model: config.asrModel,
-            asset_id: asset.id
-          });
-          const words = parseCaptionWords(asrResult);
-          useTimelineStore.getState().patchClip(clip.id, { caption: { words } });
-          setClipStatus(clip.id, "idle");
-        } catch (err) {
-          setClipStatus(clip.id, "failed");
-          throw err instanceof Error ? err : new Error(String(err));
+          const trackId =
+            mediaType === "audio" ? ensureVoiceoverTrack() : ensureVideoTrack();
+
+          // An empty caption marks the clip as a (recorded) transcript clip up
+          // front, so it shows a "transcribing…" paragraph before words arrive.
+          const base = assetToClip(asset, trackId, timelineEndMs());
+          const clip = {
+            ...base,
+            paragraphId: base.id,
+            caption: { words: [] as CaptionWord[] }
+          };
+          timeline.getState().addClip(clip);
+
+          setClipStatus(clip.id, "generating");
+          try {
+            const { config } = get();
+            const asrResult = await rpcRequest("transcribe_audio", {
+              provider: config.asrProvider,
+              model: config.asrModel,
+              asset_id: asset.id
+            });
+            const words = parseCaptionWords(asrResult);
+            timeline.getState().patchClip(clip.id, { caption: { words } });
+            setClipStatus(clip.id, "idle");
+          } catch (err) {
+            setClipStatus(clip.id, "failed");
+            throw err instanceof Error ? err : new Error(String(err));
+          }
+          return clip.id;
+        } finally {
+          timeline.release();
         }
-        return clip.id;
       }
     };
   }

--- a/web/src/stores/timeline/__tests__/TimelineGenerationStore.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineGenerationStore.test.ts
@@ -1,14 +1,35 @@
 import { describe, it, expect, beforeEach } from "@jest/globals";
 import { act } from "@testing-library/react";
+import type { TimelineClip } from "@nodetool-ai/timeline";
 import { useTimelineGenerationStore } from "../TimelineGenerationStore";
+import ResultsStore from "../../ResultsStore";
+
+const mockPatchClip = jest.fn();
+let mockClips: TimelineClip[] = [];
 
 jest.mock("../TimelineStore", () => ({
   useTimelineStore: {
     getState: () => ({
-      patchClip: jest.fn()
+      clips: mockClips,
+      patchClip: mockPatchClip
     })
   }
 }));
+
+const makeMockClip = (overrides: Partial<TimelineClip> = {}): TimelineClip =>
+  ({
+    id: "clip-1",
+    trackId: "track-1",
+    name: "Clip",
+    startMs: 0,
+    durationMs: 1000,
+    mediaType: "video",
+    sourceType: "generated",
+    status: "generating",
+    locked: false,
+    versions: [],
+    ...overrides
+  }) as TimelineClip;
 
 jest.mock("../../ResultsStore", () => ({
   __esModule: true,
@@ -29,6 +50,8 @@ function resetStore() {
 describe("TimelineGenerationStore", () => {
   beforeEach(() => {
     resetStore();
+    mockPatchClip.mockReset();
+    mockClips = [];
   });
 
   describe("initial state", () => {
@@ -65,6 +88,25 @@ describe("TimelineGenerationStore", () => {
       const { clipJobs, jobToClip } = useTimelineGenerationStore.getState();
       expect(clipJobs["clip-1"].jobId).toBe("job-2");
       expect(jobToClip["job-2"]).toBe("clip-1");
+    });
+
+    it("removes the superseded job's reverse mapping so its replayed events no-op", () => {
+      act(() => {
+        useTimelineGenerationStore.getState().registerJob("clip-1", "job-1", "wf-1");
+        useTimelineGenerationStore.getState().registerJob("clip-1", "job-2", "wf-1");
+      });
+
+      expect(
+        useTimelineGenerationStore.getState().jobToClip["job-1"]
+      ).toBeUndefined();
+
+      // A late event for the old job must not mutate the new job.
+      act(() => {
+        useTimelineGenerationStore.getState().updateJobStatus("job-1", "running");
+      });
+      expect(
+        useTimelineGenerationStore.getState().clipJobs["clip-1"].status
+      ).toBe("queued");
     });
 
     it("tracks multiple clips independently", () => {
@@ -112,6 +154,73 @@ describe("TimelineGenerationStore", () => {
       const job = useTimelineGenerationStore.getState().clipJobs["clip-1"];
       expect(job.status).toBe("completed");
       expect(job.assetId).toBe("asset-42");
+    });
+
+    it("applies the completed asset to the clip: version, currentAssetId, lastGeneratedHash", () => {
+      mockClips = [
+        makeMockClip({
+          dependencyHash: "hash-1",
+          paramOverrides: { prompt: "hello" }
+        })
+      ];
+
+      act(() => {
+        useTimelineGenerationStore.getState().registerJob("clip-1", "job-1", "wf-1");
+        mockPatchClip.mockClear();
+        useTimelineGenerationStore.getState().updateJobStatus("job-1", "completed", {
+          assetId: "asset-42"
+        });
+      });
+
+      expect(mockPatchClip).toHaveBeenCalledWith(
+        "clip-1",
+        expect.objectContaining({
+          status: "generated",
+          currentAssetId: "asset-42",
+          lastGeneratedHash: "hash-1",
+          versions: [
+            expect.objectContaining({
+              jobId: "job-1",
+              assetId: "asset-42",
+              dependencyHash: "hash-1",
+              paramOverridesSnapshot: { prompt: "hello" },
+              status: "success"
+            })
+          ]
+        })
+      );
+    });
+
+    it("records the version but keeps currentAssetId on a locked clip", () => {
+      mockClips = [makeMockClip({ locked: true, currentAssetId: "asset-old" })];
+
+      act(() => {
+        useTimelineGenerationStore.getState().registerJob("clip-1", "job-1", "wf-1");
+        mockPatchClip.mockClear();
+        useTimelineGenerationStore.getState().updateJobStatus("job-1", "completed", {
+          assetId: "asset-new"
+        });
+      });
+
+      const patch = mockPatchClip.mock.calls[0]?.[1] as Partial<TimelineClip>;
+      expect(patch.currentAssetId).toBeUndefined();
+      expect(patch.lastGeneratedHash).toBeUndefined();
+      expect(patch.versions).toHaveLength(1);
+    });
+
+    it("treats completed without an assetId as a failure", () => {
+      mockClips = [makeMockClip()];
+
+      act(() => {
+        useTimelineGenerationStore.getState().registerJob("clip-1", "job-1", "wf-1");
+        mockPatchClip.mockClear();
+        useTimelineGenerationStore.getState().updateJobStatus("job-1", "completed");
+      });
+
+      const job = useTimelineGenerationStore.getState().clipJobs["clip-1"];
+      expect(job.status).toBe("failed");
+      expect(job.errorMessage).toBeTruthy();
+      expect(mockPatchClip).toHaveBeenCalledWith("clip-1", { status: "failed" });
     });
 
     it("no-ops for an unknown jobId", () => {
@@ -206,9 +315,9 @@ describe("TimelineGenerationStore", () => {
 
     it("returns asset_id from an object result", () => {
       const mockGetOutputResult = jest.fn().mockReturnValue({ asset_id: "asset-42" });
-      jest.spyOn(
-        require("../../ResultsStore").default, "getState"
-      ).mockReturnValue({ getOutputResult: mockGetOutputResult });
+      jest
+        .spyOn(ResultsStore, "getState")
+        .mockReturnValue({ getOutputResult: mockGetOutputResult } as never);
 
       const result = useTimelineGenerationStore.getState().resolveOutputAssetId("wf-1", "job-1", "node-1");
       expect(result).toBe("asset-42");
@@ -216,9 +325,9 @@ describe("TimelineGenerationStore", () => {
 
     it("returns a string result directly", () => {
       const mockGetOutputResult = jest.fn().mockReturnValue("direct-id");
-      jest.spyOn(
-        require("../../ResultsStore").default, "getState"
-      ).mockReturnValue({ getOutputResult: mockGetOutputResult });
+      jest
+        .spyOn(ResultsStore, "getState")
+        .mockReturnValue({ getOutputResult: mockGetOutputResult } as never);
 
       const result = useTimelineGenerationStore.getState().resolveOutputAssetId("wf-1", "job-1", "node-1");
       expect(result).toBe("direct-id");

--- a/web/src/stores/timeline/__tests__/TimelineStore.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach } from "@jest/globals";
-import { createTimelineStore } from "../TimelineStore";
+import { createTimelineStore, timelineTemporalOf } from "../TimelineStore";
 import { makeTrack, makeClip } from "@nodetool-ai/timeline";
 import type { Asset } from "../../ApiTypes";
 // Import mock helpers directly from the mock file so TypeScript resolves the
@@ -246,6 +246,61 @@ describe("TimelineStore — moveClip", () => {
   });
 });
 
+describe("TimelineStore — moveSelectedClips", () => {
+  let store: ReturnType<typeof mkStore>;
+
+  beforeEach(() => {
+    store = mkStore();
+  });
+
+  it("preserves relative spacing when the group is dragged against t=0", () => {
+    const track = makeTrack({ type: "video" });
+    const c1 = makeClip({ trackId: track.id, startMs: 200, durationMs: 500 });
+    const c2 = makeClip({ trackId: track.id, startMs: 1000, durationMs: 500 });
+    store.setState({ tracks: [track], clips: [c1, c2] });
+
+    store
+      .getState()
+      .moveSelectedClips(c1.id, new Set([c1.id, c2.id]), -1000);
+
+    const clips = store.getState().clips;
+    expect(clips.find((c) => c.id === c1.id)!.startMs).toBe(0);
+    // The 800ms gap must survive the clamp (not collapse to 0/0).
+    expect(clips.find((c) => c.id === c2.id)!.startMs).toBe(800);
+  });
+
+  it("clamps against the earliest selected clip even when it is not primary", () => {
+    const track = makeTrack({ type: "video" });
+    const c1 = makeClip({ trackId: track.id, startMs: 200, durationMs: 500 });
+    const c2 = makeClip({ trackId: track.id, startMs: 1000, durationMs: 500 });
+    store.setState({ tracks: [track], clips: [c1, c2] });
+
+    // Primary is the later clip; the earlier one still bounds the move.
+    store
+      .getState()
+      .moveSelectedClips(c2.id, new Set([c1.id, c2.id]), -600);
+
+    const clips = store.getState().clips;
+    expect(clips.find((c) => c.id === c1.id)!.startMs).toBe(0);
+    expect(clips.find((c) => c.id === c2.id)!.startMs).toBe(800);
+  });
+
+  it("moves the group unclamped when the delta keeps everything >= 0", () => {
+    const track = makeTrack({ type: "video" });
+    const c1 = makeClip({ trackId: track.id, startMs: 200, durationMs: 500 });
+    const c2 = makeClip({ trackId: track.id, startMs: 1000, durationMs: 500 });
+    store.setState({ tracks: [track], clips: [c1, c2] });
+
+    store
+      .getState()
+      .moveSelectedClips(c1.id, new Set([c1.id, c2.id]), 300);
+
+    const clips = store.getState().clips;
+    expect(clips.find((c) => c.id === c1.id)!.startMs).toBe(500);
+    expect(clips.find((c) => c.id === c2.id)!.startMs).toBe(1300);
+  });
+});
+
 describe("TimelineStore — trimClipStart / trimClipEnd", () => {
   let store: ReturnType<typeof mkStore>;
 
@@ -268,6 +323,30 @@ describe("TimelineStore — trimClipStart / trimClipEnd", () => {
     const { clip } = addTrackAndClip(store, { startMs: 0, durationMs: 3000 });
     store.getState().trimClipEnd(clip.id, 1000);
     expect(store.getState().clips[0].durationMs).toBe(4000);
+  });
+
+  it("trimClipEnd clamps grow so outPoint cannot exceed source duration", () => {
+    const { clip } = addTrackAndClip(store, {
+      startMs: 0,
+      durationMs: 3000,
+      inPointMs: 0,
+      outPointMs: 3000
+    });
+    store.getState().trimClipEnd(clip.id, 5000, 4000); // source is only 4s
+    expect(store.getState().clips[0].durationMs).toBe(4000);
+  });
+
+  it("trimClipEnd still shrinks an over-extended clip", () => {
+    // outPointMs (5000) already exceeds the source duration (4000) — a
+    // shrink must never be clamped/replaced by the grow guard.
+    const { clip } = addTrackAndClip(store, {
+      startMs: 0,
+      durationMs: 5000,
+      inPointMs: 0,
+      outPointMs: 5000
+    });
+    store.getState().trimClipEnd(clip.id, -500, 4000);
+    expect(store.getState().clips[0].durationMs).toBe(4500);
   });
 
   it("trimClipStart no-ops when it would produce zero/negative duration", () => {
@@ -431,6 +510,40 @@ describe("TimelineStore — undo/redo (temporal)", () => {
 
     temporal.getState().redo();
     expect(store.getState().clips[0].startMs).toBe(1000);
+  });
+
+  it("records exactly one undo entry per effective change", () => {
+    const store = mkStore();
+    const { clip } = addTrackAndClip(store, { startMs: 0, durationMs: 2000 });
+    const before = timelineTemporalOf(store).pastStates.length;
+
+    store.getState().moveClip(clip.id, 1000);
+
+    expect(timelineTemporalOf(store).pastStates.length).toBe(before + 1);
+  });
+
+  it("does not record an undo entry for guard-return no-ops", () => {
+    const store = mkStore();
+    const { clip } = addTrackAndClip(store, { startMs: 0, durationMs: 2000 });
+    const before = timelineTemporalOf(store).pastStates.length;
+
+    store.getState().moveClip("nonexistent", 500); // guard return
+    store.getState().splitClipAtTime(clip.id, 99999); // outside bounds
+    store.getState().trimClipStart(clip.id, -5000); // invalid trim
+    store.getState().mergeClipsAt(12345); // nothing to merge → {}
+
+    expect(timelineTemporalOf(store).pastStates.length).toBe(before);
+  });
+
+  it("does not record an undo entry for a value-identical remap", () => {
+    const store = mkStore();
+    const { clip } = addTrackAndClip(store, { startMs: 1000, durationMs: 2000 });
+    const before = timelineTemporalOf(store).pastStates.length;
+
+    // map() produces a new clip object with identical values.
+    store.getState().moveClip(clip.id, 0);
+
+    expect(timelineTemporalOf(store).pastStates.length).toBe(before);
   });
 });
 

--- a/web/src/stores/timeline/__tests__/transcriptOps.test.ts
+++ b/web/src/stores/timeline/__tests__/transcriptOps.test.ts
@@ -598,4 +598,24 @@ describe("migrateTranscriptToClips", () => {
     const clips = [audioClip("a-aud")];
     expect(migrateTranscriptToClips([], clips, "audio")).toBe(clips);
   });
+
+  it("keeps the voiceover clip when it carries the caption itself", () => {
+    // The audio clip already has caption words (clip-sourced model). It must
+    // not be mistaken for a redundant caption clip and removed.
+    const aud: TimelineClip = {
+      ...audioClip("a-aud", "hello"),
+      caption: { words: words(["hello", 0, 300]) }
+    };
+    const line: TranscriptLine = {
+      id: "l",
+      text: "hello",
+      beatStartMs: 0,
+      clipIds: ["a-aud"]
+    };
+    const out = migrateTranscriptToClips([line], [aud], "audio");
+    expect(out).toHaveLength(1);
+    const kept = out.find((c) => c.id === "a-aud")!;
+    expect(kept.mediaType).toBe("audio");
+    expect(kept.caption?.words).toEqual(words(["hello", 0, 300]));
+  });
 });

--- a/web/src/stores/timeline/transcriptOps.ts
+++ b/web/src/stores/timeline/transcriptOps.ts
@@ -716,7 +716,9 @@ export function migrateTranscriptToClips(
       .map((id) => byId.get(id))
       .filter((c): c is TimelineClip => c !== undefined);
     const audio = bound.find((c) => c.mediaType === "audio");
-    const caption = bound.find((c) => c.caption !== undefined);
+    // Exclude the audio clip itself: if it already carries the caption it
+    // must not be treated as the redundant caption clip and removed.
+    const caption = bound.find((c) => c !== audio && c.caption !== undefined);
 
     if (audio) {
       const base = patched.get(audio.id) ?? audio;


### PR DESCRIPTION
## Summary

This PR addresses multiple issues across clip generation, timeline state management, and preview rendering. Key fixes include proper handling of completed generation jobs without output assets, deduplication of no-op store mutations to prevent spurious undo entries, instance-aware timeline store subscriptions, and corrections to coordinate math and audio graph cleanup.

## Key Changes

### Clip Generation & Job Handling
- **Treat completed jobs without output assets as failures**: When a workflow finishes without producing the selected output asset, the job is now marked as failed with an error message instead of silently reverting the clip to draft status
- **Prevent double-click job duplication**: Added `startingClips` set to close the race condition where two rapid `generateClip()` calls both pass the store guard before the first registers its job
- **Superseded job event filtering**: When a new job is registered for a clip, the old job's reverse mapping is removed so replayed events from the superseded job no-op instead of mutating the new job's state
- **Apply completed assets to clips**: The generation store now properly appends a `ClipVersion`, sets `currentAssetId` and `lastGeneratedHash`, and settles clip status when a job completes with an asset

### Timeline State Management
- **Temporal equality deduping**: Added shallow per-key equality checking to `TimelineStore` so guard-returns and no-op mutations never create undo history entries, reducing clutter in the undo stack
- **Instance-aware subscriptions**: Timeline hooks (`useWorkflowFreshnessCheck`, `useTimelineDirectGenJob`, `useTimelineAutosave`) now subscribe to the surrounding provider's instance via context instead of the static active store, fixing issues when multiple timeline instances exist
- **Pinned timeline store for async flows**: `TimelineTranscriptStore.generateBeat()` now pins the active instance at call time so multi-await flows target the same timeline document even if another instance becomes active mid-generation
- **Autosave baseUpdatedAt freshness**: Autosave now reads `baseUpdatedAt` at SEND time (not capture time) so an edit queued behind an in-flight save doesn't self-conflict with that save's response token
- **Autosave failure recovery**: Failed saves now restore the snapshot to `pendingRef` so the next edit or unmount flush retries automatically
- **Load migration persistence**: Added `markTimelineLoadMigrated()` to persist legacy transcript migrations once instead of on every edit

### Clip Movement & Selection
- **Preserve relative spacing on group drag**: `moveSelectedClips()` now clamps against the earliest selected clip (not just the primary) and preserves gaps when dragging a group to t=0
- **Rubber-band union mode**: TrackLane now snapshots the base selection at pointerdown when Shift is held, enabling proper union-mode selection

### Preview & Rendering
- **Aspect-corrected rotation**: Transform matrix now applies rotation in pixel-aspect space (sandwich A⁻¹ · R · A) so rotating a clip on a non-square sequence doesn't shear
- **Coordinate space clarity**: `TransformGizmoOverlay` and `buildTransformMatrix` now use sequence pixel dimensions (not canvas backing size) so stored positions mean the same thing in preview, gizmo, and offline export
- **Video pool keying by clip**: `OffscreenVideoPool` now keys elements by clip ID instead of URL, allowing two clips of the same asset to hold separate elements (export loop seeks every layer before any upload)
- **Timecode rounding**: `formatTimecode()` now rounds fractional frame rates (29.97, 23.976) to integers to prevent fractions leaking into the frame field
- **Audio graph cleanup**: `AudioGraph.retainTracks()` now tears down chains for deleted tracks, releasing GainNodes and effect chains to prevent leaks

### UI & Interaction
- **Undo batching for drag gestures**: Clip drag/trim handlers now call `zundo.pause()` after the first mutation and `resume()` on gesture end, collapsing the entire gesture into a single undo entry
- **Non-passive wheel listeners**: TrackEffectsPanel and TracksRegion now attach wheel handlers as native non-passive listeners so `preventDefault()` can stop page scrolling
- **

https://claude.ai/code/session_019thP2g1tGgK9kgnsLbmPpy