### PR TITLE
fix(cli): default chat workspace to the current directory

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -175,7 +175,7 @@ if (opts.agent !== undefined) {
   );
 }
 
-const workspace = opts.workspace ?? settings.workspace;
+const workspace = opts.workspace ?? process.cwd();
 const enabledTools = opts.tools
   ? opts.tools.split(",").map((t) => t.trim())
   : settings.enabledTools;

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -6,7 +6,6 @@ export interface ChatSettings {
   provider: string;
   model: string;
   enabledTools: string[];
-  workspace: string;
 }
 
 export const DEFAULT_SETTINGS: ChatSettings = {
@@ -43,8 +42,7 @@ export const DEFAULT_SETTINGS: ChatSettings = {
     "list_assets",
     "get_asset",
     "list_models"
-  ],
-  workspace: process.cwd()
+  ]
 };
 
 function detectDefaultProvider(): string {
@@ -72,18 +70,20 @@ const SETTINGS_DIR = join(homedir(), ".nodetool");
 const SETTINGS_FILE = join(SETTINGS_DIR, "chat-settings.json");
 
 /**
- * Drop any persisted agent-mode / planner fields from older settings files.
- * The unified chat agent has no mode toggle; we strip the legacy keys so a
- * stale value can't be passed through to anything that still reads them.
+ * Drop legacy fields from older settings files: agent-mode / planner toggles
+ * (the unified chat agent has no mode) and `workspace` (it now always defaults
+ * to the current directory and is never persisted).
  */
 function migrateSettings(raw: Record<string, unknown>): Record<string, unknown> {
   const {
     agentMode: _dropMode,
     agentPlanner: _dropPlanner,
+    workspace: _dropWorkspace,
     ...rest
   } = raw;
   void _dropMode;
   void _dropPlanner;
+  void _dropWorkspace;
   return rest;
 }
 


### PR DESCRIPTION
## Problem

`nodetool-chat` resolved its workspace from a persisted `workspace` field in `~/.nodetool/chat-settings.json`. That field defaulted to `process.cwd()` **at the time the settings file was first created**, so on later runs from a different directory the chat agent's file tools operated against a stale, unrelated workspace.

## Fix

- Resolve the workspace to `process.cwd()` at invocation time, unless `--workspace` is explicitly passed.
- Remove `workspace` from `ChatSettings` and `DEFAULT_SETTINGS` so it's no longer persisted.
- `migrateSettings` now strips the legacy `workspace` key from older settings files (alongside the existing `agentMode` / `agentPlanner` cleanup).

## Verification

- Confirmed the only reader of `settings.workspace` was the single line in `index.ts`; no other references remain.
- CLI package typechecks clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)