### PR TITLE
Add CodeBody component for inline code editing in code nodes

### DIFF
--- a/web/src/components/node/NodeContent.tsx
+++ b/web/src/components/node/NodeContent.tsx
@@ -7,9 +7,10 @@ import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
 import NodePropertyForm from "./NodePropertyForm";
 import { isContentCardNode } from "../node_types/contentCardRegistry";
 import ContentCardBody from "../node_types/ContentCardBody";
+import CodeBody from "../node_types/CodeBody";
 import { getBespokeBody } from "../node_types/editing/bespokeRegistry";
 import HandleColumn from "./HandleColumn";
-import { isSnippetCodeNode } from "./codeNodeUi";
+import { isSnippetCodeNode, isCodeBodyNode } from "./codeNodeUi";
 import {
   resolveExposedInputNames,
   resolveInlineFieldNames
@@ -80,6 +81,19 @@ const NodeContent: React.FC<NodeContentProps> = ({
           properties={allProperties}
         />
       </FlexColumn>
+    );
+  }
+  if (isCodeBodyNode(nodeMetadata, data)) {
+    return (
+      <CodeBody
+        id={id}
+        nodeType={nodeType}
+        nodeMetadata={nodeMetadata}
+        data={data}
+        workflowId={workflowId}
+        status={status}
+        isOutputNode={isOutputNode}
+      />
     );
   }
   if (isContentCardNode(nodeMetadata)) {

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -20,7 +20,7 @@ import useMetadataStore from "../../stores/MetadataStore";
 import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
 import { NodeData } from "../../stores/NodeData";
 import { useInputNodeAutoRun } from "../../hooks/nodes/useInputNodeAutoRun";
-import { inferOutputKeysFromCode, inferInputKeysFromCode } from "../../utils/codeOutputInference";
+import { deriveCodeIOUpdates } from "../../utils/codeOutputInference";
 import { InspectorHeaderResetProvider } from "../../contexts/InspectorPropertyHeaderContext";
 import { getComponentForProperty } from "./PropertyInput.resolver";
 import type { PropertyProps } from "./PropertyInput.types";
@@ -260,33 +260,10 @@ const PropertyInput: React.FC<PropertyInputProps> = ({
         nodeType === "nodetool.code.Code" &&
         typeof value === "string"
       ) {
-        const outputKeys = inferOutputKeysFromCode(value);
-        const inputKeys = inferInputKeysFromCode(value);
-        const updates: Record<string, unknown> = {};
-
-        if (outputKeys) {
-          const dynOutputs: Record<string, { type: string; type_args: never[]; optional: boolean }> = {};
-          for (const key of outputKeys) {
-            dynOutputs[key] = { type: "any", type_args: [], optional: false };
-          }
-          updates.dynamic_outputs = dynOutputs;
-        } else {
-          updates.dynamic_outputs = {};
-        }
-
-        // Build dynamic_properties from inferred inputs, preserving existing values.
         const node = findNode(id);
-        const existingDynProps = (node?.data?.dynamic_properties || {}) as Record<string, unknown>;
-        const newDynProps: Record<string, unknown> = {};
-        if (inputKeys) {
-          for (const key of inputKeys) {
-            // Preserve existing value if the input already exists
-            newDynProps[key] = key in existingDynProps ? existingDynProps[key] : "";
-          }
-        }
-        updates.dynamic_properties = newDynProps;
-
-        updateNodeData(id, updates);
+        const existingDynProps = (node?.data?.dynamic_properties ||
+          {}) as Record<string, unknown>;
+        updateNodeData(id, deriveCodeIOUpdates(value, existingDynProps));
       }
 
       // Trigger auto-run (hook decides based on settings and node type)

--- a/web/src/components/node/__tests__/codeNodeUi.test.ts
+++ b/web/src/components/node/__tests__/codeNodeUi.test.ts
@@ -3,8 +3,28 @@ import {
   isCodeNode,
   isSnippetCodeNode,
   resolveCodeNodeTitle,
-  isCodeNodeTitleEditable
+  isCodeNodeTitleEditable,
+  getCodeNodeLanguage,
+  codeLanguageLabel,
+  hasCodeProperty,
+  isCodeBodyNode
 } from "../codeNodeUi";
+import type { NodeMetadata } from "../../../stores/ApiTypes";
+
+const makeMetadata = (
+  overrides: Partial<NodeMetadata> = {}
+): NodeMetadata =>
+  ({
+    node_type: CODE_NODE_TYPE,
+    inline_fields: ["code"],
+    properties: [
+      {
+        name: "code",
+        type: { type: "str", type_args: [], optional: false }
+      }
+    ],
+    ...overrides
+  }) as unknown as NodeMetadata;
 
 describe("codeNodeUi", () => {
   describe("isCodeNode", () => {
@@ -64,6 +84,72 @@ describe("codeNodeUi", () => {
       expect(resolveCodeNodeTitle(CODE_NODE_TYPE, undefined, "Code")).toBe(
         "Code"
       );
+    });
+  });
+
+  describe("getCodeNodeLanguage", () => {
+    it("maps executor node types to Monaco languages", () => {
+      expect(getCodeNodeLanguage("nodetool.code.ExecutePython")).toBe("python");
+      expect(getCodeNodeLanguage("nodetool.code.ExecuteJavaScript")).toBe(
+        "javascript"
+      );
+      expect(getCodeNodeLanguage(CODE_NODE_TYPE)).toBe("javascript");
+      expect(getCodeNodeLanguage("nodetool.code.ExecuteBash")).toBe("bash");
+      expect(getCodeNodeLanguage("nodetool.code.ExecuteRuby")).toBe("ruby");
+      expect(getCodeNodeLanguage("nodetool.code.ExecuteLua")).toBe("lua");
+    });
+
+    it("falls back to text for unknown node types", () => {
+      expect(getCodeNodeLanguage("nodetool.text.Concat")).toBe("text");
+    });
+  });
+
+  describe("codeLanguageLabel", () => {
+    it("returns a human label for known languages", () => {
+      expect(codeLanguageLabel("python")).toBe("Python");
+      expect(codeLanguageLabel("javascript")).toBe("JavaScript");
+      expect(codeLanguageLabel("text")).toBe("Code");
+    });
+  });
+
+  describe("hasCodeProperty", () => {
+    it("returns true for a node with an inline str code property", () => {
+      expect(hasCodeProperty(makeMetadata())).toBe(true);
+    });
+
+    it("returns false when code is not in inline_fields", () => {
+      expect(hasCodeProperty(makeMetadata({ inline_fields: [] }))).toBe(false);
+    });
+
+    it("returns false when there is no code property", () => {
+      expect(hasCodeProperty(makeMetadata({ properties: [] }))).toBe(false);
+    });
+
+    it("returns false for undefined metadata", () => {
+      expect(hasCodeProperty(undefined)).toBe(false);
+    });
+  });
+
+  describe("isCodeBodyNode", () => {
+    it("returns true for a non-snippet code node", () => {
+      expect(isCodeBodyNode(makeMetadata(), { codeNodeMode: undefined })).toBe(
+        true
+      );
+    });
+
+    it("returns false for snippet-backed code nodes", () => {
+      expect(
+        isCodeBodyNode(makeMetadata(), { codeNodeMode: "snippet" })
+      ).toBe(false);
+    });
+
+    it("returns false for nodes without a code property", () => {
+      expect(
+        isCodeBodyNode(
+          makeMetadata({ inline_fields: [], properties: [] }),
+          { codeNodeMode: undefined }
+        )
+      ).toBe(false);
     });
   });
 

--- a/web/src/components/node/codeNodeUi.ts
+++ b/web/src/components/node/codeNodeUi.ts
@@ -1,4 +1,5 @@
 import type { NodeData } from "../../stores/NodeData";
+import type { NodeMetadata } from "../../stores/ApiTypes";
 import { CODE_NODE_TYPE } from "../../constants/nodeTypes";
 
 export { CODE_NODE_TYPE };
@@ -12,6 +13,84 @@ export function isSnippetCodeNode(
   data: Pick<NodeData, "codeNodeMode">
 ): boolean {
   return isCodeNode(nodeType) && data.codeNodeMode === "snippet";
+}
+
+/**
+ * Monaco language id for a code node's `code` property, derived from its
+ * node_type. The universal Code node and ExecuteJavaScript run JS; the
+ * remaining `nodetool.code.*` executors each map to their interpreter.
+ * Falls back to plain text for unknown node types.
+ */
+export function getCodeNodeLanguage(nodeType: string): string {
+  switch (nodeType) {
+    case "nodetool.code.ExecutePython":
+      return "python";
+    case "nodetool.code.ExecuteJavaScript":
+    case CODE_NODE_TYPE:
+      return "javascript";
+    case "nodetool.code.ExecuteBash":
+      return "bash";
+    case "nodetool.code.ExecuteRuby":
+      return "ruby";
+    case "nodetool.code.ExecuteLua":
+    case "nodetool.code.EvaluateExpression":
+      return "lua";
+    default:
+      return "text";
+  }
+}
+
+/** Human label for a Monaco language id, shown in the code body toolbar. */
+export function codeLanguageLabel(language: string): string {
+  switch (language) {
+    case "python":
+      return "Python";
+    case "javascript":
+      return "JavaScript";
+    case "bash":
+      return "Bash";
+    case "ruby":
+      return "Ruby";
+    case "lua":
+      return "Lua";
+    default:
+      return "Code";
+  }
+}
+
+/**
+ * True when a node exposes an inline `code` string property — i.e. a code
+ * executor whose body should render a Monaco editor (see `CodeBody`). Matches
+ * nodes that list `"code"` in `inline_fields` and declare a matching `str`
+ * property.
+ */
+export function hasCodeProperty(metadata: NodeMetadata | undefined): boolean {
+  if (!metadata) {
+    return false;
+  }
+  if (!(metadata.inline_fields ?? []).includes("code")) {
+    return false;
+  }
+  const codeProp = (metadata.properties ?? []).find((p) => p.name === "code");
+  return !!codeProp && codeProp.type?.type === "str";
+}
+
+/**
+ * Routing predicate for the bespoke `CodeBody`. A node renders the Monaco code
+ * body when it has an inline `code` property, except snippet-backed Code nodes
+ * which intentionally hide their code and fall back to the generic body.
+ */
+export function isCodeBodyNode(
+  metadata: NodeMetadata | undefined,
+  data: Pick<NodeData, "codeNodeMode">
+): boolean {
+  if (!metadata) {
+    return false;
+  }
+  if (isSnippetCodeNode(metadata.node_type, data)) {
+    return false;
+  }
+  return hasCodeProperty(metadata);
 }
 
 export function resolveCodeNodeTitle(

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -20,6 +20,7 @@ import React, {
   useState
 } from "react";
 import { css } from "@emotion/react";
+import { shallow } from "zustand/shallow";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import type * as monaco from "monaco-editor";
@@ -45,6 +46,8 @@ import type { NodeData } from "../../stores/NodeData";
 import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
 import { useBespokePropertyWriter } from "../../hooks/nodes/useBespokePropertyWriter";
 import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
+import { useNodes } from "../../contexts/NodeContext";
+import { deriveCodeIOUpdates } from "../../utils/codeOutputInference";
 import {
   getCodeNodeLanguage,
   codeLanguageLabel
@@ -202,6 +205,19 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
 
   const { handleAddProperty } = useDynamicProperty(id, data.dynamic_properties);
 
+  const { findNode, updateNodeData } = useNodes(
+    (state) => ({
+      findNode: state.findNode,
+      updateNodeData: state.updateNodeData
+    }),
+    shallow
+  );
+
+  // The universal Code node derives its input/output handles from the code
+  // itself (referenced-but-undeclared identifiers → inputs, last `return {…}`
+  // keys → outputs). Re-derive on every edit so the handles stay in sync.
+  const inferIO = nodeType === "nodetool.code.Code";
+
   const {
     MonacoEditor,
     monacoLoadError,
@@ -210,28 +226,73 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
     monacoOnMount
   } = useMonacoEditor();
 
+  // Monaco measures its container when the editor instance is created. Inside a
+  // ReactFlow node the body starts at zero size during the first layout passes,
+  // so creating the editor immediately leaves it stuck tiny. Gate creation on
+  // the editor area actually having a measured size, and relayout on resize.
+  const editorAreaRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const [hasSize, setHasSize] = useState(false);
+
   useEffect(() => {
-    void loadMonacoIfNeeded();
-  }, [loadMonacoIfNeeded]);
+    const el = editorAreaRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      const ready = width > 0 && height > 0;
+      setHasSize(ready);
+      if (ready) {
+        editorRef.current?.layout({ width, height });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Prefetch the bundle once sized so the editor appears without a load delay.
+  useEffect(() => {
+    if (hasSize) {
+      void loadMonacoIfNeeded();
+    }
+  }, [hasSize, loadMonacoIfNeeded]);
 
   // Refs keep Monaco's mount-time listeners pointing at the latest writer so
   // they don't capture stale closures.
   const setPropertyRef = useRef(setProperty);
   const completeRef = useRef(setPropertyComplete);
+  const inferRef = useRef({ inferIO, findNode, updateNodeData });
   useEffect(() => {
     setPropertyRef.current = setProperty;
     completeRef.current = setPropertyComplete;
-  }, [setProperty, setPropertyComplete]);
+    inferRef.current = { inferIO, findNode, updateNodeData };
+  }, [setProperty, setPropertyComplete, inferIO, findNode, updateNodeData]);
 
   const handleChange = useCallback((next: string | undefined) => {
     const code = next ?? "";
     setValue(code);
     setPropertyRef.current("code", code);
-  }, []);
+
+    const { inferIO, findNode, updateNodeData } = inferRef.current;
+    if (inferIO) {
+      const node = findNode(id);
+      const existingDynProps = (node?.data?.dynamic_properties || {}) as Record<
+        string,
+        unknown
+      >;
+      updateNodeData(id, deriveCodeIOUpdates(code, existingDynProps));
+    }
+  }, [id]);
 
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {
       monacoOnMount(editor);
+      editorRef.current = editor;
+      // Lay out against the current container size immediately — the gate
+      // guarantees the area is measured by the time we mount.
+      const el = editorAreaRef.current;
+      if (el) {
+        editor.layout({ width: el.clientWidth, height: el.clientHeight });
+      }
       const focus = editor.onDidFocusEditorText(() => setIsFocused(true));
       const blur = editor.onDidBlurEditorText(() => {
         setIsFocused(false);
@@ -240,6 +301,9 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
       editor.onDidDispose(() => {
         focus.dispose();
         blur.dispose();
+        if (editorRef.current === editor) {
+          editorRef.current = null;
+        }
       });
     },
     [monacoOnMount]
@@ -260,8 +324,14 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
       setValue(next);
       setProperty("code", next);
       setPropertyComplete();
+      if (inferIO) {
+        const node = findNode(id);
+        const existingDynProps = (node?.data?.dynamic_properties ||
+          {}) as Record<string, unknown>;
+        updateNodeData(id, deriveCodeIOUpdates(next, existingDynProps));
+      }
     },
-    [setProperty, setPropertyComplete]
+    [setProperty, setPropertyComplete, inferIO, findNode, updateNodeData, id]
   );
 
   const isDynamic =
@@ -282,7 +352,7 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
           <div className="code-actions">
             <ToolbarIconButton
               tooltip="Open Editor"
-              icon={<OpenInFullIcon />}
+              icon={<OpenInFullIcon sx={{ fontSize: "0.875rem" }} />}
               onClick={toggleExpand}
               size="small"
             />
@@ -291,6 +361,7 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
         </div>
 
         <div
+          ref={editorAreaRef}
           className={cn(
             "editor-area",
             editorClassNames.nodrag,
@@ -299,7 +370,7 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
           onMouseDown={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >
-          {MonacoEditor ? (
+          {MonacoEditor && hasSize ? (
             <MonacoEditor
               value={value}
               onChange={handleChange}

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -1,0 +1,384 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * CodeBody — bespoke node body for code-executor nodes (`nodetool.code.*`).
+ *
+ * Replaces the generic property-list body with a Monaco code editor bound to
+ * the node's inline `code` property, with syntax highlighting derived from the
+ * node type (Python / JavaScript / Bash / Ruby / Lua). The rest of the generic
+ * body — input handles, dynamic inputs/outputs, exposed inputs, outputs and
+ * progress — is preserved so the node keeps its full behavior.
+ *
+ * Routed from `NodeContent` via the `isCodeBodyNode` predicate.
+ */
+
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import type * as monaco from "monaco-editor";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+
+import {
+  FlexColumn,
+  CopyButton,
+  LoadingSpinner,
+  ToolbarIconButton
+} from "../ui_primitives";
+import { editorClassNames, cn } from "../editor_ui";
+import HandleColumn from "../node/HandleColumn";
+import { NodeInputs } from "../node/NodeInputs";
+import { NodeOutputs } from "../node/NodeOutputs";
+import NodeProgress from "../node/NodeProgress";
+import NodePropertyForm from "../node/NodePropertyForm";
+import ExposedLabeledInputs from "../node/ExposedLabeledInputs";
+import TextEditorModal from "../properties/TextEditorModal";
+
+import type { NodeMetadata } from "../../stores/ApiTypes";
+import type { NodeData } from "../../stores/NodeData";
+import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import { useBespokePropertyWriter } from "../../hooks/nodes/useBespokePropertyWriter";
+import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
+import {
+  getCodeNodeLanguage,
+  codeLanguageLabel
+} from "../node/codeNodeUi";
+import { resolveExposedInputNames } from "../../utils/exposedInputs";
+
+export interface CodeBodyProps {
+  id: string;
+  nodeType: string;
+  nodeMetadata: NodeMetadata;
+  data: NodeData;
+  workflowId: string;
+  status?: string;
+  isOutputNode: boolean;
+}
+
+const EDITOR_OPTIONS: Record<string, unknown> = {
+  minimap: { enabled: false },
+  automaticLayout: true,
+  scrollBeyondLastLine: false,
+  lineNumbers: "on",
+  folding: false,
+  glyphMargin: false,
+  lineDecorationsWidth: 4,
+  lineNumbersMinChars: 2,
+  fontSize: 12,
+  wordWrap: "off",
+  renderLineHighlight: "none",
+  tabSize: 2,
+  scrollbar: {
+    verticalScrollbarSize: 8,
+    horizontalScrollbarSize: 8
+  }
+};
+
+const styles = (theme: Theme) =>
+  css({
+    "&.code-body": {
+      position: "relative",
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.5),
+      minHeight: 0
+    },
+    ".code-toolbar": {
+      flex: "0 0 auto",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing(0.5),
+      padding: `0 ${theme.spacing(0.5)}`
+    },
+    ".code-language": {
+      fontFamily: theme.fontFamily2,
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em",
+      lineHeight: 1
+    },
+    ".code-actions": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(0.5)
+    },
+    ".editor-area": {
+      flex: "1 1 auto",
+      minHeight: 180,
+      position: "relative",
+      overflow: "hidden",
+      backgroundColor: "var(--palette-grey-600)",
+      border: "1px solid var(--palette-grey-500)",
+      borderRadius: "var(--rounded-sm)"
+    },
+    ".editor-area:focus-within": {
+      borderColor: "var(--palette-grey-400)"
+    },
+    ".editor-loading, .editor-error, .editor-placeholder": {
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.text.secondary
+    },
+    ".editor-placeholder": {
+      padding: theme.spacing(0.75),
+      fontFamily: "monospace",
+      whiteSpace: "pre-wrap",
+      overflow: "hidden",
+      alignItems: "flex-start",
+      cursor: "text"
+    },
+    ".outputs-row": {
+      flex: "0 0 auto"
+    }
+  });
+
+const CodeBodyInner: React.FC<CodeBodyProps> = ({
+  id,
+  nodeType,
+  nodeMetadata,
+  data,
+  workflowId,
+  status,
+  isOutputNode
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  const language = getCodeNodeLanguage(nodeType);
+  const languageLabel = codeLanguageLabel(language);
+
+  const properties = nodeMetadata.properties ?? [];
+
+  // Exposed input-field handles (left column). Code executors usually declare
+  // no input fields, but honor any the node author or user promoted.
+  const inputProperties = useMemo(() => {
+    const inputNames = new Set(resolveExposedInputNames(nodeMetadata, data));
+    return properties.filter((p) => inputNames.has(p.name));
+  }, [nodeMetadata, data, properties]);
+
+  // Other inline properties (everything inline except `code`, which the editor
+  // renders). NodeInputs also renders the node's dynamic inputs.
+  const otherInlineProperties = useMemo(() => {
+    const inline = new Set(nodeMetadata.inline_fields ?? []);
+    return properties.filter((p) => inline.has(p.name) && p.name !== "code");
+  }, [nodeMetadata.inline_fields, properties]);
+
+  const storeCode =
+    typeof data.properties?.code === "string"
+      ? (data.properties.code as string)
+      : "";
+
+  const [value, setValue] = useState(storeCode);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Keep the editor in sync with external store changes (undo/redo, snippet
+  // load, agent edits) while the user is not actively typing.
+  useEffect(() => {
+    if (!isFocused && storeCode !== value) {
+      setValue(storeCode);
+    }
+  }, [storeCode, isFocused, value]);
+
+  const { setProperty, setPropertyComplete } = useBespokePropertyWriter({
+    nodeId: id,
+    nodeType
+  });
+
+  const { handleAddProperty } = useDynamicProperty(id, data.dynamic_properties);
+
+  const {
+    MonacoEditor,
+    monacoLoadError,
+    isMonacoLoading,
+    loadMonacoIfNeeded,
+    monacoOnMount
+  } = useMonacoEditor();
+
+  useEffect(() => {
+    void loadMonacoIfNeeded();
+  }, [loadMonacoIfNeeded]);
+
+  // Refs keep Monaco's mount-time listeners pointing at the latest writer so
+  // they don't capture stale closures.
+  const setPropertyRef = useRef(setProperty);
+  const completeRef = useRef(setPropertyComplete);
+  useEffect(() => {
+    setPropertyRef.current = setProperty;
+    completeRef.current = setPropertyComplete;
+  }, [setProperty, setPropertyComplete]);
+
+  const handleChange = useCallback((next: string | undefined) => {
+    const code = next ?? "";
+    setValue(code);
+    setPropertyRef.current("code", code);
+  }, []);
+
+  const handleEditorMount = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      monacoOnMount(editor);
+      const focus = editor.onDidFocusEditorText(() => setIsFocused(true));
+      const blur = editor.onDidBlurEditorText(() => {
+        setIsFocused(false);
+        completeRef.current();
+      });
+      editor.onDidDispose(() => {
+        focus.dispose();
+        blur.dispose();
+      });
+    },
+    [monacoOnMount]
+  );
+
+  const toggleExpand = useCallback(() => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      if (next) {
+        window.dispatchEvent(new Event("close-text-editor-modal"));
+      }
+      return next;
+    });
+  }, []);
+
+  const handleModalChange = useCallback(
+    (next: string) => {
+      setValue(next);
+      setProperty("code", next);
+      setPropertyComplete();
+    },
+    [setProperty, setPropertyComplete]
+  );
+
+  const isDynamic =
+    nodeMetadata.supports_dynamic_inputs ||
+    nodeMetadata.supports_dynamic_outputs;
+
+  return (
+    <FlexColumn
+      fullWidth
+      fullHeight
+      sx={{ position: "relative", minHeight: 0 }}
+    >
+      <div css={cssStyles} className="code-body" data-bespoke-body="Code">
+        <HandleColumn id={id} properties={inputProperties} />
+
+        <div className="code-toolbar">
+          <span className="code-language">{languageLabel}</span>
+          <div className="code-actions">
+            <ToolbarIconButton
+              tooltip="Open Editor"
+              icon={<OpenInFullIcon />}
+              onClick={toggleExpand}
+              size="small"
+            />
+            <CopyButton value={value} buttonSize="small" />
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            "editor-area",
+            editorClassNames.nodrag,
+            isFocused && editorClassNames.nowheel
+          )}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {MonacoEditor ? (
+            <MonacoEditor
+              value={value}
+              onChange={handleChange}
+              language={language === "text" ? "plaintext" : language}
+              theme="vs-dark"
+              width="100%"
+              height="100%"
+              onMount={handleEditorMount}
+              options={EDITOR_OPTIONS}
+            />
+          ) : monacoLoadError ? (
+            <div className="editor-error">{monacoLoadError}</div>
+          ) : isMonacoLoading ? (
+            <div className="editor-loading">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <div className="editor-placeholder">{value}</div>
+          )}
+        </div>
+
+        {otherInlineProperties.length > 0 || isDynamic ? (
+          <NodeInputs
+            id={id}
+            nodeMetadata={nodeMetadata}
+            layout={nodeMetadata.layout}
+            properties={otherInlineProperties}
+            nodeType={nodeType}
+            data={data}
+          />
+        ) : null}
+
+        <ExposedLabeledInputs
+          id={id}
+          nodeMetadata={nodeMetadata}
+          nodeType={nodeType}
+          data={data}
+          properties={properties}
+        />
+
+        {isDynamic && (
+          <NodePropertyForm
+            id={id}
+            isDynamic={nodeMetadata.supports_dynamic_inputs}
+            supportsDynamicOutputs={nodeMetadata.supports_dynamic_outputs}
+            dynamicOutputs={data.dynamic_outputs || {}}
+            onAddProperty={handleAddProperty}
+            nodeType={nodeType}
+          />
+        )}
+
+        {!isOutputNode && (
+          <div className="outputs-row">
+            <NodeOutputs id={id} outputs={nodeMetadata.outputs} />
+          </div>
+        )}
+
+        {status === "running" && (
+          <NodeProgress id={id} workflowId={workflowId} />
+        )}
+      </div>
+
+      {isExpanded && (
+        <TextEditorModal
+          value={value}
+          language={language}
+          nodeType={nodeType}
+          propertyType="str"
+          onChange={handleModalChange}
+          onClose={toggleExpand}
+          propertyName="code"
+          propertyDescription=""
+        />
+      )}
+    </FlexColumn>
+  );
+};
+
+export const CodeBody = memo(CodeBodyInner);
+CodeBody.displayName = "CodeBody";
+
+export default CodeBody;

--- a/web/src/components/node_types/__tests__/CodeBody.test.tsx
+++ b/web/src/components/node_types/__tests__/CodeBody.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import CodeBody from "../CodeBody";
+import mockTheme from "../../../__mocks__/themeMock";
+import "@testing-library/jest-dom";
+
+const mockSetProperty = jest.fn();
+const mockSetPropertyComplete = jest.fn();
+
+jest.mock("../../../hooks/nodes/useBespokePropertyWriter", () => ({
+  useBespokePropertyWriter: jest.fn(() => ({
+    setProperty: mockSetProperty,
+    setProperties: jest.fn(),
+    setPropertyComplete: mockSetPropertyComplete
+  }))
+}));
+
+jest.mock("../../../hooks/nodes/useDynamicProperty", () => ({
+  useDynamicProperty: () => ({
+    handleAddProperty: jest.fn(),
+    handleDeleteProperty: jest.fn(),
+    handleUpdatePropertyName: jest.fn()
+  })
+}));
+
+// Stub Monaco with a textarea so we can drive onChange without the real editor.
+jest.mock("../../../hooks/editor/useMonacoEditor", () => ({
+  useMonacoEditor: () => ({
+    MonacoEditor: ({
+      value,
+      onChange,
+      language
+    }: {
+      value: string;
+      onChange?: (val?: string) => void;
+      language?: string;
+    }) => (
+      <textarea
+        data-testid="monaco"
+        data-language={language}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+    ),
+    monacoLoadError: null,
+    isMonacoLoading: false,
+    loadMonacoIfNeeded: jest.fn().mockResolvedValue(undefined),
+    monacoRef: { current: null },
+    monacoOnMount: jest.fn(),
+    handleMonacoFind: jest.fn(),
+    handleMonacoFormat: jest.fn()
+  })
+}));
+
+jest.mock("../../node/HandleColumn", () => ({
+  __esModule: true,
+  default: () => <div data-testid="handle-column" />
+}));
+
+jest.mock("../../node/NodeInputs", () => ({
+  __esModule: true,
+  NodeInputs: () => <div data-testid="node-inputs" />,
+  default: () => <div data-testid="node-inputs" />
+}));
+
+jest.mock("../../node/NodeOutputs", () => ({
+  __esModule: true,
+  NodeOutputs: () => <div data-testid="node-outputs" />
+}));
+
+jest.mock("../../node/NodeProgress", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-progress" />
+}));
+
+jest.mock("../../node/NodePropertyForm", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-property-form" />
+}));
+
+jest.mock("../../node/ExposedLabeledInputs", () => ({
+  __esModule: true,
+  default: () => <div data-testid="exposed-labeled-inputs" />
+}));
+
+jest.mock("../../properties/TextEditorModal", () => ({
+  __esModule: true,
+  default: ({ language }: { language?: string }) => (
+    <div data-testid="text-editor-modal" data-language={language} />
+  )
+}));
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+const makeProps = (overrides: Record<string, unknown> = {}) => ({
+  id: "node-1",
+  nodeType: "nodetool.code.ExecutePython",
+  nodeMetadata: {
+    node_type: "nodetool.code.ExecutePython",
+    inline_fields: ["code"],
+    properties: [
+      { name: "code", type: { type: "str", type_args: [], optional: false } }
+    ],
+    outputs: [],
+    supports_dynamic_inputs: true,
+    supports_dynamic_outputs: true,
+    is_streaming_output: false,
+    layout: "default"
+  } as unknown as Parameters<typeof CodeBody>[0]["nodeMetadata"],
+  data: {
+    properties: { code: "print('hello')" }
+  } as unknown as Parameters<typeof CodeBody>[0]["data"],
+  workflowId: "wf-1",
+  isOutputNode: false,
+  ...overrides
+});
+
+describe("CodeBody", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the language label and seeds the editor from the code property", () => {
+    renderWithTheme(<CodeBody {...makeProps()} />);
+    expect(screen.getByText("Python")).toBeInTheDocument();
+    const editor = screen.getByTestId("monaco") as HTMLTextAreaElement;
+    expect(editor.value).toBe("print('hello')");
+    expect(editor).toHaveAttribute("data-language", "python");
+  });
+
+  it("writes the code property on change", () => {
+    renderWithTheme(<CodeBody {...makeProps()} />);
+    const editor = screen.getByTestId("monaco");
+    fireEvent.change(editor, { target: { value: "print('bye')" } });
+    expect(mockSetProperty).toHaveBeenCalledWith("code", "print('bye')");
+  });
+
+  it("uses plaintext for unknown code node types", () => {
+    renderWithTheme(
+      <CodeBody
+        {...makeProps({
+          nodeType: "nodetool.code.Unknown",
+          nodeMetadata: {
+            node_type: "nodetool.code.Unknown",
+            inline_fields: ["code"],
+            properties: [
+              {
+                name: "code",
+                type: { type: "str", type_args: [], optional: false }
+              }
+            ],
+            outputs: [],
+            supports_dynamic_inputs: false,
+            supports_dynamic_outputs: false,
+            is_streaming_output: false,
+            layout: "default"
+          }
+        })}
+      />
+    );
+    expect(screen.getByTestId("monaco")).toHaveAttribute(
+      "data-language",
+      "plaintext"
+    );
+  });
+
+  it("toggles the full editor modal", () => {
+    renderWithTheme(<CodeBody {...makeProps()} />);
+    expect(screen.queryByTestId("text-editor-modal")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /open editor/i }));
+    expect(screen.getByTestId("text-editor-modal")).toHaveAttribute(
+      "data-language",
+      "python"
+    );
+  });
+
+  it("renders the dynamic property form for dynamic code nodes", () => {
+    renderWithTheme(<CodeBody {...makeProps()} />);
+    expect(screen.getByTestId("node-property-form")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/node_types/__tests__/CodeBody.test.tsx
+++ b/web/src/components/node_types/__tests__/CodeBody.test.tsx
@@ -5,6 +5,26 @@ import CodeBody from "../CodeBody";
 import mockTheme from "../../../__mocks__/themeMock";
 import "@testing-library/jest-dom";
 
+// jsdom has no layout; report a real size so CodeBody's size-gate mounts Monaco.
+class SizedResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {}
+  observe(el: Element) {
+    this.cb(
+      [
+        {
+          target: el,
+          contentRect: { width: 320, height: 200 } as DOMRectReadOnly
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+  SizedResizeObserver as unknown as typeof ResizeObserver;
+
 const mockSetProperty = jest.fn();
 const mockSetPropertyComplete = jest.fn();
 
@@ -14,6 +34,17 @@ jest.mock("../../../hooks/nodes/useBespokePropertyWriter", () => ({
     setProperties: jest.fn(),
     setPropertyComplete: mockSetPropertyComplete
   }))
+}));
+
+const mockFindNode = jest.fn(() => ({ data: { dynamic_properties: {} } }));
+const mockUpdateNodeData = jest.fn();
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: (selector: (state: unknown) => unknown) =>
+    selector({
+      findNode: mockFindNode,
+      updateNodeData: mockUpdateNodeData
+    })
 }));
 
 jest.mock("../../../hooks/nodes/useDynamicProperty", () => ({
@@ -179,5 +210,35 @@ describe("CodeBody", () => {
   it("renders the dynamic property form for dynamic code nodes", () => {
     renderWithTheme(<CodeBody {...makeProps()} />);
     expect(screen.getByTestId("node-property-form")).toBeInTheDocument();
+  });
+
+  it("derives dynamic inputs/outputs from code for the universal Code node", () => {
+    renderWithTheme(
+      <CodeBody
+        {...makeProps({
+          nodeType: "nodetool.code.Code",
+          data: { properties: { code: "" } }
+        })}
+      />
+    );
+    const editor = screen.getByTestId("monaco");
+    fireEvent.change(editor, {
+      target: { value: "return { sum: a + b };" }
+    });
+
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+      dynamic_outputs: {
+        sum: { type: "any", type_args: [], optional: false }
+      },
+      dynamic_properties: { a: "", b: "" }
+    });
+  });
+
+  it("does not derive IO for non-universal code executors", () => {
+    renderWithTheme(<CodeBody {...makeProps()} />);
+    fireEvent.change(screen.getByTestId("monaco"), {
+      target: { value: "return { x: y };" }
+    });
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -14,31 +14,7 @@ import { NodeTextField, editorClassNames, cn } from "../editor_ui";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import ConnectedBadge from "./ConnectedBadge";
 import { useInspectorHeaderSupplementalRegistration } from "../../hooks/useInspectorHeaderSupplemental";
-
-const determineCodeLanguage = (nodeType: string) => {
-  if (nodeType === "nodetool.code.ExecutePython") {
-    return "python";
-  }
-  if (
-    nodeType === "nodetool.code.ExecuteJavaScript" ||
-    nodeType === "nodetool.code.Code"
-  ) {
-    return "javascript";
-  }
-  if (nodeType === "nodetool.code.ExecuteBash") {
-    return "bash";
-  }
-  if (nodeType === "nodetool.code.ExecuteRuby") {
-    return "ruby";
-  }
-  if (
-    nodeType === "nodetool.code.ExecuteLua" ||
-    nodeType === "nodetool.code.EvaluateExpression"
-  ) {
-    return "lua";
-  }
-  return "text";
-};
+import { getCodeNodeLanguage } from "../node/codeNodeUi";
 
 const propertyStyles = (theme: Theme) =>
   css({
@@ -98,7 +74,7 @@ const StringProperty = ({
     [theme]
   );
 
-  const codeLanguage = determineCodeLanguage(nodeType);
+  const codeLanguage = getCodeNodeLanguage(nodeType);
   const stringValue = typeof value === "string" ? value : "";
 
   const toggleExpand = useCallback(() => {

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -171,6 +171,51 @@ export function inferInputKeysFromCode(code: string): string[] | null {
   return inputs.length > 0 ? inputs : null;
 }
 
+// ---------------------------------------------------------------------------
+// Node-data derivation
+// ---------------------------------------------------------------------------
+
+interface CodeIOUpdates {
+  dynamic_outputs: Record<
+    string,
+    { type: string; type_args: never[]; optional: boolean }
+  >;
+  dynamic_properties: Record<string, unknown>;
+}
+
+/**
+ * Derive the `dynamic_outputs` / `dynamic_properties` node-data updates from the
+ * `code` property of a Code node. Inferred inputs preserve any existing value;
+ * inputs/outputs no longer referenced by the code are dropped.
+ *
+ * Shared by the inline property editor and the Monaco-based CodeBody so both
+ * keep the node's handles in sync with the code.
+ */
+export function deriveCodeIOUpdates(
+  code: string,
+  existingDynProps: Record<string, unknown> = {}
+): CodeIOUpdates {
+  const outputKeys = inferOutputKeysFromCode(code);
+  const inputKeys = inferInputKeysFromCode(code);
+
+  const dynamic_outputs: CodeIOUpdates["dynamic_outputs"] = {};
+  if (outputKeys) {
+    for (const key of outputKeys) {
+      dynamic_outputs[key] = { type: "any", type_args: [], optional: false };
+    }
+  }
+
+  const dynamic_properties: Record<string, unknown> = {};
+  if (inputKeys) {
+    for (const key of inputKeys) {
+      dynamic_properties[key] =
+        key in existingDynProps ? existingDynProps[key] : "";
+    }
+  }
+
+  return { dynamic_outputs, dynamic_properties };
+}
+
 /**
  * Collect binding names from a pattern node (handles destructuring).
  */


### PR DESCRIPTION
## Summary

Introduces a bespoke `CodeBody` component that replaces the generic property-list body for code executor nodes (`nodetool.code.*`). The component renders a Monaco code editor bound to the node's inline `code` property, with syntax highlighting derived from the node type (Python, JavaScript, Bash, Ruby, Lua), while preserving all other node functionality (input/output handles, dynamic properties, exposed inputs, progress tracking).

## Key Changes

- **New `CodeBody` component** (`web/src/components/node_types/CodeBody.tsx`):
  - Monaco editor with language-specific syntax highlighting
  - Toolbar with language label, copy button, and fullscreen editor toggle
  - Syncs editor state with external store changes (undo/redo, snippet load, agent edits) while preserving user focus
  - Preserves all generic node body features: input handles, dynamic inputs/outputs, exposed inputs, outputs, and progress
  - Fullscreen editing via `TextEditorModal` when expanded

- **New routing predicates in `codeNodeUi.ts`**:
  - `getCodeNodeLanguage(nodeType)`: Maps code executor types to Monaco language IDs
  - `codeLanguageLabel(language)`: Human-readable labels for the toolbar
  - `hasCodeProperty(metadata)`: Checks if a node has an inline `code` string property
  - `isCodeBodyNode(metadata, data)`: Routing predicate that returns true for non-snippet code nodes with a code property

- **Updated `NodeContent.tsx`**:
  - Routes code nodes to `CodeBody` when `isCodeBodyNode()` returns true
  - Falls back to generic body for snippet-backed code nodes

- **Refactored `StringProperty.tsx`**:
  - Extracted `determineCodeLanguage` logic to `getCodeNodeLanguage()` in `codeNodeUi.ts` to avoid duplication

- **Comprehensive test coverage** (`CodeBody.test.tsx`):
  - Verifies language detection and editor seeding
  - Tests code property writes on change
  - Validates plaintext fallback for unknown node types
  - Confirms fullscreen modal toggle and dynamic property form rendering

## Implementation Details

- Uses `useMonacoEditor` hook for lazy-loading Monaco with error handling
- Refs maintain closure stability for Monaco mount-time listeners
- Focus/blur tracking prevents external updates from overwriting active edits
- Event propagation stopped on editor container to prevent node dragging during editing
- Memoized to prevent unnecessary re-renders

https://claude.ai/code/session_01Ba4LFYEBcDyeQ5cr3oRv8i