### PR TITLE
Add modular synthesis and realtime audio streaming nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42713,6 +42713,7 @@
       "license": "MIT",
       "dependencies": {
         "@k13engineering/rubberband": "^0.0.8",
+        "@nodetool-ai/config": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",

--- a/packages/audio-nodes/package.json
+++ b/packages/audio-nodes/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@k13engineering/rubberband": "^0.0.8",
+    "@nodetool-ai/config": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/nodes-utils": "*",
     "@nodetool-ai/protocol": "*",

--- a/packages/audio-nodes/src/index.ts
+++ b/packages/audio-nodes/src/index.ts
@@ -3,8 +3,11 @@ export * from "./nodes/lib-audio-dsp.js";
 export * from "./nodes/lib-audio-effects.js";
 export * from "./nodes/output.js";
 export * from "./nodes/realtime-audio.js";
+export * from "./nodes/synthesis.js";
 
 // Audio codec helpers — exposed so sibling node packages (e.g. video) can
 // reuse the canonical encode/decode without duplicating the implementation.
 export * from "./lib/audio-wav.js";
 export * from "./lib/biquad.js";
+export * from "./lib/cv.js";
+export * from "./lib/synth-dsp.js";

--- a/packages/audio-nodes/src/index.ts
+++ b/packages/audio-nodes/src/index.ts
@@ -2,7 +2,9 @@ export * from "./nodes/audio.js";
 export * from "./nodes/lib-audio-dsp.js";
 export * from "./nodes/lib-audio-effects.js";
 export * from "./nodes/output.js";
+export * from "./nodes/realtime-audio.js";
 
 // Audio codec helpers — exposed so sibling node packages (e.g. video) can
 // reuse the canonical encode/decode without duplicating the implementation.
 export * from "./lib/audio-wav.js";
+export * from "./lib/biquad.js";

--- a/packages/audio-nodes/src/lib/audio-context.ts
+++ b/packages/audio-nodes/src/lib/audio-context.ts
@@ -1,0 +1,38 @@
+/// <reference lib="dom" />
+/**
+ * Environment seam for WebAudio's `OfflineAudioContext`.
+ *
+ * On Node the constructor comes from `node-web-audio-api`, loaded via a
+ * bundler-hidden import so the web bundle never tries to resolve the native
+ * addon. In the browser it is the global — when present: the browser workflow
+ * runner executes inside a Web Worker, where `OfflineAudioContext` is not
+ * guaranteed (absent in Firefox/Safari workers), so callers must handle the
+ * `null` case with a pure-JS fallback (see `lib/biquad.ts`).
+ */
+import { IS_NODE, importHidden } from "@nodetool-ai/config";
+
+export type OfflineAudioContextCtor = typeof OfflineAudioContext;
+
+let cached: Promise<OfflineAudioContextCtor | null> | null = null;
+
+/**
+ * Resolve the `OfflineAudioContext` constructor for the current environment,
+ * or `null` when WebAudio is unavailable (e.g. a Web Worker without it).
+ */
+export async function loadOfflineAudioContext(): Promise<OfflineAudioContextCtor | null> {
+  if (!cached) {
+    cached = (async () => {
+      if (IS_NODE) {
+        const mod = await importHidden<{
+          OfflineAudioContext: OfflineAudioContextCtor;
+        }>("node-web-audio-api");
+        return mod?.OfflineAudioContext ?? null;
+      }
+      return (
+        (globalThis as { OfflineAudioContext?: OfflineAudioContextCtor })
+          .OfflineAudioContext ?? null
+      );
+    })();
+  }
+  return cached;
+}

--- a/packages/audio-nodes/src/lib/audio-wav.ts
+++ b/packages/audio-nodes/src/lib/audio-wav.ts
@@ -10,7 +10,11 @@
  *   them at call sites.
  */
 
-import { loadNodeFsPromises } from "@nodetool-ai/nodes-utils";
+import {
+  base64ToBytes,
+  bytesToBase64,
+  loadNodeFsPromises
+} from "@nodetool-ai/nodes-utils";
 import type { AudioRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
@@ -30,7 +34,7 @@ export function toBytes(value: Uint8Array | string | undefined): Uint8Array {
   if (!value) return new Uint8Array();
   if (value instanceof Uint8Array) return value;
   if (typeof value !== "string") throw new Error("Invalid audio data");
-  return Uint8Array.from(Buffer.from(value, "base64"));
+  return base64ToBytes(value);
 }
 
 /** Synchronously extract raw bytes from an AudioRef's inline `data` field. */
@@ -95,7 +99,7 @@ export function audioRefFromBytes(data: Uint8Array, uri?: string): AudioRef {
   return {
     type: "audio",
     uri: uri ?? "",
-    data: Buffer.from(data).toString("base64")
+    data: bytesToBase64(data)
   };
 }
 
@@ -116,6 +120,46 @@ export function concatBytes(chunks: Uint8Array[]): Uint8Array {
   return out;
 }
 
+/** Write an ASCII tag (e.g. "RIFF") into a byte buffer at `offset`. */
+function writeAscii(out: Uint8Array, offset: number, text: string): void {
+  for (let i = 0; i < text.length; i++) out[offset + i] = text.charCodeAt(i);
+}
+
+/** Read bytes [start, end) as an ASCII string. */
+function asciiAt(bytes: Uint8Array, start: number, end: number): string {
+  let text = "";
+  for (let i = start; i < end && i < bytes.length; i++) {
+    text += String.fromCharCode(bytes[i]);
+  }
+  return text;
+}
+
+/** Write the canonical 44-byte RIFF/WAVE PCM header into `out`. */
+function writeWavHeader(
+  out: Uint8Array,
+  view: DataView,
+  sampleRate: number,
+  numChannels: number,
+  dataSize: number
+): void {
+  const bitsPerSample = 16;
+  const blockAlign = (numChannels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  writeAscii(out, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(out, 8, "WAVE");
+  writeAscii(out, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeAscii(out, 36, "data");
+  view.setUint32(40, dataSize, true);
+}
+
 /**
  * Wrap a buffer of already-encoded little-endian 16-bit PCM samples in a
  * RIFF/WAVE container. Use when the caller already has Int16 samples (e.g.
@@ -127,29 +171,12 @@ export function encodePcm16Wav(
   sampleRate: number,
   numChannels = 1
 ): Uint8Array {
-  const bitsPerSample = 16;
-  const blockAlign = (numChannels * bitsPerSample) / 8;
-  const byteRate = sampleRate * blockAlign;
   const dataSize = pcmBytes.length;
-  const buffer = Buffer.alloc(44 + dataSize);
-  buffer.write("RIFF", 0);
-  buffer.writeUInt32LE(36 + dataSize, 4);
-  buffer.write("WAVE", 8);
-  buffer.write("fmt ", 12);
-  buffer.writeUInt32LE(16, 16);
-  buffer.writeUInt16LE(1, 20); // PCM
-  buffer.writeUInt16LE(numChannels, 22);
-  buffer.writeUInt32LE(sampleRate, 24);
-  buffer.writeUInt32LE(byteRate, 28);
-  buffer.writeUInt16LE(blockAlign, 32);
-  buffer.writeUInt16LE(bitsPerSample, 34);
-  buffer.write("data", 36);
-  buffer.writeUInt32LE(dataSize, 40);
-  Buffer.from(pcmBytes.buffer, pcmBytes.byteOffset, pcmBytes.byteLength).copy(
-    buffer,
-    44
-  );
-  return new Uint8Array(buffer);
+  const out = new Uint8Array(44 + dataSize);
+  const view = new DataView(out.buffer);
+  writeWavHeader(out, view, sampleRate, numChannels, dataSize);
+  out.set(pcmBytes, 44);
+  return out;
 }
 
 /**
@@ -161,29 +188,15 @@ export function encodeWav(
   sampleRate: number,
   numChannels = 1
 ): Uint8Array {
-  const bitsPerSample = 16;
-  const blockAlign = (numChannels * bitsPerSample) / 8;
-  const byteRate = sampleRate * blockAlign;
   const dataSize = samples.length * 2;
-  const buffer = Buffer.alloc(44 + dataSize);
-  buffer.write("RIFF", 0);
-  buffer.writeUInt32LE(36 + dataSize, 4);
-  buffer.write("WAVE", 8);
-  buffer.write("fmt ", 12);
-  buffer.writeUInt32LE(16, 16);
-  buffer.writeUInt16LE(1, 20); // PCM
-  buffer.writeUInt16LE(numChannels, 22);
-  buffer.writeUInt32LE(sampleRate, 24);
-  buffer.writeUInt32LE(byteRate, 28);
-  buffer.writeUInt16LE(blockAlign, 32);
-  buffer.writeUInt16LE(bitsPerSample, 34);
-  buffer.write("data", 36);
-  buffer.writeUInt32LE(dataSize, 40);
+  const out = new Uint8Array(44 + dataSize);
+  const view = new DataView(out.buffer);
+  writeWavHeader(out, view, sampleRate, numChannels, dataSize);
   for (let i = 0; i < samples.length; i++) {
     const s = Math.max(-1, Math.min(1, samples[i]));
-    buffer.writeInt16LE(Math.round(s * 0x7fff), 44 + i * 2);
+    view.setInt16(44 + i * 2, Math.round(s * 0x7fff), true);
   }
-  return new Uint8Array(buffer);
+  return out;
 }
 
 export interface WavHeader {
@@ -208,11 +221,8 @@ export interface WavHeader {
  */
 export function readWavHeader(bytes: Uint8Array): WavHeader | null {
   if (bytes.length < 12) return null;
-  const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  if (
-    buf.toString("ascii", 0, 4) !== "RIFF" ||
-    buf.toString("ascii", 8, 12) !== "WAVE"
-  ) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (asciiAt(bytes, 0, 4) !== "RIFF" || asciiAt(bytes, 8, 12) !== "WAVE") {
     return null;
   }
 
@@ -223,14 +233,14 @@ export function readWavHeader(bytes: Uint8Array): WavHeader | null {
   let dataSize = 0;
 
   let offset = 12;
-  while (offset + 8 <= buf.length) {
-    const chunkId = buf.toString("ascii", offset, offset + 4);
-    const chunkSize = buf.readUInt32LE(offset + 4);
+  while (offset + 8 <= bytes.length) {
+    const chunkId = asciiAt(bytes, offset, offset + 4);
+    const chunkSize = view.getUint32(offset + 4, true);
     const body = offset + 8;
-    if (chunkId === "fmt " && body + 16 <= buf.length) {
-      numChannels = buf.readUInt16LE(body + 2);
-      sampleRate = buf.readUInt32LE(body + 4);
-      bitsPerSample = buf.readUInt16LE(body + 14);
+    if (chunkId === "fmt " && body + 16 <= bytes.length) {
+      numChannels = view.getUint16(body + 2, true);
+      sampleRate = view.getUint32(body + 4, true);
+      bitsPerSample = view.getUint16(body + 14, true);
     } else if (chunkId === "data") {
       // `fmt ` always precedes `data` in a well-formed file, so the format
       // fields are populated by the time we get here.
@@ -242,7 +252,7 @@ export function readWavHeader(bytes: Uint8Array): WavHeader | null {
   }
 
   if (dataOffset < 0) return null;
-  const available = buf.length - dataOffset;
+  const available = bytes.length - dataOffset;
   if (dataSize <= 0 || dataSize > available) dataSize = available;
   return { sampleRate, numChannels, bitsPerSample, dataOffset, dataSize };
 }
@@ -261,16 +271,16 @@ export function parseWavBytes(bytes: Uint8Array): WavData | null {
   const bytesPerSample = bitsPerSample / 8;
   if (bytesPerSample !== 1 && bytesPerSample !== 2) return null;
 
-  const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const totalSamples = Math.floor(dataSize / bytesPerSample);
   const samples = new Float32Array(totalSamples);
 
   for (let i = 0; i < totalSamples; i++) {
     const pos = dataOffset + i * bytesPerSample;
     if (bitsPerSample === 16) {
-      samples[i] = buf.readInt16LE(pos) / 0x7fff;
+      samples[i] = view.getInt16(pos, true) / 0x7fff;
     } else if (bitsPerSample === 8) {
-      samples[i] = (buf.readUInt8(pos) - 128) / 128;
+      samples[i] = (bytes[pos] - 128) / 128;
     }
   }
 
@@ -302,6 +312,28 @@ export function interleave(planes: Float32Array[]): Float32Array {
     for (let i = 0; i < frames; i++) {
       out[i * numChannels + ch] = planes[ch][i];
     }
+  }
+  return out;
+}
+
+/** Decode raw little-endian 16-bit PCM bytes into Float32 samples ([-1, 1]). */
+export function pcm16ToFloat32(bytes: Uint8Array): Float32Array {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const count = Math.floor(bytes.length / 2);
+  const samples = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    samples[i] = view.getInt16(i * 2, true) / 0x7fff;
+  }
+  return samples;
+}
+
+/** Encode Float32 samples (clipped to [-1, 1]) as little-endian 16-bit PCM bytes. */
+export function float32ToPcm16(samples: Float32Array): Uint8Array {
+  const out = new Uint8Array(samples.length * 2);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(i * 2, Math.round(s * 0x7fff), true);
   }
   return out;
 }

--- a/packages/audio-nodes/src/lib/biquad.ts
+++ b/packages/audio-nodes/src/lib/biquad.ts
@@ -1,0 +1,177 @@
+/**
+ * RBJ Audio-EQ-Cookbook biquad filters, pure TypeScript.
+ *
+ * Serves two purposes:
+ *   - Fallback for the batch filter nodes when `OfflineAudioContext` is
+ *     unavailable (Web Workers in Firefox/Safari — see `lib/audio-context.ts`).
+ *   - The engine for the streaming filter nodes, whose `BiquadState` carries
+ *     filter memory across chunk boundaries (something a per-chunk
+ *     OfflineAudioContext cannot do).
+ *
+ * Coefficients follow the same cookbook formulas WebAudio's
+ * `BiquadFilterNode` is specified against, so parity with the WebAudio path
+ * is close but not bit-exact.
+ */
+
+import { deinterleave, interleave, type WavData } from "./audio-wav.js";
+
+export type BiquadType =
+  | "lowpass"
+  | "highpass"
+  | "lowshelf"
+  | "highshelf"
+  | "peaking";
+
+/** Filter coefficients, normalized by a0. */
+export interface BiquadCoeffs {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+}
+
+/** Direct Form I delay-line state for one channel. */
+export interface BiquadState {
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+/** WebAudio's default Q (Butterworth response for lowpass/highpass). */
+export const DEFAULT_Q = Math.SQRT1_2;
+
+/** Compute normalized biquad coefficients per the RBJ Audio-EQ-Cookbook. */
+export function biquadCoeffs(
+  type: BiquadType,
+  sampleRate: number,
+  frequency: number,
+  q: number = DEFAULT_Q,
+  gainDb = 0
+): BiquadCoeffs {
+  // Clamp to a valid digital frequency range to keep the filter stable.
+  const nyquist = sampleRate / 2;
+  const f = Math.min(Math.max(frequency, 1), nyquist * 0.9999);
+  const w0 = (2 * Math.PI * f) / sampleRate;
+  const cosW0 = Math.cos(w0);
+  const sinW0 = Math.sin(w0);
+  const safeQ = Math.max(q, 1e-4);
+  const alpha = sinW0 / (2 * safeQ);
+  const A = Math.pow(10, gainDb / 40);
+
+  let b0: number;
+  let b1: number;
+  let b2: number;
+  let a0: number;
+  let a1: number;
+  let a2: number;
+
+  switch (type) {
+    case "lowpass": {
+      b0 = (1 - cosW0) / 2;
+      b1 = 1 - cosW0;
+      b2 = (1 - cosW0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+    case "highpass": {
+      b0 = (1 + cosW0) / 2;
+      b1 = -(1 + cosW0);
+      b2 = (1 + cosW0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+    case "lowshelf": {
+      const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha;
+      b0 = A * (A + 1 - (A - 1) * cosW0 + twoSqrtAAlpha);
+      b1 = 2 * A * (A - 1 - (A + 1) * cosW0);
+      b2 = A * (A + 1 - (A - 1) * cosW0 - twoSqrtAAlpha);
+      a0 = A + 1 + (A - 1) * cosW0 + twoSqrtAAlpha;
+      a1 = -2 * (A - 1 + (A + 1) * cosW0);
+      a2 = A + 1 + (A - 1) * cosW0 - twoSqrtAAlpha;
+      break;
+    }
+    case "highshelf": {
+      const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha;
+      b0 = A * (A + 1 + (A - 1) * cosW0 + twoSqrtAAlpha);
+      b1 = -2 * A * (A - 1 + (A + 1) * cosW0);
+      b2 = A * (A + 1 + (A - 1) * cosW0 - twoSqrtAAlpha);
+      a0 = A + 1 - (A - 1) * cosW0 + twoSqrtAAlpha;
+      a1 = 2 * (A - 1 - (A + 1) * cosW0);
+      a2 = A + 1 - (A - 1) * cosW0 - twoSqrtAAlpha;
+      break;
+    }
+    case "peaking": {
+      b0 = 1 + alpha * A;
+      b1 = -2 * cosW0;
+      b2 = 1 - alpha * A;
+      a0 = 1 + alpha / A;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha / A;
+      break;
+    }
+  }
+
+  return { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 };
+}
+
+/** Fresh (all-zero) delay-line state. */
+export function createBiquadState(): BiquadState {
+  return { x1: 0, x2: 0, y1: 0, y2: 0 };
+}
+
+/**
+ * Run a Direct Form I biquad over `input`, returning the filtered samples.
+ * Mutates `state` so callers can carry filter memory across chunks.
+ */
+export function processBiquad(
+  coeffs: BiquadCoeffs,
+  state: BiquadState,
+  input: Float32Array
+): Float32Array {
+  const { b0, b1, b2, a1, a2 } = coeffs;
+  let { x1, x2, y1, y2 } = state;
+  const out = new Float32Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const x0 = input[i];
+    const y0 = b0 * x0 + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2;
+    out[i] = y0;
+    x2 = x1;
+    x1 = x0;
+    y2 = y1;
+    y1 = y0;
+  }
+  state.x1 = x1;
+  state.x2 = x2;
+  state.y1 = y1;
+  state.y2 = y2;
+  return out;
+}
+
+/**
+ * Apply a biquad filter to whole interleaved WAV data (independent state per
+ * channel). Whole-buffer convenience used as the OfflineAudioContext fallback.
+ */
+export function applyBiquadToWav(
+  wav: WavData,
+  type: BiquadType,
+  frequency: number,
+  q: number = DEFAULT_Q,
+  gainDb = 0
+): WavData {
+  const coeffs = biquadCoeffs(type, wav.sampleRate, frequency, q, gainDb);
+  const planes = deinterleave(wav.samples, wav.numChannels);
+  const filtered = planes.map((plane) =>
+    processBiquad(coeffs, createBiquadState(), plane)
+  );
+  return {
+    samples: interleave(filtered),
+    sampleRate: wav.sampleRate,
+    numChannels: wav.numChannels
+  };
+}

--- a/packages/audio-nodes/src/lib/cv.ts
+++ b/packages/audio-nodes/src/lib/cv.ts
@@ -1,0 +1,326 @@
+/**
+ * Control-voltage (CV) signal helpers for the modular synthesis nodes.
+ *
+ * CV rides the same chunk wire shape as streaming audio (`type:"chunk"`,
+ * `content_type:"audio"`, base64 payload, `done:true` terminator) but with
+ * `encoding:"f32le"`: pcm16 clamps to [-1,1] and quantizes, which is wrong
+ * for multi-octave pitch CV. `readSignalChunk` decodes both encodings, so
+ * any signal node accepts audio and CV interchangeably (Eurorack semantics).
+ *
+ * Also home to the sample-domain timing utilities:
+ *  - `SampleFifo` / `alignedSignalStreams` — the "zip-with-hold" pattern for
+ *    multi-input streaming nodes (the kernel has no sample-aligned zip;
+ *    alignment is exact when one clock drives the patch, hold-last
+ *    otherwise).
+ *  - `abortableSleep` / `RealtimePacer` — wall-clock pacing for
+ *    `realtime: true` generators. Pacing only delays emission; signal
+ *    content is identical to a free run.
+ */
+import type { StreamingInputs } from "@nodetool-ai/node-sdk";
+import { base64ToBytes, bytesToBase64 } from "@nodetool-ai/nodes-utils";
+import { float32ToPcm16, pcm16ToFloat32 } from "./audio-wav.js";
+
+export type SignalEncoding = "pcm16le" | "f32le";
+
+/** Default sample rate for synth generators (matches the chunk default). */
+export const SYNTH_SAMPLE_RATE = 24000;
+/** Frames per generated chunk (~21 ms @ 24 kHz). */
+export const SYNTH_CHUNK_FRAMES = 512;
+
+/** Default value for `@prop({ type: "chunk" })` declarations on signal nodes. */
+export const CHUNK_PROP_DEFAULT = {
+  type: "chunk",
+  node_id: null,
+  thread_id: null,
+  workflow_id: null,
+  content_type: "audio",
+  content: "",
+  content_metadata: {},
+  done: false,
+  thinking: false
+};
+
+export interface SignalChunk {
+  /** Channel-interleaved samples; empty for done markers. */
+  samples: Float32Array;
+  sampleRate: number;
+  channels: number;
+  done: boolean;
+}
+
+/**
+ * Parse a streamed item as a signal (audio or CV) chunk. Returns null for
+ * non-audio chunks and non-chunk values, which callers skip. Decodes
+ * `encoding:"f32le"` payloads as little-endian float32; anything else
+ * (including absent metadata) takes the legacy pcm16le path.
+ */
+export function readSignalChunk(item: unknown): SignalChunk | null {
+  if (!item || typeof item !== "object") return null;
+  const c = item as {
+    content?: unknown;
+    content_type?: unknown;
+    content_metadata?: unknown;
+    done?: unknown;
+  };
+  if (c.content_type !== undefined && c.content_type !== "audio") return null;
+  const meta = (c.content_metadata ?? {}) as {
+    encoding?: unknown;
+    sample_rate?: unknown;
+    channels?: unknown;
+  };
+  const sampleRate =
+    typeof meta.sample_rate === "number" && meta.sample_rate > 0
+      ? meta.sample_rate
+      : SYNTH_SAMPLE_RATE;
+  const channels =
+    typeof meta.channels === "number" && meta.channels > 0 ? meta.channels : 1;
+  const content = typeof c.content === "string" ? c.content : "";
+  let samples: Float32Array;
+  if (!content) {
+    samples = new Float32Array(0);
+  } else {
+    const bytes = base64ToBytes(content);
+    samples =
+      meta.encoding === "f32le" ? f32leToFloat32(bytes) : pcm16ToFloat32(bytes);
+  }
+  return { samples, sampleRate, channels, done: Boolean(c.done ?? false) };
+}
+
+/** Build a signal chunk in the shared chunk wire shape. */
+export function makeSignalChunk(
+  samples: Float32Array,
+  sampleRate: number,
+  channels: number,
+  done: boolean,
+  encoding: SignalEncoding
+): Record<string, unknown> {
+  const bytes =
+    encoding === "f32le" ? float32ToF32le(samples) : float32ToPcm16(samples);
+  return {
+    type: "chunk",
+    content: samples.length > 0 ? bytesToBase64(bytes) : "",
+    done,
+    content_type: "audio",
+    content_metadata: {
+      encoding,
+      sample_rate: sampleRate,
+      channels,
+      format: "pcm",
+      duration_seconds: samples.length / Math.max(1, channels) / sampleRate
+    }
+  };
+}
+
+/** End-of-stream marker: empty content, `done: true`. */
+export function makeDoneSignalChunk(
+  sampleRate: number,
+  channels: number,
+  encoding: SignalEncoding
+): Record<string, unknown> {
+  return makeSignalChunk(new Float32Array(0), sampleRate, channels, true, encoding);
+}
+
+/** Decode little-endian float32 bytes (explicit DataView for endianness safety). */
+export function f32leToFloat32(bytes: Uint8Array): Float32Array {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const count = Math.floor(bytes.length / 4);
+  const out = new Float32Array(count);
+  for (let i = 0; i < count; i++) out[i] = view.getFloat32(i * 4, true);
+  return out;
+}
+
+/** Encode samples as little-endian float32 bytes. */
+export function float32ToF32le(samples: Float32Array): Uint8Array {
+  const out = new Uint8Array(samples.length * 4);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < samples.length; i++) {
+    view.setFloat32(i * 4, samples[i], true);
+  }
+  return out;
+}
+
+// ── Sample FIFO + zip-with-hold ────────────────────────────────────
+
+/**
+ * Mono sample queue with hold-last semantics: pulling past the available
+ * samples repeats the last seen value ("hold", the modular sample-&-hold
+ * convention for a lagging or finished CV source) or fills zeros ("zero",
+ * correct for ended audio in a mixer). Initial held value is 0.
+ */
+export class SampleFifo {
+  private _segments: Float32Array[] = [];
+  private _offset = 0;
+  private _available = 0;
+  private _last = 0;
+
+  get available(): number {
+    return this._available;
+  }
+
+  /** The most recently pushed (or pulled) sample value; 0 before any data. */
+  get last(): number {
+    return this._last;
+  }
+
+  push(samples: Float32Array): void {
+    if (samples.length === 0) return;
+    this._segments.push(samples);
+    this._available += samples.length;
+  }
+
+  pull(n: number, mode: "hold" | "zero"): Float32Array {
+    const out = new Float32Array(n);
+    let written = 0;
+    while (written < n && this._segments.length > 0) {
+      const seg = this._segments[0];
+      const take = Math.min(n - written, seg.length - this._offset);
+      out.set(seg.subarray(this._offset, this._offset + take), written);
+      written += take;
+      this._offset += take;
+      if (this._offset >= seg.length) {
+        this._segments.shift();
+        this._offset = 0;
+      }
+    }
+    this._available -= written;
+    if (written > 0) this._last = out[written - 1];
+    if (written < n && mode === "hold") {
+      out.fill(this._last, written);
+    }
+    return out;
+  }
+}
+
+export interface AlignedFrame {
+  /** The primary (driving) chunk — never a done marker. */
+  primary: SignalChunk;
+  /**
+   * Per-CV-handle mono sample arrays, one value per primary *frame*
+   * (hold-last when a CV source lags or has ended). Unconnected handles are
+   * absent — check membership rather than relying on defaults.
+   */
+  cv: Record<string, Float32Array>;
+}
+
+/**
+ * Zip-with-hold: consume one primary stream and any number of CV streams,
+ * yielding the primary chunks paired with frame-aligned CV values.
+ *
+ * Sample-exact when all streams share cadence (a patch driven by a single
+ * clock source); otherwise CV degrades to hold-last. Deadlock-free: the
+ * single `inputs.any()` loop only blocks while some upstream is open, and a
+ * primary chunk is released as soon as every connected CV handle can cover
+ * it (buffered, done, or the whole loop ended). Multichannel CV inputs are
+ * collapsed to channel 0.
+ */
+export async function* alignedSignalStreams(
+  inputs: StreamingInputs,
+  opts: { primary: string; cvHandles: readonly string[] }
+): AsyncGenerator<AlignedFrame> {
+  const connected = opts.cvHandles.filter((h) => inputs.hasStream(h));
+  const fifos = new Map(connected.map((h) => [h, new SampleFifo()]));
+  const cvDone = new Map(connected.map((h) => [h, false]));
+  const pending: SignalChunk[] = [];
+  let primaryDone = false;
+
+  const frameCount = (chunk: SignalChunk): number =>
+    Math.floor(chunk.samples.length / Math.max(1, chunk.channels));
+
+  const covered = (frames: number): boolean =>
+    connected.every(
+      (h) => cvDone.get(h) || (fifos.get(h)?.available ?? 0) >= frames
+    );
+
+  function* drain(force: boolean): Generator<AlignedFrame> {
+    while (pending.length > 0) {
+      const frames = frameCount(pending[0]);
+      if (!force && !covered(frames)) break;
+      const primary = pending.shift()!;
+      const cv: Record<string, Float32Array> = {};
+      for (const h of connected) cv[h] = fifos.get(h)!.pull(frames, "hold");
+      yield { primary, cv };
+    }
+  }
+
+  for await (const [handle, item] of inputs.any()) {
+    const chunk = readSignalChunk(item);
+    if (!chunk) continue;
+    if (handle === opts.primary) {
+      if (chunk.done) primaryDone = true;
+      else if (chunk.samples.length > 0) pending.push(chunk);
+    } else if (fifos.has(handle)) {
+      if (chunk.done) cvDone.set(handle, true);
+      else fifos.get(handle)!.push(monoChannel(chunk));
+    } else {
+      continue;
+    }
+    yield* drain(false);
+    if (primaryDone && pending.length === 0) break;
+  }
+  // The any() loop ended (EOS everywhere) — release whatever is left with
+  // hold-last CV.
+  yield* drain(true);
+}
+
+/** Channel 0 of an interleaved chunk (CV is conceptually mono). */
+function monoChannel(chunk: SignalChunk): Float32Array {
+  const channels = Math.max(1, chunk.channels);
+  if (channels === 1) return chunk.samples;
+  const frames = Math.floor(chunk.samples.length / channels);
+  const out = new Float32Array(frames);
+  for (let i = 0; i < frames; i++) out[i] = chunk.samples[i * channels];
+  return out;
+}
+
+// ── Realtime pacing ────────────────────────────────────────────────
+
+/** Sleep that resolves early (without throwing) when `signal` aborts. */
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (!signal) {
+      setTimeout(resolve, ms);
+      return;
+    }
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Drift-compensated wall-clock pacer for `realtime: true` generators: chunk
+ * k is released no earlier than `start + k·chunkMs` (same scheme as
+ * IntervalTriggerNode). Pacing never alters chunk contents — a realtime
+ * render is bit-identical to a free run.
+ */
+export class RealtimePacer {
+  private readonly _startMs = Date.now();
+  private _emitted = 0;
+
+  constructor(private readonly _signal?: AbortSignal) {}
+
+  /**
+   * Wait for the next emission slot. Returns false when the run was
+   * cancelled — the caller must stop producing.
+   */
+  async waitNext(chunkMs: number): Promise<boolean> {
+    const targetMs = this._startMs + this._emitted * chunkMs;
+    this._emitted++;
+    const waitMs = targetMs - Date.now();
+    if (waitMs > 0) await abortableSleep(waitMs, this._signal);
+    return !(this._signal?.aborted ?? false);
+  }
+}

--- a/packages/audio-nodes/src/lib/cv.ts
+++ b/packages/audio-nodes/src/lib/cv.ts
@@ -302,24 +302,25 @@ export function abortableSleep(
 
 /**
  * Drift-compensated wall-clock pacer for `realtime: true` generators: chunk
- * k is released no earlier than `start + k·chunkMs` (same scheme as
- * IntervalTriggerNode). Pacing never alters chunk contents — a realtime
- * render is bit-identical to a free run.
+ * k is released no earlier than the cumulative duration of chunks 0..k-1
+ * after start (absolute target times, same scheme as IntervalTriggerNode).
+ * Tracking the target cumulatively keeps variable-length chunks — e.g. the
+ * shorter final chunk of a bounded render — correctly paced. Pacing never
+ * alters chunk contents — a realtime render is bit-identical to a free run.
  */
 export class RealtimePacer {
-  private readonly _startMs = Date.now();
-  private _emitted = 0;
+  private _nextTargetMs = Date.now();
 
   constructor(private readonly _signal?: AbortSignal) {}
 
   /**
-   * Wait for the next emission slot. Returns false when the run was
+   * Wait for the chunk's emission slot, then advance the next slot by
+   * `chunkMs` (this chunk's duration). Returns false when the run was
    * cancelled — the caller must stop producing.
    */
   async waitNext(chunkMs: number): Promise<boolean> {
-    const targetMs = this._startMs + this._emitted * chunkMs;
-    this._emitted++;
-    const waitMs = targetMs - Date.now();
+    const waitMs = this._nextTargetMs - Date.now();
+    this._nextTargetMs += chunkMs;
     if (waitMs > 0) await abortableSleep(waitMs, this._signal);
     return !(this._signal?.aborted ?? false);
   }

--- a/packages/audio-nodes/src/lib/synth-dsp.ts
+++ b/packages/audio-nodes/src/lib/synth-dsp.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure DSP cores for the modular synthesis nodes — oscillator waveforms and
+ * the ADSR envelope state machine. No streaming, no I/O: everything here is
+ * a per-sample function over plain numbers, unit-testable in isolation.
+ */
+
+export type Waveform = "sine" | "saw" | "square" | "triangle" | "noise";
+
+/**
+ * One oscillator sample for `phase` ∈ [0, 1). Naive (non-bandlimited)
+ * waveforms — saw/square alias above a few kHz; polyBLEP is a follow-up.
+ */
+export function oscSample(
+  wave: Waveform,
+  phase: number,
+  pulseWidth = 0.5
+): number {
+  switch (wave) {
+    case "sine":
+      return Math.sin(2 * Math.PI * phase);
+    case "saw":
+      return 2 * phase - 1;
+    case "square":
+      return phase < pulseWidth ? 1 : -1;
+    case "triangle":
+      return 1 - 4 * Math.abs(phase - 0.5);
+    case "noise":
+      return Math.random() * 2 - 1;
+  }
+}
+
+// ── ADSR ───────────────────────────────────────────────────────────
+
+export type AdsrStage = "idle" | "attack" | "decay" | "sustain" | "release";
+
+/**
+ * Per-sample one-pole coefficients. Exponential segments (vs linear) cost
+ * the same per sample, give click-free analog-style curves, and make
+ * retrigger-from-current-level automatic — the pole just pulls the env
+ * from wherever it is toward the new target.
+ */
+export interface AdsrParams {
+  attackCoeff: number;
+  decayCoeff: number;
+  releaseCoeff: number;
+  sustain: number;
+}
+
+export interface AdsrState {
+  stage: AdsrStage;
+  env: number;
+  /** Previous sample's gate level (for edge detection). */
+  gateWasHigh: boolean;
+}
+
+/** Gate threshold: a CV sample ≥ 0.5 counts as gate-high. */
+export const GATE_THRESHOLD = 0.5;
+
+/**
+ * The attack pole drives toward this overshoot target and switches to decay
+ * at 1.0, so the named attack time is roughly met instead of asymptoting.
+ */
+const ATTACK_TARGET = 1.3;
+
+/** One-pole coefficient for a segment of `seconds` at `sampleRate`. */
+export function adsrCoeff(seconds: number, sampleRate: number): number {
+  return 1 - Math.exp(-1 / Math.max(1, seconds * sampleRate));
+}
+
+export function createAdsrState(): AdsrState {
+  return { stage: "idle", env: 0, gateWasHigh: false };
+}
+
+/**
+ * Advance the envelope by one sample given the current gate level. Mutates
+ * `state`; returns the new envelope value. Gate edges (rising → attack
+ * retrigger from the current level, falling → release) are detected here,
+ * so calling this per sample inside a chunk gives sample-accurate timing.
+ */
+export function adsrStep(
+  state: AdsrState,
+  gateHigh: boolean,
+  params: AdsrParams
+): number {
+  if (gateHigh && !state.gateWasHigh) {
+    state.stage = "attack";
+  } else if (!gateHigh && state.gateWasHigh) {
+    state.stage = "release";
+  }
+  state.gateWasHigh = gateHigh;
+
+  switch (state.stage) {
+    case "attack": {
+      state.env += params.attackCoeff * (ATTACK_TARGET - state.env);
+      if (state.env >= 1) {
+        state.env = 1;
+        state.stage = "decay";
+      }
+      break;
+    }
+    case "decay": {
+      state.env += params.decayCoeff * (params.sustain - state.env);
+      if (Math.abs(state.env - params.sustain) < 1e-4) {
+        state.env = params.sustain;
+        state.stage = "sustain";
+      }
+      break;
+    }
+    case "sustain": {
+      state.env = params.sustain;
+      break;
+    }
+    case "release": {
+      state.env += params.releaseCoeff * (0 - state.env);
+      if (state.env < 1e-5) {
+        state.env = 0;
+        state.stage = "idle";
+      }
+      break;
+    }
+    case "idle": {
+      state.env = 0;
+      break;
+    }
+  }
+  return state.env;
+}

--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -5,7 +5,7 @@ import type {
   Platform
 } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsServer } from "@nodetool-ai/nodes-utils";
+import { tagAsHybrid, tagAsServer } from "@nodetool-ai/nodes-utils";
 import {
   loadNodeFsPromises,
   loadNodePath
@@ -1683,12 +1683,12 @@ export class GetAudioInfoNode extends BaseNode {
   }
 }
 
-export const AUDIO_NODES = tagAsServer([
-  LoadAudioAssetsNode,
-  LoadAudioFileNode,
-  LoadAudioFolderNode,
-  SaveAudioNode,
-  SaveAudioFileNode,
+/**
+ * Pure sample/byte transforms — run on Node and in the browser workflow
+ * runner (all byte access goes through `audioBytesAsync`, whose `file://`
+ * branch is lazy and never taken in the browser).
+ */
+const AUDIO_HYBRID_NODES = tagAsHybrid([
   NormalizeAudioNode,
   OverlayAudioNode,
   RemoveSilenceNode,
@@ -1704,7 +1704,22 @@ export const AUDIO_NODES = tagAsServer([
   CreateSilenceNode,
   ConcatAudioNode,
   ConcatAudioListNode,
-  TextToSpeechNode,
   ChunkToAudioNode,
   GetAudioInfoNode
 ]);
+
+/**
+ * Server-only nodes: asset/file I/O (the Load/Save classes also declare
+ * `static platforms = NODE_ONLY`, which wins over the tagger) and TTS,
+ * which needs the server's provider prediction.
+ */
+const AUDIO_SERVER_NODES = tagAsServer([
+  LoadAudioAssetsNode,
+  LoadAudioFileNode,
+  LoadAudioFolderNode,
+  SaveAudioNode,
+  SaveAudioFileNode,
+  TextToSpeechNode
+]);
+
+export const AUDIO_NODES = [...AUDIO_HYBRID_NODES, ...AUDIO_SERVER_NODES];

--- a/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
@@ -1,6 +1,7 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { AudioRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsServer } from "@nodetool-ai/nodes-utils";
+import { tagAsHybrid } from "@nodetool-ai/nodes-utils";
 import {
   audioBytesAsync,
   audioRefFromWav,
@@ -8,30 +9,34 @@ import {
   encodeWav,
   type WavData
 } from "../lib/audio-wav.js";
+import {
+  loadOfflineAudioContext,
+  type OfflineAudioContextCtor
+} from "../lib/audio-context.js";
+import { applyBiquadToWav, DEFAULT_Q, type BiquadType } from "../lib/biquad.js";
 
-// ── Part B: Audio filter/effect nodes (node-web-audio-api) ─────────
+// ── Part B: Audio filter/effect nodes (WebAudio / biquad) ─────────
 
-async function processAudioWithEffect(
+export interface BiquadSpec {
+  type: BiquadType;
+  frequency: number;
+  q?: number;
+  gainDb?: number;
+}
+
+async function renderFilterWebAudio(
+  Ctor: OfflineAudioContextCtor,
   wav: WavData,
-  setupEffect: (ctx: any, source: any) => void,
-  extraLength = 0
-): Promise<Record<string, unknown>> {
-  const { OfflineAudioContext } = await import("node-web-audio-api");
+  spec: BiquadSpec
+): Promise<WavData> {
   const frameSamples = Math.floor(wav.samples.length / wav.numChannels);
-  const totalFrames = frameSamples + extraLength;
-
-  const ctx = new OfflineAudioContext(
-    wav.numChannels,
-    totalFrames,
-    wav.sampleRate
-  );
+  const ctx = new Ctor(wav.numChannels, frameSamples, wav.sampleRate);
   const buffer = ctx.createBuffer(
     wav.numChannels,
     frameSamples,
     wav.sampleRate
   );
 
-  // Fill buffer channels
   for (let ch = 0; ch < wav.numChannels; ch++) {
     const channelData = buffer.getChannelData(ch);
     for (let i = 0; i < frameSamples; i++) {
@@ -41,15 +46,20 @@ async function processAudioWithEffect(
 
   const source = ctx.createBufferSource();
   source.buffer = buffer;
-
-  setupEffect(ctx, source);
+  const filter = ctx.createBiquadFilter();
+  filter.type = spec.type;
+  filter.frequency.value = spec.frequency;
+  if (spec.q !== undefined) filter.Q.value = spec.q;
+  if (spec.gainDb !== undefined) filter.gain.value = spec.gainDb;
+  source.connect(filter);
+  filter.connect(ctx.destination);
   source.start();
 
   const renderedBuffer = await ctx.startRendering();
 
-  // Interleave channels back
-  const outLength = renderedBuffer.length * wav.numChannels;
-  const outSamples = new Float32Array(outLength);
+  const outSamples = new Float32Array(
+    renderedBuffer.length * wav.numChannels
+  );
   for (let ch = 0; ch < wav.numChannels; ch++) {
     const channelData = renderedBuffer.getChannelData(ch);
     for (let i = 0; i < renderedBuffer.length; i++) {
@@ -57,9 +67,36 @@ async function processAudioWithEffect(
     }
   }
 
+  return {
+    samples: outSamples,
+    sampleRate: wav.sampleRate,
+    numChannels: wav.numChannels
+  };
+}
+
+/**
+ * Apply a biquad filter to whole WAV data, preferring WebAudio's
+ * `OfflineAudioContext` (node-web-audio-api on Node, the global in the
+ * browser) and falling back to the pure-JS RBJ biquad when WebAudio is
+ * unavailable (e.g. Web Workers without it). Exported for tests.
+ */
+export async function applyFilter(
+  wav: WavData,
+  spec: BiquadSpec
+): Promise<AudioRef> {
+  const Ctor = await loadOfflineAudioContext();
+  const filtered = Ctor
+    ? await renderFilterWebAudio(Ctor, wav, spec)
+    : applyBiquadToWav(
+        wav,
+        spec.type,
+        spec.frequency,
+        spec.q ?? DEFAULT_Q,
+        spec.gainDb ?? 0
+      );
   return audioRefFromWav(
-    encodeWav(outSamples, wav.sampleRate, wav.numChannels)
-  ) as unknown as Record<string, unknown>;
+    encodeWav(filtered.samples, filtered.sampleRate, filtered.numChannels)
+  );
 }
 
 export class GainNode_ extends BaseNode {
@@ -105,17 +142,19 @@ export class GainNode_ extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const gainNode = ctx.createGain();
-        gainNode.gain.value = Math.pow(10, gainDb / 20);
-        source.connect(gainNode);
-        gainNode.connect(ctx.destination);
-      }
-    );
+    // A gain is a plain per-sample multiply — no WebAudio context needed.
+    const wav = decodeWav({ data: bytes });
+    const factor = Math.pow(10, gainDb / 20);
+    const outSamples = new Float32Array(wav.samples.length);
+    for (let i = 0; i < wav.samples.length; i++) {
+      outSamples[i] = wav.samples[i] * factor;
+    }
 
-    return { output };
+    return {
+      output: audioRefFromWav(
+        encodeWav(outSamples, wav.sampleRate, wav.numChannels)
+      )
+    };
   }
 }
 
@@ -263,16 +302,10 @@ export class HighPassFilterNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const filter = ctx.createBiquadFilter();
-        filter.type = "highpass";
-        filter.frequency.value = cutoff;
-        source.connect(filter);
-        filter.connect(ctx.destination);
-      }
-    );
+    const output = await applyFilter(decodeWav({ data: bytes }), {
+      type: "highpass",
+      frequency: cutoff
+    });
 
     return { output };
   }
@@ -320,16 +353,10 @@ export class LowPassFilterNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const filter = ctx.createBiquadFilter();
-        filter.type = "lowpass";
-        filter.frequency.value = cutoff;
-        source.connect(filter);
-        filter.connect(ctx.destination);
-      }
-    );
+    const output = await applyFilter(decodeWav({ data: bytes }), {
+      type: "lowpass",
+      frequency: cutoff
+    });
 
     return { output };
   }
@@ -389,17 +416,11 @@ export class HighShelfFilterNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const filter = ctx.createBiquadFilter();
-        filter.type = "highshelf";
-        filter.frequency.value = cutoff;
-        filter.gain.value = gainDb;
-        source.connect(filter);
-        filter.connect(ctx.destination);
-      }
-    );
+    const output = await applyFilter(decodeWav({ data: bytes }), {
+      type: "highshelf",
+      frequency: cutoff,
+      gainDb
+    });
 
     return { output };
   }
@@ -459,17 +480,11 @@ export class LowShelfFilterNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const filter = ctx.createBiquadFilter();
-        filter.type = "lowshelf";
-        filter.frequency.value = cutoff;
-        filter.gain.value = gainDb;
-        source.connect(filter);
-        filter.connect(ctx.destination);
-      }
-    );
+    const output = await applyFilter(decodeWav({ data: bytes }), {
+      type: "lowshelf",
+      frequency: cutoff,
+      gainDb
+    });
 
     return { output };
   }
@@ -541,24 +556,18 @@ export class PeakFilterNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const output = await processAudioWithEffect(
-      decodeWav({ data: bytes }),
-      (ctx: any, source: any) => {
-        const filter = ctx.createBiquadFilter();
-        filter.type = "peaking";
-        filter.frequency.value = cutoff;
-        filter.Q.value = q;
-        filter.gain.value = gainDb;
-        source.connect(filter);
-        filter.connect(ctx.destination);
-      }
-    );
+    const output = await applyFilter(decodeWav({ data: bytes }), {
+      type: "peaking",
+      frequency: cutoff,
+      q,
+      gainDb
+    });
 
     return { output };
   }
 }
 
-export const LIB_AUDIO_DSP_NODES = tagAsServer([
+export const LIB_AUDIO_DSP_NODES = tagAsHybrid([
   GainNode_,
   DelayNode_,
   HighPassFilterNode,

--- a/packages/audio-nodes/src/nodes/lib-audio-effects.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-effects.ts
@@ -1,6 +1,7 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsServer } from "@nodetool-ai/nodes-utils";
+import { tagAsHybrid, tagAsServer } from "@nodetool-ai/nodes-utils";
+import { importHidden } from "@nodetool-ai/config";
 import {
   audioBytesAsync,
   audioRefFromWav,
@@ -544,6 +545,26 @@ export class ReverbNode extends BaseNode {
 
 // ── PitchShift (rubberband WASM) ─────────────────────────────────
 
+type RubberbandModule = typeof import("@k13engineering/rubberband");
+
+/**
+ * Lazily load rubberband via a bundler-hidden import. The hidden import keeps
+ * the native/WASM package out of the web bundle (this file is loaded in the
+ * browser for its hybrid effects); the two nodes that need it stay
+ * server-only and throw when invoked off Node.
+ */
+async function loadRubberband(): Promise<RubberbandModule> {
+  const mod = await importHidden<RubberbandModule>(
+    "@k13engineering/rubberband"
+  );
+  if (!mod) {
+    throw new Error(
+      "PitchShift/TimeStretch require Node (rubberband is not available in the browser)"
+    );
+  }
+  return mod;
+}
+
 export class PitchShiftNode extends BaseNode {
   static readonly nodeType = "lib.audio.PitchShift";
   static readonly title = "Pitch Shift";
@@ -590,9 +611,7 @@ export class PitchShiftNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const { createRubberbandWrapper } = await import(
-      "@k13engineering/rubberband"
-    );
+    const { createRubberbandWrapper } = await loadRubberband();
     const wav = decodeWav({ data: bytes });
     const { samples, sampleRate, numChannels } = wav;
     const frameSamples = Math.floor(samples.length / numChannels);
@@ -724,9 +743,7 @@ export class TimeStretchNode extends BaseNode {
     const bytes = await audioBytesAsync(audio, context);
     if (bytes.length === 0) return { output: audio };
 
-    const { createRubberbandWrapper } = await import(
-      "@k13engineering/rubberband"
-    );
+    const { createRubberbandWrapper } = await loadRubberband();
     const wav = decodeWav({ data: bytes });
     const { samples, sampleRate, numChannels } = wav;
     const frameSamples = Math.floor(samples.length / numChannels);
@@ -1061,14 +1078,24 @@ export class PhaserNode extends BaseNode {
 
 // ── Export ────────────────────────────────────────────────────────
 
-export const LIB_PEDALBOARD_EXTRA_NODES = tagAsServer([
+/** Pure-JS effects — run on Node and in the browser workflow runner. */
+export const LIB_AUDIO_EFFECTS_HYBRID_NODES = tagAsHybrid([
   BitcrushNode,
   CompressNode,
   DistortionNode,
   LimiterNode,
   ReverbNode,
-  PitchShiftNode,
-  TimeStretchNode,
   NoiseGateNode,
   PhaserNode
 ]);
+
+/** Rubberband-backed effects — native/WASM addon, Node only. */
+export const LIB_AUDIO_EFFECTS_SERVER_NODES = tagAsServer([
+  PitchShiftNode,
+  TimeStretchNode
+]);
+
+export const LIB_PEDALBOARD_EXTRA_NODES = [
+  ...LIB_AUDIO_EFFECTS_HYBRID_NODES,
+  ...LIB_AUDIO_EFFECTS_SERVER_NODES
+];

--- a/packages/audio-nodes/src/nodes/realtime-audio.ts
+++ b/packages/audio-nodes/src/nodes/realtime-audio.ts
@@ -21,22 +21,22 @@ import type {
 } from "@nodetool-ai/node-sdk";
 import type { OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import {
-  base64ToBytes,
-  bytesToBase64,
-  tagAsHybrid
-} from "@nodetool-ai/nodes-utils";
+import { tagAsHybrid } from "@nodetool-ai/nodes-utils";
 import {
   audioBytesAsync,
   audioRefFromWav,
-  concatBytes,
   deinterleave,
-  encodePcm16Wav,
-  float32ToPcm16,
+  encodeWav,
   interleave,
-  parseWavBytes,
-  pcm16ToFloat32
+  parseWavBytes
 } from "../lib/audio-wav.js";
+import {
+  CHUNK_PROP_DEFAULT,
+  makeDoneSignalChunk,
+  makeSignalChunk,
+  readSignalChunk,
+  SYNTH_SAMPLE_RATE
+} from "../lib/cv.js";
 import {
   biquadCoeffs,
   createBiquadState,
@@ -47,81 +47,11 @@ import {
 } from "../lib/biquad.js";
 
 // ── Chunk helpers ──────────────────────────────────────────────────
+// Signal chunks (parse + build, both pcm16le and f32le CV encodings) live in
+// ../lib/cv.ts — shared with the synthesis nodes so CV streams can be patched
+// into any of these audio inputs.
 
-const DEFAULT_SAMPLE_RATE = 24000;
-
-interface AudioChunkMetadata {
-  encoding: "pcm16le";
-  sample_rate: number;
-  channels: number;
-  format: string;
-  duration_seconds: number;
-}
-
-function makeAudioChunk(
-  content: string,
-  meta: AudioChunkMetadata,
-  done: boolean
-): Record<string, unknown> {
-  return {
-    type: "chunk",
-    content,
-    done,
-    content_type: "audio",
-    content_metadata: meta
-  };
-}
-
-interface ParsedAudioChunk {
-  bytes: Uint8Array;
-  sampleRate: number;
-  channels: number;
-  done: boolean;
-}
-
-/**
- * Parse a streamed item as an audio chunk. Returns null for non-audio chunks
- * (e.g. text) and non-chunk values, which callers skip.
- */
-function readChunk(item: unknown): ParsedAudioChunk | null {
-  if (!item || typeof item !== "object") return null;
-  const c = item as {
-    content?: unknown;
-    content_type?: unknown;
-    content_metadata?: unknown;
-    done?: unknown;
-  };
-  if (c.content_type !== undefined && c.content_type !== "audio") return null;
-  const meta = (c.content_metadata ?? {}) as {
-    sample_rate?: unknown;
-    channels?: unknown;
-  };
-  const sampleRate =
-    typeof meta.sample_rate === "number" && meta.sample_rate > 0
-      ? meta.sample_rate
-      : DEFAULT_SAMPLE_RATE;
-  const channels =
-    typeof meta.channels === "number" && meta.channels > 0 ? meta.channels : 1;
-  const content = typeof c.content === "string" ? c.content : "";
-  return {
-    bytes: content ? base64ToBytes(content) : new Uint8Array(),
-    sampleRate,
-    channels,
-    done: Boolean(c.done ?? false)
-  };
-}
-
-const CHUNK_PROP_DEFAULT = {
-  type: "chunk",
-  node_id: null,
-  thread_id: null,
-  workflow_id: null,
-  content_type: "audio",
-  content: "",
-  content_metadata: {},
-  done: false,
-  thinking: false
-};
+const DEFAULT_SAMPLE_RATE = SYNTH_SAMPLE_RATE;
 
 // ── AudioToChunks ──────────────────────────────────────────────────
 
@@ -186,35 +116,12 @@ export class AudioToChunksNode extends BaseNode {
     for (let start = 0; start < totalFrames; start += framesPerChunk) {
       const end = Math.min(start + framesPerChunk, totalFrames);
       const slice = samples.subarray(start * channels, end * channels);
-      const meta: AudioChunkMetadata = {
-        encoding: "pcm16le",
-        sample_rate: sampleRate,
-        channels,
-        format: "pcm",
-        duration_seconds: (end - start) / sampleRate
-      };
       yield {
-        chunk: makeAudioChunk(
-          bytesToBase64(float32ToPcm16(slice)),
-          meta,
-          false
-        )
+        chunk: makeSignalChunk(slice, sampleRate, channels, false, "pcm16le")
       };
     }
 
-    yield {
-      chunk: makeAudioChunk(
-        "",
-        {
-          encoding: "pcm16le",
-          sample_rate: sampleRate,
-          channels,
-          format: "pcm",
-          duration_seconds: 0
-        },
-        true
-      )
-    };
+    yield { chunk: makeDoneSignalChunk(sampleRate, channels, "pcm16le") };
   }
 }
 
@@ -246,26 +153,36 @@ export class ChunksToAudioNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const parts: Uint8Array[] = [];
+    const parts: Float32Array[] = [];
+    let total = 0;
     let sampleRate = DEFAULT_SAMPLE_RATE;
     let channels = 1;
     let formatSeen = false;
 
     for await (const item of inputs.stream("chunk")) {
-      const chunk = readChunk(item);
+      const chunk = readSignalChunk(item);
       if (!chunk) continue;
-      if (!formatSeen && chunk.bytes.length > 0) {
+      if (!formatSeen && chunk.samples.length > 0) {
         sampleRate = chunk.sampleRate;
         channels = chunk.channels;
         formatSeen = true;
       }
-      if (chunk.bytes.length > 0) parts.push(chunk.bytes);
+      if (chunk.samples.length > 0) {
+        parts.push(chunk.samples);
+        total += chunk.samples.length;
+      }
       if (chunk.done) break;
     }
 
+    const samples = new Float32Array(total);
+    let offset = 0;
+    for (const part of parts) {
+      samples.set(part, offset);
+      offset += part.length;
+    }
     await outputs.emit(
       "audio",
-      audioRefFromWav(encodePcm16Wav(concatBytes(parts), sampleRate, channels))
+      audioRefFromWav(encodeWav(samples, sampleRate, channels))
     );
   }
 }
@@ -313,32 +230,29 @@ export class StreamingGainNode extends BaseNode {
     const factor = Math.pow(10, gainDb / 20);
 
     for await (const item of inputs.stream("chunk")) {
-      const chunk = readChunk(item);
+      const chunk = readSignalChunk(item);
       if (!chunk) continue;
-
-      const meta: AudioChunkMetadata = {
-        encoding: "pcm16le",
-        sample_rate: chunk.sampleRate,
-        channels: chunk.channels,
-        format: "pcm",
-        duration_seconds:
-          chunk.bytes.length / 2 / chunk.channels / chunk.sampleRate
-      };
 
       if (chunk.done) {
         await outputs.emit(
           "chunk",
-          makeAudioChunk("", { ...meta, duration_seconds: 0 }, true)
+          makeDoneSignalChunk(chunk.sampleRate, chunk.channels, "pcm16le")
         );
         break;
       }
-      if (chunk.bytes.length === 0) continue;
+      if (chunk.samples.length === 0) continue;
 
-      const samples = pcm16ToFloat32(chunk.bytes);
+      const samples = chunk.samples;
       for (let i = 0; i < samples.length; i++) samples[i] *= factor;
       await outputs.emit(
         "chunk",
-        makeAudioChunk(bytesToBase64(float32ToPcm16(samples)), meta, false)
+        makeSignalChunk(
+          samples,
+          chunk.sampleRate,
+          chunk.channels,
+          false,
+          "pcm16le"
+        )
       );
     }
   }
@@ -362,42 +276,35 @@ async function runStreamingFilter(
   let states: BiquadState[] = [];
 
   for await (const item of inputs.stream("chunk")) {
-    const chunk = readChunk(item);
+    const chunk = readSignalChunk(item);
     if (!chunk) continue;
-
-    const meta: AudioChunkMetadata = {
-      encoding: "pcm16le",
-      sample_rate: chunk.sampleRate,
-      channels: chunk.channels,
-      format: "pcm",
-      duration_seconds:
-        chunk.bytes.length / 2 / chunk.channels / chunk.sampleRate
-    };
 
     if (chunk.done) {
       await outputs.emit(
         "chunk",
-        makeAudioChunk("", { ...meta, duration_seconds: 0 }, true)
+        makeDoneSignalChunk(chunk.sampleRate, chunk.channels, "pcm16le")
       );
       break;
     }
-    if (chunk.bytes.length === 0) continue;
+    if (chunk.samples.length === 0) continue;
 
     if (!coeffs) {
       coeffs = biquadCoeffs(type, chunk.sampleRate, frequency, q, 0);
       states = Array.from({ length: chunk.channels }, createBiquadState);
     }
 
-    const planes = deinterleave(pcm16ToFloat32(chunk.bytes), chunk.channels);
+    const planes = deinterleave(chunk.samples, chunk.channels);
     const filtered = planes.map((plane, ch) =>
       processBiquad(coeffs!, states[ch] ?? createBiquadState(), plane)
     );
     await outputs.emit(
       "chunk",
-      makeAudioChunk(
-        bytesToBase64(float32ToPcm16(interleave(filtered))),
-        meta,
-        false
+      makeSignalChunk(
+        interleave(filtered),
+        chunk.sampleRate,
+        chunk.channels,
+        false,
+        "pcm16le"
       )
     );
   }

--- a/packages/audio-nodes/src/nodes/realtime-audio.ts
+++ b/packages/audio-nodes/src/nodes/realtime-audio.ts
@@ -1,0 +1,524 @@
+/**
+ * Realtime/streaming audio nodes — chunked PCM16LE audio flowing through the
+ * kernel's streaming machinery.
+ *
+ * Chunk convention (shared with the elevenlabs realtime nodes and the web
+ * app's `useRealtimeAudioStream`): `content` carries base64 PCM16LE bytes,
+ * `content_type` is `"audio"`, `content_metadata` describes the format, and
+ * end-of-stream is an empty-content chunk with `done: true`.
+ *
+ * All nodes here are pure sample math — no WebAudio, no node-only APIs — so
+ * they run on Node and in the browser workflow runner alike. The streaming
+ * filters keep biquad state across chunks (see `lib/biquad.ts`), which is the
+ * point: a per-chunk batch filter would lose its delay line at every chunk
+ * boundary.
+ */
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type {
+  NodeClass,
+  StreamingInputs,
+  StreamingOutputs
+} from "@nodetool-ai/node-sdk";
+import type { OutputCorrelation } from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  base64ToBytes,
+  bytesToBase64,
+  tagAsHybrid
+} from "@nodetool-ai/nodes-utils";
+import {
+  audioBytesAsync,
+  audioRefFromWav,
+  concatBytes,
+  deinterleave,
+  encodePcm16Wav,
+  float32ToPcm16,
+  interleave,
+  parseWavBytes,
+  pcm16ToFloat32
+} from "../lib/audio-wav.js";
+import {
+  biquadCoeffs,
+  createBiquadState,
+  processBiquad,
+  DEFAULT_Q,
+  type BiquadState,
+  type BiquadType
+} from "../lib/biquad.js";
+
+// ── Chunk helpers ──────────────────────────────────────────────────
+
+const DEFAULT_SAMPLE_RATE = 24000;
+
+interface AudioChunkMetadata {
+  encoding: "pcm16le";
+  sample_rate: number;
+  channels: number;
+  format: string;
+  duration_seconds: number;
+}
+
+function makeAudioChunk(
+  content: string,
+  meta: AudioChunkMetadata,
+  done: boolean
+): Record<string, unknown> {
+  return {
+    type: "chunk",
+    content,
+    done,
+    content_type: "audio",
+    content_metadata: meta
+  };
+}
+
+interface ParsedAudioChunk {
+  bytes: Uint8Array;
+  sampleRate: number;
+  channels: number;
+  done: boolean;
+}
+
+/**
+ * Parse a streamed item as an audio chunk. Returns null for non-audio chunks
+ * (e.g. text) and non-chunk values, which callers skip.
+ */
+function readChunk(item: unknown): ParsedAudioChunk | null {
+  if (!item || typeof item !== "object") return null;
+  const c = item as {
+    content?: unknown;
+    content_type?: unknown;
+    content_metadata?: unknown;
+    done?: unknown;
+  };
+  if (c.content_type !== undefined && c.content_type !== "audio") return null;
+  const meta = (c.content_metadata ?? {}) as {
+    sample_rate?: unknown;
+    channels?: unknown;
+  };
+  const sampleRate =
+    typeof meta.sample_rate === "number" && meta.sample_rate > 0
+      ? meta.sample_rate
+      : DEFAULT_SAMPLE_RATE;
+  const channels =
+    typeof meta.channels === "number" && meta.channels > 0 ? meta.channels : 1;
+  const content = typeof c.content === "string" ? c.content : "";
+  return {
+    bytes: content ? base64ToBytes(content) : new Uint8Array(),
+    sampleRate,
+    channels,
+    done: Boolean(c.done ?? false)
+  };
+}
+
+const CHUNK_PROP_DEFAULT = {
+  type: "chunk",
+  node_id: null,
+  thread_id: null,
+  workflow_id: null,
+  content_type: "audio",
+  content: "",
+  content_metadata: {},
+  done: false,
+  thinking: false
+};
+
+// ── AudioToChunks ──────────────────────────────────────────────────
+
+export class AudioToChunksNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.AudioToChunks";
+  static readonly title = "Audio To Chunks";
+  static readonly description =
+    "Slices an audio file into a stream of fixed-duration PCM16 chunks.\n    audio, stream, chunk, realtime\n\n    Use cases:\n    - Feed batch audio into realtime/streaming nodes\n    - Simulate a live audio feed from a recording\n    - Drive streaming effects and transcription nodes";
+  static readonly metadataOutputTypes = {
+    chunk: "chunk"
+  };
+  static readonly outputCorrelation: Record<string, OutputCorrelation> = {
+    chunk: { kind: "iteration", source: "__execution__", group: "stream" }
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["audio"];
+
+  @prop({
+    type: "audio",
+    default: {
+      type: "audio",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    },
+    title: "Audio",
+    description: "The audio file to slice into chunks (must be WAV)."
+  })
+  declare audio: any;
+
+  @prop({
+    type: "float",
+    default: 0.25,
+    title: "Chunk Duration",
+    description: "Duration of each emitted chunk in seconds.",
+    min: 0.01,
+    max: 10
+  })
+  declare chunk_duration: any;
+
+  // Required by BaseNode but unused — genProcess is the execution path
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async *genProcess(
+    context?: ProcessingContext
+  ): AsyncGenerator<Record<string, unknown>> {
+    const audio = (this.audio ?? {}) as Record<string, unknown>;
+    const chunkDuration = Number(this.chunk_duration ?? 0.25);
+
+    const bytes = await audioBytesAsync(audio, context);
+    const wav = parseWavBytes(bytes);
+    if (!wav) throw new Error("AudioToChunks requires a valid WAV input");
+
+    const { samples, sampleRate, numChannels } = wav;
+    const channels = Math.max(1, numChannels);
+    const totalFrames = Math.floor(samples.length / channels);
+    const framesPerChunk = Math.max(1, Math.round(chunkDuration * sampleRate));
+
+    for (let start = 0; start < totalFrames; start += framesPerChunk) {
+      const end = Math.min(start + framesPerChunk, totalFrames);
+      const slice = samples.subarray(start * channels, end * channels);
+      const meta: AudioChunkMetadata = {
+        encoding: "pcm16le",
+        sample_rate: sampleRate,
+        channels,
+        format: "pcm",
+        duration_seconds: (end - start) / sampleRate
+      };
+      yield {
+        chunk: makeAudioChunk(
+          bytesToBase64(float32ToPcm16(slice)),
+          meta,
+          false
+        )
+      };
+    }
+
+    yield {
+      chunk: makeAudioChunk(
+        "",
+        {
+          encoding: "pcm16le",
+          sample_rate: sampleRate,
+          channels,
+          format: "pcm",
+          duration_seconds: 0
+        },
+        true
+      )
+    };
+  }
+}
+
+// ── ChunksToAudio ──────────────────────────────────────────────────
+
+export class ChunksToAudioNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.ChunksToAudio";
+  static readonly title = "Chunks To Audio";
+  static readonly description =
+    "Accumulates a stream of PCM16 audio chunks into a single audio file.\n    audio, stream, chunk, realtime, accumulate\n\n    Use cases:\n    - Capture the output of streaming TTS or effects as a file\n    - Terminate a realtime audio chain with a playable result\n    - Record a processed live feed";
+  static readonly metadataOutputTypes = {
+    audio: "audio"
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["chunk"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Chunk",
+    description: "Stream of PCM16LE audio chunks to accumulate."
+  })
+  declare chunk: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const parts: Uint8Array[] = [];
+    let sampleRate = DEFAULT_SAMPLE_RATE;
+    let channels = 1;
+    let formatSeen = false;
+
+    for await (const item of inputs.stream("chunk")) {
+      const chunk = readChunk(item);
+      if (!chunk) continue;
+      if (!formatSeen && chunk.bytes.length > 0) {
+        sampleRate = chunk.sampleRate;
+        channels = chunk.channels;
+        formatSeen = true;
+      }
+      if (chunk.bytes.length > 0) parts.push(chunk.bytes);
+      if (chunk.done) break;
+    }
+
+    await outputs.emit(
+      "audio",
+      audioRefFromWav(encodePcm16Wav(concatBytes(parts), sampleRate, channels))
+    );
+  }
+}
+
+// ── StreamingGain ──────────────────────────────────────────────────
+
+export class StreamingGainNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.StreamingGain";
+  static readonly title = "Streaming Gain";
+  static readonly description =
+    "Applies a gain (volume adjustment) to each chunk of a realtime audio stream.\n    audio, stream, chunk, realtime, effect, volume\n\n    Use cases:\n    - Adjust the level of a live audio feed\n    - Balance streaming sources before mixing\n    - Attenuate or boost streaming TTS output";
+  static readonly metadataOutputTypes = {
+    chunk: "chunk"
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["chunk"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Chunk",
+    description: "Stream of PCM16LE audio chunks to process."
+  })
+  declare chunk: any;
+
+  @prop({
+    type: "float",
+    default: 0,
+    title: "Gain Db",
+    description:
+      "Gain to apply in decibels. Positive values increase volume, negative values decrease it.",
+    min: -60,
+    max: 24
+  })
+  declare gain_db: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const gainDb = Number(this.gain_db ?? 0);
+    const factor = Math.pow(10, gainDb / 20);
+
+    for await (const item of inputs.stream("chunk")) {
+      const chunk = readChunk(item);
+      if (!chunk) continue;
+
+      const meta: AudioChunkMetadata = {
+        encoding: "pcm16le",
+        sample_rate: chunk.sampleRate,
+        channels: chunk.channels,
+        format: "pcm",
+        duration_seconds:
+          chunk.bytes.length / 2 / chunk.channels / chunk.sampleRate
+      };
+
+      if (chunk.done) {
+        await outputs.emit(
+          "chunk",
+          makeAudioChunk("", { ...meta, duration_seconds: 0 }, true)
+        );
+        break;
+      }
+      if (chunk.bytes.length === 0) continue;
+
+      const samples = pcm16ToFloat32(chunk.bytes);
+      for (let i = 0; i < samples.length; i++) samples[i] *= factor;
+      await outputs.emit(
+        "chunk",
+        makeAudioChunk(bytesToBase64(float32ToPcm16(samples)), meta, false)
+      );
+    }
+  }
+}
+
+// ── Streaming biquad filters ───────────────────────────────────────
+
+/**
+ * Shared body of the streaming low/high-pass filters: one biquad per channel
+ * whose state persists across chunk boundaries, so the filter behaves exactly
+ * as if it had processed the unchunked signal.
+ */
+async function runStreamingFilter(
+  type: BiquadType,
+  frequency: number,
+  q: number,
+  inputs: StreamingInputs,
+  outputs: StreamingOutputs
+): Promise<void> {
+  let coeffs: ReturnType<typeof biquadCoeffs> | null = null;
+  let states: BiquadState[] = [];
+
+  for await (const item of inputs.stream("chunk")) {
+    const chunk = readChunk(item);
+    if (!chunk) continue;
+
+    const meta: AudioChunkMetadata = {
+      encoding: "pcm16le",
+      sample_rate: chunk.sampleRate,
+      channels: chunk.channels,
+      format: "pcm",
+      duration_seconds:
+        chunk.bytes.length / 2 / chunk.channels / chunk.sampleRate
+    };
+
+    if (chunk.done) {
+      await outputs.emit(
+        "chunk",
+        makeAudioChunk("", { ...meta, duration_seconds: 0 }, true)
+      );
+      break;
+    }
+    if (chunk.bytes.length === 0) continue;
+
+    if (!coeffs) {
+      coeffs = biquadCoeffs(type, chunk.sampleRate, frequency, q, 0);
+      states = Array.from({ length: chunk.channels }, createBiquadState);
+    }
+
+    const planes = deinterleave(pcm16ToFloat32(chunk.bytes), chunk.channels);
+    const filtered = planes.map((plane, ch) =>
+      processBiquad(coeffs!, states[ch] ?? createBiquadState(), plane)
+    );
+    await outputs.emit(
+      "chunk",
+      makeAudioChunk(
+        bytesToBase64(float32ToPcm16(interleave(filtered))),
+        meta,
+        false
+      )
+    );
+  }
+}
+
+export class StreamingLowPassNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.StreamingLowPass";
+  static readonly title = "Streaming Low Pass";
+  static readonly description =
+    "Applies a low-pass filter to a realtime audio stream, keeping filter state across chunks.\n    audio, stream, chunk, realtime, effect, equalizer\n\n    Use cases:\n    - Soften a live audio feed\n    - Remove high-frequency noise from streaming audio\n    - Create realtime dub-style effects";
+  static readonly metadataOutputTypes = {
+    chunk: "chunk"
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["chunk"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Chunk",
+    description: "Stream of PCM16LE audio chunks to process."
+  })
+  declare chunk: any;
+
+  @prop({
+    type: "float",
+    default: 5000,
+    title: "Cutoff Frequency Hz",
+    description: "The cutoff frequency of the low-pass filter in Hz.",
+    min: 500,
+    max: 20000
+  })
+  declare cutoff_frequency_hz: any;
+
+  @prop({
+    type: "float",
+    default: DEFAULT_Q,
+    title: "Q",
+    description: "Filter resonance (quality factor).",
+    min: 0.1,
+    max: 10
+  })
+  declare q: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    await runStreamingFilter(
+      "lowpass",
+      Number(this.cutoff_frequency_hz ?? 5000),
+      Number(this.q ?? DEFAULT_Q),
+      inputs,
+      outputs
+    );
+  }
+}
+
+export class StreamingHighPassNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.StreamingHighPass";
+  static readonly title = "Streaming High Pass";
+  static readonly description =
+    "Applies a high-pass filter to a realtime audio stream, keeping filter state across chunks.\n    audio, stream, chunk, realtime, effect, equalizer\n\n    Use cases:\n    - Remove rumble from a live microphone feed\n    - Clean up the low end of streaming audio\n    - Thin out streaming sources before mixing";
+  static readonly metadataOutputTypes = {
+    chunk: "chunk"
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["chunk"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Chunk",
+    description: "Stream of PCM16LE audio chunks to process."
+  })
+  declare chunk: any;
+
+  @prop({
+    type: "float",
+    default: 80,
+    title: "Cutoff Frequency Hz",
+    description: "The cutoff frequency of the high-pass filter in Hz.",
+    min: 20,
+    max: 5000
+  })
+  declare cutoff_frequency_hz: any;
+
+  @prop({
+    type: "float",
+    default: DEFAULT_Q,
+    title: "Q",
+    description: "Filter resonance (quality factor).",
+    min: 0.1,
+    max: 10
+  })
+  declare q: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    await runStreamingFilter(
+      "highpass",
+      Number(this.cutoff_frequency_hz ?? 80),
+      Number(this.q ?? DEFAULT_Q),
+      inputs,
+      outputs
+    );
+  }
+}
+
+export const REALTIME_AUDIO_NODES: readonly NodeClass[] = tagAsHybrid([
+  AudioToChunksNode,
+  ChunksToAudioNode,
+  StreamingGainNode,
+  StreamingLowPassNode,
+  StreamingHighPassNode
+]);

--- a/packages/audio-nodes/src/nodes/synthesis.ts
+++ b/packages/audio-nodes/src/nodes/synthesis.ts
@@ -1,0 +1,1198 @@
+/**
+ * Modular synthesis nodes (`nodetool.audio.synth.*`) — a subtractive synth
+ * voice operating on streamed signal chunks: oscillator, LFO, ADSR, gate
+ * source, VCA, VCF, CV utilities, and a mixer.
+ *
+ * Timing is sample-domain: time = sample count, never the wall clock.
+ * Generators render a bounded duration deterministically (or run infinitely
+ * with `realtime: true`, paced by `RealtimePacer` — pacing delays emission
+ * but never changes signal content). Driven nodes derive all timing from
+ * their input chunks (one output chunk per input chunk, same frame count),
+ * so a patch driven by one Gate source is sample-aligned by construction.
+ *
+ * Control voltage (CV) is a first-class socket type riding the chunk wire
+ * shape with `encoding: "f32le"` (see ../lib/cv.ts) — interchangeable with
+ * audio chunk streams, Eurorack-style. Pitch CV is volts/octave equivalent:
+ * `freq = base_frequency * 2^cv`, cv in octaves.
+ *
+ * Limitation: the workflow graph is a strict DAG — feedback patching (e.g.
+ * an envelope modulating its own gate) is not supported.
+ */
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type {
+  NodeClass,
+  StreamingInputs,
+  StreamingOutputs
+} from "@nodetool-ai/node-sdk";
+import { tagAsHybrid } from "@nodetool-ai/nodes-utils";
+import { deinterleave, interleave } from "../lib/audio-wav.js";
+import {
+  alignedSignalStreams,
+  CHUNK_PROP_DEFAULT,
+  makeDoneSignalChunk,
+  makeSignalChunk,
+  readSignalChunk,
+  RealtimePacer,
+  SampleFifo,
+  SYNTH_CHUNK_FRAMES,
+  SYNTH_SAMPLE_RATE,
+  type SignalEncoding
+} from "../lib/cv.js";
+import {
+  biquadCoeffs,
+  createBiquadState,
+  processBiquad,
+  DEFAULT_Q,
+  type BiquadState
+} from "../lib/biquad.js";
+import {
+  adsrCoeff,
+  adsrStep,
+  createAdsrState,
+  GATE_THRESHOLD,
+  oscSample,
+  type Waveform
+} from "../lib/synth-dsp.js";
+
+// ── Shared generator scaffolding ───────────────────────────────────
+
+/**
+ * Run a bounded (or realtime-infinite) generator loop: calls `fill` to
+ * produce each chunk's samples, paces with the wall clock when `realtime`,
+ * and stops on run cancellation. `totalFrames === Infinity` only when the
+ * caller has validated `realtime` is on.
+ */
+async function runGenerator(
+  outputs: StreamingOutputs,
+  opts: {
+    slot: string;
+    sampleRate: number;
+    encoding: SignalEncoding;
+    totalFrames: number;
+    realtime: boolean;
+    signal: AbortSignal;
+    fill: (buf: Float32Array, startFrame: number) => void;
+  }
+): Promise<void> {
+  const { slot, sampleRate, encoding, totalFrames, realtime, signal } = opts;
+  const pacer = realtime ? new RealtimePacer(signal) : null;
+  let emitted = 0;
+  while (emitted < totalFrames) {
+    if (signal.aborted) break;
+    const frames = Math.min(SYNTH_CHUNK_FRAMES, totalFrames - emitted);
+    if (pacer && !(await pacer.waitNext((frames / sampleRate) * 1000))) break;
+    const buf = new Float32Array(frames);
+    opts.fill(buf, emitted);
+    await outputs.emit(
+      slot,
+      makeSignalChunk(buf, sampleRate, 1, false, encoding)
+    );
+    emitted += frames;
+  }
+  await outputs.emit(slot, makeDoneSignalChunk(sampleRate, 1, encoding));
+}
+
+/**
+ * Frame budget for a generator: `seconds <= 0` means infinite, which is
+ * only legal in realtime mode (inbox buffering is unbounded by default — an
+ * unpaced infinite producer would never terminate and exhaust memory).
+ */
+function generatorFrames(
+  seconds: number,
+  sampleRate: number,
+  realtime: boolean,
+  what: string
+): number {
+  if (seconds > 0) return Math.max(1, Math.round(seconds * sampleRate));
+  if (!realtime) {
+    throw new Error(
+      `${what} of 0 (infinite) requires realtime: true — an unpaced infinite generator would run unbounded`
+    );
+  }
+  return Infinity;
+}
+
+/** Channel 0 of an interleaved chunk — CV inputs are conceptually mono. */
+function chunkMono(samples: Float32Array, channels: number): Float32Array {
+  const ch = Math.max(1, channels);
+  if (ch === 1) return samples;
+  const frames = Math.floor(samples.length / ch);
+  const out = new Float32Array(frames);
+  for (let i = 0; i < frames; i++) out[i] = samples[i * ch];
+  return out;
+}
+
+// ── Oscillator (VCO) ───────────────────────────────────────────────
+
+export class OscillatorNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.Oscillator";
+  static readonly title = "Oscillator";
+  static readonly description =
+    "Voltage-controlled oscillator generating sine, saw, square, triangle or noise audio.\n    audio, synthesis, oscillator, vco, modular\n\n    Pitch CV is volts/octave: freq = frequency * 2^cv (cv in octaves). With pitch_cv or fm patched, output follows that stream's chunk cadence (sample-aligned); otherwise it free-runs for `duration` seconds (0 = infinite, realtime only). Naive waveforms — saw/square alias at high frequencies.\n\n    Use cases:\n    - Sound source for a modular synth voice\n    - FM/vibrato via the fm input driven by an LFO\n    - Melodic sequences via a pitch CV stream";
+  static readonly metadataOutputTypes = { chunk: "chunk" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["pitch_cv", "fm"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Pitch CV",
+    description:
+      "Pitch control stream in octaves (volts/octave): freq = frequency * 2^cv. When patched, drives the output chunk cadence."
+  })
+  declare pitch_cv: any;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "FM",
+    description:
+      "Linear frequency modulation stream: freq is multiplied by (1 + fm_amount * fm)."
+  })
+  declare fm: any;
+
+  @prop({
+    type: "enum",
+    default: "sine",
+    title: "Waveform",
+    description: "Oscillator waveform.",
+    values: ["sine", "saw", "square", "triangle", "noise"]
+  })
+  declare waveform: any;
+
+  @prop({
+    type: "float",
+    default: 220,
+    title: "Frequency",
+    description: "Base frequency in Hz.",
+    min: 0.1,
+    max: 20000
+  })
+  declare frequency: any;
+
+  @prop({
+    type: "float",
+    default: 0.8,
+    title: "Amplitude",
+    description: "Output amplitude (linear).",
+    min: 0,
+    max: 1
+  })
+  declare amplitude: any;
+
+  @prop({
+    type: "float",
+    default: 0.5,
+    title: "Pulse Width",
+    description: "Duty cycle for the square waveform.",
+    min: 0.05,
+    max: 0.95
+  })
+  declare pulse_width: any;
+
+  @prop({
+    type: "float",
+    default: 0,
+    title: "FM Amount",
+    description: "Depth of linear frequency modulation from the fm input.",
+    min: 0,
+    max: 10
+  })
+  declare fm_amount: any;
+
+  @prop({
+    type: "float",
+    default: 2,
+    title: "Duration",
+    description:
+      "Free-run render length in seconds. 0 = infinite (requires realtime). Ignored when pitch_cv/fm is patched.",
+    min: 0,
+    max: 600
+  })
+  declare duration: any;
+
+  @prop({
+    type: "int",
+    default: SYNTH_SAMPLE_RATE,
+    title: "Sample Rate",
+    description: "Free-run sample rate in Hz.",
+    min: 8000,
+    max: 96000
+  })
+  declare sample_rate: any;
+
+  @prop({
+    type: "bool",
+    default: false,
+    title: "Realtime",
+    description:
+      "Pace free-run emission with the wall clock (content is identical to a free run)."
+  })
+  declare realtime: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const waveform = String(this.waveform ?? "sine") as Waveform;
+    const baseFreq = Number(this.frequency ?? 220);
+    const amplitude = Number(this.amplitude ?? 0.8);
+    const pulseWidth = Number(this.pulse_width ?? 0.5);
+    const fmAmount = Number(this.fm_amount ?? 0);
+
+    // Double-precision phase accumulator carried across chunks — no drift.
+    let phase = 0;
+    const sampleAt = (freq: number, sampleRate: number): number => {
+      const f = Math.min(Math.max(freq, 0), sampleRate / 2 - 1e-6);
+      const out = amplitude * oscSample(waveform, phase, pulseWidth);
+      phase = (phase + f / sampleRate) % 1;
+      return out;
+    };
+
+    const hasPitch = inputs.hasStream("pitch_cv");
+    const hasFm = inputs.hasStream("fm");
+
+    if (hasPitch || hasFm) {
+      // Clocked: the patched CV stream drives chunk cadence; the other
+      // handle (if any) is frame-aligned via zip-with-hold.
+      const primary = hasPitch ? "pitch_cv" : "fm";
+      const secondary = hasPitch ? "fm" : "pitch_cv";
+      let sampleRate = SYNTH_SAMPLE_RATE;
+      for await (const frame of alignedSignalStreams(inputs, {
+        primary,
+        cvHandles: [secondary]
+      })) {
+        sampleRate = frame.primary.sampleRate;
+        const drive = chunkMono(frame.primary.samples, frame.primary.channels);
+        const other = frame.cv[secondary];
+        const buf = new Float32Array(drive.length);
+        for (let i = 0; i < drive.length; i++) {
+          const pitch = hasPitch ? drive[i] : (other?.[i] ?? 0);
+          const fm = hasPitch ? (other?.[i] ?? 0) : drive[i];
+          const freq = baseFreq * Math.pow(2, pitch) * (1 + fmAmount * fm);
+          buf[i] = sampleAt(freq, sampleRate);
+        }
+        await outputs.emit(
+          "chunk",
+          makeSignalChunk(buf, sampleRate, 1, false, "pcm16le")
+        );
+      }
+      await outputs.emit(
+        "chunk",
+        makeDoneSignalChunk(sampleRate, 1, "pcm16le")
+      );
+      return;
+    }
+
+    const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
+    const realtime = Boolean(this.realtime ?? false);
+    const totalFrames = generatorFrames(
+      Number(this.duration ?? 2),
+      sampleRate,
+      realtime,
+      "Oscillator duration"
+    );
+    await runGenerator(outputs, {
+      slot: "chunk",
+      sampleRate,
+      encoding: "pcm16le",
+      totalFrames,
+      realtime,
+      signal: inputs.signal,
+      fill: (buf) => {
+        for (let i = 0; i < buf.length; i++) {
+          buf[i] = sampleAt(baseFreq, sampleRate);
+        }
+      }
+    });
+  }
+}
+
+// ── LFO ────────────────────────────────────────────────────────────
+
+export class LfoNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.LFO";
+  static readonly title = "LFO";
+  static readonly description =
+    "Low-frequency oscillator emitting a control-voltage stream.\n    cv, synthesis, lfo, modulation, modular\n\n    Output is offset + depth * wave(phase). With a clock patched, emits one chunk per clock chunk (sample-aligned) and resets phase on each clock rising edge; otherwise free-runs for `duration` seconds (0 = infinite, realtime only).\n\n    Use cases:\n    - Vibrato/tremolo via Oscillator fm or VCA cv\n    - Filter sweeps via VCF cutoff_cv\n    - Slow parameter drift in generative patches";
+  static readonly metadataOutputTypes = { cv: "cv" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["clock"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Clock",
+    description:
+      "Optional clock stream: drives chunk cadence; phase resets on each rising edge."
+  })
+  declare clock: any;
+
+  @prop({
+    type: "enum",
+    default: "sine",
+    title: "Waveform",
+    description: "LFO waveform.",
+    values: ["sine", "triangle", "saw", "square"]
+  })
+  declare waveform: any;
+
+  @prop({
+    type: "float",
+    default: 2,
+    title: "Rate Hz",
+    description: "LFO frequency in Hz.",
+    min: 0.01,
+    max: 100
+  })
+  declare rate_hz: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Depth",
+    description: "Output amplitude scale.",
+    min: 0,
+    max: 10
+  })
+  declare depth: any;
+
+  @prop({
+    type: "float",
+    default: 0,
+    title: "Offset",
+    description: "Constant added to the output.",
+    min: -10,
+    max: 10
+  })
+  declare offset: any;
+
+  @prop({
+    type: "float",
+    default: 4,
+    title: "Duration",
+    description:
+      "Free-run render length in seconds. 0 = infinite (requires realtime). Ignored when clock is patched.",
+    min: 0,
+    max: 600
+  })
+  declare duration: any;
+
+  @prop({
+    type: "int",
+    default: SYNTH_SAMPLE_RATE,
+    title: "Sample Rate",
+    description: "Free-run sample rate in Hz.",
+    min: 8000,
+    max: 96000
+  })
+  declare sample_rate: any;
+
+  @prop({
+    type: "bool",
+    default: false,
+    title: "Realtime",
+    description:
+      "Pace free-run emission with the wall clock (content is identical to a free run)."
+  })
+  declare realtime: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const waveform = String(this.waveform ?? "sine") as Waveform;
+    const rateHz = Number(this.rate_hz ?? 2);
+    const depth = Number(this.depth ?? 1);
+    const offset = Number(this.offset ?? 0);
+
+    let phase = 0;
+
+    if (inputs.hasStream("clock")) {
+      let sampleRate = SYNTH_SAMPLE_RATE;
+      let clockWasHigh = false;
+      for await (const item of inputs.stream("clock")) {
+        const chunk = readSignalChunk(item);
+        if (!chunk) continue;
+        if (chunk.done) break;
+        if (chunk.samples.length === 0) continue;
+        sampleRate = chunk.sampleRate;
+        const clock = chunkMono(chunk.samples, chunk.channels);
+        const buf = new Float32Array(clock.length);
+        for (let i = 0; i < clock.length; i++) {
+          const high = clock[i] >= GATE_THRESHOLD;
+          if (high && !clockWasHigh) phase = 0; // sample-accurate reset
+          clockWasHigh = high;
+          buf[i] = offset + depth * oscSample(waveform, phase);
+          phase = (phase + rateHz / sampleRate) % 1;
+        }
+        await outputs.emit(
+          "cv",
+          makeSignalChunk(buf, sampleRate, 1, false, "f32le")
+        );
+      }
+      await outputs.emit("cv", makeDoneSignalChunk(sampleRate, 1, "f32le"));
+      return;
+    }
+
+    const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
+    const realtime = Boolean(this.realtime ?? false);
+    const totalFrames = generatorFrames(
+      Number(this.duration ?? 4),
+      sampleRate,
+      realtime,
+      "LFO duration"
+    );
+    await runGenerator(outputs, {
+      slot: "cv",
+      sampleRate,
+      encoding: "f32le",
+      totalFrames,
+      realtime,
+      signal: inputs.signal,
+      fill: (buf) => {
+        for (let i = 0; i < buf.length; i++) {
+          buf[i] = offset + depth * oscSample(waveform, phase);
+          phase = (phase + rateHz / sampleRate) % 1;
+        }
+      }
+    });
+  }
+}
+
+// ── ADSR ───────────────────────────────────────────────────────────
+
+export class AdsrNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.ADSR";
+  static readonly title = "ADSR";
+  static readonly description =
+    "ADSR envelope generator driven by a gate CV stream.\n    cv, synthesis, envelope, adsr, modular\n\n    Gate edges (threshold 0.5) are detected at exact sample offsets inside chunks; attack/decay/release run as exponential one-pole segments counted in samples, so timing is sample-accurate without any clock. Emits one envelope chunk per gate chunk (same frame count). Retriggering mid-release continues from the current level.\n\n    Use cases:\n    - Amplitude envelope via VCA cv\n    - Filter envelope via VCF cutoff_cv\n    - Click-free gating of any signal";
+  static readonly metadataOutputTypes = { cv: "cv" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["gate"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Gate",
+    description: "Gate CV stream — values ≥ 0.5 count as gate-high."
+  })
+  declare gate: any;
+
+  @prop({
+    type: "float",
+    default: 0.01,
+    title: "Attack",
+    description: "Attack time in seconds.",
+    min: 0.0005,
+    max: 10
+  })
+  declare attack: any;
+
+  @prop({
+    type: "float",
+    default: 0.1,
+    title: "Decay",
+    description: "Decay time in seconds.",
+    min: 0.0005,
+    max: 10
+  })
+  declare decay: any;
+
+  @prop({
+    type: "float",
+    default: 0.7,
+    title: "Sustain",
+    description: "Sustain level (0–1).",
+    min: 0,
+    max: 1
+  })
+  declare sustain: any;
+
+  @prop({
+    type: "float",
+    default: 0.3,
+    title: "Release",
+    description: "Release time in seconds.",
+    min: 0.0005,
+    max: 10
+  })
+  declare release: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const attack = Number(this.attack ?? 0.01);
+    const decay = Number(this.decay ?? 0.1);
+    const sustain = Number(this.sustain ?? 0.7);
+    const release = Number(this.release ?? 0.3);
+
+    const state = createAdsrState();
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let params = {
+      attackCoeff: adsrCoeff(attack, sampleRate),
+      decayCoeff: adsrCoeff(decay, sampleRate),
+      releaseCoeff: adsrCoeff(release, sampleRate),
+      sustain
+    };
+
+    for await (const item of inputs.stream("gate")) {
+      const chunk = readSignalChunk(item);
+      if (!chunk) continue;
+      if (chunk.done) break;
+      if (chunk.samples.length === 0) continue;
+      if (chunk.sampleRate !== sampleRate) {
+        sampleRate = chunk.sampleRate;
+        params = {
+          attackCoeff: adsrCoeff(attack, sampleRate),
+          decayCoeff: adsrCoeff(decay, sampleRate),
+          releaseCoeff: adsrCoeff(release, sampleRate),
+          sustain
+        };
+      }
+      const gate = chunkMono(chunk.samples, chunk.channels);
+      const buf = new Float32Array(gate.length);
+      for (let i = 0; i < gate.length; i++) {
+        buf[i] = adsrStep(state, gate[i] >= GATE_THRESHOLD, params);
+      }
+      await outputs.emit(
+        "cv",
+        makeSignalChunk(buf, sampleRate, 1, false, "f32le")
+      );
+    }
+    await outputs.emit("cv", makeDoneSignalChunk(sampleRate, 1, "f32le"));
+  }
+}
+
+// ── Gate ───────────────────────────────────────────────────────────
+
+export class GateNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.Gate";
+  static readonly title = "Gate";
+  static readonly description =
+    "Generates a repeating on/off gate CV pattern — the patch's master clock.\n    cv, synthesis, gate, trigger, clock, modular\n\n    Emits `amplitude` for on_duration seconds, 0 for off_duration, `repeats` times (0 = infinite, realtime only). Drive an ADSR with it; every node downstream is sample-aligned to it by construction, and with realtime: true the whole driven patch is wall-clock paced.\n\n    Use cases:\n    - Trigger envelopes rhythmically\n    - Master clock for clocked LFOs and sample & hold\n    - Live patches via realtime mode";
+  static readonly metadataOutputTypes = { cv: "cv" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = [];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "float",
+    default: 0.25,
+    title: "On Duration",
+    description: "Gate-high time per cycle in seconds.",
+    min: 0.001,
+    max: 60
+  })
+  declare on_duration: any;
+
+  @prop({
+    type: "float",
+    default: 0.25,
+    title: "Off Duration",
+    description: "Gate-low time per cycle in seconds.",
+    min: 0.001,
+    max: 60
+  })
+  declare off_duration: any;
+
+  @prop({
+    type: "int",
+    default: 4,
+    title: "Repeats",
+    description: "Number of on/off cycles. 0 = infinite (requires realtime).",
+    min: 0,
+    max: 1024
+  })
+  declare repeats: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Amplitude",
+    description: "Gate-high output level.",
+    min: 0,
+    max: 10
+  })
+  declare amplitude: any;
+
+  @prop({
+    type: "int",
+    default: SYNTH_SAMPLE_RATE,
+    title: "Sample Rate",
+    description: "Output sample rate in Hz.",
+    min: 8000,
+    max: 96000
+  })
+  declare sample_rate: any;
+
+  @prop({
+    type: "bool",
+    default: false,
+    title: "Realtime",
+    description:
+      "Pace emission with the wall clock (content is identical to a free run)."
+  })
+  declare realtime: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const onDuration = Number(this.on_duration ?? 0.25);
+    const offDuration = Number(this.off_duration ?? 0.25);
+    const repeats = Number(this.repeats ?? 4);
+    const amplitude = Number(this.amplitude ?? 1);
+    const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
+    const realtime = Boolean(this.realtime ?? false);
+
+    const onFrames = Math.max(1, Math.round(onDuration * sampleRate));
+    const periodFrames =
+      onFrames + Math.max(1, Math.round(offDuration * sampleRate));
+    const totalFrames = generatorFrames(
+      repeats > 0 ? (repeats * periodFrames) / sampleRate : 0,
+      sampleRate,
+      realtime,
+      "Gate repeats"
+    );
+
+    await runGenerator(outputs, {
+      slot: "cv",
+      sampleRate,
+      encoding: "f32le",
+      totalFrames,
+      realtime,
+      signal: inputs.signal,
+      fill: (buf, startFrame) => {
+        for (let i = 0; i < buf.length; i++) {
+          buf[i] =
+            (startFrame + i) % periodFrames < onFrames ? amplitude : 0;
+        }
+      }
+    });
+  }
+}
+
+// ── VCA ────────────────────────────────────────────────────────────
+
+export class VcaNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.VCA";
+  static readonly title = "VCA";
+  static readonly description =
+    "Voltage-controlled amplifier: multiplies an audio stream by a CV stream.\n    audio, cv, synthesis, vca, amplifier, modular\n\n    Output = audio * gain * max(0, cv) per sample (negative CV is clamped — a VCA doesn't invert). The audio input drives chunk cadence; the CV is frame-aligned with hold-last when it lags or ends. With nothing patched into cv, acts as a plain gain.\n\n    Use cases:\n    - Shape a note with an ADSR envelope\n    - Tremolo via an LFO\n    - Sidechain-style ducking from any CV source";
+  static readonly metadataOutputTypes = { chunk: "chunk" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["audio", "cv"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Audio",
+    description: "Audio chunk stream to amplify (drives chunk cadence)."
+  })
+  declare audio: any;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "CV",
+    description: "Amplitude control stream; negative values clamp to 0."
+  })
+  declare cv: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Gain",
+    description: "Constant gain multiplier.",
+    min: 0,
+    max: 10
+  })
+  declare gain: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const gain = Number(this.gain ?? 1);
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let channels = 1;
+
+    for await (const frame of alignedSignalStreams(inputs, {
+      primary: "audio",
+      cvHandles: ["cv"]
+    })) {
+      sampleRate = frame.primary.sampleRate;
+      channels = frame.primary.channels;
+      const input = frame.primary.samples;
+      const cv = frame.cv["cv"];
+      const buf = new Float32Array(input.length);
+      for (let i = 0; i < input.length; i++) {
+        const level =
+          cv !== undefined ? Math.max(0, cv[Math.floor(i / channels)]) : 1;
+        buf[i] = input[i] * gain * level;
+      }
+      await outputs.emit(
+        "chunk",
+        makeSignalChunk(buf, sampleRate, channels, false, "pcm16le")
+      );
+    }
+    await outputs.emit(
+      "chunk",
+      makeDoneSignalChunk(sampleRate, channels, "pcm16le")
+    );
+  }
+}
+
+// ── VCF ────────────────────────────────────────────────────────────
+
+/** Control-rate block size for cutoff recomputation (frames). */
+const VCF_CONTROL_BLOCK = 64;
+
+export class VcfNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.VCF";
+  static readonly title = "VCF";
+  static readonly description =
+    "Voltage-controlled filter: a biquad whose cutoff is modulated by a CV stream.\n    audio, cv, synthesis, vcf, filter, modular\n\n    Cutoff = cutoff_hz * 2^(cv * cv_amount) (volts/octave), recomputed every 64 samples (control rate); filter state persists across chunks so chunked output equals a single pass. The audio input drives chunk cadence; CV is frame-aligned with hold-last.\n\n    Use cases:\n    - Classic envelope filter sweeps (ADSR → cutoff_cv)\n    - Wah/auto-filter via an LFO\n    - Static tone shaping with nothing patched into cutoff_cv";
+  static readonly metadataOutputTypes = { chunk: "chunk" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["audio", "cutoff_cv"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Audio",
+    description: "Audio chunk stream to filter (drives chunk cadence)."
+  })
+  declare audio: any;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Cutoff CV",
+    description:
+      "Cutoff modulation in octaves: cutoff = cutoff_hz * 2^(cv * cv_amount)."
+  })
+  declare cutoff_cv: any;
+
+  @prop({
+    type: "enum",
+    default: "lowpass",
+    title: "Mode",
+    description: "Filter mode.",
+    values: ["lowpass", "highpass"]
+  })
+  declare mode: any;
+
+  @prop({
+    type: "float",
+    default: 1000,
+    title: "Cutoff Hz",
+    description: "Base cutoff frequency in Hz.",
+    min: 20,
+    max: 20000
+  })
+  declare cutoff_hz: any;
+
+  @prop({
+    type: "float",
+    default: DEFAULT_Q,
+    title: "Q",
+    description: "Filter resonance (quality factor).",
+    min: 0.1,
+    max: 10
+  })
+  declare q: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "CV Amount",
+    description: "Octaves of cutoff shift per unit of CV.",
+    min: 0,
+    max: 5
+  })
+  declare cv_amount: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const mode = String(this.mode ?? "lowpass") as "lowpass" | "highpass";
+    const cutoffHz = Number(this.cutoff_hz ?? 1000);
+    const q = Number(this.q ?? DEFAULT_Q);
+    const cvAmount = Number(this.cv_amount ?? 1);
+
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let channels = 1;
+    let states: BiquadState[] = [];
+
+    for await (const frame of alignedSignalStreams(inputs, {
+      primary: "audio",
+      cvHandles: ["cutoff_cv"]
+    })) {
+      sampleRate = frame.primary.sampleRate;
+      if (states.length !== frame.primary.channels) {
+        channels = frame.primary.channels;
+        states = Array.from({ length: channels }, createBiquadState);
+      }
+      const cv = frame.cv["cutoff_cv"];
+      const planes = deinterleave(frame.primary.samples, channels);
+      const outPlanes = planes.map(() => new Float32Array(planes[0].length));
+
+      // Control-rate cutoff: recompute coefficients per 64-frame block from
+      // the CV value at block start (biquadCoeffs clamps to Nyquist).
+      const frames = planes[0].length;
+      for (let block = 0; block < frames; block += VCF_CONTROL_BLOCK) {
+        const end = Math.min(block + VCF_CONTROL_BLOCK, frames);
+        const fc =
+          cv !== undefined
+            ? cutoffHz * Math.pow(2, cv[block] * cvAmount)
+            : cutoffHz;
+        const coeffs = biquadCoeffs(mode, sampleRate, fc, q, 0);
+        for (let ch = 0; ch < channels; ch++) {
+          const filtered = processBiquad(
+            coeffs,
+            states[ch],
+            planes[ch].subarray(block, end)
+          );
+          outPlanes[ch].set(filtered, block);
+        }
+      }
+
+      await outputs.emit(
+        "chunk",
+        makeSignalChunk(
+          interleave(outPlanes),
+          sampleRate,
+          channels,
+          false,
+          "pcm16le"
+        )
+      );
+    }
+    await outputs.emit(
+      "chunk",
+      makeDoneSignalChunk(sampleRate, channels, "pcm16le")
+    );
+  }
+}
+
+// ── Attenuverter ───────────────────────────────────────────────────
+
+export class AttenuverterNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.Attenuverter";
+  static readonly title = "Attenuverter";
+  static readonly description =
+    "Scales and offsets a CV (or audio) stream: out = in * scale + offset.\n    cv, synthesis, utility, attenuverter, modular\n\n    Negative scale inverts the signal. The Swiss-army CV utility — adapt an LFO's range to a pitch input, invert an envelope, add a constant bias.\n\n    Use cases:\n    - Reduce LFO depth before a pitch input\n    - Invert an envelope for ducking\n    - Add a DC offset to centre a modulation";
+  static readonly metadataOutputTypes = { cv: "cv" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["signal"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Signal",
+    description: "Input CV or audio stream."
+  })
+  declare signal: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Scale",
+    description: "Multiplier; negative values invert.",
+    min: -10,
+    max: 10
+  })
+  declare scale: any;
+
+  @prop({
+    type: "float",
+    default: 0,
+    title: "Offset",
+    description: "Constant added after scaling.",
+    min: -10,
+    max: 10
+  })
+  declare offset: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const scale = Number(this.scale ?? 1);
+    const offset = Number(this.offset ?? 0);
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let channels = 1;
+
+    for await (const item of inputs.stream("signal")) {
+      const chunk = readSignalChunk(item);
+      if (!chunk) continue;
+      if (chunk.done) break;
+      if (chunk.samples.length === 0) continue;
+      sampleRate = chunk.sampleRate;
+      channels = chunk.channels;
+      const buf = chunk.samples;
+      for (let i = 0; i < buf.length; i++) buf[i] = buf[i] * scale + offset;
+      await outputs.emit(
+        "cv",
+        makeSignalChunk(buf, sampleRate, channels, false, "f32le")
+      );
+    }
+    await outputs.emit(
+      "cv",
+      makeDoneSignalChunk(sampleRate, channels, "f32le")
+    );
+  }
+}
+
+// ── Sample & Hold ──────────────────────────────────────────────────
+
+export class SampleHoldNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.SampleHold";
+  static readonly title = "Sample & Hold";
+  static readonly description =
+    "Samples the signal input on each trigger rising edge and holds it.\n    cv, synthesis, sample-hold, modular\n\n    On a trigger rising edge (≥ 0.5) at sample k, the held value becomes signal[k]; the output is the held value every sample. The signal input drives chunk cadence; the trigger is frame-aligned with hold-last.\n\n    Use cases:\n    - Classic random-stepped CV (noise → signal, clock → trigger)\n    - Quantize an LFO into steps\n    - Freeze a modulation value on demand";
+  static readonly metadataOutputTypes = { cv: "cv" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["signal", "trigger"];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Signal",
+    description: "Stream to sample (drives chunk cadence)."
+  })
+  declare signal: any;
+
+  @prop({
+    type: "cv",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Trigger",
+    description: "Sampling clock — samples on each rising edge (≥ 0.5)."
+  })
+  declare trigger: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let held = 0;
+    let triggerWasHigh = false;
+
+    for await (const frame of alignedSignalStreams(inputs, {
+      primary: "signal",
+      cvHandles: ["trigger"]
+    })) {
+      sampleRate = frame.primary.sampleRate;
+      const signal = chunkMono(frame.primary.samples, frame.primary.channels);
+      const trigger = frame.cv["trigger"];
+      const buf = new Float32Array(signal.length);
+      for (let i = 0; i < signal.length; i++) {
+        const high = trigger !== undefined && trigger[i] >= GATE_THRESHOLD;
+        if (high && !triggerWasHigh) held = signal[i];
+        triggerWasHigh = high;
+        buf[i] = held;
+      }
+      await outputs.emit(
+        "cv",
+        makeSignalChunk(buf, sampleRate, 1, false, "f32le")
+      );
+    }
+    await outputs.emit("cv", makeDoneSignalChunk(sampleRate, 1, "f32le"));
+  }
+}
+
+// ── Mixer ──────────────────────────────────────────────────────────
+
+const MIXER_HANDLES = ["in1", "in2", "in3", "in4"] as const;
+
+export class MixerNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.synth.Mixer";
+  static readonly title = "Mixer";
+  static readonly description =
+    "Sums up to four audio streams with per-input levels.\n    audio, synthesis, mixer, modular\n\n    Output = Σ level_i * in_i, emitted as soon as every still-open input can cover the frames; inputs that have ended contribute silence. The stream ends when all connected inputs end. Assumes matching sample rates and channel counts (no resampling).\n\n    Use cases:\n    - Combine oscillators into a richer voice\n    - Mix a dry signal with a filtered copy\n    - Sub-mix several synth voices";
+  static readonly metadataOutputTypes = { chunk: "chunk" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = [...MIXER_HANDLES];
+  static readonly isStreamingInput = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "In 1",
+    description: "Audio input 1."
+  })
+  declare in1: any;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "In 2",
+    description: "Audio input 2."
+  })
+  declare in2: any;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "In 3",
+    description: "Audio input 3."
+  })
+  declare in3: any;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "In 4",
+    description: "Audio input 4."
+  })
+  declare in4: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Level 1",
+    description: "Gain for input 1.",
+    min: 0,
+    max: 2
+  })
+  declare level1: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Level 2",
+    description: "Gain for input 2.",
+    min: 0,
+    max: 2
+  })
+  declare level2: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Level 3",
+    description: "Gain for input 3.",
+    min: 0,
+    max: 2
+  })
+  declare level3: any;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Level 4",
+    description: "Gain for input 4.",
+    min: 0,
+    max: 2
+  })
+  declare level4: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    const levels: Record<string, number> = {
+      in1: Number(this.level1 ?? 1),
+      in2: Number(this.level2 ?? 1),
+      in3: Number(this.level3 ?? 1),
+      in4: Number(this.level4 ?? 1)
+    };
+    const connected: string[] = MIXER_HANDLES.filter((h) =>
+      inputs.hasStream(h)
+    );
+    const fifos = new Map<string, SampleFifo>(
+      connected.map((h) => [h, new SampleFifo()])
+    );
+    const done = new Map<string, boolean>(connected.map((h) => [h, false]));
+    let sampleRate = SYNTH_SAMPLE_RATE;
+    let channels = 1;
+    let formatSeen = false;
+
+    const emitMixed = async (n: number): Promise<void> => {
+      if (n <= 0) return;
+      const buf = new Float32Array(n);
+      for (const h of connected) {
+        // Ended/short inputs contribute zeros — silence is correct for
+        // finished audio, unlike CV's hold-last.
+        const part = fifos.get(h)!.pull(n, "zero");
+        const level = levels[h];
+        for (let i = 0; i < n; i++) buf[i] += level * part[i];
+      }
+      await outputs.emit(
+        "chunk",
+        makeSignalChunk(buf, sampleRate, channels, false, "pcm16le")
+      );
+    };
+
+    for await (const [handle, item] of inputs.any()) {
+      if (!fifos.has(handle)) continue;
+      const chunk = readSignalChunk(item);
+      if (!chunk) continue;
+      if (!formatSeen && chunk.samples.length > 0) {
+        sampleRate = chunk.sampleRate;
+        channels = chunk.channels;
+        formatSeen = true;
+      }
+      if (chunk.done) done.set(handle, true);
+      else fifos.get(handle)!.push(chunk.samples);
+
+      const open = connected.filter((h) => !done.get(h));
+      if (open.length === 0) break;
+      const n = Math.min(...open.map((h) => fifos.get(h)!.available));
+      if (n > 0 && Number.isFinite(n)) await emitMixed(n);
+    }
+
+    // All inputs ended — flush the remainder zero-padded to the longest.
+    const remaining = Math.max(
+      0,
+      ...connected.map((h) => fifos.get(h)!.available)
+    );
+    await emitMixed(remaining);
+    await outputs.emit(
+      "chunk",
+      makeDoneSignalChunk(sampleRate, channels, "pcm16le")
+    );
+  }
+}
+
+export const SYNTHESIS_NODES: readonly NodeClass[] = tagAsHybrid([
+  OscillatorNode,
+  LfoNode,
+  AdsrNode,
+  GateNode,
+  VcaNode,
+  VcfNode,
+  AttenuverterNode,
+  SampleHoldNode,
+  MixerNode
+]);

--- a/packages/audio-nodes/tests/audio-wav.test.ts
+++ b/packages/audio-nodes/tests/audio-wav.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  audioRefFromBytes,
   encodePcm16Wav,
+  encodeWav,
+  float32ToPcm16,
   parseWavBytes,
-  readWavHeader
+  pcm16ToFloat32,
+  readWavHeader,
+  toBytes
 } from "@nodetool-ai/audio-nodes";
 
 describe("encodePcm16Wav", () => {
@@ -90,5 +95,58 @@ describe("parseWavBytes chunk traversal", () => {
   it("returns null for non-RIFF input", () => {
     expect(readWavHeader(new Uint8Array([1, 2, 3, 4]))).toBeNull();
     expect(parseWavBytes(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+  });
+});
+
+describe("Buffer-free operation (browser environment)", () => {
+  // The browser bundle stubs `node:buffer`, so every codec path must work
+  // with `Buffer` absent. Simulate that by removing the global.
+  beforeEach(() => {
+    vi.stubGlobal("Buffer", undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("encodeWav → parseWavBytes round-trips without Buffer", () => {
+    const samples = new Float32Array([0, 0.5, -0.5, 1, -1, 0.25]);
+    const wav = encodeWav(samples, 24000, 2);
+    const decoded = parseWavBytes(wav);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.sampleRate).toBe(24000);
+    expect(decoded?.numChannels).toBe(2);
+    for (let i = 0; i < samples.length; i++) {
+      expect(decoded!.samples[i]).toBeCloseTo(samples[i], 4);
+    }
+  });
+
+  it("encodePcm16Wav → readWavHeader round-trips without Buffer", () => {
+    const pcm = new Uint8Array([0, 0, 232, 3, 24, 252]);
+    const wav = encodePcm16Wav(pcm, 16000, 1);
+    const header = readWavHeader(wav);
+    expect(header?.sampleRate).toBe(16000);
+    expect(header?.numChannels).toBe(1);
+    expect(header?.bitsPerSample).toBe(16);
+    expect(header?.dataSize).toBe(pcm.length);
+    expect(wav.slice(44)).toEqual(pcm);
+  });
+
+  it("audioRefFromBytes → toBytes base64 round-trips without Buffer", () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+    const ref = audioRefFromBytes(bytes);
+    expect(typeof ref.data).toBe("string");
+    expect(toBytes(ref.data as string)).toEqual(bytes);
+  });
+
+  it("pcm16ToFloat32 / float32ToPcm16 round-trip and clip", () => {
+    const samples = new Float32Array([0, 0.5, -0.5, 1, -1]);
+    const back = pcm16ToFloat32(float32ToPcm16(samples));
+    for (let i = 0; i < samples.length; i++) {
+      expect(back[i]).toBeCloseTo(samples[i], 4);
+    }
+    // Out-of-range input clips instead of wrapping.
+    const clipped = pcm16ToFloat32(float32ToPcm16(new Float32Array([2, -2])));
+    expect(clipped[0]).toBeCloseTo(1, 4);
+    expect(clipped[1]).toBeCloseTo(-1, 4);
   });
 });

--- a/packages/audio-nodes/tests/biquad.test.ts
+++ b/packages/audio-nodes/tests/biquad.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyBiquadToWav,
+  biquadCoeffs,
+  createBiquadState,
+  processBiquad,
+  DEFAULT_Q
+} from "@nodetool-ai/audio-nodes";
+
+const SAMPLE_RATE = 16000;
+
+/** RMS over the tail of a buffer (skips the filter settling transient). */
+function tailRms(samples: Float32Array, skip = 256): number {
+  let sum = 0;
+  for (let i = skip; i < samples.length; i++) sum += samples[i] * samples[i];
+  return Math.sqrt(sum / (samples.length - skip));
+}
+
+describe("biquadCoeffs + processBiquad frequency response", () => {
+  it("lowpass passes DC and attenuates Nyquist", () => {
+    const coeffs = biquadCoeffs("lowpass", SAMPLE_RATE, 1000, DEFAULT_Q);
+
+    const dc = new Float32Array(2048).fill(1);
+    const dcOut = processBiquad(coeffs, createBiquadState(), dc);
+    expect(tailRms(dcOut)).toBeCloseTo(1, 2);
+
+    const nyquist = new Float32Array(2048);
+    for (let i = 0; i < nyquist.length; i++) nyquist[i] = i % 2 === 0 ? 1 : -1;
+    const nyquistOut = processBiquad(coeffs, createBiquadState(), nyquist);
+    expect(tailRms(nyquistOut)).toBeLessThan(0.05);
+  });
+
+  it("highpass attenuates DC and passes Nyquist", () => {
+    const coeffs = biquadCoeffs("highpass", SAMPLE_RATE, 1000, DEFAULT_Q);
+
+    const dc = new Float32Array(2048).fill(1);
+    const dcOut = processBiquad(coeffs, createBiquadState(), dc);
+    expect(tailRms(dcOut)).toBeLessThan(0.05);
+
+    const nyquist = new Float32Array(2048);
+    for (let i = 0; i < nyquist.length; i++) nyquist[i] = i % 2 === 0 ? 1 : -1;
+    const nyquistOut = processBiquad(coeffs, createBiquadState(), nyquist);
+    expect(tailRms(nyquistOut)).toBeCloseTo(1, 2);
+  });
+});
+
+describe("biquad state carry across chunks", () => {
+  // The contract the streaming filter nodes depend on: filtering a signal in
+  // chunks with a shared state must equal filtering it in one pass.
+  it("8 chunks of 512 with shared state equal a single 4096-sample pass", () => {
+    const input = new Float32Array(4096);
+    // Deterministic pseudo-random signal (no test flakiness).
+    let seed = 12345;
+    for (let i = 0; i < input.length; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      input[i] = (seed / 0x7fffffff) * 2 - 1;
+    }
+
+    const coeffs = biquadCoeffs("lowpass", SAMPLE_RATE, 2000, DEFAULT_Q);
+
+    const single = processBiquad(coeffs, createBiquadState(), input);
+
+    const chunked = new Float32Array(input.length);
+    const state = createBiquadState();
+    for (let start = 0; start < input.length; start += 512) {
+      const out = processBiquad(
+        coeffs,
+        state,
+        input.subarray(start, start + 512)
+      );
+      chunked.set(out, start);
+    }
+
+    for (let i = 0; i < input.length; i++) {
+      expect(Math.abs(single[i] - chunked[i])).toBeLessThan(1e-6);
+    }
+  });
+});
+
+describe("applyBiquadToWav", () => {
+  it("filters interleaved stereo with independent per-channel state", () => {
+    const frames = 2048;
+    const samples = new Float32Array(frames * 2);
+    for (let i = 0; i < frames; i++) {
+      samples[i * 2] = 1; // left: DC
+      samples[i * 2 + 1] = i % 2 === 0 ? 1 : -1; // right: Nyquist
+    }
+    const out = applyBiquadToWav(
+      { samples, sampleRate: SAMPLE_RATE, numChannels: 2 },
+      "lowpass",
+      1000,
+      DEFAULT_Q,
+      0
+    );
+    expect(out.numChannels).toBe(2);
+    expect(out.samples.length).toBe(samples.length);
+
+    const left = new Float32Array(frames);
+    const right = new Float32Array(frames);
+    for (let i = 0; i < frames; i++) {
+      left[i] = out.samples[i * 2];
+      right[i] = out.samples[i * 2 + 1];
+    }
+    expect(tailRms(left)).toBeCloseTo(1, 2);
+    expect(tailRms(right)).toBeLessThan(0.05);
+  });
+});

--- a/packages/audio-nodes/tests/browser-platform.test.ts
+++ b/packages/audio-nodes/tests/browser-platform.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Browser-eligibility guard for the audio nodes.
+ *
+ * The in-browser workflow runner routes a sub-graph client-side only when
+ * every node type is in a registry built with `createBrowserRegistry`, which
+ * keeps a class iff `supportsPlatform(cls.platforms, "browser")`. The pure
+ * sample-math groups are tagged `tagAsHybrid` (`["node","browser"]`); file
+ * I/O, TTS, and the rubberband nodes stay server-only. This test pins that
+ * contract in both directions: a server-only retag would silently drop the
+ * hybrid nodes back to the server, and a hybrid retag of a node-only node
+ * would crash in the browser.
+ */
+import { describe, it, expect } from "vitest";
+import { supportsPlatform, type Platform } from "@nodetool-ai/protocol";
+import {
+  AUDIO_NODES,
+  LIB_AUDIO_DSP_NODES,
+  LIB_AUDIO_EFFECTS_HYBRID_NODES,
+  LIB_AUDIO_EFFECTS_SERVER_NODES,
+  REALTIME_AUDIO_NODES,
+  AudioToChunksNode,
+  ChunksToAudioNode,
+  StreamingGainNode,
+  StreamingLowPassNode,
+  StreamingHighPassNode
+} from "@nodetool-ai/audio-nodes";
+
+type NodeClassLike = {
+  nodeType?: string;
+  platforms?: readonly Platform[];
+  isStreamingInput?: boolean;
+};
+
+const HYBRID_GROUPS: Record<string, readonly unknown[]> = {
+  "lib.audio (dsp)": LIB_AUDIO_DSP_NODES,
+  "lib.audio (effects)": LIB_AUDIO_EFFECTS_HYBRID_NODES,
+  "nodetool.audio.realtime": REALTIME_AUDIO_NODES
+};
+
+const HYBRID_AUDIO_TYPES = [
+  "nodetool.audio.Normalize",
+  "nodetool.audio.OverlayAudio",
+  "nodetool.audio.RemoveSilence",
+  "nodetool.audio.SliceAudio",
+  "nodetool.audio.MonoToStereo",
+  "nodetool.audio.StereoToMono",
+  "nodetool.audio.Reverse",
+  "nodetool.audio.FadeIn",
+  "nodetool.audio.FadeOut",
+  "nodetool.audio.Repeat",
+  "nodetool.audio.AudioMixer",
+  "nodetool.audio.Trim",
+  "nodetool.audio.CreateSilence",
+  "nodetool.audio.Concat",
+  "nodetool.audio.ConcatList",
+  "nodetool.audio.ChunkToAudio",
+  "nodetool.audio.GetAudioInfo"
+];
+
+const SERVER_ONLY_TYPES = [
+  "lib.audio.PitchShift",
+  "lib.audio.TimeStretch",
+  "nodetool.audio.LoadAudioAssets",
+  "nodetool.audio.LoadAudioFile",
+  "nodetool.audio.LoadAudioFolder",
+  "nodetool.audio.SaveAudio",
+  "nodetool.audio.SaveAudioFile",
+  "nodetool.audio.TextToSpeech"
+];
+
+function byType(nodes: readonly unknown[]): Map<string, NodeClassLike> {
+  const map = new Map<string, NodeClassLike>();
+  for (const cls of nodes as NodeClassLike[]) {
+    if (cls.nodeType) map.set(cls.nodeType, cls);
+  }
+  return map;
+}
+
+describe("hybrid audio nodes declare browser platform support", () => {
+  for (const [group, nodes] of Object.entries(HYBRID_GROUPS)) {
+    it(`${group} nodes are all browser-capable`, () => {
+      expect(nodes.length).toBeGreaterThan(0);
+      for (const cls of nodes as NodeClassLike[]) {
+        expect(
+          supportsPlatform(cls.platforms, "browser"),
+          `${cls.nodeType} must support the browser platform`
+        ).toBe(true);
+      }
+    });
+  }
+
+  it("the pure transforms in AUDIO_NODES are browser-capable", () => {
+    const all = byType(AUDIO_NODES);
+    for (const nodeType of HYBRID_AUDIO_TYPES) {
+      const cls = all.get(nodeType);
+      expect(cls, `${nodeType} must be registered`).toBeDefined();
+      expect(
+        supportsPlatform(cls?.platforms, "browser"),
+        `${nodeType} must support the browser platform`
+      ).toBe(true);
+    }
+  });
+});
+
+describe("server-only audio nodes do NOT declare browser support", () => {
+  it("file I/O, TTS and rubberband nodes stay off the browser", () => {
+    const all = byType([
+      ...AUDIO_NODES,
+      ...LIB_AUDIO_EFFECTS_SERVER_NODES
+    ]);
+    for (const nodeType of SERVER_ONLY_TYPES) {
+      const cls = all.get(nodeType);
+      expect(cls, `${nodeType} must be registered`).toBeDefined();
+      expect(
+        supportsPlatform(cls?.platforms, "browser"),
+        `${nodeType} must NOT support the browser platform`
+      ).toBe(false);
+    }
+  });
+});
+
+describe("realtime audio node streaming flags", () => {
+  it("streaming-input nodes declare isStreamingInput", () => {
+    expect(ChunksToAudioNode.isStreamingInput).toBe(true);
+    expect(StreamingGainNode.isStreamingInput).toBe(true);
+    expect(StreamingLowPassNode.isStreamingInput).toBe(true);
+    expect(StreamingHighPassNode.isStreamingInput).toBe(true);
+  });
+
+  it("AudioToChunks streams output via a genProcess override", () => {
+    expect(typeof AudioToChunksNode.prototype.genProcess).toBe("function");
+    expect(AudioToChunksNode.isStreamingInput).not.toBe(true);
+  });
+});

--- a/packages/audio-nodes/tests/browser-platform.test.ts
+++ b/packages/audio-nodes/tests/browser-platform.test.ts
@@ -18,6 +18,7 @@ import {
   LIB_AUDIO_EFFECTS_HYBRID_NODES,
   LIB_AUDIO_EFFECTS_SERVER_NODES,
   REALTIME_AUDIO_NODES,
+  SYNTHESIS_NODES,
   AudioToChunksNode,
   ChunksToAudioNode,
   StreamingGainNode,
@@ -34,7 +35,8 @@ type NodeClassLike = {
 const HYBRID_GROUPS: Record<string, readonly unknown[]> = {
   "lib.audio (dsp)": LIB_AUDIO_DSP_NODES,
   "lib.audio (effects)": LIB_AUDIO_EFFECTS_HYBRID_NODES,
-  "nodetool.audio.realtime": REALTIME_AUDIO_NODES
+  "nodetool.audio.realtime": REALTIME_AUDIO_NODES,
+  "nodetool.audio.synth": SYNTHESIS_NODES
 };
 
 const HYBRID_AUDIO_TYPES = [
@@ -130,5 +132,17 @@ describe("realtime audio node streaming flags", () => {
   it("AudioToChunks streams output via a genProcess override", () => {
     expect(typeof AudioToChunksNode.prototype.genProcess).toBe("function");
     expect(AudioToChunksNode.isStreamingInput).not.toBe(true);
+  });
+
+  it("every synthesis node is streaming-input (generators included)", () => {
+    expect(SYNTHESIS_NODES.length).toBe(9);
+    for (const cls of SYNTHESIS_NODES as Array<
+      NodeClassLike & { isStreamingInput?: boolean }
+    >) {
+      expect(
+        cls.isStreamingInput,
+        `${cls.nodeType} must declare isStreamingInput`
+      ).toBe(true);
+    }
   });
 });

--- a/packages/audio-nodes/tests/cv.test.ts
+++ b/packages/audio-nodes/tests/cv.test.ts
@@ -4,6 +4,7 @@ import {
   float32ToF32le,
   makeSignalChunk,
   readSignalChunk,
+  RealtimePacer,
   SampleFifo,
   float32ToPcm16
 } from "@nodetool-ai/audio-nodes";
@@ -113,5 +114,26 @@ describe("SampleFifo", () => {
     const fifo = new SampleFifo();
     fifo.push(new Float32Array([5]));
     expect([...fifo.pull(3, "zero")]).toEqual([5, 0, 0]);
+  });
+});
+
+describe("RealtimePacer", () => {
+  it("paces variable-length chunks by cumulative duration", async () => {
+    const pacer = new RealtimePacer();
+    const start = Date.now();
+    // Chunk 0 (80 ms) is released immediately; its duration sets the next slot.
+    await pacer.waitNext(80);
+    expect(Date.now() - start).toBeLessThan(40);
+    // A short final chunk must still wait out chunk 0's duration — pacing by
+    // `emitted * chunkMs` would release it ~70 ms early here.
+    await pacer.waitNext(10);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(70);
+  });
+
+  it("returns false once the signal aborts", async () => {
+    const controller = new AbortController();
+    const pacer = new RealtimePacer(controller.signal);
+    controller.abort();
+    expect(await pacer.waitNext(1000)).toBe(false);
   });
 });

--- a/packages/audio-nodes/tests/cv.test.ts
+++ b/packages/audio-nodes/tests/cv.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  f32leToFloat32,
+  float32ToF32le,
+  makeSignalChunk,
+  readSignalChunk,
+  SampleFifo,
+  float32ToPcm16
+} from "@nodetool-ai/audio-nodes";
+
+function b64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+function bytesToB64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(binary);
+}
+
+describe("f32le codec", () => {
+  it("round-trips bit-exact, including values beyond [-1, 1] and negatives", () => {
+    const samples = new Float32Array([0, 1, -1, 3.75, -2.5, 1e-7, 12345.678]);
+    const back = f32leToFloat32(float32ToF32le(samples));
+    expect(back).toEqual(samples);
+  });
+});
+
+describe("readSignalChunk", () => {
+  it("decodes f32le chunks built by makeSignalChunk", () => {
+    const samples = new Float32Array([0.5, -0.25, 2.0]);
+    const chunk = makeSignalChunk(samples, 24000, 1, false, "f32le");
+    const parsed = readSignalChunk(chunk);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.samples).toEqual(samples);
+    expect(parsed!.sampleRate).toBe(24000);
+    expect(parsed!.channels).toBe(1);
+    expect(parsed!.done).toBe(false);
+  });
+
+  it("decodes legacy pcm16le chunks with absent encoding metadata", () => {
+    const samples = new Float32Array([0.5, -0.5, 1, -1]);
+    const legacy = {
+      type: "chunk",
+      content: bytesToB64(float32ToPcm16(samples)),
+      done: false,
+      content_type: "audio",
+      content_metadata: { sample_rate: 16000, channels: 1 }
+    };
+    const parsed = readSignalChunk(legacy);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.sampleRate).toBe(16000);
+    for (let i = 0; i < samples.length; i++) {
+      expect(parsed!.samples[i]).toBeCloseTo(samples[i], 4);
+    }
+  });
+
+  it("rejects non-audio chunks and non-objects", () => {
+    expect(
+      readSignalChunk({ type: "chunk", content: "x", content_type: "text" })
+    ).toBeNull();
+    expect(readSignalChunk("hello")).toBeNull();
+    expect(readSignalChunk(null)).toBeNull();
+  });
+
+  it("pcm16 clamps values beyond [-1, 1] while f32le preserves them", () => {
+    const samples = new Float32Array([2.5, -3]);
+    const viaPcm = readSignalChunk(
+      makeSignalChunk(samples, 24000, 1, false, "pcm16le")
+    )!;
+    expect(viaPcm.samples[0]).toBeCloseTo(1, 3);
+    expect(viaPcm.samples[1]).toBeCloseTo(-1, 3);
+    const viaF32 = readSignalChunk(
+      makeSignalChunk(samples, 24000, 1, false, "f32le")
+    )!;
+    expect(viaF32.samples[0]).toBe(2.5);
+    expect(viaF32.samples[1]).toBe(-3);
+  });
+
+  it("reads base64 content via the standard decoder", () => {
+    const samples = new Float32Array([1, 2, 3]);
+    const chunk = makeSignalChunk(samples, 24000, 1, false, "f32le") as {
+      content: string;
+    };
+    expect(f32leToFloat32(b64ToBytes(chunk.content))).toEqual(samples);
+  });
+});
+
+describe("SampleFifo", () => {
+  it("pulls across segment boundaries", () => {
+    const fifo = new SampleFifo();
+    fifo.push(new Float32Array([1, 2]));
+    fifo.push(new Float32Array([3, 4, 5]));
+    expect(fifo.available).toBe(5);
+    expect([...fifo.pull(3, "hold")]).toEqual([1, 2, 3]);
+    expect(fifo.available).toBe(2);
+    expect([...fifo.pull(2, "hold")]).toEqual([4, 5]);
+  });
+
+  it("holds the last value on underrun, starting from 0", () => {
+    const fifo = new SampleFifo();
+    expect([...fifo.pull(2, "hold")]).toEqual([0, 0]);
+    fifo.push(new Float32Array([7]));
+    expect([...fifo.pull(3, "hold")]).toEqual([7, 7, 7]);
+    expect(fifo.last).toBe(7);
+  });
+
+  it("zero-fills on underrun in zero mode", () => {
+    const fifo = new SampleFifo();
+    fifo.push(new Float32Array([5]));
+    expect([...fifo.pull(3, "zero")]).toEqual([5, 0, 0]);
+  });
+});

--- a/packages/audio-nodes/tests/lib-audio-dsp-fallback.test.ts
+++ b/packages/audio-nodes/tests/lib-audio-dsp-fallback.test.ts
@@ -43,19 +43,31 @@ async function runLowPass(): Promise<Float32Array> {
   return wav.samples;
 }
 
-describe("applyFilter seam", () => {
-  it("WebAudio branch (Node): low-pass attenuates a Nyquist square wave", async () => {
-    const out = await runLowPass();
-    expect(out.length).toBe(2048);
-    expect(tailRms(out)).toBeLessThan(0.05);
-  });
+// Generous timeout: node-web-audio-api's OfflineAudioContext render can blow
+// the 5 s default when the whole workspace's test suites run in parallel.
+const RENDER_TIMEOUT_MS = 30_000;
 
-  it("fallback branch: biquad path used when OfflineAudioContext is unavailable", async () => {
-    vi.doMock("@nodetool-ai/audio-nodes/lib/audio-context", () => ({
-      loadOfflineAudioContext: async () => null
-    }));
-    const out = await runLowPass();
-    expect(out.length).toBe(2048);
-    expect(tailRms(out)).toBeLessThan(0.05);
-  });
+describe("applyFilter seam", () => {
+  it(
+    "WebAudio branch (Node): low-pass attenuates a Nyquist square wave",
+    { timeout: RENDER_TIMEOUT_MS },
+    async () => {
+      const out = await runLowPass();
+      expect(out.length).toBe(2048);
+      expect(tailRms(out)).toBeLessThan(0.05);
+    }
+  );
+
+  it(
+    "fallback branch: biquad path used when OfflineAudioContext is unavailable",
+    { timeout: RENDER_TIMEOUT_MS },
+    async () => {
+      vi.doMock("@nodetool-ai/audio-nodes/lib/audio-context", () => ({
+        loadOfflineAudioContext: async () => null
+      }));
+      const out = await runLowPass();
+      expect(out.length).toBe(2048);
+      expect(tailRms(out)).toBeLessThan(0.05);
+    }
+  );
 });

--- a/packages/audio-nodes/tests/lib-audio-dsp-fallback.test.ts
+++ b/packages/audio-nodes/tests/lib-audio-dsp-fallback.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Pins the two branches of the batch filter seam (`applyFilter`):
+ *  - WebAudio branch — on Node, `loadOfflineAudioContext` resolves the
+ *    node-web-audio-api constructor.
+ *  - Pure-JS fallback — when the constructor is unavailable (Web Workers
+ *    without WebAudio), the RBJ biquad path must produce equivalent output.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const SAMPLE_RATE = 16000;
+
+function nyquistWav(frames = 2048) {
+  const samples = new Float32Array(frames);
+  for (let i = 0; i < frames; i++) samples[i] = i % 2 === 0 ? 0.8 : -0.8;
+  return { samples, sampleRate: SAMPLE_RATE, numChannels: 1 };
+}
+
+function tailRms(samples: Float32Array, skip = 256): number {
+  let sum = 0;
+  for (let i = skip; i < samples.length; i++) sum += samples[i] * samples[i];
+  return Math.sqrt(sum / (samples.length - skip));
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("@nodetool-ai/audio-nodes/lib/audio-context");
+});
+
+async function runLowPass(): Promise<Float32Array> {
+  const { applyFilter } = await import(
+    "@nodetool-ai/audio-nodes/nodes/lib-audio-dsp"
+  );
+  const { parseWavBytes } = await import("@nodetool-ai/audio-nodes");
+  const ref = await applyFilter(nyquistWav(), {
+    type: "lowpass",
+    frequency: 1000
+  });
+  const binary = atob(String(ref.data));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  const wav = parseWavBytes(bytes);
+  if (!wav) throw new Error("expected WAV output");
+  return wav.samples;
+}
+
+describe("applyFilter seam", () => {
+  it("WebAudio branch (Node): low-pass attenuates a Nyquist square wave", async () => {
+    const out = await runLowPass();
+    expect(out.length).toBe(2048);
+    expect(tailRms(out)).toBeLessThan(0.05);
+  });
+
+  it("fallback branch: biquad path used when OfflineAudioContext is unavailable", async () => {
+    vi.doMock("@nodetool-ai/audio-nodes/lib/audio-context", () => ({
+      loadOfflineAudioContext: async () => null
+    }));
+    const out = await runLowPass();
+    expect(out.length).toBe(2048);
+    expect(tailRms(out)).toBeLessThan(0.05);
+  });
+});

--- a/packages/audio-nodes/tests/realtime-audio.test.ts
+++ b/packages/audio-nodes/tests/realtime-audio.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AudioRef,
+  StreamingInputs,
+  StreamingOutputs
+} from "@nodetool-ai/node-sdk";
+import {
+  AudioToChunksNode,
+  ChunksToAudioNode,
+  StreamingGainNode,
+  StreamingLowPassNode,
+  applyBiquadToWav,
+  encodeWav,
+  parseWavBytes,
+  pcm16ToFloat32,
+  float32ToPcm16,
+  DEFAULT_Q
+} from "@nodetool-ai/audio-nodes";
+
+const SAMPLE_RATE = 16000;
+
+/** Base64 helpers for assertions (mirror the node-internal encoding). */
+function b64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+function bytesToB64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(binary);
+}
+
+/** Minimal StreamingInputs fake: yields the given items on every handle. */
+function inputsFrom(items: unknown[]): StreamingInputs {
+  return {
+    async *stream(_name: string) {
+      for (const item of items) yield item;
+    },
+    async *any() {
+      for (const item of items) yield ["chunk", item] as [string, unknown];
+    }
+  } as unknown as StreamingInputs;
+}
+
+/** Minimal StreamingOutputs fake recording every emit. */
+function recordingOutputs(): {
+  outputs: StreamingOutputs;
+  emitted: Array<[string, unknown]>;
+} {
+  const emitted: Array<[string, unknown]> = [];
+  const outputs = {
+    async emit(slot: string, value: unknown) {
+      emitted.push([slot, value]);
+    }
+  } as unknown as StreamingOutputs;
+  return { outputs, emitted };
+}
+
+type ChunkShape = {
+  type: string;
+  content: string;
+  done: boolean;
+  content_type: string;
+  content_metadata: {
+    encoding: string;
+    sample_rate: number;
+    channels: number;
+    format: string;
+    duration_seconds: number;
+  };
+};
+
+function makeChunk(
+  pcm: Uint8Array,
+  sampleRate: number,
+  channels: number,
+  done = false
+): ChunkShape {
+  return {
+    type: "chunk",
+    content: pcm.length > 0 ? bytesToB64(pcm) : "",
+    done,
+    content_type: "audio",
+    content_metadata: {
+      encoding: "pcm16le",
+      sample_rate: sampleRate,
+      channels,
+      format: "pcm",
+      duration_seconds: pcm.length / 2 / channels / sampleRate
+    }
+  };
+}
+
+/** 1 s of quantization-stable mono samples (already on the PCM16 grid). */
+function testSamples(count = SAMPLE_RATE): Float32Array {
+  const samples = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    samples[i] = Math.round(Math.sin(i / 50) * 16000) / 0x7fff;
+  }
+  return samples;
+}
+
+async function collectGen(
+  gen: AsyncGenerator<Record<string, unknown>>
+): Promise<ChunkShape[]> {
+  const out: ChunkShape[] = [];
+  for await (const item of gen) out.push(item.chunk as ChunkShape);
+  return out;
+}
+
+describe("AudioToChunks", () => {
+  it("slices 1 s of mono audio into 4 × 0.25 s chunks plus a done chunk", async () => {
+    const samples = testSamples();
+    const node = new AudioToChunksNode({
+      audio: { type: "audio", uri: "", data: encodeWav(samples, SAMPLE_RATE, 1) },
+      chunk_duration: 0.25
+    });
+
+    const chunks = await collectGen(node.genProcess());
+    expect(chunks).toHaveLength(5);
+
+    const data = chunks.slice(0, 4);
+    for (const chunk of data) {
+      expect(chunk.done).toBe(false);
+      expect(chunk.content_type).toBe("audio");
+      expect(chunk.content_metadata.encoding).toBe("pcm16le");
+      expect(chunk.content_metadata.sample_rate).toBe(SAMPLE_RATE);
+      expect(chunk.content_metadata.channels).toBe(1);
+      expect(chunk.content_metadata.duration_seconds).toBeCloseTo(0.25, 6);
+      expect(b64ToBytes(chunk.content).length).toBe(SAMPLE_RATE * 0.25 * 2);
+    }
+
+    const last = chunks[4];
+    expect(last.done).toBe(true);
+    expect(last.content).toBe("");
+
+    // The concatenated PCM equals the original samples (PCM16-quantized).
+    const allPcm = data.flatMap((c) => [...b64ToBytes(c.content)]);
+    const decoded = pcm16ToFloat32(Uint8Array.from(allPcm));
+    expect(decoded.length).toBe(samples.length);
+    for (let i = 0; i < samples.length; i += 997) {
+      expect(decoded[i]).toBeCloseTo(samples[i], 4);
+    }
+  });
+
+  it("throws on non-WAV input", async () => {
+    const node = new AudioToChunksNode({
+      audio: { type: "audio", uri: "", data: new Uint8Array([1, 2, 3]) },
+      chunk_duration: 0.25
+    });
+    await expect(collectGen(node.genProcess())).rejects.toThrow(/WAV/);
+  });
+});
+
+describe("ChunksToAudio", () => {
+  it("accumulates a chunk stream back into the original audio", async () => {
+    const samples = testSamples();
+    const source = new AudioToChunksNode({
+      audio: { type: "audio", uri: "", data: encodeWav(samples, SAMPLE_RATE, 1) },
+      chunk_duration: 0.25
+    });
+    const chunks = await collectGen(source.genProcess());
+
+    const sink = new ChunksToAudioNode({});
+    const { outputs, emitted } = recordingOutputs();
+    await sink.run(inputsFrom(chunks), outputs);
+
+    expect(emitted).toHaveLength(1);
+    const [slot, audio] = emitted[0];
+    expect(slot).toBe("audio");
+
+    const ref = audio as AudioRef;
+    expect(ref.type).toBe("audio");
+    const wav = parseWavBytes(b64ToBytes(String(ref.data)));
+    expect(wav).not.toBeNull();
+    expect(wav?.sampleRate).toBe(SAMPLE_RATE);
+    expect(wav?.numChannels).toBe(1);
+    expect(wav?.samples.length).toBe(samples.length);
+    for (let i = 0; i < samples.length; i += 997) {
+      expect(wav!.samples[i]).toBeCloseTo(samples[i], 4);
+    }
+  });
+
+  it("skips non-audio chunks", async () => {
+    const pcm = float32ToPcm16(testSamples(1024));
+    const sink = new ChunksToAudioNode({});
+    const { outputs, emitted } = recordingOutputs();
+    await sink.run(
+      inputsFrom([
+        { type: "chunk", content: "hello", content_type: "text", done: false },
+        makeChunk(pcm, SAMPLE_RATE, 1),
+        makeChunk(new Uint8Array(), SAMPLE_RATE, 1, true)
+      ]),
+      outputs
+    );
+    const ref = emitted[0][1] as AudioRef;
+    const wav = parseWavBytes(b64ToBytes(String(ref.data)));
+    expect(wav?.samples.length).toBe(1024);
+  });
+});
+
+describe("StreamingGain", () => {
+  it("+6.0206 dB doubles sample values and forwards the done chunk", async () => {
+    const samples = new Float32Array(512).fill(0.25);
+    const node = new StreamingGainNode({ gain_db: 6.0206 });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      inputsFrom([
+        makeChunk(float32ToPcm16(samples), SAMPLE_RATE, 1),
+        makeChunk(new Uint8Array(), SAMPLE_RATE, 1, true)
+      ]),
+      outputs
+    );
+
+    expect(emitted).toHaveLength(2);
+    const first = emitted[0][1] as ChunkShape;
+    expect(first.done).toBe(false);
+    expect(first.content_metadata.sample_rate).toBe(SAMPLE_RATE);
+    const out = pcm16ToFloat32(b64ToBytes(first.content));
+    for (let i = 0; i < out.length; i += 37) {
+      expect(out[i]).toBeCloseTo(0.5, 3);
+    }
+
+    const last = emitted[1][1] as ChunkShape;
+    expect(last.done).toBe(true);
+    expect(last.content).toBe("");
+  });
+});
+
+describe("StreamingLowPass", () => {
+  it("chunked filtering equals whole-buffer applyBiquadToWav (state continuity)", async () => {
+    const samples = testSamples(4096);
+    const pcm = float32ToPcm16(samples);
+
+    // Stream the PCM in 8 chunks of 512 samples.
+    const chunks: ChunkShape[] = [];
+    for (let i = 0; i < 8; i++) {
+      chunks.push(
+        makeChunk(pcm.subarray(i * 1024, (i + 1) * 1024), SAMPLE_RATE, 1)
+      );
+    }
+    chunks.push(makeChunk(new Uint8Array(), SAMPLE_RATE, 1, true));
+
+    const node = new StreamingLowPassNode({
+      cutoff_frequency_hz: 1000,
+      q: DEFAULT_Q
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(inputsFrom(chunks), outputs);
+
+    expect(emitted).toHaveLength(9);
+    const streamed: number[] = [];
+    for (const [, value] of emitted.slice(0, 8)) {
+      streamed.push(...pcm16ToFloat32(b64ToBytes((value as ChunkShape).content)));
+    }
+
+    // Reference: the same quantized input filtered in a single pass.
+    const reference = applyBiquadToWav(
+      { samples: pcm16ToFloat32(pcm), sampleRate: SAMPLE_RATE, numChannels: 1 },
+      "lowpass",
+      1000,
+      DEFAULT_Q,
+      0
+    ).samples;
+
+    expect(streamed.length).toBe(reference.length);
+    // Only output PCM16 quantization separates the two paths.
+    for (let i = 0; i < reference.length; i++) {
+      expect(Math.abs(streamed[i] - reference[i])).toBeLessThan(1e-3);
+    }
+  });
+});

--- a/packages/audio-nodes/tests/synthesis.test.ts
+++ b/packages/audio-nodes/tests/synthesis.test.ts
@@ -6,11 +6,15 @@ import {
   AdsrNode,
   GateNode,
   VcaNode,
+  VcfNode,
+  AttenuverterNode,
   MixerNode,
   SampleHoldNode,
+  applyBiquadToWav,
   makeSignalChunk,
   makeDoneSignalChunk,
   readSignalChunk,
+  DEFAULT_Q,
   SYNTH_CHUNK_FRAMES
 } from "@nodetool-ai/audio-nodes";
 
@@ -416,6 +420,111 @@ describe("VCA", () => {
     );
     const out = concatEmitted(emitted);
     for (let i = 0; i < frames; i += 17) expect(out[i]).toBeCloseTo(1, 3);
+  });
+});
+
+describe("Attenuverter", () => {
+  it("applies out = in * scale + offset, preserving values beyond ±1 (f32le)", async () => {
+    const signal = new Float32Array([0, 0.5, -0.5, 1]);
+    const node = new AttenuverterNode({ scale: -2, offset: 1 });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          signal: [
+            makeSignalChunk(signal, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+    const out = concatEmitted(emitted);
+    // -2 * 1 + 1 = -1 and -2 * -0.5 + 1 = 2: inversion and >1 survive on the
+    // f32le wire (pcm16 would clamp the 2).
+    expect([...out]).toEqual([1, 0, 2, -1]);
+    const last = readSignalChunk(emitted[emitted.length - 1][1])!;
+    expect(last.done).toBe(true);
+  });
+});
+
+describe("VCF", () => {
+  function nyquistTone(frames: number): Float32Array {
+    const samples = new Float32Array(frames);
+    for (let i = 0; i < frames; i++) samples[i] = i % 2 === 0 ? 0.8 : -0.8;
+    return samples;
+  }
+
+  function rms(samples: Float32Array, skip = 256): number {
+    let sum = 0;
+    for (let i = skip; i < samples.length; i++) sum += samples[i] * samples[i];
+    return Math.sqrt(sum / (samples.length - skip));
+  }
+
+  async function runVcf(
+    audio: Float32Array,
+    props: Record<string, unknown>,
+    cv?: Float32Array
+  ): Promise<Float32Array> {
+    const handles: Record<string, unknown[]> = {
+      audio: [
+        makeSignalChunk(audio, SR, 1, false, "pcm16le"),
+        makeDoneSignalChunk(SR, 1, "pcm16le")
+      ]
+    };
+    if (cv) {
+      handles.cutoff_cv = [
+        makeSignalChunk(cv, SR, 1, false, "f32le"),
+        makeDoneSignalChunk(SR, 1, "f32le")
+      ];
+    }
+    const node = new VcfNode(props);
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles }), outputs);
+    return concatEmitted(emitted);
+  }
+
+  it("static lowpass matches the whole-buffer biquad (state persists across control blocks)", async () => {
+    const audio = nyquistTone(2048);
+    const out = await runVcf(audio, {
+      mode: "lowpass",
+      cutoff_hz: 1000,
+      q: DEFAULT_Q
+    });
+    const reference = applyBiquadToWav(
+      { samples: audio, sampleRate: SR, numChannels: 1 },
+      "lowpass",
+      1000,
+      DEFAULT_Q,
+      0
+    ).samples;
+    expect(out.length).toBe(reference.length);
+    for (let i = 0; i < out.length; i++) {
+      expect(Math.abs(out[i] - reference[i])).toBeLessThan(1e-3); // pcm16 LSB
+    }
+  });
+
+  it("cutoff CV opens the filter: cutoff = cutoff_hz * 2^(cv * cv_amount)", async () => {
+    // 3 kHz sine — well inside the passband once the CV lifts the cutoff.
+    // (A Nyquist tone won't do: the RBJ lowpass has a double zero at
+    // Nyquist, so it is annihilated at any cutoff.)
+    const audio = new Float32Array(2048);
+    for (let i = 0; i < audio.length; i++) {
+      audio[i] = 0.8 * Math.sin((2 * Math.PI * 3000 * i) / SR);
+    }
+    const closed = await runVcf(audio, {
+      mode: "lowpass",
+      cutoff_hz: 500,
+      cv_amount: 1
+    });
+    const opened = await runVcf(
+      audio,
+      { mode: "lowpass", cutoff_hz: 500, cv_amount: 1 },
+      new Float32Array(2048).fill(4) // +4 octaves → 8 kHz cutoff
+    );
+    expect(rms(closed)).toBeLessThan(0.1);
+    expect(rms(opened)).toBeGreaterThan(0.3);
+    expect(rms(opened)).toBeGreaterThan(rms(closed) * 4);
   });
 });
 

--- a/packages/audio-nodes/tests/synthesis.test.ts
+++ b/packages/audio-nodes/tests/synthesis.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect } from "vitest";
+import type { StreamingInputs, StreamingOutputs } from "@nodetool-ai/node-sdk";
+import {
+  OscillatorNode,
+  LfoNode,
+  AdsrNode,
+  GateNode,
+  VcaNode,
+  MixerNode,
+  SampleHoldNode,
+  makeSignalChunk,
+  makeDoneSignalChunk,
+  readSignalChunk,
+  SYNTH_CHUNK_FRAMES
+} from "@nodetool-ai/audio-nodes";
+
+const SR = 24000;
+
+/**
+ * Multi-handle streaming fake. A handle is "patched" iff its key exists in
+ * `handles`. `any()` interleaves round-robin (one item per handle per turn)
+ * unless an explicit `order` of [handle, itemIndex] pairs is scripted.
+ */
+function makeInputs(opts: {
+  handles: Record<string, unknown[]>;
+  order?: Array<[string, number]>;
+  signal?: AbortSignal;
+}): StreamingInputs {
+  const { handles, order } = opts;
+  return {
+    signal: opts.signal ?? new AbortController().signal,
+    hasStream: (name: string) => name in handles,
+    async *stream(name: string) {
+      for (const item of handles[name] ?? []) yield item;
+    },
+    async *any() {
+      if (order) {
+        for (const [h, i] of order) yield [h, handles[h][i]];
+        return;
+      }
+      const keys = Object.keys(handles);
+      const idx: Record<string, number> = {};
+      for (const k of keys) idx[k] = 0;
+      let progressed = true;
+      while (progressed) {
+        progressed = false;
+        for (const k of keys) {
+          if (idx[k] < handles[k].length) {
+            yield [k, handles[k][idx[k]++]] as [string, unknown];
+            progressed = true;
+          }
+        }
+      }
+    }
+  } as unknown as StreamingInputs;
+}
+
+function recordingOutputs(): {
+  outputs: StreamingOutputs;
+  emitted: Array<[string, unknown]>;
+} {
+  const emitted: Array<[string, unknown]> = [];
+  const outputs = {
+    async emit(slot: string, value: unknown) {
+      emitted.push([slot, value]);
+    }
+  } as unknown as StreamingOutputs;
+  return { outputs, emitted };
+}
+
+/** Decode all non-done chunks on a slot into one concatenated Float32Array. */
+function concatEmitted(emitted: Array<[string, unknown]>): Float32Array {
+  const parts: Float32Array[] = [];
+  for (const [, value] of emitted) {
+    const chunk = readSignalChunk(value);
+    if (chunk && !chunk.done) parts.push(chunk.samples);
+  }
+  const total = parts.reduce((s, p) => s + p.length, 0);
+  const out = new Float32Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function signChanges(samples: Float32Array): number {
+  let count = 0;
+  for (let i = 1; i < samples.length; i++) {
+    if ((samples[i] >= 0) !== (samples[i - 1] >= 0)) count++;
+  }
+  return count;
+}
+
+describe("Oscillator (free run)", () => {
+  it("renders the requested duration in 512-frame chunks plus a done marker", async () => {
+    const node = new OscillatorNode({
+      waveform: "sine",
+      frequency: 100,
+      amplitude: 1,
+      duration: 1,
+      sample_rate: SR
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles: {} }), outputs);
+
+    const expectedChunks = Math.ceil(SR / SYNTH_CHUNK_FRAMES);
+    expect(emitted).toHaveLength(expectedChunks + 1);
+    const last = readSignalChunk(emitted[emitted.length - 1][1])!;
+    expect(last.done).toBe(true);
+
+    const samples = concatEmitted(emitted);
+    expect(samples.length).toBe(SR);
+    // 100 Hz over 1 s → ~200 zero crossings.
+    expect(Math.abs(signChanges(samples) - 200)).toBeLessThanOrEqual(2);
+  });
+
+  it("keeps phase continuous across chunk boundaries", async () => {
+    const node = new OscillatorNode({
+      waveform: "sine",
+      frequency: 440,
+      amplitude: 1,
+      duration: 0.5,
+      sample_rate: SR
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles: {} }), outputs);
+
+    const samples = concatEmitted(emitted);
+    // Max per-sample step of a 440 Hz sine @ 24 kHz, with quantization slack.
+    const maxStep = 2 * Math.PI * (440 / SR) + 1e-3;
+    for (let i = 1; i < samples.length; i++) {
+      expect(Math.abs(samples[i] - samples[i - 1])).toBeLessThanOrEqual(
+        maxStep
+      );
+    }
+  });
+
+  it("throws on duration 0 without realtime", async () => {
+    const node = new OscillatorNode({ duration: 0, sample_rate: SR });
+    const { outputs } = recordingOutputs();
+    await expect(
+      node.run(makeInputs({ handles: {} }), outputs)
+    ).rejects.toThrow(/realtime/);
+  });
+});
+
+describe("Oscillator (clocked by pitch CV)", () => {
+  async function crossingsForCv(cvValue: number): Promise<number> {
+    const frames = 512;
+    const chunks = [0, 1, 2].map(() =>
+      makeSignalChunk(
+        new Float32Array(frames).fill(cvValue),
+        SR,
+        1,
+        false,
+        "f32le"
+      )
+    );
+    chunks.push(makeDoneSignalChunk(SR, 1, "f32le"));
+    const node = new OscillatorNode({
+      waveform: "sine",
+      frequency: 220,
+      amplitude: 1
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles: { pitch_cv: chunks } }), outputs);
+
+    // One output chunk per input chunk, same frame count, plus done.
+    expect(emitted).toHaveLength(4);
+    for (let i = 0; i < 3; i++) {
+      expect(readSignalChunk(emitted[i][1])!.samples.length).toBe(frames);
+    }
+    expect(readSignalChunk(emitted[3][1])!.done).toBe(true);
+    return signChanges(concatEmitted(emitted));
+  }
+
+  it("pins freq = base * 2^cv (cv = 1 doubles the frequency)", async () => {
+    const base = await crossingsForCv(0);
+    const octaveUp = await crossingsForCv(1);
+    const ratio = octaveUp / base;
+    expect(ratio).toBeGreaterThan(1.8);
+    expect(ratio).toBeLessThan(2.2);
+  });
+});
+
+describe("ADSR", () => {
+  it("detects gate edges at exact sample offsets and times segments in samples", async () => {
+    const frames = 2048;
+    const edgeAt = 100;
+    const releaseAt = 1500;
+    const gate = new Float32Array(frames);
+    gate.fill(1, edgeAt, releaseAt);
+    const attack = 0.01; // 240 samples @ 24 kHz
+    const node = new AdsrNode({
+      attack,
+      decay: 0.01, // settles to sustain well before the falling edge
+      sustain: 0.7,
+      release: 0.01
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          gate: [
+            makeSignalChunk(gate, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+
+    const env = concatEmitted(emitted);
+    expect(env.length).toBe(frames);
+    // Silent before the rising edge…
+    for (let i = 0; i < edgeAt; i++) expect(env[i]).toBe(0);
+    // …rising right after it.
+    expect(env[edgeAt + 5]).toBeGreaterThan(0);
+
+    // Attack peaks at exactly 1.0 within a loose multiple of the named time.
+    const peakAt = env.indexOf(1);
+    expect(peakAt).toBeGreaterThan(edgeAt + attack * SR * 0.5);
+    expect(peakAt).toBeLessThan(edgeAt + attack * SR * 3);
+
+    // Sustain plateau before release.
+    expect(env[releaseAt - 1]).toBeCloseTo(0.7, 2);
+    // Release decays from the exact falling-edge offset.
+    expect(env[releaseAt + 200]).toBeLessThan(env[releaseAt - 1]);
+    expect(env[frames - 1]).toBeLessThan(0.2);
+  });
+
+  it("retriggers mid-release from the current level, not from 0", async () => {
+    const frames = 4096;
+    const gate = new Float32Array(frames);
+    gate.fill(1, 0, 1000); // first note
+    gate.fill(1, 1100, 4096); // retrigger 100 samples into the release
+    const node = new AdsrNode({
+      attack: 0.01,
+      decay: 0.05,
+      sustain: 0.7,
+      release: 0.1
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          gate: [
+            makeSignalChunk(gate, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+    const env = concatEmitted(emitted);
+    const levelAtRetrigger = env[1100];
+    expect(levelAtRetrigger).toBeGreaterThan(0.3); // still mid-release
+    // The very next samples continue upward from that level — no reset to 0.
+    expect(env[1101]).toBeGreaterThanOrEqual(levelAtRetrigger);
+    expect(env[1110]).toBeGreaterThan(levelAtRetrigger);
+  });
+});
+
+describe("Gate", () => {
+  it("emits the on/off pattern with sample-exact period", async () => {
+    const node = new GateNode({
+      on_duration: 0.01, // 240 frames
+      off_duration: 0.01,
+      repeats: 2,
+      amplitude: 1,
+      sample_rate: SR
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles: {} }), outputs);
+    const cv = concatEmitted(emitted);
+    expect(cv.length).toBe(2 * 480);
+    expect(cv[0]).toBe(1);
+    expect(cv[239]).toBe(1);
+    expect(cv[240]).toBe(0);
+    expect(cv[479]).toBe(0);
+    expect(cv[480]).toBe(1); // second cycle
+  });
+
+  it("realtime pacing delays emission without changing content", async () => {
+    const props = {
+      on_duration: 0.02,
+      off_duration: 0.02,
+      repeats: 2,
+      amplitude: 1,
+      sample_rate: SR
+    };
+    const free = recordingOutputs();
+    await new GateNode({ ...props }).run(makeInputs({ handles: {} }), free.outputs);
+
+    const paced = recordingOutputs();
+    const startMs = Date.now();
+    await new GateNode({ ...props, realtime: true }).run(
+      makeInputs({ handles: {} }),
+      paced.outputs
+    );
+    const elapsedMs = Date.now() - startMs;
+
+    // 1920 frames @ 24 kHz = 80 ms of audio in 512-frame chunks → the paced
+    // run must take at least ~3 chunk periods (loose bound against CI jitter).
+    expect(elapsedMs).toBeGreaterThan(40);
+    expect(concatEmitted(paced.emitted)).toEqual(concatEmitted(free.emitted));
+  });
+
+  it("infinite (repeats 0) requires realtime and stops on abort", async () => {
+    const { outputs } = recordingOutputs();
+    await expect(
+      new GateNode({ repeats: 0, sample_rate: SR }).run(
+        makeInputs({ handles: {} }),
+        outputs
+      )
+    ).rejects.toThrow(/realtime/);
+
+    const controller = new AbortController();
+    const paced = recordingOutputs();
+    const run = new GateNode({
+      repeats: 0,
+      realtime: true,
+      sample_rate: SR
+    }).run(makeInputs({ handles: {}, signal: controller.signal }), paced.outputs);
+    setTimeout(() => controller.abort(), 80);
+    await expect(run).resolves.toBeUndefined();
+    expect(paced.emitted.length).toBeGreaterThan(0);
+    const last = readSignalChunk(paced.emitted[paced.emitted.length - 1][1])!;
+    expect(last.done).toBe(true);
+  });
+});
+
+describe("VCA", () => {
+  it("multiplies audio by frame-aligned CV", async () => {
+    const frames = 512;
+    const audio = new Float32Array(frames).fill(1);
+    const ramp = new Float32Array(frames);
+    for (let i = 0; i < frames; i++) ramp[i] = i / frames;
+
+    const node = new VcaNode({ gain: 1 });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          audio: [
+            makeSignalChunk(audio, SR, 1, false, "pcm16le"),
+            makeDoneSignalChunk(SR, 1, "pcm16le")
+          ],
+          cv: [
+            makeSignalChunk(ramp, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+
+    const out = concatEmitted(emitted);
+    expect(out.length).toBe(frames);
+    for (let i = 0; i < frames; i += 37) {
+      expect(out[i]).toBeCloseTo(ramp[i], 3); // pcm16 quantization tolerance
+    }
+  });
+
+  it("holds the last CV value when the CV stream ends early", async () => {
+    const frames = 256;
+    const audio = new Float32Array(frames).fill(1);
+    const cv = new Float32Array(frames).fill(0.5);
+    cv[frames - 1] = 0.25;
+
+    const node = new VcaNode({ gain: 1 });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          audio: [
+            makeSignalChunk(audio, SR, 1, false, "pcm16le"),
+            makeSignalChunk(audio, SR, 1, false, "pcm16le"),
+            makeDoneSignalChunk(SR, 1, "pcm16le")
+          ],
+          cv: [
+            makeSignalChunk(cv, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+
+    const out = concatEmitted(emitted);
+    expect(out.length).toBe(frames * 2);
+    expect(out[0]).toBeCloseTo(0.5, 3);
+    // Second audio chunk is covered by holding the CV's final value.
+    for (let i = frames; i < frames * 2; i += 31) {
+      expect(out[i]).toBeCloseTo(0.25, 3);
+    }
+  });
+
+  it("acts as a plain gain when cv is unpatched", async () => {
+    const frames = 128;
+    const audio = new Float32Array(frames).fill(0.5);
+    const node = new VcaNode({ gain: 2 });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          audio: [
+            makeSignalChunk(audio, SR, 1, false, "pcm16le"),
+            makeDoneSignalChunk(SR, 1, "pcm16le")
+          ]
+        }
+      }),
+      outputs
+    );
+    const out = concatEmitted(emitted);
+    for (let i = 0; i < frames; i += 17) expect(out[i]).toBeCloseTo(1, 3);
+  });
+});
+
+describe("LFO (clocked)", () => {
+  it("matches the clock's chunk cadence and resets phase on rising edges", async () => {
+    const sizes = [512, 256, 128];
+    const clocks = sizes.map((n, idx) => {
+      const buf = new Float32Array(n);
+      if (idx === 1) buf.fill(1); // rising edge at the start of chunk 2
+      return makeSignalChunk(buf, SR, 1, false, "f32le");
+    });
+    clocks.push(makeDoneSignalChunk(SR, 1, "f32le"));
+
+    const node = new LfoNode({
+      waveform: "saw",
+      rate_hz: 10,
+      depth: 1,
+      offset: 0
+    });
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles: { clock: clocks } }), outputs);
+
+    expect(emitted).toHaveLength(4);
+    for (let i = 0; i < 3; i++) {
+      expect(readSignalChunk(emitted[i][1])!.samples.length).toBe(sizes[i]);
+    }
+    expect(readSignalChunk(emitted[3][1])!.done).toBe(true);
+
+    // Saw at phase 0 is -1: the reset lands exactly at chunk 2's first sample.
+    const secondChunk = readSignalChunk(emitted[1][1])!.samples;
+    expect(secondChunk[0]).toBe(-1);
+  });
+});
+
+describe("SampleHold", () => {
+  it("samples on trigger rising edges and holds between them", async () => {
+    const frames = 8;
+    const signal = new Float32Array([10, 20, 30, 40, 50, 60, 70, 80]);
+    const trigger = new Float32Array([0, 1, 0, 0, 1, 1, 0, 1]);
+    const node = new SampleHoldNode({});
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(
+      makeInputs({
+        handles: {
+          signal: [
+            makeSignalChunk(signal, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ],
+          trigger: [
+            makeSignalChunk(trigger, SR, 1, false, "f32le"),
+            makeDoneSignalChunk(SR, 1, "f32le")
+          ]
+        }
+      }),
+      outputs
+    );
+    const out = concatEmitted(emitted);
+    expect([...out]).toEqual([0, 20, 20, 20, 50, 50, 50, 80]);
+    expect(out.length).toBe(frames);
+  });
+});
+
+describe("Mixer", () => {
+  it("sums while open, contributes silence after a handle ends, and ends after all end", async () => {
+    // Levels chosen so the sum stays below 1 — the pcm16le output clamps.
+    const ones = new Float32Array(4).fill(0.5);
+    const halves = new Float32Array(4).fill(0.25);
+    const handles = {
+      in1: [
+        makeSignalChunk(ones, SR, 1, false, "pcm16le"),
+        makeSignalChunk(ones, SR, 1, false, "pcm16le"),
+        makeDoneSignalChunk(SR, 1, "pcm16le")
+      ],
+      in2: [
+        makeSignalChunk(halves, SR, 1, false, "pcm16le"),
+        makeDoneSignalChunk(SR, 1, "pcm16le")
+      ]
+    };
+    const order: Array<[string, number]> = [
+      ["in1", 0],
+      ["in2", 0],
+      ["in2", 1], // in2 done
+      ["in1", 1],
+      ["in1", 2] // in1 done
+    ];
+    const node = new MixerNode({});
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(makeInputs({ handles, order }), outputs);
+
+    const chunks = emitted.map(([, v]) => readSignalChunk(v)!);
+    expect(chunks[chunks.length - 1].done).toBe(true);
+    const out = concatEmitted(emitted);
+    expect(out.length).toBe(8);
+    for (let i = 0; i < 4; i++) expect(out[i]).toBeCloseTo(0.75, 3);
+    // in2 has ended — it contributes silence.
+    for (let i = 4; i < 8; i++) expect(out[i]).toBeCloseTo(0.5, 3);
+  });
+});

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -283,6 +283,14 @@ export {
   AUDIO_NODES
 } from "@nodetool-ai/audio-nodes/nodes/audio";
 export {
+  AudioToChunksNode,
+  ChunksToAudioNode,
+  StreamingGainNode,
+  StreamingLowPassNode,
+  StreamingHighPassNode,
+  REALTIME_AUDIO_NODES
+} from "@nodetool-ai/audio-nodes/nodes/realtime-audio";
+export {
   WaitNode,
   ManualTriggerNode,
   IntervalTriggerNode,
@@ -715,6 +723,7 @@ import { DATA_NODES } from "@nodetool-ai/data-nodes/nodes/data";
 import { CODE_NODES } from "@nodetool-ai/code-nodes/nodes/code";
 import { CodeNode } from "@nodetool-ai/code-nodes/nodes/code-node";
 import { AUDIO_NODES } from "@nodetool-ai/audio-nodes/nodes/audio";
+import { REALTIME_AUDIO_NODES } from "@nodetool-ai/audio-nodes/nodes/realtime-audio";
 import { TRIGGER_NODES } from "@nodetool-ai/automation-nodes/nodes/triggers";
 import { IMAGE_NODES } from "@nodetool-ai/image-nodes/nodes/image";
 import { VIDEO_NODES } from "@nodetool-ai/video-nodes/nodes/video";
@@ -797,6 +806,7 @@ export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...LIB_DATETIME_NODES,
   ...LIB_VALIDATE_NODES,
   ...AUDIO_NODES,
+  ...REALTIME_AUDIO_NODES,
   ...TRIGGER_NODES,
   ...IMAGE_NODES,
   ...VIDEO_NODES,

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -291,6 +291,18 @@ export {
   REALTIME_AUDIO_NODES
 } from "@nodetool-ai/audio-nodes/nodes/realtime-audio";
 export {
+  OscillatorNode,
+  LfoNode,
+  AdsrNode,
+  GateNode,
+  VcaNode,
+  VcfNode,
+  AttenuverterNode,
+  SampleHoldNode,
+  MixerNode,
+  SYNTHESIS_NODES
+} from "@nodetool-ai/audio-nodes/nodes/synthesis";
+export {
   WaitNode,
   ManualTriggerNode,
   IntervalTriggerNode,
@@ -724,6 +736,7 @@ import { CODE_NODES } from "@nodetool-ai/code-nodes/nodes/code";
 import { CodeNode } from "@nodetool-ai/code-nodes/nodes/code-node";
 import { AUDIO_NODES } from "@nodetool-ai/audio-nodes/nodes/audio";
 import { REALTIME_AUDIO_NODES } from "@nodetool-ai/audio-nodes/nodes/realtime-audio";
+import { SYNTHESIS_NODES } from "@nodetool-ai/audio-nodes/nodes/synthesis";
 import { TRIGGER_NODES } from "@nodetool-ai/automation-nodes/nodes/triggers";
 import { IMAGE_NODES } from "@nodetool-ai/image-nodes/nodes/image";
 import { VIDEO_NODES } from "@nodetool-ai/video-nodes/nodes/video";
@@ -807,6 +820,7 @@ export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...LIB_VALIDATE_NODES,
   ...AUDIO_NODES,
   ...REALTIME_AUDIO_NODES,
+  ...SYNTHESIS_NODES,
   ...TRIGGER_NODES,
   ...IMAGE_NODES,
   ...VIDEO_NODES,

--- a/packages/image-nodes/src/nodes/image-io.ts
+++ b/packages/image-nodes/src/nodes/image-io.ts
@@ -53,23 +53,8 @@ export function rawRgbaImageRef(
 
 /* -------------------------- base64 (Buffer-free) -------------------------- */
 
-/** Decode a base64 string to bytes without `Buffer` (works on Node and browser). */
-export function base64ToBytes(b64: string): Uint8Array {
-  const binary = atob(b64);
-  const out = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
-  return out;
-}
-
-/** Encode bytes to a base64 string without `Buffer`. */
-export function bytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
-}
+import { base64ToBytes, bytesToBase64 } from "@nodetool-ai/nodes-utils";
+export { base64ToBytes, bytesToBase64 };
 
 /** Strip a `data:...;base64,` prefix if present, returning the raw base64. */
 function stripDataUrlPrefix(data: string): string {

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -183,6 +183,13 @@ export class NodeActor {
    */
   private _iterationCounters = new Map<string, Map<string, number>>();
 
+  /**
+   * Run-level cancellation signal (aborted by `WorkflowRunner.cancel()`),
+   * exposed to node code via `NodeInputs.signal`. Defaults to a
+   * never-aborted signal for test fixtures.
+   */
+  private _cancelSignal: AbortSignal;
+
   constructor(opts: {
     node: NodeDescriptor;
     inbox: NodeInbox;
@@ -197,6 +204,7 @@ export class NodeActor {
     listInputHandles?: Set<string>;
     controlContext?: Record<string, unknown> | null;
     correlation?: NodeAnalysis;
+    cancelSignal?: AbortSignal;
   }) {
     this.node = opts.node;
     this.inbox = opts.inbox;
@@ -207,6 +215,7 @@ export class NodeActor {
     this._listInputHandles = opts.listInputHandles ?? new Set();
     this._controlContext = opts.controlContext ?? null;
     this._correlation = opts.correlation;
+    this._cancelSignal = opts.cancelSignal ?? new AbortController().signal;
   }
 
   // -----------------------------------------------------------------------
@@ -251,7 +260,8 @@ export class NodeActor {
           const nodeInputs = new NodeInputs(
             this.inbox,
             this._lastEnvelopes,
-            this._correlation
+            this._correlation,
+            this._cancelSignal
           );
           const nodeOutputs = new NodeOutputs({
             sendFn: async (slot: string, value: unknown, opts) => {

--- a/packages/kernel/src/io.ts
+++ b/packages/kernel/src/io.ts
@@ -17,6 +17,7 @@ export class NodeInputs {
   private _inbox: NodeInbox;
   private _envelopeTracker: Map<string, MessageEnvelope> | null;
   private _analysis: NodeAnalysis | undefined;
+  private _signal: AbortSignal;
 
   /**
    * `envelopeTracker`, when provided, records the most recently consumed
@@ -28,15 +29,29 @@ export class NodeInputs {
    * `analysis` is the per-node static correlation analysis; nodes that need
    * scope information at runtime (Zip/Cross) read it via `scopeFor()` and
    * `invocationScope()`.
+   *
+   * `signal` is the run's cancellation signal (aborted by
+   * `WorkflowRunner.cancel()`). Defaults to a never-aborted signal so test
+   * fixtures that construct NodeInputs directly stay terse.
    */
   constructor(
     inbox: NodeInbox,
     envelopeTracker?: Map<string, MessageEnvelope> | null,
-    analysis?: NodeAnalysis
+    analysis?: NodeAnalysis,
+    signal?: AbortSignal
   ) {
     this._inbox = inbox;
     this._envelopeTracker = envelopeTracker ?? null;
     this._analysis = analysis;
+    this._signal = signal ?? new AbortController().signal;
+  }
+
+  /**
+   * Aborted when the run is cancelled. Inbox closure only unblocks
+   * consumers; producing loops (generators, pacers) must observe this.
+   */
+  get signal(): AbortSignal {
+    return this._signal;
   }
 
   /**

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -217,6 +217,9 @@ export class WorkflowRunner {
   /** Cancellation flag. */
   private _cancelled = false;
 
+  /** Run-level cancellation signal source; aborted by `cancel()`. */
+  private _abortController = new AbortController();
+
   /**
    * Pending response resolvers for sendControlEvent, FIFO per node. The
    * controlled actor processes control events in order and emits outputs in
@@ -515,6 +518,7 @@ export class WorkflowRunner {
     this._outputs = new Map();
     this._messages = [];
     this._cancelled = false;
+    this._abortController = new AbortController();
     this._pendingControlResponses = new Map();
     this._completedNodes = new Set();
     this._executors = new Map();
@@ -528,6 +532,10 @@ export class WorkflowRunner {
   cancel(): void {
     log.info("Job cancelled", { jobId: this.jobId });
     this._cancelled = true;
+    // Stop producing loops (generators, pacers) that never wait on inputs —
+    // closing inboxes only unblocks consumers. Nodes observe this via
+    // `inputs.signal`.
+    this._abortController.abort();
     // Close all inboxes to unblock waiting actors
     for (const inbox of this._inboxes.values()) {
       void inbox.closeAll();
@@ -876,7 +884,8 @@ export class WorkflowRunner {
         executionContext: this._options.executionContext,
         listInputHandles: this._multiEdgeListInputs.get(node.id),
         controlContext,
-        correlation: this._correlation?.nodes.get(node.id)
+        correlation: this._correlation?.nodes.get(node.id),
+        cancelSignal: this._abortController.signal
       });
 
       actorPromises.push(

--- a/packages/kernel/tests/cancel-signal.test.ts
+++ b/packages/kernel/tests/cancel-signal.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Run-level cancellation signal: `WorkflowRunner.cancel()` aborts an
+ * AbortController whose signal reaches node code via `NodeInputs.signal`.
+ * Inbox closure only unblocks consumers — this signal is how producing
+ * loops (generators, wall-clock pacers) learn the run is over.
+ */
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner } from "../src/runner.js";
+import { NodeActor, type NodeExecutor } from "../src/actor.js";
+import { NodeInbox } from "../src/inbox.js";
+import { NodeInputs } from "../src/io.js";
+import type { NodeAnalysis } from "../src/correlation-analysis.js";
+import type { NodeDescriptor } from "@nodetool-ai/protocol";
+
+const EMPTY_ANALYSIS: NodeAnalysis = {
+  invocationScope: [],
+  inputs: new Map(),
+  outputs: new Map()
+};
+
+describe("NodeInputs.signal", () => {
+  it("defaults to a never-aborted signal", () => {
+    const inputs = new NodeInputs(new NodeInbox());
+    expect(inputs.signal.aborted).toBe(false);
+  });
+
+  it("exposes the supplied signal", () => {
+    const controller = new AbortController();
+    const inputs = new NodeInputs(
+      new NodeInbox(),
+      null,
+      undefined,
+      controller.signal
+    );
+    expect(inputs.signal.aborted).toBe(false);
+    controller.abort();
+    expect(inputs.signal.aborted).toBe(true);
+  });
+});
+
+describe("NodeActor cancelSignal wiring", () => {
+  it("passes cancelSignal through to inputs.signal in run()", async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    const node: NodeDescriptor = {
+      id: "n1",
+      type: "test.Streaming",
+      is_streaming_input: true
+    };
+    const executor: NodeExecutor = {
+      async process() {
+        return {};
+      },
+      async run(inputs) {
+        seen = (inputs as { signal: AbortSignal }).signal;
+      }
+    };
+    const actor = new NodeActor({
+      node,
+      inbox: new NodeInbox(),
+      executor,
+      correlation: EMPTY_ANALYSIS,
+      sendOutputs: async () => {},
+      emitMessage: () => {},
+      cancelSignal: controller.signal
+    });
+    await actor.run();
+    expect(seen).toBeDefined();
+    expect(seen!.aborted).toBe(false);
+    controller.abort();
+    expect(seen!.aborted).toBe(true);
+  });
+});
+
+describe("WorkflowRunner.cancel() aborts the run signal", () => {
+  it("a producing streaming node observes the abort and stops", async () => {
+    let observed: AbortSignal | undefined;
+    let stoppedByAbort = false;
+
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "src",
+        type: "test.InfiniteSource",
+        is_streaming_input: true,
+        outputs: { out: "int" }
+      },
+      { id: "sink", type: "test.Sink", outputs: { result: "int" } }
+    ];
+    const edges = [
+      { source: "src", sourceHandle: "out", target: "sink", targetHandle: "a" }
+    ];
+
+    const sourceExecutor: NodeExecutor = {
+      async process() {
+        return {};
+      },
+      async run(inputs, outputs) {
+        observed = (inputs as { signal: AbortSignal }).signal;
+        // Producing loop with no input waits — only the signal can stop it.
+        for (let i = 0; i < 10_000; i++) {
+          if (observed.aborted) {
+            stoppedByAbort = true;
+            return;
+          }
+          await outputs.emit("out", i);
+          await new Promise((r) => setTimeout(r, 1));
+        }
+      }
+    };
+    const sinkExecutor: NodeExecutor = {
+      async process() {
+        return { result: 0 };
+      }
+    };
+
+    const runner = new WorkflowRunner("job-cancel", {
+      resolveExecutor: (node) =>
+        node.id === "src" ? sourceExecutor : sinkExecutor
+    });
+
+    const runPromise = runner.run({ job_id: "job-cancel" }, { nodes, edges });
+    await new Promise((r) => setTimeout(r, 50));
+    runner.cancel();
+    const result = await runPromise;
+
+    expect(result.status).toBe("cancelled");
+    expect(observed?.aborted).toBe(true);
+    expect(stoppedByAbort).toBe(true);
+  });
+});

--- a/packages/nodes-utils/src/base64.ts
+++ b/packages/nodes-utils/src/base64.ts
@@ -1,0 +1,25 @@
+/**
+ * Buffer-free base64 helpers shared by the `*-nodes` packages.
+ *
+ * `atob`/`btoa` are global on Node ≥ 16 and in every browser, so these work
+ * in both environments without touching `node:buffer` (which the web bundle
+ * stubs out).
+ */
+
+/** Decode a base64 string to bytes without `Buffer` (works on Node and browser). */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+/** Encode bytes to a base64 string without `Buffer`. */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}

--- a/packages/nodes-utils/src/index.ts
+++ b/packages/nodes-utils/src/index.ts
@@ -12,6 +12,8 @@
  *     non-Node runtimes.
  *   - `template.ts` — `{{ variable }}` / `{variable}` substitution shared by
  *     the Prompt, Format Text and Agent nodes.
+ *   - `base64.ts` — Buffer-free base64 encode/decode usable in Node and the
+ *     browser bundle alike.
  */
 
 export {
@@ -30,3 +32,5 @@ export {
 } from "./node-only-modules.js";
 
 export { renderTemplate } from "./template.js";
+
+export { base64ToBytes, bytesToBase64 } from "./base64.js";

--- a/packages/runtime/src/node-executor.ts
+++ b/packages/runtime/src/node-executor.ts
@@ -49,6 +49,21 @@ export interface StreamingInputs {
    * join nodes (§7). `[]` when analysis is off or the node has no inputs.
    */
   invocationScope(): ReadonlyArray<string>;
+
+  /**
+   * True if the handle has at least one open upstream source. Distinguishes
+   * patched from unpatched optional streaming inputs (upstream counts are
+   * registered before actors start, so this is race-free at the top of
+   * `run()`).
+   */
+  hasStream(name: string): boolean;
+
+  /**
+   * Aborted when the run is cancelled. Producers that emit without waiting
+   * on inputs (generators, wall-clock pacers) must observe it — inbox
+   * closure only unblocks consumers, it does not stop a producing loop.
+   */
+  readonly signal: AbortSignal;
 }
 
 /**

--- a/web/src/components/node/output/ChunkRenderer.tsx
+++ b/web/src/components/node/output/ChunkRenderer.tsx
@@ -43,6 +43,7 @@ export const ChunkRenderer: React.FC<Props> = memo(({ chunk }) => {
           base64={chunk.content as string}
           sampleRate={(meta?.sample_rate as number | undefined) ?? 22000}
           channels={(meta?.channels as number | undefined) ?? 1}
+          encoding={meta?.encoding === "f32le" ? "f32le" : "pcm16le"}
         />
       );
     }

--- a/web/src/components/node/output/StreamPcm16Player.tsx
+++ b/web/src/components/node/output/StreamPcm16Player.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef } from "react";
-import { playPcm16Base64 } from "./audio";
+import { playPcm16Base64, type PcmEncoding } from "./audio";
 
 const StreamPcm16Player: React.FC<{
   base64: string;
   sampleRate?: number;
   channels?: number;
-}> = ({ base64, sampleRate = 16000, channels = 1 }) => {
+  encoding?: PcmEncoding;
+}> = ({ base64, sampleRate = 16000, channels = 1, encoding = "pcm16le" }) => {
   const lastPlayedRef = useRef<string | null>(null);
   useEffect(() => {
     if (
@@ -14,13 +15,13 @@ const StreamPcm16Player: React.FC<{
       base64 !== lastPlayedRef.current
     ) {
       try {
-        playPcm16Base64(base64, { sampleRate, channels });
+        playPcm16Base64(base64, { sampleRate, channels, encoding });
       } catch (e) {
         console.error("PCM16 chunk playback failed", e);
       }
       lastPlayedRef.current = base64;
     }
-  }, [base64, sampleRate, channels]);
+  }, [base64, sampleRate, channels, encoding]);
   return null;
 };
 

--- a/web/src/components/node/output/audio.ts
+++ b/web/src/components/node/output/audio.ts
@@ -35,12 +35,15 @@ export function int16ToFloat32(int16Array: Int16Array): Float32Array {
   return float32;
 }
 
+export type PcmEncoding = "pcm16le" | "f32le";
+
 export function playPcm16Base64(
   base64: string,
-  opts?: { sampleRate?: number; channels?: number }
+  opts?: { sampleRate?: number; channels?: number; encoding?: PcmEncoding }
 ): void {
   const sampleRate = opts?.sampleRate ?? 22000;
   const channels = opts?.channels ?? 1;
+  const encoding = opts?.encoding ?? "pcm16le";
 
   const ctx = getAudioContext();
   ctx.resume().catch((err) => {
@@ -50,18 +53,30 @@ export function playPcm16Base64(
 
   const u8 = base64ToUint8Array(base64);
   const view = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
-  const frameCount = Math.floor(u8.byteLength / 2 / channels);
+  const bytesPerSample = encoding === "f32le" ? 4 : 2;
+  const frameCount = Math.floor(u8.byteLength / bytesPerSample / channels);
   const buffer = ctx.createBuffer(channels, frameCount, sampleRate);
 
   for (let ch = 0; ch < channels; ch++) {
-    const channelData = new Int16Array(frameCount);
-    let srcIndex = ch * 2;
-    for (let i = 0; i < frameCount; i++) {
-      const sample = view.getInt16(srcIndex, true);
-      channelData[i] = sample;
-      srcIndex += channels * 2;
+    let floatData: Float32Array;
+    if (encoding === "f32le") {
+      floatData = new Float32Array(frameCount);
+      let srcIndex = ch * 4;
+      for (let i = 0; i < frameCount; i++) {
+        // CV legitimately exceeds [-1, 1]; clamp for the speaker path.
+        floatData[i] = Math.max(-1, Math.min(1, view.getFloat32(srcIndex, true)));
+        srcIndex += channels * 4;
+      }
+    } else {
+      const channelData = new Int16Array(frameCount);
+      let srcIndex = ch * 2;
+      for (let i = 0; i < frameCount; i++) {
+        const sample = view.getInt16(srcIndex, true);
+        channelData[i] = sample;
+        srcIndex += channels * 2;
+      }
+      floatData = int16ToFloat32(channelData);
     }
-    const floatData = int16ToFloat32(channelData);
     buffer.copyToChannel(floatData as Float32Array<ArrayBuffer>, ch);
   }
 

--- a/web/src/config/data_types.ts
+++ b/web/src/config/data_types.ts
@@ -149,6 +149,18 @@ const NODETOOL_DATA_TYPES: DataType[] = [
     icon: "Message"
   },
   {
+    value: "cv",
+    label: "CV",
+    description:
+      "Control-voltage signal for modular synthesis — a streaming float32 chunk carrying pitch, gate, or modulation data. Interoperable with audio chunk streams.",
+    color: colour("event"),
+    textColor: "var(--palette-action-active)",
+    name: "",
+    slug: "",
+    namespace: "",
+    icon: "SettingsInputComponent"
+  },
+  {
     value: "dataframe",
     label: "Dataframe",
     description:

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -135,7 +135,8 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     audioCore,
     audioDsp,
     audioEffects,
-    audioRealtime
+    audioRealtime,
+    audioSynthesis
   ] = await Promise.all([
     import("@nodetool-ai/workflow-runner/browser"),
     import("@nodetool-ai/core-nodes/nodes/constant"),
@@ -178,7 +179,8 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     import("@nodetool-ai/audio-nodes/nodes/audio"),
     import("@nodetool-ai/audio-nodes/nodes/lib-audio-dsp"),
     import("@nodetool-ai/audio-nodes/nodes/lib-audio-effects"),
-    import("@nodetool-ai/audio-nodes/nodes/realtime-audio")
+    import("@nodetool-ai/audio-nodes/nodes/realtime-audio"),
+    import("@nodetool-ai/audio-nodes/nodes/synthesis")
   ]);
 
   const groups: Array<[string, unknown]> = [
@@ -209,7 +211,8 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     ["audio", audioCore],
     ["lib-audio-dsp", audioDsp],
     ["lib-audio-effects", audioEffects],
-    ["realtime-audio", audioRealtime]
+    ["realtime-audio", audioRealtime],
+    ["synthesis", audioSynthesis]
   ];
   const nodeClasses: unknown[] = [];
   const perGroup: Record<string, number> = {};

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -131,7 +131,11 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     imageEnhance,
     imageDraw,
     imageCore,
-    audioPreview
+    audioPreview,
+    audioCore,
+    audioDsp,
+    audioEffects,
+    audioRealtime
   ] = await Promise.all([
     import("@nodetool-ai/workflow-runner/browser"),
     import("@nodetool-ai/core-nodes/nodes/constant"),
@@ -165,7 +169,16 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     // Preview is a pure pass-through that renders any value; its own browser-safe
     // module (no audio-codec deps) lets pass-through graphs ending in a Preview
     // run client-side instead of forcing a server round-trip.
-    import("@nodetool-ai/audio-nodes/nodes/preview")
+    import("@nodetool-ai/audio-nodes/nodes/preview"),
+    // audio.ts mixes pure sample/byte transforms (hybrid) with node-only
+    // Load/Save/TTS nodes tagged server; dsp/effects route WebAudio through
+    // lib/audio-context.ts (global OfflineAudioContext or pure-JS biquad
+    // fallback) and hide node-web-audio-api / rubberband behind importHidden,
+    // so all four modules bundle cleanly.
+    import("@nodetool-ai/audio-nodes/nodes/audio"),
+    import("@nodetool-ai/audio-nodes/nodes/lib-audio-dsp"),
+    import("@nodetool-ai/audio-nodes/nodes/lib-audio-effects"),
+    import("@nodetool-ai/audio-nodes/nodes/realtime-audio")
   ]);
 
   const groups: Array<[string, unknown]> = [
@@ -192,7 +205,11 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     ["lib-image-enhance", imageEnhance],
     ["lib-image-draw", imageDraw],
     ["image", imageCore],
-    ["preview", audioPreview]
+    ["preview", audioPreview],
+    ["audio", audioCore],
+    ["lib-audio-dsp", audioDsp],
+    ["lib-audio-effects", audioEffects],
+    ["realtime-audio", audioRealtime]
   ];
   const nodeClasses: unknown[] = [];
   const perGroup: Record<string, number> = {};

--- a/web/src/utils/TypeHandler.ts
+++ b/web/src/utils/TypeHandler.ts
@@ -210,6 +210,17 @@ export const isConnectable = (
     return true;
   }
 
+  // CV ↔ chunk interop (Eurorack semantics): control-voltage streams ride
+  // the same chunk wire shape, so cv patches into chunk sockets and vice
+  // versa — an LFO can drive any streaming audio input, and audio can be
+  // used as a modulation source.
+  if (
+    (source.type === "cv" && target.type === "chunk") ||
+    (source.type === "chunk" && target.type === "cv")
+  ) {
+    return true;
+  }
+
   // COLLECT HANDLE LOGIC: Allow connecting T -> list[T]
   // This enables "collect" handles where multiple outputs of type T can connect
   // to a single input of type list[T].

--- a/web/src/utils/__tests__/TypeHandler.test.ts
+++ b/web/src/utils/__tests__/TypeHandler.test.ts
@@ -384,6 +384,35 @@ describe("TypeHandler", () => {
       expect(isConnectable(str1, str2)).toBe(true);
     });
 
+    describe("cv (control voltage) interop", () => {
+      const cv: TypeMetadata = { type: "cv", optional: false, type_args: [] };
+      const chunk: TypeMetadata = { type: "chunk", optional: false, type_args: [] };
+      const audio: TypeMetadata = { type: "audio", optional: false, type_args: [] };
+      const float: TypeMetadata = { type: "float", optional: false, type_args: [] };
+      const any: TypeMetadata = { type: "any", optional: false, type_args: [] };
+
+      it("connects cv to cv", () => {
+        expect(isConnectable(cv, cv)).toBe(true);
+      });
+
+      it("connects cv and chunk bidirectionally (Eurorack interop)", () => {
+        expect(isConnectable(cv, chunk)).toBe(true);
+        expect(isConnectable(chunk, cv)).toBe(true);
+      });
+
+      it("does not connect cv to audio or float", () => {
+        expect(isConnectable(cv, audio)).toBe(false);
+        expect(isConnectable(audio, cv)).toBe(false);
+        expect(isConnectable(cv, float)).toBe(false);
+        expect(isConnectable(float, cv)).toBe(false);
+      });
+
+      it("connects cv to any", () => {
+        expect(isConnectable(cv, any)).toBe(true);
+        expect(isConnectable(any, cv)).toBe(true);
+      });
+    });
+
     it("should not connect different basic types", () => {
       const str: TypeMetadata = { type: "str", optional: false, type_args: [] };
       const num: TypeMetadata = { type: "number", optional: false, type_args: [] };


### PR DESCRIPTION
## Summary

Introduces a complete modular synthesis subsystem and realtime audio streaming infrastructure to the audio-nodes package. This enables Eurorack-style patching of oscillators, envelopes, filters, and control-voltage (CV) streams, plus streaming audio effects that maintain filter state across chunk boundaries.

## Key Changes

### New Synthesis Nodes (`packages/audio-nodes/src/nodes/synthesis.ts`)
- **OscillatorNode** (VCO): Sine, saw, square, triangle, noise waveforms with pitch CV (volts/octave) and FM modulation
- **LfoNode**: Low-frequency oscillator for modulation (vibrato, tremolo, filter sweeps)
- **AdsrNode**: Attack-Decay-Sustain-Release envelope with gate input
- **GateNode**: Gate signal generator (trigger/pulse source)
- **VcaNode**: Voltage-controlled amplifier (CV-driven gain)
- **VcfNode**: Voltage-controlled filter (lowpass/highpass with CV cutoff)
- **SampleHoldNode**: Sample-and-hold for quantization/sequencing
- **MixerNode**: Multi-input audio mixer

All synthesis nodes operate on sample-domain timing (never wall-clock), render deterministically for bounded durations, and support realtime pacing via `RealtimePacer`. Driven nodes (with CV inputs) derive timing from their input streams; free-running generators emit for a specified duration or infinitely in realtime mode.

### New Realtime Audio Streaming Nodes (`packages/audio-nodes/src/nodes/realtime-audio.ts`)
- **AudioToChunksNode**: Slices WAV files into fixed-duration PCM16 chunks for streaming
- **ChunksToAudioNode**: Reassembles chunks back into WAV files
- **StreamingGainNode**: Per-chunk gain control
- **StreamingLowPassNode** / **StreamingHighPassNode**: Biquad filters with state carried across chunks

### Control-Voltage (CV) Infrastructure (`packages/audio-nodes/src/lib/cv.ts`)
- `SignalChunk` type and codec (`readSignalChunk`, `makeSignalChunk`) supporting both PCM16LE audio and F32LE CV encodings
- `SampleFifo` and `alignedSignalStreams`: "zip-with-hold" pattern for sample-aligned multi-input streaming (one output chunk per input chunk, same frame count)
- `RealtimePacer`: Wall-clock pacing for infinite generators (delays emission only, never changes signal content)
- CV is first-class: rides the same chunk wire as audio, enabling Eurorack-style patching (CV ↔ chunk interop)

### DSP Cores (`packages/audio-nodes/src/lib/synth-dsp.ts`, `packages/audio-nodes/src/lib/biquad.ts`)
- Pure sample-domain oscillator waveforms (`oscSample`) and ADSR state machine (`adsrStep`, `adsrCoeff`)
- RBJ Audio-EQ-Cookbook biquad filters with normalized coefficients and Direct Form I state
- `applyBiquadToWav`: Batch filter for WAV files (fallback when WebAudio unavailable)

### Type System & Interop
- New `"cv"` data type in the type system (web/src/config/data_types.ts)
- CV ↔ chunk socket interop in TypeHandler (web/src/utils/TypeHandler.ts) — control-voltage streams patch into audio sockets and vice versa
- Browser platform support: synthesis and realtime audio nodes tagged `tagAsHybrid` (run on Node and in browser workflow runner)

### Infrastructure
- `AbortSignal` propagation: `NodeInputs.signal` exposes run-level cancellation (aborted by `WorkflowRunner.cancel()`), allowing generators and pacers to cleanly exit on workflow cancellation
- Buffer-free base64 helpers (packages/nodes-utils/src/base64.ts) — `atob`/`btoa` work on Node ≥16 and all browsers without touching `node:buffer`

https://claude.ai/code/session_012Wj7r6QsWhTBZp8w3iUB7M