### PR TITLE
Make AutomaticSpeechRecognitionNode cross-platform compatible

### DIFF
--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -2,7 +2,11 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { Platform } from "@nodetool-ai/protocol";
 import type { OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { tagAsServer, renderTemplate } from "@nodetool-ai/nodes-utils";
+import {
+  tagAsServer,
+  renderTemplate,
+  base64ToBytes
+} from "@nodetool-ai/nodes-utils";
 import {
   loadNodeFsPromises,
   loadNodePath
@@ -1779,7 +1783,6 @@ export class HtmlToTextNode extends BaseNode {
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "nodetool.text.AutomaticSpeechRecognition";
   static readonly body = "content_card";
-  static readonly platforms = NODE_ONLY;
   static readonly title = "Automatic Speech Recognition";
   static readonly description =
     "Transcribe audio to text using automatic speech recognition models.\n    audio, speech, recognition, transcription, ASR, whisper";
@@ -1846,9 +1849,9 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const { providerId, modelId } = modelConfig(this.serialize());
     const audio = (this.audio ?? {}) as Record<string, unknown>;
-    let bytes = new Uint8Array();
+    let bytes: Uint8Array = new Uint8Array();
     if (typeof audio.data === "string") {
-      bytes = Uint8Array.from(Buffer.from(audio.data, "base64"));
+      bytes = base64ToBytes(audio.data);
     } else if (audio.data instanceof Uint8Array) {
       bytes = new Uint8Array(audio.data);
     } else if (typeof audio.uri === "string" && audio.uri) {

--- a/packages/text-nodes/tests/text-extra.test.ts
+++ b/packages/text-nodes/tests/text-extra.test.ts
@@ -220,3 +220,24 @@ describe("SliceTextNode unicode", () => {
     expect((await node.process()).output).toBe("😀");
   });
 });
+
+describe("AutomaticSpeechRecognitionNode platforms", () => {
+  it("is available in the production cloud (node + workers + edge)", async () => {
+    const { AutomaticSpeechRecognitionNode } = await import(
+      "@nodetool-ai/text-nodes"
+    );
+    const platforms = AutomaticSpeechRecognitionNode.platforms ?? [];
+    expect(platforms).toContain("node");
+    expect(platforms).toContain("workers");
+    expect(platforms).toContain("edge");
+  });
+
+  it("keeps filesystem-bound text nodes node-only", async () => {
+    const { SaveTextFileNode, SaveTextNode, LoadTextFolderNode } = await import(
+      "@nodetool-ai/text-nodes"
+    );
+    for (const cls of [SaveTextFileNode, SaveTextNode, LoadTextFolderNode]) {
+      expect(cls.platforms).toEqual(["node"]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Removes the `NODE_ONLY` platform restriction from `AutomaticSpeechRecognitionNode` to enable it to run on production cloud platforms (node, workers, and edge), while keeping filesystem-bound text nodes restricted to node-only execution.

## Key Changes
- **Removed platform restriction**: Deleted `static readonly platforms = NODE_ONLY;` from `AutomaticSpeechRecognitionNode` to allow execution on node, workers, and edge platforms
- **Improved cross-platform audio handling**: Replaced Node.js-specific `Buffer.from()` with the platform-agnostic `base64ToBytes()` utility function for base64 decoding
- **Added import**: Imported `base64ToBytes` from `@nodetool-ai/nodes-utils`
- **Added test coverage**: New test suite verifying that:
  - `AutomaticSpeechRecognitionNode` is available on all production cloud platforms (node, workers, edge)
  - Filesystem-bound nodes (`SaveTextFileNode`, `SaveTextNode`, `LoadTextFolderNode`) remain node-only

## Implementation Details
The change enables ASR functionality across multiple runtime environments by removing the Node.js-specific platform constraint and replacing Node.js Buffer APIs with platform-agnostic alternatives. Filesystem operations remain appropriately restricted to node-only execution.

https://claude.ai/code/session_01JLJ2PsjiGBtptjzKjSegLP