### PR TITLE
fix(web): let native video controls receive mouse events in nodes

### DIFF
--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -731,6 +731,9 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           <video
             ref={videoRef}
             controls
+            // nodrag/nopan stop ReactFlow's drag from capturing the pointer so
+            // the native controls (scrub, volume) get the mouse events.
+            className="nodrag nopan"
             aria-label="Video output"
             style={{ width: "100%", height: "100%" }}
           />

--- a/web/src/components/node/output/ChunkRenderer.tsx
+++ b/web/src/components/node/output/ChunkRenderer.tsx
@@ -56,6 +56,9 @@ export const ChunkRenderer: React.FC<Props> = memo(({ chunk }) => {
         <video
           src={chunk.content as string}
           controls
+          // nodrag/nopan stop ReactFlow's drag from capturing the pointer so
+          // the native controls (scrub, volume) get the mouse events.
+          className="nodrag nopan"
           aria-label="Video output"
           style={{ width: "100%" }}
         />


### PR DESCRIPTION
## Problem

The video player in node content didn't allow scrubbing or most mouse interactions — the node selection/drag handler got the mouse events instead.

## Root cause

Native `<video controls>` rendered in node output (`OutputRenderer`, streaming `ChunkRenderer`) had no `nodrag` class and no `nodrag` ancestor. ReactFlow's d3-drag filter only skips dragging when the event target (or an ancestor up to the node) carries `.nodrag`:

```js
isDraggable = !event.button &&
  (!noDragClassName || !hasSelector(target, '.nodrag', domNode)) &&
  (!handleSelector || hasSelector(target, handleSelector, domNode));
```

With no `nodrag`, the filter passed → d3-drag captured the pointer on pointerdown → node selection/drag preempted the native scrubber and volume controls. Because d3-drag's listener is native and sits on an ancestor of the content div, the content div's React `onPointerDown`→`stopPropagation()` runs too late — only `nodrag` stops it.

The `ContentCardBody`→`VideoPlayer` path already had `nodrag nopan`, which is why that path worked.

## Fix

Add `nodrag nopan` to the two interactive native `<video controls>` elements rendered inside nodes:

- `web/src/components/node/OutputRenderer.tsx` (the reported one)
- `web/src/components/node/output/ChunkRenderer.tsx` (same bug in the streaming-chunk renderer)

## Scope notes

- `NodeHistoryViewer`'s `<video>` is a muted, control-less thumbnail — not scrubbable, left alone.
- The timeline `PreviewArea` transport controls are already `nodrag`-guarded via the `NodeSlider` and `ToolbarIconButton` primitives, so they don't have this bug.

## Verification

Confirmed the mechanism with isolated CDP repros dispatching real mouse-drag events: `nodrag` prevents d3-drag's pointer capture; without it the pointer is stolen. Typecheck and lint pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)