### PR TITLE
perf: overhaul realtime audio pipeline for browser execution

### DIFF
--- a/electron/src/menu.ts
+++ b/electron/src/menu.ts
@@ -4,6 +4,7 @@ import { getMainWindow } from "./state";
 import { createPackageManagerWindow, createLogViewerWindow, createSettingsWindow } from "./window";
 import { createChatWindow } from "./workflowWindow";
 import { getSystemInfo } from "./systemInfo";
+import { openPerformanceMonitorWindow } from "./perfMonitor";
 
 /**
  * Builds the application menu
@@ -234,6 +235,10 @@ const buildMenu = () => {
         {
           label: "Log Viewer",
           click: () => createLogViewerWindow(),
+        },
+        {
+          label: "Performance Monitor",
+          click: () => openPerformanceMonitorWindow(),
         },
         { type: "separator" },
         {

--- a/electron/src/perfMonitor.ts
+++ b/electron/src/perfMonitor.ts
@@ -1,0 +1,147 @@
+/**
+ * Performance Monitor window — Electron's stand-in for Chrome's Task Manager
+ * (which isn't available in Electron; `chrome.send('openTaskManager')` only
+ * exists on Chrome WebUI pages).
+ *
+ * Polls `app.getAppMetrics()` once a second and renders per-process CPU and
+ * memory into a small self-contained window (data: URL page, no preload, no
+ * IPC surface). Renderer processes are labeled with their window title /
+ * URL via `webContents.getAllWebContents()`.
+ */
+
+import { app, BrowserWindow, webContents } from "electron";
+import { hardenWebContents } from "./windowSecurity";
+
+interface MetricRow {
+  label: string;
+  pid: number;
+  cpu: number;
+  memoryMb: number;
+}
+
+let perfWindow: BrowserWindow | null = null;
+
+const PAGE_HTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Performance Monitor</title>
+<style>
+  body { margin: 0; background: #111; color: #ddd; font: 13px/1.5 -apple-system, system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { text-align: left; padding: 4px 12px; white-space: nowrap; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  th { position: sticky; top: 0; background: #1b1b1b; color: #999; font-weight: 600; border-bottom: 1px solid #333; }
+  tr:nth-child(even) td { background: #161616; }
+  td.label { max-width: 360px; overflow: hidden; text-overflow: ellipsis; }
+  .hot { color: #ff9966; }
+</style>
+</head>
+<body>
+<table>
+  <thead>
+    <tr><th>Process</th><th class="num">PID</th><th class="num">CPU %</th><th class="num">Memory</th></tr>
+  </thead>
+  <tbody id="rows"><tr><td colspan="4" style="padding:16px;color:#777">Collecting…</td></tr></tbody>
+</table>
+<script>
+  window.__updateMetrics = function (rows) {
+    const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+    document.getElementById("rows").innerHTML = rows
+      .map((r) =>
+        "<tr><td class='label' title='" + esc(r.label) + "'>" + esc(r.label) +
+        "</td><td class='num'>" + r.pid +
+        "</td><td class='num" + (r.cpu >= 50 ? " hot" : "") + "'>" + r.cpu.toFixed(1) +
+        "</td><td class='num'>" + r.memoryMb.toFixed(0) + " MB</td></tr>"
+      )
+      .join("");
+  };
+</script>
+</body>
+</html>`;
+
+/** One row per OS process, labeled and sorted by CPU (descending). */
+function collectMetrics(): MetricRow[] {
+  // Label renderer pids with what they're showing.
+  const rendererLabels = new Map<number, string>();
+  for (const wc of webContents.getAllWebContents()) {
+    try {
+      const pid = wc.getOSProcessId();
+      const title = wc.getTitle() || wc.getURL() || "renderer";
+      const existing = rendererLabels.get(pid);
+      rendererLabels.set(pid, existing ? `${existing}, ${title}` : title);
+    } catch {
+      // WebContents may be mid-destruction; skip it.
+    }
+  }
+
+  return app
+    .getAppMetrics()
+    .map((m) => {
+      let label: string = m.type;
+      if (m.type === "Browser") {
+        label = "Main process";
+      } else if (m.type === "Tab") {
+        label = rendererLabels.get(m.pid) ?? "Renderer";
+      } else if (m.name) {
+        label = `${m.type}: ${m.name}`;
+      } else if (m.serviceName) {
+        label = `${m.type}: ${m.serviceName}`;
+      }
+      return {
+        label,
+        pid: m.pid,
+        cpu: m.cpu?.percentCPUUsage ?? 0,
+        memoryMb: (m.memory?.workingSetSize ?? 0) / 1024
+      };
+    })
+    .sort((a, b) => b.cpu - a.cpu);
+}
+
+/**
+ * Opens (or focuses) the Performance Monitor window.
+ */
+export function openPerformanceMonitorWindow(): void {
+  if (perfWindow && !perfWindow.isDestroyed()) {
+    perfWindow.focus();
+    return;
+  }
+
+  const window = new BrowserWindow({
+    width: 700,
+    height: 420,
+    title: "Performance Monitor",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  });
+  perfWindow = window;
+  window.setBackgroundColor("#111111");
+  hardenWebContents(window.webContents);
+  void window.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(PAGE_HTML)}`
+  );
+
+  const push = (): void => {
+    if (window.isDestroyed()) return;
+    const rows = collectMetrics();
+    window.webContents
+      .executeJavaScript(
+        `window.__updateMetrics?.(${JSON.stringify(rows)})`,
+        true
+      )
+      .catch(() => {
+        // Page not ready yet or window closing — next tick will retry.
+      });
+  };
+
+  const timer = setInterval(push, 1000);
+  window.webContents.once("did-finish-load", push);
+  window.on("closed", () => {
+    clearInterval(timer);
+    perfWindow = null;
+  });
+}

--- a/electron/src/perfMonitor.ts
+++ b/electron/src/perfMonitor.ts
@@ -46,8 +46,8 @@ const PAGE_HTML = `<!doctype html>
 </table>
 <script>
   window.__updateMetrics = function (rows) {
-    const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
-      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+    const esc = (s) => String(s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     document.getElementById("rows").innerHTML = rows
       .map((r) =>
         "<tr><td class='label' title='" + esc(r.label) + "'>" + esc(r.label) +

--- a/mobile/src/stores/ChatStore.ts
+++ b/mobile/src/stores/ChatStore.ts
@@ -139,6 +139,10 @@ function handleWebSocketMessage(
       const chunk = data as Chunk;
       if (!threadId) {break;}
 
+      // Audio chunks carry binary payloads (Float32Array or base64); only
+      // text contributes to the assistant message.
+      const chunkText = typeof chunk.content === 'string' ? chunk.content : '';
+
       const messages = state.messageCache[threadId] || [];
       const lastMessage = messages[messages.length - 1];
 
@@ -146,7 +150,7 @@ function handleWebSocketMessage(
         // Append to existing assistant message
         const updatedMessage: Message = {
           ...lastMessage,
-          content: (lastMessage.content || '') + chunk.content,
+          content: (lastMessage.content || '') + chunkText,
         };
         set((s) => ({
           status: chunk.done ? 'connected' : 'streaming',
@@ -161,7 +165,7 @@ function handleWebSocketMessage(
           id: `local-stream-${Date.now()}`,
           type: 'message',
           role: 'assistant',
-          content: chunk.content,
+          content: chunkText,
         };
         set((s) => ({
           status: chunk.done ? 'connected' : 'streaming',

--- a/packages/agents/src/agent-workflow-runner.ts
+++ b/packages/agents/src/agent-workflow-runner.ts
@@ -7,7 +7,7 @@
  */
 
 import { WorkflowRunner } from "@nodetool-ai/kernel";
-import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { hydrateGraphNodeFlags, type NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
 import type {
   GraphData,
@@ -95,7 +95,13 @@ export class AgentWorkflowRunner {
     let runError: unknown = null;
     let done = false;
     const runPromise = runner
-      .run({ job_id: jobId, params: this.opts.inputs }, graphData)
+      .run(
+        { job_id: jobId, params: this.opts.inputs },
+        // Planned graphs carry no behavior flags; stamp them from the
+        // registry so streaming nodes run streaming. The agent-step node
+        // type is not in the registry and keeps default (buffered) mode.
+        hydrateGraphNodeFlags(graphData, registry)
+      )
       .catch((err) => {
         runError = err;
         return undefined;

--- a/packages/audio-nodes/src/lib/cv.ts
+++ b/packages/audio-nodes/src/lib/cv.ts
@@ -1,24 +1,26 @@
 /**
  * Control-voltage (CV) signal helpers for the modular synthesis nodes.
  *
- * CV rides the same chunk wire shape as streaming audio (`type:"chunk"`,
- * `content_type:"audio"`, base64 payload, `done:true` terminator) but with
- * `encoding:"f32le"`: pcm16 clamps to [-1,1] and quantizes, which is wrong
- * for multi-octave pitch CV. `readSignalChunk` decodes both encodings, so
- * any signal node accepts audio and CV interchangeably (Eurorack semantics).
+ * CV rides the same chunk shape as streaming audio (`type:"chunk"`,
+ * `content_type:"audio"`, `done:true` terminator). In-process the payload is
+ * a native `Float32Array` (zero per-hop conversions); encoded string
+ * payloads from external sources are still decoded, where `encoding:"f32le"`
+ * matters for CV: pcm16 clamps to [-1,1] and quantizes, which is wrong for
+ * multi-octave pitch CV. `readSignalChunk` accepts all three forms, so any
+ * signal node accepts audio and CV interchangeably (Eurorack semantics).
  *
  * Also home to the sample-domain timing utilities:
  *  - `SampleFifo` / `alignedSignalStreams` — the "zip-with-hold" pattern for
  *    multi-input streaming nodes (the kernel has no sample-aligned zip;
  *    alignment is exact when one clock drives the patch, hold-last
  *    otherwise).
- *  - `abortableSleep` / `RealtimePacer` — wall-clock pacing for
- *    `realtime: true` generators. Pacing only delays emission; signal
- *    content is identical to a free run.
+ *  - `abortableSleep` / `RealtimePacer` — wall-clock pacing for the
+ *    free-running generators. Pacing only delays emission; signal content
+ *    is identical to an unpaced run.
  */
 import type { StreamingInputs } from "@nodetool-ai/node-sdk";
-import { base64ToBytes, bytesToBase64 } from "@nodetool-ai/nodes-utils";
-import { float32ToPcm16, pcm16ToFloat32 } from "./audio-wav.js";
+import { base64ToBytes } from "@nodetool-ai/nodes-utils";
+import { pcm16ToFloat32 } from "./audio-wav.js";
 
 export type SignalEncoding = "pcm16le" | "f32le";
 
@@ -74,19 +76,28 @@ export function readSignalChunk(item: unknown): SignalChunk | null {
       : SYNTH_SAMPLE_RATE;
   const channels =
     typeof meta.channels === "number" && meta.channels > 0 ? meta.channels : 1;
-  const content = typeof c.content === "string" ? c.content : "";
   let samples: Float32Array;
-  if (!content) {
-    samples = new Float32Array(0);
-  } else {
-    const bytes = base64ToBytes(content);
+  if (c.content instanceof Float32Array) {
+    // Native in-process payload — zero conversions.
+    samples = c.content;
+  } else if (typeof c.content === "string" && c.content) {
+    // Encoded payload (external sources, websocket wire format).
+    const bytes = base64ToBytes(c.content);
     samples =
       meta.encoding === "f32le" ? f32leToFloat32(bytes) : pcm16ToFloat32(bytes);
+  } else {
+    samples = new Float32Array(0);
   }
   return { samples, sampleRate, channels, done: Boolean(c.done ?? false) };
 }
 
-/** Build a signal chunk in the shared chunk wire shape. */
+/**
+ * Build a signal chunk in the shared chunk shape. Samples stay a native
+ * `Float32Array` — no encoding between nodes; the websocket transport
+ * encodes to base64 at the wire boundary. The `encoding` parameter is kept
+ * as metadata describing the *preferred wire encoding* for consumers that do
+ * serialize (pcm16le clamps to [-1,1], wrong for multi-octave CV).
+ */
 export function makeSignalChunk(
   samples: Float32Array,
   sampleRate: number,
@@ -94,11 +105,9 @@ export function makeSignalChunk(
   done: boolean,
   encoding: SignalEncoding
 ): Record<string, unknown> {
-  const bytes =
-    encoding === "f32le" ? float32ToF32le(samples) : float32ToPcm16(samples);
   return {
     type: "chunk",
-    content: samples.length > 0 ? bytesToBase64(bytes) : "",
+    content: samples.length > 0 ? samples : "",
     done,
     content_type: "audio",
     content_metadata: {
@@ -301,12 +310,11 @@ export function abortableSleep(
 }
 
 /**
- * Drift-compensated wall-clock pacer for `realtime: true` generators: chunk
- * k is released no earlier than the cumulative duration of chunks 0..k-1
+ * Drift-compensated wall-clock pacer for free-running generators: chunk k
+ * is released no earlier than the cumulative duration of chunks 0..k-1
  * after start (absolute target times, same scheme as IntervalTriggerNode).
- * Tracking the target cumulatively keeps variable-length chunks — e.g. the
- * shorter final chunk of a bounded render — correctly paced. Pacing never
- * alters chunk contents — a realtime render is bit-identical to a free run.
+ * Pacing never alters chunk contents — a paced render is bit-identical to
+ * an unpaced one.
  */
 export class RealtimePacer {
   private _nextTargetMs = Date.now();

--- a/packages/audio-nodes/src/nodes/realtime-audio.ts
+++ b/packages/audio-nodes/src/nodes/realtime-audio.ts
@@ -187,6 +187,50 @@ export class ChunksToAudioNode extends BaseNode {
   }
 }
 
+// ── AudioOutput ────────────────────────────────────────────────────
+
+export class AudioOutputNode extends BaseNode {
+  static readonly nodeType = "nodetool.audio.realtime.AudioOutput";
+  static readonly title = "Audio Out";
+  static readonly description =
+    "Plays a realtime audio chunk stream — the patch's speaker.\n    audio, stream, chunk, realtime, output, speaker, monitor\n\n    Passes every chunk through verbatim; the editor picks the chunks up from the live stream and plays them as they arrive. Terminate any synth patch or streaming effect chain here to hear it.\n\n    Use cases:\n    - Monitor a live modular synth patch\n    - Hear streaming TTS or effects output as it renders\n    - Audition a chain before recording it with ChunksToAudio";
+  static readonly metadataOutputTypes = {
+    chunk: "chunk"
+  };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["chunk"];
+  static readonly isStreamingInput = true;
+  // The editor's monitor buffer is fed by this node's output_updates; keep
+  // them flowing even when the pass-through output is patched into a
+  // recorder (the runner suppresses connected handles by default).
+  static readonly alwaysEmitOutputUpdates = true;
+
+  @prop({
+    type: "chunk",
+    default: CHUNK_PROP_DEFAULT,
+    title: "Chunk",
+    description: "Stream of PCM16LE audio chunks to play."
+  })
+  declare chunk: any;
+
+  // Required by BaseNode but unused for streaming
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
+    for await (const item of inputs.stream("chunk")) {
+      const chunk = readSignalChunk(item);
+      if (!chunk) continue;
+      // Verbatim pass-through: each emit becomes an output_update the
+      // editor's playback buffer consumes; downstream nodes can still
+      // record the same stream.
+      await outputs.emit("chunk", item);
+      if (chunk.done) break;
+    }
+  }
+}
+
 // ── StreamingGain ──────────────────────────────────────────────────
 
 export class StreamingGainNode extends BaseNode {
@@ -226,9 +270,6 @@ export class StreamingGainNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const gainDb = Number(this.gain_db ?? 0);
-    const factor = Math.pow(10, gainDb / 20);
-
     for await (const item of inputs.stream("chunk")) {
       const chunk = readSignalChunk(item);
       if (!chunk) continue;
@@ -242,12 +283,18 @@ export class StreamingGainNode extends BaseNode {
       }
       if (chunk.samples.length === 0) continue;
 
+      // Per chunk — live updates apply. Write into a fresh buffer: the input
+      // Float32Array is shared by reference with fan-out edges and any UI
+      // buffer holding the upstream chunk; mutating it in place would
+      // corrupt those.
+      const factor = Math.pow(10, Number(this.gain_db ?? 0) / 20);
       const samples = chunk.samples;
-      for (let i = 0; i < samples.length; i++) samples[i] *= factor;
+      const scaled = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) scaled[i] = samples[i] * factor;
       await outputs.emit(
         "chunk",
         makeSignalChunk(
-          samples,
+          scaled,
           chunk.sampleRate,
           chunk.channels,
           false,
@@ -263,16 +310,15 @@ export class StreamingGainNode extends BaseNode {
 /**
  * Shared body of the streaming low/high-pass filters: one biquad per channel
  * whose state persists across chunk boundaries, so the filter behaves exactly
- * as if it had processed the unchunked signal.
+ * as if it had processed the unchunked signal. The cutoff/Q are read via
+ * `params` and coefficients recomputed per chunk, so live updates apply.
  */
 async function runStreamingFilter(
   type: BiquadType,
-  frequency: number,
-  q: number,
+  params: () => { frequency: number; q: number },
   inputs: StreamingInputs,
   outputs: StreamingOutputs
 ): Promise<void> {
-  let coeffs: ReturnType<typeof biquadCoeffs> | null = null;
   let states: BiquadState[] = [];
 
   for await (const item of inputs.stream("chunk")) {
@@ -288,19 +334,29 @@ async function runStreamingFilter(
     }
     if (chunk.samples.length === 0) continue;
 
-    if (!coeffs) {
-      coeffs = biquadCoeffs(type, chunk.sampleRate, frequency, q, 0);
+    if (states.length !== chunk.channels) {
       states = Array.from({ length: chunk.channels }, createBiquadState);
     }
+    const { frequency, q } = params();
+    const coeffs = biquadCoeffs(type, chunk.sampleRate, frequency, q, 0);
 
-    const planes = deinterleave(chunk.samples, chunk.channels);
-    const filtered = planes.map((plane, ch) =>
-      processBiquad(coeffs!, states[ch] ?? createBiquadState(), plane)
-    );
+    // Mono fast path: filter the interleaved buffer directly — the
+    // deinterleave/interleave round trip would add two full copies per
+    // chunk, pure GC churn at realtime rates.
+    let filteredSamples: Float32Array;
+    if (chunk.channels === 1) {
+      filteredSamples = processBiquad(coeffs, states[0]!, chunk.samples);
+    } else {
+      const planes = deinterleave(chunk.samples, chunk.channels);
+      const filtered = planes.map((plane, ch) =>
+        processBiquad(coeffs, states[ch] ?? createBiquadState(), plane)
+      );
+      filteredSamples = interleave(filtered);
+    }
     await outputs.emit(
       "chunk",
       makeSignalChunk(
-        interleave(filtered),
+        filteredSamples,
         chunk.sampleRate,
         chunk.channels,
         false,
@@ -358,8 +414,10 @@ export class StreamingLowPassNode extends BaseNode {
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
     await runStreamingFilter(
       "lowpass",
-      Number(this.cutoff_frequency_hz ?? 5000),
-      Number(this.q ?? DEFAULT_Q),
+      () => ({
+        frequency: Number(this.cutoff_frequency_hz ?? 5000),
+        q: Number(this.q ?? DEFAULT_Q)
+      }),
       inputs,
       outputs
     );
@@ -414,8 +472,10 @@ export class StreamingHighPassNode extends BaseNode {
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
     await runStreamingFilter(
       "highpass",
-      Number(this.cutoff_frequency_hz ?? 80),
-      Number(this.q ?? DEFAULT_Q),
+      () => ({
+        frequency: Number(this.cutoff_frequency_hz ?? 80),
+        q: Number(this.q ?? DEFAULT_Q)
+      }),
       inputs,
       outputs
     );
@@ -424,6 +484,7 @@ export class StreamingHighPassNode extends BaseNode {
 
 export const REALTIME_AUDIO_NODES: readonly NodeClass[] = tagAsHybrid([
   AudioToChunksNode,
+  AudioOutputNode,
   ChunksToAudioNode,
   StreamingGainNode,
   StreamingLowPassNode,

--- a/packages/audio-nodes/src/nodes/synthesis.ts
+++ b/packages/audio-nodes/src/nodes/synthesis.ts
@@ -3,12 +3,13 @@
  * voice operating on streamed signal chunks: oscillator, LFO, ADSR, gate
  * source, VCA, VCF, CV utilities, and a mixer.
  *
- * Timing is sample-domain: time = sample count, never the wall clock.
- * Generators render a bounded duration deterministically (or run infinitely
- * with `realtime: true`, paced by `RealtimePacer` — pacing delays emission
- * but never changes signal content). Driven nodes derive all timing from
- * their input chunks (one output chunk per input chunk, same frame count),
- * so a patch driven by one Gate source is sample-aligned by construction.
+ * Timing is sample-domain: time = sample count; the wall clock only paces
+ * emission. Free-running generators (Oscillator, LFO, Gate) are realtime
+ * modules: they emit forever, paced by `RealtimePacer`, until the run is
+ * cancelled (pacing delays emission but never changes signal content).
+ * Driven nodes derive all timing from their input chunks (one output chunk
+ * per input chunk, same frame count), so a patch driven by one Gate source
+ * is sample-aligned by construction.
  *
  * Control voltage (CV) is a first-class socket type riding the chunk wire
  * shape with `encoding: "f32le"` (see ../lib/cv.ts) — interchangeable with
@@ -57,10 +58,12 @@ import {
 // ── Shared generator scaffolding ───────────────────────────────────
 
 /**
- * Run a bounded (or realtime-infinite) generator loop: calls `fill` to
- * produce each chunk's samples, paces with the wall clock when `realtime`,
- * and stops on run cancellation. `totalFrames === Infinity` only when the
- * caller has validated `realtime` is on.
+ * Run a free-running generator loop: calls `fill` to produce each chunk's
+ * samples, paces emission with the wall clock, and runs until cancellation
+ * (`signal`) — free-running synth sources have no other end; they play
+ * until the patch is stopped. Pacing is what keeps the infinite stream
+ * legal: inbox buffering is unbounded by default, and an unpaced infinite
+ * producer would exhaust memory.
  */
 async function runGenerator(
   outputs: StreamingOutputs,
@@ -68,48 +71,24 @@ async function runGenerator(
     slot: string;
     sampleRate: number;
     encoding: SignalEncoding;
-    totalFrames: number;
-    realtime: boolean;
     signal: AbortSignal;
     fill: (buf: Float32Array, startFrame: number) => void;
   }
 ): Promise<void> {
-  const { slot, sampleRate, encoding, totalFrames, realtime, signal } = opts;
-  const pacer = realtime ? new RealtimePacer(signal) : null;
+  const { slot, sampleRate, encoding, signal } = opts;
+  const pacer = new RealtimePacer(signal);
+  const chunkMs = (SYNTH_CHUNK_FRAMES / sampleRate) * 1000;
   let emitted = 0;
-  while (emitted < totalFrames) {
-    if (signal.aborted) break;
-    const frames = Math.min(SYNTH_CHUNK_FRAMES, totalFrames - emitted);
-    if (pacer && !(await pacer.waitNext((frames / sampleRate) * 1000))) break;
-    const buf = new Float32Array(frames);
+  while (await pacer.waitNext(chunkMs)) {
+    const buf = new Float32Array(SYNTH_CHUNK_FRAMES);
     opts.fill(buf, emitted);
     await outputs.emit(
       slot,
       makeSignalChunk(buf, sampleRate, 1, false, encoding)
     );
-    emitted += frames;
+    emitted += SYNTH_CHUNK_FRAMES;
   }
   await outputs.emit(slot, makeDoneSignalChunk(sampleRate, 1, encoding));
-}
-
-/**
- * Frame budget for a generator: `seconds <= 0` means infinite, which is
- * only legal in realtime mode (inbox buffering is unbounded by default — an
- * unpaced infinite producer would never terminate and exhaust memory).
- */
-function generatorFrames(
-  seconds: number,
-  sampleRate: number,
-  realtime: boolean,
-  what: string
-): number {
-  if (seconds > 0) return Math.max(1, Math.round(seconds * sampleRate));
-  if (!realtime) {
-    throw new Error(
-      `${what} of 0 (infinite) requires realtime: true — an unpaced infinite generator would run unbounded`
-    );
-  }
-  return Infinity;
 }
 
 /** Channel 0 of an interleaved chunk — CV inputs are conceptually mono. */
@@ -128,7 +107,7 @@ export class OscillatorNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.synth.Oscillator";
   static readonly title = "Oscillator";
   static readonly description =
-    "Voltage-controlled oscillator generating sine, saw, square, triangle or noise audio.\n    audio, synthesis, oscillator, vco, modular\n\n    Pitch CV is volts/octave: freq = frequency * 2^cv (cv in octaves). With pitch_cv or fm patched, output follows that stream's chunk cadence (sample-aligned); otherwise it free-runs for `duration` seconds (0 = infinite, realtime only). Naive waveforms — saw/square alias at high frequencies.\n\n    Use cases:\n    - Sound source for a modular synth voice\n    - FM/vibrato via the fm input driven by an LFO\n    - Melodic sequences via a pitch CV stream";
+    "Voltage-controlled oscillator generating sine, saw, square, triangle or noise audio.\n    audio, synthesis, oscillator, vco, modular\n\n    Pitch CV is volts/octave: freq = frequency * 2^cv (cv in octaves). With pitch_cv or fm patched, output follows that stream's chunk cadence (sample-aligned); otherwise it free-runs wall-clock paced until the run is stopped. Naive waveforms — saw/square alias at high frequencies.\n\n    Use cases:\n    - Sound source for a modular synth voice\n    - FM/vibrato via the fm input driven by an LFO\n    - Melodic sequences via a pitch CV stream";
   static readonly metadataOutputTypes = { chunk: "chunk" };
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["pitch_cv", "fm"];
@@ -202,17 +181,6 @@ export class OscillatorNode extends BaseNode {
   declare fm_amount: any;
 
   @prop({
-    type: "float",
-    default: 2,
-    title: "Duration",
-    description:
-      "Free-run render length in seconds. 0 = infinite (requires realtime). Ignored when pitch_cv/fm is patched.",
-    min: 0,
-    max: 600
-  })
-  declare duration: any;
-
-  @prop({
     type: "int",
     default: SYNTH_SAMPLE_RATE,
     title: "Sample Rate",
@@ -222,32 +190,41 @@ export class OscillatorNode extends BaseNode {
   })
   declare sample_rate: any;
 
-  @prop({
-    type: "bool",
-    default: false,
-    title: "Realtime",
-    description:
-      "Pace free-run emission with the wall clock (content is identical to a free run)."
-  })
-  declare realtime: any;
-
   // Required by BaseNode but unused for streaming
   async process(): Promise<Record<string, unknown>> {
     return {};
   }
 
-  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const waveform = String(this.waveform ?? "sine") as Waveform;
-    const baseFreq = Number(this.frequency ?? 220);
-    const amplitude = Number(this.amplitude ?? 0.8);
-    const pulseWidth = Number(this.pulse_width ?? 0.5);
-    const fmAmount = Number(this.fm_amount ?? 0);
+  /** Current property values — read per chunk so live updates apply. */
+  private params(): {
+    waveform: Waveform;
+    baseFreq: number;
+    amplitude: number;
+    pulseWidth: number;
+    fmAmount: number;
+  } {
+    return {
+      waveform: String(this.waveform ?? "sine") as Waveform,
+      baseFreq: Number(this.frequency ?? 220),
+      amplitude: Number(this.amplitude ?? 0.8),
+      pulseWidth: Number(this.pulse_width ?? 0.5),
+      fmAmount: Number(this.fm_amount ?? 0)
+    };
+  }
 
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
     // Double-precision phase accumulator carried across chunks — no drift.
+    // Properties are re-read at every chunk boundary (params()), so live
+    // updates pushed via applyProperties land on the next chunk.
     let phase = 0;
-    const sampleAt = (freq: number, sampleRate: number): number => {
+    type OscParams = ReturnType<OscillatorNode["params"]>;
+    const sampleAt = (
+      p: OscParams,
+      freq: number,
+      sampleRate: number
+    ): number => {
       const f = Math.min(Math.max(freq, 0), sampleRate / 2 - 1e-6);
-      const out = amplitude * oscSample(waveform, phase, pulseWidth);
+      const out = p.amplitude * oscSample(p.waveform, phase, p.pulseWidth);
       phase = (phase + f / sampleRate) % 1;
       return out;
     };
@@ -265,6 +242,7 @@ export class OscillatorNode extends BaseNode {
         primary,
         cvHandles: [secondary]
       })) {
+        const p = this.params();
         sampleRate = frame.primary.sampleRate;
         const drive = chunkMono(frame.primary.samples, frame.primary.channels);
         const other = frame.cv[secondary];
@@ -272,8 +250,8 @@ export class OscillatorNode extends BaseNode {
         for (let i = 0; i < drive.length; i++) {
           const pitch = hasPitch ? drive[i] : (other?.[i] ?? 0);
           const fm = hasPitch ? (other?.[i] ?? 0) : drive[i];
-          const freq = baseFreq * Math.pow(2, pitch) * (1 + fmAmount * fm);
-          buf[i] = sampleAt(freq, sampleRate);
+          const freq = p.baseFreq * Math.pow(2, pitch) * (1 + p.fmAmount * fm);
+          buf[i] = sampleAt(p, freq, sampleRate);
         }
         await outputs.emit(
           "chunk",
@@ -288,23 +266,15 @@ export class OscillatorNode extends BaseNode {
     }
 
     const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
-    const realtime = Boolean(this.realtime ?? false);
-    const totalFrames = generatorFrames(
-      Number(this.duration ?? 2),
-      sampleRate,
-      realtime,
-      "Oscillator duration"
-    );
     await runGenerator(outputs, {
       slot: "chunk",
       sampleRate,
       encoding: "pcm16le",
-      totalFrames,
-      realtime,
       signal: inputs.signal,
       fill: (buf) => {
+        const p = this.params();
         for (let i = 0; i < buf.length; i++) {
-          buf[i] = sampleAt(baseFreq, sampleRate);
+          buf[i] = sampleAt(p, p.baseFreq, sampleRate);
         }
       }
     });
@@ -317,7 +287,7 @@ export class LfoNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.synth.LFO";
   static readonly title = "LFO";
   static readonly description =
-    "Low-frequency oscillator emitting a control-voltage stream.\n    cv, synthesis, lfo, modulation, modular\n\n    Output is offset + depth * wave(phase). With a clock patched, emits one chunk per clock chunk (sample-aligned) and resets phase on each clock rising edge; otherwise free-runs for `duration` seconds (0 = infinite, realtime only).\n\n    Use cases:\n    - Vibrato/tremolo via Oscillator fm or VCA cv\n    - Filter sweeps via VCF cutoff_cv\n    - Slow parameter drift in generative patches";
+    "Low-frequency oscillator emitting a control-voltage stream.\n    cv, synthesis, lfo, modulation, modular\n\n    Output is offset + depth * wave(phase). With a clock patched, emits one chunk per clock chunk (sample-aligned) and resets phase on each clock rising edge; otherwise free-runs wall-clock paced until the run is stopped.\n\n    Use cases:\n    - Vibrato/tremolo via Oscillator fm or VCA cv\n    - Filter sweeps via VCF cutoff_cv\n    - Slow parameter drift in generative patches";
   static readonly metadataOutputTypes = { cv: "cv" };
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = ["clock"];
@@ -372,17 +342,6 @@ export class LfoNode extends BaseNode {
   declare offset: any;
 
   @prop({
-    type: "float",
-    default: 4,
-    title: "Duration",
-    description:
-      "Free-run render length in seconds. 0 = infinite (requires realtime). Ignored when clock is patched.",
-    min: 0,
-    max: 600
-  })
-  declare duration: any;
-
-  @prop({
     type: "int",
     default: SYNTH_SAMPLE_RATE,
     title: "Sample Rate",
@@ -392,26 +351,27 @@ export class LfoNode extends BaseNode {
   })
   declare sample_rate: any;
 
-  @prop({
-    type: "bool",
-    default: false,
-    title: "Realtime",
-    description:
-      "Pace free-run emission with the wall clock (content is identical to a free run)."
-  })
-  declare realtime: any;
-
   // Required by BaseNode but unused for streaming
   async process(): Promise<Record<string, unknown>> {
     return {};
   }
 
-  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const waveform = String(this.waveform ?? "sine") as Waveform;
-    const rateHz = Number(this.rate_hz ?? 2);
-    const depth = Number(this.depth ?? 1);
-    const offset = Number(this.offset ?? 0);
+  /** Current property values — read per chunk so live updates apply. */
+  private params(): {
+    waveform: Waveform;
+    rateHz: number;
+    depth: number;
+    offset: number;
+  } {
+    return {
+      waveform: String(this.waveform ?? "sine") as Waveform,
+      rateHz: Number(this.rate_hz ?? 2),
+      depth: Number(this.depth ?? 1),
+      offset: Number(this.offset ?? 0)
+    };
+  }
 
+  async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
     let phase = 0;
 
     if (inputs.hasStream("clock")) {
@@ -422,6 +382,7 @@ export class LfoNode extends BaseNode {
         if (!chunk) continue;
         if (chunk.done) break;
         if (chunk.samples.length === 0) continue;
+        const p = this.params();
         sampleRate = chunk.sampleRate;
         const clock = chunkMono(chunk.samples, chunk.channels);
         const buf = new Float32Array(clock.length);
@@ -429,8 +390,8 @@ export class LfoNode extends BaseNode {
           const high = clock[i] >= GATE_THRESHOLD;
           if (high && !clockWasHigh) phase = 0; // sample-accurate reset
           clockWasHigh = high;
-          buf[i] = offset + depth * oscSample(waveform, phase);
-          phase = (phase + rateHz / sampleRate) % 1;
+          buf[i] = p.offset + p.depth * oscSample(p.waveform, phase);
+          phase = (phase + p.rateHz / sampleRate) % 1;
         }
         await outputs.emit(
           "cv",
@@ -442,24 +403,16 @@ export class LfoNode extends BaseNode {
     }
 
     const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
-    const realtime = Boolean(this.realtime ?? false);
-    const totalFrames = generatorFrames(
-      Number(this.duration ?? 4),
-      sampleRate,
-      realtime,
-      "LFO duration"
-    );
     await runGenerator(outputs, {
       slot: "cv",
       sampleRate,
       encoding: "f32le",
-      totalFrames,
-      realtime,
       signal: inputs.signal,
       fill: (buf) => {
+        const p = this.params();
         for (let i = 0; i < buf.length; i++) {
-          buf[i] = offset + depth * oscSample(waveform, phase);
-          phase = (phase + rateHz / sampleRate) % 1;
+          buf[i] = p.offset + p.depth * oscSample(p.waveform, phase);
+          phase = (phase + p.rateHz / sampleRate) % 1;
         }
       }
     });
@@ -532,34 +485,23 @@ export class AdsrNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const attack = Number(this.attack ?? 0.01);
-    const decay = Number(this.decay ?? 0.1);
-    const sustain = Number(this.sustain ?? 0.7);
-    const release = Number(this.release ?? 0.3);
-
     const state = createAdsrState();
     let sampleRate = SYNTH_SAMPLE_RATE;
-    let params = {
-      attackCoeff: adsrCoeff(attack, sampleRate),
-      decayCoeff: adsrCoeff(decay, sampleRate),
-      releaseCoeff: adsrCoeff(release, sampleRate),
-      sustain
-    };
 
     for await (const item of inputs.stream("gate")) {
       const chunk = readSignalChunk(item);
       if (!chunk) continue;
       if (chunk.done) break;
       if (chunk.samples.length === 0) continue;
-      if (chunk.sampleRate !== sampleRate) {
-        sampleRate = chunk.sampleRate;
-        params = {
-          attackCoeff: adsrCoeff(attack, sampleRate),
-          decayCoeff: adsrCoeff(decay, sampleRate),
-          releaseCoeff: adsrCoeff(release, sampleRate),
-          sustain
-        };
-      }
+      sampleRate = chunk.sampleRate;
+      // Coefficients recomputed per chunk from the current property values
+      // (three exp() calls per ~21 ms chunk) so live updates apply.
+      const params = {
+        attackCoeff: adsrCoeff(Number(this.attack ?? 0.01), sampleRate),
+        decayCoeff: adsrCoeff(Number(this.decay ?? 0.1), sampleRate),
+        releaseCoeff: adsrCoeff(Number(this.release ?? 0.3), sampleRate),
+        sustain: Number(this.sustain ?? 0.7)
+      };
       const gate = chunkMono(chunk.samples, chunk.channels);
       const buf = new Float32Array(gate.length);
       for (let i = 0; i < gate.length; i++) {
@@ -580,7 +522,7 @@ export class GateNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.synth.Gate";
   static readonly title = "Gate";
   static readonly description =
-    "Generates a repeating on/off gate CV pattern — the patch's master clock.\n    cv, synthesis, gate, trigger, clock, modular\n\n    Emits `amplitude` for on_duration seconds, 0 for off_duration, `repeats` times (0 = infinite, realtime only). Drive an ADSR with it; every node downstream is sample-aligned to it by construction, and with realtime: true the whole driven patch is wall-clock paced.\n\n    Use cases:\n    - Trigger envelopes rhythmically\n    - Master clock for clocked LFOs and sample & hold\n    - Live patches via realtime mode";
+    "Generates a repeating on/off gate CV pattern — the patch's master clock.\n    cv, synthesis, gate, trigger, clock, modular\n\n    Emits `amplitude` for on_duration seconds, 0 for off_duration, cycling wall-clock paced until the run is stopped. Drive an ADSR with it; every node downstream is sample-aligned to it by construction and paced with it.\n\n    Use cases:\n    - Trigger envelopes rhythmically\n    - Master clock for clocked LFOs and sample & hold\n    - Heartbeat of a live patch";
   static readonly metadataOutputTypes = { cv: "cv" };
   static readonly inlineFields: string[] = [];
   static readonly inputFields: string[] = [];
@@ -607,16 +549,6 @@ export class GateNode extends BaseNode {
   declare off_duration: any;
 
   @prop({
-    type: "int",
-    default: 4,
-    title: "Repeats",
-    description: "Number of on/off cycles. 0 = infinite (requires realtime).",
-    min: 0,
-    max: 1024
-  })
-  declare repeats: any;
-
-  @prop({
     type: "float",
     default: 1,
     title: "Amplitude",
@@ -636,46 +568,34 @@ export class GateNode extends BaseNode {
   })
   declare sample_rate: any;
 
-  @prop({
-    type: "bool",
-    default: false,
-    title: "Realtime",
-    description:
-      "Pace emission with the wall clock (content is identical to a free run)."
-  })
-  declare realtime: any;
-
   // Required by BaseNode but unused for streaming
   async process(): Promise<Record<string, unknown>> {
     return {};
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const onDuration = Number(this.on_duration ?? 0.25);
-    const offDuration = Number(this.off_duration ?? 0.25);
-    const repeats = Number(this.repeats ?? 4);
-    const amplitude = Number(this.amplitude ?? 1);
     const sampleRate = Number(this.sample_rate ?? SYNTH_SAMPLE_RATE);
-    const realtime = Boolean(this.realtime ?? false);
-
-    const onFrames = Math.max(1, Math.round(onDuration * sampleRate));
-    const periodFrames =
-      onFrames + Math.max(1, Math.round(offDuration * sampleRate));
-    const totalFrames = generatorFrames(
-      repeats > 0 ? (repeats * periodFrames) / sampleRate : 0,
-      sampleRate,
-      realtime,
-      "Gate repeats"
-    );
 
     await runGenerator(outputs, {
       slot: "cv",
       sampleRate,
       encoding: "f32le",
-      totalFrames,
-      realtime,
       signal: inputs.signal,
       fill: (buf, startFrame) => {
+        // Timing re-read per chunk so live updates apply; the phase derives
+        // from the absolute frame counter, so a period change just re-grids
+        // the pattern instead of glitching it.
+        const onFrames = Math.max(
+          1,
+          Math.round(Number(this.on_duration ?? 0.25) * sampleRate)
+        );
+        const periodFrames =
+          onFrames +
+          Math.max(
+            1,
+            Math.round(Number(this.off_duration ?? 0.25) * sampleRate)
+          );
+        const amplitude = Number(this.amplitude ?? 1);
         for (let i = 0; i < buf.length; i++) {
           buf[i] =
             (startFrame + i) % periodFrames < onFrames ? amplitude : 0;
@@ -729,7 +649,6 @@ export class VcaNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const gain = Number(this.gain ?? 1);
     let sampleRate = SYNTH_SAMPLE_RATE;
     let channels = 1;
 
@@ -737,6 +656,7 @@ export class VcaNode extends BaseNode {
       primary: "audio",
       cvHandles: ["cv"]
     })) {
+      const gain = Number(this.gain ?? 1); // per chunk — live updates apply
       sampleRate = frame.primary.sampleRate;
       channels = frame.primary.channels;
       const input = frame.primary.samples;
@@ -836,11 +756,6 @@ export class VcfNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const mode = String(this.mode ?? "lowpass") as "lowpass" | "highpass";
-    const cutoffHz = Number(this.cutoff_hz ?? 1000);
-    const q = Number(this.q ?? DEFAULT_Q);
-    const cvAmount = Number(this.cv_amount ?? 1);
-
     let sampleRate = SYNTH_SAMPLE_RATE;
     let channels = 1;
     let states: BiquadState[] = [];
@@ -849,6 +764,12 @@ export class VcfNode extends BaseNode {
       primary: "audio",
       cvHandles: ["cutoff_cv"]
     })) {
+      // Per chunk — live updates apply (coefficients are recomputed per
+      // 64-frame control block below anyway).
+      const mode = String(this.mode ?? "lowpass") as "lowpass" | "highpass";
+      const cutoffHz = Number(this.cutoff_hz ?? 1000);
+      const q = Number(this.q ?? DEFAULT_Q);
+      const cvAmount = Number(this.cv_amount ?? 1);
       sampleRate = frame.primary.sampleRate;
       if (states.length !== frame.primary.channels) {
         channels = frame.primary.channels;
@@ -942,8 +863,6 @@ export class AttenuverterNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const scale = Number(this.scale ?? 1);
-    const offset = Number(this.offset ?? 0);
     let sampleRate = SYNTH_SAMPLE_RATE;
     let channels = 1;
 
@@ -952,6 +871,8 @@ export class AttenuverterNode extends BaseNode {
       if (!chunk) continue;
       if (chunk.done) break;
       if (chunk.samples.length === 0) continue;
+      const scale = Number(this.scale ?? 1); // per chunk — live updates apply
+      const offset = Number(this.offset ?? 0);
       sampleRate = chunk.sampleRate;
       channels = chunk.channels;
       const buf = chunk.samples;
@@ -1121,12 +1042,13 @@ export class MixerNode extends BaseNode {
   }
 
   async run(inputs: StreamingInputs, outputs: StreamingOutputs): Promise<void> {
-    const levels: Record<string, number> = {
+    // Read per emitted block — live updates apply.
+    const levels = (): Record<string, number> => ({
       in1: Number(this.level1 ?? 1),
       in2: Number(this.level2 ?? 1),
       in3: Number(this.level3 ?? 1),
       in4: Number(this.level4 ?? 1)
-    };
+    });
     const connected: string[] = MIXER_HANDLES.filter((h) =>
       inputs.hasStream(h)
     );
@@ -1140,12 +1062,13 @@ export class MixerNode extends BaseNode {
 
     const emitMixed = async (n: number): Promise<void> => {
       if (n <= 0) return;
+      const lv = levels();
       const buf = new Float32Array(n);
       for (const h of connected) {
         // Ended/short inputs contribute zeros — silence is correct for
         // finished audio, unlike CV's hold-last.
         const part = fifos.get(h)!.pull(n, "zero");
-        const level = levels[h];
+        const level = lv[h];
         for (let i = 0; i < n; i++) buf[i] += level * part[i];
       }
       await outputs.emit(

--- a/packages/audio-nodes/tests/cv.test.ts
+++ b/packages/audio-nodes/tests/cv.test.ts
@@ -68,26 +68,46 @@ describe("readSignalChunk", () => {
     expect(readSignalChunk(null)).toBeNull();
   });
 
-  it("pcm16 clamps values beyond [-1, 1] while f32le preserves them", () => {
+  it("native chunks preserve out-of-range CV values regardless of declared encoding", () => {
+    // In-process chunks carry samples natively — no pcm16 clamping until a
+    // boundary actually serializes them.
     const samples = new Float32Array([2.5, -3]);
-    const viaPcm = readSignalChunk(
-      makeSignalChunk(samples, 24000, 1, false, "pcm16le")
-    )!;
-    expect(viaPcm.samples[0]).toBeCloseTo(1, 3);
-    expect(viaPcm.samples[1]).toBeCloseTo(-1, 3);
-    const viaF32 = readSignalChunk(
-      makeSignalChunk(samples, 24000, 1, false, "f32le")
-    )!;
-    expect(viaF32.samples[0]).toBe(2.5);
-    expect(viaF32.samples[1]).toBe(-3);
+    for (const enc of ["pcm16le", "f32le"] as const) {
+      const parsed = readSignalChunk(makeSignalChunk(samples, 24000, 1, false, enc))!;
+      expect(parsed.samples[0]).toBe(2.5);
+      expect(parsed.samples[1]).toBe(-3);
+    }
   });
 
-  it("reads base64 content via the standard decoder", () => {
+  it("decoding base64 pcm16 (the lossy wire encoding) clamps beyond [-1, 1]", () => {
+    const samples = new Float32Array([2.5, -3]);
+    const viaPcm = readSignalChunk({
+      type: "chunk",
+      content: bytesToB64(float32ToPcm16(samples)),
+      content_type: "audio",
+      content_metadata: { sample_rate: 24000, channels: 1 }
+    })!;
+    expect(viaPcm.samples[0]).toBeCloseTo(1, 3);
+    expect(viaPcm.samples[1]).toBeCloseTo(-1, 3);
+  });
+
+  it("carries samples as a native Float32Array (zero-conversion payload)", () => {
     const samples = new Float32Array([1, 2, 3]);
     const chunk = makeSignalChunk(samples, 24000, 1, false, "f32le") as {
-      content: string;
+      content: unknown;
     };
-    expect(f32leToFloat32(b64ToBytes(chunk.content))).toEqual(samples);
+    expect(chunk.content).toBe(samples);
+  });
+
+  it("decodes base64 f32le wire-format content", () => {
+    const samples = new Float32Array([1, 2, 3]);
+    const parsed = readSignalChunk({
+      type: "chunk",
+      content: bytesToB64(float32ToF32le(samples)),
+      content_type: "audio",
+      content_metadata: { encoding: "f32le", sample_rate: 24000, channels: 1 }
+    })!;
+    expect(parsed.samples).toEqual(samples);
   });
 });
 

--- a/packages/audio-nodes/tests/realtime-audio.test.ts
+++ b/packages/audio-nodes/tests/realtime-audio.test.ts
@@ -5,6 +5,7 @@ import type {
   StreamingOutputs
 } from "@nodetool-ai/node-sdk";
 import {
+  AudioOutputNode,
   AudioToChunksNode,
   ChunksToAudioNode,
   StreamingGainNode,
@@ -62,7 +63,8 @@ function recordingOutputs(): {
 
 type ChunkShape = {
   type: string;
-  content: string;
+  /** Native Float32Array in-process; "" for done markers. */
+  content: Float32Array | string;
   done: boolean;
   content_type: string;
   content_metadata: {
@@ -93,6 +95,12 @@ function makeChunk(
       duration_seconds: pcm.length / 2 / channels / sampleRate
     }
   };
+}
+
+/** Samples of an emitted chunk (native Float32Array payload). */
+function chunkSamples(chunk: ChunkShape): Float32Array {
+  expect(chunk.content).toBeInstanceOf(Float32Array);
+  return chunk.content as Float32Array;
 }
 
 /** 1 s of quantization-stable mono samples (already on the PCM16 grid). */
@@ -131,16 +139,16 @@ describe("AudioToChunks", () => {
       expect(chunk.content_metadata.sample_rate).toBe(SAMPLE_RATE);
       expect(chunk.content_metadata.channels).toBe(1);
       expect(chunk.content_metadata.duration_seconds).toBeCloseTo(0.25, 6);
-      expect(b64ToBytes(chunk.content).length).toBe(SAMPLE_RATE * 0.25 * 2);
+      expect(chunkSamples(chunk).length).toBe(SAMPLE_RATE * 0.25);
     }
 
     const last = chunks[4];
     expect(last.done).toBe(true);
     expect(last.content).toBe("");
 
-    // The concatenated PCM equals the original samples (PCM16-quantized).
-    const allPcm = data.flatMap((c) => [...b64ToBytes(c.content)]);
-    const decoded = pcm16ToFloat32(Uint8Array.from(allPcm));
+    // The concatenated samples equal the original (PCM16-quantized by the
+    // WAV round-trip on input; chunk payloads themselves are lossless).
+    const decoded = Float32Array.from(data.flatMap((c) => [...chunkSamples(c)]));
     expect(decoded.length).toBe(samples.length);
     for (let i = 0; i < samples.length; i += 997) {
       expect(decoded[i]).toBeCloseTo(samples[i], 4);
@@ -203,6 +211,29 @@ describe("ChunksToAudio", () => {
   });
 });
 
+describe("AudioOutput", () => {
+  it("passes audio chunks through verbatim and stops on done", async () => {
+    const pcm = float32ToPcm16(testSamples(512));
+    const items = [
+      { type: "chunk", content: "ignored", content_type: "text", done: false },
+      makeChunk(pcm, SAMPLE_RATE, 1),
+      makeChunk(pcm, SAMPLE_RATE, 1),
+      makeChunk(new Uint8Array(), SAMPLE_RATE, 1, true)
+    ];
+    const node = new AudioOutputNode({});
+    const { outputs, emitted } = recordingOutputs();
+    await node.run(inputsFrom(items), outputs);
+
+    // Non-audio chunk skipped; the two data chunks + done pass through
+    // as the exact same objects.
+    expect(emitted).toHaveLength(3);
+    expect(emitted[0][0]).toBe("chunk");
+    expect(emitted[0][1]).toBe(items[1]);
+    expect(emitted[1][1]).toBe(items[2]);
+    expect((emitted[2][1] as ChunkShape).done).toBe(true);
+  });
+});
+
 describe("StreamingGain", () => {
   it("+6.0206 dB doubles sample values and forwards the done chunk", async () => {
     const samples = new Float32Array(512).fill(0.25);
@@ -220,7 +251,7 @@ describe("StreamingGain", () => {
     const first = emitted[0][1] as ChunkShape;
     expect(first.done).toBe(false);
     expect(first.content_metadata.sample_rate).toBe(SAMPLE_RATE);
-    const out = pcm16ToFloat32(b64ToBytes(first.content));
+    const out = chunkSamples(first);
     for (let i = 0; i < out.length; i += 37) {
       expect(out[i]).toBeCloseTo(0.5, 3);
     }
@@ -255,7 +286,7 @@ describe("StreamingLowPass", () => {
     expect(emitted).toHaveLength(9);
     const streamed: number[] = [];
     for (const [, value] of emitted.slice(0, 8)) {
-      streamed.push(...pcm16ToFloat32(b64ToBytes((value as ChunkShape).content)));
+      streamed.push(...chunkSamples(value as ChunkShape));
     }
 
     // Reference: the same quantized input filtered in a single pass.

--- a/packages/audio-nodes/tests/synthesis.test.ts
+++ b/packages/audio-nodes/tests/synthesis.test.ts
@@ -72,6 +72,32 @@ function recordingOutputs(): {
   return { outputs, emitted };
 }
 
+/**
+ * Recording outputs that abort the run signal after `n` data chunks — the
+ * free-running generators never end on their own, so tests bound them via
+ * cancellation, exactly like a stopped patch.
+ */
+function abortAfter(n: number): {
+  outputs: StreamingOutputs;
+  emitted: Array<[string, unknown]>;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+  const emitted: Array<[string, unknown]> = [];
+  let count = 0;
+  const outputs = {
+    async emit(slot: string, value: unknown) {
+      emitted.push([slot, value]);
+      const chunk = readSignalChunk(value);
+      if (chunk && !chunk.done && chunk.samples.length > 0) {
+        count++;
+        if (count >= n) controller.abort();
+      }
+    }
+  } as unknown as StreamingOutputs;
+  return { outputs, emitted, signal: controller.signal };
+}
+
 /** Decode all non-done chunks on a slot into one concatenated Float32Array. */
 function concatEmitted(emitted: Array<[string, unknown]>): Float32Array {
   const parts: Float32Array[] = [];
@@ -98,26 +124,72 @@ function signChanges(samples: Float32Array): number {
 }
 
 describe("Oscillator (free run)", () => {
-  it("renders the requested duration in 512-frame chunks plus a done marker", async () => {
+  it("emits 512-frame chunks until cancelled, then a done marker", async () => {
     const node = new OscillatorNode({
       waveform: "sine",
       frequency: 100,
       amplitude: 1,
-      duration: 1,
       sample_rate: SR
     });
-    const { outputs, emitted } = recordingOutputs();
-    await node.run(makeInputs({ handles: {} }), outputs);
+    const chunks = 8;
+    const { outputs, emitted, signal } = abortAfter(chunks);
+    await node.run(makeInputs({ handles: {}, signal }), outputs);
 
-    const expectedChunks = Math.ceil(SR / SYNTH_CHUNK_FRAMES);
-    expect(emitted).toHaveLength(expectedChunks + 1);
+    expect(emitted).toHaveLength(chunks + 1);
     const last = readSignalChunk(emitted[emitted.length - 1][1])!;
     expect(last.done).toBe(true);
 
     const samples = concatEmitted(emitted);
-    expect(samples.length).toBe(SR);
-    // 100 Hz over 1 s → ~200 zero crossings.
-    expect(Math.abs(signChanges(samples) - 200)).toBeLessThanOrEqual(2);
+    expect(samples.length).toBe(chunks * SYNTH_CHUNK_FRAMES);
+    // 100 Hz sine → 2 zero crossings per period.
+    const expected = Math.round((2 * 100 * samples.length) / SR);
+    expect(Math.abs(signChanges(samples) - expected)).toBeLessThanOrEqual(2);
+  });
+
+  it("picks up live property updates between chunks", async () => {
+    const node = new OscillatorNode({
+      waveform: "sine",
+      frequency: 100,
+      amplitude: 1,
+      sample_rate: SR
+    });
+    // Retune mid-run via the live-parameter path (applyProperties → assign);
+    // the generator reads properties per chunk, so chunks 5+ are at 800 Hz.
+    const controller = new AbortController();
+    const emitted: Array<[string, unknown]> = [];
+    let count = 0;
+    const outputs = {
+      async emit(slot: string, value: unknown) {
+        emitted.push([slot, value]);
+        const c = readSignalChunk(value);
+        if (c && !c.done && c.samples.length > 0) {
+          count++;
+          if (count === 4) node.assign({ frequency: 800 });
+          if (count >= 8) controller.abort();
+        }
+      }
+    } as unknown as StreamingOutputs;
+    await node.run(
+      makeInputs({ handles: {}, signal: controller.signal }),
+      outputs
+    );
+
+    const data = emitted
+      .map(([, v]) => readSignalChunk(v)!)
+      .filter((c) => !c.done && c.samples.length > 0);
+    const concat = (chunks: typeof data) => {
+      const total = chunks.reduce((s, c) => s + c.samples.length, 0);
+      const out = new Float32Array(total);
+      let off = 0;
+      for (const c of chunks) {
+        out.set(c.samples, off);
+        off += c.samples.length;
+      }
+      return out;
+    };
+    const head = concat(data.slice(0, 4)); // 100 Hz
+    const tail = concat(data.slice(4)); // 800 Hz
+    expect(signChanges(tail)).toBeGreaterThan(signChanges(head) * 4);
   });
 
   it("keeps phase continuous across chunk boundaries", async () => {
@@ -125,11 +197,10 @@ describe("Oscillator (free run)", () => {
       waveform: "sine",
       frequency: 440,
       amplitude: 1,
-      duration: 0.5,
       sample_rate: SR
     });
-    const { outputs, emitted } = recordingOutputs();
-    await node.run(makeInputs({ handles: {} }), outputs);
+    const { outputs, emitted, signal } = abortAfter(6);
+    await node.run(makeInputs({ handles: {}, signal }), outputs);
 
     const samples = concatEmitted(emitted);
     // Max per-sample step of a 440 Hz sine @ 24 kHz, with quantization slack.
@@ -139,14 +210,6 @@ describe("Oscillator (free run)", () => {
         maxStep
       );
     }
-  });
-
-  it("throws on duration 0 without realtime", async () => {
-    const node = new OscillatorNode({ duration: 0, sample_rate: SR });
-    const { outputs } = recordingOutputs();
-    await expect(
-      node.run(makeInputs({ handles: {} }), outputs)
-    ).rejects.toThrow(/realtime/);
   });
 });
 
@@ -272,66 +335,54 @@ describe("Gate", () => {
     const node = new GateNode({
       on_duration: 0.01, // 240 frames
       off_duration: 0.01,
-      repeats: 2,
       amplitude: 1,
       sample_rate: SR
     });
-    const { outputs, emitted } = recordingOutputs();
-    await node.run(makeInputs({ handles: {} }), outputs);
+    // 2 chunks = 1024 frames, covering two full 480-frame cycles.
+    const { outputs, emitted, signal } = abortAfter(2);
+    await node.run(makeInputs({ handles: {}, signal }), outputs);
     const cv = concatEmitted(emitted);
-    expect(cv.length).toBe(2 * 480);
+    expect(cv.length).toBe(2 * SYNTH_CHUNK_FRAMES);
     expect(cv[0]).toBe(1);
     expect(cv[239]).toBe(1);
     expect(cv[240]).toBe(0);
     expect(cv[479]).toBe(0);
     expect(cv[480]).toBe(1); // second cycle
+    expect(cv[719]).toBe(1);
+    expect(cv[720]).toBe(0);
+    expect(cv[960]).toBe(1); // third cycle
   });
 
-  it("realtime pacing delays emission without changing content", async () => {
-    const props = {
+  it("paces emission with the wall clock", async () => {
+    const node = new GateNode({
       on_duration: 0.02,
       off_duration: 0.02,
-      repeats: 2,
       amplitude: 1,
       sample_rate: SR
-    };
-    const free = recordingOutputs();
-    await new GateNode({ ...props }).run(makeInputs({ handles: {} }), free.outputs);
-
-    const paced = recordingOutputs();
+    });
+    const { outputs, emitted, signal } = abortAfter(4);
     const startMs = Date.now();
-    await new GateNode({ ...props, realtime: true }).run(
-      makeInputs({ handles: {} }),
-      paced.outputs
-    );
+    await node.run(makeInputs({ handles: {}, signal }), outputs);
     const elapsedMs = Date.now() - startMs;
 
-    // 1920 frames @ 24 kHz = 80 ms of audio in 512-frame chunks → the paced
-    // run must take at least ~3 chunk periods (loose bound against CI jitter).
+    // 4 chunks = 2048 frames @ 24 kHz ≈ 85 ms of audio; the first chunk is
+    // unpaced, so the run must take at least ~3 chunk periods (loose bound
+    // against CI jitter).
     expect(elapsedMs).toBeGreaterThan(40);
-    expect(concatEmitted(paced.emitted)).toEqual(concatEmitted(free.emitted));
+    expect(concatEmitted(emitted).length).toBe(4 * SYNTH_CHUNK_FRAMES);
   });
 
-  it("infinite (repeats 0) requires realtime and stops on abort", async () => {
-    const { outputs } = recordingOutputs();
-    await expect(
-      new GateNode({ repeats: 0, sample_rate: SR }).run(
-        makeInputs({ handles: {} }),
-        outputs
-      )
-    ).rejects.toThrow(/realtime/);
-
+  it("stops on abort and terminates the stream with a done marker", async () => {
     const controller = new AbortController();
-    const paced = recordingOutputs();
-    const run = new GateNode({
-      repeats: 0,
-      realtime: true,
-      sample_rate: SR
-    }).run(makeInputs({ handles: {}, signal: controller.signal }), paced.outputs);
+    const { outputs, emitted } = recordingOutputs();
+    const run = new GateNode({ sample_rate: SR }).run(
+      makeInputs({ handles: {}, signal: controller.signal }),
+      outputs
+    );
     setTimeout(() => controller.abort(), 80);
     await expect(run).resolves.toBeUndefined();
-    expect(paced.emitted.length).toBeGreaterThan(0);
-    const last = readSignalChunk(paced.emitted[paced.emitted.length - 1][1])!;
+    expect(emitted.length).toBeGreaterThan(0);
+    const last = readSignalChunk(emitted[emitted.length - 1][1])!;
     expect(last.done).toBe(true);
   });
 });
@@ -556,6 +607,31 @@ describe("LFO (clocked)", () => {
     // Saw at phase 0 is -1: the reset lands exactly at chunk 2's first sample.
     const secondChunk = readSignalChunk(emitted[1][1])!.samples;
     expect(secondChunk[0]).toBe(-1);
+  });
+});
+
+describe("LFO (free run)", () => {
+  it("free-runs paced chunks until cancelled, then a done marker", async () => {
+    const node = new LfoNode({
+      waveform: "saw",
+      rate_hz: 10,
+      depth: 1,
+      offset: 0,
+      sample_rate: SR
+    });
+    const { outputs, emitted, signal } = abortAfter(3);
+    await node.run(makeInputs({ handles: {}, signal }), outputs);
+
+    expect(emitted).toHaveLength(4);
+    const cv = concatEmitted(emitted);
+    expect(cv.length).toBe(3 * SYNTH_CHUNK_FRAMES);
+    expect(cv[0]).toBe(-1); // saw starts at phase 0
+    // Phase advances across chunk boundaries: 10 Hz over 1536 frames stays
+    // within the first period, so the saw rises monotonically throughout.
+    for (let i = 1; i < cv.length; i++) {
+      expect(cv[i]).toBeGreaterThan(cv[i - 1]);
+    }
+    expect(readSignalChunk(emitted[3][1])!.done).toBe(true);
   });
 });
 

--- a/packages/chat/src/message-processor.ts
+++ b/packages/chat/src/message-processor.ts
@@ -205,6 +205,9 @@ export async function processChat(opts: {
       if (isChunk(item)) {
         // Skip thinking chunks — they must not appear in user-visible text output.
         if (item.thinking) continue;
+        // Audio chunks carry binary payloads (native Float32Array or base64);
+        // they aren't assistant text.
+        if (typeof item.content !== "string") continue;
 
         const text = item.content ?? "";
         callbacks?.onChunk?.(text);

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -27,7 +27,8 @@ import { initDb, Workflow, Secret, getSecret } from "@nodetool-ai/models";
 import { initMasterKey } from "@nodetool-ai/security";
 import { getDefaultDbPath, getDefaultAssetsPath } from "@nodetool-ai/config";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
-import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { hydrateGraphNodeFlags, NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { GraphData } from "@nodetool-ai/protocol";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
 import { registerMinimaxNodes } from "@nodetool-ai/minimax-nodes";
@@ -555,7 +556,9 @@ workflows
                 workflow_id: workflowId ?? undefined,
                 params
               },
-              graph
+              // Saved workflow JSON carries no behavior flags; stamp them
+              // from the registry or streaming nodes run as one-shots.
+              hydrateGraphNodeFlags(graph as GraphData, registry)
             );
           } finally {
             pythonBridge?.close();

--- a/packages/core-nodes/src/nodes/subgraph.ts
+++ b/packages/core-nodes/src/nodes/subgraph.ts
@@ -1,9 +1,13 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import { WorkflowRunner, Graph } from "@nodetool-ai/kernel";
+import {
+  WorkflowRunner,
+  Graph,
+  withExplicitNodeFlags
+} from "@nodetool-ai/kernel";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type {
-  NodeDescriptor,
-  Edge,
+  GraphData,
+  HydratedGraphData,
   InputMode,
   OutputCorrelation
 } from "@nodetool-ai/protocol";
@@ -81,21 +85,20 @@ export class SubgraphNode extends BaseNode {
       return { ...rest, edge_type };
     });
 
-    let hydratedGraph: {
-      nodes: Array<Record<string, unknown>>;
-      edges: Array<Record<string, unknown>>;
-    };
+    let hydratedGraph: HydratedGraphData;
     if (context.resolveNodeType) {
       const loaded = await Graph.loadFromDict(
         { nodes: normalizedNodes, edges: normalizedEdges },
         { resolver: { resolveNodeType: context.resolveNodeType } }
       );
-      hydratedGraph = {
-        nodes: [...loaded.nodes] as unknown as Array<Record<string, unknown>>,
-        edges: [...loaded.edges] as unknown as Array<Record<string, unknown>>
-      };
+      hydratedGraph = { nodes: [...loaded.nodes], edges: [...loaded.edges] };
     } else {
-      hydratedGraph = { nodes: normalizedNodes, edges: normalizedEdges };
+      // No registry resolver on the context — behavior flags can only come
+      // from the saved sub-graph itself; absent ones default off.
+      hydratedGraph = withExplicitNodeFlags({
+        nodes: normalizedNodes,
+        edges: normalizedEdges
+      } as unknown as GraphData);
     }
 
     // Dynamic prop values become params keyed by inner Input nodes' `name`.
@@ -116,7 +119,7 @@ export class SubgraphNode extends BaseNode {
       const nodeId = String(n.id ?? "");
       const nodeName = n.name as string | undefined;
       const runnerKey = nodeName ?? nodeId;
-      const props = (n.properties ?? n.data ?? {}) as Record<string, unknown>;
+      const props = (n.properties ?? {}) as Record<string, unknown>;
       const outputName =
         typeof props.name === "string" && props.name.trim()
           ? props.name.trim()
@@ -133,10 +136,7 @@ export class SubgraphNode extends BaseNode {
       executionContext: context
     });
 
-    const result = await runner.run(
-      { job_id: jobId, params },
-      hydratedGraph as unknown as { nodes: NodeDescriptor[]; edges: Edge[] }
-    );
+    const result = await runner.run({ job_id: jobId, params }, hydratedGraph);
 
     if (result.status === "failed") {
       throw new Error(

--- a/packages/core-nodes/src/nodes/workflow.ts
+++ b/packages/core-nodes/src/nodes/workflow.ts
@@ -1,7 +1,16 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import { WorkflowRunner, Graph } from "@nodetool-ai/kernel";
+import {
+  WorkflowRunner,
+  Graph,
+  withExplicitNodeFlags
+} from "@nodetool-ai/kernel";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import type { NodeDescriptor, Edge, InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
+import type {
+  GraphData,
+  HydratedGraphData,
+  InputMode,
+  OutputCorrelation
+} from "@nodetool-ai/protocol";
 import { tagAsUniversal } from "@nodetool-ai/nodes-utils";
 
 const randomUUID = (): string =>
@@ -90,21 +99,20 @@ export class WorkflowNode extends BaseNode {
     });
 
     // Hydrate graph via resolver if available
-    let hydratedGraph: {
-      nodes: Array<Record<string, unknown>>;
-      edges: Array<Record<string, unknown>>;
-    };
+    let hydratedGraph: HydratedGraphData;
     if (context.resolveNodeType) {
       const loaded = await Graph.loadFromDict(
         { nodes: normalizedNodes, edges: normalizedEdges },
         { resolver: { resolveNodeType: context.resolveNodeType } }
       );
-      hydratedGraph = {
-        nodes: [...loaded.nodes] as unknown as Array<Record<string, unknown>>,
-        edges: [...loaded.edges] as unknown as Array<Record<string, unknown>>
-      };
+      hydratedGraph = { nodes: [...loaded.nodes], edges: [...loaded.edges] };
     } else {
-      hydratedGraph = { nodes: normalizedNodes, edges: normalizedEdges };
+      // No registry resolver on the context — behavior flags can only come
+      // from the saved sub-workflow itself; absent ones default off.
+      hydratedGraph = withExplicitNodeFlags({
+        nodes: normalizedNodes,
+        edges: normalizedEdges
+      } as unknown as GraphData);
     }
 
     // Collect dynamic input values as params for the sub-workflow's input nodes
@@ -126,7 +134,7 @@ export class WorkflowNode extends BaseNode {
       const nodeId = String(n.id ?? "");
       const nodeName = n.name as string | undefined;
       const runnerKey = nodeName ?? nodeId;
-      const props = (n.properties ?? n.data ?? {}) as Record<string, unknown>;
+      const props = (n.properties ?? {}) as Record<string, unknown>;
       const outputName =
         typeof props.name === "string" && props.name.trim()
           ? props.name.trim()
@@ -149,7 +157,7 @@ export class WorkflowNode extends BaseNode {
         workflow_id: this.workflow_id || undefined,
         params
       },
-      hydratedGraph as unknown as { nodes: NodeDescriptor[]; edges: Edge[] }
+      hydratedGraph
     );
 
     if (result.status === "failed") {

--- a/packages/dsl/src/core.ts
+++ b/packages/dsl/src/core.ts
@@ -4,7 +4,7 @@
  * OutputHandle, Connectable, DslNode, SingleOutput, createNode(), workflow(), run()
  */
 
-import { WorkflowRunner } from "@nodetool-ai/kernel";
+import { WorkflowRunner, withExplicitNodeFlags } from "@nodetool-ai/kernel";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import {
   ProcessingContext,
@@ -450,7 +450,12 @@ export async function run(
 
   const result = await (async () => {
     try {
-      return await runner.run({ job_id: jobId }, { nodes, edges });
+      // DSL nodes carry their streaming flags from generated metadata
+      // (`n.streaming` / `n.streamingInput` above); the rest default off.
+      return await runner.run(
+        { job_id: jobId },
+        withExplicitNodeFlags({ nodes, edges })
+      );
     } finally {
       pythonBridge?.close();
     }

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -13,7 +13,9 @@ import { createLogger } from "@nodetool-ai/config";
 import type {
   Edge,
   NodeDescriptor,
-  GraphData
+  HydratedNodeDescriptor,
+  GraphData,
+  HydratedGraphData
 } from "@nodetool-ai/protocol";
 
 // Stryker disable next-line StringLiteral: logger name is a diagnostic label, not a behavioural contract
@@ -116,6 +118,31 @@ function resolveNodeTypeWith(
 // ---------------------------------------------------------------------------
 // Graph
 // ---------------------------------------------------------------------------
+
+/**
+ * Mark a code-constructed graph as hydrated by defaulting absent behavior
+ * flags to false. For graphs built in code (tests, DSL output) where the
+ * author already set the flags that matter. NOT a substitute for registry
+ * hydration of client/wire graphs — there an absent flag means "unknown",
+ * not "off"; use `Graph.loadFromDict` or node-sdk's `hydrateGraphNodeFlags`.
+ */
+export function withExplicitNodeFlags(graph: GraphData): HydratedGraphData {
+  return {
+    nodes: graph.nodes.map((node) => ({
+      ...node,
+      is_streaming_input: node.is_streaming_input ?? false,
+      is_streaming_output: node.is_streaming_output ?? false,
+      is_controlled: node.is_controlled ?? false,
+      is_join_node: node.is_join_node ?? false
+    })),
+    edges: [...graph.edges]
+  };
+}
+
+/** A Graph whose descriptors carry resolved behavior flags (see loadFromDict). */
+export interface HydratedGraph extends Graph {
+  readonly nodes: ReadonlyArray<HydratedNodeDescriptor>;
+}
 
 export class Graph {
   readonly nodes: ReadonlyArray<NodeDescriptor>;
@@ -328,7 +355,7 @@ export class Graph {
   static async loadFromDict(
     data: unknown,
     options: GraphLoadOptions
-  ): Promise<Graph> {
+  ): Promise<HydratedGraph> {
     const {
       resolver,
       skipErrors = true,
@@ -344,7 +371,7 @@ export class Graph {
       pruneEdgeProperties: false
     });
 
-    const resolvedNodes: NodeDescriptor[] = [];
+    const resolvedNodes: HydratedNodeDescriptor[] = [];
     const validNodeIds = new Set<string>();
 
     for (const node of normalized.nodes) {
@@ -378,7 +405,7 @@ export class Graph {
 
       const descriptorDefaults: Partial<NodeDescriptor> =
         resolved.descriptorDefaults ?? {};
-      const hydratedNode: NodeDescriptor = {
+      const hydratedNode: HydratedNodeDescriptor = {
         ...descriptorDefaults,
         ...node,
         type: resolved.nodeType,
@@ -413,7 +440,7 @@ export class Graph {
         // Correlation metadata is registry-authoritative; saved JSON is a
         // cache that gets overwritten — matching `input_mode` /
         // `output_correlation` above. See docs/correlation-design.md §1.
-        is_join_node: descriptorDefaults.is_join_node
+        is_join_node: descriptorDefaults.is_join_node ?? false
       };
 
       resolvedNodes.push(hydratedNode);
@@ -424,7 +451,11 @@ export class Graph {
       (edge) => validNodeIds.has(edge.source) && validNodeIds.has(edge.target)
     );
     Graph._pruneEdgeFedProperties(resolvedNodes, validEdges);
-    return new Graph({ nodes: resolvedNodes, edges: validEdges });
+    // Sound: resolvedNodes were built as HydratedNodeDescriptor above.
+    return new Graph({
+      nodes: resolvedNodes,
+      edges: validEdges
+    }) as HydratedGraph;
   }
 
   // -----------------------------------------------------------------------

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -440,7 +440,8 @@ export class Graph {
         // Correlation metadata is registry-authoritative; saved JSON is a
         // cache that gets overwritten — matching `input_mode` /
         // `output_correlation` above. See docs/correlation-design.md §1.
-        is_join_node: descriptorDefaults.is_join_node ?? false
+        is_join_node:
+          descriptorDefaults.is_join_node || node.is_join_node || false
       };
 
       resolvedNodes.push(hydratedNode);

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -5,6 +5,8 @@
 export {
   Graph,
   GraphValidationError,
+  withExplicitNodeFlags,
+  type HydratedGraph,
   type GraphValidationIssue,
   type GraphFromDictOptions,
   type GraphLoadOptions,

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -17,6 +17,7 @@
 import { createLogger } from "@nodetool-ai/config";
 import type {
   NodeDescriptor,
+  HydratedGraphData,
   Edge,
   ProcessingMessage,
   ControlEvent
@@ -24,6 +25,31 @@ import type {
 import { TypeMetadata } from "@nodetool-ai/protocol";
 
 const log = createLogger("nodetool.kernel.runner");
+
+/**
+ * Minimum interval between edge_update emissions per edge. The first message
+ * on an edge always emits (it starts the flow animation); afterwards the
+ * counter badge is refreshed at most this often, with the exact final count
+ * flushed at run end. Keeps audio-rate streams (~50 chunks/s per edge) from
+ * flooding the message transport.
+ */
+const EDGE_UPDATE_MIN_INTERVAL_MS = 1000;
+
+/**
+ * Cap on messages retained for RunResult.messages. Long-running streaming
+ * jobs would otherwise accumulate messages without bound; when the cap is
+ * hit, the oldest half is dropped (block-wise, so the cost amortizes).
+ */
+const MAX_RETAINED_MESSAGES = 10_000;
+
+/** An output_update whose value is a streamed audio chunk (sample payload). */
+function isAudioChunkOutputUpdate(msg: ProcessingMessage): boolean {
+  if (msg.type !== "output_update") return false;
+  const value = (msg as { value?: unknown }).value;
+  if (!value || typeof value !== "object") return false;
+  const v = value as { type?: unknown; content_type?: unknown };
+  return v.type === "chunk" && v.content_type === "audio";
+}
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 // Import span helpers from the narrow `/tracing` subpath, not the package root,
 // so thin consumers (e.g. the in-browser workflow runner) don't drag the
@@ -191,6 +217,12 @@ export class WorkflowRunner {
   /** Per-edge message counters (for EdgeUpdate tracking). */
   private _edgeCounters = new Map<string, number>();
 
+  /** Per-edge timestamp of the last emitted edge_update (throttling). */
+  private _edgeCounterLastEmitMs = new Map<string, number>();
+
+  /** Edges whose counter advanced since their last emitted edge_update. */
+  private _edgeCounterDirty = new Set<string>();
+
   /** Per-edge streaming flag (true if on a streaming path). */
   private _streamingEdges = new Map<string, boolean>();
 
@@ -331,10 +363,17 @@ export class WorkflowRunner {
 
   /**
    * Execute a workflow graph.
+   *
+   * Requires hydrated descriptors: the actor trusts the behavior flags
+   * (`is_streaming_input` & co.) to pick the execution mode, so accepting a
+   * raw wire graph here would silently run streaming nodes as one-shot
+   * process() calls. Hydrate via `Graph.loadFromDict`, node-sdk's
+   * `hydrateGraphNodeFlags(graph, registry)`, or — for graphs constructed in
+   * code where the author sets the flags — `withExplicitNodeFlags`.
    */
   async run(
     request: RunJobRequest,
-    graphData: { nodes: NodeDescriptor[]; edges: Edge[] }
+    graphData: HydratedGraphData
   ): Promise<RunResult> {
     return withWorkflowSpan(
       {
@@ -348,7 +387,7 @@ export class WorkflowRunner {
 
   private async _runImpl(
     request: RunJobRequest,
-    graphData: { nodes: NodeDescriptor[]; edges: Edge[] }
+    graphData: HydratedGraphData
   ): Promise<RunResult> {
     this._resetRunState();
 
@@ -512,6 +551,8 @@ export class WorkflowRunner {
   private _resetRunState(): void {
     this._inboxes = new Map();
     this._edgeCounters = new Map();
+    this._edgeCounterLastEmitMs = new Map();
+    this._edgeCounterDirty = new Set();
     this._streamingEdges = new Map();
     this._controlEdgesRouted = new Set();
     this._multiEdgeListInputs = new Map();
@@ -529,6 +570,23 @@ export class WorkflowRunner {
   /**
    * Cancel the running workflow.
    */
+  /**
+   * Push property updates into a running node's executor instance (live
+   * parameter changes — e.g. turning a synth knob while the patch plays).
+   * Returns true when the node's executor exists and supports live updates;
+   * false is not an error — the caller's canvas state already holds the new
+   * value for the next run.
+   */
+  updateNodeProperties(
+    nodeId: string,
+    properties: Record<string, unknown>
+  ): boolean {
+    const executor = this._executors.get(nodeId);
+    if (!executor?.applyProperties) return false;
+    executor.applyProperties(properties);
+    return true;
+  }
+
   cancel(): void {
     log.info("Job cancelled", { jobId: this.jobId });
     this._cancelled = true;
@@ -1125,16 +1183,33 @@ export class WorkflowRunner {
     // Skip constant and input nodes: the client already holds their value
     // as a property (or supplied it as a runtime param), so re-sending it
     // (often a large image/audio payload) is redundant.
+    // Also skip handles with outgoing data edges: the value travels to its
+    // consumer on the edge, and clients only display terminal (unconnected)
+    // handles — Output/Preview nodes and dangling outputs. Without this,
+    // every intermediate module of a streaming patch firehoses the client
+    // (~50 output_updates/s per handle for realtime audio). Nodes whose
+    // output_updates are part of their UI contract even when patched onward
+    // (e.g. the realtime AudioOutput monitor) opt out via the
+    // `always_emit_output_updates` descriptor flag.
     const sourceNode = this._graph.findNode(sourceNodeId);
     if (
       sourceNode &&
       !sourceNode.type.startsWith("nodetool.constant.") &&
       !sourceNode.type.startsWith("nodetool.input.")
     ) {
+      const alwaysEmit = Boolean(
+        (sourceNode as { always_emit_output_updates?: boolean })
+          .always_emit_output_updates
+      );
       const declaredOutputs = sourceNode.outputs ?? {};
       for (const [handle, value] of Object.entries(outputs)) {
         if (value === undefined) continue;
         if (handle === "__control__" || handle === "__control_output__")
+          continue;
+        if (
+          !alwaysEmit &&
+          this._graph.findEdges(sourceNodeId, handle).some(isDataEdge)
+        )
           continue;
         const outputName = clientFacingOutputName(sourceNode, handle);
         this._emit({
@@ -1350,6 +1425,20 @@ export class WorkflowRunner {
     const counter = (this._edgeCounters.get(id) ?? 0) + 1;
     this._edgeCounters.set(id, counter);
 
+    // Per-message edge_updates only drive UI affordances: the flow animation
+    // needs the first message, and the "N streamed" badge doesn't need more
+    // than a few updates per second. Realtime audio streams cross edges at
+    // chunk rate (~50/s per edge), which would otherwise flood the transport.
+    // Emit the first update immediately, throttle the rest, and flush exact
+    // final counters in _flushEdgeCounters() at run end.
+    const now = Date.now();
+    const last = this._edgeCounterLastEmitMs.get(id);
+    if (last !== undefined && now - last < EDGE_UPDATE_MIN_INTERVAL_MS) {
+      this._edgeCounterDirty.add(id);
+      return;
+    }
+    this._edgeCounterLastEmitMs.set(id, now);
+    this._edgeCounterDirty.delete(id);
     this._emit({
       type: "edge_update",
       workflow_id: this.jobId,
@@ -1357,6 +1446,24 @@ export class WorkflowRunner {
       status: "active",
       counter
     });
+  }
+
+  /**
+   * Emit the final counter for every edge whose count advanced past its last
+   * throttled edge_update, so the badge ends on the exact total. Called from
+   * _drainActiveEdges (which runs on completion, cancellation and error).
+   */
+  private _flushEdgeCounters(): void {
+    for (const id of this._edgeCounterDirty) {
+      this._emit({
+        type: "edge_update",
+        workflow_id: this.jobId,
+        edge_id: id,
+        status: "active",
+        counter: this._edgeCounters.get(id) ?? null
+      });
+    }
+    this._edgeCounterDirty.clear();
   }
 
   // -----------------------------------------------------------------------
@@ -1371,6 +1478,9 @@ export class WorkflowRunner {
    */
   private _drainActiveEdges(): void {
     if (!this._graph || this._graph.edges.length === 0) return;
+    // Settle the throttled counters first; a "drained" update below may then
+    // override the status for still-open edges.
+    this._flushEdgeCounters();
     for (const edge of this._graph.edges) {
       try {
         const inbox = this._inboxes.get(edge.target);
@@ -1492,7 +1602,21 @@ export class WorkflowRunner {
   }
 
   private _emit(msg: ProcessingMessage): void {
-    this._messages.push(msg);
+    // Retain for RunResult.messages — except the realtime-audio firehose: a
+    // live synth patch emits ~50 audio-chunk output_updates per node per
+    // second, each holding a sample buffer, so retaining them grows the heap
+    // without bound (~25MB/min for a small patch) and the mounting GC
+    // pressure progressively degrades whichever thread runs the kernel.
+    // Streaming delivery (executionContext.emit) is unaffected. A generous
+    // cap backstops other unbounded streams.
+    if (!isAudioChunkOutputUpdate(msg)) {
+      if (this._messages.length >= MAX_RETAINED_MESSAGES) {
+        this._messages = this._messages.slice(
+          this._messages.length - MAX_RETAINED_MESSAGES / 2
+        );
+      }
+      this._messages.push(msg);
+    }
     if (this._options.executionContext) {
       this._options.executionContext.emit(msg);
     }

--- a/packages/kernel/tests/e2e/actor-modes.test.ts
+++ b/packages/kernel/tests/e2e/actor-modes.test.ts
@@ -115,14 +115,20 @@ describe("ACTOR-003: Streaming output node yields multiple values", () => {
     );
 
     expect(result.status).toBe("completed");
-    // 3 values emitted from counter → 3 edge_update active messages
+    // 3 values emitted from counter. edge_update is throttled (first
+    // message immediately, then at most one per interval, exact final
+    // counter flushed at run end) — assert the final counter, not the
+    // message count.
     const edgeUpdates = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
         (m as { edge_id: string }).edge_id === "e-counter-sink" &&
         (m as { status: string }).status === "active"
     );
-    expect(edgeUpdates.length).toBe(3);
+    expect(edgeUpdates.length).toBeGreaterThanOrEqual(1);
+    expect(
+      (edgeUpdates[edgeUpdates.length - 1] as { counter?: number }).counter
+    ).toBe(3);
   });
 });
 
@@ -259,14 +265,18 @@ describe("ACTOR-007: Sticky input semantics with streaming upstream", () => {
     );
 
     expect(result.status).toBe("completed");
-    // 3 values from counter (1,2,3) + sticky b=10 → 3 executions: 11, 12, 13
+    // 3 values from counter (1,2,3) + sticky b=10 → 3 executions: 11, 12, 13.
+    // edge_update is throttled; the last active update carries the total.
     const edgeUpdates = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
         (m as { edge_id: string }).edge_id === "e-add" &&
         (m as { status: string }).status === "active"
     );
-    expect(edgeUpdates.length).toBe(3);
+    expect(edgeUpdates.length).toBeGreaterThanOrEqual(1);
+    expect(
+      (edgeUpdates[edgeUpdates.length - 1] as { counter?: number }).counter
+    ).toBe(3);
   });
 });
 

--- a/packages/kernel/tests/e2e/complex-topologies.test.ts
+++ b/packages/kernel/tests/e2e/complex-topologies.test.ts
@@ -291,14 +291,16 @@ describe("COMPLEX-010: Static constant + streaming counter feeds Add", () => {
     );
 
     expect(result.status).toBe("completed");
-    // 3 values (10,11,12) + b=1 → Add fires 3 times
+    // 3 values (10,11,12) + b=1 → Add fires 3 times. edge_update is
+    // throttled; the last active update carries the total.
     const active = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
         (m as EdgeUpdate).edge_id === "e-sc-add" &&
         (m as EdgeUpdate).status === "active"
     );
-    expect(active.length).toBe(3);
+    expect(active.length).toBeGreaterThanOrEqual(1);
+    expect((active[active.length - 1] as EdgeUpdate).counter).toBe(3);
   });
 });
 

--- a/packages/kernel/tests/e2e/runner-lifecycle.test.ts
+++ b/packages/kernel/tests/e2e/runner-lifecycle.test.ts
@@ -319,14 +319,16 @@ describe("RUNNER-019: Streaming output node propagates streaming flag downstream
     );
 
     expect(result.status).toBe("completed");
-    // 4 items emitted → 4 active edge_update on e1
+    // 4 items emitted on e1. edge_update is throttled; the last active
+    // update carries the total.
     const active = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
         (m as EdgeUpdate).edge_id === "e1" &&
         (m as EdgeUpdate).status === "active"
     );
-    expect(active.length).toBe(4);
+    expect(active.length).toBeGreaterThanOrEqual(1);
+    expect((active[active.length - 1] as EdgeUpdate).counter).toBe(4);
   });
 });
 

--- a/packages/kernel/tests/output-update.test.ts
+++ b/packages/kernel/tests/output-update.test.ts
@@ -1,5 +1,9 @@
 /**
  * Tests for T-K-9: OutputUpdate messages emitted after node produces output.
+ *
+ * Contract: output_update is emitted for terminal (unconnected) handles only —
+ * connected handles deliver their value downstream on the edge and are
+ * suppressed — unless the node sets `always_emit_output_updates`.
  */
 import { describe, it, expect } from "vitest";
 import { WorkflowRunner } from "../src/runner.js";
@@ -15,7 +19,7 @@ function makeExecutor(
 }
 
 describe("T-K-9: OutputUpdate messages", () => {
-  it("emits output_update after node produces output", async () => {
+  it("emits output_update for terminal handles, suppresses connected ones", async () => {
     const nodes: NodeDescriptor[] = [
       { id: "n1", type: "test.Source", outputs: { output: "int" } },
       { id: "n2", type: "test.Sink", outputs: { result: "int" } }
@@ -38,20 +42,23 @@ describe("T-K-9: OutputUpdate messages", () => {
     const outputUpdates = result.messages.filter(
       (m) => m.type === "output_update"
     );
-    expect(outputUpdates.length).toBeGreaterThanOrEqual(1);
-
-    // Check that at least one output_update has the node's output
-    const n1Update = outputUpdates.find(
-      (m) => m.type === "output_update" && m.node_id === "n1"
+    // n1's "output" is connected → suppressed; n2's "result" is terminal.
+    expect(
+      outputUpdates.some(
+        (m) => m.type === "output_update" && m.node_id === "n1"
+      )
+    ).toBe(false);
+    const n2Update = outputUpdates.find(
+      (m) => m.type === "output_update" && m.node_id === "n2"
     );
-    expect(n1Update).toBeDefined();
-    if (n1Update && n1Update.type === "output_update") {
-      expect(n1Update.output_name).toBe("output");
-      expect(n1Update.value).toBe(42);
+    expect(n2Update).toBeDefined();
+    if (n2Update && n2Update.type === "output_update") {
+      expect(n2Update.output_name).toBe("result");
+      expect(n2Update.value).toBe(99);
     }
   });
 
-  it("emits output_update for each output handle", async () => {
+  it("emits output_update only for unconnected handles of a multi-output node", async () => {
     const nodes: NodeDescriptor[] = [
       { id: "n1", type: "test.MultiOut", outputs: { a: "int", b: "str" } },
       { id: "n2", type: "test.Sink", outputs: { result: "int" } }
@@ -74,20 +81,21 @@ describe("T-K-9: OutputUpdate messages", () => {
     const outputUpdates = result.messages.filter(
       (m) => m.type === "output_update" && m.node_id === "n1"
     );
-    expect(outputUpdates.length).toBe(2);
-    const handles = outputUpdates.map((m) =>
-      m.type === "output_update" ? m.output_name : ""
-    );
-    expect(handles).toContain("a");
-    expect(handles).toContain("b");
+    // "a" is connected → suppressed; "b" is terminal → emitted.
+    expect(outputUpdates.length).toBe(1);
+    if (outputUpdates[0].type === "output_update") {
+      expect(outputUpdates[0].output_name).toBe("b");
+      expect(outputUpdates[0].value).toBe("hello");
+    }
   });
 
-  it("does not emit output_update for undefined values", async () => {
+  it("always_emit_output_updates restores emission for connected handles", async () => {
     const nodes: NodeDescriptor[] = [
       {
         id: "n1",
-        type: "test.Source",
-        outputs: { output: "int", extra: "str" }
+        type: "test.Monitor",
+        outputs: { output: "int" },
+        always_emit_output_updates: true
       },
       { id: "n2", type: "test.Sink", outputs: { result: "int" } }
     ];
@@ -98,11 +106,37 @@ describe("T-K-9: OutputUpdate messages", () => {
     const runner = new WorkflowRunner("job1", {
       resolveExecutor: (node) => {
         if (node.id === "n1") {
-          // Only output on "output", not "extra"
-          return makeExecutor(() => ({ output: 5 }));
+          return makeExecutor(() => ({ output: 7 }));
         }
-        return makeExecutor(() => ({ result: 5 }));
+        return makeExecutor(() => ({ result: 7 }));
       }
+    });
+
+    const result = await runner.run({ job_id: "job1" }, { nodes, edges });
+
+    const n1Update = result.messages.find(
+      (m) => m.type === "output_update" && m.node_id === "n1"
+    );
+    expect(n1Update).toBeDefined();
+    if (n1Update && n1Update.type === "output_update") {
+      expect(n1Update.output_name).toBe("output");
+      expect(n1Update.value).toBe(7);
+    }
+  });
+
+  it("does not emit output_update for undefined values", async () => {
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "n1",
+        type: "test.Source",
+        outputs: { output: "int", extra: "str" }
+      }
+    ];
+    const edges: Array<Record<string, unknown>> = [];
+
+    const runner = new WorkflowRunner("job1", {
+      // Only output on "output", not "extra" — both handles terminal.
+      resolveExecutor: () => makeExecutor(() => ({ output: 5 }))
     });
 
     const result = await runner.run({ job_id: "job1" }, { nodes, edges });

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1140,7 +1140,7 @@ export async function runAgentLoop(
         // agent_status, etc.) — those must not leak into the text output.
         // (Tool execution uses the structured ToolCall items below.)
         if (!item.thinking && item.content_type === "text") {
-          const delta = item.content ?? "";
+          const delta = typeof item.content === "string" ? item.content : "";
           assistantText += delta;
           if (delta) options.onText?.(delta);
         }
@@ -2704,9 +2704,16 @@ export class AgentNode extends BaseNode {
             if (item.content_type === "audio") {
               audioChunkCount += 1;
               yield { chunk: item, thinking: null, text: null, audio: null };
-              const audioBytes = item.content
-                ? Buffer.from(item.content, "base64")
-                : Buffer.alloc(0);
+              const audioBytes =
+                typeof item.content === "string" && item.content
+                  ? Buffer.from(item.content, "base64")
+                  : item.content instanceof Float32Array
+                    ? Buffer.from(
+                        item.content.buffer,
+                        item.content.byteOffset,
+                        item.content.byteLength
+                      )
+                    : Buffer.alloc(0);
               yield {
                 chunk: null,
                 thinking: null,
@@ -2714,7 +2721,8 @@ export class AgentNode extends BaseNode {
                 audio: { data: new Uint8Array(audioBytes) }
               };
             } else {
-              const rawPiece = item.content ?? "";
+              const rawPiece =
+                typeof item.content === "string" ? item.content : "";
               assistantText += rawPiece;
               for (const y of yieldSplitThinkChunks(item, rawPiece, thinkSplitter)) {
                 if (y.thinking != null) streamedRedactedThinking = true;

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -67,6 +67,7 @@ export type NodeClass = {
   requiredRuntimes?: string[];
   isStreamingInput: boolean;
   isStreamingOutput: boolean;
+  alwaysEmitOutputUpdates?: boolean;
   inputMode?: InputMode;
   outputCorrelation?: Record<string, OutputCorrelation>;
   supportsDynamicInputs: boolean;
@@ -211,6 +212,13 @@ export abstract class BaseNode {
   static readonly requiredRuntimes: string[] | undefined = undefined;
   static readonly isStreamingInput: boolean = false;
   static readonly isStreamingOutput: boolean = false;
+  /**
+   * Emit output_update for this node's handles even when they are connected
+   * onward. The runner suppresses output_update for connected handles by
+   * default; nodes whose updates feed a UI surface regardless of patching
+   * (e.g. the realtime audio monitor) opt in.
+   */
+  static readonly alwaysEmitOutputUpdates: boolean = false;
   static readonly inputMode: InputMode | undefined = undefined;
   static readonly outputCorrelation:
     | Record<string, OutputCorrelation>
@@ -511,6 +519,11 @@ export abstract class BaseNode {
         this.assign(props);
         yield* this.genProcess(context);
       }.bind(this) as NodeExecutor["genProcess"],
+      // Live parameter path: assign() only touches the supplied declared
+      // properties, so a running run() loop that reads `this.<prop>` per
+      // chunk sees the new value on its next chunk.
+      applyProperties: (properties: Record<string, unknown>) =>
+        this.assign(properties),
       preProcess: () => this.preProcess(),
       finalize: () => this.finalize(),
       initialize: () => this.initialize()

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -98,6 +98,8 @@ export interface NodeMetadata {
   is_controlled?: boolean;
   /** §7 — Zip/Cross nodes opt out of the incomparable-scope check. */
   is_join_node?: boolean;
+  /** Emit output_update even for connected handles (UI-monitor nodes). */
+  always_emit_output_updates?: boolean;
   supports_dynamic_outputs?: boolean;
   auto_save_asset?: boolean;
   model_packs?: unknown[];

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -288,6 +288,7 @@ export function getNodeMetadata(
     output_correlation: nodeClass.outputCorrelation,
     is_controlled: nodeClass.isControlled || false,
     is_join_node: nodeClass.isJoinNode || undefined,
+    always_emit_output_updates: nodeClass.alwaysEmitOutputUpdates || undefined,
     supports_dynamic_inputs: nodeClass.supportsDynamicInputs || false,
     supports_dynamic_outputs: nodeClass.supportsDynamicOutputs,
     auto_save_asset: nodeClass.autoSaveAsset || undefined,

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -1,4 +1,9 @@
-import type { NodeDescriptor, Platform } from "@nodetool-ai/protocol";
+import type {
+  GraphData,
+  HydratedGraphData,
+  NodeDescriptor,
+  Platform
+} from "@nodetool-ai/protocol";
 import { supportsPlatform } from "@nodetool-ai/protocol";
 import type { NodeExecutor, ResolvedNodeType } from "@nodetool-ai/kernel";
 import type { NodeClass } from "./base-node.js";
@@ -277,6 +282,43 @@ function typeMetadataToString(
   return args.length > 0 ? `${typeMeta.type}[${args.join(", ")}]` : typeMeta.type;
 }
 
+/**
+ * Stamp streaming/control flags from the registry's node classes onto graph
+ * descriptors. Graphs arriving from a client carry only `type` and
+ * `properties`, and the kernel actor trusts `node.is_streaming_input` to
+ * pick run() over a one-shot process() — without this every streaming node
+ * "completes" instantly with empty outputs. The full-fat equivalent (which
+ * also resolves property/output types and drops unknown node types) is
+ * `Graph.loadFromDict` with `createGraphNodeTypeResolver`; this is the
+ * lightweight synchronous version for runners that only need correct
+ * execution semantics. Node types the registry doesn't know keep their own
+ * flags, defaulted to false (resolveExecutor reports unknown types loudly).
+ */
+export function hydrateGraphNodeFlags(
+  graph: GraphData,
+  registry: Pick<NodeRegistry, "getClass">
+): HydratedGraphData {
+  const nodes = graph.nodes.map((node) => {
+    const cls = registry.getClass(node.type);
+    return {
+      ...node,
+      is_streaming_input:
+        cls?.isStreamingInput || node.is_streaming_input || false,
+      is_streaming_output:
+        cls?.isStreamingOutput || node.is_streaming_output || false,
+      is_controlled: cls?.isControlled || node.is_controlled || false,
+      is_join_node: cls?.isJoinNode || node.is_join_node || false,
+      always_emit_output_updates:
+        cls?.alwaysEmitOutputUpdates ||
+        node.always_emit_output_updates ||
+        false,
+      input_mode: cls?.inputMode ?? node.input_mode,
+      output_correlation: cls?.outputCorrelation ?? node.output_correlation
+    };
+  });
+  return { nodes, edges: [...graph.edges] };
+}
+
 function deriveNamespace(nodeType: string): string {
   const lastDot = nodeType.lastIndexOf(".");
   // Stryker disable next-line EqualityOperator: at lastDot === 0 both arms yield "" (slice(0,0) === the else ""), so > 0 vs >= 0 are indistinguishable (equivalent).
@@ -343,6 +385,9 @@ export function createGraphNodeTypeResolver(
           }),
           ...(metadata.is_controlled && { is_controlled: true }),
           ...(metadata.is_join_node && { is_join_node: true }),
+          ...(metadata.always_emit_output_updates && {
+            always_emit_output_updates: true
+          }),
           ...(Object.keys(propertyMeta).length > 0 && { propertyMeta })
         }
       };

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -151,6 +151,15 @@ export interface NodeDescriptor {
   /** Whether this node produces streaming output. */
   is_streaming_output?: boolean;
 
+  /**
+   * Emit output_update for this node's handles even when they have outgoing
+   * data edges. The runner suppresses output_update for connected handles by
+   * default (downstream receives the value on the edge; clients display only
+   * terminal handles). Nodes whose output_updates feed a UI surface
+   * regardless of patching — e.g. the realtime audio monitor — set this.
+   */
+  always_emit_output_updates?: boolean;
+
   /** Correlation-aware input execution mode. */
   input_mode?: InputMode;
 
@@ -181,11 +190,33 @@ export interface NodeDescriptor {
   >;
 }
 
+/**
+ * A node descriptor whose behavior-critical flags have been resolved — the
+ * kernel trusts these flags to pick the execution mode (streaming run() vs
+ * one-shot process(), controlled mode, join semantics), so a runner must
+ * never receive a descriptor where they are merely absent. Produced by the
+ * hydration helpers (`Graph.loadFromDict`, node-sdk's `hydrateGraphNodeFlags`,
+ * kernel's `withExplicitNodeFlags`); raw wire graphs (`NodeDescriptor`) are
+ * deliberately not assignable.
+ */
+export interface HydratedNodeDescriptor extends NodeDescriptor {
+  is_streaming_input: boolean;
+  is_streaming_output: boolean;
+  is_controlled: boolean;
+  is_join_node: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Graph
 // ---------------------------------------------------------------------------
 
 export interface GraphData {
   nodes: NodeDescriptor[];
+  edges: Edge[];
+}
+
+/** GraphData whose nodes carry resolved behavior flags. See {@link HydratedNodeDescriptor}. */
+export interface HydratedGraphData {
+  nodes: HydratedNodeDescriptor[];
   edges: Edge[];
 }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -318,7 +318,15 @@ export interface Chunk {
   thread_id?: string | null;
   workflow_id?: string | null;
   content_type?: ContentType;
-  content: string;
+  /**
+   * Text chunks and externally-sourced audio carry a string (base64 for
+   * binary payloads). In-process audio/CV chunks carry their samples as a
+   * native interleaved `Float32Array` — no per-hop encode/decode. The
+   * websocket transport encodes native samples to base64 (`encoding:
+   * "f32le"`) at the wire boundary; worker postMessage structured-clones
+   * them natively.
+   */
+  content: string | Float32Array;
   content_metadata?: Record<string, unknown>;
   done?: boolean;
   thinking?: boolean;
@@ -397,6 +405,7 @@ export type UnifiedCommandType =
   | "reconnect_job"
   | "resume_job"
   | "cancel_job"
+  | "update_node_properties"
   | "get_status"
   | "set_mode"
   | "clear_models"

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -821,6 +821,8 @@ export class ProcessingContext {
 
   /** Message queue: all emitted processing messages. */
   private _messages: ProcessingMessage[] = [];
+  /** Whether emit() feeds the pull queue (see constructor option). */
+  private _retainMessageQueue = true;
   /** Latest node status by node id. */
   private _nodeStatuses = new Map<string, ProcessingMessage>();
   /** Latest edge status by edge id. */
@@ -926,6 +928,15 @@ export class ProcessingContext {
     fetchFn?: (input: string, init?: RequestInit) => Promise<Response>;
     tempUrlResolver?: (uri: string) => Promise<string> | string;
     modelInterfaces?: ProcessingContextModelInterfaces;
+    /**
+     * Keep emitted messages in the pull queue (popMessage/waitMessage).
+     * Consumers that stream via message listeners instead (the browser/
+     * workflow-runner path) should pass false — with nothing draining the
+     * queue, an infinite realtime stream otherwise retains every chunk
+     * payload for the lifetime of the run. Default true (server paths pull
+     * from the queue).
+     */
+    retainMessageQueue?: boolean;
   }) {
     this.jobId = opts.jobId;
     this.workflowId = opts.workflowId ?? null;
@@ -951,6 +962,7 @@ export class ProcessingContext {
       ((input: string, init?: RequestInit) => fetch(input, init));
     this._tempUrlResolver = opts.tempUrlResolver ?? null;
     this._modelInterfaces = opts.modelInterfaces ?? null;
+    this._retainMessageQueue = opts.retainMessageQueue ?? true;
   }
 
   copy(): ProcessingContext {
@@ -1255,7 +1267,9 @@ export class ProcessingContext {
    * Appended to the internal queue and forwarded to listeners if set.
    */
   emit(msg: ProcessingMessage): void {
-    this._messages.push(msg);
+    if (this._retainMessageQueue) {
+      this._messages.push(msg);
+    }
     this._notifyMessage();
     if (msg.type === "node_update" && msg.node_id) {
       this._nodeStatuses.set(msg.node_id, msg);

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -980,7 +980,9 @@ export class ProcessingContext {
       environment: { ...this.environment },
       fetchFn: this._fetch,
       secretResolver: this._secretResolver ?? undefined,
-      tempUrlResolver: this._tempUrlResolver ?? undefined
+      tempUrlResolver: this._tempUrlResolver ?? undefined,
+      modelInterfaces: this._modelInterfaces ?? undefined,
+      retainMessageQueue: this._retainMessageQueue
     });
     for (const listener of this._messageListeners) {
       next.addMessageListener(listener);

--- a/packages/runtime/src/node-executor.ts
+++ b/packages/runtime/src/node-executor.ts
@@ -152,6 +152,14 @@ export interface NodeExecutor {
     context?: ProcessingContext
   ): Promise<void>;
 
+  /**
+   * Apply property updates to a live executor instance. Long-running
+   * streaming nodes (synth generators, realtime effects) that read their
+   * properties per chunk pick the new values up on the next chunk —
+   * the basis for live parameter changes while a patch is running.
+   */
+  applyProperties?(properties: Record<string, unknown>): void;
+
   /** Called before process/genProcess. */
   preProcess?(): Promise<void>;
 

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -28,10 +28,12 @@ import {
   Asset
 } from "@nodetool-ai/models";
 import {
+  hydrateGraphNodeFlags,
   loadPythonPackageMetadata,
   type NodeMetadata,
   NodeRegistry
 } from "@nodetool-ai/node-sdk";
+import type { GraphData } from "@nodetool-ai/protocol";
 import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   PythonNodeExecutor,
@@ -673,7 +675,10 @@ export async function handleWorkflowRun(
   });
   const result = await runner.run(
     { job_id: job.id, workflow_id: workflowId, params },
-    runnableGraph
+    hydrateGraphNodeFlags(
+      runnableGraph as unknown as GraphData,
+      runtime.registry
+    )
   );
 
   if (result.status === "completed") {

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -33,10 +33,12 @@ import {
 type JsonObject = Record<string, unknown>;
 import { uiToolSchemas } from "@nodetool-ai/protocol";
 import {
+  hydrateGraphNodeFlags,
   NodeRegistry,
   rankNodeMetadata,
   type NodeMetadata
 } from "@nodetool-ai/node-sdk";
+import type { GraphData } from "@nodetool-ai/protocol";
 import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   PythonNodeExecutor,
@@ -446,7 +448,10 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
         });
         const result = await runner.run(
           { job_id: job.id, workflow_id, params },
-          runnableGraph
+          hydrateGraphNodeFlags(
+            runnableGraph as unknown as GraphData,
+            runtime.registry
+          )
         );
 
         if (result.status === "completed") {

--- a/packages/websocket/src/trpc/routers/workflows.ts
+++ b/packages/websocket/src/trpc/routers/workflows.ts
@@ -34,8 +34,11 @@ import type {
 } from "@nodetool-ai/models";
 import { PythonNodeExecutor } from "@nodetool-ai/runtime";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
-import type { NodeDescriptor } from "@nodetool-ai/protocol";
-import { loadPythonPackageMetadata } from "@nodetool-ai/node-sdk";
+import type { GraphData, NodeDescriptor } from "@nodetool-ai/protocol";
+import {
+  hydrateGraphNodeFlags,
+  loadPythonPackageMetadata
+} from "@nodetool-ai/node-sdk";
 import { createLogger } from "@nodetool-ai/config";
 import {
   loadExampleGraph,
@@ -652,7 +655,7 @@ export const workflowsRouter = router({
       const runner = new WorkflowRunner(job.id, { resolveExecutor });
       const result = await runner.run(
         { job_id: job.id, workflow_id: input.id, params },
-        runnableGraph
+        hydrateGraphNodeFlags(runnableGraph as unknown as GraphData, registry)
       );
 
       if (result.status === "completed") {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -19,6 +19,7 @@ import { resolveContentUrls, resolveContentForProvider } from "./resolve-media-u
 import {
   Graph,
   WorkflowRunner,
+  withExplicitNodeFlags,
   type NodeExecutor,
   type NodeTypeResolver,
   type NodeValidator
@@ -56,6 +57,9 @@ import {
 import { isRawRgbaImage } from "@nodetool-ai/protocol";
 import type {
   Chunk,
+  GraphData,
+  HydratedGraphData,
+  NodeDescriptor,
   ProcessingMessage,
   ProviderCost
 } from "@nodetool-ai/protocol";
@@ -295,6 +299,67 @@ function isAssetLikeValue(
     ASSET_MEDIA_TYPES.has(v.type as string) &&
     ("data" in v || "uri" in v)
   );
+}
+
+/**
+ * A chunk whose content is the native in-process `Float32Array` sample
+ * payload (see protocol `Chunk.content`). Must be encoded before crossing
+ * the websocket: msgpack/JSON would mangle the typed array.
+ */
+function isNativeAudioChunk(
+  value: unknown
+): value is Record<string, unknown> & { content: Float32Array } {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return v.type === "chunk" && v.content instanceof Float32Array;
+}
+
+/** Encode a native audio chunk's samples to base64 f32le for the wire. */
+function encodeAudioChunkForWire(
+  chunk: Record<string, unknown> & { content: Float32Array }
+): Record<string, unknown> {
+  const samples = chunk.content;
+  const bytes = Buffer.from(
+    samples.buffer,
+    samples.byteOffset,
+    samples.byteLength
+  );
+  return {
+    ...chunk,
+    content: bytes.toString("base64"),
+    content_metadata: {
+      ...(chunk.content_metadata as Record<string, unknown> | undefined),
+      encoding: "f32le"
+    }
+  };
+}
+
+/**
+ * Replace native-Float32Array chunk payloads in an outgoing message with
+ * their base64 wire form. Chunks appear as the message itself (chat
+ * streaming), as `value` (output_update), or as `result`/array elements
+ * (node_update); nested generic walks are deliberately avoided — this runs
+ * per message on the hot streaming path.
+ */
+function encodeNativeAudioChunks(
+  message: Record<string, unknown>
+): Record<string, unknown> {
+  if (isNativeAudioChunk(message)) return encodeAudioChunkForWire(message);
+  let out = message;
+  for (const key of ["value", "result", "chunk"]) {
+    const v = out[key];
+    if (isNativeAudioChunk(v)) {
+      out = { ...out, [key]: encodeAudioChunkForWire(v) };
+    } else if (Array.isArray(v) && v.some(isNativeAudioChunk)) {
+      out = {
+        ...out,
+        [key]: v.map((item) =>
+          isNativeAudioChunk(item) ? encodeAudioChunkForWire(item) : item
+        )
+      };
+    }
+  }
+  return out;
 }
 
 function decodeAssetBytes(data: unknown): Uint8Array | null {
@@ -694,10 +759,7 @@ interface ActiveJob {
   workflowId: string | null;
   context: ProcessingContext;
   runner: WorkflowRunner;
-  graph: {
-    nodes: Array<Record<string, unknown>>;
-    edges: Array<Record<string, unknown>>;
-  };
+  graph: HydratedGraphData;
   finished: boolean;
   status: "running" | "completed" | "failed" | "cancelled";
   error?: string;
@@ -788,7 +850,7 @@ export interface UnifiedWebSocketRunnerOptions {
   ) => Promise<string | null>;
   /** Called before a workflow job starts — used to lazily connect the Python bridge. */
   beforeRunJob?: (graph: {
-    nodes: Array<Record<string, unknown>>;
+    nodes: ReadonlyArray<NodeDescriptor>;
   }) => Promise<void>;
   /** Resolve node metadata by type — used for auto_save_asset detection. */
   getNodeMetadata?: (nodeType: string) => NodeMetadata | undefined;
@@ -1044,6 +1106,11 @@ export class UnifiedWebSocketRunner {
       };
     }
 
+    // In-process audio/CV chunks carry samples as a native Float32Array,
+    // which neither msgpack nor JSON represents. Encode them to base64
+    // f32le here — the one and only conversion on the path to the client.
+    message = encodeNativeAudioChunks(message);
+
     const payload =
       this.mode === "text"
         ? (this.serializeForJson(message) as Record<string, unknown>)
@@ -1157,21 +1224,20 @@ export class UnifiedWebSocketRunner {
   private async hydrateGraph(graph: {
     nodes: Array<Record<string, unknown>>;
     edges: Array<Record<string, unknown>>;
-  }): Promise<{
-    nodes: Array<Record<string, unknown>>;
-    edges: Array<Record<string, unknown>>;
-  }> {
+  }): Promise<HydratedGraphData> {
     const normalized = this.normalizeGraph(graph);
     if (!this.resolveNodeType) {
-      return normalized;
+      // No registry resolver configured — behavior flags can only come from
+      // the saved graph itself; absent ones are explicitly defaulted off.
+      return withExplicitNodeFlags(normalized as unknown as GraphData);
     }
 
     const hydrated = await Graph.loadFromDict(normalized, {
       resolver: this.resolveNodeType
     });
     return {
-      nodes: [...hydrated.nodes] as unknown as Array<Record<string, unknown>>,
-      edges: [...hydrated.edges] as unknown as Array<Record<string, unknown>>
+      nodes: [...hydrated.nodes],
+      edges: [...hydrated.edges]
     };
   }
 
@@ -1616,17 +1682,7 @@ export class UnifiedWebSocketRunner {
         workflow_id: workflowId ?? undefined,
         params: req.params ?? {}
       },
-      graph as unknown as {
-        nodes: Array<{ id: string; type: string; [key: string]: unknown }>;
-        edges: Array<{
-          id?: string | null;
-          source: string;
-          target: string;
-          sourceHandle: string;
-          targetHandle: string;
-          edge_type: "data" | "control";
-        }>;
-      }
+      graph
     );
 
     active.streamTask = this.streamJobMessages(active, executePromise);
@@ -2181,10 +2237,7 @@ export class UnifiedWebSocketRunner {
       edges: [] as Array<Record<string, unknown>>
     };
 
-    let graph: {
-      nodes: Array<Record<string, unknown>>;
-      edges: Array<Record<string, unknown>>;
-    };
+    let graph: HydratedGraphData;
     try {
       graph = await this.hydrateGraph(rawGraph);
     } catch (err) {
@@ -2241,20 +2294,7 @@ export class UnifiedWebSocketRunner {
       validateNode: this.validateNode
     });
 
-    const result = await runner.run(
-      { job_id: jobId, params: {} },
-      graph as unknown as {
-        nodes: Array<{ id: string; type: string; [key: string]: unknown }>;
-        edges: Array<{
-          id?: string | null;
-          source: string;
-          target: string;
-          sourceHandle: string;
-          targetHandle: string;
-          edge_type: "data" | "control";
-        }>;
-      }
-    );
+    const result = await runner.run({ job_id: jobId, params: {} }, graph);
 
     // Capture the node's completed result from the streamed updates.
     let nodeResult: unknown;
@@ -3986,14 +4026,14 @@ export class UnifiedWebSocketRunner {
         edges: Array<Record<string, unknown>>;
       };
 
-      if (this.beforeRunJob) {
-        await this.beforeRunJob(rawGraph);
-      }
-
       // Detect message input names from raw graph (reads node.data) — matches Python
       const { messageName, messagesName } =
         this.detectMessageInputNames(rawGraph);
       const graph = await this.hydrateGraph(rawGraph);
+
+      if (this.beforeRunJob) {
+        await this.beforeRunJob(graph);
+      }
       const messageInputName =
         (typeof data.workflow_message_input_name === "string"
           ? data.workflow_message_input_name
@@ -4117,17 +4157,7 @@ export class UnifiedWebSocketRunner {
       // Execute workflow and stream messages
       const executePromise = runner.run(
         { job_id: jobId, workflow_id: workflowId, params },
-        graph as unknown as {
-          nodes: Array<{ id: string; type: string; [key: string]: unknown }>;
-          edges: Array<{
-            id?: string | null;
-            source: string;
-            target: string;
-            sourceHandle: string;
-            targetHandle: string;
-            edge_type: "data" | "control";
-          }>;
-        }
+        graph
       );
 
       // Stream events, collect output_update results
@@ -4886,6 +4916,27 @@ export class UnifiedWebSocketRunner {
       case "cancel_job":
         if (!jobId) return { error: "job_id is required" };
         return this.cancelJob(jobId, workflowId);
+      case "update_node_properties": {
+        // Live parameter path: push property changes into a running job's
+        // node executors (e.g. synth knobs while a patch plays). Misses are
+        // not errors — the canvas already holds the value for the next run.
+        if (!jobId) return { error: "job_id is required" };
+        const nodeId = data.node_id;
+        const properties = data.properties;
+        if (typeof nodeId !== "string" || nodeId.length === 0) {
+          return { error: "node_id is required" };
+        }
+        if (properties === null || typeof properties !== "object") {
+          return { error: "properties must be an object" };
+        }
+        const active = this.activeJobs.get(jobId);
+        const applied =
+          active?.runner.updateNodeProperties(
+            nodeId,
+            properties as Record<string, unknown>
+          ) ?? false;
+        return { applied };
+      }
       case "get_status":
         return this.getStatus(jobId);
       case "set_mode": {

--- a/packages/workflow-runner/src/run.ts
+++ b/packages/workflow-runner/src/run.ts
@@ -13,7 +13,10 @@ import {
   type RunJobRequest,
   type RunResult
 } from "@nodetool-ai/kernel";
-import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import {
+  hydrateGraphNodeFlags,
+  type NodeRegistry
+} from "@nodetool-ai/node-sdk";
 // Narrow `/context` subpath (not the package root) so the browser bundle of
 // this runner doesn't pull the provider / python-bridge barrel.
 import {
@@ -57,6 +60,13 @@ export interface RunWorkflowOptions {
   signal?: AbortSignal;
 
   /**
+   * Receives the live WorkflowRunner right after construction — lets the
+   * caller push live property updates into running nodes
+   * (`runner.updateNodeProperties`) or otherwise drive the run.
+   */
+  onRunner?: (runner: WorkflowRunner) => void;
+
+  /**
    * Reject graphs whose nodes do not declare support for this deployment
    * platform. When set, the runner runs both property validation and
    * platform validation as a pre-flight; unsupported nodes cause the run
@@ -88,6 +98,8 @@ export async function* runWorkflow(
     return { outputs: {}, messages: [message], status: "cancelled" };
   }
 
+  const graph = hydrateGraphNodeFlags(opts.graph, opts.registry);
+
   const context =
     opts.context ??
     new ProcessingContext({
@@ -97,7 +109,10 @@ export async function* runWorkflow(
       workspaceStorage: opts.workspaceStorage ?? null,
       cache: opts.cache,
       environment: opts.environment,
-      secretResolver: opts.secretResolver
+      secretResolver: opts.secretResolver,
+      // This path streams via the message listener below and never drains
+      // the pull queue — retaining it would pin every streamed chunk.
+      retainMessageQueue: false
     });
 
   const runner = new WorkflowRunner(jobId, {
@@ -110,6 +125,7 @@ export async function* runWorkflow(
         : null
     )
   });
+  opts.onRunner?.(runner);
 
   const queue: ProcessingMessage[] = [];
   let wake: (() => void) | null = null;
@@ -134,7 +150,7 @@ export async function* runWorkflow(
   let result: RunResult | null = null;
 
   const runPromise = runner
-    .run(request, opts.graph)
+    .run(request, graph)
     .then((r) => {
       result = r;
     })

--- a/packages/workflow-runner/tests/run.test.ts
+++ b/packages/workflow-runner/tests/run.test.ts
@@ -27,7 +27,8 @@ function fakeRegistry(
 ): NodeRegistry {
   return {
     resolve,
-    createNodeValidator: () => () => []
+    createNodeValidator: () => () => [],
+    getClass: () => undefined
   } as unknown as NodeRegistry;
 }
 
@@ -156,7 +157,8 @@ describe("runWorkflow", () => {
     const registry = {
       resolve: () => passthrough(),
       createNodeValidator: () => propValidator,
-      createPlatformValidator: () => platformValidator
+      createPlatformValidator: () => platformValidator,
+      getClass: () => undefined
     } as unknown as NodeRegistry;
 
     const gen = runWorkflow({
@@ -181,6 +183,41 @@ describe("runWorkflow", () => {
     expect(result.error).toMatch(/workers/);
     expect(propCalls).toBeGreaterThan(0);
     expect(platformCalls).toBeGreaterThan(0);
+  });
+
+  it("hydrates streaming flags from the registry's classes", async () => {
+    // The graph carries NO is_streaming_input — exactly what a web client
+    // sends. Without hydration the actor one-shots process() and the node
+    // never streams (the synth "stops immediately" regression).
+    let streamed = false;
+    const streamingExecutor: NodeExecutor = {
+      async process() {
+        return {};
+      },
+      async run(inputs) {
+        streamed = true;
+        for await (const value of inputs.stream("value")) {
+          void value;
+        }
+      }
+    };
+    const registry = {
+      resolve: () => streamingExecutor,
+      createNodeValidator: () => () => [],
+      getClass: () => ({ isStreamingInput: true })
+    } as unknown as NodeRegistry;
+
+    const gen = runWorkflow({
+      graph: {
+        nodes: [{ id: "stream", type: "test.Streaming" }],
+        edges: []
+      },
+      registry
+    });
+    while (!(await gen.next()).done) {
+      // drain
+    }
+    expect(streamed).toBe(true);
   });
 
   it("honours an AbortSignal before the run begins", async () => {

--- a/web/perf-realtime.html
+++ b/web/perf-realtime.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Realtime Workflow Perf Harness</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        background: #111;
+        color: #ddd;
+        font-family: monospace;
+      }
+      pre {
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Realtime workflow perf harness</h3>
+    <p>
+      Drive via <code>window.__realtimePerf.start({ voices, durationMs })</code>
+      or <code>?autorun=1&amp;voices=8&amp;durationMs=10000</code>.
+    </p>
+    <pre id="status">idle</pre>
+    <pre id="result"></pre>
+    <script type="module" src="/src/perf/realtimePerfHarness.ts"></script>
+  </body>
+</html>

--- a/web/scripts/install-mega-synth.ts
+++ b/web/scripts/install-mega-synth.ts
@@ -1,0 +1,59 @@
+/**
+ * Install the Mega Synth demo workflow into the local NodeTool library.
+ *
+ * Builds the same graph the perf harness stress-tests with
+ * (src/perf/megaSynthPatch.ts), laid out for the editor, and creates it via
+ * the running backend. Open it in the editor and hit Run.
+ *
+ *   npx tsx web/scripts/install-mega-synth.ts [layers=1]
+ *
+ * layers=1 is the demo; higher values stack detuned copies of the whole
+ * ensemble (8 ≈ super-ensemble, 24 ≈ ~1,100-node stress test).
+ */
+import { buildMegaSynthPatch } from "../src/perf/megaSynthPatch";
+
+const API = process.env.NODETOOL_API_URL ?? "http://localhost:7777";
+const layers = Math.max(1, Number(process.argv[2] ?? 1));
+
+const { nodes, edges } = buildMegaSynthPatch(layers);
+
+const workflowGraph = {
+  nodes: nodes.map(({ id, type, properties, ui_properties }) => ({
+    id,
+    parent_id: null,
+    type,
+    data: properties,
+    ui_properties,
+    dynamic_properties: {},
+    dynamic_outputs: {},
+    sync_mode: "on_any"
+  })),
+  edges: edges.map((e) => ({ ...e, ui_properties: null }))
+};
+
+const res = await fetch(`${API}/trpc/workflows.create`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    json: {
+      name: layers === 1 ? "Mega Synth" : `Mega Synth ×${layers}`,
+      description:
+        "Generative modular ensemble: bass, 4-step arp, detuned pad, S&H " +
+        "sparkle lead, hat, kick and FM drone on shared clocks. " +
+        `${layers} layer(s), ${nodes.length} nodes. ` +
+        "Doubles as the realtime perf stress patch (PERF_PATCH=mega).",
+      access: "private",
+      graph: workflowGraph
+    }
+  })
+});
+
+if (!res.ok) {
+  console.error("create failed:", res.status, await res.text());
+  process.exit(1);
+}
+const workflow = (await res.json()).result.data.json;
+console.log(
+  `Mega Synth installed (${nodes.length} nodes, ${edges.length} edges, ` +
+    `${layers} layer(s))\n→ http://localhost:3000/editor/${workflow.id}`
+);

--- a/web/scripts/repro-audio-dropout.mjs
+++ b/web/scripts/repro-audio-dropout.mjs
@@ -1,0 +1,197 @@
+/**
+ * Field repro for realtime-audio dropouts in the REAL editor.
+ *
+ * Unlike the perf harness (which feeds the worklet directly and showed a
+ * rock-steady buffer for 90s), this drives the actual app: real ReactFlow
+ * canvas, the bespoke AudioOut node body (visualizer canvas, knobs), the
+ * bus → effect → worklet delivery path, and whichever execution path
+ * (browser worker or server WebSocket) the app actually picks.
+ *
+ * Requires the dev stack running (`make dev`: backend :7777 + vite :3000).
+ *
+ *   node web/scripts/repro-audio-dropout.mjs [durationSec=100]
+ *
+ * Prints, every 5s, the playback worklet's buffer level + underrun/drop
+ * counters (from window.__nodetoolRealtimeAudio, fed by the worklet's 1 Hz
+ * stats), plus any [realtime-audio] distress warnings and the run-path
+ * console lines — enough to tell producer starvation, delivery jitter and
+ * consumer drops apart.
+ */
+import { chromium } from "@playwright/test";
+
+const API = "http://localhost:7777";
+const APP = "http://localhost:3000";
+const DURATION_S = Number(process.argv[2] ?? 100);
+
+const graph = {
+  nodes: [
+    {
+      id: "osc",
+      parent_id: null,
+      type: "nodetool.audio.synth.Oscillator",
+      data: { waveform: "saw", frequency: 110, amplitude: 0.5 },
+      ui_properties: { position: { x: 100, y: 100 } },
+      dynamic_properties: {},
+      dynamic_outputs: {},
+      sync_mode: "on_any"
+    },
+    {
+      id: "out",
+      parent_id: null,
+      type: "nodetool.audio.realtime.AudioOutput",
+      data: {},
+      ui_properties: { position: { x: 420, y: 100 } },
+      dynamic_properties: {},
+      dynamic_outputs: {},
+      sync_mode: "on_any"
+    }
+  ],
+  edges: [
+    {
+      id: "e1",
+      source: "osc",
+      sourceHandle: "chunk",
+      target: "out",
+      targetHandle: "chunk",
+      ui_properties: null
+    }
+  ]
+};
+
+const res = await fetch(`${API}/trpc/workflows.create`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    json: {
+      name: `repro-audio-dropout-${Date.now()}`,
+      description: "1 osc -> audio out dropout repro",
+      access: "private",
+      graph
+    }
+  })
+});
+if (!res.ok) {
+  console.error("workflow create failed:", res.status, await res.text());
+  process.exit(1);
+}
+const workflow = (await res.json()).result.data.json;
+console.log(`workflow ${workflow.id} created`);
+
+const browser = await chromium.launch({
+  headless: false,
+  args: ["--autoplay-policy=no-user-gesture-required"]
+});
+const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+
+page.on("console", (msg) => {
+  const text = msg.text();
+  if (
+    text.includes("[realtime-audio]") ||
+    text.includes("[browserRunner]") ||
+    text.toLowerCase().includes("dropout")
+  ) {
+    console.log(`  [console] ${text}`);
+  }
+});
+
+await page.goto(`${APP}/editor/${workflow.id}`, {
+  waitUntil: "domcontentloaded"
+});
+await page.waitForSelector(".react-flow__pane", { timeout: 60_000 });
+// Let the canvas settle and node bodies mount.
+await page.waitForTimeout(3000);
+
+await page.click('[aria-label="Run workflow"]');
+console.log(`run started; sampling for ${DURATION_S}s…`);
+
+// CPU-profile the degradation window (the store's 1024-chunk rolling cap
+// engages at ~22s; distress historically starts right there).
+const cdp = await page.context().newCDPSession(page);
+await cdp.send("Profiler.enable");
+await cdp.send("Profiler.setSamplingInterval", { interval: 1000 });
+const profileWindow = { startS: 16, stopS: 26, started: false, done: false };
+
+const t0 = Date.now();
+let lastWarnCounts = "";
+const samples = [];
+let profile = null;
+while ((Date.now() - t0) / 1000 < DURATION_S) {
+  await page.waitForTimeout(2500);
+  const elapsedS = (Date.now() - t0) / 1000;
+  if (!profileWindow.started && elapsedS >= profileWindow.startS) {
+    profileWindow.started = true;
+    await cdp.send("Profiler.start");
+    console.log("  [profiler] started");
+  } else if (
+    profileWindow.started &&
+    !profileWindow.done &&
+    elapsedS >= profileWindow.stopS
+  ) {
+    profileWindow.done = true;
+    profile = (await cdp.send("Profiler.stop")).profile;
+    console.log("  [profiler] stopped");
+  }
+  const stats = await page.evaluate(() => {
+    const w = window;
+    return {
+      audio: w.__nodetoolRealtimeAudio ?? null,
+      // rough main-thread health while sampling
+      heap: performance.memory ? performance.memory.usedJSHeapSize : null
+    };
+  });
+  const t = Math.round((Date.now() - t0) / 1000);
+  const entries = Object.entries(stats.audio ?? {});
+  if (entries.length === 0) {
+    console.log(`t=${t}s  (no playback stats yet)`);
+    continue;
+  }
+  for (const [id, s] of entries) {
+    const line =
+      `t=${t}s  [${id}] buffered=${s.buffered}f ` +
+      `underruns=${s.underruns} dropped=${s.droppedFrames}f ` +
+      `in=${s.framesIn} out=${s.framesOut} ` +
+      `bus=${s.busChunks ?? 0} effect=${s.effectChunks ?? 0} ` +
+      `maxGap=${s.maxDeliveryGapMs ?? 0}ms` +
+      (stats.heap ? `  heap=${(stats.heap / 1048576).toFixed(0)}MB` : "");
+    console.log(line);
+    samples.push({ t, ...s });
+    const counts = `${s.underruns}/${s.droppedFrames}`;
+    if (lastWarnCounts && counts !== lastWarnCounts) {
+      console.log(`  ^^ distress counters advanced`);
+    }
+    lastWarnCounts = counts;
+  }
+}
+
+if (samples.length >= 2) {
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const dt = last.t - first.t;
+  console.log("\n=== summary ===");
+  console.log(`buffer slope: ${((last.buffered - first.buffered) / dt).toFixed(1)} frames/s`);
+  console.log(`producer rate: ${((last.framesIn - first.framesIn) / dt).toFixed(1)} frames/s (expected 24000)`);
+  console.log(`consumer rate: ${((last.framesOut - first.framesOut) / dt).toFixed(1)} frames/s`);
+  console.log(`underruns: ${last.underruns}, dropped: ${last.droppedFrames} frames`);
+}
+
+if (profile) {
+  // Top self-time functions in the degradation window.
+  const hits = new Map();
+  for (const node of profile.nodes) {
+    if (!node.hitCount) continue;
+    const f = node.callFrame;
+    const url = (f.url || "").split("/").slice(-2).join("/");
+    const key = `${f.functionName || "(anonymous)"} @ ${url}:${f.lineNumber}`;
+    hits.set(key, (hits.get(key) ?? 0) + node.hitCount);
+  }
+  const total = [...hits.values()].reduce((a, b) => a + b, 0);
+  console.log(`\n=== CPU profile t=${profileWindow.startS}-${profileWindow.stopS}s (top self-time) ===`);
+  [...hits.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 18)
+    .forEach(([k, v]) =>
+      console.log(`${((v / total) * 100).toFixed(1).padStart(5)}%  ${k}`)
+    );
+}
+
+await browser.close();

--- a/web/src/components/dialogs/RunWarningDialog.tsx
+++ b/web/src/components/dialogs/RunWarningDialog.tsx
@@ -10,6 +10,7 @@ import { Dialog, Checkbox, Text, FlexColumn } from "../ui_primitives";
  */
 const RunWarningDialog: React.FC = () => {
   const open = useRunWarningStore((s) => s.open);
+  const kind = useRunWarningStore((s) => s.kind);
   const heavyCount = useRunWarningStore((s) => s.heavyCount);
   const threshold = useRunWarningStore((s) => s.threshold);
   const confirm = useRunWarningStore((s) => s.confirm);
@@ -18,38 +19,53 @@ const RunWarningDialog: React.FC = () => {
   const [dontAskAgain, setDontAskAgain] = useState(false);
 
   const handleConfirm = useCallback(() => {
-    confirm(dontAskAgain);
+    // The session suppression only applies to the heavy-run warning; a
+    // concurrent-run confirmation always asks.
+    confirm(kind === "heavy" && dontAskAgain);
     setDontAskAgain(false);
-  }, [confirm, dontAskAgain]);
+  }, [confirm, dontAskAgain, kind]);
 
   const handleCancel = useCallback(() => {
     cancel();
     setDontAskAgain(false);
   }, [cancel]);
 
+  const isConcurrent = kind === "concurrent";
+
   return (
     <Dialog
       open={open}
       onClose={handleCancel}
-      title="Run this workflow?"
+      title={isConcurrent ? "Start another run?" : "Run this workflow?"}
       onConfirm={handleConfirm}
       onCancel={handleCancel}
-      confirmText="Run anyway"
+      confirmText={isConcurrent ? "Start second run" : "Run anyway"}
       cancelText="Cancel"
       content={
         <FlexColumn gap={1.5}>
-          <Text>
-            This run will execute{" "}
-            <strong>{heavyCount} model/provider nodes</strong> — above the
-            warning threshold of {threshold}. Each may call an external API or
-            run a model, so running them all at once can be slow or hit provider
-            rate limits.
-          </Text>
-          <Checkbox
-            label="Don't ask again for this session"
-            checked={dontAskAgain}
-            onChange={(_event, checked) => setDontAskAgain(checked)}
-          />
+          {isConcurrent ? (
+            <Text>
+              This workflow is <strong>already running</strong>. Starting
+              another run will execute both at the same time — for realtime
+              audio patches that means overlapping sound. Stop the current run
+              first if you meant to restart it.
+            </Text>
+          ) : (
+            <>
+              <Text>
+                This run will execute{" "}
+                <strong>{heavyCount} model/provider nodes</strong> — above the
+                warning threshold of {threshold}. Each may call an external API
+                or run a model, so running them all at once can be slow or hit
+                provider rate limits.
+              </Text>
+              <Checkbox
+                label="Don't ask again for this session"
+                checked={dontAskAgain}
+                onChange={(_event, checked) => setDontAskAgain(checked)}
+              />
+            </>
+          )}
         </FlexColumn>
       }
     />

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -792,6 +792,36 @@ function SettingsPage() {
 
                       <SearchItem
                         search={generalSearch}
+                        keywords="audio buffer latency realtime synth playback dropout"
+                      >
+                        <TextInput
+                          type="number"
+                          autoComplete="off"
+                          slotProps={{ htmlInput: { min: 20, max: 1000, step: 10 } }}
+                          id="audio-buffer-ms-input"
+                          label="Audio Buffer (ms)"
+                          value={settings.audioBufferMs ?? 100}
+                          onChange={(e) =>
+                            updateSettings({
+                              audioBufferMs: Math.min(
+                                1000,
+                                Math.max(20, Number(e.target.value) || 100)
+                              )
+                            })
+                          }
+                          variant="standard"
+                          size="small"
+                        />
+                        <Text className="description">
+                          Playback buffer for realtime audio (modular synth
+                          patches). Lower values reduce knob-to-ear latency;
+                          higher values prevent dropouts when the editor is
+                          busy.
+                        </Text>
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
                         keywords="execution max concurrent jobs runs queue concurrency parallel"
                       >
                         <ServerNumberSetting

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -65,7 +65,7 @@ import { ChunkRenderer } from "./output/ChunkRenderer";
 import { ImageComparisonRenderer, type ImageComparisonData } from "./output/ImageComparisonRenderer";
 import { JSONRenderer } from "./output/JSONRenderer";
 import ObjectRenderer from "./output/ObjectRenderer";
-import { RealtimeAudioOutput } from "./output";
+import { RealtimeAudioOutputFromChunks } from "./output";
 import PlotlyRenderer from "./output/PlotlyRenderer";
 import DataframeRenderer from "./output/DataframeRenderer";
 import { isAudioChunkLike, isTextLikeChunk } from "./outputChunkUtils";
@@ -781,7 +781,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
               if (audioChunks.length >= 2) {
                 const firstMeta = audioChunks[0].content_metadata;
                 return (
-                  <RealtimeAudioOutput
+                  <RealtimeAudioOutputFromChunks
                     chunks={audioChunks}
                     sampleRate={(firstMeta?.sample_rate as number | undefined) ?? 22000}
                     channels={(firstMeta?.channels as number | undefined) ?? 1}

--- a/web/src/components/node/output/ChunkRenderer.tsx
+++ b/web/src/components/node/output/ChunkRenderer.tsx
@@ -35,7 +35,11 @@ export const ChunkRenderer: React.FC<Props> = memo(({ chunk }) => {
     case "agent_status":
       return <AgentStatusRenderer chunk={chunk} />;
     case "image":
-      return <ImageView source={chunk.content} />;
+      return (
+        <ImageView
+          source={typeof chunk.content === "string" ? chunk.content : undefined}
+        />
+      );
     case "audio": {
       const meta = chunk.content_metadata;
       return (

--- a/web/src/components/node/output/RealtimeAudioOutput.tsx
+++ b/web/src/components/node/output/RealtimeAudioOutput.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -10,7 +10,13 @@ import { useWebsocketRunner } from "../../../stores/WorkflowRunner";
 import { useRealtimeAudioPlayback } from "../../../hooks/browser/useRealtimeAudioPlayback";
 
 type Props = {
-  chunks: Chunk[];
+  /**
+   * Buffer accessor + change signal instead of the array itself: large chunk
+   * arrays passed as props get deep-serialized per commit by react-dom's
+   * dev performance instrumentation (see useRealtimeAudioPlayback).
+   */
+  getChunks: () => Chunk[];
+  chunksVersion: number;
   sampleRate?: number;
   channels?: number;
   nodeId?: string;
@@ -34,7 +40,8 @@ const styles = (theme: Theme) =>
   });
 
 const RealtimeAudioOutput: React.FC<Props> = ({
-  chunks,
+  getChunks,
+  chunksVersion,
   sampleRate = 22000,
   channels = 1,
   nodeId,
@@ -53,7 +60,8 @@ const RealtimeAudioOutput: React.FC<Props> = ({
     stream,
     visualizerVersion
   } = useRealtimeAudioPlayback({
-    chunks,
+    getChunks,
+    chunksVersion,
     sampleRate,
     channels,
     nodeId,
@@ -90,3 +98,27 @@ const RealtimeAudioOutput: React.FC<Props> = ({
 };
 
 export default React.memo(RealtimeAudioOutput);
+
+/**
+ * Adapter for call sites that hold a plain chunk array (e.g. OutputRenderer's
+ * preview of a completed stream). Converts to the getter+version contract so
+ * the array stops at this boundary instead of flowing further down the tree.
+ */
+export const RealtimeAudioOutputFromChunks: React.FC<
+  Omit<Props, "getChunks" | "chunksVersion"> & { chunks: Chunk[] }
+> = ({ chunks, ...rest }) => {
+  const chunksRef = useRef<Chunk[]>(chunks);
+  const versionRef = useRef(0);
+  if (chunksRef.current !== chunks) {
+    chunksRef.current = chunks;
+    versionRef.current++;
+  }
+  const getChunks = useCallback(() => chunksRef.current, []);
+  return (
+    <RealtimeAudioOutput
+      getChunks={getChunks}
+      chunksVersion={versionRef.current}
+      {...rest}
+    />
+  );
+};

--- a/web/src/components/node/output/RealtimeAudioOutput.tsx
+++ b/web/src/components/node/output/RealtimeAudioOutput.tsx
@@ -14,6 +14,8 @@ type Props = {
   sampleRate?: number;
   channels?: number;
   nodeId?: string;
+  /** Live-monitoring mode: bound scheduling lead, drop stale chunks. */
+  live?: boolean;
 };
 
 const styles = (theme: Theme) =>
@@ -35,7 +37,8 @@ const RealtimeAudioOutput: React.FC<Props> = ({
   chunks,
   sampleRate = 22000,
   channels = 1,
-  nodeId
+  nodeId,
+  live = false
 }) => {
   const theme = useTheme();
   const workflowState = useWebsocketRunner((s) => s.state);
@@ -53,7 +56,8 @@ const RealtimeAudioOutput: React.FC<Props> = ({
     chunks,
     sampleRate,
     channels,
-    nodeId
+    nodeId,
+    live
   });
 
   // Stop playback when workflow stops

--- a/web/src/components/node/output/index.ts
+++ b/web/src/components/node/output/index.ts
@@ -14,5 +14,8 @@ export { EmailRenderer } from "./EmailRenderer";
 export { TextRenderer } from "./TextRenderer";
 export { ImageComparisonRenderer } from "./ImageComparisonRenderer";
 export { JSONRenderer } from "./JSONRenderer";
-export { default as RealtimeAudioOutput } from "./RealtimeAudioOutput";
+export {
+  default as RealtimeAudioOutput,
+  RealtimeAudioOutputFromChunks
+} from "./RealtimeAudioOutput";
 export { default as DataframeRenderer } from "./DataframeRenderer";

--- a/web/src/components/node_types/editing/bespokeRegistry.test.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.test.ts
@@ -20,6 +20,8 @@ import ResizeBody from "./ResizeBody";
 import RotateAndFlipBody from "./RotateAndFlipBody";
 import ScaleBody from "./ScaleBody";
 import SimpleFilterBody from "./SimpleFilterBody";
+import SynthModuleBody from "../synth/SynthModuleBody";
+import { SYNTH_NODE_TYPES } from "../synth/synthModules";
 import type { NodeMetadata } from "../../../stores/ApiTypes";
 
 const meta = (node_type: string): NodeMetadata =>
@@ -176,6 +178,14 @@ describe("bespokeRegistry", () => {
       expect(isBespokeNode(m)).toBe(true);
       expect(getBespokeBody(m)).toBe(SimpleFilterBody);
       expect(BESPOKE_BODY_REGISTRY[t]).toBe(SimpleFilterBody);
+    }
+  });
+
+  it("maps every synth module node type → SynthModuleBody", () => {
+    for (const t of SYNTH_NODE_TYPES) {
+      const m = meta(t);
+      expect(isBespokeNode(m)).toBe(true);
+      expect(getBespokeBody(m)).toBe(SynthModuleBody);
     }
   });
 });

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -49,6 +49,12 @@ import RotateAndFlipBody, {
 import ScaleBody, { SCALE_NODE_TYPE } from "./ScaleBody";
 import SimpleFilterBody from "./SimpleFilterBody";
 import { SIMPLE_FILTER_NODE_TYPES } from "./SimpleFilterBody.constants";
+import AudioOutBody, { AUDIO_OUT_NODE_TYPE } from "../synth/AudioOutBody";
+import SynthModuleBody from "../synth/SynthModuleBody";
+import {
+  SYNTH_MODULE_CONFIGS,
+  SYNTH_NODE_TYPES
+} from "../synth/synthModules";
 
 export interface BespokeBodyProps {
   id: string;
@@ -98,7 +104,11 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   ),
   ...Object.fromEntries(
     ADJUSTMENT_NODE_TYPES.map((t) => [t, AdjustmentBody] as const)
-  )
+  ),
+  ...Object.fromEntries(
+    SYNTH_NODE_TYPES.map((t) => [t, SynthModuleBody] as const)
+  ),
+  [AUDIO_OUT_NODE_TYPE]: AudioOutBody
 };
 
 /**
@@ -113,7 +123,20 @@ export const BESPOKE_DEFAULT_HEIGHTS: Readonly<Record<string, number>> = {
   ...Object.fromEntries(GENERATOR_NODE_TYPES.map((t) => [t, 460] as const)),
   // Adjustment nodes with many sliders that overflow the generic height.
   "lib.image.color_grading.LiftGammaGain": 580,
-  "lib.image.color_grading.SplitToning": 380
+  "lib.image.color_grading.SplitToning": 380,
+  // Synth modules: label strip + extras + knob rows (≈80px per wrapped row
+  // of knobs at the default node width) + output jacks.
+  ...Object.fromEntries(
+    SYNTH_NODE_TYPES.map((t) => {
+      const c = SYNTH_MODULE_CONFIGS[t];
+      const knobRows = Math.ceil(c.knobs.length / 3);
+      const extras =
+        (c.waveform ? 26 : 0) + (c.modeToggle ? 28 : 0) + (c.adsrPreview ? 42 : 0);
+      return [t, 96 + extras + knobRows * 84] as const;
+    })
+  ),
+  // Audio Out: label strip + transport buttons + visualizer.
+  [AUDIO_OUT_NODE_TYPE]: 220
 };
 
 export const isBespokeNode = (

--- a/web/src/components/node_types/synth/AdsrPreview.tsx
+++ b/web/src/components/node_types/synth/AdsrPreview.tsx
@@ -1,0 +1,96 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * AdsrPreview — small SVG sketch of the envelope shape. Segment widths are
+ * log-proportional to the attack/decay/release times (with a floor so tiny
+ * times stay visible) plus a fixed sustain plateau; height is the level.
+ * Purely illustrative — the DSP runs server-side.
+ */
+
+import React, { memo } from "react";
+import { useTheme } from "@mui/material/styles";
+
+const W = 120;
+const H = 36;
+const PAD = 3;
+
+/** Log-compress a time in [0.0005, 10] s to a relative width. */
+const seg = (seconds: number): number => {
+  const t = Math.max(0.0005, Math.min(10, seconds));
+  // 0.0005 → 0, 10 → 1 on a log axis, floored so the segment never vanishes.
+  return Math.max(0.08, Math.log(t / 0.0005) / Math.log(10 / 0.0005));
+};
+
+export interface AdsrPreviewProps {
+  attack: number;
+  decay: number;
+  sustain: number;
+  release: number;
+  accentColor: string;
+}
+
+const AdsrPreviewInner: React.FC<AdsrPreviewProps> = ({
+  attack,
+  decay,
+  sustain,
+  release,
+  accentColor
+}) => {
+  const theme = useTheme();
+  const a = seg(attack);
+  const d = seg(decay);
+  const r = seg(release);
+  const hold = 0.55; // fixed sustain plateau width, relative
+  const total = a + d + hold + r;
+  const usable = W - PAD * 2;
+
+  const x0 = PAD;
+  const x1 = x0 + (a / total) * usable;
+  const x2 = x1 + (d / total) * usable;
+  const x3 = x2 + (hold / total) * usable;
+  const x4 = W - PAD;
+
+  const yBase = H - PAD;
+  const yPeak = PAD;
+  const s = Math.max(0, Math.min(1, sustain));
+  const ySus = yBase - s * (yBase - yPeak);
+
+  const line = `M ${x0},${yBase} L ${x1},${yPeak} L ${x2},${ySus} L ${x3},${ySus} L ${x4},${yBase}`;
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ display: "block", height: H }}
+      aria-label="Envelope shape"
+      role="img"
+    >
+      <path
+        d={`${line} Z`}
+        fill={accentColor}
+        opacity={0.15}
+        stroke="none"
+      />
+      <path
+        d={line}
+        fill="none"
+        stroke={accentColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <line
+        x1={PAD}
+        y1={yBase}
+        x2={W - PAD}
+        y2={yBase}
+        stroke={theme.vars.palette.grey[700]}
+        strokeWidth={1}
+      />
+    </svg>
+  );
+};
+
+export const AdsrPreview = memo(AdsrPreviewInner);
+AdsrPreview.displayName = "AdsrPreview";
+export default AdsrPreview;

--- a/web/src/components/node_types/synth/AudioOutBody.tsx
+++ b/web/src/components/node_types/synth/AudioOutBody.tsx
@@ -8,7 +8,7 @@
  * transport buttons and a visualizer on the faceplate.
  */
 
-import React, { memo, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -136,6 +136,18 @@ const AudioOutBodyInner: React.FC<AudioOutBodyProps> = ({
     return isAudioChunk(streamBuffer) ? [streamBuffer] : [];
   }, [streamBuffer]);
 
+  // Hand the buffer to the player as getter+version, never as a prop: the
+  // full rolling window (1024 chunks × sample payloads) as a React prop gets
+  // deep-serialized by react-dom's dev performance instrumentation on every
+  // commit — the GC storm behind "dropouts after ~30s".
+  const chunksRef = useRef(chunks);
+  const versionRef = useRef(0);
+  if (chunksRef.current !== chunks) {
+    chunksRef.current = chunks;
+    versionRef.current++;
+  }
+  const getChunks = useCallback(() => chunksRef.current, []);
+
   const firstMeta = chunks[0]?.content_metadata;
 
   return (
@@ -146,7 +158,8 @@ const AudioOutBodyInner: React.FC<AudioOutBodyProps> = ({
       {chunks.length > 0 ? (
         <div className="player nodrag">
           <RealtimeAudioOutput
-            chunks={chunks}
+            getChunks={getChunks}
+            chunksVersion={versionRef.current}
             sampleRate={(firstMeta?.sample_rate as number | undefined) ?? 24000}
             channels={(firstMeta?.channels as number | undefined) ?? 1}
             nodeId={id}

--- a/web/src/components/node_types/synth/AudioOutBody.tsx
+++ b/web/src/components/node_types/synth/AudioOutBody.tsx
@@ -1,0 +1,172 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * AudioOutBody — bespoke body for `nodetool.audio.realtime.AudioOutput`,
+ * the modular patch's speaker module. The node passes chunks through
+ * verbatim; this body reads the node's live stream buffer (`outputResults`,
+ * appended per `output_update` during the run — the same mechanism
+ * OutputNode uses) and plays it via the realtime playback hook, with
+ * transport buttons and a visualizer on the faceplate.
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import HandleColumn from "../../node/HandleColumn";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import RealtimeAudioOutput from "../../node/output/RealtimeAudioOutput";
+
+import type { Chunk, NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import useResultsStore from "../../../stores/ResultsStore";
+import useWorkflowRunsStore from "../../../stores/WorkflowRunsStore";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.audio-out-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.75),
+      padding: theme.spacing(1),
+      minHeight: 0,
+      borderRadius: "var(--rounded-sm)",
+      backgroundColor: theme.vars.palette.grey[900]
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: 0
+    },
+    ".module-label": {
+      alignSelf: "center",
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeTiny,
+      fontWeight: 700,
+      letterSpacing: "0.18em",
+      textTransform: "uppercase",
+      lineHeight: 1,
+      color: theme.vars.palette.text.secondary,
+      padding: `2px ${theme.spacing(1)}`,
+      borderRadius: "var(--rounded-sm)",
+      border: `1px solid ${theme.vars.palette.grey[800]}`
+    },
+    ".player": {
+      flex: "1 1 auto",
+      minHeight: 0,
+      padding: `0 ${theme.spacing(0.5)}`
+    },
+    ".idle-hint": {
+      flex: "1 1 auto",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      fontSize: theme.fontSizeTiny,
+      color: theme.vars.palette.text.secondary,
+      textAlign: "center"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    },
+    ".node-body.collapsed &.audio-out-body": {
+      padding: 0,
+      gap: 0,
+      minHeight: 0,
+      height: 0,
+      overflow: "visible",
+      "& > .module-label, & > .player, & > .idle-hint": {
+        display: "none"
+      },
+      "& > .outputs-row": {
+        height: 0,
+        minHeight: 0,
+        padding: 0
+      }
+    }
+  });
+
+const isAudioChunk = (v: unknown): v is Chunk => {
+  if (!v || typeof v !== "object") return false;
+  const c = v as Record<string, unknown>;
+  if (c.type !== "chunk" || c.content_type !== "audio") return false;
+  // Payload is either a native Float32Array (in-process) or a non-empty
+  // base64 string (wire form / external sources).
+  return (
+    (c.content instanceof Float32Array && c.content.length > 0) ||
+    (typeof c.content === "string" && c.content !== "")
+  );
+};
+
+export interface AudioOutBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const AudioOutBodyInner: React.FC<AudioOutBodyProps> = ({
+  id,
+  nodeMetadata,
+  workflowId,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const chunkProperty = useMemo(
+    () => (nodeMetadata.properties ?? []).filter((p) => p.name === "chunk"),
+    [nodeMetadata.properties]
+  );
+
+  const focusedJob = useWorkflowRunsStore((s) => s.focusedJob[workflowId]);
+  const streamBuffer = useResultsStore((s) =>
+    focusedJob ? s.getOutputResult(workflowId, focusedJob, id) : undefined
+  );
+
+  const chunks = useMemo(() => {
+    if (Array.isArray(streamBuffer)) {
+      return streamBuffer.filter(isAudioChunk);
+    }
+    return isAudioChunk(streamBuffer) ? [streamBuffer] : [];
+  }, [streamBuffer]);
+
+  const firstMeta = chunks[0]?.content_metadata;
+
+  return (
+    <div css={cssStyles} className="audio-out-body" data-bespoke-body="AudioOut">
+      <HandleColumn id={id} properties={chunkProperty} />
+      <span className="module-label">Out</span>
+
+      {chunks.length > 0 ? (
+        <div className="player nodrag">
+          <RealtimeAudioOutput
+            chunks={chunks}
+            sampleRate={(firstMeta?.sample_rate as number | undefined) ?? 24000}
+            channels={(firstMeta?.channels as number | undefined) ?? 1}
+            nodeId={id}
+            live
+          />
+        </div>
+      ) : (
+        <div className="idle-hint">Run the patch to hear it</div>
+      )}
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const AUDIO_OUT_NODE_TYPE = "nodetool.audio.realtime.AudioOutput";
+export const AudioOutBody = memo(AudioOutBodyInner);
+AudioOutBody.displayName = "AudioOutBody";
+export default AudioOutBody;

--- a/web/src/components/node_types/synth/SynthKnob.tsx
+++ b/web/src/components/node_types/synth/SynthKnob.tsx
@@ -1,0 +1,253 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SynthKnob — rotary knob for the synth module bodies. 270° sweep, SVG arc
+ * with a pointer line; drag vertically to adjust (Shift = fine), double-click
+ * to reset to default, arrow keys when focused. Log-scaled specs sweep
+ * perceptually (frequencies, envelope times); bipolar specs fill the arc
+ * outward from their neutral point.
+ */
+
+import React, { memo, useCallback, useRef } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import {
+  clamp,
+  formatKnobValue,
+  knobDenorm,
+  knobNorm,
+  type KnobSpec
+} from "./synthModules";
+
+const KNOB_SIZE = 44;
+const ARC_RADIUS = 18;
+const ARC_STROKE = 3;
+/** Sweep: -135° (min) to +135° (max), 0° pointing up. */
+const SWEEP_DEG = 270;
+const START_DEG = -135;
+/** Vertical drag distance for a full min→max sweep. */
+const DRAG_RANGE_PX = 160;
+
+const polar = (deg: number, r: number): { x: number; y: number } => {
+  const rad = ((deg - 90) * Math.PI) / 180;
+  const c = KNOB_SIZE / 2;
+  return { x: c + r * Math.cos(rad), y: c + r * Math.sin(rad) };
+};
+
+const arcPath = (fromDeg: number, toDeg: number): string => {
+  const a = Math.min(fromDeg, toDeg);
+  const b = Math.max(fromDeg, toDeg);
+  const start = polar(a, ARC_RADIUS);
+  const end = polar(b, ARC_RADIUS);
+  const largeArc = b - a > 180 ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${ARC_RADIUS} ${ARC_RADIUS} 0 ${largeArc} 1 ${end.x} ${end.y}`;
+};
+
+export const synthKnobStyles = (theme: Theme) =>
+  css({
+    ".knob": {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: 2,
+      width: KNOB_SIZE + 12,
+      outline: "none",
+      "&:focus-visible .knob-face": {
+        boxShadow: `0 0 0 2px color-mix(in srgb, ${theme.vars.palette.primary.main} 60%, transparent)`
+      }
+    },
+    ".knob-face": {
+      width: KNOB_SIZE,
+      height: KNOB_SIZE,
+      borderRadius: "50%",
+      cursor: "ns-resize",
+      touchAction: "none",
+      backgroundColor: theme.vars.palette.grey[800],
+      boxShadow: "inset 0 1px 2px rgba(0,0,0,0.5), 0 1px 1px rgba(0,0,0,0.3)"
+    },
+    ".knob-label": {
+      fontSize: theme.fontSizeTiny,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.05em",
+      lineHeight: 1,
+      whiteSpace: "nowrap"
+    },
+    ".knob-value": {
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeTiny,
+      fontVariantNumeric: "tabular-nums",
+      color: theme.vars.palette.text.primary,
+      lineHeight: 1,
+      whiteSpace: "nowrap"
+    }
+  });
+
+export interface SynthKnobProps {
+  spec: KnobSpec;
+  value: number;
+  /** Arc/pointer color — the module's resolved accent. */
+  accentColor: string;
+  onChange: (name: string, v: number) => void;
+  onCommit: () => void;
+}
+
+const roundForSpec = (spec: KnobSpec, v: number): number => {
+  // Log specs span decades — keep 4 significant digits; linear specs keep
+  // two decimals (enough for every current 0–10-ish range).
+  if (spec.scale === "log") {
+    return Number(v.toPrecision(4));
+  }
+  return Math.round(v * 100) / 100;
+};
+
+const SynthKnobInner: React.FC<SynthKnobProps> = ({
+  spec,
+  value,
+  accentColor,
+  onChange,
+  onCommit
+}) => {
+  const theme = useTheme();
+  const dragStart = useRef<{ y: number; t: number } | null>(null);
+
+  const t = knobNorm(spec, value);
+  const angle = START_DEG + t * SWEEP_DEG;
+  // Bipolar knobs fill from their neutral point (where 0 sits); unipolar
+  // knobs fill from the minimum.
+  const neutralT = spec.bipolar ? knobNorm(spec, 0) : 0;
+  const neutralAngle = START_DEG + neutralT * SWEEP_DEG;
+  const pointerTip = polar(angle, ARC_RADIUS - 5);
+  const pointerBase = polar(angle, 6);
+
+  const applyNorm = useCallback(
+    (nextT: number) => {
+      onChange(spec.name, roundForSpec(spec, knobDenorm(spec, nextT)));
+    },
+    [onChange, spec]
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragStart.current = { y: e.clientY, t: knobNorm(spec, value) };
+    },
+    [spec, value]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragStart.current) {
+        return;
+      }
+      const fine = e.shiftKey ? 0.1 : 1;
+      const dt =
+        ((dragStart.current.y - e.clientY) / DRAG_RANGE_PX) * fine;
+      applyNorm(clamp(dragStart.current.t + dt, 0, 1));
+    },
+    [applyNorm]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragStart.current) {
+        return;
+      }
+      dragStart.current = null;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      onCommit();
+    },
+    [onCommit]
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    onChange(spec.name, spec.default);
+    onCommit();
+  }, [onChange, onCommit, spec]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const step = e.shiftKey ? 0.005 : 0.02;
+      let nextT: number | null = null;
+      if (e.key === "ArrowUp" || e.key === "ArrowRight") {
+        nextT = clamp(knobNorm(spec, value) + step, 0, 1);
+      } else if (e.key === "ArrowDown" || e.key === "ArrowLeft") {
+        nextT = clamp(knobNorm(spec, value) - step, 0, 1);
+      } else if (e.key === "Home") {
+        nextT = 0;
+      } else if (e.key === "End") {
+        nextT = 1;
+      }
+      if (nextT !== null) {
+        e.preventDefault();
+        applyNorm(nextT);
+        onCommit();
+      }
+    },
+    [applyNorm, onCommit, spec, value]
+  );
+
+  return (
+    <div
+      className="knob nodrag"
+      role="slider"
+      tabIndex={0}
+      aria-label={spec.label}
+      aria-valuemin={spec.min}
+      aria-valuemax={spec.max}
+      aria-valuenow={value}
+      aria-valuetext={formatKnobValue(spec, value)}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className="knob-face"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+      >
+        <svg
+          width={KNOB_SIZE}
+          height={KNOB_SIZE}
+          viewBox={`0 0 ${KNOB_SIZE} ${KNOB_SIZE}`}
+          aria-hidden="true"
+        >
+          <path
+            d={arcPath(START_DEG, START_DEG + SWEEP_DEG)}
+            fill="none"
+            stroke={theme.vars.palette.grey[600]}
+            strokeWidth={ARC_STROKE}
+            strokeLinecap="round"
+          />
+          {Math.abs(angle - neutralAngle) > 0.5 && (
+            <path
+              d={arcPath(neutralAngle, angle)}
+              fill="none"
+              stroke={accentColor}
+              strokeWidth={ARC_STROKE}
+              strokeLinecap="round"
+            />
+          )}
+          <line
+            x1={pointerBase.x}
+            y1={pointerBase.y}
+            x2={pointerTip.x}
+            y2={pointerTip.y}
+            stroke={theme.vars.palette.text.primary}
+            strokeWidth={2}
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+      <span className="knob-label">{spec.label}</span>
+      <span className="knob-value">{formatKnobValue(spec, value)}</span>
+    </div>
+  );
+};
+
+export const SynthKnob = memo(SynthKnobInner);
+SynthKnob.displayName = "SynthKnob";
+export default SynthKnob;

--- a/web/src/components/node_types/synth/SynthModuleBody.tsx
+++ b/web/src/components/node_types/synth/SynthModuleBody.tsx
@@ -1,0 +1,333 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SynthModuleBody — shared bespoke body for the modular-synthesis audio
+ * nodes. Renders a Eurorack-style faceplate: input jacks on the left
+ * (HandleColumn), a module label strip, optional waveform selector / mode
+ * toggle / ADSR preview, and a grid of rotary knobs for the numeric
+ * parameters. Per-node configuration lives in `synthModules.ts`.
+ */
+
+import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { ToggleGroup, ToggleOption } from "../../ui_primitives";
+import HandleColumn from "../../node/HandleColumn";
+import { NodeOutputs } from "../../node/NodeOutputs";
+import NodeProgress from "../../node/NodeProgress";
+
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+import type { NodeData } from "../../../stores/NodeData";
+import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
+import { useWebsocketRunner } from "../../../stores/WorkflowRunner";
+import AdsrPreview from "./AdsrPreview";
+import SynthKnob, { synthKnobStyles } from "./SynthKnob";
+import {
+  SYNTH_MODULE_CONFIGS,
+  type SynthAccent
+} from "./synthModules";
+import WaveformSelector, {
+  waveformSelectorStyles
+} from "./WaveformSelector";
+
+const styles = (theme: Theme) =>
+  css({
+    "&.synth-module-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.75),
+      padding: theme.spacing(1),
+      minHeight: 0,
+      borderRadius: "var(--rounded-sm)",
+      backgroundColor: theme.vars.palette.grey[900]
+    },
+    "& > .handle-column": {
+      top: theme.spacing(1),
+      bottom: theme.spacing(1),
+      left: 0
+    },
+    ".module-label": {
+      alignSelf: "center",
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeTiny,
+      fontWeight: 700,
+      letterSpacing: "0.18em",
+      textTransform: "uppercase",
+      lineHeight: 1,
+      color: theme.vars.palette.text.secondary,
+      padding: `2px ${theme.spacing(1)}`,
+      borderRadius: "var(--rounded-sm)",
+      border: `1px solid ${theme.vars.palette.grey[800]}`
+    },
+    ".adsr-preview": {
+      padding: `0 ${theme.spacing(0.5)}`
+    },
+    ".mode-toggle": {
+      alignSelf: "center",
+      ".MuiToggleButton-root": {
+        padding: `2px ${theme.spacing(1.5)}`,
+        fontSize: theme.fontSizeTiny,
+        fontFamily: theme.fontFamily2,
+        lineHeight: 1.4,
+        minWidth: 0
+      }
+    },
+    ".knob-grid": {
+      flex: "1 1 auto",
+      display: "flex",
+      flexWrap: "wrap",
+      justifyContent: "center",
+      alignItems: "flex-start",
+      alignContent: "center",
+      columnGap: theme.spacing(0.5),
+      rowGap: theme.spacing(1),
+      minHeight: 0
+    },
+    ".jack-labels": {
+      display: "flex",
+      flexDirection: "column",
+      gap: 2,
+      position: "absolute",
+      left: theme.spacing(1.25),
+      top: theme.spacing(1),
+      pointerEvents: "none"
+    },
+    ".jack-label": {
+      fontSize: theme.fontSizeTiny,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.05em",
+      lineHeight: "18px",
+      height: 18,
+      marginBottom: theme.spacing(2),
+      "&:last-child": { marginBottom: 0 }
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    },
+    /* Collapsed: hide the faceplate, keep handles. */
+    ".node-body.collapsed &.synth-module-body": {
+      padding: 0,
+      gap: 0,
+      minHeight: 0,
+      height: 0,
+      overflow: "visible",
+      "& > .module-label, & > .adsr-preview, & > .mode-toggle, & > .knob-grid, & > .waveform-row, & > .jack-labels":
+        {
+          display: "none"
+        },
+      "& > .outputs-row": {
+        height: 0,
+        minHeight: 0,
+        padding: 0
+      }
+    }
+  });
+
+const ACCENT_FALLBACK: SynthAccent = "primary";
+
+export interface SynthModuleBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(
+    () => [styles(theme), synthKnobStyles(theme), waveformSelectorStyles(theme)],
+    [theme]
+  );
+
+  const config = SYNTH_MODULE_CONFIGS[nodeType];
+  const accentColor =
+    theme.vars.palette[config?.accent ?? ACCENT_FALLBACK].main;
+
+  const inputProperties = useMemo(() => {
+    const names = new Set(config?.inputs ?? []);
+    return (nodeMetadata.properties ?? []).filter((p) => names.has(p.name));
+  }, [config, nodeMetadata.properties]);
+
+  const props = data.properties ?? {};
+
+  const { setProperty, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  // Live parameter path: while a patch is running, knob/selector changes are
+  // also pushed straight into the running job's node instance, so the sound
+  // follows the knob. Throttled to chunk-ish cadence; trailing value wins.
+  const updateRunningNodeProperties = useWebsocketRunner(
+    (s) => s.updateRunningNodeProperties
+  );
+  const liveThrottle = useRef<{
+    timer: ReturnType<typeof setTimeout> | null;
+    pending: Record<string, unknown>;
+  }>({ timer: null, pending: {} });
+  const pushLive = useCallback(
+    (name: string, value: unknown) => {
+      const t = liveThrottle.current;
+      t.pending[name] = value;
+      if (t.timer !== null) {
+        return;
+      }
+      t.timer = setTimeout(() => {
+        t.timer = null;
+        const updates = t.pending;
+        t.pending = {};
+        updateRunningNodeProperties(id, updates);
+      }, 33);
+    },
+    [id, updateRunningNodeProperties]
+  );
+  useEffect(() => {
+    const t = liveThrottle.current;
+    return () => {
+      if (t.timer !== null) {
+        clearTimeout(t.timer);
+      }
+    };
+  }, []);
+
+  const handleKnobChange = useCallback(
+    (name: string, v: number) => {
+      setProperty(name, v);
+      pushLive(name, v);
+    },
+    [pushLive, setProperty]
+  );
+
+  const handleWaveformChange = useCallback(
+    (value: string) => {
+      setProperty(config!.waveform!.name, value);
+      pushLive(config!.waveform!.name, value);
+      setPropertyComplete();
+    },
+    [config, pushLive, setProperty, setPropertyComplete]
+  );
+
+  const handleModeChange = useCallback(
+    (_: unknown, value: string | null) => {
+      if (value !== null) {
+        setProperty(config!.modeToggle!.name, value);
+        pushLive(config!.modeToggle!.name, value);
+        setPropertyComplete();
+      }
+    },
+    [config, pushLive, setProperty, setPropertyComplete]
+  );
+
+  if (!config) {
+    return null;
+  }
+
+  const numberProp = (name: string, def: number): number => {
+    const v = Number(props[name]);
+    return Number.isFinite(v) ? v : def;
+  };
+
+  return (
+    <div
+      css={cssStyles}
+      className="synth-module-body"
+      data-bespoke-body="SynthModule"
+    >
+      <HandleColumn id={id} properties={inputProperties} />
+      {inputProperties.length > 0 && (
+        <div className="jack-labels" aria-hidden="true">
+          {inputProperties.map((p) => (
+            <span key={p.name} className="jack-label">
+              {p.name.replace(/_/g, " ")}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <span className="module-label">{config.label}</span>
+
+      {config.waveform && (
+        <WaveformSelector
+          options={config.waveform.options}
+          value={String(props[config.waveform.name] ?? config.waveform.default)}
+          accentColor={accentColor}
+          onChange={handleWaveformChange}
+        />
+      )}
+
+      {config.modeToggle && (
+        <ToggleGroup
+          className="mode-toggle nodrag"
+          size="small"
+          exclusive
+          value={String(
+            props[config.modeToggle.name] ?? config.modeToggle.default
+          )}
+          onChange={handleModeChange}
+          aria-label={config.modeToggle.name}
+        >
+          {config.modeToggle.options.map((o) => (
+            <ToggleOption key={o.value} value={o.value}>
+              {o.label}
+            </ToggleOption>
+          ))}
+        </ToggleGroup>
+      )}
+
+      {config.adsrPreview && (
+        <div className="adsr-preview">
+          <AdsrPreview
+            attack={numberProp("attack", 0.01)}
+            decay={numberProp("decay", 0.1)}
+            sustain={numberProp("sustain", 0.7)}
+            release={numberProp("release", 0.3)}
+            accentColor={accentColor}
+          />
+        </div>
+      )}
+
+      {config.knobs.length > 0 && (
+        <div className="knob-grid">
+          {config.knobs.map((spec) => (
+            <SynthKnob
+              key={spec.name}
+              spec={spec}
+              value={numberProp(spec.name, spec.default)}
+              accentColor={accentColor}
+              onChange={handleKnobChange}
+              onCommit={setPropertyComplete}
+            />
+          ))}
+        </div>
+      )}
+
+      {!isOutputNode && (
+        <div className="outputs-row">
+          <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+        </div>
+      )}
+
+      {status === "running" && <NodeProgress id={id} workflowId={workflowId} />}
+    </div>
+  );
+};
+
+export const SynthModuleBody = memo(SynthModuleBodyInner);
+SynthModuleBody.displayName = "SynthModuleBody";
+export default SynthModuleBody;

--- a/web/src/components/node_types/synth/WaveformSelector.tsx
+++ b/web/src/components/node_types/synth/WaveformSelector.tsx
@@ -70,7 +70,7 @@ const WaveformSelectorInner: React.FC<WaveformSelectorProps> = ({
   );
 
   return (
-    <div className="waveform-row nodrag" role="radiogroup" aria-label="Waveform">
+    <div className="waveform-row nodrag" role="group" aria-label="Waveform">
       {options.map((w) => {
         const active = w === value;
         return (
@@ -79,8 +79,7 @@ const WaveformSelectorInner: React.FC<WaveformSelectorProps> = ({
             type="button"
             value={w}
             className={`waveform-btn${active ? " active" : ""}`}
-            role="radio"
-            aria-checked={active}
+            aria-pressed={active}
             aria-label={w}
             title={w}
             onClick={handleClick}

--- a/web/src/components/node_types/synth/WaveformSelector.tsx
+++ b/web/src/components/node_types/synth/WaveformSelector.tsx
@@ -1,0 +1,112 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * WaveformSelector — icon toggle row for an oscillator/LFO waveform enum.
+ * One small SVG glyph per waveform; the active one lights in the module's
+ * accent color.
+ */
+
+import React, { memo, useCallback } from "react";
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+
+const GLYPH_W = 18;
+const GLYPH_H = 10;
+
+/** Waveform glyph paths in an 18×10 viewBox (stroke, no fill). */
+const WAVE_PATHS: Readonly<Record<string, string>> = {
+  sine: "M0,5 C2.5,-1 6.5,-1 9,5 C11.5,11 15.5,11 18,5",
+  saw: "M0,9 L8,1 L8,9 L16,1 L16,9",
+  square: "M0,9 L0,1 L6,1 L6,9 L12,9 L12,1 L18,1",
+  triangle: "M0,9 L4.5,1 L13.5,9 L18,1",
+  noise: "M0,5 L2,2 L4,8 L6,3 L8,7 L10,1 L12,9 L14,4 L16,6 L18,5"
+};
+
+export const waveformSelectorStyles = (theme: Theme) =>
+  css({
+    ".waveform-row": {
+      display: "flex",
+      justifyContent: "center",
+      gap: 2
+    },
+    ".waveform-btn": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: 26,
+      height: 20,
+      padding: 0,
+      border: "none",
+      borderRadius: "var(--rounded-sm)",
+      backgroundColor: "transparent",
+      color: theme.vars.palette.text.secondary,
+      cursor: "pointer",
+      "&:hover": {
+        backgroundColor: theme.vars.palette.grey[800]
+      },
+      "&.active": {
+        backgroundColor: theme.vars.palette.grey[800]
+      }
+    }
+  });
+
+export interface WaveformSelectorProps {
+  options: readonly string[];
+  value: string;
+  accentColor: string;
+  onChange: (value: string) => void;
+}
+
+const WaveformSelectorInner: React.FC<WaveformSelectorProps> = ({
+  options,
+  value,
+  accentColor,
+  onChange
+}) => {
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      onChange(e.currentTarget.value);
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="waveform-row nodrag" role="radiogroup" aria-label="Waveform">
+      {options.map((w) => {
+        const active = w === value;
+        return (
+          <button
+            key={w}
+            type="button"
+            value={w}
+            className={`waveform-btn${active ? " active" : ""}`}
+            role="radio"
+            aria-checked={active}
+            aria-label={w}
+            title={w}
+            onClick={handleClick}
+          >
+            <svg
+              width={GLYPH_W}
+              height={GLYPH_H}
+              viewBox={`0 0 ${GLYPH_W} ${GLYPH_H}`}
+              aria-hidden="true"
+            >
+              <path
+                d={WAVE_PATHS[w] ?? WAVE_PATHS.sine}
+                fill="none"
+                stroke={active ? accentColor : "currentColor"}
+                strokeWidth={1.5}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export const WaveformSelector = memo(WaveformSelectorInner);
+WaveformSelector.displayName = "WaveformSelector";
+export default WaveformSelector;

--- a/web/src/components/node_types/synth/__tests__/synthModules.test.ts
+++ b/web/src/components/node_types/synth/__tests__/synthModules.test.ts
@@ -1,0 +1,75 @@
+import {
+  formatKnobValue,
+  knobDenorm,
+  knobNorm,
+  SYNTH_MODULE_CONFIGS,
+  SYNTH_NODE_TYPES,
+  type KnobSpec
+} from "../synthModules";
+
+const linear: KnobSpec = { name: "x", label: "X", min: 0, max: 10, default: 1 };
+const log: KnobSpec = {
+  name: "f",
+  label: "F",
+  min: 20,
+  max: 20000,
+  default: 1000,
+  scale: "log",
+  unit: "hz"
+};
+
+describe("knob math", () => {
+  it("normalizes linearly and round-trips", () => {
+    expect(knobNorm(linear, 0)).toBe(0);
+    expect(knobNorm(linear, 10)).toBe(1);
+    expect(knobNorm(linear, 5)).toBeCloseTo(0.5);
+    expect(knobDenorm(linear, knobNorm(linear, 7.3))).toBeCloseTo(7.3);
+  });
+
+  it("normalizes log scale: geometric midpoint sits at t = 0.5", () => {
+    expect(knobNorm(log, 20)).toBe(0);
+    expect(knobNorm(log, 20000)).toBe(1);
+    // sqrt(20 * 20000) ≈ 632.45
+    expect(knobNorm(log, Math.sqrt(20 * 20000))).toBeCloseTo(0.5);
+    expect(knobDenorm(log, knobNorm(log, 440))).toBeCloseTo(440);
+  });
+
+  it("clamps out-of-range values", () => {
+    expect(knobNorm(linear, -5)).toBe(0);
+    expect(knobNorm(linear, 99)).toBe(1);
+    expect(knobDenorm(linear, 2)).toBe(10);
+  });
+
+  it("formats units compactly", () => {
+    expect(formatKnobValue(log, 440)).toBe("440 Hz");
+    expect(formatKnobValue(log, 1200)).toBe("1.20 kHz");
+    expect(
+      formatKnobValue({ ...linear, unit: "s" }, 0.25)
+    ).toBe("250 ms");
+    expect(formatKnobValue({ ...linear, unit: "s" }, 1.5)).toBe("1.50 s");
+    expect(
+      formatKnobValue({ ...linear, unit: "db", bipolar: true }, 3)
+    ).toBe("+3.0 dB");
+  });
+});
+
+describe("synth module configs", () => {
+  it("log-scaled knobs have a strictly positive minimum", () => {
+    for (const t of SYNTH_NODE_TYPES) {
+      for (const k of SYNTH_MODULE_CONFIGS[t].knobs) {
+        if (k.scale === "log") {
+          expect(k.min).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("every knob default lies within its range", () => {
+    for (const t of SYNTH_NODE_TYPES) {
+      for (const k of SYNTH_MODULE_CONFIGS[t].knobs) {
+        expect(k.default).toBeGreaterThanOrEqual(k.min);
+        expect(k.default).toBeLessThanOrEqual(k.max);
+      }
+    }
+  });
+});

--- a/web/src/components/node_types/synth/synthModules.ts
+++ b/web/src/components/node_types/synth/synthModules.ts
@@ -1,0 +1,328 @@
+/**
+ * Synth module configs — drives `SynthModuleBody`, the shared bespoke body
+ * for the modular-synthesis audio nodes (`nodetool.audio.synth.*`) and the
+ * realtime streaming effects. One config per node type: which input handles
+ * to render as jacks, which properties become knobs, and the module's
+ * accent color and extras (waveform selector, mode toggle, ADSR preview).
+ */
+
+export type KnobUnit = "hz" | "s" | "db" | "x" | "";
+
+export interface KnobSpec {
+  name: string;
+  label: string;
+  min: number;
+  max: number;
+  default: number;
+  /** "log" requires min > 0 — used for frequencies and envelope times. */
+  scale?: "linear" | "log";
+  /** Range straddles 0 with a neutral midpoint — arc fills outward from it. */
+  bipolar?: boolean;
+  unit?: KnobUnit;
+}
+
+export interface EnumToggleSpec {
+  name: string;
+  default: string;
+  options: ReadonlyArray<{ value: string; label: string }>;
+}
+
+/** Palette key used for the module's accent (knob arcs, waveform icons). */
+export type SynthAccent =
+  | "primary"
+  | "secondary"
+  | "warning"
+  | "info"
+  | "success"
+  | "error";
+
+export interface SynthModuleConfig {
+  /** Short faceplate label, Eurorack style ("VCO", "ADSR", …). */
+  label: string;
+  accent: SynthAccent;
+  /** Property names rendered as input jacks (the node's `inputFields`). */
+  inputs: readonly string[];
+  knobs: readonly KnobSpec[];
+  /** Waveform enum property, rendered as an icon selector. */
+  waveform?: { name: string; default: string; options: readonly string[] };
+  /** Generic enum toggle (e.g. VCF lowpass/highpass). */
+  modeToggle?: EnumToggleSpec;
+  /** Render the ADSR envelope preview above the knobs. */
+  adsrPreview?: boolean;
+}
+
+const ENVELOPE_TIME = { min: 0.0005, max: 10, scale: "log", unit: "s" } as const;
+
+export const SYNTH_MODULE_CONFIGS: Readonly<Record<string, SynthModuleConfig>> =
+  {
+    "nodetool.audio.synth.Oscillator": {
+      label: "VCO",
+      accent: "warning",
+      inputs: ["pitch_cv", "fm"],
+      waveform: {
+        name: "waveform",
+        default: "sine",
+        options: ["sine", "saw", "square", "triangle", "noise"]
+      },
+      knobs: [
+        {
+          name: "frequency",
+          label: "Freq",
+          min: 0.1,
+          max: 20000,
+          default: 220,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "amplitude", label: "Level", min: 0, max: 1, default: 0.8 },
+        {
+          name: "pulse_width",
+          label: "PW",
+          min: 0.05,
+          max: 0.95,
+          default: 0.5
+        },
+        { name: "fm_amount", label: "FM Amt", min: 0, max: 10, default: 0 }
+      ]
+    },
+    "nodetool.audio.synth.LFO": {
+      label: "LFO",
+      accent: "info",
+      inputs: ["clock"],
+      waveform: {
+        name: "waveform",
+        default: "sine",
+        options: ["sine", "triangle", "saw", "square"]
+      },
+      knobs: [
+        {
+          name: "rate_hz",
+          label: "Rate",
+          min: 0.01,
+          max: 100,
+          default: 2,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "depth", label: "Depth", min: 0, max: 10, default: 1 },
+        {
+          name: "offset",
+          label: "Offset",
+          min: -10,
+          max: 10,
+          default: 0,
+          bipolar: true
+        }
+      ]
+    },
+    "nodetool.audio.synth.ADSR": {
+      label: "ADSR",
+      accent: "success",
+      inputs: ["gate"],
+      adsrPreview: true,
+      knobs: [
+        { name: "attack", label: "A", default: 0.01, ...ENVELOPE_TIME },
+        { name: "decay", label: "D", default: 0.1, ...ENVELOPE_TIME },
+        { name: "sustain", label: "S", min: 0, max: 1, default: 0.7 },
+        { name: "release", label: "R", default: 0.3, ...ENVELOPE_TIME }
+      ]
+    },
+    "nodetool.audio.synth.Gate": {
+      label: "GATE",
+      accent: "error",
+      inputs: [],
+      knobs: [
+        {
+          name: "on_duration",
+          label: "On",
+          min: 0.001,
+          max: 60,
+          default: 0.25,
+          scale: "log",
+          unit: "s"
+        },
+        {
+          name: "off_duration",
+          label: "Off",
+          min: 0.001,
+          max: 60,
+          default: 0.25,
+          scale: "log",
+          unit: "s"
+        },
+        { name: "amplitude", label: "Level", min: 0, max: 10, default: 1 }
+      ]
+    },
+    "nodetool.audio.synth.VCA": {
+      label: "VCA",
+      accent: "primary",
+      inputs: ["audio", "cv"],
+      knobs: [{ name: "gain", label: "Gain", min: 0, max: 10, default: 1 }]
+    },
+    "nodetool.audio.synth.VCF": {
+      label: "VCF",
+      accent: "secondary",
+      inputs: ["audio", "cutoff_cv"],
+      modeToggle: {
+        name: "mode",
+        default: "lowpass",
+        options: [
+          { value: "lowpass", label: "LP" },
+          { value: "highpass", label: "HP" }
+        ]
+      },
+      knobs: [
+        {
+          name: "cutoff_hz",
+          label: "Cutoff",
+          min: 20,
+          max: 20000,
+          default: 1000,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "q", label: "Res", min: 0.1, max: 10, default: 0.707 },
+        { name: "cv_amount", label: "CV Amt", min: 0, max: 5, default: 1 }
+      ]
+    },
+    "nodetool.audio.synth.Attenuverter": {
+      label: "ATTV",
+      accent: "info",
+      inputs: ["signal"],
+      knobs: [
+        {
+          name: "scale",
+          label: "Scale",
+          min: -10,
+          max: 10,
+          default: 1,
+          bipolar: true
+        },
+        {
+          name: "offset",
+          label: "Offset",
+          min: -10,
+          max: 10,
+          default: 0,
+          bipolar: true
+        }
+      ]
+    },
+    "nodetool.audio.synth.SampleHold": {
+      label: "S & H",
+      accent: "warning",
+      inputs: ["signal", "trigger"],
+      knobs: []
+    },
+    "nodetool.audio.synth.Mixer": {
+      label: "MIX",
+      accent: "primary",
+      inputs: ["in1", "in2", "in3", "in4"],
+      knobs: [
+        { name: "level1", label: "Ch 1", min: 0, max: 2, default: 1 },
+        { name: "level2", label: "Ch 2", min: 0, max: 2, default: 1 },
+        { name: "level3", label: "Ch 3", min: 0, max: 2, default: 1 },
+        { name: "level4", label: "Ch 4", min: 0, max: 2, default: 1 }
+      ]
+    },
+    "nodetool.audio.realtime.StreamingGain": {
+      label: "GAIN",
+      accent: "primary",
+      inputs: ["chunk"],
+      knobs: [
+        {
+          name: "gain_db",
+          label: "Gain",
+          min: -60,
+          max: 24,
+          default: 0,
+          bipolar: true,
+          unit: "db"
+        }
+      ]
+    },
+    "nodetool.audio.realtime.StreamingLowPass": {
+      label: "LPF",
+      accent: "secondary",
+      inputs: ["chunk"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Cutoff",
+          min: 500,
+          max: 20000,
+          default: 5000,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "q", label: "Res", min: 0.1, max: 10, default: 0.707 }
+      ]
+    },
+    "nodetool.audio.realtime.StreamingHighPass": {
+      label: "HPF",
+      accent: "secondary",
+      inputs: ["chunk"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Cutoff",
+          min: 20,
+          max: 5000,
+          default: 80,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "q", label: "Res", min: 0.1, max: 10, default: 0.707 }
+      ]
+    }
+  };
+
+export const SYNTH_NODE_TYPES: readonly string[] = Object.keys(
+  SYNTH_MODULE_CONFIGS
+);
+
+// ── Knob value math ────────────────────────────────────────────────
+
+export const clamp = (v: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, v));
+
+/** Normalize a knob value to t ∈ [0, 1] on the spec's scale. */
+export const knobNorm = (spec: KnobSpec, value: number): number => {
+  const v = clamp(value, spec.min, spec.max);
+  if (spec.scale === "log") {
+    return Math.log(v / spec.min) / Math.log(spec.max / spec.min);
+  }
+  return spec.max === spec.min ? 0 : (v - spec.min) / (spec.max - spec.min);
+};
+
+/** Inverse of {@link knobNorm}. */
+export const knobDenorm = (spec: KnobSpec, t: number): number => {
+  const c = clamp(t, 0, 1);
+  if (spec.scale === "log") {
+    return spec.min * Math.pow(spec.max / spec.min, c);
+  }
+  return spec.min + c * (spec.max - spec.min);
+};
+
+/** Compact human-readable knob value ("440 Hz", "1.2 kHz", "250 ms", "+3.0 dB"). */
+export const formatKnobValue = (spec: KnobSpec, value: number): string => {
+  switch (spec.unit) {
+    case "hz":
+      return value >= 1000
+        ? `${(value / 1000).toFixed(value >= 10000 ? 1 : 2)} kHz`
+        : `${value < 10 ? value.toFixed(2) : Math.round(value)} Hz`;
+    case "s":
+      return value < 1
+        ? `${Math.round(value * 1000)} ms`
+        : `${value.toFixed(value < 10 ? 2 : 1)} s`;
+    case "db": {
+      const sign = value > 0 ? "+" : "";
+      return `${sign}${value.toFixed(1)} dB`;
+    }
+    default: {
+      const rounded = Math.round(value * 100) / 100;
+      const sign = spec.bipolar && rounded > 0 ? "+" : "";
+      return `${sign}${rounded}`;
+    }
+  }
+};

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -370,6 +370,10 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
   const messages = state.messageCache[threadId] || [];
   const lastMessage = messages[messages.length - 1];
 
+  // Audio chunks carry binary payloads (native Float32Array or base64);
+  // only text contributes to the assistant message stream.
+  const chunkText = typeof chunk.content === "string" ? chunk.content : "";
+
   // Get current message length for deduplication check
   const currentMessageLength =
     lastMessage && lastMessage.role === "assistant"
@@ -377,7 +381,7 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
       : 0;
 
   // Check for duplicate chunk (can happen with multiple WebSocket handlers)
-  if (isChunkDuplicate(threadId, chunk.content, currentMessageLength)) {
+  if (isChunkDuplicate(threadId, chunkText, currentMessageLength)) {
     // Still update status if this is the final chunk
     if (chunk.done) {
       clearChunkCache(threadId);
@@ -398,7 +402,7 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
   let newMessageLength: number;
 
   if (lastMessage && lastMessage.role === "assistant") {
-    const newContent = (lastMessage.content || "") + chunk.content;
+    const newContent = (lastMessage.content || "") + chunkText;
     newMessageLength = newContent.length;
     const updatedMessage: Message = {
       ...lastMessage,
@@ -409,18 +413,18 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
     const localStreamId = `local-stream-${Date.now()}-${Math.random()
       .toString(16)
       .slice(2)}`;
-    newMessageLength = chunk.content.length;
+    newMessageLength = chunkText.length;
     const message: Message = {
       id: localStreamId,
       role: "assistant",
       type: "message",
-      content: chunk.content
+      content: chunkText
     };
     updatedMessages = [...messages, message];
   }
 
   // Record this chunk as processed for deduplication
-  recordProcessedChunk(threadId, chunk.content, newMessageLength);
+  recordProcessedChunk(threadId, chunkText, newMessageLength);
 
   // Preserve statusMessage during media generation (it's set from
   // content_metadata.media_generation in the chunk handler above).

--- a/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
+++ b/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
@@ -8,6 +8,7 @@ import { triggerAutosaveForWorkflow } from "../useAutosave";
 import useNodeMenuStore from "../../stores/NodeMenuStore";
 import { useBottomPanelStore } from "../../stores/BottomPanelStore";
 import { useMiniMapStore } from "../../stores/MiniMapStore";
+import { useRunWarningStore } from "../../stores/RunWarningStore";
 
 jest.mock("react-router-dom", () => ({
   useNavigate: jest.fn(() => jest.fn()),
@@ -204,7 +205,7 @@ describe("useFloatingToolbarActions", () => {
       expect(mockRun).toHaveBeenCalled();
     });
 
-    it("still calls run while running so the store can queue it", async () => {
+    it("asks for confirmation while running, then runs on confirm", async () => {
       mockUseWebsocketRunner.mockImplementation((selector) => {
         const mockRunnerState = {
           run: mockRun,
@@ -227,7 +228,16 @@ describe("useFloatingToolbarActions", () => {
         await result.current.handleRun();
       });
 
-      // Clicking Run while busy now reaches the store, which enqueues it.
+      // Clicking Run while busy opens the concurrent-run confirmation
+      // instead of starting a second run outright.
+      expect(mockRun).not.toHaveBeenCalled();
+      const warning = useRunWarningStore.getState();
+      expect(warning.open).toBe(true);
+      expect(warning.kind).toBe("concurrent");
+
+      await act(async () => {
+        useRunWarningStore.getState().confirm(false);
+      });
       expect(mockRun).toHaveBeenCalled();
     });
 

--- a/web/src/hooks/browser/useRealtimeAudioPlayback.ts
+++ b/web/src/hooks/browser/useRealtimeAudioPlayback.ts
@@ -9,7 +9,18 @@ import { useSettingsStore } from "../../stores/SettingsStore";
 import { subscribeRealtimeAudioChunks } from "../../lib/audio/realtimeAudioChunkBus";
 
 interface UseRealtimeAudioPlaybackOptions {
-  chunks: Chunk[];
+  /**
+   * Accessor for the current chunk buffer, paired with `chunksVersion` to
+   * signal updates. The array is deliberately NOT taken as a plain value:
+   * anything passed as a React prop gets deep-serialized by react-dom's
+   * dev-build performance instrumentation on every commit — for a full
+   * 1024-chunk rolling buffer that is megabytes per commit, enough GC churn
+   * to stall the main thread and starve the playback worklet (the
+   * "dropouts after ~30s" failure mode; onset = time to fill the window).
+   */
+  getChunks: () => Chunk[];
+  /** Increment whenever the buffer content changes. */
+  chunksVersion: number;
   sampleRate?: number;
   channels?: number;
   nodeId?: string; // Optional ID for this audio source
@@ -29,6 +40,34 @@ const DEFAULT_AUDIO_BUFFER_MS = 100;
 const MIN_AUDIO_BUFFER_MS = 20;
 const MAX_AUDIO_BUFFER_MS = 1000;
 
+interface RealtimeAudioStats {
+  buffered: number;
+  underruns: number;
+  droppedFrames: number;
+  framesIn: number;
+  framesOut: number;
+  updatedAt: number;
+  /** Chunks delivered via the realtime bus (fast path). */
+  busChunks?: number;
+  /** Chunks delivered via the store-driven scheduling effect. */
+  effectChunks?: number;
+  /** Largest gap between consecutive worklet hand-offs (ms). */
+  maxDeliveryGapMs?: number;
+}
+
+/**
+ * Per-instance worklet buffer stats, exposed for field debugging:
+ * `window.__nodetoolRealtimeAudio` in the console shows live buffer level,
+ * underrun and stale-drop counters for every playing realtime output.
+ */
+function getRealtimeAudioDebug(): Record<string, RealtimeAudioStats> {
+  const w = window as Window & {
+    __nodetoolRealtimeAudio?: Record<string, RealtimeAudioStats>;
+  };
+  w.__nodetoolRealtimeAudio ??= {};
+  return w.__nodetoolRealtimeAudio;
+}
+
 interface UseRealtimeAudioPlaybackReturn {
   isPlaying: boolean;
   isQueued: boolean;
@@ -46,7 +85,8 @@ interface UseRealtimeAudioPlaybackReturn {
  * Integrates with global audio queue to prevent overlapping playback.
  */
 export const useRealtimeAudioPlayback = ({
-  chunks,
+  getChunks,
+  chunksVersion,
   sampleRate = 22000,
   channels = 1,
   nodeId,
@@ -70,6 +110,23 @@ export const useRealtimeAudioPlayback = ({
   // flushed — only then may bus-delivered chunks go straight to the worklet
   // (engaging earlier would post new chunks ahead of the unflushed backlog).
   const liveSinkActiveRef = useRef<boolean>(false);
+  const audioStatsRef = useRef<RealtimeAudioStats | null>(null);
+  const deliveryDebugRef = useRef({
+    busChunks: 0,
+    effectChunks: 0,
+    lastDeliveryAt: 0,
+    maxDeliveryGapMs: 0
+  });
+  const noteDelivery = useCallback((via: "bus" | "effect") => {
+    const d = deliveryDebugRef.current;
+    const now = performance.now();
+    if (d.lastDeliveryAt > 0) {
+      d.maxDeliveryGapMs = Math.max(d.maxDeliveryGapMs, now - d.lastDeliveryAt);
+    }
+    d.lastDeliveryAt = now;
+    if (via === "bus") d.busChunks++;
+    else d.effectChunks++;
+  }, []);
   const [internalPlaying, setInternalPlaying] = useState<boolean>(false);
   const [wantsToPlay, setWantsToPlay] = useState<boolean>(true);
   const [visualizerVersion, setVisualizerVersion] = useState<number>(0);
@@ -150,6 +207,47 @@ export const useRealtimeAudioPlayback = ({
           outputChannelCount: [Math.max(1, channels)]
         });
         node.connect(gain);
+        // Buffer-health telemetry (1 Hz from the processor). Underruns and
+        // stale-drops are the two dropout mechanisms; warn when they advance
+        // so a field report pinpoints which side starves/floods the buffer.
+        node.port.onmessage = (event: MessageEvent) => {
+          const d = event.data as {
+            type?: string;
+            buffered?: number;
+            underruns?: number;
+            droppedFrames?: number;
+            framesIn?: number;
+            framesOut?: number;
+          };
+          if (d?.type !== "stats") return;
+          const prev = audioStatsRef.current;
+          audioStatsRef.current = {
+            buffered: d.buffered ?? 0,
+            underruns: d.underruns ?? 0,
+            droppedFrames: d.droppedFrames ?? 0,
+            framesIn: d.framesIn ?? 0,
+            framesOut: d.framesOut ?? 0,
+            updatedAt: Date.now(),
+            busChunks: deliveryDebugRef.current.busChunks,
+            effectChunks: deliveryDebugRef.current.effectChunks,
+            maxDeliveryGapMs: Math.round(
+              deliveryDebugRef.current.maxDeliveryGapMs
+            )
+          };
+          getRealtimeAudioDebug()[instanceIdRef.current] =
+            audioStatsRef.current;
+          if (
+            prev &&
+            ((d.underruns ?? 0) > prev.underruns ||
+              (d.droppedFrames ?? 0) > prev.droppedFrames)
+          ) {
+            console.warn(
+              `[realtime-audio] ${instanceIdRef.current} buffer distress: ` +
+                `buffered=${d.buffered} underruns=${d.underruns} ` +
+                `droppedFrames=${d.droppedFrames} (in=${d.framesIn} out=${d.framesOut})`
+            );
+          }
+        };
         workletNodeRef.current = node;
         setWorkletState("ready");
       } catch {
@@ -356,7 +454,7 @@ export const useRealtimeAudioPlayback = ({
       return;
     }
     const ctx = audioContextRef.current;
-    const pending = chunks.filter(
+    const pending = getChunks().filter(
       (c) =>
         c?.content_type === "audio" &&
         (typeof c.content === "string" ||
@@ -373,6 +471,7 @@ export const useRealtimeAudioPlayback = ({
         scheduledChunksRef.current.add(chunk);
         const samples = decodeChunkSamples(chunk);
         if (samples && samples.length > 0) {
+          noteDelivery("effect");
           workletNode.port.postMessage({ type: "chunk", samples });
         }
       }
@@ -422,7 +521,8 @@ export const useRealtimeAudioPlayback = ({
       }
     }
   }, [
-    chunks,
+    getChunks,
+    chunksVersion,
     internalPlaying,
     isQueuedPlaying,
     live,
@@ -431,7 +531,8 @@ export const useRealtimeAudioPlayback = ({
     maxLeadSeconds,
     decodeChunkSamples,
     chunkDurationSeconds,
-    scheduleChunk
+    scheduleChunk,
+    noteDelivery
   ]);
 
   // React-free live feed: chunks published by the message handler go to the
@@ -456,10 +557,11 @@ export const useRealtimeAudioPlayback = ({
       scheduledChunksRef.current.add(chunk);
       const samples = decodeChunkSamples(chunk);
       if (samples && samples.length > 0) {
+        noteDelivery("bus");
         workletNode.port.postMessage({ type: "chunk", samples });
       }
     });
-  }, [nodeId, decodeChunkSamples]);
+  }, [nodeId, decodeChunkSamples, noteDelivery]);
 
   // Public start: requests playback via queue
   const start = useCallback(() => {

--- a/web/src/hooks/browser/useRealtimeAudioPlayback.ts
+++ b/web/src/hooks/browser/useRealtimeAudioPlayback.ts
@@ -5,13 +5,29 @@ import {
   int16ToFloat32
 } from "../../components/node/output/audio";
 import { useAudioQueue } from "../../stores/AudioQueueStore";
+import { useSettingsStore } from "../../stores/SettingsStore";
+import { subscribeRealtimeAudioChunks } from "../../lib/audio/realtimeAudioChunkBus";
 
 interface UseRealtimeAudioPlaybackOptions {
   chunks: Chunk[];
   sampleRate?: number;
   channels?: number;
   nodeId?: string; // Optional ID for this audio source
+  /**
+   * Live-monitoring mode: keep the scheduled lead over the playhead within a
+   * small bound by dropping stale chunks instead of queueing them. Use for
+   * infinite realtime streams (modular patches) where hearing "now" matters
+   * more than hearing everything. Off by default so completed streams keep
+   * full replay semantics.
+   */
+  live?: boolean;
 }
+
+/** Default live buffer when the setting is absent/invalid (ms). */
+const DEFAULT_AUDIO_BUFFER_MS = 100;
+/** Clamp range for the configurable buffer (ms). */
+const MIN_AUDIO_BUFFER_MS = 20;
+const MAX_AUDIO_BUFFER_MS = 1000;
 
 interface UseRealtimeAudioPlaybackReturn {
   isPlaying: boolean;
@@ -33,22 +49,55 @@ export const useRealtimeAudioPlayback = ({
   chunks,
   sampleRate = 22000,
   channels = 1,
-  nodeId
+  nodeId,
+  live = false
 }: UseRealtimeAudioPlaybackOptions): UseRealtimeAudioPlaybackReturn => {
   const audioContextRef = useRef<AudioContext | null>(null);
   const streamDestRef = useRef<MediaStreamAudioDestinationNode | null>(null);
   const gainRef = useRef<GainNode | null>(null);
   const nextStartTimeRef = useRef<number>(0);
   const sourcesRef = useRef<AudioBufferSourceNode[]>([]);
-  const lastIndexRef = useRef<number>(0);
-  const scheduledChunkIndices = useRef<Set<number>>(new Set());
+  // Scheduled chunks tracked by object identity, not array index: chunk
+  // arrays get replaced when a new run starts and may be head-trimmed by the
+  // store's live-buffer cap, so indices are not stable but the chunk objects
+  // are.
+  const scheduledChunksRef = useRef<WeakSet<Chunk>>(new WeakSet());
   const instanceIdRef = useRef<string>(
     nodeId || `audio-${Date.now()}-${Math.random()}`
   );
   const restartTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True once the worklet sink is playing and the store-side backlog has been
+  // flushed — only then may bus-delivered chunks go straight to the worklet
+  // (engaging earlier would post new chunks ahead of the unflushed backlog).
+  const liveSinkActiveRef = useRef<boolean>(false);
   const [internalPlaying, setInternalPlaying] = useState<boolean>(false);
   const [wantsToPlay, setWantsToPlay] = useState<boolean>(true);
   const [visualizerVersion, setVisualizerVersion] = useState<number>(0);
+
+  // Preferred sink: an AudioWorklet that buffers and renders chunks on the
+  // audio rendering thread — playback is then immune to main-thread jank.
+  // "pending" while the worklet module loads; "unavailable" falls back to
+  // AudioBufferSourceNode-per-chunk scheduling.
+  const workletNodeRef = useRef<AudioWorkletNode | null>(null);
+  const [workletState, setWorkletState] = useState<
+    "pending" | "ready" | "unavailable"
+  >("pending");
+
+  // Configurable live buffer: max audio held ahead of the playhead. Smaller
+  // = lower knob-to-ear latency, larger = more dropout resilience. The prime
+  // (jitter re-fill) level scales with it.
+  const audioBufferMs = useSettingsStore((s) => s.settings.audioBufferMs);
+  const maxLeadSeconds =
+    Math.min(
+      MAX_AUDIO_BUFFER_MS,
+      Math.max(
+        MIN_AUDIO_BUFFER_MS,
+        Number.isFinite(audioBufferMs) && audioBufferMs > 0
+          ? audioBufferMs
+          : DEFAULT_AUDIO_BUFFER_MS
+      )
+    ) / 1000;
+  const primeSeconds = Math.min(0.04, maxLeadSeconds / 2);
 
   const audioQueue = useAudioQueue();
   const isQueuedPlaying = audioQueue.isPlaying(instanceIdRef.current);
@@ -62,7 +111,15 @@ export const useRealtimeAudioPlayback = ({
     type WebkitAudioWindow = Window & { webkitAudioContext?: typeof AudioContext };
     const Ctx: typeof AudioContext =
       window.AudioContext || (window as WebkitAudioWindow).webkitAudioContext!;
-    const ctx: AudioContext = new Ctx();
+    // Ask for the chunk sample rate so the worklet's resampler is a
+    // pass-through; browsers that don't support the option get their default
+    // rate and the worklet interpolates.
+    let ctx: AudioContext;
+    try {
+      ctx = new Ctx({ sampleRate, latencyHint: "interactive" });
+    } catch {
+      ctx = new Ctx();
+    }
     audioContextRef.current = ctx;
     const streamDest = ctx.createMediaStreamDestination();
     streamDestRef.current = streamDest;
@@ -72,14 +129,36 @@ export const useRealtimeAudioPlayback = ({
     gain.connect(streamDest);
     nextStartTimeRef.current = ctx.currentTime;
 
-    let raf = 0;
-    const tick = () => {
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
+    // Load the worklet sink. The URL module is imported dynamically so its
+    // `import.meta.url` never reaches the jest transform; environments
+    // without AudioWorklet (or a failed module load) fall back to
+    // buffer-source scheduling.
+    let cancelled = false;
+    setWorkletState("pending");
+    (async () => {
+      try {
+        if (typeof ctx.audioWorklet?.addModule !== "function") {
+          throw new Error("AudioWorklet unavailable");
+        }
+        const { getChunkPlayerWorkletUrl } = await import(
+          "../../lib/audio/chunkPlayerWorkletUrl"
+        );
+        await ctx.audioWorklet.addModule(getChunkPlayerWorkletUrl());
+        if (cancelled) return;
+        const node = new AudioWorkletNode(ctx, "nodetool-chunk-player", {
+          numberOfInputs: 0,
+          outputChannelCount: [Math.max(1, channels)]
+        });
+        node.connect(gain);
+        workletNodeRef.current = node;
+        setWorkletState("ready");
+      } catch {
+        if (!cancelled) setWorkletState("unavailable");
+      }
+    })();
 
     return () => {
-      cancelAnimationFrame(raf);
+      cancelled = true;
       sourcesRef.current.forEach((s) => {
         try {
           s.stop();
@@ -89,6 +168,12 @@ export const useRealtimeAudioPlayback = ({
         }
       });
       sourcesRef.current = [];
+      try {
+        workletNodeRef.current?.disconnect();
+      } catch {
+        // Silently ignore worklet disconnect errors during unmount
+      }
+      workletNodeRef.current = null;
       try {
         ctx.close();
       } catch {
@@ -103,29 +188,76 @@ export const useRealtimeAudioPlayback = ({
         restartTimeoutRef.current = null;
       }
     };
-  }, []);
+  }, [sampleRate, channels]);
+
+  // Keep the worklet's stream parameters current.
+  useEffect(() => {
+    const node = workletNodeRef.current;
+    if (workletState !== "ready" || !node) return;
+    node.port.postMessage({
+      type: "config",
+      sampleRate,
+      channels,
+      live,
+      // Live patches prime a small jitter buffer and cap the backlog (drop
+      // stale audio, monitor "now"); replay streams buffer without bound.
+      primeSeconds: live ? primeSeconds : 0.02,
+      maxLeadSeconds: live ? maxLeadSeconds : 0
+    });
+  }, [workletState, sampleRate, channels, live, primeSeconds, maxLeadSeconds]);
+
+  // Interleaved float samples from any of the three chunk payload forms:
+  // native Float32Array (in-process), base64 f32le (websocket wire form),
+  // or base64 pcm16 (external/legacy sources).
+  const decodeChunkSamples = useCallback(
+    (chunk: Chunk): Float32Array | null => {
+      const content = chunk.content;
+      if (content instanceof Float32Array) {
+        return content;
+      }
+      if (typeof content !== "string" || !content) {
+        return null;
+      }
+      const u8 = base64ToUint8Array(content);
+      const encoding = (
+        chunk.content_metadata as { encoding?: unknown } | undefined
+      )?.encoding;
+      if (encoding === "f32le") {
+        return new Float32Array(u8.buffer, u8.byteOffset, u8.byteLength / 4);
+      }
+      const frameSamples = new Int16Array(
+        u8.buffer,
+        u8.byteOffset,
+        u8.byteLength / 2
+      );
+      return int16ToFloat32(frameSamples);
+    },
+    []
+  );
 
   const scheduleChunk = useCallback(
-    (base64: string) => {
+    (chunk: Chunk) => {
       const ctx = audioContextRef.current;
       const gain = gainRef.current;
-      if (!ctx || !gain || !base64) {
+      if (!ctx || !gain) {
         return;
       }
-      const u8 = base64ToUint8Array(base64);
-      const view = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
-      const frameCount = Math.floor(u8.byteLength / 2 / channels);
+      const samples = decodeChunkSamples(chunk);
+      if (!samples || samples.length === 0) {
+        return;
+      }
+      const frameCount = Math.floor(samples.length / channels);
       const buffer = ctx.createBuffer(channels, frameCount, sampleRate);
-      for (let ch = 0; ch < channels; ch++) {
-        const channelData = new Int16Array(frameCount);
-        let srcIndex = ch * 2;
-        for (let i = 0; i < frameCount; i++) {
-          const sample = view.getInt16(srcIndex, true);
-          channelData[i] = sample;
-          srcIndex += channels * 2;
+      if (channels === 1) {
+        buffer.copyToChannel(samples as Float32Array<ArrayBuffer>, 0);
+      } else {
+        for (let ch = 0; ch < channels; ch++) {
+          const channelData = new Float32Array(frameCount);
+          for (let i = 0; i < frameCount; i++) {
+            channelData[i] = samples[i * channels + ch];
+          }
+          buffer.copyToChannel(channelData, ch);
         }
-        const floatData = int16ToFloat32(channelData);
-        buffer.copyToChannel(floatData as Float32Array<ArrayBuffer>, ch);
       }
       const source = ctx.createBufferSource();
       source.buffer = buffer;
@@ -148,7 +280,7 @@ export const useRealtimeAudioPlayback = ({
       };
       sourcesRef.current.push(source);
     },
-    [channels, sampleRate]
+    [channels, sampleRate, decodeChunkSamples]
   );
 
   // Internal play/stop functions (called by queue)
@@ -168,6 +300,9 @@ export const useRealtimeAudioPlayback = ({
 
   const internalStop = useCallback(() => {
     setInternalPlaying(false);
+    liveSinkActiveRef.current = false;
+    // Drop the worklet's buffered audio so sound stops immediately.
+    workletNodeRef.current?.port.postMessage({ type: "reset" });
     sourcesRef.current.forEach((s) => {
       try {
         s.stop();
@@ -183,24 +318,148 @@ export const useRealtimeAudioPlayback = ({
     }
   }, []);
 
+  // Duration of one chunk without decoding it (native Float32Array, base64
+  // f32le, or base64 pcm16 payloads).
+  const chunkDurationSeconds = useCallback(
+    (chunk: Chunk): number => {
+      const content = chunk.content;
+      if (content instanceof Float32Array) {
+        return Math.floor(content.length / channels) / sampleRate;
+      }
+      if (typeof content !== "string" || !content) {
+        return 0;
+      }
+      let bytes = Math.floor((content.length * 3) / 4);
+      if (content.endsWith("==")) {
+        bytes -= 2;
+      } else if (content.endsWith("=")) {
+        bytes -= 1;
+      }
+      const encoding = (
+        chunk.content_metadata as { encoding?: unknown } | undefined
+      )?.encoding;
+      const bytesPerSample = encoding === "f32le" ? 4 : 2;
+      return Math.floor(bytes / bytesPerSample / channels) / sampleRate;
+    },
+    [channels, sampleRate]
+  );
+
   // Schedule newly arrived chunks when actually playing (queue approved)
   useEffect(() => {
     if (!internalPlaying || !isQueuedPlaying) {
+      liveSinkActiveRef.current = false;
       return;
     }
-    const audioChunks = chunks.filter(
-      (c) => c?.content_type === "audio" && typeof c.content === "string"
-    );
-    for (let i = lastIndexRef.current; i < audioChunks.length; i++) {
-      // Skip if already scheduled (prevents double-scheduling in StrictMode)
-      if (scheduledChunkIndices.current.has(i)) {
-        continue;
-      }
-      scheduleChunk(audioChunks[i].content as string);
-      scheduledChunkIndices.current.add(i);
+    if (workletState === "pending") {
+      // Sink not decided yet; chunks stay unscheduled (WeakSet untouched)
+      // and re-enter on the next effect run once the worklet resolves.
+      return;
     }
-    lastIndexRef.current = audioChunks.length;
-  }, [chunks, internalPlaying, isQueuedPlaying, scheduleChunk]);
+    const ctx = audioContextRef.current;
+    const pending = chunks.filter(
+      (c) =>
+        c?.content_type === "audio" &&
+        (typeof c.content === "string" ||
+          c.content instanceof Float32Array) &&
+        !scheduledChunksRef.current.has(c)
+    );
+
+    // Worklet sink: hand the samples to the audio thread and be done — the
+    // processor owns priming, jitter buffering and live stale-dropping.
+    const workletNode =
+      workletState === "ready" ? workletNodeRef.current : null;
+    if (workletNode) {
+      for (const chunk of pending) {
+        scheduledChunksRef.current.add(chunk);
+        const samples = decodeChunkSamples(chunk);
+        if (samples && samples.length > 0) {
+          workletNode.port.postMessage({ type: "chunk", samples });
+        }
+      }
+      // Backlog flushed — from here on, the bus delivers new chunks to the
+      // worklet directly (same task as the message, no render round trip).
+      liveSinkActiveRef.current = true;
+      return;
+    }
+    liveSinkActiveRef.current = false;
+    if (pending.length === 0) {
+      return;
+    }
+
+    // Fallback sink: buffer-source-per-chunk scheduling on the main thread.
+    // In live mode, cap how far the schedule may run ahead of the playhead.
+    // Without the cap, any backlog — chunks buffered before the audio queue
+    // approved playback, or a burst after a main-thread stall — is queued
+    // back-to-back and becomes *permanent* monitoring latency. Walk the
+    // pending chunks newest-first, keep what fits in the lead budget, and
+    // drop the rest as stale.
+    let firstKept = 0;
+    if (live && ctx) {
+      if (nextStartTimeRef.current <= ctx.currentTime) {
+        // Underrun (or fresh start): re-prime a small jitter buffer so the
+        // next late chunk doesn't click.
+        nextStartTimeRef.current = ctx.currentTime + primeSeconds;
+      }
+      let budget =
+        maxLeadSeconds - (nextStartTimeRef.current - ctx.currentTime);
+      firstKept = pending.length;
+      for (let i = pending.length - 1; i >= 0; i--) {
+        const duration = chunkDurationSeconds(pending[i]);
+        if (duration > budget) {
+          break;
+        }
+        budget -= duration;
+        firstKept = i;
+      }
+    }
+
+    for (let i = 0; i < pending.length; i++) {
+      // Dropped chunks are marked scheduled too — they're consumed, not
+      // deferred.
+      scheduledChunksRef.current.add(pending[i]);
+      if (i >= firstKept) {
+        scheduleChunk(pending[i]);
+      }
+    }
+  }, [
+    chunks,
+    internalPlaying,
+    isQueuedPlaying,
+    live,
+    workletState,
+    primeSeconds,
+    maxLeadSeconds,
+    decodeChunkSamples,
+    chunkDurationSeconds,
+    scheduleChunk
+  ]);
+
+  // React-free live feed: chunks published by the message handler go to the
+  // worklet in the delivery task itself, so playback doesn't wait on a React
+  // render. The WeakSet dedupes against the store-driven effect above, which
+  // remains the path for backlog flush, fallback scheduling and replay.
+  useEffect(() => {
+    if (!nodeId) {
+      return;
+    }
+    return subscribeRealtimeAudioChunks(nodeId, (chunk) => {
+      if (!liveSinkActiveRef.current) return;
+      const workletNode = workletNodeRef.current;
+      if (!workletNode || scheduledChunksRef.current.has(chunk)) return;
+      if (
+        chunk.content_type !== "audio" ||
+        (typeof chunk.content !== "string" &&
+          !(chunk.content instanceof Float32Array))
+      ) {
+        return;
+      }
+      scheduledChunksRef.current.add(chunk);
+      const samples = decodeChunkSamples(chunk);
+      if (samples && samples.length > 0) {
+        workletNode.port.postMessage({ type: "chunk", samples });
+      }
+    });
+  }, [nodeId, decodeChunkSamples]);
 
   // Public start: requests playback via queue
   const start = useCallback(() => {
@@ -221,8 +480,7 @@ export const useRealtimeAudioPlayback = ({
 
   const restart = useCallback(() => {
     stop();
-    lastIndexRef.current = 0; // Reset to replay all chunks
-    scheduledChunkIndices.current.clear(); // Clear scheduled indices for replay
+    scheduledChunksRef.current = new WeakSet(); // Reset to replay all chunks
     setVisualizerVersion((v) => v + 1);
     // Clear any existing timeout before setting a new one
     if (restartTimeoutRef.current !== null) {

--- a/web/src/hooks/browser/useRealtimeAudioPlayback.ts
+++ b/web/src/hooks/browser/useRealtimeAudioPlayback.ts
@@ -168,12 +168,14 @@ export const useRealtimeAudioPlayback = ({
     type WebkitAudioWindow = Window & { webkitAudioContext?: typeof AudioContext };
     const Ctx: typeof AudioContext =
       window.AudioContext || (window as WebkitAudioWindow).webkitAudioContext!;
-    // Ask for the chunk sample rate so the worklet's resampler is a
-    // pass-through; browsers that don't support the option get their default
-    // rate and the worklet interpolates.
+    // Run the context at the system's native sample rate. Forcing the chunk
+    // rate (24 kHz) makes the browser resample the whole context output to
+    // the hardware rate downstream — extra latency, and flaky on devices
+    // that dislike non-native rates (Bluetooth, macOS aggregate devices).
+    // The chunk-player worklet resamples chunk-rate → context-rate itself.
     let ctx: AudioContext;
     try {
-      ctx = new Ctx({ sampleRate, latencyHint: "interactive" });
+      ctx = new Ctx({ latencyHint: "interactive" });
     } catch {
       ctx = new Ctx();
     }
@@ -286,7 +288,10 @@ export const useRealtimeAudioPlayback = ({
         restartTimeoutRef.current = null;
       }
     };
-  }, [sampleRate, channels]);
+    // channels only: the context runs at the system rate regardless of the
+    // chunk rate, so a sampleRate change just reconfigures the worklet (next
+    // effect) instead of rebuilding the AudioContext.
+  }, [channels]);
 
   // Keep the worklet's stream parameters current.
   useEffect(() => {

--- a/web/src/hooks/useFloatingToolbarActions.ts
+++ b/web/src/hooks/useFloatingToolbarActions.ts
@@ -119,13 +119,31 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
       // Access current state directly to avoid re-renders on every node drag
       const { nodes, edges } = nodeStore.getState();
       run({}, workflow, nodes, edges, undefined, undefined, true);
+      setTimeout(() => {
+        const w = getWorkflowById(workflow.id);
+        if (w) {
+          saveWorkflow(w);
+        }
+      }, 100);
     };
 
-    // Clicking Run while a run is in progress queues another run rather than
-    // being ignored — the store enqueues it and fires it when the current run
-    // finishes. "Run Workflow" fires every executable node at once, so warn
-    // first when a run would launch many provider/model nodes, unless the user
-    // disabled the warning or dismissed it for this session.
+    // Clicking Run while a run is in progress starts a second run alongside
+    // it (for in-browser runs the server queue can't see the active run, so
+    // "queued" starts immediately). That's rarely what a double-click meant —
+    // always confirm first. Never suppressed.
+    if (isWorkflowRunning || isPaused || isSuspended) {
+      requestRunConfirmation({
+        kind: "concurrent",
+        onConfirm: () => {
+          void doRun();
+        }
+      });
+      return;
+    }
+
+    // "Run Workflow" fires every executable node at once, so warn first when
+    // a run would launch many provider/model nodes, unless the user disabled
+    // the warning or dismissed it for this session.
     const { nodes } = nodeStore.getState();
     const heavyCount = countHeavyNodes(
       nodes,
@@ -143,12 +161,6 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     } else {
       await doRun();
     }
-    setTimeout(() => {
-      const w = getWorkflowById(workflow.id);
-      if (w) {
-        saveWorkflow(w);
-      }
-    }, 100);
   }, [
     run,
     workflow,
@@ -158,7 +170,10 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     autosave,
     confirmLargeRun,
     largeRunThreshold,
-    requestRunConfirmation
+    requestRunConfirmation,
+    isWorkflowRunning,
+    isPaused,
+    isSuspended
   ]);
 
   const handleStop = useCallback(() => {

--- a/web/src/lib/audio/chunkPlayerProcessor.js
+++ b/web/src/lib/audio/chunkPlayerProcessor.js
@@ -14,8 +14,10 @@
  *   the max lead — a live patch monitors "now", stale audio is worse than a
  *   dropped instant.
  * - Linear-interpolation resampling from the chunk sample rate to the
- *   context rate (the context is created at the chunk rate when the browser
- *   allows it, making this a pass-through).
+ *   context rate. The context runs at the system's native rate (forcing the
+ *   chunk rate would make the browser resample the whole context output and
+ *   misbehaves on some devices), so this resampler is the normal path —
+ *   e.g. 24 kHz chunks into a 48 kHz context.
  *
  * Port protocol (main→worklet):
  *   { type: "config", sampleRate, channels, live, primeSeconds, maxLeadSeconds }
@@ -134,6 +136,10 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
         }
         this.segOffset++;
         this.buffered--;
+        // framesOut counts SOURCE frames consumed (same unit as framesIn),
+        // so producer/consumer rates stay comparable whatever the context
+        // rate is.
+        this.framesOut++;
         return true;
       }
       this.segments.shift();
@@ -185,7 +191,6 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
           // Underrun: go silent for the rest of the block and re-prime.
           this.rolling = false;
           this.underruns++;
-          this.framesOut += i;
           return true;
         }
         this.pos -= 1;
@@ -197,7 +202,6 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
           this.prevFrame[src] + (this.currFrame[src] - this.prevFrame[src]) * t;
       }
     }
-    this.framesOut += frames;
     return true;
   }
 }

--- a/web/src/lib/audio/chunkPlayerProcessor.js
+++ b/web/src/lib/audio/chunkPlayerProcessor.js
@@ -17,10 +17,17 @@
  *   context rate (the context is created at the chunk rate when the browser
  *   allows it, making this a pass-through).
  *
- * Port protocol (all main→worklet):
+ * Port protocol (main→worklet):
  *   { type: "config", sampleRate, channels, live, primeSeconds, maxLeadSeconds }
  *   { type: "chunk", samples: Float32Array }   interleaved samples
  *   { type: "reset" }                          drop all buffered audio
+ *
+ * Worklet→main (once per rendered second):
+ *   { type: "stats", buffered, underruns, droppedFrames, framesOut,
+ *     framesIn, srcRate }
+ * Buffer-health telemetry: `buffered` trending down ⇒ the producer clock is
+ * slow relative to the audio clock (ends in underruns); trending up ⇒ fast
+ * (ends in live-mode stale drops).
  */
 
 /* global AudioWorkletProcessor, registerProcessor, sampleRate */
@@ -43,6 +50,12 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
 
     /** True while primed and emitting audio. */
     this.rolling = false;
+    /** Telemetry counters (reported via "stats" messages). */
+    this.underruns = 0;
+    this.droppedFrames = 0;
+    this.framesOut = 0;
+    this.framesIn = 0;
+    this._statFrames = 0;
     /** Fractional source-frame position between prevFrame (0) and currFrame (1). */
     this.pos = 1;
     this.prevFrame = null;
@@ -91,6 +104,7 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
       if (frames <= 0) return;
       this.segments.push(d.samples);
       this.buffered += frames;
+      this.framesIn += frames;
       // Live monitoring: a backlog beyond the max lead is stale — drop the
       // oldest whole segments down to the prime level (jump to "now").
       if (this.buffered > this.maxFrames) {
@@ -102,6 +116,7 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
           this.segments.shift();
           this.segOffset = 0;
           this.buffered -= remaining;
+          this.droppedFrames += remaining;
         }
       }
     }
@@ -127,10 +142,26 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
     return false;
   }
 
+  emitStatsMaybe(frames) {
+    this._statFrames += frames;
+    if (this._statFrames < sampleRate) return;
+    this._statFrames -= sampleRate;
+    this.port.postMessage({
+      type: "stats",
+      buffered: this.buffered,
+      underruns: this.underruns,
+      droppedFrames: this.droppedFrames,
+      framesOut: this.framesOut,
+      framesIn: this.framesIn,
+      srcRate: this.srcRate
+    });
+  }
+
   process(_inputs, outputs) {
     const out = outputs[0];
     if (!out || out.length === 0) return true;
     const frames = out[0].length;
+    this.emitStatsMaybe(frames);
 
     if (!this.rolling) {
       if (this.buffered >= this.primeFrames) {
@@ -153,6 +184,8 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
         if (!this.pullFrame(this.currFrame)) {
           // Underrun: go silent for the rest of the block and re-prime.
           this.rolling = false;
+          this.underruns++;
+          this.framesOut += i;
           return true;
         }
         this.pos -= 1;
@@ -164,6 +197,7 @@ class NodetoolChunkPlayer extends AudioWorkletProcessor {
           this.prevFrame[src] + (this.currFrame[src] - this.prevFrame[src]) * t;
       }
     }
+    this.framesOut += frames;
     return true;
   }
 }

--- a/web/src/lib/audio/chunkPlayerProcessor.js
+++ b/web/src/lib/audio/chunkPlayerProcessor.js
@@ -1,0 +1,171 @@
+/**
+ * AudioWorklet processor for realtime chunk playback.
+ *
+ * Receives interleaved Float32Array sample chunks over its MessagePort and
+ * renders them on the audio rendering thread — playback is immune to
+ * main-thread jank (canvas drags, React renders, GC). Replaces the old
+ * AudioBufferSourceNode-per-chunk scheduling, which glitched whenever the
+ * main thread stalled past the scheduled lead.
+ *
+ * Behavior:
+ * - Primes a small jitter buffer before starting (and re-primes after an
+ *   underrun) so a single late chunk doesn't crackle.
+ * - In live mode, drops the oldest buffered audio when the backlog exceeds
+ *   the max lead — a live patch monitors "now", stale audio is worse than a
+ *   dropped instant.
+ * - Linear-interpolation resampling from the chunk sample rate to the
+ *   context rate (the context is created at the chunk rate when the browser
+ *   allows it, making this a pass-through).
+ *
+ * Port protocol (all main→worklet):
+ *   { type: "config", sampleRate, channels, live, primeSeconds, maxLeadSeconds }
+ *   { type: "chunk", samples: Float32Array }   interleaved samples
+ *   { type: "reset" }                          drop all buffered audio
+ */
+
+/* global AudioWorkletProcessor, registerProcessor, sampleRate */
+
+class NodetoolChunkPlayer extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    /** Queued interleaved sample chunks (FIFO). */
+    this.segments = [];
+    /** Frames already consumed from segments[0]. */
+    this.segOffset = 0;
+    /** Total buffered source frames across all segments. */
+    this.buffered = 0;
+
+    this.srcRate = sampleRate;
+    this.channels = 1;
+    this.live = false;
+    this.primeFrames = Math.round(0.04 * sampleRate);
+    this.maxFrames = Infinity;
+
+    /** True while primed and emitting audio. */
+    this.rolling = false;
+    /** Fractional source-frame position between prevFrame (0) and currFrame (1). */
+    this.pos = 1;
+    this.prevFrame = null;
+    this.currFrame = null;
+
+    this.port.onmessage = (event) => this.handleMessage(event.data);
+  }
+
+  handleMessage(d) {
+    if (!d || typeof d !== "object") return;
+    if (d.type === "config") {
+      if (typeof d.sampleRate === "number" && d.sampleRate > 0) {
+        this.srcRate = d.sampleRate;
+      }
+      if (typeof d.channels === "number" && d.channels >= 1) {
+        this.channels = Math.floor(d.channels);
+      }
+      this.live = Boolean(d.live);
+      const prime =
+        typeof d.primeSeconds === "number" && d.primeSeconds > 0
+          ? d.primeSeconds
+          : 0.04;
+      this.primeFrames = Math.max(1, Math.round(prime * this.srcRate));
+      const maxLead =
+        typeof d.maxLeadSeconds === "number" && d.maxLeadSeconds > 0
+          ? d.maxLeadSeconds
+          : 0;
+      this.maxFrames =
+        this.live && maxLead > 0
+          ? Math.round(maxLead * this.srcRate)
+          : Infinity;
+      return;
+    }
+    if (d.type === "reset") {
+      this.segments = [];
+      this.segOffset = 0;
+      this.buffered = 0;
+      this.rolling = false;
+      this.pos = 1;
+      this.prevFrame = null;
+      this.currFrame = null;
+      return;
+    }
+    if (d.type === "chunk" && d.samples instanceof Float32Array) {
+      const frames = Math.floor(d.samples.length / this.channels);
+      if (frames <= 0) return;
+      this.segments.push(d.samples);
+      this.buffered += frames;
+      // Live monitoring: a backlog beyond the max lead is stale — drop the
+      // oldest whole segments down to the prime level (jump to "now").
+      if (this.buffered > this.maxFrames) {
+        while (this.segments.length > 1) {
+          const seg = this.segments[0];
+          const remaining =
+            Math.floor(seg.length / this.channels) - this.segOffset;
+          if (this.buffered - remaining < this.primeFrames) break;
+          this.segments.shift();
+          this.segOffset = 0;
+          this.buffered -= remaining;
+        }
+      }
+    }
+  }
+
+  /** Copy the next source frame into `target`; false on underrun. */
+  pullFrame(target) {
+    while (this.segments.length > 0) {
+      const seg = this.segments[0];
+      const framesInSeg = Math.floor(seg.length / this.channels);
+      if (this.segOffset < framesInSeg) {
+        const base = this.segOffset * this.channels;
+        for (let c = 0; c < this.channels; c++) {
+          target[c] = seg[base + c];
+        }
+        this.segOffset++;
+        this.buffered--;
+        return true;
+      }
+      this.segments.shift();
+      this.segOffset = 0;
+    }
+    return false;
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0];
+    if (!out || out.length === 0) return true;
+    const frames = out[0].length;
+
+    if (!this.rolling) {
+      if (this.buffered >= this.primeFrames) {
+        this.rolling = true;
+        this.pos = 1; // force pulling the first frame
+        this.prevFrame = new Float32Array(this.channels);
+        this.currFrame = new Float32Array(this.channels);
+      } else {
+        return true; // output buffers are pre-zeroed → silence
+      }
+    }
+
+    const ratio = this.srcRate / sampleRate;
+    for (let i = 0; i < frames; i++) {
+      this.pos += ratio;
+      while (this.pos >= 1) {
+        const tmp = this.prevFrame;
+        this.prevFrame = this.currFrame;
+        this.currFrame = tmp;
+        if (!this.pullFrame(this.currFrame)) {
+          // Underrun: go silent for the rest of the block and re-prime.
+          this.rolling = false;
+          return true;
+        }
+        this.pos -= 1;
+      }
+      const t = this.pos;
+      for (let c = 0; c < out.length; c++) {
+        const src = c < this.channels ? c : 0;
+        out[c][i] =
+          this.prevFrame[src] + (this.currFrame[src] - this.prevFrame[src]) * t;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor("nodetool-chunk-player", NodetoolChunkPlayer);

--- a/web/src/lib/audio/chunkPlayerWorkletUrl.ts
+++ b/web/src/lib/audio/chunkPlayerWorkletUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolves the chunk-player AudioWorklet module URL.
+ *
+ * Isolated in its own module (and only ever loaded via dynamic import) so the
+ * `import.meta.url` reference never reaches the jest CJS transform — same
+ * pattern as `browserWorkerClient.ts`.
+ */
+export function getChunkPlayerWorkletUrl(): string {
+  return new URL("./chunkPlayerProcessor.js", import.meta.url).toString();
+}

--- a/web/src/lib/audio/realtimeAudioChunkBus.ts
+++ b/web/src/lib/audio/realtimeAudioChunkBus.ts
@@ -1,0 +1,50 @@
+/**
+ * Realtime audio chunk bus — the React-free fast path from message delivery
+ * to the playback worklet.
+ *
+ * Streamed audio chunks normally reach playback via ResultsStore →
+ * component re-render → scheduling effect, which puts the entire React
+ * commit pipeline in the latency-critical path: any main-thread jank
+ * (canvas drags, large renders) delays chunk delivery past the worklet's
+ * jitter buffer and audibly drops out. The bus lets the message handler
+ * hand a chunk straight to the subscribed playback hook in the same task
+ * the message arrives in.
+ *
+ * The ResultsStore append still happens in parallel — it serves replay,
+ * restart and mount/unmount decisions, none of which are latency-critical.
+ * Publisher and store share chunk object identity, so the playback hook's
+ * WeakSet dedupes the two delivery paths.
+ */
+import type { Chunk } from "../../stores/ApiTypes";
+
+type ChunkListener = (chunk: Chunk) => void;
+
+const listeners = new Map<string, Set<ChunkListener>>();
+
+/** Deliver a streamed audio chunk to live subscribers of `nodeId`. */
+export function publishRealtimeAudioChunk(nodeId: string, chunk: Chunk): void {
+  const set = listeners.get(nodeId);
+  if (!set) return;
+  for (const listener of set) {
+    listener(chunk);
+  }
+}
+
+/** Subscribe to live audio chunks for a node. Returns the unsubscriber. */
+export function subscribeRealtimeAudioChunks(
+  nodeId: string,
+  listener: ChunkListener
+): () => void {
+  let set = listeners.get(nodeId);
+  if (!set) {
+    set = new Set();
+    listeners.set(nodeId, set);
+  }
+  set.add(listener);
+  return () => {
+    const current = listeners.get(nodeId);
+    if (!current) return;
+    current.delete(listener);
+    if (current.size === 0) listeners.delete(nodeId);
+  };
+}

--- a/web/src/lib/websocket/GlobalWebSocketManager.ts
+++ b/web/src/lib/websocket/GlobalWebSocketManager.ts
@@ -68,6 +68,8 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
   private static instance: GlobalWebSocketManager | null = null;
   private wsManager: WebSocketManager | null = null;
   private messageHandlers: Map<string, Set<MessageHandler>> = new Map();
+  /** Routing keys already reported as unhandled (log once, payload-free). */
+  private loggedUnhandledKeys = new Set<string>();
   private isConnecting = false;
   private isConnected = false;
   private networkListenersSetup = false;
@@ -234,9 +236,11 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
     }
 
     if (routingKeys.size === 0) {
+      // Never log the message object itself: the console buffer retains its
+      // arguments (for a later DevTools attach), so logging streamed chunk
+      // payloads here pins them all — a multi-MB/s leak on realtime runs.
       console.debug(
-        "GlobalWebSocketManager: Message without routing key (job_id/workflow_id/thread_id)",
-        message
+        `GlobalWebSocketManager: Message without routing key (${message.type})`
       );
       return;
     }
@@ -260,10 +264,14 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
             console.error("GlobalWebSocketManager: Handler error:", error);
           }
         });
-      } else {
+      } else if (!this.loggedUnhandledKeys.has(routingKey)) {
+        // Once per key and payload-free: streamed runs hit this branch at
+        // chunk rate (the job_id key often has no handler even when the
+        // workflow_id key does), and console arguments are retained by the
+        // browser — logging the message would pin every chunk.
+        this.loggedUnhandledKeys.add(routingKey);
         console.debug(
-          `GlobalWebSocketManager: No handlers for ${routingKey}`,
-          message
+          `GlobalWebSocketManager: No handlers for ${routingKey} (first: ${message.type})`
         );
       }
     });

--- a/web/src/lib/workflow/browserRunner.worker.ts
+++ b/web/src/lib/workflow/browserRunner.worker.ts
@@ -10,10 +10,16 @@
  * Protocol (see `browserWorkerClient.ts` for the main-thread half):
  *   ← { type: "ready", browserNodeTypes }   once, after the registry builds
  *   ← { type: "init-error", error }         registry build failed → main falls back
- *   ← { type: "message", jobId, message }   a raw kernel ProcessingMessage
+ *   ← { type: "messages", jobId, messages } a batch of kernel ProcessingMessages
  *   ← { type: "done", jobId, status, error }
  *   → { type: "run", jobId, graph, params, workflowId }
  *   → { type: "cancel", jobId }
+ *   → { type: "update-properties", jobId, nodeId, properties }   live params
+ *
+ * Messages are BATCHED: streaming nodes (realtime audio) emit hundreds of
+ * messages per second, and one postMessage → one main-thread task each would
+ * dominate the main thread. Messages buffer for up to BATCH_INTERVAL_MS and
+ * cross as a single postMessage; the client delivers them in order.
  *
  * Messages are streamed with image outputs resolved for transport: GPU textures
  * are read back to CPU, then converted to transferable ImageBitmaps
@@ -32,6 +38,18 @@ import { attachPreviewBitmaps } from "./attachPreviewBitmaps";
 declare const self: DedicatedWorkerGlobalScope;
 
 const controllers = new Map<string, AbortController>();
+
+/** Streamed audio chunk payload — never contains image refs to resolve. */
+const isAudioChunkValue = (value: unknown): boolean => {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { type?: unknown; content_type?: unknown };
+  return v.type === "chunk" && v.content_type === "audio";
+};
+/** Live WorkflowRunner per job, for in-flight property updates. */
+const runners = new Map<
+  string,
+  { updateNodeProperties: (nodeId: string, props: Record<string, unknown>) => boolean }
+>();
 
 // Build the registry once for the worker's lifetime; announce readiness (and
 // the browser-capable node types, so the main thread can make routing
@@ -65,6 +83,12 @@ interface CancelMessage {
   type: "cancel";
   jobId: string;
 }
+interface UpdatePropertiesMessage {
+  type: "update-properties";
+  jobId: string;
+  nodeId: string;
+  properties: Record<string, unknown>;
+}
 
 async function runJob(msg: RunMessage): Promise<void> {
   const { jobId, graph, params = {}, workflowId } = msg;
@@ -84,6 +108,37 @@ async function runJob(msg: RunMessage): Promise<void> {
 
   const controller = new AbortController();
   controllers.set(jobId, controller);
+
+  // Message batching: coalesce the streaming firehose into one postMessage
+  // (= one main-thread task) per interval. ~16ms keeps UI updates at frame
+  // cadence while cutting task churn by an order of magnitude.
+  const BATCH_INTERVAL_MS = 16;
+  let batch: Array<Record<string, unknown>> = [];
+  let batchTransfer: Transferable[] = [];
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  const flush = () => {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (batch.length === 0) return;
+    const messages = batch;
+    const transfer = batchTransfer;
+    batch = [];
+    batchTransfer = [];
+    self.postMessage({ type: "messages", jobId, messages }, transfer);
+  };
+  const enqueue = (
+    message: Record<string, unknown>,
+    transfer: Transferable[]
+  ) => {
+    batch.push(message);
+    if (transfer.length > 0) batchTransfer.push(...transfer);
+    if (flushTimer === null) {
+      flushTimer = setTimeout(flush, BATCH_INTERVAL_MS);
+    }
+  };
+
   try {
     const gen = runner.runBrowserWorkflow({
       graph: normalizeGraphForKernel(graph) as unknown as Parameters<
@@ -93,13 +148,19 @@ async function runJob(msg: RunMessage): Promise<void> {
       params,
       jobId,
       workflowId,
-      signal: controller.signal
+      signal: controller.signal,
+      onRunner: (workflowRunner) => {
+        runners.set(jobId, workflowRunner);
+      }
     });
 
     while (true) {
       const next = await gen.next();
       if (next.done) {
         const result = next.value;
+        // Deliver any buffered messages before the terminal signal so the
+        // client never sees "done" with updates still in flight.
+        flush();
         self.postMessage({
           type: "done",
           jobId,
@@ -123,16 +184,23 @@ async function runJob(msg: RunMessage): Promise<void> {
             await resolve(message.result),
             transfer
           );
-        } else if (message.type === "output_update" && message.value != null) {
+        } else if (
+          message.type === "output_update" &&
+          message.value != null &&
+          // Audio chunks stream at ~50/s per node and never hold image refs
+          // — skip the async resolve/walk entirely on the hot path.
+          !isAudioChunkValue(message.value)
+        ) {
           message.value = await attachPreviewBitmaps(
             await resolve(message.value),
             transfer
           );
         }
       }
-      self.postMessage({ type: "message", jobId, message }, transfer);
+      enqueue(message, transfer);
     }
   } catch (error) {
+    flush();
     self.postMessage({
       type: "done",
       jobId,
@@ -140,17 +208,28 @@ async function runJob(msg: RunMessage): Promise<void> {
       error: error instanceof Error ? error.message : "Browser execution failed"
     });
   } finally {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
     // Free every GPU texture this run created (run-scoped lifecycle).
     runner.releaseRunTextures?.(jobId);
     controllers.delete(jobId);
+    runners.delete(jobId);
   }
 }
 
-self.onmessage = (event: MessageEvent<RunMessage | CancelMessage>) => {
+self.onmessage = (
+  event: MessageEvent<RunMessage | CancelMessage | UpdatePropertiesMessage>
+) => {
   const data = event.data;
   if (!data) return;
   if (data.type === "cancel") {
     controllers.get(data.jobId)?.abort();
+    return;
+  }
+  if (data.type === "update-properties") {
+    runners.get(data.jobId)?.updateNodeProperties(data.nodeId, data.properties);
     return;
   }
   if (data.type === "run") {

--- a/web/src/lib/workflow/browserWorkerClient.ts
+++ b/web/src/lib/workflow/browserWorkerClient.ts
@@ -31,13 +31,23 @@ interface StreamMessage {
   jobId: string;
   message: WebSocketMessage;
 }
+interface StreamBatchMessage {
+  type: "messages";
+  jobId: string;
+  messages: WebSocketMessage[];
+}
 interface DoneMessage {
   type: "done";
   jobId: string;
   status: "completed" | "failed" | "cancelled";
   error?: string;
 }
-type FromWorker = ReadyMessage | InitErrorMessage | StreamMessage | DoneMessage;
+type FromWorker =
+  | ReadyMessage
+  | InitErrorMessage
+  | StreamMessage
+  | StreamBatchMessage
+  | DoneMessage;
 
 let worker: Worker | null = null;
 let ready: Promise<Set<string>> | null = null;
@@ -84,6 +94,19 @@ export function getBrowserWorkerReady(): Promise<Set<string>> {
 }
 
 /**
+ * Push live property updates into a running worker job's node instances
+ * (e.g. turning a synth knob while the patch plays). Fire-and-forget; a
+ * no-op when the worker isn't running or the job has finished.
+ */
+export function updateBrowserJobNodeProperties(
+  jobId: string,
+  nodeId: string,
+  properties: Record<string, unknown>
+): void {
+  worker?.postMessage({ type: "update-properties", jobId, nodeId, properties });
+}
+
+/**
  * Run a graph in the worker, streaming its messages into `deliverLocal`. Assumes
  * the worker is already ready (caller awaits {@link getBrowserWorkerReady}).
  */
@@ -122,31 +145,41 @@ export function runBrowserGraphJobInWorker(
     };
     const onAbort = () => w.postMessage({ type: "cancel", jobId });
 
+    const handleStreamMessage = (message: WebSocketMessage) => {
+      const mutable = message as Record<string, unknown>;
+      if (message.type === "node_update" && mutable.result != null) {
+        mutable.result = materializeBrowserOutputs(mutable.result);
+      } else if (message.type === "output_update" && mutable.value != null) {
+        mutable.value = materializeBrowserOutputs(mutable.value);
+      }
+      globalWebSocketManager.deliverLocal(message);
+
+      if (message.type === "node_update") {
+        const status = (mutable.status as string | undefined) ?? "";
+        const nodeId = (mutable.node_id as string | undefined) ?? "";
+        if (status === "completed" && nodeId && mutable.result != null) {
+          outputs[nodeId] = mutable.result;
+        }
+      } else if (message.type === "job_update") {
+        const res = mutable.result as { outputs?: unknown } | undefined;
+        if (res?.outputs && typeof res.outputs === "object") {
+          Object.assign(outputs, res.outputs as Record<string, unknown>);
+        }
+      }
+    };
+
     const onMessage = (event: MessageEvent<FromWorker>) => {
       const data = event.data;
       if (!data || (data as { jobId?: string }).jobId !== jobId) return;
 
       if (data.type === "message") {
-        const message = data.message;
-        const mutable = message as Record<string, unknown>;
-        if (message.type === "node_update" && mutable.result != null) {
-          mutable.result = materializeBrowserOutputs(mutable.result);
-        } else if (message.type === "output_update" && mutable.value != null) {
-          mutable.value = materializeBrowserOutputs(mutable.value);
-        }
-        globalWebSocketManager.deliverLocal(message);
+        handleStreamMessage(data.message);
+        return;
+      }
 
-        if (message.type === "node_update") {
-          const status = (mutable.status as string | undefined) ?? "";
-          const nodeId = (mutable.node_id as string | undefined) ?? "";
-          if (status === "completed" && nodeId && mutable.result != null) {
-            outputs[nodeId] = mutable.result;
-          }
-        } else if (message.type === "job_update") {
-          const res = mutable.result as { outputs?: unknown } | undefined;
-          if (res?.outputs && typeof res.outputs === "object") {
-            Object.assign(outputs, res.outputs as Record<string, unknown>);
-          }
+      if (data.type === "messages") {
+        for (const message of data.messages) {
+          handleStreamMessage(message);
         }
         return;
       }

--- a/web/src/lib/workflow/browserWorkflowRunner.ts
+++ b/web/src/lib/workflow/browserWorkflowRunner.ts
@@ -282,6 +282,40 @@ const asString = (value: unknown): string | undefined =>
  * `GlobalWebSocketManager.deliverLocal` so the UI updates exactly as it would
  * for a server run.
  */
+/** Live runners of main-thread (fallback) jobs, keyed by job id. */
+const localRunners = new Map<
+  string,
+  {
+    updateNodeProperties: (
+      nodeId: string,
+      props: Record<string, unknown>
+    ) => boolean;
+  }
+>();
+
+/**
+ * Push live property updates into a running browser job's node instances
+ * (e.g. turning a synth knob while a patch plays). Routes to the worker when
+ * worker runs are active, and to the main-thread runner otherwise.
+ * Fire-and-forget; a no-op when the job isn't running.
+ */
+export function updateBrowserJobNodeProperties(
+  jobId: string,
+  nodeId: string,
+  properties: Record<string, unknown>
+): void {
+  const local = localRunners.get(jobId);
+  if (local) {
+    local.updateNodeProperties(nodeId, properties);
+    return;
+  }
+  if (shouldUseWorker() && !workerDisabled) {
+    void import("./browserWorkerClient")
+      .then((m) => m.updateBrowserJobNodeProperties(jobId, nodeId, properties))
+      .catch(() => undefined);
+  }
+}
+
 export async function runBrowserGraphJob(
   options: BrowserGraphJobOptions
 ): Promise<BrowserGraphJobResult> {
@@ -342,7 +376,10 @@ async function runBrowserGraphJobLocal(
     params,
     jobId,
     workflowId,
-    signal
+    signal,
+    onRunner: (workflowRunner) => {
+      localRunners.set(jobId, workflowRunner);
+    }
   });
 
   try {
@@ -422,5 +459,6 @@ async function runBrowserGraphJobLocal(
   } finally {
     // Free every GPU texture this main-thread run created (run-scoped lifecycle).
     runner.releaseRunTextures?.(jobId);
+    localRunners.delete(jobId);
   }
 }

--- a/web/src/lib/workflow/materializeBrowserOutputs.ts
+++ b/web/src/lib/workflow/materializeBrowserOutputs.ts
@@ -73,7 +73,12 @@ export function bitmapToPngDataUrl(bitmap: ImageBitmap): string {
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  // Typed arrays (e.g. native Float32Array audio-chunk payloads) must pass
+  // through untouched — Object.entries would explode them per-sample.
+  !ArrayBuffer.isView(value);
 
 const isImageRef = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) &&

--- a/web/src/perf/megaSynthPatch.ts
+++ b/web/src/perf/megaSynthPatch.ts
@@ -1,0 +1,386 @@
+/**
+ * The Mega Synth — a generative modular piece that doubles as the stress
+ * patch for the realtime perf environment.
+ *
+ * Musically it's a Berlin-school ensemble in A, ~120 BPM, built only from
+ * the shipped synth modules:
+ *
+ *  - clk16/clk8/clk2/clkBar — four wall-clock Gates (16ths, 8ths, beats,
+ *    bars) shared by every layer, so the whole ensemble stays locked.
+ *  - bass     saw 55 Hz alternating root/fifth (square-LFO pitch CV), ADSR
+ *             driving both VCA and VCF cutoff (classic envelope filter).
+ *  - arp      square 220 Hz; pitch CV is the SUM of two square LFOs (1 Hz ×
+ *             octave + 0.5 Hz × fifth, mixed in a Mixer — CV rides the chunk
+ *             wire) → a repeating 4-step arpeggio: root, fifth, octave,
+ *             octave+fifth. Plucky ADSR, resonant low-pass swept by a 20 s
+ *             triangle LFO.
+ *  - pad      two detuned saws → slow sine-swept low-pass → bar-length
+ *             ADSR swells.
+ *  - lead     noise → Sample&Hold (beat trigger) → Attenuverter → pitch CV
+ *             of a triangle osc: sparse random sparkle on top of the tonal
+ *             bed.
+ *  - hat      noise → high-pass 6 kHz → 8 Hz tick envelope.
+ *  - kick     50 Hz sine thump on the beat.
+ *  - drone    FM sine an octave below the bass, breathing over bars.
+ *
+ * `layers` stacks detuned, phase-decorrelated copies of the whole ensemble
+ * (osc pitch × 2^(0.004·layer), LFO rates × (1 + 0.017·layer), levels
+ * 1/√layers) — one layer is the demo, 8 is a super-ensemble, 24 is the
+ * stress test (~1,100 streaming nodes).
+ *
+ * Node positions are laid out for the editor, so the same graph installs as
+ * a presentable workflow (scripts/install-mega-synth.ts).
+ */
+
+export interface MegaNode {
+  [key: string]: unknown;
+  id: string;
+  type: string;
+  properties: Record<string, unknown>;
+  ui_properties: { position: { x: number; y: number } };
+}
+export interface MegaEdge {
+  [key: string]: unknown;
+  id: string;
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}
+
+const SEMI = 1 / 12;
+const FIFTH = 7 * SEMI;
+
+const T = {
+  gate: "nodetool.audio.synth.Gate",
+  osc: "nodetool.audio.synth.Oscillator",
+  lfo: "nodetool.audio.synth.LFO",
+  adsr: "nodetool.audio.synth.ADSR",
+  vca: "nodetool.audio.synth.VCA",
+  vcf: "nodetool.audio.synth.VCF",
+  att: "nodetool.audio.synth.Attenuverter",
+  sh: "nodetool.audio.synth.SampleHold",
+  mixer: "nodetool.audio.synth.Mixer",
+  gain: "nodetool.audio.realtime.StreamingGain",
+  highpass: "nodetool.audio.realtime.StreamingHighPass",
+  out: "nodetool.audio.realtime.AudioOutput"
+} as const;
+
+export function buildMegaSynthPatch(layers: number): {
+  nodes: MegaNode[];
+  edges: MegaEdge[];
+} {
+  const L = Math.max(1, Math.floor(layers));
+  const nodes: MegaNode[] = [];
+  const edges: MegaEdge[] = [];
+  let edgeSeq = 0;
+
+  const add = (
+    id: string,
+    type: string,
+    properties: Record<string, unknown>,
+    x: number,
+    y: number
+  ): string => {
+    nodes.push({ id, type, properties, ui_properties: { position: { x, y } } });
+    return id;
+  };
+  const wire = (
+    source: string,
+    sourceHandle: string,
+    target: string,
+    targetHandle: string
+  ): void => {
+    edges.push({
+      id: `e${edgeSeq++}`,
+      source,
+      sourceHandle,
+      target,
+      targetHandle
+    });
+  };
+
+  // ── Shared clocks (one set for all layers) ─────────────────────────
+  // 120 BPM: beat 0.5s. Slight off-50% duty so gates read as pulses.
+  add("clk16", T.gate, { on_duration: 0.06, off_duration: 0.065 }, 0, 0);
+  add("clk8", T.gate, { on_duration: 0.11, off_duration: 0.14 }, 0, 140);
+  add("clk2", T.gate, { on_duration: 0.22, off_duration: 0.28 }, 0, 280);
+  add("clkBar", T.gate, { on_duration: 1.4, off_duration: 2.6 }, 0, 420);
+
+  const layerOuts: string[] = [];
+  const level = Number((1 / Math.sqrt(L)).toFixed(3));
+
+  for (let l = 0; l < L; l++) {
+    const id = (name: string): string => (L === 1 ? name : `${name}-${l}`);
+    // Gentle ensemble spread: pitch detune in cents, LFO rate decorrelation.
+    const det = Math.pow(2, 0.004 * l * (l % 2 === 0 ? 1 : -1));
+    const rate = (hz: number): number =>
+      Number((hz * (1 + 0.017 * l)).toFixed(4));
+    const Y = l * 1700;
+    const col = (c: number): number => 380 + c * 260;
+
+    // ── Bass: root/fifth saw with envelope filter ────────────────────
+    add(id("bass-pitch"), T.lfo, {
+      waveform: "square",
+      rate_hz: rate(0.125),
+      depth: FIFTH / 2,
+      offset: FIFTH / 2
+    }, col(0), Y + 0);
+    add(id("bass-osc"), T.osc, {
+      waveform: "saw",
+      frequency: 55 * det,
+      amplitude: 0.7
+    }, col(1), Y + 0);
+    add(id("bass-env"), T.adsr, {
+      attack: 0.005,
+      decay: 0.15,
+      sustain: 0.5,
+      release: 0.2
+    }, col(0), Y + 120);
+    add(id("bass-vcf"), T.vcf, {
+      mode: "lowpass",
+      cutoff_hz: 220,
+      q: 3,
+      cv_amount: 2.5
+    }, col(2), Y + 0);
+    add(id("bass-vca"), T.vca, { gain: 1 }, col(3), Y + 0);
+    wire(id("bass-pitch"), "cv", id("bass-osc"), "pitch_cv");
+    wire("clk2", "cv", id("bass-env"), "gate");
+    wire(id("bass-osc"), "chunk", id("bass-vcf"), "audio");
+    wire(id("bass-env"), "cv", id("bass-vcf"), "cutoff_cv");
+    wire(id("bass-vcf"), "chunk", id("bass-vca"), "audio");
+    wire(id("bass-env"), "cv", id("bass-vca"), "cv");
+
+    // ── Arp: 4-step pattern from summed square LFOs ──────────────────
+    add(id("arp-oct"), T.lfo, {
+      waveform: "square",
+      rate_hz: rate(1),
+      depth: 0.5,
+      offset: 0.5
+    }, col(0), Y + 260);
+    add(id("arp-fifth"), T.lfo, {
+      waveform: "square",
+      rate_hz: rate(0.5),
+      depth: FIFTH / 2,
+      offset: FIFTH / 2
+    }, col(0), Y + 380);
+    add(id("arp-cv"), T.mixer, { level1: 1, level2: 1 }, col(1), Y + 260);
+    add(id("arp-osc"), T.osc, {
+      waveform: "square",
+      frequency: 220 * det,
+      amplitude: 0.45
+    }, col(2), Y + 260);
+    add(id("arp-sweep"), T.lfo, {
+      waveform: "triangle",
+      rate_hz: rate(0.05),
+      depth: 0.9,
+      offset: 0.4
+    }, col(2), Y + 380);
+    add(id("arp-vcf"), T.vcf, {
+      mode: "lowpass",
+      cutoff_hz: 700,
+      q: 6,
+      cv_amount: 2
+    }, col(3), Y + 260);
+    add(id("arp-env"), T.adsr, {
+      attack: 0.003,
+      decay: 0.09,
+      sustain: 0.15,
+      release: 0.08
+    }, col(3), Y + 380);
+    add(id("arp-vca"), T.vca, { gain: 1 }, col(4), Y + 260);
+    wire(id("arp-oct"), "cv", id("arp-cv"), "in1");
+    wire(id("arp-fifth"), "cv", id("arp-cv"), "in2");
+    wire(id("arp-cv"), "chunk", id("arp-osc"), "pitch_cv");
+    wire(id("arp-osc"), "chunk", id("arp-vcf"), "audio");
+    wire(id("arp-sweep"), "cv", id("arp-vcf"), "cutoff_cv");
+    wire("clk8", "cv", id("arp-env"), "gate");
+    wire(id("arp-vcf"), "chunk", id("arp-vca"), "audio");
+    wire(id("arp-env"), "cv", id("arp-vca"), "cv");
+
+    // ── Pad: detuned saw swell ───────────────────────────────────────
+    add(id("pad-osc1"), T.osc, {
+      waveform: "saw",
+      frequency: 110 * det,
+      amplitude: 0.4
+    }, col(0), Y + 540);
+    add(id("pad-osc2"), T.osc, {
+      waveform: "saw",
+      frequency: 110.8 * det,
+      amplitude: 0.4
+    }, col(0), Y + 660);
+    add(id("pad-mix"), T.mixer, { level1: 0.5, level2: 0.5 }, col(1), Y + 540);
+    add(id("pad-sweep"), T.lfo, {
+      waveform: "sine",
+      rate_hz: rate(0.03),
+      depth: 0.8,
+      offset: 0.5
+    }, col(1), Y + 660);
+    add(id("pad-vcf"), T.vcf, {
+      mode: "lowpass",
+      cutoff_hz: 350,
+      q: 2,
+      cv_amount: 2
+    }, col(2), Y + 540);
+    add(id("pad-env"), T.adsr, {
+      attack: 1.2,
+      decay: 1.0,
+      sustain: 0.7,
+      release: 1.5
+    }, col(2), Y + 660);
+    add(id("pad-vca"), T.vca, { gain: 1 }, col(3), Y + 540);
+    wire(id("pad-osc1"), "chunk", id("pad-mix"), "in1");
+    wire(id("pad-osc2"), "chunk", id("pad-mix"), "in2");
+    wire(id("pad-mix"), "chunk", id("pad-vcf"), "audio");
+    wire(id("pad-sweep"), "cv", id("pad-vcf"), "cutoff_cv");
+    wire("clkBar", "cv", id("pad-env"), "gate");
+    wire(id("pad-vcf"), "chunk", id("pad-vca"), "audio");
+    wire(id("pad-env"), "cv", id("pad-vca"), "cv");
+
+    // ── Lead: S&H random sparkle ─────────────────────────────────────
+    add(id("lead-noise"), T.osc, { waveform: "noise", amplitude: 1 }, col(0), Y + 820);
+    add(id("lead-sh"), T.sh, {}, col(1), Y + 820);
+    add(id("lead-att"), T.att, { scale: 0.4, offset: 0.6 }, col(2), Y + 820);
+    add(id("lead-osc"), T.osc, {
+      waveform: "triangle",
+      frequency: 440 * det,
+      amplitude: 0.5
+    }, col(3), Y + 820);
+    add(id("lead-vcf"), T.vcf, {
+      mode: "lowpass",
+      cutoff_hz: 2500,
+      q: 4,
+      cv_amount: 0
+    }, col(4), Y + 820);
+    add(id("lead-env"), T.adsr, {
+      attack: 0.01,
+      decay: 0.3,
+      sustain: 0.2,
+      release: 0.4
+    }, col(4), Y + 940);
+    add(id("lead-vca"), T.vca, { gain: 1 }, col(5), Y + 820);
+    wire(id("lead-noise"), "chunk", id("lead-sh"), "signal");
+    wire("clk2", "cv", id("lead-sh"), "trigger");
+    wire(id("lead-sh"), "cv", id("lead-att"), "signal");
+    wire(id("lead-att"), "cv", id("lead-osc"), "pitch_cv");
+    wire(id("lead-osc"), "chunk", id("lead-vcf"), "audio");
+    wire("clk2", "cv", id("lead-env"), "gate");
+    wire(id("lead-vcf"), "chunk", id("lead-vca"), "audio");
+    wire(id("lead-env"), "cv", id("lead-vca"), "cv");
+
+    // ── Hat: 8 Hz noise tick ─────────────────────────────────────────
+    add(id("hat-noise"), T.osc, { waveform: "noise", amplitude: 0.8 }, col(0), Y + 1100);
+    add(id("hat-vcf"), T.vcf, {
+      mode: "highpass",
+      cutoff_hz: 6000,
+      q: 1,
+      cv_amount: 0
+    }, col(1), Y + 1100);
+    add(id("hat-env"), T.adsr, {
+      attack: 0.001,
+      decay: 0.03,
+      sustain: 0,
+      release: 0.02
+    }, col(1), Y + 1220);
+    add(id("hat-vca"), T.vca, { gain: 1 }, col(2), Y + 1100);
+    wire(id("hat-noise"), "chunk", id("hat-vcf"), "audio");
+    wire("clk16", "cv", id("hat-env"), "gate");
+    wire(id("hat-vcf"), "chunk", id("hat-vca"), "audio");
+    wire(id("hat-env"), "cv", id("hat-vca"), "cv");
+
+    // ── Kick: beat thump ─────────────────────────────────────────────
+    add(id("kick-osc"), T.osc, {
+      waveform: "sine",
+      frequency: 50,
+      amplitude: 1
+    }, col(3), Y + 1100);
+    add(id("kick-env"), T.adsr, {
+      attack: 0.001,
+      decay: 0.12,
+      sustain: 0,
+      release: 0.05
+    }, col(3), Y + 1220);
+    add(id("kick-vca"), T.vca, { gain: 1 }, col(4), Y + 1100);
+    wire("clk2", "cv", id("kick-env"), "gate");
+    wire(id("kick-osc"), "chunk", id("kick-vca"), "audio");
+    wire(id("kick-env"), "cv", id("kick-vca"), "cv");
+
+    // ── Drone: breathing FM sub ──────────────────────────────────────
+    add(id("drone-fm"), T.lfo, {
+      waveform: "sine",
+      rate_hz: rate(0.07),
+      depth: 1,
+      offset: 0
+    }, col(0), Y + 1380);
+    add(id("drone-osc"), T.osc, {
+      waveform: "sine",
+      frequency: 27.5 * det,
+      amplitude: 0.8,
+      fm_amount: 0.4
+    }, col(1), Y + 1380);
+    add(id("drone-env"), T.adsr, {
+      attack: 2,
+      decay: 2,
+      sustain: 0.8,
+      release: 2
+    }, col(1), Y + 1500);
+    add(id("drone-vca"), T.vca, { gain: 1 }, col(2), Y + 1380);
+    wire(id("drone-fm"), "cv", id("drone-osc"), "fm");
+    wire("clkBar", "cv", id("drone-env"), "gate");
+    wire(id("drone-osc"), "chunk", id("drone-vca"), "audio");
+    wire(id("drone-env"), "cv", id("drone-vca"), "cv");
+
+    // ── Layer mix: rhythm bus + melodic bus → layer bus ──────────────
+    add(id("mix-rhythm"), T.mixer, {
+      level1: 0.85, // bass
+      level2: 0.9, // kick
+      level3: 0.4, // arp
+      level4: 0.16 // hat
+    }, col(5), Y + 200);
+    add(id("mix-tonal"), T.mixer, {
+      level1: 0.4, // pad
+      level2: 0.32, // lead
+      level3: 0.3 // drone
+    }, col(5), Y + 540);
+    add(id("mix-layer"), T.mixer, { level1: level, level2: level }, col(6), Y + 340);
+    wire(id("bass-vca"), "chunk", id("mix-rhythm"), "in1");
+    wire(id("kick-vca"), "chunk", id("mix-rhythm"), "in2");
+    wire(id("arp-vca"), "chunk", id("mix-rhythm"), "in3");
+    wire(id("hat-vca"), "chunk", id("mix-rhythm"), "in4");
+    wire(id("pad-vca"), "chunk", id("mix-tonal"), "in1");
+    wire(id("lead-vca"), "chunk", id("mix-tonal"), "in2");
+    wire(id("drone-vca"), "chunk", id("mix-tonal"), "in3");
+    wire(id("mix-rhythm"), "chunk", id("mix-layer"), "in1");
+    wire(id("mix-tonal"), "chunk", id("mix-layer"), "in2");
+    layerOuts.push(id("mix-layer"));
+  }
+
+  // ── Fold layers 4-at-a-time, then master chain ─────────────────────
+  let stage = layerOuts;
+  let foldSeq = 0;
+  while (stage.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < stage.length; i += 4) {
+      const group = stage.slice(i, i + 4);
+      const mixer = `fold-${foldSeq++}`;
+      add(mixer, T.mixer, {
+        level1: 1,
+        level2: 1,
+        level3: 1,
+        level4: 1
+      }, 2300 + foldSeq * 60, Math.floor(i / 4) * 300);
+      group.forEach((src, g) => wire(src, "chunk", mixer, `in${g + 1}`));
+      next.push(mixer);
+    }
+    stage = next;
+  }
+
+  add("master-gain", T.gain, { gain_db: -8 }, 2700, 200);
+  add("master-hp", T.highpass, { cutoff_frequency_hz: 35 }, 2960, 200);
+  add("speaker", T.out, {}, 3220, 200);
+  wire(stage[0], "chunk", "master-gain", "chunk");
+  wire("master-gain", "chunk", "master-hp", "chunk");
+  wire("master-hp", "chunk", "speaker", "chunk");
+
+  return { nodes, edges };
+}

--- a/web/src/perf/realtimePerfHarness.ts
+++ b/web/src/perf/realtimePerfHarness.ts
@@ -42,6 +42,25 @@ export interface PerfRunOptions {
    *    zip-with-hold alignment paths.
    */
   patch?: "voices" | "complex";
+  /**
+   * Real playback: route the AudioOutput stream(s) into an actual
+   * AudioContext + chunk-player worklet (live config, production defaults)
+   * and collect the worklet's per-second buffer-health stats. This is the
+   * only mode that exercises the audio-hardware clock — producer/consumer
+   * clock skew is invisible without it. Requires an audio output device
+   * (run the Playwright spec headed) and autoplay permission.
+   */
+  playback?: boolean;
+}
+
+export interface PlaybackStatsSample {
+  /** ms since run start (main-thread clock). */
+  t: number;
+  buffered: number;
+  underruns: number;
+  droppedFrames: number;
+  framesIn: number;
+  framesOut: number;
 }
 
 export interface PerfRunSummary {
@@ -74,6 +93,15 @@ export interface PerfRunSummary {
     /** Sawtooth drops between samples (≥1MB) ≈ major GC events. */
     gcEvents: number;
     gcReclaimedMb: number;
+  } | null;
+  /** Worklet buffer-health timeline; null unless options.playback. */
+  playback: {
+    stats: PlaybackStatsSample[];
+    underruns: number;
+    droppedFrames: number;
+    framesIn: number;
+    framesOut: number;
+    contextSampleRate: number;
   } | null;
   runError?: string;
 }
@@ -356,6 +384,60 @@ export async function startPerfRun(
   // we measure the steady-state stream, not startup.
   await getBrowserWorkerReady();
 
+  // Real playback sink: production worklet, production live config.
+  const audioOutIds = new Set(
+    nodes
+      .filter((n) => n.type === "nodetool.audio.realtime.AudioOutput")
+      .map((n) => n.id)
+  );
+  const playbackStats: PlaybackStatsSample[] = [];
+  let playbackCtx: AudioContext | null = null;
+  let playbackNode: AudioWorkletNode | null = null;
+  const runStartRef = { t: 0 };
+  if (options.playback) {
+    playbackCtx = new AudioContext({
+      sampleRate: SYNTH_SAMPLE_RATE,
+      latencyHint: "interactive"
+    });
+    const { getChunkPlayerWorkletUrl } = await import(
+      "../lib/audio/chunkPlayerWorkletUrl"
+    );
+    await playbackCtx.audioWorklet.addModule(getChunkPlayerWorkletUrl());
+    playbackNode = new AudioWorkletNode(playbackCtx, "nodetool-chunk-player", {
+      numberOfInputs: 0,
+      outputChannelCount: [1]
+    });
+    playbackNode.connect(playbackCtx.destination);
+    playbackNode.port.postMessage({
+      type: "config",
+      sampleRate: SYNTH_SAMPLE_RATE,
+      channels: 1,
+      live: true,
+      primeSeconds: 0.04,
+      maxLeadSeconds: 0.1
+    });
+    playbackNode.port.onmessage = (event: MessageEvent) => {
+      const d = event.data as {
+        type?: string;
+        buffered?: number;
+        underruns?: number;
+        droppedFrames?: number;
+        framesIn?: number;
+        framesOut?: number;
+      };
+      if (d?.type !== "stats") return;
+      playbackStats.push({
+        t: Math.round(performance.now() - runStartRef.t),
+        buffered: d.buffered ?? 0,
+        underruns: d.underruns ?? 0,
+        droppedFrames: d.droppedFrames ?? 0,
+        framesIn: d.framesIn ?? 0,
+        framesOut: d.framesOut ?? 0
+      });
+    };
+    await playbackCtx.resume();
+  }
+
   const chunksPerNode: Record<string, number> = {};
   const messageCountsByType: Record<string, number> = {};
   let totalAudioChunks = 0;
@@ -381,6 +463,12 @@ export async function startPerfRun(
         totalAudioChunks++;
         if (m.value.content instanceof Float32Array) {
           totalSamples += m.value.content.length;
+          if (playbackNode && audioOutIds.has(nodeId)) {
+            playbackNode.port.postMessage({
+              type: "chunk",
+              samples: m.value.content
+            });
+          }
         }
       }
     }
@@ -420,6 +508,7 @@ export async function startPerfRun(
 
   const controller = new AbortController();
   const started = performance.now();
+  runStartRef.t = started;
   const runPromise = runBrowserGraphJobInWorker({
     graph: { nodes, edges },
     jobId: `perf-${Date.now()}`,
@@ -436,6 +525,13 @@ export async function startPerfRun(
   clearInterval(lagInterval);
   longTaskObserver?.disconnect();
   unsubscribe();
+  const lastPlayback = playbackStats[playbackStats.length - 1];
+  try {
+    playbackNode?.disconnect();
+    await playbackCtx?.close();
+  } catch {
+    // playback teardown is best-effort
+  }
   const endHeap = heapBytes();
   if (endHeap !== null) heapSamples.push(endHeap);
 
@@ -464,6 +560,17 @@ export async function startPerfRun(
     },
     longTasks: { count: longTaskCount, totalMs: Math.round(longTaskTotalMs) },
     heap: heapStats(heapSamples, elapsedMs),
+    playback:
+      options.playback && playbackCtx
+        ? {
+            stats: playbackStats,
+            underruns: lastPlayback?.underruns ?? 0,
+            droppedFrames: lastPlayback?.droppedFrames ?? 0,
+            framesIn: lastPlayback?.framesIn ?? 0,
+            framesOut: lastPlayback?.framesOut ?? 0,
+            contextSampleRate: playbackCtx.sampleRate
+          }
+        : null,
     // The harness ends every run by aborting the infinite patch — that
     // cancellation is the expected outcome, not a failure.
     runError:
@@ -495,6 +602,7 @@ if (params.get("autorun")) {
   void window.__realtimePerf.start({
     voices: Number(params.get("voices") ?? 8),
     durationMs: Number(params.get("durationMs") ?? 10_000),
-    patch: params.get("patch") === "complex" ? "complex" : "voices"
+    patch: params.get("patch") === "complex" ? "complex" : "voices",
+    playback: params.get("playback") === "1"
   });
 }

--- a/web/src/perf/realtimePerfHarness.ts
+++ b/web/src/perf/realtimePerfHarness.ts
@@ -21,6 +21,7 @@ import {
   runBrowserGraphJobInWorker
 } from "../lib/workflow/browserWorkerClient";
 import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
+import { buildMegaSynthPatch } from "./megaSynthPatch";
 
 const SYNTH_SAMPLE_RATE = 24000;
 const SYNTH_CHUNK_FRAMES = 512;
@@ -40,8 +41,10 @@ export interface PerfRunOptions {
    *    high-pass → ONE output. ~9 nodes/voice, deep chains, fan-outs and
    *    several clock domains — stresses kernel scheduling and the
    *    zip-with-hold alignment paths.
+   *  - "mega": the Mega Synth demo ensemble (see megaSynthPatch.ts) —
+   *    `voices` = detuned ensemble layers; 1 layer ≈ 50 nodes, 24 ≈ 1,100.
    */
-  patch?: "voices" | "complex";
+  patch?: "voices" | "complex" | "mega";
   /**
    * Real playback: route the AudioOutput stream(s) into an actual
    * AudioContext + chunk-player worklet (live config, production defaults)
@@ -65,7 +68,7 @@ export interface PlaybackStatsSample {
 
 export interface PerfRunSummary {
   voices: number;
-  patch: "voices" | "complex";
+  patch: "voices" | "complex" | "mega";
   nodeCount: number;
   edgeCount: number;
   /** Number of AudioOutput streams (expected-rate basis). */
@@ -375,7 +378,11 @@ export async function startPerfRun(
   const durationMs = Math.max(1000, Math.floor(options.durationMs ?? 10_000));
   const patch = options.patch ?? "voices";
   const { nodes, edges } =
-    patch === "complex" ? buildComplexPatch(voices) : buildPatch(voices);
+    patch === "mega"
+      ? buildMegaSynthPatch(voices)
+      : patch === "complex"
+        ? buildComplexPatch(voices)
+        : buildPatch(voices);
   const outputStreams = nodes.filter(
     (n) => n.type === "nodetool.audio.realtime.AudioOutput"
   ).length;
@@ -395,10 +402,9 @@ export async function startPerfRun(
   let playbackNode: AudioWorkletNode | null = null;
   const runStartRef = { t: 0 };
   if (options.playback) {
-    playbackCtx = new AudioContext({
-      sampleRate: SYNTH_SAMPLE_RATE,
-      latencyHint: "interactive"
-    });
+    // System-native rate, matching the production hook — the worklet
+    // resamples chunk-rate → context-rate.
+    playbackCtx = new AudioContext({ latencyHint: "interactive" });
     const { getChunkPlayerWorkletUrl } = await import(
       "../lib/audio/chunkPlayerWorkletUrl"
     );
@@ -602,7 +608,12 @@ if (params.get("autorun")) {
   void window.__realtimePerf.start({
     voices: Number(params.get("voices") ?? 8),
     durationMs: Number(params.get("durationMs") ?? 10_000),
-    patch: params.get("patch") === "complex" ? "complex" : "voices",
+    patch:
+      params.get("patch") === "mega"
+        ? "mega"
+        : params.get("patch") === "complex"
+          ? "complex"
+          : "voices",
     playback: params.get("playback") === "1"
   });
 }

--- a/web/src/perf/realtimePerfHarness.ts
+++ b/web/src/perf/realtimePerfHarness.ts
@@ -1,0 +1,500 @@
+/**
+ * Realtime workflow perf harness (see perf-realtime.html).
+ *
+ * Runs a parametric modular-synth patch in the real browser-runner Web Worker
+ * — the exact production path (kernel in worker, 16ms message batches,
+ * deliverLocal on the main thread) — and measures what the editor would
+ * experience, without mounting the editor:
+ *
+ *  - chunk throughput per output node vs the expected realtime rate
+ *    (24000 Hz / 512-frame chunks ≈ 46.9 chunks/s per voice) — the realtime
+ *    health signal: a CPU-bound worker falls below it
+ *  - main-thread event-loop lag and long tasks while the stream runs
+ *  - JS heap samples (Chrome) for leak/GC-churn detection
+ *
+ * Worker-side CPU/heap is sampled externally by the Playwright spec
+ * (tests/benchmarks/realtime-perf.spec.ts) via worker.evaluate and CDP, so
+ * this module needs no instrumentation hooks in production worker code.
+ */
+import {
+  getBrowserWorkerReady,
+  runBrowserGraphJobInWorker
+} from "../lib/workflow/browserWorkerClient";
+import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
+
+const SYNTH_SAMPLE_RATE = 24000;
+const SYNTH_CHUNK_FRAMES = 512;
+
+export interface PerfRunOptions {
+  /** Number of synth voices. */
+  voices?: number;
+  /** How long to let the patch run before aborting it. */
+  durationMs?: number;
+  /**
+   * Patch topology:
+   *  - "voices": N independent chains (osc → low-pass → gain → audio out),
+   *    one output stream each — scales transport/UI load linearly.
+   *  - "complex": a real modular patch — master Gate clock, per voice a
+   *    noise→S&H→Attenuverter random pitch CV, clocked FM + filter LFOs,
+   *    ADSR→VCA, resonant VCF, all voices through a mixer tree → gain →
+   *    high-pass → ONE output. ~9 nodes/voice, deep chains, fan-outs and
+   *    several clock domains — stresses kernel scheduling and the
+   *    zip-with-hold alignment paths.
+   */
+  patch?: "voices" | "complex";
+}
+
+export interface PerfRunSummary {
+  voices: number;
+  patch: "voices" | "complex";
+  nodeCount: number;
+  edgeCount: number;
+  /** Number of AudioOutput streams (expected-rate basis). */
+  outputStreams: number;
+  durationMs: number;
+  /** Audio-chunk output_updates received on the main thread, per node. */
+  chunksPerNode: Record<string, number>;
+  totalAudioChunks: number;
+  totalSamples: number;
+  /** Achieved vs expected chunk rate across all voices (1 = realtime). */
+  chunkRateRatio: number;
+  expectedChunksPerSecondPerVoice: number;
+  messageCountsByType: Record<string, number>;
+  /** Main-thread event-loop lag over-delay (ms) percentiles. */
+  mainThreadLagMs: { p50: number; p95: number; max: number };
+  /** PerformanceObserver longtask totals during the run. */
+  longTasks: { count: number; totalMs: number };
+  /** usedJSHeapSize stats (bytes); null when performance.memory is absent. */
+  heap: {
+    start: number;
+    end: number;
+    peak: number;
+    /** Net heap growth rate — the memory-pressure signal on long runs. */
+    growthMbPerMin: number;
+    /** Sawtooth drops between samples (≥1MB) ≈ major GC events. */
+    gcEvents: number;
+    gcReclaimedMb: number;
+  } | null;
+  runError?: string;
+}
+
+interface GraphNode {
+  [key: string]: unknown;
+  id: string;
+  type: string;
+  properties: Record<string, unknown>;
+}
+interface GraphEdge {
+  [key: string]: unknown;
+  id: string;
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}
+
+/** V independent voices: Oscillator → StreamingLowPass → StreamingGain → AudioOutput. */
+function buildPatch(voices: number): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  for (let i = 0; i < voices; i++) {
+    const osc = `osc-${i}`;
+    const lp = `lp-${i}`;
+    const gain = `gain-${i}`;
+    const out = `out-${i}`;
+    nodes.push(
+      {
+        id: osc,
+        type: "nodetool.audio.synth.Oscillator",
+        properties: {
+          waveform: "saw",
+          frequency: 110 + 55 * i,
+          amplitude: 0.5,
+          sample_rate: SYNTH_SAMPLE_RATE
+        }
+      },
+      {
+        id: lp,
+        type: "nodetool.audio.realtime.StreamingLowPass",
+        properties: { cutoff_frequency_hz: 4000 }
+      },
+      {
+        id: gain,
+        type: "nodetool.audio.realtime.StreamingGain",
+        properties: { gain_db: -12 }
+      },
+      { id: out, type: "nodetool.audio.realtime.AudioOutput", properties: {} }
+    );
+    const chain = [osc, lp, gain, out];
+    for (let s = 0; s < chain.length - 1; s++) {
+      edges.push({
+        id: `e-${i}-${s}`,
+        source: chain[s],
+        sourceHandle: "chunk",
+        target: chain[s + 1],
+        targetHandle: "chunk"
+      });
+    }
+  }
+  return { nodes, edges };
+}
+
+/**
+ * A full modular synth patch, Eurorack-style:
+ *
+ *   gate ──────────────┬─► adsr-v ─► vca-v.cv
+ *                      ├─► lfo-fm-v.clock ─► osc-v.fm
+ *                      ├─► lfo-cut-v.clock ─► vcf-v.cutoff_cv
+ *                      └─► sh-v.trigger
+ *   noise-v ─► sh-v.signal ─► att-v ─► osc-v.pitch_cv
+ *   osc-v ─► vcf-v.audio ─► vca-v.audio ─► mixer tree ─► gain ─► hp ─► out
+ *
+ * One shared master clock; per-voice free-running noise generators add
+ * independent clock domains, so the kernel's sample-FIFO hold-last paths get
+ * exercised alongside the clocked, sample-aligned ones.
+ */
+function buildComplexPatch(voices: number): {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+} {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  let edgeSeq = 0;
+  const connect = (
+    source: string,
+    sourceHandle: string,
+    target: string,
+    targetHandle: string
+  ): void => {
+    edges.push({
+      id: `e-${edgeSeq++}`,
+      source,
+      sourceHandle,
+      target,
+      targetHandle
+    });
+  };
+
+  nodes.push({
+    id: "gate",
+    type: "nodetool.audio.synth.Gate",
+    properties: { on_duration: 0.15, off_duration: 0.1, amplitude: 1 }
+  });
+
+  const voiceOuts: string[] = [];
+  for (let v = 0; v < voices; v++) {
+    const noise = `noise-${v}`;
+    const sh = `sh-${v}`;
+    const att = `att-${v}`;
+    const lfoFm = `lfo-fm-${v}`;
+    const lfoCut = `lfo-cut-${v}`;
+    const osc = `osc-${v}`;
+    const vcf = `vcf-${v}`;
+    const adsr = `adsr-${v}`;
+    const vca = `vca-${v}`;
+    nodes.push(
+      {
+        id: noise,
+        type: "nodetool.audio.synth.Oscillator",
+        properties: { waveform: "noise", amplitude: 1 }
+      },
+      { id: sh, type: "nodetool.audio.synth.SampleHold", properties: {} },
+      {
+        id: att,
+        type: "nodetool.audio.synth.Attenuverter",
+        // Quantize-ish spread: each voice holds a different octave offset.
+        properties: { scale: 1.5, offset: (v % 4) * 0.5 }
+      },
+      {
+        id: lfoFm,
+        type: "nodetool.audio.synth.LFO",
+        properties: { waveform: "sine", rate_hz: 4 + v * 0.37, depth: 0.2 }
+      },
+      {
+        id: lfoCut,
+        type: "nodetool.audio.synth.LFO",
+        properties: {
+          waveform: "triangle",
+          rate_hz: 0.15 + v * 0.07,
+          depth: 0.5,
+          offset: 0.5
+        }
+      },
+      {
+        id: osc,
+        type: "nodetool.audio.synth.Oscillator",
+        properties: {
+          waveform: v % 2 === 0 ? "saw" : "square",
+          frequency: 55 * Math.pow(2, v % 3),
+          amplitude: 0.6,
+          fm_amount: 0.3
+        }
+      },
+      {
+        id: vcf,
+        type: "nodetool.audio.synth.VCF",
+        properties: { mode: "lowpass", cutoff_hz: 800, q: 4, cv_amount: 3 }
+      },
+      {
+        id: adsr,
+        type: "nodetool.audio.synth.ADSR",
+        properties: { attack: 0.01, decay: 0.08, sustain: 0.6, release: 0.12 }
+      },
+      { id: vca, type: "nodetool.audio.synth.VCA", properties: { gain: 1 } }
+    );
+    connect("gate", "cv", adsr, "gate");
+    connect("gate", "cv", lfoFm, "clock");
+    connect("gate", "cv", lfoCut, "clock");
+    connect("gate", "cv", sh, "trigger");
+    connect(noise, "chunk", sh, "signal");
+    connect(sh, "cv", att, "signal");
+    connect(att, "cv", osc, "pitch_cv");
+    connect(lfoFm, "cv", osc, "fm");
+    connect(osc, "chunk", vcf, "audio");
+    connect(lfoCut, "cv", vcf, "cutoff_cv");
+    connect(adsr, "cv", vca, "cv");
+    connect(vcf, "chunk", vca, "audio");
+    voiceOuts.push(vca);
+  }
+
+  // Mixer tree: fold streams 4-at-a-time until one remains.
+  let stage = voiceOuts;
+  let mixerSeq = 0;
+  while (stage.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < stage.length; i += 4) {
+      const group = stage.slice(i, i + 4);
+      const mixer = `mixer-${mixerSeq++}`;
+      nodes.push({
+        id: mixer,
+        type: "nodetool.audio.synth.Mixer",
+        properties: { level1: 0.3, level2: 0.3, level3: 0.3, level4: 0.3 }
+      });
+      group.forEach((source, g) =>
+        connect(source, "chunk", mixer, `in${g + 1}`)
+      );
+      next.push(mixer);
+    }
+    stage = next;
+  }
+
+  nodes.push(
+    {
+      id: "master-gain",
+      type: "nodetool.audio.realtime.StreamingGain",
+      properties: { gain_db: -6 }
+    },
+    {
+      id: "master-hp",
+      type: "nodetool.audio.realtime.StreamingHighPass",
+      properties: { cutoff_frequency_hz: 40 }
+    },
+    { id: "out", type: "nodetool.audio.realtime.AudioOutput", properties: {} }
+  );
+  connect(stage[0], "chunk", "master-gain", "chunk");
+  connect("master-gain", "chunk", "master-hp", "chunk");
+  connect("master-hp", "chunk", "out", "chunk");
+
+  return { nodes, edges };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.floor((p / 100) * sorted.length)
+  );
+  return sorted[idx];
+}
+
+function heapStats(
+  samples: number[],
+  elapsedMs: number
+): PerfRunSummary["heap"] {
+  if (samples.length === 0) return null;
+  let gcEvents = 0;
+  let gcReclaimed = 0;
+  for (let i = 1; i < samples.length; i++) {
+    const drop = samples[i - 1] - samples[i];
+    if (drop >= 1024 * 1024) {
+      gcEvents++;
+      gcReclaimed += drop;
+    }
+  }
+  const minutes = Math.max(elapsedMs / 60_000, 1e-6);
+  return {
+    start: samples[0],
+    end: samples[samples.length - 1],
+    peak: Math.max(...samples),
+    growthMbPerMin:
+      (samples[samples.length - 1] - samples[0]) / 1024 / 1024 / minutes,
+    gcEvents,
+    gcReclaimedMb: gcReclaimed / 1024 / 1024
+  };
+}
+
+const heapBytes = (): number | null => {
+  const mem = (
+    performance as Performance & { memory?: { usedJSHeapSize: number } }
+  ).memory;
+  return mem ? mem.usedJSHeapSize : null;
+};
+
+export async function startPerfRun(
+  options: PerfRunOptions = {}
+): Promise<PerfRunSummary> {
+  const voices = Math.max(1, Math.floor(options.voices ?? 8));
+  const durationMs = Math.max(1000, Math.floor(options.durationMs ?? 10_000));
+  const patch = options.patch ?? "voices";
+  const { nodes, edges } =
+    patch === "complex" ? buildComplexPatch(voices) : buildPatch(voices);
+  const outputStreams = nodes.filter(
+    (n) => n.type === "nodetool.audio.realtime.AudioOutput"
+  ).length;
+
+  // Worker init (module load, registry build) happens before measurement —
+  // we measure the steady-state stream, not startup.
+  await getBrowserWorkerReady();
+
+  const chunksPerNode: Record<string, number> = {};
+  const messageCountsByType: Record<string, number> = {};
+  let totalAudioChunks = 0;
+  let totalSamples = 0;
+
+  const unsubscribe = globalWebSocketManager.subscribeEvent(
+    "message",
+    (message: unknown) => {
+      const m = message as {
+        type?: string;
+        node_id?: string;
+        value?: { type?: string; content_type?: string; content?: unknown };
+      };
+      const type = m.type ?? "unknown";
+      messageCountsByType[type] = (messageCountsByType[type] ?? 0) + 1;
+      if (
+        type === "output_update" &&
+        m.value?.type === "chunk" &&
+        m.value.content_type === "audio"
+      ) {
+        const nodeId = m.node_id ?? "unknown";
+        chunksPerNode[nodeId] = (chunksPerNode[nodeId] ?? 0) + 1;
+        totalAudioChunks++;
+        if (m.value.content instanceof Float32Array) {
+          totalSamples += m.value.content.length;
+        }
+      }
+    }
+  );
+
+  // Main-thread event-loop lag: how much later than scheduled each tick runs.
+  const lagSamples: number[] = [];
+  const TICK_MS = 20;
+  let expectedTick = performance.now() + TICK_MS;
+  const heapSamples: number[] = [];
+  const startHeap = heapBytes();
+  if (startHeap !== null) heapSamples.push(startHeap);
+  const lagInterval = setInterval(() => {
+    const now = performance.now();
+    lagSamples.push(Math.max(0, now - expectedTick));
+    expectedTick = now + TICK_MS;
+    if (lagSamples.length % 25 === 0) {
+      const h = heapBytes();
+      if (h !== null) heapSamples.push(h);
+    }
+  }, TICK_MS);
+
+  let longTaskCount = 0;
+  let longTaskTotalMs = 0;
+  let longTaskObserver: PerformanceObserver | null = null;
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTaskCount++;
+        longTaskTotalMs += entry.duration;
+      }
+    });
+    longTaskObserver.observe({ entryTypes: ["longtask"] });
+  } catch {
+    // longtask observation unsupported — counts stay zero
+  }
+
+  const controller = new AbortController();
+  const started = performance.now();
+  const runPromise = runBrowserGraphJobInWorker({
+    graph: { nodes, edges },
+    jobId: `perf-${Date.now()}`,
+    workflowId: "perf-realtime",
+    signal: controller.signal
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, durationMs));
+  const elapsedMs = performance.now() - started;
+
+  controller.abort();
+  const result = await runPromise;
+
+  clearInterval(lagInterval);
+  longTaskObserver?.disconnect();
+  unsubscribe();
+  const endHeap = heapBytes();
+  if (endHeap !== null) heapSamples.push(endHeap);
+
+  const expectedChunksPerSecondPerVoice = SYNTH_SAMPLE_RATE / SYNTH_CHUNK_FRAMES;
+  const expectedTotal =
+    expectedChunksPerSecondPerVoice * outputStreams * (elapsedMs / 1000);
+  lagSamples.sort((a, b) => a - b);
+
+  return {
+    voices,
+    patch,
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    outputStreams,
+    durationMs: Math.round(elapsedMs),
+    chunksPerNode,
+    totalAudioChunks,
+    totalSamples,
+    chunkRateRatio: expectedTotal > 0 ? totalAudioChunks / expectedTotal : 0,
+    expectedChunksPerSecondPerVoice,
+    messageCountsByType,
+    mainThreadLagMs: {
+      p50: percentile(lagSamples, 50),
+      p95: percentile(lagSamples, 95),
+      max: lagSamples[lagSamples.length - 1] ?? 0
+    },
+    longTasks: { count: longTaskCount, totalMs: Math.round(longTaskTotalMs) },
+    heap: heapStats(heapSamples, elapsedMs),
+    // The harness ends every run by aborting the infinite patch — that
+    // cancellation is the expected outcome, not a failure.
+    runError:
+      result.success || result.error === "Cancelled" ? undefined : result.error
+  };
+}
+
+declare global {
+  interface Window {
+    __realtimePerf: { start: (opts?: PerfRunOptions) => Promise<PerfRunSummary> };
+  }
+}
+
+const statusEl = document.getElementById("status");
+const resultEl = document.getElementById("result");
+
+window.__realtimePerf = {
+  start: async (opts?: PerfRunOptions) => {
+    if (statusEl) statusEl.textContent = `running ${JSON.stringify(opts ?? {})}`;
+    const summary = await startPerfRun(opts);
+    if (statusEl) statusEl.textContent = "done";
+    if (resultEl) resultEl.textContent = JSON.stringify(summary, null, 2);
+    return summary;
+  }
+};
+
+const params = new URLSearchParams(window.location.search);
+if (params.get("autorun")) {
+  void window.__realtimePerf.start({
+    voices: Number(params.get("voices") ?? 8),
+    durationMs: Number(params.get("durationMs") ?? 10_000),
+    patch: params.get("patch") === "complex" ? "complex" : "voices"
+  });
+}

--- a/web/src/stores/ResultsStore.ts
+++ b/web/src/stores/ResultsStore.ts
@@ -13,6 +13,18 @@ import { PlanningUpdate, ProviderCost, Task, ToolCallUpdate } from "./ApiTypes";
 import { nodeKey, edgeKey, type NodeKey, type EdgeKey } from "./nodeKey";
 import type { Generation } from "../utils/nodeGenerations";
 
+/** Rolling-window size for appended audio-chunk stream buffers (~20s of
+ * audio at the synth nodes' 512-frame / 24 kHz chunks). */
+const MAX_AUDIO_STREAM_CHUNKS = 1024;
+
+const isAudioStreamChunk = (v: unknown): boolean => {
+  if (!v || typeof v !== "object") {
+    return false;
+  }
+  const c = v as Record<string, unknown>;
+  return c.type === "chunk" && c.content_type === "audio";
+};
+
 type ResultsStore = {
   outputResults: Record<NodeKey, unknown>;
   liveGenerations: Record<string, Generation[]>;
@@ -33,6 +45,7 @@ type ResultsStore = {
   clearChunks: (workflowId: string, nodeIds?: Set<string>) => void;
   clearPlanningUpdates: (workflowId: string, nodeIds?: Set<string>) => void;
   clearEdges: (workflowId: string, edgeIds?: Set<string>) => void;
+  clearJobRunVisuals: (workflowId: string, jobId: string) => void;
   setEdge: (
     workflowId: string,
     jobId: string,
@@ -74,6 +87,12 @@ type ResultsStore = {
     nodeId: string,
     result: unknown,
     append?: boolean
+  ) => void;
+  appendOutputResults: (
+    workflowId: string,
+    jobId: string,
+    nodeId: string,
+    results: unknown[]
   ) => void;
   setTask: (
     workflowId: string,
@@ -204,6 +223,31 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
   clearEdges: (workflowId: string, edgeIds?: Set<string>) => {
     set((state) => ({
       edges: filterRecord(state.edges, workflowId, edgeIds)
+    }));
+  },
+  /**
+   * Drop one run's transient visuals — edge animations and node progress.
+   * Job-scoped (keys are `${workflowId}:${jobId}:…`), so concurrent sibling
+   * runs keep theirs. Outputs/generations are left intact so the cancelled
+   * run can still be focused and inspected.
+   */
+  clearJobRunVisuals: (workflowId: string, jobId: string) => {
+    const prefix = `${workflowId}:${jobId}:`;
+    const dropJobKeys = <K extends string, T>(
+      record: Record<K, T>
+    ): Record<K, T> => {
+      const next = { ...record };
+      for (const key in next) {
+        if (key.startsWith(prefix)) {
+          delete next[key];
+        }
+      }
+      return next;
+    };
+    set((state) => ({
+      edges: dropJobKeys(state.edges),
+      progress: dropJobKeys(state.progress),
+      resultsVersion: state.resultsVersion + 1
     }));
   },
   /**
@@ -492,10 +536,22 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
         };
       } else {
         if (Array.isArray(currentResult)) {
+          let appended = [...currentResult, result];
+          // Realtime audio streams are infinite; without a cap the buffer
+          // (and the per-chunk array copy above) grows unboundedly and the
+          // resulting GC churn turns into audible scheduling jank. Keep a
+          // rolling window — playback tracks chunks by identity, so head
+          // trimming is safe. Text/other streams are left untouched.
+          if (
+            appended.length > MAX_AUDIO_STREAM_CHUNKS &&
+            isAudioStreamChunk(result)
+          ) {
+            appended = appended.slice(appended.length - MAX_AUDIO_STREAM_CHUNKS);
+          }
           return {
             outputResults: {
               ...state.outputResults,
-              [key]: [...currentResult, result]
+              [key]: appended
             },
             resultsVersion: nextVersion
           };
@@ -509,6 +565,43 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
           };
         }
       }
+    });
+  },
+
+  /**
+   * Append a batch of streamed results to a node's buffer in ONE store set.
+   *
+   * Realtime audio streams arrive at ~50 chunks/s per node; appending each
+   * chunk via setOutputResult would do one array copy + one subscriber
+   * notification per chunk. Callers coalesce chunks (workflowUpdates flushes
+   * on a timer) and land them here in a single copy/notify.
+   */
+  appendOutputResults: (
+    workflowId: string,
+    jobId: string,
+    nodeId: string,
+    results: unknown[]
+  ) => {
+    if (results.length === 0) return;
+    const key = nodeKey(workflowId, jobId, nodeId);
+    set((state) => {
+      const current = state.outputResults[key];
+      let appended =
+        current === undefined
+          ? [...results]
+          : Array.isArray(current)
+            ? [...current, ...results]
+            : [current, ...results];
+      if (
+        appended.length > MAX_AUDIO_STREAM_CHUNKS &&
+        isAudioStreamChunk(results[results.length - 1])
+      ) {
+        appended = appended.slice(appended.length - MAX_AUDIO_STREAM_CHUNKS);
+      }
+      return {
+        outputResults: { ...state.outputResults, [key]: appended },
+        resultsVersion: state.resultsVersion + 1
+      };
     });
   },
 

--- a/web/src/stores/RunWarningStore.ts
+++ b/web/src/stores/RunWarningStore.ts
@@ -1,28 +1,38 @@
 import { create } from "zustand";
 
 /**
- * Session-scoped state for the "large run" confirmation dialog.
+ * Session-scoped state for the run-confirmation dialog.
  *
- * The "Run Workflow" button executes every node in the workspace at once. For
- * graphs with many provider/model nodes that can fire a lot of API calls in
- * one click, so we ask the user to confirm. Not persisted: `suppressedThisSession`
- * resets on reload, which is exactly the "don't ask again for this session"
- * semantics.
+ * Two situations ask for confirmation before starting a run:
+ * - "heavy": the "Run Workflow" button executes every node in the workspace
+ *   at once; for graphs with many provider/model nodes that can fire a lot of
+ *   API calls in one click. Suppressible per session.
+ * - "concurrent": a run of this workflow is already in progress; confirming
+ *   starts a second run alongside it. Never suppressed.
+ *
+ * Not persisted: `suppressedThisSession` resets on reload, which is exactly
+ * the "don't ask again for this session" semantics.
  */
+export type RunWarningKind = "heavy" | "concurrent";
+
 interface RunWarningState {
   /** True while the confirmation dialog is open. */
   open: boolean;
-  /** Heavy-node count that triggered the warning. */
+  /** What is being confirmed (drives the dialog copy). */
+  kind: RunWarningKind;
+  /** Heavy-node count that triggered the warning (heavy kind only). */
   heavyCount: number;
-  /** Threshold that was exceeded (shown in the dialog). */
+  /** Threshold that was exceeded (heavy kind only). */
   threshold: number;
-  /** When true, skip the warning for the rest of this browser session. */
+  /** When true, skip the heavy-run warning for the rest of this browser
+   * session. Does not apply to "concurrent" confirmations. */
   suppressedThisSession: boolean;
   /** Action to run if the user confirms. */
   onConfirm: (() => void) | null;
   requestConfirmation: (params: {
-    heavyCount: number;
-    threshold: number;
+    kind?: RunWarningKind;
+    heavyCount?: number;
+    threshold?: number;
     onConfirm: () => void;
   }) => void;
   confirm: (dontAskAgain: boolean) => void;
@@ -31,12 +41,13 @@ interface RunWarningState {
 
 export const useRunWarningStore = create<RunWarningState>((set, get) => ({
   open: false,
+  kind: "heavy",
   heavyCount: 0,
   threshold: 0,
   suppressedThisSession: false,
   onConfirm: null,
-  requestConfirmation: ({ heavyCount, threshold, onConfirm }) =>
-    set({ open: true, heavyCount, threshold, onConfirm }),
+  requestConfirmation: ({ kind = "heavy", heavyCount = 0, threshold = 0, onConfirm }) =>
+    set({ open: true, kind, heavyCount, threshold, onConfirm }),
   confirm: (dontAskAgain) => {
     const { onConfirm, suppressedThisSession } = get();
     set({

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -55,6 +55,13 @@ export interface Settings {
   confirmLargeRun: boolean;
   /** Heavy-node count above which the large-run warning is shown. */
   largeRunThreshold: number;
+  /**
+   * Realtime audio playback buffer in milliseconds. The live-monitoring
+   * buffer between the synth graph and the speakers: smaller = lower
+   * knob-to-ear latency, larger = more resilience against dropouts under
+   * load. Applies to live patches (Audio Out node).
+   */
+  audioBufferMs: number;
   autosave: AutosaveSettings;
 }
 
@@ -98,6 +105,7 @@ export const defaultSettings: Settings = {
   imageEditorOpenMode: "modal",
   confirmLargeRun: true,
   largeRunThreshold: 5,
+  audioBufferMs: 100,
   autosave: { ...defaultAutosaveSettings }
 };
 

--- a/web/src/stores/StatusStore.ts
+++ b/web/src/stores/StatusStore.ts
@@ -33,6 +33,7 @@ type StatusStore = {
     nodeId: string
   ) => StatusValue | undefined;
   clearStatuses: (workflowId: string, nodeIds?: Set<string>) => void;
+  clearJobStatuses: (workflowId: string, jobId: string) => void;
 };
 
 /** @deprecated kept as a re-export of `nodeKey` for backwards compatibility. */
@@ -75,6 +76,30 @@ const useStatusStore = create<StatusStore>((set, get) => ({
       }
     }
 
+    if (changed) {
+      set({ statuses: newStatuses });
+    }
+  },
+
+  /**
+   * Clear all node statuses belonging to one run. Job-scoped, so a
+   * concurrently running sibling job of the same workflow is untouched —
+   * used when a run is cancelled and its "running" borders must stop.
+   *
+   * @param workflowId The id of the workflow.
+   * @param jobId The id of the run/job whose statuses to drop.
+   */
+  clearJobStatuses: (workflowId: string, jobId: string) => {
+    const statuses = get().statuses;
+    const newStatuses = { ...statuses };
+    let changed = false;
+    const prefix = `${workflowId}:${jobId}:`;
+    for (const key in newStatuses) {
+      if (key.startsWith(prefix)) {
+        delete newStatuses[key as NodeKey];
+        changed = true;
+      }
+    }
     if (changed) {
       set({ statuses: newStatuses });
     }

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -22,7 +22,8 @@ import {
 } from "./ApiTypes";
 import {
   reportBrowserEligibility,
-  runBrowserGraphJob
+  runBrowserGraphJob,
+  updateBrowserJobNodeProperties
 } from "../lib/workflow/browserWorkflowRunner";
 import { uuidv4 } from "./uuidv4";
 import { useNotificationStore, Notification } from "./NotificationStore";
@@ -37,6 +38,8 @@ import { shallow } from "zustand/shallow";
 import { createRunnerMessageHandler } from "../core/workflow/runnerProtocol";
 import { materializeBitmapRefs } from "../lib/workflow/materializeBrowserOutputs";
 import { getNodeStore, MsgpackData } from "./workflowUpdates";
+import useStatusStore from "./StatusStore";
+import useResultsStore from "./ResultsStore";
 import { queryClient } from "../queryClient";
 
 export type MessageHandler = (
@@ -77,6 +80,11 @@ export const deriveJobTitle = (
   }
   return workflow.name || "Workflow";
 };
+
+/** Abort handles for in-flight in-browser runs, keyed by job id. Browser
+ * runs have no server-side job, so cancel() aborts these instead of sending
+ * `cancel_job` over the websocket. */
+const browserRunAbortControllers = new Map<string, AbortController>();
 
 const buildRunJobData = (opts: {
   jobId: string;
@@ -165,6 +173,15 @@ export type WorkflowRunner = {
   cancel: () => Promise<void>;
   pause: () => Promise<void>;
   resume: () => Promise<void>;
+  /**
+   * Push property updates into the running job's node executors (live
+   * parameters — e.g. synth knobs while a patch plays). No-op when nothing
+   * is running; the canvas state already holds the value for the next run.
+   */
+  updateRunningNodeProperties: (
+    nodeId: string,
+    properties: Record<string, unknown>
+  ) => void;
   /**
    * Start (or queue) a run and resolve with the `job_id` of the run that was
    * initiated. Callers must use this id — when the runner is already busy the
@@ -545,20 +562,30 @@ export const createWorkflowRunnerStore = (
           `WorkflowRunner[${workflowId}]: Running graph in-browser`,
           { jobId }
         );
+        // Browser runs have no server job to cancel; cancel() aborts this
+        // controller instead, which both run paths (worker + main thread)
+        // honor.
+        const abortController = new AbortController();
+        browserRunAbortControllers.set(jobId, abortController);
         void runBrowserGraphJob({
           graph: req.graph as unknown as WorkflowGraph,
           params,
           workflowId,
-          jobId
-        }).catch((error) => {
-          set({
-            state: "error",
-            statusMessage:
-              error instanceof Error
-                ? error.message
-                : "Browser execution failed"
+          jobId,
+          signal: abortController.signal
+        })
+          .catch((error) => {
+            set({
+              state: "error",
+              statusMessage:
+                error instanceof Error
+                  ? error.message
+                  : "Browser execution failed"
+            });
+          })
+          .finally(() => {
+            browserRunAbortControllers.delete(jobId);
           });
-        });
         return jobId;
       }
 
@@ -612,8 +639,29 @@ export const createWorkflowRunnerStore = (
     /**
      * Cancel the current workflow run.
      */
+    updateRunningNodeProperties: (nodeId, properties) => {
+      const { job_id, state, isBrowserRun } = get();
+      if (state !== "running" || !job_id) {
+        return;
+      }
+      if (isBrowserRun) {
+        updateBrowserJobNodeProperties(job_id, nodeId, properties);
+        return;
+      }
+      void globalWebSocketManager.send({
+        type: "update_node_properties",
+        command: "update_node_properties",
+        data: {
+          job_id,
+          workflow_id: workflowId,
+          node_id: nodeId,
+          properties
+        }
+      });
+    },
+
     cancel: async () => {
-      const { job_id, state } = get();
+      const { job_id, state, isBrowserRun } = get();
       console.info(`WorkflowRunner[${workflowId}]: Cancelling job`, { job_id });
 
       if (state === "cancelled" || state === "idle" || state === "error") {
@@ -626,6 +674,21 @@ export const createWorkflowRunnerStore = (
       set({ state: "cancelled", queuePosition: null });
 
       if (!job_id) {
+        return;
+      }
+
+      // Stop this run's visuals (node "running" borders, edge animations,
+      // progress) right away: once state is "cancelled" the message handler
+      // drops all further node/edge updates, so the backend's own cleanup
+      // messages would never land. Job-scoped — sibling runs keep theirs.
+      useStatusStore.getState().clearJobStatuses(workflowId, job_id);
+      useResultsStore.getState().clearJobRunVisuals(workflowId, job_id);
+
+      // In-browser runs have no server-side job — abort the local run; the
+      // kernel then emits the cancelled job_update / node statuses through
+      // the same message pipeline as a server cancel.
+      if (isBrowserRun) {
+        browserRunAbortControllers.get(job_id)?.abort();
         return;
       }
 
@@ -762,6 +825,7 @@ const defaultWorkflowRunner: WorkflowRunner = {
   cancel: async () => {},
   pause: async () => {},
   resume: async () => {},
+  updateRunningNodeProperties: () => {},
   run: async () => "",
   reconnect: async () => {},
   reconnectWithWorkflow: async () => {},

--- a/web/src/stores/__tests__/WorkflowRunner.test.ts
+++ b/web/src/stores/__tests__/WorkflowRunner.test.ts
@@ -48,6 +48,7 @@ jest.mock("../ResultsStore", () => ({
       clearChunks: jest.fn(),
       clearPlanningUpdates: jest.fn(),
       clearOutputResults: jest.fn(),
+      clearJobRunVisuals: jest.fn(),
     }),
   },
 }));
@@ -57,6 +58,7 @@ jest.mock("../StatusStore", () => ({
   default: {
     getState: jest.fn().mockReturnValue({
       clearStatuses: jest.fn(),
+      clearJobStatuses: jest.fn(),
       setNodeStatus: jest.fn(),
     }),
   },

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -37,6 +37,53 @@ import { useWorkflowAssetStore } from "./WorkflowAssetStore";
 import { NodeStore } from "./NodeStore";
 import { DYNAMIC_KIE_NODE_TYPE } from "../components/node/DynamicKieSchemaNode";
 import { normalizeOutputUpdateValue } from "./outputUpdateValue";
+import { publishRealtimeAudioChunk } from "../lib/audio/realtimeAudioChunkBus";
+
+/**
+ * Pending audio-chunk store appends, coalesced per node and flushed on a
+ * timer. Realtime streams append ~50 chunks/s per node; landing each one as
+ * its own ResultsStore set means one array copy + full subscriber sweep per
+ * chunk. Playback latency is unaffected — the chunk bus above delivers to
+ * the worklet immediately; the store buffer only serves mount/replay/restart,
+ * which tolerate a flush interval.
+ */
+const AUDIO_APPEND_FLUSH_MS = 200;
+const pendingAudioAppends = new Map<
+  string,
+  { workflowId: string; jobId: string; nodeId: string; chunks: unknown[] }
+>();
+let audioAppendFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const flushAudioAppends = (): void => {
+  if (audioAppendFlushTimer !== null) {
+    clearTimeout(audioAppendFlushTimer);
+    audioAppendFlushTimer = null;
+  }
+  if (pendingAudioAppends.size === 0) return;
+  const appendOutputResults = useResultsStore.getState().appendOutputResults;
+  for (const { workflowId, jobId, nodeId, chunks } of pendingAudioAppends.values()) {
+    appendOutputResults(workflowId, jobId, nodeId, chunks);
+  }
+  pendingAudioAppends.clear();
+};
+
+const queueAudioAppend = (
+  workflowId: string,
+  jobId: string,
+  nodeId: string,
+  chunk: unknown
+): void => {
+  const key = `${workflowId}:${jobId}:${nodeId}`;
+  const pending = pendingAudioAppends.get(key);
+  if (pending) {
+    pending.chunks.push(chunk);
+  } else {
+    pendingAudioAppends.set(key, { workflowId, jobId, nodeId, chunks: [chunk] });
+  }
+  if (audioAppendFlushTimer === null) {
+    audioAppendFlushTimer = setTimeout(flushAudioAppends, AUDIO_APPEND_FLUSH_MS);
+  }
+};
 
 export type { NodeStore };
 
@@ -404,36 +451,66 @@ export const handleUpdate = (
 
   if (data.type === "output_update") {
     const normalizedValue = normalizeOutputUpdateValue(data);
+
+    // Realtime audio streams emit ~50 chunks/s per node; logging/tracing each
+    // one would copy the (capped) log array per chunk for entries nobody
+    // reads. Skip audio chunks entirely.
+    const isAudioChunk =
+      typeof normalizedValue === "object" &&
+      normalizedValue !== null &&
+      (normalizedValue as { type?: unknown }).type === "chunk" &&
+      (normalizedValue as { content_type?: unknown }).content_type === "audio";
+
     // output_update feeds the output-node stream buffer only. It does NOT
     // create or modify a live generation — generations are driven solely by
-    // node_update (see the live-generations branch below).
+    // node_update (see the live-generations branch below). Audio chunks are
+    // coalesced and flushed on a timer; everything else lands immediately.
     if (messageJobId) {
-      setOutputResult(workflow.id, messageJobId, data.node_id, normalizedValue, true);
+      if (isAudioChunk) {
+        queueAudioAppend(workflow.id, messageJobId, data.node_id, normalizedValue);
+      } else {
+        setOutputResult(workflow.id, messageJobId, data.node_id, normalizedValue, true);
+      }
     }
 
-    appendLog({
-      workflowId: workflow.id,
-      workflowName: workflow.name,
-      nodeId: data.node_id,
-      nodeName: data.node_name,
-      content: `Output: ${typeof normalizedValue === "string"
-          ? normalizedValue
-          : JSON.stringify(normalizedValue)
-        }`,
-      severity: "info",
-      timestamp: Date.now()
-    });
+    if (isAudioChunk && data.node_id) {
+      // React-free fast path to the playback worklet: deliver in this task,
+      // not after the store→render→effect round trip. Same object identity
+      // as the store append above, so playback dedupes the two paths.
+      publishRealtimeAudioChunk(data.node_id, normalizedValue as Chunk);
+    }
 
-    appendTrace(
-      "output",
-      `${data.node_name || data.node_id} → ${data.output_name}`,
-      data,
-      { nodeId: data.node_id, nodeName: data.node_name }
-    );
+    if (!isAudioChunk) {
+      appendLog({
+        workflowId: workflow.id,
+        workflowName: workflow.name,
+        nodeId: data.node_id,
+        nodeName: data.node_name,
+        content: `Output: ${typeof normalizedValue === "string"
+            ? normalizedValue
+            : JSON.stringify(normalizedValue)
+          }`,
+        severity: "info",
+        timestamp: Date.now()
+      });
+
+      appendTrace(
+        "output",
+        `${data.node_name || data.node_id} → ${data.output_name}`,
+        data,
+        { nodeId: data.node_id, nodeName: data.node_name }
+      );
+    }
   }
 
   if (data.type === "chunk") {
-    if (data.node_id && data.content && messageJobId) {
+    // Binary (audio) chunk payloads don't belong in the text-chunk channel.
+    if (
+      data.node_id &&
+      typeof data.content === "string" &&
+      data.content &&
+      messageJobId
+    ) {
       addChunk(workflow.id, messageJobId, data.node_id, data.content);
     }
   }
@@ -445,6 +522,16 @@ export const handleUpdate = (
     // job list on every frame.
     const silentJob = isSilentJob(job.job_id);
     const runnerJobId = runnerStore.getState().job_id;
+    // Land any coalesced audio-chunk appends before the run's terminal state
+    // is processed, so the buffer holds the complete stream (incl. the done
+    // marker) the moment the job ends.
+    if (
+      ["completed", "failed", "cancelled", "error", "timed_out"].includes(
+        String(job.status)
+      )
+    ) {
+      flushAudioAppends();
+    }
     // The per-workflow runner represents the single full run. Concurrent
     // inline/per-node jobs share this workflow_id but have their own job_id, so
     // only updates for the runner's OWN job (or a fresh run when the runner is
@@ -602,8 +689,17 @@ export const handleUpdate = (
           alert: true,
           content: "Job cancelled"
         });
-        // Keep this run's per-job slice (see "completed"): broad clears here
-        // would erase a concurrent sibling.
+        // Keep this run's per-job results slice (see "completed"): broad
+        // clears here would erase a concurrent sibling. But do stop the
+        // run's transient visuals — node/edge updates are dropped once the
+        // runner state is "cancelled", so without this job-scoped clear the
+        // "running" borders and edge animations would persist forever.
+        if (job.job_id) {
+          useStatusStore.getState().clearJobStatuses(workflow.id, job.job_id);
+          useResultsStore
+            .getState()
+            .clearJobRunVisuals(workflow.id, job.job_id);
+        }
         break;
       case "failed":
       case "timed_out": {

--- a/web/src/utils/createAssetFile.ts
+++ b/web/src/utils/createAssetFile.ts
@@ -268,15 +268,18 @@ const chunkToOutput = (chunk: Chunk) => {
         typeof chunk.content === "string" ? chunk.content.length : undefined
     });
   }
+  // Native Float32Array audio payloads aren't a saveable string; the asset
+  // path only handles encoded (string) content.
+  const content = typeof chunk.content === "string" ? chunk.content : "";
   switch (chunk.content_type) {
     case "text":
-      return { type: "text", data: chunk.content ?? "" };
+      return { type: "text", data: content };
     case "image":
     case "audio":
     case "video":
-      return { type: chunk.content_type, data: chunk.content ?? "" };
+      return { type: chunk.content_type, data: content };
     default:
-      return chunk.content ?? chunk;
+      return content || chunk;
   }
 };
 

--- a/web/tests/benchmarks/realtime-perf.spec.ts
+++ b/web/tests/benchmarks/realtime-perf.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Realtime workflow performance test.
+ *
+ * Drives the perf harness page (perf-realtime.html), which runs a parametric
+ * synth patch in the real browser-runner Web Worker, and measures:
+ *
+ *  - main thread: CPU (CDP Performance.TaskDuration delta / wall time), JS
+ *    heap growth + GC sawtooth, event-loop lag, long tasks (harness-reported)
+ *  - worker: event-loop lag (GC pauses show up as spikes) sampled from inside
+ *    the worker via worker.evaluate — no production instrumentation needed
+ *  - agent-cluster memory: performance.measureUserAgentSpecificMemory with
+ *    per-realm attribution (page vs worker). Requires the harness page to be
+ *    cross-origin isolated — vite.config's perfPageIsolationPlugin sets
+ *    COOP/COEP for /perf-realtime only. Falls back to null when unavailable.
+ *  - stream health: achieved vs expected chunk rate (a CPU-bound worker
+ *    falls below realtime; broken pacing runs hot)
+ *
+ * The default 60s duration is deliberate: memory pressure and GC cadence
+ * only become visible once rolling buffers hit their caps (~22s) and the
+ * heap reaches steady state.
+ *
+ * Knobs: PERF_VOICES (default 8), PERF_DURATION_MS (default 60000).
+ *
+ * Run:
+ *   cd web && npx playwright test tests/benchmarks/realtime-perf.spec.ts --project=chromium
+ *
+ * Skipped in CI — perf numbers on shared runners are noise.
+ */
+import { test, expect } from "@playwright/test";
+import type { Page, Worker } from "@playwright/test";
+
+const VOICES = Number(process.env.PERF_VOICES ?? 8);
+const DURATION_MS = Number(process.env.PERF_DURATION_MS ?? 60_000);
+/** "voices" = N independent chains; "complex" = full modular patch
+ * (clock, S&H pitch CV, FM/filter LFOs, ADSR/VCA, mixer tree → 1 output). */
+const PATCH = process.env.PERF_PATCH === "complex" ? "complex" : "voices";
+
+/** Worker timer ticks arriving this late are almost certainly GC pauses. */
+const GC_PAUSE_THRESHOLD_MS = 20;
+
+const percentile = (sorted: number[], p: number): number =>
+  sorted.length === 0
+    ? 0
+    : sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+
+const mb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+
+interface AgentMemory {
+  totalBytes: number;
+  windowBytes: number;
+  workerBytes: number;
+}
+
+/**
+ * Post-GC retained memory per realm (page vs worker). The UA forces a GC
+ * before reporting, so consecutive measurements compare *retained* heap —
+ * the leak signal — rather than transient garbage.
+ */
+const measureAgentMemory = (page: Page): Promise<AgentMemory | null> =>
+  page.evaluate(async () => {
+    interface Breakdown {
+      bytes: number;
+      attribution: Array<{ scope?: string }>;
+    }
+    const perf = performance as Performance & {
+      measureUserAgentSpecificMemory?: () => Promise<{
+        bytes: number;
+        breakdown: Breakdown[];
+      }>;
+    };
+    if (!crossOriginIsolated || !perf.measureUserAgentSpecificMemory) {
+      return null;
+    }
+    let result: { bytes: number; breakdown: Breakdown[] } | null;
+    try {
+      // The UA resolves this on the next major GC (forcing one after a
+      // randomized delay) — under sustained streaming load that trigger can
+      // starve, so cap the wait rather than hang the test.
+      result = await Promise.race([
+        perf.measureUserAgentSpecificMemory(),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 30_000))
+      ]);
+    } catch {
+      // Headless-shell / stripped builds expose the API but refuse it.
+      return null;
+    }
+    if (!result) return null;
+    let workerBytes = 0;
+    let windowBytes = 0;
+    for (const entry of result.breakdown) {
+      const isWorker = entry.attribution.some((a) =>
+        (a.scope ?? "").includes("Worker")
+      );
+      if (isWorker) workerBytes += entry.bytes;
+      else windowBytes += entry.bytes;
+    }
+    return { totalBytes: result.bytes, windowBytes, workerBytes };
+  });
+
+// Unquantized performance.memory readings — required for the GC sawtooth
+// analysis (bucketed values hide small collections). channel "chromium"
+// forces the full Chromium binary (new headless): Playwright's default
+// headless shell lacks measureUserAgentSpecificMemory. Must be top-level:
+// these options force a dedicated browser worker.
+test.use({
+  channel: "chromium",
+  launchOptions: { args: ["--enable-precise-memory-info"] }
+});
+
+test.describe("Realtime workflow performance", () => {
+  test.skip(process.env.CI === "true", "perf numbers on CI runners are noise");
+  test.setTimeout(DURATION_MS + 180_000);
+
+  test(`synth patch (${PATCH}): ${VOICES} voices for ${DURATION_MS}ms`, async ({
+    page
+  }) => {
+    await page.goto("/perf-realtime.html", { waitUntil: "domcontentloaded" });
+
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send("Performance.enable");
+
+    const getMetric = async (name: string): Promise<number> => {
+      const { metrics } = await cdp.send("Performance.getMetrics");
+      return metrics.find((m) => m.name === name)?.value ?? 0;
+    };
+
+    // The runner worker spawns when the harness initializes it; arm the
+    // listener before starting the run.
+    const workerPromise = page.waitForEvent("worker", {
+      predicate: (w: Worker) => w.url().includes("browserRunner"),
+      timeout: 60_000
+    });
+
+    const runPromise = page.evaluate(
+      ({ voices, durationMs, patch }) =>
+        window.__realtimePerf.start({ voices, durationMs, patch }),
+      { voices: VOICES, durationMs: DURATION_MS, patch: PATCH as "voices" | "complex" }
+    );
+
+    const worker = await workerPromise;
+
+    // Sample event-loop lag from inside the worker while the patch runs.
+    // Sustained lag = CPU saturation; isolated spikes ≈ GC pauses.
+    await worker.evaluate(() => {
+      const g = globalThis as unknown as {
+        __perf?: { lag: number[] };
+        __perfTimer?: ReturnType<typeof setInterval>;
+      };
+      const samples: { lag: number[] } = { lag: [] };
+      g.__perf = samples;
+      const TICK = 20;
+      let expected = performance.now() + TICK;
+      g.__perfTimer = setInterval(() => {
+        const now = performance.now();
+        samples.lag.push(Math.max(0, now - expected));
+        expected = now + TICK;
+      }, TICK);
+    });
+
+    const pageTaskStart = await getMetric("TaskDuration");
+    const wallStart = Date.now();
+
+    // Retained-memory baseline a few seconds into the stream (worker up,
+    // buffers filling). The call itself forces a GC, so the comparison
+    // below is retained-vs-retained.
+    await page.waitForTimeout(3000);
+    const memoryStart = await measureAgentMemory(page);
+
+    const summary = await runPromise;
+
+    const wallSeconds = (Date.now() - wallStart) / 1000;
+    const pageTaskEnd = await getMetric("TaskDuration");
+    const memoryEnd = await measureAgentMemory(page);
+
+    const workerSamples = await worker.evaluate(() => {
+      const g = globalThis as unknown as {
+        __perf?: { lag: number[] };
+        __perfTimer?: ReturnType<typeof setInterval>;
+      };
+      if (g.__perfTimer) clearInterval(g.__perfTimer);
+      return g.__perf ?? { lag: [] };
+    });
+
+    const workerLag = [...workerSamples.lag].sort((a, b) => a - b);
+    const gcPauses = workerSamples.lag.filter(
+      (l) => l > GC_PAUSE_THRESHOLD_MS
+    );
+    const heap = summary.heap;
+
+    const report = {
+      config: {
+        voices: VOICES,
+        durationMs: DURATION_MS,
+        patch: PATCH,
+        nodes: summary.nodeCount,
+        edges: summary.edgeCount,
+        outputStreams: summary.outputStreams
+      },
+      stream: {
+        chunkRateRatio: Number(summary.chunkRateRatio.toFixed(3)),
+        totalAudioChunks: summary.totalAudioChunks,
+        messageCountsByType: summary.messageCountsByType,
+        runError: summary.runError ?? null
+      },
+      mainThread: {
+        // Fraction of wall time the page's main thread spent in tasks.
+        cpu: Number(((pageTaskEnd - pageTaskStart) / wallSeconds).toFixed(3)),
+        heap: heap
+          ? {
+              start: mb(heap.start),
+              end: mb(heap.end),
+              peak: mb(heap.peak),
+              growthMbPerMin: Number(heap.growthMbPerMin.toFixed(2)),
+              gcEvents: heap.gcEvents,
+              gcReclaimedMb: Number(heap.gcReclaimedMb.toFixed(1))
+            }
+          : null,
+        lagMs: summary.mainThreadLagMs,
+        longTasks: summary.longTasks
+      },
+      worker: {
+        lagMs: {
+          p50: Number(percentile(workerLag, 50).toFixed(2)),
+          p95: Number(percentile(workerLag, 95).toFixed(2)),
+          p99: Number(percentile(workerLag, 99).toFixed(2)),
+          max: Number((workerLag[workerLag.length - 1] ?? 0).toFixed(2))
+        },
+        gcPauses: {
+          count: gcPauses.length,
+          perMinute: Number(
+            (gcPauses.length / (wallSeconds / 60)).toFixed(2)
+          ),
+          maxMs: Number(
+            (gcPauses.length > 0 ? Math.max(...gcPauses) : 0).toFixed(2)
+          )
+        }
+      },
+      retainedMemory:
+        memoryStart && memoryEnd
+          ? {
+              page: {
+                start: mb(memoryStart.windowBytes),
+                end: mb(memoryEnd.windowBytes),
+                growth: mb(memoryEnd.windowBytes - memoryStart.windowBytes)
+              },
+              worker: {
+                start: mb(memoryStart.workerBytes),
+                end: mb(memoryEnd.workerBytes),
+                growth: mb(memoryEnd.workerBytes - memoryStart.workerBytes)
+              }
+            }
+          : null
+    };
+
+    console.log(
+      `\n=== realtime perf (${VOICES} voices, ${DURATION_MS}ms) ===\n` +
+        JSON.stringify(report, null, 2)
+    );
+
+    expect(summary.runError).toBeUndefined();
+    // Realtime health: the worker must sustain (close to) the realtime chunk
+    // rate. 0.8 is deliberately generous — this guards against collapse, not
+    // jitter; read the logged report for the actual numbers.
+    expect(summary.chunkRateRatio).toBeGreaterThan(0.8);
+    // And the stream must not run hot (producing faster than realtime would
+    // mean pacing is broken and buffers grow without bound).
+    expect(summary.chunkRateRatio).toBeLessThan(1.2);
+    // Memory pressure: with capped rolling buffers the main-thread heap must
+    // reach steady state. Generous bound — this catches unbounded growth,
+    // not GC noise.
+    if (heap && DURATION_MS >= 30_000) {
+      expect(heap.growthMbPerMin).toBeLessThan(50);
+    }
+    // Retained worker memory must not climb across the run (post-GC vs
+    // post-GC). 64MB headroom absorbs measurement jitter.
+    if (memoryStart && memoryEnd) {
+      expect(memoryEnd.workerBytes - memoryStart.workerBytes).toBeLessThan(
+        64 * 1024 * 1024
+      );
+    }
+  });
+});

--- a/web/tests/benchmarks/realtime-perf.spec.ts
+++ b/web/tests/benchmarks/realtime-perf.spec.ts
@@ -34,6 +34,10 @@ const DURATION_MS = Number(process.env.PERF_DURATION_MS ?? 60_000);
 /** "voices" = N independent chains; "complex" = full modular patch
  * (clock, S&H pitch CV, FM/filter LFOs, ADSR/VCA, mixer tree → 1 output). */
 const PATCH = process.env.PERF_PATCH === "complex" ? "complex" : "voices";
+/** PERF_PLAYBACK=1: route the output into a real AudioContext + worklet and
+ * report buffer health. Runs HEADED — clock-skew diagnosis needs the real
+ * audio-hardware clock; headless fake audio is paced by the system clock. */
+const PLAYBACK = process.env.PERF_PLAYBACK === "1";
 
 /** Worker timer ticks arriving this late are almost certainly GC pauses. */
 const GC_PAUSE_THRESHOLD_MS = 20;
@@ -104,7 +108,13 @@ const measureAgentMemory = (page: Page): Promise<AgentMemory | null> =>
 // these options force a dedicated browser worker.
 test.use({
   channel: "chromium",
-  launchOptions: { args: ["--enable-precise-memory-info"] }
+  ...(PLAYBACK ? { headless: false } : {}),
+  launchOptions: {
+    args: [
+      "--enable-precise-memory-info",
+      "--autoplay-policy=no-user-gesture-required"
+    ]
+  }
 });
 
 test.describe("Realtime workflow performance", () => {
@@ -132,9 +142,14 @@ test.describe("Realtime workflow performance", () => {
     });
 
     const runPromise = page.evaluate(
-      ({ voices, durationMs, patch }) =>
-        window.__realtimePerf.start({ voices, durationMs, patch }),
-      { voices: VOICES, durationMs: DURATION_MS, patch: PATCH as "voices" | "complex" }
+      ({ voices, durationMs, patch, playback }) =>
+        window.__realtimePerf.start({ voices, durationMs, patch, playback }),
+      {
+        voices: VOICES,
+        durationMs: DURATION_MS,
+        patch: PATCH as "voices" | "complex",
+        playback: PLAYBACK
+      }
     );
 
     const worker = await workerPromise;
@@ -235,6 +250,38 @@ test.describe("Realtime workflow performance", () => {
           )
         }
       },
+      playback: summary.playback
+        ? (() => {
+            const s = summary.playback.stats;
+            const first = s[0];
+            const last = s[s.length - 1];
+            const seconds = first && last ? (last.t - first.t) / 1000 : 0;
+            // Buffer drift in source frames per second over the run. With
+            // matched clocks this is ~0; a steady slope is producer/consumer
+            // clock skew (negative ⇒ heading for underruns, positive ⇒
+            // heading for live-mode stale drops).
+            const slope =
+              first && last && seconds > 0
+                ? (last.buffered - first.buffered) / seconds
+                : 0;
+            return {
+              contextSampleRate: summary.playback.contextSampleRate,
+              underruns: summary.playback.underruns,
+              droppedFrames: summary.playback.droppedFrames,
+              bufferedFrames: {
+                first: first?.buffered ?? 0,
+                last: last?.buffered ?? 0,
+                min: Math.min(...s.map((x) => x.buffered)),
+                max: Math.max(...s.map((x) => x.buffered))
+              },
+              bufferSlopeFramesPerSec: Number(slope.toFixed(2)),
+              impliedClockSkewPpm: Number(((slope / 24000) * 1e6).toFixed(0)),
+              timeline: s
+                .filter((_, i) => i % 5 === 0)
+                .map((x) => `${Math.round(x.t / 1000)}s:${x.buffered}f/${x.underruns}u/${x.droppedFrames}d`)
+            };
+          })()
+        : null,
       retainedMemory:
         memoryStart && memoryEnd
           ? {

--- a/web/tests/benchmarks/realtime-perf.spec.ts
+++ b/web/tests/benchmarks/realtime-perf.spec.ts
@@ -33,7 +33,12 @@ const VOICES = Number(process.env.PERF_VOICES ?? 8);
 const DURATION_MS = Number(process.env.PERF_DURATION_MS ?? 60_000);
 /** "voices" = N independent chains; "complex" = full modular patch
  * (clock, S&H pitch CV, FM/filter LFOs, ADSR/VCA, mixer tree → 1 output). */
-const PATCH = process.env.PERF_PATCH === "complex" ? "complex" : "voices";
+const PATCH =
+  process.env.PERF_PATCH === "mega"
+    ? "mega"
+    : process.env.PERF_PATCH === "complex"
+      ? "complex"
+      : "voices";
 /** PERF_PLAYBACK=1: route the output into a real AudioContext + worklet and
  * report buffer health. Runs HEADED — clock-skew diagnosis needs the real
  * audio-hardware clock; headless fake audio is paced by the system clock. */
@@ -147,7 +152,7 @@ test.describe("Realtime workflow performance", () => {
       {
         voices: VOICES,
         durationMs: DURATION_MS,
-        patch: PATCH as "voices" | "complex",
+        patch: PATCH as "voices" | "complex" | "mega",
         playback: PLAYBACK
       }
     );

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -106,6 +106,33 @@ function stubServerTelemetryPlugin(): Plugin {
   };
 }
 
+// Cross-origin isolation for the perf harness page only. crossOriginIsolated
+// unlocks performance.measureUserAgentSpecificMemory(), which attributes JS
+// heap to every realm in the agent cluster — including the browser-runner
+// Web Worker, whose memory is otherwise unreadable (dedicated workers expose
+// no performance.memory). Scoped to /perf-realtime so the app keeps its
+// normal embedding behavior.
+function perfPageIsolationPlugin(): Plugin {
+  return {
+    name: "perf-page-isolation",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? "";
+        if (url.startsWith("/perf-realtime")) {
+          res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+          res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+        } else if (url.includes("browserRunner.worker")) {
+          // A require-corp document may only spawn dedicated workers whose
+          // script response also carries COEP. Harmless for the normal app
+          // (a non-isolated owner accepts any worker policy).
+          res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+        }
+        next();
+      });
+    }
+  };
+}
+
 export default defineConfig(async ({ mode }) => {
   // Load all env vars (including non-VITE_ prefixed ones) for server-side config
   const env = loadEnv(mode, configDir, "");
@@ -195,6 +222,7 @@ export default defineConfig(async ({ mode }) => {
       plugins: () => [stubServerTelemetryPlugin(), stubNodeProtocolPlugin(true)]
     },
     plugins: [
+      perfPageIsolationPlugin(),
       stubNodeProtocolPlugin(),
       react({
         jsxImportSource: "@emotion/react",


### PR DESCRIPTION
## Summary

A live synth patch overloaded the editor — UI slowdown and audio dropouts shared one root cause: every intermediate module's chunk stream crossed worker→main per chunk, fed React state per message, and worklet delivery rode the React render cycle.

**Kernel / messages**
- `output_update` is now suppressed for handles with outgoing data edges (downstream gets the value on the edge; clients display terminal handles only). UI-monitor nodes (AudioOutput) opt out via a new `always_emit_output_updates` descriptor flag plumbed through protocol/node-sdk/hydration.
- `ProcessingContext` gains `retainMessageQueue: false` for listener-based consumers — the undrained pull queue retained every streamed chunk in the worker.

**Main thread**
- React-free audio fast path: a chunk bus hands audio chunks from the message handler straight to the playback worklet in the same task; store appends remain for replay/restart, coalesced to one set per 200ms.
- `GlobalWebSocketManager` no longer logs unrouted/unhandled messages with payloads — the console buffer pinned every logged chunk (+187MB retained per minute at 32 voices).
- Removed a dead per-frame rAF loop in the playback hook.

**Worker / DSP**
- Audio-chunk messages skip the async image-resolve walk; mono fast path in streaming filters (1 allocation vs 3 + two copies per chunk); `StreamingGain` no longer mutates the shared upstream buffer in place.

**Perf test environment**
- `web/perf-realtime.html` harness runs parametric synth patches in the real browser-runner worker.
- Playwright spec (60s default) measures main-thread CPU (CDP `TaskDuration`), worker event-loop lag / GC pauses, heap GC sawtooth, and per-realm retained memory via `measureUserAgentSpecificMemory` (perf page cross-origin isolated through a scoped vite middleware).
- `PERF_PATCH=complex` builds a full modular patch (master clock, S&H pitch CV, FM/filter LFOs, ADSR/VCA, resonant VCF, mixer tree) for stress testing.

## Results

| 32 voices / 60s | before | after |
|---|---|---|
| main-thread CPU | 14.1% | **2.1%** |
| retained page growth | +187.6MB | **−1.2MB** |
| worker GC pauses | 1 (31.7ms) | 0 |
| chunk rate vs realtime | 1.000 | 1.000 |

Complex-patch ceiling: 1,199 streaming nodes hold 0.999 realtime with single-digit-ms worker jitter; saturation (93% realtime, multi-second stalls) begins between 1,200 and 2,400 nodes — CPU-bound, memory stays flat.

## Test plan

- [x] `npm run typecheck` / `npm run lint` (warnings pre-existing, untouched files)
- [x] Package suites: kernel (739), node-sdk (528), protocol (268), audio-nodes (62), runtime (1570), workflow-runner (12), websocket (735), dsl (138), agents (1059), base-nodes (1613)
- [x] Web jest: workflowUpdates / ResultsStore / GlobalWebSocketManager / RealtimeAudio suites
- [x] `cd web && PERF_PATCH=complex PERF_VOICES=128 npx playwright test tests/benchmarks/realtime-perf.spec.ts --project=chromium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up fix: the 30–60s dropout (single oscillator → AudioOutput)

After the work above, a trivial patch — one oscillator into one AudioOutput — still produced heavy audio dropouts beginning 30–60 seconds into a run. This turned out to be a separate root cause, found and fixed on this branch (`e0af84e47`).

### Investigation

The perf harness (which feeds the worklet directly, no React tree) played 90s of real headed audio with a rock-steady buffer — so the transport, kernel pacing, and audio-hardware clock were all exonerated. A new end-to-end repro (`web/scripts/repro-audio-dropout.mjs`) drives the **real editor**: creates the workflow via API, opens the canvas with the actual AudioOut node body, clicks Run, and samples new worklet telemetry every few seconds.

That repro showed a sharp phase transition:

- **t < 21s**: healthy — bus-path delivery, max inter-chunk gap 28ms, zero distress, page heap ~260MB.
- **t ≈ 21s onward**: delivery gaps of 600ms+, page heap climbing to 800MB, the worklet alternating between live-cap stale drops and underruns. Net effect: **31% of all audio dropped, ~2 underruns/sec, only ~67% of wall time rendering sound.**

t≈21s is exactly when the 1024-chunk rolling store window (`MAX_AUDIO_STREAM_CHUNKS`, ~21.8s of audio) first fills. A CPU profile of the degradation window named the culprit:

```
18.4%  run
 9.4%  addValueToProperties  @ react-dom_client.js
 3.9%  addObjectToProperties @ react-dom_client.js
```

`addValueToProperties` is **react-dom's dev-build performance instrumentation**: React 19 dev mode deep-serializes every component's props into performance-timeline entries on every commit. The entire rolling buffer — 1024 chunks with sample payloads, serialized **per element** for `Float32Array` content — was passed as `RealtimeAudioOutput`'s `chunks` prop. Once the window filled, every 200ms store flush serialized megabytes of audio data, the heap ballooned, and the resulting GC stalls (600ms+) exceeded the worklet's 100ms live buffer. **Onset time = time to fill the rolling window** — hence "dropouts after 30–60 seconds". Dev-build-only pathology (prod React doesn't serialize props), which is why it haunted `make dev` sessions.

### Fix

Chunk buffers never cross a React component boundary as a value anymore. `AudioOutBody` → `RealtimeAudioOutput` → `useRealtimeAudioPlayback` now pass a **stable `getChunks()` getter + a numeric `chunksVersion`** (bumped on buffer identity change); `OutputRenderer`'s preview path goes through a small `RealtimeAudioOutputFromChunks` adapter so the array stops at that boundary. The scheduling effect reads the buffer through the getter, keyed on the version — behavior is identical, but React never sees the data.

### Verification (same repro, 76s)

| | before | after |
|---|---|---|
| underruns | 186 / 100s | **1** (single transient at window-fill) |
| audio dropped as stale | 31% (748k frames) | ~0 after t=21s |
| page heap | climbing to ~800MB | flat at ~255MB |
| main thread (degradation window) | saturated, 600ms stalls | **92.5% idle** |
| consumer rate | 16.2k frames/s | 23.8k ≈ realtime |

### Diagnosis tooling (kept in-tree)

- **Worklet buffer-health telemetry**: `chunkPlayerProcessor` emits 1 Hz stats (buffered frames, underruns, stale-dropped frames, frames in/out); `useRealtimeAudioPlayback` exposes them on `window.__nodetoolRealtimeAudio` with bus/effect delivery counters + max delivery gap, and logs a console warning whenever distress counters advance.
- **`PERF_PLAYBACK=1`** on the perf spec: routes the output into a real `AudioContext` + worklet (headed, real audio-hardware clock) and reports buffer slope / implied clock skew — the mode that ruled out clock drift.
- **`web/scripts/repro-audio-dropout.mjs`**: the full field repro against the running dev stack, including a CPU profile of the t=16–26s window.

Known residual: a single ~600ms blip when the rolling window first fills (one-time major GC of the accumulated buffer growth). If audible in practice, the next step is pre-allocating the window instead of grow-then-trim.
