### PR TITLE
Add first-party nodetool.ai domains to CORS allowed origins

### DIFF
--- a/packages/websocket/src/cors.ts
+++ b/packages/websocket/src/cors.ts
@@ -10,15 +10,19 @@
  * the storage and MCP endpoints.
  *
  * Defaults cover the known web dev server and the server's own origin
- * (localhost / 127.0.0.1 / [::1] on any port) plus the Electron renderer
- * (`file://`). Additional origins are granted via the
- * `NODETOOL_ALLOWED_ORIGINS` env var (comma-separated). Set it to `*` to
- * restore allow-all behaviour for trusted deployments fronted by their own
- * gateway.
+ * (localhost / 127.0.0.1 / [::1] on any port), the Electron renderer
+ * (`file://`), and the first-party NodeTool product domains
+ * (`https://nodetool.ai` and its subdomains, e.g. `app.nodetool.ai`).
+ * Additional origins are granted via the `NODETOOL_ALLOWED_ORIGINS` env var
+ * (comma-separated). Set it to `*` to restore allow-all behaviour for trusted
+ * deployments fronted by their own gateway.
  */
 import { getEnv } from "@nodetool-ai/config";
 
-/** Origins always permitted: localhost/127.0.0.1/[::1] (any port) + Electron file://. */
+/**
+ * Origins always permitted: localhost/127.0.0.1/[::1] (any port), Electron
+ * file://, and the first-party `nodetool.ai` product domains over HTTPS.
+ */
 const DEFAULT_ALLOWED_ORIGIN_PATTERNS: RegExp[] = [
   /^https?:\/\/localhost(?::\d+)?$/,
   /^https?:\/\/127\.0\.0\.1(?::\d+)?$/,
@@ -26,7 +30,11 @@ const DEFAULT_ALLOWED_ORIGIN_PATTERNS: RegExp[] = [
   // Electron renderer requests that carry a literal `file://` origin. (A
   // `file://` document that sends `Origin: null` is handled by the
   // missing-origin branch in isOriginAllowed, not this pattern.)
-  /^file:\/\//
+  /^file:\/\//,
+  // First-party NodeTool product: https://nodetool.ai and any subdomain
+  // (app.nodetool.ai, api.nodetool.ai, …). HTTPS only — no port allowed so a
+  // look-alike like `nodetool.ai.evil.com` cannot match.
+  /^https:\/\/([a-z0-9-]+\.)*nodetool\.ai$/
 ];
 
 interface CorsConfig {

--- a/packages/websocket/tests/cors.test.ts
+++ b/packages/websocket/tests/cors.test.ts
@@ -43,12 +43,25 @@ describe("isOriginAllowed — defaults", () => {
     expect(isOriginAllowed("file:///index.html")).toBe(true);
   });
 
+  it("allows the first-party nodetool.ai product domains over HTTPS", () => {
+    expect(isOriginAllowed("https://app.nodetool.ai")).toBe(true);
+    expect(isOriginAllowed("https://api.nodetool.ai")).toBe(true);
+    expect(isOriginAllowed("https://nodetool.ai")).toBe(true);
+    expect(isOriginAllowed("https://staging.app.nodetool.ai")).toBe(true);
+  });
+
   it("rejects unknown remote origins", () => {
     expect(isOriginAllowed("https://evil.example.com")).toBe(false);
     expect(isOriginAllowed("http://attacker.test")).toBe(false);
     // look-alike that must not match the localhost pattern
     expect(isOriginAllowed("http://localhost.evil.com")).toBe(false);
     expect(isOriginAllowed("http://127.0.0.1.evil.com")).toBe(false);
+    // look-alikes that must not match the nodetool.ai pattern
+    expect(isOriginAllowed("https://nodetool.ai.evil.com")).toBe(false);
+    expect(isOriginAllowed("https://notnodetool.ai")).toBe(false);
+    // HTTP (non-TLS) and ports are not part of the first-party default
+    expect(isOriginAllowed("http://app.nodetool.ai")).toBe(false);
+    expect(isOriginAllowed("https://app.nodetool.ai:8443")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Extends the default CORS allowed origins to include first-party NodeTool product domains (`nodetool.ai` and all subdomains) over HTTPS, improving security by explicitly allowing known trusted origins while maintaining strict validation.

## Changes

- **CORS pattern**: Added regex pattern `/^https:\/\/([a-z0-9-]+\.)*nodetool\.ai$/` to `DEFAULT_ALLOWED_ORIGIN_PATTERNS` to permit:
  - `https://nodetool.ai` (root domain)
  - `https://app.nodetool.ai`, `https://api.nodetool.ai`, etc. (any subdomain)
  - HTTPS only — no HTTP or custom ports allowed
  
- **Documentation**: Updated module and constant JSDoc comments to clarify that first-party domains are now included in defaults alongside localhost, 127.0.0.1, [::1], and `file://`

- **Test coverage**: Added comprehensive test cases validating:
  - Root domain and multiple subdomains are allowed
  - Look-alike domains (`nodetool.ai.evil.com`, `notnodetool.ai`) are rejected
  - HTTP and custom ports on `nodetool.ai` are rejected (HTTPS-only enforcement)

## Implementation Details

The regex pattern uses a non-capturing group `([a-z0-9-]+\.)*` to match zero or more subdomains, ensuring:
- Exact domain matching (no suffix matching that could allow `nodetool.ai.evil.com`)
- Lowercase alphanumeric and hyphen characters only (standard subdomain rules)
- HTTPS scheme enforcement via the literal `https://` prefix
- No port specification allowed (stricter than localhost patterns)

https://claude.ai/code/session_01VJRH1t8HiMLUtVCHERPBQR