### PR TITLE
Fix redundant nullish coalescing and improve text node logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,7 @@
         "@nodetool-ai/websocket": "*",
         "@types/jest": "^29.5.14",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^22.19.19",
+        "@types/node": "^22.19.20",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
@@ -43578,6 +43578,7 @@
         "cheerio": "^1.2.0",
         "compromise": "^14.15.0",
         "html-to-text": "^9.0.5",
+        "js-tiktoken": "^1.0.21",
         "linkedom": "^0.18.9",
         "natural": "^8.1.1",
         "turndown": "^7.2.2"

--- a/packages/base-nodes/tests/coverage-100pct-remaining.test.ts
+++ b/packages/base-nodes/tests/coverage-100pct-remaining.test.ts
@@ -1354,7 +1354,8 @@ describe("text-extra nodes full coverage", () => {
   it("TruncateTextNode max_length <= 0", async () => {
     const node = new TruncateTextNode();
     node.assign({ text: "hello", max_length: 0, ellipsis: "..." });
-    expect((await node.process()).output).toBe("...");
+    // max_length is a hard cap: nothing fits in 0 characters.
+    expect((await node.process()).output).toBe("");
   });
 
   it("TruncateTextNode no ellipsis, truncate", async () => {
@@ -1366,7 +1367,8 @@ describe("text-extra nodes full coverage", () => {
   it("TruncateTextNode ellipsis longer than max_length", async () => {
     const node = new TruncateTextNode();
     node.assign({ text: "hello world", max_length: 2, ellipsis: "..." });
-    expect((await node.process()).output).toBe("he");
+    // The ellipsis itself is truncated to fit the cap.
+    expect((await node.process()).output).toBe("..");
   });
 
   it("PadTextNode right", async () => {

--- a/packages/base-nodes/tests/nodes.test.ts
+++ b/packages/base-nodes/tests/nodes.test.ts
@@ -686,11 +686,29 @@ describe("text nodes", () => {
     expect(items.length).toBe(1);
     expect(items[0].text).toBe("abc");
 
+    // Embedding requires a provider-backed context — no more fake fallback.
+    const _embNoCtx = new EmbeddingTextNode();
+    _embNoCtx.assign({ input: "hello world" });
+    await expect(_embNoCtx.process()).rejects.toThrow(
+      /provider/i
+    );
+
     const _emb = new EmbeddingTextNode();
     _emb.assign({ input: "hello world" });
-    const emb = await _emb.process();
-    expect(Array.isArray(emb.output)).toBe(true);
-    expect((emb.output as number[]).length).toBe(64);
+    const runProviderPrediction = vi
+      .fn()
+      .mockResolvedValue([[0.1, 0.2, 0.3]]);
+    const emb = await _emb.process({
+      runProviderPrediction
+    } as never);
+    expect(emb.output).toEqual([0.1, 0.2, 0.3]);
+    expect(runProviderPrediction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability: "generate_embedding",
+        provider: "openai",
+        model: "text-embedding-3-small"
+      })
+    );
   });
 });
 

--- a/packages/text-nodes/package.json
+++ b/packages/text-nodes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nodetool-ai/text-nodes",
   "version": "0.7.0-rc.23",
-  "description": "NodeTool text-processing nodes \u2014 text manipulation, NLP, markdown, HTML parse, SVG",
+  "description": "NodeTool text-processing nodes — text manipulation, NLP, markdown, HTML parse, SVG",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,7 @@
     "cheerio": "^1.2.0",
     "compromise": "^14.15.0",
     "html-to-text": "^9.0.5",
+    "js-tiktoken": "^1.0.21",
     "linkedom": "^0.18.9",
     "natural": "^8.1.1",
     "turndown": "^7.2.2"

--- a/packages/text-nodes/src/nodes/lib-html-parse.ts
+++ b/packages/text-nodes/src/nodes/lib-html-parse.ts
@@ -5,6 +5,16 @@ import { Readability } from "@mozilla/readability";
 import { parseHTML } from "linkedom";
 import { tagAsUniversal } from "@nodetool-ai/nodes-utils";
 
+// Resolve src against an optional base URL; relative URLs without a base (or
+// otherwise unparseable values) pass through unchanged instead of throwing.
+function resolveUrl(src: string, baseUrl: string): string {
+  try {
+    return new URL(src, baseUrl || undefined).href;
+  } catch {
+    return src;
+  }
+}
+
 export class BaseUrlLibNode extends BaseNode {
   static readonly nodeType = "lib.html.BaseUrl";
   static readonly title = "Base Url";
@@ -71,14 +81,28 @@ export class ExtractLinksLibNode extends BaseNode {
     const $ = cheerio.load(html);
     const results: Array<{ href: string; text: string; type: string }> = [];
 
+    const isInternal = (href: string): boolean => {
+      if (!href || href.startsWith("#")) return true;
+      if (/^(mailto|tel|javascript):/i.test(href)) return false;
+      if (baseUrl) {
+        try {
+          return new URL(href, baseUrl).origin === new URL(baseUrl).origin;
+        } catch {
+          // Unparseable href/base — fall through to the scheme heuristic.
+        }
+      }
+      // Without a base URL, relative links are internal by definition.
+      return !/^[a-z][a-z0-9+.-]*:|^\/\//i.test(href);
+    };
+
     $("a[href]").each((_, el) => {
       const href = $(el).attr("href") ?? "";
       const text = $(el).text().trim();
-      const linkType =
-        (baseUrl && href.startsWith(baseUrl)) || href.startsWith("/")
-          ? "internal"
-          : "external";
-      results.push({ href, text, type: linkType });
+      results.push({
+        href,
+        text,
+        type: isInternal(href) ? "internal" : "external"
+      });
     });
 
     return results;
@@ -142,8 +166,7 @@ export class ExtractImagesLibNode extends BaseNode {
 
     $("img[src]").each((_, el) => {
       const src = $(el).attr("src") ?? "";
-      const fullUrl = new URL(src, baseUrl || undefined).href;
-      images.push({ uri: fullUrl, type: "image" });
+      images.push({ uri: resolveUrl(src, baseUrl), type: "image" });
     });
 
     return images;
@@ -206,8 +229,7 @@ export class ExtractAudioLibNode extends BaseNode {
     $("audio, audio source").each((_, el) => {
       const src = $(el).attr("src");
       if (src) {
-        const fullUrl = new URL(src, baseUrl || undefined).href;
-        audioList.push({ uri: fullUrl, type: "audio" });
+        audioList.push({ uri: resolveUrl(src, baseUrl), type: "audio" });
       }
     });
 
@@ -271,8 +293,7 @@ export class ExtractVideosLibNode extends BaseNode {
     $("video, video source, iframe").each((_, el) => {
       const src = $(el).attr("src");
       if (src) {
-        const fullUrl = new URL(src, baseUrl || undefined).href;
-        videos.push({ uri: fullUrl, type: "video" });
+        videos.push({ uri: resolveUrl(src, baseUrl), type: "video" });
       }
     });
 

--- a/packages/text-nodes/src/nodes/lib-markdown.ts
+++ b/packages/text-nodes/src/nodes/lib-markdown.ts
@@ -32,7 +32,9 @@ export class ExtractLinksMarkdownLibNode extends BaseNode {
     const markdown = String(this.markdown ?? "");
     const includeTitles = Boolean(this.include_titles ?? true);
     const links: Array<Record<string, string>> = [];
-    const pattern = /\[([^\]]+)\]\(([^)]+)\)|<([^>]+)>/g;
+    // Autolinks (<...>) must carry a scheme so inline HTML tags like <div>
+    // are not mistaken for links.
+    const pattern = /\[([^\]]+)\]\(([^)]+)\)|<([a-zA-Z][a-zA-Z0-9+.-]*:[^>\s]+)>/g;
     for (const match of markdown.matchAll(pattern)) {
       if (match[1] && match[2]) {
         links.push({ url: match[2], title: includeTitles ? match[1] : "" });
@@ -97,7 +99,7 @@ export class ExtractBulletListsMarkdownLibNode extends BaseNode {
   static readonly inlineFields = ["markdown"];
   static readonly inputFields = [];
   static readonly metadataOutputTypes = {
-    output: "list[dict[str, any]]"
+    output: "list[list[dict[str, str]]]"
   };
 
   @prop({
@@ -135,7 +137,7 @@ export class ExtractNumberedListsMarkdownLibNode extends BaseNode {
   static readonly inlineFields = ["markdown"];
   static readonly inputFields = [];
   static readonly metadataOutputTypes = {
-    output: "list[str]"
+    output: "list[list[str]]"
   };
 
   @prop({
@@ -233,9 +235,14 @@ export class ExtractTablesMarkdownLibNode extends BaseNode {
       }
     }
 
-    if (currentTable.length > 2) {
+    if (currentTable.length >= 2) {
       const headers = currentTable[0];
-      const data = currentTable.slice(2);
+      // Only skip the second row when it actually is the |---|---| separator;
+      // tables written without one keep all their data rows.
+      const isSeparator = currentTable[1].every((cell) =>
+        /^:?-+:?$/.test(cell)
+      );
+      const data = currentTable.slice(isSeparator ? 2 : 1);
       const rows = data.map((row) =>
         Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
       );

--- a/packages/text-nodes/src/nodes/lib-nlp.ts
+++ b/packages/text-nodes/src/nodes/lib-nlp.ts
@@ -43,8 +43,21 @@ export class SentimentAnalysisLibNode extends BaseNode {
 
     const tokenizer = new natural.WordTokenizer();
     const tokens = tokenizer.tokenize(text) ?? [];
-    const stemmer = natural.PorterStemmer;
-    const analyzer = new natural.SentimentAnalyzer(language, stemmer, "afinn");
+    // natural only ships "afinn" vocabularies for English/Spanish; French
+    // sentiment requires the "pattern" vocabulary. Stemmers must match the
+    // language because the analyzer stems its vocabulary at construction.
+    const stemmer =
+      language === "Spanish"
+        ? natural.PorterStemmerEs
+        : language === "French"
+          ? natural.PorterStemmerFr
+          : natural.PorterStemmer;
+    const vocabularyType = language === "French" ? "pattern" : "afinn";
+    const analyzer = new natural.SentimentAnalyzer(
+      language,
+      stemmer,
+      vocabularyType
+    );
 
     const comparative = analyzer.getSentiment(tokens);
     const vocabulary = (analyzer as unknown as { vocabulary: Record<string, number> }).vocabulary;
@@ -54,9 +67,12 @@ export class SentimentAnalysisLibNode extends BaseNode {
     let totalScore = 0;
 
     for (const token of tokens) {
-      const stemmed = stemmer.stem(token);
-      const wordScore = vocabulary[stemmed];
-      if (wordScore !== undefined) {
+      // Mirror getSentiment's lookup: lowercased token first, then its stem.
+      // The "pattern" vocabulary stores polarities as strings, so coerce.
+      const lower = token.toLowerCase();
+      const raw = vocabulary[lower] ?? vocabulary[stemmer.stem(lower)];
+      const wordScore = raw === undefined ? undefined : Number(raw);
+      if (wordScore !== undefined && !Number.isNaN(wordScore)) {
         totalScore += wordScore;
         if (wordScore > 0) {
           positiveWords.push(token);

--- a/packages/text-nodes/src/nodes/lib-svg.ts
+++ b/packages/text-nodes/src/nodes/lib-svg.ts
@@ -16,13 +16,32 @@ function asColor(value: unknown, fallback: string): string {
   return fallback;
 }
 
+function escapeXmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replaceAll('"', "&quot;");
+}
+
+// Counter for element ids (filters, gradients, clip paths) so multiple
+// instances in one document don't collide.
+let svgIdCounter = 0;
+function nextSvgId(prefix: string): string {
+  svgIdCounter += 1;
+  return `${prefix}_${svgIdCounter}`;
+}
+
 function elementToString(el: SvgElementLike): string {
   const attrs = Object.entries(el.attributes ?? {})
-    .map(([k, v]) => `${k}="${String(v).replaceAll('"', "&quot;")}"`)
+    .map(([k, v]) => `${k}="${escapeXmlAttribute(String(v))}"`)
     .join(" ");
   const open = attrs ? `<${el.name} ${attrs}>` : `<${el.name}>`;
   const children = (el.children ?? []).map(elementToString).join("");
-  const content = el.content ?? "";
+  const content = escapeXmlText(el.content ?? "");
   return `${open}${content}${children}</${el.name}>`;
 }
 
@@ -583,7 +602,7 @@ export class GaussianBlurLibNode extends BaseNode {
     return {
       output: {
         name: "filter",
-        attributes: { id: "filter_gaussian_blur" },
+        attributes: { id: nextSvgId("filter_gaussian_blur") },
         children: [
           {
             name: "feGaussianBlur",
@@ -645,7 +664,7 @@ export class DropShadowLibNode extends BaseNode {
     return {
       output: {
         name: "filter",
-        attributes: { id: "filter_drop_shadow" },
+        attributes: { id: nextSvgId("filter_drop_shadow") },
         children: [
           {
             name: "feGaussianBlur",
@@ -894,7 +913,9 @@ export class GradientLibNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const gradientType = String(this.gradient_type ?? "linearGradient");
-    const attrs: Record<string, string> = { id: `gradient_${gradientType}` };
+    const attrs: Record<string, string> = {
+      id: nextSvgId(`gradient_${gradientType}`)
+    };
     if (gradientType === "linearGradient") {
       attrs.x1 = `${String(this.x1 ?? 0)}%`;
       attrs.y1 = `${String(this.y1 ?? 0)}%`;
@@ -1065,7 +1086,7 @@ export class ClipPathLibNode extends BaseNode {
     if (!clipContent || !content || !clipContent.name || !content.name) {
       return { output: { name: "g", attributes: {}, children: [] } };
     }
-    const clipId = `clip_path_${Date.now()}`;
+    const clipId = nextSvgId("clip_path");
     content.attributes = {
       ...(content.attributes ?? {}),
       "clip-path": `url(#${clipId})`

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -118,8 +118,8 @@ export class SplitTextNode extends BaseNode {
   declare delimiter: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const delimiter = String(this.delimiter ?? this.delimiter ?? ",");
+    const text = String(this.text ?? "");
+    const delimiter = String(this.delimiter ?? ",");
     return { output: text.split(delimiter) };
   }
 }
@@ -145,10 +145,11 @@ export class ExtractTextNode extends BaseNode {
   declare end: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const start = Number(this.start ?? this.start ?? 0);
-    const end = Number(this.end ?? this.end ?? 0);
-    return { output: text.slice(start, end) };
+    const text = String(this.text ?? "");
+    const start = Number(this.start ?? 0);
+    const end = Number(this.end ?? 0);
+    // end=0 means "unset" (props default to 0): slice to the end of the text.
+    return { output: text.slice(start, end === 0 ? undefined : end) };
   }
 }
 
@@ -176,10 +177,10 @@ export class ChunkTextNode extends BaseNode {
   declare separator: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const length = Number(this.length ?? this.length ?? 100);
-    const overlap = Number(this.overlap ?? this.overlap ?? 0);
-    const separator = String(this.separator ?? this.separator ?? " ");
+    const text = String(this.text ?? "");
+    const length = Number(this.length ?? 100);
+    const overlap = Number(this.overlap ?? 0);
+    const separator = String(this.separator ?? " ");
 
     const step = length - overlap;
     if (length < 1 || step <= 0) {
@@ -222,12 +223,12 @@ export class ExtractRegexNode extends BaseNode {
   declare multiline: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.regex ?? this.regex ?? "");
+    const text = String(this.text ?? "");
+    const pattern = String(this.regex ?? "");
     const flags = flagsFromOpts({
-      dotall: this.dotall ?? this.dotall,
-      ignorecase: this.ignorecase ?? this.ignorecase,
-      multiline: this.multiline ?? this.multiline
+      dotall: this.dotall,
+      ignorecase: this.ignorecase,
+      multiline: this.multiline
     });
 
     const match = new RegExp(pattern, flags).exec(text);
@@ -265,12 +266,12 @@ export class FindAllRegexNode extends BaseNode {
   declare multiline: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.regex ?? this.regex ?? "");
+    const text = String(this.text ?? "");
+    const pattern = String(this.regex ?? "");
     const flags = `${flagsFromOpts({
-      dotall: this.dotall ?? this.dotall,
-      ignorecase: this.ignorecase ?? this.ignorecase,
-      multiline: this.multiline ?? this.multiline
+      dotall: this.dotall,
+      ignorecase: this.ignorecase,
+      multiline: this.multiline
     })}g`;
 
     const matches = [...text.matchAll(new RegExp(pattern, flags))].map(
@@ -295,7 +296,7 @@ export class TextParseJSONNode extends BaseNode {
   declare text: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? "");
     return { output: JSON.parse(text) };
   }
 }
@@ -304,8 +305,11 @@ function jsonPathFind(path: string, root: unknown): unknown[] {
   if (!path.startsWith("$")) {
     return [];
   }
+  // Strip the leading "$" (and optional ".") so a bare "$" resolves to the
+  // root value instead of matching nothing.
   const tokens = path
-    .replace(/^\$\./, "")
+    .slice(1)
+    .replace(/^\./, "")
     .replace(/\[(\d+)\]/g, ".$1")
     .split(".")
     .filter(Boolean);
@@ -362,9 +366,9 @@ export class ExtractJSONNode extends BaseNode {
   declare find_all: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const jsonPath = String(this.json_path ?? this.json_path ?? "$.*");
-    const findAll = Boolean(this.find_all ?? this.find_all ?? false);
+    const text = String(this.text ?? "");
+    const jsonPath = String(this.json_path ?? "$.*");
+    const findAll = Boolean(this.find_all ?? false);
 
     const parsed = JSON.parse(text) as unknown;
     const matches = jsonPathFind(jsonPath, parsed);
@@ -414,9 +418,9 @@ export class RegexMatchNode extends BaseNode {
   declare group: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.pattern ?? this.pattern ?? "");
-    const group = this.group ?? this.group;
+    const text = String(this.text ?? "");
+    const pattern = String(this.pattern ?? "");
+    const group = this.group;
 
     if (group === null || group === undefined) {
       return {
@@ -542,9 +546,9 @@ export class RegexSplitNode extends BaseNode {
   declare maxsplit: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.pattern ?? this.pattern ?? "");
-    const maxsplit = Number(this.maxsplit ?? this.maxsplit ?? 0);
+    const text = String(this.text ?? "");
+    const pattern = String(this.pattern ?? "");
+    const maxsplit = Number(this.maxsplit ?? 0);
 
     if (maxsplit <= 0) {
       return { output: text.split(new RegExp(pattern)) };
@@ -594,8 +598,8 @@ export class RegexValidateNode extends BaseNode {
   declare pattern: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const pattern = String(this.pattern ?? this.pattern ?? "");
+    const text = String(this.text ?? "");
+    const pattern = String(this.pattern ?? "");
     // Anchor at start to match Python's re.match() behavior
     const anchored = pattern.startsWith("^") ? pattern : `^(?:${pattern})`;
     return { output: new RegExp(anchored).test(text) };
@@ -636,13 +640,13 @@ export class CompareTextNode extends BaseNode {
   declare trim_whitespace: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const textA = String(this.text_a ?? this.text_a ?? "");
-    const textB = String(this.text_b ?? this.text_b ?? "");
+    const textA = String(this.text_a ?? "");
+    const textB = String(this.text_b ?? "");
     const caseSensitive = Boolean(
-      this.case_sensitive ?? this.case_sensitive ?? true
+      this.case_sensitive ?? true
     );
     const trimWhitespace = Boolean(
-      this.trim_whitespace ?? this.trim_whitespace ?? false
+      this.trim_whitespace ?? false
     );
 
     const normalize = (value: string) => {
@@ -697,10 +701,13 @@ export class EqualsTextNode extends BaseNode {
   declare trim_whitespace: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const cmp = new CompareTextNode();
-    cmp.assign(this.serialize());
-    const result = await cmp.process();
-    return { output: result.output === "equal" };
+    const caseSensitive = Boolean(this.case_sensitive ?? true);
+    const trimWhitespace = Boolean(this.trim_whitespace ?? false);
+    const normalize = (value: unknown) => {
+      const trimmed = trimWhitespace ? String(value ?? "").trim() : String(value ?? "");
+      return caseSensitive ? trimmed : trimmed.toLowerCase();
+    };
+    return { output: normalize(this.text_a) === normalize(this.text_b) };
   }
 }
 
@@ -719,7 +726,7 @@ export class ToUppercaseNode extends BaseNode {
   declare text: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: String(this.text ?? this.text ?? "").toUpperCase() };
+    return { output: String(this.text ?? "").toUpperCase() };
   }
 }
 
@@ -738,7 +745,7 @@ export class ToLowercaseNode extends BaseNode {
   declare text: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: String(this.text ?? this.text ?? "").toLowerCase() };
+    return { output: String(this.text ?? "").toLowerCase() };
   }
 }
 
@@ -757,7 +764,7 @@ export class ToTitlecaseNode extends BaseNode {
   declare text: any;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: toTitleCase(String(this.text ?? this.text ?? "")) };
+    return { output: toTitleCase(String(this.text ?? "")) };
   }
 }
 
@@ -776,7 +783,7 @@ export class CapitalizeTextNode extends BaseNode {
   declare text: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? "");
     if (!text) {
       return { output: "" };
     }
@@ -810,21 +817,24 @@ export class SliceTextNode extends BaseNode {
   declare step: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const start = Number(this.start ?? this.start ?? 0);
-    const stop = Number(this.stop ?? this.stop ?? 0);
-    const step = Number(this.step ?? this.step ?? 1);
+    const text = String(this.text ?? "");
+    const start = Number(this.start ?? 0);
+    const stop = Number(this.stop ?? 0);
+    const step = Number(this.step ?? 1);
 
     if (step === 0) {
       throw new Error("slice step cannot be zero");
     }
 
+    // Slice on code points (not UTF-16 code units) so all step values treat
+    // characters like emoji consistently.
+    const chars = [...text];
+
     if (step === 1) {
       const effectiveStop = stop === 0 ? undefined : stop;
-      return { output: text.slice(start, effectiveStop) };
+      return { output: chars.slice(start, effectiveStop).join("") };
     }
 
-    const chars = [...text];
     const result: string[] = [];
     const len = chars.length;
 
@@ -879,8 +889,8 @@ export class StartsWithTextNode extends BaseNode {
   declare prefix: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const prefix = String(this.prefix ?? this.prefix ?? "");
+    const text = String(this.text ?? "");
+    const prefix = String(this.prefix ?? "");
     return { output: text.startsWith(prefix) };
   }
 }
@@ -903,8 +913,8 @@ export class EndsWithTextNode extends BaseNode {
   declare suffix: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const suffix = String(this.suffix ?? this.suffix ?? "");
+    const text = String(this.text ?? "");
+    const suffix = String(this.suffix ?? "");
     return { output: text.endsWith(suffix) };
   }
 }
@@ -948,17 +958,17 @@ export class ContainsTextNode extends BaseNode {
   declare match_mode: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const substring = String(this.substring ?? this.substring ?? "");
-    const searchValues = Array.isArray(this.search_values ?? this.search_values)
-      ? ((this.search_values ?? this.search_values) as unknown[]).map((v) =>
+    const text = String(this.text ?? "");
+    const substring = String(this.substring ?? "");
+    const searchValues = Array.isArray(this.search_values)
+      ? ((this.search_values) as unknown[]).map((v) =>
           String(v)
         )
       : [];
     const caseSensitive = Boolean(
-      this.case_sensitive ?? this.case_sensitive ?? true
+      this.case_sensitive ?? true
     );
-    const matchMode = String(this.match_mode ?? this.match_mode ?? "any");
+    const matchMode = String(this.match_mode ?? "any");
 
     const targets =
       searchValues.length > 0 ? searchValues : substring ? [substring] : [];
@@ -1002,9 +1012,9 @@ export class TrimWhitespaceNode extends BaseNode {
   declare trim_end: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const trimStart = Boolean(this.trim_start ?? this.trim_start ?? true);
-    const trimEnd = Boolean(this.trim_end ?? this.trim_end ?? true);
+    const text = String(this.text ?? "");
+    const trimStart = Boolean(this.trim_start ?? true);
+    const trimEnd = Boolean(this.trim_end ?? true);
 
     if (trimStart && trimEnd) {
       return { output: text.trim() };
@@ -1058,12 +1068,12 @@ export class CollapseWhitespaceNode extends BaseNode {
   declare trim_edges: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? "");
     const preserveNewlines = Boolean(
-      this.preserve_newlines ?? this.preserve_newlines ?? false
+      this.preserve_newlines ?? false
     );
-    const replacement = String(this.replacement ?? this.replacement ?? " ");
-    const trimEdges = Boolean(this.trim_edges ?? this.trim_edges ?? true);
+    const replacement = String(this.replacement ?? " ");
+    const trimEdges = Boolean(this.trim_edges ?? true);
 
     const value = trimEdges ? text.trim() : text;
     if (preserveNewlines) {
@@ -1091,9 +1101,9 @@ export class IsEmptyTextNode extends BaseNode {
   declare trim_whitespace: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? "");
     const trimWhitespace = Boolean(
-      this.trim_whitespace ?? this.trim_whitespace ?? true
+      this.trim_whitespace ?? true
     );
     return { output: (trimWhitespace ? text.trim() : text).length === 0 };
   }
@@ -1130,14 +1140,15 @@ export class RemovePunctuationNode extends BaseNode {
   declare punctuation: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const replacement = String(this.replacement ?? this.replacement ?? "");
+    const text = String(this.text ?? "");
+    const replacement = String(this.replacement ?? "");
     const punctuation = String(
-      this.punctuation ??
-        `!"#$%&'()*+,\\-./:;<=>?@[\\]^_{|}~`
+      this.punctuation ?? "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
     );
 
-    const escaped = punctuation.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Also escape "-" so user-supplied characters can't form ranges inside
+    // the character class (e.g. punctuation "a-z" must not match b..y).
+    const escaped = punctuation.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
     return {
       output: text.replace(new RegExp(`[${escaped}]`, "g"), replacement)
     };
@@ -1167,9 +1178,9 @@ export class StripAccentsNode extends BaseNode {
   declare preserve_non_ascii: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
+    const text = String(this.text ?? "");
     const preserveNonAscii = Boolean(
-      this.preserve_non_ascii ?? this.preserve_non_ascii ?? true
+      this.preserve_non_ascii ?? true
     );
 
     const normalized = text.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
@@ -1210,11 +1221,11 @@ export class SlugifyNode extends BaseNode {
   declare allow_unicode: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const separator = String(this.separator ?? this.separator ?? "-");
-    const lowercase = Boolean(this.lowercase ?? this.lowercase ?? true);
+    const text = String(this.text ?? "");
+    const separator = String(this.separator ?? "-");
+    const lowercase = Boolean(this.lowercase ?? true);
     const allowUnicode = Boolean(
-      this.allow_unicode ?? this.allow_unicode ?? false
+      this.allow_unicode ?? false
     );
 
     let value = text.normalize("NFKD");
@@ -1255,10 +1266,10 @@ export class HasLengthTextNode extends BaseNode {
   declare exact_length: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const minLength = Number(this.min_length ?? this.min_length ?? 0);
-    const maxLength = Number(this.max_length ?? this.max_length ?? 0);
-    const exactLength = Number(this.exact_length ?? this.exact_length ?? 0);
+    const text = String(this.text ?? "");
+    const minLength = Number(this.min_length ?? 0);
+    const maxLength = Number(this.max_length ?? 0);
+    const exactLength = Number(this.exact_length ?? 0);
 
     const length = text.length;
 
@@ -1302,17 +1313,20 @@ export class TruncateTextNode extends BaseNode {
   declare ellipsis: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const maxLength = Number(this.max_length ?? this.max_length ?? 100);
-    const ellipsis = String(this.ellipsis ?? this.ellipsis ?? "");
+    const text = String(this.text ?? "");
+    const maxLength = Number(this.max_length ?? 100);
+    const ellipsis = String(this.ellipsis ?? "");
 
     if (maxLength <= 0) {
-      return { output: ellipsis || "" };
+      return { output: "" };
     }
     if (text.length <= maxLength) {
       return { output: text };
     }
-    if (ellipsis && ellipsis.length < maxLength) {
+    if (ellipsis) {
+      if (ellipsis.length >= maxLength) {
+        return { output: ellipsis.slice(0, maxLength) };
+      }
       const cut = maxLength - ellipsis.length;
       return { output: `${text.slice(0, cut)}${ellipsis}` };
     }
@@ -1355,12 +1369,12 @@ export class PadTextNode extends BaseNode {
   declare direction: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const length = Number(this.length ?? this.length ?? 0);
+    const text = String(this.text ?? "");
+    const length = Number(this.length ?? 0);
     const padCharacter = String(
-      this.pad_character ?? this.pad_character ?? " "
+      this.pad_character ?? " "
     );
-    const direction = String(this.direction ?? this.direction ?? "right");
+    const direction = String(this.direction ?? "right");
 
     if (padCharacter.length !== 1) {
       throw new Error("pad_character must be a single character");
@@ -1416,10 +1430,10 @@ export class LengthTextNode extends BaseNode {
   declare trim_whitespace: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const measure = String(this.measure ?? this.measure ?? "characters");
+    const text = String(this.text ?? "");
+    const measure = String(this.measure ?? "characters");
     const trimWhitespace = Boolean(
-      this.trim_whitespace ?? this.trim_whitespace ?? false
+      this.trim_whitespace ?? false
     );
 
     const value = trimWhitespace ? text.trim() : text;
@@ -1486,15 +1500,15 @@ export class IndexOfTextNode extends BaseNode {
   declare search_from_end: any;
 
   async process(): Promise<Record<string, unknown>> {
-    let haystack = String(this.text ?? this.text ?? "");
-    let needle = String(this.substring ?? this.substring ?? "");
+    let haystack = String(this.text ?? "");
+    let needle = String(this.substring ?? "");
     const caseSensitive = Boolean(
-      this.case_sensitive ?? this.case_sensitive ?? true
+      this.case_sensitive ?? true
     );
-    const startIndex = Number(this.start_index ?? this.start_index ?? 0);
-    const endIndex = Number(this.end_index ?? this.end_index ?? 0);
+    const startIndex = Number(this.start_index ?? 0);
+    const endIndex = Number(this.end_index ?? 0);
     const searchFromEnd = Boolean(
-      this.search_from_end ?? this.search_from_end ?? false
+      this.search_from_end ?? false
     );
 
     if (!caseSensitive) {
@@ -1505,10 +1519,11 @@ export class IndexOfTextNode extends BaseNode {
     const effectiveEnd = endIndex > 0 ? endIndex : haystack.length;
 
     if (searchFromEnd) {
-      // lastIndexOf's second arg is the position to search backward from.
-      // We want to find the last occurrence within [startIndex, effectiveEnd).
-      // Search backward from effectiveEnd - 1, then verify >= startIndex.
-      const idx = haystack.lastIndexOf(needle, effectiveEnd - 1);
+      // lastIndexOf's second arg is the highest index a match may *start* at.
+      // For the match to fit within [startIndex, effectiveEnd) it must start
+      // no later than effectiveEnd - needle.length.
+      const fromIndex = effectiveEnd - needle.length;
+      const idx = fromIndex < 0 ? -1 : haystack.lastIndexOf(needle, fromIndex);
       return { output: idx >= startIndex ? idx : -1 };
     }
 
@@ -1547,11 +1562,11 @@ export class SurroundWithTextNode extends BaseNode {
   declare skip_if_wrapped: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    const prefix = String(this.prefix ?? this.prefix ?? "");
-    const suffix = String(this.suffix ?? this.suffix ?? "");
+    const text = String(this.text ?? "");
+    const prefix = String(this.prefix ?? "");
+    const suffix = String(this.suffix ?? "");
     const skipIfWrapped = Boolean(
-      this.skip_if_wrapped ?? this.skip_if_wrapped ?? true
+      this.skip_if_wrapped ?? true
     );
 
     if (skipIfWrapped && text.startsWith(prefix) && text.endsWith(suffix)) {
@@ -1585,12 +1600,17 @@ export class CountTokensNode extends BaseNode {
   declare encoding: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const text = String(this.text ?? this.text ?? "");
-    if (!text.trim()) {
+    const text = String(this.text ?? "");
+    if (!text) {
       return { output: 0 };
     }
-    const tokens = text.match(/[A-Za-z0-9_]+|[^\s]/g) ?? [];
-    return { output: tokens.length };
+    const encodingName = String(this.encoding ?? "cl100k_base") as
+      | "cl100k_base"
+      | "p50k_base"
+      | "r50k_base";
+    const { getEncoding } = await import("js-tiktoken");
+    const encoder = getEncoding(encodingName);
+    return { output: encoder.encode(text).length };
   }
 }
 
@@ -1644,14 +1664,27 @@ export class HtmlToTextNode extends BaseNode {
   declare ignore_mailto_links: any;
 
   async process(): Promise<Record<string, unknown>> {
-    const html = String(this.html ?? this.html ?? "");
-    const baseUrl = String(this.base_url ?? this.base_url ?? "");
-    const bodyWidth = Number(this.body_width ?? this.body_width ?? 1000);
+    const html = String(this.html ?? "");
+    const baseUrl = String(this.base_url ?? "");
+    const bodyWidth = Number(this.body_width ?? 1000);
+    const ignoreImages = Boolean(this.ignore_images ?? true);
+    const ignoreMailtoLinks = Boolean(this.ignore_mailto_links ?? true);
 
     let text = html;
     // Remove scripts and styles
     text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
     text = text.replace(/<style[\s\S]*?<\/style>/gi, "");
+
+    // Images: drop entirely, or render as markdown when not ignored
+    if (ignoreImages) {
+      text = text.replace(/<img[^>]*>/gi, "");
+    } else {
+      text = text.replace(/<img[^>]*>/gi, (tag: string) => {
+        const src = tag.match(/src=["']([^"']*)["']/i)?.[1] ?? "";
+        const alt = tag.match(/alt=["']([^"']*)["']/i)?.[1] ?? "";
+        return src ? `![${alt}](${src})` : alt;
+      });
+    }
 
     // Convert headers to markdown-style
     text = text.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, level: string, content: string) => {
@@ -1663,12 +1696,15 @@ export class HtmlToTextNode extends BaseNode {
     // Convert links: <a href="url">text</a> -> text (url)
     text = text.replace(/<a\s+[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi, (_m, href: string, linkText: string) => {
       const clean = linkText.replace(/<[^>]+>/g, "").trim();
+      if (ignoreMailtoLinks && /^mailto:/i.test(href)) {
+        return clean;
+      }
       let resolvedUrl = href;
-      if (baseUrl && href && !href.match(/^https?:\/\//)) {
+      if (baseUrl && href && !/^[a-z][a-z0-9+.-]*:/i.test(href)) {
         const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
         resolvedUrl = href.startsWith("/") ? baseUrl.replace(/\/$/, "") + href : base + href;
       }
-      if (baseUrl && resolvedUrl && resolvedUrl !== clean) {
+      if (resolvedUrl && resolvedUrl !== clean) {
         return `${clean} (${resolvedUrl})`;
       }
       return clean;
@@ -1709,8 +1745,8 @@ export class HtmlToTextNode extends BaseNode {
       .replace(/&#39;/g, "'")
       .replace(/&apos;/g, "'")
       .replace(/&quot;/g, '"')
-      .replace(/&#(\d+);/g, (_m, code: string) => String.fromCharCode(Number(code)))
-      .replace(/&#x([0-9a-fA-F]+);/g, (_m, code: string) => String.fromCharCode(parseInt(code, 16)));
+      .replace(/&#(\d+);/g, (_m, code: string) => String.fromCodePoint(Number(code)))
+      .replace(/&#x([0-9a-fA-F]+);/g, (_m, code: string) => String.fromCodePoint(parseInt(code, 16)));
 
     // Normalize whitespace: collapse multiple blank lines
     text = text.replace(/\n{3,}/g, "\n\n");
@@ -1738,17 +1774,6 @@ export class HtmlToTextNode extends BaseNode {
 
     return { output: text.trim() };
   }
-}
-
-function seededEmbedding(input: string, dims: number = 64): number[] {
-  const out = new Array<number>(dims).fill(0);
-  for (let i = 0; i < input.length; i++) {
-    const code = input.charCodeAt(i);
-    const idx = i % dims;
-    out[idx] += (code % 97) / 97;
-  }
-  const norm = Math.sqrt(out.reduce((a, b) => a + b * b, 0)) || 1;
-  return out.map((v) => v / norm);
 }
 
 export class AutomaticSpeechRecognitionNode extends BaseNode {
@@ -1792,9 +1817,35 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
   })
   declare audio: any;
 
+  @prop({
+    type: "str",
+    default: "",
+    title: "Language",
+    description: "Language of the audio (ISO 639-1 code, empty for auto-detect)"
+  })
+  declare language: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Prompt",
+    description: "Optional prompt to guide the transcription"
+  })
+  declare prompt: any;
+
+  @prop({
+    type: "float",
+    default: 0,
+    title: "Temperature",
+    description: "Sampling temperature for the transcription model",
+    min: 0,
+    max: 1
+  })
+  declare temperature: any;
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const { providerId, modelId } = modelConfig(this.serialize());
-    const audio = (this.audio ?? this.audio ?? {}) as Record<string, unknown>;
+    const audio = (this.audio ?? {}) as Record<string, unknown>;
     let bytes = new Uint8Array();
     if (typeof audio.data === "string") {
       bytes = Uint8Array.from(Buffer.from(audio.data, "base64"));
@@ -1826,9 +1877,9 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
         model: modelId,
         params: {
           audio: bytes,
-          language: (this as any).language,
-          prompt: (this as any).prompt,
-          temperature: (this as any).temperature
+          language: String(this.language ?? "") || undefined,
+          prompt: String(this.prompt ?? "") || undefined,
+          temperature: Number(this.temperature ?? 0) || undefined
         }
       })) as string;
       return { text, output: text };
@@ -1884,9 +1935,30 @@ export class EmbeddingTextNode extends BaseNode {
   })
   declare chunk_size: any;
 
-  async process(): Promise<Record<string, unknown>> {
-    const text = String(this.input ?? this.input ?? "");
-    return { output: seededEmbedding(text) };
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const text = String(this.input ?? "");
+    if (!text) {
+      throw new Error("input text must not be empty");
+    }
+    const { providerId, modelId } = modelConfig(this.serialize());
+    if (!context || typeof context.runProviderPrediction !== "function") {
+      throw new Error("Embedding requires a processing context with provider access");
+    }
+    if (!providerId || !modelId) {
+      throw new Error("Embedding requires an embedding model with provider and id");
+    }
+    const model = (this.model ?? {}) as Record<string, unknown>;
+    const dimensions = Number(model.dimensions ?? 0);
+    const vectors = (await context.runProviderPrediction({
+      provider: providerId,
+      capability: "generate_embedding",
+      model: modelId,
+      params: {
+        text,
+        ...(dimensions > 0 ? { dimensions } : {})
+      }
+    })) as number[][];
+    return { output: vectors[0] ?? [] };
   }
 }
 
@@ -2059,12 +2131,12 @@ export class LoadTextFolderNode extends BaseNode {
     text: string;
     path: string;
   }> {
-    const folder = String(this.folder ?? this.folder ?? "");
+    const folder = String(this.folder ?? "");
     const includeSubdirs = Boolean(
-      this.include_subdirectories ?? this.include_subdirectories ?? false
+      this.include_subdirectories ?? false
     );
-    const extensions = Array.isArray(this.extensions ?? this.extensions)
-      ? ((this.extensions ?? this.extensions) as unknown[]).map((v) =>
+    const extensions = Array.isArray(this.extensions)
+      ? ((this.extensions) as unknown[]).map((v) =>
           String(v).toLowerCase()
         )
       : [".txt"];

--- a/packages/text-nodes/tests/lib-html-parse.test.ts
+++ b/packages/text-nodes/tests/lib-html-parse.test.ts
@@ -32,3 +32,35 @@ describe("ExtractLinksLibNode", () => {
     ]);
   });
 });
+
+describe("ExtractImagesLibNode relative URLs", () => {
+  it("passes relative srcs through when no base_url is set", async () => {
+    const { ExtractImagesLibNode } = await import("@nodetool-ai/text-nodes");
+    const node = new ExtractImagesLibNode();
+    node.assign({ html: '<img src="img/cat.png">' });
+    const result = await node.process();
+    expect((result.images as Array<{ uri: string }>)[0].uri).toBe(
+      "img/cat.png"
+    );
+  });
+});
+
+describe("ExtractLinksLibNode classification", () => {
+  it("treats relative and same-origin links as internal", async () => {
+    const { ExtractLinksLibNode } = await import("@nodetool-ai/text-nodes");
+    const node = new ExtractLinksLibNode();
+    node.assign({
+      html:
+        '<a href="page.html">a</a>' +
+        '<a href="https://example.com/x">b</a>' +
+        '<a href="https://other.com/x">c</a>' +
+        '<a href="mailto:a@b.com">d</a>',
+      base_url: "https://example.com"
+    });
+    const result = await node.process();
+    const types = (result.links as Array<{ type: string }>).map(
+      (l) => l.type
+    );
+    expect(types).toEqual(["internal", "internal", "external", "external"]);
+  });
+});

--- a/packages/text-nodes/tests/lib-svg.test.ts
+++ b/packages/text-nodes/tests/lib-svg.test.ts
@@ -223,7 +223,7 @@ describe("GaussianBlurLibNode", () => {
 
     const result = await node.process();
     expect(result.output.name).toBe("filter");
-    expect(result.output.attributes?.id).toBe("filter_gaussian_blur");
+    expect(result.output.attributes?.id).toMatch(/^filter_gaussian_blur_\d+$/);
     expect(result.output.children).toHaveLength(1);
     expect(result.output.children![0].name).toBe("feGaussianBlur");
     expect(result.output.children![0].attributes?.stdDeviation).toBe("5");
@@ -242,7 +242,7 @@ describe("DropShadowLibNode", () => {
 
     const result = await node.process();
     expect(result.output.name).toBe("filter");
-    expect(result.output.attributes?.id).toBe("filter_drop_shadow");
+    expect(result.output.attributes?.id).toMatch(/^filter_drop_shadow_\d+$/);
 
     const children = result.output.children!;
     expect(children).toHaveLength(5);
@@ -321,7 +321,7 @@ describe("GradientLibNode", () => {
 
     const result = await node.process();
     expect(result.output.name).toBe("linearGradient");
-    expect(result.output.attributes?.id).toBe("gradient_linearGradient");
+    expect(result.output.attributes?.id).toMatch(/^gradient_linearGradient_\d+$/);
     expect(result.output.attributes?.x1).toBe("0%");
     expect(result.output.attributes?.y1).toBe("0%");
     expect(result.output.attributes?.x2).toBe("100%");
@@ -450,5 +450,34 @@ describe("ClipPathLibNode", () => {
     const result = await node.process();
     expect(result.output.name).toBe("g");
     expect(result.output.children).toEqual([]);
+  });
+});
+
+describe("XML escaping", () => {
+  it("escapes special characters in text content and attributes", async () => {
+    const { TextLibNode, DocumentLibNode } = await import(
+      "@nodetool-ai/text-nodes"
+    );
+    const textNode = new TextLibNode();
+    textNode.assign({ text: "Tom & Jerry <3", x: 0, y: 0 });
+    const el = (await textNode.process()).output;
+
+    const doc = new DocumentLibNode();
+    doc.assign({ elements: [el] });
+    const out = (await doc.process()).output as { data: string };
+    const xml = Buffer.from(out.data, "base64").toString("utf-8");
+    expect(xml).toContain("Tom &amp; Jerry &lt;3");
+    expect(xml).not.toContain("& Jerry <3");
+  });
+
+  it("generates unique filter ids across instances", async () => {
+    const { GaussianBlurLibNode } = await import("@nodetool-ai/text-nodes");
+    const a = (await new GaussianBlurLibNode().process()).output as {
+      attributes?: Record<string, string>;
+    };
+    const b = (await new GaussianBlurLibNode().process()).output as {
+      attributes?: Record<string, string>;
+    };
+    expect(a.attributes?.id).not.toBe(b.attributes?.id);
   });
 });

--- a/packages/text-nodes/tests/text-extra.test.ts
+++ b/packages/text-nodes/tests/text-extra.test.ts
@@ -97,3 +97,126 @@ describe("RegexReplaceNode", () => {
     expect((await node.process()).output).toBe("Smith John");
   });
 });
+
+describe("ExtractTextNode", () => {
+  it("slices to the end of text when end is unset (0)", async () => {
+    const { ExtractTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new ExtractTextNode();
+    node.assign({ text: "hello world", start: 6 });
+    expect((await node.process()).output).toBe("world");
+  });
+
+  it("honors an explicit end index", async () => {
+    const { ExtractTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new ExtractTextNode();
+    node.assign({ text: "hello world", start: 0, end: 5 });
+    expect((await node.process()).output).toBe("hello");
+  });
+});
+
+describe("IndexOfTextNode", () => {
+  it("excludes matches extending past end_index when searching from end", async () => {
+    const { IndexOfTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new IndexOfTextNode();
+    node.assign({
+      text: "abcdef",
+      substring: "def",
+      end_index: 4,
+      search_from_end: true
+    });
+    expect((await node.process()).output).toBe(-1);
+  });
+
+  it("finds the last occurrence fully inside the range", async () => {
+    const { IndexOfTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new IndexOfTextNode();
+    node.assign({ text: "abcabc", substring: "abc", search_from_end: true });
+    expect((await node.process()).output).toBe(3);
+  });
+});
+
+describe("TruncateTextNode", () => {
+  it("never exceeds max_length even with a long ellipsis", async () => {
+    const { TruncateTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new TruncateTextNode();
+    node.assign({ text: "abcdef", max_length: 2, ellipsis: "..." });
+    expect((await node.process()).output).toBe("..");
+  });
+
+  it("returns empty string for max_length=0", async () => {
+    const { TruncateTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new TruncateTextNode();
+    node.assign({ text: "abcdef", max_length: 0, ellipsis: "..." });
+    expect((await node.process()).output).toBe("");
+  });
+});
+
+describe("RemovePunctuationNode", () => {
+  it("treats '-' in custom punctuation literally, not as a range", async () => {
+    const { RemovePunctuationNode } = await import("@nodetool-ai/text-nodes");
+    const node = new RemovePunctuationNode();
+    node.assign({ text: "abc a-z xyz", punctuation: "a-z" });
+    expect((await node.process()).output).toBe("bc  xy");
+  });
+});
+
+describe("ExtractJSONNode", () => {
+  it("resolves the bare $ path to the root value", async () => {
+    const { ExtractJSONNode } = await import("@nodetool-ai/text-nodes");
+    const node = new ExtractJSONNode();
+    node.assign({ text: '{"a": 1}', json_path: "$" });
+    expect((await node.process()).output).toEqual({ a: 1 });
+  });
+});
+
+describe("CountTokensNode", () => {
+  it("counts tokens with the requested tiktoken encoding", async () => {
+    const { CountTokensNode } = await import("@nodetool-ai/text-nodes");
+    const node = new CountTokensNode();
+    node.assign({ text: "hello world", encoding: "cl100k_base" });
+    expect((await node.process()).output).toBe(2);
+  });
+});
+
+describe("HtmlToTextNode", () => {
+  it("keeps absolute link URLs without a base_url", async () => {
+    const { HtmlToTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new HtmlToTextNode();
+    node.assign({ html: '<a href="https://example.com/page">Docs</a>' });
+    expect((await node.process()).output).toBe(
+      "Docs (https://example.com/page)"
+    );
+  });
+
+  it("drops mailto links by default but keeps the text", async () => {
+    const { HtmlToTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new HtmlToTextNode();
+    node.assign({ html: '<a href="mailto:a@b.com">Mail me</a>' });
+    expect((await node.process()).output).toBe("Mail me");
+  });
+
+  it("renders images as markdown when ignore_images is false", async () => {
+    const { HtmlToTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new HtmlToTextNode();
+    node.assign({
+      html: '<img src="/cat.png" alt="cat">',
+      ignore_images: false
+    });
+    expect((await node.process()).output).toBe("![cat](/cat.png)");
+  });
+
+  it("decodes astral numeric entities", async () => {
+    const { HtmlToTextNode } = await import("@nodetool-ai/text-nodes");
+    const node = new HtmlToTextNode();
+    node.assign({ html: "<p>&#128512;</p>" });
+    expect((await node.process()).output).toBe("\u{1F600}");
+  });
+});
+
+describe("SliceTextNode unicode", () => {
+  it("slices code points consistently for step=1", async () => {
+    const node = new SliceTextNode();
+    node.assign({ text: "a😀b", start: 1, stop: 2 });
+    expect((await node.process()).output).toBe("😀");
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes redundant nullish coalescing operators (`??`) throughout the text-nodes package and improves the logic of several text processing nodes to handle edge cases correctly.

## Key Changes

### Redundant Nullish Coalescing Fixes
- Removed duplicate nullish coalescing in all text node `process()` methods (e.g., `this.text ?? this.text ?? ""` → `this.text ?? ""`)
- Applied across 30+ node classes including `SplitTextNode`, `ExtractTextNode`, `ChunkTextNode`, `ExtractRegexNode`, `FindAllRegexNode`, and many others

### Logic Improvements

**ExtractTextNode**
- Fixed `end=0` handling: now treats 0 as "unset" and slices to the end of text instead of returning empty string
- Added comment explaining the behavior

**IndexOfTextNode**
- Fixed `lastIndexOf` calculation when searching from end with `end_index` constraint
- Now correctly excludes matches that would extend past `end_index`
- Calculates `fromIndex = effectiveEnd - needle.length` to ensure matches fit within range

**TruncateTextNode**
- Fixed edge case where ellipsis longer than `max_length` would exceed the limit
- Now truncates ellipsis itself if needed: `ellipsis.slice(0, maxLength)`
- Returns empty string for `max_length=0` instead of returning ellipsis

**RemovePunctuationNode**
- Fixed regex escaping to treat `-` literally in custom punctuation strings
- Prevents user-supplied characters like `"a-z"` from forming character ranges

**ExtractJSONNode / jsonPathFind**
- Fixed bare `$` path resolution to return root value instead of matching nothing
- Changed from `.replace(/^\$\./, "")` to `.slice(1).replace(/^\./, "")` to properly strip leading `$`

**EqualsTextNode**
- Refactored to avoid creating temporary `CompareTextNode` instance
- Now directly implements comparison logic inline for efficiency

**SliceTextNode**
- Fixed Unicode handling: now slices on code points (not UTF-16 code units) for consistent emoji/astral character handling
- Uses `[...text]` to split into code points before slicing

**CountTokensNode**
- Replaced simple regex-based token counting with proper `js-tiktoken` integration
- Now supports multiple encoding formats (`cl100k_base`, `p50k_base`, `r50k_base`)
- Changed empty check from `.trim()` to just checking if text is empty

**HtmlToTextNode**
- Added `ignore_images` and `ignore_mailto_links` boolean properties
- Images can now be rendered as markdown (`![alt](src)`) when `ignore_images=false`
- Mailto links are dropped by default but text is preserved
- Fixed URL resolution to use `String.fromCodePoint()` instead of `String.fromCharCode()` for astral plane characters (emoji)
- Improved link classification logic with `isInternal()` helper function
- Fixed base URL resolution to handle all URI schemes, not just `http(s)://`

**lib-html-parse.ts**
- Added `resolveUrl()` helper to safely resolve relative URLs against base URL
- Improved `ExtractLinksLibNode` link classification to properly detect internal vs external links
- Applied URL resolution to `ExtractImagesLibNode` and `ExtractVideosLibNode`

**lib-svg.ts**
- Added XML escaping functions for text content and attributes
- Implemented unique ID generation for SVG filters/gradients/clip paths to prevent collisions across multiple instances
- Fixed attribute and content escaping in `elementToString()`

**lib-nlp.ts**
- Fixed `SentimentAnalysisLibNode` to use language-appropriate stemmers (PorterStemmerEs for Spanish, PorterStemmerFr for French)
- Fixed vocabulary lookup to check lowercased token first, then stemmed form
- Coerced "pattern" vocabulary values (strings) to numbers

**lib-markdown.ts**
- Fixed autolink pattern to require URI scheme, preventing inline HTML tags like `

https://claude.ai/code/session_01GKhKLihZ1pwctEqi2Wms8v