### PR TITLE
Add Canvas2D compositor fallback & WebGPU capability detection

### DIFF
--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -20,7 +20,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  tagAsHybrid,
+  tagAsBrowserGpu,
   tagAsServer,
   tagAsContentCard
 } from "@nodetool-ai/nodes-utils";
@@ -2842,7 +2842,7 @@ export class VectorizeImageNode extends BaseNode {
 // GPU transform nodes: pure WebGPU pixel ops (no sharp) — runnable in the
 // browser and rendered as media content cards.
 const IMAGE_TRANSFORM_NODES = tagAsContentCard(
-  tagAsHybrid([
+  tagAsBrowserGpu([
     PasteNode,
     ScaleNode,
     ResizeNode,

--- a/packages/image-nodes/src/nodes/lib-image-channel.ts
+++ b/packages/image-nodes/src/nodes/lib-image-channel.ts
@@ -10,7 +10,7 @@
 import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   colorChannelShuffleV1,
   colorChannelMergeV1
@@ -90,7 +90,7 @@ registerDeclaredProperty(
   intProp(3, { min: 0, max: 4, label: "Alpha channel" })
 );
 
-export const LIB_IMAGE_CHANNEL_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_CHANNEL_NODES = tagAsBrowserGpu(tagAsContentCard([
   ChannelShuffleNode,
   ChannelMergeNode
 ]));

--- a/packages/image-nodes/src/nodes/lib-image-color-grading.ts
+++ b/packages/image-nodes/src/nodes/lib-image-color-grading.ts
@@ -16,7 +16,7 @@ import {
 } from "@nodetool-ai/gpu/pool";
 import { pickImage, hsvToRgb } from "./lib-image-utils.js";
 import { runShaderNode } from "./lib-shader-utils.js";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 function num(value: unknown, fallback: number): number {
   const n = Number(value);
@@ -1229,6 +1229,6 @@ const DESCRIPTORS: readonly Desc[] = [
   }
 ];
 
-export const LIB_IMAGE_COLOR_GRADING_NODES: readonly NodeClass[] = tagAsHybrid(
+export const LIB_IMAGE_COLOR_GRADING_NODES: readonly NodeClass[] = tagAsBrowserGpu(
   tagAsContentCard(DESCRIPTORS.map(createColorGradingNode))
 );

--- a/packages/image-nodes/src/nodes/lib-image-color.ts
+++ b/packages/image-nodes/src/nodes/lib-image-color.ts
@@ -8,7 +8,7 @@
 import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   colorInvertV1,
   colorBrightnessContrastV1,
@@ -243,7 +243,7 @@ registerDeclaredProperty(
   intProp(0, { min: 0, max: 3, label: "Channel", notes: "0=R, 1=G, 2=B, 3=A" })
 );
 
-export const LIB_IMAGE_COLOR_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_COLOR_NODES = tagAsBrowserGpu(tagAsContentCard([
   InvertNode,
   BrightnessContrastNode,
   HSBNode,

--- a/packages/image-nodes/src/nodes/lib-image-draw.ts
+++ b/packages/image-nodes/src/nodes/lib-image-draw.ts
@@ -39,6 +39,16 @@ function isServerOnlyDraw(nodeType: string): boolean {
   return nodeType === "lib.image.Mask";
 }
 
+// Background + GaussianNoise composite on the GPU (WebGPU in the browser);
+// RenderText uses Canvas2D / sharp and needs no GPU. Only the GPU ones must
+// route to the server when the browser lacks WebGPU — see `tagAsBrowserGpu`.
+function drawRequiresGpu(nodeType: string): boolean {
+  return (
+    nodeType === "lib.image.draw.Background" ||
+    nodeType === "lib.image.draw.GaussianNoise"
+  );
+}
+
 function createDrawNode(desc: Desc): NodeClass {
   const serverOnly = isServerOnlyDraw(desc.nodeType);
   const C = class extends BaseNode {
@@ -51,6 +61,11 @@ function createDrawNode(desc: Desc): NodeClass {
     static readonly platforms = serverOnly
       ? SERVER_PLATFORMS
       : NODE_AND_BROWSER_PLATFORMS;
+    static readonly requiresGpu: boolean | undefined = drawRequiresGpu(
+      desc.nodeType
+    )
+      ? true
+      : undefined;
     static readonly body: string | undefined = serverOnly
       ? undefined
       : "content_card";

--- a/packages/image-nodes/src/nodes/lib-image-effects.ts
+++ b/packages/image-nodes/src/nodes/lib-image-effects.ts
@@ -9,7 +9,7 @@ import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import * as d from "typegpu/data";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   mixerAddV1,
   mixerColorOverlayV1,
@@ -197,7 +197,7 @@ registerDeclaredProperty(AddBlendNode, "image", IMAGE_PROP);
 registerDeclaredProperty(AddBlendNode, "over", extraImageProp("Over", "Image added on top of the source"));
 registerDeclaredProperty(AddBlendNode, "gain", floatProp(1, { min: 0, max: 4, label: "Gain" }));
 
-export const LIB_IMAGE_EFFECTS_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_EFFECTS_NODES = tagAsBrowserGpu(tagAsContentCard([
   ColorOverlayNode,
   OutlineNode,
   DropShadowNode,

--- a/packages/image-nodes/src/nodes/lib-image-enhance.ts
+++ b/packages/image-nodes/src/nodes/lib-image-enhance.ts
@@ -6,7 +6,7 @@ import { filtersConvolve3x3V1 } from "@nodetool-ai/gpu/pool";
 import { pickImage } from "./lib-image-utils.js";
 import { runShaderNode } from "./lib-shader-utils.js";
 import { decodeRgba, rawRgbaImageRef } from "./image-io.js";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 type Desc = {
   nodeType: string;
@@ -468,6 +468,6 @@ const DESCRIPTORS: readonly Desc[] = [
   }
 ];
 
-export const LIB_IMAGE_ENHANCE_NODES: NodeClass[] = tagAsHybrid(
+export const LIB_IMAGE_ENHANCE_NODES: NodeClass[] = tagAsBrowserGpu(
   tagAsContentCard(DESCRIPTORS.map(createEnhanceNode))
 );

--- a/packages/image-nodes/src/nodes/lib-image-filter-extras.ts
+++ b/packages/image-nodes/src/nodes/lib-image-filter-extras.ts
@@ -8,7 +8,7 @@
 import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   filtersPixelateV1,
   filtersThresholdV1,
@@ -194,7 +194,7 @@ registerDeclaredProperty(
   floatProp(0.5, { min: 0, max: 1, label: "Softness" })
 );
 
-export const LIB_IMAGE_FILTER_EXTRAS_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_FILTER_EXTRAS_NODES = tagAsBrowserGpu(tagAsContentCard([
   ThresholdNode,
   PixelateNode,
   GaussianBlurNode,

--- a/packages/image-nodes/src/nodes/lib-image-filter.ts
+++ b/packages/image-nodes/src/nodes/lib-image-filter.ts
@@ -13,7 +13,7 @@ import {
 import { pickImage } from "./lib-image-utils.js";
 import { runShaderNode } from "./lib-shader-utils.js";
 import { decodeRgba, rawRgbaImageRef } from "./image-io.js";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 type Desc = {
   nodeType: string;
@@ -677,6 +677,6 @@ const DESCRIPTORS: readonly Desc[] = [
   }
 ];
 
-export const LIB_IMAGE_FILTER_NODES: readonly NodeClass[] = tagAsHybrid(
+export const LIB_IMAGE_FILTER_NODES: readonly NodeClass[] = tagAsBrowserGpu(
   tagAsContentCard(DESCRIPTORS.map(createFilterNode))
 );

--- a/packages/image-nodes/src/nodes/lib-image-generators.ts
+++ b/packages/image-nodes/src/nodes/lib-image-generators.ts
@@ -8,7 +8,7 @@ import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef, PropOptions } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import * as d from "typegpu/data";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   sourcesLinearGradientV1,
   sourcesCheckerboardV1,
@@ -207,7 +207,7 @@ registerDeclaredProperty(CheckerboardNode, "color_a", colorProp("#ffffff", { lab
 registerDeclaredProperty(CheckerboardNode, "color_b", colorProp("#000000", { label: "Color B" }));
 registerDeclaredProperty(CheckerboardNode, "cell_size", intProp(32, { min: 1, max: 512, label: "Cell size (px)" }));
 
-export const LIB_IMAGE_GENERATORS_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_GENERATORS_NODES = tagAsBrowserGpu(tagAsContentCard([
   LinearGradientNode,
   RadialGradientNode,
   AngularGradientNode,

--- a/packages/image-nodes/src/nodes/lib-image-keyer.ts
+++ b/packages/image-nodes/src/nodes/lib-image-keyer.ts
@@ -8,7 +8,7 @@ import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import * as d from "typegpu/data";
 import { chromaKeyV1, keyerLumaKeyV1 } from "@nodetool-ai/gpu/pool";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   IMAGE_PROP,
   colorProp,
@@ -83,7 +83,7 @@ registerDeclaredProperty(LumaKeyNode, "low", floatProp(0, { min: 0, max: 1, labe
 registerDeclaredProperty(LumaKeyNode, "high", floatProp(1, { min: 0, max: 1, label: "High" }));
 registerDeclaredProperty(LumaKeyNode, "softness", floatProp(0.05, { min: 0, max: 0.5, label: "Softness" }));
 
-export const LIB_IMAGE_KEYER_NODES = tagAsHybrid(
+export const LIB_IMAGE_KEYER_NODES = tagAsBrowserGpu(
   tagAsContentCard([ChromaKeyNode, LumaKeyNode])
 );
 export { ChromaKeyNode, LumaKeyNode };

--- a/packages/image-nodes/src/nodes/lib-image-mask.ts
+++ b/packages/image-nodes/src/nodes/lib-image-mask.ts
@@ -7,7 +7,7 @@
 import { BaseNode, registerDeclaredProperty } from "@nodetool-ai/node-sdk";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 import {
   maskApplyV1,
   maskFromImageV1,
@@ -94,7 +94,7 @@ class MaskInvertNode extends BaseNode {
 }
 registerDeclaredProperty(MaskInvertNode, "image", IMAGE_PROP);
 
-export const LIB_IMAGE_MASK_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_MASK_NODES = tagAsBrowserGpu(tagAsContentCard([
   MaskApplyNode,
   MaskFromImageNode,
   MaskInvertNode

--- a/packages/image-nodes/src/nodes/lib-image-warp.ts
+++ b/packages/image-nodes/src/nodes/lib-image-warp.ts
@@ -35,7 +35,7 @@ import {
   type RunShaderOptions
 } from "./lib-shader-utils.js";
 import { decodeRgba } from "./image-io.js";
-import { tagAsHybrid, tagAsContentCard } from "@nodetool-ai/nodes-utils";
+import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 function num(value: unknown, fallback: number): number {
   const n = Number(value);
@@ -361,7 +361,7 @@ registerDeclaredProperty(
   floatProp(0.5, { min: -1, max: 1, label: "Amount", notes: "negative pinches" })
 );
 
-export const LIB_IMAGE_WARP_NODES = tagAsHybrid(tagAsContentCard([
+export const LIB_IMAGE_WARP_NODES = tagAsBrowserGpu(tagAsContentCard([
   OffsetNode,
   PadNode,
   TileNode,

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -81,6 +81,13 @@ export type NodeClass = {
    * Platform type. Unset is treated as ["node"].
    */
   platforms?: readonly Platform[];
+  /**
+   * Requires a WebGPU device when run in the browser. The in-browser runner
+   * routes graphs containing these nodes to the server (where a GPU is always
+   * available via Dawn) when `navigator.gpu` is unavailable, instead of failing
+   * the run. Server execution is unaffected. Set via `tagAsBrowserGpu`.
+   */
+  requiresGpu?: boolean;
   deprecated: boolean;
   replacedBy?: string;
   metadataOutputTypes?: DeclaredOutputTypes;
@@ -242,6 +249,12 @@ export abstract class BaseNode {
    * explicitly. See `@nodetool-ai/protocol`'s Platform type.
    */
   static readonly platforms: readonly Platform[] | undefined = undefined;
+  /**
+   * Requires a WebGPU device in the browser (set via `tagAsBrowserGpu`). The
+   * in-browser runner routes graphs with these nodes to the server when
+   * `navigator.gpu` is unavailable. Unset/undefined means no GPU requirement.
+   */
+  static readonly requiresGpu: boolean | undefined = undefined;
   static readonly deprecated: boolean = false;
   static readonly replacedBy: string | undefined = undefined;
   static readonly metadataOutputTypes: DeclaredOutputTypes | undefined =

--- a/packages/nodes-utils/src/index.ts
+++ b/packages/nodes-utils/src/index.ts
@@ -19,6 +19,7 @@
 export {
   tagAsServer,
   tagAsHybrid,
+  tagAsBrowserGpu,
   tagAsUniversal,
   tagAsContentCard
 } from "./platform-tags.js";

--- a/packages/nodes-utils/src/platform-tags.ts
+++ b/packages/nodes-utils/src/platform-tags.ts
@@ -70,6 +70,33 @@ export function tagAsUniversal<T extends readonly NodeClass[]>(classes: T): T {
 }
 
 /**
+ * Like {@link tagAsHybrid} (node + browser) but additionally marks the classes
+ * as requiring a WebGPU device in the browser. WebGPU shader nodes use this so
+ * the in-browser runner routes graphs containing them to the server — where a
+ * GPU is always available via Dawn — when `navigator.gpu` is missing, instead
+ * of failing the run. Server execution is unchanged.
+ *
+ * `requiresGpu` is stamped only on classes that end up browser-capable: a class
+ * already tagged server keeps its platforms and is left unmarked (it can't run
+ * in the browser anyway). Per-class `static requiresGpu` overrides win.
+ */
+export function tagAsBrowserGpu<T extends readonly NodeClass[]>(classes: T): T {
+  const tagged = tagWith(classes, NODE_AND_BROWSER_PLATFORMS);
+  for (const cls of tagged) {
+    const platforms = (cls as { platforms?: readonly Platform[] }).platforms;
+    if (!platforms?.includes("browser")) continue;
+    if ((cls as { requiresGpu?: unknown }).requiresGpu !== undefined) continue;
+    Object.defineProperty(cls, "requiresGpu", {
+      value: true,
+      writable: false,
+      configurable: true,
+      enumerable: true
+    });
+  }
+  return tagged;
+}
+
+/**
  * Stamp `static body = "content_card"` on every class in `classes` so the
  * editor renders them as a media content card (the image/video/audio preview
  * body) instead of the generic input/output layout. Leaves any class that

--- a/packages/nodes-utils/tests/platform-tags.test.ts
+++ b/packages/nodes-utils/tests/platform-tags.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import {
+  tagAsBrowserGpu,
+  tagAsServer,
+  tagAsHybrid
+} from "../src/platform-tags.js";
+
+// Minimal node-class shape the taggers operate on (static `nodeType` + the
+// mutable `platforms` / `requiresGpu` they stamp).
+interface Taggable {
+  nodeType: string;
+  platforms?: readonly string[];
+  requiresGpu?: boolean;
+}
+
+function makeNodeClass(nodeType: string): Taggable {
+  return class {
+    static nodeType = nodeType;
+  } as unknown as Taggable;
+}
+
+/** The taggers want the full NodeClass[]; our fakes only carry what they touch. */
+const asClasses = (classes: Taggable[]): NodeClass[] =>
+  classes as unknown as NodeClass[];
+
+describe("tagAsBrowserGpu", () => {
+  it("tags classes as node + browser and marks them requiresGpu", () => {
+    const A = makeNodeClass("a");
+    tagAsBrowserGpu(asClasses([A]));
+    expect(A.platforms).toEqual(["node", "browser"]);
+    expect(A.requiresGpu).toBe(true);
+  });
+
+  it("does not mark a class already tagged server", () => {
+    const Server = makeNodeClass("server");
+    tagAsServer(asClasses([Server]));
+    // Re-tagging via tagAsBrowserGpu must not flip platforms or mark GPU: a
+    // server node can't run in the browser, so the GPU flag is irrelevant.
+    tagAsBrowserGpu(asClasses([Server]));
+    expect(Server.platforms).not.toContain("browser");
+    expect(Server.requiresGpu).toBeUndefined();
+  });
+
+  it("leaves an explicit per-class requiresGpu override intact", () => {
+    const Override = makeNodeClass("override");
+    Object.defineProperty(Override, "requiresGpu", {
+      value: false,
+      configurable: true
+    });
+    tagAsBrowserGpu(asClasses([Override]));
+    expect(Override.requiresGpu).toBe(false);
+  });
+
+  it("does not retroactively change tagAsHybrid (no requiresGpu)", () => {
+    const Hybrid = makeNodeClass("hybrid");
+    tagAsHybrid(asClasses([Hybrid]));
+    expect(Hybrid.platforms).toEqual(["node", "browser"]);
+    expect(Hybrid.requiresGpu).toBeUndefined();
+  });
+});

--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -70,3 +70,19 @@ live preview, so an exported frame is identical to what playback showed:
 The renderer composites at the sequence's true `width × height` (clamped to even
 dimensions for H.264). mediabunny and the WebGPU compositor are dynamically
 imported only when an export runs, keeping the editor importable under jsdom.
+
+### Compositor backend & Canvas2D fallback
+
+Both the live preview and the offline renderer obtain their compositor through
+`createCompositor` (`preview/gpu/createCompositor.ts`), which prefers WebGPU and
+falls back to a `Canvas2DCompositor` (`preview/gpu/canvas2dCompositor.ts`) when
+WebGPU is unavailable — older browsers, locked-down environments, and headless
+CI where SwiftShader's WebGPU fails to initialise. The fallback reuses the exact
+placement math: `buildTransformMatrix` produces the clip-space matrix and
+`clipMatrixToCanvasAffine` converts it to the 2D affine handed to
+`ctx.setTransform`, so layer position / scale / rotation / contain-fit, opacity,
+blend modes, and border radius all match the GPU path. Color and blur effects
+are approximated with `ctx.filter`; the GPU-only effects (chroma key, vignette,
+sharpen) are skipped in the fallback. This keeps the timeline preview rendering
+and documentation screenshots capturing real frames without a GPU. The heavier
+WebGPU/typegpu bundle is dynamically imported only when `navigator.gpu` exists.

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -22,8 +22,12 @@ import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
 import { FONT_SIZE_SANS, FONT_WEIGHT, BORDER_RADIUS } from "../../ui_primitives";
 
-import { WebGPUCompositor } from "./gpu/compositor";
-import type { CompositeLayer, CompositorBlendMode } from "./gpu/types";
+import { createCompositor } from "./gpu/createCompositor";
+import type {
+  CompositeLayer,
+  CompositorBlendMode,
+  TimelineCompositor
+} from "./gpu/types";
 import { TransformGizmoOverlay } from "./TransformGizmoOverlay";
 import {
   clipSourceTimeSec,
@@ -236,7 +240,7 @@ export const PreviewCompositor: React.FC = memo(() => {
   const containerRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const compositorRef = useRef<WebGPUCompositor | null>(null);
+  const compositorRef = useRef<TimelineCompositor | null>(null);
   const captionRasterizerRef = useRef<CaptionRasterizer>(new CaptionRasterizer());
   const [gpuReady, setGpuReady] = useState(false);
   const [gpuFailed, setGpuFailed] = useState(false);
@@ -287,15 +291,13 @@ export const PreviewCompositor: React.FC = memo(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const compositor = new WebGPUCompositor();
-    compositor
-      .init(canvas)
-      .then((res) => {
+    createCompositor(canvas)
+      .then(({ compositor, init }) => {
         if (cancelled) {
           compositor.dispose();
           return;
         }
-        if (res.ok) {
+        if (init.ok) {
           compositorRef.current = compositor;
           setGpuReady(true);
         } else {
@@ -305,7 +307,6 @@ export const PreviewCompositor: React.FC = memo(() => {
       })
       .catch(() => {
         if (!cancelled) setGpuFailed(true);
-        compositor.dispose();
       });
 
     const rasterizer = captionRasterizerRef.current;
@@ -865,7 +866,7 @@ export const PreviewCompositor: React.FC = memo(() => {
             css={placeholderLayerStyles(theme)}
             style={{ zIndex: 1, color: "#c08000" }}
           >
-            <span style={{ fontSize: 12 }}>WebGPU not available</span>
+            <span style={{ fontSize: 12 }}>Preview rendering unavailable</span>
           </div>
         )}
 

--- a/web/src/components/timeline/preview/gpu/__tests__/createCompositor.test.ts
+++ b/web/src/components/timeline/preview/gpu/__tests__/createCompositor.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import { createCompositor } from "../createCompositor";
+
+/**
+ * Minimal fake canvas: vends a stub 2D context and refuses WebGPU, so the
+ * factory exercises its fallback path without a real GPU. jsdom's own
+ * `<canvas>` returns null for every `getContext`, which would also fall back
+ * — but a stub lets us assert the Canvas2D path actually initialises.
+ */
+function fakeCanvas(): HTMLCanvasElement {
+  const ctx2d = {
+    setTransform() {},
+    fillRect() {},
+    drawImage() {},
+    save() {},
+    restore() {},
+    beginPath() {},
+    moveTo() {},
+    arcTo() {},
+    closePath() {},
+    clip() {},
+    fillStyle: "",
+    filter: "none",
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over"
+  };
+  return {
+    width: 320,
+    height: 180,
+    getContext: (type: string) => (type === "2d" ? ctx2d : null)
+  } as unknown as HTMLCanvasElement;
+}
+
+describe("createCompositor", () => {
+  const originalGpu = (navigator as { gpu?: unknown }).gpu;
+
+  beforeEach(() => {
+    // Ensure WebGPU looks unavailable regardless of the host environment.
+    Object.defineProperty(navigator, "gpu", {
+      value: undefined,
+      configurable: true
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "gpu", {
+      value: originalGpu,
+      configurable: true
+    });
+  });
+
+  it("falls back to the Canvas2D backend when WebGPU is unavailable", async () => {
+    const { backend, init, compositor } = await createCompositor(fakeCanvas());
+    expect(backend).toBe("canvas2d");
+    expect(init.ok).toBe(true);
+    // The fallback compositor honours the shared interface.
+    expect(typeof compositor.render).toBe("function");
+    compositor.dispose();
+  });
+
+  it("reports failure when neither backend can initialise", async () => {
+    const blankCanvas = {
+      width: 10,
+      height: 10,
+      getContext: () => null
+    } as unknown as HTMLCanvasElement;
+    const { backend, init } = await createCompositor(blankCanvas);
+    expect(backend).toBe("canvas2d");
+    expect(init.ok).toBe(false);
+  });
+});

--- a/web/src/components/timeline/preview/gpu/__tests__/transform.test.ts
+++ b/web/src/components/timeline/preview/gpu/__tests__/transform.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
-import { containBaseScale, buildTransformMatrix, IDENTITY_TRANSFORM } from "../transform";
+import {
+  containBaseScale,
+  buildTransformMatrix,
+  clipMatrixToCanvasAffine,
+  IDENTITY_TRANSFORM
+} from "../transform";
 
 interface ClipTransform {
   position: { x: number; y: number };
@@ -189,5 +194,65 @@ describe("buildTransformMatrix", () => {
       expect(after.x).toBeCloseTo(before.x, 3);
       expect(after.y).toBeCloseTo(before.y, 3);
     });
+  });
+});
+
+describe("clipMatrixToCanvasAffine", () => {
+  // Apply the affine to an image-pixel corner the way Canvas2D would.
+  const apply = (
+    t: { a: number; b: number; c: number; d: number; e: number; f: number },
+    ix: number,
+    iy: number
+  ) => ({ x: t.a * ix + t.c * iy + t.e, y: t.b * ix + t.d * iy + t.f });
+
+  it("maps an identity full-frame source onto the whole canvas", () => {
+    const W = 100;
+    const H = 100;
+    const m = buildTransformMatrix(IDENTITY_TRANSFORM, { x: 1, y: 1 }, W, H);
+    const t = clipMatrixToCanvasAffine(m, W, H, W, H);
+    // top-left image pixel → top-left canvas pixel, bottom-right → bottom-right.
+    expect(apply(t, 0, 0).x).toBeCloseTo(0);
+    expect(apply(t, 0, 0).y).toBeCloseTo(0);
+    expect(apply(t, W, H).x).toBeCloseTo(W);
+    expect(apply(t, W, H).y).toBeCloseTo(H);
+  });
+
+  it("shifts the source right when position.x is positive", () => {
+    const W = 100;
+    const H = 100;
+    const m = buildTransformMatrix(
+      { ...IDENTITY_TRANSFORM, position: { x: 50, y: 0 } },
+      { x: 1, y: 1 },
+      W,
+      H
+    );
+    const t = clipMatrixToCanvasAffine(m, W, H, W, H);
+    // +50 px on a 100-wide reference is half the frame → 50 canvas px right.
+    expect(apply(t, 0, 0).x).toBeCloseTo(50);
+    expect(apply(t, W, H).x).toBeCloseTo(150);
+  });
+
+  it("contain-fits a square source onto a 16:9 canvas (pillarbox)", () => {
+    const W = 1920;
+    const H = 1080;
+    const src = 1080;
+    const base = containBaseScale(src, src, W, H);
+    const m = buildTransformMatrix(IDENTITY_TRANSFORM, base, W, H);
+    const t = clipMatrixToCanvasAffine(m, src, src, W, H);
+    // Source spans the full height and is horizontally centered.
+    const tl = apply(t, 0, 0);
+    const br = apply(t, src, src);
+    expect(tl.y).toBeCloseTo(0);
+    expect(br.y).toBeCloseTo(H);
+    expect(tl.x).toBeCloseTo((W - H) / 2);
+    expect(br.x).toBeCloseTo((W + H) / 2);
+  });
+
+  it("does not divide by zero for a zero-sized source", () => {
+    const m = buildTransformMatrix(IDENTITY_TRANSFORM, { x: 1, y: 1 }, 100, 100);
+    const t = clipMatrixToCanvasAffine(m, 0, 0, 100, 100);
+    for (const v of [t.a, t.b, t.c, t.d, t.e, t.f]) {
+      expect(Number.isFinite(v)).toBe(true);
+    }
   });
 });

--- a/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
+++ b/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
@@ -1,0 +1,219 @@
+import { blendModeToCanvasOp } from "@nodetool-ai/gpu";
+import {
+  IDENTITY_TRANSFORM,
+  buildTransformMatrix,
+  clipMatrixToCanvasAffine,
+  containBaseScale
+} from "./transform";
+import { isSourceReady, sourceDimensions } from "./source";
+import type {
+  CompositeLayer,
+  CompositorInitResult,
+  TimelineCompositor
+} from "./types";
+import type { ClipEffect, TrackEffect } from "@nodetool-ai/timeline";
+
+/**
+ * Canvas2D fallback for the timeline preview compositor.
+ *
+ * Drop-in for {@link WebGPUCompositor} when WebGPU is unavailable (older
+ * browsers, locked-down environments, and headless CI where SwiftShader's
+ * WebGPU fails to initialise) so the live preview and offline export still
+ * composite — and documentation screenshots still capture real frames.
+ *
+ * It draws each layer's decoded source with the *same* placement math as the
+ * GPU path: {@link buildTransformMatrix} produces the clip-space matrix and
+ * {@link clipMatrixToCanvasAffine} converts it to the 2D affine handed to
+ * `setTransform`. Opacity maps to `globalAlpha`, blend modes to
+ * `globalCompositeOperation`, and border radius to a rounded-rect clip.
+ * Color/blur effects are approximated with `ctx.filter`; the heavier GPU-only
+ * effects (chroma key, vignette, sharpen) are skipped in the fallback.
+ */
+export class Canvas2DCompositor implements TimelineCompositor {
+  private ctx: CanvasRenderingContext2D | null = null;
+  private canvasWidth = 0;
+  private canvasHeight = 0;
+  private refWidth = 0;
+  private refHeight = 0;
+  private layers: CompositeLayer[] = [];
+
+  async init(canvas: HTMLCanvasElement): Promise<CompositorInitResult> {
+    // A canvas can only ever vend one context type. If WebGPU init already
+    // claimed it (e.g. `getContext("webgpu")` succeeded but later configure
+    // failed), the 2D request returns null and the fallback can't reuse it.
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return { ok: false, reason: "Failed to get 2D canvas context" };
+    }
+    this.ctx = ctx;
+    this.canvasWidth = canvas.width;
+    this.canvasHeight = canvas.height;
+    return { ok: true };
+  }
+
+  setReferenceSize(width: number, height: number): void {
+    this.refWidth = width;
+    this.refHeight = height;
+  }
+
+  resize(width: number, height: number): void {
+    this.canvasWidth = width;
+    this.canvasHeight = height;
+  }
+
+  setLayers(layers: CompositeLayer[]): void {
+    this.layers = [...layers].sort((a, b) => a.zIndex - b.zIndex);
+  }
+
+  render(): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+    ctx.filter = "none";
+    // Seed with opaque black to match the GPU compositor's clear.
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
+
+    for (const layer of this.layers) {
+      if (!isSourceReady(layer.source)) continue;
+      const { width, height } = sourceDimensions(layer.source);
+      if (width === 0 || height === 0) continue;
+
+      const transform = layer.transform ?? IDENTITY_TRANSFORM;
+      const base = containBaseScale(
+        width,
+        height,
+        this.canvasWidth,
+        this.canvasHeight
+      );
+      const matrix = buildTransformMatrix(
+        transform,
+        base,
+        this.refWidth || this.canvasWidth,
+        this.refHeight || this.canvasHeight
+      );
+      const t = clipMatrixToCanvasAffine(
+        matrix,
+        width,
+        height,
+        this.canvasWidth,
+        this.canvasHeight
+      );
+
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, Math.min(1, layer.opacity));
+      ctx.globalCompositeOperation = blendModeToCanvasOp(
+        layer.blendMode
+      ) as GlobalCompositeOperation;
+      ctx.filter = filterForEffects(layer.effects, layer.trackEffects);
+      ctx.setTransform(t.a, t.b, t.c, t.d, t.e, t.f);
+
+      const radiusPx = layer.borderRadius ?? 0;
+      if (radiusPx > 0) {
+        const r = Math.min(radiusPx, width / 2, height / 2);
+        clipRoundedRect(ctx, 0, 0, width, height, r);
+      }
+
+      try {
+        ctx.drawImage(layer.source, 0, 0, width, height);
+      } catch {
+        // Source not yet usable (e.g. a video element mid-seek). Skip this
+        // frame; the next render re-draws once it's ready.
+      }
+      ctx.restore();
+    }
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+    ctx.filter = "none";
+  }
+
+  async flush(): Promise<void> {
+    // Canvas2D draws synchronously; nothing to await.
+  }
+
+  dispose(): void {
+    this.ctx = null;
+    this.layers = [];
+  }
+}
+
+/** Clip the current path to a rounded rectangle in the active transform space. */
+function clipRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+  ctx.clip();
+}
+
+/**
+ * Approximate the clip + track color/blur effects with a CSS `filter` string.
+ * This is a best-effort fallback — it covers the common brightness / contrast /
+ * saturation / hue / blur adjustments and ignores the GPU-only effects.
+ */
+function filterForEffects(
+  clipEffects: ClipEffect[] | undefined,
+  trackEffects: TrackEffect[] | undefined
+): string {
+  let brightness = 0;
+  let contrast = 1;
+  let saturation = 1;
+  let hue = 0;
+  let blur = 0;
+
+  for (const e of clipEffects ?? []) {
+    if (!e.enabled) continue;
+    if (e.type === "color") {
+      brightness += e.brightness ?? 0;
+      contrast *= e.contrast ?? 1;
+      saturation *= e.saturation ?? 1;
+      hue += e.hue ?? 0;
+    } else if (e.type === "blur") {
+      blur += e.radius;
+    }
+  }
+  for (const e of trackEffects ?? []) {
+    if (!e.enabled) continue;
+    if (e.type === "colorCorrection") {
+      brightness += e.brightness;
+      contrast *= e.contrast;
+      saturation *= e.saturation;
+      hue += e.hue;
+    } else if (e.type === "videoBlur") {
+      blur += e.radius;
+    }
+  }
+
+  const parts: string[] = [];
+  if (Math.abs(brightness) > 0.001) {
+    parts.push(`brightness(${(1 + brightness).toFixed(3)})`);
+  }
+  if (Math.abs(contrast - 1) > 0.001) {
+    parts.push(`contrast(${contrast.toFixed(3)})`);
+  }
+  if (Math.abs(saturation - 1) > 0.001) {
+    parts.push(`saturate(${saturation.toFixed(3)})`);
+  }
+  if (Math.abs(hue) > 0.001) {
+    parts.push(`hue-rotate(${hue.toFixed(2)}deg)`);
+  }
+  if (blur >= 0.5) {
+    parts.push(`blur(${Math.min(40, blur).toFixed(2)}px)`);
+  }
+  return parts.length > 0 ? parts.join(" ") : "none";
+}

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -12,8 +12,10 @@ import {
 import type {
   CompositeLayer,
   CompositeSource,
-  CompositorInitResult
+  CompositorInitResult,
+  TimelineCompositor
 } from "./types";
+import { isSourceReady, sourceDimensions } from "./source";
 
 interface SourceTexture {
   texture: GPUTexture;
@@ -21,35 +23,6 @@ interface SourceTexture {
   height: number;
   source: CompositeSource;
   lastUploadKey: string;
-}
-
-function isSourceReady(source: CompositeSource): boolean {
-  if (source instanceof HTMLVideoElement) {
-    return source.readyState >= 2;
-  }
-  if (source instanceof HTMLImageElement) {
-    return source.complete && source.naturalWidth > 0;
-  }
-  return source.width > 0;
-}
-
-function sourceDimensions(source: CompositeSource): {
-  width: number;
-  height: number;
-} {
-  if (source instanceof HTMLVideoElement) {
-    return {
-      width: source.videoWidth || 0,
-      height: source.videoHeight || 0
-    };
-  }
-  if (source instanceof HTMLImageElement) {
-    return {
-      width: source.naturalWidth || 0,
-      height: source.naturalHeight || 0
-    };
-  }
-  return { width: source.width, height: source.height };
 }
 
 function uploadKey(source: CompositeSource): string {
@@ -77,7 +50,7 @@ function uploadKey(source: CompositeSource): string {
  * affine placement comes from {@link buildTransformMatrix}, converted to the
  * compositor's inverse-affine form.
  */
-export class WebGPUCompositor {
+export class WebGPUCompositor implements TimelineCompositor {
   private device: GPUDevice | null = null;
   private context: GPUCanvasContext | null = null;
   private canvasFormat: GPUTextureFormat = "rgba8unorm";

--- a/web/src/components/timeline/preview/gpu/createCompositor.ts
+++ b/web/src/components/timeline/preview/gpu/createCompositor.ts
@@ -1,0 +1,48 @@
+import { Canvas2DCompositor } from "./canvas2dCompositor";
+import type { CompositorInitResult, TimelineCompositor } from "./types";
+
+export type CompositorBackend = "webgpu" | "canvas2d";
+
+export interface CreateCompositorResult {
+  compositor: TimelineCompositor;
+  backend: CompositorBackend;
+  init: CompositorInitResult;
+}
+
+/**
+ * Create and initialise a timeline compositor for `canvas`, preferring WebGPU
+ * and falling back to a Canvas2D implementation when WebGPU is unavailable.
+ *
+ * The fallback keeps the live preview and the offline export working on
+ * browsers without WebGPU and in headless CI where SwiftShader's WebGPU fails
+ * to initialise — so documentation screenshots still capture composited frames
+ * instead of a "WebGPU not available" placeholder.
+ *
+ * The WebGPU backend (and its typegpu/GPU bundle) is dynamically imported only
+ * when `navigator.gpu` is present, so a browser without WebGPU never pays to
+ * load it. When WebGPU fails before it ever claims the canvas context — the
+ * common case: no adapter — the same canvas is reused for Canvas2D. The
+ * returned `compositor` is already initialised when `init.ok` is true; the
+ * caller owns disposing it.
+ */
+export async function createCompositor(
+  canvas: HTMLCanvasElement
+): Promise<CreateCompositorResult> {
+  if (typeof navigator !== "undefined" && navigator.gpu) {
+    try {
+      const { WebGPUCompositor } = await import("./compositor");
+      const gpu = new WebGPUCompositor();
+      const gpuInit = await gpu.init(canvas);
+      if (gpuInit.ok) {
+        return { compositor: gpu, backend: "webgpu", init: gpuInit };
+      }
+      gpu.dispose();
+    } catch {
+      // Fall through to the Canvas2D backend below.
+    }
+  }
+
+  const canvas2d = new Canvas2DCompositor();
+  const init = await canvas2d.init(canvas);
+  return { compositor: canvas2d, backend: "canvas2d", init };
+}

--- a/web/src/components/timeline/preview/gpu/source.ts
+++ b/web/src/components/timeline/preview/gpu/source.ts
@@ -1,0 +1,36 @@
+import type { CompositeSource } from "./types";
+
+/**
+ * Whether a composite source has decoded pixels ready to sample. Shared by the
+ * WebGPU compositor (before uploading to a texture) and the Canvas2D fallback
+ * (before `drawImage`).
+ */
+export function isSourceReady(source: CompositeSource): boolean {
+  if (source instanceof HTMLVideoElement) {
+    return source.readyState >= 2;
+  }
+  if (source instanceof HTMLImageElement) {
+    return source.complete && source.naturalWidth > 0;
+  }
+  return source.width > 0;
+}
+
+/** Intrinsic pixel dimensions of a composite source. */
+export function sourceDimensions(source: CompositeSource): {
+  width: number;
+  height: number;
+} {
+  if (source instanceof HTMLVideoElement) {
+    return {
+      width: source.videoWidth || 0,
+      height: source.videoHeight || 0
+    };
+  }
+  if (source instanceof HTMLImageElement) {
+    return {
+      width: source.naturalWidth || 0,
+      height: source.naturalHeight || 0
+    };
+  }
+  return { width: source.width, height: source.height };
+}

--- a/web/src/components/timeline/preview/gpu/transform.ts
+++ b/web/src/components/timeline/preview/gpu/transform.ts
@@ -102,3 +102,50 @@ export function buildTransformMatrix(
   m[15] = 1;
   return m;
 }
+
+/** A 2D affine in `CanvasRenderingContext2D.setTransform` order. */
+export interface CanvasAffine {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
+/**
+ * Convert a clip-space transform matrix (from {@link buildTransformMatrix}) into
+ * the 2D affine that draws a `srcWidth × srcHeight` source image onto a
+ * `canvasWidth × canvasHeight` Canvas2D context with the same placement the
+ * WebGPU compositor produces. Use as:
+ *
+ *   const t = clipMatrixToCanvasAffine(m, src.w, src.h, cw, ch);
+ *   ctx.setTransform(t.a, t.b, t.c, t.d, t.e, t.f);
+ *   ctx.drawImage(source, 0, 0, src.w, src.h);
+ *
+ * The matrix maps an NDC quad in [-1,1]² to clip space; an image pixel
+ * `(ix, iy)` maps to `ndc = (2·ix/srcW − 1, 1 − 2·iy/srcH)`, then to clip space,
+ * then to canvas pixels via `px = (clip.x + 1)·W/2`, `py = (1 − clip.y)·H/2`.
+ * Composing those linear maps yields the affine below.
+ */
+export function clipMatrixToCanvasAffine(
+  m: Float32Array,
+  srcWidth: number,
+  srcHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+): CanvasAffine {
+  const halfW = canvasWidth / 2;
+  const halfH = canvasHeight / 2;
+  const sw = srcWidth || 1;
+  const sh = srcHeight || 1;
+
+  return {
+    a: (canvasWidth * m[0]) / sw,
+    b: (-canvasHeight * m[1]) / sw,
+    c: (-canvasWidth * m[4]) / sh,
+    d: (canvasHeight * m[5]) / sh,
+    e: halfW * (-m[0] + m[4] + m[12]) + halfW,
+    f: halfH - halfH * (-m[1] + m[5] + m[13])
+  };
+}

--- a/web/src/components/timeline/preview/gpu/types.ts
+++ b/web/src/components/timeline/preview/gpu/types.ts
@@ -36,3 +36,20 @@ export interface CompositorInitResult {
   ok: boolean;
   reason?: string;
 }
+
+/**
+ * Common surface implemented by both the WebGPU compositor and the Canvas2D
+ * fallback, so the live preview and the offline renderer can drive either
+ * backend through one reference. See {@link createCompositor}.
+ */
+export interface TimelineCompositor {
+  init(canvas: HTMLCanvasElement): Promise<CompositorInitResult>;
+  /** Reference (sequence) resolution that `transform.position` is stored in. */
+  setReferenceSize(width: number, height: number): void;
+  resize(width: number, height: number): void;
+  setLayers(layers: CompositeLayer[]): void;
+  render(): void;
+  /** Resolve once all submitted GPU work has completed (no-op on Canvas2D). */
+  flush(): Promise<void>;
+  dispose(): void;
+}

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -1,10 +1,10 @@
 /**
  * renderTimeline — offline, frame-by-frame export of a timeline to an MP4.
  *
- * The renderer drives the *same* {@link WebGPUCompositor} and the *same*
- * {@link computeActiveLayers} scene description as the live preview, so the
- * exported video is 1:1 with what playback showed. Instead of a real-time rAF
- * loop it:
+ * The renderer drives the *same* compositor (WebGPU, or the Canvas2D fallback
+ * via {@link createCompositor}) and the *same* {@link computeActiveLayers}
+ * scene description as the live preview, so the exported video is 1:1 with what
+ * playback showed. Instead of a real-time rAF loop it:
  *
  *   1. steps the playhead in exact `1 / fps` increments,
  *   2. seeks each video element to the precise source frame (waiting for
@@ -107,7 +107,8 @@ function makeImageLoader(): (url: string) => Promise<HTMLImageElement | null> {
 
 /**
  * Render the timeline and return the encoded MP4 bytes. Throws an
- * `AbortError` if `signal` is aborted, or an `Error` if WebGPU is unavailable.
+ * `AbortError` if `signal` is aborted, or an `Error` if no compositor backend
+ * (WebGPU or the Canvas2D fallback) can be initialised.
  */
 export async function renderTimeline(
   opts: RenderTimelineOptions
@@ -154,25 +155,24 @@ export async function renderTimeline(
       QUALITY_MEDIUM,
       AudioBufferSource: AudioBufferSourceCtor
     },
-    { WebGPUCompositor }
+    { createCompositor }
   ] = await Promise.all([
     import("mediabunny"),
-    import("../preview/gpu/compositor")
+    import("../preview/gpu/createCompositor")
   ]);
 
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;
 
-  const compositor = new WebGPUCompositor();
+  const { compositor, init } = await createCompositor(canvas);
   const videoPool = new OffscreenVideoPool();
   const captionRasterizer = new CaptionRasterizer();
   const loadImage = makeImageLoader();
 
   try {
-    const init = await compositor.init(canvas);
     if (!init.ok) {
-      throw new Error(init.reason ?? "WebGPU compositor unavailable");
+      throw new Error(init.reason ?? "Timeline compositor unavailable");
     }
     compositor.resize(width, height);
 

--- a/web/src/lib/workflow/__tests__/browserRunnerCore.test.ts
+++ b/web/src/lib/workflow/__tests__/browserRunnerCore.test.ts
@@ -1,4 +1,11 @@
-import { collectNodeClasses, normalizeGraphForKernel } from "../browserRunnerCore";
+import {
+  applyGpuCapability,
+  buildBrowserRunner,
+  capabilityFilteredBrowserNodeTypes,
+  collectNodeClasses,
+  normalizeGraphForKernel,
+  type LoadedModules
+} from "../browserRunnerCore";
 import type { WorkflowGraph } from "../../../stores/ApiTypes";
 
 function makeGraph(
@@ -162,6 +169,79 @@ describe("browserRunnerCore", () => {
       const result = normalizeGraphForKernel({} as WorkflowGraph);
       expect(result.nodes).toHaveLength(0);
       expect(result.edges).toHaveLength(0);
+    });
+  });
+
+  describe("applyGpuCapability", () => {
+    const browser = ["plain.A", "gpu.Shader", "audio.B"];
+    const gpu = new Set(["gpu.Shader"]);
+
+    it("keeps every type when a GPU is available", () => {
+      expect(applyGpuCapability(browser, gpu, true)).toEqual(browser);
+    });
+
+    it("drops GPU-requiring types when no GPU is available", () => {
+      expect(applyGpuCapability(browser, gpu, false)).toEqual([
+        "plain.A",
+        "audio.B"
+      ]);
+    });
+
+    it("is a no-op when there are no GPU types, even without a GPU", () => {
+      expect(applyGpuCapability(browser, new Set(), false)).toBe(browser);
+    });
+  });
+
+  describe("buildBrowserRunner", () => {
+    // Fake modules: a registry that accepts everything except server types,
+    // and node classes with/without the requiresGpu marker.
+    function fakeModules(): LoadedModules {
+      const serverTypes = new Set(["server.Only"]);
+      const registry = {
+        has: (t: string) => !serverTypes.has(t)
+      };
+      return {
+        wf: {
+          createBrowserRegistry: () => registry,
+          runBrowserWorkflow: (() => {}) as never
+        },
+        nodeClasses: [
+          { nodeType: "plain.A" },
+          { nodeType: "gpu.Shader", requiresGpu: true },
+          { nodeType: "server.Only", requiresGpu: true }
+        ]
+      } as unknown as LoadedModules;
+    }
+
+    it("collects only browser-capable GPU types into gpuNodeTypes", () => {
+      const runner = buildBrowserRunner(fakeModules());
+      expect(runner.browserNodeTypes).toEqual(["plain.A", "gpu.Shader"]);
+      // server.Only is requiresGpu but filtered out by platform → not counted.
+      expect([...runner.gpuNodeTypes]).toEqual(["gpu.Shader"]);
+    });
+
+    it("withholds GPU types from the capability-filtered set under jsdom (no WebGPU)", async () => {
+      const runner = buildBrowserRunner(fakeModules());
+      // jsdom exposes no navigator.gpu, so the probe resolves false.
+      const types = await capabilityFilteredBrowserNodeTypes(runner);
+      expect(types).toEqual(["plain.A"]);
+    });
+
+    it("returns all browser types when the graph uses no GPU nodes", async () => {
+      const serverTypes = new Set<string>();
+      const mods = {
+        wf: {
+          createBrowserRegistry: () => ({ has: (t: string) => !serverTypes.has(t) }),
+          runBrowserWorkflow: (() => {}) as never
+        },
+        nodeClasses: [{ nodeType: "plain.A" }, { nodeType: "plain.B" }]
+      } as unknown as LoadedModules;
+      const runner = buildBrowserRunner(mods);
+      expect(runner.gpuNodeTypes.size).toBe(0);
+      await expect(capabilityFilteredBrowserNodeTypes(runner)).resolves.toEqual([
+        "plain.A",
+        "plain.B"
+      ]);
     });
   });
 });

--- a/web/src/lib/workflow/browserRunner.worker.ts
+++ b/web/src/lib/workflow/browserRunner.worker.ts
@@ -30,6 +30,7 @@
 import {
   loadBrowserModules,
   buildBrowserRunner,
+  capabilityFilteredBrowserNodeTypes,
   normalizeGraphForKernel,
   type LoadedBrowserRunner
 } from "./browserRunnerCore";
@@ -60,10 +61,14 @@ const runnerPromise: Promise<LoadedBrowserRunner> = (async () => {
 })();
 
 runnerPromise.then(
-  (runner) =>
+  // Probe WebGPU here (workers expose navigator.gpu) and report only the types
+  // we can actually run: when no GPU device is available, the GPU shader node
+  // types are withheld so graphs using them route to the server (Dawn) instead
+  // of failing mid-run.
+  async (runner) =>
     self.postMessage({
       type: "ready",
-      browserNodeTypes: runner.browserNodeTypes
+      browserNodeTypes: await capabilityFilteredBrowserNodeTypes(runner)
     }),
   (error) =>
     self.postMessage({

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -42,6 +42,13 @@ export interface LoadedBrowserRunner {
   registry: ReturnType<WorkflowRunnerModule["createBrowserRegistry"]>;
   /** Node types the registry can run client-side (browser platform). */
   browserNodeTypes: string[];
+  /**
+   * Browser-capable node types that require a WebGPU device (`requiresGpu`).
+   * When `navigator.gpu` is unavailable, the runner drops these from the
+   * browser-capable set so any graph using them routes to the server (where a
+   * GPU is always present via Dawn) instead of failing the run.
+   */
+  gpuNodeTypes: Set<string>;
   /** GPU-texture boundary resolve (browser GPU runs only). */
   resolveImageRefForTransport?: ResolveImageRefForTransport;
   /** Free the run's GPU textures (browser GPU runs only). */
@@ -256,17 +263,93 @@ export function buildBrowserRunner(mods: LoadedModules): LoadedBrowserRunner {
     .filter((t): t is string => typeof t === "string");
   const browserNodeTypes = candidates.filter((t) => registry.has(t));
   const filteredOut = candidates.filter((t) => !registry.has(t));
+  // Browser-capable types that need a WebGPU device (tagged via tagAsBrowserGpu).
+  const gpuNodeTypes = new Set(
+    (mods.nodeClasses as Array<{ nodeType?: unknown; requiresGpu?: unknown }>)
+      .filter(
+        (c) =>
+          c.requiresGpu === true &&
+          typeof c.nodeType === "string" &&
+          registry.has(c.nodeType)
+      )
+      .map((c) => c.nodeType as string)
+  );
   console.info(
     `[browserRunner] registry ready — ${browserNodeTypes.length}/${candidates.length} loaded node type(s) are browser-capable`,
-    { registered: browserNodeTypes, filteredOutByPlatform: filteredOut }
+    {
+      registered: browserNodeTypes,
+      filteredOutByPlatform: filteredOut,
+      requireWebGpu: [...gpuNodeTypes]
+    }
   );
   return {
     runBrowserWorkflow: mods.wf.runBrowserWorkflow,
     registry,
     browserNodeTypes,
+    gpuNodeTypes,
     resolveImageRefForTransport: mods.resolveImageRefForTransport,
     releaseRunTextures: mods.releaseRunTextures
   };
+}
+
+/**
+ * Pure: drop the GPU-requiring node types from `browserNodeTypes` when no
+ * WebGPU device is available. Graphs using them then route to the server.
+ */
+export function applyGpuCapability(
+  browserNodeTypes: string[],
+  gpuNodeTypes: ReadonlySet<string>,
+  gpuAvailable: boolean
+): string[] {
+  if (gpuAvailable || gpuNodeTypes.size === 0) return browserNodeTypes;
+  return browserNodeTypes.filter((t) => !gpuNodeTypes.has(t));
+}
+
+let gpuProbe: Promise<boolean> | null = null;
+
+/**
+ * Probe whether a usable WebGPU device is available in the current execution
+ * context (Web Worker or main thread). Cached for the context's lifetime.
+ * Resolves `false` when `navigator.gpu` is absent or no adapter can be
+ * acquired — the exact CI / locked-down-browser case the server fallback
+ * targets. Worker-safe: `navigator` exists in workers and is read off
+ * `globalThis` so this module stays DOM-free at type level.
+ */
+export function probeBrowserGpu(): Promise<boolean> {
+  if (!gpuProbe) {
+    gpuProbe = (async () => {
+      const nav = (
+        globalThis as {
+          navigator?: { gpu?: { requestAdapter(): Promise<unknown> } };
+        }
+      ).navigator;
+      const gpu = nav?.gpu;
+      if (!gpu) return false;
+      try {
+        return (await gpu.requestAdapter()) != null;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  return gpuProbe;
+}
+
+/**
+ * The runner's browser-capable node types after applying the WebGPU capability
+ * probe: identical to `browserNodeTypes` when a GPU is present (or the graph
+ * uses no GPU nodes), with the GPU-requiring types removed otherwise.
+ */
+export async function capabilityFilteredBrowserNodeTypes(
+  runner: LoadedBrowserRunner
+): Promise<string[]> {
+  const gpuAvailable =
+    runner.gpuNodeTypes.size === 0 ? true : await probeBrowserGpu();
+  return applyGpuCapability(
+    runner.browserNodeTypes,
+    runner.gpuNodeTypes,
+    gpuAvailable
+  );
 }
 
 /**

--- a/web/src/lib/workflow/browserWorkflowRunner.ts
+++ b/web/src/lib/workflow/browserWorkflowRunner.ts
@@ -30,6 +30,7 @@ import {
   collectNodeClasses,
   loadBrowserModules,
   normalizeGraphForKernel,
+  probeBrowserGpu,
   type BrowserGraphJobOptions,
   type BrowserGraphJobResult,
   type LoadedBrowserRunner,
@@ -82,6 +83,7 @@ export function __setBrowserRunnerLoader(
   loadModules = loader ?? defaultLoadModules;
   localRunnerPromise = null;
   cachedLocalRunner = undefined;
+  localGpuAvailable = undefined;
   cachedBrowserNodeTypes = undefined;
   workerDisabled = false;
 }
@@ -96,6 +98,10 @@ const defaultLoadModules = async (): Promise<LoadedModules | null> => {
 let loadModules: () => Promise<LoadedModules | null> = defaultLoadModules;
 let localRunnerPromise: Promise<LoadedBrowserRunner | null> | null = null;
 let cachedLocalRunner: LoadedBrowserRunner | null | undefined;
+// Whether this (main) thread has a usable WebGPU device. Resolved alongside the
+// runner so `browserSupportsSync` can gate GPU node types without going async.
+// Stays `undefined` until the probe completes (set before `cachedLocalRunner`).
+let localGpuAvailable: boolean | undefined;
 
 function loadLocalRunner(): Promise<LoadedBrowserRunner | null> {
   if (!localRunnerPromise) {
@@ -107,6 +113,10 @@ function loadLocalRunner(): Promise<LoadedBrowserRunner | null> {
           return null;
         }
         const runner = buildBrowserRunner(mods);
+        // Resolve GPU availability before the runner is observable, so the
+        // routing gate in browserSupportsSync sees a settled value.
+        localGpuAvailable =
+          runner.gpuNodeTypes.size === 0 ? true : await probeBrowserGpu();
         cachedLocalRunner = runner;
         return runner;
       } catch (error) {
@@ -165,11 +175,19 @@ async function ensureRunnerLoaded(): Promise<boolean> {
  */
 export function browserSupportsSync(type: string): boolean | undefined {
   if (usingWorker()) {
+    // The worker already withheld GPU types from its reported set when no
+    // WebGPU device was available, so this needs no extra gate.
     if (cachedBrowserNodeTypes === undefined) return undefined;
     return cachedBrowserNodeTypes?.has(type) ?? false;
   }
   if (cachedLocalRunner === undefined) return undefined;
-  return cachedLocalRunner?.registry.has(type) ?? false;
+  if (!cachedLocalRunner) return false;
+  // No GPU here → GPU shader nodes can't run client-side; force them to the
+  // server (which has Dawn) by reporting them as unsupported.
+  if (localGpuAvailable === false && cachedLocalRunner.gpuNodeTypes.has(type)) {
+    return false;
+  }
+  return cachedLocalRunner.registry.has(type);
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a Canvas2D fallback compositor for timeline preview and export when WebGPU is unavailable, plus infrastructure to detect WebGPU capability and route GPU-requiring nodes to the server when the browser lacks a GPU device.

## Key Changes

### Canvas2D Compositor Fallback
- **`canvas2dCompositor.ts`** (new): Drop-in replacement for `WebGPUCompositor` that renders timeline layers using Canvas2D API. Implements the same `TimelineCompositor` interface with:
  - Transform matrix conversion via `clipMatrixToCanvasAffine` (converts clip-space to 2D affine)
  - Opacity, blend modes, and border radius support
  - CSS `filter` approximation for color/blur effects (brightness, contrast, saturation, hue, blur)
  - Graceful handling of video/image readiness via `isSourceReady` and `sourceDimensions`

- **`createCompositor.ts`** (new): Factory function that probes `navigator.gpu`, attempts WebGPU initialization, and falls back to Canvas2D if unavailable. Enables live preview and offline export to work on older browsers and headless CI (where SwiftShader's WebGPU fails).

- **`source.ts`** (new): Extracted source readiness and dimension helpers shared by both WebGPU and Canvas2D compositors.

- **`transform.ts`** (modified): Added `clipMatrixToCanvasAffine` to convert clip-space transform matrices to Canvas2D affine transforms, with comprehensive test coverage.

- **`types.ts`** (modified): Added `TimelineCompositor` interface as the common surface for both backends.

### WebGPU Capability Detection & GPU Node Routing
- **`browserRunnerCore.ts`** (modified):
  - Added `gpuNodeTypes` set to `LoadedBrowserRunner` to track browser-capable nodes requiring WebGPU
  - `probeBrowserGpu()`: Async probe for `navigator.gpu` availability (cached per context, worker-safe)
  - `applyGpuCapability()`: Pure function to filter out GPU-requiring node types when no GPU is available
  - `capabilityFilteredBrowserNodeTypes()`: Combines the probe and filter for the runner's effective browser node types

- **`browserWorkflowRunner.ts`** (modified): Integrated GPU capability detection so graphs using GPU nodes route to the server when `navigator.gpu` is unavailable, instead of failing the run.

- **`browserRunner.worker.ts`** (modified): Worker-side GPU probe and capability filtering.

### Platform Tagging for GPU Nodes
- **`platform-tags.ts`** (new `tagAsBrowserGpu`): Tags node classes as browser-capable with `requiresGpu: true`, so the runner knows to drop them from the browser-capable set when no GPU is present. Respects per-class `requiresGpu` overrides and skips server-only nodes.

- **`node-sdk/base-node.ts`** (modified): Added `requiresGpu?: boolean` property to `NodeClass` type.

### Image Node Updates
Updated image nodes to use `tagAsBrowserGpu` instead of `tagAsHybrid` where GPU is required:
- `lib-image.ts`, `lib-image-channel.ts`, `lib-image-color-grading.ts`, `lib-image-color.ts`, `lib-image-effects.ts`, `lib-image-enhance.ts`, `lib-image-filter-extras.ts`, `lib-image-filter.ts`, `lib-image-generators.ts`, `lib-image-keyer.ts`, `lib-image-mask.ts`, `lib-image-warp.ts`
- `lib-image-draw.ts`: Added `drawRequiresGpu` helper to tag only GPU-dependent draw nodes (Background, GaussianNoise).

### UI Integration
- **`PreviewCompositor.tsx`** (modified): Uses `createCompositor` factory instead of directly instantiating `WebGPUCompositor`, typed against `TimelineCompositor` interface.

https://claude.ai/code/session_01ULwGZd172zrT5jn4FH72NJ