### PR TITLE
fix(web): restore streaming agent preview; cap text card with popup

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1841,15 +1841,21 @@ export class UnifiedWebSocketRunner {
 
           const meta = this.getNodeMetadata?.(nodeType);
 
-          // Relay output_update for Output-type nodes and for streaming or
-          // auto-saving generative nodes (FAL / Replicate / Kie / …) so the
-          // client receives one event per yielded item — the UI accumulates
-          // and renders each generation as it arrives.
+          // Relay output_update for display-sink nodes (Output, Preview) and
+          // for streaming or auto-saving generative nodes (FAL / Replicate /
+          // Kie / …) so the client receives one event per yielded item — the
+          // UI accumulates and renders each generation as it arrives. The
+          // Preview node re-emits each chunk it receives on its own terminal
+          // `output` handle; relaying those is what lets the preview stream
+          // incrementally instead of collapsing to the final value.
           if (outbound.type === "output_update") {
+            const isDisplaySink =
+              nodeType.includes("Output") ||
+              nodeType.endsWith(".Preview");
             const isStreamingLeaf =
               Boolean(meta?.is_streaming_output) ||
               Boolean(meta?.auto_save_asset);
-            if (!nodeType.includes("Output") && !isStreamingLeaf) continue;
+            if (!isDisplaySink && !isStreamingLeaf) continue;
             outputUpdateSeen = true;
           }
 

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -604,6 +604,16 @@ describe("UnifiedWebSocketRunner", () => {
     expect(genProcessCalls).toBe(1);
     expect(sinkValues).toEqual(["first", "second"]);
 
+    // The Preview node is a display sink: its per-chunk output_updates must be
+    // relayed to the client so the preview streams incrementally instead of
+    // collapsing to a single final value.
+    const previewUpdates = ws.sentBytes
+      .map((b) => unpack(b) as Record<string, unknown>)
+      .filter(
+        (m) => m.type === "output_update" && m.node_id === "preview"
+      );
+    expect(previewUpdates.map((m) => m.value)).toEqual(["first", "second"]);
+
     await outputRunner.disconnect();
   });
 

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -24,8 +24,10 @@ import { useNodeGenerations } from "../../hooks/nodes/useNodeGenerations";
 import { outputOf } from "../../utils/nodeGenerations";
 import type { Asset } from "../../stores/ApiTypes";
 import { useWebsocketRunner } from "../../stores/WorkflowRunner";
-import { ToolbarIconButton, MOTION } from "../ui_primitives";
+import { CopyButton, Dialog, ToolbarIconButton, MOTION } from "../ui_primitives";
 import { MediaOverlaySuppressProvider } from "./MediaOverlayContext";
+import { TextRenderer } from "./output/TextRenderer";
+import { extractTextValue } from "../../utils/extractTextValue";
 
 interface NodeHistoryViewerProps {
   workflowId: string;
@@ -266,14 +268,21 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     setMode((m) => (m === "single" ? "multi" : "single"));
   }, []);
 
-  // The fullscreen AssetViewer only renders media; text generations use the
-  // inline preview only.
+  // The fullscreen AssetViewer renders media; text generations open in a
+  // readable text popup instead. Both are triggered from the same overlay
+  // "open" control so the affordance lives in the generations navigator.
   const canOpenViewer =
     !!currentAsset && !showingLive && isMediaAsset(currentAsset);
+  const currentText = useMemo(
+    () => extractTextValue(valueToRender),
+    [valueToRender]
+  );
+  const hasTextToOpen = !canOpenViewer && currentText.trim().length > 0;
+  const canOpen = canOpenViewer || hasTextToOpen;
   const handleOpenViewer = useCallback(() => {
-    if (!canOpenViewer) return;
+    if (!canOpenViewer && !hasTextToOpen) return;
     setViewerOpen(true);
-  }, [canOpenViewer]);
+  }, [canOpenViewer, hasTextToOpen]);
 
   // Children (ImageView) render under this context: it suppresses their own
   // overlay/viewer and routes "open" here, so the viewer's gallery reflects the
@@ -472,12 +481,12 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
       <div className="node-history-overlay overlay-top-right">
         <div className="overlay-cluster">
           <ToolbarIconButton
-            title="Open in viewer"
+            title={hasTextToOpen ? "Open full text" : "Open in viewer"}
             size="small"
             onClick={handleOpenViewer}
-            disabled={!canOpenViewer}
+            disabled={!canOpen}
             className="overlay-icon-btn"
-            aria-label="Open in viewer"
+            aria-label={hasTextToOpen ? "Open full text" : "Open in viewer"}
           >
             <OpenInFullIcon />
           </ToolbarIconButton>
@@ -516,6 +525,21 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           open={viewerOpen}
           onClose={handleCloseViewer}
         />
+      ) : hasTextToOpen ? (
+        <Dialog
+          open={viewerOpen}
+          onClose={handleCloseViewer}
+          title="Generated text"
+          minWidth="min(720px, 90vw)"
+          titleActions={<CopyButton value={currentText} tooltip="Copy text" />}
+        >
+          <div
+            className="text-popup nowheel"
+            style={{ maxHeight: "70vh", overflow: "auto" }}
+          >
+            <TextRenderer text={currentText} showActions={false} />
+          </div>
+        </Dialog>
       ) : null}
     </div>
   );

--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -9,7 +9,10 @@ import type { Theme } from "@mui/material/styles";
 import isEqual from "fast-deep-equal";
 
 import { NodeData } from "../../../stores/NodeData";
-import { useNodeResultValue } from "../../../hooks/nodes/useNodeExecState";
+import { useNodeGenerations } from "../../../hooks/nodes/useNodeGenerations";
+import useResultsStore from "../../../stores/ResultsStore";
+import useWorkflowRunsStore from "../../../stores/WorkflowRunsStore";
+import { outputOf } from "../../../utils/nodeGenerations";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 import { createAssetFile } from "../../../utils/createAssetFile";
@@ -308,15 +311,24 @@ const PreviewNode: React.FC<PreviewNodeProps> = (props) => {
     [getEdges, props.id]
   );
 
-  // The connected source node's accumulated output is the single source.
-  // PreviewNode no longer emits a redundant `preview_update` for itself —
-  // the runner's `output_update` for the source already carries the value.
-  const rawSourceNodeValue = useNodeResultValue(
-    props.data.workflow_id,
-    incomingValueEdge?.source ?? "",
-    incomingValueEdge?.sourceHandle ?? undefined
+  // Live display reads this Preview node's OWN stream buffer (outputResults),
+  // which `output_update` appends to per chunk during a run, scoped to the
+  // focused job — same contract as OutputNode. The source's `output_update` is
+  // suppressed by the runner for handles with outgoing data edges, and the
+  // source's generation timeline only carries its final `process()` result
+  // (never streamed chunks), so reading the source would collapse a stream to
+  // one big object. The Preview node re-emits each incoming chunk on its own
+  // terminal `output` handle, so its buffer holds the full incremental stream.
+  const workflowId = props.data.workflow_id;
+  const focusedJob = useWorkflowRunsStore((s) => s.focusedJob[workflowId]);
+  const streamBuffer = useResultsStore((s) =>
+    focusedJob ? s.getOutputResult(workflowId, focusedJob, props.id) : undefined
   );
-  const sourceNodeValue = incomingValueEdge?.source ? rawSourceNodeValue : undefined;
+  const { current } = useNodeGenerations(workflowId, props.id);
+  const settledValue = useMemo(
+    () => (current ? outputOf(current) : undefined),
+    [current]
+  );
 
   // The kernel intentionally skips `output_update` for `nodetool.input.*`
   // and `nodetool.constant.*` nodes (runner.ts) since the client already
@@ -351,11 +363,17 @@ const PreviewNode: React.FC<PreviewNodeProps> = (props) => {
   );
 
   const displayResult = useMemo(
-    // Show every generation from the latest execution; for streaming
-    // outputs (e.g. `num_images=N`) this is the array accumulated under
-    // outputResults during the run.
-    () => sourceNodeValue ?? sourcePropertyValue ?? sourceFallbackValue,
-    [sourceNodeValue, sourcePropertyValue, sourceFallbackValue]
+    // Live stream buffer first (the per-chunk array accumulated under
+    // outputResults during the run — streaming text, `num_images=N`, etc.),
+    // then the property value for unrun input/constant sources, then the
+    // source's durable saved assets on reload, then this node's settled
+    // generation as a final fallback for non-asset scalar values.
+    () =>
+      streamBuffer ??
+      sourcePropertyValue ??
+      sourceFallbackValue ??
+      settledValue,
+    [streamBuffer, sourcePropertyValue, sourceFallbackValue, settledValue]
   );
 
   const previewOutput = useMemo(

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -69,6 +69,7 @@ import {
 } from "../../utils/exposedInputs";
 import ExposedLabeledInputs from "../node/ExposedLabeledInputs";
 import NodeHistoryViewer from "../node/NodeHistoryViewer";
+import { extractTextValue } from "../../utils/extractTextValue";
 
 const styles = (theme: Theme) =>
   css({
@@ -84,9 +85,12 @@ const styles = (theme: Theme) =>
     },
     // Text variant inherits the node body color instead of the dark media
     // backdrop — keeps text content visually flush with the rest of the
-    // node and matches the PreviewNode look.
+    // node and matches the PreviewNode look. The height is capped so a long
+    // (or streaming) generation scrolls inside the card instead of growing
+    // the node unbounded; the "expand" button opens the full text in a popup.
     "&[data-content-card-variant=\"text\"] .preview-area": {
-      backgroundColor: "transparent"
+      backgroundColor: "transparent",
+      maxHeight: theme.spacing(30)
     },
     // Preview keeps a minimum strip when the node is resized very small;
     // params (flex-shrink: 0) clip at the bottom via node-content-container.
@@ -354,26 +358,6 @@ const useMediaSrc = (
   return blobUrl || signedUrl || "";
 };
 
-const extractTextValue = (value: unknown): string => {
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => extractTextValue(item))
-      .filter((item) => item.length > 0)
-      .join("\n");
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (value && typeof value === "object") {
-    const v = value as Record<string, unknown>;
-    if (typeof v.value === "string") {return v.value;}
-    if (typeof v.text === "string") {return v.text;}
-    if (typeof v.data === "string") {return v.data;}
-    if (v.output !== undefined) {return extractTextValue(v.output);}
-  }
-  return "";
-};
-
 type ImagePreviewSource = string | Uint8Array;
 
 const isNumberArray = (value: unknown[]): value is number[] =>
@@ -501,7 +485,10 @@ const AudioPreview: React.FC<{ value: unknown }> = ({ value }) => {
 
 const TextPreview: React.FC<{ value: unknown }> = ({ value }) => {
   // Render via the same TextRenderer PreviewNode uses (markdown + theme
-  // typography) so the card and the preview node match visually.
+  // typography) so the card and the preview node match visually. The card's
+  // height is capped (see `.preview-area` CSS) so long/streaming text scrolls
+  // in place; the generations navigator's "Open full text" control
+  // (NodeHistoryViewer) opens the full text in a readable popup.
   const text = extractTextValue(value);
   return (
     <div

--- a/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
+++ b/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
@@ -298,6 +298,23 @@ describe("ContentCardBody results", () => {
     expect(container).toHaveTextContent("first second");
   });
 
+  it("opens the full text in a popup from the generations navigator", async () => {
+    const user = userEvent.setup();
+    seedLiveGeneration("j1", { output: "first second" });
+
+    renderContentCard(metadataForOutput("str"));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // The "Open full text" control lives in the generations navigator overlay.
+    await user.click(
+      screen.getByRole("button", { name: /open full text/i })
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("first second");
+  });
+
   it("shows a history navigator over persisted text generations", () => {
     const textAsset = (
       id: string,

--- a/web/src/utils/extractTextValue.ts
+++ b/web/src/utils/extractTextValue.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolve the plain-text content from a node output value.
+ *
+ * Output values arrive in several shapes depending on the source: a raw
+ * string, a `{ type: "text", text }` / `{ data }` / `{ value }` record, a
+ * generation wrapper carrying `output`, or an array (e.g. chunked streaming
+ * output) whose items resolve recursively and join with newlines. Anything
+ * that doesn't resolve to text yields an empty string.
+ */
+export const extractTextValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => extractTextValue(item))
+      .filter((item) => item.length > 0)
+      .join("\n");
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const v = value as Record<string, unknown>;
+    if (typeof v.value === "string") return v.value;
+    if (typeof v.text === "string") return v.text;
+    if (typeof v.data === "string") return v.data;
+    if (typeof v.content === "string") return v.content;
+    if (v.output !== undefined) return extractTextValue(v.output);
+  }
+  return "";
+};


### PR DESCRIPTION
## Problem

Two regressions around agent/streaming output display:

1. **Preview shows one big JSON instead of streaming text.** A `Preview` node fed by a streaming source (e.g. the Agent node's `chunk` output) stopped rendering incremental text and instead dumped the source's final result as JSON.
2. **The agent's text content card auto-grows the node.** Long or streaming text expanded the node unbounded instead of staying a fixed, scrollable size.

## Root causes

- `PreviewNode` was reading the **source node's generation timeline** (`useNodeResultValue`), which only carries the final `process()` result — never streamed chunks. So `outputOf(gen, "chunk")` found no `chunk` key and returned the whole record → rendered as JSON.
- The websocket layer (`unified-websocket-runner`) only relayed `output_update` for nodes whose type contains `"Output"` or streaming/auto-saving leaves. The `Preview` node matched neither, so its per-chunk re-emissions (which the kernel does emit on its terminal `output` handle) never reached the client.
- The text content-card variant had no height bound.

## Changes

- **`PreviewNode`** reads its own per-job stream buffer from `outputResults` (scoped to the focused job), mirroring `OutputNode`. The accumulated chunk array renders through `OutputRenderer`'s chunk-grouping branch as incremental text.
- **`unified-websocket-runner`** treats `Preview` as a display sink alongside `Output`, relaying its per-chunk `output_update`s to the client.
- **`ContentCardBody`** caps the text variant's preview area height so long/streaming text scrolls in place instead of growing the node.
- **`NodeHistoryViewer`**'s existing "Open" overlay control (top-right of the generations navigator) now opens a readable text popup (`70vh` scroll, copy button) for text generations — previously only media could open the fullscreen viewer.
- Extracted a shared **`extractTextValue`** util used by both `ContentCardBody` and `NodeHistoryViewer`.

## Tests

- `unified-websocket-runner.test.ts`: extended the streaming Streamer→Preview test to assert the Preview now relays per-chunk `output_update`s (`["first", "second"]`).
- `ContentCardBody.test.tsx`: added a test that the "Open full text" control in the generations navigator opens a popup containing the full text.
- All affected suites green; `tsc` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)