### PR TITLE
ui_primitives: consistent, readable input sizing

### DIFF
--- a/web/src/components/collections/CollectionForm.tsx
+++ b/web/src/components/collections/CollectionForm.tsx
@@ -87,10 +87,9 @@ const styles = (theme: Theme) =>
           borderColor: theme.vars.palette.primary.main,
           borderWidth: 1
         }
-      },
-      "& .MuiOutlinedInput-input": {
-        padding: theme.spacing(1, 1.5)
       }
+      // Height/padding/font are owned by the TextInput primitive (size="small"
+      // gives the compact height) — no internal padding override here.
     },
     ".model-select": {
       "& button": {

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -328,11 +328,6 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     display: "flex",
     flexDirection: "column",
     gap: ".5em",
-    // SelectField wraps its control in a div with a hardcoded 24px bottom
-    // margin; neutralize it here so the row gap controls spacing consistently.
-    "& > div[style]": {
-      marginBottom: "0 !important"
-    },
     ".MuiInputBase-root": {
       maxWidth: "200px !important"
     },

--- a/web/src/components/ui_primitives/Autocomplete.tsx
+++ b/web/src/components/ui_primitives/Autocomplete.tsx
@@ -103,11 +103,23 @@ function AutocompleteInternal<
         error={error}
         helperText={helperText}
         sx={{
-          ...(compact && {
-            "& .MuiInputBase-input": {
-              fontSize: theme.fontSizeSmall,
-            },
-          }),
+          // Same form-control sizing as TextInput/SelectField: the value renders
+          // at the body token (15px) regardless of `compact` — compact only
+          // tightens height (via size="small"), never shrinks the text.
+          "& .MuiInputBase-input": {
+            fontSize: theme.fontSizeNormal || "15px",
+          },
+          // Resting label doubles as the placeholder hint — soften it (and let
+          // MUI own its sizing/centering). It returns to full strength once
+          // shrunk into the notch.
+          "& .MuiInputLabel-root:not(.MuiInputLabel-shrink)": {
+            opacity: 0.6,
+          },
+          // The native placeholder (shown when there's no label, or when focused
+          // with a label) should read as a muted hint too, not entered text.
+          "& .MuiInputBase-input::placeholder": {
+            opacity: 0.6,
+          },
         }}
       />
     );

--- a/web/src/components/ui_primitives/AutocompleteTagInput.tsx
+++ b/web/src/components/ui_primitives/AutocompleteTagInput.tsx
@@ -123,7 +123,25 @@ const AutocompleteTagInputInternal: React.FC<AutocompleteTagInputProps> = ({
         getOptionLabel={getOptionLabel}
         renderOption={renderOption}
         renderInput={(params) => (
-          <TextField {...params} label={label} placeholder={placeholder} />
+          <TextField
+            {...params}
+            label={label}
+            placeholder={placeholder}
+            sx={{
+              // Shared form-control sizing with TextInput/SelectField: value at
+              // the 15px body token, resting label + placeholder softened to read
+              // as hints (full strength once the label shrinks into the notch).
+              "& .MuiInputBase-input": {
+                fontSize: theme.fontSizeNormal || "15px"
+              },
+              "& .MuiInputLabel-root:not(.MuiInputLabel-shrink)": {
+                opacity: 0.6
+              },
+              "& .MuiInputBase-input::placeholder": {
+                opacity: 0.6
+              }
+            }}
+          />
         )}
       />
       {description && (

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -45,15 +45,24 @@ const styles = (theme: Theme) => css`
       border-radius: 8px;
       background-color: ${theme.vars.palette.action.hover};
       transition: all 0.2s ease;
-      
+
       &:hover {
         background-color: ${theme.vars.palette.action.selected};
       }
-      
+
       &.Mui-focused {
         background-color: ${theme.vars.palette.action.selected};
         box-shadow: 0 0 0 2px ${theme.vars.palette.primary.main}40;
       }
+    }
+
+    /* Shared form-control sizing: value at the 15px body token, placeholder
+       softened to read as a muted hint rather than entered text. */
+    .MuiInputBase-input {
+      font-size: var(--fontSizeNormal);
+    }
+    .MuiInputBase-input::placeholder {
+      opacity: 0.6;
     }
     
     .MuiOutlinedInput-notchedOutline {

--- a/web/src/components/ui_primitives/SelectField.tsx
+++ b/web/src/components/ui_primitives/SelectField.tsx
@@ -111,19 +111,33 @@ const SelectFieldInternal: React.FC<SelectFieldProps> = ({
     [onChange]
   );
 
+  const fieldFontSize = theme.fontSizeNormal || "15px";
+
   return (
-    <div className={className} style={{ marginBottom: hideLabel ? 0 : "24px" }}>
+    // No baked outer margin — spacing is the parent's job (e.g. FlexColumn gap),
+    // like every other primitive. The control's value/label render at the same
+    // 15px body token as TextInput so the two line up in a shared form.
+    <div className={className}>
       <FormControl size={size} disabled={disabled} fullWidth>
-        {!hideLabel && label && <InputLabel htmlFor={selectId}>{label}</InputLabel>}
+        {!hideLabel && label && (
+          <InputLabel htmlFor={selectId} sx={{ fontSize: fieldFontSize }}>
+            {label}
+          </InputLabel>
+        )}
         <Select
           id={selectId}
           value={value}
           onChange={handleChange}
           variant={variant}
           label={variant !== "standard" && !hideLabel ? label : undefined}
+          sx={{ "& .MuiSelect-select": { fontSize: fieldFontSize } }}
         >
           {options.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
+            <MenuItem
+              key={option.value}
+              value={option.value}
+              sx={{ fontSize: fieldFontSize }}
+            >
               {option.label}
             </MenuItem>
           ))}

--- a/web/src/components/ui_primitives/SelectField.tsx
+++ b/web/src/components/ui_primitives/SelectField.tsx
@@ -120,12 +120,19 @@ const SelectFieldInternal: React.FC<SelectFieldProps> = ({
     <div className={className}>
       <FormControl size={size} disabled={disabled} fullWidth>
         {!hideLabel && label && (
-          <InputLabel htmlFor={selectId} sx={{ fontSize: fieldFontSize }}>
+          <InputLabel
+            id={`${selectId}-label`}
+            htmlFor={selectId}
+            sx={{ fontSize: fieldFontSize }}
+          >
             {label}
           </InputLabel>
         )}
         <Select
           id={selectId}
+          // Associate the label so the control has an accessible name
+          // (getByRole("combobox", { name }) / screen readers).
+          labelId={!hideLabel && label ? `${selectId}-label` : undefined}
           value={value}
           onChange={handleChange}
           variant={variant}

--- a/web/src/components/ui_primitives/TextInput.tsx
+++ b/web/src/components/ui_primitives/TextInput.tsx
@@ -76,14 +76,18 @@ export const TextInput = memo(
           helperText={displayHelperText}
           sx={{
             // One readable form-control size shared with SelectField: the value
-            // and label always render at the body token (15px). `compact` only
-            // tightens height (via MUI `size="small"`), never shrinks the text —
-            // shrinking the font is what made inputs read as "too small".
+            // renders at the body token (15px). `compact` only tightens height
+            // (via MUI size="small"), never shrinks the text — shrinking the
+            // font is what made inputs read as "too small".
             "& .MuiInputBase-input": {
               fontSize: theme.fontSizeNormal || "15px",
             },
-            "& .MuiInputLabel-root": {
-              fontSize: theme.fontSizeNormal || "15px",
+            // The resting label doubles as the placeholder. Leave MUI's native
+            // sizing/centering alone (forcing its font pushed it ~1px high) and
+            // just soften the colour so it reads as a hint, not entered text.
+            // Once shrunk into the notch it returns to full strength as a label.
+            "& .MuiInputLabel-root:not(.MuiInputLabel-shrink)": {
+              opacity: 0.6,
             },
             ...sx,
           }}

--- a/web/src/components/ui_primitives/TextInput.tsx
+++ b/web/src/components/ui_primitives/TextInput.tsx
@@ -82,13 +82,23 @@ export const TextInput = memo(
             "& .MuiInputBase-input": {
               fontSize: theme.fontSizeNormal || "15px",
             },
-            // The resting label doubles as the placeholder. Leave MUI's native
-            // sizing/centering alone (forcing its font pushed it ~1px high) and
-            // just soften the colour so it reads as a hint, not entered text.
-            // Once shrunk into the notch it returns to full strength as a label.
+            // The resting label doubles as the placeholder, so it must sit ON the
+            // input text it morphs into. Match its font to the 15px input value
+            // (a 16px label over 15px text reads as floating high) and soften the
+            // colour so it's a hint, not entered text. Full strength once shrunk.
             "& .MuiInputLabel-root:not(.MuiInputLabel-shrink)": {
+              fontSize: theme.fontSizeNormal || "15px",
               opacity: 0.6,
             },
+            // MUI's outlined resting transform is calibrated for 16px; at 15px the
+            // label lands a touch high. Nudge it down onto the text baseline.
+            "& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)": {
+              transform: "translate(14px, 17px) scale(1)",
+            },
+            "& .MuiInputLabel-outlined.MuiInputLabel-sizeSmall:not(.MuiInputLabel-shrink)":
+              {
+                transform: "translate(14px, 10px) scale(1)",
+              },
             ...sx,
           }}
           {...props}

--- a/web/src/components/ui_primitives/TextInput.tsx
+++ b/web/src/components/ui_primitives/TextInput.tsx
@@ -75,15 +75,16 @@ export const TextInput = memo(
           error={hasError}
           helperText={displayHelperText}
           sx={{
-            ...(compact && {
-              "& .MuiInputBase-input": {
-                py: 1,
-                fontSize: theme.fontSizeSmall,
-              },
-              "& .MuiInputLabel-root": {
-                fontSize: theme.fontSizeSmall,
-              },
-            }),
+            // One readable form-control size shared with SelectField: the value
+            // and label always render at the body token (15px). `compact` only
+            // tightens height (via MUI `size="small"`), never shrinks the text —
+            // shrinking the font is what made inputs read as "too small".
+            "& .MuiInputBase-input": {
+              fontSize: theme.fontSizeNormal || "15px",
+            },
+            "& .MuiInputLabel-root": {
+              fontSize: theme.fontSizeNormal || "15px",
+            },
             ...sx,
           }}
           {...props}

--- a/web/src/components/workflows/WorkflowForm.tsx
+++ b/web/src/components/workflows/WorkflowForm.tsx
@@ -62,22 +62,17 @@ const styles = (theme: Theme) =>
       marginBottom: theme.spacing(2)
     },
     
-    // Form controls — both FormControl and TextField
+    // Form controls — both FormControl and TextField. Spacing only; the input
+    // and its floating label are owned by the ui_primitives (TextInput,
+    // SelectField, AutocompleteTagInput) — don't restyle the label here or it
+    // breaks the resting-label-as-placeholder morph.
     ".MuiFormControl-root, .MuiTextField-root": {
       marginBottom: theme.spacing(2),
       "&:last-child": {
         marginBottom: 0
       }
     },
-    
-    ".MuiFormLabel-root": {
-      fontSize: theme.fontSizeSmall,
-      fontWeight: 500,
-      color: theme.vars.palette.text.secondary,
-      marginBottom: theme.spacing(1),
-      display: "block"
-    },
-    
+
     ".MuiOutlinedInput-root": {
       backgroundColor: theme.vars.palette.background.paper,
       borderRadius: "var(--rounded-md)",
@@ -95,11 +90,12 @@ const styles = (theme: Theme) =>
       }
     },
     
+    // Only the dark-section essentials: brand font + light text for contrast on
+    // the grey[900] field. Size and vertical padding stay at the primitive /
+    // MUI defaults so the floating label centres correctly.
     ".MuiOutlinedInput-input": {
       fontFamily: theme.fontFamily1,
-      fontSize: theme.fontSizeNormal,
-      color: theme.vars.palette.text.primary,
-      padding: "10px 12px"
+      color: theme.vars.palette.text.primary
     },
 
     ".MuiFormHelperText-root": {


### PR DESCRIPTION
Consistent, readable sizing across the form-control primitives (TextInput, SelectField, Autocomplete, AutocompleteTagInput, SearchInput): the value/label render at the 15px body token regardless of `compact` (which now only tightens height), the resting label is softened and centred, and SelectField gains an accessible name (`labelId`) so `getByRole("combobox", { name })` and screen readers work.

**Independent PR** (base `main`). Part of splitting the `feat/hf-worker-docker` branch. The worker stack (#3762→) builds on this.

## Verification
- web typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)