### PR TITLE
Fix input/vector node output routing and validation bugs

### DIFF
--- a/packages/base-nodes/tests/coverage-io-control-nodes.test.ts
+++ b/packages/base-nodes/tests/coverage-io-control-nodes.test.ts
@@ -328,8 +328,8 @@ describe("input nodes — full coverage", () => {
     it(`${Cls.nodeType} returns default value`, async () => {
       const node = new Cls();
       const result = await node.process();
-      if (verify) verify(result.value);
-      else expect(result).toEqual({ value: expected });
+      if (verify) verify(result.output);
+      else expect(result).toEqual({ output: expected });
     });
   }
 
@@ -337,14 +337,14 @@ describe("input nodes — full coverage", () => {
     const node = new FloatInputNode();
     node.assign({ value: 3.14 });
     const result = await node.process();
-    expect(result).toEqual({ value: 3.14 });
+    expect(result).toEqual({ output: 3.14 });
   });
 
   it("StringInputNode returns full string when no max_length", async () => {
     const node = new StringInputNode();
     node.assign({ value: "hello world", max_length: 0 });
     const result = await node.process();
-    expect(result).toEqual({ value: "hello world" });
+    expect(result).toEqual({ output: "hello world" });
   });
 
   it("StringInputNode defaults include line_mode", () => {
@@ -377,7 +377,7 @@ describe("input nodes — full coverage", () => {
     node.assign({ value: "/some/doc.pdf" });
     const result = await node.process();
     expect(result).toEqual({
-      document: { uri: "file:///some/doc.pdf" },
+      document: { type: "document", uri: "file:///some/doc.pdf" },
       path: "/some/doc.pdf"
     });
   });
@@ -385,7 +385,10 @@ describe("input nodes — full coverage", () => {
   it("DocumentFileInputNode handles empty path", async () => {
     const node = new DocumentFileInputNode();
     const result = await node.process();
-    expect(result).toEqual({ document: { uri: "" }, path: "" });
+    expect(result).toEqual({
+      document: { type: "document", uri: "" },
+      path: ""
+    });
   });
 
   it("MessageDeconstructorNode handles string content", async () => {
@@ -760,7 +763,6 @@ describe("constant nodes — full coverage", () => {
     expect(d).toEqual({ value: null });
     const result = await node.process();
     expect(result).toEqual({
-      output: { width: 1024, height: 1024 },
       image_size: { width: 1024, height: 1024 },
       width: 1024,
       height: 1024

--- a/packages/base-nodes/tests/nodes.test.ts
+++ b/packages/base-nodes/tests/nodes.test.ts
@@ -117,7 +117,7 @@ describe("input/output/workspace nodes", () => {
   it("StringInputNode enforces max length", async () => {
     const node = new StringInputNode();
     node.assign({ value: "abcdef", max_length: 3 });
-    await expect(node.process({})).resolves.toEqual({ value: "abc" });
+    await expect(node.process({})).resolves.toEqual({ output: "abc" });
   });
 
   it("MessageDeconstructorNode extracts text and metadata", async () => {
@@ -713,7 +713,6 @@ describe("constant nodes", () => {
     const _cis = new ConstantImageSizeNode();
     _cis.assign({ value: { width: 640, height: 480 } });
     await expect(_cis.process()).resolves.toEqual({
-      output: { width: 640, height: 480 },
       image_size: { width: 640, height: 480 },
       width: 640,
       height: 480

--- a/packages/base-nodes/tests/vector.test.ts
+++ b/packages/base-nodes/tests/vector.test.ts
@@ -115,7 +115,9 @@ describe("CollectionNode", () => {
     const node = new CollectionNode();
     node.assign({ name: "test-collection" });
     const result = await node.process();
-    expect(result).toEqual({ output: { name: "test-collection" } });
+    expect(result).toEqual({
+      output: { type: "collection", name: "test-collection" }
+    });
     expect(mockProvider.getOrCreateCollection).toHaveBeenCalledWith({
       name: "test-collection",
       metadata: { embedding_model: "" }
@@ -168,11 +170,15 @@ describe("GetDocumentsNode", () => {
     expect(mockCollection.get).toHaveBeenCalledWith({ ids: ["a", "b"], limit: 50, offset: 10 });
   });
 
-  it("passes empty ids array when ids list is empty", async () => {
+  it("omits the ids filter when ids list is empty", async () => {
     const node = new GetDocumentsNode();
     node.assign({ collection: { name: "my-col" }, ids: [] });
     await node.process();
-    expect(mockCollection.get).toHaveBeenCalledWith({ ids: [], limit: 100, offset: 0 });
+    expect(mockCollection.get).toHaveBeenCalledWith({
+      ids: undefined,
+      limit: 100,
+      offset: 0
+    });
   });
 });
 
@@ -463,10 +469,9 @@ describe("QueryImageNode", () => {
       n_results: 2
     });
     const result = await node.process();
-    const output = result.output as Record<string, unknown>;
-    expect(output.ids).toEqual(["id1", "id2"]);
-    expect(output.documents).toEqual(["doc1", "doc2"]);
-    expect(output.distances).toEqual([0.1, 0.5]);
+    expect(result.ids).toEqual(["id1", "id2"]);
+    expect(result.documents).toEqual(["doc1", "doc2"]);
+    expect(result.distances).toEqual([0.1, 0.5]);
 
     expect(mockCollection.query).toHaveBeenCalledWith({
       uri: "http://x.com/img.png",
@@ -509,9 +514,8 @@ describe("QueryTextNode", () => {
       n_results: 2
     });
     const result = await node.process();
-    const output = result.output as Record<string, unknown>;
-    expect(output.ids).toEqual(["a-id", "z-id"]);
-    expect(output.documents).toEqual(["a-doc", "z-doc"]);
+    expect(result.ids).toEqual(["a-id", "z-id"]);
+    expect(result.documents).toEqual(["a-doc", "z-doc"]);
 
     expect(mockCollection.query).toHaveBeenCalledWith({
       text: "search query",

--- a/packages/core-nodes/src/nodes/constant.ts
+++ b/packages/core-nodes/src/nodes/constant.ts
@@ -495,14 +495,13 @@ export class ConstantImageSizeNode extends BaseNode {
   declare value: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const value = (this.value ??
-      this.value ?? { width: 1024, height: 1024 }) as {
+    const value = (this.value ?? { width: 1024, height: 1024 }) as {
       width?: number;
       height?: number;
     };
     const width = Number(value.width ?? 1024);
     const height = Number(value.height ?? 1024);
-    return { output: value, image_size: value, width, height };
+    return { image_size: value, width, height };
   }
 }
 
@@ -548,9 +547,9 @@ export class ConstantDateNode extends BaseNode {
   declare day: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const year = Number(this.year ?? this.year ?? 2024);
-    const month = Number(this.month ?? this.month ?? 1);
-    const day = Number(this.day ?? this.day ?? 1);
+    const year = Number(this.year ?? 2024);
+    const month = Number(this.month ?? 1);
+    const day = Number(this.day ?? 1);
     return { output: { year, month, day } };
   }
 }
@@ -655,18 +654,18 @@ export class ConstantDateTimeNode extends BaseNode {
   declare utc_offset: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const millisecond = Number(this.millisecond ?? this.millisecond ?? 0);
-    const utcOffsetMinutes = Number(this.utc_offset ?? this.utc_offset ?? 0);
+    const millisecond = Number(this.millisecond ?? 0);
+    const utcOffsetMinutes = Number(this.utc_offset ?? 0);
     return {
       output: {
-        year: Number(this.year ?? this.year ?? 2024),
-        month: Number(this.month ?? this.month ?? 1),
-        day: Number(this.day ?? this.day ?? 1),
-        hour: Number(this.hour ?? this.hour ?? 0),
-        minute: Number(this.minute ?? this.minute ?? 0),
-        second: Number(this.second ?? this.second ?? 0),
+        year: Number(this.year ?? 2024),
+        month: Number(this.month ?? 1),
+        day: Number(this.day ?? 1),
+        hour: Number(this.hour ?? 0),
+        minute: Number(this.minute ?? 0),
+        second: Number(this.second ?? 0),
         microsecond: millisecond * 1000,
-        tzinfo: String(this.tzinfo ?? this.tzinfo ?? ""),
+        tzinfo: String(this.tzinfo ?? ""),
         utc_offset: utcOffsetMinutes * 60
       }
     };

--- a/packages/core-nodes/src/nodes/control.ts
+++ b/packages/core-nodes/src/nodes/control.ts
@@ -1165,7 +1165,7 @@ export class ZipNode extends BaseNode {
         throw new Error(
           `Zip received a duplicate item for bucket "${key}" on handle ` +
             `"${handle}" — upstream emitted two values with the same ` +
-            `iteration index. §7.`
+            `iteration index.`
         );
       }
       side.set(key, pending);

--- a/packages/core-nodes/src/nodes/control.ts
+++ b/packages/core-nodes/src/nodes/control.ts
@@ -37,8 +37,8 @@ export class IfNode extends BaseNode {
   declare value: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const condition = Boolean(this.condition ?? this.condition ?? false);
-    const value = this.value ?? this.value ?? null;
+    const condition = Boolean(this.condition ?? false);
+    const value = this.value ?? null;
 
     if (condition) {
       return { if_true: value, if_false: null };
@@ -315,7 +315,7 @@ export class RerouteNode extends BaseNode {
   declare input_value: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: this.input_value ?? this.input_value ?? null };
+    return { output: this.input_value ?? null };
   }
 }
 
@@ -380,7 +380,7 @@ export class TryCatchNode extends BaseNode {
   static readonly nodeType = "nodetool.control.TryCatch";
   static readonly title = "Try / Catch";
   static readonly description =
-    "Error handling wrapper: passes the value through on success, or returns error info on failure.\n    control, error, try, catch, exception, handling, retry, flow-control\n\n    Use cases:\n    - Gracefully handle errors in workflows\n    - Provide fallback values when operations fail\n    - Log error details for debugging";
+    "Fallback wrapper: passes the value through when present, or emits the fallback with error info when the value is null/undefined (e.g. an upstream step produced nothing).\n    control, error, fallback, default, null, missing, flow-control\n\n    Use cases:\n    - Provide fallback values when an upstream step produced no value\n    - Detect missing values in workflows\n    - Log error details for debugging";
   static readonly metadataOutputTypes = {
     output: "any",
     error: "str",
@@ -399,7 +399,7 @@ export class TryCatchNode extends BaseNode {
     type: "any",
     default: null,
     title: "Value",
-    description: "The value to pass through. If this node receives an error signal, the fallback is used."
+    description: "The value to pass through. When null/undefined, the fallback is used."
   })
   declare value: any;
 
@@ -407,21 +407,20 @@ export class TryCatchNode extends BaseNode {
     type: "any",
     default: null,
     title: "Fallback",
-    description: "Value to return if an error occurs."
+    description: "Value to return when the input value is null/undefined."
   })
   declare fallback: any;
 
   async process(): Promise<Record<string, unknown>> {
-    try {
-      const value = this.value;
-      if (value !== null && value !== undefined) {
-        return { output: value, error: "", has_error: false };
-      }
-      return { output: this.fallback ?? null, error: "Value is null or undefined", has_error: true };
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      return { output: this.fallback ?? null, error: message, has_error: true };
+    const value = this.value;
+    if (value !== null && value !== undefined) {
+      return { output: value, error: "", has_error: false };
     }
+    return {
+      output: this.fallback ?? null,
+      error: "Value is null or undefined",
+      has_error: true
+    };
   }
 }
 
@@ -1154,6 +1153,24 @@ export class ZipNode extends BaseNode {
     const lefts = new Map<string, Pending>();
     const rights = new Map<string, Pending>();
 
+    // A duplicate bucket key means upstream emitted two values with the same
+    // iteration index; overwriting would silently drop the first one. §7.
+    const setOnce = (
+      side: Map<string, Pending>,
+      handle: string,
+      key: string,
+      pending: Pending
+    ) => {
+      if (side.has(key)) {
+        throw new Error(
+          `Zip received a duplicate item for bucket "${key}" on handle ` +
+            `"${handle}" — upstream emitted two values with the same ` +
+            `iteration index. §7.`
+        );
+      }
+      side.set(key, pending);
+    };
+
     const tryEmit = async () => {
       for (const [key, l] of lefts) {
         const r = rights.get(key);
@@ -1182,7 +1199,7 @@ export class ZipNode extends BaseNode {
     const leftLoop = (async () => {
       for await (const env of inputs.streamWithEnvelope("left")) {
         const { key, index } = bucketKey(env, leftDiff);
-        lefts.set(key, { data: env.data, index });
+        setOnce(lefts, "left", key, { data: env.data, index });
         watchLimit();
         await tryEmit();
       }
@@ -1190,7 +1207,7 @@ export class ZipNode extends BaseNode {
     const rightLoop = (async () => {
       for await (const env of inputs.streamWithEnvelope("right")) {
         const { key, index } = bucketKey(env, rightDiff);
-        rights.set(key, { data: env.data, index });
+        setOnce(rights, "right", key, { data: env.data, index });
         watchLimit();
         await tryEmit();
       }

--- a/packages/core-nodes/src/nodes/input.ts
+++ b/packages/core-nodes/src/nodes/input.ts
@@ -39,7 +39,7 @@ export class FloatInputNode extends BaseNode {
   declare max: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? 0.0 };
+    return { output: this.value ?? 0.0 };
   }
 }
 
@@ -74,7 +74,7 @@ export class BooleanInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? false };
+    return { output: this.value ?? false };
   }
 }
 
@@ -115,7 +115,7 @@ export class IntegerInputNode extends BaseNode {
   declare max: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? 0 };
+    return { output: this.value ?? 0 };
   }
 }
 
@@ -175,7 +175,7 @@ export class SelectInputNode extends BaseNode {
   declare enum_type_name: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? "" };
+    return { output: this.value ?? "" };
   }
 }
 
@@ -215,7 +215,7 @@ export class StringListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -258,7 +258,7 @@ export class FolderPathInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? "" };
+    return { output: this.value ?? "" };
   }
 }
 
@@ -305,7 +305,7 @@ export class HuggingFaceModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -348,7 +348,7 @@ export class ColorInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -389,7 +389,7 @@ export class ImageSizeInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -436,7 +436,7 @@ export class LanguageModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -483,7 +483,7 @@ export class ImageModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -530,7 +530,7 @@ export class VideoModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -578,7 +578,7 @@ export class TTSModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -624,7 +624,7 @@ export class ASRModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -670,7 +670,7 @@ export class EmbeddingModelInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -717,7 +717,7 @@ export class DataframeInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -763,7 +763,7 @@ export class DocumentInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -809,7 +809,7 @@ export class ImageInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -849,7 +849,7 @@ export class ImageListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -889,7 +889,7 @@ export class VideoListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -929,7 +929,7 @@ export class AudioListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -969,7 +969,7 @@ export class TextListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -1017,7 +1017,7 @@ export class VideoInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -1063,7 +1063,7 @@ export class AudioInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -1112,7 +1112,7 @@ export class Model3DInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -1158,7 +1158,7 @@ export class AssetFolderInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -1222,7 +1222,7 @@ export class MessageInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? {} };
+    return { output: this.value ?? {} };
   }
 }
 
@@ -1262,7 +1262,7 @@ export class MessageListInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? [] };
+    return { output: this.value ?? [] };
   }
 }
 
@@ -1323,9 +1323,9 @@ export class StringInputNode extends BaseNode {
     const raw = String(this.value ?? "");
     const max = Number(this.max_length ?? 0);
     if (max > 0 && raw.length > max) {
-      return { value: raw.slice(0, max) };
+      return { output: raw.slice(0, max) };
     }
-    return { value: raw };
+    return { output: raw };
   }
 }
 
@@ -1424,7 +1424,10 @@ export class DocumentFileInputNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const p = String(this.value ?? "");
-    return { document: { uri: p ? `file://${p}` : "" }, path: p };
+    return {
+      document: { type: "document", uri: p ? `file://${p}` : "" },
+      path: p
+    };
   }
 }
 
@@ -1467,7 +1470,7 @@ export class FilePathInputNode extends BaseNode {
   declare description: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { value: this.value ?? "" };
+    return { output: this.value ?? "" };
   }
 }
 

--- a/packages/core-nodes/src/nodes/lib-datetime.ts
+++ b/packages/core-nodes/src/nodes/lib-datetime.ts
@@ -46,8 +46,15 @@ const MS = {
 
 /** Parse an input into a Date. Throws with a friendly error on failure. */
 export function parseDate(input: unknown): Date {
-  if (input instanceof Date) return new Date(input.getTime());
-  if (typeof input === "number") return new Date(input);
+  if (input instanceof Date) {
+    if (!Number.isNaN(input.getTime())) return new Date(input.getTime());
+    throw new Error("Could not parse date: Invalid Date");
+  }
+  if (typeof input === "number") {
+    const d = new Date(input);
+    if (!Number.isNaN(d.getTime())) return d;
+    throw new Error(`Could not parse date: ${String(input)}`);
+  }
   if (typeof input === "string" && input.trim()) {
     const d = new Date(input);
     if (!Number.isNaN(d.getTime())) return d;

--- a/packages/core-nodes/src/nodes/lib-validate.ts
+++ b/packages/core-nodes/src/nodes/lib-validate.ts
@@ -50,14 +50,31 @@ export function isIPv4(value: string): boolean {
 }
 
 export function isIPv6(value: string): boolean {
-  if (typeof value !== "string") return false;
-  // Accept fully-written, "::"-compressed, and IPv4-suffixed forms.
-  if (value.length < 2 || value.indexOf(":") === -1) return false;
-  const groups = value.split("::");
-  if (groups.length > 2) return false;
-  const parts = value.replace("::", ":x:").split(":");
-  // each chunk must be 1-4 hex chars (or our placeholder)
-  return parts.every((p) => p === "" || p === "x" || /^[0-9a-fA-F]{1,4}$/.test(p));
+  if (typeof value !== "string" || value.indexOf(":") === -1) return false;
+  let v = value;
+
+  // IPv4-suffixed form (e.g. ::ffff:192.168.1.1): validate the dotted quad,
+  // then substitute it with the two hex groups it occupies.
+  const ipv4Match = /^(.*:)(\d{1,3}(?:\.\d{1,3}){3})$/.exec(v);
+  if (ipv4Match) {
+    if (!isIPv4(ipv4Match[2])) return false;
+    v = `${ipv4Match[1]}0:0`;
+  }
+
+  const isHexGroup = (p: string) => /^[0-9a-fA-F]{1,4}$/.test(p);
+  const halves = v.split("::");
+  if (halves.length > 2) return false;
+
+  if (halves.length === 2) {
+    const left = halves[0] === "" ? [] : halves[0].split(":");
+    const right = halves[1] === "" ? [] : halves[1].split(":");
+    if (![...left, ...right].every(isHexGroup)) return false;
+    // "::" must stand in for at least one zero group.
+    return left.length + right.length <= 7;
+  }
+
+  const parts = v.split(":");
+  return parts.length === 8 && parts.every(isHexGroup);
 }
 
 export function isIP(value: string): boolean {

--- a/packages/core-nodes/src/nodes/list.ts
+++ b/packages/core-nodes/src/nodes/list.ts
@@ -16,6 +16,13 @@ export function clampTimes(raw: unknown, fallback = 1): number {
   return n;
 }
 
+export function resolveMaxOutputLength(raw: unknown): number {
+  const n = Number(raw ?? DEFAULT_MAX_LIST_LENGTH);
+  // Non-numeric input must fall back to the default instead of yielding NaN,
+  // which would silently disable the length guard (`length > NaN` is false).
+  return Number.isFinite(n) ? Math.max(1, n) : DEFAULT_MAX_LIST_LENGTH;
+}
+
 export function assertOutputLength(
   length: number,
   max: number,
@@ -112,13 +119,12 @@ export class RangeNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const rawStop = Number(this.stop ?? -1);
     const step = Number(this.step ?? 1);
-    const maxLen = Math.max(
-      1,
-      Number(this.max_output_length ?? DEFAULT_MAX_LIST_LENGTH)
-    );
+    const maxLen = resolveMaxOutputLength(this.max_output_length);
 
     let values: number[];
-    if (Number.isFinite(rawStop) && rawStop >= 0) {
+    // Only the documented sentinel -1 switches to count mode; other negative
+    // stops are legitimate (e.g. descending ranges like 0..-10 step -1).
+    if (Number.isFinite(rawStop) && rawStop !== -1) {
       const start = Number(this.start ?? 0);
       values = buildRange(start, rawStop, step);
     } else {
@@ -170,10 +176,7 @@ export class TileNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const list = asList(this.input_list);
     const times = clampTimes(this.times ?? 1, 1);
-    const maxLen = Math.max(
-      1,
-      Number(this.max_output_length ?? DEFAULT_MAX_LIST_LENGTH)
-    );
+    const maxLen = resolveMaxOutputLength(this.max_output_length);
     const outLength = list.length * times;
 
     assertOutputLength(outLength, maxLen, "Tile");
@@ -229,10 +232,7 @@ export class RepeatEachNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const list = asList(this.input_list);
     const times = clampTimes(this.times ?? 1, 1);
-    const maxLen = Math.max(
-      1,
-      Number(this.max_output_length ?? DEFAULT_MAX_LIST_LENGTH)
-    );
+    const maxLen = resolveMaxOutputLength(this.max_output_length);
     const outLength = list.length * times;
 
     assertOutputLength(outLength, maxLen, "RepeatEach");
@@ -290,10 +290,7 @@ export class RepeatValueNode extends BaseNode {
   async process(): Promise<Record<string, unknown>> {
     const value = this.value ?? null;
     const times = clampTimes(this.times ?? 1, 1);
-    const maxLen = Math.max(
-      1,
-      Number(this.max_output_length ?? DEFAULT_MAX_LIST_LENGTH)
-    );
+    const maxLen = resolveMaxOutputLength(this.max_output_length);
 
     assertOutputLength(times, maxLen, "RepeatValue");
     return { output: buildRepeatedValues(value, times) };

--- a/packages/core-nodes/src/nodes/vector.ts
+++ b/packages/core-nodes/src/nodes/vector.ts
@@ -105,7 +105,7 @@ export class CollectionNode extends BaseNode {
       metadata: { embedding_model: embeddingModel.repo_id ?? "" }
     });
 
-    return { output: { name } };
+    return { output: { type: "collection", name } };
   }
 }
 
@@ -203,9 +203,10 @@ export class GetDocumentsNode extends BaseNode {
     const offset = Number(this.offset ?? 0);
 
     const collection = await getCollectionByName(name);
-    // Empty ids list returns nothing — matches Python's empty-list semantics.
+    // Empty ids means "no id filter": return all documents honoring
+    // limit/offset (the provider treats a missing ids option as unfiltered).
     const records = await collection.get({
-      ids: ids.length > 0 ? ids : [],
+      ids: ids.length > 0 ? ids : undefined,
       limit,
       offset
     });
@@ -280,9 +281,15 @@ export class IndexImageNode extends BaseNode {
 
   @prop({
     type: "image",
-    default: [],
+    default: {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
     title: "Image",
-    description: "List of image assets to index"
+    description: "The image asset to index"
   })
   declare image: any;
 
@@ -412,7 +419,7 @@ export class IndexEmbeddingNode extends BaseNode {
       }
     } else if (embeddingRaw && typeof embeddingRaw === "object") {
       const obj = embeddingRaw as Record<string, unknown>;
-      const data = obj.data ?? obj.array ?? obj.embedding;
+      const data = obj.data ?? obj.array ?? obj.embedding ?? obj.value;
       if (Array.isArray(data)) {
         if (typeof data[0] === "number") {
           embeddings = [data as number[]];
@@ -808,12 +815,10 @@ export class QueryImageNode extends BaseNode {
     );
 
     return {
-      output: {
-        ids: matches.map((m) => m.id),
-        documents: matches.map((m) => m.document ?? ""),
-        metadatas: matches.map((m) => m.metadata),
-        distances: matches.map((m) => m.distance)
-      }
+      ids: matches.map((m) => m.id),
+      documents: matches.map((m) => m.document ?? ""),
+      metadatas: matches.map((m) => m.metadata),
+      distances: matches.map((m) => m.distance)
     };
   }
 }
@@ -874,12 +879,10 @@ export class QueryTextNode extends BaseNode {
     );
 
     return {
-      output: {
-        ids: matches.map((m) => m.id),
-        documents: matches.map((m) => m.document ?? ""),
-        metadatas: matches.map((m) => m.metadata),
-        distances: matches.map((m) => m.distance)
-      }
+      ids: matches.map((m) => m.id),
+      documents: matches.map((m) => m.document ?? ""),
+      metadatas: matches.map((m) => m.metadata),
+      distances: matches.map((m) => m.distance)
     };
   }
 }
@@ -1069,15 +1072,16 @@ export class HybridSearchNode extends BaseNode {
       topK: nResults * 2
     });
 
+    // Without a keyword filter there is no second ranking to fuse — fusing
+    // the semantic list against itself would only double every score.
     const keywordFilter = this._getKeywordFilter(text, minKeywordLength);
-    let keywordMatches = semanticMatches;
-    if (keywordFilter) {
-      keywordMatches = await collection.query({
-        text,
-        topK: nResults * 2,
-        filter: keywordFilter
-      });
-    }
+    const keywordMatches: VectorMatch[] = keywordFilter
+      ? await collection.query({
+          text,
+          topK: nResults * 2,
+          filter: keywordFilter
+        })
+      : [];
 
     const combinedScores = new Map<
       string,

--- a/packages/core-nodes/tests/input-nodes.test.ts
+++ b/packages/core-nodes/tests/input-nodes.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for input node dispatch:
+ *  - Input nodes previously returned `{ value }` while declaring an `output`
+ *    handle, and the runner pushed the raw property value to every outgoing
+ *    edge without running process(). Transforming inputs (DocumentFileInput,
+ *    StringInput max_length) therefore leaked raw values downstream.
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner } from "@nodetool-ai/kernel";
+import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
+import { registerBaseNodes } from "@nodetool-ai/base-nodes";
+import {
+  DocumentFileInputNode,
+  FloatInputNode,
+  StringInputNode
+} from "@nodetool-ai/core-nodes";
+import { OutputNode } from "@nodetool-ai/audio-nodes";
+
+describe("input node process() outputs", () => {
+  it("StringInputNode emits the declared `output` handle and applies max_length", async () => {
+    const node = new StringInputNode();
+    node.assign({ value: "hello world", max_length: 5 });
+    await expect(node.process()).resolves.toEqual({ output: "hello" });
+  });
+
+  it("FloatInputNode emits the declared `output` handle", async () => {
+    const node = new FloatInputNode();
+    node.assign({ value: 1.5 });
+    await expect(node.process()).resolves.toEqual({ output: 1.5 });
+  });
+
+  it("DocumentFileInputNode builds a typed DocumentRef", async () => {
+    const node = new DocumentFileInputNode();
+    node.assign({ value: "/tmp/report.pdf" });
+    await expect(node.process()).resolves.toEqual({
+      document: { type: "document", uri: "file:///tmp/report.pdf" },
+      path: "/tmp/report.pdf"
+    });
+  });
+});
+
+function makeRunner(): WorkflowRunner {
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  return new WorkflowRunner("input-dispatch", {
+    resolveExecutor: (node) => {
+      if (!registry.has(node.type)) {
+        return {
+          async process() {
+            return {};
+          }
+        };
+      }
+      return registry.resolve(node);
+    }
+  });
+}
+
+async function runWorkflow(
+  nodes: NodeDescriptor[],
+  edges: Edge[],
+  params: Record<string, unknown> = {}
+) {
+  return makeRunner().run(
+    { job_id: `input-dispatch-${Date.now()}`, params },
+    { nodes, edges }
+  );
+}
+
+describe("input node dispatch through the runner", () => {
+  it("routes the processed value (max_length applied) on the `output` handle", async () => {
+    const result = await runWorkflow(
+      [
+        {
+          id: "in",
+          type: StringInputNode.nodeType,
+          properties: { name: "text", value: "hello world", max_length: 5 }
+        },
+        { id: "out", type: OutputNode.nodeType, name: "sink" }
+      ],
+      [
+        {
+          source: "in",
+          sourceHandle: "output",
+          target: "out",
+          targetHandle: "value"
+        }
+      ]
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.outputs.sink).toEqual(["hello"]);
+  });
+
+  it("routes per-handle outputs for DocumentFileInput (document vs path)", async () => {
+    const result = await runWorkflow(
+      [
+        {
+          id: "in",
+          type: DocumentFileInputNode.nodeType,
+          properties: { name: "doc", value: "/tmp/a.pdf" }
+        },
+        { id: "doc_out", type: OutputNode.nodeType, name: "doc_sink" },
+        { id: "path_out", type: OutputNode.nodeType, name: "path_sink" }
+      ],
+      [
+        {
+          source: "in",
+          sourceHandle: "document",
+          target: "doc_out",
+          targetHandle: "value"
+        },
+        {
+          source: "in",
+          sourceHandle: "path",
+          target: "path_out",
+          targetHandle: "value"
+        }
+      ]
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.outputs.doc_sink).toEqual([
+      { type: "document", uri: "file:///tmp/a.pdf" }
+    ]);
+    expect(result.outputs.path_sink).toEqual(["/tmp/a.pdf"]);
+  });
+
+  it("runtime params override the stored property value", async () => {
+    const result = await runWorkflow(
+      [
+        {
+          id: "in",
+          type: StringInputNode.nodeType,
+          properties: { name: "text", value: "stored" }
+        },
+        { id: "out", type: OutputNode.nodeType, name: "sink" }
+      ],
+      [
+        {
+          source: "in",
+          sourceHandle: "output",
+          target: "out",
+          targetHandle: "value"
+        }
+      ],
+      { text: "runtime" }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.outputs.sink).toEqual(["runtime"]);
+  });
+});

--- a/packages/core-nodes/tests/lib-datetime.test.ts
+++ b/packages/core-nodes/tests/lib-datetime.test.ts
@@ -64,6 +64,17 @@ describe("parseDate", () => {
   it("throws on garbage strings", () => {
     expect(() => parseDate("not-a-date")).toThrow(/Could not parse date/);
   });
+
+  it("throws a friendly error on non-finite numbers", () => {
+    expect(() => parseDate(NaN)).toThrow(/Could not parse date/);
+    expect(() => parseDate(Infinity)).toThrow(/Could not parse date/);
+  });
+
+  it("throws a friendly error on an Invalid Date instance", () => {
+    expect(() => parseDate(new Date("not-a-date"))).toThrow(
+      /Could not parse date/
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core-nodes/tests/lib-validate.test.ts
+++ b/packages/core-nodes/tests/lib-validate.test.ts
@@ -81,6 +81,16 @@ describe("isIPv4/isIPv6/isIP", () => {
     expect(isIPv6("gggg::1")).toBe(false);
     expect(isIPv6("1::2::3")).toBe(false);
     expect(isIPv6("")).toBe(false);
+    expect(isIPv6(":::")).toBe(false);
+    expect(isIPv6("1:2:3:4:5:6:7:8:9")).toBe(false);
+    expect(isIPv6("1:2:3:4:5:6:7")).toBe(false);
+    expect(isIPv6("1:2:3:4:5:6:7:8::")).toBe(false);
+  });
+  it("accepts full and IPv4-suffixed IPv6 forms", () => {
+    expect(isIPv6("1:2:3:4:5:6:7:8")).toBe(true);
+    expect(isIPv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334")).toBe(true);
+    expect(isIPv6("::ffff:192.168.1.1")).toBe(true);
+    expect(isIPv6("::ffff:999.168.1.1")).toBe(false);
   });
   it("isIP is the union", () => {
     expect(isIP("1.2.3.4")).toBe(true);

--- a/packages/core-nodes/tests/list-repeat.test.ts
+++ b/packages/core-nodes/tests/list-repeat.test.ts
@@ -34,6 +34,22 @@ describe("list nodes", () => {
     await expect(node.process()).rejects.toThrow(/max_output_length/i);
   });
 
+  it("RangeNode supports descending ranges to a negative stop", async () => {
+    const node = new RangeNode();
+    node.assign({ start: 0, stop: -10, step: -2 });
+    await expect(node.process()).resolves.toEqual({
+      output: [0, -2, -4, -6, -8]
+    });
+  });
+
+  it("RangeNode falls back to the default cap for non-numeric max_output_length", async () => {
+    const node = new RangeNode();
+    node.assign({ count: 5, max_output_length: "not-a-number" });
+    await expect(node.process()).resolves.toEqual({
+      output: [0, 1, 2, 3, 4]
+    });
+  });
+
   it("TileNode repeats the full list N times", async () => {
     const node = new TileNode();
     node.assign({ input_list: ["A", "B", "C"], times: 3 });

--- a/packages/core-nodes/tests/vector-nodes.test.ts
+++ b/packages/core-nodes/tests/vector-nodes.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for vector node bugs:
+ *  - QueryText/QueryImage wrapped their results in a single `output` key,
+ *    so the declared `ids`/`documents`/`metadatas`/`distances` handles never
+ *    routed anything downstream.
+ *  - GetDocuments passed `ids: []` (dead ternary) with a comment claiming
+ *    empty ids return nothing, while the provider treats it as "no filter".
+ *  - IndexEmbedding could not extract data from objects keyed by `value`,
+ *    the very shape its own prop default declares.
+ *  - Collection emitted a ref without its `type` tag.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => {
+  const query = vi.fn();
+  const get = vi.fn();
+  const upsert = vi.fn();
+  const count = vi.fn();
+  const collection = {
+    query,
+    get,
+    upsert,
+    count,
+    metadata: { embedding_model: "test-model" }
+  };
+  return {
+    query,
+    get,
+    upsert,
+    count,
+    collection,
+    getCollection: vi.fn(async () => collection),
+    getOrCreateCollection: vi.fn(async () => collection)
+  };
+});
+
+vi.mock("@nodetool-ai/vectorstore", () => ({
+  getDefaultVectorProvider: () => ({
+    getCollection: h.getCollection,
+    getOrCreateCollection: h.getOrCreateCollection
+  }),
+  OllamaEmbeddingFunction: class {
+    async generate(texts: string[]): Promise<number[][]> {
+      return texts.map(() => [0.1, 0.2]);
+    }
+  }
+}));
+
+// Import from source (not the package's dist entry) so the vectorstore mock
+// above intercepts the import — dist modules are externalized by vitest and
+// would load the real provider.
+import {
+  CollectionNode,
+  GetDocumentsNode,
+  IndexEmbeddingNode,
+  QueryImageNode,
+  QueryTextNode
+} from "../src/nodes/vector.js";
+
+beforeEach(() => {
+  h.query.mockReset();
+  h.get.mockReset();
+  h.upsert.mockReset();
+});
+
+describe("QueryTextNode", () => {
+  it("returns results on the declared top-level handles, not wrapped in `output`", async () => {
+    h.query.mockResolvedValue([
+      { id: "b", document: "doc-b", metadata: { k: 1 }, distance: 0.2 },
+      { id: "a", document: "doc-a", metadata: { k: 2 }, distance: 0.1 }
+    ]);
+    const node = new QueryTextNode();
+    node.assign({ collection: { name: "c" }, text: "hello", n_results: 2 });
+
+    const out = await node.process();
+    expect(out).not.toHaveProperty("output");
+    expect(out.ids).toEqual(["a", "b"]);
+    expect(out.documents).toEqual(["doc-a", "doc-b"]);
+    expect(out.metadatas).toEqual([{ k: 2 }, { k: 1 }]);
+    expect(out.distances).toEqual([0.1, 0.2]);
+  });
+});
+
+describe("QueryImageNode", () => {
+  it("returns results on the declared top-level handles, not wrapped in `output`", async () => {
+    h.query.mockResolvedValue([
+      { id: "x", document: "img", metadata: {}, distance: 0.5 }
+    ]);
+    const node = new QueryImageNode();
+    node.assign({
+      collection: { name: "c" },
+      image: { type: "image", uri: "file:///img.png" }
+    });
+
+    const out = await node.process();
+    expect(out).not.toHaveProperty("output");
+    expect(out.ids).toEqual(["x"]);
+    expect(out.distances).toEqual([0.5]);
+  });
+});
+
+describe("GetDocumentsNode", () => {
+  it("treats empty ids as no filter so limit/offset listing works", async () => {
+    h.get.mockResolvedValue([
+      { id: "1", document: "d1", uri: null, metadata: {} }
+    ]);
+    const node = new GetDocumentsNode();
+    node.assign({ collection: { name: "c" }, ids: [], limit: 10, offset: 0 });
+
+    const out = await node.process();
+    expect(h.get).toHaveBeenCalledWith({ ids: undefined, limit: 10, offset: 0 });
+    expect(out).toEqual({ output: ["d1"] });
+  });
+
+  it("passes explicit ids through", async () => {
+    h.get.mockResolvedValue([]);
+    const node = new GetDocumentsNode();
+    node.assign({ collection: { name: "c" }, ids: ["a", "b"] });
+
+    await node.process();
+    expect(h.get).toHaveBeenCalledWith({
+      ids: ["a", "b"],
+      limit: 100,
+      offset: 0
+    });
+  });
+});
+
+describe("IndexEmbeddingNode", () => {
+  it("extracts embedding data from objects keyed by `value`", async () => {
+    h.upsert.mockResolvedValue(undefined);
+    const node = new IndexEmbeddingNode();
+    node.assign({
+      collection: { name: "c" },
+      embedding: { type: "list", value: [0.1, 0.2, 0.3] },
+      index_id: "doc-1"
+    });
+
+    await node.process();
+    expect(h.upsert).toHaveBeenCalledWith([
+      { id: "doc-1", embedding: [0.1, 0.2, 0.3], metadata: {} }
+    ]);
+  });
+});
+
+describe("CollectionNode", () => {
+  it("returns a typed collection ref", async () => {
+    const node = new CollectionNode();
+    node.assign({ name: "my-collection" });
+
+    const out = await node.process();
+    expect(out).toEqual({
+      output: { type: "collection", name: "my-collection" }
+    });
+  });
+});

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -741,21 +741,22 @@ export class WorkflowRunner {
       // DocumentFileInput building a DocumentRef, StringInput applying
       // max_length, MessageDeconstructor splitting a message) emit their
       // declared per-handle outputs instead of leaking the raw value to
-      // every edge. Nodes whose executor cannot run here (e.g. test doubles
-      // without a registered implementation) fall back to raw-value dispatch.
-      let nodeOutputs: Record<string, unknown> | undefined;
+      // every edge. Uses the cached executor instance initialized in
+      // _initializeGraph. Test doubles whose process() returns an empty
+      // record fall back to raw-value dispatch per handle below; a real
+      // process() failure fails the run rather than leaking the raw value.
+      const executor = this._resolveExecutor(node);
+      let nodeOutputs: Record<string, unknown>;
       try {
-        const executor = this._options.resolveExecutor(node);
         nodeOutputs = await executor.process(
           { value },
           this._options.executionContext
         );
       } catch (err) {
-        log.debug("_dispatchInputs: process() failed, using raw value", {
-          nodeId: node.id,
-          nodeType: node.type,
-          error: err instanceof Error ? err.message : String(err)
-        });
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Input node "${node.name ?? node.id}" (${node.type}) failed: ${message}`
+        );
       }
 
       const outgoing = this._graph
@@ -765,7 +766,7 @@ export class WorkflowRunner {
         const targetInbox = this._inboxes.get(edge.target);
         if (targetInbox) {
           const handleValue =
-            nodeOutputs && nodeOutputs[edge.sourceHandle] !== undefined
+            nodeOutputs[edge.sourceHandle] !== undefined
               ? nodeOutputs[edge.sourceHandle]
               : value;
           await targetInbox.put(edge.targetHandle, handleValue, {

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -710,13 +710,39 @@ export class WorkflowRunner {
       }
 
       const value = hasRuntimeParam ? params[inputName] : properties.value;
+
+      // Run the node's own process() so transforming input nodes (e.g.
+      // DocumentFileInput building a DocumentRef, StringInput applying
+      // max_length, MessageDeconstructor splitting a message) emit their
+      // declared per-handle outputs instead of leaking the raw value to
+      // every edge. Nodes whose executor cannot run here (e.g. test doubles
+      // without a registered implementation) fall back to raw-value dispatch.
+      let nodeOutputs: Record<string, unknown> | undefined;
+      try {
+        const executor = this._options.resolveExecutor(node);
+        nodeOutputs = await executor.process(
+          { value },
+          this._options.executionContext
+        );
+      } catch (err) {
+        log.debug("_dispatchInputs: process() failed, using raw value", {
+          nodeId: node.id,
+          nodeType: node.type,
+          error: err instanceof Error ? err.message : String(err)
+        });
+      }
+
       const outgoing = this._graph
         .findOutgoingEdges(node.id)
         .filter(isDataEdge);
       for (const edge of outgoing) {
         const targetInbox = this._inboxes.get(edge.target);
         if (targetInbox) {
-          await targetInbox.put(edge.targetHandle, value, {
+          const handleValue =
+            nodeOutputs && nodeOutputs[edge.sourceHandle] !== undefined
+              ? nodeOutputs[edge.sourceHandle]
+              : value;
+          await targetInbox.put(edge.targetHandle, handleValue, {
             source_edge_id:
               edge.id ??
               syntheticEdgeId(

--- a/web/src/components/node/OutputNode/__tests__/OutputNodePerf.test.ts
+++ b/web/src/components/node/OutputNode/__tests__/OutputNodePerf.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { createAssetFile } from '../../../../utils/createAssetFile';
 
 // Mock createAssetFile just to return something we can iterate over
@@ -15,22 +15,34 @@ describe("OutputNode Asset Creation Performance", () => {
   const createAssetMock = jest.fn();
 
   beforeEach(() => {
+    jest.useFakeTimers();
     createAssetMock.mockReset();
     // Simulate network delay of 100ms
     createAssetMock.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 100)));
   });
 
-  it("measures execution time (optimized)", async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("uploads all asset files concurrently", async () => {
     // @ts-expect-error Mocked function call
     const assetFiles = await createAssetFile();
-    const start = Date.now();
 
-    await Promise.all(assetFiles.map(({ file }: { file: any }) => createAssetMock(file)));
+    let settled = false;
+    const uploads = Promise.all(
+      assetFiles.map(({ file }: { file: any }) => createAssetMock(file))
+    ).then(() => {
+      settled = true;
+    });
 
-    const end = Date.now();
-    const duration = end - start;
-    console.log(`Concurrent duration: ${duration}ms`);
-    // 3 files * 100ms concurrently = ~100ms
-    expect(duration).toBeLessThan(200); // 100ms + overhead
+    // A single 100ms timer advance must settle ALL uploads — sequential
+    // awaits would need 300ms of timer time, so this fails if the uploads
+    // ever regress to running one after another. Fake timers keep the
+    // assertion deterministic; the previous wall-clock check
+    // (duration < 200ms) flaked on loaded CI runners.
+    await jest.advanceTimersByTimeAsync(100);
+    expect(settled).toBe(true);
+    await uploads;
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes multiple bugs in input nodes, vector nodes, and supporting utilities that prevented proper output routing and data extraction:

1. **Input nodes** were returning `{ value }` instead of `{ output }`, causing the runner to bypass `process()` and leak raw values downstream
2. **Vector query nodes** wrapped results in an `output` key, breaking the declared per-handle routing
3. **GetDocumentsNode** passed empty `ids: []` instead of `undefined`, preventing limit/offset listing
4. **IndexEmbeddingNode** couldn't extract embeddings from objects keyed by `value`
5. **CollectionNode** emitted refs without the `type` tag
6. Various validation and utility functions had logic errors

## Key Changes

### Input Nodes (`packages/core-nodes/src/nodes/input.ts`)
- Changed all input node `process()` methods to return `{ output: value }` instead of `{ value }` to match declared handles and enable proper runner dispatch
- Affected: `FloatInputNode`, `BooleanInputNode`, `IntegerInputNode`, `SelectInputNode`, `StringListInputNode`, `FolderPathInputNode`, `HuggingFaceModelInputNode`, `ColorInputNode`, `ImageSizeInputNode`, `LanguageModelInputNode`, `ImageModelInputNode`, `VideoModelInputNode`, `TTSModelInputNode`, `ASRModelInputNode`, `EmbeddingModelInputNode`, `DataframeInputNode`, `DocumentInputNode`, `ImageInputNode`, `ImageListInputNode`

### Vector Nodes (`packages/core-nodes/src/nodes/vector.ts`)
- **QueryTextNode** & **QueryImageNode**: Unwrapped results from `{ output: { ids, documents, ... } }` to top-level handles so declared outputs route correctly
- **GetDocumentsNode**: Changed empty ids filter from `[]` to `undefined` to allow limit/offset listing (provider treats missing ids as "no filter")
- **IndexEmbeddingNode**: Added `obj.value` as fallback when extracting embeddings from objects
- **CollectionNode**: Added `type: "collection"` tag to emitted refs
- **IndexImageNode**: Fixed default value from `[]` to proper image object shape
- **HybridSearchNode**: Simplified keyword filter logic with clearer comments

### Runner (`packages/kernel/src/runner.ts`)
- Modified `_dispatchInputs()` to call `process()` on input nodes before routing, enabling transforming inputs (e.g., `StringInput` with `max_length`, `DocumentFileInput` building refs) to emit their declared per-handle outputs instead of raw values

### Control Nodes (`packages/core-nodes/src/nodes/control.ts`)
- **IfNode**: Removed redundant null-coalescing (`this.condition ?? this.condition`)
- **RerouteNode**: Removed redundant null-coalescing
- **TryCatchNode**: Removed try-catch wrapper (node is a fallback for null/undefined, not error handling); updated description and comments to clarify semantics

### Constant Nodes (`packages/core-nodes/src/nodes/constant.ts`)
- **ConstantImageSizeNode**: Removed `output` handle (only `image_size`, `width`, `height` are declared); removed redundant null-coalescing
- **ConstantDateNode** & **ConstantDateTimeNode**: Removed redundant null-coalescing

### List Nodes (`packages/core-nodes/src/nodes/list.ts`)
- Added `resolveMaxOutputLength()` helper to safely convert non-numeric `max_output_length` to default instead of NaN
- **RangeNode**: Fixed sentinel logic — only `-1` switches to count mode; other negative stops are legitimate (e.g., descending ranges)
- **TileNode** & **RepeatEachNode**: Use new helper for robust max length handling

### Validation (`packages/core-nodes/src/nodes/lib-validate.ts`)
- **isIPv6()**: Rewrote to properly handle IPv4-suffixed forms (e.g., `::ffff:192.168.1.1`), full 8-group

https://claude.ai/code/session_011ByUPSMGHtYJnN2ppcMHbQ