### PR TITLE
fix(auth): use constant-time token comparison in StaticTokenProvider

### DIFF
--- a/packages/auth/src/providers/static-token-provider.ts
+++ b/packages/auth/src/providers/static-token-provider.ts
@@ -8,7 +8,15 @@
  *   - STATIC_AUTH_TOKENS: JSON object mapping tokens to user IDs
  */
 
+import { timingSafeEqual } from "node:crypto";
+
 import { AuthProvider, AuthResult, TokenType } from "../auth-provider.js";
+
+/**
+ * Minimum length (in bytes) for a presented token to be considered.
+ * Rejects empty or trivially short tokens before any comparison.
+ */
+const MIN_TOKEN_LENGTH = 16;
 
 export class StaticTokenProvider extends AuthProvider {
   private tokens: Map<string, string>;
@@ -53,9 +61,28 @@ export class StaticTokenProvider extends AuthProvider {
   }
 
   async verifyToken(token: string): Promise<AuthResult> {
-    const userId = this.tokens.get(token);
-    if (userId) {
-      return { ok: true, userId, tokenType: TokenType.STATIC };
+    if (typeof token !== "string" || token.length < MIN_TOKEN_LENGTH) {
+      return { ok: false, error: "Invalid token" };
+    }
+
+    const provided = Buffer.from(token);
+
+    // Compare against every configured token using a constant-time comparison
+    // so verification time does not leak which (if any) token matched. We do
+    // not short-circuit on the first match for the same reason.
+    let matchedUserId: string | undefined;
+    for (const [candidate, userId] of this.tokens) {
+      const expected = Buffer.from(candidate);
+      if (
+        provided.length === expected.length &&
+        timingSafeEqual(provided, expected)
+      ) {
+        matchedUserId = userId;
+      }
+    }
+
+    if (matchedUserId !== undefined) {
+      return { ok: true, userId: matchedUserId, tokenType: TokenType.STATIC };
     }
     return { ok: false, error: "Invalid token" };
   }

--- a/packages/auth/src/providers/static-token-provider.ts
+++ b/packages/auth/src/providers/static-token-provider.ts
@@ -61,18 +61,21 @@ export class StaticTokenProvider extends AuthProvider {
   }
 
   async verifyToken(token: string): Promise<AuthResult> {
-    if (typeof token !== "string" || token.length < MIN_TOKEN_LENGTH) {
+    if (typeof token !== "string") {
       return { ok: false, error: "Invalid token" };
     }
 
-    const provided = Buffer.from(token);
+    const provided = Buffer.from(token, "utf-8");
+    if (provided.length < MIN_TOKEN_LENGTH) {
+      return { ok: false, error: "Invalid token" };
+    }
 
     // Compare against every configured token using a constant-time comparison
     // so verification time does not leak which (if any) token matched. We do
     // not short-circuit on the first match for the same reason.
     let matchedUserId: string | undefined;
     for (const [candidate, userId] of this.tokens) {
-      const expected = Buffer.from(candidate);
+      const expected = Buffer.from(candidate, "utf-8");
       if (
         provided.length === expected.length &&
         timingSafeEqual(provided, expected)

--- a/packages/auth/tests/auth-provider.test.ts
+++ b/packages/auth/tests/auth-provider.test.ts
@@ -167,28 +167,38 @@ describe("LocalAuthProvider", () => {
 // ---------------------------------------------------------------------------
 describe("StaticTokenProvider", () => {
   it("accepts a valid token", async () => {
-    const provider = new StaticTokenProvider({ secret123: "user42" });
-    const result = await provider.verifyToken("secret123");
+    const provider = new StaticTokenProvider({ "secret123-token-value": "user42" });
+    const result = await provider.verifyToken("secret123-token-value");
     expect(result.ok).toBe(true);
     expect(result.userId).toBe("user42");
     expect(result.tokenType).toBe(TokenType.STATIC);
   });
 
   it("rejects an invalid token", async () => {
-    const provider = new StaticTokenProvider({ secret123: "user42" });
-    const result = await provider.verifyToken("wrong");
+    const provider = new StaticTokenProvider({ "secret123-token-value": "user42" });
+    const result = await provider.verifyToken("wrong-token-value-1234");
     expect(result.ok).toBe(false);
     expect(result.error).toBe("Invalid token");
   });
 
+  it("rejects a token below the minimum length", async () => {
+    const provider = new StaticTokenProvider({ "secret123-token-value": "user42" });
+    expect((await provider.verifyToken("short")).ok).toBe(false);
+    expect((await provider.verifyToken("")).ok).toBe(false);
+  });
+
   it("supports multiple tokens", async () => {
     const provider = new StaticTokenProvider({
-      tok1: "u1",
-      tok2: "u2"
+      "tok1-value-1234567890": "u1",
+      "tok2-value-1234567890": "u2"
     });
-    expect((await provider.verifyToken("tok1")).userId).toBe("u1");
-    expect((await provider.verifyToken("tok2")).userId).toBe("u2");
-    expect((await provider.verifyToken("tok3")).ok).toBe(false);
+    expect((await provider.verifyToken("tok1-value-1234567890")).userId).toBe(
+      "u1"
+    );
+    expect((await provider.verifyToken("tok2-value-1234567890")).userId).toBe(
+      "u2"
+    );
+    expect((await provider.verifyToken("tok3-value-1234567890")).ok).toBe(false);
   });
 
   describe("from environment variables", () => {
@@ -199,21 +209,25 @@ describe("StaticTokenProvider", () => {
     });
 
     it("reads STATIC_AUTH_TOKEN", async () => {
-      process.env["STATIC_AUTH_TOKEN"] = "envtok";
+      process.env["STATIC_AUTH_TOKEN"] = "envtok-value-1234567890";
       const provider = new StaticTokenProvider();
-      const result = await provider.verifyToken("envtok");
+      const result = await provider.verifyToken("envtok-value-1234567890");
       expect(result.ok).toBe(true);
       expect(result.userId).toBe("1");
     });
 
     it("reads STATIC_AUTH_TOKENS as JSON", async () => {
       process.env["STATIC_AUTH_TOKENS"] = JSON.stringify({
-        alpha: "uA",
-        beta: "uB"
+        "alpha-value-1234567890": "uA",
+        "beta-value-12345678901": "uB"
       });
       const provider = new StaticTokenProvider();
-      expect((await provider.verifyToken("alpha")).userId).toBe("uA");
-      expect((await provider.verifyToken("beta")).userId).toBe("uB");
+      expect((await provider.verifyToken("alpha-value-1234567890")).userId).toBe(
+        "uA"
+      );
+      expect((await provider.verifyToken("beta-value-12345678901")).userId).toBe(
+        "uB"
+      );
     });
 
     it("ignores malformed STATIC_AUTH_TOKENS JSON", async () => {
@@ -231,7 +245,7 @@ describe("StaticTokenProvider", () => {
 // ---------------------------------------------------------------------------
 describe("createAuthMiddleware", () => {
   it("returns default user when enforceAuth is false and no token", async () => {
-    const staticProvider = new StaticTokenProvider({ tok: "u1" });
+    const staticProvider = new StaticTokenProvider({ "tok-value-1234567890": "u1" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       enforceAuth: false
@@ -244,19 +258,19 @@ describe("createAuthMiddleware", () => {
   });
 
   it("still validates token when enforceAuth is false and token is provided", async () => {
-    const staticProvider = new StaticTokenProvider({ tok: "u1" });
+    const staticProvider = new StaticTokenProvider({ "tok-value-1234567890": "u1" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       enforceAuth: false
     });
 
-    const request = makeRequest({ authorization: "Bearer tok" });
+    const request = makeRequest({ authorization: "Bearer tok-value-1234567890" });
     const user = await authenticate(request);
     expect(user.userId).toBe("u1");
   });
 
   it("throws 401 when enforceAuth is true and no token", async () => {
-    const staticProvider = new StaticTokenProvider({ tok: "u1" });
+    const staticProvider = new StaticTokenProvider({ "tok-value-1234567890": "u1" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       enforceAuth: true
@@ -272,53 +286,53 @@ describe("createAuthMiddleware", () => {
   });
 
   it("authenticates via static provider", async () => {
-    const staticProvider = new StaticTokenProvider({ secret: "u5" });
+    const staticProvider = new StaticTokenProvider({ "secret-value-1234567890": "u5" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       enforceAuth: true
     });
 
-    const request = makeRequest({ authorization: "Bearer secret" });
+    const request = makeRequest({ authorization: "Bearer secret-value-1234567890" });
     const user = await authenticate(request);
     expect(user.userId).toBe("u5");
   });
 
   it("falls back to user provider when static fails", async () => {
-    const staticProvider = new StaticTokenProvider({ stok: "u1" });
-    const userProvider = new StaticTokenProvider({ utok: "u2" });
+    const staticProvider = new StaticTokenProvider({ "stok-value-1234567890": "u1" });
+    const userProvider = new StaticTokenProvider({ "utok-value-1234567890": "u2" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       userProvider,
       enforceAuth: true
     });
 
-    const request = makeRequest({ authorization: "Bearer utok" });
+    const request = makeRequest({ authorization: "Bearer utok-value-1234567890" });
     const user = await authenticate(request);
     expect(user.userId).toBe("u2");
     expect(user.tokenType).toBe(TokenType.STATIC);
   });
 
   it("throws 401 when both providers reject", async () => {
-    const staticProvider = new StaticTokenProvider({ stok: "u1" });
-    const userProvider = new StaticTokenProvider({ utok: "u2" });
+    const staticProvider = new StaticTokenProvider({ "stok-value-1234567890": "u1" });
+    const userProvider = new StaticTokenProvider({ "utok-value-1234567890": "u2" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       userProvider,
       enforceAuth: true
     });
 
-    const request = makeRequest({ authorization: "Bearer bad" });
+    const request = makeRequest({ authorization: "Bearer bad-value-1234567890" });
     await expect(authenticate(request)).rejects.toThrow(HttpError);
   });
 
   it("throws 401 with static error when no user provider", async () => {
-    const staticProvider = new StaticTokenProvider({ stok: "u1" });
+    const staticProvider = new StaticTokenProvider({ "stok-value-1234567890": "u1" });
     const authenticate = createAuthMiddleware({
       staticProvider,
       enforceAuth: true
     });
 
-    const request = makeRequest({ authorization: "Bearer bad" });
+    const request = makeRequest({ authorization: "Bearer bad-value-1234567890" });
     try {
       await authenticate(request);
       expect.unreachable("should have thrown");

--- a/packages/auth/tests/static-token-provider.test.ts
+++ b/packages/auth/tests/static-token-provider.test.ts
@@ -8,43 +8,69 @@ describe("StaticTokenProvider", () => {
   // -------------------------------------------------------------------------
   describe("explicit tokens", () => {
     it("accepts a valid token and returns the mapped userId", async () => {
-      const provider = new StaticTokenProvider({ "secret-token": "user-42" });
-      const result = await provider.verifyToken("secret-token");
+      const provider = new StaticTokenProvider({
+        "secret-token-value-1234": "user-42"
+      });
+      const result = await provider.verifyToken("secret-token-value-1234");
       expect(result.ok).toBe(true);
       expect(result.userId).toBe("user-42");
       expect(result.tokenType).toBe(TokenType.STATIC);
     });
 
     it("rejects an unknown token", async () => {
-      const provider = new StaticTokenProvider({ "secret-token": "user-42" });
-      const result = await provider.verifyToken("wrong-token");
+      const provider = new StaticTokenProvider({
+        "secret-token-value-1234": "user-42"
+      });
+      const result = await provider.verifyToken("wrong-token-value-1234");
       expect(result.ok).toBe(false);
       expect(result.error).toBeDefined();
     });
 
     it("supports multiple tokens mapped to different users", async () => {
       const provider = new StaticTokenProvider({
-        "token-a": "user-1",
-        "token-b": "user-2"
+        "token-a-value-1234567890": "user-1",
+        "token-b-value-1234567890": "user-2"
       });
-      const a = await provider.verifyToken("token-a");
-      const b = await provider.verifyToken("token-b");
+      const a = await provider.verifyToken("token-a-value-1234567890");
+      const b = await provider.verifyToken("token-b-value-1234567890");
       expect(a.userId).toBe("user-1");
       expect(b.userId).toBe("user-2");
     });
 
     it("is case-sensitive – similar tokens with different casing are distinct", async () => {
-      const provider = new StaticTokenProvider({ Token: "user-1" });
-      const upper = await provider.verifyToken("Token");
-      const lower = await provider.verifyToken("token");
+      const provider = new StaticTokenProvider({
+        "Token-Value-MixedCase-12": "user-1"
+      });
+      const upper = await provider.verifyToken("Token-Value-MixedCase-12");
+      const lower = await provider.verifyToken("token-value-mixedcase-12");
       expect(upper.ok).toBe(true);
       expect(lower.ok).toBe(false);
     });
 
     it("returns ok:false with no tokens configured", async () => {
       const provider = new StaticTokenProvider({});
-      const result = await provider.verifyToken("any-token");
+      const result = await provider.verifyToken("any-token-value-12345");
       expect(result.ok).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Minimum token length enforcement
+  // -------------------------------------------------------------------------
+  describe("minimum token length", () => {
+    it("rejects the empty string even with no tokens configured", async () => {
+      const provider = new StaticTokenProvider({});
+      expect((await provider.verifyToken("")).ok).toBe(false);
+    });
+
+    it("rejects a token shorter than the minimum length", async () => {
+      // A short token must never be accepted even if it is a prefix of, or
+      // otherwise resembles, a configured token.
+      const provider = new StaticTokenProvider({
+        "secret-token-value-1234": "user-42"
+      });
+      expect((await provider.verifyToken("secret-token")).ok).toBe(false);
+      expect((await provider.verifyToken("short")).ok).toBe(false);
     });
   });
 
@@ -53,7 +79,7 @@ describe("StaticTokenProvider", () => {
   // -------------------------------------------------------------------------
   describe("STATIC_AUTH_TOKEN env var", () => {
     beforeEach(() => {
-      process.env["STATIC_AUTH_TOKEN"] = "env-single-token";
+      process.env["STATIC_AUTH_TOKEN"] = "env-single-token-value-123";
     });
 
     afterEach(() => {
@@ -62,7 +88,7 @@ describe("StaticTokenProvider", () => {
 
     it("maps the env token to userId '1'", async () => {
       const provider = new StaticTokenProvider();
-      const result = await provider.verifyToken("env-single-token");
+      const result = await provider.verifyToken("env-single-token-value-123");
       expect(result.ok).toBe(true);
       expect(result.userId).toBe("1");
       expect(result.tokenType).toBe(TokenType.STATIC);
@@ -70,7 +96,7 @@ describe("StaticTokenProvider", () => {
 
     it("rejects unknown tokens when env token is configured", async () => {
       const provider = new StaticTokenProvider();
-      const result = await provider.verifyToken("other-token");
+      const result = await provider.verifyToken("other-token-value-12345");
       expect(result.ok).toBe(false);
     });
   });
@@ -78,8 +104,8 @@ describe("StaticTokenProvider", () => {
   describe("STATIC_AUTH_TOKENS env var", () => {
     beforeEach(() => {
       process.env["STATIC_AUTH_TOKENS"] = JSON.stringify({
-        "multi-token-a": "user-100",
-        "multi-token-b": "user-200"
+        "multi-token-a-value-1234": "user-100",
+        "multi-token-b-value-1234": "user-200"
       });
     });
 
@@ -89,8 +115,8 @@ describe("StaticTokenProvider", () => {
 
     it("maps tokens from JSON to their respective user IDs", async () => {
       const provider = new StaticTokenProvider();
-      const a = await provider.verifyToken("multi-token-a");
-      const b = await provider.verifyToken("multi-token-b");
+      const a = await provider.verifyToken("multi-token-a-value-1234");
+      const b = await provider.verifyToken("multi-token-b-value-1234");
       expect(a.ok).toBe(true);
       expect(a.userId).toBe("user-100");
       expect(b.ok).toBe(true);
@@ -99,7 +125,7 @@ describe("StaticTokenProvider", () => {
 
     it("rejects a token not listed in STATIC_AUTH_TOKENS", async () => {
       const provider = new StaticTokenProvider();
-      const result = await provider.verifyToken("unlisted-token");
+      const result = await provider.verifyToken("unlisted-token-value-123");
       expect(result.ok).toBe(false);
     });
   });
@@ -130,7 +156,7 @@ describe("StaticTokenProvider", () => {
 
     it("silently ignores malformed JSON and rejects all tokens", async () => {
       const provider = new StaticTokenProvider();
-      const result = await provider.verifyToken("any-token");
+      const result = await provider.verifyToken("any-token-value-12345");
       expect(result.ok).toBe(false);
     });
   });
@@ -139,11 +165,17 @@ describe("StaticTokenProvider", () => {
   // Explicit tokens override env vars
   // -------------------------------------------------------------------------
   it("explicit tokens constructor argument takes precedence over env vars", async () => {
-    process.env["STATIC_AUTH_TOKEN"] = "env-token";
+    process.env["STATIC_AUTH_TOKEN"] = "env-token-value-1234567";
     try {
-      const provider = new StaticTokenProvider({ "explicit-token": "user-x" });
-      expect((await provider.verifyToken("env-token")).ok).toBe(false);
-      expect((await provider.verifyToken("explicit-token")).ok).toBe(true);
+      const provider = new StaticTokenProvider({
+        "explicit-token-value-123": "user-x"
+      });
+      expect((await provider.verifyToken("env-token-value-1234567")).ok).toBe(
+        false
+      );
+      expect((await provider.verifyToken("explicit-token-value-123")).ok).toBe(
+        true
+      );
     } finally {
       delete process.env["STATIC_AUTH_TOKEN"];
     }


### PR DESCRIPTION
Replace the Map.get() lookup in StaticTokenProvider.verifyToken with a
crypto.timingSafeEqual comparison against every configured token, matching
the existing pattern in packages/deploy/src/auth.ts. Map.get leaks timing
information about whether and which token matched. Tokens are now also
rejected below a minimum length (16 bytes), so empty/trivial bearer tokens
are refused before any comparison.

Update test fixtures to use realistic token lengths and add coverage for
the minimum-length rejection.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dbc4QNsvmWx3uWkNLp6XkH