### PR TITLE
Refine spacing and padding in property components

### DIFF
--- a/web/src/components/properties/AudioListProperty.tsx
+++ b/web/src/components/properties/AudioListProperty.tsx
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     ".audio-grid": {
       display: "flex",
@@ -102,7 +102,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "5px 0",
+      margin: "6px 0",
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/AudioListProperty.tsx
+++ b/web/src/components/properties/AudioListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, Text, CloseButton, MOTION } from "../ui_primitives";
+import { Tooltip, Text, CloseButton, MOTION, SPACING } from "../ui_primitives";
 import AudioFileIcon from "@mui/icons-material/AudioFile";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     ".audio-grid": {
       display: "flex",
@@ -102,7 +102,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "6px 0",
+      margin: `${theme.spacing(SPACING.sm)} 0`,
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/AudioProperty.tsx
+++ b/web/src/components/properties/AudioProperty.tsx
@@ -7,16 +7,18 @@ import { PropertyProps } from "../node/PropertyInput";
 import PropertyDropzone from "./PropertyDropzone";
 import { memo, useState } from "react";
 import isEqual from "fast-deep-equal";
-import { EditorButton, NodeTextField, MOTION } from "../ui_primitives";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { EditorButton, NodeTextField, MOTION, SPACING } from "../ui_primitives";
 import { useNodes } from "../../contexts/NodeContext";
 import AudioVisualizer from "../common/AudioVisualizer";
 import { useRealtimeAudioStream } from "../../hooks/useRealtimeAudioStream";
 import type { NodeData } from "../../stores/NodeData";
 
-const styles = () =>
+const styles = (theme: Theme) =>
   css({
     "& .property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     "& .dropzone": {
       width: "100%"
@@ -67,6 +69,7 @@ const styles = () =>
   });
 
 const AudioProperty = (props: PropertyProps) => {
+  const theme = useTheme();
   const id = `audio-${props.property.name}-${props.propertyIndex}`;
   const { asset, uri } = useAsset({ audio: props.value });
   const showRecorder =
@@ -85,7 +88,7 @@ const AudioProperty = (props: PropertyProps) => {
 
   if (isRealtime) {
     return (
-      <div className="audio-property" css={styles()}>
+      <div className="audio-property" css={styles(theme)}>
         <div className="realtime-audio-controls">
           {isStreaming ? (
             <div
@@ -139,7 +142,7 @@ const AudioProperty = (props: PropertyProps) => {
   }
 
   return (
-    <div className="audio-property" css={styles()}>
+    <div className="audio-property" css={styles(theme)}>
       <PropertyLabel
         name={props.property.name}
         description={props.property.description}

--- a/web/src/components/properties/AudioProperty.tsx
+++ b/web/src/components/properties/AudioProperty.tsx
@@ -16,7 +16,7 @@ import type { NodeData } from "../../stores/NodeData";
 const styles = () =>
   css({
     "& .property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     "& .dropzone": {
       width: "100%"

--- a/web/src/components/properties/DataframeProperty.tsx
+++ b/web/src/components/properties/DataframeProperty.tsx
@@ -8,7 +8,7 @@ import { ColumnDef, DataframeRef } from "../../stores/ApiTypes";
 import DataTable from "../node/DataTable/DataTable";
 import ColumnsManager from "../node/ColumnsManager";
 import DataframeEditorModal from "./DataframeEditorModal";
-import { ToolbarIconButton, EditorButton, ButtonGroup, MOTION } from "../ui_primitives";
+import { ToolbarIconButton, EditorButton, ButtonGroup, MOTION, SPACING } from "../ui_primitives";
 // icons
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
@@ -43,7 +43,7 @@ const styles = (theme: Theme) =>
       zIndex: 10
     },
     ".dataframe-action-buttons .MuiIconButton-root": {
-      margin: "0 0 0 6px",
+      margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,
       padding: "0.2em",
       color: theme.vars.palette.primary.main,
       "&:hover": {
@@ -87,7 +87,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "6px 0",
+      margin: `${theme.spacing(SPACING.sm)} 0`,
       backgroundColor: alpha(theme.palette.common.black, 0.2),
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/DataframeProperty.tsx
+++ b/web/src/components/properties/DataframeProperty.tsx
@@ -43,7 +43,7 @@ const styles = (theme: Theme) =>
       zIndex: 10
     },
     ".dataframe-action-buttons .MuiIconButton-root": {
-      margin: "0 0 0 5px",
+      margin: "0 0 0 6px",
       padding: "0.2em",
       color: theme.vars.palette.primary.main,
       "&:hover": {
@@ -87,7 +87,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "5px 0",
+      margin: "6px 0",
       backgroundColor: alpha(theme.palette.common.black, 0.2),
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/ImageListProperty.tsx
+++ b/web/src/components/properties/ImageListProperty.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     ".image-grid": {
       display: "grid",
@@ -100,7 +100,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "5px 0",
+      margin: "6px 0",
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",
@@ -500,7 +500,7 @@ const ImageListProperty = (props: PropertyProps) => {
               padding: "16px 8px",
               outline: "1px dashed rgba(255,255,255,0.1)",
               borderRadius: "var(--rounded-md)",
-              margin: "5px 0"
+              margin: "6px 0"
             })}
           >
             Awaiting upstream

--- a/web/src/components/properties/ImageListProperty.tsx
+++ b/web/src/components/properties/ImageListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, CloseButton, MOTION } from "../ui_primitives";
+import { Tooltip, CloseButton, MOTION, SPACING } from "../ui_primitives";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import ImageDimensions from "../node/ImageDimensions";
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     ".image-grid": {
       display: "grid",
@@ -100,7 +100,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "6px 0",
+      margin: `${theme.spacing(SPACING.sm)} 0`,
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",
@@ -500,7 +500,7 @@ const ImageListProperty = (props: PropertyProps) => {
               padding: "16px 8px",
               outline: "1px dashed rgba(255,255,255,0.1)",
               borderRadius: "var(--rounded-md)",
-              margin: "6px 0"
+              margin: `${theme.spacing(SPACING.sm)} 0`
             })}
           >
             Awaiting upstream

--- a/web/src/components/properties/ImageProperty.tsx
+++ b/web/src/components/properties/ImageProperty.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import { SPACING } from "../ui_primitives";
 import { useAsset } from "../../serverState/useAsset";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
@@ -30,6 +32,7 @@ const awaitingStyles = css({
 });
 
 const ImageProperty = (props: PropertyProps) => {
+  const theme = useTheme();
   const id = `image-${props.property.name}-${props.propertyIndex}`;
 
   const { asset, uri } = useAsset({ image: props.value });
@@ -45,7 +48,7 @@ const ImageProperty = (props: PropertyProps) => {
       className="image-property"
       css={css({
         "& .property-label": {
-          marginBottom: "6px"
+          marginBottom: theme.spacing(SPACING.sm)
         }
       })}
     >

--- a/web/src/components/properties/ImageProperty.tsx
+++ b/web/src/components/properties/ImageProperty.tsx
@@ -45,7 +45,7 @@ const ImageProperty = (props: PropertyProps) => {
       className="image-property"
       css={css({
         "& .property-label": {
-          marginBottom: "5px"
+          marginBottom: "6px"
         }
       })}
     >

--- a/web/src/components/properties/JSONProperty.tsx
+++ b/web/src/components/properties/JSONProperty.tsx
@@ -6,7 +6,7 @@ import { PropertyProps } from "../node/PropertyInput";
 import PropertyLabel from "../node/PropertyLabel";
 import isEqual from "fast-deep-equal";
 import { useTheme } from "@mui/material/styles";
-import { CopyButton, LoadingSpinner, ToolbarIconButton } from "../ui_primitives";
+import { CopyButton, LoadingSpinner, ToolbarIconButton, SPACING } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import TextEditorModal from "./TextEditorModal";
 import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
@@ -161,7 +161,7 @@ const JSONProperty = (props: PropertyProps) => {
           zIndex: 10
         },
         ".json-action-buttons .MuiIconButton-root": {
-          margin: "0 0 0 6px",
+          margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,
           padding: 0
         },
         ".json-action-buttons .MuiIconButton-root svg": {

--- a/web/src/components/properties/JSONProperty.tsx
+++ b/web/src/components/properties/JSONProperty.tsx
@@ -161,7 +161,7 @@ const JSONProperty = (props: PropertyProps) => {
           zIndex: 10
         },
         ".json-action-buttons .MuiIconButton-root": {
-          margin: "0 0 0 5px",
+          margin: "0 0 0 6px",
           padding: 0
         },
         ".json-action-buttons .MuiIconButton-root svg": {

--- a/web/src/components/properties/Model3DProperty.tsx
+++ b/web/src/components/properties/Model3DProperty.tsx
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       flexDirection: "column"
     },
     "& .property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     ".drop-container": {
       position: "relative",

--- a/web/src/components/properties/Model3DProperty.tsx
+++ b/web/src/components/properties/Model3DProperty.tsx
@@ -12,7 +12,7 @@ import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import ConnectedBadge from "./ConnectedBadge";
 import { useFileDrop } from "../../hooks/handlers/useFileDrop";
 import { Asset } from "../../stores/ApiTypes";
-import { Tooltip, EditorButton, NodeTextField, MOTION, BORDER_RADIUS } from "../ui_primitives";
+import { Tooltip, EditorButton, NodeTextField, MOTION, BORDER_RADIUS, SPACING } from "../ui_primitives";
 import AssetViewer from "../assets/AssetViewer";
 import LazyModel3DViewer from "../asset_viewer/LazyModel3DViewer";
 import { resolveAssetUri } from "../node/output/hooks";
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       flexDirection: "column"
     },
     "& .property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     ".drop-container": {
       position: "relative",

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -4,7 +4,7 @@ import type { Theme } from "@mui/material/styles";
 import { memo, useCallback, useMemo, useState, useRef, ChangeEvent } from "react";
 import { Asset } from "../../stores/ApiTypes";
 import { useFileDrop } from "../../hooks/handlers/useFileDrop";
-import { Tooltip, ToolbarIconButton, MOTION } from "../ui_primitives";
+import { Tooltip, ToolbarIconButton, MOTION, SPACING } from "../ui_primitives";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import ImageDimensions from "../node/ImageDimensions";
 import { useTheme } from "@mui/material/styles";
@@ -73,7 +73,7 @@ const PropertyDropzone = ({
         textAlign: "left",
         transition: MOTION.all,
         outline: `1px dashed ${theme.vars.palette.divider}`,
-        margin: "6px 0",
+        margin: `${theme.spacing(SPACING.sm)} 0`,
         backgroundColor: theme.vars.palette.Paper.overlay,
         borderRadius: "var(--rounded-md)",
 

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -73,7 +73,7 @@ const PropertyDropzone = ({
         textAlign: "left",
         transition: MOTION.all,
         outline: `1px dashed ${theme.vars.palette.divider}`,
-        margin: "5px 0",
+        margin: "6px 0",
         backgroundColor: theme.vars.palette.Paper.overlay,
         borderRadius: "var(--rounded-md)",
 

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -8,7 +8,7 @@ import isEqual from "fast-deep-equal";
 import { useNodes } from "../../contexts/NodeContext";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { CopyButton, Tooltip, ToolbarIconButton, SPACING } from "../ui_primitives";
+import { CopyButton, ToolbarIconButton, SPACING } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { NodeTextField, editorClassNames, cn } from "../editor_ui";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -7,7 +7,8 @@ import TextEditorModal from "./TextEditorModal";
 import isEqual from "fast-deep-equal";
 import { useNodes } from "../../contexts/NodeContext";
 import { useTheme } from "@mui/material/styles";
-import { CopyButton, Tooltip, ToolbarIconButton } from "../ui_primitives";
+import type { Theme } from "@mui/material/styles";
+import { CopyButton, Tooltip, ToolbarIconButton, SPACING } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { NodeTextField, editorClassNames, cn } from "../editor_ui";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
@@ -39,34 +40,35 @@ const determineCodeLanguage = (nodeType: string) => {
   return "text";
 };
 
-const propertyStyles = css({
-  ".property-row": {
-    width: "100%",
-    display: "flex",
-    flexDirection: "column"
-  },
-  ".property-row > .property-label": {
-    order: 1
-  },
-  ".value-container": {
-    width: "100%",
-    order: 2
-  },
-  ".string-action-buttons": {
-    position: "absolute",
-    right: 0,
-    top: "-3px",
-    opacity: 0.8,
-    zIndex: 10
-  },
-  ".string-action-buttons .MuiIconButton-root": {
-    margin: "0 0 0 6px",
-    padding: 0
-  },
-  ".string-action-buttons .MuiIconButton-root svg": {
-    fontSize: "var(--fontSizeSmall)"
-  }
-});
+const propertyStyles = (theme: Theme) =>
+  css({
+    ".property-row": {
+      width: "100%",
+      display: "flex",
+      flexDirection: "column"
+    },
+    ".property-row > .property-label": {
+      order: 1
+    },
+    ".value-container": {
+      width: "100%",
+      order: 2
+    },
+    ".string-action-buttons": {
+      position: "absolute",
+      right: 0,
+      top: "-3px",
+      opacity: 0.8,
+      zIndex: 10
+    },
+    ".string-action-buttons .MuiIconButton-root": {
+      margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,
+      padding: 0
+    },
+    ".string-action-buttons .MuiIconButton-root svg": {
+      fontSize: "var(--fontSizeSmall)"
+    }
+  });
 
 const StringProperty = ({
   property,
@@ -150,7 +152,7 @@ const StringProperty = ({
   }
 
   return (
-    <div className="string-property" css={propertyStyles}>
+    <div className="string-property" css={propertyStyles(theme)}>
       <div
         className="property-row"
         onMouseEnter={() => setIsHovered(true)}

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -60,7 +60,7 @@ const propertyStyles = css({
     zIndex: 10
   },
   ".string-action-buttons .MuiIconButton-root": {
-    margin: "0 0 0 5px",
+    margin: "0 0 0 6px",
     padding: 0
   },
   ".string-action-buttons .MuiIconButton-root svg": {

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -24,7 +24,7 @@ import TextDecreaseIcon from "@mui/icons-material/TextDecrease";
 import TextIncreaseIcon from "@mui/icons-material/TextIncrease";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import ChatBubbleIcon from "@mui/icons-material/ChatBubble";
-import { Tooltip, LoadingSpinner, MOTION, BORDER_RADIUS } from "../ui_primitives";
+import { Tooltip, LoadingSpinner, MOTION, BORDER_RADIUS, SPACING } from "../ui_primitives";
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { ListItemNode, ListNode } from "@lexical/list";
@@ -582,7 +582,9 @@ const styles = (theme: Theme) =>
           }
         },
         ".chat-view": {
-          padding: "0 12px 12px 12px !important",
+          padding: `0 ${theme.spacing(SPACING.lg)} ${theme.spacing(
+            SPACING.lg
+          )} ${theme.spacing(SPACING.lg)} !important`,
           minHeight: 0,
           flex: 1
         },
@@ -601,7 +603,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".button": {
-      padding: "6px",
+      padding: theme.spacing(SPACING.sm),
       minWidth: "32px",
       minHeight: "32px",
       cursor: "pointer",

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -582,7 +582,7 @@ const styles = (theme: Theme) =>
           }
         },
         ".chat-view": {
-          padding: "0 10px 10px 10px !important",
+          padding: "0 12px 12px 12px !important",
           minHeight: 0,
           flex: 1
         },
@@ -601,7 +601,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".button": {
-      padding: "5px",
+      padding: "6px",
       minWidth: "32px",
       minHeight: "32px",
       cursor: "pointer",

--- a/web/src/components/properties/TextListProperty.tsx
+++ b/web/src/components/properties/TextListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, Text, CloseButton, MOTION } from "../ui_primitives";
+import { Tooltip, Text, CloseButton, MOTION, SPACING } from "../ui_primitives";
 import DescriptionIcon from "@mui/icons-material/Description";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     ".text-grid": {
       display: "flex",
@@ -97,7 +97,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "6px 0",
+      margin: `${theme.spacing(SPACING.sm)} 0`,
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/TextListProperty.tsx
+++ b/web/src/components/properties/TextListProperty.tsx
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     ".text-grid": {
       display: "flex",
@@ -97,7 +97,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "5px 0",
+      margin: "6px 0",
       backgroundColor: `rgba(0, 0, 0, 0.2)`,
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/VideoListProperty.tsx
+++ b/web/src/components/properties/VideoListProperty.tsx
@@ -25,7 +25,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     },
     ".video-grid": {
       display: "grid",
@@ -94,7 +94,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "5px 0",
+      margin: "6px 0",
       backgroundColor: "rgba(0, 0, 0, 0.2)",
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/VideoListProperty.tsx
+++ b/web/src/components/properties/VideoListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, CloseButton, MOTION } from "../ui_primitives";
+import { Tooltip, CloseButton, MOTION, SPACING } from "../ui_primitives";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { isElectron } from "../../utils/browser";
@@ -25,7 +25,7 @@ const styles = (theme: Theme) =>
       marginBottom: "8px"
     },
     ".property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     },
     ".video-grid": {
       display: "grid",
@@ -94,7 +94,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       transition: MOTION.all,
       outline: `1px dashed ${theme.vars.palette.grey[600]}`,
-      margin: "6px 0",
+      margin: `${theme.spacing(SPACING.sm)} 0`,
       backgroundColor: "rgba(0, 0, 0, 0.2)",
       borderRadius: "var(--rounded-md)",
       display: "flex",

--- a/web/src/components/properties/VideoProperty.tsx
+++ b/web/src/components/properties/VideoProperty.tsx
@@ -10,7 +10,7 @@ import { memo } from "react";
 const styles = () =>
   css({
     "& .property-label": {
-      marginBottom: "5px"
+      marginBottom: "6px"
     }
   });
 

--- a/web/src/components/properties/VideoProperty.tsx
+++ b/web/src/components/properties/VideoProperty.tsx
@@ -1,5 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { SPACING } from "../ui_primitives";
 import { useAsset } from "../../serverState/useAsset";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
@@ -7,21 +10,22 @@ import PropertyDropzone from "./PropertyDropzone";
 import isEqual from "fast-deep-equal";
 import { memo } from "react";
 
-const styles = () =>
+const styles = (theme: Theme) =>
   css({
     "& .property-label": {
-      marginBottom: "6px"
+      marginBottom: theme.spacing(SPACING.sm)
     }
   });
 
 const VideoProperty = (props: PropertyProps) => {
+  const theme = useTheme();
   const id = `video-${props.property.name}-${props.propertyIndex}`;
   const { asset, uri } = useAsset({ video: props.value });
   const showRecorder =
     props.nodeType === "nodetool.input.VideoInput" ||
     props.nodeType === "nodetool.constant.Video";
   return (
-    <div className="video-property" css={styles()}>
+    <div className="video-property" css={styles(theme)}>
       <PropertyLabel
         name={props.property.name}
         description={props.property.description}


### PR DESCRIPTION
## Summary
Updated spacing and padding values across property components to improve visual consistency and alignment with the design system. Changed several hardcoded spacing values from `5px` to `6px` and `10px` to `12px` to better align with the 4px grid-based spacing system.

## Changes
- **Property label margins**: Updated `.property-label` `marginBottom` from `5px` to `6px` in ImageListProperty, AudioListProperty, TextListProperty, VideoListProperty, AudioProperty, ImageProperty, Model3DProperty, and VideoProperty
- **Dropzone/placeholder margins**: Changed `margin: "5px 0"` to `margin: "6px 0"` in ImageListProperty, AudioListProperty, DataframeProperty, TextListProperty, VideoListProperty, and PropertyDropzone
- **Action button spacing**: Updated `.MuiIconButton-root` margins from `5px` to `6px` in DataframeProperty, JSONProperty, and StringProperty
- **Chat view padding**: Increased padding in TextEditorModal `.chat-view` from `10px` to `12px` on horizontal and vertical axes
- **Modal button padding**: Updated `.button` padding from `5px` to `6px` in TextEditorModal

## Implementation Details
These changes enforce consistent spacing aligned with the 4px grid system defined in the design tokens (see `docs/DESIGN.md`). The updates avoid hardcoded off-grid values (`5px`, `10px`) in favor of values that maintain proper alignment (`6px`, `12px`). This improves visual hierarchy and consistency across all property input components.

https://claude.ai/code/session_01XwWWiChpA4KzSw33PqNFhM