### PR TITLE
Snap off-grid spacing values to the 4px grid

### DIFF
--- a/web/src/components/LayoutTest.tsx
+++ b/web/src/components/LayoutTest.tsx
@@ -165,7 +165,7 @@ const styles = (theme: Theme) => css`
   }
   
   .card-body {
-    padding: 20px;
+    padding: 24px;
     min-height: 120px;
     display: flex;
     flex-direction: column;

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -25,8 +25,8 @@ const logoStyles = (
   css({
     display: "flex",
     alignItems: "center",
-    gap: "20px",
-    margin: "1px 0 0 0",
+    gap: "24px",
+    margin: "2px 0 0 0",
     ".nt": {
       fontFamily: theme.fontFamily1,
       fontWeight: 600,
@@ -35,7 +35,7 @@ const logoStyles = (
       height: height,
       backgroundColor: "transparent",
       opacity: opacity,
-      marginTop: "1px",
+      marginTop: "2px",
       transition: "opacity 1s ease-in-out .2s"
     },
     ".nodetool": {

--- a/web/src/components/audio/AudioPlayer.tsx
+++ b/web/src/components/audio/AudioPlayer.tsx
@@ -79,7 +79,7 @@ const styles = (theme: Theme) =>
     button: {
       width: "25px !important",
       height: "25px !important",
-      padding: "10px",
+      padding: "12px",
       transition: "border",
       backgroundColor: "transparent",
       border: "1px solid rgba(70, 70, 70, 0.3)",

--- a/web/src/components/content/Help/DraggableNodeDocumentation.tsx
+++ b/web/src/components/content/Help/DraggableNodeDocumentation.tsx
@@ -48,7 +48,7 @@ const styles = (theme: Theme) => css`
     color: ${theme.vars.palette.warning.main};
   }
   .content {
-    padding: 10px;
+    padding: 12px;
   }
 
   .close-button {
@@ -64,8 +64,8 @@ const styles = (theme: Theme) => css`
 
   .open-node-menu-button {
     color: ${"var(--palette-primary-main)"};
-    margin-top: 10px;
-    margin-right: 10px;
+    margin-top: 12px;
+    margin-right: 12px;
   }
 `;
 
@@ -130,7 +130,7 @@ const DraggableNodeDocumentation: React.FC<DraggableNodeDocumentationProps> = ({
             density="compact"
             className="open-node-menu-button"
             onClick={handleOpenNodeMenu}
-            sx={{ marginTop: "10px" }}
+            sx={{ marginTop: "12px" }}
           >
             Search for similar nodes
           </EditorButton>
@@ -143,7 +143,7 @@ const DraggableNodeDocumentation: React.FC<DraggableNodeDocumentationProps> = ({
           variant="contained"
           density="normal"
           onClick={handleAddNode}
-          sx={{ marginTop: "10px", marginRight: "10px" }}
+          sx={{ marginTop: "12px", marginRight: "12px" }}
         >
           Add Node
         </EditorButton>

--- a/web/src/components/content/Help/Help.tsx
+++ b/web/src/components/content/Help/Help.tsx
@@ -100,7 +100,7 @@ const helpStyles = (theme: Theme) =>
     ".docs-button": {
       display: "flex",
       alignItems: "center",
-      gap: "10px",
+      gap: "12px",
       color: theme.vars.palette.secondary.contrastText,
       backgroundColor: theme.vars.palette.secondary.main,
       textDecoration: "none",
@@ -165,7 +165,7 @@ const helpStyles = (theme: Theme) =>
         marginTop: "2px",
         color: theme.vars.palette.grey[200],
         border: `1px solid ${theme.vars.palette.grey[600]}`,
-        padding: "1px 6px",
+        padding: "2px 6px",
         textAlign: "left",
         lineHeight: "1.3em",
         minWidth: "unset",

--- a/web/src/components/context_menus/ConnectableNodes.tsx
+++ b/web/src/components/context_menus/ConnectableNodes.tsx
@@ -50,13 +50,13 @@ const scrollableContentStyles = (theme: Theme) =>
       padding: "0"
     },
     ".node-item-container": {
-      padding: "1px 6px"
+      padding: "2px 6px"
     },
     ".node": {
       display: "flex",
       alignItems: "center",
       margin: 0,
-      padding: "3px 6px",
+      padding: "4px 6px",
       borderRadius: "var(--rounded-md)",
       cursor: "pointer",
       transition: MOTION.background,

--- a/web/src/components/context_menus/InputContextMenu.tsx
+++ b/web/src/components/context_menus/InputContextMenu.tsx
@@ -817,7 +817,7 @@ const InputContextMenu: React.FC = () => {
     gap: "0.5em",
     margin: 0,
     minHeight: "28px",
-    padding: "1px 6px",
+    padding: "2px 6px",
     textAlign: "left",
     width: "100%",
     "&:hover": { backgroundColor: theme.vars.palette.action.hover },
@@ -830,7 +830,7 @@ const InputContextMenu: React.FC = () => {
       flexShrink: 0,
       height: "18px",
       justifyContent: "center",
-      padding: "1px",
+      padding: "2px",
       width: "18px"
     },
     ".icon-bg svg": {

--- a/web/src/components/context_menus/OutputContextMenu.tsx
+++ b/web/src/components/context_menus/OutputContextMenu.tsx
@@ -417,7 +417,7 @@ const OutputContextMenu: React.FC = () => {
     gap: "0.5em",
     margin: 0,
     minHeight: "28px",
-    padding: "1px 6px",
+    padding: "2px 6px",
     textAlign: "left",
     width: "100%",
     "&:hover": { backgroundColor: theme.vars.palette.action.hover },
@@ -430,7 +430,7 @@ const OutputContextMenu: React.FC = () => {
       flexShrink: 0,
       height: "18px",
       justifyContent: "center",
-      padding: "1px",
+      padding: "2px",
       width: "18px"
     },
     ".icon-bg svg": {

--- a/web/src/components/costs/CostsDashboard.tsx
+++ b/web/src/components/costs/CostsDashboard.tsx
@@ -60,7 +60,7 @@ const segmentedSx = (theme: Theme): SxProps<Theme> => ({
   backgroundColor: theme.vars.palette.action.hover,
   border: `1px solid ${theme.vars.palette.divider}`,
   borderRadius: "var(--rounded-lg)",
-  padding: "3px",
+  padding: "4px",
   gap: "2px",
   "& .MuiToggleButton-root": {
     border: "none",
@@ -461,7 +461,7 @@ const DashboardContent: React.FC<DashboardContentProps> = ({
                 gap={0.5}
                 align="center"
                 sx={{
-                  padding: "1px 6px",
+                  padding: "2px 6px",
                   borderRadius: BORDER_RADIUS.md,
                   backgroundColor: `${deltaColor}1F`
                 }}

--- a/web/src/components/inputs/SliderBasic.tsx
+++ b/web/src/components/inputs/SliderBasic.tsx
@@ -8,7 +8,7 @@ import type { Theme } from "@mui/material/styles";
 const sliderBasicStyles = (theme: Theme) =>
   css({
     "&": {
-      marginTop: "3px",
+      marginTop: "4px",
       padding: "0"
     },
     ".MuiSlider-rail": {

--- a/web/src/components/miniapps/components/MiniWorkflowGraph.tsx
+++ b/web/src/components/miniapps/components/MiniWorkflowGraph.tsx
@@ -74,7 +74,7 @@ const graphStyles = css({
     display: "flex",
     alignItems: "center",
     gap: "4px",
-    padding: "3px 8px",
+    padding: "4px 8px",
     background: "var(--palette-background-default)",
     border: "1px solid var(--palette-divider)",
     borderRadius: "var(--rounded-sm)",

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -115,7 +115,7 @@ const propertyInputContainerStyles = (theme: Theme) =>
       transition: MOTION.opacity,
       zIndex: 2,
       cursor: "pointer",
-      padding: "1px",
+      padding: "2px",
       borderRadius: BORDER_RADIUS.sm,
       color: theme.vars.palette.text.secondary,
       "&:hover": {

--- a/web/src/components/node/PropertyLabel.tsx
+++ b/web/src/components/node/PropertyLabel.tsx
@@ -159,7 +159,7 @@ const PropertyLabel: React.FC<PropertyLabelProps> = ({
             fontSize: theme.fontSizeSmaller,
             color: theme.vars.palette.text.disabled,
             lineHeight: 1.3,
-            marginTop: "1px",
+            marginTop: "2px",
             marginBottom: theme.spacing(0.5),
             userSelect: "none",
           })}

--- a/web/src/components/node_menu/NamespaceList.tsx
+++ b/web/src/components/node_menu/NamespaceList.tsx
@@ -30,7 +30,7 @@ const namespaceStyles = (theme: Theme) =>
       height: "60vh",
       display: "flex",
       flexDirection: "column",
-      marginTop: "20px",
+      marginTop: "24px",
       overflow: "auto"
     },
     "& h4": {

--- a/web/src/components/node_menu/NamespacePanel.tsx
+++ b/web/src/components/node_menu/NamespacePanel.tsx
@@ -122,7 +122,7 @@ const namespacePanelStyles = (theme: Theme) =>
       lineHeight: 1.2,
       transition: `${MOTION.background}, ${MOTION.opacity}`,
       overflow: "hidden",
-      margin: "1px 0",
+      margin: "2px 0",
       borderRadius: "var(--rounded-md)"
     },
     "& .namespaces .list-item.disabled": {

--- a/web/src/components/node_menu/NodeItem.tsx
+++ b/web/src/components/node_menu/NodeItem.tsx
@@ -217,7 +217,7 @@ const NodeItem = memo(
         () => ({
           backgroundColor: theme.vars.palette.grey[900],
           margin: "0",
-          padding: "1px",
+          padding: "2px",
           borderRadius: "0 0 2px 0",
           boxShadow: `inset 1px 1px 2px ${theme.vars.palette.action.disabledBackground}`,
           width: "20px",

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -62,7 +62,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
     ".nl-count": {
       display: "inline-flex",
       alignItems: "center",
-      padding: "1px 8px",
+      padding: "2px 8px",
       borderRadius: "var(--rounded-sm)",
       backgroundColor: theme.vars.palette.action.selected,
       color: theme.vars.palette.text.secondary,
@@ -118,7 +118,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
-      padding: "1px 6px",
+      padding: "2px 6px",
       height: "18px",
       borderRadius: "var(--rounded-sm)",
       backgroundColor: theme.vars.palette.action.hover,

--- a/web/src/components/node_menu/SearchResultItem.tsx
+++ b/web/src/components/node_menu/SearchResultItem.tsx
@@ -318,7 +318,7 @@ const SearchResultItem = memo(
                 width: "18px",
                 height: "18px",
                 margin: 0,
-                padding: "1px",
+                padding: "2px",
                 borderRadius: BORDER_RADIUS.sm
               }}
               svgProps={{ width: "14px", height: "14px" }}

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -202,7 +202,7 @@ const typeFilterChipsStyles = (theme: Theme) =>
     },
     ".filter-select": {
       width: "100%",
-      marginBottom: "10px",
+      marginBottom: "12px",
       "& .MuiInputBase-root": {
         fontSize: theme.fontSizeSmaller,
         padding: ".5em .75em"

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -133,8 +133,8 @@ const styles = (
       gap: "8px",
       backgroundColor: theme.vars.palette.background.default,
       borderRight: `1px solid ${theme.vars.palette.divider}`,
-      paddingTop: "10px",
-      paddingBottom: "10px",
+      paddingTop: "12px",
+      paddingBottom: "12px",
 
       "& .toolbar-divider": {
         height: "1px",

--- a/web/src/components/panels/TracePanel.tsx
+++ b/web/src/components/panels/TracePanel.tsx
@@ -47,7 +47,7 @@ const styles = (theme: Theme) =>
     ".trace-row": {
       display: "flex",
       alignItems: "flex-start",
-      padding: "3px 12px",
+      padding: "4px 12px",
       gap: 8,
       borderBottom: `1px solid ${theme.vars.palette.divider}22`,
       cursor: "pointer",

--- a/web/src/components/portal/DashboardFooter.tsx
+++ b/web/src/components/portal/DashboardFooter.tsx
@@ -16,10 +16,10 @@ const styles = (theme: Theme) =>
       gap: 8,
       flexWrap: "wrap",
       minHeight: 46,
-      padding: "10px 40px",
+      padding: "12px 40px",
       fontSize: 12,
       color: theme.vars.palette.text.disabled,
-      [theme.breakpoints.down("sm")]: { padding: "10px 18px" }
+      [theme.breakpoints.down("sm")]: { padding: "12px 16px" }
     },
     ".foot-links button": {
       background: "none",

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -37,7 +37,7 @@ const heroStyles = (theme: Theme) =>
       }
     },
     ".hero-composer": {
-      margin: "26px auto 0",
+      margin: "24px auto 0",
       maxWidth: 720
     },
     ".hero-foot": {

--- a/web/src/components/portal/GettingStartedChecklist.tsx
+++ b/web/src/components/portal/GettingStartedChecklist.tsx
@@ -18,7 +18,7 @@ const styles = (theme: Theme) =>
       alignItems: "center",
       gap: 10,
       flexWrap: "wrap",
-      padding: "10px 0"
+      padding: "12px 0"
     },
     ".checklist-label": {
       fontFamily: theme.fontFamily2,

--- a/web/src/components/portal/PortalSetupFlow.tsx
+++ b/web/src/components/portal/PortalSetupFlow.tsx
@@ -62,7 +62,7 @@ const styles = (theme: Theme) =>
       fontWeight: 600,
       textTransform: "uppercase" as const,
       letterSpacing: "0.05em",
-      padding: "1px 6px",
+      padding: "2px 6px",
       borderRadius: 9999,
       background: `color-mix(in srgb, ${theme.palette.primary.main} 18%, transparent)`,
       color: theme.palette.primary.main,

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -631,7 +631,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".button-close": {
-      marginLeft: "3px",
+      marginLeft: "4px",
       border: `1px solid rgba(${theme.vars.palette.common.whiteChannel} / 0.08)`,
       "&:hover": {
         backgroundColor: theme.vars.palette.error.main,

--- a/web/src/components/properties/ToolsListProperty.tsx
+++ b/web/src/components/properties/ToolsListProperty.tsx
@@ -185,7 +185,7 @@ const ToolsListProperty = (props: PropertyProps) => {
             onClick={handleToolClick}
             data-tool={entry.id}
             sx={{
-              padding: "1px",
+              padding: "2px",
               marginLeft: "0 !important",
               transition: `color ${MOTION.normal}`,
               color: "c_hl1",
@@ -207,7 +207,7 @@ const ToolsListProperty = (props: PropertyProps) => {
           size="small"
           onClick={openMenu}
           sx={{
-            padding: "1px",
+            padding: "2px",
             marginLeft: "0 !important",
             color: "palette-grey-400",
             "&:hover": {

--- a/web/src/components/timeline/transcript/SceneBreakNode.tsx
+++ b/web/src/components/timeline/transcript/SceneBreakNode.tsx
@@ -41,7 +41,7 @@ const Row = styled("div")(({ theme }) => ({
     display: "inline-flex",
     alignItems: "center",
     gap: 6,
-    padding: "1px 8px",
+    padding: "2px 8px",
     borderRadius: BORDER_RADIUS.pill,
     fontSize: FONT_SIZE_SANS.caption,
     fontWeight: FONT_WEIGHT.semibold,

--- a/web/src/components/workflows/GettingStartedStrip.tsx
+++ b/web/src/components/workflows/GettingStartedStrip.tsx
@@ -20,7 +20,7 @@ const stripStyles = (theme: Theme) =>
     padding: "0 1.25em 1em",
     display: "flex",
     flexDirection: "column",
-    gap: "10px",
+    gap: "12px",
     ".strip-header": {
       display: "flex",
       alignItems: "baseline",

--- a/web/src/components/workflows/WorkflowCard.tsx
+++ b/web/src/components/workflows/WorkflowCard.tsx
@@ -157,7 +157,7 @@ const cardStyles = (theme: Theme) =>
       display: "flex",
       flexDirection: "column",
       gap: "6px",
-      padding: "10px 12px 12px",
+      padding: "12px 12px 12px",
       flex: 1,
       minHeight: 0
     },
@@ -211,7 +211,7 @@ const cardStyles = (theme: Theme) =>
     ".chip-category": {
       display: "inline-flex",
       alignItems: "center",
-      gap: "5px",
+      gap: "6px",
       textTransform: "none",
       fontWeight: 600
     },
@@ -284,7 +284,7 @@ const WorkflowCard = ({
             backgroundColor: theme.vars.palette.grey[800],
             color: theme.vars.palette.text.primary,
             fontSize: "var(--fontSizeNormal)",
-            padding: "10px 14px",
+            padding: "12px 16px",
             maxWidth: 300,
             borderRadius: BORDER_RADIUS.lg,
             boxShadow: "0 4px 20px rgba(0, 0, 0, 0.3)"

--- a/web/src/components/workflows/WorkflowForm.tsx
+++ b/web/src/components/workflows/WorkflowForm.tsx
@@ -99,7 +99,7 @@ const styles = (theme: Theme) =>
       fontFamily: theme.fontFamily1,
       fontSize: theme.fontSizeNormal,
       color: theme.vars.palette.text.primary,
-      padding: "10px 12px"
+      padding: "12px 12px"
     },
 
     ".MuiFormHelperText-root": {

--- a/web/src/components/workflows/WorkflowListItem.tsx
+++ b/web/src/components/workflows/WorkflowListItem.tsx
@@ -290,7 +290,7 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
             title="Open workflow"
             density="compact"
             sx={{
-              padding: "3px 10px",
+              padding: "4px 12px",
               minWidth: "unset",
               fontSize: "var(--fontSizeSmall)",
               fontWeight: 600,

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -160,7 +160,7 @@ const styles = (theme: Theme) =>
       flexShrink: 0,
       display: "flex",
       alignItems: "center",
-      gap: "5px",
+      gap: "6px",
       padding: "0 14px",
       border: "none",
       borderRight: `1px solid ${theme.vars.palette.divider}`,
@@ -177,7 +177,7 @@ const styles = (theme: Theme) =>
       },
       "& .new-tab-caret": {
         fontSize: "var(--fontSizeSmall)",
-        marginLeft: "1px",
+        marginLeft: "2px",
         opacity: 0.75,
         lineHeight: 1
       },
@@ -200,7 +200,7 @@ const styles = (theme: Theme) =>
         color: theme.vars.palette.text.secondary,
         cursor: "pointer",
         fontSize: "var(--fontSizeSmaller)",
-        padding: "3px 12px",
+        padding: "4px 12px",
         "&:first-of-type": { borderRadius: `${BORDER_RADIUS.sm} 0 0 ${BORDER_RADIUS.sm}`, borderRight: "none" },
         "&:last-of-type": { borderRadius: `0 ${BORDER_RADIUS.sm} ${BORDER_RADIUS.sm} 0` },
         "&.on": {

--- a/web/src/components/workspaces/WorkspaceSelect.tsx
+++ b/web/src/components/workspaces/WorkspaceSelect.tsx
@@ -35,7 +35,7 @@ const styles = (theme: Theme) =>
         display: "flex",
         alignItems: "center",
         gap: theme.spacing(1.5),
-        padding: "10px 14px"
+        padding: "12px 16px"
       },
       "&.compact .MuiSelect-select": {
         padding: "4px 10px"
@@ -314,7 +314,7 @@ const WorkspaceSelect: React.FC<WorkspaceSelectProps> = memo(
                     opacity: 0.6
                   },
                   "& .MuiMenuItem-root": {
-                    padding: "10px 14px",
+                    padding: "12px 16px",
                     borderRadius: "var(--rounded-sm)",
                     margin: "2px 4px",
                     "&:hover": {

--- a/web/src/e2e_runner/E2ERunnerApp.tsx
+++ b/web/src/e2e_runner/E2ERunnerApp.tsx
@@ -126,7 +126,7 @@ function Sidebar({
         <div
           key={rec.id}
           style={{
-            padding: "10px 16px",
+            padding: "12px 16px",
             borderBottom: "1px solid #141d2e",
             background: i === state.currentIndex ? "#13203b" : "transparent"
           }}

--- a/web/src/styles/TableStyles.ts
+++ b/web/src/styles/TableStyles.ts
@@ -109,7 +109,7 @@ export const tableStyles = (theme: Theme) =>
       borderRight: `1px solid ${theme.vars.palette.grey[900]}`
     },
     ".tabulator .tabulator-header .tabulator-col .tabulator-col-content": {
-      padding: "5px 0px 0px 2px"
+      padding: "6px 0px 0px 2px"
     },
 
     // Table action buttons


### PR DESCRIPTION
Snaps hardcoded **off-grid** `padding`/`margin`/`gap` pixel values in web component code to the nearest canonical step on the `SPACING` 4px grid (`0·2·4·6·8·12·16·24·32`), per [docs/DESIGN.md §2](https://github.com/nodetool-ai/nodetool/blob/HEAD/docs/DESIGN.md). Ties round up, matching `snapSpacing` in [spacing.ts](https://github.com/nodetool-ai/nodetool/blob/HEAD/web/src/components/ui_primitives/spacing.ts).

Typical snaps: `1px→2px`, `3px→4px`, `5px→6px`, `10px→12px`, `20px→24px`, `26px→24px`.

Scope notes:
- Targets only genuinely off-grid values in `.tsx`/`.ts` component files. On-grid raw px (`8px`, `16px`, …) is intentionally left as-is — the design doc explicitly permits the raw pixel grid.
- Large functional dimensions above the 32px scale (e.g. `paddingRight: "250px"`, `"84px"`, fixed section paddings) are left unchanged, as no grid step exists for them and snapping would distort layout.
- Values kept as snapped px strings rather than `SPACING` tokens because many sites are emotion `css()` blocks where a theme-unit token would resolve incorrectly.

Part of the design-token migration series (sibling issues cover border radii, motion, and font sizes separately). 36 files changed.

Verification: `typecheck` and `lint` failures on this branch are pre-existing (unbuilt node packages; a `react-hooks/exhaustive-deps` rule-resolution quirk) and reproduce identically on the base commit — none are introduced by these edits.