### PR TITLE
Add enable/disable toggles for included node packs

### DIFF
--- a/electron/jest.config.ts
+++ b/electron/jest.config.ts
@@ -13,6 +13,7 @@ export default {
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/src/__mocks__/fileMock.ts',
     '^@nodetool-ai/protocol$': '<rootDir>/src/__mocks__/protocol.ts',
     '^@nodetool-ai/protocol/bridge-protocol$': '<rootDir>/../packages/protocol/src/bridge-protocol.ts',
+    '^@nodetool-ai/protocol/builtin-packs$': '<rootDir>/../packages/protocol/src/builtin-packs.ts',
     '^@nodetool-ai/websocket/trpc$': '<rootDir>/src/__mocks__/websocket-trpc.ts',
     '^superjson$': '<rootDir>/src/__mocks__/superjson.ts',
     '^@nodetool-ai/config$': '<rootDir>/../packages/config/src/index.ts',

--- a/electron/src/__tests__/builtinPacks.test.ts
+++ b/electron/src/__tests__/builtinPacks.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Built-in pack enable/disable persistence.
+ *
+ * The module reads/writes `disabledBuiltins` in the packs config file shared
+ * with the backend pack loader, so these tests pin: defaults (everything
+ * enabled), round-tripping a toggle, preservation of unrelated config keys,
+ * and the guards (unknown id, required pack).
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { listBuiltinPacks, setBuiltinPackEnabled } from "../builtinPacks";
+
+describe("builtinPacks", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nodetool-builtin-packs-"));
+    configPath = join(dir, "packs.json");
+    process.env.NODETOOL_PACKS_CONFIG = configPath;
+  });
+
+  afterEach(() => {
+    delete process.env.NODETOOL_PACKS_CONFIG;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("all packs enabled by default when no config file exists", () => {
+    const packs = listBuiltinPacks();
+    expect(packs.length).toBeGreaterThan(0);
+    expect(packs.every((p) => p.enabled)).toBe(true);
+    const base = packs.find((p) => p.id === "base");
+    expect(base?.required).toBe(true);
+  });
+
+  test("disabling a pack persists and round-trips", () => {
+    const updated = setBuiltinPackEnabled("fal", false);
+    expect(updated.find((p) => p.id === "fal")?.enabled).toBe(false);
+
+    // Fresh read sees the same state.
+    expect(listBuiltinPacks().find((p) => p.id === "fal")?.enabled).toBe(false);
+
+    const reEnabled = setBuiltinPackEnabled("fal", true);
+    expect(reEnabled.find((p) => p.id === "fal")?.enabled).toBe(true);
+    expect(listBuiltinPacks().every((p) => p.enabled)).toBe(true);
+  });
+
+  test("preserves unrelated keys in the shared packs config file", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ allow: ["@acme/cool-nodes"], allowUnlisted: false }),
+      "utf8",
+    );
+
+    setBuiltinPackEnabled("replicate", false);
+
+    const config = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(config.allow).toEqual(["@acme/cool-nodes"]);
+    expect(config.allowUnlisted).toBe(false);
+    expect(config.disabledBuiltins).toEqual(["replicate"]);
+  });
+
+  test("rejects unknown pack ids", () => {
+    expect(() => setBuiltinPackEnabled("nope", false)).toThrow(
+      /Unknown built-in pack/,
+    );
+  });
+
+  test("required packs cannot be disabled", () => {
+    expect(() => setBuiltinPackEnabled("base", false)).toThrow(
+      /cannot be disabled/,
+    );
+  });
+
+  test("tolerates a corrupt config file", () => {
+    writeFileSync(configPath, "not json", "utf8");
+    expect(listBuiltinPacks().every((p) => p.enabled)).toBe(true);
+    const updated = setBuiltinPackEnabled("kie", false);
+    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(false);
+  });
+});

--- a/electron/src/__tests__/builtinPacks.test.ts
+++ b/electron/src/__tests__/builtinPacks.test.ts
@@ -1,10 +1,12 @@
 /**
  * Built-in pack enable/disable persistence.
  *
- * The module reads/writes `disabledBuiltins` in the packs config file shared
- * with the backend pack loader, so these tests pin: defaults (everything
- * enabled), round-tripping a toggle, preservation of unrelated config keys,
- * and the guards (unknown id, required pack).
+ * Built-in packs are opt-in: only `required` / `defaultEnabled` packs are on
+ * after a fresh install. The module reads/writes `enabledBuiltins` /
+ * `disabledBuiltins` in the packs config file shared with the backend pack
+ * loader, so these tests pin: install defaults, round-tripping overrides in
+ * both directions, preservation of unrelated config keys, and the guards
+ * (unknown id, required pack).
  */
 
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -28,24 +30,36 @@ describe("builtinPacks", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("all packs enabled by default when no config file exists", () => {
+  test("only required and default-enabled packs are on after a fresh install", () => {
     const packs = listBuiltinPacks();
-    expect(packs.length).toBeGreaterThan(0);
-    expect(packs.every((p) => p.enabled)).toBe(true);
-    const base = packs.find((p) => p.id === "base");
-    expect(base?.required).toBe(true);
+    const byId = new Map(packs.map((p) => [p.id, p]));
+
+    expect(byId.get("base")).toMatchObject({ enabled: true, required: true });
+    // The essentials ship enabled…
+    for (const id of ["fal", "replicate", "huggingface"]) {
+      expect(byId.get(id)?.enabled).toBe(true);
+    }
+    // …everything else is opt-in.
+    for (const id of ["elevenlabs", "minimax", "kie", "topaz", "reve"]) {
+      expect(byId.get(id)?.enabled).toBe(false);
+    }
   });
 
-  test("disabling a pack persists and round-trips", () => {
-    const updated = setBuiltinPackEnabled("fal", false);
-    expect(updated.find((p) => p.id === "fal")?.enabled).toBe(false);
+  test("enabling an opt-in pack persists and round-trips", () => {
+    const updated = setBuiltinPackEnabled("kie", true);
+    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(true);
 
     // Fresh read sees the same state.
-    expect(listBuiltinPacks().find((p) => p.id === "fal")?.enabled).toBe(false);
+    expect(listBuiltinPacks().find((p) => p.id === "kie")?.enabled).toBe(true);
 
-    const reEnabled = setBuiltinPackEnabled("fal", true);
-    expect(reEnabled.find((p) => p.id === "fal")?.enabled).toBe(true);
-    expect(listBuiltinPacks().every((p) => p.enabled)).toBe(true);
+    const reverted = setBuiltinPackEnabled("kie", false);
+    expect(reverted.find((p) => p.id === "kie")?.enabled).toBe(false);
+  });
+
+  test("disabling a default-enabled pack persists", () => {
+    const updated = setBuiltinPackEnabled("fal", false);
+    expect(updated.find((p) => p.id === "fal")?.enabled).toBe(false);
+    expect(listBuiltinPacks().find((p) => p.id === "fal")?.enabled).toBe(false);
   });
 
   test("preserves unrelated keys in the shared packs config file", () => {
@@ -56,11 +70,13 @@ describe("builtinPacks", () => {
     );
 
     setBuiltinPackEnabled("replicate", false);
+    setBuiltinPackEnabled("kie", true);
 
     const config = JSON.parse(readFileSync(configPath, "utf8"));
     expect(config.allow).toEqual(["@acme/cool-nodes"]);
     expect(config.allowUnlisted).toBe(false);
     expect(config.disabledBuiltins).toEqual(["replicate"]);
+    expect(config.enabledBuiltins).toEqual(["kie"]);
   });
 
   test("rejects unknown pack ids", () => {
@@ -77,8 +93,8 @@ describe("builtinPacks", () => {
 
   test("tolerates a corrupt config file", () => {
     writeFileSync(configPath, "not json", "utf8");
-    expect(listBuiltinPacks().every((p) => p.enabled)).toBe(true);
-    const updated = setBuiltinPackEnabled("kie", false);
-    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(false);
+    expect(listBuiltinPacks().find((p) => p.id === "base")?.enabled).toBe(true);
+    const updated = setBuiltinPackEnabled("kie", true);
+    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(true);
   });
 });

--- a/electron/src/__tests__/builtinPacks.test.ts
+++ b/electron/src/__tests__/builtinPacks.test.ts
@@ -36,24 +36,24 @@ describe("builtinPacks", () => {
 
     expect(byId.get("base")).toMatchObject({ enabled: true, required: true });
     // The essentials ship enabled…
-    for (const id of ["fal", "replicate", "huggingface"]) {
+    for (const id of ["fal", "replicate", "huggingface", "kie"]) {
       expect(byId.get(id)?.enabled).toBe(true);
     }
     // …everything else is opt-in.
-    for (const id of ["elevenlabs", "minimax", "kie", "topaz", "reve"]) {
+    for (const id of ["elevenlabs", "minimax", "topaz", "reve"]) {
       expect(byId.get(id)?.enabled).toBe(false);
     }
   });
 
   test("enabling an opt-in pack persists and round-trips", () => {
-    const updated = setBuiltinPackEnabled("kie", true);
-    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(true);
+    const updated = setBuiltinPackEnabled("minimax", true);
+    expect(updated.find((p) => p.id === "minimax")?.enabled).toBe(true);
 
     // Fresh read sees the same state.
-    expect(listBuiltinPacks().find((p) => p.id === "kie")?.enabled).toBe(true);
+    expect(listBuiltinPacks().find((p) => p.id === "minimax")?.enabled).toBe(true);
 
-    const reverted = setBuiltinPackEnabled("kie", false);
-    expect(reverted.find((p) => p.id === "kie")?.enabled).toBe(false);
+    const reverted = setBuiltinPackEnabled("minimax", false);
+    expect(reverted.find((p) => p.id === "minimax")?.enabled).toBe(false);
   });
 
   test("disabling a default-enabled pack persists", () => {
@@ -70,13 +70,13 @@ describe("builtinPacks", () => {
     );
 
     setBuiltinPackEnabled("replicate", false);
-    setBuiltinPackEnabled("kie", true);
+    setBuiltinPackEnabled("minimax", true);
 
     const config = JSON.parse(readFileSync(configPath, "utf8"));
     expect(config.allow).toEqual(["@acme/cool-nodes"]);
     expect(config.allowUnlisted).toBe(false);
     expect(config.disabledBuiltins).toEqual(["replicate"]);
-    expect(config.enabledBuiltins).toEqual(["kie"]);
+    expect(config.enabledBuiltins).toEqual(["minimax"]);
   });
 
   test("rejects unknown pack ids", () => {
@@ -94,7 +94,7 @@ describe("builtinPacks", () => {
   test("tolerates a corrupt config file", () => {
     writeFileSync(configPath, "not json", "utf8");
     expect(listBuiltinPacks().find((p) => p.id === "base")?.enabled).toBe(true);
-    const updated = setBuiltinPackEnabled("kie", true);
-    expect(updated.find((p) => p.id === "kie")?.enabled).toBe(true);
+    const updated = setBuiltinPackEnabled("minimax", true);
+    expect(updated.find((p) => p.id === "minimax")?.enabled).toBe(true);
   });
 });

--- a/electron/src/__tests__/preload.contract.test.ts
+++ b/electron/src/__tests__/preload.contract.test.ts
@@ -54,6 +54,8 @@ const IpcChannels = {
   NODE_PACK_INSTALL: "node-pack-install",
   NODE_PACK_UNINSTALL: "node-pack-uninstall",
   NODE_PACK_GET_INSTALL_DIR: "node-pack-get-install-dir",
+  BUILTIN_PACK_LIST: "builtin-pack-list",
+  BUILTIN_PACK_SET_ENABLED: "builtin-pack-set-enabled",
   RUNTIME_PACKAGE_STATUSES: "runtime-package-statuses",
   RUNTIME_PACKAGE_INSTALL: "runtime-package-install",
   RUNTIME_PACKAGE_UNINSTALL: "runtime-package-uninstall",
@@ -178,6 +180,8 @@ describe("preload contract", () => {
     api.nodePacks.install("@acme/cool-nodes");
     api.nodePacks.uninstall("@acme/cool-nodes");
     api.nodePacks.getInstallDir();
+    api.nodePacks.listBuiltin();
+    api.nodePacks.setBuiltinEnabled("fal", false);
 
     const channels = (electronMock.ipcRenderer.invoke as jest.Mock).mock.calls
       .map((c: unknown[]) => c[0]);
@@ -187,6 +191,8 @@ describe("preload contract", () => {
       IpcChannels.NODE_PACK_INSTALL,
       IpcChannels.NODE_PACK_UNINSTALL,
       IpcChannels.NODE_PACK_GET_INSTALL_DIR,
+      IpcChannels.BUILTIN_PACK_LIST,
+      IpcChannels.BUILTIN_PACK_SET_ENABLED,
     ]);
   });
 

--- a/electron/src/builtinPacks.ts
+++ b/electron/src/builtinPacks.ts
@@ -1,17 +1,21 @@
 /**
  * Enable/disable the built-in node packs that ship with NodeTool.
  *
- * The user's choices are persisted as `disabledBuiltins` in the packs config
- * file the backend already reads at bootstrap
- * (`~/.config/nodetool/packs.json`, override via `NODETOOL_PACKS_CONFIG`).
- * The server skips disabled packs on its next start, so callers should
- * prompt for a server restart after toggling.
+ * Packs are opt-in: only those marked `defaultEnabled` (or `required`) in the
+ * catalog load on a fresh install. The user's explicit choices are persisted
+ * as `enabledBuiltins` / `disabledBuiltins` in the packs config file the
+ * backend already reads at bootstrap (`~/.config/nodetool/packs.json`,
+ * override via `NODETOOL_PACKS_CONFIG`). Changes apply on the next server
+ * start, so callers should prompt for a restart after toggling.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol/builtin-packs";
+import {
+  BUILTIN_NODE_PACKS,
+  resolveBuiltinPackEnabled,
+} from "@nodetool-ai/protocol/builtin-packs";
 import type { BuiltinPackStatus } from "./types.d";
 
 /** Must match the path used by `@nodetool-ai/node-sdk`'s pack loader. */
@@ -35,33 +39,46 @@ function readPacksConfig(): Record<string, unknown> {
   }
 }
 
-function readDisabledBuiltins(): Set<string> {
-  const raw = readPacksConfig().disabledBuiltins;
-  return new Set(
-    Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [],
-  );
+function idList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
 }
 
-function writeDisabledBuiltins(ids: Set<string>): void {
+/** Explicit user overrides keyed by pack id; absent packs keep their default. */
+function readOverrides(): Record<string, boolean> {
+  const config = readPacksConfig();
+  const overrides: Record<string, boolean> = {};
+  for (const id of idList(config.disabledBuiltins)) overrides[id] = false;
+  for (const id of idList(config.enabledBuiltins)) overrides[id] = true;
+  return overrides;
+}
+
+function writeOverrides(overrides: Record<string, boolean>): void {
   const path = packsConfigPath();
-  const config = { ...readPacksConfig(), disabledBuiltins: [...ids].sort() };
+  const config = {
+    ...readPacksConfig(),
+    enabledBuiltins: Object.keys(overrides)
+      .filter((id) => overrides[id])
+      .sort(),
+    disabledBuiltins: Object.keys(overrides)
+      .filter((id) => !overrides[id])
+      .sort(),
+  };
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf8");
 }
 
 /** All built-in packs with their current enabled state. */
 export function listBuiltinPacks(): BuiltinPackStatus[] {
-  const disabled = readDisabledBuiltins();
-  return BUILTIN_NODE_PACKS.map((pack) => {
-    const required = pack.required ?? false;
-    return {
-      id: pack.id,
-      name: pack.name,
-      description: pack.description,
-      required,
-      enabled: required || !disabled.has(pack.id),
-    };
-  });
+  const overrides = readOverrides();
+  return BUILTIN_NODE_PACKS.map((pack) => ({
+    id: pack.id,
+    name: pack.name,
+    description: pack.description,
+    required: pack.required ?? false,
+    enabled: resolveBuiltinPackEnabled(pack, overrides[pack.id]),
+  }));
 }
 
 /**
@@ -79,12 +96,6 @@ export function setBuiltinPackEnabled(
   if (pack.required && !enabled) {
     throw new Error(`Built-in pack "${id}" cannot be disabled`);
   }
-  const disabled = readDisabledBuiltins();
-  if (enabled) {
-    disabled.delete(id);
-  } else {
-    disabled.add(id);
-  }
-  writeDisabledBuiltins(disabled);
+  writeOverrides({ ...readOverrides(), [id]: enabled });
   return listBuiltinPacks();
 }

--- a/electron/src/builtinPacks.ts
+++ b/electron/src/builtinPacks.ts
@@ -1,0 +1,90 @@
+/**
+ * Enable/disable the built-in node packs that ship with NodeTool.
+ *
+ * The user's choices are persisted as `disabledBuiltins` in the packs config
+ * file the backend already reads at bootstrap
+ * (`~/.config/nodetool/packs.json`, override via `NODETOOL_PACKS_CONFIG`).
+ * The server skips disabled packs on its next start, so callers should
+ * prompt for a server restart after toggling.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol/builtin-packs";
+import type { BuiltinPackStatus } from "./types.d";
+
+/** Must match the path used by `@nodetool-ai/node-sdk`'s pack loader. */
+function packsConfigPath(): string {
+  return (
+    process.env.NODETOOL_PACKS_CONFIG ??
+    join(homedir(), ".config", "nodetool", "packs.json")
+  );
+}
+
+function readPacksConfig(): Record<string, unknown> {
+  const path = packsConfigPath();
+  if (!existsSync(path)) return {};
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function readDisabledBuiltins(): Set<string> {
+  const raw = readPacksConfig().disabledBuiltins;
+  return new Set(
+    Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [],
+  );
+}
+
+function writeDisabledBuiltins(ids: Set<string>): void {
+  const path = packsConfigPath();
+  const config = { ...readPacksConfig(), disabledBuiltins: [...ids].sort() };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+/** All built-in packs with their current enabled state. */
+export function listBuiltinPacks(): BuiltinPackStatus[] {
+  const disabled = readDisabledBuiltins();
+  return BUILTIN_NODE_PACKS.map((pack) => {
+    const required = pack.required ?? false;
+    return {
+      id: pack.id,
+      name: pack.name,
+      description: pack.description,
+      required,
+      enabled: required || !disabled.has(pack.id),
+    };
+  });
+}
+
+/**
+ * Persist a pack's enabled state and return the refreshed list. Throws on an
+ * unknown pack id or an attempt to disable a required pack.
+ */
+export function setBuiltinPackEnabled(
+  id: string,
+  enabled: boolean,
+): BuiltinPackStatus[] {
+  const pack = BUILTIN_NODE_PACKS.find((p) => p.id === id);
+  if (!pack) {
+    throw new Error(`Unknown built-in pack "${id}"`);
+  }
+  if (pack.required && !enabled) {
+    throw new Error(`Built-in pack "${id}" cannot be disabled`);
+  }
+  const disabled = readDisabledBuiltins();
+  if (enabled) {
+    disabled.delete(id);
+  } else {
+    disabled.add(id);
+  }
+  writeDisabledBuiltins(disabled);
+  return listBuiltinPacks();
+}

--- a/electron/src/components/PackageManager.tsx
+++ b/electron/src/components/PackageManager.tsx
@@ -420,8 +420,9 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
               className="section-description"
               style={{ color: "#999", margin: "4px 0 12px", fontSize: "13px" }}
             >
-              These node packs ship with NodeTool. Disable the ones you don't
-              use to keep the node menu focused.
+              These node packs ship with NodeTool, but only the essentials are
+              enabled out of the box. Enable the providers you use to add
+              their nodes to the editor.
             </p>
 
             {builtinRestartNeeded && (

--- a/electron/src/components/PackageManager.tsx
+++ b/electron/src/components/PackageManager.tsx
@@ -6,6 +6,7 @@ import {
   InstalledPackageListResponse,
   RuntimePackageStatus,
   RuntimePackageId,
+  BuiltinPackStatus,
 } from "../types";
 
 interface PackageManagerProps {
@@ -22,6 +23,8 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
   const [runtimePackages, setRuntimePackages] = useState<
     RuntimePackageStatus[]
   >([]);
+  const [builtinPacks, setBuiltinPacks] = useState<BuiltinPackStatus[]>([]);
+  const [builtinRestartNeeded, setBuiltinRestartNeeded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [installing, setInstalling] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
@@ -48,10 +51,12 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
       setLoading(true);
       setError(null);
 
-      const [availableResponse, installedResponse] = await Promise.all([
-        window.api.packages.listAvailable().catch(() => ({ packages: [] })),
-        window.api.packages.listInstalled().catch(() => ({ packages: [] })),
-      ]);
+      const [availableResponse, installedResponse, builtinResponse] =
+        await Promise.all([
+          window.api.packages.listAvailable().catch(() => ({ packages: [] })),
+          window.api.packages.listInstalled().catch(() => ({ packages: [] })),
+          window.api.nodePacks.listBuiltin().catch(() => []),
+        ]);
 
       setAvailablePackages(
         (availableResponse as PackageListResponse).packages || []
@@ -59,6 +64,7 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
       setInstalledPackages(
         (installedResponse as InstalledPackageListResponse).packages || []
       );
+      setBuiltinPacks(builtinResponse);
 
       await loadRuntimeStatuses();
     } catch (err) {
@@ -144,6 +150,34 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
     },
     [loadRuntimeStatuses, installLocation]
   );
+
+  const handleToggleBuiltin = useCallback(
+    async (pack: BuiltinPackStatus) => {
+      try {
+        const updated = await window.api.nodePacks.setBuiltinEnabled(
+          pack.id,
+          !pack.enabled
+        );
+        setBuiltinPacks(updated);
+        setBuiltinRestartNeeded(true);
+      } catch (err) {
+        console.error("Failed to toggle built-in pack:", err);
+        setError(
+          `Failed to ${pack.enabled ? "disable" : "enable"} ${pack.name}. Please try again.`
+        );
+      }
+    },
+    []
+  );
+
+  const handleRestartForBuiltins = useCallback(() => {
+    try {
+      window.api.server.restart();
+      setBuiltinRestartNeeded(false);
+    } catch (e) {
+      console.warn("Restart server failed:", e);
+    }
+  }, []);
 
   const handleInstall = useCallback(
     async (repoId: string) => {
@@ -377,6 +411,96 @@ const PackageManager: React.FC<PackageManagerProps> = ({ onSkip }) => {
             })}
           </div>
         </div>
+
+        {/* Included Node Packs Section */}
+        {builtinPacks.length > 0 && (
+          <div className="package-section">
+            <h2>Included Node Packs</h2>
+            <p
+              className="section-description"
+              style={{ color: "#999", margin: "4px 0 12px", fontSize: "13px" }}
+            >
+              These node packs ship with NodeTool. Disable the ones you don't
+              use to keep the node menu focused.
+            </p>
+
+            {builtinRestartNeeded && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "12px",
+                  margin: "0 0 16px",
+                  padding: "10px 14px",
+                  background: "rgba(74, 158, 255, 0.12)",
+                  border: "1px solid rgba(74, 158, 255, 0.4)",
+                  borderRadius: "8px",
+                  fontSize: "13px",
+                  color: "#ccc",
+                }}
+              >
+                <span style={{ flex: 1 }}>
+                  Changes take effect after the server restarts.
+                </span>
+                <button
+                  className="install-button"
+                  onClick={handleRestartForBuiltins}
+                >
+                  Restart Server
+                </button>
+              </div>
+            )}
+
+            <div className="package-list">
+              {builtinPacks.map((pack) => (
+                <div
+                  key={pack.id}
+                  className={`package-item ${pack.enabled ? "installed" : "available"}`}
+                  style={pack.enabled ? undefined : { opacity: 0.6 }}
+                >
+                  <div className="package-info">
+                    <div className="package-header-row">
+                      <h3>{pack.name}</h3>
+                      {pack.enabled ? (
+                        <span className="status-badge up-to-date">ENABLED</span>
+                      ) : (
+                        <span className="status-badge update-available">
+                          DISABLED
+                        </span>
+                      )}
+                    </div>
+                    <p className="package-description">{pack.description}</p>
+                  </div>
+                  <div className="package-actions">
+                    {pack.required ? (
+                      <button
+                        className="installed-indicator"
+                        disabled
+                        title="Core nodes — always enabled"
+                      >
+                        Always On
+                      </button>
+                    ) : pack.enabled ? (
+                      <button
+                        className="uninstall-button"
+                        onClick={() => handleToggleBuiltin(pack)}
+                      >
+                        Disable
+                      </button>
+                    ) : (
+                      <button
+                        className="install-button"
+                        onClick={() => handleToggleBuiltin(pack)}
+                      >
+                        Enable
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Installed Packages Section */}
         {installedPackages.length > 0 && (

--- a/electron/src/ipc.ts
+++ b/electron/src/ipc.ts
@@ -60,6 +60,7 @@ import {
   listInstalledNodePacks,
   getNodePackInstallRoot,
 } from "./nodePackManager";
+import { listBuiltinPacks, setBuiltinPackEnabled } from "./builtinPacks";
 import {
   openModelDirectory,
   openPathInExplorer,
@@ -904,6 +905,20 @@ export function initializeIpcHandlers(): void {
   createIpcMainHandler(IpcChannels.NODE_PACK_GET_INSTALL_DIR, async () => {
     return getNodePackInstallRoot();
   });
+
+  // Built-in node pack handlers (first-party packs shipped with NodeTool)
+  createIpcMainHandler(IpcChannels.BUILTIN_PACK_LIST, async () => {
+    return listBuiltinPacks();
+  });
+  createIpcMainHandler(
+    IpcChannels.BUILTIN_PACK_SET_ENABLED,
+    async (_event, req) => {
+      logMessage(
+        `${req.enabled ? "Enabling" : "Disabling"} built-in node pack: ${req.id}`,
+      );
+      return setBuiltinPackEnabled(req.id, req.enabled);
+    },
+  );
 
   // Runtime package handlers
   createIpcMainHandler(IpcChannels.RUNTIME_PACKAGE_STATUSES, async () => {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -368,6 +368,16 @@ const api = {
     /** Path of the install root (so the UI can show it). */
     getInstallDir: () =>
       ipcRenderer.invoke(IpcChannels.NODE_PACK_GET_INSTALL_DIR),
+
+    /** List the built-in packs that ship with NodeTool and their enabled state. */
+    listBuiltin: () => ipcRenderer.invoke(IpcChannels.BUILTIN_PACK_LIST),
+
+    /** Enable or disable a built-in pack. Takes effect on the next server restart. */
+    setBuiltinEnabled: (id: string, enabled: boolean) =>
+      ipcRenderer.invoke(IpcChannels.BUILTIN_PACK_SET_ENABLED, {
+        id,
+        enabled,
+      }),
   },
 
   // ============================================================================

--- a/electron/src/types.d.ts
+++ b/electron/src/types.d.ts
@@ -91,6 +91,19 @@ declare global {
         selectInstallLocation: () => Promise<string | null>;
       };
 
+      // Third-party TypeScript node packs + built-in pack toggles
+      nodePacks: {
+        listInstalled: () => Promise<NodePackInfo[]>;
+        install: (spec: string) => Promise<NodePackActionResult>;
+        uninstall: (name: string) => Promise<NodePackActionResult>;
+        getInstallDir: () => Promise<string>;
+        listBuiltin: () => Promise<BuiltinPackStatus[]>;
+        setBuiltinEnabled: (
+          id: string,
+          enabled: boolean,
+        ) => Promise<BuiltinPackStatus[]>;
+      };
+
       // Window controls
       window: {
         close: () => void;
@@ -529,6 +542,9 @@ export enum IpcChannels {
   NODE_PACK_INSTALL = "node-pack-install",
   NODE_PACK_UNINSTALL = "node-pack-uninstall",
   NODE_PACK_GET_INSTALL_DIR = "node-pack-get-install-dir",
+  // Built-in node pack channels (first-party packs shipped with NodeTool)
+  BUILTIN_PACK_LIST = "builtin-pack-list",
+  BUILTIN_PACK_SET_ENABLED = "builtin-pack-set-enabled",
   // Runtime package channels
   RUNTIME_PACKAGE_STATUSES = "runtime-package-statuses",
   RUNTIME_PACKAGE_INSTALL = "runtime-package-install",
@@ -680,6 +696,8 @@ export interface IpcRequest {
   [IpcChannels.NODE_PACK_INSTALL]: { spec: string };
   [IpcChannels.NODE_PACK_UNINSTALL]: { name: string };
   [IpcChannels.NODE_PACK_GET_INSTALL_DIR]: void;
+  [IpcChannels.BUILTIN_PACK_LIST]: void;
+  [IpcChannels.BUILTIN_PACK_SET_ENABLED]: { id: string; enabled: boolean };
   [IpcChannels.RUNTIME_PACKAGE_STATUSES]: void;
   [IpcChannels.RUNTIME_PACKAGE_INSTALL]: { packageId: string; installLocation?: string };
   [IpcChannels.RUNTIME_PACKAGE_UNINSTALL]: { packageId: string };
@@ -794,6 +812,8 @@ export interface IpcResponse {
   [IpcChannels.NODE_PACK_INSTALL]: NodePackActionResult;
   [IpcChannels.NODE_PACK_UNINSTALL]: NodePackActionResult;
   [IpcChannels.NODE_PACK_GET_INSTALL_DIR]: string;
+  [IpcChannels.BUILTIN_PACK_LIST]: BuiltinPackStatus[];
+  [IpcChannels.BUILTIN_PACK_SET_ENABLED]: BuiltinPackStatus[];
   [IpcChannels.RUNTIME_PACKAGE_STATUSES]: RuntimePackageStatus[];
   [IpcChannels.RUNTIME_PACKAGE_INSTALL]: { success: boolean; message: string };
   [IpcChannels.RUNTIME_PACKAGE_UNINSTALL]: { success: boolean; message: string };
@@ -946,6 +966,16 @@ export interface NodePackInfo {
 export interface NodePackActionResult {
   success: boolean;
   message: string;
+}
+
+/** A first-party node pack shipped with NodeTool, plus its enabled state. */
+export interface BuiltinPackStatus {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  /** Required packs (core nodes) cannot be disabled. */
+  required: boolean;
 }
 
 export type RuntimePackageId =

--- a/packages/node-sdk/src/pack-loader.ts
+++ b/packages/node-sdk/src/pack-loader.ts
@@ -209,7 +209,7 @@ function readEnvPackPaths(): string[] {
 export function resolvePackTrust(
   options: PackTrustOptions = {}
 ): Required<PackTrustOptions> {
-  const fromFile = readTrustConfigFile();
+  const fromFile = readPacksConfigFile();
   const envAllow = process.env["NODETOOL_PACKS_ALLOWLIST"];
   const envList = envAllow
     ? envAllow
@@ -236,11 +236,18 @@ function trustConfigPath(): string {
   );
 }
 
-function readTrustConfigFile(): { allow?: string[]; allowUnlisted?: boolean } {
+interface PacksConfigFile {
+  allow?: string[];
+  allowUnlisted?: boolean;
+  disabledBuiltins?: string[];
+}
+
+function readPacksConfigFile(path: string = trustConfigPath()): PacksConfigFile {
   try {
-    const parsed = JSON.parse(readFileSync(trustConfigPath(), "utf8")) as {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as {
       allow?: unknown;
       allowUnlisted?: unknown;
+      disabledBuiltins?: unknown;
     };
     return {
       allow: Array.isArray(parsed.allow)
@@ -249,11 +256,45 @@ function readTrustConfigFile(): { allow?: string[]; allowUnlisted?: boolean } {
       allowUnlisted:
         typeof parsed.allowUnlisted === "boolean"
           ? parsed.allowUnlisted
-          : undefined
+          : undefined,
+      disabledBuiltins: Array.isArray(parsed.disabledBuiltins)
+        ? parsed.disabledBuiltins.filter(
+            (v): v is string => typeof v === "string"
+          )
+        : undefined
     };
   } catch {
     return {};
   }
+}
+
+/**
+ * Built-in pack ids the user disabled in the package manager. The server
+ * skips registering these packs at bootstrap; changes take effect on restart.
+ */
+export function readDisabledBuiltinPacks(): string[] {
+  return readPacksConfigFile().disabledBuiltins ?? [];
+}
+
+/**
+ * Persist the disabled built-in pack ids, preserving the trust fields already
+ * in the config file. Creates parent directories as needed.
+ */
+export function writeDisabledBuiltinPacks(
+  ids: string[],
+  path: string = trustConfigPath()
+): void {
+  const current = readPacksConfigFile(path);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify(
+      { ...current, disabledBuiltins: [...new Set(ids)].sort() },
+      null,
+      2
+    ) + "\n",
+    "utf8"
+  );
 }
 
 /**
@@ -264,11 +305,17 @@ export function writePackTrustConfig(
   trust: { allowlist: string[]; allowUnlisted: boolean },
   path: string = trustConfigPath()
 ): void {
+  // Preserve unrelated fields (e.g. disabledBuiltins) already in the file.
+  const current = readPacksConfigFile(path);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(
     path,
     JSON.stringify(
-      { allow: trust.allowlist, allowUnlisted: trust.allowUnlisted },
+      {
+        ...current,
+        allow: trust.allowlist,
+        allowUnlisted: trust.allowUnlisted
+      },
       null,
       2
     ) + "\n",

--- a/packages/node-sdk/src/pack-loader.ts
+++ b/packages/node-sdk/src/pack-loader.ts
@@ -239,7 +239,14 @@ function trustConfigPath(): string {
 interface PacksConfigFile {
   allow?: string[];
   allowUnlisted?: boolean;
+  enabledBuiltins?: string[];
   disabledBuiltins?: string[];
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : undefined;
 }
 
 function readPacksConfigFile(path: string = trustConfigPath()): PacksConfigFile {
@@ -247,21 +254,17 @@ function readPacksConfigFile(path: string = trustConfigPath()): PacksConfigFile 
     const parsed = JSON.parse(readFileSync(path, "utf8")) as {
       allow?: unknown;
       allowUnlisted?: unknown;
+      enabledBuiltins?: unknown;
       disabledBuiltins?: unknown;
     };
     return {
-      allow: Array.isArray(parsed.allow)
-        ? parsed.allow.filter((v): v is string => typeof v === "string")
-        : undefined,
+      allow: stringArray(parsed.allow),
       allowUnlisted:
         typeof parsed.allowUnlisted === "boolean"
           ? parsed.allowUnlisted
           : undefined,
-      disabledBuiltins: Array.isArray(parsed.disabledBuiltins)
-        ? parsed.disabledBuiltins.filter(
-            (v): v is string => typeof v === "string"
-          )
-        : undefined
+      enabledBuiltins: stringArray(parsed.enabledBuiltins),
+      disabledBuiltins: stringArray(parsed.disabledBuiltins)
     };
   } catch {
     return {};
@@ -269,27 +272,37 @@ function readPacksConfigFile(path: string = trustConfigPath()): PacksConfigFile 
 }
 
 /**
- * Built-in pack ids the user disabled in the package manager. The server
- * skips registering these packs at bootstrap; changes take effect on restart.
+ * Explicit user overrides for built-in packs, keyed by pack id. Packs absent
+ * from the map keep their install default (`defaultEnabled` in the catalog).
+ * The server applies this at bootstrap; changes take effect on restart.
  */
-export function readDisabledBuiltinPacks(): string[] {
-  return readPacksConfigFile().disabledBuiltins ?? [];
+export function readBuiltinPackOverrides(): Record<string, boolean> {
+  const config = readPacksConfigFile();
+  const overrides: Record<string, boolean> = {};
+  for (const id of config.disabledBuiltins ?? []) overrides[id] = false;
+  for (const id of config.enabledBuiltins ?? []) overrides[id] = true;
+  return overrides;
 }
 
 /**
- * Persist the disabled built-in pack ids, preserving the trust fields already
- * in the config file. Creates parent directories as needed.
+ * Persist built-in pack overrides as `enabledBuiltins` / `disabledBuiltins`
+ * lists, preserving the trust fields already in the config file. Creates
+ * parent directories as needed.
  */
-export function writeDisabledBuiltinPacks(
-  ids: string[],
+export function writeBuiltinPackOverrides(
+  overrides: Record<string, boolean>,
   path: string = trustConfigPath()
 ): void {
   const current = readPacksConfigFile(path);
+  const enabled = Object.keys(overrides).filter((id) => overrides[id]).sort();
+  const disabled = Object.keys(overrides)
+    .filter((id) => !overrides[id])
+    .sort();
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(
     path,
     JSON.stringify(
-      { ...current, disabledBuiltins: [...new Set(ids)].sort() },
+      { ...current, enabledBuiltins: enabled, disabledBuiltins: disabled },
       null,
       2
     ) + "\n",

--- a/packages/node-sdk/tests/pack-loader.test.ts
+++ b/packages/node-sdk/tests/pack-loader.test.ts
@@ -8,9 +8,9 @@ import {
   defaultPackSearchPaths,
   discoverPacks,
   loadInstalledPacks,
-  readDisabledBuiltinPacks,
+  readBuiltinPackOverrides,
   resolvePackTrust,
-  writeDisabledBuiltinPacks,
+  writeBuiltinPackOverrides,
   writePackTrustConfig,
   PACK_API_VERSION
 } from "../src/pack-loader.js";
@@ -333,12 +333,16 @@ describe("writePackTrustConfig", () => {
     });
   });
 
-  it("preserves disabledBuiltins already in the file", () => {
+  it("preserves built-in pack overrides already in the file", () => {
     const path = joinPath(root, "packs.json");
     process.env["NODETOOL_PACKS_CONFIG"] = path;
-    writeFileSync(path, JSON.stringify({ disabledBuiltins: ["fal"] }));
+    writeFileSync(
+      path,
+      JSON.stringify({ enabledBuiltins: ["kie"], disabledBuiltins: ["fal"] })
+    );
     writePackTrustConfig({ allowlist: ["@acme/a"], allowUnlisted: false }, path);
     expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      enabledBuiltins: ["kie"],
       disabledBuiltins: ["fal"],
       allow: ["@acme/a"],
       allowUnlisted: false
@@ -346,27 +350,39 @@ describe("writePackTrustConfig", () => {
   });
 });
 
-describe("disabled built-in packs", () => {
-  it("defaults to an empty list", () => {
-    expect(readDisabledBuiltinPacks()).toEqual([]);
+describe("built-in pack overrides", () => {
+  it("defaults to an empty map", () => {
+    expect(readBuiltinPackOverrides()).toEqual({});
   });
 
-  it("round-trips, dedupes, and sorts ids", () => {
+  it("round-trips overrides in both directions, sorted", () => {
     const path = joinPath(root, "packs.json");
     process.env["NODETOOL_PACKS_CONFIG"] = path;
-    writeDisabledBuiltinPacks(["replicate", "fal", "fal"], path);
-    expect(readDisabledBuiltinPacks()).toEqual(["fal", "replicate"]);
+    writeBuiltinPackOverrides(
+      { kie: true, fal: false, elevenlabs: true },
+      path
+    );
+    expect(readBuiltinPackOverrides()).toEqual({
+      kie: true,
+      elevenlabs: true,
+      fal: false
+    });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      enabledBuiltins: ["elevenlabs", "kie"],
+      disabledBuiltins: ["fal"]
+    });
   });
 
   it("preserves trust fields already in the file", () => {
     const path = joinPath(root, "packs.json");
     process.env["NODETOOL_PACKS_CONFIG"] = path;
     writePackTrustConfig({ allowlist: ["@acme/a"], allowUnlisted: true }, path);
-    writeDisabledBuiltinPacks(["kie"], path);
+    writeBuiltinPackOverrides({ kie: true }, path);
     expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
       allow: ["@acme/a"],
       allowUnlisted: true,
-      disabledBuiltins: ["kie"]
+      enabledBuiltins: ["kie"],
+      disabledBuiltins: []
     });
     const resolved = resolvePackTrust();
     expect(resolved.allowlist).toEqual(["@acme/a"]);
@@ -376,8 +392,11 @@ describe("disabled built-in packs", () => {
   it("ignores non-string entries in the config file", () => {
     const path = joinPath(root, "packs.json");
     process.env["NODETOOL_PACKS_CONFIG"] = path;
-    writeFileSync(path, JSON.stringify({ disabledBuiltins: ["fal", 3, null] }));
-    expect(readDisabledBuiltinPacks()).toEqual(["fal"]);
+    writeFileSync(
+      path,
+      JSON.stringify({ enabledBuiltins: ["kie", 3], disabledBuiltins: [null, "fal"] })
+    );
+    expect(readBuiltinPackOverrides()).toEqual({ kie: true, fal: false });
   });
 });
 

--- a/packages/node-sdk/tests/pack-loader.test.ts
+++ b/packages/node-sdk/tests/pack-loader.test.ts
@@ -8,7 +8,9 @@ import {
   defaultPackSearchPaths,
   discoverPacks,
   loadInstalledPacks,
+  readDisabledBuiltinPacks,
   resolvePackTrust,
+  writeDisabledBuiltinPacks,
   writePackTrustConfig,
   PACK_API_VERSION
 } from "../src/pack-loader.js";
@@ -329,6 +331,53 @@ describe("writePackTrustConfig", () => {
       allow: [],
       allowUnlisted: true
     });
+  });
+
+  it("preserves disabledBuiltins already in the file", () => {
+    const path = joinPath(root, "packs.json");
+    process.env["NODETOOL_PACKS_CONFIG"] = path;
+    writeFileSync(path, JSON.stringify({ disabledBuiltins: ["fal"] }));
+    writePackTrustConfig({ allowlist: ["@acme/a"], allowUnlisted: false }, path);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      disabledBuiltins: ["fal"],
+      allow: ["@acme/a"],
+      allowUnlisted: false
+    });
+  });
+});
+
+describe("disabled built-in packs", () => {
+  it("defaults to an empty list", () => {
+    expect(readDisabledBuiltinPacks()).toEqual([]);
+  });
+
+  it("round-trips, dedupes, and sorts ids", () => {
+    const path = joinPath(root, "packs.json");
+    process.env["NODETOOL_PACKS_CONFIG"] = path;
+    writeDisabledBuiltinPacks(["replicate", "fal", "fal"], path);
+    expect(readDisabledBuiltinPacks()).toEqual(["fal", "replicate"]);
+  });
+
+  it("preserves trust fields already in the file", () => {
+    const path = joinPath(root, "packs.json");
+    process.env["NODETOOL_PACKS_CONFIG"] = path;
+    writePackTrustConfig({ allowlist: ["@acme/a"], allowUnlisted: true }, path);
+    writeDisabledBuiltinPacks(["kie"], path);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      allow: ["@acme/a"],
+      allowUnlisted: true,
+      disabledBuiltins: ["kie"]
+    });
+    const resolved = resolvePackTrust();
+    expect(resolved.allowlist).toEqual(["@acme/a"]);
+    expect(resolved.allowUnlisted).toBe(true);
+  });
+
+  it("ignores non-string entries in the config file", () => {
+    const path = joinPath(root, "packs.json");
+    process.env["NODETOOL_PACKS_CONFIG"] = path;
+    writeFileSync(path, JSON.stringify({ disabledBuiltins: ["fal", 3, null] }));
+    expect(readDisabledBuiltinPacks()).toEqual(["fal"]);
   });
 });
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -26,6 +26,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./builtin-packs": {
+      "nodetool-dev": "./src/builtin-packs.ts",
+      "types": "./dist/builtin-packs.d.ts",
+      "import": "./dist/builtin-packs.js",
+      "default": "./dist/builtin-packs.js"
+    },
     "./bridge-protocol": {
       "nodetool-dev": "./src/bridge-protocol.ts",
       "types": "./dist/bridge-protocol.d.ts",

--- a/packages/protocol/src/builtin-packs.ts
+++ b/packages/protocol/src/builtin-packs.ts
@@ -3,13 +3,15 @@
  *
  * Shared between the server (which registers the packs at bootstrap) and the
  * Electron package manager (which lets users enable/disable them), so both
- * sides agree on the stable pack ids. Disabled ids are persisted in the packs
- * config file (`~/.config/nodetool/packs.json`, key `disabledBuiltins`) and
- * honored on the next server start.
+ * sides agree on the stable pack ids. Only packs marked `defaultEnabled` (or
+ * `required`) load on a fresh install; the rest are opt-in. User overrides
+ * are persisted in the packs config file (`~/.config/nodetool/packs.json`,
+ * keys `enabledBuiltins` / `disabledBuiltins`) and honored on the next
+ * server start.
  */
 
 export interface BuiltinNodePack {
-  /** Stable id used in the disabled list. Never rename. */
+  /** Stable id used in the enabled/disabled lists. Never rename. */
   id: string;
   /** Display name shown in the package manager. */
   name: string;
@@ -17,6 +19,24 @@ export interface BuiltinNodePack {
   description: string;
   /** Required packs cannot be disabled (core nodes the editor depends on). */
   required?: boolean;
+  /**
+   * Enabled on a fresh install. All other packs are opt-in via the package
+   * manager, keeping the node namespace small by default.
+   */
+  defaultEnabled?: boolean;
+}
+
+/**
+ * Effective enabled state for a built-in pack: required packs are always on;
+ * otherwise an explicit user override wins, falling back to the install
+ * default.
+ */
+export function resolveBuiltinPackEnabled(
+  pack: BuiltinNodePack,
+  override?: boolean
+): boolean {
+  if (pack.required) return true;
+  return override ?? pack.defaultEnabled ?? false;
 }
 
 export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
@@ -46,7 +66,8 @@ export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
   {
     id: "fal",
     name: "FAL",
-    description: "Hosted image, video, and audio models on fal.ai."
+    description: "Hosted image, video, and audio models on fal.ai.",
+    defaultEnabled: true
   },
   {
     id: "kie",
@@ -78,12 +99,14 @@ export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
   {
     id: "replicate",
     name: "Replicate",
-    description: "Community AI models hosted on Replicate."
+    description: "Community AI models hosted on Replicate.",
+    defaultEnabled: true
   },
   {
     id: "huggingface",
     name: "Hugging Face",
     description:
-      "Hugging Face Inference Providers nodes across all task modalities."
+      "Hugging Face Inference Providers nodes across all task modalities.",
+    defaultEnabled: true
   }
 ];

--- a/packages/protocol/src/builtin-packs.ts
+++ b/packages/protocol/src/builtin-packs.ts
@@ -1,0 +1,89 @@
+/**
+ * Catalog of the first-party node packs that ship with NodeTool.
+ *
+ * Shared between the server (which registers the packs at bootstrap) and the
+ * Electron package manager (which lets users enable/disable them), so both
+ * sides agree on the stable pack ids. Disabled ids are persisted in the packs
+ * config file (`~/.config/nodetool/packs.json`, key `disabledBuiltins`) and
+ * honored on the next server start.
+ */
+
+export interface BuiltinNodePack {
+  /** Stable id used in the disabled list. Never rename. */
+  id: string;
+  /** Display name shown in the package manager. */
+  name: string;
+  /** Short user-facing description of what the pack provides. */
+  description: string;
+  /** Required packs cannot be disabled (core nodes the editor depends on). */
+  required?: boolean;
+}
+
+export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
+  {
+    id: "base",
+    name: "Base Nodes",
+    description:
+      "Core nodes for text, data, documents, images, audio, video, agents, and LLM chat.",
+    required: true
+  },
+  {
+    id: "elevenlabs",
+    name: "ElevenLabs",
+    description: "Text-to-speech and voice generation via ElevenLabs."
+  },
+  {
+    id: "minimax",
+    name: "MiniMax",
+    description: "MiniMax image, video, and audio generation."
+  },
+  {
+    id: "transformers-js",
+    name: "Transformers.js",
+    description:
+      "Run Hugging Face NLP, vision, and audio models locally via ONNX Runtime."
+  },
+  {
+    id: "fal",
+    name: "FAL",
+    description: "Hosted image, video, and audio models on fal.ai."
+  },
+  {
+    id: "kie",
+    name: "Kie.ai",
+    description: "Image and video generation models on Kie.ai."
+  },
+  {
+    id: "topaz",
+    name: "Topaz Labs",
+    description: "Image and video upscaling and enhancement via Topaz Labs."
+  },
+  {
+    id: "reve",
+    name: "Reve",
+    description: "Reve image generation, editing, and remix."
+  },
+  {
+    id: "atlascloud",
+    name: "AtlasCloud",
+    description:
+      "Seedance video and GPT Image / Nano Banana image generation on AtlasCloud."
+  },
+  {
+    id: "together",
+    name: "Together AI",
+    description:
+      "Serverless image, video, text-to-speech, and transcription models on Together AI."
+  },
+  {
+    id: "replicate",
+    name: "Replicate",
+    description: "Community AI models hosted on Replicate."
+  },
+  {
+    id: "huggingface",
+    name: "Hugging Face",
+    description:
+      "Hugging Face Inference Providers nodes across all task modalities."
+  }
+];

--- a/packages/protocol/src/builtin-packs.ts
+++ b/packages/protocol/src/builtin-packs.ts
@@ -24,6 +24,25 @@ export interface BuiltinNodePack {
    * manager, keeping the node namespace small by default.
    */
   defaultEnabled?: boolean;
+  /**
+   * First segments of the node types this pack registers (e.g. `fal` for
+   * `fal.image.*`). Lets UIs map a missing node type back to the pack that
+   * provides it.
+   */
+  namespaces: readonly string[];
+}
+
+/**
+ * The optional pack providing `nodeType`, if any. Required packs are excluded
+ * — they are always loaded, so a missing node type can't be theirs.
+ */
+export function findBuiltinPackForNodeType(
+  nodeType: string
+): BuiltinNodePack | undefined {
+  const head = nodeType.split(".")[0];
+  return BUILTIN_NODE_PACKS.find(
+    (pack) => !pack.required && pack.namespaces.includes(head)
+  );
 }
 
 /**
@@ -45,68 +64,81 @@ export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
     name: "Base Nodes",
     description:
       "Core nodes for text, data, documents, images, audio, video, agents, and LLM chat.",
-    required: true
+    required: true,
+    namespaces: ["apify", "gemini", "kie", "lib", "messaging", "mistral", "nodetool", "openai", "search", "vector", "xai"]
   },
   {
     id: "elevenlabs",
     name: "ElevenLabs",
-    description: "Text-to-speech and voice generation via ElevenLabs."
+    description: "Text-to-speech and voice generation via ElevenLabs.",
+    namespaces: ["elevenlabs"]
   },
   {
     id: "minimax",
     name: "MiniMax",
-    description: "MiniMax image, video, and audio generation."
+    description: "MiniMax image, video, and audio generation.",
+    namespaces: ["minimax"]
   },
   {
     id: "transformers-js",
     name: "Transformers.js",
     description:
-      "Run Hugging Face NLP, vision, and audio models locally via ONNX Runtime."
+      "Run Hugging Face NLP, vision, and audio models locally via ONNX Runtime.",
+    namespaces: ["transformers"]
   },
   {
     id: "fal",
     name: "FAL",
     description: "Hosted image, video, and audio models on fal.ai.",
-    defaultEnabled: true
+    defaultEnabled: true,
+    namespaces: ["fal"]
   },
   {
     id: "kie",
     name: "Kie.ai",
-    description: "Image and video generation models on Kie.ai."
+    description: "Image and video generation models on Kie.ai.",
+    defaultEnabled: true,
+    namespaces: ["kie"]
   },
   {
     id: "topaz",
     name: "Topaz Labs",
-    description: "Image and video upscaling and enhancement via Topaz Labs."
+    description: "Image and video upscaling and enhancement via Topaz Labs.",
+    namespaces: ["topaz"]
   },
   {
     id: "reve",
     name: "Reve",
-    description: "Reve image generation, editing, and remix."
+    description: "Reve image generation, editing, and remix.",
+    namespaces: ["reve"]
   },
   {
     id: "atlascloud",
     name: "AtlasCloud",
     description:
-      "Seedance video and GPT Image / Nano Banana image generation on AtlasCloud."
+      "Seedance video and GPT Image / Nano Banana image generation on AtlasCloud.",
+    namespaces: ["atlascloud"]
   },
   {
     id: "together",
     name: "Together AI",
     description:
-      "Serverless image, video, text-to-speech, and transcription models on Together AI."
+      "Serverless image, video, text-to-speech, and transcription models on Together AI.",
+    namespaces: ["together"]
   },
   {
     id: "replicate",
     name: "Replicate",
     description: "Community AI models hosted on Replicate.",
-    defaultEnabled: true
+    defaultEnabled: true,
+    namespaces: ["replicate"]
   },
   {
     id: "huggingface",
     name: "Hugging Face",
     description:
       "Hugging Face Inference Providers nodes across all task modalities.",
-    defaultEnabled: true
+    defaultEnabled: true,
+    namespaces: ["huggingface"]
   }
 ];

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export {
   type WrappedPrimitive
 } from "./wrap-primitives.js";
 export * from "./toolSchemas.js";
+export * from "./builtin-packs.js";
 export * from "./agent-protocol.js";
 export {
   type Platform,

--- a/packages/protocol/tests/builtin-packs.test.ts
+++ b/packages/protocol/tests/builtin-packs.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUILTIN_NODE_PACKS,
+  findBuiltinPackForNodeType,
+  resolveBuiltinPackEnabled
+} from "../src/builtin-packs.js";
+
+describe("BUILTIN_NODE_PACKS catalog", () => {
+  it("has unique ids and non-empty namespaces", () => {
+    const ids = BUILTIN_NODE_PACKS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const pack of BUILTIN_NODE_PACKS) {
+      expect(pack.namespaces.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("base is required; the essentials are enabled by default", () => {
+    const byId = new Map(BUILTIN_NODE_PACKS.map((p) => [p.id, p]));
+    expect(byId.get("base")?.required).toBe(true);
+    for (const id of ["huggingface", "fal", "replicate", "kie"]) {
+      expect(byId.get(id)?.defaultEnabled).toBe(true);
+    }
+  });
+});
+
+describe("resolveBuiltinPackEnabled", () => {
+  const optIn = { id: "x", name: "X", description: "", namespaces: ["x"] };
+  const def = { ...optIn, defaultEnabled: true };
+  const req = { ...optIn, required: true };
+
+  it("falls back to the install default without an override", () => {
+    expect(resolveBuiltinPackEnabled(optIn)).toBe(false);
+    expect(resolveBuiltinPackEnabled(def)).toBe(true);
+  });
+
+  it("explicit overrides win over defaults", () => {
+    expect(resolveBuiltinPackEnabled(optIn, true)).toBe(true);
+    expect(resolveBuiltinPackEnabled(def, false)).toBe(false);
+  });
+
+  it("required packs are always enabled", () => {
+    expect(resolveBuiltinPackEnabled(req, false)).toBe(true);
+  });
+});
+
+describe("findBuiltinPackForNodeType", () => {
+  it("maps a node type to the optional pack that provides it", () => {
+    expect(findBuiltinPackForNodeType("elevenlabs.tts.TextToSpeech")?.id).toBe(
+      "elevenlabs"
+    );
+    expect(findBuiltinPackForNodeType("fal.image.FluxDev")?.id).toBe("fal");
+  });
+
+  it("skips required packs (their node types are never missing)", () => {
+    expect(findBuiltinPackForNodeType("nodetool.text.Concat")).toBeUndefined();
+    expect(findBuiltinPackForNodeType("lib.json.ParseJson")).toBeUndefined();
+  });
+
+  it("maps the shared kie namespace to the kie pack", () => {
+    // base-nodes also registers under `kie.`, but base is required, so the
+    // optional kie pack is the only enable-able candidate.
+    expect(findBuiltinPackForNodeType("kie.image.Imagen4")?.id).toBe("kie");
+  });
+
+  it("returns undefined for unknown namespaces", () => {
+    expect(findBuiltinPackForNodeType("acme.cool.Node")).toBeUndefined();
+    expect(findBuiltinPackForNodeType("")).toBeUndefined();
+  });
+});

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -117,6 +117,33 @@ export function registerBuiltInNodes(
   }
 }
 
+/**
+ * Apply a built-in pack toggle to a live registry so the change takes effect
+ * without a server restart. Enabling re-runs the registrar (idempotent —
+ * `register` is last-write-wins); disabling unregisters exactly the node
+ * types the pack's registrar produces, so packs sharing a namespace prefix
+ * with other packs are untouched.
+ */
+export function applyBuiltinPackEnabled(
+  registry: NodeRegistry,
+  id: string,
+  enabled: boolean
+): void {
+  const register = BUILTIN_PACK_REGISTRARS[id];
+  if (!register) {
+    throw new Error(`No registrar for built-in node pack "${id}"`);
+  }
+  if (enabled) {
+    register(registry);
+    return;
+  }
+  const packOnly = new NodeRegistry();
+  register(packOnly);
+  for (const nodeType of packOnly.list()) {
+    registry.unregister(nodeType);
+  }
+}
+
 /** Drop optional node types that aren't available in cloud/production builds. */
 export function applyProductionNodePolicy(
   registry: NodeRegistry,

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -11,8 +11,10 @@
 import {
   NodeRegistry,
   loadInstalledPacks,
+  readDisabledBuiltinPacks,
   type LoadedPackResult
 } from "@nodetool-ai/node-sdk";
+import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
 import { setPackSnapshot } from "./pack-snapshot.js";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
@@ -54,22 +56,56 @@ function isProduction(): boolean {
   return process.env["NODETOOL_ENV"] === "production";
 }
 
+/**
+ * Registrar for each catalog entry in {@link BUILTIN_NODE_PACKS}. Keyed by the
+ * stable pack id; a missing key would mean the catalog and this map drifted.
+ */
+const BUILTIN_PACK_REGISTRARS: Record<string, (registry: NodeRegistry) => void> =
+  {
+    base: registerBaseNodes,
+    elevenlabs: registerElevenLabsNodes,
+    minimax: registerMinimaxNodes,
+    "transformers-js": registerTransformersJsNodes,
+    fal: registerFalNodes,
+    kie: registerKieNodes,
+    topaz: registerTopazNodes,
+    reve: registerReveNodes,
+    atlascloud: registerAtlasCloudNodes,
+    together: registerTogetherNodes,
+    replicate: registerReplicateNodes,
+    huggingface: registerHuggingFaceNodes
+  };
+
+export interface RegisterBuiltInNodesOptions {
+  /**
+   * Built-in pack ids to skip. If omitted, read from the packs config file
+   * (`~/.config/nodetool/packs.json`, key `disabledBuiltins`) where the
+   * Electron package manager persists the user's choices.
+   */
+  disabledPacks?: string[];
+  log?: BootstrapLogger;
+}
+
 /** Register all first-party node packs into `registry` (synchronous). */
-export function registerBuiltInNodes(registry: NodeRegistry): void {
-  registerBaseNodes(registry);
-  registerElevenLabsNodes(registry);
-  registerMinimaxNodes(registry);
-  if (!isProduction()) {
-    registerTransformersJsNodes(registry);
+export function registerBuiltInNodes(
+  registry: NodeRegistry,
+  options: RegisterBuiltInNodesOptions = {}
+): void {
+  const disabled = new Set(options.disabledPacks ?? readDisabledBuiltinPacks());
+  for (const pack of BUILTIN_NODE_PACKS) {
+    if (!pack.required && disabled.has(pack.id)) {
+      options.log?.info(`Skipped built-in node pack ${pack.id} (disabled)`);
+      continue;
+    }
+    // Transformers.js pulls in ONNX Runtime, which isn't available in
+    // cloud/production builds.
+    if (pack.id === "transformers-js" && isProduction()) continue;
+    const register = BUILTIN_PACK_REGISTRARS[pack.id];
+    if (!register) {
+      throw new Error(`No registrar for built-in node pack "${pack.id}"`);
+    }
+    register(registry);
   }
-  registerFalNodes(registry);
-  registerKieNodes(registry);
-  registerTopazNodes(registry);
-  registerReveNodes(registry);
-  registerAtlasCloudNodes(registry);
-  registerTogetherNodes(registry);
-  registerReplicateNodes(registry);
-  registerHuggingFaceNodes(registry);
 }
 
 /** Drop optional node types that aren't available in cloud/production builds. */
@@ -118,7 +154,7 @@ export async function bootstrapNodeRegistry(
     roots: options.metadataRoots,
     maxDepth: options.metadataMaxDepth ?? 8
   });
-  registerBuiltInNodes(registry);
+  registerBuiltInNodes(registry, options.log ? { log: options.log } : {});
   if (options.loadPacks !== false) {
     const results = await loadInstalledPacks(registry, {
       ...(options.packSearchPaths

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -11,10 +11,13 @@
 import {
   NodeRegistry,
   loadInstalledPacks,
-  readDisabledBuiltinPacks,
+  readBuiltinPackOverrides,
   type LoadedPackResult
 } from "@nodetool-ai/node-sdk";
-import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
+import {
+  BUILTIN_NODE_PACKS,
+  resolveBuiltinPackEnabled
+} from "@nodetool-ai/protocol";
 import { setPackSnapshot } from "./pack-snapshot.js";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
@@ -78,22 +81,28 @@ const BUILTIN_PACK_REGISTRARS: Record<string, (registry: NodeRegistry) => void> 
 
 export interface RegisterBuiltInNodesOptions {
   /**
-   * Built-in pack ids to skip. If omitted, read from the packs config file
-   * (`~/.config/nodetool/packs.json`, key `disabledBuiltins`) where the
-   * Electron package manager persists the user's choices.
+   * Per-pack enabled overrides keyed by pack id. Packs absent from the map
+   * keep their install default (`defaultEnabled` in the catalog — most packs
+   * are opt-in). If omitted, read from the packs config file
+   * (`~/.config/nodetool/packs.json`) where the Electron package manager
+   * persists the user's choices.
    */
-  disabledPacks?: string[];
+  enabledOverrides?: Record<string, boolean>;
   log?: BootstrapLogger;
 }
 
-/** Register all first-party node packs into `registry` (synchronous). */
+/**
+ * Register the enabled first-party node packs into `registry` (synchronous).
+ * Required packs and packs enabled by default or by the user load; the rest
+ * are skipped.
+ */
 export function registerBuiltInNodes(
   registry: NodeRegistry,
   options: RegisterBuiltInNodesOptions = {}
 ): void {
-  const disabled = new Set(options.disabledPacks ?? readDisabledBuiltinPacks());
+  const overrides = options.enabledOverrides ?? readBuiltinPackOverrides();
   for (const pack of BUILTIN_NODE_PACKS) {
-    if (!pack.required && disabled.has(pack.id)) {
+    if (!resolveBuiltinPackEnabled(pack, overrides[pack.id])) {
       options.log?.info(`Skipped built-in node pack ${pack.id} (disabled)`);
       continue;
     }

--- a/packages/websocket/src/trpc/routers/packs.ts
+++ b/packages/websocket/src/trpc/routers/packs.ts
@@ -12,13 +12,16 @@ import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { getPackSnapshot, reloadPacks } from "../../pack-snapshot.js";
 import {
-  readDisabledBuiltinPacks,
+  readBuiltinPackOverrides,
   resolvePackTrust,
-  writeDisabledBuiltinPacks,
+  writeBuiltinPackOverrides,
   writePackTrustConfig,
   type LoadedPackResult
 } from "@nodetool-ai/node-sdk";
-import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
+import {
+  BUILTIN_NODE_PACKS,
+  resolveBuiltinPackEnabled
+} from "@nodetool-ai/protocol";
 
 // ── Schemas ──────────────────────────────────────────────────────────────
 
@@ -83,17 +86,14 @@ function toDto(r: LoadedPackResult): z.infer<typeof packResultSchema> {
 }
 
 function builtinPackDtos(): z.infer<typeof builtinPackSchema>[] {
-  const disabled = new Set(readDisabledBuiltinPacks());
-  return BUILTIN_NODE_PACKS.map((pack) => {
-    const required = pack.required ?? false;
-    return {
-      id: pack.id,
-      name: pack.name,
-      description: pack.description,
-      required,
-      enabled: required || !disabled.has(pack.id)
-    };
-  });
+  const overrides = readBuiltinPackOverrides();
+  return BUILTIN_NODE_PACKS.map((pack) => ({
+    id: pack.id,
+    name: pack.name,
+    description: pack.description,
+    required: pack.required ?? false,
+    enabled: resolveBuiltinPackEnabled(pack, overrides[pack.id])
+  }));
 }
 
 // ── Router ───────────────────────────────────────────────────────────────
@@ -147,13 +147,10 @@ export const packsRouter = router({
       if (pack.required && !input.enabled) {
         throw new Error(`Built-in pack "${input.id}" cannot be disabled`);
       }
-      const disabled = new Set(readDisabledBuiltinPacks());
-      if (input.enabled) {
-        disabled.delete(input.id);
-      } else {
-        disabled.add(input.id);
-      }
-      writeDisabledBuiltinPacks([...disabled]);
+      writeBuiltinPackOverrides({
+        ...readBuiltinPackOverrides(),
+        [input.id]: input.enabled
+      });
       return { packs: builtinPackDtos() };
     }),
 

--- a/packages/websocket/src/trpc/routers/packs.ts
+++ b/packages/websocket/src/trpc/routers/packs.ts
@@ -12,10 +12,13 @@ import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { getPackSnapshot, reloadPacks } from "../../pack-snapshot.js";
 import {
+  readDisabledBuiltinPacks,
   resolvePackTrust,
+  writeDisabledBuiltinPacks,
   writePackTrustConfig,
   type LoadedPackResult
 } from "@nodetool-ai/node-sdk";
+import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
 
 // ── Schemas ──────────────────────────────────────────────────────────────
 
@@ -55,6 +58,16 @@ const trustUpdateInput = z
     message: "at least one of allowlist or allowUnlisted must be set"
   });
 
+const builtinPackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  enabled: z.boolean(),
+  required: z.boolean()
+});
+
+const builtinsOutput = z.object({ packs: z.array(builtinPackSchema) });
+
 // ── DTO mapping ──────────────────────────────────────────────────────────
 
 function toDto(r: LoadedPackResult): z.infer<typeof packResultSchema> {
@@ -67,6 +80,20 @@ function toDto(r: LoadedPackResult): z.infer<typeof packResultSchema> {
     skippedNodes: r.skippedNodes,
     ...(r.error ? { error: r.error.message } : {})
   };
+}
+
+function builtinPackDtos(): z.infer<typeof builtinPackSchema>[] {
+  const disabled = new Set(readDisabledBuiltinPacks());
+  return BUILTIN_NODE_PACKS.map((pack) => {
+    const required = pack.required ?? false;
+    return {
+      id: pack.id,
+      name: pack.name,
+      description: pack.description,
+      required,
+      enabled: required || !disabled.has(pack.id)
+    };
+  });
 }
 
 // ── Router ───────────────────────────────────────────────────────────────
@@ -98,6 +125,36 @@ export const packsRouter = router({
       };
       writePackTrustConfig(next);
       return next;
+    }),
+
+  /** Built-in packs that ship with NodeTool and whether each is enabled. */
+  listBuiltins: protectedProcedure
+    .output(builtinsOutput)
+    .query(() => ({ packs: builtinPackDtos() })),
+
+  /**
+   * Enable or disable a built-in pack. Persisted to
+   * `~/.config/nodetool/packs.json`; takes effect on the next server start.
+   */
+  setBuiltinEnabled: protectedProcedure
+    .input(z.object({ id: z.string(), enabled: z.boolean() }))
+    .output(builtinsOutput)
+    .mutation(({ input }) => {
+      const pack = BUILTIN_NODE_PACKS.find((p) => p.id === input.id);
+      if (!pack) {
+        throw new Error(`Unknown built-in pack "${input.id}"`);
+      }
+      if (pack.required && !input.enabled) {
+        throw new Error(`Built-in pack "${input.id}" cannot be disabled`);
+      }
+      const disabled = new Set(readDisabledBuiltinPacks());
+      if (input.enabled) {
+        disabled.delete(input.id);
+      } else {
+        disabled.add(input.id);
+      }
+      writeDisabledBuiltinPacks([...disabled]);
+      return { packs: builtinPackDtos() };
     }),
 
   /**

--- a/packages/websocket/src/trpc/routers/packs.ts
+++ b/packages/websocket/src/trpc/routers/packs.ts
@@ -134,12 +134,13 @@ export const packsRouter = router({
 
   /**
    * Enable or disable a built-in pack. Persisted to
-   * `~/.config/nodetool/packs.json`; takes effect on the next server start.
+   * `~/.config/nodetool/packs.json` and applied to the live registry
+   * immediately, so clients only need to refetch node metadata.
    */
   setBuiltinEnabled: protectedProcedure
     .input(z.object({ id: z.string(), enabled: z.boolean() }))
     .output(builtinsOutput)
-    .mutation(({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       const pack = BUILTIN_NODE_PACKS.find((p) => p.id === input.id);
       if (!pack) {
         throw new Error(`Unknown built-in pack "${input.id}"`);
@@ -151,6 +152,12 @@ export const packsRouter = router({
         ...readBuiltinPackOverrides(),
         [input.id]: input.enabled
       });
+      // Lazy import: node-registry-setup pulls in every built-in pack, which
+      // must not load just because the router module is imported.
+      const { applyBuiltinPackEnabled } = await import(
+        "../../node-registry-setup.js"
+      );
+      applyBuiltinPackEnabled(ctx.registry, input.id, input.enabled);
       return { packs: builtinPackDtos() };
     }),
 

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
+import { registerBuiltInNodes } from "../src/node-registry-setup.js";
+
+describe("registerBuiltInNodes", () => {
+  it("catalog and registrars cover every built-in pack", () => {
+    const registry = new NodeRegistry();
+    // Throws if a catalog id has no registrar.
+    registerBuiltInNodes(registry, { disabledPacks: [] });
+    expect(registry.list().length).toBeGreaterThan(0);
+  });
+
+  it("skips disabled packs", () => {
+    const all = new NodeRegistry();
+    registerBuiltInNodes(all, { disabledPacks: [] });
+
+    const withoutFal = new NodeRegistry();
+    registerBuiltInNodes(withoutFal, { disabledPacks: ["fal"] });
+
+    const falTypes = all.list().filter((t) => t.startsWith("fal."));
+    expect(falTypes.length).toBeGreaterThan(0);
+    for (const t of falTypes) {
+      expect(withoutFal.has(t)).toBe(false);
+    }
+    // Everything else is untouched.
+    expect(withoutFal.list().length).toBe(all.list().length - falTypes.length);
+  });
+
+  it("ignores disabling required packs", () => {
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, { disabledPacks: ["base"] });
+    expect(
+      registry.list().some((t) => t.startsWith("nodetool."))
+    ).toBe(true);
+  });
+
+  it("base pack is marked required in the catalog", () => {
+    expect(
+      BUILTIN_NODE_PACKS.find((p) => p.id === "base")?.required
+    ).toBe(true);
+  });
+});

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -3,33 +3,50 @@ import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
 import { registerBuiltInNodes } from "../src/node-registry-setup.js";
 
+function allEnabled(): Record<string, boolean> {
+  return Object.fromEntries(BUILTIN_NODE_PACKS.map((p) => [p.id, true]));
+}
+
 describe("registerBuiltInNodes", () => {
   it("catalog and registrars cover every built-in pack", () => {
     const registry = new NodeRegistry();
     // Throws if a catalog id has no registrar.
-    registerBuiltInNodes(registry, { disabledPacks: [] });
+    registerBuiltInNodes(registry, { enabledOverrides: allEnabled() });
     expect(registry.list().length).toBeGreaterThan(0);
   });
 
-  it("skips disabled packs", () => {
-    const all = new NodeRegistry();
-    registerBuiltInNodes(all, { disabledPacks: [] });
+  it("only registers required and default-enabled packs out of the box", () => {
+    const everything = new NodeRegistry();
+    registerBuiltInNodes(everything, { enabledOverrides: allEnabled() });
 
-    const withoutFal = new NodeRegistry();
-    registerBuiltInNodes(withoutFal, { disabledPacks: ["fal"] });
+    const defaults = new NodeRegistry();
+    registerBuiltInNodes(defaults, { enabledOverrides: {} });
 
-    const falTypes = all.list().filter((t) => t.startsWith("fal."));
-    expect(falTypes.length).toBeGreaterThan(0);
-    for (const t of falTypes) {
-      expect(withoutFal.has(t)).toBe(false);
+    // Defaults are a strict subset: opt-in packs (e.g. ElevenLabs) are absent…
+    const elevenlabsTypes = everything
+      .list()
+      .filter((t) => t.startsWith("elevenlabs."));
+    expect(elevenlabsTypes.length).toBeGreaterThan(0);
+    for (const t of elevenlabsTypes) {
+      expect(defaults.has(t)).toBe(false);
     }
-    // Everything else is untouched.
-    expect(withoutFal.list().length).toBe(all.list().length - falTypes.length);
+    // …while default-enabled packs (e.g. FAL) are present.
+    expect(defaults.list().some((t) => t.startsWith("fal."))).toBe(true);
+    expect(defaults.list().length).toBeLessThan(everything.list().length);
+  });
+
+  it("user overrides enable opt-in packs and disable default ones", () => {
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, {
+      enabledOverrides: { elevenlabs: true, fal: false }
+    });
+    expect(registry.list().some((t) => t.startsWith("elevenlabs."))).toBe(true);
+    expect(registry.list().some((t) => t.startsWith("fal."))).toBe(false);
   });
 
   it("ignores disabling required packs", () => {
     const registry = new NodeRegistry();
-    registerBuiltInNodes(registry, { disabledPacks: ["base"] });
+    registerBuiltInNodes(registry, { enabledOverrides: { base: false } });
     expect(
       registry.list().some((t) => t.startsWith("nodetool."))
     ).toBe(true);

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
-import { registerBuiltInNodes } from "../src/node-registry-setup.js";
+import {
+  applyBuiltinPackEnabled,
+  registerBuiltInNodes
+} from "../src/node-registry-setup.js";
 
 function allEnabled(): Record<string, boolean> {
   return Object.fromEntries(BUILTIN_NODE_PACKS.map((p) => [p.id, true]));
@@ -56,5 +59,56 @@ describe("registerBuiltInNodes", () => {
     expect(
       BUILTIN_NODE_PACKS.find((p) => p.id === "base")?.required
     ).toBe(true);
+  });
+});
+
+describe("applyBuiltinPackEnabled", () => {
+  it("registers and unregisters exactly the pack's node types", () => {
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, { enabledOverrides: {} });
+    const before = registry.list().length;
+
+    applyBuiltinPackEnabled(registry, "elevenlabs", true);
+    const elevenlabsTypes = registry
+      .list()
+      .filter((t) => t.startsWith("elevenlabs."));
+    expect(elevenlabsTypes.length).toBeGreaterThan(0);
+
+    applyBuiltinPackEnabled(registry, "elevenlabs", false);
+    expect(
+      registry.list().some((t) => t.startsWith("elevenlabs."))
+    ).toBe(false);
+    expect(registry.list().length).toBe(before);
+  });
+
+  it("disabling kie leaves base's kie.* nodes intact", () => {
+    // base-nodes also registers types under the `kie.` namespace; live
+    // disable must remove only what kie-nodes itself registers.
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, { enabledOverrides: { kie: false } });
+    const baseKieTypes = registry
+      .list()
+      .filter((t) => t.startsWith("kie."));
+
+    applyBuiltinPackEnabled(registry, "kie", true);
+    applyBuiltinPackEnabled(registry, "kie", false);
+    expect(registry.list().filter((t) => t.startsWith("kie."))).toEqual(
+      baseKieTypes
+    );
+  });
+
+  it("enabling is idempotent", () => {
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, { enabledOverrides: {} });
+    applyBuiltinPackEnabled(registry, "minimax", true);
+    const count = registry.list().length;
+    applyBuiltinPackEnabled(registry, "minimax", true);
+    expect(registry.list().length).toBe(count);
+  });
+
+  it("throws for unknown pack ids", () => {
+    expect(() =>
+      applyBuiltinPackEnabled(new NodeRegistry(), "nope", true)
+    ).toThrow(/No registrar/);
   });
 });

--- a/packages/websocket/tests/trpc-packs.test.ts
+++ b/packages/websocket/tests/trpc-packs.test.ts
@@ -142,30 +142,34 @@ describe("packs router", () => {
     await expect(caller.setTrust({})).rejects.toThrow();
   });
 
-  it("listBuiltins reports every built-in pack as enabled by default", async () => {
+  it("listBuiltins enables only required and default-enabled packs out of the box", async () => {
     const caller = createCaller(makeCtx());
     const result = await caller.listBuiltins();
-    expect(result.packs.length).toBeGreaterThan(0);
-    expect(result.packs.every((p) => p.enabled)).toBe(true);
-    expect(result.packs.find((p) => p.id === "base")?.required).toBe(true);
+    const byId = new Map(result.packs.map((p) => [p.id, p]));
+    expect(byId.get("base")).toMatchObject({ enabled: true, required: true });
+    expect(byId.get("fal")?.enabled).toBe(true);
+    // Opt-in packs start disabled.
+    expect(byId.get("elevenlabs")?.enabled).toBe(false);
+    expect(byId.get("kie")?.enabled).toBe(false);
   });
 
-  it("setBuiltinEnabled persists the disabled list and round-trips", async () => {
+  it("setBuiltinEnabled persists overrides in both directions", async () => {
     const caller = createCaller(makeCtx());
+    const enabled = await caller.setBuiltinEnabled({
+      id: "kie",
+      enabled: true
+    });
+    expect(enabled.packs.find((p) => p.id === "kie")?.enabled).toBe(true);
+
     const disabled = await caller.setBuiltinEnabled({
       id: "fal",
       enabled: false
     });
     expect(disabled.packs.find((p) => p.id === "fal")?.enabled).toBe(false);
-    expect(
-      JSON.parse(readFileSync(configPath, "utf8")).disabledBuiltins
-    ).toEqual(["fal"]);
 
-    const reEnabled = await caller.setBuiltinEnabled({
-      id: "fal",
-      enabled: true
-    });
-    expect(reEnabled.packs.every((p) => p.enabled)).toBe(true);
+    const config = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(config.enabledBuiltins).toEqual(["kie"]);
+    expect(config.disabledBuiltins).toEqual(["fal"]);
   });
 
   it("setBuiltinEnabled rejects unknown ids and required packs", async () => {

--- a/packages/websocket/tests/trpc-packs.test.ts
+++ b/packages/websocket/tests/trpc-packs.test.ts
@@ -148,28 +148,38 @@ describe("packs router", () => {
     const byId = new Map(result.packs.map((p) => [p.id, p]));
     expect(byId.get("base")).toMatchObject({ enabled: true, required: true });
     expect(byId.get("fal")?.enabled).toBe(true);
+    expect(byId.get("kie")?.enabled).toBe(true);
     // Opt-in packs start disabled.
     expect(byId.get("elevenlabs")?.enabled).toBe(false);
-    expect(byId.get("kie")?.enabled).toBe(false);
+    expect(byId.get("minimax")?.enabled).toBe(false);
   });
 
-  it("setBuiltinEnabled persists overrides in both directions", async () => {
-    const caller = createCaller(makeCtx());
+  it("setBuiltinEnabled persists overrides and applies them to the live registry", async () => {
+    const ctx = makeCtx();
+    const caller = createCaller(ctx);
+
     const enabled = await caller.setBuiltinEnabled({
-      id: "kie",
+      id: "minimax",
       enabled: true
     });
-    expect(enabled.packs.find((p) => p.id === "kie")?.enabled).toBe(true);
+    expect(enabled.packs.find((p) => p.id === "minimax")?.enabled).toBe(true);
+    // Applied live: the pack's nodes are registered without a restart.
+    expect(
+      ctx.registry.list().some((t) => t.startsWith("minimax."))
+    ).toBe(true);
 
     const disabled = await caller.setBuiltinEnabled({
-      id: "fal",
+      id: "minimax",
       enabled: false
     });
-    expect(disabled.packs.find((p) => p.id === "fal")?.enabled).toBe(false);
+    expect(disabled.packs.find((p) => p.id === "minimax")?.enabled).toBe(false);
+    expect(
+      ctx.registry.list().some((t) => t.startsWith("minimax."))
+    ).toBe(false);
 
     const config = JSON.parse(readFileSync(configPath, "utf8"));
-    expect(config.enabledBuiltins).toEqual(["kie"]);
-    expect(config.disabledBuiltins).toEqual(["fal"]);
+    expect(config.enabledBuiltins).toEqual([]);
+    expect(config.disabledBuiltins).toEqual(["minimax"]);
   });
 
   it("setBuiltinEnabled rejects unknown ids and required packs", async () => {

--- a/packages/websocket/tests/trpc-packs.test.ts
+++ b/packages/websocket/tests/trpc-packs.test.ts
@@ -142,6 +142,42 @@ describe("packs router", () => {
     await expect(caller.setTrust({})).rejects.toThrow();
   });
 
+  it("listBuiltins reports every built-in pack as enabled by default", async () => {
+    const caller = createCaller(makeCtx());
+    const result = await caller.listBuiltins();
+    expect(result.packs.length).toBeGreaterThan(0);
+    expect(result.packs.every((p) => p.enabled)).toBe(true);
+    expect(result.packs.find((p) => p.id === "base")?.required).toBe(true);
+  });
+
+  it("setBuiltinEnabled persists the disabled list and round-trips", async () => {
+    const caller = createCaller(makeCtx());
+    const disabled = await caller.setBuiltinEnabled({
+      id: "fal",
+      enabled: false
+    });
+    expect(disabled.packs.find((p) => p.id === "fal")?.enabled).toBe(false);
+    expect(
+      JSON.parse(readFileSync(configPath, "utf8")).disabledBuiltins
+    ).toEqual(["fal"]);
+
+    const reEnabled = await caller.setBuiltinEnabled({
+      id: "fal",
+      enabled: true
+    });
+    expect(reEnabled.packs.every((p) => p.enabled)).toBe(true);
+  });
+
+  it("setBuiltinEnabled rejects unknown ids and required packs", async () => {
+    const caller = createCaller(makeCtx());
+    await expect(
+      caller.setBuiltinEnabled({ id: "nope", enabled: false })
+    ).rejects.toThrow(/Unknown built-in pack/);
+    await expect(
+      caller.setBuiltinEnabled({ id: "base", enabled: false })
+    ).rejects.toThrow(/cannot be disabled/);
+  });
+
   it("reload re-runs the loader against the registry and refreshes the snapshot", async () => {
     // Empty searchPaths → loader finds nothing, snapshot becomes [].
     setPackSnapshot([fakePack("@acme/cool")]);

--- a/web/src/components/node_types/PlaceholderNode.tsx
+++ b/web/src/components/node_types/PlaceholderNode.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useMemo, useCallback } from "react";
+import { memo, useMemo, useCallback, useEffect, useState } from "react";
 import { Node, NodeProps } from "@xyflow/react";
 import isEqual from "fast-deep-equal";
 import { Container } from "@mui/material";
@@ -13,8 +13,11 @@ import { useNodes } from "../../contexts/NodeContext";
 import { NodeInputs } from "../node/NodeInputs";
 import { NodeOutputs } from "../node/NodeOutputs";
 import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
+import ExtensionIcon from "@mui/icons-material/Extension";
 import type { Edge } from "@xyflow/react";
 import type { NodeStoreState } from "../../stores/NodeStore";
+import { findBuiltinPackForNodeType } from "@nodetool-ai/protocol";
+import usePacksStore from "../../stores/PacksStore";
 import {
   EditorButton,
   FlexColumn,
@@ -181,6 +184,41 @@ const PlaceholderNode = (props: NodeProps<PlaceholderNodeData>) => {
     return resolvedType.split(".").slice(0, -1).join(".") || "unknown";
   }, [resolvedType]);
 
+  // If the missing type belongs to a built-in pack that's merely disabled,
+  // offer to enable it in place instead of sending the user to the package
+  // manager. The server applies the toggle live; refetched metadata swaps
+  // this placeholder for the real node.
+  const candidatePack = useMemo(
+    () => findBuiltinPackForNodeType(resolvedType),
+    [resolvedType]
+  );
+  const builtins = usePacksStore((state) => state.builtins);
+  const fetchBuiltins = usePacksStore((state) => state.fetchBuiltins);
+  const setBuiltinEnabled = usePacksStore((state) => state.setBuiltinEnabled);
+  const [enabling, setEnabling] = useState(false);
+
+  useEffect(() => {
+    if (candidatePack && builtins.length === 0) {
+      void fetchBuiltins();
+    }
+  }, [candidatePack, builtins.length, fetchBuiltins]);
+
+  const disabledPack = useMemo(() => {
+    if (!candidatePack) return undefined;
+    const status = builtins.find((p) => p.id === candidatePack.id);
+    return status && !status.enabled ? candidatePack : undefined;
+  }, [candidatePack, builtins]);
+
+  const enablePack = useCallback(async () => {
+    if (!disabledPack) return;
+    setEnabling(true);
+    try {
+      await setBuiltinEnabled(disabledPack.id, true);
+    } finally {
+      setEnabling(false);
+    }
+  }, [disabledPack, setBuiltinEnabled]);
+
   const installPackage = useCallback(() => {
     // Pass the node type to the package manager to pre-fill the search
     const nodeTypeToSearch = nodeData?.originalType || nodeType || "";
@@ -298,17 +336,36 @@ const PlaceholderNode = (props: NodeProps<PlaceholderNodeData>) => {
       </Tooltip>
 
       <FlexColumn gap={1} align="center" className="node-actions" sx={{ margin: "8px 0" }}>
-        <Tooltip title={`Search for ${resolvedType} in Package Manager`}>
-          <EditorButton
-            variant="contained"
-            density="compact"
-            className="install-button"
-            onClick={installPackage}
-            startIcon={<CloudDownloadIcon />}
+        {disabledPack ? (
+          <Tooltip
+            title={`This node is part of the ${disabledPack.name} pack, which is currently disabled. Enable it to load the node.`}
           >
-            Search Package Manager
-          </EditorButton>
-        </Tooltip>
+            <EditorButton
+              variant="contained"
+              density="compact"
+              className="install-button"
+              onClick={enablePack}
+              disabled={enabling}
+              startIcon={<ExtensionIcon />}
+            >
+              {enabling
+                ? "Enabling…"
+                : `Enable ${disabledPack.name} Nodes`}
+            </EditorButton>
+          </Tooltip>
+        ) : (
+          <Tooltip title={`Search for ${resolvedType} in Package Manager`}>
+            <EditorButton
+              variant="contained"
+              density="compact"
+              className="install-button"
+              onClick={installPackage}
+              startIcon={<CloudDownloadIcon />}
+            >
+              Search Package Manager
+            </EditorButton>
+          </Tooltip>
+        )}
       </FlexColumn>
 
       {mockProperties.length > 0 && (

--- a/web/src/stores/PacksStore.ts
+++ b/web/src/stores/PacksStore.ts
@@ -10,6 +10,7 @@ import { create } from "zustand";
 
 import { trpcClient } from "../trpc/client";
 import { createErrorMessage } from "../utils/errorHandling";
+import { loadMetadata } from "../serverState/useMetadata";
 
 export type PackStatus = "loaded" | "skipped" | "error";
 
@@ -40,12 +41,30 @@ export interface PackTrust {
   allowUnlisted: boolean;
 }
 
+/** A first-party pack shipped with NodeTool and its enabled state. */
+export interface BuiltinPack {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  required: boolean;
+}
+
 interface PacksStore {
   packs: PackInfo[];
   trust: PackTrust;
+  builtins: BuiltinPack[];
   isLoading: boolean;
   error: string | null;
   fetch: () => Promise<void>;
+  /** Load the built-in pack list (cheap; safe to call from any component). */
+  fetchBuiltins: () => Promise<void>;
+  /**
+   * Enable/disable a built-in pack. The server applies the change to its live
+   * registry, so on success node metadata is refetched and new nodes appear
+   * without a restart. Resolves to `true` on success.
+   */
+  setBuiltinEnabled: (id: string, enabled: boolean) => Promise<boolean>;
   /** Toggle one pack on/off in the allowlist and soft-reload. */
   setTrusted: (packName: string, trusted: boolean) => Promise<void>;
   setAllowUnlisted: (allow: boolean) => Promise<void>;
@@ -66,22 +85,59 @@ let trustMutation: Promise<unknown> = Promise.resolve();
 const usePacksStore = create<PacksStore>((set, get) => ({
   packs: [],
   trust: { allowlist: [], allowUnlisted: false },
+  builtins: [],
   isLoading: false,
   error: null,
 
   fetch: async () => {
     set({ isLoading: true, error: null });
     try {
-      const [packsRes, trust] = await Promise.all([
+      const [packsRes, trust, builtinsRes] = await Promise.all([
         trpcClient.packs.list.query(),
-        trpcClient.packs.getTrust.query()
+        trpcClient.packs.getTrust.query(),
+        trpcClient.packs.listBuiltins.query()
       ]);
-      set({ packs: packsRes.packs, trust, isLoading: false });
+      set({
+        packs: packsRes.packs,
+        trust,
+        builtins: builtinsRes.packs,
+        isLoading: false
+      });
     } catch (err: unknown) {
       set({
         isLoading: false,
         error: createErrorMessage(err, "Failed to load packs").message
       });
+    }
+  },
+
+  fetchBuiltins: async () => {
+    try {
+      const res = await trpcClient.packs.listBuiltins.query();
+      set({ builtins: res.packs });
+    } catch (err: unknown) {
+      set({
+        error: createErrorMessage(err, "Failed to load built-in packs").message
+      });
+    }
+  },
+
+  setBuiltinEnabled: async (id, enabled) => {
+    try {
+      const res = await trpcClient.packs.setBuiltinEnabled.mutate({
+        id,
+        enabled
+      });
+      set({ builtins: res.packs });
+      // The server already applied the toggle to its live registry; pull the
+      // refreshed node metadata so (placeholder) nodes re-render immediately.
+      await loadMetadata();
+      return true;
+    } catch (err: unknown) {
+      set({
+        error: createErrorMessage(err, "Failed to update built-in pack").message
+      });
+      return false;
     }
   },
 

--- a/web/src/stores/__tests__/PacksStore.test.ts
+++ b/web/src/stores/__tests__/PacksStore.test.ts
@@ -5,18 +5,26 @@ jest.mock("../../trpc/client", () => {
   const getTrust = jest.fn();
   const setTrust = jest.fn();
   const reload = jest.fn();
+  const listBuiltins = jest.fn();
+  const setBuiltinEnabled = jest.fn();
   return {
     trpcClient: {
       packs: {
         list: { query: list },
         getTrust: { query: getTrust },
         setTrust: { mutate: setTrust },
-        reload: { mutate: reload }
+        reload: { mutate: reload },
+        listBuiltins: { query: listBuiltins },
+        setBuiltinEnabled: { mutate: setBuiltinEnabled }
       }
     },
-    __mocks: { list, getTrust, setTrust, reload }
+    __mocks: { list, getTrust, setTrust, reload, listBuiltins, setBuiltinEnabled }
   };
 });
+
+jest.mock("../../serverState/useMetadata", () => ({
+  loadMetadata: jest.fn().mockResolvedValue("success")
+}));
 
 const { __mocks } = require("../../trpc/client") as {
   __mocks: {
@@ -24,7 +32,13 @@ const { __mocks } = require("../../trpc/client") as {
     getTrust: jest.Mock;
     setTrust: jest.Mock;
     reload: jest.Mock;
+    listBuiltins: jest.Mock;
+    setBuiltinEnabled: jest.Mock;
   };
+};
+
+const { loadMetadata } = require("../../serverState/useMetadata") as {
+  loadMetadata: jest.Mock;
 };
 
 import usePacksStore from "../PacksStore";
@@ -35,9 +49,12 @@ describe("PacksStore", () => {
     usePacksStore.setState({
       packs: [],
       trust: { allowlist: [], allowUnlisted: false },
+      builtins: [],
       isLoading: false,
       error: null
     });
+    // fetch() always queries builtins alongside packs/trust.
+    __mocks.listBuiltins.mockResolvedValue({ packs: [] });
   });
 
   describe("initial state", () => {
@@ -196,6 +213,57 @@ describe("PacksStore", () => {
 
       expect(usePacksStore.getState().isLoading).toBe(false);
       expect(usePacksStore.getState().error).toBeTruthy();
+    });
+  });
+
+  describe("builtins", () => {
+    const mockBuiltins = [
+      { id: "base", name: "Base Nodes", description: "", enabled: true, required: true },
+      { id: "minimax", name: "MiniMax", description: "", enabled: false, required: false }
+    ];
+
+    it("fetchBuiltins loads the built-in pack list", async () => {
+      __mocks.listBuiltins.mockResolvedValue({ packs: mockBuiltins });
+
+      await act(async () => {
+        await usePacksStore.getState().fetchBuiltins();
+      });
+
+      expect(usePacksStore.getState().builtins).toEqual(mockBuiltins);
+    });
+
+    it("setBuiltinEnabled updates builtins and refreshes node metadata", async () => {
+      const updated = [
+        mockBuiltins[0],
+        { ...mockBuiltins[1], enabled: true }
+      ];
+      __mocks.setBuiltinEnabled.mockResolvedValue({ packs: updated });
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await usePacksStore.getState().setBuiltinEnabled("minimax", true);
+      });
+
+      expect(result).toBe(true);
+      expect(__mocks.setBuiltinEnabled).toHaveBeenCalledWith({
+        id: "minimax",
+        enabled: true
+      });
+      expect(usePacksStore.getState().builtins).toEqual(updated);
+      expect(loadMetadata).toHaveBeenCalled();
+    });
+
+    it("setBuiltinEnabled returns false and sets error on failure", async () => {
+      __mocks.setBuiltinEnabled.mockRejectedValue(new Error("nope"));
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await usePacksStore.getState().setBuiltinEnabled("minimax", true);
+      });
+
+      expect(result).toBe(false);
+      expect(usePacksStore.getState().error).toBeTruthy();
+      expect(loadMetadata).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
All first-party node packs were registered unconditionally, polluting the
node namespace for users who don't need them. This adds a user-facing way
to turn shipped packs off:

- protocol: new BUILTIN_NODE_PACKS catalog (stable ids, names,
  descriptions, required flag) shared by server and Electron, exposed via
  the ./builtin-packs subpath export.
- node-sdk: packs.json gains a disabledBuiltins list with read/write
  helpers; writePackTrustConfig now preserves unrelated config fields.
- websocket: registerBuiltInNodes skips disabled packs (read from the
  packs config at bootstrap); base nodes are required and always load.
  New packs.listBuiltins / packs.setBuiltinEnabled tRPC endpoints.
- electron: new "Included Node Packs" section in the Package Manager with
  per-pack Enable/Disable buttons and a restart-server banner, backed by
  builtin-pack-list / builtin-pack-set-enabled IPC channels that persist
  to the same packs.json the server reads on its next start.

https://claude.ai/code/session_01UaTinAofs6wzzujeVyoai8