### PR TITLE
Standardize spacing and typography using design tokens

### DIFF
--- a/web/src/components/asset_viewer/Model3DViewer.tsx
+++ b/web/src/components/asset_viewer/Model3DViewer.tsx
@@ -714,7 +714,10 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
                   color={i === 0 ? "error" : "secondary"}
                   sx={{
                     wordBreak: "break-word",
-                    fontSize: i === 0 ? "0.875rem" : "0.75rem",
+                    fontSize:
+                      i === 0
+                        ? "var(--fontSizeNormal)"
+                        : "var(--fontSizeSmall)",
                     opacity: i === 0 ? 1 : 0.8
                   }}
                 >

--- a/web/src/components/asset_viewer/Model3DViewer.tsx
+++ b/web/src/components/asset_viewer/Model3DViewer.tsx
@@ -710,14 +710,10 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
               {loadError.split("\n").map((line, i) => (
                 <Text
                   key={`${i}:${line}`}
-                  size="small"
+                  size={i === 0 ? "normal" : "small"}
                   color={i === 0 ? "error" : "secondary"}
                   sx={{
                     wordBreak: "break-word",
-                    fontSize:
-                      i === 0
-                        ? "var(--fontSizeNormal)"
-                        : "var(--fontSizeSmall)",
                     opacity: i === 0 ? 1 : 0.8
                   }}
                 >

--- a/web/src/components/assets/assetGridStyles.ts
+++ b/web/src/components/assets/assetGridStyles.ts
@@ -56,7 +56,7 @@ export const assetGridStyles = (theme: Theme) => {
       userSelect: "none"
     },
     ".selected-asset-info": {
-      fontSize: "var(--fontSizeSmall) !important",
+      fontSize: `${theme.vars.fontSizeSmall} !important`,
       color: theme.vars.palette.grey[400],
       minHeight: "25px",
       padding: "0",

--- a/web/src/components/assets/assetGridStyles.ts
+++ b/web/src/components/assets/assetGridStyles.ts
@@ -56,7 +56,7 @@ export const assetGridStyles = (theme: Theme) => {
       userSelect: "none"
     },
     ".selected-asset-info": {
-      fontSize: "12px !important",
+      fontSize: "var(--fontSizeSmall) !important",
       color: theme.vars.palette.grey[400],
       minHeight: "25px",
       padding: "0",

--- a/web/src/components/hugging_face/model_list/ModelCompatibilityDialog.tsx
+++ b/web/src/components/hugging_face/model_list/ModelCompatibilityDialog.tsx
@@ -268,7 +268,7 @@ const ModelCompatibilityDialog: React.FC<ModelCompatibilityDialogProps> = ({
       }}
     >
       <div css={styles(theme)}>
-        <FlexColumn gap={2.5} sx={{ p: 3, pt: 0 }}>
+        <FlexColumn gap={3} sx={{ p: 3, pt: 0 }}>
           <FlexColumn className="compatibility-section" gap={1}>
             <FlexRow justify="space-between" align="center" className="section-header" fullWidth>
               <FlexRow gap={1} align="center">

--- a/web/src/components/model_editor/Model3DEditor.tsx
+++ b/web/src/components/model_editor/Model3DEditor.tsx
@@ -60,7 +60,7 @@ const styles = (theme: Theme) =>
       backgroundColor: theme.vars.palette.grey[900]
     },
     ".editor-toolbar": {
-      padding: "6px 12px",
+      padding: theme.spacing(1.5, 3),
       gap: "8px",
       alignItems: "center",
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
@@ -90,7 +90,7 @@ const styles = (theme: Theme) =>
       borderLeft: `1px solid ${theme.vars.palette.divider}`
     },
     ".panel-header": {
-      padding: "8px 12px",
+      padding: theme.spacing(2, 3),
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
       flexShrink: 0
     },

--- a/web/src/components/model_editor/Model3DEditor.tsx
+++ b/web/src/components/model_editor/Model3DEditor.tsx
@@ -60,7 +60,7 @@ const styles = (theme: Theme) =>
       backgroundColor: theme.vars.palette.grey[900]
     },
     ".editor-toolbar": {
-      padding: "6px 10px",
+      padding: "6px 12px",
       gap: "8px",
       alignItems: "center",
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
@@ -90,7 +90,7 @@ const styles = (theme: Theme) =>
       borderLeft: `1px solid ${theme.vars.palette.divider}`
     },
     ".panel-header": {
-      padding: "8px 10px",
+      padding: "8px 12px",
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
       flexShrink: 0
     },

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -731,7 +731,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                       <span
                         className={`model-menu__provider-badge model-menu__provider-badge--${b.label.toLowerCase()}`}
                         style={{
-                          padding: "2px 6px",
+                          padding: theme.spacing(0.5, 1.5),
                           fontSize: theme.vars.fontSizeTiny,
                           lineHeight: 1.1,
                           borderRadius: BORDER_RADIUS.sm,

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -639,7 +639,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
         selected={selected === null && !forceUnselect}
         onClick={handleSelectNull}
         sx={{
-          py: iconOnly ? 0.75 : 0.25,
+          py: iconOnly ? 1 : 0.5,
           justifyContent: iconOnly ? "center" : "flex-start",
           px: iconOnly ? 0 : 2,
           minHeight: iconOnly ? 52 : "auto",
@@ -731,7 +731,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                       <span
                         className={`model-menu__provider-badge model-menu__provider-badge--${b.label.toLowerCase()}`}
                         style={{
-                          padding: "1px 5px",
+                          padding: "2px 6px",
                           fontSize: theme.vars.fontSizeTiny,
                           lineHeight: 1.1,
                           borderRadius: BORDER_RADIUS.sm,
@@ -769,7 +769,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                 sx={{
                   gap: 0.5,
                   opacity: enabled && available ? 1 : 0.5,
-                  py: iconOnly ? 0.75 : 0.25,
+                  py: iconOnly ? 1 : 0.5,
                   justifyContent: iconOnly ? "center" : "flex-start",
                   px: iconOnly ? 0 : 2,
                   minHeight: iconOnly ? 68 : "auto",

--- a/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
+++ b/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
@@ -412,7 +412,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
               selected={customView === "favorites"}
               onClick={handleSetFavoritesView}
               sx={{
-                py: isIconOnly ? 1 : 0.25,
+                py: isIconOnly ? 1 : 0.5,
                 borderRadius: BORDER_RADIUS.xs,
                 mx: 0,
                 mb: 0.5,
@@ -489,7 +489,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
               selected={customView === "recent"}
               onClick={handleSetRecentView}
               sx={{
-                py: isIconOnly ? 1 : 0.25,
+                py: isIconOnly ? 1 : 0.5,
                 borderRadius: BORDER_RADIUS.xs,
                 mx: 0,
                 justifyContent: isIconOnly ? "center" : "flex-start",
@@ -566,7 +566,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
                 selected={customView === "downloads"}
                 onClick={handleSetDownloadsView}
                 sx={{
-                  py: isIconOnly ? 1 : 0.25,
+                  py: isIconOnly ? 1 : 0.5,
                   borderRadius: BORDER_RADIUS.xs,
                   mx: 0,
                   mt: 0.5,


### PR DESCRIPTION
## Summary
Replaced hardcoded pixel values for spacing and font sizes with design token references throughout the codebase, improving consistency and maintainability across the UI.

## Key Changes
- **ProviderList.tsx**: Updated vertical padding (`py`) values from `0.25`/`0.75` to `0.5`/`1` for better visual hierarchy; replaced inline badge padding `"1px 5px"` with `theme.spacing(0.5, 1.5)` for consistency
- **ModelMenuDialogBase.tsx**: Standardized vertical padding on view toggle buttons from `0.25` to `0.5` (when not icon-only)
- **Model3DEditor.tsx**: Converted toolbar padding from `"6px 10px"` to `theme.spacing(1.5, 3)` and panel header padding from `"8px 10px"` to `theme.spacing(2, 3)`
- **Model3DViewer.tsx**: Refactored error message text sizing to use `size` prop (`"normal"` for first line, `"small"` for rest) instead of hardcoded `fontSize` values; removed redundant inline style
- **assetGridStyles.ts**: Replaced hardcoded `"12px !important"` font size with `theme.vars.fontSizeSmall` token
- **ModelCompatibilityDialog.tsx**: Increased gap spacing from `2.5` to `3` for better visual balance

## Implementation Details
- All changes follow the design token system documented in `docs/DESIGN.md`
- Spacing uses the 4px grid via `theme.spacing()` utility
- Typography uses theme font size variables (`fontSizeSmall`, `fontSizeTiny`)
- No functional changes; purely stylistic improvements for consistency and maintainability

https://claude.ai/code/session_01RVnRRR2fuQWo6avWkmt5Qy