### PR TITLE
Refine spacing and padding values across UI components

### DIFF
--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -159,7 +159,7 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = memo(function ChainNo
       <FlexRow
         gap={1.5}
         align="center"
-        padding={1.75}
+        padding={2}
         onClick={onToggleExpanded}
         sx={{ cursor: "pointer", "&:hover": { backgroundColor: theme.vars.palette.action.hover } }}
       >

--- a/web/src/components/chain_editor/ChainNodeProperties.tsx
+++ b/web/src/components/chain_editor/ChainNodeProperties.tsx
@@ -119,7 +119,7 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
                   </FlexRow>
                   <Box
                     sx={{
-                      p: 1.25,
+                      p: 1.5,
                       borderRadius: BORDER_RADIUS.xs,
                       border: `1px dashed ${theme.vars.palette.secondary.main}40`,
                       backgroundColor: `${theme.vars.palette.secondary.main}08`,

--- a/web/src/components/chain_editor/InputMappingSelector.tsx
+++ b/web/src/components/chain_editor/InputMappingSelector.tsx
@@ -197,7 +197,7 @@ export const InputMappingSelector: React.FC<InputMappingSelectorProps> = ({
                       onSetMapping(prop.name, null);
                     }}
                     icon={<CloseIcon sx={{ fontSize: 14, color: theme.vars.palette.secondary.main }} />}
-                    sx={{ p: 0.25 }}
+                    sx={{ p: 0.5 }}
                   />
                 </FlexRow>
               ) : (

--- a/web/src/components/node/GroupNode.tsx
+++ b/web/src/components/node/GroupNode.tsx
@@ -602,7 +602,7 @@ const GroupNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: "10px",
+            gap: "12px",
             padding: "12px"
           }}
         >

--- a/web/src/components/node/ModelSetupCallout.tsx
+++ b/web/src/components/node/ModelSetupCallout.tsx
@@ -19,7 +19,7 @@ const styles = (theme: Theme) =>
   css({
     position: "relative",
     marginTop: 6,
-    padding: "8px 10px",
+    padding: "8px 12px",
     borderRadius: "var(--rounded-buttonSmall)",
     border: `1px solid ${theme.vars.palette.primary.main}`,
     backgroundColor: `rgba(var(--palette-primary-mainChannel) / 0.12)`,

--- a/web/src/components/node/NodeDependencyWarning.tsx
+++ b/web/src/components/node/NodeDependencyWarning.tsx
@@ -18,7 +18,7 @@ const warningStyles = (theme: Theme) =>
   css({
     backgroundColor: `color-mix(in srgb, ${theme.vars.palette.warning.main} 15%, transparent)`,
     borderRadius: BORDER_RADIUS.xs,
-    padding: "8px 10px",
+    padding: "8px 12px",
     display: "flex",
     flexDirection: "column",
     gap: "4px",
@@ -63,7 +63,7 @@ const warningStyles = (theme: Theme) =>
       backgroundColor: theme.vars.palette.primary.main,
       border: "none",
       borderRadius: BORDER_RADIUS.sm,
-      padding: "3px 10px",
+      padding: "3px 12px",
       cursor: "pointer",
       marginTop: "2px",
       "&:hover": {

--- a/web/src/components/node/NodeErrors.tsx
+++ b/web/src/components/node/NodeErrors.tsx
@@ -87,7 +87,7 @@ const errorStyles = (theme: Theme) =>
     position: "relative",
     backgroundColor: theme.vars.palette.error.main,
     borderRadius: "var(--rounded-xs)",
-    padding: "10px",
+    padding: "12px",
     transition: `background-color ${MOTION.normal}`,
     display: "flex",
     flexDirection: "column",

--- a/web/src/components/node/PreviewImageGrid.tsx
+++ b/web/src/components/node/PreviewImageGrid.tsx
@@ -531,7 +531,7 @@ const PreviewImageGrid: React.FC<PreviewImageGridProps> = ({
           >
             <ClearIcon fontSize="small" />
           </ToolbarIconButton>
-          <Box sx={{ fontSize: 12, color: "grey.400", ml: 1 }}>
+          <Box sx={{ fontSize: "var(--fontSizeSmall)", color: "grey.400", ml: 1 }}>
             {selectedIndices.size} selected
           </Box>
         </Box>

--- a/web/src/components/node/ThreadMessageList.tsx
+++ b/web/src/components/node/ThreadMessageList.tsx
@@ -79,7 +79,7 @@ const styles = (theme: Theme) =>
     },
     ".messages": {
       listStyleType: "none",
-      padding: "14px"
+      padding: "16px"
     },
     ".messages li.chat-message": {
       fontFamily: theme.fontFamily2,

--- a/web/src/components/node/output/AgentStatusRenderer.tsx
+++ b/web/src/components/node/output/AgentStatusRenderer.tsx
@@ -86,7 +86,7 @@ export const AgentStatusRenderer: React.FC<Props> = memo(({ chunk }) => {
         display: "flex",
         alignItems: "flex-start",
         gap: 8,
-        padding: "6px 10px",
+        padding: "6px 12px",
         margin: "2px 8px",
         borderLeft: `2px solid ${color}`,
         background: `${color}14`,

--- a/web/src/components/node_editor/FindInWorkflowDialog.tsx
+++ b/web/src/components/node_editor/FindInWorkflowDialog.tsx
@@ -106,7 +106,7 @@ const styles = (theme: Theme) =>
     "& .result-button": {
       display: "flex",
       alignItems: "center",
-      padding: "10px 16px",
+      padding: "12px 16px",
       minHeight: "44px",
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
       "&:hover": {

--- a/web/src/components/node_editor/NodeInfoPanel.tsx
+++ b/web/src/components/node_editor/NodeInfoPanel.tsx
@@ -142,7 +142,7 @@ const styles = (theme: Theme) =>
     },
     "& .error-message": {
       marginTop: "8px",
-      padding: "8px 10px",
+      padding: "8px 12px",
       backgroundColor: `${theme.vars.palette.error.main}15`,
       borderRadius: "var(--rounded-lg)",
       borderLeft: `3px solid ${theme.vars.palette.error.main}`
@@ -186,7 +186,7 @@ const styles = (theme: Theme) =>
       flex: 1,
       minWidth: "80px",
       fontSize: "var(--fontSizeSmall)",
-      padding: "6px 10px",
+      padding: "6px 12px",
       borderRadius: "var(--rounded-md)",
       marginTop: "12px",
       "& .MuiButton-startIcon": {

--- a/web/src/components/node_editor/QuickAddNodeDialog.tsx
+++ b/web/src/components/node_editor/QuickAddNodeDialog.tsx
@@ -119,7 +119,7 @@ const styles = (theme: Theme) =>
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      padding: "40px 20px",
+      padding: "40px 24px",
       color: theme.vars.palette.text.secondary
     },
     ".footer-hints": {

--- a/web/src/components/node_menu/NamespaceList.tsx
+++ b/web/src/components/node_menu/NamespaceList.tsx
@@ -291,7 +291,7 @@ const namespaceStyles = (theme: Theme) =>
     ".node-packs-info .MuiButton-root": {
       textTransform: "none",
       borderRadius: BORDER_RADIUS.lg,
-      padding: "6px 10px",
+      padding: "6px 12px",
       borderColor: theme.vars.palette.divider,
       color: theme.vars.palette.text.secondary,
       "&:hover": {

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -62,7 +62,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
     ".nl-count": {
       display: "inline-flex",
       alignItems: "center",
-      padding: "1px 7px",
+      padding: "1px 8px",
       borderRadius: "var(--rounded-sm)",
       backgroundColor: theme.vars.palette.action.selected,
       color: theme.vars.palette.text.secondary,

--- a/web/src/components/node_menu/QuickActionTiles.tsx
+++ b/web/src/components/node_menu/QuickActionTiles.tsx
@@ -120,7 +120,7 @@ const tileStyles = (theme: Theme) =>
     },
     ".constant-tile": {
       minHeight: "70px",
-      padding: "10px 6px",
+      padding: "12px 6px",
       "& .tile-icon": {
         marginBottom: "4px",
         "& svg": {

--- a/web/src/components/node_menu/SearchResultItem.tsx
+++ b/web/src/components/node_menu/SearchResultItem.tsx
@@ -153,7 +153,7 @@ const searchResultStyles = (theme: Theme, compact: boolean) =>
       },
       ".provider-tag": {
         fontSize: "var(--fontSizeSmaller)",
-        padding: "2px 5px",
+        padding: "2px 6px",
         borderRadius: BORDER_RADIUS.md,
         letterSpacing: "0.3px",
         opacity: 1,

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -138,8 +138,8 @@ const typeFilterChipsStyles = (theme: Theme) =>
         paddingInline: theme.spacing(0.5)
       },
       "& .MuiChip-icon": {
-        marginLeft: theme.spacing(0.75),
-        marginRight: theme.spacing(0.25),
+        marginLeft: theme.spacing(1),
+        marginRight: theme.spacing(0.5),
         display: "inline-flex",
         alignItems: "center"
       },
@@ -155,7 +155,7 @@ const typeFilterChipsStyles = (theme: Theme) =>
     ".filter-actions": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(1.25),
+      gap: theme.spacing(1.5),
       flexShrink: 0
     },
     ".node-count": {

--- a/web/src/components/node_types/editing/AdjustmentBody.tsx
+++ b/web/src/components/node_types/editing/AdjustmentBody.tsx
@@ -78,9 +78,9 @@ const styles = (theme: Theme) =>
       display: "grid",
       gridTemplateColumns: "minmax(52px, auto) 1fr auto",
       alignItems: "center",
-      columnGap: theme.spacing(1.25),
-      rowGap: theme.spacing(0.75),
-      padding: `${theme.spacing(0.75)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      columnGap: theme.spacing(1.5),
+      rowGap: theme.spacing(1),
+      padding: `${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/GeneratorBody.tsx
+++ b/web/src/components/node_types/editing/GeneratorBody.tsx
@@ -117,9 +117,9 @@ const styles = (theme: Theme) =>
       display: "grid",
       gridTemplateColumns: "minmax(52px, auto) 1fr auto",
       alignItems: "center",
-      columnGap: theme.spacing(1.25),
-      rowGap: theme.spacing(0.75),
-      padding: `${theme.spacing(0.75)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      columnGap: theme.spacing(1.5),
+      rowGap: theme.spacing(1),
+      padding: `${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/LayerRow.tsx
+++ b/web/src/components/node_types/editing/LayerRow.tsx
@@ -83,7 +83,7 @@ const styles = (theme: Theme) =>
       marginBottom: "0 !important",
       "& .MuiSelect-select": {
         fontSize: theme.fontSizeSmall,
-        padding: "2px 18px 2px 2px",
+        padding: "2px 16px 2px 2px",
         minHeight: "unset"
       },
       "& .MuiInput-root": { marginTop: 0 },

--- a/web/src/components/node_types/editing/ListGeneratorBody.tsx
+++ b/web/src/components/node_types/editing/ListGeneratorBody.tsx
@@ -101,7 +101,7 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       gap: 8,
-      padding: "5px 8px",
+      padding: "6px 8px",
       cursor: "pointer",
       userSelect: "none",
       transition: MOTION.background,
@@ -121,7 +121,7 @@ const styles = (theme: Theme) =>
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
-      padding: "0 5px"
+      padding: "0 6px"
     },
     ".list-preview": {
       flex: 1,

--- a/web/src/components/node_types/editing/OffsetBody.tsx
+++ b/web/src/components/node_types/editing/OffsetBody.tsx
@@ -88,7 +88,7 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      paddingTop: theme.spacing(0.25)
+      paddingTop: theme.spacing(0.5)
     },
     ".wrap-label": {
       fontSize: theme.fontSizeSmaller,

--- a/web/src/components/node_types/synth/AudioOutBody.tsx
+++ b/web/src/components/node_types/synth/AudioOutBody.tsx
@@ -31,7 +31,7 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.75),
+      gap: theme.spacing(1),
       padding: theme.spacing(1),
       minHeight: 0,
       borderRadius: BORDER_RADIUS.sm,

--- a/web/src/components/node_types/synth/SynthModuleBody.tsx
+++ b/web/src/components/node_types/synth/SynthModuleBody.tsx
@@ -39,7 +39,7 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.75),
+      gap: theme.spacing(1),
       padding: theme.spacing(1),
       minHeight: 0,
       borderRadius: BORDER_RADIUS.sm,


### PR DESCRIPTION
## Summary
Standardized spacing and padding values across the UI to improve visual consistency and alignment with the design token system. This PR adjusts margins, gaps, and padding throughout multiple components to use rounder, more consistent spacing values.

## Key Changes

### Spacing Token Updates
- **TypeFilterChips**: Increased chip icon margins (`marginLeft` 0.75 → 1, `marginRight` 0.25 → 0.5) and filter actions gap (1.25 → 1.5)
- **AdjustmentBody & GeneratorBody**: Increased column gap (1.25 → 1.5), row gap (0.75 → 1), and normalized padding to consistent 1 unit
- **ChainNodeCard**: Increased padding from 1.75 to 2
- **ChainNodeProperties**: Increased padding from 1.25 to 1.5
- **InputMappingSelector**: Increased icon button padding from 0.25 to 0.5
- **OffsetBody**: Increased top padding from 0.25 to 0.5
- **AudioOutBody & SynthModuleBody**: Increased gap from 0.75 to 1

### Pixel-Based Padding Refinements
- **NodeDependencyWarning**: Adjusted padding from "8px 10px" to "8px 12px" and button padding from "3px 10px" to "3px 12px"
- **NodeInfoPanel**: Updated error message and button padding from "8px 10px" / "6px 10px" to "8px 12px" / "6px 12px"
- **ListGeneratorBody**: Increased item padding from "5px 8px" to "6px 8px" and icon padding from "0 5px" to "0 6px"
- **GroupNode**: Increased gap from "10px" to "12px"
- **ModelSetupCallout**: Updated padding from "8px 10px" to "8px 12px"
- **NodeErrors**: Increased padding from "10px" to "12px"
- **AgentStatusRenderer**: Updated padding from "6px 10px" to "6px 12px"
- **FindInWorkflowDialog**: Increased result button padding from "10px 16px" to "12px 16px"
- **QuickAddNodeDialog**: Increased padding from "40px 20px" to "40px 24px"
- **NamespaceList**: Updated button padding from "6px 10px" to "6px 12px"
- **NodeLibrary**: Increased count badge padding from "1px 7px" to "1px 8px"
- **QuickActionTiles**: Increased constant tile padding from "10px 6px" to "12px 6px"
- **SearchResultItem**: Increased provider tag padding from "2px 5px" to "2px 6px"
- **LayerRow**: Adjusted select padding from "2px 18px 2px 2px" to "2px 16px 2px 2px"
- **ThreadMessageList**: Increased padding from "14px" to "16px"

### Minor Refinements
- **PreviewImageGrid**: Changed font size from hardcoded `12` to design token `"var(--fontSizeSmall)"`

## Implementation Details
All changes maintain visual hierarchy and improve spacing consistency across the application. The adjustments follow the design token system (SPACING grid) and eliminate off-grid pixel values where possible, replacing them with standardized spacing units or design token variables.

https://claude.ai/code/session_014MpsnQV1mFBsKvJU1jeyAF