### PR TITLE
Refactor base64 encoding and message waiting logic

### DIFF
--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1315,21 +1315,19 @@ export class ProcessingContext {
     return this._messages.shift();
   }
 
-  private _messageResolve: (() => void) | null = null;
+  private _messageWaiters: Array<() => void> = [];
 
   /** Notify that a new message has been pushed. */
   private _notifyMessage(): void {
-    if (this._messageResolve) {
-      const resolve = this._messageResolve;
-      this._messageResolve = null;
-      resolve();
-    }
+    const waiters = this._messageWaiters;
+    this._messageWaiters = [];
+    for (const resolve of waiters) resolve();
   }
 
   async popMessageAsync(): Promise<ProcessingMessage> {
     while (this._messages.length === 0) {
       await new Promise<void>((r) => {
-        this._messageResolve = r;
+        this._messageWaiters.push(r);
       });
     }
     return this._messages.shift() as ProcessingMessage;

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -39,12 +39,12 @@ export function encodeBase64(bytes: Uint8Array): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(bytes).toString("base64");
   }
-  let binary = "";
+  const chunks: string[] = [];
   const CHUNK = 0x8000;
   for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
   }
-  return btoa(binary);
+  return btoa(chunks.join(""));
 }
 
 /** Encode a UTF-8 string → bytes without requiring the `Buffer` global. */

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -34,6 +34,19 @@ function decodeBase64(b64: string): Uint8Array {
   return out;
 }
 
+/** Encode bytes → base64 without requiring the `Buffer` global. */
+export function encodeBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
 /** Encode a UTF-8 string → bytes without requiring the `Buffer` global. */
 function encodeUtf8(text: string): Uint8Array {
   if (typeof Buffer !== "undefined") {
@@ -65,16 +78,21 @@ export function isAbsoluteFilePath(uri: string): boolean {
   );
 }
 
+/** Decode a `data:` URI's payload, honoring the `;base64` header flag. */
+function decodeDataUri(uri: string): Uint8Array | null {
+  const parts = uri.split(",", 2);
+  if (parts.length !== 2) {
+    return null;
+  }
+  const [header, data] = parts;
+  return header.includes(";base64")
+    ? decodeBase64(data)
+    : encodeUtf8(decodeURIComponent(data));
+}
+
 async function readUriBytes(uri: string): Promise<Uint8Array | null> {
   if (uri.startsWith("data:")) {
-    const parts = uri.split(",", 2);
-    if (parts.length !== 2) {
-      return null;
-    }
-    const [header, data] = parts;
-    return header.includes(";base64")
-      ? decodeBase64(data)
-      : encodeUtf8(decodeURIComponent(data));
+    return decodeDataUri(uri);
   }
 
   if (uri.startsWith("file://")) {
@@ -110,9 +128,7 @@ export async function loadMediaRefBytes(
 
   const data = value.data;
   if (typeof data === "string" && data.length > 0) {
-    const comma = data.startsWith("data:") ? data.indexOf(",") : -1;
-    const b64 = comma >= 0 ? data.slice(comma + 1) : data;
-    return decodeBase64(b64);
+    return data.startsWith("data:") ? decodeDataUri(data) : decodeBase64(data);
   }
   if (data instanceof Uint8Array && data.length > 0) {
     return data;

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -22,7 +22,7 @@
  */
 
 import type { ProcessingContext } from "./context.js";
-import { loadMediaRefBytes } from "./media-ref-bytes.js";
+import { encodeBase64, loadMediaRefBytes } from "./media-ref-bytes.js";
 
 export type AssetMediaKind = "image" | "audio" | "video";
 
@@ -483,7 +483,7 @@ export async function mapPromptAssetsToInputs(
       context
     );
     if (bytes && bytes.length > 0) {
-      injected.data = Buffer.from(bytes).toString("base64");
+      injected.data = encodeBase64(bytes);
     }
     return injected;
   };

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -103,6 +103,18 @@ describe("ProcessingContext – message queue", () => {
     });
   });
 
+  it("resolves concurrent popMessageAsync waiters one message each", async () => {
+    const ctx = new ProcessingContext({ jobId: "j1" });
+    const first = ctx.popMessageAsync();
+    const second = ctx.popMessageAsync();
+    ctx.emit({ type: "job_update", status: "running" });
+    ctx.emit({ type: "job_update", status: "completed" });
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toMatchObject({ type: "job_update", status: "running" });
+    expect(b).toMatchObject({ type: "job_update", status: "completed" });
+    expect(ctx.hasMessages()).toBe(false);
+  });
+
   it("tracks latest node and edge statuses", () => {
     const ctx = new ProcessingContext({ jobId: "j1" });
     ctx.emit({

--- a/packages/runtime/tests/media-ref-bytes.test.ts
+++ b/packages/runtime/tests/media-ref-bytes.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { loadMediaRefBytes } from "../src/media-ref-bytes.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { encodeBase64, loadMediaRefBytes } from "../src/media-ref-bytes.js";
 import type { ProcessingContext } from "../src/context.js";
 
 describe("loadMediaRefBytes", () => {
@@ -11,6 +11,34 @@ describe("loadMediaRefBytes", () => {
       data: payload
     });
     expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("loads inline base64 data: URIs", async () => {
+    const payload = Buffer.from([1, 2, 3]).toString("base64");
+    const bytes = await loadMediaRefBytes({
+      type: "image",
+      uri: "",
+      data: `data:image/png;base64,${payload}`
+    });
+    expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("loads inline plain-text data: URIs without base64-decoding", async () => {
+    const bytes = await loadMediaRefBytes({
+      type: "image",
+      uri: "",
+      data: "data:text/plain,hello%20world"
+    });
+    expect(bytes).toEqual(new TextEncoder().encode("hello world"));
+  });
+
+  it("returns null for malformed data: strings without a comma", async () => {
+    const bytes = await loadMediaRefBytes({
+      type: "image",
+      uri: "",
+      data: "data:text/plain"
+    });
+    expect(bytes).toBeNull();
   });
 
   it("resolves storage via asset_id when uri is stale", async () => {
@@ -49,5 +77,33 @@ describe("loadMediaRefBytes", () => {
 
     expect(bytes).toEqual(new Uint8Array([7, 8, 9]));
     expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://abc-123.png");
+  });
+});
+
+describe("encodeBase64", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("encodes bytes via Buffer on Node", () => {
+    const bytes = new TextEncoder().encode("hello world");
+    expect(encodeBase64(bytes)).toBe(
+      Buffer.from(bytes).toString("base64")
+    );
+  });
+
+  it("falls back to btoa when Buffer is unavailable", () => {
+    const bytes = new TextEncoder().encode("hello world");
+    const expected = Buffer.from(bytes).toString("base64");
+    vi.stubGlobal("Buffer", undefined);
+    expect(encodeBase64(bytes)).toBe(expected);
+  });
+
+  it("handles payloads larger than one fromCharCode chunk without Buffer", () => {
+    const bytes = new Uint8Array(0x8000 * 2 + 17);
+    for (let i = 0; i < bytes.length; i += 1) bytes[i] = i % 251;
+    const expected = Buffer.from(bytes).toString("base64");
+    vi.stubGlobal("Buffer", undefined);
+    expect(encodeBase64(bytes)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors two areas of the runtime to improve code reusability and support environments without the `Buffer` global:

1. **Extract `encodeBase64` function** — Makes base64 encoding available as a public export with fallback support for non-Node.js environments (uses `btoa` when `Buffer` is unavailable)
2. **Extract `decodeDataUri` function** — Centralizes data URI parsing logic to reduce duplication
3. **Refactor message waiting** — Changes from single-resolver to multi-waiter pattern to support concurrent async message consumers

## Key Changes

- **`media-ref-bytes.ts`**:
  - Added `encodeBase64()` export that uses `Buffer` when available, falls back to `btoa()` for browser/non-Node environments
  - Extracted `decodeDataUri()` helper to parse `data:` URIs with `;base64` flag support
  - Simplified `loadMediaRefBytes()` to use the new `decodeDataUri()` helper
  - Updated `mapPromptAssetsToInputs()` in `prompt-asset-refs.ts` to use `encodeBase64()` instead of direct `Buffer` call

- **`context.ts`**:
  - Changed `_messageResolve` (single resolver) to `_messageWaiters` (array of resolvers)
  - Updated `_notifyMessage()` to notify all waiting consumers instead of just one
  - Updated `popMessageAsync()` to push resolvers to the array instead of replacing a single one
  - Enables multiple concurrent `popMessageAsync()` calls to be resolved when a message arrives

## Implementation Details

The `encodeBase64()` function uses a chunked approach (`0x8000` bytes at a time) when falling back to `btoa()` to avoid stack overflow on large inputs, since `String.fromCharCode()` has a call stack limit.

The message waiter refactor changes the semantics from "wake one waiter" to "wake all waiters," allowing multiple async consumers to wait on the message queue concurrently.

https://claude.ai/code/session_013K2uNBAYi2wxm4hw5bUFzi