### PR TITLE
Add valueVariant prop to CostStatCard for flexible value display

### DIFF
--- a/web/src/components/costs/CostStatCard.tsx
+++ b/web/src/components/costs/CostStatCard.tsx
@@ -15,6 +15,12 @@ export interface CostStatCardProps {
   caption: React.ReactNode;
   /** Optional emphasized badge (e.g. the +64% delta chip). */
   badge?: React.ReactNode;
+  /**
+   * `metric` (default) renders a big numeric headline.
+   * `label` renders an identifier-shaped value smaller and lets it wrap so
+   * long names (e.g. `kie.video.BytedanceSeedreamV4`) don't overflow.
+   */
+  valueVariant?: "metric" | "label";
 }
 
 const CostStatCardInternal: React.FC<CostStatCardProps> = ({
@@ -24,8 +30,10 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
   decimal,
   valueDotColor,
   caption,
-  badge
+  badge,
+  valueVariant = "metric"
 }) => {
+  const isLabel = valueVariant === "label";
   const theme = useTheme();
   return (
     <FlexColumn
@@ -67,7 +75,7 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
         </Box>
       </FlexRow>
 
-      <FlexRow gap={1} align="center">
+      <FlexRow gap={1} align={isLabel ? "flex-start" : "center"} sx={{ minWidth: 0 }}>
         {valueDotColor && (
           <Box
             sx={{
@@ -75,17 +83,23 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
               height: 11,
               borderRadius: "var(--rounded-sm)",
               backgroundColor: valueDotColor,
-              flexShrink: 0
+              flexShrink: 0,
+              mt: isLabel ? "7px" : 0
             }}
           />
         )}
         <Text
           component="span"
           sx={{
-            fontSize: "2rem",
-            lineHeight: 1.05,
+            fontSize: isLabel ? "1.25rem" : "2rem",
+            lineHeight: isLabel ? 1.2 : 1.05,
             fontWeight: 600,
-            color: theme.vars.palette.text.primary
+            color: theme.vars.palette.text.primary,
+            minWidth: 0,
+            ...(isLabel && {
+              wordBreak: "break-word",
+              overflowWrap: "anywhere"
+            })
           }}
         >
           {value}

--- a/web/src/components/costs/CostsDashboard.tsx
+++ b/web/src/components/costs/CostsDashboard.tsx
@@ -493,6 +493,7 @@ const DashboardContent: React.FC<DashboardContentProps> = ({
           label="Top cost driver"
           icon={BarChartIcon}
           value={driver ? driver.label : "—"}
+          valueVariant="label"
           valueDotColor={driver ? providerColor(driver.providerId) : undefined}
           caption={
             driver


### PR DESCRIPTION
## Summary
Adds a new `valueVariant` prop to the `CostStatCard` component to support two display modes for the value: a large metric display (default) and a smaller label display that wraps long text.

## Changes
- **CostStatCard.tsx**
  - Added `valueVariant?: "metric" | "label"` prop to `CostStatCardProps` interface with documentation
  - Updated component to conditionally render value text based on variant:
    - `"metric"` (default): Large 2rem font, centered alignment, single-line display
    - `"label"`: Smaller 1.25rem font, flex-start alignment, word-wrapping enabled for long identifiers
  - Applied responsive styling: adjusted font size, line height, color dot margin, and text wrapping behavior per variant
  - Added `minWidth: 0` to flex container to enable proper text wrapping

- **CostsDashboard.tsx**
  - Applied `valueVariant="label"` to the "Top cost driver" stat card to accommodate long provider names (e.g., `kie.video.BytedanceSeedreamV4`) without overflow

## Implementation Details
The label variant uses `wordBreak: "break-word"` and `overflowWrap: "anywhere"` to handle long identifiers that don't contain spaces. The flex container's `minWidth: 0` is critical for enabling text wrapping in flex children. The color dot indicator is vertically adjusted (+7px margin-top) in label mode to align with the smaller text.

https://claude.ai/code/session_01R8dvqwxnmHh5butYyr2FpC