### PR TITLE
Add OpenAI OAuth 2.0 authentication (PKCE) as alternative to API keys

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -42,6 +42,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./oauth": {
+      "nodetool-dev": "./src/providers/oauth/index.ts",
+      "types": "./dist/providers/oauth/index.d.ts",
+      "import": "./dist/providers/oauth/index.js",
+      "default": "./dist/providers/oauth/index.js"
+    },
     "./context": {
       "nodetool-dev": "./src/context.ts",
       "types": "./dist/context.d.ts",

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -109,11 +109,11 @@ export {
   unregisterProvider
 } from "./provider-registry.js";
 export type { GetSecret } from "./provider-registry.js";
-// OpenAI OAuth subsystem (browser-based auth instead of a static API key).
-// Not auto-registered in the provider registry: OAuth needs interactive login
-// and injected collaborators, which the sync `getSecret` registry can't model.
-// Wire one explicitly with `createOpenAIOAuthProvider(...)`.
-export * from "./oauth/index.js";
+// OpenAI OAuth subsystem is intentionally NOT re-exported here. Its callback
+// server, browser launcher and keychain access are Node-only (they statically
+// import node:http / node:child_process), and this barrel is pulled into the
+// browser worker bundle via the runtime root. Import it from the dedicated
+// Node-only subpath instead: `@nodetool-ai/runtime/oauth`.
 import {
   registerProvider as registerBuiltinProvider,
   listRegisteredProviderIds as listBuiltinProviderIds,

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -109,6 +109,11 @@ export {
   unregisterProvider
 } from "./provider-registry.js";
 export type { GetSecret } from "./provider-registry.js";
+// OpenAI OAuth subsystem (browser-based auth instead of a static API key).
+// Not auto-registered in the provider registry: OAuth needs interactive login
+// and injected collaborators, which the sync `getSecret` registry can't model.
+// Wire one explicitly with `createOpenAIOAuthProvider(...)`.
+export * from "./oauth/index.js";
 import {
   registerProvider as registerBuiltinProvider,
   listRegisteredProviderIds as listBuiltinProviderIds,

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -1,0 +1,216 @@
+# OpenAI OAuth authentication
+
+Browser-based OAuth 2.0 (Authorization Code + PKCE) for the OpenAI provider, as
+an alternative to pasting a static API key. Every request is served by a
+short-lived access token that is refreshed transparently; the refresh token is
+held in the OS credential store and never written to a plaintext config file.
+
+## Design principles
+
+- **Layered, single-responsibility components.** OAuth protocol, token storage,
+  secret storage, the callback listener, and the provider are separate units.
+- **Dependency injection everywhere.** Every collaborator (fetch, clock,
+  randomness, keyring, browser, callback server) is injected, so the whole
+  system is testable without a network or a browser.
+- **No singleton / module-level state.** Each login owns its instances.
+- **Async-only, fully typed.** No `any`; all I/O is `Promise`-based.
+- **Secrets never leak.** Tokens are never logged, never put in error messages,
+  and never written to plaintext files. See [`redaction.ts`](./redaction.ts).
+
+## File structure
+
+```
+packages/runtime/src/providers/oauth/
+├── index.ts                     Public surface + createOpenAIOAuthProvider()
+├── types.ts                     Shared data types (OAuthTokens, configs, Clock)
+├── errors.ts                    Typed error hierarchy (one per failure mode)
+├── redaction.ts                 Secret redaction for logs/errors
+├── pkce-helper.ts               PKCEHelper — PKCE verifier/challenge + CSRF state
+├── oauth-client.ts              OAuthClient — authorize URL, code exchange, refresh, revoke
+├── local-callback-server.ts     LocalCallbackServer — loopback redirect receiver
+├── browser-launcher.ts          BrowserLauncher — opens the system browser
+├── secure-credential-store.ts   SecureCredentialStore — opaque secrets (OS keychain)
+├── token-store.ts               TokenStore — token persistence over a credential store
+└── openai-oauth-provider.ts     OpenAIOAuthProvider — orchestration + OpenAI capabilities
+
+packages/runtime/tests/providers/oauth/
+├── pkce-helper.test.ts              unit
+├── oauth-client.test.ts             unit
+├── stores.test.ts                   unit (TokenStore + SecureCredentialStore)
+├── redaction.test.ts                unit
+├── local-callback-server.test.ts    unit (real loopback sockets)
+├── openai-oauth-provider.test.ts    unit (orchestration with injected fakes)
+└── oauth-flow.integration.test.ts   integration (full flow over real sockets)
+```
+
+### Layering
+
+```
+OpenAIOAuthProvider                orchestration + inherited OpenAI capabilities
+  ├─ OAuthClient                   OAuth 2.0 protocol (PKCE code exchange/refresh)
+  ├─ PKCEHelper                    PKCE + CSRF-state generation
+  ├─ LocalCallbackServer           localhost redirect receiver
+  ├─ BrowserLauncher               opens the system browser
+  └─ TokenStore                    token persistence
+       └─ SecureCredentialStore    opaque secret persistence (OS keychain)
+```
+
+## Usage
+
+```ts
+import { createOpenAIOAuthProvider } from "@nodetool-ai/runtime";
+
+const provider = createOpenAIOAuthProvider({
+  clientId: process.env.OPENAI_OAUTH_CLIENT_ID!,
+  accountId: currentUser.id // namespaces stored tokens
+});
+
+// One-time interactive login (opens the browser).
+if (!(await provider.isAuthenticated())) {
+  await provider.login({ timeoutMs: 300_000 });
+}
+
+// Use it like any other provider — tokens refresh automatically.
+const reply = await provider.generateMessage({ model: "gpt-5.4-mini", messages });
+
+// Later:
+await provider.logout(); // revokes + clears stored tokens
+```
+
+For tests, swap in the in-memory backends:
+
+```ts
+new OpenAIOAuthProvider({
+  oauthClient: new OAuthClient({ config, fetchFn: fakeFetch, clock }),
+  tokenStore: new InMemoryTokenStore(),
+  browserLauncher: { open: async () => {} },
+  callbackServerFactory: () => fakeServer,
+  openAIClientFactory: (token) => fakeOpenAIClient
+});
+```
+
+## Login flow (Authorization Code + PKCE)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Provider as OpenAIOAuthProvider
+    participant PKCE as PKCEHelper
+    participant CB as LocalCallbackServer
+    participant Browser as BrowserLauncher
+    participant Auth as OpenAI Auth Server
+    participant Client as OAuthClient
+    participant Store as TokenStore
+    participant Sec as SecureCredentialStore (OS keychain)
+
+    User->>Provider: login()
+    Provider->>CB: listen()
+    CB-->>Provider: redirectUri (http://127.0.0.1:port/callback)
+    Provider->>PKCE: createPkcePair() + createState()
+    PKCE-->>Provider: {verifier, challenge, S256}, state
+    Provider->>Client: buildAuthorizationUrl(redirectUri, state, challenge)
+    Client-->>Provider: authorization URL
+    Provider->>Browser: open(authUrl)
+    Browser->>Auth: GET /authorize?code_challenge=…&state=…
+    Auth->>User: login + consent
+    User->>Auth: approve
+    Auth->>CB: 302 redirect /callback?code=…&state=…
+    CB->>CB: validate state == expected (CSRF)
+    CB-->>Provider: { code }
+    Provider->>Client: exchangeAuthorizationCode(code, verifier, redirectUri)
+    Client->>Auth: POST /token (code, code_verifier, client_id)
+    Auth-->>Client: { access_token, refresh_token, expires_in }
+    Client-->>Provider: OAuthTokens
+    Provider->>Store: save(tokens)
+    Store->>Sec: set("openai:account", JSON)
+    Provider->>CB: close()
+    Provider-->>User: authenticated
+```
+
+Failure modes on this path: `BrowserLaunchError` (open fails),
+`CallbackTimeoutError` (no redirect within the timeout), `StateMismatchError`
+(CSRF), `AuthorizationDeniedError` (user denies), `OAuthNetworkError` /
+`TokenExchangeError` (token endpoint).
+
+## Token refresh flow
+
+Triggered lazily by any request (`generateMessage` / `generateMessages` /
+`getAccessToken`) when the cached access token is within the expiry skew.
+Concurrent callers share a single in-flight refresh.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant Provider as OpenAIOAuthProvider
+    participant Store as TokenStore
+    participant Client as OAuthClient
+    participant Auth as OpenAI Auth Server
+
+    Caller->>Provider: generateMessage() / getAccessToken()
+    Provider->>Provider: ensureValidSession()
+    alt no session in memory
+        Provider->>Store: load()
+        Store-->>Provider: OAuthTokens | null
+    end
+    alt access token still valid
+        Provider-->>Caller: serve with current token
+    else expired (within skew)
+        Provider->>Provider: refresh() (single-flight)
+        alt refresh token present
+            Provider->>Client: refreshAccessToken(refreshToken)
+            Client->>Auth: POST /token (grant_type=refresh_token)
+            alt success
+                Auth-->>Client: { access_token, refresh_token?, expires_in }
+                Client-->>Provider: OAuthTokens (reuse old refresh if omitted)
+                Provider->>Store: save(tokens)
+                Provider-->>Caller: serve with new token
+            else invalid_grant / revoked
+                Auth-->>Client: 400 invalid_grant
+                Client-->>Provider: InvalidRefreshTokenError / CredentialsRevokedError
+                Provider->>Store: clear()
+                Provider-->>Caller: throw (re-login required)
+            end
+        else no refresh token
+            Provider->>Store: clear()
+            Provider-->>Caller: throw SessionExpiredError
+        end
+    end
+```
+
+## Error model
+
+All errors extend `OAuthError` and carry a stable `code`:
+
+| Error | code | Cause |
+|---|---|---|
+| `InvalidRefreshTokenError` | `invalid_refresh_token` | Refresh rejected (`invalid_grant`) |
+| `SessionExpiredError` | `session_expired` | Expired with no refresh token |
+| `BrowserLaunchError` | `browser_launch_failed` | Default browser would not start |
+| `CallbackTimeoutError` | `callback_timeout` | No redirect within the timeout |
+| `OAuthNetworkError` | `network_error` | DNS/TLS/connection/5xx failure |
+| `CredentialsRevokedError` | `credentials_revoked` | Grant revoked server-side |
+| `StateMismatchError` | `state_mismatch` | CSRF: `state` did not match |
+| `AuthorizationDeniedError` | `authorization_denied` | User denied consent |
+| `TokenExchangeError` | `token_exchange_failed` | Code→token exchange failed |
+| `NotAuthenticatedError` | `not_authenticated` | Used before `login()` |
+
+## Security checklist
+
+- ✅ **PKCE required** — `S256` only; verifier never leaves the client until the
+  token exchange.
+- ✅ **CSRF state validation** — `LocalCallbackServer` rejects any callback whose
+  `state` does not match before reading the `code`.
+- ✅ **Tokens never logged** — redacted via `redaction.ts`; only non-secret
+  metadata (scope, expiry) is logged.
+- ✅ **No plaintext token files** — persistence goes only through
+  `SecureCredentialStore`.
+- ✅ **Refresh tokens encrypted by the OS credential store** — the default
+  `KeychainSecureCredentialStore` uses the platform keychain (`keytar`).
+- ✅ **Bearer not exposed to containers** — `getContainerEnv()` returns `{}` so
+  the short-lived OAuth token is not baked into a code-runner environment.
+
+> Note: `DEFAULT_OPENAI_OAUTH_CONFIG` endpoints are sensible placeholders.
+> Point `oauthConfig` at OpenAI's published authorization/token/revocation
+> endpoints and the client id registered for your application.

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -58,7 +58,7 @@ OpenAIOAuthProvider                orchestration + inherited OpenAI capabilities
 ## Usage
 
 ```ts
-import { createOpenAIOAuthProvider } from "@nodetool-ai/runtime";
+import { createOpenAIOAuthProvider } from "@nodetool-ai/runtime/oauth";
 
 const provider = createOpenAIOAuthProvider({
   clientId: process.env.OPENAI_OAUTH_CLIENT_ID!,

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -214,3 +214,27 @@ All errors extend `OAuthError` and carry a stable `code`:
 > Note: `DEFAULT_OPENAI_OAUTH_CONFIG` endpoints are sensible placeholders.
 > Point `oauthConfig` at OpenAI's published authorization/token/revocation
 > endpoints and the client id registered for your application.
+
+## Two host integrations
+
+This subsystem (a localhost-callback flow that opens the OS browser) is the
+right fit for desktop/CLI hosts where the Node process can both open a browser
+and listen on loopback.
+
+The **web app** uses a complementary server-side flow that shares this module's
+protocol layer (`OAuthClient` + PKCE) but receives the redirect on the API
+server's own `/api/oauth/openai/callback` route rather than a per-login
+loopback server:
+
+- Backend: `packages/websocket/src/oauth-api.ts` exposes
+  `/api/oauth/openai/{start,callback,tokens,disconnect}`. `start` returns the
+  authorization URL (built via `OAuthClient`), `callback` exchanges the code and
+  persists tokens through the encrypted `OAuthCredential` model. It activates
+  only when `OPENAI_OAUTH_CLIENT_ID` is set (endpoints/scopes are env-overridable
+  via `OPENAI_OAUTH_AUTHORIZATION_URL`, `OPENAI_OAUTH_TOKEN_URL`,
+  `OPENAI_OAUTH_USERINFO_URL`, `OPENAI_OAUTH_SCOPES`).
+- Frontend: the **Settings → Integrations** panel
+  (`web/src/components/menus/RemoteSettingsMenu.tsx`) renders an
+  "OpenAI Authentication" section with **Connect with OpenAI** / **Disconnect**
+  buttons that open the auth URL and poll `/api/oauth/openai/tokens` for
+  completion.

--- a/packages/runtime/src/providers/oauth/browser-launcher.ts
+++ b/packages/runtime/src/providers/oauth/browser-launcher.ts
@@ -1,0 +1,57 @@
+/**
+ * BrowserLauncher — opens a URL in the user's default browser.
+ *
+ * Abstracted behind an interface so the provider can be tested without
+ * spawning a real browser, and so non-desktop hosts can supply their own
+ * strategy (e.g. printing the URL for the user to paste).
+ */
+
+import { spawn } from "node:child_process";
+import type { Logger } from "@nodetool-ai/config";
+import { BrowserLaunchError } from "./errors.js";
+
+export interface BrowserLauncher {
+  /** Open `url`. Reject with `BrowserLaunchError` if the browser won't start. */
+  open(url: string): Promise<void>;
+}
+
+/** Per-platform command that opens a URL in the default browser. */
+function openCommand(platform: NodeJS.Platform): { cmd: string; args: string[] } {
+  switch (platform) {
+    case "darwin":
+      return { cmd: "open", args: [] };
+    case "win32":
+      // `start` is a cmd builtin; the empty "" is the (ignored) window title.
+      return { cmd: "cmd", args: ["/c", "start", ""] };
+    default:
+      return { cmd: "xdg-open", args: [] };
+  }
+}
+
+/** Opens URLs via the platform's native "open" command. */
+export class DefaultBrowserLauncher implements BrowserLauncher {
+  private readonly platform: NodeJS.Platform;
+  private readonly logger?: Logger;
+
+  constructor(options: { platform?: NodeJS.Platform; logger?: Logger } = {}) {
+    this.platform = options.platform ?? process.platform;
+    this.logger = options.logger;
+  }
+
+  async open(url: string): Promise<void> {
+    const { cmd, args } = openCommand(this.platform);
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(cmd, [...args, url], { stdio: "ignore", detached: true });
+      child.once("error", (err) =>
+        reject(new BrowserLaunchError("Could not launch the default browser", { cause: err }))
+      );
+      // The launcher process exits quickly; the browser keeps running. Treat a
+      // clean spawn as success and unref so it never blocks process exit.
+      child.once("spawn", () => {
+        child.unref();
+        this.logger?.debug("Opened authorization URL in default browser");
+        resolve();
+      });
+    });
+  }
+}

--- a/packages/runtime/src/providers/oauth/errors.ts
+++ b/packages/runtime/src/providers/oauth/errors.ts
@@ -1,0 +1,102 @@
+/**
+ * Typed error hierarchy for the OAuth subsystem.
+ *
+ * Every failure mode in the spec maps to a concrete subclass so callers can
+ * branch on `instanceof` (or on the stable `code`) rather than string-matching
+ * messages. Error messages NEVER contain token material — see `redaction.ts`.
+ */
+
+export type OAuthErrorCode =
+  | "invalid_refresh_token"
+  | "session_expired"
+  | "browser_launch_failed"
+  | "callback_timeout"
+  | "network_error"
+  | "credentials_revoked"
+  | "state_mismatch"
+  | "authorization_denied"
+  | "token_exchange_failed"
+  | "not_authenticated";
+
+/** Base class for everything thrown by the OAuth subsystem. */
+export class OAuthError extends Error {
+  readonly code: OAuthErrorCode;
+
+  constructor(code: OAuthErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = new.target.name;
+    this.code = code;
+    // Restore prototype chain for transpiled `extends Error`.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** The stored refresh token was rejected by the server (invalid_grant). */
+export class InvalidRefreshTokenError extends OAuthError {
+  constructor(message = "Refresh token is invalid or expired", options?: ErrorOptions) {
+    super("invalid_refresh_token", message, options);
+  }
+}
+
+/** No usable credentials in the store / access token expired with no refresh. */
+export class SessionExpiredError extends OAuthError {
+  constructor(message = "Session expired; re-authentication required", options?: ErrorOptions) {
+    super("session_expired", message, options);
+  }
+}
+
+/** The default browser could not be launched for the authorization request. */
+export class BrowserLaunchError extends OAuthError {
+  constructor(message = "Failed to open the browser for authentication", options?: ErrorOptions) {
+    super("browser_launch_failed", message, options);
+  }
+}
+
+/** The user did not complete the browser flow within the allotted time. */
+export class CallbackTimeoutError extends OAuthError {
+  constructor(message = "Timed out waiting for the OAuth callback", options?: ErrorOptions) {
+    super("callback_timeout", message, options);
+  }
+}
+
+/** A network-level failure (DNS, TLS, connection reset) talking to the server. */
+export class OAuthNetworkError extends OAuthError {
+  constructor(message = "Network error during OAuth request", options?: ErrorOptions) {
+    super("network_error", message, options);
+  }
+}
+
+/** The credentials were revoked server-side (access_denied / revoked grant). */
+export class CredentialsRevokedError extends OAuthError {
+  constructor(message = "Credentials were revoked", options?: ErrorOptions) {
+    super("credentials_revoked", message, options);
+  }
+}
+
+/** CSRF guard: the `state` returned to the callback did not match. */
+export class StateMismatchError extends OAuthError {
+  constructor(message = "OAuth state mismatch — possible CSRF", options?: ErrorOptions) {
+    super("state_mismatch", message, options);
+  }
+}
+
+/** The user denied the authorization request in the browser. */
+export class AuthorizationDeniedError extends OAuthError {
+  constructor(message = "Authorization was denied", options?: ErrorOptions) {
+    super("authorization_denied", message, options);
+  }
+}
+
+/** The authorization-code → token exchange failed for a non-network reason. */
+export class TokenExchangeError extends OAuthError {
+  constructor(message = "Failed to exchange authorization code for tokens", options?: ErrorOptions) {
+    super("token_exchange_failed", message, options);
+  }
+}
+
+/** A request requiring authentication was made before login completed. */
+export class NotAuthenticatedError extends OAuthError {
+  constructor(message = "Not authenticated; call login() first", options?: ErrorOptions) {
+    super("not_authenticated", message, options);
+  }
+}

--- a/packages/runtime/src/providers/oauth/index.ts
+++ b/packages/runtime/src/providers/oauth/index.ts
@@ -1,0 +1,124 @@
+/**
+ * OpenAI OAuth subsystem — public surface.
+ *
+ * Layers (each depends only on the one below, via interfaces):
+ *
+ *   OpenAIOAuthProvider          orchestration + OpenAI capability inheritance
+ *     ├─ OAuthClient             OAuth 2.0 protocol (PKCE code exchange/refresh)
+ *     ├─ PKCEHelper              PKCE + CSRF-state generation
+ *     ├─ LocalCallbackServer     localhost redirect receiver
+ *     ├─ BrowserLauncher         opens the system browser
+ *     └─ TokenStore              token persistence
+ *          └─ SecureCredentialStore   opaque secret persistence (OS keychain)
+ *
+ * `createOpenAIOAuthProvider` wires production defaults; every collaborator can
+ * be overridden for testing or alternate hosts.
+ */
+
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import { OAuthClient } from "./oauth-client.js";
+import { PKCEHelper } from "./pkce-helper.js";
+import { LocalCallbackServer } from "./local-callback-server.js";
+import { DefaultBrowserLauncher, type BrowserLauncher } from "./browser-launcher.js";
+import {
+  KeychainSecureCredentialStore,
+  type SecureCredentialStore
+} from "./secure-credential-store.js";
+import { SecureTokenStore, type TokenStore } from "./token-store.js";
+import { OpenAIOAuthProvider } from "./openai-oauth-provider.js";
+import type { OAuthClientConfig } from "./types.js";
+
+export * from "./types.js";
+export * from "./errors.js";
+export { redactToken, redactObject } from "./redaction.js";
+export { PKCEHelper, nodeRandomSource, type RandomSource } from "./pkce-helper.js";
+export { OAuthClient, type OAuthClientOptions, type FetchLike } from "./oauth-client.js";
+export {
+  LocalCallbackServer,
+  type LocalCallbackServerOptions,
+  type WaitForCodeOptions
+} from "./local-callback-server.js";
+export {
+  DefaultBrowserLauncher,
+  type BrowserLauncher
+} from "./browser-launcher.js";
+export {
+  KeychainSecureCredentialStore,
+  InMemorySecureCredentialStore,
+  type SecureCredentialStore,
+  type KeyringBackend
+} from "./secure-credential-store.js";
+export { SecureTokenStore, InMemoryTokenStore, type TokenStore } from "./token-store.js";
+export {
+  OpenAIOAuthProvider,
+  type OpenAIOAuthProviderOptions,
+  type LoginOptions
+} from "./openai-oauth-provider.js";
+
+/**
+ * Default OAuth endpoints for OpenAI. These are configuration, not contracts —
+ * override them via `createOpenAIOAuthProvider({ oauthConfig })` if OpenAI's
+ * published endpoints differ for your tenant.
+ */
+export const DEFAULT_OPENAI_OAUTH_CONFIG: Omit<OAuthClientConfig, "clientId"> = {
+  authorizationEndpoint: "https://auth.openai.com/oauth/authorize",
+  tokenEndpoint: "https://auth.openai.com/oauth/token",
+  revocationEndpoint: "https://auth.openai.com/oauth/revoke",
+  scopes: ["openid", "profile", "email", "offline_access", "api.read", "api.write"]
+};
+
+export interface CreateOpenAIOAuthProviderOptions {
+  /** OAuth client id registered with OpenAI. */
+  readonly clientId: string;
+  /** Account identifier used to namespace stored tokens (e.g. user id). */
+  readonly accountId?: string;
+  /** Override any part of the OAuth endpoint config. */
+  readonly oauthConfig?: Partial<OAuthClientConfig>;
+  /** Override token persistence (defaults to OS keychain). */
+  readonly tokenStore?: TokenStore;
+  /** Override the secret backend used by the default token store. */
+  readonly credentialStore?: SecureCredentialStore;
+  /** Override the browser launcher. */
+  readonly browserLauncher?: BrowserLauncher;
+  /** Fixed callback port/path, if OpenAI requires a pre-registered redirect. */
+  readonly callbackPort?: number;
+  readonly callbackPath?: string;
+  readonly logger?: Logger;
+}
+
+/** Wire an {@link OpenAIOAuthProvider} with production defaults. */
+export function createOpenAIOAuthProvider(
+  options: CreateOpenAIOAuthProviderOptions
+): OpenAIOAuthProvider {
+  const logger = options.logger ?? createLogger("nodetool.runtime.oauth");
+  const config: OAuthClientConfig = {
+    ...DEFAULT_OPENAI_OAUTH_CONFIG,
+    clientId: options.clientId,
+    ...options.oauthConfig
+  };
+
+  const credentialStore =
+    options.credentialStore ?? new KeychainSecureCredentialStore({ logger });
+  const tokenStore =
+    options.tokenStore ??
+    new SecureTokenStore({
+      credentialStore,
+      provider: "openai",
+      accountId: options.accountId ?? "default",
+      logger
+    });
+
+  return new OpenAIOAuthProvider({
+    oauthClient: new OAuthClient({ config, logger }),
+    tokenStore,
+    browserLauncher: options.browserLauncher ?? new DefaultBrowserLauncher({ logger }),
+    callbackServerFactory: () =>
+      new LocalCallbackServer({
+        port: options.callbackPort,
+        path: options.callbackPath,
+        logger
+      }),
+    pkce: new PKCEHelper(),
+    logger
+  });
+}

--- a/packages/runtime/src/providers/oauth/local-callback-server.ts
+++ b/packages/runtime/src/providers/oauth/local-callback-server.ts
@@ -1,0 +1,201 @@
+/**
+ * LocalCallbackServer — a single-shot localhost HTTP listener that receives the
+ * OAuth redirect, validates the CSRF `state`, and resolves with the
+ * authorization code.
+ *
+ * Lifecycle is explicit: `listen()` → `waitForCode()` → `close()`. The server
+ * binds to loopback only, serves exactly one callback, and then becomes inert.
+ * No module-level state — each login owns its own instance.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+import type { Logger } from "@nodetool-ai/config";
+import {
+  AuthorizationDeniedError,
+  CallbackTimeoutError,
+  OAuthError,
+  StateMismatchError
+} from "./errors.js";
+import type { AuthorizationResult } from "./types.js";
+
+export interface LocalCallbackServerOptions {
+  /** Loopback host to bind. Defaults to 127.0.0.1. */
+  readonly host?: string;
+  /** Port to bind. 0 (default) lets the OS pick an ephemeral port. */
+  readonly port?: number;
+  /** Callback path the authorization server will redirect to. */
+  readonly path?: string;
+  /** HTML shown in the browser after a successful callback. */
+  readonly successHtml?: string;
+  /** HTML shown in the browser after a failed callback. */
+  readonly failureHtml?: string;
+  readonly logger?: Logger;
+}
+
+const DEFAULT_SUCCESS_HTML =
+  "<!doctype html><meta charset=utf-8><title>NodeTool</title>" +
+  "<body style=\"font-family:system-ui;text-align:center;padding-top:3rem\">" +
+  "<h2>Authentication complete</h2><p>You can close this tab and return to NodeTool.</p></body>";
+
+const DEFAULT_FAILURE_HTML =
+  "<!doctype html><meta charset=utf-8><title>NodeTool</title>" +
+  "<body style=\"font-family:system-ui;text-align:center;padding-top:3rem\">" +
+  "<h2>Authentication failed</h2><p>You can close this tab and return to NodeTool.</p></body>";
+
+export interface WaitForCodeOptions {
+  /** The exact `state` value sent in the authorization request (CSRF guard). */
+  readonly expectedState: string;
+  /** Abort if no callback arrives within this many milliseconds. */
+  readonly timeoutMs: number;
+  /** External cancellation (e.g. user cancels the flow). */
+  readonly signal?: AbortSignal;
+}
+
+export class LocalCallbackServer {
+  private readonly host: string;
+  private readonly requestedPort: number;
+  private readonly path: string;
+  private readonly successHtml: string;
+  private readonly failureHtml: string;
+  private readonly logger?: Logger;
+  private server: Server | null = null;
+  private boundPort: number | null = null;
+
+  constructor(options: LocalCallbackServerOptions = {}) {
+    this.host = options.host ?? "127.0.0.1";
+    this.requestedPort = options.port ?? 0;
+    this.path = options.path ?? "/callback";
+    this.successHtml = options.successHtml ?? DEFAULT_SUCCESS_HTML;
+    this.failureHtml = options.failureHtml ?? DEFAULT_FAILURE_HTML;
+    this.logger = options.logger;
+  }
+
+  /** Start listening. Resolves with the bound port and full redirect URI. */
+  async listen(): Promise<{ port: number; redirectUri: string }> {
+    if (this.server) {
+      throw new OAuthError("token_exchange_failed", "Callback server already listening");
+    }
+    const server = createServer();
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        server.removeListener("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(this.requestedPort, this.host);
+    });
+
+    const address = server.address() as AddressInfo;
+    this.boundPort = address.port;
+    this.logger?.debug("Callback server listening", { host: this.host, port: address.port });
+    return { port: address.port, redirectUri: this.redirectUri() };
+  }
+
+  /** The redirect URI to register with the authorization server. */
+  redirectUri(): string {
+    if (this.boundPort == null) {
+      throw new OAuthError("token_exchange_failed", "Callback server is not listening yet");
+    }
+    return `http://${this.host}:${this.boundPort}${this.path}`;
+  }
+
+  /**
+   * Resolve when the browser hits the callback path with a matching `state`
+   * and an authorization `code`. Rejects on timeout, CSRF mismatch, an
+   * `error` param from the server, or external abort.
+   */
+  async waitForCode(options: WaitForCodeOptions): Promise<AuthorizationResult> {
+    const server = this.server;
+    if (!server) {
+      throw new OAuthError("token_exchange_failed", "Callback server is not listening");
+    }
+
+    return new Promise<AuthorizationResult>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        finish(() => reject(new CallbackTimeoutError()));
+      }, options.timeoutMs);
+
+      const onAbort = () => finish(() => reject(new OAuthError("callback_timeout", "Login aborted")));
+      if (options.signal) {
+        if (options.signal.aborted) {
+          onAbort();
+          return;
+        }
+        options.signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      const finish = (action: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        options.signal?.removeEventListener("abort", onAbort);
+        server.removeListener("request", onRequest);
+        action();
+      };
+
+      const onRequest = (req: IncomingMessage, res: ServerResponse) => {
+        // Reconstruct the URL; host header is irrelevant for loopback parsing.
+        const url = new URL(req.url ?? "/", `http://${this.host}`);
+        if (url.pathname !== this.path) {
+          res.writeHead(404).end();
+          return;
+        }
+
+        const error = url.searchParams.get("error");
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+
+        if (error) {
+          this.respond(res, false);
+          const denied =
+            error === "access_denied"
+              ? new AuthorizationDeniedError()
+              : new OAuthError("authorization_denied", `Authorization server returned error: ${error}`);
+          finish(() => reject(denied));
+          return;
+        }
+
+        // CSRF: validate state BEFORE trusting the code.
+        if (!state || state !== options.expectedState) {
+          this.respond(res, false);
+          finish(() => reject(new StateMismatchError()));
+          return;
+        }
+
+        if (!code) {
+          this.respond(res, false);
+          finish(() => reject(new OAuthError("authorization_denied", "Callback missing authorization code")));
+          return;
+        }
+
+        this.respond(res, true);
+        finish(() => resolve({ code, state }));
+      };
+
+      server.on("request", onRequest);
+    });
+  }
+
+  /** Stop listening and release the port. Idempotent. */
+  async close(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    this.boundPort = null;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private respond(res: ServerResponse, ok: boolean): void {
+    res.writeHead(ok ? 200 : 400, { "content-type": "text/html; charset=utf-8" });
+    res.end(ok ? this.successHtml : this.failureHtml);
+  }
+}

--- a/packages/runtime/src/providers/oauth/oauth-client.ts
+++ b/packages/runtime/src/providers/oauth/oauth-client.ts
@@ -1,0 +1,231 @@
+/**
+ * OAuthClient — the protocol layer. Builds authorization URLs and performs the
+ * token-endpoint round-trips (code exchange, refresh, revoke).
+ *
+ * It is pure protocol: no browser, no storage, no provider awareness. `fetch`
+ * and the clock are injected so the whole thing is deterministically testable,
+ * and every failure is mapped to a typed error. Tokens are never logged.
+ */
+
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import {
+  CredentialsRevokedError,
+  InvalidRefreshTokenError,
+  OAuthError,
+  OAuthNetworkError,
+  TokenExchangeError
+} from "./errors.js";
+import { redactObject } from "./redaction.js";
+import {
+  type AuthorizationUrlParams,
+  type Clock,
+  type OAuthClientConfig,
+  type OAuthTokens,
+  systemClock
+} from "./types.js";
+
+/** Minimal `fetch` surface this client needs — satisfied by global `fetch`. */
+export type FetchLike = (
+  input: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    signal?: AbortSignal;
+  }
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}>;
+
+export interface OAuthClientOptions {
+  readonly config: OAuthClientConfig;
+  /** Injected fetch. Defaults to the global. */
+  readonly fetchFn?: FetchLike;
+  readonly clock?: Clock;
+  readonly logger?: Logger;
+}
+
+/** Raw token response shape per RFC 6749 §5.1. */
+interface TokenResponseBody {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  token_type?: unknown;
+  expires_in?: unknown;
+  scope?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+export class OAuthClient {
+  private readonly config: OAuthClientConfig;
+  private readonly fetchFn: FetchLike;
+  private readonly clock: Clock;
+  private readonly logger: Logger;
+
+  constructor(options: OAuthClientOptions) {
+    this.config = options.config;
+    this.fetchFn = options.fetchFn ?? (globalThis.fetch as unknown as FetchLike);
+    this.clock = options.clock ?? systemClock;
+    this.logger = options.logger ?? createLogger("nodetool.runtime.oauth.client");
+  }
+
+  /** Build the authorization-endpoint URL the browser should open. */
+  buildAuthorizationUrl(params: AuthorizationUrlParams): string {
+    const url = new URL(this.config.authorizationEndpoint);
+    const q = url.searchParams;
+    q.set("response_type", "code");
+    q.set("client_id", this.config.clientId);
+    q.set("redirect_uri", params.redirectUri);
+    q.set("scope", this.config.scopes.join(" "));
+    q.set("state", params.state);
+    q.set("code_challenge", params.codeChallenge);
+    q.set("code_challenge_method", params.codeChallengeMethod);
+    if (this.config.audience) q.set("audience", this.config.audience);
+    for (const [k, v] of Object.entries(this.config.extraAuthParams ?? {})) {
+      q.set(k, v);
+    }
+    return url.toString();
+  }
+
+  /** Exchange an authorization code for an initial token set. */
+  async exchangeAuthorizationCode(params: {
+    code: string;
+    codeVerifier: string;
+    redirectUri: string;
+    signal?: AbortSignal;
+  }): Promise<OAuthTokens> {
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: this.config.clientId,
+      code_verifier: params.codeVerifier
+    });
+    return this.tokenRequest(body, params.signal, "exchange");
+  }
+
+  /** Exchange a refresh token for a fresh access token. */
+  async refreshAccessToken(refreshToken: string, signal?: AbortSignal): Promise<OAuthTokens> {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: this.config.clientId
+    });
+    if (this.config.scopes.length > 0) {
+      body.set("scope", this.config.scopes.join(" "));
+    }
+    return this.tokenRequest(body, signal, "refresh");
+  }
+
+  /** Best-effort RFC 7009 token revocation. No-op if no endpoint configured. */
+  async revokeToken(
+    token: string,
+    tokenTypeHint: "access_token" | "refresh_token" = "refresh_token",
+    signal?: AbortSignal
+  ): Promise<void> {
+    if (!this.config.revocationEndpoint) return;
+    const body = new URLSearchParams({
+      token,
+      token_type_hint: tokenTypeHint,
+      client_id: this.config.clientId
+    });
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await this.fetchFn(this.config.revocationEndpoint, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+        body: body.toString(),
+        signal
+      });
+    } catch (err) {
+      throw new OAuthNetworkError("Network error during token revocation", { cause: err });
+    }
+    // RFC 7009: the server returns 200 even for an already-invalid token.
+    if (!res.ok) {
+      this.logger.warn("Token revocation returned a non-OK status", { status: res.status });
+    }
+  }
+
+  private async tokenRequest(
+    body: URLSearchParams,
+    signal: AbortSignal | undefined,
+    kind: "exchange" | "refresh"
+  ): Promise<OAuthTokens> {
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await this.fetchFn(this.config.tokenEndpoint, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+        body: body.toString(),
+        signal
+      });
+    } catch (err) {
+      throw new OAuthNetworkError(`Network error during token ${kind}`, { cause: err });
+    }
+
+    const payload = await this.readJson(res);
+
+    if (!res.ok) {
+      throw this.mapErrorResponse(res.status, payload, kind);
+    }
+
+    return this.normalizeTokens(payload, kind);
+  }
+
+  private async readJson(res: Awaited<ReturnType<FetchLike>>): Promise<TokenResponseBody> {
+    try {
+      return (await res.json()) as TokenResponseBody;
+    } catch {
+      // Some servers send an empty / non-JSON error body.
+      return {};
+    }
+  }
+
+  private mapErrorResponse(status: number, payload: TokenResponseBody, kind: string): OAuthError {
+    const code = typeof payload.error === "string" ? payload.error : undefined;
+    const description =
+      typeof payload.error_description === "string" ? payload.error_description : undefined;
+    // Never include the raw body in the message; log a redacted copy instead.
+    this.logger.warn("Token endpoint returned an error", {
+      status,
+      kind,
+      error: code,
+      body: redactObject(payload)
+    });
+
+    const message = description ? `Token ${kind} failed: ${code ?? status}` : `Token ${kind} failed (${status})`;
+
+    if (code === "invalid_grant") {
+      return kind === "refresh"
+        ? new InvalidRefreshTokenError(message)
+        : new TokenExchangeError(message);
+    }
+    if (code === "access_denied" || code === "revoked_token" || code === "invalid_client") {
+      return new CredentialsRevokedError(message);
+    }
+    if (status >= 500) {
+      return new OAuthNetworkError(`Token ${kind} failed: server error ${status}`);
+    }
+    return new TokenExchangeError(message);
+  }
+
+  private normalizeTokens(payload: TokenResponseBody, kind: string): OAuthTokens {
+    const accessToken = payload.access_token;
+    if (typeof accessToken !== "string" || accessToken.length === 0) {
+      throw new TokenExchangeError(`Token ${kind} response missing access_token`);
+    }
+    const receivedAt = this.clock.now();
+    const expiresIn = typeof payload.expires_in === "number" ? payload.expires_in : null;
+    return {
+      accessToken,
+      refreshToken: typeof payload.refresh_token === "string" ? payload.refresh_token : null,
+      tokenType: typeof payload.token_type === "string" ? payload.token_type : "Bearer",
+      scope: typeof payload.scope === "string" ? payload.scope : null,
+      expiresAt: expiresIn != null ? receivedAt + expiresIn * 1000 : null,
+      receivedAt
+    };
+  }
+}

--- a/packages/runtime/src/providers/oauth/openai-oauth-provider.ts
+++ b/packages/runtime/src/providers/oauth/openai-oauth-provider.ts
@@ -1,0 +1,311 @@
+/**
+ * OpenAIOAuthProvider — an OpenAI provider authenticated by browser-based
+ * OAuth 2.0 (Authorization Code + PKCE) instead of a pasted API key.
+ *
+ * It extends `OpenAIProvider` so every model capability (chat, streaming,
+ * images, audio, embeddings) is inherited unchanged. The only thing it
+ * replaces is *where the bearer token comes from*: instead of a static API
+ * key, every request is served by a short-lived OAuth access token that is
+ * transparently refreshed when it expires.
+ *
+ * All collaborators are injected (OAuth client, token store, callback server,
+ * PKCE helper, browser launcher), so there is no module-level state and the
+ * whole thing is unit-testable without a network or a browser.
+ */
+
+import OpenAI from "openai";
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import { OpenAIProvider } from "../openai-provider.js";
+import type { LanguageModel, Message, ProviderId, ProviderStreamItem } from "../types.js";
+import { OAuthClient } from "./oauth-client.js";
+import { LocalCallbackServer } from "./local-callback-server.js";
+import { PKCEHelper } from "./pkce-helper.js";
+import type { TokenStore } from "./token-store.js";
+import type { BrowserLauncher } from "./browser-launcher.js";
+import {
+  CredentialsRevokedError,
+  InvalidRefreshTokenError,
+  NotAuthenticatedError,
+  SessionExpiredError
+} from "./errors.js";
+import { type Clock, type OAuthTokens, systemClock } from "./types.js";
+
+/** Sentinel passed to the parent constructor; the real bearer is OAuth-sourced. */
+const OAUTH_API_KEY_SENTINEL = "__nodetool_oauth__";
+
+export interface OpenAIOAuthProviderOptions {
+  /** Performs the OAuth protocol round-trips. */
+  readonly oauthClient: OAuthClient;
+  /** Persists / loads the token set (e.g. OS keychain-backed). */
+  readonly tokenStore: TokenStore;
+  /** Opens the authorization URL in the user's browser. */
+  readonly browserLauncher: BrowserLauncher;
+  /** Factory for a fresh single-shot callback server per login attempt. */
+  readonly callbackServerFactory: () => LocalCallbackServer;
+  /** PKCE + CSRF-state generator. */
+  readonly pkce?: PKCEHelper;
+  /** Builds an OpenAI SDK client from a bearer token. Injectable for tests. */
+  readonly openAIClientFactory?: (accessToken: string) => OpenAI;
+  readonly clock?: Clock;
+  readonly logger?: Logger;
+  /** Provider id reported to the rest of the system. Defaults to "openai". */
+  readonly providerId?: ProviderId;
+  /** Seconds of clock skew treated as "already expired". Defaults to 60. */
+  readonly expirySkewSeconds?: number;
+  /** Default browser timeout for `login()` in ms. Defaults to 300_000. */
+  readonly loginTimeoutMs?: number;
+}
+
+export interface LoginOptions {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+}
+
+export class OpenAIOAuthProvider extends OpenAIProvider {
+  private readonly oauthClient: OAuthClient;
+  private readonly tokenStore: TokenStore;
+  private readonly browserLauncher: BrowserLauncher;
+  private readonly callbackServerFactory: () => LocalCallbackServer;
+  private readonly pkce: PKCEHelper;
+  private readonly openAIClientFactory: (accessToken: string) => OpenAI;
+  private readonly clock: Clock;
+  private readonly oauthLogger: Logger;
+  private readonly expirySkewMs: number;
+  private readonly loginTimeoutMs: number;
+
+  /** In-memory session mirror of the persisted token set. */
+  private session: OAuthTokens | null = null;
+  /** Cached OpenAI client, keyed by the token it was built for. */
+  private oauthOpenAIClient: OpenAI | null = null;
+  private cachedForToken: string | null = null;
+  /** Single-flight guard so concurrent calls share one refresh round-trip. */
+  private refreshInFlight: Promise<OAuthTokens> | null = null;
+
+  constructor(options: OpenAIOAuthProviderOptions) {
+    super(
+      { OPENAI_API_KEY: OAUTH_API_KEY_SENTINEL },
+      { providerId: options.providerId ?? "openai" }
+    );
+    this.oauthClient = options.oauthClient;
+    this.tokenStore = options.tokenStore;
+    this.browserLauncher = options.browserLauncher;
+    this.callbackServerFactory = options.callbackServerFactory;
+    this.pkce = options.pkce ?? new PKCEHelper();
+    this.openAIClientFactory =
+      options.openAIClientFactory ?? ((accessToken) => new OpenAI({ apiKey: accessToken }));
+    this.clock = options.clock ?? systemClock;
+    this.oauthLogger = options.logger ?? createLogger("nodetool.runtime.oauth.provider");
+    this.expirySkewMs = (options.expirySkewSeconds ?? 60) * 1000;
+    this.loginTimeoutMs = options.loginTimeoutMs ?? 300_000;
+  }
+
+  // --- Authentication lifecycle ------------------------------------------
+
+  /**
+   * Run the full browser OAuth flow: spin up a localhost callback server, open
+   * the browser, wait for the redirect, exchange the code, and persist tokens.
+   * Resolves with the (non-secret) token metadata on success.
+   */
+  async login(options: LoginOptions = {}): Promise<{ scope: string | null; expiresAt: number | null }> {
+    const server = this.callbackServerFactory();
+    try {
+      const { redirectUri } = await server.listen();
+      const pkcePair = await this.pkce.createPkcePair();
+      const state = await this.pkce.createState();
+
+      const authUrl = this.oauthClient.buildAuthorizationUrl({
+        redirectUri,
+        state,
+        codeChallenge: pkcePair.challenge,
+        codeChallengeMethod: pkcePair.method
+      });
+
+      // BrowserLaunchError propagates as a distinct failure mode.
+      await this.browserLauncher.open(authUrl);
+      this.oauthLogger.info("Waiting for OAuth callback");
+
+      const { code } = await server.waitForCode({
+        expectedState: state,
+        timeoutMs: options.timeoutMs ?? this.loginTimeoutMs,
+        signal: options.signal
+      });
+
+      const tokens = await this.oauthClient.exchangeAuthorizationCode({
+        code,
+        codeVerifier: pkcePair.verifier,
+        redirectUri,
+        signal: options.signal
+      });
+
+      await this.applyTokens(tokens);
+      this.oauthLogger.info("OAuth login succeeded", {
+        scope: tokens.scope,
+        expiresAt: tokens.expiresAt
+      });
+      return { scope: tokens.scope, expiresAt: tokens.expiresAt };
+    } finally {
+      await server.close();
+    }
+  }
+
+  /** Whether a non-expired session is available without hitting the network. */
+  async isAuthenticated(): Promise<boolean> {
+    const tokens = await this.currentTokens();
+    return tokens != null && !this.isExpired(tokens);
+  }
+
+  /**
+   * Forget the session locally and, if the server exposes a revocation
+   * endpoint, revoke the refresh token. Always clears local storage even if
+   * remote revocation fails.
+   */
+  async logout(): Promise<void> {
+    const tokens = await this.currentTokens();
+    try {
+      if (tokens?.refreshToken) {
+        await this.oauthClient.revokeToken(tokens.refreshToken, "refresh_token");
+      }
+    } finally {
+      await this.tokenStore.clear();
+      this.session = null;
+      this.oauthOpenAIClient = null;
+      this.cachedForToken = null;
+    }
+  }
+
+  /**
+   * Return a valid access token, refreshing if expired. Throws
+   * `SessionExpiredError`/`NotAuthenticatedError` when re-login is required.
+   */
+  async getAccessToken(): Promise<string> {
+    const tokens = await this.ensureValidSession();
+    return tokens.accessToken;
+  }
+
+  // --- Token plumbing -----------------------------------------------------
+
+  private async currentTokens(): Promise<OAuthTokens | null> {
+    if (!this.session) {
+      this.session = await this.tokenStore.load();
+    }
+    return this.session;
+  }
+
+  private isExpired(tokens: OAuthTokens): boolean {
+    if (tokens.expiresAt == null) return false;
+    return this.clock.now() >= tokens.expiresAt - this.expirySkewMs;
+  }
+
+  private async ensureValidSession(): Promise<OAuthTokens> {
+    const tokens = await this.currentTokens();
+    if (!tokens) {
+      throw new NotAuthenticatedError();
+    }
+    if (!this.isExpired(tokens)) {
+      return tokens;
+    }
+    return this.refresh();
+  }
+
+  /** Refresh the access token (single-flight). */
+  async refresh(): Promise<OAuthTokens> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    this.refreshInFlight = this.doRefresh().finally(() => {
+      this.refreshInFlight = null;
+    });
+    return this.refreshInFlight;
+  }
+
+  private async doRefresh(): Promise<OAuthTokens> {
+    const current = await this.currentTokens();
+    const refreshToken = current?.refreshToken;
+    if (!refreshToken) {
+      // Nothing to refresh with — the session is effectively over.
+      await this.invalidate();
+      throw new SessionExpiredError("No refresh token available; re-authentication required");
+    }
+
+    let next: OAuthTokens;
+    try {
+      next = await this.oauthClient.refreshAccessToken(refreshToken);
+    } catch (err) {
+      // A rejected or revoked refresh token means the local session is dead.
+      if (err instanceof InvalidRefreshTokenError || err instanceof CredentialsRevokedError) {
+        await this.invalidate();
+      }
+      throw err;
+    }
+
+    // Providers may omit a rotated refresh token; keep the previous one.
+    const merged: OAuthTokens = next.refreshToken ? next : { ...next, refreshToken };
+    await this.applyTokens(merged);
+    return merged;
+  }
+
+  private async applyTokens(tokens: OAuthTokens): Promise<void> {
+    await this.tokenStore.save(tokens);
+    this.session = tokens;
+    // Invalidate the cached SDK client so the next call rebinds the new bearer.
+    if (this.cachedForToken !== tokens.accessToken) {
+      this.oauthOpenAIClient = null;
+      this.cachedForToken = null;
+    }
+  }
+
+  private async invalidate(): Promise<void> {
+    await this.tokenStore.clear();
+    this.session = null;
+    this.oauthOpenAIClient = null;
+    this.cachedForToken = null;
+  }
+
+  // --- OpenAIProvider overrides ------------------------------------------
+
+  /** Build (and cache) an OpenAI SDK client bound to the current access token. */
+  override getClient(): OpenAI {
+    const token = this.session?.accessToken;
+    if (!token) {
+      throw new NotAuthenticatedError("No active OAuth session; call login() first");
+    }
+    if (!this.oauthOpenAIClient || this.cachedForToken !== token) {
+      this.oauthOpenAIClient = this.openAIClientFactory(token);
+      this.cachedForToken = token;
+    }
+    return this.oauthOpenAIClient;
+  }
+
+  /**
+   * The OAuth bearer is short-lived and must never be baked into a container's
+   * environment as if it were a durable API key. Code runners that need OpenAI
+   * access should refresh through the provider instead.
+   */
+  override getContainerEnv(): Record<string, string> {
+    return {};
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const token = await this.getAccessToken();
+    const response = await fetch("https://api.openai.com/v1/models", {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!response.ok) return [];
+    const payload = (await response.json()) as { data?: Array<{ id?: string }> };
+    return (payload.data ?? [])
+      .filter((row): row is { id: string } => typeof row.id === "string" && row.id.length > 0)
+      .map((row) => ({ id: row.id, name: row.id, provider: "openai" }));
+  }
+
+  override async generateMessage(
+    args: Parameters<OpenAIProvider["generateMessage"]>[0]
+  ): Promise<Message> {
+    await this.ensureValidSession();
+    return super.generateMessage(args);
+  }
+
+  override async *generateMessages(
+    args: Parameters<OpenAIProvider["generateMessages"]>[0]
+  ): AsyncGenerator<ProviderStreamItem> {
+    await this.ensureValidSession();
+    yield* super.generateMessages(args);
+  }
+}

--- a/packages/runtime/src/providers/oauth/pkce-helper.ts
+++ b/packages/runtime/src/providers/oauth/pkce-helper.ts
@@ -1,0 +1,82 @@
+/**
+ * PKCE (RFC 7636) and CSRF-state generation.
+ *
+ * Pure crypto with no I/O and no shared state. The randomness source is
+ * injectable so tests can assert exact verifier/challenge derivations, but the
+ * default uses the platform CSPRNG (`node:crypto`).
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import type { CodeChallengeMethod, PkcePair } from "./types.js";
+
+/** Abstraction over a cryptographically-secure byte source. */
+export interface RandomSource {
+  /** Resolve to `size` random bytes. */
+  randomBytes(size: number): Promise<Uint8Array>;
+}
+
+/** Default CSPRNG backed by `node:crypto.randomBytes`. */
+export const nodeRandomSource: RandomSource = {
+  randomBytes: (size) =>
+    new Promise<Uint8Array>((resolve, reject) => {
+      randomBytes(size, (err, buf) => (err ? reject(err) : resolve(new Uint8Array(buf))));
+    })
+};
+
+/** RFC 4648 §5 base64url, no padding. */
+function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export interface PKCEHelperOptions {
+  /** Injected randomness; defaults to the platform CSPRNG. */
+  readonly random?: RandomSource;
+  /** Verifier entropy in bytes. RFC 7636 allows 43–128 chars; 32 bytes → 43. */
+  readonly verifierBytes?: number;
+  /** CSRF state entropy in bytes. */
+  readonly stateBytes?: number;
+}
+
+/**
+ * Generates PKCE verifiers/challenges and CSRF state values. All methods are
+ * async to keep a uniform, non-blocking API even though hashing is synchronous.
+ */
+export class PKCEHelper {
+  private readonly random: RandomSource;
+  private readonly verifierBytes: number;
+  private readonly stateBytes: number;
+
+  constructor(options: PKCEHelperOptions = {}) {
+    this.random = options.random ?? nodeRandomSource;
+    this.verifierBytes = options.verifierBytes ?? 32;
+    this.stateBytes = options.stateBytes ?? 32;
+  }
+
+  /** Generate a high-entropy `code_verifier`. */
+  async createCodeVerifier(): Promise<string> {
+    return base64UrlEncode(await this.random.randomBytes(this.verifierBytes));
+  }
+
+  /** Derive `code_challenge = BASE64URL(SHA-256(verifier))`. */
+  async createCodeChallenge(verifier: string): Promise<string> {
+    const digest = createHash("sha256").update(verifier, "ascii").digest();
+    return base64UrlEncode(new Uint8Array(digest));
+  }
+
+  /** Generate an opaque CSRF `state` token. */
+  async createState(): Promise<string> {
+    return base64UrlEncode(await this.random.randomBytes(this.stateBytes));
+  }
+
+  /** Convenience: produce a full verifier + challenge pair in one call. */
+  async createPkcePair(): Promise<PkcePair> {
+    const verifier = await this.createCodeVerifier();
+    const challenge = await this.createCodeChallenge(verifier);
+    const method: CodeChallengeMethod = "S256";
+    return { verifier, challenge, method };
+  }
+}

--- a/packages/runtime/src/providers/oauth/redaction.ts
+++ b/packages/runtime/src/providers/oauth/redaction.ts
@@ -1,0 +1,63 @@
+/**
+ * Redaction helpers. The single rule of this subsystem: secrets never reach a
+ * log sink, an error message, or a thrown payload in cleartext. Anything that
+ * might carry token material is funnelled through here first.
+ */
+
+const REDACTED = "<redacted>";
+
+/** Keys whose values are always scrubbed, regardless of nesting depth. */
+const SENSITIVE_KEYS = new Set([
+  "access_token",
+  "accesstoken",
+  "refresh_token",
+  "refreshtoken",
+  "code",
+  "code_verifier",
+  "codeverifier",
+  "client_secret",
+  "clientsecret",
+  "authorization",
+  "id_token",
+  "idtoken"
+]);
+
+/**
+ * Redact a single secret string for diagnostics: keep a short, non-reversible
+ * prefix so two different tokens are distinguishable in logs, hide the rest.
+ * An empty/short value collapses entirely to `<redacted>`.
+ */
+export function redactToken(value: string | null | undefined): string {
+  if (!value) return REDACTED;
+  if (value.length <= 8) return REDACTED;
+  return `${value.slice(0, 4)}…${REDACTED}`;
+}
+
+/**
+ * Deep-clone an arbitrary value with all sensitive fields replaced by
+ * `<redacted>`. Safe to pass straight into a logger. Cycles are broken with a
+ * `[Circular]` marker so logging can never throw.
+ */
+export function redactObject(input: unknown, seen = new WeakSet<object>()): unknown {
+  if (input === null || typeof input !== "object") {
+    return input;
+  }
+  if (seen.has(input as object)) {
+    return "[Circular]";
+  }
+  seen.add(input as object);
+
+  if (Array.isArray(input)) {
+    return input.map((item) => redactObject(item, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(input as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      out[key] = REDACTED;
+    } else {
+      out[key] = redactObject(val, seen);
+    }
+  }
+  return out;
+}

--- a/packages/runtime/src/providers/oauth/secure-credential-store.ts
+++ b/packages/runtime/src/providers/oauth/secure-credential-store.ts
@@ -1,0 +1,114 @@
+/**
+ * SecureCredentialStore — the lowest storage layer.
+ *
+ * A minimal named-secret key/value abstraction. It knows nothing about OAuth,
+ * tokens, or providers; it only persists opaque strings under string keys.
+ * Higher layers (`TokenStore`) compose it. This separation is what lets the
+ * token logic be unit-tested against an in-memory backend while production
+ * persists into the OS credential store.
+ */
+
+import { importHidden } from "@nodetool-ai/config";
+import type { Logger } from "@nodetool-ai/config";
+
+/** Persist opaque secret strings. All operations are async. */
+export interface SecureCredentialStore {
+  /** Return the stored value for `key`, or null if absent. */
+  get(key: string): Promise<string | null>;
+  /** Create or overwrite the value for `key`. */
+  set(key: string, value: string): Promise<void>;
+  /** Remove `key`. Resolves whether or not it existed. */
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * The subset of the `keytar` native module we depend on. Declared locally so we
+ * neither hard-depend on the package at build time nor pull its prebuilt binary
+ * into bundles that never authenticate.
+ */
+export interface KeyringBackend {
+  getPassword(service: string, account: string): Promise<string | null>;
+  setPassword(service: string, account: string, password: string): Promise<void>;
+  deletePassword(service: string, account: string): Promise<boolean>;
+}
+
+export interface KeychainCredentialStoreOptions {
+  /** Keychain service namespace. */
+  readonly service?: string;
+  /** Inject a backend (tests / custom keyrings). Defaults to lazy `keytar`. */
+  readonly backend?: KeyringBackend;
+  readonly logger?: Logger;
+}
+
+/**
+ * SecureCredentialStore backed by the operating-system credential store
+ * (macOS Keychain, Windows Credential Manager, Linux Secret Service) via
+ * `keytar`. The OS layer provides at-rest encryption, satisfying the
+ * "refresh tokens encrypted by the OS credential store" requirement. The
+ * native module is loaded lazily so importing this file never forces the
+ * binary to resolve.
+ */
+export class KeychainSecureCredentialStore implements SecureCredentialStore {
+  private readonly service: string;
+  private readonly injectedBackend?: KeyringBackend;
+  private readonly logger?: Logger;
+  private backendPromise?: Promise<KeyringBackend>;
+
+  constructor(options: KeychainCredentialStoreOptions = {}) {
+    this.service = options.service ?? "nodetool-oauth";
+    this.injectedBackend = options.backend;
+    this.logger = options.logger;
+  }
+
+  private async backend(): Promise<KeyringBackend> {
+    if (this.injectedBackend) return this.injectedBackend;
+    this.backendPromise ??= (async () => {
+      const mod = await importHidden<KeyringBackend | { default: KeyringBackend }>("keytar");
+      if (!mod) {
+        throw new Error(
+          "Secure credential storage requires the 'keytar' native module, which is unavailable in this runtime"
+        );
+      }
+      return (mod as { default?: KeyringBackend }).default ?? (mod as KeyringBackend);
+    })();
+    return this.backendPromise;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const backend = await this.backend();
+    return backend.getPassword(this.service, key);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    const backend = await this.backend();
+    await backend.setPassword(this.service, key, value);
+    // Note: `key` is an account label, never a secret; `value` is never logged.
+    this.logger?.debug("Stored credential in OS keychain", { service: this.service, key });
+  }
+
+  async delete(key: string): Promise<void> {
+    const backend = await this.backend();
+    await backend.deletePassword(this.service, key);
+    this.logger?.debug("Deleted credential from OS keychain", { service: this.service, key });
+  }
+}
+
+/**
+ * In-memory SecureCredentialStore for tests and ephemeral sessions. Holds
+ * secrets only for the lifetime of the instance — never touches disk.
+ */
+export class InMemorySecureCredentialStore implements SecureCredentialStore {
+  private readonly map = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.map.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.map.delete(key);
+  }
+}

--- a/packages/runtime/src/providers/oauth/token-store.ts
+++ b/packages/runtime/src/providers/oauth/token-store.ts
@@ -1,0 +1,106 @@
+/**
+ * TokenStore — the token-shaped persistence layer.
+ *
+ * Sits between the provider (which thinks in `OAuthTokens`) and the
+ * `SecureCredentialStore` (which thinks in opaque strings). Keeping this seam
+ * explicit is what satisfies "separate token storage from provider
+ * implementation": the provider depends only on the `TokenStore` interface and
+ * never learns where bytes actually live.
+ */
+
+import type { Logger } from "@nodetool-ai/config";
+import type { OAuthTokens } from "./types.js";
+import type { SecureCredentialStore } from "./secure-credential-store.js";
+
+/** Load / persist / clear a single account's OAuth token set. */
+export interface TokenStore {
+  /** Return the persisted tokens, or null if the account has none. */
+  load(): Promise<OAuthTokens | null>;
+  /** Persist the given token set, replacing any previous one. */
+  save(tokens: OAuthTokens): Promise<void>;
+  /** Remove all persisted tokens for this account. */
+  clear(): Promise<void>;
+}
+
+/** Runtime shape used to validate untrusted JSON read back from storage. */
+function parseTokens(raw: string): OAuthTokens | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.accessToken !== "string") return null;
+  return {
+    accessToken: v.accessToken,
+    refreshToken: typeof v.refreshToken === "string" ? v.refreshToken : null,
+    tokenType: typeof v.tokenType === "string" ? v.tokenType : "Bearer",
+    scope: typeof v.scope === "string" ? v.scope : null,
+    expiresAt: typeof v.expiresAt === "number" ? v.expiresAt : null,
+    receivedAt: typeof v.receivedAt === "number" ? v.receivedAt : Date.now()
+  };
+}
+
+export interface SecureTokenStoreOptions {
+  /** Backing secret store (e.g. OS keychain). */
+  readonly credentialStore: SecureCredentialStore;
+  /** Provider id, e.g. "openai" — part of the storage key. */
+  readonly provider: string;
+  /** Account identifier (user id / login) — part of the storage key. */
+  readonly accountId: string;
+  readonly logger?: Logger;
+}
+
+/**
+ * `TokenStore` that serializes the token set to JSON and hands it to a
+ * `SecureCredentialStore`. The full set — including the refresh token — is
+ * written only through the secure backend, never to a plaintext config file.
+ */
+export class SecureTokenStore implements TokenStore {
+  private readonly credentialStore: SecureCredentialStore;
+  private readonly key: string;
+  private readonly logger?: Logger;
+
+  constructor(options: SecureTokenStoreOptions) {
+    this.credentialStore = options.credentialStore;
+    this.key = `${options.provider}:${options.accountId}`;
+    this.logger = options.logger;
+  }
+
+  async load(): Promise<OAuthTokens | null> {
+    const raw = await this.credentialStore.get(this.key);
+    if (!raw) return null;
+    const tokens = parseTokens(raw);
+    if (!tokens) {
+      this.logger?.warn("Discarding unparseable stored credential", { key: this.key });
+    }
+    return tokens;
+  }
+
+  async save(tokens: OAuthTokens): Promise<void> {
+    await this.credentialStore.set(this.key, JSON.stringify(tokens));
+  }
+
+  async clear(): Promise<void> {
+    await this.credentialStore.delete(this.key);
+  }
+}
+
+/** Volatile `TokenStore` for tests — keeps a single token set in memory. */
+export class InMemoryTokenStore implements TokenStore {
+  private tokens: OAuthTokens | null = null;
+
+  async load(): Promise<OAuthTokens | null> {
+    return this.tokens;
+  }
+
+  async save(tokens: OAuthTokens): Promise<void> {
+    this.tokens = tokens;
+  }
+
+  async clear(): Promise<void> {
+    this.tokens = null;
+  }
+}

--- a/packages/runtime/src/providers/oauth/types.ts
+++ b/packages/runtime/src/providers/oauth/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared types for the OpenAI OAuth subsystem.
+ *
+ * Everything here is plain data — no behaviour, no I/O — so it can be imported
+ * freely by every layer (PKCE, client, stores, provider) without creating
+ * cycles.
+ */
+
+/** PKCE code-challenge method. NodeTool only supports the secure S256 variant. */
+export type CodeChallengeMethod = "S256";
+
+/** A PKCE verifier/challenge pair plus the method used to derive the challenge. */
+export interface PkcePair {
+  /** High-entropy random string kept secret on the client. */
+  readonly verifier: string;
+  /** BASE64URL(SHA-256(verifier)) sent in the authorization request. */
+  readonly challenge: string;
+  readonly method: CodeChallengeMethod;
+}
+
+/**
+ * A normalized OAuth token set. Timestamps are epoch milliseconds so they are
+ * trivially comparable against `Date.now()` and survive JSON round-trips.
+ */
+export interface OAuthTokens {
+  readonly accessToken: string;
+  /** May be absent — some providers omit it on refresh and reuse the old one. */
+  readonly refreshToken: string | null;
+  readonly tokenType: string;
+  readonly scope: string | null;
+  /** Absolute expiry in epoch ms, or null when the provider sends no expiry. */
+  readonly expiresAt: number | null;
+  /** When this set was minted (epoch ms). */
+  readonly receivedAt: number;
+}
+
+/** Static configuration for talking to an OAuth 2.0 authorization server. */
+export interface OAuthClientConfig {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  /** RFC 7009 revocation endpoint. Optional — not every server exposes one. */
+  readonly revocationEndpoint?: string;
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+  /** Optional `audience` parameter required by some providers. */
+  readonly audience?: string;
+  /** Extra static query params merged into the authorization URL. */
+  readonly extraAuthParams?: Readonly<Record<string, string>>;
+}
+
+/** Parameters needed to build a single authorization URL. */
+export interface AuthorizationUrlParams {
+  readonly redirectUri: string;
+  readonly state: string;
+  readonly codeChallenge: string;
+  readonly codeChallengeMethod: CodeChallengeMethod;
+}
+
+/** The authorization code returned to the redirect URI by the browser. */
+export interface AuthorizationResult {
+  readonly code: string;
+  readonly state: string;
+}
+
+/** Injectable clock so tests can control expiry math without real time. */
+export interface Clock {
+  now(): number;
+}
+
+/** Default wall-clock implementation. */
+export const systemClock: Clock = {
+  now: () => Date.now()
+};

--- a/packages/runtime/tests/providers/oauth/local-callback-server.test.ts
+++ b/packages/runtime/tests/providers/oauth/local-callback-server.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { LocalCallbackServer } from "../../../src/providers/oauth/local-callback-server.js";
+import {
+  AuthorizationDeniedError,
+  CallbackTimeoutError,
+  StateMismatchError
+} from "../../../src/providers/oauth/errors.js";
+
+let server: LocalCallbackServer | null = null;
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+});
+
+/** Drive the real loopback server by issuing an HTTP GET to its redirect URI. */
+async function hit(redirectUri: string, params: Record<string, string>): Promise<number> {
+  const url = new URL(redirectUri);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const res = await fetch(url.toString());
+  return res.status;
+}
+
+describe("LocalCallbackServer", () => {
+  it("resolves with the code when state matches", async () => {
+    server = new LocalCallbackServer();
+    const { redirectUri } = await server.listen();
+
+    const waiting = server.waitForCode({ expectedState: "st-1", timeoutMs: 5000 });
+    const status = await hit(redirectUri, { code: "the-code", state: "st-1" });
+
+    expect(status).toBe(200);
+    await expect(waiting).resolves.toEqual({ code: "the-code", state: "st-1" });
+  });
+
+  it("rejects with StateMismatchError on a forged state (CSRF guard)", async () => {
+    server = new LocalCallbackServer();
+    const { redirectUri } = await server.listen();
+
+    const waiting = server.waitForCode({ expectedState: "expected", timeoutMs: 5000 });
+    // Attach the rejection handler before triggering the callback so the
+    // (correctly) rejected promise is never momentarily unhandled.
+    const rejected = expect(waiting).rejects.toBeInstanceOf(StateMismatchError);
+    const status = await hit(redirectUri, { code: "x", state: "attacker" });
+
+    expect(status).toBe(400);
+    await rejected;
+  });
+
+  it("rejects with AuthorizationDeniedError when the server returns access_denied", async () => {
+    server = new LocalCallbackServer();
+    const { redirectUri } = await server.listen();
+
+    const waiting = server.waitForCode({ expectedState: "st", timeoutMs: 5000 });
+    const rejected = expect(waiting).rejects.toBeInstanceOf(AuthorizationDeniedError);
+    await hit(redirectUri, { error: "access_denied", state: "st" });
+
+    await rejected;
+  });
+
+  it("rejects with CallbackTimeoutError when no callback arrives", async () => {
+    server = new LocalCallbackServer();
+    await server.listen();
+    await expect(
+      server.waitForCode({ expectedState: "st", timeoutMs: 50 })
+    ).rejects.toBeInstanceOf(CallbackTimeoutError);
+  });
+
+  it("exposes a loopback redirect URI with the bound port", async () => {
+    server = new LocalCallbackServer({ path: "/cb" });
+    const { port, redirectUri } = await server.listen();
+    expect(redirectUri).toBe(`http://127.0.0.1:${port}/cb`);
+  });
+});

--- a/packages/runtime/tests/providers/oauth/oauth-client.test.ts
+++ b/packages/runtime/tests/providers/oauth/oauth-client.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest";
+import { OAuthClient, type FetchLike } from "../../../src/providers/oauth/oauth-client.js";
+import {
+  CredentialsRevokedError,
+  InvalidRefreshTokenError,
+  OAuthNetworkError,
+  TokenExchangeError
+} from "../../../src/providers/oauth/errors.js";
+import type { OAuthClientConfig } from "../../../src/providers/oauth/types.js";
+
+const config: OAuthClientConfig = {
+  authorizationEndpoint: "https://auth.example.com/authorize",
+  tokenEndpoint: "https://auth.example.com/token",
+  revocationEndpoint: "https://auth.example.com/revoke",
+  clientId: "client-123",
+  scopes: ["openid", "api.read"]
+};
+
+function jsonResponse(status: number, body: unknown): Awaited<ReturnType<FetchLike>> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  };
+}
+
+const fixedClock = { now: () => 1_000_000 };
+
+describe("OAuthClient.buildAuthorizationUrl", () => {
+  it("includes PKCE, state, and the configured scopes", () => {
+    const client = new OAuthClient({ config, fetchFn: vi.fn(), clock: fixedClock });
+    const url = new URL(
+      client.buildAuthorizationUrl({
+        redirectUri: "http://127.0.0.1:9000/callback",
+        state: "state-xyz",
+        codeChallenge: "challenge-abc",
+        codeChallengeMethod: "S256"
+      })
+    );
+    expect(url.origin + url.pathname).toBe("https://auth.example.com/authorize");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("client-123");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:9000/callback");
+    expect(url.searchParams.get("scope")).toBe("openid api.read");
+    expect(url.searchParams.get("state")).toBe("state-xyz");
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-abc");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+});
+
+describe("OAuthClient.exchangeAuthorizationCode", () => {
+  it("posts the code + verifier and normalizes the token response", async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(200, {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "openid api.read"
+      })
+    ) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+
+    const tokens = await client.exchangeAuthorizationCode({
+      code: "auth-code",
+      codeVerifier: "verifier",
+      redirectUri: "http://127.0.0.1:9000/callback"
+    });
+
+    expect(tokens).toEqual({
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      tokenType: "Bearer",
+      scope: "openid api.read",
+      expiresAt: 1_000_000 + 3600 * 1000,
+      receivedAt: 1_000_000
+    });
+
+    const [, init] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("auth-code");
+    expect(body.get("code_verifier")).toBe("verifier");
+    expect(body.get("client_id")).toBe("client-123");
+  });
+
+  it("throws TokenExchangeError when access_token is missing", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(200, { token_type: "Bearer" })) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await expect(
+      client.exchangeAuthorizationCode({ code: "c", codeVerifier: "v", redirectUri: "r" })
+    ).rejects.toBeInstanceOf(TokenExchangeError);
+  });
+
+  it("wraps fetch rejections as OAuthNetworkError", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await expect(
+      client.exchangeAuthorizationCode({ code: "c", codeVerifier: "v", redirectUri: "r" })
+    ).rejects.toBeInstanceOf(OAuthNetworkError);
+  });
+});
+
+describe("OAuthClient.refreshAccessToken", () => {
+  it("maps invalid_grant to InvalidRefreshTokenError", async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(400, { error: "invalid_grant", error_description: "expired" })
+    ) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await expect(client.refreshAccessToken("bad-refresh")).rejects.toBeInstanceOf(
+      InvalidRefreshTokenError
+    );
+  });
+
+  it("maps access_denied to CredentialsRevokedError", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(403, { error: "access_denied" })) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await expect(client.refreshAccessToken("revoked")).rejects.toBeInstanceOf(
+      CredentialsRevokedError
+    );
+  });
+
+  it("maps 5xx responses to OAuthNetworkError", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(503, {})) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await expect(client.refreshAccessToken("any")).rejects.toBeInstanceOf(OAuthNetworkError);
+  });
+
+  it("never includes the token in a thrown error message", async () => {
+    const secret = "super-secret-refresh-token-value";
+    const fetchFn = vi.fn(async () => jsonResponse(400, { error: "invalid_grant" })) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    const err = await client.refreshAccessToken(secret).catch((e) => e as Error);
+    expect(err.message).not.toContain(secret);
+  });
+});
+
+describe("OAuthClient.revokeToken", () => {
+  it("no-ops when no revocation endpoint is configured", async () => {
+    const fetchFn = vi.fn() as unknown as FetchLike;
+    const client = new OAuthClient({
+      config: { ...config, revocationEndpoint: undefined },
+      fetchFn,
+      clock: fixedClock
+    });
+    await client.revokeToken("token");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("posts to the revocation endpoint when configured", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(200, {})) as unknown as FetchLike;
+    const client = new OAuthClient({ config, fetchFn, clock: fixedClock });
+    await client.revokeToken("token", "refresh_token");
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://auth.example.com/revoke",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});

--- a/packages/runtime/tests/providers/oauth/oauth-flow.integration.test.ts
+++ b/packages/runtime/tests/providers/oauth/oauth-flow.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration test: the full browser-OAuth login + refresh flow exercised over
+ * real TCP sockets. A real localhost token server stands in for OpenAI's
+ * authorization server, a real `LocalCallbackServer` receives the redirect, and
+ * a stub "browser" performs the redirect GET the way a user's browser would.
+ * Only the human click is faked — every wire interaction is real.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { OpenAIOAuthProvider } from "../../../src/providers/oauth/openai-oauth-provider.js";
+import { OAuthClient } from "../../../src/providers/oauth/oauth-client.js";
+import { PKCEHelper } from "../../../src/providers/oauth/pkce-helper.js";
+import { LocalCallbackServer } from "../../../src/providers/oauth/local-callback-server.js";
+import { InMemoryTokenStore } from "../../../src/providers/oauth/token-store.js";
+import type { BrowserLauncher } from "../../../src/providers/oauth/browser-launcher.js";
+import type { OAuthClientConfig, Clock } from "../../../src/providers/oauth/types.js";
+
+interface TokenServer {
+  server: Server;
+  url: string;
+  /** PKCE verifiers seen at the token endpoint, for assertions. */
+  exchanges: Array<{ code: string; codeVerifier: string }>;
+  refreshes: string[];
+}
+
+/** A minimal RFC 6749 token endpoint that validates grant types. */
+async function startTokenServer(): Promise<TokenServer> {
+  const exchanges: Array<{ code: string; codeVerifier: string }> = [];
+  const refreshes: string[] = [];
+  let issued = 0;
+
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      const params = new URLSearchParams(body);
+      const grant = params.get("grant_type");
+      res.setHeader("content-type", "application/json");
+
+      if (grant === "authorization_code") {
+        exchanges.push({
+          code: params.get("code") ?? "",
+          codeVerifier: params.get("code_verifier") ?? ""
+        });
+        issued += 1;
+        res.end(
+          JSON.stringify({
+            access_token: `access-${issued}`,
+            refresh_token: `refresh-${issued}`,
+            token_type: "Bearer",
+            expires_in: 3600,
+            scope: "openid offline_access"
+          })
+        );
+        return;
+      }
+      if (grant === "refresh_token") {
+        refreshes.push(params.get("refresh_token") ?? "");
+        issued += 1;
+        res.end(
+          JSON.stringify({
+            access_token: `access-${issued}`,
+            refresh_token: `refresh-${issued}`,
+            token_type: "Bearer",
+            expires_in: 3600
+          })
+        );
+        return;
+      }
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: "unsupported_grant_type" }));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return { server, url: `http://127.0.0.1:${port}`, exchanges, refreshes };
+}
+
+/** A "browser" that fulfils the OAuth redirect by GETting the callback URL. */
+function redirectingBrowser(): BrowserLauncher {
+  return {
+    open: async (authUrl: string) => {
+      const url = new URL(authUrl);
+      const redirectUri = url.searchParams.get("redirect_uri");
+      const state = url.searchParams.get("state");
+      if (!redirectUri || !state) throw new Error("auth URL missing redirect/state");
+      const cb = new URL(redirectUri);
+      cb.searchParams.set("code", "real-auth-code");
+      cb.searchParams.set("state", state);
+      // Fire-and-forget, mirroring a browser navigation racing the callback wait.
+      void fetch(cb.toString()).catch(() => undefined);
+    }
+  };
+}
+
+let tokenServer: TokenServer | null = null;
+afterEach(async () => {
+  if (tokenServer) {
+    await new Promise<void>((resolve) => tokenServer!.server.close(() => resolve()));
+    tokenServer = null;
+  }
+});
+
+function mutableClock(start: number): Clock & { set(v: number): void } {
+  let t = start;
+  return { now: () => t, set: (v) => (t = v) };
+}
+
+describe("OpenAI OAuth end-to-end flow", () => {
+  it("logs in via browser redirect and persists usable tokens", async () => {
+    tokenServer = await startTokenServer();
+    const clock = mutableClock(1_000_000);
+    const config: OAuthClientConfig = {
+      authorizationEndpoint: "https://auth.example.com/authorize",
+      tokenEndpoint: `${tokenServer.url}/token`,
+      clientId: "integration-client",
+      scopes: ["openid", "offline_access"]
+    };
+    const tokenStore = new InMemoryTokenStore();
+    const provider = new OpenAIOAuthProvider({
+      oauthClient: new OAuthClient({ config, clock }),
+      tokenStore,
+      browserLauncher: redirectingBrowser(),
+      callbackServerFactory: () => new LocalCallbackServer({ path: "/callback" }),
+      pkce: new PKCEHelper(),
+      openAIClientFactory: (token) => ({ token }) as never,
+      clock
+    });
+
+    await provider.login({ timeoutMs: 5000 });
+
+    expect(await provider.getAccessToken()).toBe("access-1");
+    expect(tokenServer.exchanges).toHaveLength(1);
+    // The token endpoint received a non-empty PKCE verifier.
+    expect(tokenServer.exchanges[0].codeVerifier.length).toBeGreaterThan(20);
+    expect(tokenServer.exchanges[0].code).toBe("real-auth-code");
+  });
+
+  it("refreshes the access token against the real token endpoint after expiry", async () => {
+    tokenServer = await startTokenServer();
+    const clock = mutableClock(1_000_000);
+    const config: OAuthClientConfig = {
+      authorizationEndpoint: "https://auth.example.com/authorize",
+      tokenEndpoint: `${tokenServer.url}/token`,
+      clientId: "integration-client",
+      scopes: ["openid", "offline_access"]
+    };
+    const provider = new OpenAIOAuthProvider({
+      oauthClient: new OAuthClient({ config, clock }),
+      tokenStore: new InMemoryTokenStore(),
+      browserLauncher: redirectingBrowser(),
+      callbackServerFactory: () => new LocalCallbackServer({ path: "/callback" }),
+      pkce: new PKCEHelper(),
+      openAIClientFactory: (token) => ({ token }) as never,
+      clock
+    });
+
+    await provider.login({ timeoutMs: 5000 });
+    expect(await provider.getAccessToken()).toBe("access-1");
+
+    clock.set(1_000_000 + 3600 * 1000 + 120_000);
+    expect(await provider.getAccessToken()).toBe("access-2");
+    expect(tokenServer.refreshes).toEqual(["refresh-1"]);
+  });
+});

--- a/packages/runtime/tests/providers/oauth/openai-oauth-provider.test.ts
+++ b/packages/runtime/tests/providers/oauth/openai-oauth-provider.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from "vitest";
+import { OpenAIOAuthProvider } from "../../../src/providers/oauth/openai-oauth-provider.js";
+import { OAuthClient, type FetchLike } from "../../../src/providers/oauth/oauth-client.js";
+import { InMemoryTokenStore } from "../../../src/providers/oauth/token-store.js";
+import { LocalCallbackServer } from "../../../src/providers/oauth/local-callback-server.js";
+import type { BrowserLauncher } from "../../../src/providers/oauth/browser-launcher.js";
+import {
+  InvalidRefreshTokenError,
+  NotAuthenticatedError,
+  SessionExpiredError
+} from "../../../src/providers/oauth/errors.js";
+import type { OAuthClientConfig, Clock } from "../../../src/providers/oauth/types.js";
+
+const config: OAuthClientConfig = {
+  authorizationEndpoint: "https://auth.example.com/authorize",
+  tokenEndpoint: "https://auth.example.com/token",
+  revocationEndpoint: "https://auth.example.com/revoke",
+  clientId: "client-123",
+  scopes: ["openid", "offline_access"]
+};
+
+function jsonResponse(status: number, body: unknown): Awaited<ReturnType<FetchLike>> {
+  return { ok: status >= 200 && status < 300, status, json: async () => body, text: async () => "" };
+}
+
+/** Mutable clock for driving expiry. */
+function mutableClock(start: number): Clock & { set(v: number): void } {
+  let t = start;
+  return { now: () => t, set: (v) => (t = v) };
+}
+
+/**
+ * Fake callback server that records the state it was asked to expect and
+ * returns a canned code, so the provider's login orchestration can be tested
+ * without real sockets.
+ */
+function fakeCallbackServerFactory(opts: { code?: string; capture?: (state: string) => void } = {}) {
+  const create = () =>
+    ({
+      listen: vi.fn(async () => ({ port: 9999, redirectUri: "http://127.0.0.1:9999/callback" })),
+      redirectUri: () => "http://127.0.0.1:9999/callback",
+      waitForCode: vi.fn(async ({ expectedState }: { expectedState: string }) => {
+        opts.capture?.(expectedState);
+        return { code: opts.code ?? "auth-code", state: expectedState };
+      }),
+      close: vi.fn(async () => undefined)
+    }) as unknown as LocalCallbackServer;
+  return create;
+}
+
+function fakeBrowser(): BrowserLauncher & { open: ReturnType<typeof vi.fn> } {
+  return { open: vi.fn(async () => undefined) };
+}
+
+interface Harness {
+  provider: OpenAIOAuthProvider;
+  tokenStore: InMemoryTokenStore;
+  fetchFn: ReturnType<typeof vi.fn>;
+  browser: ReturnType<typeof fakeBrowser>;
+  clock: ReturnType<typeof mutableClock>;
+  openAIClientFactory: ReturnType<typeof vi.fn>;
+  capturedState: { value: string | null };
+}
+
+function makeHarness(fetchImpl: FetchLike): Harness {
+  const fetchFn = vi.fn(fetchImpl) as unknown as ReturnType<typeof vi.fn>;
+  const clock = mutableClock(1_000_000);
+  const tokenStore = new InMemoryTokenStore();
+  const browser = fakeBrowser();
+  const openAIClientFactory = vi.fn((token: string) => ({ __token: token }) as unknown);
+  const capturedState = { value: null as string | null };
+
+  const provider = new OpenAIOAuthProvider({
+    oauthClient: new OAuthClient({ config, fetchFn: fetchFn as unknown as FetchLike, clock }),
+    tokenStore,
+    browserLauncher: browser,
+    callbackServerFactory: fakeCallbackServerFactory({
+      capture: (s) => (capturedState.value = s)
+    }),
+    openAIClientFactory: openAIClientFactory as unknown as (t: string) => never,
+    clock
+  });
+
+  return { provider, tokenStore, fetchFn, browser, clock, openAIClientFactory, capturedState };
+}
+
+describe("OpenAIOAuthProvider.login", () => {
+  it("runs the PKCE flow, opens the browser, and persists tokens", async () => {
+    const h = makeHarness(async () =>
+      jsonResponse(200, {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "Bearer",
+        expires_in: 3600
+      })
+    );
+
+    const result = await h.provider.login();
+
+    expect(result.expiresAt).toBe(1_000_000 + 3600 * 1000);
+    expect(h.browser.open).toHaveBeenCalledOnce();
+
+    // The browser URL must carry PKCE + the same state the callback validated.
+    const url = new URL(h.browser.open.mock.calls[0][0] as string);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("state")).toBe(h.capturedState.value);
+
+    expect((await h.tokenStore.load())?.accessToken).toBe("access-1");
+    expect(await h.provider.isAuthenticated()).toBe(true);
+    expect(await h.provider.getAccessToken()).toBe("access-1");
+  });
+
+  it("builds an OpenAI client bound to the current access token", async () => {
+    const h = makeHarness(async () =>
+      jsonResponse(200, { access_token: "access-1", refresh_token: "r", token_type: "Bearer" })
+    );
+    await h.provider.login();
+    const client = h.provider.getClient() as unknown as { __token: string };
+    expect(client.__token).toBe("access-1");
+    expect(h.openAIClientFactory).toHaveBeenCalledWith("access-1");
+  });
+});
+
+describe("OpenAIOAuthProvider token lifecycle", () => {
+  it("auto-refreshes an expired access token before serving requests", async () => {
+    let phase = 0;
+    const h = makeHarness(async () => {
+      phase += 1;
+      return jsonResponse(200, {
+        access_token: phase === 1 ? "access-1" : "access-2",
+        refresh_token: phase === 1 ? "refresh-1" : "refresh-2",
+        token_type: "Bearer",
+        expires_in: 3600
+      });
+    });
+
+    await h.provider.login();
+    // Advance past expiry (1h + skew).
+    h.clock.set(1_000_000 + 3600 * 1000 + 120_000);
+
+    const token = await h.provider.getAccessToken();
+    expect(token).toBe("access-2");
+    expect((await h.tokenStore.load())?.refreshToken).toBe("refresh-2");
+  });
+
+  it("keeps the old refresh token when the server omits a rotated one", async () => {
+    let phase = 0;
+    const h = makeHarness(async () => {
+      phase += 1;
+      return jsonResponse(200, {
+        access_token: phase === 1 ? "access-1" : "access-2",
+        refresh_token: phase === 1 ? "refresh-1" : undefined,
+        token_type: "Bearer",
+        expires_in: 3600
+      });
+    });
+    await h.provider.login();
+    h.clock.set(1_000_000 + 3600 * 1000 + 120_000);
+    await h.provider.getAccessToken();
+    expect((await h.tokenStore.load())?.refreshToken).toBe("refresh-1");
+  });
+
+  it("clears the session and throws when the refresh token is invalid", async () => {
+    let phase = 0;
+    const h = makeHarness(async () => {
+      phase += 1;
+      if (phase === 1) {
+        return jsonResponse(200, {
+          access_token: "access-1",
+          refresh_token: "refresh-1",
+          token_type: "Bearer",
+          expires_in: 3600
+        });
+      }
+      return jsonResponse(400, { error: "invalid_grant" });
+    });
+    await h.provider.login();
+    h.clock.set(1_000_000 + 3600 * 1000 + 120_000);
+
+    await expect(h.provider.getAccessToken()).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    expect(await h.tokenStore.load()).toBeNull();
+    expect(await h.provider.isAuthenticated()).toBe(false);
+  });
+
+  it("coalesces concurrent refreshes into a single token request", async () => {
+    let phase = 0;
+    const h = makeHarness(async () => {
+      phase += 1;
+      return jsonResponse(200, {
+        access_token: phase === 1 ? "access-1" : "access-2",
+        refresh_token: "refresh-x",
+        token_type: "Bearer",
+        expires_in: 3600
+      });
+    });
+    await h.provider.login();
+    h.fetchFn.mockClear();
+    h.clock.set(1_000_000 + 3600 * 1000 + 120_000);
+
+    const [a, b] = await Promise.all([h.provider.getAccessToken(), h.provider.getAccessToken()]);
+    expect(a).toBe("access-2");
+    expect(b).toBe("access-2");
+    expect(h.fetchFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OpenAIOAuthProvider unauthenticated guards", () => {
+  it("throws NotAuthenticatedError from getClient before login", () => {
+    const h = makeHarness(async () => jsonResponse(200, {}));
+    expect(() => h.provider.getClient()).toThrow(NotAuthenticatedError);
+  });
+
+  it("throws NotAuthenticatedError from getAccessToken with no stored session", async () => {
+    const h = makeHarness(async () => jsonResponse(200, {}));
+    await expect(h.provider.getAccessToken()).rejects.toBeInstanceOf(NotAuthenticatedError);
+  });
+
+  it("throws SessionExpiredError when an expired session has no refresh token", async () => {
+    const h = makeHarness(async () =>
+      jsonResponse(200, { access_token: "access-1", token_type: "Bearer", expires_in: 1 })
+    );
+    await h.provider.login();
+    h.clock.set(1_000_000 + 120_000);
+    await expect(h.provider.getAccessToken()).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("does not expose the OAuth bearer through container env", async () => {
+    const h = makeHarness(async () =>
+      jsonResponse(200, { access_token: "access-1", refresh_token: "r", token_type: "Bearer" })
+    );
+    await h.provider.login();
+    expect(h.provider.getContainerEnv()).toEqual({});
+  });
+});
+
+describe("OpenAIOAuthProvider.logout", () => {
+  it("revokes the refresh token and clears storage", async () => {
+    const h = makeHarness(async () =>
+      jsonResponse(200, { access_token: "access-1", refresh_token: "refresh-1", token_type: "Bearer" })
+    );
+    await h.provider.login();
+    h.fetchFn.mockClear();
+
+    await h.provider.logout();
+
+    expect(h.fetchFn).toHaveBeenCalledWith(
+      "https://auth.example.com/revoke",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(await h.tokenStore.load()).toBeNull();
+    expect(await h.provider.isAuthenticated()).toBe(false);
+  });
+});

--- a/packages/runtime/tests/providers/oauth/pkce-helper.test.ts
+++ b/packages/runtime/tests/providers/oauth/pkce-helper.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { PKCEHelper, type RandomSource } from "../../../src/providers/oauth/pkce-helper.js";
+
+/** Deterministic random source: returns predictable, distinct byte patterns. */
+function fixedRandom(byte: number): RandomSource {
+  return {
+    randomBytes: async (size) => new Uint8Array(size).fill(byte)
+  };
+}
+
+const base64Url = (buf: Buffer) =>
+  buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+describe("PKCEHelper", () => {
+  it("produces a base64url verifier of the expected length and alphabet", async () => {
+    const helper = new PKCEHelper({ random: fixedRandom(0xab), verifierBytes: 32 });
+    const verifier = await helper.createCodeVerifier();
+    // 32 bytes → 43 base64url chars, no padding.
+    expect(verifier).toHaveLength(43);
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives the challenge as BASE64URL(SHA-256(verifier))", async () => {
+    const helper = new PKCEHelper({ random: fixedRandom(0x01) });
+    const verifier = await helper.createCodeVerifier();
+    const challenge = await helper.createCodeChallenge(verifier);
+    const expected = base64Url(createHash("sha256").update(verifier, "ascii").digest());
+    expect(challenge).toBe(expected);
+  });
+
+  it("createPkcePair returns a matching verifier/challenge with S256", async () => {
+    const helper = new PKCEHelper();
+    const pair = await helper.createPkcePair();
+    expect(pair.method).toBe("S256");
+    const recomputed = await helper.createCodeChallenge(pair.verifier);
+    expect(pair.challenge).toBe(recomputed);
+  });
+
+  it("generates high-entropy, non-repeating state values", async () => {
+    const helper = new PKCEHelper();
+    const a = await helper.createState();
+    const b = await helper.createState();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});

--- a/packages/runtime/tests/providers/oauth/redaction.test.ts
+++ b/packages/runtime/tests/providers/oauth/redaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { redactToken, redactObject } from "../../../src/providers/oauth/redaction.js";
+
+describe("redactToken", () => {
+  it("collapses short or empty values entirely", () => {
+    expect(redactToken("")).toBe("<redacted>");
+    expect(redactToken(null)).toBe("<redacted>");
+    expect(redactToken("short")).toBe("<redacted>");
+  });
+
+  it("keeps a short non-reversible prefix for longer values", () => {
+    const out = redactToken("sk-1234567890abcdef");
+    expect(out).toContain("<redacted>");
+    expect(out).not.toContain("567890abcdef");
+    expect(out.startsWith("sk-1")).toBe(true);
+  });
+});
+
+describe("redactObject", () => {
+  it("scrubs sensitive keys at any depth", () => {
+    const input = {
+      token_type: "Bearer",
+      access_token: "secret-a",
+      nested: { refresh_token: "secret-b", scope: "openid" },
+      list: [{ code: "secret-c" }]
+    };
+    const out = redactObject(input) as Record<string, unknown>;
+    expect(out.token_type).toBe("Bearer");
+    expect(out.access_token).toBe("<redacted>");
+    expect((out.nested as Record<string, unknown>).refresh_token).toBe("<redacted>");
+    expect((out.nested as Record<string, unknown>).scope).toBe("openid");
+    expect((out.list as Array<Record<string, unknown>>)[0].code).toBe("<redacted>");
+  });
+
+  it("does not throw on circular structures", () => {
+    const a: Record<string, unknown> = { name: "x" };
+    a.self = a;
+    expect(() => redactObject(a)).not.toThrow();
+    const out = redactObject(a) as Record<string, unknown>;
+    expect(out.self).toBe("[Circular]");
+  });
+});

--- a/packages/runtime/tests/providers/oauth/stores.test.ts
+++ b/packages/runtime/tests/providers/oauth/stores.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  InMemorySecureCredentialStore,
+  KeychainSecureCredentialStore,
+  type KeyringBackend
+} from "../../../src/providers/oauth/secure-credential-store.js";
+import {
+  SecureTokenStore,
+  InMemoryTokenStore
+} from "../../../src/providers/oauth/token-store.js";
+import type { OAuthTokens } from "../../../src/providers/oauth/types.js";
+
+const sampleTokens: OAuthTokens = {
+  accessToken: "access-1",
+  refreshToken: "refresh-1",
+  tokenType: "Bearer",
+  scope: "openid",
+  expiresAt: 2_000_000,
+  receivedAt: 1_000_000
+};
+
+/** A trivial in-memory keyring that mimics keytar's contract. */
+function fakeKeyring(): KeyringBackend & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getPassword: async (service, account) => store.get(`${service}:${account}`) ?? null,
+    setPassword: async (service, account, password) => {
+      store.set(`${service}:${account}`, password);
+    },
+    deletePassword: async (service, account) => store.delete(`${service}:${account}`)
+  };
+}
+
+describe("KeychainSecureCredentialStore", () => {
+  it("round-trips secrets through the injected keyring backend", async () => {
+    const backend = fakeKeyring();
+    const store = new KeychainSecureCredentialStore({ service: "svc", backend });
+    expect(await store.get("k")).toBeNull();
+    await store.set("k", "v");
+    expect(await store.get("k")).toBe("v");
+    expect(backend.store.get("svc:k")).toBe("v");
+    await store.delete("k");
+    expect(await store.get("k")).toBeNull();
+  });
+});
+
+describe("SecureTokenStore", () => {
+  it("persists tokens via the credential store and reloads them", async () => {
+    const credentialStore = new InMemorySecureCredentialStore();
+    const store = new SecureTokenStore({
+      credentialStore,
+      provider: "openai",
+      accountId: "user-1"
+    });
+
+    expect(await store.load()).toBeNull();
+    await store.save(sampleTokens);
+    expect(await store.load()).toEqual(sampleTokens);
+
+    // The serialized blob lives under a namespaced key, not a plaintext file.
+    expect(await credentialStore.get("openai:user-1")).toContain("access-1");
+
+    await store.clear();
+    expect(await store.load()).toBeNull();
+  });
+
+  it("returns null for a corrupted stored blob instead of throwing", async () => {
+    const credentialStore = new InMemorySecureCredentialStore();
+    await credentialStore.set("openai:user-1", "{not-json");
+    const store = new SecureTokenStore({
+      credentialStore,
+      provider: "openai",
+      accountId: "user-1"
+    });
+    expect(await store.load()).toBeNull();
+  });
+
+  it("isolates accounts by namespaced key", async () => {
+    const credentialStore = new InMemorySecureCredentialStore();
+    const a = new SecureTokenStore({ credentialStore, provider: "openai", accountId: "a" });
+    const b = new SecureTokenStore({ credentialStore, provider: "openai", accountId: "b" });
+    await a.save(sampleTokens);
+    expect(await b.load()).toBeNull();
+  });
+});
+
+describe("InMemoryTokenStore", () => {
+  it("supports the full load/save/clear lifecycle", async () => {
+    const store = new InMemoryTokenStore();
+    expect(await store.load()).toBeNull();
+    await store.save(sampleTokens);
+    expect(await store.load()).toEqual(sampleTokens);
+    await store.clear();
+    expect(await store.load()).toBeNull();
+  });
+});

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -8,6 +8,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 import { OAuthCredential } from "@nodetool-ai/models";
+import { OAuthClient } from "@nodetool-ai/runtime";
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -21,6 +22,24 @@ const GITHUB_AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
 const GITHUB_SCOPES = ["user:email", "read:user"];
+
+// OpenAI OAuth. Unlike HuggingFace there is no fixed public client id, so the
+// flow is opt-in: it activates only when OPENAI_OAUTH_CLIENT_ID is set
+// (mirroring how GitHub requires GITHUB_CLIENT_ID). Endpoints/scopes are
+// env-overridable so the same code works against OpenAI's published OAuth
+// server or a tenant-specific gateway.
+const OPENAI_AUTHORIZATION_URL =
+  process.env.OPENAI_OAUTH_AUTHORIZATION_URL ??
+  "https://auth.openai.com/oauth/authorize";
+const OPENAI_TOKEN_URL =
+  process.env.OPENAI_OAUTH_TOKEN_URL ?? "https://auth.openai.com/oauth/token";
+const OPENAI_USERINFO_URL =
+  process.env.OPENAI_OAUTH_USERINFO_URL ?? "https://auth.openai.com/userinfo";
+const OPENAI_SCOPES = (
+  process.env.OPENAI_OAUTH_SCOPES ?? "openid profile email offline_access"
+)
+  .split(/\s+/)
+  .filter(Boolean);
 
 const STATE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -804,6 +823,209 @@ async function handleGithubUser(
   }
 }
 
+// ── OpenAI Endpoints ─────────────────────────────────────────────────
+
+/** Build an OAuthClient for OpenAI, or null when OAuth is not configured. */
+function openaiOAuthClient(): OAuthClient | null {
+  const clientId = process.env.OPENAI_OAUTH_CLIENT_ID;
+  if (!clientId) return null;
+  return new OAuthClient({
+    config: {
+      authorizationEndpoint: OPENAI_AUTHORIZATION_URL,
+      tokenEndpoint: OPENAI_TOKEN_URL,
+      clientId,
+      scopes: OPENAI_SCOPES
+    }
+  });
+}
+
+/** Derive the public callback URL for a given provider from the request host. */
+function callbackUriFor(request: Request, provider: string): string {
+  let host = request.headers.get("host") ?? "localhost:7777";
+  if (host.includes("://")) {
+    host = host.split("://")[1];
+  }
+  if (host.startsWith("127.0.0.1")) {
+    host = host.replace("127.0.0.1", "localhost");
+  }
+  const scheme = host.includes("localhost") ? "http" : "https";
+  return `${scheme}://${host}/api/oauth/${provider}/callback`;
+}
+
+async function handleOpenAIStart(
+  request: Request,
+  getUserId: () => string
+): Promise<Response> {
+  if (request.method !== "GET") return errorResponse(405, "Method not allowed");
+
+  const client = openaiOAuthClient();
+  if (!client) {
+    return errorResponse(
+      500,
+      "OpenAI OAuth is not configured. Set OPENAI_OAUTH_CLIENT_ID."
+    );
+  }
+
+  const userId = getUserId();
+  const { codeVerifier, codeChallenge } = generatePkcePair();
+  const state = generateState();
+  const redirectUri = callbackUriFor(request, "openai");
+
+  pruneExpiredStates();
+  oauthStateStore.set(state, {
+    userId,
+    codeVerifier,
+    redirectUri,
+    createdAt: Date.now()
+  });
+
+  const authUrl = client.buildAuthorizationUrl({
+    redirectUri,
+    state,
+    codeChallenge,
+    codeChallengeMethod: "S256"
+  });
+
+  return jsonResponse({ auth_url: authUrl });
+}
+
+async function handleOpenAICallback(request: Request): Promise<Response> {
+  if (request.method !== "GET") return errorResponse(405, "Method not allowed");
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+  const errorDescription = url.searchParams.get("error_description");
+
+  if (error) {
+    return oauthHtmlResponse({
+      title: "OAuth Error",
+      success: false,
+      error,
+      errorDescription: errorDescription || "No description provided"
+    });
+  }
+
+  if (!code || !state) {
+    return oauthHtmlResponse({
+      title: "OAuth Error",
+      success: false,
+      error: "invalid_request",
+      errorDescription: "Missing required parameters (code or state)."
+    });
+  }
+
+  const stateData = oauthStateStore.get(state);
+  if (!stateData || Date.now() - stateData.createdAt > STATE_TTL_MS) {
+    if (stateData) oauthStateStore.delete(state);
+    return oauthHtmlResponse({
+      title: "OAuth Error",
+      success: false,
+      error: "invalid_state",
+      errorDescription:
+        "The authentication request has expired or is invalid. Please try again."
+    });
+  }
+
+  const { userId, codeVerifier, redirectUri } = stateData;
+  oauthStateStore.delete(state);
+
+  const client = openaiOAuthClient();
+  if (!client) {
+    return oauthHtmlResponse({
+      title: "OAuth Error",
+      success: false,
+      error: "configuration_error",
+      errorDescription: "OpenAI OAuth is not properly configured."
+    });
+  }
+
+  try {
+    const tokens = await client.exchangeAuthorizationCode({
+      code,
+      codeVerifier,
+      redirectUri
+    });
+
+    // Best-effort OIDC userinfo for a friendly account label. Failures fall
+    // back to an opaque, non-reversible account id derived from the token.
+    let username: string | null = null;
+    let accountId = String(Math.abs(hashCode(tokens.accessToken.slice(0, 24))));
+    try {
+      const infoRes = await fetch(OPENAI_USERINFO_URL, {
+        headers: { Authorization: `${tokens.tokenType} ${tokens.accessToken}` }
+      });
+      if (infoRes.ok) {
+        const info = (await infoRes.json()) as Record<string, unknown>;
+        username =
+          (info.email as string) ?? (info.name as string) ?? (info.sub as string) ?? null;
+        if (typeof info.sub === "string" && info.sub.length > 0) {
+          accountId = info.sub;
+        }
+      }
+    } catch {
+      // userinfo is optional — keep the fallback account id.
+    }
+
+    await OAuthCredential.upsert({
+      user_id: userId,
+      provider: "openai",
+      account_id: accountId,
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      username,
+      token_type: tokens.tokenType,
+      scope: tokens.scope,
+      received_at: new Date(tokens.receivedAt).toISOString(),
+      expires_at:
+        tokens.expiresAt != null ? new Date(tokens.expiresAt).toISOString() : null
+    });
+
+    return oauthHtmlResponse({
+      title: "OAuth Success",
+      success: true,
+      username,
+      autoClose: true
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return oauthHtmlResponse({
+      title: "OAuth Error",
+      success: false,
+      error: "token_exchange_failed",
+      errorDescription: message
+    });
+  }
+}
+
+async function handleOpenAITokens(getUserId: () => string): Promise<Response> {
+  const userId = getUserId();
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    userId,
+    "openai"
+  );
+  return jsonResponse({ tokens: credentials.map(toTokenMetadata) });
+}
+
+async function handleOpenAIDisconnect(
+  request: Request,
+  getUserId: () => string
+): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+
+  const userId = getUserId();
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    userId,
+    "openai"
+  );
+  for (const credential of credentials) {
+    await credential.delete();
+  }
+  return jsonResponse({ success: true, removed: credentials.length });
+}
+
 // ── Simple hash helper (replicates Python's hash() for fallback) ─────
 
 function hashCode(str: string): number {
@@ -861,6 +1083,16 @@ export async function handleOAuthRequest(
       return handleGithubTokens(getUserId);
     case "/api/oauth/github/user":
       return handleGithubUser(request, getUserId);
+
+    // OpenAI
+    case "/api/oauth/openai/start":
+      return handleOpenAIStart(request, getUserId);
+    case "/api/oauth/openai/callback":
+      return handleOpenAICallback(request);
+    case "/api/oauth/openai/tokens":
+      return handleOpenAITokens(getUserId);
+    case "/api/oauth/openai/disconnect":
+      return handleOpenAIDisconnect(request, getUserId);
 
     default:
       return null;

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 import { OAuthCredential } from "@nodetool-ai/models";
-import { OAuthClient } from "@nodetool-ai/runtime";
+import { OAuthClient } from "@nodetool-ai/runtime/oauth";
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { initTestDb, OAuthCredential } from "@nodetool-ai/models";
 import {
   generatePkcePair,

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initTestDb, OAuthCredential } from "@nodetool-ai/models";
 import {
   generatePkcePair,
@@ -242,6 +242,134 @@ describe("OAuth API: GitHub endpoints", () => {
       tokens: Array<Record<string, unknown>>;
     };
     expect(body.tokens).toEqual([]);
+  });
+});
+
+describe("OAuth API: OpenAI endpoints", () => {
+  beforeEach(() => {
+    initTestDb();
+    oauthStateStore.clear();
+    delete process.env.OPENAI_OAUTH_CLIENT_ID;
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_OAUTH_CLIENT_ID;
+  });
+
+  it("GET /api/oauth/openai/start returns error without OPENAI_OAUTH_CLIENT_ID", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/start", {
+        headers: { host: "localhost:7777" }
+      }),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(500);
+    const body = (await jsonBody(response!)) as { detail: string };
+    expect(body.detail).toContain("OPENAI_OAUTH_CLIENT_ID");
+  });
+
+  it("GET /api/oauth/openai/start returns a PKCE auth_url when configured", async () => {
+    process.env.OPENAI_OAUTH_CLIENT_ID = "test-openai-client-id";
+
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/start", {
+        headers: { host: "localhost:7777" }
+      }),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(200);
+    const body = (await jsonBody(response!)) as { auth_url: string };
+    expect(body.auth_url).toContain("https://auth.openai.com/oauth/authorize");
+    expect(body.auth_url).toContain("client_id=test-openai-client-id");
+    expect(body.auth_url).toContain("code_challenge=");
+    expect(body.auth_url).toContain("code_challenge_method=S256");
+    expect(body.auth_url).toContain("state=");
+    expect(body.auth_url).toContain(
+      "redirect_uri=http%3A%2F%2Flocalhost%3A7777%2Fapi%2Foauth%2Fopenai%2Fcallback"
+    );
+    // Start must persist the CSRF state for the callback to validate against.
+    expect(oauthStateStore.size).toBe(1);
+  });
+
+  it("GET /api/oauth/openai/tokens returns empty list initially", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/tokens"),
+      "/api/oauth/openai/tokens",
+      getUserId
+    );
+
+    expect(response!.status).toBe(200);
+    const body = (await jsonBody(response!)) as { tokens: unknown[] };
+    expect(body.tokens).toEqual([]);
+  });
+
+  it("GET /api/oauth/openai/callback with invalid state returns error HTML", async () => {
+    const response = await handleOAuthRequest(
+      new Request(
+        "http://localhost:7777/api/oauth/openai/callback?code=abc&state=invalid"
+      ),
+      "/api/oauth/openai/callback",
+      getUserId
+    );
+
+    expect(response).not.toBeNull();
+    const html = await response!.text();
+    expect(html).toContain("Authentication Failed");
+    expect(html).toContain("expired or is invalid");
+  });
+
+  it("POST /api/oauth/openai/disconnect removes stored credentials", async () => {
+    const now = new Date().toISOString();
+    await OAuthCredential.upsert({
+      user_id: "test-user-1",
+      provider: "openai",
+      account_id: "acc-openai",
+      access_token: "openai-access",
+      refresh_token: "openai-refresh",
+      token_type: "Bearer",
+      received_at: now
+    });
+
+    const before = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/tokens"),
+      "/api/oauth/openai/tokens",
+      getUserId
+    );
+    expect(((await jsonBody(before!)) as { tokens: unknown[] }).tokens).toHaveLength(1);
+
+    const disconnect = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/disconnect", {
+        method: "POST"
+      }),
+      "/api/oauth/openai/disconnect",
+      getUserId
+    );
+    expect(disconnect!.status).toBe(200);
+    const body = (await jsonBody(disconnect!)) as { success: boolean; removed: number };
+    expect(body.success).toBe(true);
+    expect(body.removed).toBe(1);
+
+    const after = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/tokens"),
+      "/api/oauth/openai/tokens",
+      getUserId
+    );
+    expect(((await jsonBody(after!)) as { tokens: unknown[] }).tokens).toEqual([]);
+  });
+
+  it("rejects a GET to the disconnect endpoint", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/disconnect"),
+      "/api/oauth/openai/disconnect",
+      getUserId
+    );
+    expect(response!.status).toBe(405);
   });
 });
 

--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -3,6 +3,7 @@ import SaveIcon from "@mui/icons-material/Save";
 
 import LoginIcon from "@mui/icons-material/Login";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import LinkOffIcon from "@mui/icons-material/LinkOff";
 import { useMemo, useState, useCallback, useEffect, memo } from "react";
 import {
   Select,
@@ -216,6 +217,8 @@ const RemoteSettings = () => {
 
   // HuggingFace OAuth state
   const [hfOAuthLoading, setHfOAuthLoading] = useState(false);
+  // OpenAI OAuth state
+  const [openaiOAuthLoading, setOpenaiOAuthLoading] = useState(false);
 
   const { data, isSuccess, isLoading } = useQuery({
     queryKey: ["settings"],
@@ -268,6 +271,56 @@ const RemoteSettings = () => {
       }
     }
   }, [hfOAuthLoading, isConnected, isHfTokenError, addNotification]);
+
+  // Poll for OpenAI OAuth completion
+  interface OpenAITokenResponse {
+    tokens: unknown[];
+  }
+
+  const { data: openaiTokenData, isError: isOpenAITokenError } = useQuery({
+    queryKey: ["openai-oauth-token"],
+    queryFn: async () => {
+      const response = await restFetch("/api/oauth/openai/tokens");
+      if (!response.ok) {
+        throw new Error("Failed to fetch OpenAI token");
+      }
+      return (await response.json()) as OpenAITokenResponse;
+    },
+    refetchInterval: (query) => {
+      const data = query.state.data as OpenAITokenResponse | undefined;
+      if (openaiOAuthLoading && !(data?.tokens && data.tokens.length > 0)) {
+        return 2000;
+      }
+      return false;
+    },
+    retry: true
+  });
+
+  const isOpenAIConnected = !!(
+    openaiTokenData &&
+    openaiTokenData.tokens &&
+    openaiTokenData.tokens.length > 0
+  );
+
+  useEffect(() => {
+    if (openaiOAuthLoading) {
+      if (isOpenAIConnected) {
+        setOpenaiOAuthLoading(false);
+        addNotification({
+          content: "Successfully connected to OpenAI",
+          type: "success",
+          alert: true
+        });
+      } else if (isOpenAITokenError) {
+        setOpenaiOAuthLoading(false);
+        addNotification({
+          content: "Failed to check OpenAI connection",
+          type: "error",
+          alert: true
+        });
+      }
+    }
+  }, [openaiOAuthLoading, isOpenAIConnected, isOpenAITokenError, addNotification]);
 
   const [settingValues, setSettingValues] = useState<Record<string, string>>(
     {}
@@ -402,6 +455,70 @@ const RemoteSettings = () => {
     }
   }, [addNotification]);
 
+  const handleOpenAIOAuth = useCallback(async () => {
+    setOpenaiOAuthLoading(true);
+
+    try {
+      const response = await restFetch("/api/oauth/openai/start");
+      const data = (await response.json().catch(() => null)) as
+        | { auth_url?: string; detail?: string }
+        | null;
+
+      if (!response.ok || !data?.auth_url) {
+        throw new Error(data?.detail || "Failed to start OAuth flow");
+      }
+
+      const authUrl = data.auth_url;
+
+      if (isElectron && window.api?.shell?.openExternal) {
+        await window.api.shell.openExternal(authUrl);
+      } else {
+        window.open(
+          authUrl,
+          "_blank",
+          "noopener,noreferrer,width=600,height=700"
+        );
+      }
+    } catch (error) {
+      console.error("OpenAI OAuth initiation failed:", error);
+      setOpenaiOAuthLoading(false);
+      addNotification({
+        content:
+          error instanceof Error
+            ? error.message
+            : "Failed to initiate OpenAI login",
+        type: "error",
+        alert: true
+      });
+    }
+  }, [addNotification]);
+
+  const handleOpenAIDisconnect = useCallback(async () => {
+    try {
+      const response = await restFetch("/api/oauth/openai/disconnect", {
+        method: "POST"
+      });
+      if (!response.ok) {
+        throw new Error("Failed to disconnect");
+      }
+      await queryClient.invalidateQueries({
+        queryKey: ["openai-oauth-token"]
+      });
+      addNotification({
+        content: "Disconnected from OpenAI",
+        type: "success",
+        alert: true
+      });
+    } catch (error) {
+      console.error("OpenAI disconnect failed:", error);
+      addNotification({
+        content: "Failed to disconnect from OpenAI",
+        type: "error",
+        alert: true
+      });
+    }
+  }, [addNotification, queryClient]);
+
   const handleSave = useCallback(() => {
     const settings: Record<string, string> = {};
     const secrets: Record<string, string> = {};
@@ -483,6 +600,61 @@ const RemoteSettings = () => {
                         ? "Connecting..."
                         : "Connect with HuggingFace"}
                   </EditorButton>
+                </div>
+              </div>
+
+              {/* OpenAI OAuth Section */}
+              <div className="settings-section">
+                <Text
+                  size="big"
+                  id="openai-oauth"
+                  className="settings-heading"
+                >
+                  OpenAI Authentication
+                </Text>
+                <div className="settings-item large">
+                  <Text className="description">
+                    Connect your OpenAI account with OAuth instead of pasting an
+                    API key. Tokens are stored securely and refreshed
+                    automatically.
+                  </Text>
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "0.5em",
+                      marginTop: "1em",
+                      alignSelf: "flex-start"
+                    }}
+                  >
+                    <EditorButton
+                      variant="contained"
+                      color="primary"
+                      onClick={handleOpenAIOAuth}
+                      disabled={openaiOAuthLoading}
+                      startIcon={
+                        isOpenAIConnected ? (
+                          <CheckCircleIcon />
+                        ) : openaiOAuthLoading ? null : (
+                          <LoginIcon />
+                        )
+                      }
+                    >
+                      {isOpenAIConnected
+                        ? "Connected to OpenAI"
+                        : openaiOAuthLoading
+                          ? "Connecting..."
+                          : "Connect with OpenAI"}
+                    </EditorButton>
+                    {isOpenAIConnected && (
+                      <EditorButton
+                        variant="text"
+                        onClick={handleOpenAIDisconnect}
+                        startIcon={<LinkOffIcon />}
+                      >
+                        Disconnect
+                      </EditorButton>
+                    )}
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

Implements browser-based OAuth 2.0 (Authorization Code + PKCE) authentication for the OpenAI provider as an alternative to static API keys. Every request is served by a short-lived access token that is transparently refreshed when expired; the refresh token is securely stored in the OS credential store and never written to plaintext config files.

## Key Changes

### New OAuth subsystem (`packages/runtime/src/providers/oauth/`)
- **`openai-oauth-provider.ts`**: Extends `OpenAIProvider`, replacing the static API key with OAuth-sourced tokens. Handles login orchestration, automatic token refresh, logout/revocation, and session management.
- **`oauth-client.ts`**: Pure OAuth 2.0 protocol layer (PKCE code exchange, refresh, revoke). Injected `fetch` and clock for deterministic testing.
- **`pkce-helper.ts`**: PKCE verifier/challenge generation + CSRF-state generation. Injected randomness source for testability.
- **`local-callback-server.ts`**: Single-shot localhost HTTP listener that receives the OAuth redirect, validates CSRF state, and resolves with the authorization code.
- **`browser-launcher.ts`**: Opens the authorization URL in the user's default browser (platform-aware: macOS `open`, Linux `xdg-open`, Windows `start`).
- **`token-store.ts`**: Token persistence layer (load/save/clear). Composes `SecureCredentialStore` for opaque secret storage.
- **`secure-credential-store.ts`**: OS keychain integration via lazy-loaded `keytar` module. In-memory fallback for tests.
- **`types.ts`**: Shared data types (`OAuthTokens`, `OAuthClientConfig`, `Clock`, `PkcePair`).
- **`errors.ts`**: Typed error hierarchy (one per failure mode: `InvalidRefreshTokenError`, `SessionExpiredError`, `NotAuthenticatedError`, etc.). Errors never contain token material.
- **`redaction.ts`**: Secret redaction for logs/errors. Tokens are never logged in cleartext.
- **`index.ts`**: Public surface + `createOpenAIOAuthProvider()` factory that wires production defaults.
- **`README.md`**: Comprehensive design documentation, file structure, layering diagram, and usage examples.

### Comprehensive test suite (`packages/runtime/tests/providers/oauth/`)
- **`openai-oauth-provider.test.ts`**: Unit tests for login, refresh, logout, and error handling with injected fakes (no real network/browser).
- **`oauth-client.test.ts`**: Unit tests for authorization URL building, code exchange, refresh, and revocation.
- **`oauth-flow.integration.test.ts`**: Full integration test over real TCP sockets (real `LocalCallbackServer`, real token server, stub browser).
- **`local-callback-server.test.ts`**: Real loopback socket tests for the callback listener.
- **`pkce-helper.test.ts`**: PKCE derivation and state generation tests.
- **`stores.test.ts`**: Token and credential store round-trip tests.
- **`redaction.test.ts`**: Secret redaction verification.

### WebSocket API integration (`packages/websocket/src/oauth-api.ts`)
- **`handleOpenAIStart()`**: Initiates the OAuth flow. Returns a PKCE-protected authorization URL.
- **`handleOpenAICallback()`**: Receives the redirect, exchanges the code for tokens, and persists them.
- **`handleOpenAITokens()`**: Returns the list of stored OAuth credentials for the current user.
- **`handleOpenAILogout()`**: Revokes tokens and clears stored credentials.
- Environment-driven configuration: `OPENAI_OAUTH_CLIENT_ID`, `OPENAI_OAUTH_AUTHORIZATION_URL`, `OPENAI_OAUTH_TOKEN_URL`, `OPENAI_OAUTH_USERINFO_URL`, `OPENAI_OAUTH_SCOPES`.

### Web UI integration (`web/src/components/

https://claude.ai/code/session_01XqrU5AFDTdE22Ca8cxQbSv