### PR TITLE
Guide users to set up a provider when chat has none configured

### DIFF
--- a/web/src/components/chat/containers/WelcomePlaceholder.tsx
+++ b/web/src/components/chat/containers/WelcomePlaceholder.tsx
@@ -2,9 +2,25 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Text, Chip, MOTION } from "../../ui_primitives";
+import {
+  Text,
+  Chip,
+  FlexRow,
+  FlexColumn,
+  Box,
+  EditorButton,
+  BORDER_RADIUS,
+  MOTION
+} from "../../ui_primitives";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
 import { memo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLanguageModelProviders } from "../../../hooks/useProviders";
+
+import openaiIcon from "@lobehub/icons-static-svg/icons/openai.svg";
+import anthropicIcon from "@lobehub/icons-static-svg/icons/anthropic.svg";
+import geminiColorIcon from "@lobehub/icons-static-svg/icons/gemini-color.svg";
 
 const styles = (theme: Theme) =>
   css({
@@ -70,14 +86,30 @@ const SUGGESTIONS = [
   "Help me with code"
 ];
 
+// Cloud LLM providers we point first-time users at. Each maps to an API key
+// they can add on the Settings → API Keys tab.
+const SETUP_PROVIDERS = [
+  { name: "OpenAI", icon: openaiIcon, mono: true },
+  { name: "Anthropic", icon: anthropicIcon, mono: true },
+  { name: "Gemini", icon: geminiColorIcon, mono: false }
+] as const;
+
 interface WelcomePlaceholderProps {
   onSuggestionClick?: (suggestion: string) => void;
 }
 
+/**
+ * Shown when a chat thread has no messages yet. When no language-model
+ * provider is configured we guide the user to add an API key first (otherwise
+ * sending a message just fails); once a provider is available we show the
+ * regular prompt suggestions.
+ */
 const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
   onSuggestionClick
 }) => {
   const theme = useTheme();
+  const navigate = useNavigate();
+  const { providers, isLoading, error } = useLanguageModelProviders();
 
   const handleClick = useCallback(
     (suggestion: string) => {
@@ -86,37 +118,102 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
     [onSuggestionClick]
   );
 
+  const handleOpenSettings = useCallback(() => {
+    navigate("/settings?tab=1");
+  }, [navigate]);
+
+  // Only treat the chat as "no provider" once the provider query has settled
+  // successfully — while loading (or on a transient fetch error, which the
+  // connection banner already surfaces) we keep the neutral suggestions view.
+  const noProvider = !isLoading && !error && providers.length === 0;
+
   return (
     <div css={styles(theme)}>
       <div className="welcome-inner">
-        <div className="chat-suggestions-block">
-          <AutoAwesomeIcon className="welcome-icon" />
-          <Text className="welcome-title">How can I help you today?</Text>
-          <Text className="welcome-subtitle">
-            Ask me anything, drop files to analyze, or try one of these:
-          </Text>
-          <div className="suggestions">
-            {SUGGESTIONS.map((suggestion) => (
-              <Chip
-                key={suggestion}
-                label={suggestion}
-                variant="outlined"
-                onClick={() => handleClick(suggestion)}
-                sx={{
-                  borderColor: theme.vars.palette.divider,
-                  color: theme.vars.palette.text.secondary,
-                  cursor: "pointer",
-                  transition: `all ${MOTION.fast}`,
-                  "&:hover": {
-                    borderColor: theme.vars.palette.primary.main,
-                    color: theme.vars.palette.primary.main,
-                    backgroundColor: `${theme.vars.palette.primary.main}10`
-                  }
-                }}
-              />
-            ))}
+        {noProvider ? (
+          <FlexColumn align="center" gap={1.5} sx={{ textAlign: "center" }}>
+            <KeyRoundedIcon className="welcome-icon" />
+            <Text className="welcome-title">
+              Connect an AI provider to get started
+            </Text>
+            <Text className="welcome-subtitle" sx={{ maxWidth: 520 }}>
+              Add an API key for OpenAI, Anthropic, or Gemini to start chatting.
+              Your keys are encrypted and stored securely.
+            </Text>
+            <FlexRow gap={1} justify="center" wrap sx={{ mt: 0.5 }}>
+              {SETUP_PROVIDERS.map((provider) => (
+                <FlexRow
+                  key={provider.name}
+                  align="center"
+                  gap={0.75}
+                  sx={{
+                    px: 1.25,
+                    py: 0.5,
+                    borderRadius: BORDER_RADIUS.pill,
+                    border: `1px solid ${theme.vars.palette.divider}`,
+                    backgroundColor: theme.vars.palette.background.paper
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={provider.icon}
+                    alt=""
+                    aria-hidden
+                    sx={{
+                      width: 16,
+                      height: 16,
+                      objectFit: "contain",
+                      ...(provider.mono &&
+                        theme.applyStyles("dark", { filter: "invert(1)" }))
+                    }}
+                  />
+                  <Text size="small" weight={500}>
+                    {provider.name}
+                  </Text>
+                </FlexRow>
+              ))}
+            </FlexRow>
+            <EditorButton
+              variant="contained"
+              color="primary"
+              size="small"
+              startIcon={<KeyRoundedIcon sx={{ fontSize: 16 }} />}
+              onClick={handleOpenSettings}
+              sx={{ mt: 1 }}
+            >
+              Add API keys in Settings
+            </EditorButton>
+          </FlexColumn>
+        ) : (
+          <div className="chat-suggestions-block">
+            <AutoAwesomeIcon className="welcome-icon" />
+            <Text className="welcome-title">How can I help you today?</Text>
+            <Text className="welcome-subtitle">
+              Ask me anything, drop files to analyze, or try one of these:
+            </Text>
+            <div className="suggestions">
+              {SUGGESTIONS.map((suggestion) => (
+                <Chip
+                  key={suggestion}
+                  label={suggestion}
+                  variant="outlined"
+                  onClick={() => handleClick(suggestion)}
+                  sx={{
+                    borderColor: theme.vars.palette.divider,
+                    color: theme.vars.palette.text.secondary,
+                    cursor: "pointer",
+                    transition: `all ${MOTION.fast}`,
+                    "&:hover": {
+                      borderColor: theme.vars.palette.primary.main,
+                      color: theme.vars.palette.primary.main,
+                      backgroundColor: `${theme.vars.palette.primary.main}10`
+                    }
+                  }}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
+++ b/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+import WelcomePlaceholder from "../WelcomePlaceholder";
+import { useLanguageModelProviders } from "../../../../hooks/useProviders";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate
+}));
+
+jest.mock("../../../../hooks/useProviders", () => ({
+  useLanguageModelProviders: jest.fn()
+}));
+
+const mockUseLanguageModelProviders =
+  useLanguageModelProviders as jest.MockedFunction<
+    typeof useLanguageModelProviders
+  >;
+
+const renderWelcome = (onSuggestionClick = jest.fn()) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <WelcomePlaceholder onSuggestionClick={onSuggestionClick} />
+    </ThemeProvider>
+  );
+
+describe("WelcomePlaceholder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("guides the user to add an API key when no provider is configured", () => {
+    mockUseLanguageModelProviders.mockReturnValue({
+      providers: [],
+      isLoading: false,
+      isFetching: false,
+      error: null
+    });
+
+    renderWelcome();
+
+    expect(
+      screen.getByText("Connect an AI provider to get started")
+    ).toBeInTheDocument();
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+    expect(screen.getByText("Gemini")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add API keys in Settings/i })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/settings?tab=1");
+  });
+
+  it("shows prompt suggestions once a provider is configured", () => {
+    const onSuggestionClick = jest.fn();
+    mockUseLanguageModelProviders.mockReturnValue({
+      providers: [
+        { provider: "openai", capabilities: ["generate_message"] }
+      ],
+      isLoading: false,
+      isFetching: false,
+      error: null
+    });
+
+    renderWelcome(onSuggestionClick);
+
+    expect(screen.getByText("How can I help you today?")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Connect an AI provider to get started")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Summarize a document"));
+    expect(onSuggestionClick).toHaveBeenCalledWith("Summarize a document");
+  });
+
+  it("keeps the neutral suggestions view while providers are loading", () => {
+    mockUseLanguageModelProviders.mockReturnValue({
+      providers: [],
+      isLoading: true,
+      isFetching: true,
+      error: null
+    });
+
+    renderWelcome();
+
+    expect(screen.getByText("How can I help you today?")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Connect an AI provider to get started")
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The chat welcome screen previously always showed prompt suggestions, even
when no language-model provider was configured — clicking a suggestion then
just failed. WelcomePlaceholder now checks for configured LLM providers and,
when none exist, shows a "Connect an AI provider to get started" guide with
OpenAI / Anthropic / Gemini and a button that deep-links to Settings → API
Keys. While the provider query is loading or errors, the neutral suggestions
view is kept to avoid a flash.

The generative-node (ApiKeyValidation, e.g. "FAL API Key is missing") and
model-select dialog (ModelList/ProviderList empty states) already guide users
to add keys, so no changes were needed there.

https://claude.ai/code/session_0193Z8m6ov49pyYSZdbD2pzL