### PR TITLE
Add audio effect module configs for Eurorack-style UI

### DIFF
--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -65,6 +65,10 @@ import {
   SYNTH_MODULE_CONFIGS,
   SYNTH_NODE_TYPES
 } from "../synth/synthModules";
+import {
+  AUDIO_EFFECT_CONFIGS,
+  AUDIO_EFFECT_NODE_TYPES
+} from "../synth/audioEffectModules";
 
 export interface BespokeBodyProps {
   id: string;
@@ -122,6 +126,9 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
   ...Object.fromEntries(
     SYNTH_NODE_TYPES.map((t) => [t, SynthModuleBody] as const)
   ),
+  ...Object.fromEntries(
+    AUDIO_EFFECT_NODE_TYPES.map((t) => [t, SynthModuleBody] as const)
+  ),
   [AUDIO_OUT_NODE_TYPE]: AudioOutBody
 };
 
@@ -152,6 +159,14 @@ export const BESPOKE_DEFAULT_HEIGHTS: Readonly<Record<string, number>> = {
       const extras =
         (c.waveform ? 26 : 0) + (c.modeToggle ? 28 : 0) + (c.adsrPreview ? 42 : 0);
       return [t, 96 + extras + knobRows * 84] as const;
+    })
+  ),
+  // Audio effects: same knob faceplate as synth modules (single audio jack).
+  ...Object.fromEntries(
+    AUDIO_EFFECT_NODE_TYPES.map((t) => {
+      const c = AUDIO_EFFECT_CONFIGS[t];
+      const knobRows = Math.ceil(c.knobs.length / 3);
+      return [t, 96 + knobRows * 84] as const;
     })
   ),
   // Audio Out: label strip + transport buttons + visualizer.

--- a/web/src/components/node_types/synth/SynthKnob.tsx
+++ b/web/src/components/node_types/synth/SynthKnob.tsx
@@ -96,6 +96,10 @@ export interface SynthKnobProps {
 }
 
 const roundForSpec = (spec: KnobSpec, v: number): number => {
+  // Integer-typed properties (bit depth, sample-rate reduction) must stay whole.
+  if (spec.integer) {
+    return Math.round(v);
+  }
   // Log specs span decades — keep 4 significant digits; linear specs keep
   // two decimals (enough for every current 0–10-ish range).
   if (spec.scale === "log") {

--- a/web/src/components/node_types/synth/SynthModuleBody.tsx
+++ b/web/src/components/node_types/synth/SynthModuleBody.tsx
@@ -27,6 +27,7 @@ import {
   SYNTH_MODULE_CONFIGS,
   type SynthAccent
 } from "./synthModules";
+import { AUDIO_EFFECT_CONFIGS } from "./audioEffectModules";
 import WaveformSelector, {
   waveformSelectorStyles
 } from "./WaveformSelector";
@@ -155,7 +156,7 @@ const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
     [theme]
   );
 
-  const config = SYNTH_MODULE_CONFIGS[nodeType];
+  const config = SYNTH_MODULE_CONFIGS[nodeType] ?? AUDIO_EFFECT_CONFIGS[nodeType];
   const accentColor =
     theme.vars.palette[config?.accent ?? ACCENT_FALLBACK].main;
 

--- a/web/src/components/node_types/synth/__tests__/audioEffectModules.test.ts
+++ b/web/src/components/node_types/synth/__tests__/audioEffectModules.test.ts
@@ -1,0 +1,67 @@
+import {
+  AUDIO_EFFECT_CONFIGS,
+  AUDIO_EFFECT_NODE_TYPES
+} from "../audioEffectModules";
+import { formatKnobValue, type KnobSpec } from "../synthModules";
+import {
+  BESPOKE_BODY_REGISTRY,
+  BESPOKE_DEFAULT_HEIGHTS,
+  isBespokeNode
+} from "../../editing/bespokeRegistry";
+import SynthModuleBody from "../SynthModuleBody";
+import type { NodeMetadata } from "../../../../stores/ApiTypes";
+
+const linear: KnobSpec = { name: "x", label: "X", min: 0, max: 10, default: 1 };
+
+describe("audio effect configs", () => {
+  it("registers every effect with a single audio input jack", () => {
+    for (const t of AUDIO_EFFECT_NODE_TYPES) {
+      expect(AUDIO_EFFECT_CONFIGS[t].inputs).toEqual(["audio"]);
+    }
+  });
+
+  it("log-scaled knobs have a strictly positive minimum", () => {
+    for (const t of AUDIO_EFFECT_NODE_TYPES) {
+      for (const k of AUDIO_EFFECT_CONFIGS[t].knobs) {
+        if (k.scale === "log") {
+          expect(k.min).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("every knob default lies within its range", () => {
+    for (const t of AUDIO_EFFECT_NODE_TYPES) {
+      for (const k of AUDIO_EFFECT_CONFIGS[t].knobs) {
+        expect(k.default).toBeGreaterThanOrEqual(k.min);
+        expect(k.default).toBeLessThanOrEqual(k.max);
+      }
+    }
+  });
+
+  it("routes every effect node type to the synth module body", () => {
+    for (const t of AUDIO_EFFECT_NODE_TYPES) {
+      expect(BESPOKE_BODY_REGISTRY[t]).toBe(SynthModuleBody);
+      expect(isBespokeNode({ node_type: t } as NodeMetadata)).toBe(true);
+      expect(BESPOKE_DEFAULT_HEIGHTS[t]).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("knob value formatting", () => {
+  it("formats milliseconds, rolling over to seconds", () => {
+    expect(formatKnobValue({ ...linear, unit: "ms" }, 50)).toBe("50 ms");
+    expect(formatKnobValue({ ...linear, unit: "ms" }, 5)).toBe("5.0 ms");
+    expect(formatKnobValue({ ...linear, unit: "ms" }, 1500)).toBe("1.50 s");
+  });
+
+  it("formats multipliers with a times sign", () => {
+    expect(formatKnobValue({ ...linear, unit: "x" }, 4)).toBe("4×");
+    expect(formatKnobValue({ ...linear, unit: "x" }, 1.5)).toBe("1.5×");
+  });
+
+  it("formats integer knobs without decimals", () => {
+    expect(formatKnobValue({ ...linear, integer: true }, 8)).toBe("8");
+    expect(formatKnobValue({ ...linear, integer: true }, 8.4)).toBe("8");
+  });
+});

--- a/web/src/components/node_types/synth/audioEffectModules.ts
+++ b/web/src/components/node_types/synth/audioEffectModules.ts
@@ -1,0 +1,362 @@
+/**
+ * Audio effect / DSP module configs — drives the shared `SynthModuleBody`
+ * (the Eurorack-style knob faceplate) for the offline audio effect nodes in
+ * `lib.audio.*`: gain, delay, EQ filters, compressor, distortion, limiter,
+ * reverb, pitch/time, noise gate and phaser. Same config shape as the synth
+ * modules; each effect has a single `audio` input jack and an `output` handle.
+ *
+ * Ranges/defaults/property names mirror the backend node definitions in
+ * `packages/audio-nodes/src/nodes/lib-audio-dsp.ts` and `lib-audio-effects.ts`.
+ * Log scaling is reserved for strictly-positive ranges (frequencies, times);
+ * dB ranges that include 0 or go negative stay linear.
+ */
+
+import type { SynthModuleConfig } from "./synthModules";
+
+export const AUDIO_EFFECT_CONFIGS: Readonly<Record<string, SynthModuleConfig>> =
+  {
+    "lib.audio.Gain": {
+      label: "GAIN",
+      accent: "primary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "gain_db",
+          label: "Gain",
+          min: -60,
+          max: 24,
+          default: 0,
+          bipolar: true,
+          unit: "db"
+        }
+      ]
+    },
+    "lib.audio.Delay": {
+      label: "DELAY",
+      accent: "info",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "delay_seconds",
+          label: "Time",
+          min: 0.01,
+          max: 5,
+          default: 0.5,
+          scale: "log",
+          unit: "s"
+        },
+        { name: "feedback", label: "Fdbk", min: 0, max: 0.99, default: 0.3 },
+        { name: "mix", label: "Mix", min: 0, max: 1, default: 0.5 }
+      ]
+    },
+    "lib.audio.HighPassFilter": {
+      label: "HPF",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Cutoff",
+          min: 20,
+          max: 5000,
+          default: 80,
+          scale: "log",
+          unit: "hz"
+        }
+      ]
+    },
+    "lib.audio.LowPassFilter": {
+      label: "LPF",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Cutoff",
+          min: 500,
+          max: 20000,
+          default: 5000,
+          scale: "log",
+          unit: "hz"
+        }
+      ]
+    },
+    "lib.audio.HighShelfFilter": {
+      label: "HI SHLF",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Freq",
+          min: 1000,
+          max: 20000,
+          default: 5000,
+          scale: "log",
+          unit: "hz"
+        },
+        {
+          name: "gain_db",
+          label: "Gain",
+          min: -24,
+          max: 24,
+          default: 0,
+          bipolar: true,
+          unit: "db"
+        }
+      ]
+    },
+    "lib.audio.LowShelfFilter": {
+      label: "LO SHLF",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Freq",
+          min: 20,
+          max: 1000,
+          default: 200,
+          scale: "log",
+          unit: "hz"
+        },
+        {
+          name: "gain_db",
+          label: "Gain",
+          min: -24,
+          max: 24,
+          default: 0,
+          bipolar: true,
+          unit: "db"
+        }
+      ]
+    },
+    "lib.audio.PeakFilter": {
+      label: "PEAK",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "cutoff_frequency_hz",
+          label: "Freq",
+          min: 20,
+          max: 20000,
+          default: 1000,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "q_factor", label: "Q", min: 0.1, max: 10, default: 1 },
+        {
+          name: "gain_db",
+          label: "Gain",
+          min: -24,
+          max: 24,
+          default: 0,
+          bipolar: true,
+          unit: "db"
+        }
+      ]
+    },
+    "lib.audio.Bitcrush": {
+      label: "CRUSH",
+      accent: "error",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "bit_depth",
+          label: "Bits",
+          min: 1,
+          max: 16,
+          default: 8,
+          integer: true
+        },
+        {
+          name: "sample_rate_reduction",
+          label: "Rate",
+          min: 1,
+          max: 100,
+          default: 1,
+          integer: true
+        }
+      ]
+    },
+    "lib.audio.Compress": {
+      label: "COMP",
+      accent: "warning",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "threshold",
+          label: "Thresh",
+          min: -60,
+          max: 0,
+          default: -20,
+          unit: "db"
+        },
+        { name: "ratio", label: "Ratio", min: 1, max: 20, default: 4, unit: "x" },
+        {
+          name: "attack",
+          label: "Attack",
+          min: 0.1,
+          max: 100,
+          default: 5,
+          scale: "log",
+          unit: "ms"
+        },
+        {
+          name: "release",
+          label: "Release",
+          min: 5,
+          max: 1000,
+          default: 50,
+          scale: "log",
+          unit: "ms"
+        }
+      ]
+    },
+    "lib.audio.Distortion": {
+      label: "DRIVE",
+      accent: "error",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "drive_db",
+          label: "Drive",
+          min: 0,
+          max: 100,
+          default: 25,
+          unit: "db"
+        }
+      ]
+    },
+    "lib.audio.Limiter": {
+      label: "LIMIT",
+      accent: "warning",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "threshold_db",
+          label: "Ceil",
+          min: -60,
+          max: 0,
+          default: -2,
+          unit: "db"
+        },
+        {
+          name: "release_ms",
+          label: "Release",
+          min: 1,
+          max: 1000,
+          default: 250,
+          scale: "log",
+          unit: "ms"
+        }
+      ]
+    },
+    "lib.audio.Reverb": {
+      label: "VERB",
+      accent: "info",
+      inputs: ["audio"],
+      knobs: [
+        { name: "room_scale", label: "Room", min: 0, max: 1, default: 0.5 },
+        { name: "damping", label: "Damp", min: 0, max: 1, default: 0.5 },
+        { name: "wet_level", label: "Wet", min: 0, max: 1, default: 0.15 },
+        { name: "dry_level", label: "Dry", min: 0, max: 1, default: 0.5 }
+      ]
+    },
+    "lib.audio.PitchShift": {
+      label: "PITCH",
+      accent: "success",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "semitones",
+          label: "Semis",
+          min: -12,
+          max: 12,
+          default: 0,
+          bipolar: true
+        }
+      ]
+    },
+    "lib.audio.TimeStretch": {
+      label: "STRETCH",
+      accent: "success",
+      inputs: ["audio"],
+      knobs: [
+        { name: "rate", label: "Rate", min: 0.5, max: 2, default: 1, unit: "x" }
+      ]
+    },
+    "lib.audio.NoiseGate": {
+      label: "GATE",
+      accent: "warning",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "threshold_db",
+          label: "Thresh",
+          min: -90,
+          max: 0,
+          default: -50,
+          unit: "db"
+        },
+        {
+          name: "attack_ms",
+          label: "Attack",
+          min: 0.1,
+          max: 100,
+          default: 1,
+          scale: "log",
+          unit: "ms"
+        },
+        {
+          name: "release_ms",
+          label: "Release",
+          min: 5,
+          max: 1000,
+          default: 100,
+          scale: "log",
+          unit: "ms"
+        }
+      ]
+    },
+    "lib.audio.Phaser": {
+      label: "PHASER",
+      accent: "secondary",
+      inputs: ["audio"],
+      knobs: [
+        {
+          name: "rate_hz",
+          label: "Rate",
+          min: 0.1,
+          max: 10,
+          default: 1,
+          scale: "log",
+          unit: "hz"
+        },
+        { name: "depth", label: "Depth", min: 0, max: 1, default: 0.5 },
+        {
+          name: "centre_frequency_hz",
+          label: "Freq",
+          min: 100,
+          max: 5000,
+          default: 1300,
+          scale: "log",
+          unit: "hz"
+        },
+        {
+          name: "feedback",
+          label: "Fdbk",
+          min: -1,
+          max: 1,
+          default: 0,
+          bipolar: true
+        },
+        { name: "mix", label: "Mix", min: 0, max: 1, default: 0.5 }
+      ]
+    }
+  };
+
+export const AUDIO_EFFECT_NODE_TYPES: readonly string[] = Object.keys(
+  AUDIO_EFFECT_CONFIGS
+);

--- a/web/src/components/node_types/synth/synthModules.ts
+++ b/web/src/components/node_types/synth/synthModules.ts
@@ -6,7 +6,7 @@
  * accent color and extras (waveform selector, mode toggle, ADSR preview).
  */
 
-export type KnobUnit = "hz" | "s" | "db" | "x" | "";
+export type KnobUnit = "hz" | "s" | "ms" | "db" | "x" | "";
 
 export interface KnobSpec {
   name: string;
@@ -18,6 +18,8 @@ export interface KnobSpec {
   scale?: "linear" | "log";
   /** Range straddles 0 with a neutral midpoint — arc fills outward from it. */
   bipolar?: boolean;
+  /** Snap to whole numbers — for integer-typed properties (e.g. bit depth). */
+  integer?: boolean;
   unit?: KnobUnit;
 }
 
@@ -315,11 +317,20 @@ export const formatKnobValue = (spec: KnobSpec, value: number): string => {
       return value < 1
         ? `${Math.round(value * 1000)} ms`
         : `${value.toFixed(value < 10 ? 2 : 1)} s`;
+    case "ms":
+      return value >= 1000
+        ? `${(value / 1000).toFixed(2)} s`
+        : `${value < 10 ? value.toFixed(1) : Math.round(value)} ms`;
     case "db": {
       const sign = value > 0 ? "+" : "";
       return `${sign}${value.toFixed(1)} dB`;
     }
+    case "x":
+      return `${Math.round(value * 100) / 100}×`;
     default: {
+      if (spec.integer) {
+        return `${Math.round(value)}`;
+      }
       const rounded = Math.round(value * 100) / 100;
       const sign = spec.bipolar && rounded > 0 ? "+" : "";
       return `${sign}${rounded}`;


### PR DESCRIPTION
## Summary

Adds configuration definitions for 14 offline audio effect nodes (gain, delay, filters, compressor, distortion, limiter, reverb, pitch/time shift, noise gate, phaser) to render as Eurorack-style knob faceplates in the node graph UI. These effects mirror the existing synth module system, reusing the `SynthModuleBody` component and knob infrastructure.

## Key Changes

- **New file: `audioEffectModules.ts`** — Defines `AUDIO_EFFECT_CONFIGS` with knob specs for all 14 effect types:
  - Filter nodes (HPF, LPF, shelf, peak) with log-scaled frequency ranges
  - Time-domain effects (delay, reverb, pitch shift, time stretch) with appropriate time/frequency units
  - Dynamic processors (compressor, limiter, noise gate) with dB thresholds and attack/release times
  - Distortion (bitcrush, drive) with integer bit-depth and sample-rate reduction
  - Phaser with modulation controls
  - Each effect has a single `audio` input jack and output handle

- **Enhanced `synthModules.ts`**:
  - Added `"ms"` (milliseconds) to `KnobUnit` type
  - Added `integer?: boolean` flag to `KnobSpec` for whole-number properties (bit depth, sample-rate reduction)
  - Extended `formatKnobValue()` to handle milliseconds (auto-converts to seconds ≥1000ms) and multiplier units (`×`)
  - Added integer formatting (no decimals when `integer: true`)

- **Updated `SynthKnob.tsx`**:
  - Added rounding logic for integer-typed knobs in `roundForSpec()`

- **Updated `SynthModuleBody.tsx`**:
  - Imported `AUDIO_EFFECT_CONFIGS` to support rendering audio effect modules alongside synth modules

- **Updated `bespokeRegistry.ts`**:
  - Registered all audio effect node types to use `SynthModuleBody` component
  - Added height calculations for audio effect nodes (96px base + 84px per knob row, matching synth module layout)

- **New test file: `audioEffectModules.test.ts`**:
  - Validates all effects have single `audio` input
  - Ensures log-scaled knobs have strictly positive minimums
  - Verifies all knob defaults fall within their ranges
  - Confirms all effect types route to `SynthModuleBody` and have valid heights
  - Tests knob value formatting (milliseconds, multipliers, integers)

## Implementation Details

- **Scaling strategy**: Log scaling reserved for strictly-positive ranges (frequencies, times); dB ranges that include 0 or go negative use linear scaling
- **Unit conventions**: Frequencies in Hz, times in seconds (s) or milliseconds (ms), dB for gain/threshold, × for multipliers
- **Accent colors**: Effects grouped by category (info for time effects, secondary for filters, warning for dynamics, error for distortion, success for pitch/time)
- **Knob layout**: Automatically calculates module height based on knob count (3 knobs per row)
- **Defaults and ranges**: Mirror backend node definitions in `packages/audio-nodes/src/nodes/lib-audio-dsp.ts` and `lib-audio-effects.ts`

https://claude.ai/code/session_01SJKQjnUp94dWnfwsrwRvRs