### PR TITLE
Lock aspect ratio on resize handle for constant image/video nodes

### DIFF
--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -66,6 +66,10 @@ import {
   resolveCodeNodeTitle
 } from "./codeNodeUi";
 import { isContentCardNode } from "../node_types/contentCardRegistry";
+import {
+  CONSTANT_IMAGE_NODE_TYPE,
+  CONSTANT_VIDEO_NODE_TYPE
+} from "../../constants/nodeTypes";
 
 // CONSTANTS
 const BASE_HEIGHT = 0;
@@ -427,7 +431,11 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       isConstantNode: type.startsWith("nodetool.constant"),
       isInputNode: type.startsWith("nodetool.input"),
       isOutputNode: type.startsWith("nodetool.output"),
-      isAgentNode: isAgentNodeType(type)
+      isAgentNode: isAgentNodeType(type),
+      // Constant image/video nodes preview their media, so resizing should
+      // preserve the media's aspect ratio rather than distort it.
+      lockAspectRatio:
+        type === CONSTANT_IMAGE_NODE_TYPE || type === CONSTANT_VIDEO_NODE_TYPE
     }),
     [type]
   );
@@ -764,7 +772,11 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
         isConnectable={true}
       />
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={150} minHeight={styleProps.minHeight} />
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={styleProps.minHeight}
+        keepAspectRatio={nodeType.lockAspectRatio}
+      />
       <NodeHeader
         id={id}
         selected={selected}

--- a/web/src/components/node/NodeResizeHandle.tsx
+++ b/web/src/components/node/NodeResizeHandle.tsx
@@ -12,6 +12,8 @@ interface NodeResizeHandleProps {
   minWidth: number;
   minHeight: number;
   onResize?: OnResize;
+  /** Lock the width/height ratio while dragging the handle. */
+  keepAspectRatio?: boolean;
 }
 
 const styles = (theme: Theme) =>
@@ -54,7 +56,8 @@ const styles = (theme: Theme) =>
 const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResizeHandle({
   minWidth,
   minHeight,
-  onResize
+  onResize,
+  keepAspectRatio
 }) {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
@@ -64,6 +67,7 @@ const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResi
         minWidth={minWidth}
         minHeight={minHeight}
         onResize={onResize}
+        keepAspectRatio={keepAspectRatio}
       >
         <KeyboardArrowDownIcon />
       </NodeResizeControl>

--- a/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
+++ b/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import NodeResizeHandle from "../NodeResizeHandle";
+
+// Capture the props ReactFlow's NodeResizeControl receives so we can assert the
+// aspect-ratio lock is forwarded.
+const resizeControlProps: Array<Record<string, unknown>> = [];
+jest.mock("@xyflow/react", () => ({
+  NodeResizeControl: (props: { children?: React.ReactNode }) => {
+    resizeControlProps.push(props as Record<string, unknown>);
+    return <div data-testid="resize-control">{props.children}</div>;
+  }
+}));
+
+jest.mock("@mui/material/styles", () => {
+  const original = jest.requireActual("@mui/material/styles");
+  return {
+    ...original,
+    useTheme: () => ({ vars: { palette: { grey: { 100: "#eee" } } } })
+  };
+});
+
+describe("NodeResizeHandle", () => {
+  beforeEach(() => {
+    resizeControlProps.length = 0;
+  });
+
+  it("does not lock aspect ratio by default", () => {
+    render(<NodeResizeHandle minWidth={150} minHeight={100} />);
+    expect(resizeControlProps[0]?.keepAspectRatio).toBeUndefined();
+  });
+
+  it("forwards keepAspectRatio to the resize control when set", () => {
+    render(
+      <NodeResizeHandle minWidth={150} minHeight={100} keepAspectRatio />
+    );
+    expect(resizeControlProps[0]?.keepAspectRatio).toBe(true);
+  });
+});

--- a/web/src/constants/nodeTypes.ts
+++ b/web/src/constants/nodeTypes.ts
@@ -22,6 +22,8 @@ export const SUBGRAPH_NODE_TYPE = "nodetool.workflows.subgraph.Subgraph";
 export const SKETCH_NODE_TYPE = "nodetool.constant.Sketch";
 export const CODE_NODE_TYPE = "nodetool.code.Code";
 export const STRING_NODE_TYPE = "nodetool.constant.String";
+export const CONSTANT_IMAGE_NODE_TYPE = "nodetool.constant.Image";
+export const CONSTANT_VIDEO_NODE_TYPE = "nodetool.constant.Video";
 
 // --- Dynamic-schema nodes --------------------------------------------------
 export const DYNAMIC_FAL_NODE_TYPE = "fal.DynamicFal";


### PR DESCRIPTION
## Summary

Constant image (`nodetool.constant.Image`) and video (`nodetool.constant.Video`) nodes preview their media inline, so distorting them on resize looked wrong. The corner resize handle now locks the width/height ratio for these node types, preserving the media's proportions while dragging. All other node types keep free resizing.

## Changes

- **`web/src/constants/nodeTypes.ts`** — Added `CONSTANT_IMAGE_NODE_TYPE` and `CONSTANT_VIDEO_NODE_TYPE` to the single source of truth for node-type strings.
- **`web/src/components/node/NodeResizeHandle.tsx`** — Added an optional `keepAspectRatio` prop, forwarded to ReactFlow's `NodeResizeControl` (a valid `ResizeControlProps` field in `@xyflow/react` 12.10.2). Existing call sites are unchanged — the default remains free resize.
- **`web/src/components/node/BaseNode.tsx`** (the renderer all constant nodes use) — Added a `lockAspectRatio` flag to the existing `nodeType` memo and passed it through to the resize handle.
- **`web/src/components/node/__tests__/NodeResizeHandle.test.tsx`** — New unit test verifying the prop is off by default and forwarded when set.

## Notes

Only the corner resize handle is affected. When a node is selected, `BaseNode` also renders a full-area `ResizeOverlay` (edge handles via `NodeResizer`), but for constant image/video nodes that show a result it is suppressed (`!hasToggleableResult`), so the corner handle is the active resize path. The same `keepAspectRatio` prop can be wired into `NodeResizer.tsx` later if edge handles should lock too.

## Verification

- `npm run typecheck` (web) — passes (after `npm run build:packages`)
- `npm run lint` on changed files — passes
- New tests — 2/2 pass

https://claude.ai/code/session_01VTQSAqxFeTSS8qQ9DsGe4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTQSAqxFeTSS8qQ9DsGe4g)_