### PR TITLE
harden Docker code-runner containers against untrusted code

### DIFF
--- a/packages/code-runners/src/server-docker-runner.ts
+++ b/packages/code-runners/src/server-docker-runner.ts
@@ -41,6 +41,16 @@ export interface ServerDockerRunnerOptions {
   readyTimeoutSeconds?: number;
   /** Path suffix appended to the endpoint URL. */
   endpointPath?: string;
+  /** IPC namespace mode. Defaults to "private" (see StreamRunnerOptions). */
+  ipcMode?: StreamRunnerOptions["ipcMode"];
+  /** Linux capabilities to drop. Defaults to ["ALL"]. */
+  capDrop?: StreamRunnerOptions["capDrop"];
+  /** Docker --security-opt flags. Defaults to ["no-new-privileges"]. */
+  securityOpt?: StreamRunnerOptions["securityOpt"];
+  /** Mount the container root filesystem read-only. Default false. */
+  readonlyRootfs?: StreamRunnerOptions["readonlyRootfs"];
+  /** Mount the workspace bind read-only. Default false. */
+  readonlyWorkspace?: StreamRunnerOptions["readonlyWorkspace"];
 }
 
 // ---------------------------------------------------------------------------
@@ -134,7 +144,12 @@ export class ServerDockerRunner extends StreamRunnerBase {
       memLimit: options.memLimit ?? "256m",
       nanoCpus: options.nanoCpus ?? 1_000_000_000,
       networkDisabled: false,
-      mode: "docker"
+      mode: "docker",
+      ipcMode: options.ipcMode,
+      capDrop: options.capDrop,
+      securityOpt: options.securityOpt,
+      readonlyRootfs: options.readonlyRootfs,
+      readonlyWorkspace: options.readonlyWorkspace
     };
     super(baseOptions);
 

--- a/packages/code-runners/src/server-docker-runner.ts
+++ b/packages/code-runners/src/server-docker-runner.ts
@@ -203,7 +203,8 @@ export class ServerDockerRunner extends StreamRunnerBase {
     const hostWorkspace = this.getWorkspaceHostPath(options?.workspaceDir);
     const binds: string[] = [];
     if (hostWorkspace) {
-      binds.push(`${hostWorkspace}:/workspace:rw`);
+      const mountMode = this.readonlyWorkspace ? "ro" : "rw";
+      binds.push(`${hostWorkspace}:/workspace:${mountMode}`);
     }
 
     // Port binding: container port -> ephemeral host port
@@ -213,6 +214,10 @@ export class ServerDockerRunner extends StreamRunnerBase {
       NanoCpus: this.nanoCpus,
       Binds: binds.length > 0 ? binds : undefined,
       IpcMode: this.ipcMode ?? undefined,
+      CapDrop: this.capDrop.length > 0 ? this.capDrop : undefined,
+      SecurityOpt: this.securityOpt.length > 0 ? this.securityOpt : undefined,
+      ReadonlyRootfs: this.readonlyRootfs || undefined,
+      Tmpfs: this.readonlyRootfs ? { "/tmp": "rw,noexec,nosuid,size=64m" } : undefined,
       PortBindings: {
         [portKey]: [{ HostIp: this.hostIp, HostPort: "" }]
       }

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -144,8 +144,10 @@ export class StreamRunnerBase {
       options?.dockerWorkdir === undefined
         ? "/workspace"
         : options.dockerWorkdir;
-    this.capDrop = options?.capDrop ?? ["ALL"];
-    this.securityOpt = options?.securityOpt ?? ["no-new-privileges"];
+    this.capDrop = options?.capDrop ? [...options.capDrop] : ["ALL"];
+    this.securityOpt = options?.securityOpt
+      ? [...options.securityOpt]
+      : ["no-new-privileges"];
     this.readonlyRootfs = options?.readonlyRootfs ?? false;
     this.readonlyWorkspace = options?.readonlyWorkspace ?? false;
   }
@@ -452,8 +454,10 @@ export class StreamRunnerBase {
       CapDrop: this.capDrop.length > 0 ? this.capDrop : undefined,
       SecurityOpt: this.securityOpt.length > 0 ? this.securityOpt : undefined,
       ReadonlyRootfs: this.readonlyRootfs || undefined,
-      // A read-only rootfs would break interpreters that need scratch space,
-      // so give them a small in-memory /tmp that never touches the host.
+      // A read-only rootfs would break interpreters that need scratch space, so
+      // give them a small in-memory /tmp that never touches the host. It is
+      // mounted noexec/nosuid: scratch data only, code cannot be executed from
+      // it — keep those flags when changing this.
       Tmpfs: this.readonlyRootfs ? { "/tmp": "rw,noexec,nosuid,size=64m" } : undefined
     };
 

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -45,6 +45,27 @@ export interface StreamRunnerOptions {
   mode?: "docker" | "subprocess";
   workspaceMountPath?: string | "host" | null;
   dockerWorkdir?: string | null;
+  /**
+   * Linux capabilities to drop from the container. Defaults to `["ALL"]` —
+   * code runners execute untrusted code and need no capabilities.
+   */
+  capDrop?: string[];
+  /**
+   * Docker `--security-opt` flags. Defaults to `["no-new-privileges"]` to
+   * block privilege escalation via setuid binaries.
+   */
+  securityOpt?: string[];
+  /**
+   * Mount the container root filesystem read-only. Default `false`. When
+   * enabled, a small writable tmpfs is mounted at `/tmp` so interpreters that
+   * need scratch space keep working.
+   */
+  readonlyRootfs?: boolean;
+  /**
+   * Mount the workspace bind read-only. Default `false`. Enable for runners
+   * that only need to read inputs and never write back to the workspace.
+   */
+  readonlyWorkspace?: boolean;
 }
 
 export interface StreamOptions {
@@ -91,6 +112,10 @@ export class StreamRunnerBase {
   public readonly mode: "docker" | "subprocess";
   public readonly workspaceMountPath: string | "host" | null;
   public readonly dockerWorkdir: string | null;
+  public readonly capDrop: string[];
+  public readonly securityOpt: string[];
+  public readonly readonlyRootfs: boolean;
+  public readonly readonlyWorkspace: boolean;
 
   // `protected` (not `private`) so subclasses that implement their own
   // `stream()` — e.g. ServerDockerRunner — can register their container and
@@ -107,7 +132,9 @@ export class StreamRunnerBase {
     this.memLimit = options?.memLimit ?? "256m";
     this.nanoCpus = options?.nanoCpus ?? 1_000_000_000;
     this.networkDisabled = options?.networkDisabled ?? true;
-    this.ipcMode = options?.ipcMode === undefined ? "host" : options.ipcMode;
+    // Private IPC namespace by default: never share the host's (or another
+    // container's) System V IPC / POSIX shared memory with untrusted code.
+    this.ipcMode = options?.ipcMode === undefined ? "private" : options.ipcMode;
     this.mode = options?.mode ?? "docker";
     this.workspaceMountPath =
       options?.workspaceMountPath === undefined
@@ -117,6 +144,10 @@ export class StreamRunnerBase {
       options?.dockerWorkdir === undefined
         ? "/workspace"
         : options.dockerWorkdir;
+    this.capDrop = options?.capDrop ?? ["ALL"];
+    this.securityOpt = options?.securityOpt ?? ["no-new-privileges"];
+    this.readonlyRootfs = options?.readonlyRootfs ?? false;
+    this.readonlyWorkspace = options?.readonlyWorkspace ?? false;
   }
 
   // ---- Public API --------------------------------------------------------
@@ -404,17 +435,26 @@ export class StreamRunnerBase {
     const workspaceMount = this._resolveWorkspaceMount(options?.workspaceDir);
     const binds: string[] = [];
     if (workspaceMount) {
-      binds.push(`${workspaceMount[0]}:${workspaceMount[1]}:rw`);
+      const mountMode = this.readonlyWorkspace ? "ro" : "rw";
+      binds.push(`${workspaceMount[0]}:${workspaceMount[1]}:${mountMode}`);
     }
     const workingDir = this._determineContainerWorkdir(workspaceMount);
 
-    // Create container
+    // Create container. Defense-in-depth for untrusted code: drop all Linux
+    // capabilities, block privilege escalation, and (optionally) lock down the
+    // root and workspace filesystems.
     const hostConfig: Dockerode.HostConfig = {
       Memory: this._parseMemLimit(this.memLimit),
       NanoCpus: this.nanoCpus,
       NetworkMode: this.networkDisabled ? "none" : undefined,
       Binds: binds.length > 0 ? binds : undefined,
-      IpcMode: this.ipcMode ?? undefined
+      IpcMode: this.ipcMode ?? undefined,
+      CapDrop: this.capDrop.length > 0 ? this.capDrop : undefined,
+      SecurityOpt: this.securityOpt.length > 0 ? this.securityOpt : undefined,
+      ReadonlyRootfs: this.readonlyRootfs || undefined,
+      // A read-only rootfs would break interpreters that need scratch space,
+      // so give them a small in-memory /tmp that never touches the host.
+      Tmpfs: this.readonlyRootfs ? { "/tmp": "rw,noexec,nosuid,size=64m" } : undefined
     };
 
     const container = await docker.createContainer({

--- a/packages/code-runners/tests/server-docker-runner.test.ts
+++ b/packages/code-runners/tests/server-docker-runner.test.ts
@@ -128,6 +128,35 @@ describe("ServerDockerRunner constructor", () => {
     expect(runner.nanoCpus).toBe(1_000_000_000);
   });
 
+  it("inherits hardening defaults from the base runner", () => {
+    const runner = new ServerDockerRunner({
+      image: "test:latest",
+      containerPort: 8080
+    });
+    expect(runner.ipcMode).toBe("private");
+    expect(runner.capDrop).toEqual(["ALL"]);
+    expect(runner.securityOpt).toEqual(["no-new-privileges"]);
+    expect(runner.readonlyRootfs).toBe(false);
+    expect(runner.readonlyWorkspace).toBe(false);
+  });
+
+  it("threads hardening overrides through to the base runner", () => {
+    const runner = new ServerDockerRunner({
+      image: "test:latest",
+      containerPort: 8080,
+      ipcMode: "shareable",
+      capDrop: ["NET_RAW"],
+      securityOpt: ["seccomp=unconfined"],
+      readonlyRootfs: true,
+      readonlyWorkspace: true
+    });
+    expect(runner.ipcMode).toBe("shareable");
+    expect(runner.capDrop).toEqual(["NET_RAW"]);
+    expect(runner.securityOpt).toEqual(["seccomp=unconfined"]);
+    expect(runner.readonlyRootfs).toBe(true);
+    expect(runner.readonlyWorkspace).toBe(true);
+  });
+
   it("normalizes endpointPath by adding leading slash", () => {
     const runner = new ServerDockerRunner({
       image: "test:latest",

--- a/packages/code-runners/tests/stream-runner-base.test.ts
+++ b/packages/code-runners/tests/stream-runner-base.test.ts
@@ -160,6 +160,16 @@ describe("StreamRunnerBase constructor defaults", () => {
     expect(runner.readonlyWorkspace).toBe(true);
   });
 
+  it("clones capDrop/securityOpt so later option mutation can't change settings", () => {
+    const capDrop = ["NET_RAW"];
+    const securityOpt = ["no-new-privileges"];
+    const runner = new EchoRunner({ capDrop, securityOpt });
+    capDrop.push("ALL");
+    securityOpt.push("seccomp=unconfined");
+    expect(runner.capDrop).toEqual(["NET_RAW"]);
+    expect(runner.securityOpt).toEqual(["no-new-privileges"]);
+  });
+
   it("defaults workspaceMountPath to /workspace", () => {
     const runner = new EchoRunner();
     expect(runner.workspaceMountPath).toBe("/workspace");

--- a/packages/code-runners/tests/stream-runner-base.test.ts
+++ b/packages/code-runners/tests/stream-runner-base.test.ts
@@ -117,9 +117,47 @@ describe("StreamRunnerBase constructor defaults", () => {
     expect(runner.networkDisabled).toBe(true);
   });
 
-  it("defaults ipcMode to host", () => {
+  it("defaults ipcMode to private", () => {
     const runner = new EchoRunner();
-    expect(runner.ipcMode).toBe("host");
+    expect(runner.ipcMode).toBe("private");
+  });
+
+  it("drops all capabilities by default", () => {
+    const runner = new EchoRunner();
+    expect(runner.capDrop).toEqual(["ALL"]);
+  });
+
+  it("blocks privilege escalation by default", () => {
+    const runner = new EchoRunner();
+    expect(runner.securityOpt).toEqual(["no-new-privileges"]);
+  });
+
+  it("defaults readonlyRootfs to false", () => {
+    const runner = new EchoRunner();
+    expect(runner.readonlyRootfs).toBe(false);
+  });
+
+  it("defaults readonlyWorkspace to false", () => {
+    const runner = new EchoRunner();
+    expect(runner.readonlyWorkspace).toBe(false);
+  });
+
+  it("accepts custom capDrop and securityOpt", () => {
+    const runner = new EchoRunner({
+      capDrop: ["NET_RAW"],
+      securityOpt: ["seccomp=unconfined"]
+    });
+    expect(runner.capDrop).toEqual(["NET_RAW"]);
+    expect(runner.securityOpt).toEqual(["seccomp=unconfined"]);
+  });
+
+  it("accepts readonly filesystem options", () => {
+    const runner = new EchoRunner({
+      readonlyRootfs: true,
+      readonlyWorkspace: true
+    });
+    expect(runner.readonlyRootfs).toBe(true);
+    expect(runner.readonlyWorkspace).toBe(true);
   });
 
   it("defaults workspaceMountPath to /workspace", () => {


### PR DESCRIPTION
Defense-in-depth for the code runners that execute untrusted user code in
Docker containers:

- Default IpcMode to "private" instead of "host" so containers never share
  the host's System V IPC / POSIX shared-memory namespace.
- Drop all Linux capabilities (CapDrop: ["ALL"]) and block privilege
  escalation (SecurityOpt: ["no-new-privileges"]) by default.
- Add opt-in ReadonlyRootfs (with a writable tmpfs at /tmp so interpreters
  keep working) and a read-only workspace bind mode.

All four are configurable via StreamRunnerOptions. The same hardening is
applied to ServerDockerRunner. Defaults are chosen to be safe for arbitrary
code execution without breaking existing runners (rootfs/workspace stay
writable unless explicitly locked down).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014ysc3uy7qVifg2jzXaCM62