### PR TITLE
Add cloud profile: curated node/provider surface for commercial product

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -1,0 +1,149 @@
+# Cloud Node Curation
+
+The commercial NodeTool cloud product ships a **deliberately small, curated
+node set** rather than the full open-source catalog. The goal is a high-quality,
+focused **creative AI workspace** — generating and editing text, images, audio,
+video, and 3D — that a **two-person team can maintain**.
+
+The full catalog is ~3,500 nodes across ~60 namespaces. Most of the long tail is
+developer/automation plumbing (filesystem, databases, scraping, messaging,
+office-doc tooling, local model runtimes) that is powerful but "nerdy" — it
+dilutes the creative mission and balloons the support surface. The cloud profile
+drops it.
+
+> **One exception:** the **Code node** (`nodetool.code`) is kept. It is the
+> intentional power-user escape hatch.
+
+## How it's enforced
+
+Curation is **opt-in** and off by default, so OSS/local installs are unchanged.
+Set the env var on the cloud server:
+
+```bash
+NODETOOL_NODE_PROFILE=cloud
+```
+
+When active, three things happen at server bootstrap:
+
+1. **Provider packs** — only `base`, `fal`, and `kie` load (other provider
+   packs like Replicate, Hugging Face, Together, MiniMax, … are never
+   registered).
+2. **Node registry** — every node type outside the curated allowlist is pruned
+   (`applyCloudNodePolicy`).
+3. **Provider registry** — every provider outside the allowlist is pruned, so
+   only the curated providers appear in model selectors.
+
+The single source of truth is
+[`packages/protocol/src/cloud-profile.ts`](../packages/protocol/src/cloud-profile.ts):
+`CLOUD_NODE_NAMESPACES`, `CLOUD_NODE_DENYLIST`, `CLOUD_PROVIDER_IDS`,
+`CLOUD_BUILTIN_PACK_IDS`. Maintaining the cloud offering = editing those lists.
+
+## Providers
+
+Limited to the big foundation-model labs plus Fal + Kie for media.
+
+| Provider  | Id        | Role                          |
+| --------- | --------- | ----------------------------- |
+| OpenAI    | `openai`  | LLM, image, audio, realtime   |
+| Anthropic | `anthropic` | LLM (via Agent/Chat nodes)  |
+| Google    | `gemini`  | LLM, image, audio, video      |
+| Mistral   | `mistral` | LLM, vision                   |
+| xAI       | `xai`     | LLM, image, vision            |
+| Groq      | `groq`    | Fast LLM (via Agent/Chat nodes) |
+| Fal       | `fal_ai`  | Hosted image/video/audio models |
+| Kie       | `kie`     | Hosted image/video/audio models |
+
+Anthropic and Groq have **no dedicated node namespace** — they reach users
+through the Agent / Chat / generator nodes via the provider registry.
+
+**Dropped providers:** Replicate, Together, MiniMax, Topaz, Reve, AtlasCloud,
+ElevenLabs, Cohere, Voyage, Jina, Moonshot, DeepSeek, OpenRouter, Cerebras,
+Evolink, Aki, Meshy, Rodin, and all local runtimes (Ollama, LM Studio,
+llama.cpp, vLLM, Hugging Face local, Transformers.js).
+
+## Namespaces kept
+
+### Workflow scaffolding (editor-essential)
+
+| Namespace            | What it is                              |
+| -------------------- | --------------------------------------- |
+| `nodetool.input`     | Input nodes (text, number, image, …)    |
+| `nodetool.output`    | Output nodes                            |
+| `nodetool.constant`  | Constants                               |
+| `nodetool.control`   | Control flow (If, ForEach, Switch, …)   |
+| `nodetool.list`      | List ops                                |
+| `nodetool.compare`   | Compare                                 |
+| `nodetool.workflows` | Sub-workflow, Subgraph, Preview         |
+| `nodetool.group`     | Editor Loop / Group containers          |
+| `nodetool.llm`       | Generic Chat node                       |
+
+### Creative generation core
+
+| Namespace              | What it is                                   |
+| ---------------------- | -------------------------------------------- |
+| `nodetool.text`        | Text manipulation, prompts, templates        |
+| `nodetool.image`       | Image generate / edit / transform            |
+| `nodetool.sketch`      | Sketch / vector drawing                       |
+| `nodetool.audio`       | Audio + `.synth` + `.realtime`                |
+| `nodetool.video`       | Video editing, effects, generation            |
+| `nodetool.timeline`    | Media timeline / sequencing                   |
+| `nodetool.model3d`     | 3D model generation & processing              |
+| `nodetool.generators`  | Data/List/StructuredOutput/Chart/SVG gen      |
+| `nodetool.agents`      | AI agents (creative subset — see denylist)    |
+| `nodetool.code`        | **The Code node** (kept on purpose)           |
+
+### Creative media toolkit
+
+| Namespace   | What it is                                            |
+| ----------- | ----------------------------------------------------- |
+| `lib.image` | Photoshop-style ops: warp, color, draw, effects, …    |
+| `lib.svg`   | SVG / vector graphics                                  |
+| `lib.grid`  | Image grid combine/slice                               |
+| `lib.audio` | Audio DSP/effects (reverb, delay, EQ, …)               |
+
+### Provider node namespaces
+
+`openai.*`, `gemini.*`, `mistral.*`, `xai.*`, `fal.*`, `kie.*`
+
+## Namespaces dropped (the "nerdy" set)
+
+- **Data/docs:** `nodetool.data` (dataframes), `nodetool.document`, `lib.pdf`,
+  `lib.docx`, `lib.epub`, `lib.pptx`, `lib.excel`, `lib.ocr`, `lib.convert`,
+  `lib.markdown`, `lib.html`, `lib.charts`
+- **System/automation:** `lib.os`, `nodetool.workspace`, `nodetool.sandbox`,
+  `nodetool.triggers`, `lib.browser`, `lib.video.download`
+- **Databases/cloud/integrations:** `lib.sqlite`, `lib.supabase`, `lib.notion`,
+  `lib.s3`, `lib.http`, `lib.graphql`, `lib.mail`, `lib.twilio`, `lib.rss`,
+  `lib.secret`, `lib.comfy`
+- **Search/scraping/messaging:** `search.google`, `apify.scraping`,
+  `messaging.discord`, `messaging.telegram`
+- **NLP/ML utility:** `lib.nlp`, `lib.tensorflow`, `vector` (RAG),
+  `lib.validate`, `lib.datetime`
+- **Out-of-scope providers:** `huggingface`, `transformers`, `minimax`, `reve`,
+  `elevenlabs`, `replicate`, `together`, `topaz`, `atlascloud`
+
+### Agents trimmed within `nodetool.agents`
+
+The `nodetool.agents` namespace is kept, but the developer/automation agents are
+removed via `CLOUD_NODE_DENYLIST` because they wrap the very integrations the
+cloud profile drops:
+
+`BrowserAgent`, `LiveBrowserAgent`, `DocxAgent`, `EmailAgent`,
+`FilesystemAgent`, `GitAgent`, `HtmlAgent`, `HttpApiAgent`, `PdfLibAgent`,
+`PptxAgent`, `SQLiteAgent`, `ShellAgent`, `SpreadsheetAgent`, `SupabaseAgent`,
+`VectorStoreAgent`, `YtDlpDownloaderAgent`.
+
+**Kept agents:** `Agent`, `Classifier`, `Extractor`, `Summarizer`,
+`CreateThread`, `ImageAgent`, `MediaAgent`, `FfmpegAgent`, `DocumentAgent`.
+
+## Open considerations
+
+- **`nodetool.code` breadth.** The whole namespace (19 nodes) includes
+  multi-language exec (Bash, Ruby, Lua) and Docker runners. In a managed cloud,
+  arbitrary code execution is a security surface — consider trimming to the
+  sandboxed `Code` node, or ensuring all runners use the hardened sandbox.
+- **`nodetool.text` breadth.** 51 nodes, a few are low-level (regex/token
+  utilities). Fine to keep at namespace granularity; trim later if it clutters
+  the palette.
+- Re-adding a dropped capability is a one-line change to
+  `CLOUD_NODE_NAMESPACES`.

--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -11,19 +11,30 @@ office-doc tooling, local model runtimes) that is powerful but "nerdy" — it
 dilutes the creative mission and balloons the support surface. The cloud profile
 drops it.
 
-> **One exception:** the **Code node** (`nodetool.code`) is kept. It is the
-> intentional power-user escape hatch.
+> **One exception:** the **sandboxed Code node** (`nodetool.code.Code`, vm-based
+> JavaScript) is kept. It is the intentional power-user escape hatch. The rest
+> of `nodetool.code` (Python/Bash/Ruby/Lua subprocess + Docker runners) stays
+> out — arbitrary process/Docker execution isn't appropriate for a managed
+> multi-tenant cloud.
 
-## How it's enforced
+## How it's enabled
 
-Curation is **opt-in** and off by default, so OSS/local installs are unchanged.
-Set the env var on the cloud server:
+The commercial cloud product runs in **production mode**, so production *is* the
+cloud profile — no extra flag needed:
+
+```bash
+NODETOOL_ENV=production
+```
+
+It can also be enabled outside production (e.g. for local testing) with an
+explicit flag:
 
 ```bash
 NODETOOL_NODE_PROFILE=cloud
 ```
 
-When active, three things happen at server bootstrap:
+When neither applies (the default for OSS/local installs), the full catalog
+loads unchanged. When active, three things happen at server bootstrap:
 
 1. **Provider packs** — only `base`, `fal`, and `kie` load (other provider
    packs like Replicate, Hugging Face, Together, MiniMax, … are never
@@ -35,7 +46,10 @@ When active, three things happen at server bootstrap:
 
 The single source of truth is
 [`packages/protocol/src/cloud-profile.ts`](../packages/protocol/src/cloud-profile.ts):
-`CLOUD_NODE_NAMESPACES`, `CLOUD_NODE_DENYLIST`, `CLOUD_PROVIDER_IDS`,
+`CLOUD_NODE_NAMESPACES` (whole namespaces kept), `CLOUD_NODE_ALLOWLIST`
+(individual node types kept from an otherwise-trimmed namespace — the sandboxed
+Code node and the curated text nodes), `CLOUD_NODE_DENYLIST` (individual node
+types dropped from a kept namespace), `CLOUD_PROVIDER_IDS`, and
 `CLOUD_BUILTIN_PACK_IDS`. Maintaining the cloud offering = editing those lists.
 
 ## Providers
@@ -81,7 +95,6 @@ llama.cpp, vLLM, Hugging Face local, Transformers.js).
 
 | Namespace              | What it is                                   |
 | ---------------------- | -------------------------------------------- |
-| `nodetool.text`        | Text manipulation, prompts, templates        |
 | `nodetool.image`       | Image generate / edit / transform            |
 | `nodetool.sketch`      | Sketch / vector drawing                       |
 | `nodetool.audio`       | Audio + `.synth` + `.realtime`                |
@@ -90,7 +103,23 @@ llama.cpp, vLLM, Hugging Face local, Transformers.js).
 | `nodetool.model3d`     | 3D model generation & processing              |
 | `nodetool.generators`  | Data/List/StructuredOutput/Chart/SVG gen      |
 | `nodetool.agents`      | AI agents (creative subset — see denylist)    |
-| `nodetool.code`        | **The Code node** (kept on purpose)           |
+
+`nodetool.text` and `nodetool.code` are **not** kept whole — only a curated
+slice of each is admitted via `CLOUD_NODE_ALLOWLIST`:
+
+| From `nodetool.code`   | Kept node                                     |
+| ---------------------- | --------------------------------------------- |
+| `Code`                 | Sandboxed (vm) JavaScript only                |
+
+| From `nodetool.text`   | Kept nodes                                                  |
+| ---------------------- | ---------------------------------------------------------- |
+| Prompt building        | `Prompt`, `Template`, `FormatText`                          |
+| Composition            | `Concat`, `Join`, `Collect`, `Replace`, `ToString`          |
+| Light parsing/IO       | `Split`, `Slice`, `Chunk`, `Extract`, `ParseJSON`, `ExtractJSON`, `SaveText` |
+
+Everything else in `nodetool.text` (regex, case/whitespace utilities, token
+counting, embeddings, predicates, file I/O) and `nodetool.code` (Python/Bash/
+Ruby/Lua subprocess + Docker runners) is dropped.
 
 ### Creative media toolkit
 
@@ -136,14 +165,12 @@ cloud profile drops:
 **Kept agents:** `Agent`, `Classifier`, `Extractor`, `Summarizer`,
 `CreateThread`, `ImageAgent`, `MediaAgent`, `FfmpegAgent`, `DocumentAgent`.
 
-## Open considerations
+## Maintenance
 
-- **`nodetool.code` breadth.** The whole namespace (19 nodes) includes
-  multi-language exec (Bash, Ruby, Lua) and Docker runners. In a managed cloud,
-  arbitrary code execution is a security surface — consider trimming to the
-  sandboxed `Code` node, or ensuring all runners use the hardened sandbox.
-- **`nodetool.text` breadth.** 51 nodes, a few are low-level (regex/token
-  utilities). Fine to keep at namespace granularity; trim later if it clutters
-  the palette.
-- Re-adding a dropped capability is a one-line change to
-  `CLOUD_NODE_NAMESPACES`.
+- Re-add a whole capability → add a namespace to `CLOUD_NODE_NAMESPACES`.
+- Re-add a single node from a trimmed namespace (text/code) → add its node type
+  to `CLOUD_NODE_ALLOWLIST`.
+- Hide a single node from a kept namespace → add its node type to
+  `CLOUD_NODE_DENYLIST`.
+- Add/remove a provider → edit `CLOUD_PROVIDER_IDS` (and, for whole provider
+  packs, `CLOUD_BUILTIN_PACK_IDS`).

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -1,0 +1,154 @@
+/**
+ * Curated "cloud" node + provider profile for the commercial NodeTool cloud
+ * product.
+ *
+ * The full NodeTool catalog ships ~3,500 nodes across ~60 namespaces — far
+ * more than a small team can support at a high quality bar, and much of it
+ * (filesystem, databases, scraping, messaging, office-doc tooling, local model
+ * runtimes) is developer/automation plumbing that dilutes the "creative AI
+ * workspace" mission. The cloud product instead offers a deliberately small,
+ * curated surface focused on generating and editing text, images, audio,
+ * video, and 3D — plus the Code node for power users.
+ *
+ * This module is the single source of truth, shared between the server (which
+ * prunes the registry and the provider list at bootstrap) and any UI that
+ * wants to reflect the same policy. It is intentionally pure data + pure
+ * predicates: the env read that decides *whether* the profile is active lives
+ * at the application boundary (see {@link isCloudProfileValue}).
+ *
+ * Activate by setting `NODETOOL_NODE_PROFILE=cloud`. When unset (the default),
+ * none of this applies and the full catalog loads unchanged.
+ */
+
+/** Env var that selects the active node profile. */
+export const CLOUD_PROFILE_ENV = "NODETOOL_NODE_PROFILE";
+
+/** Value of {@link CLOUD_PROFILE_ENV} that turns on the curated cloud profile. */
+export const CLOUD_PROFILE_VALUE = "cloud";
+
+/**
+ * True when the supplied env value selects the cloud profile. Callers pass
+ * `process.env[CLOUD_PROFILE_ENV]` so this stays free of any runtime/env
+ * dependency and remains trivially testable.
+ */
+export function isCloudProfileValue(value: string | undefined | null): boolean {
+  return value === CLOUD_PROFILE_VALUE;
+}
+
+/**
+ * Namespace prefixes kept in the cloud product. A node type is allowed when it
+ * sits under one of these (segment-boundary match), unless it appears in
+ * {@link CLOUD_NODE_DENYLIST}.
+ *
+ * Grouped by intent — keep this list short; every entry is surface a small
+ * team has to support.
+ */
+export const CLOUD_NODE_NAMESPACES: readonly string[] = [
+  // — Workflow scaffolding & editor-essential plumbing —
+  "nodetool.input",
+  "nodetool.output",
+  "nodetool.constant",
+  "nodetool.control",
+  "nodetool.list",
+  "nodetool.compare",
+  "nodetool.workflows", // workflow_node, subgraph, base_node (Preview)
+  "nodetool.group", // editor Loop/Group containers
+  "nodetool.llm", // generic Chat node (also surfaces Anthropic/Groq)
+
+  // — Creative generation core —
+  "nodetool.text",
+  "nodetool.image",
+  "nodetool.sketch",
+  "nodetool.audio", // covers .synth and .realtime
+  "nodetool.video",
+  "nodetool.timeline",
+  "nodetool.model3d",
+  "nodetool.generators",
+  "nodetool.agents", // trimmed by CLOUD_NODE_DENYLIST below
+  "nodetool.code", // the Code node — explicitly kept for power users
+
+  // — Creative media toolkit (Photoshop/After-Effects-style ops) —
+  "lib.image", // warp, color, draw, effects, filter, channel, keyer, mask, …
+  "lib.svg",
+  "lib.grid",
+  "lib.audio", // DSP / effects (reverb, delay, EQ, …)
+
+  // — Provider node namespaces: the big LLM/multimodal labs + Fal + Kie —
+  "openai", // openai.text / .image / .audio / .agents
+  "gemini", // gemini.text / .image / .audio / .video
+  "mistral", // mistral.text / .vision / .embeddings
+  "xai", // xai.text / .image / .vision
+  "fal", // fal.* (hosted image/video/audio models)
+  "kie" // kie.* (hosted image/video/audio models)
+];
+
+/**
+ * Node types removed even though their namespace is allowed. These are the
+ * developer/automation-flavored agents inside `nodetool.agents`: they wrap the
+ * very integrations the cloud profile drops (shell, git, sqlite, supabase,
+ * http, filesystem, browser, office docs) and don't fit a creative workspace.
+ *
+ * Kept agents: Agent, Classifier, Extractor, Summarizer, CreateThread,
+ * ImageAgent, MediaAgent, FfmpegAgent, DocumentAgent.
+ */
+export const CLOUD_NODE_DENYLIST: readonly string[] = [
+  "nodetool.agents.BrowserAgent",
+  "nodetool.agents.LiveBrowserAgent",
+  "nodetool.agents.DocxAgent",
+  "nodetool.agents.EmailAgent",
+  "nodetool.agents.FilesystemAgent",
+  "nodetool.agents.GitAgent",
+  "nodetool.agents.HtmlAgent",
+  "nodetool.agents.HttpApiAgent",
+  "nodetool.agents.PdfLibAgent",
+  "nodetool.agents.PptxAgent",
+  "nodetool.agents.SQLiteAgent",
+  "nodetool.agents.ShellAgent",
+  "nodetool.agents.SpreadsheetAgent",
+  "nodetool.agents.SupabaseAgent",
+  "nodetool.agents.VectorStoreAgent",
+  "nodetool.agents.YtDlpDownloaderAgent"
+];
+
+/**
+ * Provider ids exposed in the cloud product: the big foundation-model labs
+ * plus Fal and Kie for media. Anthropic and Groq have no dedicated node
+ * namespace — they reach users through the Agent / Chat / generator nodes via
+ * the provider registry, so they live here only.
+ */
+export const CLOUD_PROVIDER_IDS: readonly string[] = [
+  "openai",
+  "anthropic",
+  "gemini",
+  "groq",
+  "mistral",
+  "xai",
+  "fal_ai",
+  "kie"
+];
+
+/**
+ * Built-in node packs loaded under the cloud profile. `base` is required and
+ * always loads; `fal` and `kie` are the only provider packs kept. Every other
+ * provider pack (Replicate, Hugging Face, Together, MiniMax, Topaz, Reve,
+ * AtlasCloud, ElevenLabs, Transformers.js) stays off.
+ */
+export const CLOUD_BUILTIN_PACK_IDS: readonly string[] = ["base", "fal", "kie"];
+
+/**
+ * Whether `nodeType` is offered in the cloud product. Denylist wins, then the
+ * node must fall under an allowed namespace at a segment boundary so that e.g.
+ * `lib.image` admits `lib.image.warp.Offset` but not a hypothetical
+ * `lib.imagery.*`.
+ */
+export function isCloudNodeType(nodeType: string): boolean {
+  if (CLOUD_NODE_DENYLIST.includes(nodeType)) return false;
+  return CLOUD_NODE_NAMESPACES.some(
+    (ns) => nodeType === ns || nodeType.startsWith(`${ns}.`)
+  );
+}
+
+/** Whether `providerId` is exposed in the cloud product. */
+export function isCloudProvider(providerId: string): boolean {
+  return CLOUD_PROVIDER_IDS.includes(providerId);
+}

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -14,7 +14,7 @@
  * prunes the registry and the provider list at bootstrap) and any UI that
  * wants to reflect the same policy. It is intentionally pure data + pure
  * predicates: the env read that decides *whether* the profile is active lives
- * at the application boundary (see {@link isCloudProfileValue}).
+ * at the application boundary (see {@link isCloudProfileActive}).
  *
  * Activate by setting `NODETOOL_NODE_PROFILE=cloud`. When unset (the default),
  * none of this applies and the full catalog loads unchanged.
@@ -26,13 +26,25 @@ export const CLOUD_PROFILE_ENV = "NODETOOL_NODE_PROFILE";
 /** Value of {@link CLOUD_PROFILE_ENV} that turns on the curated cloud profile. */
 export const CLOUD_PROFILE_VALUE = "cloud";
 
+/** Env var + value that put the server in production mode. */
+export const NODE_ENV_VAR = "NODETOOL_ENV";
+export const PRODUCTION_ENV_VALUE = "production";
+
 /**
- * True when the supplied env value selects the cloud profile. Callers pass
- * `process.env[CLOUD_PROFILE_ENV]` so this stays free of any runtime/env
- * dependency and remains trivially testable.
+ * True when the cloud profile should apply. The commercial cloud product runs
+ * in production mode, so production *is* the cloud profile; the explicit
+ * `NODETOOL_NODE_PROFILE=cloud` flag additionally enables it outside
+ * production (e.g. for local testing). Callers pass the raw env values so this
+ * stays free of any runtime/env dependency and remains trivially testable.
  */
-export function isCloudProfileValue(value: string | undefined | null): boolean {
-  return value === CLOUD_PROFILE_VALUE;
+export function isCloudProfileActive(
+  profileValue: string | undefined | null,
+  nodeEnvValue: string | undefined | null
+): boolean {
+  return (
+    profileValue === CLOUD_PROFILE_VALUE ||
+    nodeEnvValue === PRODUCTION_ENV_VALUE
+  );
 }
 
 /**
@@ -56,7 +68,8 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
   "nodetool.llm", // generic Chat node (also surfaces Anthropic/Groq)
 
   // — Creative generation core —
-  "nodetool.text",
+  // (nodetool.text and nodetool.code are NOT whole-namespace allows: only a
+  // curated subset is kept via CLOUD_NODE_ALLOWLIST below.)
   "nodetool.image",
   "nodetool.sketch",
   "nodetool.audio", // covers .synth and .realtime
@@ -65,7 +78,6 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
   "nodetool.model3d",
   "nodetool.generators",
   "nodetool.agents", // trimmed by CLOUD_NODE_DENYLIST below
-  "nodetool.code", // the Code node — explicitly kept for power users
 
   // — Creative media toolkit (Photoshop/After-Effects-style ops) —
   "lib.image", // warp, color, draw, effects, filter, channel, keyer, mask, …
@@ -80,6 +92,40 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
   "xai", // xai.text / .image / .vision
   "fal", // fal.* (hosted image/video/audio models)
   "kie" // kie.* (hosted image/video/audio models)
+];
+
+/**
+ * Individual node types kept even though their namespace is *not* whole-listed
+ * above. Used to admit a narrow slice of an otherwise-trimmed namespace:
+ *
+ * - `nodetool.code.Code` — the sandboxed (vm-based) JavaScript node only. The
+ *   rest of `nodetool.code` (Python/Bash/Ruby/Lua subprocess + Docker runners)
+ *   stays out: arbitrary process/Docker execution isn't appropriate for a
+ *   managed multi-tenant cloud.
+ * - `nodetool.text.*` — a creative-text toolkit (prompt building, formatting,
+ *   templating, joining, light parsing/splitting). The low-level string/regex/
+ *   token/whitespace utilities and file I/O are dropped — they're programmer
+ *   plumbing, not creative tools.
+ */
+export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
+  // Sandboxed code only.
+  "nodetool.code.Code",
+  // Curated creative-text nodes.
+  "nodetool.text.Prompt",
+  "nodetool.text.Template",
+  "nodetool.text.FormatText",
+  "nodetool.text.Concat",
+  "nodetool.text.Join",
+  "nodetool.text.Collect",
+  "nodetool.text.Replace",
+  "nodetool.text.ToString",
+  "nodetool.text.SaveText",
+  "nodetool.text.Split",
+  "nodetool.text.Slice",
+  "nodetool.text.Chunk",
+  "nodetool.text.Extract",
+  "nodetool.text.ParseJSON",
+  "nodetool.text.ExtractJSON"
 ];
 
 /**
@@ -136,12 +182,14 @@ export const CLOUD_PROVIDER_IDS: readonly string[] = [
 export const CLOUD_BUILTIN_PACK_IDS: readonly string[] = ["base", "fal", "kie"];
 
 /**
- * Whether `nodeType` is offered in the cloud product. Denylist wins, then the
- * node must fall under an allowed namespace at a segment boundary so that e.g.
+ * Whether `nodeType` is offered in the cloud product. An explicit allowlist
+ * entry always wins; otherwise the denylist excludes it; otherwise it must
+ * fall under an allowed namespace at a segment boundary so that e.g.
  * `lib.image` admits `lib.image.warp.Offset` but not a hypothetical
  * `lib.imagery.*`.
  */
 export function isCloudNodeType(nodeType: string): boolean {
+  if (CLOUD_NODE_ALLOWLIST.includes(nodeType)) return true;
   if (CLOUD_NODE_DENYLIST.includes(nodeType)) return false;
   return CLOUD_NODE_NAMESPACES.some(
     (ns) => nodeType === ns || nodeType.startsWith(`${ns}.`)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from "./wrap-primitives.js";
 export * from "./toolSchemas.js";
 export * from "./builtin-packs.js";
+export * from "./cloud-profile.js";
 export * from "./agent-protocol.js";
 export {
   type Platform,

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  CLOUD_NODE_NAMESPACES,
+  CLOUD_NODE_DENYLIST,
+  CLOUD_PROVIDER_IDS,
+  CLOUD_BUILTIN_PACK_IDS,
+  CLOUD_PROFILE_VALUE,
+  isCloudNodeType,
+  isCloudProvider,
+  isCloudProfileValue
+} from "../src/cloud-profile.js";
+import { BUILTIN_NODE_PACKS } from "../src/builtin-packs.js";
+
+describe("cloud profile activation", () => {
+  it("only the cloud value turns it on", () => {
+    expect(isCloudProfileValue(CLOUD_PROFILE_VALUE)).toBe(true);
+    expect(isCloudProfileValue("cloud")).toBe(true);
+    expect(isCloudProfileValue("full")).toBe(false);
+    expect(isCloudProfileValue("")).toBe(false);
+    expect(isCloudProfileValue(undefined)).toBe(false);
+    expect(isCloudProfileValue(null)).toBe(false);
+  });
+});
+
+describe("isCloudNodeType", () => {
+  it("admits the creative core namespaces", () => {
+    for (const nodeType of [
+      "nodetool.image.TextToImage",
+      "nodetool.audio.synth.Oscillator",
+      "nodetool.audio.realtime.AudioOutput",
+      "nodetool.video.ImageToVideo",
+      "nodetool.model3d.TextTo3D",
+      "nodetool.code.Code",
+      "nodetool.agents.Agent",
+      "nodetool.generators.SVGGenerator",
+      "lib.image.warp.Offset",
+      "lib.audio.Reverb",
+      "lib.svg.Document",
+      "openai.image.CreateImage",
+      "gemini.video.TextToVideo",
+      "mistral.text.ChatComplete",
+      "xai.image.GenerateImage",
+      "fal.image.flux",
+      "kie.video.veo"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
+    }
+  });
+
+  it("rejects the nerdy / out-of-scope namespaces", () => {
+    for (const nodeType of [
+      "lib.os.ListFiles",
+      "lib.sqlite.Query",
+      "lib.supabase.Select",
+      "lib.http.GetJSON",
+      "lib.pdf.ExtractText",
+      "lib.docx.CreateDocument",
+      "lib.nlp.Tokenize",
+      "nodetool.data.Filter",
+      "nodetool.document.SplitDocument",
+      "nodetool.workspace.ReadTextFile",
+      "nodetool.triggers.WebhookTrigger",
+      "vector.Collection",
+      "search.google.GoogleSearch",
+      "apify.scraping.ApifyWebScraper",
+      "messaging.discord.DiscordSendMessage",
+      "huggingface.TextGeneration",
+      "transformers.TextGeneration",
+      "replicate.something",
+      "together.flux",
+      "minimax.TextToVideo"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+  });
+
+  it("applies the denylist inside an allowed namespace", () => {
+    expect(isCloudNodeType("nodetool.agents.ShellAgent")).toBe(false);
+    expect(isCloudNodeType("nodetool.agents.SQLiteAgent")).toBe(false);
+    // …but keeps the creative agents in the same namespace.
+    expect(isCloudNodeType("nodetool.agents.ImageAgent")).toBe(true);
+    expect(isCloudNodeType("nodetool.agents.Summarizer")).toBe(true);
+  });
+
+  it("matches namespaces only at segment boundaries", () => {
+    // A look-alike namespace must not be admitted by a prefix.
+    expect(isCloudNodeType("lib.imagery.Thing")).toBe(false);
+    expect(isCloudNodeType("openairtable.Thing")).toBe(false);
+  });
+});
+
+describe("cloud provider + pack allowlists", () => {
+  it("keeps the big labs plus Fal and Kie, drops the rest", () => {
+    for (const id of ["openai", "anthropic", "gemini", "mistral", "xai", "groq", "fal_ai", "kie"]) {
+      expect(isCloudProvider(id)).toBe(true);
+    }
+    for (const id of ["replicate", "together", "minimax", "topaz", "cohere", "ollama"]) {
+      expect(isCloudProvider(id)).toBe(false);
+    }
+  });
+
+  it("denylisted node types never leak into the allowed namespaces", () => {
+    for (const nodeType of CLOUD_NODE_DENYLIST) {
+      const ns = CLOUD_NODE_NAMESPACES.find(
+        (n) => nodeType === n || nodeType.startsWith(`${n}.`)
+      );
+      expect(ns).toBeDefined(); // denylist entries target an allowed namespace
+      expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+  });
+
+  it("every cloud pack id exists in the catalog", () => {
+    const ids = new Set(BUILTIN_NODE_PACKS.map((p) => p.id));
+    for (const id of CLOUD_BUILTIN_PACK_IDS) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
+
+  it("provider allowlist is non-empty and unique", () => {
+    expect(CLOUD_PROVIDER_IDS.length).toBeGreaterThan(0);
+    expect(new Set(CLOUD_PROVIDER_IDS).size).toBe(CLOUD_PROVIDER_IDS.length);
+  });
+});

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -1,24 +1,32 @@
 import { describe, it, expect } from "vitest";
 import {
   CLOUD_NODE_NAMESPACES,
+  CLOUD_NODE_ALLOWLIST,
   CLOUD_NODE_DENYLIST,
   CLOUD_PROVIDER_IDS,
   CLOUD_BUILTIN_PACK_IDS,
-  CLOUD_PROFILE_VALUE,
   isCloudNodeType,
   isCloudProvider,
-  isCloudProfileValue
+  isCloudProfileActive
 } from "../src/cloud-profile.js";
 import { BUILTIN_NODE_PACKS } from "../src/builtin-packs.js";
 
 describe("cloud profile activation", () => {
-  it("only the cloud value turns it on", () => {
-    expect(isCloudProfileValue(CLOUD_PROFILE_VALUE)).toBe(true);
-    expect(isCloudProfileValue("cloud")).toBe(true);
-    expect(isCloudProfileValue("full")).toBe(false);
-    expect(isCloudProfileValue("")).toBe(false);
-    expect(isCloudProfileValue(undefined)).toBe(false);
-    expect(isCloudProfileValue(null)).toBe(false);
+  it("activates for the explicit cloud flag", () => {
+    expect(isCloudProfileActive("cloud", undefined)).toBe(true);
+    expect(isCloudProfileActive("cloud", "development")).toBe(true);
+  });
+
+  it("activates in production mode", () => {
+    expect(isCloudProfileActive(undefined, "production")).toBe(true);
+    expect(isCloudProfileActive(null, "production")).toBe(true);
+  });
+
+  it("stays off otherwise", () => {
+    expect(isCloudProfileActive(undefined, undefined)).toBe(false);
+    expect(isCloudProfileActive("full", "development")).toBe(false);
+    expect(isCloudProfileActive("", "")).toBe(false);
+    expect(isCloudProfileActive(null, null)).toBe(false);
   });
 });
 
@@ -30,7 +38,6 @@ describe("isCloudNodeType", () => {
       "nodetool.audio.realtime.AudioOutput",
       "nodetool.video.ImageToVideo",
       "nodetool.model3d.TextTo3D",
-      "nodetool.code.Code",
       "nodetool.agents.Agent",
       "nodetool.generators.SVGGenerator",
       "lib.image.warp.Offset",
@@ -83,9 +90,51 @@ describe("isCloudNodeType", () => {
   });
 
   it("matches namespaces only at segment boundaries", () => {
-    // A look-alike namespace must not be admitted by a prefix.
     expect(isCloudNodeType("lib.imagery.Thing")).toBe(false);
     expect(isCloudNodeType("openairtable.Thing")).toBe(false);
+  });
+});
+
+describe("code + text are node-level trimmed", () => {
+  it("keeps only the sandboxed Code node", () => {
+    expect(isCloudNodeType("nodetool.code.Code")).toBe(true);
+    for (const nodeType of [
+      "nodetool.code.ExecutePython",
+      "nodetool.code.ExecuteBash",
+      "nodetool.code.ExecuteRuby",
+      "nodetool.code.RunPythonCommandDocker",
+      "nodetool.code.RunShellCommandDocker"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+  });
+
+  it("keeps the curated creative-text nodes, drops the utilities", () => {
+    for (const nodeType of [
+      "nodetool.text.Prompt",
+      "nodetool.text.Template",
+      "nodetool.text.Concat",
+      "nodetool.text.FormatText",
+      "nodetool.text.ExtractJSON"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
+    }
+    for (const nodeType of [
+      "nodetool.text.RegexMatch",
+      "nodetool.text.ToUppercase",
+      "nodetool.text.CountTokens",
+      "nodetool.text.Slugify",
+      "nodetool.text.SaveTextFile",
+      "nodetool.text.Embedding"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+  });
+
+  it("admits every explicit allowlist entry", () => {
+    for (const nodeType of CLOUD_NODE_ALLOWLIST) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
+    }
   });
 });
 
@@ -99,12 +148,12 @@ describe("cloud provider + pack allowlists", () => {
     }
   });
 
-  it("denylisted node types never leak into the allowed namespaces", () => {
+  it("denylisted node types target an allowed namespace and stay out", () => {
     for (const nodeType of CLOUD_NODE_DENYLIST) {
       const ns = CLOUD_NODE_NAMESPACES.find(
         (n) => nodeType === n || nodeType.startsWith(`${n}.`)
       );
-      expect(ns).toBeDefined(); // denylist entries target an allowed namespace
+      expect(ns).toBeDefined();
       expect(isCloudNodeType(nodeType)).toBe(false);
     }
   });

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -117,7 +117,8 @@ import {
 import {
   PROVIDER_IDS,
   CLOUD_PROFILE_ENV,
-  isCloudProfileValue,
+  NODE_ENV_VAR,
+  isCloudProfileActive,
   isCloudProvider
 } from "@nodetool-ai/protocol";
 export type {
@@ -237,11 +238,17 @@ if (
   registerBuiltinProvider(PROVIDER_IDS.FAKE, FakeProvider, {});
 }
 
-// Cloud profile: keep only the curated provider allowlist (the big LLM labs
-// plus Fal + Kie). Pruning after registration — rather than gating each
-// register call — keeps the registration block above untouched and works
-// regardless of which providers a future edit adds.
-if (isCloudProfileValue(_envProcess.env[CLOUD_PROFILE_ENV])) {
+// Cloud profile (production, or NODETOOL_NODE_PROFILE=cloud): keep only the
+// curated provider allowlist (the big LLM labs plus Fal + Kie). Pruning after
+// registration — rather than gating each register call — keeps the
+// registration block above untouched and works regardless of which providers
+// a future edit adds.
+if (
+  isCloudProfileActive(
+    _envProcess.env[CLOUD_PROFILE_ENV],
+    _envProcess.env[NODE_ENV_VAR]
+  )
+) {
   for (const id of listBuiltinProviderIds()) {
     if (!isCloudProvider(id)) unregisterBuiltinProvider(id);
   }

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -105,11 +105,21 @@ export {
   getProvider,
   getProviderSecretKey,
   isProviderConfigured,
-  listRegisteredProviderIds
+  listRegisteredProviderIds,
+  unregisterProvider
 } from "./provider-registry.js";
 export type { GetSecret } from "./provider-registry.js";
-import { registerProvider as registerBuiltinProvider } from "./provider-registry.js";
-import { PROVIDER_IDS } from "@nodetool-ai/protocol";
+import {
+  registerProvider as registerBuiltinProvider,
+  listRegisteredProviderIds as listBuiltinProviderIds,
+  unregisterProvider as unregisterBuiltinProvider
+} from "./provider-registry.js";
+import {
+  PROVIDER_IDS,
+  CLOUD_PROFILE_ENV,
+  isCloudProfileValue,
+  isCloudProvider
+} from "@nodetool-ai/protocol";
 export type {
   ProviderId,
   LanguageModel,
@@ -225,4 +235,14 @@ if (
   _envProcess.env["NODETOOL_ENABLE_FAKE_PROVIDER"] === "1"
 ) {
   registerBuiltinProvider(PROVIDER_IDS.FAKE, FakeProvider, {});
+}
+
+// Cloud profile: keep only the curated provider allowlist (the big LLM labs
+// plus Fal + Kie). Pruning after registration — rather than gating each
+// register call — keeps the registration block above untouched and works
+// regardless of which providers a future edit adds.
+if (isCloudProfileValue(_envProcess.env[CLOUD_PROFILE_ENV])) {
+  for (const id of listBuiltinProviderIds()) {
+    if (!isCloudProvider(id)) unregisterBuiltinProvider(id);
+  }
 }

--- a/packages/runtime/src/providers/provider-registry.ts
+++ b/packages/runtime/src/providers/provider-registry.ts
@@ -43,6 +43,11 @@ export function listRegisteredProviderIds(): string[] {
   return Array.from(_PROVIDER_REGISTRY.keys());
 }
 
+/** Remove a provider from the registry. Returns true if one was removed. */
+export function unregisterProvider(providerId: string): boolean {
+  return _PROVIDER_REGISTRY.delete(providerId);
+}
+
 /**
  * Build a fresh provider instance, resolving any unset credential kwargs via
  * `getSecret` first, then `process.env` as fallback. The caller owns any

--- a/packages/runtime/tests/providers/cloud-profile-providers.test.ts
+++ b/packages/runtime/tests/providers/cloud-profile-providers.test.ts
@@ -1,19 +1,40 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
-// The provider registry registers (and, under the cloud profile, prunes)
-// at module-load time, so each case sets the env and re-imports a fresh
-// module graph via resetModules.
+const CLOUD = ["openai", "anthropic", "gemini", "groq", "mistral", "xai", "fal_ai", "kie"];
+const OUT_OF_SCOPE = [
+  "replicate",
+  "together",
+  "minimax",
+  "topaz",
+  "reve",
+  "atlascloud",
+  "cohere",
+  "voyage",
+  "jina",
+  "huggingface",
+  "openrouter",
+  "deepseek",
+  "moonshot",
+  "ollama"
+];
+
+// The provider registry registers (and, under the cloud profile, prunes) at
+// module-load time, so each case sets env and re-imports a fresh module graph.
 describe("cloud profile provider pruning", () => {
-  const original = process.env["NODETOOL_NODE_PROFILE"];
+  const originalProfile = process.env["NODETOOL_NODE_PROFILE"];
+  const originalEnv = process.env["NODETOOL_ENV"];
 
   afterEach(() => {
-    if (original === undefined) delete process.env["NODETOOL_NODE_PROFILE"];
-    else process.env["NODETOOL_NODE_PROFILE"] = original;
+    if (originalProfile === undefined) delete process.env["NODETOOL_NODE_PROFILE"];
+    else process.env["NODETOOL_NODE_PROFILE"] = originalProfile;
+    if (originalEnv === undefined) delete process.env["NODETOOL_ENV"];
+    else process.env["NODETOOL_ENV"] = originalEnv;
     vi.resetModules();
   });
 
   it("registers out-of-scope providers when the profile is off", async () => {
     delete process.env["NODETOOL_NODE_PROFILE"];
+    delete process.env["NODETOOL_ENV"];
     vi.resetModules();
     const mod = await import("../../src/providers/index.js");
     const ids = mod.listRegisteredProviderIds();
@@ -23,40 +44,22 @@ describe("cloud profile provider pruning", () => {
   });
 
   it("keeps only the curated allowlist under NODETOOL_NODE_PROFILE=cloud", async () => {
+    delete process.env["NODETOOL_ENV"];
     process.env["NODETOOL_NODE_PROFILE"] = "cloud";
     vi.resetModules();
     const mod = await import("../../src/providers/index.js");
     const ids = mod.listRegisteredProviderIds();
+    for (const id of CLOUD) expect(ids).toContain(id);
+    for (const id of OUT_OF_SCOPE) expect(ids).not.toContain(id);
+  });
 
-    for (const id of [
-      "openai",
-      "anthropic",
-      "gemini",
-      "groq",
-      "mistral",
-      "xai",
-      "fal_ai",
-      "kie"
-    ]) {
-      expect(ids).toContain(id);
-    }
-    for (const id of [
-      "replicate",
-      "together",
-      "minimax",
-      "topaz",
-      "reve",
-      "atlascloud",
-      "cohere",
-      "voyage",
-      "jina",
-      "huggingface",
-      "openrouter",
-      "deepseek",
-      "moonshot",
-      "ollama"
-    ]) {
-      expect(ids).not.toContain(id);
-    }
+  it("keeps only the curated allowlist in production mode", async () => {
+    delete process.env["NODETOOL_NODE_PROFILE"];
+    process.env["NODETOOL_ENV"] = "production";
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    const ids = mod.listRegisteredProviderIds();
+    for (const id of CLOUD) expect(ids).toContain(id);
+    for (const id of OUT_OF_SCOPE) expect(ids).not.toContain(id);
   });
 });

--- a/packages/runtime/tests/providers/cloud-profile-providers.test.ts
+++ b/packages/runtime/tests/providers/cloud-profile-providers.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+// The provider registry registers (and, under the cloud profile, prunes)
+// at module-load time, so each case sets the env and re-imports a fresh
+// module graph via resetModules.
+describe("cloud profile provider pruning", () => {
+  const original = process.env["NODETOOL_NODE_PROFILE"];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env["NODETOOL_NODE_PROFILE"];
+    else process.env["NODETOOL_NODE_PROFILE"] = original;
+    vi.resetModules();
+  });
+
+  it("registers out-of-scope providers when the profile is off", async () => {
+    delete process.env["NODETOOL_NODE_PROFILE"];
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    const ids = mod.listRegisteredProviderIds();
+    expect(ids).toContain("openai");
+    expect(ids).toContain("replicate");
+    expect(ids).toContain("together");
+  });
+
+  it("keeps only the curated allowlist under NODETOOL_NODE_PROFILE=cloud", async () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    const ids = mod.listRegisteredProviderIds();
+
+    for (const id of [
+      "openai",
+      "anthropic",
+      "gemini",
+      "groq",
+      "mistral",
+      "xai",
+      "fal_ai",
+      "kie"
+    ]) {
+      expect(ids).toContain(id);
+    }
+    for (const id of [
+      "replicate",
+      "together",
+      "minimax",
+      "topaz",
+      "reve",
+      "atlascloud",
+      "cohere",
+      "voyage",
+      "jina",
+      "huggingface",
+      "openrouter",
+      "deepseek",
+      "moonshot",
+      "ollama"
+    ]) {
+      expect(ids).not.toContain(id);
+    }
+  });
+});

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -18,8 +18,9 @@ import {
   BUILTIN_NODE_PACKS,
   resolveBuiltinPackEnabled,
   CLOUD_PROFILE_ENV,
+  NODE_ENV_VAR,
   CLOUD_BUILTIN_PACK_IDS,
-  isCloudProfileValue,
+  isCloudProfileActive,
   isCloudNodeType
 } from "@nodetool-ai/protocol";
 import { setPackSnapshot } from "./pack-snapshot.js";
@@ -65,7 +66,10 @@ function isProduction(): boolean {
 
 /** True when the curated commercial cloud profile is active. */
 function isCloudProfile(): boolean {
-  return isCloudProfileValue(process.env[CLOUD_PROFILE_ENV]);
+  return isCloudProfileActive(
+    process.env[CLOUD_PROFILE_ENV],
+    process.env[NODE_ENV_VAR]
+  );
 }
 
 /**

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -16,7 +16,11 @@ import {
 } from "@nodetool-ai/node-sdk";
 import {
   BUILTIN_NODE_PACKS,
-  resolveBuiltinPackEnabled
+  resolveBuiltinPackEnabled,
+  CLOUD_PROFILE_ENV,
+  CLOUD_BUILTIN_PACK_IDS,
+  isCloudProfileValue,
+  isCloudNodeType
 } from "@nodetool-ai/protocol";
 import { setPackSnapshot } from "./pack-snapshot.js";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
@@ -57,6 +61,25 @@ export interface BootstrapRegistryOptions {
 
 function isProduction(): boolean {
   return process.env["NODETOOL_ENV"] === "production";
+}
+
+/** True when the curated commercial cloud profile is active. */
+function isCloudProfile(): boolean {
+  return isCloudProfileValue(process.env[CLOUD_PROFILE_ENV]);
+}
+
+/**
+ * Pack-enabled map for the cloud profile: only `base` (required), `fal`, and
+ * `kie` load; every other provider pack is off so we don't register thousands
+ * of out-of-scope nodes just to prune them.
+ */
+function cloudPackOverrides(): Record<string, boolean> {
+  return Object.fromEntries(
+    BUILTIN_NODE_PACKS.map((pack) => [
+      pack.id,
+      CLOUD_BUILTIN_PACK_IDS.includes(pack.id)
+    ])
+  );
 }
 
 /**
@@ -100,7 +123,9 @@ export function registerBuiltInNodes(
   registry: NodeRegistry,
   options: RegisterBuiltInNodesOptions = {}
 ): void {
-  const overrides = options.enabledOverrides ?? readBuiltinPackOverrides();
+  const overrides =
+    options.enabledOverrides ??
+    (isCloudProfile() ? cloudPackOverrides() : readBuiltinPackOverrides());
   for (const pack of BUILTIN_NODE_PACKS) {
     if (!resolveBuiltinPackEnabled(pack, overrides[pack.id])) {
       options.log?.info(`Skipped built-in node pack ${pack.id} (disabled)`);
@@ -159,6 +184,28 @@ export function applyProductionNodePolicy(
   }
 }
 
+/**
+ * Prune the registry down to the curated commercial-cloud surface when the
+ * cloud profile (`NODETOOL_NODE_PROFILE=cloud`) is active. Drops every node
+ * type outside {@link isCloudNodeType} — nerdy/automation namespaces,
+ * out-of-scope provider packs, and the developer-flavored agents — leaving the
+ * creative AI workspace set (text, image, audio, video, 3D, agents, Code).
+ * A no-op when the profile is off, so OSS/local installs are unaffected.
+ */
+export function applyCloudNodePolicy(
+  registry: NodeRegistry,
+  log?: BootstrapLogger
+): void {
+  if (!isCloudProfile()) return;
+  for (const nodeType of registry.list()) {
+    if (!isCloudNodeType(nodeType)) {
+      if (registry.unregister(nodeType)) {
+        log?.info(`Cloud profile: dropped ${nodeType}`);
+      }
+    }
+  }
+}
+
 function logPackResult(result: LoadedPackResult, log?: BootstrapLogger): void {
   const { pack } = result;
   const id = `${pack.name}@${pack.version ?? "?"}`;
@@ -201,6 +248,7 @@ export async function bootstrapNodeRegistry(
     setPackSnapshot(results);
   }
   applyProductionNodePolicy(registry, options.log);
+  applyCloudNodePolicy(registry, options.log);
   return registry;
 }
 

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -120,10 +120,12 @@ describe("applyBuiltinPackEnabled", () => {
 });
 
 describe("applyCloudNodePolicy", () => {
+  const originalProfile = process.env[CLOUD_PROFILE_ENV];
   const originalEnv = process.env[NODE_ENV_VAR];
 
   afterEach(() => {
-    delete process.env[CLOUD_PROFILE_ENV];
+    if (originalProfile === undefined) delete process.env[CLOUD_PROFILE_ENV];
+    else process.env[CLOUD_PROFILE_ENV] = originalProfile;
     if (originalEnv === undefined) delete process.env[NODE_ENV_VAR];
     else process.env[NODE_ENV_VAR] = originalEnv;
   });

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -3,6 +3,7 @@ import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import {
   BUILTIN_NODE_PACKS,
   CLOUD_PROFILE_ENV,
+  NODE_ENV_VAR,
   isCloudNodeType
 } from "@nodetool-ai/protocol";
 import {
@@ -119,8 +120,12 @@ describe("applyBuiltinPackEnabled", () => {
 });
 
 describe("applyCloudNodePolicy", () => {
+  const originalEnv = process.env[NODE_ENV_VAR];
+
   afterEach(() => {
     delete process.env[CLOUD_PROFILE_ENV];
+    if (originalEnv === undefined) delete process.env[NODE_ENV_VAR];
+    else process.env[NODE_ENV_VAR] = originalEnv;
   });
 
   function fullRegistry(): NodeRegistry {
@@ -133,21 +138,7 @@ describe("applyCloudNodePolicy", () => {
     return registry;
   }
 
-  it("is a no-op when the cloud profile is off", () => {
-    delete process.env[CLOUD_PROFILE_ENV];
-    const registry = fullRegistry();
-    const before = registry.list().length;
-    applyCloudNodePolicy(registry);
-    expect(registry.list().length).toBe(before);
-    // Nerdy namespaces survive without the profile.
-    expect(registry.list().some((t) => t.startsWith("lib.os."))).toBe(true);
-  });
-
-  it("drops nerdy/out-of-scope nodes when the cloud profile is on", () => {
-    process.env[CLOUD_PROFILE_ENV] = "cloud";
-    const registry = fullRegistry();
-    applyCloudNodePolicy(registry);
-
+  function expectCuratedSurface(registry: NodeRegistry): void {
     const remaining = registry.list();
     expect(remaining.length).toBeGreaterThan(0);
     // Every survivor is part of the curated cloud surface…
@@ -166,11 +157,45 @@ describe("applyCloudNodePolicy", () => {
     ]) {
       expect(remaining.some((t) => t.startsWith(prefix))).toBe(false);
     }
-    // …the developer-flavored agents are gone…
+    // …developer-flavored agents are gone…
     expect(remaining).not.toContain("nodetool.agents.ShellAgent");
-    // …while the creative core stays.
+    // …only the sandboxed Code node survives nodetool.code…
     expect(remaining).toContain("nodetool.code.Code");
+    expect(remaining).not.toContain("nodetool.code.ExecutePython");
+    expect(remaining).not.toContain("nodetool.code.RunShellCommandDocker");
+    // …text is trimmed to the curated set…
+    expect(remaining).toContain("nodetool.text.Prompt");
+    expect(remaining).not.toContain("nodetool.text.RegexMatch");
+    expect(remaining).not.toContain("nodetool.text.CountTokens");
+    // …while the creative media core stays.
     expect(remaining.some((t) => t.startsWith("nodetool.image."))).toBe(true);
     expect(remaining.some((t) => t.startsWith("nodetool.audio."))).toBe(true);
+  }
+
+  it("is a no-op when the cloud profile is off", () => {
+    delete process.env[CLOUD_PROFILE_ENV];
+    delete process.env[NODE_ENV_VAR];
+    const registry = fullRegistry();
+    const before = registry.list().length;
+    applyCloudNodePolicy(registry);
+    expect(registry.list().length).toBe(before);
+    // Nerdy namespaces survive without the profile.
+    expect(registry.list().some((t) => t.startsWith("lib.os."))).toBe(true);
+  });
+
+  it("prunes to the curated surface under NODETOOL_NODE_PROFILE=cloud", () => {
+    delete process.env[NODE_ENV_VAR];
+    process.env[CLOUD_PROFILE_ENV] = "cloud";
+    const registry = fullRegistry();
+    applyCloudNodePolicy(registry);
+    expectCuratedSurface(registry);
+  });
+
+  it("prunes to the curated surface in production mode", () => {
+    delete process.env[CLOUD_PROFILE_ENV];
+    process.env[NODE_ENV_VAR] = "production";
+    const registry = fullRegistry();
+    applyCloudNodePolicy(registry);
+    expectCuratedSurface(registry);
   });
 });

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
-import { BUILTIN_NODE_PACKS } from "@nodetool-ai/protocol";
+import {
+  BUILTIN_NODE_PACKS,
+  CLOUD_PROFILE_ENV,
+  isCloudNodeType
+} from "@nodetool-ai/protocol";
 import {
   applyBuiltinPackEnabled,
+  applyCloudNodePolicy,
   registerBuiltInNodes
 } from "../src/node-registry-setup.js";
 
@@ -110,5 +115,62 @@ describe("applyBuiltinPackEnabled", () => {
     expect(() =>
       applyBuiltinPackEnabled(new NodeRegistry(), "nope", true)
     ).toThrow(/No registrar/);
+  });
+});
+
+describe("applyCloudNodePolicy", () => {
+  afterEach(() => {
+    delete process.env[CLOUD_PROFILE_ENV];
+  });
+
+  function fullRegistry(): NodeRegistry {
+    const registry = new NodeRegistry();
+    registerBuiltInNodes(registry, {
+      enabledOverrides: Object.fromEntries(
+        BUILTIN_NODE_PACKS.map((p) => [p.id, true])
+      )
+    });
+    return registry;
+  }
+
+  it("is a no-op when the cloud profile is off", () => {
+    delete process.env[CLOUD_PROFILE_ENV];
+    const registry = fullRegistry();
+    const before = registry.list().length;
+    applyCloudNodePolicy(registry);
+    expect(registry.list().length).toBe(before);
+    // Nerdy namespaces survive without the profile.
+    expect(registry.list().some((t) => t.startsWith("lib.os."))).toBe(true);
+  });
+
+  it("drops nerdy/out-of-scope nodes when the cloud profile is on", () => {
+    process.env[CLOUD_PROFILE_ENV] = "cloud";
+    const registry = fullRegistry();
+    applyCloudNodePolicy(registry);
+
+    const remaining = registry.list();
+    expect(remaining.length).toBeGreaterThan(0);
+    // Every survivor is part of the curated cloud surface…
+    for (const nodeType of remaining) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
+    }
+    // …nerdy namespaces are gone…
+    for (const prefix of [
+      "lib.os.",
+      "lib.sqlite.",
+      "nodetool.data.",
+      "nodetool.workspace.",
+      "vector.",
+      "search.google.",
+      "huggingface."
+    ]) {
+      expect(remaining.some((t) => t.startsWith(prefix))).toBe(false);
+    }
+    // …the developer-flavored agents are gone…
+    expect(remaining).not.toContain("nodetool.agents.ShellAgent");
+    // …while the creative core stays.
+    expect(remaining).toContain("nodetool.code.Code");
+    expect(remaining.some((t) => t.startsWith("nodetool.image."))).toBe(true);
+    expect(remaining.some((t) => t.startsWith("nodetool.audio."))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Introduces a **cloud profile** — a deliberately curated node and provider surface for the commercial NodeTool cloud product. The full open-source catalog (~3,500 nodes across ~60 namespaces) is trimmed to a focused **creative AI workspace** (text, image, audio, video, 3D generation/editing) that a small team can maintain at high quality. Nerdy/automation plumbing (filesystem, databases, scraping, subprocess runners, office-doc tooling) is dropped.

The profile activates in production mode (`NODETOOL_ENV=production`) or via explicit flag (`NODETOOL_NODE_PROFILE=cloud`). When off (the default), the full catalog loads unchanged — OSS/local installs are unaffected.

## Key Changes

- **`packages/protocol/src/cloud-profile.ts`** (new)
  - Single source of truth: `CLOUD_NODE_NAMESPACES` (whole namespaces kept), `CLOUD_NODE_ALLOWLIST` (individual nodes from trimmed namespaces — sandboxed Code node + curated text nodes), `CLOUD_NODE_DENYLIST` (developer-flavored agents dropped from kept namespace), `CLOUD_PROVIDER_IDS`, `CLOUD_BUILTIN_PACK_IDS`
  - Predicates: `isCloudProfileActive()`, `isCloudNodeType()`, `isCloudProvider()`
  - Env vars: `CLOUD_PROFILE_ENV` (`NODETOOL_NODE_PROFILE`), `NODE_ENV_VAR` (`NODETOOL_ENV`)

- **`docs/CLOUD_NODE_CURATION.md`** (new)
  - Comprehensive guide: why the profile exists, how it's enabled, which providers/namespaces/nodes are kept/dropped, maintenance instructions

- **`packages/websocket/src/node-registry-setup.ts`** (modified)
  - `isCloudProfile()` helper checks env vars
  - `cloudPackOverrides()` restricts pack loading to `base`, `fal`, `kie` only
  - `applyCloudNodePolicy()` prunes registry to `isCloudNodeType()` when profile is active
  - `registerBuiltInNodes()` applies cloud pack overrides if profile is on
  - `bootstrapNodeRegistry()` calls `applyCloudNodePolicy()` after production policy

- **`packages/runtime/src/providers/index.ts`** (modified)
  - Post-registration pruning: unregisters any provider not in `isCloudProvider()` when profile is active
  - Keeps registration block untouched; pruning happens after all providers are registered

- **`packages/runtime/src/providers/provider-registry.ts`** (modified)
  - New `unregisterProvider()` export to remove providers from registry

- **`packages/protocol/src/index.ts`** (modified)
  - Exports `cloud-profile.ts` module

- **Tests** (new)
  - `packages/protocol/tests/cloud-profile.test.ts`: activation logic, node/provider filtering, allowlist/denylist enforcement, namespace boundary matching
  - `packages/websocket/tests/node-registry-setup.test.ts`: `applyCloudNodePolicy()` integration — verifies nerdy namespaces are dropped, creative core survives, denylist applies
  - `packages/runtime/tests/providers/cloud-profile-providers.test.ts`: provider registry pruning under both activation modes

## Implementation Details

- **Namespace matching**: Segment-boundary only — `lib.image` admits `lib.image.warp.Offset` but not `lib.imagery.*`
- **Allowlist wins**: Explicit allowlist entries always pass, denylist can't override
- **Denylist scope**: Only applies within allowed namespaces (e.g., `nodetool.agents.ShellAgent` is dropped, but `nodetool.agents.Agent` survives)
- **Code node**: Only `nodetool.code.Code` (sandboxed vm-based JavaScript) is kept; Python/Bash/Ruby/Lua subprocess + Docker runners are dropped

https://claude.ai/code/session_01FyXsstLjvoGyVTo6ohHD9a