### PR TITLE
Refine NodeEditor composer, empty state, and chat overlay behavior

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -67,6 +67,7 @@ export const createMediaComposerStyles = (theme: Theme) =>
       boxSizing: "border-box",
       display: "block",
       overflowY: "hidden",
+      transition: `padding ${MOTION.normal}`,
       "&::placeholder": {
         color: theme.vars.palette.grey[500],
         fontStyle: "normal"
@@ -80,23 +81,53 @@ export const createMediaComposerStyles = (theme: Theme) =>
       width: "100%",
       padding: `0 ${theme.spacing(2)}`,
       boxSizing: "border-box",
-      flexWrap: "wrap"
+      // Trailing run actions must stay pinned to the right even when the
+      // collapsible cluster below shrinks to zero height, so the row itself
+      // does not wrap. The chip cluster wraps internally instead.
+      flexWrap: "nowrap"
     },
 
-    // Idle state: dim the border and footer controls while the composer is
-    // unfocused, brightening them back on focus. The textarea stays full
-    // opacity so the placeholder/prompt remains readable.
+    // The collapsible cluster of mode/model chips + primary action. Fills the
+    // row horizontally (flex:1) so the trailing actions stay right-aligned,
+    // and wraps its own chips when they overflow.
+    ".media-chip-main": {
+      flex: 1,
+      minWidth: 0,
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1),
+      flexWrap: "wrap",
+      // Generous cap so an expanded multi-row chip cluster is never clipped;
+      // animates down to 0 when minimized.
+      maxHeight: 200,
+      opacity: 1,
+      overflow: "hidden",
+      transition: `max-height ${MOTION.normal}, opacity ${MOTION.normal}`
+    },
+
+    // Minimized state: the composer collapses to just the textarea + trailing
+    // run actions while unfocused and empty, expanding to the full chip row on
+    // focus. The border dims and the chip cluster animates away to zero height.
     ".media-compose-card.dimmed": {
       borderColor:
         theme.palette.mode === "light"
           ? theme.vars.palette.grey[800]
-          : theme.vars.palette.grey[900]
+          : theme.vars.palette.grey[900],
+      gap: theme.spacing(0.5)
     },
-    ".media-compose-card.dimmed .media-chip-row": {
-      opacity: 0.55
+    ".media-compose-card.dimmed .media-chip-main": {
+      maxHeight: 0,
+      opacity: 0,
+      pointerEvents: "none"
     },
-    ".media-compose-card .media-chip-row": {
-      transition: `opacity ${MOTION.normal}`
+    // Tighten the textarea to a slim single line while minimized.
+    ".media-compose-card.dimmed textarea.media-compose-input": {
+      paddingTop: theme.spacing(1.5),
+      paddingBottom: theme.spacing(1.5)
+    },
+    // Collapse the (empty) file-preview row so it adds no height when minimized.
+    ".media-compose-card.dimmed .media-file-preview-row:empty": {
+      display: "none"
     },
 
     ".media-chip-row .divider-dot": {

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -944,6 +944,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         )}
 
         <div className="media-chip-row">
+          {/* Collapsible cluster: mode/model chips + primary action. Hidden
+              while the composer is minimized (idle + empty); the trailing
+              run actions below stay visible so the workflow can still run. */}
+          <div className="media-chip-main">
           {/* Mode selector chip */}
           <MediaControlChip
             icon={modeIcon}
@@ -1461,9 +1465,11 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
               {isMediaMode ? "Generate" : <ArrowUpwardIcon fontSize="small" />}
             </button>
           )}
+          </div>
 
           {/* Host-supplied actions at the end of the footer (e.g. the canvas
-              Run button + workflow menu). Empty in the chat panel. */}
+              Run button + workflow menu). Empty in the chat panel. Stays
+              visible even while the composer is minimized. */}
           {trailingActions}
         </div>
       </div>

--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -66,6 +66,10 @@ import {
   resolveCodeNodeTitle
 } from "./codeNodeUi";
 import { isContentCardNode } from "../node_types/contentCardRegistry";
+import {
+  CONSTANT_IMAGE_NODE_TYPE,
+  CONSTANT_VIDEO_NODE_TYPE
+} from "../../constants/nodeTypes";
 
 // CONSTANTS
 const BASE_HEIGHT = 0;
@@ -427,7 +431,11 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       isConstantNode: type.startsWith("nodetool.constant"),
       isInputNode: type.startsWith("nodetool.input"),
       isOutputNode: type.startsWith("nodetool.output"),
-      isAgentNode: isAgentNodeType(type)
+      isAgentNode: isAgentNodeType(type),
+      // Constant image/video nodes preview their media, so resizing should
+      // preserve the media's aspect ratio rather than distort it.
+      lockAspectRatio:
+        type === CONSTANT_IMAGE_NODE_TYPE || type === CONSTANT_VIDEO_NODE_TYPE
     }),
     [type]
   );
@@ -764,7 +772,11 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
         isConnectable={true}
       />
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={150} minHeight={styleProps.minHeight} />
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={styleProps.minHeight}
+        keepAspectRatio={nodeType.lockAspectRatio}
+      />
       <NodeHeader
         id={id}
         selected={selected}

--- a/web/src/components/node/NodeResizeHandle.tsx
+++ b/web/src/components/node/NodeResizeHandle.tsx
@@ -12,6 +12,8 @@ interface NodeResizeHandleProps {
   minWidth: number;
   minHeight: number;
   onResize?: OnResize;
+  /** Lock the width/height ratio while dragging the handle. */
+  keepAspectRatio?: boolean;
 }
 
 const styles = (theme: Theme) =>
@@ -54,7 +56,8 @@ const styles = (theme: Theme) =>
 const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResizeHandle({
   minWidth,
   minHeight,
-  onResize
+  onResize,
+  keepAspectRatio
 }) {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
@@ -64,6 +67,7 @@ const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResi
         minWidth={minWidth}
         minHeight={minHeight}
         onResize={onResize}
+        keepAspectRatio={keepAspectRatio}
       >
         <KeyboardArrowDownIcon />
       </NodeResizeControl>

--- a/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
+++ b/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import NodeResizeHandle from "../NodeResizeHandle";
+
+// Capture the props ReactFlow's NodeResizeControl receives so we can assert the
+// aspect-ratio lock is forwarded.
+const resizeControlProps: Array<Record<string, unknown>> = [];
+jest.mock("@xyflow/react", () => ({
+  NodeResizeControl: (props: { children?: React.ReactNode }) => {
+    resizeControlProps.push(props as Record<string, unknown>);
+    return <div data-testid="resize-control">{props.children}</div>;
+  }
+}));
+
+jest.mock("@mui/material/styles", () => {
+  const original = jest.requireActual("@mui/material/styles");
+  return {
+    ...original,
+    useTheme: () => ({ vars: { palette: { grey: { 100: "#eee" } } } })
+  };
+});
+
+describe("NodeResizeHandle", () => {
+  beforeEach(() => {
+    resizeControlProps.length = 0;
+  });
+
+  it("does not lock aspect ratio by default", () => {
+    render(<NodeResizeHandle minWidth={150} minHeight={100} />);
+    expect(resizeControlProps[0]?.keepAspectRatio).toBeUndefined();
+  });
+
+  it("forwards keepAspectRatio to the resize control when set", () => {
+    render(
+      <NodeResizeHandle minWidth={150} minHeight={100} keepAspectRatio />
+    );
+    expect(resizeControlProps[0]?.keepAspectRatio).toBe(true);
+  });
+});

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -13,7 +13,7 @@ import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
 import BoltIcon from "@mui/icons-material/Bolt";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import LayoutIcon from "@mui/icons-material/ViewModule";
+import LayoutIcon from "@mui/icons-material/AutoFixHigh";
 import MapIcon from "@mui/icons-material/Map";
 import SaveIcon from "@mui/icons-material/Save";
 import DownloadIcon from "@mui/icons-material/Download";
@@ -280,14 +280,15 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
   // view to surface them, so show them as a dismissible banner above the composer.
   const chatError = useGlobalChatStore((state) => state.error);
   const clearChatError = useGlobalChatStore((state) => state.clearError);
-  const [conversationCollapsed, setConversationCollapsed] = useState(false);
-  const prevCount = useRef(conversationCount);
+  // Start collapsed so opening a workflow with existing conversation history
+  // doesn't pop the overlay. It auto-reveals only when chat becomes busy in
+  // this session (the user sent a message / a generation is streaming).
+  const [conversationCollapsed, setConversationCollapsed] = useState(true);
   useEffect(() => {
-    if (conversationCount > prevCount.current || chatBusy) {
+    if (chatBusy) {
       setConversationCollapsed(false);
     }
-    prevCount.current = conversationCount;
-  }, [conversationCount, chatBusy]);
+  }, [chatBusy]);
 
   const hasConversation = conversationCount > 0 || chatBusy;
   const conversationOpen = hasConversation && !conversationCollapsed;

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -79,10 +79,13 @@ const styles = (theme: Theme) =>
       minWidth: 0
     },
     "& .workspace-empty": {
-      flex: 1,
+      position: "absolute",
+      inset: 0,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
+      textAlign: "center",
+      padding: theme.spacing(0, 3),
       color: theme.vars.palette.text.secondary
     }
   });

--- a/web/src/constants/nodeTypes.ts
+++ b/web/src/constants/nodeTypes.ts
@@ -22,6 +22,8 @@ export const SUBGRAPH_NODE_TYPE = "nodetool.workflows.subgraph.Subgraph";
 export const SKETCH_NODE_TYPE = "nodetool.constant.Sketch";
 export const CODE_NODE_TYPE = "nodetool.code.Code";
 export const STRING_NODE_TYPE = "nodetool.constant.String";
+export const CONSTANT_IMAGE_NODE_TYPE = "nodetool.constant.Image";
+export const CONSTANT_VIDEO_NODE_TYPE = "nodetool.constant.Video";
 
 // --- Dynamic-schema nodes --------------------------------------------------
 export const DYNAMIC_FAL_NODE_TYPE = "fal.DynamicFal";


### PR DESCRIPTION
## Summary

A handful of NodeEditor / workspace UI refinements:

- **Minimal composer**: the canvas media composer now collapses to a slim input when unfocused and empty, expanding to the full chip row (mode/model controls + Generate) on focus. The trailing workflow run actions stay visible so the workflow can still be run.
- **Auto-layout icon**: swapped from `ViewModule` (grid) to `AutoFixHigh` (magic wand), which better signals the "tidy it automatically" action and avoids colliding with the adjacent Graph View tree icon.
- **Empty-state position**: the "No tabs open" message was pinned near the top (a `flex: 1` on a non-flex parent did nothing). Now it fills the content area and is truly centered, with wrapping padding.
- **Chat overlay**: opening a workflow with saved conversation history no longer auto-pops the conversation overlay. It starts collapsed and reveals only when chat becomes busy in-session (message sent / generation streaming). The manual toggle is unchanged.

## Test plan

- `npm run typecheck` and `eslint` pass on the touched files.
- Manual: open a workflow with existing chat history → overlay stays collapsed; send a message → overlay reveals.
- Manual: focus/blur the canvas composer → grows/shrinks smoothly; run actions stay reachable while minimized.
- Manual: close all tabs → empty message centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)