### PR TITLE
fix(node): keep media-aspect corner resize 1:1 with the cursor

### DIFF
--- a/web/src/components/node/MediaAspectResizeControl.tsx
+++ b/web/src/components/node/MediaAspectResizeControl.tsx
@@ -5,9 +5,11 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { useReactFlow } from "@xyflow/react";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import type { Node } from "@xyflow/react";
 import { Box, MOTION } from "../ui_primitives";
 import { useNodes } from "../../contexts/NodeContext";
 import type { NodeStoreState } from "../../stores/NodeStore";
+import type { NodeData } from "../../stores/NodeData";
 import {
   computeAspectResize,
   computeFreeResize,
@@ -16,11 +18,19 @@ import {
 } from "./mediaAspectResize";
 import { measureNodeMedia } from "./measureNodeMedia";
 
+export type ResizeCorner =
+  | "bottom-right"
+  | "bottom-left"
+  | "top-right"
+  | "top-left";
+
 interface MediaAspectResizeControlProps {
   nodeId: string;
   minWidth: number;
   minHeight: number;
   maxWidth: number;
+  /** Which corner this handle sits on. Defaults to bottom-right. */
+  corner?: ResizeCorner;
 }
 
 interface DragState {
@@ -28,17 +38,72 @@ interface DragState {
   startY: number;
   startWidth: number;
   startHeight: number;
+  /** Node position (flow units) at drag start, to anchor the opposite corner. */
+  startPosX: number;
+  startPosY: number;
   zoom: number;
   /** Measured media box, or null when the node holds no decoded media. */
   box: MediaBox | null;
 }
 
-const styles = (theme: Theme) =>
-  css({
+/** Per-corner geometry: which way the pointer grows the box, whether the node's
+ *  origin moves, the placement of the grip, its cursor, and the icon rotation. */
+const CORNERS: Record<
+  ResizeCorner,
+  {
+    signX: number;
+    signY: number;
+    movesX: boolean;
+    movesY: boolean;
+    placement: { left?: number; right?: number; top?: number; bottom?: number };
+    cursor: string;
+    rotate: number;
+  }
+> = {
+  "bottom-right": {
+    signX: 1,
+    signY: 1,
+    movesX: false,
+    movesY: false,
+    placement: { right: 0, bottom: 0 },
+    cursor: "nwse-resize",
+    rotate: -45
+  },
+  "bottom-left": {
+    signX: -1,
+    signY: 1,
+    movesX: true,
+    movesY: false,
+    placement: { left: 0, bottom: 0 },
+    cursor: "nesw-resize",
+    rotate: 45
+  },
+  "top-right": {
+    signX: 1,
+    signY: -1,
+    movesX: false,
+    movesY: true,
+    placement: { right: 0, top: 0 },
+    cursor: "nesw-resize",
+    rotate: -135
+  },
+  "top-left": {
+    signX: -1,
+    signY: -1,
+    movesX: true,
+    movesY: true,
+    placement: { left: 0, top: 0 },
+    cursor: "nwse-resize",
+    rotate: 135
+  }
+};
+
+const styles = (theme: Theme, corner: ResizeCorner) => {
+  const { placement, cursor, rotate } = CORNERS[corner];
+  return css({
     position: "absolute",
     zIndex: 100,
-    right: 0,
-    bottom: 0,
+    ...placement,
     width: "25px",
     height: "25px",
     overflow: "hidden",
@@ -52,27 +117,28 @@ const styles = (theme: Theme) =>
       border: "none",
       padding: 0,
       pointerEvents: "all",
-      cursor: "nwse-resize",
-      opacity: 0.6,
+      cursor,
       transition: MOTION.all,
-      "&:hover": {
-        opacity: 1
-      },
       "& svg": {
         width: "20px",
         height: "20px",
         color: theme.vars.palette.grey[100],
-        transform: "rotate(-45deg)",
+        transform: `rotate(${rotate}deg)`,
         transition: `color ${MOTION.normal}`
       }
     }
   });
+};
 
 /**
  * Corner resize handle that keeps the node's media (image / video) aspect ratio
  * while treating the surrounding chrome (header, sliders, output handles) as a
  * fixed offset. When the node holds no media it falls back to a free resize, so
  * the same handle is correct for nodes that only sometimes show an image.
+ *
+ * Works on any of the four corners: the pointer delta is converted to a growth
+ * delta per corner, and the node's origin is shifted so the *opposite* corner
+ * stays anchored — matching how the bottom-right handle behaves.
  *
  * Unlike React Flow's `NodeResizeControl`, this drives the geometry directly:
  * the built-in control applies its own width *and* height before `onResize`
@@ -82,16 +148,19 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
   nodeId,
   minWidth,
   minHeight,
-  maxWidth
+  maxWidth,
+  corner = "bottom-right"
 }: MediaAspectResizeControlProps) {
   const theme = useTheme();
-  const cssStyles = useMemo(() => styles(theme), [theme]);
+  const cssStyles = useMemo(() => styles(theme, corner), [theme, corner]);
   const reactFlow = useReactFlow();
   const updateNode = useNodes((state: NodeStoreState) => state.updateNode);
 
   const dragRef = useRef<DragState | null>(null);
-  const pendingRef = useRef<ResizeResult | null>(null);
+  const pendingRef = useRef<Partial<Node<NodeData>> | null>(null);
   const rafRef = useRef<number | null>(null);
+  /** `.react-flow` container, classed during the drag to kill the transform tween. */
+  const containerRef = useRef<Element | null>(null);
 
   const flush = useCallback(() => {
     rafRef.current = null;
@@ -106,8 +175,31 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
       }
+      containerRef.current?.classList.remove("node-resizing");
     },
     []
+  );
+
+  const toUpdate = useCallback(
+    (result: ResizeResult, drag: DragState): Partial<Node<NodeData>> => {
+      const { movesX, movesY } = CORNERS[corner];
+      const update: Partial<Node<NodeData>> = {
+        width: result.width,
+        height: result.height
+      };
+      if (movesX || movesY) {
+        update.position = {
+          x: movesX
+            ? drag.startPosX + (drag.startWidth - result.width)
+            : drag.startPosX,
+          y: movesY
+            ? drag.startPosY + (drag.startHeight - result.height)
+            : drag.startPosY
+        };
+      }
+      return update;
+    },
+    [corner]
   );
 
   const handlePointerDown = useCallback(
@@ -128,18 +220,28 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
       const rect = nodeEl.getBoundingClientRect();
       const startWidth = rect.width / zoom;
       const startHeight = rect.height / zoom;
+      const position = reactFlow.getNode(nodeId)?.position ?? { x: 0, y: 0 };
 
       dragRef.current = {
         startX: event.clientX,
         startY: event.clientY,
         startWidth,
         startHeight,
+        startPosX: position.x,
+        startPosY: position.y,
         zoom,
         box: measureNodeMedia(nodeEl, zoom, startWidth, startHeight)
       };
+      // Moving-corner resizes shift the node origin every frame. React Flow only
+      // adds `.dragging` when *it* drags the node, so the `:not(.dragging)`
+      // transform transition stays live here and the node lags ~180ms behind,
+      // snapping into place after release. Mirror the selection-drag fix and
+      // suppress the tween on the container for the duration of the gesture.
+      containerRef.current = nodeEl.closest(".react-flow");
+      containerRef.current?.classList.add("node-resizing");
       event.currentTarget.setPointerCapture(event.pointerId);
     },
-    [reactFlow]
+    [reactFlow, nodeId]
   );
 
   const handlePointerMove = useCallback(
@@ -148,22 +250,24 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
       if (!drag) {
         return;
       }
+      const { signX, signY } = CORNERS[corner];
       const delta = {
         startWidth: drag.startWidth,
         startHeight: drag.startHeight,
-        deltaX: (event.clientX - drag.startX) / drag.zoom,
-        deltaY: (event.clientY - drag.startY) / drag.zoom
+        deltaX: (signX * (event.clientX - drag.startX)) / drag.zoom,
+        deltaY: (signY * (event.clientY - drag.startY)) / drag.zoom
       };
       const bounds = { minWidth, maxWidth, minHeight };
-      pendingRef.current = drag.box
+      const result = drag.box
         ? computeAspectResize(delta, drag.box, bounds)
         : computeFreeResize(delta, bounds);
+      pendingRef.current = toUpdate(result, drag);
 
       if (rafRef.current === null) {
         rafRef.current = requestAnimationFrame(flush);
       }
     },
-    [flush, minWidth, maxWidth, minHeight]
+    [flush, minWidth, maxWidth, minHeight, corner, toUpdate]
   );
 
   const endDrag = useCallback(
@@ -172,6 +276,8 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
         return;
       }
       dragRef.current = null;
+      containerRef.current?.classList.remove("node-resizing");
+      containerRef.current = null;
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
@@ -191,7 +297,10 @@ const MediaAspectResizeControl = memo(function MediaAspectResizeControl({
   );
 
   return (
-    <Box className="node-resize-handle media-aspect-resize-handle" css={cssStyles}>
+    <Box
+      className="node-resize-handle media-aspect-resize-handle"
+      css={cssStyles}
+    >
       <button
         type="button"
         className="resize-grip nodrag nopan"

--- a/web/src/components/node/NodeResizeHandle.tsx
+++ b/web/src/components/node/NodeResizeHandle.tsx
@@ -7,10 +7,19 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Box, MOTION } from "../ui_primitives";
 import { memo, useMemo } from "react";
-import MediaAspectResizeControl from "./MediaAspectResizeControl";
+import MediaAspectResizeControl, {
+  type ResizeCorner
+} from "./MediaAspectResizeControl";
 
 /** Upper bound shared with the edge resizer so the corner handle agrees with it. */
 const MAX_NODE_WIDTH = 800;
+
+const ASPECT_CORNERS: ResizeCorner[] = [
+  "bottom-right",
+  "bottom-left",
+  "top-right",
+  "top-left"
+];
 
 interface NodeResizeHandleProps {
   minWidth: number;
@@ -80,12 +89,18 @@ const NodeResizeHandle: React.FC<NodeResizeHandleProps> = memo(function NodeResi
 
   if (contentAware && nodeId) {
     return (
-      <MediaAspectResizeControl
-        nodeId={nodeId}
-        minWidth={minWidth}
-        minHeight={minHeight}
-        maxWidth={maxWidth}
-      />
+      <>
+        {ASPECT_CORNERS.map((corner) => (
+          <MediaAspectResizeControl
+            key={corner}
+            corner={corner}
+            nodeId={nodeId}
+            minWidth={minWidth}
+            minHeight={minHeight}
+            maxWidth={maxWidth}
+          />
+        ))}
+      </>
     );
   }
 

--- a/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
+++ b/web/src/components/node/__tests__/NodeResizeHandle.test.tsx
@@ -47,8 +47,8 @@ describe("NodeResizeHandle", () => {
     expect(resizeControlProps[0]?.keepAspectRatio).toBe(true);
   });
 
-  it("renders the media-aspect control when contentAware with a nodeId", () => {
-    const { queryByTestId } = render(
+  it("renders a media-aspect control on all four corners when contentAware with a nodeId", () => {
+    const { queryAllByTestId, queryByTestId } = render(
       <NodeResizeHandle
         minWidth={150}
         minHeight={100}
@@ -56,13 +56,22 @@ describe("NodeResizeHandle", () => {
         nodeId="node-1"
       />
     );
-    expect(queryByTestId("media-aspect-control")).not.toBeNull();
+    expect(queryAllByTestId("media-aspect-control")).toHaveLength(4);
     expect(queryByTestId("resize-control")).toBeNull();
-    expect(mediaControlProps[0]).toMatchObject({
-      nodeId: "node-1",
-      minWidth: 150,
-      minHeight: 100,
-      maxWidth: 800
+    expect(mediaControlProps).toHaveLength(4);
+    expect(mediaControlProps.map((p) => p.corner)).toEqual([
+      "bottom-right",
+      "bottom-left",
+      "top-right",
+      "top-left"
+    ]);
+    mediaControlProps.forEach((props) => {
+      expect(props).toMatchObject({
+        nodeId: "node-1",
+        minWidth: 150,
+        minHeight: 100,
+        maxWidth: 800
+      });
     });
   });
 

--- a/web/src/styles/nodes.base.css
+++ b/web/src/styles/nodes.base.css
@@ -45,6 +45,16 @@
     filter 0.2s ease-in-out, outline-color 0.18s ease;
 }
 
+/* A corner resize that repositions the node (every corner but bottom-right)
+   shifts the node's transform each frame. Like a selection drag, ReactFlow
+   never adds `.dragging`, so the transform transition above would tween the
+   origin ~180ms behind — the node visibly lags out of place and snaps back on
+   release. The media-aspect resize handle adds `node-resizing` for the gesture. */
+.react-flow.node-resizing .react-flow__node {
+  transition: background-color 0.08s ease, box-shadow 0.18s ease-in-out,
+    filter 0.2s ease-in-out, outline-color 0.18s ease;
+}
+
 .node-drag-handle {
   cursor: grabbing !important;
 }

--- a/web/src/styles/nodes.resizer.css
+++ b/web/src/styles/nodes.resizer.css
@@ -43,3 +43,15 @@
 .node-resize-handle .react-flow__resize-control.nodrag.bottom.right.handle {
   cursor: nwse-resize;
 }
+
+/* Media-aspect corner grips: hidden until the node is hovered, so all four
+   corners reveal together and idle nodes stay clean. */
+.base-node .media-aspect-resize-handle .resize-grip {
+  opacity: 0;
+}
+.base-node:hover .media-aspect-resize-handle .resize-grip {
+  opacity: 0.6;
+}
+.base-node .media-aspect-resize-handle .resize-grip:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
## Problem

Resizing a media node (Preview / Output / dynamic-schema nodes) from any corner **except bottom-right** made the node lag visibly: during the drag it rendered out of place, then snapped back to the correct spot ~180ms after release.

## Root cause

Every corner but bottom-right repositions the node — its `transform: translate()` is rewritten each frame. React Flow only adds the `.dragging` class while *it* drags a node, so for our custom resize gesture the `.react-flow__node:not(.dragging)` rule kept the deliberate `transform 0.18s ease` tween live. The size jumped instantly while the origin eased in behind it → lag + snap-back. Bottom-right never moves the origin, so it was immune.

This is the same class of bug the codebase already fixed for multi-node selection drags via the `nodesselection-dragging` container class (`useDragHandlers.ts`).

## Fix

- The content-aware handle now sits on all four corners and anchors the **opposite** corner by deriving the origin shift from the *actual resulting node size* (`startWidth - result.width`), so the aspect-ratio constraint stays exact regardless of drag direction.
- During the gesture the handle toggles a `node-resizing` class on the `.react-flow` container, which drops `transform` from the node transition list — eliminating the lag while preserving the smooth tween for programmatic moves (align / arrange / collapse).

## Verification

- Drove the live app with synthetic pointer drags on all four corners (incl. cross-axis and clamping): the opposite corner stays pinned to the pixel, and the node's computed `transition-property` drops `transform` only for the duration of the drag, restoring it on release.
- `NodeResizeHandle` + `measureNodeMedia` tests pass; typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)