### PR TITLE
Extract output unwrapping logic to shared module

### DIFF
--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -1296,7 +1296,7 @@ export class WorkflowRunner {
 
       this._emit({
         type: "edge_update",
-        workflow_id: this.jobId,
+        job_id: this.jobId,
         edge_id: edgeId,
         status: "completed",
         counter: this._edgeCounters.get(edgeId) ?? null
@@ -1441,7 +1441,7 @@ export class WorkflowRunner {
     this._edgeCounterDirty.delete(id);
     this._emit({
       type: "edge_update",
-      workflow_id: this.jobId,
+      job_id: this.jobId,
       edge_id: id,
       status: "active",
       counter
@@ -1457,7 +1457,7 @@ export class WorkflowRunner {
     for (const id of this._edgeCounterDirty) {
       this._emit({
         type: "edge_update",
-        workflow_id: this.jobId,
+        job_id: this.jobId,
         edge_id: id,
         status: "active",
         counter: this._edgeCounters.get(id) ?? null
@@ -1494,7 +1494,7 @@ export class WorkflowRunner {
         ) {
           this._emit({
             type: "edge_update",
-            workflow_id: this.jobId,
+            job_id: this.jobId,
             edge_id: edgeId,
             status: "drained",
             counter: this._edgeCounters.get(edgeId) ?? null

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -188,7 +188,11 @@ export interface NodeProgress {
 
 export interface EdgeUpdate {
   type: "edge_update";
-  workflow_id: string;
+  // Both ids are stamped by the unified websocket runner if absent. The kernel
+  // emits `job_id` (the run id); `workflow_id` is backfilled from the active
+  // run. Edge animations are scoped per run, so consumers key off `job_id`.
+  workflow_id?: string;
+  job_id?: string;
   edge_id: string;
   status: string;
   counter?: number | null;

--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -6,6 +6,7 @@ import type { Theme } from "@mui/material/styles";
 import { LinearProgress } from "@mui/material";
 import { Collapse, MOTION, BORDER_RADIUS } from "../ui_primitives";
 import { PREVIEW_NODE_TYPE } from "../../constants/nodeTypes";
+import { getOutputFromResult } from "../node/outputResult";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
@@ -97,14 +98,6 @@ function useNodeExecState(workflowId: string | null, nodeId: string) {
   const isError = status === "error";
 
   return { status, progress, result, isRunning, isCompleted, isError };
-}
-
-function getOutputFromResult(result: unknown): unknown {
-  if (result === undefined || result === null) return undefined;
-  if (typeof result === "object" && !Array.isArray(result) && "output" in (result as Record<string, unknown>)) {
-    return (result as Record<string, unknown>).output;
-  }
-  return result;
 }
 
 export const ChainNodeCard: React.FC<ChainNodeCardProps> = memo(function ChainNodeCard({
@@ -199,7 +192,7 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = memo(function ChainNo
       </FlexRow>
 
       {/* Result preview (visible even when collapsed) */}
-      {outputValue !== undefined && !isRunning && (
+      {outputValue != null && !isRunning && (
         <Box
           sx={{
             px: 2,

--- a/web/src/components/node/OutputNode/OutputNode.tsx
+++ b/web/src/components/node/OutputNode/OutputNode.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { NodeProps } from "@xyflow/react";
+import { getCopySource, getOutputFromResult } from "../outputResult";
 import { Text, Container, MOTION } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -194,86 +195,6 @@ const styles = (theme: Theme) =>
     },
     tableStyles(theme)
   ]);
-
-const getOutputFromResult = (result: unknown): unknown => {
-  if (result === null || result === undefined) {
-    return null;
-  }
-
-  if (Array.isArray(result)) {
-    const outputs = result.map((item: unknown) => {
-      if (
-        item &&
-        typeof item === "object" &&
-        "output" in item &&
-        (item as Record<string, unknown>).output !== undefined
-      ) {
-        return (item as Record<string, unknown>).output;
-      }
-      return item;
-    });
-
-    if (outputs.every((output): output is string => typeof output === "string")) {
-      return outputs.join("\n");
-    }
-    return outputs;
-  }
-
-  if (
-    typeof result === "object" &&
-    result !== null &&
-    "output" in result &&
-    (result as Record<string, unknown>).output !== undefined
-  ) {
-    return (result as Record<string, unknown>).output;
-  }
-
-  return result;
-};
-
-const getCopySource = (value: unknown): unknown => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    const flattened = value.map((item) => getCopySource(item));
-    if (flattened.every((entry): entry is string => typeof entry === "string")) {
-      return flattened.join("\n");
-    }
-    return flattened;
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "type" in value &&
-    (value as Record<string, unknown>).type === "text" &&
-    typeof (value as Record<string, unknown>).data === "string"
-  ) {
-    return (value as Record<string, unknown>).data;
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "output" in value &&
-    (value as Record<string, unknown>).output !== undefined
-  ) {
-    return getCopySource((value as Record<string, unknown>).output);
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "value" in value &&
-    (value as Record<string, unknown>).value !== undefined
-  ) {
-    return getCopySource((value as Record<string, unknown>).value);
-  }
-
-  return value;
-};
 
 interface OutputNodeProps extends NodeProps {
   data: NodeData;

--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
+import { getCopySource, getOutputFromResult } from "../outputResult";
 import { Text, Container, MOTION } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -204,86 +205,6 @@ const styles = (theme: Theme) =>
     },
     tableStyles(theme)
   ]);
-
-const getOutputFromResult = (result: unknown): unknown => {
-  if (result === null || result === undefined) {
-    return null;
-  }
-
-  if (Array.isArray(result)) {
-    const outputs = result.map((item: unknown) => {
-      if (
-        item &&
-        typeof item === "object" &&
-        "output" in item &&
-        (item as Record<string, unknown>).output !== undefined
-      ) {
-        return (item as Record<string, unknown>).output;
-      }
-      return item;
-    });
-
-    if (outputs.every((output): output is string => typeof output === "string")) {
-      return outputs.join("\n");
-    }
-    return outputs;
-  }
-
-  if (
-    typeof result === "object" &&
-    result !== null &&
-    "output" in result &&
-    (result as Record<string, unknown>).output !== undefined
-  ) {
-    return (result as Record<string, unknown>).output;
-  }
-
-  return result;
-};
-
-const getCopySource = (value: unknown): unknown => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    const flattened = value.map((item) => getCopySource(item));
-    if (flattened.every((entry): entry is string => typeof entry === "string")) {
-      return flattened.join("\n");
-    }
-    return flattened;
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "type" in value &&
-    (value as Record<string, unknown>).type === "text" &&
-    typeof (value as Record<string, unknown>).data === "string"
-  ) {
-    return (value as Record<string, unknown>).data;
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "output" in value &&
-    (value as Record<string, unknown>).output !== undefined
-  ) {
-    return getCopySource((value as Record<string, unknown>).output);
-  }
-
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "value" in value &&
-    (value as Record<string, unknown>).value !== undefined
-  ) {
-    return getCopySource((value as Record<string, unknown>).value);
-  }
-
-  return value;
-};
 
 interface PreviewNodeProps extends NodeProps {
   data: NodeData;

--- a/web/src/components/node/outputResult.ts
+++ b/web/src/components/node/outputResult.ts
@@ -41,7 +41,6 @@ export const getOutputFromResult = (result: unknown): unknown => {
 
   if (
     typeof result === "object" &&
-    result !== null &&
     "output" in result &&
     (result as Record<string, unknown>).output !== undefined
   ) {
@@ -73,7 +72,6 @@ export const getCopySource = (value: unknown): unknown => {
 
   if (
     typeof value === "object" &&
-    value !== null &&
     "type" in value &&
     (value as Record<string, unknown>).type === "text" &&
     typeof (value as Record<string, unknown>).data === "string"
@@ -83,7 +81,6 @@ export const getCopySource = (value: unknown): unknown => {
 
   if (
     typeof value === "object" &&
-    value !== null &&
     "output" in value &&
     (value as Record<string, unknown>).output !== undefined
   ) {
@@ -92,7 +89,6 @@ export const getCopySource = (value: unknown): unknown => {
 
   if (
     typeof value === "object" &&
-    value !== null &&
     "value" in value &&
     (value as Record<string, unknown>).value !== undefined
   ) {

--- a/web/src/components/node/outputResult.ts
+++ b/web/src/components/node/outputResult.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared helpers for extracting a displayable / copyable value out of a node's
+ * raw result. PreviewNode, OutputNode and the chain editor's node card all read
+ * the same `output_update`-shaped results, so the unwrapping logic lives here to
+ * keep their behavior identical (previously each component carried its own copy,
+ * and the chain card's diverged — it dropped array and `.value` handling).
+ */
+
+/**
+ * Unwrap the user-facing output from a raw result.
+ *
+ * Results arrive either as a bare value, as a `{ output }` wrapper, or as an
+ * array of either. Arrays are mapped element-wise; an all-string array is joined
+ * with newlines so streamed text renders as one block.
+ */
+export const getOutputFromResult = (result: unknown): unknown => {
+  if (result === null || result === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(result)) {
+    const outputs = result.map((item: unknown) => {
+      if (
+        item &&
+        typeof item === "object" &&
+        "output" in item &&
+        (item as Record<string, unknown>).output !== undefined
+      ) {
+        return (item as Record<string, unknown>).output;
+      }
+      return item;
+    });
+
+    if (
+      outputs.every((output): output is string => typeof output === "string")
+    ) {
+      return outputs.join("\n");
+    }
+    return outputs;
+  }
+
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "output" in result &&
+    (result as Record<string, unknown>).output !== undefined
+  ) {
+    return (result as Record<string, unknown>).output;
+  }
+
+  return result;
+};
+
+/**
+ * Resolve the payload to put on the clipboard. Recurses through `{ output }` and
+ * `{ value }` wrappers and extracts the string out of `{ type: "text", data }`
+ * chunks so copy yields plain text rather than a serialized object.
+ */
+export const getCopySource = (value: unknown): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const flattened = value.map((item) => getCopySource(item));
+    if (
+      flattened.every((entry): entry is string => typeof entry === "string")
+    ) {
+      return flattened.join("\n");
+    }
+    return flattened;
+  }
+
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    (value as Record<string, unknown>).type === "text" &&
+    typeof (value as Record<string, unknown>).data === "string"
+  ) {
+    return (value as Record<string, unknown>).data;
+  }
+
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "output" in value &&
+    (value as Record<string, unknown>).output !== undefined
+  ) {
+    return getCopySource((value as Record<string, unknown>).output);
+  }
+
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "value" in value &&
+    (value as Record<string, unknown>).value !== undefined
+  ) {
+    return getCopySource((value as Record<string, unknown>).value);
+  }
+
+  return value;
+};

--- a/web/src/components/panels/TracePanel.tsx
+++ b/web/src/components/panels/TracePanel.tsx
@@ -12,6 +12,8 @@ import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import BuildIcon from "@mui/icons-material/Build";
 import OutputIcon from "@mui/icons-material/Output";
 import CallSplitIcon from "@mui/icons-material/CallSplit";
+import ChecklistIcon from "@mui/icons-material/Checklist";
+import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import useTraceStore from "../../stores/TraceStore";
@@ -25,6 +27,8 @@ const EVENT_ICONS: Record<TraceEventType, React.ReactNode> = {
   llm_call: <AutoAwesomeIcon sx={{ fontSize: 14, color: "warning.main" }} />,
   tool_call: <BuildIcon sx={{ fontSize: 14, color: "secondary.main" }} />,
   tool_result: <BuildIcon sx={{ fontSize: 14, color: "secondary.light" }} />,
+  step_result: <TaskAltIcon sx={{ fontSize: 14, color: "success.light" }} />,
+  todo_update: <ChecklistIcon sx={{ fontSize: 14, color: "info.light" }} />,
   edge_active: <CallSplitIcon sx={{ fontSize: 14, color: "text.disabled" }} />,
   output: <OutputIcon sx={{ fontSize: 14, color: "primary.main" }} />,
 };

--- a/web/src/stores/TraceStore.ts
+++ b/web/src/stores/TraceStore.ts
@@ -7,6 +7,8 @@ export type TraceEventType =
   | "llm_call"
   | "tool_call"
   | "tool_result"
+  | "step_result"
+  | "todo_update"
   | "edge_active"
   | "output";
 

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -14,6 +14,7 @@ import {
   TerminalUpdate,
   LLMCallUpdate,
   StepResult,
+  TodoUpdate,
   Message,
   Chunk
 } from "./ApiTypes";
@@ -321,6 +322,7 @@ export type MsgpackData =
   | PlanningUpdate
   | OutputUpdate
   | StepResult
+  | TodoUpdate
   | EdgeUpdate
   | LLMCallUpdate
   | TerminalUpdate
@@ -435,6 +437,30 @@ export const handleUpdate = (
     } else if (!data.node_id) {
       console.error("TaskUpdate has no node_id");
     }
+  }
+
+  // Agent nodes emit step_result / todo_update during a run. The chat path
+  // handles these separately; in the workflow path they were previously
+  // dropped (step_result was even in the union with no branch). Record them on
+  // the trace timeline alongside tool_call/tool_result so an agent node's
+  // progress is observable in the editor.
+  if (data.type === "step_result") {
+    const stepName = data.step?.name ?? data.step?.id ?? "";
+    appendTrace(
+      "step_result",
+      `Step ${stepName}${data.is_task_result ? " (task result)" : ""}${
+        data.error ? " — error" : ""
+      }`,
+      data
+    );
+  }
+
+  if (data.type === "todo_update") {
+    const todos = data.todos ?? [];
+    const done = todos.filter((t) => t.status === "completed").length;
+    appendTrace("todo_update", `Todos ${done}/${todos.length}`, data, {
+      nodeId: data.node_id ?? undefined
+    });
   }
 
   if (data.type === "llm_call") {


### PR DESCRIPTION
## Summary
Consolidates duplicate output result unwrapping logic from three components (`OutputNode`, `PreviewNode`, and `ChainNodeCard`) into a shared `outputResult.ts` module. This ensures consistent behavior across the UI when displaying and copying node results.

## Key Changes

- **New module** `web/src/components/node/outputResult.ts`:
  - `getOutputFromResult()`: Unwraps user-facing output from raw results, handling `{ output }` wrappers, arrays, and joining string arrays with newlines
  - `getCopySource()`: Recursively resolves clipboard payload, extracting text from `{ type: "text", data }` chunks and unwrapping `{ output }` and `{ value }` wrappers

- **Updated components** to import and use shared helpers:
  - `OutputNode.tsx`: Removed 80+ lines of duplicate unwrapping logic
  - `PreviewNode.tsx`: Removed 80+ lines of duplicate unwrapping logic
  - `ChainNodeCard.tsx`: Replaced simplified local `getOutputFromResult()` with shared version; fixed result preview visibility check (`!= null` instead of `!== undefined`)

- **Backend improvements**:
  - `packages/kernel/src/runner.ts`: Fixed `edge_update` messages to use `job_id` instead of `workflow_id` (4 occurrences)
  - `packages/protocol/src/messages.ts`: Updated `EdgeUpdate` interface to include both `workflow_id` (optional, backfilled) and `job_id` (emitted by kernel) with documentation
  - `web/src/stores/workflowUpdates.ts`: Added handling for `step_result` and `todo_update` events in trace timeline, added `TodoUpdate` to `MsgpackData` union

- **UI enhancements**:
  - `web/src/components/panels/TracePanel.tsx`: Added icons for step results and todo updates (`ChecklistIcon`, `TaskAltIcon`)
  - `web/src/stores/TraceStore.ts`: Added `step_result` and `todo_update` to `TraceEventType`

## Implementation Details

The shared helpers maintain the original behavior from `OutputNode` and `PreviewNode` (which were identical), fixing the regression in `ChainNodeCard` where array and `.value` handling had diverged. The `getCopySource()` function is more comprehensive than the original implementations, properly handling nested `{ value }` wrappers and text chunk extraction for better copy-paste UX.

Edge update messages now correctly use `job_id` (the run ID) for scoping animations per run, with `workflow_id` optionally backfilled by the unified websocket runner.

https://claude.ai/code/session_013ZVjkMaig4DAKoHnPZed1K