### PR TITLE
Fix HiDPI rendering and save race conditions

### DIFF
--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -468,6 +468,8 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
     [theme, props.selected, isFocused, inputAccentColor]
   );
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const isModalOpenRef = useRef(false);
+  isModalOpenRef.current = isModalOpen;
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [editorDocument, setEditorDocument] = useState<SketchDocument | null>(
     null
@@ -932,7 +934,8 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
 
           // Push the updated layer into the live editor store when open, or
           // prepare editorDocument for the next open when the modal is closed.
-          if (isModalOpen) {
+          // Read the ref so we get the current modal state, not the stale closure value.
+          if (isModalOpenRef.current) {
             const storeState = useSketchStore.getState();
             const currentDoc = storeState.document;
             const storeLayerIdx = currentDoc.layers.findIndex(
@@ -975,8 +978,7 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
     layerInputResults,
     sketchDoc,
     props.id,
-    updateNodeProperties,
-    isModalOpen
+    updateNodeProperties
   ]);
 
   // ─── Generate preview and update output properties ────────────────

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -469,7 +469,9 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
   );
   const [isModalOpen, setIsModalOpen] = useState(false);
   const isModalOpenRef = useRef(false);
-  isModalOpenRef.current = isModalOpen;
+  useEffect(() => {
+    isModalOpenRef.current = isModalOpen;
+  }, [isModalOpen]);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [editorDocument, setEditorDocument] = useState<SketchDocument | null>(
     null

--- a/web/src/components/sketch/SketchCanvasResizeHandles.tsx
+++ b/web/src/components/sketch/SketchCanvasResizeHandles.tsx
@@ -358,6 +358,16 @@ const SketchCanvasResizeHandles: React.FC<SketchCanvasResizeHandlesProps> = ({
     [onResizeEnd]
   );
 
+  const handlePointerCancel = useCallback(() => {
+    if (!dragStartRef.current) {
+      return;
+    }
+    dragStartRef.current = null;
+    lastSizeRef.current = null;
+    setActiveEdge(null);
+    onResizeEnd?.();
+  }, [onResizeEnd]);
+
   const gap = SCREEN_OUTSIDE_GAP_PX / zoom;
   const hs = SCREEN_HANDLE_PX / zoom;
 
@@ -481,6 +491,7 @@ const SketchCanvasResizeHandles: React.FC<SketchCanvasResizeHandlesProps> = ({
           onPointerDown={(e) => handlePointerDown(e, edge)}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
         />
       ))}
     </div>

--- a/web/src/components/sketch/SketchCanvasResizeHandles.tsx
+++ b/web/src/components/sketch/SketchCanvasResizeHandles.tsx
@@ -358,15 +358,22 @@ const SketchCanvasResizeHandles: React.FC<SketchCanvasResizeHandlesProps> = ({
     [onResizeEnd]
   );
 
-  const handlePointerCancel = useCallback(() => {
-    if (!dragStartRef.current) {
-      return;
-    }
-    dragStartRef.current = null;
-    lastSizeRef.current = null;
-    setActiveEdge(null);
-    onResizeEnd?.();
-  }, [onResizeEnd]);
+  const handlePointerCancel = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragStartRef.current) {
+        return;
+      }
+      const target = e.target as HTMLElement;
+      if (typeof target.releasePointerCapture === "function") {
+        target.releasePointerCapture(e.pointerId);
+      }
+      dragStartRef.current = null;
+      lastSizeRef.current = null;
+      setActiveEdge(null);
+      onResizeEnd?.();
+    },
+    [onResizeEnd]
+  );
 
   const gap = SCREEN_OUTSIDE_GAP_PX / zoom;
   const hs = SCREEN_HANDLE_PX / zoom;

--- a/web/src/components/sketch/sketchCanvasHooks/useOverlayRenderer.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useOverlayRenderer.ts
@@ -178,11 +178,13 @@ export function useOverlayRenderer({
       const cw = container.clientWidth;
       const ch = container.clientHeight;
       if (cursorCanvas) {
-        if (cursorCanvas.width !== cw) {
-          cursorCanvas.width = cw;
+        const ccw = Math.round(cw * dpr);
+        const cch = Math.round(ch * dpr);
+        if (cursorCanvas.width !== ccw) {
+          cursorCanvas.width = ccw;
         }
-        if (cursorCanvas.height !== ch) {
-          cursorCanvas.height = ch;
+        if (cursorCanvas.height !== cch) {
+          cursorCanvas.height = cch;
         }
       }
       if (gizmoCanvas) {
@@ -391,7 +393,9 @@ export function useOverlayRenderer({
 
       gc.setTransform(1, 0, 0, 1, 0, 0);
       gc.clearRect(0, 0, gizmoCanvas.width, gizmoCanvas.height);
+      gc.save();
       callback(gc, dpr, containerW, containerH);
+      gc.restore();
     },
     [gizmoCanvasRef, containerRef]
   );
@@ -527,6 +531,8 @@ export function useOverlayRenderer({
         return;
       }
 
+      // Reset transform before clearing so stale DPR scale doesn't affect the clear region.
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.clearRect(0, 0, cursorCanvas.width, cursorCanvas.height);
 
       // Only show brush cursor for tools that declare showsBrushCursor capability
@@ -543,6 +549,8 @@ export function useOverlayRenderer({
       }
       const scaleX = cursorCanvas.width / rw;
       const scaleY = cursorCanvas.height / rh;
+      // Map CSS-pixel drawing coordinates to physical canvas pixels for HiDPI sharpness.
+      ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
 
       const container = containerRef.current;
       const contRect = container?.getBoundingClientRect();
@@ -642,12 +650,12 @@ export function useOverlayRenderer({
         anchorClientX = ac.x;
         anchorClientY = ac.y;
       }
-      const localX = (anchorClientX - cRect.left) * scaleX;
-      const localY = (anchorClientY - cRect.top) * scaleY;
+      const localX = anchorClientX - cRect.left;
+      const localY = anchorClientY - cRect.top;
 
       /** Raw pointer on cursor canvas (sub-pixel); snapped dab preview uses anchorClient*. */
-      const rawLocalX = (clientX - cRect.left) * scaleX;
-      const rawLocalY = (clientY - cRect.top) * scaleY;
+      const rawLocalX = clientX - cRect.left;
+      const rawLocalY = clientY - cRect.top;
 
       let size: number;
       let roundness = 1;
@@ -756,8 +764,8 @@ export function useOverlayRenderer({
             docW,
             docH
           );
-          const rectScreenX = (tlClient.x - cRect.left) * scaleX;
-          const rectScreenY = (tlClient.y - cRect.top) * scaleY;
+          const rectScreenX = tlClient.x - cRect.left;
+          const rectScreenY = tlClient.y - cRect.top;
           const rectScreenSize = zoom * n;
 
           ctx.save();
@@ -810,8 +818,8 @@ export function useOverlayRenderer({
             docW,
             docH
           );
-          const pixelScreenX = (tlClient.x - cRect.left) * scaleX;
-          const pixelScreenY = (tlClient.y - cRect.top) * scaleY;
+          const pixelScreenX = tlClient.x - cRect.left;
+          const pixelScreenY = tlClient.y - cRect.top;
           const pixelSize = zoom;
 
           ctx.save();
@@ -955,8 +963,8 @@ export function useOverlayRenderer({
               doc.canvas.width,
               doc.canvas.height
             );
-            const srcX = (srcClient.x - cRect.left) * scaleX;
-            const srcY = (srcClient.y - cRect.top) * scaleY;
+            const srcX = srcClient.x - cRect.left;
+            const srcY = srcClient.y - cRect.top;
             const crossLen = 8;
             ctx.save();
             // Outer white stroke for contrast

--- a/web/src/components/sketch/state/slices/historySlice.ts
+++ b/web/src/components/sketch/state/slices/historySlice.ts
@@ -174,17 +174,16 @@ export const createHistorySlice: StateCreator<
     // Trim to max size — merge dropped entry's data into the new oldest
     if (newHistory.length > MAX_HISTORY_SIZE) {
       const dropped = newHistory.shift()!;
-      const newOldest = newHistory[0];
+      const oldest = newHistory[0];
       // Always merge dropped data forward to maintain the baseline invariant.
       // The dropped entry (former baseline) may have data for layers not in
       // the new oldest — e.g. layers that were removed between the two entries.
-      for (const [layerId, data] of Object.entries(dropped.layerSnapshots)) {
-        if (!(layerId in newOldest.layerSnapshots)) {
-          newOldest.layerSnapshots[layerId] = data;
-        }
-      }
-      // Mark as full snapshot since it's now the baseline
-      newOldest.changedLayerIds = undefined;
+      // Spread to avoid mutating the existing entry (Zustand state must be immutable).
+      newHistory[0] = {
+        ...oldest,
+        layerSnapshots: { ...dropped.layerSnapshots, ...oldest.layerSnapshots },
+        changedLayerIds: undefined
+      };
     }
 
     set({

--- a/web/src/stores/sketch/SketchInstance.tsx
+++ b/web/src/stores/sketch/SketchInstance.tsx
@@ -56,12 +56,15 @@ export interface SketchInstance {
   editor: SketchStoreApi;
   session: SketchSessionStoreApi;
   canvasRef: SketchCanvasRefStoreApi;
+  /** Shared save-in-flight guard: prevents autosave and manual save from racing. */
+  saveInFlight: { current: boolean };
 }
 
 const createSketchInstance = (): SketchInstance => ({
   editor: createSketchStore(),
   session: createSketchSessionStore(),
-  canvasRef: createSketchCanvasRefStore()
+  canvasRef: createSketchCanvasRefStore(),
+  saveInFlight: { current: false }
 });
 
 // A lazily-built default instance backs hooks used outside any provider

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -880,6 +880,17 @@ export function useStandaloneSketchDocument(
       }
       const store = sessionStore.getState();
       if (inFlightRef.current || !store.documentId) {
+        // A manual save may be in flight (shared guard). Re-arm the debounce
+        // so a pending hash isn't dropped if that save fails — but never
+        // after unmount (cleanup also calls flush()).
+        if (
+          alive &&
+          inFlightRef.current &&
+          pendingHashRef.current &&
+          pendingHashRef.current !== store.lastServerHash
+        ) {
+          schedule();
+        }
         return;
       }
       const nextHash = pendingHashRef.current;

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -808,10 +808,15 @@ export async function saveSketchDocument(
   onSaved?: (response: SketchDocumentResponse) => void
 ): Promise<void> {
   const store = instance.session.getState();
-  if (!store.documentId) {
+  if (!store.documentId || instance.saveInFlight.current) {
     return;
   }
-  await saveSnapshot(instance, store.documentId, store.name, onSaved);
+  instance.saveInFlight.current = true;
+  try {
+    await saveSnapshot(instance, store.documentId, store.name, onSaved);
+  } finally {
+    instance.saveInFlight.current = false;
+  }
 }
 
 export function useStandaloneSketchDocument(
@@ -823,7 +828,6 @@ export function useStandaloneSketchDocument(
   const sessionStore = instance.session;
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingHashRef = useRef<string | null>(null);
-  const inFlightRef = useRef(false);
   // Keep the latest trpc utils available to the autosave callback. Reassign
   // on every render so the closure inside `saveSnapshot` sees the current
   // utils object even though it lives outside any React effect.
@@ -865,6 +869,10 @@ export function useStandaloneSketchDocument(
       return;
     }
 
+    let alive = true;
+    // Use the instance-level flag so manual saves (saveSketchDocument) share the same guard.
+    const inFlightRef = instance.saveInFlight;
+
     const flush = () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -885,6 +893,9 @@ export function useStandaloneSketchDocument(
         utilsRef.current.sketch.get.setData({ id: documentId }, saved);
       }).finally(() => {
         inFlightRef.current = false;
+        if (!alive) {
+          return;
+        }
         const currentStore = sessionStore.getState();
         if (
           pendingHashRef.current &&
@@ -965,6 +976,7 @@ export function useStandaloneSketchDocument(
     });
 
     return () => {
+      alive = false;
       unsubscribeSketch();
       unsubscribeSession();
       flush();

--- a/web/src/stores/sketch/__tests__/persistence.test.ts
+++ b/web/src/stores/sketch/__tests__/persistence.test.ts
@@ -142,6 +142,18 @@ describe("fromPersistedSketchEditorState", () => {
     expect(result.zoom).toBe(DEFAULT_SKETCH_ZOOM);
   });
 
+  const historyEntry: HistoryEntry = {
+    layerSnapshots: { l1: null },
+    layerStructure: [],
+    documentCanvas: { width: 800, height: 600, backgroundColor: "#ffffff" },
+    activeLayerId: "l1",
+    maskLayerId: null,
+    selection: null,
+    restoreMode: "full",
+    action: "paint",
+    timestamp: 1000
+  };
+
   it("restores viewport when present", () => {
     const persisted = {
       canvas: { width: 800, height: 600 },
@@ -150,7 +162,7 @@ describe("fromPersistedSketchEditorState", () => {
       maskLayerId: null,
       activeTool: "eraser",
       viewport: { zoom: 3.5, pan: { x: 50, y: 75 } },
-      history: [],
+      history: [historyEntry],
       historyIndex: 0
     };
 
@@ -159,6 +171,29 @@ describe("fromPersistedSketchEditorState", () => {
     expect(result.zoom).toBe(3.5);
     expect(result.pan).toEqual({ x: 50, y: 75 });
     expect(result.historyIndex).toBe(0);
+  });
+
+  it("clamps historyIndex above the history length", () => {
+    const result = fromPersistedSketchEditorState({
+      history: [historyEntry],
+      historyIndex: 10
+    });
+    expect(result.historyIndex).toBe(0);
+  });
+
+  it("clamps negative and non-finite historyIndex to -1", () => {
+    expect(
+      fromPersistedSketchEditorState({
+        history: [historyEntry],
+        historyIndex: -5
+      }).historyIndex
+    ).toBe(-1);
+    expect(
+      fromPersistedSketchEditorState({
+        history: [historyEntry],
+        historyIndex: Number.NaN
+      }).historyIndex
+    ).toBe(-1);
   });
 
   it("normalizes the document through normalizeSketchDocument", () => {

--- a/web/src/stores/sketch/persistence.ts
+++ b/web/src/stores/sketch/persistence.ts
@@ -79,8 +79,11 @@ export function fromPersistedSketchEditorState(
   const history = Array.isArray(persisted.history)
     ? cloneValue(persisted.history)
     : [];
-  const historyIndex =
+  const rawIndex =
     typeof persisted.historyIndex === "number" ? persisted.historyIndex : -1;
+  // Clamp to valid range so a corrupted/hand-edited save can't cause
+  // undo/redo to walk off the array.
+  const historyIndex = Math.min(rawIndex, history.length - 1);
 
   return {
     document,

--- a/web/src/stores/sketch/persistence.ts
+++ b/web/src/stores/sketch/persistence.ts
@@ -80,10 +80,13 @@ export function fromPersistedSketchEditorState(
     ? cloneValue(persisted.history)
     : [];
   const rawIndex =
-    typeof persisted.historyIndex === "number" ? persisted.historyIndex : -1;
+    typeof persisted.historyIndex === "number" &&
+    Number.isFinite(persisted.historyIndex)
+      ? Math.trunc(persisted.historyIndex)
+      : -1;
   // Clamp to valid range so a corrupted/hand-edited save can't cause
   // undo/redo to walk off the array.
-  const historyIndex = Math.min(rawIndex, history.length - 1);
+  const historyIndex = Math.max(-1, Math.min(rawIndex, history.length - 1));
 
   return {
     document,


### PR DESCRIPTION
## Summary
This PR fixes several rendering and state management issues in the sketch editor:
1. **HiDPI canvas rendering**: Cursor and gizmo canvases now properly scale to device pixel ratio for sharp rendering on high-DPI displays
2. **Save race conditions**: Prevents autosave and manual save from racing by sharing a save-in-flight guard
3. **History state immutability**: Fixes mutation of Zustand state when trimming history
4. **Pointer event handling**: Adds missing `onPointerCancel` handler for resize operations
5. **Modal state closure**: Uses ref to read current modal state instead of stale closure value
6. **History index validation**: Clamps corrupted/hand-edited history index to valid range

## Key Changes

### Canvas Rendering (useOverlayRenderer.ts)
- Scale cursor and gizmo canvas dimensions by device pixel ratio (DPR) for HiDPI displays
- Apply canvas transform to map CSS pixels to physical pixels before drawing
- Remove manual scaling from coordinate calculations (now handled by canvas transform)
- Add `save()`/`restore()` around gizmo callback to preserve transform state
- Add comment explaining transform reset before clearing

### Save State Management (SketchSessionStore.ts, SketchInstance.tsx)
- Add `saveInFlight` ref to `SketchInstance` to share save guard between autosave and manual save
- Prevent concurrent saves by checking flag before starting save operation
- Move `inFlightRef` from local hook state to instance level for proper sharing
- Add cleanup logic to handle component unmount during in-flight save
- Track component lifecycle with `alive` flag to avoid state updates after unmount

### History Immutability (historySlice.ts)
- Fix mutation of Zustand state when merging dropped history entry
- Use spread operator to create new history entry instead of mutating existing one
- Properly merge layer snapshots while maintaining immutability

### Resize Handles (SketchCanvasResizeHandles.tsx)
- Add `handlePointerCancel` callback to clean up drag state when pointer is cancelled
- Wire up `onPointerCancel` event handler to prevent stuck drag state

### Modal State (SketchNode.tsx)
- Add `isModalOpenRef` to track current modal state
- Read from ref in autosave callback to get current modal state instead of stale closure value
- Remove `isModalOpen` from dependency array since we now use ref

### Persistence (persistence.ts)
- Clamp history index to valid range to prevent array access errors from corrupted saves
- Add comment explaining the safety check

## Implementation Details
- Canvas transforms now use `setTransform(scaleX, 0, 0, scaleY, 0, 0)` to map CSS coordinates to physical pixels
- Save guard uses try/finally to ensure flag is reset even if save fails
- History merge uses spread syntax to maintain Zustand immutability requirement
- Modal state tracking uses ref pattern to access current value in async callbacks

https://claude.ai/code/session_016M9ZLGaiwhZxi8MnxUJ86c