### PR TITLE
Slide the right inspector panel in and out

### DIFF
--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -24,13 +24,18 @@ import { useSubgraphTabsStore } from "../../stores/SubgraphTabsStore";
 
 import { PANEL_RESIZE_HANDLE_WIDTH } from "../../config/constants";
 import ContextMenus from "../context_menus/ContextMenus";
-import { MobileBottomSheet, FlexColumn, MOTION } from "../ui_primitives";
+import {
+  MobileBottomSheet,
+  FlexColumn,
+  MOTION,
+  reducedMotion
+} from "../ui_primitives";
 
 const HEADER_AREA_HEIGHT = 77;
 // Matches HEADER_HEIGHT in PanelBottom — the bar still occupies this when collapsed.
 const BOTTOM_PANEL_HEADER_HEIGHT = 32;
 
-const styles = (theme: Theme, bottomOffset: number) =>
+const styles = (theme: Theme, bottomOffset: number, isVisible: boolean) =>
   css({
     position: "fixed",
     right: 0,
@@ -39,6 +44,12 @@ const styles = (theme: Theme, bottomOffset: number) =>
     display: "flex",
     flexDirection: "row",
     zIndex: 1100,
+    // Slide off the right edge when hidden; the panel overlays (position:
+    // fixed) so this is a purely visual transform, no layout reflow.
+    transform: isVisible ? "translateX(0)" : "translateX(100%)",
+    pointerEvents: isVisible ? "auto" : "none",
+    transition: `transform ${MOTION.slow}`,
+    ...reducedMotion({ transition: MOTION.none }),
 
     ".drawer-content": {
       height: "100%",
@@ -361,30 +372,29 @@ const PanelRight: React.FC = () => {
       {activeNodeStore && (
         <InspectorVisibilitySync activeNodeStore={activeNodeStore} />
       )}
-      {isVisible && (
+      <div
+        css={styles(theme, bottomOffset, isVisible)}
+        className="panel-right-container"
+        aria-hidden={!isVisible}
+      >
         <div
-          css={styles(theme, bottomOffset)}
-          className="panel-right-container"
+          ref={panelRef}
+          className={`drawer-content ${isDragging ? "dragging" : ""}`}
+          style={{ width: `${panelSize}px` }}
         >
           <div
-            ref={panelRef}
-            className={`drawer-content ${isDragging ? "dragging" : ""}`}
-            style={{ width: `${panelSize}px` }}
-          >
-            <div
-              className="panel-button"
-              onMouseDown={handleMouseDown}
-              role="slider"
-              aria-label="Resize panel"
-              aria-valuenow={panelSize}
-              aria-valuemin={60}
-              aria-valuemax={600}
-              tabIndex={-1}
-            />
-            <div className="panel-inner-content">{inspectorBody}</div>
-          </div>
+            className="panel-button"
+            onMouseDown={handleMouseDown}
+            role="slider"
+            aria-label="Resize panel"
+            aria-valuenow={panelSize}
+            aria-valuemin={60}
+            aria-valuemax={600}
+            tabIndex={-1}
+          />
+          <div className="panel-inner-content">{inspectorBody}</div>
         </div>
-      )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## What

The right inspector panel popped in/out instantly. It now slides on and off the right edge.

## Why

The container was gated behind `{isVisible && (...)}`, so it mounted/unmounted on every selection change. An unmounting element can't animate its exit, so the panel just appeared and disappeared.

## How

- Keep the container mounted and slide it with a `transform: translateX` (`100%` hidden → `0` visible) in `web/src/components/panels/PanelRight.tsx`.
- Use the `MOTION.slow` token (350ms ease), the design system's designated timing for panel/drawer open/close.
- Transform-only, so no layout reflow: the panel is `position: fixed` and overlays the canvas, nothing else moves.
- `pointerEvents: none` + `aria-hidden` while off-screen so the hidden panel can't be clicked or reached by screen readers.
- `reducedMotion()` override honors `prefers-reduced-motion`.

## Note

Keeping the panel mounted means the `Inspector` now stays mounted while hidden (required for the exit animation) instead of unmounting on deselect. Standard for inspector panels; flagging in case anything relied on unmount-on-hide.

## Test plan

- [ ] Select a node → panel slides in from the right
- [ ] Deselect → panel slides out
- [ ] `prefers-reduced-motion: reduce` → no slide, instant toggle
- [ ] Resize handle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)