### PR TITLE
Refactor audio nodes: extract folder resolution, fix TTS/chunk handling

### DIFF
--- a/packages/audio-nodes/src/lib/audio-wav.ts
+++ b/packages/audio-nodes/src/lib/audio-wav.ts
@@ -62,6 +62,7 @@ export async function audioBytesAsync(
       }
       if (ref.uri.startsWith("http://") || ref.uri.startsWith("https://")) {
         const response = await fetch(ref.uri);
+        if (!response.ok) return new Uint8Array();
         return new Uint8Array(await response.arrayBuffer());
       }
     } catch {

--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -28,11 +28,6 @@ import {
   type WavData
 } from "../lib/audio-wav.js";
 
-type ImageLike = {
-  data?: Uint8Array | string;
-  uri?: string;
-};
-
 const DEFAULT_AUDIO_EXTENSIONS = [
   ".mp3",
   ".wav",
@@ -78,6 +73,25 @@ async function* walkAudioFiles(
     if (!extensions.includes(ext)) continue;
     yield { full, name: entry.name };
   }
+}
+
+/**
+ * Resolve a folder prop that may be a plain path string, a `file:` URI, or a
+ * folder asset ref (`{ type: "folder", uri }`) into a filesystem path.
+ */
+function resolveFolderPath(raw: unknown): string {
+  if (typeof raw === "string" && raw.length > 0) {
+    return raw.startsWith("file:") ? uriToPath(raw) : raw;
+  }
+  if (
+    raw &&
+    typeof raw === "object" &&
+    typeof (raw as { uri?: unknown }).uri === "string" &&
+    (raw as { uri: string }).uri.length > 0
+  ) {
+    return uriToPath((raw as { uri: string }).uri);
+  }
+  return "";
 }
 
 function dateName(name: string): string {
@@ -162,26 +176,20 @@ export class LoadAudioAssetsNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const collected: Record<string, unknown>[] = [];
+    const names: string[] = [];
     for await (const item of this._loadAudios()) {
       collected.push(item.audio as Record<string, unknown>);
+      names.push(String(item.name ?? ""));
     }
     return {
       audio: collected[0] ?? {},
-      name: "",
+      name: names[0] ?? "",
       audios: collected
     };
   }
 
   private async *_loadAudios(): AsyncGenerator<Record<string, unknown>> {
-    const raw = this.folder;
-    const folder =
-      typeof raw === "string" && raw.length > 0
-        ? raw.startsWith("file:")
-          ? uriToPath(raw)
-          : raw
-        : typeof raw === "object" && raw !== null && typeof raw.uri === "string" && raw.uri.length > 0
-          ? uriToPath(raw.uri)
-          : "";
+    const folder = resolveFolderPath(this.folder);
     if (!folder) return;
     const fs = await loadNodeFsPromises();
     for await (const { full, name } of walkAudioFiles(
@@ -280,22 +288,6 @@ export class LoadAudioFolderNode extends BaseNode {
   })
   declare extensions: any;
 
-  private _resolveFolder(): string {
-    const raw = this.folder;
-    if (typeof raw === "string" && raw.length > 0) {
-      return raw.startsWith("file:") ? uriToPath(raw) : raw;
-    }
-    if (
-      raw &&
-      typeof raw === "object" &&
-      typeof raw.uri === "string" &&
-      raw.uri.length > 0
-    ) {
-      return uriToPath(raw.uri);
-    }
-    return "";
-  }
-
   private _extensions(): string[] {
     const list = Array.isArray(this.extensions)
       ? (this.extensions as unknown[])
@@ -307,7 +299,7 @@ export class LoadAudioFolderNode extends BaseNode {
   }
 
   private async *_load(): AsyncGenerator<Record<string, unknown>> {
-    const folder = this._resolveFolder();
+    const folder = resolveFolderPath(this.folder);
     if (!folder) return;
     const recursive = Boolean(this.include_subdirectories);
     const extensions = this._extensions();
@@ -324,10 +316,12 @@ export class LoadAudioFolderNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const collected: Record<string, unknown>[] = [];
+    const paths: string[] = [];
     for await (const item of this._load()) {
       collected.push(item.audio as Record<string, unknown>);
+      paths.push(String(item.path ?? ""));
     }
-    return { audio: collected[0] ?? {}, path: "", audios: collected };
+    return { audio: collected[0] ?? {}, path: paths[0] ?? "", audios: collected };
   }
 
   async *genProcess(): AsyncGenerator<Record<string, unknown>> {
@@ -390,8 +384,8 @@ export class SaveAudioNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const audio = this.audio;
-    const folder = String(this.folder ?? ".");
-    const name = dateName(String(this.name ?? "audio.wav"));
+    const folder = resolveFolderPath(this.folder) || ".";
+    const name = dateName(String(this.name || "audio.wav"));
     const fs = await loadNodeFsPromises();
     const path = await loadNodePath();
     const full = path.resolve(folder, name);
@@ -460,8 +454,8 @@ export class SaveAudioFileNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     const audio = this.audio;
-    const folder = String(this.folder ?? ".");
-    const fname = dateName(String(this.filename ?? "audio.wav"));
+    const folder = String(this.folder || ".");
+    const fname = dateName(String(this.filename || "audio.wav"));
     const fs = await loadNodeFsPromises();
     const path = await loadNodePath();
     const p = path.resolve(folder, fname);
@@ -809,7 +803,7 @@ export class SliceAudioNode extends BaseNode {
     type: "float",
     default: 1,
     title: "End",
-    description: "The end time in seconds.",
+    description: "The end time in seconds. 0 or less slices to the end.",
     min: 0
   })
   declare end: any;
@@ -817,18 +811,18 @@ export class SliceAudioNode extends BaseNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await audioBytesAsync(this.audio, context);
     const start = Math.max(0, Number(this.start ?? 0));
-    const end = Number(this.end ?? -1);
+    const end = Number(this.end ?? 0);
     const wav = parseWavBytes(bytes);
     if (!wav) {
       // Non-WAV: fall back to raw byte slicing.
-      const e = end < 0 ? bytes.length : end;
+      const e = end <= 0 ? bytes.length : end;
       return { output: audioRefFromBytes(bytes.slice(start, e)) };
     }
     const { sampleRate, numChannels } = wav;
     const frames = wavFrameCount(wav);
     const startFrame = Math.min(frames, Math.round(start * sampleRate));
     const endFrame =
-      end < 0 ? frames : Math.min(frames, Math.round(end * sampleRate));
+      end <= 0 ? frames : Math.min(frames, Math.round(end * sampleRate));
     const sliced = wav.samples.slice(
       startFrame * numChannels,
       Math.max(startFrame, endFrame) * numChannels
@@ -1547,8 +1541,10 @@ export class TextToSpeechNode extends BaseNode {
       const wav = encodePcm16Wav(concatBytes(chunks), sampleRate, 1);
       return { audio: audioRefFromWav(wav) };
     }
-    const bytes = Uint8Array.from(Buffer.from(text, "utf8"));
-    return { audio: audioRefFromBytes(bytes) };
+    throw new Error(
+      `Text To Speech requires a TTS provider; no provider available for ` +
+        `provider "${providerId}" / model "${modelId}".`
+    );
   }
 }
 
@@ -1556,7 +1552,7 @@ export class ChunkToAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.ChunkToAudio";
   static readonly title = "Chunk To Audio";
   static readonly description =
-    "Aggregates audio chunks from an input stream into AudioRef objects.\n    audio, stream, chunk, aggregate, collect, batch";
+    "Converts audio chunks from an input stream into AudioRef objects.\n    audio, stream, chunk, convert";
   static readonly metadataOutputTypes = {
     audio: "audio"
   };
@@ -1581,23 +1577,32 @@ export class ChunkToAudioNode extends BaseNode {
   })
   declare chunk: any;
 
-  @prop({
-    type: "int",
-    default: 50,
-    title: "Batch Size",
-    description: "Number of chunks to aggregate per output"
-  })
-  declare batch_size: any;
-
   async process(): Promise<Record<string, unknown>> {
-    const chunk = this.chunk ?? {};
+    const chunk = this.chunk;
     if (chunk && typeof chunk === "object") {
-      const image = chunk as ImageLike;
-      if (image.data || image.uri) {
-        return { output: audioRefFromBytes(toBytes(image.data)) };
+      const c = chunk as {
+        data?: Uint8Array | string;
+        uri?: string;
+        content?: unknown;
+        content_type?: string;
+      };
+      // Audio chunks (e.g. from streaming TTS providers) carry base64 bytes
+      // in `content` with content_type "audio"; legacy refs use `data`/`uri`.
+      if (c.data) {
+        return { audio: audioRefFromBytes(toBytes(c.data)) };
+      }
+      if (
+        c.content_type === "audio" &&
+        typeof c.content === "string" &&
+        c.content.length > 0
+      ) {
+        return { audio: audioRefFromBytes(toBytes(c.content)) };
+      }
+      if (typeof c.uri === "string" && c.uri.length > 0) {
+        return { audio: { type: "audio", uri: c.uri, data: "" } };
       }
     }
-    return { output: audioRefFromBytes(new Uint8Array()) };
+    return { audio: audioRefFromBytes(new Uint8Array()) };
   }
 }
 

--- a/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
@@ -1,20 +1,22 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
 import {
+  audioBytesAsync,
   audioRefFromWav,
   decodeWav,
-  encodeWav
+  encodeWav,
+  type WavData
 } from "../lib/audio-wav.js";
 
 // ── Part B: Audio filter/effect nodes (node-web-audio-api) ─────────
 
 async function processAudioWithEffect(
-  audio: Record<string, unknown>,
+  wav: WavData,
   setupEffect: (ctx: any, source: any) => void,
   extraLength = 0
 ): Promise<Record<string, unknown>> {
   const { OfflineAudioContext } = await import("node-web-audio-api");
-  const wav = decodeWav(audio);
   const frameSamples = Math.floor(wav.samples.length / wav.numChannels);
   const totalFrames = frameSamples + extraLength;
 
@@ -96,14 +98,15 @@ export class GainNode_ extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const gainDb = Number(this.gain_db ?? 0);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const gainNode = ctx.createGain();
         gainNode.gain.value = Math.pow(10, gainDb / 20);
@@ -171,15 +174,16 @@ export class DelayNode_ extends BaseNode {
   })
   declare mix: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const delaySec = Number(this.delay_seconds ?? 0.5);
     const feedback = Number(this.feedback ?? 0.3);
     const mix = Number(this.mix ?? 0.5);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const frameSamples = Math.floor(wav.samples.length / wav.numChannels);
     const delaySamples = Math.floor(delaySec * wav.sampleRate);
 
@@ -196,18 +200,16 @@ export class DelayNode_ extends BaseNode {
         dry[i] = wav.samples[i * wav.numChannels + ch];
       }
 
-      // Apply delay with feedback
-      for (let i = 0; i < outLength; i++) {
-        const dryVal = i < frameSamples ? dry[i] : 0;
-        const delayedVal = i >= delaySamples ? wet[i - delaySamples] : 0;
-        wet[i] = dryVal + delayedVal * feedback;
+      // Wet = echoes only (delayed dry plus feedback of the delay line), so
+      // `mix` truly blends dry against wet instead of always passing dry.
+      for (let i = delaySamples; i < outLength; i++) {
+        wet[i] = dry[i - delaySamples] + wet[i - delaySamples] * feedback;
       }
 
       // Mix dry and wet
       for (let i = 0; i < outLength; i++) {
-        const dryVal = i < frameSamples ? dry[i] : 0;
         outSamples[i * wav.numChannels + ch] =
-          dryVal * (1 - mix) + wet[i] * mix;
+          dry[i] * (1 - mix) + wet[i] * mix;
       }
     }
 
@@ -254,14 +256,15 @@ export class HighPassFilterNode extends BaseNode {
   })
   declare cutoff_frequency_hz: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 80);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const filter = ctx.createBiquadFilter();
         filter.type = "highpass";
@@ -310,14 +313,15 @@ export class LowPassFilterNode extends BaseNode {
   })
   declare cutoff_frequency_hz: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 5000);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const filter = ctx.createBiquadFilter();
         filter.type = "lowpass";
@@ -377,15 +381,16 @@ export class HighShelfFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 5000);
     const gainDb = Number(this.gain_db ?? 0);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const filter = ctx.createBiquadFilter();
         filter.type = "highshelf";
@@ -446,15 +451,16 @@ export class LowShelfFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 200);
     const gainDb = Number(this.gain_db ?? 0);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const filter = ctx.createBiquadFilter();
         filter.type = "lowshelf";
@@ -526,16 +532,17 @@ export class PeakFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 1000);
     const q = Number(this.q_factor ?? 1.0);
     const gainDb = Number(this.gain_db ?? 0);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const output = await processAudioWithEffect(
-      audio,
+      decodeWav({ data: bytes }),
       (ctx: any, source: any) => {
         const filter = ctx.createBiquadFilter();
         filter.type = "peaking";

--- a/packages/audio-nodes/src/nodes/lib-audio-effects.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-effects.ts
@@ -1,6 +1,8 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
 import {
+  audioBytesAsync,
   audioRefFromWav,
   decodeWav,
   encodeWav,
@@ -85,14 +87,15 @@ export class BitcrushNode extends BaseNode {
   })
   declare sample_rate_reduction: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const bitDepth = Number(this.bit_depth ?? 8);
     const srrFactor = Number(this.sample_rate_reduction ?? 1);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const result = processPerChannel(wav, (ch) => {
       // Number of quantization steps for the target bit depth. Guard against
       // bitDepth === 1 (the prop minimum), which would otherwise yield 0 and
@@ -182,16 +185,17 @@ export class CompressNode extends BaseNode {
   })
   declare release: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold ?? -20);
     const ratio = Number(this.ratio ?? 4);
     const attackMs = Number(this.attack ?? 5);
     const releaseMs = Number(this.release ?? 50);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const result = processPerChannel(wav, (ch, sr) => {
       const out = new Float32Array(ch.length);
       const attackCoeff = Math.exp(-1 / ((sr * attackMs) / 1000));
@@ -264,13 +268,14 @@ export class DistortionNode extends BaseNode {
   })
   declare drive_db: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const driveDb = Number(this.drive_db ?? 25);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const drive = Math.pow(10, driveDb / 20);
     const result = processPerChannel(wav, (ch) => {
       const out = new Float32Array(ch.length);
@@ -336,14 +341,15 @@ export class LimiterNode extends BaseNode {
   })
   declare release_ms: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold_db ?? -2);
     const releaseMs = Number(this.release_ms ?? 250);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const threshold = Math.pow(10, thresholdDb / 20);
     const result = processPerChannel(wav, (ch, sr) => {
       const out = new Float32Array(ch.length);
@@ -443,16 +449,17 @@ export class ReverbNode extends BaseNode {
   })
   declare dry_level: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const roomScale = Number(this.room_scale ?? 0.5);
     const damping = Number(this.damping ?? 0.5);
     const wetLevel = Number(this.wet_level ?? 0.15);
     const dryLevel = Number(this.dry_level ?? 0.5);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const result = processPerChannel(wav, (ch, sr) => {
       // Schroeder reverb: 4 parallel comb filters -> 2 series allpass filters
       const baseCombDelays = [1557, 1617, 1491, 1422];
@@ -573,19 +580,20 @@ export class PitchShiftNode extends BaseNode {
   })
   declare semitones: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const semitones = Number(this.semitones ?? 0);
 
-    if (!audio.data) return { output: audio };
     if (semitones === 0) {
       return { output: audio };
     }
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const { createRubberbandWrapper } = await import(
       "@k13engineering/rubberband"
     );
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const { samples, sampleRate, numChannels } = wav;
     const frameSamples = Math.floor(samples.length / numChannels);
 
@@ -706,19 +714,20 @@ export class TimeStretchNode extends BaseNode {
   })
   declare rate: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const rate = Number(this.rate ?? 1.0);
 
-    if (!audio.data) return { output: audio };
     if (rate === 1.0) {
       return { output: audio };
     }
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
     const { createRubberbandWrapper } = await import(
       "@k13engineering/rubberband"
     );
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const { samples, sampleRate, numChannels } = wav;
     const frameSamples = Math.floor(samples.length / numChannels);
 
@@ -861,15 +870,16 @@ export class NoiseGateNode extends BaseNode {
   })
   declare release_ms: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold_db ?? -50);
     const attackMs = Math.max(0.1, Number(this.attack_ms ?? 1));
     const releaseMs = Math.max(1, Number(this.release_ms ?? 100));
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const thresholdLin = Math.pow(10, thresholdDb / 20);
 
     const result = processPerChannel(wav, (ch, sr) => {
@@ -984,7 +994,7 @@ export class PhaserNode extends BaseNode {
   })
   declare mix: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const rateHz = Number(this.rate_hz ?? 1);
     const depth = Number(this.depth ?? 0.5);
@@ -992,9 +1002,10 @@ export class PhaserNode extends BaseNode {
     const feedback = Number(this.feedback ?? 0);
     const mix = Number(this.mix ?? 0.5);
 
-    if (!audio.data) return { output: audio };
+    const bytes = await audioBytesAsync(audio, context);
+    if (bytes.length === 0) return { output: audio };
 
-    const wav = decodeWav(audio);
+    const wav = decodeWav({ data: bytes });
     const result = processPerChannel(wav, (ch, sr) => {
       const out = new Float32Array(ch.length);
       // 4-stage first-order all-pass phaser

--- a/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
+++ b/packages/base-nodes/tests/e2e/coverage-media-nodes.test.ts
@@ -711,9 +711,16 @@ describe("audio nodes — full coverage", () => {
     expect(Array.from(outData)).toEqual([1, 2, 3, 4]);
   });
 
-  it("TextToSpeechNode emits on the declared `audio` port", async () => {
+  it("TextToSpeechNode throws without a TTS-capable provider context", async () => {
     const _n = new TextToSpeechNode();
     _n.assign({ text: "hello" });
+    await expect(_n.process()).rejects.toThrow(/TTS provider/);
+  });
+
+  it("ChunkToAudioNode converts chunk with data on the `audio` port", async () => {
+    const data = Buffer.from([10, 20, 30]).toString("base64");
+    const _n = new ChunkToAudioNode();
+    _n.assign({ chunk: { data } });
     const result = await _n.process();
     // Output is keyed `audio` (matching metadataOutputTypes), not `output`.
     expect(result.output).toBeUndefined();
@@ -721,26 +728,37 @@ describe("audio nodes — full coverage", () => {
       (result.audio as { data: string }).data,
       "base64"
     );
-    expect(outData.toString("utf8")).toBe("hello");
+    expect(Array.from(outData)).toEqual([10, 20, 30]);
   });
 
-  it("ChunkToAudioNode converts chunk with data", async () => {
-    const data = Buffer.from([10, 20, 30]).toString("base64");
+  it("ChunkToAudioNode converts audio chunk content (base64)", async () => {
+    const content = Buffer.from([1, 2, 3, 4]).toString("base64");
     const _n = new ChunkToAudioNode();
-    _n.assign({ chunk: { data } });
+    _n.assign({ chunk: { type: "chunk", content_type: "audio", content } });
     const result = await _n.process();
     const outData = Buffer.from(
-      (result.output as { data: string }).data,
+      (result.audio as { data: string }).data,
       "base64"
     );
-    expect(Array.from(outData)).toEqual([10, 20, 30]);
+    expect(Array.from(outData)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("ChunkToAudioNode does not treat text chunk content as audio", async () => {
+    const _n = new ChunkToAudioNode();
+    _n.assign({ chunk: { type: "chunk", content_type: "text", content: "hi" } });
+    const result = await _n.process();
+    const outData = Buffer.from(
+      (result.audio as { data: string }).data,
+      "base64"
+    );
+    expect(outData.length).toBe(0);
   });
 
   it("ChunkToAudioNode handles chunk with uri", async () => {
     const _n = new ChunkToAudioNode();
     _n.assign({ chunk: { uri: "file://test.wav" } });
     const result = await _n.process();
-    expect((result.output as { data: string }).data).toBeDefined();
+    expect((result.audio as { uri: string }).uri).toBe("file://test.wav");
   });
 
   it("ChunkToAudioNode handles null chunk", async () => {
@@ -748,7 +766,7 @@ describe("audio nodes — full coverage", () => {
     _n.assign({ chunk: null });
     const result = await _n.process();
     const outData = Buffer.from(
-      (result.output as { data: string }).data,
+      (result.audio as { data: string }).data,
       "base64"
     );
     expect(outData.length).toBe(0);
@@ -977,8 +995,7 @@ describe("audio nodes — full coverage", () => {
       speed: 1
     });
     expect(new ChunkToAudioNode().serialize()).toMatchObject({
-      chunk: { type: "chunk", content: "", content_type: "text" },
-      batch_size: 50
+      chunk: { type: "chunk", content: "", content_type: "text" }
     });
   });
 

--- a/packages/dsl/src/generated/nodetool.audio.ts
+++ b/packages/dsl/src/generated/nodetool.audio.ts
@@ -307,7 +307,6 @@ export function textToSpeech(inputs: TextToSpeechInputs): DslNode<TextToSpeechOu
 // Chunk To Audio — nodetool.audio.ChunkToAudio
 export interface ChunkToAudioInputs {
   chunk?: Connectable<unknown>;
-  batch_size?: Connectable<number>;
 }
 
 export interface ChunkToAudioOutputs {


### PR DESCRIPTION
## Summary
Consolidates folder path resolution logic across audio nodes, fixes TextToSpeechNode to properly throw when no TTS provider is available, and improves ChunkToAudioNode to handle streaming audio chunks with proper content-type detection.

## Key Changes

### Folder Path Resolution
- **Extract `resolveFolderPath()` helper**: Moved duplicated folder resolution logic from `LoadAudioAssetsNode._loadAudios()` and `LoadAudioFolderNode._resolveFolder()` into a single reusable function that handles plain paths, `file:` URIs, and folder asset refs
- **Update SaveAudioNode**: Use `resolveFolderPath()` instead of string coercion for consistency
- **Remove `LoadAudioFolderNode._resolveFolder()`**: Now delegates to the shared helper

### Audio Loading & Naming
- **LoadAudioAssetsNode**: Capture and return actual audio names instead of empty string
- **LoadAudioFolderNode**: Capture and return actual file paths instead of empty string

### TextToSpeechNode
- **Fix fallback behavior**: Instead of silently returning text as raw bytes when no TTS provider is available, now throws a descriptive error: `"Text To Speech requires a TTS provider; no provider available for provider "{providerId}" / model "{modelId}"."`
- Prevents silent failures and makes provider misconfiguration obvious

### ChunkToAudioNode
- **Remove `batch_size` property**: No longer needed; node processes single chunks
- **Improve chunk handling**: 
  - Detect audio chunks via `content_type === "audio"` with base64 `content` field (for streaming TTS providers)
  - Fall back to legacy `data` field for backward compatibility
  - Handle `uri` field by returning audio ref with URI
  - Return empty audio for unrecognized chunk types
- **Fix output port**: Return `audio` (matching `metadataOutputTypes`) instead of `output`
- **Update description**: Changed from "Aggregates audio chunks" to "Converts audio chunks" to reflect actual behavior

### Audio DSP & Effects Nodes
- **Add ProcessingContext parameter**: All audio effect nodes (`GainNode_`, `DelayNode_`, filters, reverb, pitch shift, time stretch, noise gate, phaser) now accept optional `ProcessingContext` for proper async audio loading
- **Use `audioBytesAsync()`**: Replace direct `audio.data` checks with `audioBytesAsync()` to properly handle audio refs with URIs or remote sources
- **Decode from bytes**: Pass decoded bytes to `decodeWav()` instead of raw audio ref
- **Fix DelayNode wet/dry mixing**: Corrected delay line feedback calculation so `mix` parameter truly blends dry vs. wet instead of always passing dry signal

### Test Coverage
- **TextToSpeechNode**: Updated test to verify error is thrown when no TTS provider available
- **ChunkToAudioNode**: Added tests for:
  - Base64 `data` field conversion
  - Streaming audio chunk with `content_type: "audio"` and base64 `content`
  - Non-audio content (text) is ignored
  - URI-based chunks return audio ref with URI
  - Null chunk handling
- **Serialization**: Removed `batch_size` from ChunkToAudioNode serialization test

## Implementation Details
- Folder resolution now handles three input formats uniformly: string paths, `file:` URIs, and `{ uri: string }` objects
- Audio effect nodes use `audioBytesAsync()` to support both embedded audio data and remote URIs, enabling proper streaming and lazy-loading
- ChunkToAudioNode now distinguishes between streaming TTS chunks (with `content_type` and `content`) and legacy audio refs (with `data`/`uri`)

https://claude.ai/code/session_01LZkzho85kWMGDyRgGpdA1k