### PR TITLE
Add mutation testing workflow and score aggregation

### DIFF
--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -1,0 +1,71 @@
+name: Mutation Testing
+
+# Runs Stryker mutation testing across the backend packages that have a
+# stryker.config.json and reports the aggregate mutation score. Mutation
+# testing is slow, so this runs on a weekly schedule (and on demand) rather
+# than on every push. Reporting only — it never fails the build on a low score.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays at 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Space-separated package names to run (default: all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Run mutation testing
+        run: |
+          PKGS="${{ github.event.inputs.packages }}"
+          if [ -z "$PKGS" ]; then
+            PKGS="agents auth kernel node-sdk runtime security"
+          fi
+          echo "Running mutation testing for: $PKGS"
+          for pkg in $PKGS; do
+            echo "::group::stryker $pkg"
+            npm run test:mutation --workspace=packages/$pkg || echo "stryker run failed for $pkg (continuing)"
+            echo "::endgroup::"
+          done
+
+      - name: Report mutation score
+        if: always()
+        run: |
+          echo "## 🧬 Mutation Score" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          PKGS="${{ github.event.inputs.packages }}"
+          node scripts/mutation-score.mjs $PKGS >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutation reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-reports
+          path: packages/*/reports/mutation/
+          if-no-files-found: warn
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "test:coverage:electron": "npm run test:coverage --workspace=electron",
     "test:coverage:mobile": "npm --prefix mobile run test:coverage",
     "test:integration": "npm test --workspace=@nodetool-ai/base-nodes -- example-workflows-execute",
+    "test:mutation": "for pkg in agents auth kernel node-sdk runtime security; do npm run test:mutation --workspace=packages/$pkg || true; done",
+    "mutation:score": "node scripts/mutation-score.mjs",
     "lint:web": "npm run lint --workspace=web",
     "lint:electron": "npm run lint --workspace=electron",
     "lint:mobile": "npm --prefix mobile run lint",

--- a/scripts/mutation-score.mjs
+++ b/scripts/mutation-score.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Aggregate Stryker mutation scores from each package's
+// reports/mutation/mutation.json and emit a Markdown summary.
+//
+// Usage: node scripts/mutation-score.mjs [pkg1 pkg2 ...]
+// With no args, scans every packages/* that has a stryker.config.json.
+// Prints a Markdown table to stdout. Exits 0 always (reporting only).
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const packagesDir = join(root, "packages");
+
+// A killed or timed-out mutant counts as detected. Survived and no-coverage
+// mutants count against the score. Ignored/compile-error mutants are excluded
+// from the denominator, matching Stryker's own mutationScore.
+const DETECTED = new Set(["Killed", "Timeout"]);
+const UNDETECTED = new Set(["Survived", "NoCoverage"]);
+
+function scoreFor(reportPath) {
+  const report = JSON.parse(readFileSync(reportPath, "utf8"));
+  let detected = 0;
+  let undetected = 0;
+  for (const file of Object.values(report.files ?? {})) {
+    for (const mutant of file.mutants ?? []) {
+      if (DETECTED.has(mutant.status)) detected += 1;
+      else if (UNDETECTED.has(mutant.status)) undetected += 1;
+    }
+  }
+  const total = detected + undetected;
+  const score = total === 0 ? null : (detected / total) * 100;
+  return { detected, undetected, total, score };
+}
+
+const requested = process.argv.slice(2);
+const pkgs =
+  requested.length > 0
+    ? requested
+    : readdirSync(packagesDir).filter((name) =>
+        existsSync(join(packagesDir, name, "stryker.config.json"))
+      );
+
+const rows = [];
+let totalDetected = 0;
+let totalUndetected = 0;
+
+for (const pkg of pkgs) {
+  const reportPath = join(
+    packagesDir,
+    pkg,
+    "reports",
+    "mutation",
+    "mutation.json"
+  );
+  if (!existsSync(reportPath)) {
+    rows.push({ pkg, score: null, detected: 0, total: 0, missing: true });
+    continue;
+  }
+  const { detected, undetected, total, score } = scoreFor(reportPath);
+  totalDetected += detected;
+  totalUndetected += undetected;
+  rows.push({ pkg, score, detected, total, missing: false });
+}
+
+const fmt = (score) => (score === null ? "—" : `${score.toFixed(2)}%`);
+
+const lines = [];
+lines.push("| Package | Mutation Score | Detected / Total |");
+lines.push("| --- | --- | --- |");
+for (const row of rows) {
+  if (row.missing) {
+    lines.push(`| \`${row.pkg}\` | ⚠️ no report | — |`);
+  } else {
+    lines.push(
+      `| \`${row.pkg}\` | ${fmt(row.score)} | ${row.detected} / ${row.total} |`
+    );
+  }
+}
+const overallTotal = totalDetected + totalUndetected;
+const overall = overallTotal === 0 ? null : (totalDetected / overallTotal) * 100;
+lines.push(
+  `| **Overall** | **${fmt(overall)}** | **${totalDetected} / ${overallTotal}** |`
+);
+
+process.stdout.write(lines.join("\n") + "\n");


### PR DESCRIPTION
## Summary

Adds automated mutation testing infrastructure to the monorepo, including a GitHub Actions workflow that runs Stryker mutation tests on backend packages and a script to aggregate and report mutation scores.

## Changes

- **New workflow**: `.github/workflows/mutation-testing.yaml`
  - Runs on a weekly schedule (Mondays at 04:00 UTC) and on manual dispatch
  - Supports optional package filtering via workflow input
  - Executes mutation testing for `agents`, `auth`, `kernel`, `node-sdk`, `runtime`, and `security` packages
  - Reports aggregate mutation score to GitHub Step Summary
  - Uploads mutation reports as artifacts (30-day retention)
  - Non-blocking — never fails the build on low scores

- **New aggregation script**: `scripts/mutation-score.mjs`
  - Parses Stryker `mutation.json` reports from each package
  - Calculates mutation score (killed/timed-out mutants vs. survived/uncovered)
  - Generates Markdown table with per-package and overall scores
  - Handles missing reports gracefully with warning indicators
  - Supports filtering by package name via CLI arguments

- **Package scripts**: Added to `package.json`
  - `test:mutation`: Runs mutation testing across all backend packages
  - `mutation:score`: Generates mutation score report

## Implementation Details

- Mutation score calculation matches Stryker's own logic: killed/timed-out mutants count as detected; survived/uncovered count against the score; ignored/compile-error mutants are excluded from the denominator
- Workflow uses 120-minute timeout to accommodate slow mutation testing
- Script outputs Markdown table suitable for GitHub Step Summary or stdout
- Graceful error handling: individual package failures don't block the workflow or reporting

https://claude.ai/code/session_01F25HtHXJjKdGnhdGSehKNB