### PR TITLE
fix(web): prevent duplicate chat messages when assistant uses tools

### DIFF
--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -652,7 +652,13 @@ export function App({
             });
 
             for await (const item of stream) {
-              if (item.type === "chunk" && typeof item.content === "string") {
+              // ProviderStreamItem is Chunk | ToolCall; ToolCall has no `type`,
+              // so guard the discriminant before narrowing to a Chunk.
+              if (
+                "type" in item &&
+                item.type === "chunk" &&
+                typeof item.content === "string"
+              ) {
                 summary += item.content;
               }
             }

--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -359,6 +359,74 @@ describe("chatProtocol", () => {
     jest.useRealTimers();
   });
 
+  it("replaces the streaming placeholder when an assistant tool_call message carries the same text", async () => {
+    // Reproduces the duplicate-message bug: while streaming, applyChunk builds a
+    // local-stream-* placeholder from the text. The server then re-sends that
+    // same text as an assistant message with tool_calls. The placeholder must be
+    // replaced — not joined by a second copy of the text.
+    let capturedState: any = {
+      status: "streaming",
+      currentThreadId: "thread-1",
+      threads: {
+        "thread-1": {
+          id: "thread-1",
+          title: "T",
+          updated_at: new Date().toISOString()
+        }
+      },
+      messageCache: {
+        "thread-1": [
+          { role: "user", type: "message", content: "Search the web" },
+          {
+            id: "local-stream-123-abc",
+            role: "assistant",
+            type: "message",
+            content: "Let me search for that."
+          }
+        ]
+      },
+      selectedModel: { provider: "", id: "" },
+      summarizeThread: jest.fn(),
+      updateThreadTitle: jest.fn()
+    };
+
+    const set = jest.fn((updater) => {
+      capturedState = {
+        ...capturedState,
+        ...(typeof updater === "function" ? updater(capturedState) : updater)
+      };
+    });
+
+    const get = () => capturedState;
+
+    await handleChatWebSocketMessage(
+      {
+        type: "message",
+        id: "server-msg-1",
+        role: "assistant",
+        thread_id: "thread-1",
+        created_at: new Date().toISOString(),
+        content: "Let me search for that.",
+        tool_calls: [{ id: "call-1", name: "web_search", args: {} }]
+      } as any,
+      set,
+      get
+    );
+
+    const messages = capturedState.messageCache["thread-1"];
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toEqual(
+      expect.objectContaining({
+        id: "server-msg-1",
+        role: "assistant",
+        content: "Let me search for that.",
+        tool_calls: [{ id: "call-1", name: "web_search", args: {} }]
+      })
+    );
+    // The local streaming id is replaced by the finalized server message.
+    expect(messages[1].id).not.toMatch(/^local-stream-/);
+  });
+
   it("returns tool errors for unknown client tools", async () => {
     (FrontendToolRegistry.has as jest.Mock).mockReturnValue(false);
 

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -740,29 +740,158 @@ const applyAgentExecutionMessage = (
   return { update };
 };
 
+const normalizeTextForComparison = (text: string) =>
+  text.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
+
+const extractTextContent = (message: Message): string => {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (Array.isArray(message.content)) {
+    return message.content
+      .map((c) => (c.type === "text" ? c.text : ""))
+      .join("");
+  }
+  return "";
+};
+
+/**
+ * Locate the trailing local streaming placeholder (the `local-stream-*`
+ * assistant message that applyChunk builds from streamed text) that an incoming
+ * server-authored assistant message should replace rather than sit beside.
+ *
+ * The server re-sends the streamed text as a finalized assistant message — both
+ * when it completes a plain reply and when it attaches tool_calls. Without this
+ * reconciliation the placeholder and the finalized message both render, so the
+ * same text appears twice. Returns -1 when the incoming message is genuinely new.
+ */
+const findStreamPlaceholderIndex = (
+  messages: Message[],
+  msg: Message,
+  status: GlobalChatState["status"]
+): number => {
+  const incomingText = extractTextContent(msg);
+  const incomingNormalized = normalizeTextForComparison(incomingText);
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const candidate = messages[i];
+    if (candidate?.role !== "assistant") {
+      continue;
+    }
+    if (candidate.type !== "message") {
+      continue;
+    }
+
+    const candidateId = candidate.id ?? null;
+    const isLocalStream =
+      typeof candidateId === "string" &&
+      candidateId.startsWith("local-stream-");
+    const isServerAuthored =
+      !!candidate.created_at || (!!candidateId && !isLocalStream);
+
+    if (isServerAuthored) {
+      continue;
+    }
+
+    const candidateText = extractTextContent(candidate);
+    const candidateNormalized = normalizeTextForComparison(candidateText);
+    if (!candidateNormalized || !incomingNormalized) {
+      continue;
+    }
+
+    if (
+      candidateNormalized === incomingNormalized ||
+      incomingNormalized.startsWith(candidateNormalized) ||
+      candidateNormalized.startsWith(incomingNormalized)
+    ) {
+      return i;
+    }
+
+    // If we were streaming and the most recent assistant message looks local,
+    // prefer replacing it even if trailing whitespace differs.
+    if (
+      i === messages.length - 1 &&
+      (status === "streaming" || isLocalStream) &&
+      candidateText &&
+      incomingText
+    ) {
+      const candidateTrimmed = candidateText.trimEnd();
+      const incomingTrimmed = incomingText.trimEnd();
+      if (
+        candidateTrimmed === incomingTrimmed ||
+        incomingTrimmed.startsWith(candidateTrimmed)
+      ) {
+        return i;
+      }
+    }
+  }
+  return -1;
+};
+
+/**
+ * Replace the message at `index` with the incoming server message (merging so
+ * server fields like id/created_at/tool_calls win while keeping content when the
+ * server omits it), or append when no placeholder matched.
+ */
+const replaceStreamPlaceholderOrAppend = (
+  messages: Message[],
+  index: number,
+  msg: Message
+): Message[] => {
+  if (index < 0) {
+    return [...messages, msg];
+  }
+  const existing = messages[index];
+  const replacement: Message = {
+    ...existing,
+    ...msg,
+    content: msg.content ?? existing.content
+  };
+  return [
+    ...messages.slice(0, index),
+    replacement,
+    ...messages.slice(index + 1)
+  ];
+};
+
 const applyToolMessage = (
   state: GlobalChatState,
   threadId: string,
   messages: Message[],
   msg: Message
-) => ({
-  update: {
-    messageCache: {
-      ...state.messageCache,
-      [threadId]: [...messages, msg]
-    },
-    threads: state.threads[threadId]
-      ? updateThreadTimestamp(threadId, state.threads)
-      : state.threads,
-    ...(msg.role === "tool"
-      ? {
-          currentRunningToolCallId: null,
-          currentToolMessage: null,
-          statusMessage: null
-        }
-      : {})
-  }
-});
+) => {
+  // An assistant message carrying tool_calls finalizes the text the server just
+  // streamed, so replace the streaming placeholder instead of appending a second
+  // copy. Plain tool-result messages (role === "tool") never have a placeholder
+  // and are always appended.
+  const placeholderIndex =
+    msg.role === "assistant"
+      ? findStreamPlaceholderIndex(messages, msg, state.status)
+      : -1;
+  const updatedMessages = replaceStreamPlaceholderOrAppend(
+    messages,
+    placeholderIndex,
+    msg
+  );
+  return {
+    update: {
+      messageCache: {
+        ...state.messageCache,
+        [threadId]: updatedMessages
+      },
+      threads: state.threads[threadId]
+        ? updateThreadTimestamp(threadId, state.threads)
+        : state.threads,
+      ...(msg.role === "tool"
+        ? {
+            currentRunningToolCallId: null,
+            currentToolMessage: null,
+            statusMessage: null
+          }
+        : {})
+    }
+  };
+};
 
 const applyAssistantMessage = (
   state: GlobalChatState,
@@ -777,82 +906,15 @@ const applyAssistantMessage = (
       state.status === "streaming" ||
       state.status === "stopping");
 
-  const normalizeTextForComparison = (text: string) =>
-    text.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
+  const incomingNormalized = normalizeTextForComparison(
+    extractTextContent(msg)
+  );
 
-  const extractTextContent = (message: Message): string => {
-    if (typeof message.content === "string") {
-      return message.content;
-    }
-    if (Array.isArray(message.content)) {
-      return message.content
-        .map((c) => (c.type === "text" ? c.text : ""))
-        .join("");
-    }
-    return "";
-  };
-
-  const incomingText =
-    typeof msg.content === "string"
-      ? msg.content
-      : Array.isArray(msg.content)
-      ? msg.content.map((c) => (c.type === "text" ? c.text : "")).join("")
-      : "";
-  const incomingNormalized = normalizeTextForComparison(incomingText);
-
-  const findStreamPlaceholderIndex = (): number => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const candidate = messages[i];
-      if (candidate?.role !== "assistant") {continue;}
-      if (candidate.type !== "message") {continue;}
-
-      const candidateId = candidate.id ?? null;
-      const isLocalStream =
-        typeof candidateId === "string" &&
-        candidateId.startsWith("local-stream-");
-      const isServerAuthored =
-        !!candidate.created_at || (!!candidateId && !isLocalStream);
-
-      if (isServerAuthored) {
-        continue;
-      }
-
-      const candidateText = extractTextContent(candidate);
-      const candidateNormalized = normalizeTextForComparison(candidateText);
-      if (!candidateNormalized || !incomingNormalized) {
-        continue;
-      }
-
-      if (
-        candidateNormalized === incomingNormalized ||
-        incomingNormalized.startsWith(candidateNormalized) ||
-        candidateNormalized.startsWith(incomingNormalized)
-      ) {
-        return i;
-      }
-
-      // If we were streaming and the most recent assistant message looks local,
-      // prefer replacing it even if trailing whitespace differs.
-      if (
-        i === messages.length - 1 &&
-        (state.status === "streaming" || isLocalStream) &&
-        candidateText &&
-        incomingText
-      ) {
-        const candidateTrimmed = candidateText.trimEnd();
-        const incomingTrimmed = incomingText.trimEnd();
-        if (
-          candidateTrimmed === incomingTrimmed ||
-          incomingTrimmed.startsWith(candidateTrimmed)
-        ) {
-          return i;
-        }
-      }
-    }
-    return -1;
-  };
-
-  const streamPlaceholderIndex = findStreamPlaceholderIndex();
+  const streamPlaceholderIndex = findStreamPlaceholderIndex(
+    messages,
+    msg,
+    state.status
+  );
 
   const isNewAssistantMessage =
     streamPlaceholderIndex < 0 &&
@@ -861,17 +923,11 @@ const applyAssistantMessage = (
 
   const updatedMessages = (() => {
     if (streamPlaceholderIndex >= 0) {
-      const existing = messages[streamPlaceholderIndex];
-      const replacement: Message = {
-        ...existing,
-        ...msg,
-        content: msg.content ?? existing.content
-      };
-      return [
-        ...messages.slice(0, streamPlaceholderIndex),
-        replacement,
-        ...messages.slice(streamPlaceholderIndex + 1)
-      ];
+      return replaceStreamPlaceholderOrAppend(
+        messages,
+        streamPlaceholderIndex,
+        msg
+      );
     }
 
     const currentLast = messages[messages.length - 1];


### PR DESCRIPTION
## Root cause

The chat UI rendered duplicate messages whenever the assistant used tools — which, since every chat session now runs the unified LLM-with-tools loop, is essentially every conversation.

The streaming flow:
1. `applyChunk` accumulates streamed text into a `local-stream-*` placeholder assistant message.
2. The server then re-sends that **same text** as an assistant `message` carrying `tool_calls`.
3. That message was routed to `applyToolMessage`, which **blindly appended** it — so the cache held both the streaming placeholder *and* the finalized message with identical text. Both rendered → the text appeared twice.

`applyAssistantMessage` (the plain-reply path) already reconciled against the streaming placeholder, but the assistant-with-tool-calls path in `applyToolMessage` did not.

## Fix

In `web/src/core/chat/chatProtocol.ts`:
- Extracted the placeholder-reconciliation logic out of `applyAssistantMessage` into shared module-scope helpers: `findStreamPlaceholderIndex` and `replaceStreamPlaceholderOrAppend` (plus `extractTextContent` / `normalizeTextForComparison`).
- `applyToolMessage` now reconciles an incoming assistant tool-call message against the trailing streaming placeholder — replacing it instead of appending a second copy. Plain `role: "tool"` results still append as before.
- Refactored `applyAssistantMessage` to reuse the same helpers (no behavior change, removes ~90 lines of duplicated logic).

Added a regression test asserting that an assistant tool-call message replaces the `local-stream-*` placeholder rather than producing a duplicate.

## Verification
- `chatProtocol` tests: 12 passed (including the new case)
- `GlobalChatStore`, `chatPi`, `ChatThreadView` tests: 65 passed
- ESLint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ibU5jJReWsMDYthW2G5LT

---
_Generated by [Claude Code](https://claude.ai/code/session_017ibU5jJReWsMDYthW2G5LT)_