### PR TITLE
Add content-aware media aspect ratio resize for nodes

### DIFF
--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -432,11 +432,7 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       isConstantNode: type.startsWith("nodetool.constant"),
       isInputNode: type.startsWith("nodetool.input"),
       isOutputNode: type.startsWith("nodetool.output"),
-      isAgentNode: isAgentNodeType(type),
-      // Constant image/video nodes preview their media, so resizing should
-      // preserve the media's aspect ratio rather than distort it.
-      lockAspectRatio:
-        type === CONSTANT_IMAGE_NODE_TYPE || type === CONSTANT_VIDEO_NODE_TYPE
+      isAgentNode: isAgentNodeType(type)
     }),
     [type]
   );
@@ -488,6 +484,24 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       showFooter: !SPECIAL_NAMESPACES.includes(metadata.namespace || "")
     };
   }, [metadata.namespace]);
+
+  // Nodes that preview media (image/video) resize by keeping the *media's*
+  // aspect ratio, not the whole node box — the corner handle measures the live
+  // image and the surrounding chrome (header, sliders, outputs) at drag time.
+  // Output/preview nodes opt in too: they free-resize until media is present.
+  const hasMediaView = useMemo(() => {
+    if (
+      nodeType.isOutputNode ||
+      type === CONSTANT_IMAGE_NODE_TYPE ||
+      type === CONSTANT_VIDEO_NODE_TYPE
+    ) {
+      return true;
+    }
+    return (metadata.outputs ?? []).some((output) => {
+      const outputType = output.type?.type;
+      return outputType === "image" || outputType === "video";
+    });
+  }, [nodeType.isOutputNode, type, metadata.outputs]);
 
   const displayTitle = useMemo(
     () => resolveCodeNodeTitle(type, data.title, metadata.title),
@@ -777,7 +791,8 @@ const BaseNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       <NodeResizeHandle
         minWidth={150}
         minHeight={styleProps.minHeight}
-        keepAspectRatio={nodeType.lockAspectRatio}
+        nodeId={id}
+        contentAware={hasMediaView}
       />
       <NodeHeader
         id={id}

--- a/web/src/components/node/DynamicComfySchemaNode/DynamicComfySchemaNode.tsx
+++ b/web/src/components/node/DynamicComfySchemaNode/DynamicComfySchemaNode.tsx
@@ -99,7 +99,12 @@ const DynamicComfySchemaNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       }}
     >
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={180} minHeight={150} />
+      <NodeResizeHandle
+        minWidth={180}
+        minHeight={150}
+        nodeId={id}
+        contentAware
+      />
       <Box sx={{ position: "relative" }}>
         <NodeHeader
           id={id}

--- a/web/src/components/node/DynamicFalSchemaNode/DynamicFalSchemaNode.tsx
+++ b/web/src/components/node/DynamicFalSchemaNode/DynamicFalSchemaNode.tsx
@@ -108,7 +108,12 @@ const DynamicFalSchemaNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       }}
     >
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={150} minHeight={150} />
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={150}
+        nodeId={id}
+        contentAware
+      />
       <Box sx={{ position: "relative" }}>
         <NodeHeader
           id={id}

--- a/web/src/components/node/DynamicKieSchemaNode/DynamicKieSchemaNode.tsx
+++ b/web/src/components/node/DynamicKieSchemaNode/DynamicKieSchemaNode.tsx
@@ -105,7 +105,12 @@ const DynamicKieSchemaNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       }}
     >
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={150} minHeight={150} />
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={150}
+        nodeId={id}
+        contentAware
+      />
       <Box sx={{ position: "relative" }}>
         <NodeHeader
           id={id}

--- a/web/src/components/node/DynamicReplicateNode/DynamicReplicateNode.tsx
+++ b/web/src/components/node/DynamicReplicateNode/DynamicReplicateNode.tsx
@@ -105,7 +105,12 @@ const DynamicReplicateNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       }}
     >
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
-      <NodeResizeHandle minWidth={150} minHeight={150} />
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={150}
+        nodeId={id}
+        contentAware
+      />
       <Box sx={{ position: "relative" }}>
         <NodeHeader
           id={id}

--- a/web/src/components/node/MediaAspectResizeControl.tsx
+++ b/web/src/components/node/MediaAspectResizeControl.tsx
@@ -1,0 +1,210 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { useReactFlow } from "@xyflow/react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { Box, MOTION } from "../ui_primitives";
+import { useNodes } from "../../contexts/NodeContext";
+import type { NodeStoreState } from "../../stores/NodeStore";
+import {
+  computeAspectResize,
+  computeFreeResize,
+  type MediaBox,
+  type ResizeResult
+} from "./mediaAspectResize";
+import { measureNodeMedia } from "./measureNodeMedia";
+
+interface MediaAspectResizeControlProps {
+  nodeId: string;
+  minWidth: number;
+  minHeight: number;
+  maxWidth: number;
+}
+
+interface DragState {
+  startX: number;
+  startY: number;
+  startWidth: number;
+  startHeight: number;
+  zoom: number;
+  /** Measured media box, or null when the node holds no decoded media. */
+  box: MediaBox | null;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    zIndex: 100,
+    right: 0,
+    bottom: 0,
+    width: "25px",
+    height: "25px",
+    overflow: "hidden",
+    ".resize-grip": {
+      position: "absolute",
+      inset: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "transparent",
+      border: "none",
+      padding: 0,
+      pointerEvents: "all",
+      cursor: "nwse-resize",
+      opacity: 0.6,
+      transition: MOTION.all,
+      "&:hover": {
+        opacity: 1
+      },
+      "& svg": {
+        width: "20px",
+        height: "20px",
+        color: theme.vars.palette.grey[100],
+        transform: "rotate(-45deg)",
+        transition: `color ${MOTION.normal}`
+      }
+    }
+  });
+
+/**
+ * Corner resize handle that keeps the node's media (image / video) aspect ratio
+ * while treating the surrounding chrome (header, sliders, output handles) as a
+ * fixed offset. When the node holds no media it falls back to a free resize, so
+ * the same handle is correct for nodes that only sometimes show an image.
+ *
+ * Unlike React Flow's `NodeResizeControl`, this drives the geometry directly:
+ * the built-in control applies its own width *and* height before `onResize`
+ * runs, leaving no way to derive height from width without fighting it.
+ */
+const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
+  nodeId,
+  minWidth,
+  minHeight,
+  maxWidth
+}: MediaAspectResizeControlProps) {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+  const reactFlow = useReactFlow();
+  const updateNode = useNodes((state: NodeStoreState) => state.updateNode);
+
+  const dragRef = useRef<DragState | null>(null);
+  const pendingRef = useRef<ResizeResult | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const flush = useCallback(() => {
+    rafRef.current = null;
+    if (pendingRef.current) {
+      updateNode(nodeId, pendingRef.current);
+      pendingRef.current = null;
+    }
+  }, [nodeId, updateNode]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    },
+    []
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      const nodeEl = event.currentTarget.closest<HTMLElement>(
+        ".react-flow__node"
+      );
+      if (!nodeEl) {
+        return;
+      }
+      event.stopPropagation();
+      event.preventDefault();
+
+      const zoom = reactFlow.getViewport().zoom || 1;
+      const rect = nodeEl.getBoundingClientRect();
+      const startWidth = rect.width / zoom;
+      const startHeight = rect.height / zoom;
+
+      dragRef.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        startWidth,
+        startHeight,
+        zoom,
+        box: measureNodeMedia(nodeEl, zoom, startWidth, startHeight)
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [reactFlow]
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      const drag = dragRef.current;
+      if (!drag) {
+        return;
+      }
+      const delta = {
+        startWidth: drag.startWidth,
+        startHeight: drag.startHeight,
+        deltaX: (event.clientX - drag.startX) / drag.zoom,
+        deltaY: (event.clientY - drag.startY) / drag.zoom
+      };
+      const bounds = { minWidth, maxWidth, minHeight };
+      pendingRef.current = drag.box
+        ? computeAspectResize(delta, drag.box, bounds)
+        : computeFreeResize(delta, bounds);
+
+      if (rafRef.current === null) {
+        rafRef.current = requestAnimationFrame(flush);
+      }
+    },
+    [flush, minWidth, maxWidth, minHeight]
+  );
+
+  const endDrag = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (!dragRef.current) {
+        return;
+      }
+      dragRef.current = null;
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      // Commit the final position synchronously so a fast release isn't dropped.
+      if (pendingRef.current) {
+        updateNode(nodeId, pendingRef.current);
+        pendingRef.current = null;
+      }
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Pointer was never captured (e.g. cancelled before move) — nothing to release.
+      }
+    },
+    [nodeId, updateNode]
+  );
+
+  return (
+    <Box className="node-resize-handle media-aspect-resize-handle" css={cssStyles}>
+      <button
+        type="button"
+        className="resize-grip nodrag nopan"
+        aria-label="Resize node, keeping image aspect ratio"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <KeyboardArrowDownIcon />
+      </button>
+    </Box>
+  );
+});
+
+export default MediaAspectResizeControl;

--- a/web/src/components/node/NodeResizeHandle.tsx
+++ b/web/src/components/node/NodeResizeHandle.tsx
@@ -7,6 +7,10 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Box, MOTION } from "../ui_primitives";
 import { memo, useMemo } from "react";
+import MediaAspectResizeControl from "./MediaAspectResizeControl";
+
+/** Upper bound shared with the edge resizer so the corner handle agrees with it. */
+const MAX_NODE_WIDTH = 800;
 
 interface NodeResizeHandleProps {
   minWidth: number;
@@ -14,6 +18,15 @@ interface NodeResizeHandleProps {
   onResize?: OnResize;
   /** Lock the width/height ratio while dragging the handle. */
   keepAspectRatio?: boolean;
+  /**
+   * Keep the node's *media* (image / video) aspect ratio instead of the whole
+   * node box, treating header/sliders/outputs as a fixed offset. Requires
+   * `nodeId`. Falls back to a free resize when the node holds no media.
+   */
+  contentAware?: boolean;
+  nodeId?: string;
+  /** Override the resize upper bound (defaults to the shared node width cap). */
+  maxWidth?: number;
 }
 
 const styles = (theme: Theme) =>
@@ -57,10 +70,25 @@ const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResi
   minWidth,
   minHeight,
   onResize,
-  keepAspectRatio
+  keepAspectRatio,
+  contentAware,
+  nodeId,
+  maxWidth = MAX_NODE_WIDTH
 }) {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  if (contentAware && nodeId) {
+    return (
+      <MediaAspectResizeControl
+        nodeId={nodeId}
+        minWidth={minWidth}
+        minHeight={minHeight}
+        maxWidth={maxWidth}
+      />
+    );
+  }
+
   return (
     <Box className="node-resize-handle" css={cssStyles}>
       <NodeResizeControl

--- a/web/src/components/node/OutputNode/OutputNode.tsx
+++ b/web/src/components/node/OutputNode/OutputNode.tsx
@@ -362,7 +362,12 @@ const OutputNode: React.FC<OutputNodeProps> = (props) => {
     >
       <div className={`output-node-content `}>
         <>
-          <NodeResizeHandle minWidth={150} minHeight={150} />
+          <NodeResizeHandle
+            minWidth={150}
+            minHeight={150}
+            nodeId={props.id}
+            contentAware
+          />
           <NodeHeader
             id={props.id}
             data={props.data}

--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -428,7 +428,12 @@ const PreviewNode: React.FC<PreviewNodeProps> = (props) => {
           isConnectable={true}
         />
         <>
-          <NodeResizeHandle minWidth={150} minHeight={80} />
+          <NodeResizeHandle
+            minWidth={150}
+            minHeight={80}
+            nodeId={props.id}
+            contentAware
+          />
           <NodeHeader
             id={props.id}
             data={props.data}

--- a/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
+++ b/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
@@ -11,6 +11,16 @@ jest.mock("@xyflow/react", () => ({
   }
 }));
 
+// Isolate from the content-aware control's dependencies (node store, viewport).
+const mediaControlProps: Array<Record<string, unknown>> = [];
+jest.mock("../MediaAspectResizeControl", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    mediaControlProps.push(props);
+    return <div data-testid="media-aspect-control" />;
+  }
+}));
+
 jest.mock("@mui/material/styles", () => {
   const original = jest.requireActual("@mui/material/styles");
   return {
@@ -22,6 +32,7 @@ jest.mock("@mui/material/styles", () => {
 describe("NodeResizeHandle", () => {
   beforeEach(() => {
     resizeControlProps.length = 0;
+    mediaControlProps.length = 0;
   });
 
   it("does not lock aspect ratio by default", () => {
@@ -34,5 +45,32 @@ describe("NodeResizeHandle", () => {
       <NodeResizeHandle minWidth={150} minHeight={100} keepAspectRatio />
     );
     expect(resizeControlProps[0]?.keepAspectRatio).toBe(true);
+  });
+
+  it("renders the media-aspect control when contentAware with a nodeId", () => {
+    const { queryByTestId } = render(
+      <NodeResizeHandle
+        minWidth={150}
+        minHeight={100}
+        contentAware
+        nodeId="node-1"
+      />
+    );
+    expect(queryByTestId("media-aspect-control")).not.toBeNull();
+    expect(queryByTestId("resize-control")).toBeNull();
+    expect(mediaControlProps[0]).toMatchObject({
+      nodeId: "node-1",
+      minWidth: 150,
+      minHeight: 100,
+      maxWidth: 800
+    });
+  });
+
+  it("falls back to the default control when contentAware lacks a nodeId", () => {
+    const { queryByTestId } = render(
+      <NodeResizeHandle minWidth={150} minHeight={100} contentAware />
+    );
+    expect(queryByTestId("media-aspect-control")).toBeNull();
+    expect(queryByTestId("resize-control")).not.toBeNull();
   });
 });

--- a/web/src/components/node/__tests__/measureNodeMedia.test.ts
+++ b/web/src/components/node/__tests__/measureNodeMedia.test.ts
@@ -1,0 +1,76 @@
+import { measureNodeMedia } from "../measureNodeMedia";
+
+function makeNode(): HTMLElement {
+  const node = document.createElement("div");
+  node.className = "react-flow__node";
+  return node;
+}
+
+function mockRect(el: Element, width: number, height: number): void {
+  jest
+    .spyOn(el, "getBoundingClientRect")
+    .mockReturnValue({ width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0, toJSON: () => ({}) } as DOMRect);
+}
+
+describe("measureNodeMedia", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("returns null when the node holds no decoded media", () => {
+    const node = makeNode();
+    node.appendChild(document.createElement("span"));
+    expect(measureNodeMedia(node, 1, 200, 200)).toBeNull();
+  });
+
+  it("measures ratio and chrome offsets from the media container", () => {
+    const node = makeNode();
+    const container = document.createElement("div");
+    container.className = "image-output";
+    const canvas = document.createElement("canvas");
+    canvas.width = 200; // intrinsic
+    canvas.height = 100;
+    container.appendChild(canvas);
+    node.appendChild(container);
+
+    // Container box is 300x160 on screen; the node is 320x240 (flow units).
+    mockRect(container, 300, 160);
+
+    expect(measureNodeMedia(node, 1, 320, 240)).toEqual({
+      ratio: 2,
+      sidePad: 20, // 320 - 300
+      chrome: 80 // 240 - 160
+    });
+  });
+
+  it("divides the container box by the viewport zoom", () => {
+    const node = makeNode();
+    const container = document.createElement("div");
+    container.className = "preview-area";
+    const canvas = document.createElement("canvas");
+    canvas.width = 100;
+    canvas.height = 100;
+    container.appendChild(canvas);
+    node.appendChild(container);
+
+    // At zoom 2 a 200x200 screen box is a 100x100 flow box.
+    mockRect(container, 200, 200);
+
+    const box = measureNodeMedia(node, 2, 130, 150);
+    expect(box).not.toBeNull();
+    expect(box?.ratio).toBe(1);
+    expect(box?.sidePad).toBe(30); // 130 - 100
+    expect(box?.chrome).toBe(50); // 150 - 100
+  });
+
+  it("ignores a canvas with no intrinsic size", () => {
+    const node = makeNode();
+    const container = document.createElement("div");
+    container.className = "image-output";
+    const canvas = document.createElement("canvas");
+    canvas.width = 0;
+    canvas.height = 0;
+    container.appendChild(canvas);
+    node.appendChild(container);
+
+    expect(measureNodeMedia(node, 1, 200, 200)).toBeNull();
+  });
+});

--- a/web/src/components/node/__tests__/mediaAspectResize.test.ts
+++ b/web/src/components/node/__tests__/mediaAspectResize.test.ts
@@ -1,0 +1,94 @@
+import {
+  computeAspectResize,
+  computeFreeResize,
+  type MediaBox,
+  type ResizeBounds
+} from "../mediaAspectResize";
+
+const bounds: ResizeBounds = { minWidth: 150, maxWidth: 800, minHeight: 80 };
+
+describe("computeAspectResize", () => {
+  // Image-only node: square image, 30px of chrome (header), no side padding.
+  const squareImageOnly: MediaBox = { ratio: 1, sidePad: 0, chrome: 30 };
+
+  it("derives height from width so the media box keeps its ratio", () => {
+    const result = computeAspectResize(
+      { startWidth: 200, startHeight: 200, deltaX: 100, deltaY: 0 },
+      squareImageOnly,
+      bounds
+    );
+    // width 300 → media 300 wide → media 300 tall (ratio 1) → +30 chrome.
+    expect(result).toEqual({ width: 300, height: 330 });
+  });
+
+  it("treats sliders/chrome as a fixed offset, not scaled with the media", () => {
+    // 2:1 image, 24px side padding, 120px chrome (header + a slider + outputs).
+    const wideWithSliders: MediaBox = { ratio: 2, sidePad: 24, chrome: 120 };
+    const result = computeAspectResize(
+      { startWidth: 300, startHeight: 300, deltaX: 200, deltaY: 0 },
+      wideWithSliders,
+      bounds
+    );
+    // width 500 → media 476 wide → media 238 tall → +120 chrome = 358.
+    expect(result.width).toBe(500);
+    expect(result.height).toBe(358);
+    // The media box ratio is preserved (≈ 2), the chrome is untouched.
+    expect((result.width - 24) / (result.height - 120)).toBeCloseTo(2, 5);
+  });
+
+  it("drives from the axis the pointer moved most (height-driven)", () => {
+    const result = computeAspectResize(
+      { startWidth: 200, startHeight: 200, deltaX: 10, deltaY: 100 },
+      squareImageOnly,
+      bounds
+    );
+    // height 300 → media 270 tall → media 270 wide (ratio 1) → +0 side pad.
+    expect(result).toEqual({ width: 270, height: 300 });
+  });
+
+  it("re-derives width when the height floor clamps a width-driven resize", () => {
+    // Very wide media shrunk hard: the new width would push height under
+    // minHeight, so height floors and width grows back to honour the ratio.
+    const wide: MediaBox = { ratio: 4, sidePad: 0, chrome: 20 };
+    const result = computeAspectResize(
+      { startWidth: 600, startHeight: 200, deltaX: -500, deltaY: 0 },
+      wide,
+      bounds
+    );
+    expect(result.height).toBe(bounds.minHeight); // 80
+    // media height 60 → media width 240 (ratio 4).
+    expect(result.width).toBe(240);
+    expect((result.width - 0) / (result.height - 20)).toBeCloseTo(4, 5);
+  });
+
+  it("clamps width to maxWidth and re-derives height", () => {
+    const result = computeAspectResize(
+      { startWidth: 700, startHeight: 700, deltaX: 400, deltaY: 0 },
+      squareImageOnly,
+      bounds
+    );
+    expect(result.width).toBe(bounds.maxWidth);
+    // width 800 → media 800 → height 830.
+    expect(result.height).toBe(830);
+  });
+});
+
+describe("computeFreeResize", () => {
+  it("moves both axes independently within bounds", () => {
+    expect(
+      computeFreeResize(
+        { startWidth: 200, startHeight: 200, deltaX: 50, deltaY: -40 },
+        bounds
+      )
+    ).toEqual({ width: 250, height: 160 });
+  });
+
+  it("respects min/max bounds", () => {
+    expect(
+      computeFreeResize(
+        { startWidth: 200, startHeight: 200, deltaX: 1000, deltaY: -1000 },
+        bounds
+      )
+    ).toEqual({ width: 800, height: 80 });
+  });
+});

--- a/web/src/components/node/measureNodeMedia.ts
+++ b/web/src/components/node/measureNodeMedia.ts
@@ -1,0 +1,95 @@
+import type { MediaBox } from "./mediaAspectResize";
+
+/**
+ * Intrinsic aspect ratio (width / height) of a media element, or `null` when it
+ * has no usable dimensions yet (image not decoded, empty canvas, …).
+ */
+function intrinsicRatio(el: Element): number | null {
+  if (el instanceof HTMLImageElement) {
+    return el.naturalWidth > 0 && el.naturalHeight > 0
+      ? el.naturalWidth / el.naturalHeight
+      : null;
+  }
+  if (el instanceof HTMLCanvasElement) {
+    return el.width > 0 && el.height > 0 ? el.width / el.height : null;
+  }
+  if (el instanceof HTMLVideoElement) {
+    return el.videoWidth > 0 && el.videoHeight > 0
+      ? el.videoWidth / el.videoHeight
+      : null;
+  }
+  return null;
+}
+
+/**
+ * Containers an image view renders inside. The media element itself is sized
+ * `100%` or `max-*: 100%`, so the *container* is the box whose width tracks the
+ * node width — that's what we measure for the chrome offsets.
+ */
+const MEDIA_CONTAINER_SELECTOR = ".image-output, .preview-area";
+
+const MEDIA_SELECTOR =
+  ".image-output img, .image-output canvas, .image-output video, " +
+  ".preview-area img, .preview-area canvas, .preview-area video";
+
+function findMediaElement(nodeEl: HTMLElement): Element | null {
+  // Prefer media inside a known preview container.
+  const scoped = nodeEl.querySelectorAll(MEDIA_SELECTOR);
+  for (const el of Array.from(scoped)) {
+    if (intrinsicRatio(el) !== null) {
+      return el;
+    }
+  }
+  // Fall back to any media element that has reported intrinsic dimensions.
+  const any = nodeEl.querySelectorAll("img, canvas, video");
+  for (const el of Array.from(any)) {
+    if (intrinsicRatio(el) !== null) {
+      return el;
+    }
+  }
+  return null;
+}
+
+/**
+ * Measure the media a node is currently showing so the resize can keep that
+ * media's aspect ratio. Returns `null` when the node has no decoded media —
+ * the caller then falls back to a free resize, which is why the same handle
+ * works for nodes that only *sometimes* hold an image (Preview / Output).
+ *
+ * @param zoom        current viewport zoom, to convert screen px → flow units
+ * @param nodeWidth   node width at drag start, in flow units
+ * @param nodeHeight  node height at drag start, in flow units
+ */
+export function measureNodeMedia(
+  nodeEl: HTMLElement,
+  zoom: number,
+  nodeWidth: number,
+  nodeHeight: number
+): MediaBox | null {
+  const media = findMediaElement(nodeEl);
+  if (!media) {
+    return null;
+  }
+  const ratio = intrinsicRatio(media);
+  if (ratio === null || !Number.isFinite(ratio) || ratio <= 0) {
+    return null;
+  }
+
+  const container =
+    media.closest<HTMLElement>(MEDIA_CONTAINER_SELECTOR) ??
+    (media.parentElement as HTMLElement | null) ??
+    (media as HTMLElement);
+
+  const rect = container.getBoundingClientRect();
+  const boxWidth = rect.width / zoom;
+  const boxHeight = rect.height / zoom;
+  if (boxWidth <= 0 || boxHeight <= 0) {
+    return null;
+  }
+
+  return {
+    ratio,
+    sidePad: Math.max(0, nodeWidth - boxWidth),
+    chrome: Math.max(0, nodeHeight - boxHeight)
+  };
+}

--- a/web/src/components/node/mediaAspectResize.ts
+++ b/web/src/components/node/mediaAspectResize.ts
@@ -1,0 +1,108 @@
+/**
+ * Geometry for "keep aspect ratio" node resizing.
+ *
+ * A node that previews media (image / video / canvas) is more than the media:
+ * it also has a header, and — depending on the node — sliders, dropdowns and
+ * output handles stacked above or below the preview. Locking the *whole node*
+ * box ratio (React Flow's built-in `keepAspectRatio`) scales that fixed chrome
+ * along with the media and letterboxes the image.
+ *
+ * Instead we keep the *media box's* ratio and treat the chrome as a fixed
+ * offset measured from the live DOM (see `measureNodeMedia`):
+ *
+ *   nodeWidth  = mediaWidth  + sidePad   (left/right padding around the media)
+ *   nodeHeight = mediaHeight + chrome    (header + controls + output handles)
+ *
+ * so the relationship the resize preserves is
+ *
+ *   (nodeWidth - sidePad) / (nodeHeight - chrome) === ratio
+ *
+ * which works whether the node is image-only (chrome ≈ header) or image + a
+ * stack of sliders (chrome = header + sliders + outputs).
+ */
+
+export interface MediaBox {
+  /** Intrinsic media aspect ratio (width / height). */
+  ratio: number;
+  /** Horizontal chrome: node width minus media-box width (flow units). */
+  sidePad: number;
+  /** Vertical chrome: node height minus media-box height (flow units). */
+  chrome: number;
+}
+
+export interface ResizeBounds {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+}
+
+export interface ResizeDelta {
+  startWidth: number;
+  startHeight: number;
+  /** Pointer movement since drag start, in flow (un-zoomed) units. */
+  deltaX: number;
+  deltaY: number;
+}
+
+export interface ResizeResult {
+  width: number;
+  height: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const nodeHeightForWidth = (width: number, box: MediaBox): number =>
+  Math.max(1, width - box.sidePad) / box.ratio + box.chrome;
+
+const nodeWidthForHeight = (height: number, box: MediaBox): number =>
+  Math.max(1, height - box.chrome) * box.ratio + box.sidePad;
+
+/**
+ * Resize that keeps the media's aspect ratio. Whichever axis the pointer moved
+ * most drives the resize; the other axis is derived so the media box keeps
+ * `ratio`. Both axes are clamped to the bounds, re-deriving the partner axis so
+ * the ratio survives the clamp.
+ */
+export function computeAspectResize(
+  delta: ResizeDelta,
+  box: MediaBox,
+  bounds: ResizeBounds
+): ResizeResult {
+  const { startWidth, startHeight, deltaX, deltaY } = delta;
+  const { minWidth, maxWidth, minHeight } = bounds;
+
+  let width: number;
+  let height: number;
+
+  if (Math.abs(deltaX) >= Math.abs(deltaY)) {
+    width = clamp(startWidth + deltaX, minWidth, maxWidth);
+    height = nodeHeightForWidth(width, box);
+    if (height < minHeight) {
+      height = minHeight;
+      width = clamp(nodeWidthForHeight(height, box), minWidth, maxWidth);
+    }
+  } else {
+    height = Math.max(startHeight + deltaY, minHeight);
+    width = nodeWidthForHeight(height, box);
+    if (width < minWidth || width > maxWidth) {
+      width = clamp(width, minWidth, maxWidth);
+      height = Math.max(nodeHeightForWidth(width, box), minHeight);
+    }
+  }
+
+  return { width: Math.round(width), height: Math.round(height) };
+}
+
+/** Free resize (both axes follow the pointer) — used when no media is present. */
+export function computeFreeResize(
+  delta: ResizeDelta,
+  bounds: ResizeBounds
+): ResizeResult {
+  return {
+    width: Math.round(
+      clamp(delta.startWidth + delta.deltaX, bounds.minWidth, bounds.maxWidth)
+    ),
+    height: Math.round(Math.max(delta.startHeight + delta.deltaY, bounds.minHeight))
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new `MediaAspectResizeControl` component that intelligently resizes nodes while preserving the aspect ratio of their media content (images, videos, canvases). Unlike React Flow's built-in `keepAspectRatio` which scales the entire node box, this control measures the live media and surrounding chrome (header, sliders, outputs) at drag time, keeping only the media's ratio fixed while treating UI chrome as a fixed offset.

## Key Changes

- **New `MediaAspectResizeControl` component** (`web/src/components/node/MediaAspectResizeControl.tsx`): A corner resize handle that:
  - Measures the intrinsic aspect ratio of decoded media (image, video, canvas)
  - Calculates the fixed chrome offset (header, controls, outputs) from the live DOM
  - Drives resize from whichever axis the pointer moved most
  - Falls back to free resize when no media is present (for nodes that only sometimes show images)
  - Uses pointer capture for smooth dragging and RAF batching for performance

- **Geometry utilities** (`web/src/components/node/mediaAspectResize.ts`):
  - `computeAspectResize()`: Preserves media aspect ratio while treating chrome as fixed offset
  - `computeFreeResize()`: Fallback for nodes without media
  - Handles clamping to min/max bounds with intelligent re-derivation of the partner axis

- **Media measurement** (`web/src/components/node/measureNodeMedia.ts`):
  - `measureNodeMedia()`: Finds decoded media in the DOM and extracts intrinsic ratio
  - Supports `<img>`, `<canvas>`, and `<video>` elements
  - Accounts for viewport zoom when converting screen pixels to flow units
  - Returns `null` when no usable media is found (image not decoded, empty canvas, etc.)

- **Updated `NodeResizeHandle`** to support content-aware resizing:
  - New `contentAware` prop enables the media-aspect control
  - New `nodeId` prop required when `contentAware` is true
  - New `maxWidth` prop to override the default 800px cap
  - Falls back to standard `NodeResizeControl` when `contentAware` lacks a `nodeId`

- **Updated node components** to use content-aware resizing:
  - `BaseNode`: Detects nodes with media views (Output, Preview, Constant Image/Video, or nodes with image/video outputs)
  - `OutputNode`, `PreviewNode`, `DynamicComfySchemaNode`, `DynamicFalSchemaNode`, `DynamicKieSchemaNode`, `DynamicReplicateNode`: Pass `nodeId` and `contentAware` to `NodeResizeHandle`

- **Comprehensive test coverage**:
  - `mediaAspectResize.test.ts`: Tests aspect ratio preservation, chrome offset handling, axis-driven resize, bounds clamping
  - `measureNodeMedia.test.ts`: Tests media detection, ratio extraction, zoom handling, edge cases
  - `NodeResizeHandle.test.tsx`: Tests control selection and prop passing

## Implementation Details

- The resize geometry model treats the node as: `nodeWidth = mediaWidth + sidePad` and `nodeHeight = mediaHeight + chrome`, preserving the relationship `(nodeWidth - sidePad) / (nodeHeight - chrome) === ratio`
- Pointer capture ensures smooth dragging even when the pointer moves outside the handle
- RAF batching defers DOM updates until the next frame, reducing layout thrashing during fast drags
- The control gracefully degrades: if media is not yet decoded or the node has no media, it switches to free resize automatically
- Zoom is accounted for when converting screen coordinates to flow units

https://claude.ai/code/session_015GJDjQf2seKMiRSVx6tyMF