### PR TITLE
Fix right panel persistence to prevent empty inspector on load

### DIFF
--- a/web/src/stores/RightPanelStore.ts
+++ b/web/src/stores/RightPanelStore.ts
@@ -131,11 +131,13 @@ export const useRightPanelStore = create<ResizePanelState>()(
     }),
     {
       name: "right-panel-storage",
-      version: 2,
+      version: 3,
+      // Visibility is selection-driven — the panel only opens while a node is
+      // selected. Persisting `isVisible` would re-open an empty inspector on a
+      // fresh load (no selection yet), so only the size/view are persisted.
       partialize: (state: ResizePanelState) => ({
         panel: {
           panelSize: state.panel.panelSize,
-          isVisible: state.panel.isVisible,
           activeView: state.panel.activeView
         }
       }),
@@ -161,10 +163,9 @@ export const useRightPanelStore = create<ResizePanelState>()(
                     Math.min(persistedPanel.panelSize, MAX_PANEL_SIZE)
                   )
                 : currentState.panel.panelSize,
-            isVisible:
-              typeof persistedPanel.isVisible === "boolean"
-                ? persistedPanel.isVisible
-                : currentState.panel.isVisible,
+            // Always start hidden; selection re-derives visibility. Ignore any
+            // legacy persisted `isVisible` (pre-v3) to avoid an empty panel.
+            isVisible: false,
             activeView: "inspector"
           }
         };

--- a/web/src/stores/__tests__/RightPanelStore.test.ts
+++ b/web/src/stores/__tests__/RightPanelStore.test.ts
@@ -166,4 +166,39 @@ describe("RightPanelStore", () => {
       expect(panel.panelSize).toBe(60);
     });
   });
+
+  describe("persistence", () => {
+    it("does not persist isVisible (visibility is selection-driven)", () => {
+      const { setSize, setVisibility } = useRightPanelStore.getState();
+
+      act(() => {
+        setSize(400);
+        setVisibility(true);
+      });
+
+      const persisted = JSON.parse(
+        localStorage.getItem("right-panel-storage") ?? "{}"
+      );
+      expect(persisted.state.panel.panelSize).toBe(400);
+      expect(persisted.state.panel.isVisible).toBeUndefined();
+    });
+
+    it("rehydrates hidden even when a stored blob still carries isVisible: true", () => {
+      localStorage.setItem(
+        "right-panel-storage",
+        JSON.stringify({
+          state: { panel: { panelSize: 420, isVisible: true } },
+          version: 3
+        })
+      );
+
+      act(() => {
+        useRightPanelStore.persist.rehydrate();
+      });
+
+      const { panel } = useRightPanelStore.getState();
+      expect(panel.isVisible).toBe(false);
+      expect(panel.panelSize).toBe(420);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Updates the right panel store persistence logic to stop saving the `isVisible` state, ensuring the panel doesn't reopen with an empty inspector on fresh page loads when no node is selected.

## Key Changes
- **Version bump**: Incremented persistence schema from v2 to v3
- **Partialize update**: Removed `isVisible` from the persisted state — now only `panelSize` and `activeView` are saved
- **Rehydration logic**: Changed to always initialize `isVisible` as `false` on load, ignoring any legacy persisted `isVisible` values from pre-v3 storage
- **Test coverage**: Added two new tests:
  - Verifies that `isVisible` is not persisted to localStorage
  - Confirms that old stored blobs with `isVisible: true` are safely ignored during rehydration

## Implementation Details
The right panel's visibility is selection-driven — it should only open when a node is selected. Previously, persisting `isVisible: true` would cause the panel to reopen on a fresh load even without an active selection, showing an empty inspector. By removing `isVisible` from persistence and always starting hidden, the panel now correctly waits for a selection event to become visible.

The version bump ensures old stored data is handled gracefully; the rehydration logic explicitly sets `isVisible: false` regardless of what was previously persisted.

https://claude.ai/code/session_01GmTvoBd8YCEigAMFtpuXpm