### PR TITLE
Add Codex provider: ChatGPT OAuth login for chat and image generation

### DIFF
--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -39,6 +39,7 @@ import type { WebSocketChatClient } from "./websocket-client.js";
 export const KNOWN_PROVIDERS = [
   "anthropic",
   "openai",
+  "codex",
   "gemini",
   "xai",
   "groq",
@@ -79,6 +80,7 @@ function isAppleSilicon(): boolean {
 export const DEFAULT_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
   openai: "gpt-5.4",
+  codex: "gpt-5.5",
   gemini: "gemini-2.5-flash",
   xai: "grok-4",
   groq: "llama-3.3-70b-versatile",

--- a/packages/models/src/codex-token.ts
+++ b/packages/models/src/codex-token.ts
@@ -1,0 +1,115 @@
+/**
+ * Codex OAuth token resolution.
+ *
+ * The Codex login flow stores its tokens as an {@link OAuthCredential} under
+ * provider `"openai"`. The `codex` provider consumes the access token via
+ * `getSecret("CODEX_ACCESS_TOKEN")`; this module returns a currently-valid
+ * token, refreshing it against the OpenAI token endpoint when it has (nearly)
+ * expired and persisting the rotated tokens back.
+ */
+
+import {
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_OAUTH_TOKEN_URL
+} from "@nodetool-ai/protocol";
+import { createLogger } from "@nodetool-ai/config";
+import { OAuthCredential } from "./oauth-credential.js";
+
+const log = createLogger("nodetool.models.codex-token");
+
+/** Treat a token expiring within this window as already expired. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** The Codex credential is stored under the "openai" provider namespace. */
+const CODEX_CREDENTIAL_PROVIDER = "openai";
+
+function isExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  const expiryMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiryMs)) return false;
+  return Date.now() >= expiryMs - EXPIRY_SKEW_MS;
+}
+
+interface RefreshResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  token_type?: unknown;
+  scope?: unknown;
+  expires_in?: unknown;
+}
+
+/** Refresh the credential's access token in place. Returns the new token. */
+async function refreshCredential(
+  credential: OAuthCredential
+): Promise<string | null> {
+  const refreshToken = await credential.getDecryptedRefreshToken();
+  if (!refreshToken) return null;
+
+  const res = await fetch(CODEX_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json"
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CODEX_OAUTH_CLIENT_ID
+    }).toString()
+  });
+
+  if (!res.ok) {
+    log.warn("Codex token refresh failed", { status: res.status });
+    return null;
+  }
+
+  const body = (await res.json()) as RefreshResponse;
+  const accessToken =
+    typeof body.access_token === "string" ? body.access_token : null;
+  if (!accessToken) return null;
+
+  const expiresIn =
+    typeof body.expires_in === "number" ? body.expires_in : null;
+  await credential.updateTokens({
+    accessToken,
+    refreshToken:
+      typeof body.refresh_token === "string" ? body.refresh_token : undefined,
+    tokenType: typeof body.token_type === "string" ? body.token_type : undefined,
+    scope: typeof body.scope === "string" ? body.scope : undefined,
+    receivedAt: new Date().toISOString(),
+    expiresAt:
+      expiresIn != null
+        ? new Date(Date.now() + expiresIn * 1000).toISOString()
+        : undefined
+  });
+  return accessToken;
+}
+
+/**
+ * Resolve a valid Codex access token for a user, or null when the user has not
+ * connected via the OpenAI/Codex login. Refreshes a (nearly) expired token.
+ */
+export async function resolveCodexAccessToken(
+  userId: string
+): Promise<string | null> {
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    userId,
+    CODEX_CREDENTIAL_PROVIDER
+  );
+  // listForUserAndProvider is ordered by updated_at desc — use the freshest.
+  const credential = credentials[0];
+  if (!credential) return null;
+
+  if (isExpired(credential.expires_at)) {
+    try {
+      const refreshed = await refreshCredential(credential);
+      if (refreshed) return refreshed;
+      // Refresh failed — fall through and return the stored (expired) token so
+      // the caller surfaces a 401 rather than silently dropping the provider.
+    } catch (err) {
+      log.warn("Codex token refresh threw", { error: String(err) });
+    }
+  }
+
+  return credential.getDecryptedAccessToken();
+}

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -93,6 +93,7 @@ export type {
 } from "./image-document.js";
 
 export { OAuthCredential } from "./oauth-credential.js";
+export { resolveCodexAccessToken } from "./codex-token.js";
 
 export { Prediction } from "./prediction.js";
 export type {

--- a/packages/models/src/secret-helper.ts
+++ b/packages/models/src/secret-helper.ts
@@ -15,6 +15,7 @@
 
 import { createLogger } from "@nodetool-ai/config";
 import { Secret } from "./secret.js";
+import { resolveCodexAccessToken } from "./codex-token.js";
 
 const log = createLogger("nodetool.models.secret-helper");
 
@@ -55,6 +56,20 @@ export async function getSecret(
   defaultValue?: string
 ): Promise<string | null> {
   const resolvedUserId = userId ?? "default";
+
+  // The Codex provider's bearer is not a stored Secret — it lives in the
+  // OAuthCredential table and may need a refresh. Resolve it directly.
+  if (key === "CODEX_ACCESS_TOKEN") {
+    try {
+      return await resolveCodexAccessToken(resolvedUserId);
+    } catch (err) {
+      log.error("Codex token resolution failed", {
+        userId: resolvedUserId,
+        error: String(err)
+      });
+      return null;
+    }
+  }
 
   if (FORCE_ENV_PRIORITY.has(key)) {
     const envVal = process.env[key];

--- a/packages/models/tests/codex-token.test.ts
+++ b/packages/models/tests/codex-token.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { initTestDb } from "../src/db.js";
+import { setMasterKey } from "@nodetool-ai/security";
+import { OAuthCredential } from "../src/oauth-credential.js";
+import { resolveCodexAccessToken } from "../src/codex-token.js";
+
+const TEST_MASTER_KEY = "dGVzdC1tYXN0ZXIta2V5LWZvci11bml0LXRlc3Rz"; // base64
+
+beforeEach(() => {
+  initTestDb();
+  setMasterKey(TEST_MASTER_KEY);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveCodexAccessToken", () => {
+  it("returns null when the user has not connected", async () => {
+    expect(await resolveCodexAccessToken("user-1")).toBeNull();
+  });
+
+  it("returns the stored token when still valid", async () => {
+    await OAuthCredential.upsert({
+      user_id: "user-1",
+      provider: "openai",
+      account_id: "acct",
+      access_token: "valid-token",
+      refresh_token: "r",
+      token_type: "Bearer",
+      received_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 3_600_000).toISOString()
+    });
+    expect(await resolveCodexAccessToken("user-1")).toBe("valid-token");
+  });
+
+  it("refreshes an expired token and persists the new one", async () => {
+    await OAuthCredential.upsert({
+      user_id: "user-1",
+      provider: "openai",
+      account_id: "acct",
+      access_token: "stale-token",
+      refresh_token: "refresh-token",
+      token_type: "Bearer",
+      received_at: new Date(Date.now() - 7_200_000).toISOString(),
+      expires_at: new Date(Date.now() - 3_600_000).toISOString()
+    });
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "fresh-token",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+          expires_in: 3600
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const token = await resolveCodexAccessToken("user-1");
+    expect(token).toBe("fresh-token");
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    // The rotated token is persisted, so a follow-up read needs no refresh.
+    fetchMock.mockClear();
+    expect(await resolveCodexAccessToken("user-1")).toBe("fresh-token");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the stale token when refresh fails", async () => {
+    await OAuthCredential.upsert({
+      user_id: "user-1",
+      provider: "openai",
+      account_id: "acct",
+      access_token: "stale-token",
+      refresh_token: "refresh-token",
+      token_type: "Bearer",
+      received_at: new Date(Date.now() - 7_200_000).toISOString(),
+      expires_at: new Date(Date.now() - 3_600_000).toISOString()
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 400 })
+    );
+
+    expect(await resolveCodexAccessToken("user-1")).toBe("stale-token");
+  });
+});

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -852,6 +852,9 @@ export interface ResourceLimits {
 export const PROVIDER_IDS = {
   // Hosted LLM / multimodal APIs
   OPENAI: "openai",
+  // OpenAI via ChatGPT/Codex OAuth login (no API key — uses the stored
+  // Codex OAuth token and the chatgpt.com Codex backend).
+  CODEX: "codex",
   ANTHROPIC: "anthropic",
   GEMINI: "gemini",
   GROQ: "groq",
@@ -892,6 +895,39 @@ export const PROVIDER_IDS = {
 
 /** A provider identifier known to the registry above. */
 export type KnownProviderId = (typeof PROVIDER_IDS)[keyof typeof PROVIDER_IDS];
+
+/**
+ * Codex (ChatGPT-backed) OAuth constants, shared across packages so the login
+ * flow (`websocket`), the token resolver (`models`), and the provider
+ * (`runtime`) all agree without a cross-layer dependency. The client is the
+ * published public Codex CLI app — there is no client secret.
+ */
+export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const CODEX_OAUTH_AUTHORIZATION_URL =
+  "https://auth.openai.com/oauth/authorize";
+export const CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+export const CODEX_OAUTH_REVOCATION_URL =
+  "https://auth.openai.com/oauth/revoke";
+export const CODEX_OAUTH_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access"
+] as const;
+/** ChatGPT backend base URL the Codex routes live under. */
+export const CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex";
+/** `originator` header the ChatGPT backend expects from a Codex client. */
+export const CODEX_DEFAULT_ORIGINATOR = "codex_cli_rs";
+/**
+ * Codex client version presented to the ChatGPT backend. The backend gates its
+ * model allowlist on this: too-old a version yields an empty `/models` list and
+ * "model not supported" on `/responses`. Must be ≥ the served models'
+ * `minimal_client_version`. Override via `CODEX_CLIENT_VERSION`.
+ */
+export const CODEX_CLIENT_VERSION = "0.124.0";
+/** Loopback port/path the Codex client's redirect URI is registered against. */
+export const CODEX_CALLBACK_PORT = 1455;
+export const CODEX_CALLBACK_PATH = "/auth/callback";
 
 /**
  * Provider identifier. Resolves to a known {@link PROVIDER_IDS} value with

--- a/packages/runtime/src/providers/codex-provider.ts
+++ b/packages/runtime/src/providers/codex-provider.ts
@@ -148,14 +148,19 @@ export class CodexProvider extends OpenAIProvider {
   // --- Image generation (via the Responses image_generation tool) --------
 
   override async getAvailableImageModels(): Promise<ImageModel[]> {
+    // The Responses `image_generation` tool accepts a `model` field; every
+    // gpt-image variant the OpenAI image API exposes works against the Codex
+    // backend too (verified live).
     return [
-      {
-        id: "gpt-image-1",
-        name: "GPT Image 1",
-        provider: PROVIDER_IDS.CODEX,
-        supportedTasks: ["text_to_image"]
-      }
-    ];
+      { id: "gpt-image-2", name: "GPT Image 2" },
+      { id: "gpt-image-1.5", name: "GPT Image 1.5" },
+      { id: "gpt-image-1", name: "GPT Image 1" },
+      { id: "gpt-image-1-mini", name: "GPT Image 1 Mini" }
+    ].map((m) => ({
+      ...m,
+      provider: PROVIDER_IDS.CODEX,
+      supportedTasks: ["text_to_image"]
+    }));
   }
 
   /**
@@ -171,7 +176,10 @@ export class CodexProvider extends OpenAIProvider {
       ? `${params.prompt.trim()}\n\nDo not include: ${params.negativePrompt.trim()}`
       : params.prompt;
 
-    const imageTool: Record<string, unknown> = { type: "image_generation" };
+    const imageTool: Record<string, unknown> = {
+      type: "image_generation",
+      model: params.model.id
+    };
     const size = this.resolveImageSize(
       params.width ?? undefined,
       params.height ?? undefined

--- a/packages/runtime/src/providers/codex-provider.ts
+++ b/packages/runtime/src/providers/codex-provider.ts
@@ -1,0 +1,562 @@
+/**
+ * CodexProvider — OpenAI models reached through a ChatGPT/Codex OAuth login
+ * instead of an API key.
+ *
+ * The ChatGPT Codex backend (`chatgpt.com/backend-api/codex`) is NOT the
+ * OpenAI API: it speaks the OpenAI **Responses API** (`POST /responses`),
+ * behind a WAF that requires the request to look like the Codex CLI
+ * (`originator`, `chatgpt-account-id`, a Codex `User-Agent`, an SSE `Accept`).
+ * So this provider can't reuse {@link OpenAIProvider}'s chat-completions path —
+ * it overrides the chat methods to drive the Responses API directly and parse
+ * its SSE event stream.
+ *
+ * The bearer is the short-lived Codex OAuth access token, resolved (and
+ * refreshed) by the host through `getSecret("CODEX_ACCESS_TOKEN")` and passed
+ * in as a constructor kwarg — exactly how the registry wires every other
+ * credentialed provider.
+ */
+
+import OpenAI from "openai";
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import {
+  CODEX_BACKEND_BASE_URL,
+  CODEX_DEFAULT_ORIGINATOR,
+  CODEX_CLIENT_VERSION,
+  PROVIDER_IDS,
+  type Chunk
+} from "@nodetool-ai/protocol";
+import { OpenAIProvider } from "./openai-provider.js";
+import { extractChatGptAccountId } from "./oauth/jwt-claims.js";
+import type {
+  ImageModel,
+  LanguageModel,
+  Message,
+  MessageContent,
+  ProviderStreamItem,
+  ProviderTool,
+  TextToImageParams,
+  ToolCall
+} from "./types.js";
+
+const log = createLogger("nodetool.runtime.codex");
+
+/** Fallback model when the live `/models` listing can't be fetched. */
+const CODEX_FALLBACK_MODEL = "gpt-5.5";
+
+/**
+ * Chat model that orchestrates the `image_generation` tool call. The Codex
+ * backend has no images endpoint — images are produced by invoking the
+ * Responses built-in `image_generation` tool from a normal chat model.
+ */
+const CODEX_IMAGE_ORCHESTRATOR_MODEL = CODEX_FALLBACK_MODEL;
+
+function codexClientVersion(): string {
+  return (
+    (typeof process !== "undefined" && process.env?.CODEX_CLIENT_VERSION) ||
+    CODEX_CLIENT_VERSION
+  );
+}
+
+/** A function call accumulated across Responses streaming events. */
+interface PendingCall {
+  callId: string;
+  name: string;
+  args: string;
+}
+
+export class CodexProvider extends OpenAIProvider {
+  static override requiredSecrets(): string[] {
+    return ["CODEX_ACCESS_TOKEN"];
+  }
+
+  private readonly accessToken: string;
+  private readonly accountId: string | null;
+  private readonly originator: string;
+  private readonly codexLogger: Logger;
+
+  constructor(secrets: { CODEX_ACCESS_TOKEN?: string }) {
+    const token = secrets.CODEX_ACCESS_TOKEN;
+    if (!token) {
+      throw new Error("CODEX_ACCESS_TOKEN is required");
+    }
+    const accountId = extractChatGptAccountId(token);
+    const originator =
+      (typeof process !== "undefined" && process.env?.CODEX_ORIGINATOR) ||
+      CODEX_DEFAULT_ORIGINATOR;
+
+    super(
+      { OPENAI_API_KEY: token },
+      {
+        providerId: PROVIDER_IDS.CODEX,
+        clientFactory: (key) =>
+          new OpenAI({
+            apiKey: key,
+            baseURL: CODEX_BACKEND_BASE_URL,
+            defaultHeaders: {
+              originator,
+              ...(accountId ? { "chatgpt-account-id": accountId } : {})
+            }
+          })
+      }
+    );
+    this.accessToken = token;
+    this.accountId = accountId;
+    this.originator = originator;
+    this.codexLogger = log;
+  }
+
+  /** The OAuth bearer is short-lived — never leak it into a container env. */
+  override getContainerEnv(): Record<string, string> {
+    return {};
+  }
+
+  /**
+   * The Codex backend serves an account- and version-specific model allowlist
+   * at `GET /models?client_version=…`. Fetch it; fall back to the default model
+   * if the listing is unavailable.
+   */
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const fallback: LanguageModel[] = [
+      { id: CODEX_FALLBACK_MODEL, name: CODEX_FALLBACK_MODEL, provider: PROVIDER_IDS.CODEX }
+    ];
+    try {
+      const url = `${CODEX_BACKEND_BASE_URL}/models?client_version=${encodeURIComponent(codexClientVersion())}`;
+      const res = await fetch(url, { headers: this.buildHeaders("application/json") });
+      if (!res.ok) return fallback;
+      const payload = (await res.json()) as {
+        models?: Array<{ slug?: string; display_name?: string }>;
+      };
+      const models = (payload.models ?? [])
+        .filter((m): m is { slug: string; display_name?: string } =>
+          typeof m.slug === "string" && m.slug.length > 0
+        )
+        .map((m) => ({
+          id: m.slug,
+          name: m.display_name ?? m.slug,
+          provider: PROVIDER_IDS.CODEX
+        }));
+      return models.length ? models : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  override async hasToolSupport(): Promise<boolean> {
+    return true;
+  }
+
+  // --- Image generation (via the Responses image_generation tool) --------
+
+  override async getAvailableImageModels(): Promise<ImageModel[]> {
+    return [
+      {
+        id: "gpt-image-1",
+        name: "GPT Image 1",
+        provider: PROVIDER_IDS.CODEX,
+        supportedTasks: ["text_to_image"]
+      }
+    ];
+  }
+
+  /**
+   * Generate an image by asking a chat model to invoke the Responses built-in
+   * `image_generation` tool, then extracting the PNG bytes from the
+   * `image_generation_call` output item.
+   */
+  override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+    const prompt = params.negativePrompt
+      ? `${params.prompt.trim()}\n\nDo not include: ${params.negativePrompt.trim()}`
+      : params.prompt;
+
+    const imageTool: Record<string, unknown> = { type: "image_generation" };
+    const size = this.resolveImageSize(
+      params.width ?? undefined,
+      params.height ?? undefined
+    );
+    if (size) imageTool.size = size;
+    if (params.quality) imageTool.quality = params.quality;
+
+    const body = {
+      model: CODEX_IMAGE_ORCHESTRATOR_MODEL,
+      instructions:
+        "Generate the image the user describes by calling the image_generation tool. Do not ask clarifying questions.",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: prompt }]
+        }
+      ],
+      tools: [imageTool],
+      store: false,
+      stream: true
+    };
+
+    const res = await fetch(`${CODEX_BACKEND_BASE_URL}/responses`, {
+      method: "POST",
+      headers: this.buildHeaders(),
+      body: JSON.stringify(body)
+    });
+    if (!res.ok || !res.body) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `Codex image request failed (${res.status}): ${detail.slice(0, 300)}`
+      );
+    }
+
+    let finalB64 = "";
+    let lastPartial = "";
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let sep: number;
+        while ((sep = buffer.indexOf("\n\n")) !== -1) {
+          const rawEvent = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          const dataLine = rawEvent
+            .split("\n")
+            .find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const payload = dataLine.slice("data:".length).trim();
+          if (!payload || payload === "[DONE]") continue;
+          let event: Record<string, unknown>;
+          try {
+            event = JSON.parse(payload);
+          } catch {
+            continue;
+          }
+          if (
+            event.type === "response.image_generation_call.partial_image" &&
+            typeof event.partial_image_b64 === "string"
+          ) {
+            lastPartial = event.partial_image_b64;
+          }
+          if (event.type === "response.output_item.done") {
+            const item = event.item as Record<string, unknown> | undefined;
+            if (
+              item?.type === "image_generation_call" &&
+              typeof item.result === "string"
+            ) {
+              finalB64 = item.result;
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const b64 = finalB64 || lastPartial;
+    if (!b64) {
+      throw new Error("Codex image generation returned no image data.");
+    }
+    return Uint8Array.from(Buffer.from(b64, "base64"));
+  }
+
+  // --- Responses API transport -------------------------------------------
+
+  private buildHeaders(accept = "text/event-stream"): Record<string, string> {
+    const version = codexClientVersion();
+    return {
+      authorization: `Bearer ${this.accessToken}`,
+      "content-type": "application/json",
+      accept,
+      originator: this.originator,
+      "openai-beta": "responses=experimental",
+      version,
+      "user-agent": `${this.originator}/${version} (NodeTool)`,
+      session_id: globalThis.crypto.randomUUID(),
+      ...(this.accountId ? { "chatgpt-account-id": this.accountId } : {})
+    };
+  }
+
+  /** Translate the cross-provider message list into Responses API input. */
+  private buildRequestBody(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+    toolChoice?: string | "any";
+  }): Record<string, unknown> {
+    const instructions = args.messages
+      .filter((m) => m.role === "system")
+      .map((m) => textOf(m.content))
+      .filter(Boolean)
+      .join("\n\n");
+
+    const input: Array<Record<string, unknown>> = [];
+    for (const m of args.messages) {
+      if (m.role === "system") continue;
+      if (m.role === "tool") {
+        input.push({
+          type: "function_call_output",
+          call_id: m.toolCallId ?? "",
+          output: textOf(m.content)
+        });
+        continue;
+      }
+      if (m.role === "assistant" && m.toolCalls?.length) {
+        for (const tc of m.toolCalls) {
+          input.push({
+            type: "function_call",
+            call_id: tc.id,
+            name: tc.name,
+            arguments: JSON.stringify(tc.args ?? {})
+          });
+        }
+      }
+      const partType = m.role === "assistant" ? "output_text" : "input_text";
+      input.push({
+        type: "message",
+        role: m.role,
+        content: [{ type: partType, text: textOf(m.content) }]
+      });
+    }
+
+    const body: Record<string, unknown> = {
+      model: args.model,
+      instructions,
+      input,
+      store: false,
+      stream: true
+    };
+
+    if (args.tools?.length) {
+      body.tools = args.tools.map((t) => ({
+        type: "function",
+        name: t.name,
+        description: t.description ?? "",
+        parameters: t.inputSchema ?? { type: "object", properties: {} },
+        strict: false
+      }));
+      body.tool_choice =
+        args.toolChoice && args.toolChoice !== "any"
+          ? { type: "function", name: args.toolChoice }
+          : args.toolChoice === "any"
+            ? "required"
+            : "auto";
+    }
+
+    return body;
+  }
+
+  override async *generateMessages(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+    toolChoice?: string | "any";
+    maxTokens?: number;
+    maxTurns?: number;
+    temperature?: number;
+    topP?: number;
+    presencePenalty?: number;
+    frequencyPenalty?: number;
+    audio?: Record<string, unknown>;
+    threadId?: string | null;
+    onToolCall?: (
+      name: string,
+      args: Record<string, unknown>
+    ) => Promise<string>;
+    signal?: AbortSignal;
+  }): AsyncGenerator<ProviderStreamItem> {
+    const body = this.buildRequestBody(args);
+    this.codexLogger.debug("Codex responses request", { model: args.model });
+
+    const res = await fetch(`${CODEX_BACKEND_BASE_URL}/responses`, {
+      method: "POST",
+      headers: this.buildHeaders(),
+      body: JSON.stringify(body),
+      signal: args.signal
+    });
+
+    if (!res.ok || !res.body) {
+      const detail = await res.text().catch(() => "");
+      this.codexLogger.warn("Codex responses request failed", {
+        status: res.status,
+        detail: detail.slice(0, 500)
+      });
+      throw new Error(
+        `Codex request failed (${res.status}): ${detail.slice(0, 300)}`
+      );
+    }
+
+    const pending = new Map<string, PendingCall>();
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let sep: number;
+        while ((sep = buffer.indexOf("\n\n")) !== -1) {
+          const rawEvent = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          const dataLine = rawEvent
+            .split("\n")
+            .find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const payload = dataLine.slice("data:".length).trim();
+          if (!payload || payload === "[DONE]") continue;
+
+          let event: Record<string, unknown>;
+          try {
+            event = JSON.parse(payload);
+          } catch {
+            continue;
+          }
+
+          for (const item of this.handleEvent(event, pending, args.model)) {
+            yield item;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /** Map a single Responses SSE event to zero or more stream items. */
+  private *handleEvent(
+    event: Record<string, unknown>,
+    pending: Map<string, PendingCall>,
+    model: string
+  ): Generator<ProviderStreamItem> {
+    const type = typeof event.type === "string" ? event.type : "";
+
+    switch (type) {
+      case "response.output_text.delta": {
+        const delta = typeof event.delta === "string" ? event.delta : "";
+        if (delta) {
+          yield { type: "chunk", content: delta, done: false } as Chunk;
+        }
+        return;
+      }
+      case "response.reasoning_summary_text.delta":
+      case "response.reasoning_text.delta": {
+        const delta = typeof event.delta === "string" ? event.delta : "";
+        if (delta) {
+          yield {
+            type: "chunk",
+            content: delta,
+            done: false,
+            thinking: true
+          } as Chunk;
+        }
+        return;
+      }
+      case "response.output_item.added": {
+        const item = event.item as Record<string, unknown> | undefined;
+        if (item?.type === "function_call") {
+          const itemId = String(item.id ?? "");
+          pending.set(itemId, {
+            callId: String(item.call_id ?? itemId),
+            name: String(item.name ?? ""),
+            args: ""
+          });
+        }
+        return;
+      }
+      case "response.function_call_arguments.delta": {
+        const itemId = String(event.item_id ?? "");
+        const call = pending.get(itemId);
+        if (call && typeof event.delta === "string") {
+          call.args += event.delta;
+        }
+        return;
+      }
+      case "response.output_item.done": {
+        const item = event.item as Record<string, unknown> | undefined;
+        const itemId = String(item?.id ?? "");
+        const call = pending.get(itemId);
+        if (call) {
+          pending.delete(itemId);
+          yield this.buildToolCall(call.callId, call.name, call.args);
+        }
+        return;
+      }
+      case "response.completed": {
+        const response = event.response as Record<string, unknown> | undefined;
+        const usage = response?.usage as Record<string, unknown> | undefined;
+        if (usage) {
+          this.trackUsage(model, {
+            inputTokens: Number(usage.input_tokens ?? 0),
+            outputTokens: Number(usage.output_tokens ?? 0),
+            cachedTokens: Number(
+              (usage.input_tokens_details as Record<string, unknown>)
+                ?.cached_tokens ?? 0
+            )
+          });
+        }
+        yield { type: "chunk", content: "", done: true } as Chunk;
+        return;
+      }
+      case "response.failed":
+      case "error": {
+        const err =
+          (event.error as Record<string, unknown> | undefined) ??
+          ((event.response as Record<string, unknown> | undefined)
+            ?.error as Record<string, unknown> | undefined);
+        const message =
+          (err && typeof err.message === "string" && err.message) ||
+          "Codex response failed";
+        throw new Error(message);
+      }
+      default:
+        return;
+    }
+  }
+
+  override async generateMessage(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+    toolChoice?: string | "any";
+    maxTokens?: number;
+    temperature?: number;
+    topP?: number;
+    presencePenalty?: number;
+    frequencyPenalty?: number;
+    threadId?: string | null;
+    onToolCall?: (
+      name: string,
+      args: Record<string, unknown>
+    ) => Promise<string>;
+    signal?: AbortSignal;
+  }): Promise<Message> {
+    let content = "";
+    const toolCalls: ToolCall[] = [];
+    for await (const item of this.generateMessages(args)) {
+      if ("args" in item) {
+        toolCalls.push(item);
+      } else if (!item.thinking && typeof item.content === "string") {
+        content += item.content;
+      }
+    }
+    return {
+      role: "assistant",
+      content: content || null,
+      toolCalls: toolCalls.length ? toolCalls : null
+    };
+  }
+}
+
+/** Flatten a message's content to plain text. */
+function textOf(content: Message["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  return content
+    .filter((c): c is Extract<MessageContent, { type: "text" }> => c.type === "text")
+    .map((c) => c.text)
+    .join("");
+}

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -14,6 +14,7 @@ import { AnthropicProvider } from "./anthropic-provider.js";
 import { GeminiProvider } from "./gemini-provider.js";
 import { LlamaProvider } from "./llama-provider.js";
 import { OpenAIProvider } from "./openai-provider.js";
+import { CodexProvider } from "./codex-provider.js";
 import { OllamaProvider } from "./ollama-provider.js";
 import { GroqProvider } from "./groq-provider.js";
 import { MinimaxProvider } from "./minimax-provider.js";
@@ -49,6 +50,7 @@ export { AnthropicProvider };
 export { GeminiProvider };
 export { LlamaProvider };
 export { OpenAIProvider };
+export { CodexProvider };
 export { OllamaProvider };
 export { GroqProvider };
 export { MinimaxProvider };
@@ -165,6 +167,9 @@ export type {
 // kwarg is empty/null). Empty-string declarations force every getProvider()
 // call to ask the supplied `getSecret` (DB-then-env) at instantiation time.
 registerBuiltinProvider(PROVIDER_IDS.OPENAI, OpenAIProvider, { OPENAI_API_KEY: "" });
+// Codex: OpenAI via ChatGPT OAuth login. The token (resolved + refreshed from
+// the stored OAuth credential by the host's getSecret) stands in for an API key.
+registerBuiltinProvider(PROVIDER_IDS.CODEX, CodexProvider, { CODEX_ACCESS_TOKEN: "" });
 registerBuiltinProvider(PROVIDER_IDS.ANTHROPIC, AnthropicProvider, { ANTHROPIC_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.GEMINI, GeminiProvider, { GEMINI_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.GROQ, GroqProvider, { GROQ_API_KEY: "" });

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -221,18 +221,21 @@ This subsystem (a localhost-callback flow that opens the OS browser) is the
 right fit for desktop/CLI hosts where the Node process can both open a browser
 and listen on loopback.
 
-The **web app** uses a complementary server-side flow that shares this module's
-protocol layer (`OAuthClient` + PKCE) but receives the redirect on the API
-server's own `/api/oauth/openai/callback` route rather than a per-login
-loopback server:
+The **web app** drives the same Codex flow from the API server, sharing this
+module's protocol layer (`OAuthClient` + PKCE + `LocalCallbackServer`). Because
+the public Codex client only permits the loopback redirect
+`http://localhost:1455/auth/callback`, the redirect cannot bounce through a
+server route — the API process binds the Codex loopback listener itself:
 
 - Backend: `packages/websocket/src/oauth-api.ts` exposes
-  `/api/oauth/openai/{start,callback,tokens,disconnect}`. `start` returns the
-  authorization URL (built via `OAuthClient`), `callback` exchanges the code and
-  persists tokens through the encrypted `OAuthCredential` model. It activates
-  only when `OPENAI_OAUTH_CLIENT_ID` is set (endpoints/scopes are env-overridable
-  via `OPENAI_OAUTH_AUTHORIZATION_URL`, `OPENAI_OAUTH_TOKEN_URL`,
-  `OPENAI_OAUTH_USERINFO_URL`, `OPENAI_OAUTH_SCOPES`).
+  `/api/oauth/openai/{start,tokens,disconnect}`. `start` builds the Codex
+  authorization URL (`createCodexOAuthProvider`'s config — public client id, no
+  secret, Codex scopes/params), binds a one-shot `LocalCallbackServer` on port
+  1455, and returns the auth URL; the code exchange completes in the background
+  and persists tokens through the encrypted `OAuthCredential` model. The
+  published client id is overridable via `CODEX_OAUTH_CLIENT_ID`. Because it
+  binds loopback and relies on the same machine's browser, it is a same-machine
+  flow (desktop / local server).
 - Frontend: the **Settings → Integrations** panel
   (`web/src/components/menus/RemoteSettingsMenu.tsx`) renders an
   "OpenAI Authentication" section with **Connect with OpenAI** / **Disconnect**

--- a/packages/runtime/src/providers/oauth/index.ts
+++ b/packages/runtime/src/providers/oauth/index.ts
@@ -16,6 +16,17 @@
  */
 
 import { createLogger, type Logger } from "@nodetool-ai/config";
+import {
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_BACKEND_BASE_URL,
+  CODEX_CALLBACK_PORT,
+  CODEX_CALLBACK_PATH,
+  CODEX_OAUTH_AUTHORIZATION_URL,
+  CODEX_OAUTH_TOKEN_URL,
+  CODEX_OAUTH_REVOCATION_URL,
+  CODEX_OAUTH_SCOPES,
+  CODEX_DEFAULT_ORIGINATOR
+} from "@nodetool-ai/protocol";
 import { OAuthClient } from "./oauth-client.js";
 import { PKCEHelper } from "./pkce-helper.js";
 import { LocalCallbackServer } from "./local-callback-server.js";
@@ -140,11 +151,16 @@ export function createOpenAIOAuthProvider(
 //      a foreign originator is answered with 403.
 // These are configuration, not contracts — every value is override-able.
 
-/** Published public OAuth client id of the Codex CLI (no client secret). */
-export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-
-/** ChatGPT backend base URL the Codex routes live under. */
-export const CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex";
+// The Codex client id, endpoints, scopes, backend URL and loopback redirect are
+// the canonical constants in `@nodetool-ai/protocol` (shared with the login
+// flow and the token resolver). Re-exported here for the OAuth subsystem's
+// existing public surface.
+export {
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_BACKEND_BASE_URL,
+  CODEX_CALLBACK_PORT,
+  CODEX_CALLBACK_PATH
+};
 
 /**
  * `originator` the ChatGPT backend expects from a Codex client. A non-Codex
@@ -152,12 +168,8 @@ export const CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex";
  * Override via `CODEX_ORIGINATOR` env for resilience if the backend tightens.
  */
 export const CODEX_ORIGINATOR =
-  (typeof process !== "undefined" && process.env?.CODEX_ORIGINATOR) || "codex_cli_rs";
-
-/** Loopback port the Codex client's redirect URI is registered against. */
-export const CODEX_CALLBACK_PORT = 1455;
-/** Path component of the Codex-registered redirect URI. */
-export const CODEX_CALLBACK_PATH = "/auth/callback";
+  (typeof process !== "undefined" && process.env?.CODEX_ORIGINATOR) ||
+  CODEX_DEFAULT_ORIGINATOR;
 
 /**
  * OAuth endpoint configuration for the Codex CLI client. Scopes and the extra
@@ -165,10 +177,10 @@ export const CODEX_CALLBACK_PATH = "/auth/callback";
  * by {@link createCodexOAuthProvider}.
  */
 export const DEFAULT_CODEX_OAUTH_CONFIG: Omit<OAuthClientConfig, "clientId"> = {
-  authorizationEndpoint: "https://auth.openai.com/oauth/authorize",
-  tokenEndpoint: "https://auth.openai.com/oauth/token",
-  revocationEndpoint: "https://auth.openai.com/oauth/revoke",
-  scopes: ["openid", "profile", "email", "offline_access"],
+  authorizationEndpoint: CODEX_OAUTH_AUTHORIZATION_URL,
+  tokenEndpoint: CODEX_OAUTH_TOKEN_URL,
+  revocationEndpoint: CODEX_OAUTH_REVOCATION_URL,
+  scopes: [...CODEX_OAUTH_SCOPES],
   extraAuthParams: {
     id_token_add_organizations: "true",
     codex_cli_simplified_flow: "true"

--- a/packages/runtime/tests/providers/codex-provider.test.ts
+++ b/packages/runtime/tests/providers/codex-provider.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { CodexProvider } from "../../src/providers/codex-provider.js";
+import { CODEX_BACKEND_BASE_URL } from "@nodetool-ai/protocol";
+
+afterEach(() => vi.restoreAllMocks());
+
+/** Build a minimal unsigned JWT carrying a ChatGPT account id claim. */
+function fakeCodexJwt(accountId: string): string {
+  const payload = {
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId }
+  };
+  const b64 = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+describe("CodexProvider", () => {
+  it("requires an access token", () => {
+    expect(() => new CodexProvider({})).toThrow("CODEX_ACCESS_TOKEN");
+  });
+
+  it("reports the codex provider id and serves no container env", () => {
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    expect(provider.provider).toBe("codex");
+    expect(provider.getContainerEnv()).toEqual({});
+  });
+
+  it("points the OpenAI client at the Codex backend", () => {
+    const provider = new CodexProvider({
+      CODEX_ACCESS_TOKEN: fakeCodexJwt("acct-123")
+    });
+    const client = provider.getClient();
+    expect(client.baseURL).toBe(CODEX_BACKEND_BASE_URL);
+  });
+
+  it("lists the account's models from the live /models endpoint", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          models: [{ slug: "gpt-5.5", display_name: "GPT-5.5" }]
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    const models = await provider.getAvailableLanguageModels();
+    expect(models.map((m) => m.id)).toEqual(["gpt-5.5"]);
+    expect(models.every((m) => m.provider === "codex")).toBe(true);
+  });
+
+  it("falls back to a default model when /models is unreachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    const models = await provider.getAvailableLanguageModels();
+    expect(models.map((m) => m.id)).toEqual(["gpt-5.5"]);
+  });
+
+  it("advertises gpt-image-1 for text_to_image", async () => {
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    const models = await provider.getAvailableImageModels();
+    expect(models.map((m) => m.id)).toEqual(["gpt-image-1"]);
+    expect(models[0].supportedTasks).toContain("text_to_image");
+  });
+
+  it("extracts PNG bytes from the image_generation_call output item", async () => {
+    const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+    const b64 = Buffer.from(png).toString("base64");
+    const sse =
+      `data: ${JSON.stringify({ type: "response.image_generation_call.in_progress" })}\n\n` +
+      `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "image_generation_call", result: b64 } })}\n\n` +
+      `data: ${JSON.stringify({ type: "response.completed", response: {} })}\n\n`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(sse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      })
+    );
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    const [model] = await provider.getAvailableImageModels();
+    const bytes = await provider.textToImage({ model, prompt: "a dot" });
+    expect(Array.from(bytes)).toEqual(Array.from(png));
+  });
+});

--- a/packages/runtime/tests/providers/codex-provider.test.ts
+++ b/packages/runtime/tests/providers/codex-provider.test.ts
@@ -55,11 +55,18 @@ describe("CodexProvider", () => {
     expect(models.map((m) => m.id)).toEqual(["gpt-5.5"]);
   });
 
-  it("advertises gpt-image-1 for text_to_image", async () => {
+  it("advertises the gpt-image models for text_to_image", async () => {
     const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
     const models = await provider.getAvailableImageModels();
-    expect(models.map((m) => m.id)).toEqual(["gpt-image-1"]);
-    expect(models[0].supportedTasks).toContain("text_to_image");
+    expect(models.map((m) => m.id)).toEqual([
+      "gpt-image-2",
+      "gpt-image-1.5",
+      "gpt-image-1",
+      "gpt-image-1-mini"
+    ]);
+    expect(models.every((m) => m.supportedTasks?.includes("text_to_image"))).toBe(
+      true
+    );
   });
 
   it("extracts PNG bytes from the image_generation_call output item", async () => {

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -7,8 +7,19 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
+import { createLogger } from "@nodetool-ai/config";
 import { OAuthCredential } from "@nodetool-ai/models";
-import { OAuthClient, extractChatGptAccountId } from "@nodetool-ai/runtime/oauth";
+import {
+  OAuthClient,
+  LocalCallbackServer,
+  extractChatGptAccountId,
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_CALLBACK_PORT,
+  CODEX_CALLBACK_PATH,
+  DEFAULT_CODEX_OAUTH_CONFIG
+} from "@nodetool-ai/runtime/oauth";
+
+const logger = createLogger("nodetool.websocket.oauth");
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -23,23 +34,17 @@ const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
 const GITHUB_SCOPES = ["user:email", "read:user"];
 
-// OpenAI OAuth. Unlike HuggingFace there is no fixed public client id, so the
-// flow is opt-in: it activates only when OPENAI_OAUTH_CLIENT_ID is set
-// (mirroring how GitHub requires GITHUB_CLIENT_ID). Endpoints/scopes are
-// env-overridable so the same code works against OpenAI's published OAuth
-// server or a tenant-specific gateway.
-const OPENAI_AUTHORIZATION_URL =
-  process.env.OPENAI_OAUTH_AUTHORIZATION_URL ??
-  "https://auth.openai.com/oauth/authorize";
-const OPENAI_TOKEN_URL =
-  process.env.OPENAI_OAUTH_TOKEN_URL ?? "https://auth.openai.com/oauth/token";
+// OpenAI OAuth uses the public Codex CLI client (no client secret, no
+// per-deployment registration). The authorization server only accepts the
+// Codex-registered loopback redirect (http://localhost:1455/auth/callback), so
+// the browser is redirected to a local single-shot listener this process binds
+// rather than back to a server route. This is inherently a same-machine flow —
+// the listener must be reachable from the browser that completes the login.
 const OPENAI_USERINFO_URL =
   process.env.OPENAI_OAUTH_USERINFO_URL ?? "https://auth.openai.com/userinfo";
-const OPENAI_SCOPES = (
-  process.env.OPENAI_OAUTH_SCOPES ?? "openid profile email offline_access"
-)
-  .split(/\s+/)
-  .filter(Boolean);
+
+/** The Codex-registered loopback redirect the client id is bound to. */
+const CODEX_REDIRECT_URI = `http://localhost:${CODEX_CALLBACK_PORT}${CODEX_CALLBACK_PATH}`;
 
 const STATE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -823,33 +828,36 @@ async function handleGithubUser(
   }
 }
 
-// ── OpenAI Endpoints ─────────────────────────────────────────────────
+// ── OpenAI (Codex) Endpoints ─────────────────────────────────────────
+//
+// The login uses the public Codex CLI OAuth client. Because the Codex client's
+// only registered redirect is the loopback http://localhost:1455/auth/callback,
+// the flow can't bounce back through a server route: `start` binds a one-shot
+// loopback listener on that port, returns the authorization URL for the UI to
+// open, and finishes the code exchange in the background. The UI reflects
+// success by polling `/api/oauth/openai/tokens`.
 
-/** Build an OAuthClient for OpenAI, or null when OAuth is not configured. */
-function openaiOAuthClient(): OAuthClient | null {
-  const clientId = process.env.OPENAI_OAUTH_CLIENT_ID;
-  if (!clientId) return null;
+/** Build the Codex OAuth client (public client id, no secret). */
+function codexOAuthClient(): OAuthClient {
+  const clientId = process.env.CODEX_OAUTH_CLIENT_ID || CODEX_OAUTH_CLIENT_ID;
   return new OAuthClient({
-    config: {
-      authorizationEndpoint: OPENAI_AUTHORIZATION_URL,
-      tokenEndpoint: OPENAI_TOKEN_URL,
-      clientId,
-      scopes: OPENAI_SCOPES
-    }
+    config: { ...DEFAULT_CODEX_OAUTH_CONFIG, clientId }
   });
 }
 
-/** Derive the public callback URL for a given provider from the request host. */
-function callbackUriFor(request: Request, provider: string): string {
-  let host = request.headers.get("host") ?? "localhost:7777";
-  if (host.includes("://")) {
-    host = host.split("://")[1];
-  }
-  if (host.startsWith("127.0.0.1")) {
-    host = host.replace("127.0.0.1", "localhost");
-  }
-  const scheme = host.includes("localhost") ? "http" : "https";
-  return `${scheme}://${host}/api/oauth/${provider}/callback`;
+/** The single in-flight login, so a re-click can supersede a stale listener. */
+let activeCodexLogin: {
+  server: LocalCallbackServer;
+  abort: AbortController;
+} | null = null;
+
+/** Abort and tear down any in-flight Codex login listener. Idempotent. */
+export async function closeActiveCodexCallbackServer(): Promise<void> {
+  const active = activeCodexLogin;
+  if (!active) return;
+  activeCodexLogin = null;
+  active.abort.abort();
+  await active.server.close().catch(() => {});
 }
 
 async function handleOpenAIStart(
@@ -858,105 +866,77 @@ async function handleOpenAIStart(
 ): Promise<Response> {
   if (request.method !== "GET") return errorResponse(405, "Method not allowed");
 
-  const client = openaiOAuthClient();
-  if (!client) {
+  const userId = getUserId();
+  const client = codexOAuthClient();
+  const { codeVerifier, codeChallenge } = generatePkcePair();
+  const state = generateState();
+
+  // A new attempt supersedes any listener left over from an abandoned one.
+  await closeActiveCodexCallbackServer();
+
+  const server = new LocalCallbackServer({
+    host: "localhost",
+    port: CODEX_CALLBACK_PORT,
+    path: CODEX_CALLBACK_PATH
+  });
+  try {
+    await server.listen();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     return errorResponse(
       500,
-      "OpenAI OAuth is not configured. Set OPENAI_OAUTH_CLIENT_ID."
+      `Could not start the OAuth callback listener on port ${CODEX_CALLBACK_PORT}: ${message}`
     );
   }
 
-  const userId = getUserId();
-  const { codeVerifier, codeChallenge } = generatePkcePair();
-  const state = generateState();
-  const redirectUri = callbackUriFor(request, "openai");
-
-  pruneExpiredStates();
-  oauthStateStore.set(state, {
-    userId,
-    codeVerifier,
-    redirectUri,
-    createdAt: Date.now()
-  });
+  const abort = new AbortController();
+  activeCodexLogin = { server, abort };
 
   const authUrl = client.buildAuthorizationUrl({
-    redirectUri,
+    redirectUri: CODEX_REDIRECT_URI,
     state,
     codeChallenge,
     codeChallengeMethod: "S256"
   });
 
+  // Finish the exchange off the request path; the UI polls /tokens for success.
+  void completeCodexLogin({ server, client, state, codeVerifier, userId, abort });
+
   return jsonResponse({ auth_url: authUrl });
 }
 
-async function handleOpenAICallback(request: Request): Promise<Response> {
-  if (request.method !== "GET") return errorResponse(405, "Method not allowed");
-
-  const url = new URL(request.url);
-  const code = url.searchParams.get("code");
-  const state = url.searchParams.get("state");
-  const error = url.searchParams.get("error");
-  const errorDescription = url.searchParams.get("error_description");
-
-  if (error) {
-    return oauthHtmlResponse({
-      title: "OAuth Error",
-      success: false,
-      error,
-      errorDescription: errorDescription || "No description provided"
-    });
-  }
-
-  if (!code || !state) {
-    return oauthHtmlResponse({
-      title: "OAuth Error",
-      success: false,
-      error: "invalid_request",
-      errorDescription: "Missing required parameters (code or state)."
-    });
-  }
-
-  const stateData = oauthStateStore.get(state);
-  if (!stateData || Date.now() - stateData.createdAt > STATE_TTL_MS) {
-    if (stateData) oauthStateStore.delete(state);
-    return oauthHtmlResponse({
-      title: "OAuth Error",
-      success: false,
-      error: "invalid_state",
-      errorDescription:
-        "The authentication request has expired or is invalid. Please try again."
-    });
-  }
-
-  const { userId, codeVerifier, redirectUri } = stateData;
-  oauthStateStore.delete(state);
-
-  const client = openaiOAuthClient();
-  if (!client) {
-    return oauthHtmlResponse({
-      title: "OAuth Error",
-      success: false,
-      error: "configuration_error",
-      errorDescription: "OpenAI OAuth is not properly configured."
-    });
-  }
-
+/** Await the loopback redirect, exchange the code, and persist credentials. */
+async function completeCodexLogin(args: {
+  server: LocalCallbackServer;
+  client: OAuthClient;
+  state: string;
+  codeVerifier: string;
+  userId: string;
+  abort: AbortController;
+}): Promise<void> {
+  const { server, client, state, codeVerifier, userId, abort } = args;
   try {
+    const { code } = await server.waitForCode({
+      expectedState: state,
+      timeoutMs: STATE_TTL_MS,
+      signal: abort.signal
+    });
+
     const tokens = await client.exchangeAuthorizationCode({
       code,
       codeVerifier,
-      redirectUri
+      redirectUri: CODEX_REDIRECT_URI,
+      signal: abort.signal
     });
 
-    // Best-effort OIDC userinfo for a friendly account label. Failures fall
-    // back to an opaque, non-reversible account id derived from the token.
-    let username: string | null = null;
     // Prefer the ChatGPT account id embedded in the Codex access-token JWT — it
     // is the stable identity the ChatGPT backend addresses accounts by. Falls
     // back to the OIDC `sub`, then to an opaque token-derived id.
     const chatgptAccountId = extractChatGptAccountId(tokens.accessToken);
     let accountId =
       chatgptAccountId ?? String(Math.abs(hashCode(tokens.accessToken.slice(0, 24))));
+    // Best-effort OIDC userinfo for a friendly account label.
+    let username: string | null = null;
     try {
       const infoRes = await fetch(OPENAI_USERINFO_URL, {
         headers: { Authorization: `${tokens.tokenType} ${tokens.accessToken}` }
@@ -965,8 +945,6 @@ async function handleOpenAICallback(request: Request): Promise<Response> {
         const info = (await infoRes.json()) as Record<string, unknown>;
         username =
           (info.email as string) ?? (info.name as string) ?? (info.sub as string) ?? null;
-        // The ChatGPT account id, when present, is the canonical identity — keep
-        // it and only fall back to the OIDC `sub` otherwise.
         if (!chatgptAccountId && typeof info.sub === "string" && info.sub.length > 0) {
           accountId = info.sub;
         }
@@ -988,21 +966,14 @@ async function handleOpenAICallback(request: Request): Promise<Response> {
       expires_at:
         tokens.expiresAt != null ? new Date(tokens.expiresAt).toISOString() : null
     });
-
-    return oauthHtmlResponse({
-      title: "OAuth Success",
-      success: true,
-      username,
-      autoClose: true
-    });
+    logger.info("Codex OAuth login completed", { accountId });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return oauthHtmlResponse({
-      title: "OAuth Error",
-      success: false,
-      error: "token_exchange_failed",
-      errorDescription: message
+    logger.warn("Codex OAuth login did not complete", {
+      error: err instanceof Error ? err.message : String(err)
     });
+  } finally {
+    await server.close().catch(() => {});
+    if (activeCodexLogin?.server === server) activeCodexLogin = null;
   }
 }
 
@@ -1091,11 +1062,9 @@ export async function handleOAuthRequest(
     case "/api/oauth/github/user":
       return handleGithubUser(request, getUserId);
 
-    // OpenAI
+    // OpenAI (Codex)
     case "/api/oauth/openai/start":
       return handleOpenAIStart(request, getUserId);
-    case "/api/oauth/openai/callback":
-      return handleOpenAICallback(request);
     case "/api/oauth/openai/tokens":
       return handleOpenAITokens(getUserId);
     case "/api/oauth/openai/disconnect":

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -4,7 +4,8 @@ import {
   generatePkcePair,
   generateState,
   oauthStateStore,
-  handleOAuthRequest
+  handleOAuthRequest,
+  closeActiveCodexCallbackServer
 } from "../src/oauth-api.js";
 
 function getUserId(): string {
@@ -245,35 +246,17 @@ describe("OAuth API: GitHub endpoints", () => {
   });
 });
 
-describe("OAuth API: OpenAI endpoints", () => {
+describe("OAuth API: OpenAI (Codex) endpoints", () => {
   beforeEach(() => {
     initTestDb();
     oauthStateStore.clear();
-    delete process.env.OPENAI_OAUTH_CLIENT_ID;
   });
 
-  afterEach(() => {
-    delete process.env.OPENAI_OAUTH_CLIENT_ID;
+  afterEach(async () => {
+    await closeActiveCodexCallbackServer();
   });
 
-  it("GET /api/oauth/openai/start returns error without OPENAI_OAUTH_CLIENT_ID", async () => {
-    const response = await handleOAuthRequest(
-      new Request("http://localhost:7777/api/oauth/openai/start", {
-        headers: { host: "localhost:7777" }
-      }),
-      "/api/oauth/openai/start",
-      getUserId
-    );
-
-    expect(response).not.toBeNull();
-    expect(response!.status).toBe(500);
-    const body = (await jsonBody(response!)) as { detail: string };
-    expect(body.detail).toContain("OPENAI_OAUTH_CLIENT_ID");
-  });
-
-  it("GET /api/oauth/openai/start returns a PKCE auth_url when configured", async () => {
-    process.env.OPENAI_OAUTH_CLIENT_ID = "test-openai-client-id";
-
+  it("GET /api/oauth/openai/start returns a Codex PKCE auth_url", async () => {
     const response = await handleOAuthRequest(
       new Request("http://localhost:7777/api/oauth/openai/start", {
         headers: { host: "localhost:7777" }
@@ -286,15 +269,20 @@ describe("OAuth API: OpenAI endpoints", () => {
     expect(response!.status).toBe(200);
     const body = (await jsonBody(response!)) as { auth_url: string };
     expect(body.auth_url).toContain("https://auth.openai.com/oauth/authorize");
-    expect(body.auth_url).toContain("client_id=test-openai-client-id");
+    // The published, secret-less Codex CLI client.
+    expect(body.auth_url).toContain(
+      "client_id=app_EMoamEEZ73f0CkXaXp7hrann"
+    );
     expect(body.auth_url).toContain("code_challenge=");
     expect(body.auth_url).toContain("code_challenge_method=S256");
     expect(body.auth_url).toContain("state=");
+    // Codex's pre-registered loopback redirect — not a server route.
     expect(body.auth_url).toContain(
-      "redirect_uri=http%3A%2F%2Flocalhost%3A7777%2Fapi%2Foauth%2Fopenai%2Fcallback"
+      "redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback"
     );
-    // Start must persist the CSRF state for the callback to validate against.
-    expect(oauthStateStore.size).toBe(1);
+    // Codex-specific authorization params.
+    expect(body.auth_url).toContain("codex_cli_simplified_flow=true");
+    expect(body.auth_url).toContain("id_token_add_organizations=true");
   });
 
   it("GET /api/oauth/openai/tokens returns empty list initially", async () => {
@@ -307,21 +295,6 @@ describe("OAuth API: OpenAI endpoints", () => {
     expect(response!.status).toBe(200);
     const body = (await jsonBody(response!)) as { tokens: unknown[] };
     expect(body.tokens).toEqual([]);
-  });
-
-  it("GET /api/oauth/openai/callback with invalid state returns error HTML", async () => {
-    const response = await handleOAuthRequest(
-      new Request(
-        "http://localhost:7777/api/oauth/openai/callback?code=abc&state=invalid"
-      ),
-      "/api/oauth/openai/callback",
-      getUserId
-    );
-
-    expect(response).not.toBeNull();
-    const html = await response!.text();
-    expect(html).toContain("Authentication Failed");
-    expect(html).toContain("expired or is invalid");
   });
 
   it("POST /api/oauth/openai/disconnect removes stored credentials", async () => {


### PR DESCRIPTION
## Summary

Makes the **Settings → "Connect with OpenAI"** login actually usable. Previously it stored an OAuth token that nothing consumed. Now:

1. The login uses the public **Codex CLI OAuth flow** (loopback redirect on `localhost:1455`) instead of the unused, API-key-app flow.
2. The stored token powers a new **`codex` provider** that talks to the ChatGPT Codex backend's **Responses API**.

Select **Codex** in the model picker (or `--provider codex` in the CLI) to use your ChatGPT subscription for inference — no API key.

## Why a separate provider / Responses API

The ChatGPT OAuth token is a subscription token, **not** an API key. Tested against a live login, it only works against `chatgpt.com/backend-api/codex/responses`:

| Surface | Result |
|---|---|
| `api.openai.com/v1/*` (chat, images, embeddings, audio, responses) | ❌ missing scopes / no API billing |
| `codex/responses` — chat | ✅ |
| `codex/responses` — `image_generation` tool | ✅ |
| `codex/responses` — `web_search` tool | ✅ |

So `CodexProvider` can't reuse `OpenAIProvider`'s chat-completions/images endpoints — every capability is a Responses call. The backend also gates its model allowlist on a `client_version` header (≥ `0.124.0`), so models are fetched live from `GET /models`.

## Changes

- **protocol** — `PROVIDER_IDS.CODEX` + shared Codex OAuth/client constants (`CODEX_CLIENT_VERSION`, backend URL, endpoints, loopback redirect).
- **websocket** — the OpenAI OAuth `start` endpoint drives the Codex loopback flow; the dead server-callback route is removed.
- **models** — `resolveCodexAccessToken` (refresh + persist the rotated token), wired into `getSecret("CODEX_ACCESS_TOKEN")`.
- **runtime** — `CodexProvider` over the Responses API: chat, streaming, tool calls, and **`text_to_image`** via the `image_generation` tool; live model listing; registered in the provider barrel.
- **cli** — `codex` in the provider list (default `gpt-5.5`).

## Verification (live, against a real ChatGPT Plus login)

- Provider resolves through the registry (`getProvider("codex")` + `getSecret`), `isProviderConfigured` = true.
- Streaming, non-streaming, and tool calls all work; cost tracked.
- `text_to_image` returns a valid PNG (`gpt-image-1`).
- Build (54/54), lint, typecheck, and unit tests pass (runtime/models/protocol/websocket). The one CLI smoke failure is pre-existing and environment-specific (arm64 adds `mlx`), unrelated to this change.

## Notes / follow-ups

- `CODEX_CLIENT_VERSION` is pinned to `0.124.0` (env-overridable); bump if OpenAI ships a model needing a newer client.
- Image **input** (`image_to_image`) and `web_search` are proven feasible but not yet wired.
- Inherently a same-machine login flow (binds loopback `:1455`), which is the desktop/local Settings use case.