### PR TITLE
Refactor ScriptLane to use flexible width layout

### DIFF
--- a/web/src/components/timeline/Tracks/ScriptLane.tsx
+++ b/web/src/components/timeline/Tracks/ScriptLane.tsx
@@ -121,9 +121,7 @@ export const ScriptLaneHeader: React.FC = () => (
 
 // ── Lane (for the scrollable lanes area) ──────────────────────────────────────
 
-export const ScriptLane: React.FC<{ totalWidthPx: number }> = ({
-  totalWidthPx
-}) => {
+export const ScriptLane: React.FC = () => {
   const clips = useTimelineStore((s) => s.clips);
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
   const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
@@ -137,7 +135,7 @@ export const ScriptLane: React.FC<{ totalWidthPx: number }> = ({
   );
 
   return (
-    <LaneRoot style={{ width: totalWidthPx }} data-testid="script-lane">
+    <LaneRoot style={{ width: "100%" }} data-testid="script-lane">
       {segments.map((seg, i) => {
         const prev = segments[i - 1];
         const gapMs = prev ? seg.startMs - prev.endMs : 0;

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -466,12 +466,12 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           >
             <div
               css={lanesContainerStyles}
-              style={{ width: totalWidthPx, height: totalTracksHeight }}
+              style={{ minWidth: totalWidthPx, width: "100%", height: totalTracksHeight }}
             >
               {tracks.map((track) => (
                 <React.Fragment key={track.id}>
                   {track.id === scriptBeforeTrackId && (
-                    <ScriptLane totalWidthPx={totalWidthPx} />
+                    <ScriptLane />
                   )}
                   <TrackLane track={track} />
                   {expandedFxTrackId === track.id && (
@@ -490,7 +490,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                 </React.Fragment>
               ))}
               {scriptBeforeTrackId === null && (
-                <ScriptLane totalWidthPx={totalWidthPx} />
+                <ScriptLane />
               )}
             </div>
           </div>

--- a/web/src/components/timeline/Tracks/__tests__/ScriptLane.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ScriptLane.test.tsx
@@ -35,7 +35,7 @@ const renderLane = () =>
   render(
     <ThemeProvider theme={mockTheme}>
       <TimelineProvider>
-        <ScriptLane totalWidthPx={2000} />
+        <ScriptLane />
       </TimelineProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
Refactored the `ScriptLane` component to use flexible width layout instead of a fixed pixel-based width prop, improving responsiveness and simplifying the component API.

## Key Changes
- **ScriptLane component**: Removed `totalWidthPx` prop and updated the component to use `width: "100%"` for flexible sizing
- **TracksRegion container**: Updated the lanes container to use `minWidth: totalWidthPx` and `width: "100%"` to maintain minimum width while allowing flex growth
- **Component calls**: Removed `totalWidthPx={totalWidthPx}` arguments from both `ScriptLane` instantiations (before and after track rendering)

## Implementation Details
The change shifts from explicit width calculation passed down as a prop to a more flexible CSS-based approach where:
- The parent container (`lanesContainerStyles`) sets a minimum width to prevent content collapse
- Child lanes (`ScriptLane`) expand to fill available space with `width: "100%"`
- This pattern aligns with modern responsive design practices and reduces prop drilling

https://claude.ai/code/session_014H95ZKJpPRa9Mjwf7RzL6t