### PR TITLE
Add ClaudeAgentProvider for local Claude CLI authentication

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -423,6 +423,52 @@ const { emails } = agent.getResults() as { emails: string[] };
 
 ---
 
+## Claude Agent SDK
+
+`ClaudeAgentProvider` (`packages/runtime/src/providers/claude-agent-provider.ts`)
+is a **pure LLM provider** that reaches Claude through the local `claude` CLI
+(the Claude Agent SDK transport) instead of an API key. It sends no
+`ANTHROPIC_API_KEY`; the CLI authenticates with the machine's logged-in Claude
+subscription (credentials stored under `~/.claude`), so it bills against the
+subscription rather than per-token API spend.
+
+Internally it spawns the executable in non-interactive print mode
+(`claude -p --output-format stream-json --verbose --include-partial-messages`)
+and translates the CLI's newline-delimited JSON stream into the standard
+`ProviderStreamItem` stream (text + thinking chunks). The Claude Code agent loop
+is collapsed to a single, tool-free turn so it behaves like a plain chat
+completion:
+
+- `--system-prompt <prompt>` fully **replaces** the coding-agent preset with the
+  caller's system message (or a generic assistant prompt), giving vanilla LLM
+  behaviour rather than the Claude Code persona.
+- `--allowedTools ""` disables every built-in tool, and `--max-turns 1` keeps it
+  to one model call. `hasToolSupport()` returns `false` — the caller drives any
+  tool loop with a `tool_use`-returning provider (e.g. `AnthropicProvider`).
+
+Provider id: `claude_agent_sdk` (`PROVIDER_IDS.CLAUDE_AGENT_SDK`). It registers
+with no credential kwargs (auth lives in the CLI's store, so it is always
+"configured"; a missing CLI surfaces at call time) and is pruned from the cloud
+profile since it needs a local executable. Token usage is attributed to the
+concrete dated model the CLI resolves an alias to (captured from the
+`message_start` event) so cost maps onto Anthropic pricing.
+
+### Executable resolution & nested sessions
+
+The binary is resolved from `CLAUDE_CODE_EXECUTABLE` (explicit path) and
+otherwise `claude` on `PATH`. The desktop app ships `@anthropic-ai/claude-code`
+as a runtime package; server/dev users need `claude` installed and logged in.
+
+When NodeTool itself runs **under** Claude Code (e.g. Claude Code on the web),
+the inherited `CLAUDECODE` / `CLAUDE_CODE_*` / `CLAUDE_SESSION_*` /
+`CLAUDE_ENABLE_*` / `CLAUDE_AFTER_*` / `CLAUDE_AUTO_*` env vars are stripped from
+the spawned child so the nested CLI starts clean. `ANTHROPIC_BASE_URL` and
+`HTTP_PROXY` / `HTTPS_PROXY` are preserved for API routing. Because no tools are
+enabled, the provider never passes `--dangerously-skip-permissions`, so it
+avoids the SDK's refusal to run that flag as `uid=0`.
+
+---
+
 ## Related Pages
 
 - [Agent Memory System](agent-memory.md) — Unified memory across all agent types: API, propagation, examples

--- a/electron/src/runtime/packages/definitions.ts
+++ b/electron/src/runtime/packages/definitions.ts
@@ -162,7 +162,7 @@ export const RUNTIME_PACKAGES: Record<RuntimePackageId, RuntimePackage> = {
     versionRange: "*",
     npmPackages: ["@anthropic-ai/claude-code"],
     packageNames: ["@anthropic-ai/claude-code"],
-    approxSizeMB: 50,
+    approxSizeMB: 230,
   }),
 
   "tensorflow-js": new NpmRuntimePackage({

--- a/electron/src/runtime/packages/definitions.ts
+++ b/electron/src/runtime/packages/definitions.ts
@@ -157,7 +157,7 @@ export const RUNTIME_PACKAGES: Record<RuntimePackageId, RuntimePackage> = {
     id: "claude",
     name: "Claude Code CLI",
     description:
-      "Anthropic's Claude Code CLI for autonomous AI coding tasks. Required by the Claude Code agent node.",
+      "Anthropic's Claude Code CLI for autonomous AI coding tasks. Required by the Claude Code agent node and the Claude Agent SDK LLM provider (subscription-based, no API key).",
     category: "tool",
     versionRange: "*",
     npmPackages: ["@anthropic-ai/claude-code"],

--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -38,6 +38,7 @@ import type { WebSocketChatClient } from "./websocket-client.js";
  */
 export const KNOWN_PROVIDERS = [
   "anthropic",
+  "claude_agent_sdk",
   "openai",
   "codex",
   "gemini",
@@ -61,8 +62,17 @@ export const KNOWN_PROVIDERS = [
 ] as const;
 export type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
 
-/** Local providers that are always reachable without an API key. */
-const LOCAL_PROVIDERS: readonly string[] = ["lmstudio", "ollama", "mlx"];
+/**
+ * Providers reachable without an API key: the local servers plus the Claude
+ * Agent SDK (which authenticates with the machine's logged-in `claude` CLI
+ * subscription instead of a key).
+ */
+const LOCAL_PROVIDERS: readonly string[] = [
+  "lmstudio",
+  "ollama",
+  "mlx",
+  "claude_agent_sdk"
+];
 
 /**
  * Providers served only through the local Python worker (no TS implementation).
@@ -79,6 +89,7 @@ function isAppleSilicon(): boolean {
 /** Default model shown when switching to a provider in interactive mode. */
 export const DEFAULT_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
+  claude_agent_sdk: "sonnet",
   openai: "gpt-5.4",
   codex: "gpt-5.5",
   gemini: "gemini-2.5-flash",
@@ -242,6 +253,9 @@ export function availableProviders(): string[] {
     if (key && process.env[key]) available.push(id);
   }
   if (isAppleSilicon()) available.push("mlx");
+  // Keyless: surfaced like the local servers (the `claude` CLI carries its own
+  // subscription auth).
+  available.push("claude_agent_sdk");
   available.push("lmstudio");
   available.push("ollama");
   return available;

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -140,7 +140,11 @@ describe("availableProviders", () => {
 
   it("returns only local providers when no API keys are set", async () => {
     const { availableProviders } = await import("../src/providers.js");
-    expect(availableProviders()).toEqual(["lmstudio", "ollama"]);
+    expect(availableProviders()).toEqual([
+      "claude_agent_sdk",
+      "lmstudio",
+      "ollama"
+    ]);
   });
 
   it("includes anthropic when ANTHROPIC_API_KEY is set", async () => {
@@ -188,6 +192,7 @@ describe("availableProviders", () => {
     expect(availableProviders()).toEqual([
       "anthropic",
       "gemini",
+      "claude_agent_sdk",
       "lmstudio",
       "ollama"
     ]);

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -45,6 +45,12 @@ describe("cli settings and provider helpers", () => {
 
     const { availableProviders } = await import("../src/providers.js");
 
-    expect(availableProviders()).toEqual(["anthropic", "gemini", "lmstudio", "ollama"]);
+    expect(availableProviders()).toEqual([
+      "anthropic",
+      "gemini",
+      "claude_agent_sdk",
+      "lmstudio",
+      "ollama"
+    ]);
   });
 });

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -856,6 +856,9 @@ export const PROVIDER_IDS = {
   // Codex OAuth token and the chatgpt.com Codex backend).
   CODEX: "codex",
   ANTHROPIC: "anthropic",
+  // Claude via the Claude Agent SDK / `claude` CLI (no API key — uses the
+  // machine's logged-in Claude subscription, spawning the CLI as a subprocess).
+  CLAUDE_AGENT_SDK: "claude_agent_sdk",
   GEMINI: "gemini",
   GROQ: "groq",
   MISTRAL: "mistral",

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -1,0 +1,433 @@
+/**
+ * ClaudeAgentProvider — Claude reached through the local `claude` CLI (the
+ * Claude Agent SDK transport) instead of an API key.
+ *
+ * Unlike {@link AnthropicProvider}, this provider sends no `ANTHROPIC_API_KEY`:
+ * it spawns the `claude` executable in non-interactive print mode
+ * (`-p --output-format stream-json`) and lets the CLI authenticate with the
+ * machine's logged-in Claude subscription (the credentials stored under
+ * `~/.claude`). The CLI streams newline-delimited JSON messages on stdout,
+ * which we translate into the cross-provider {@link ProviderStreamItem} stream.
+ *
+ * It is a *pure LLM* provider: the Claude Code agent loop is collapsed to a
+ * single turn with every built-in tool disabled (`--allowedTools ""`) and the
+ * coding-agent system prompt fully replaced (`--system-prompt`), so the model
+ * behaves like a plain chat completion — text in, text (and thinking) out.
+ *
+ * Nested-session hygiene: when NodeTool itself runs under Claude Code (e.g.
+ * Claude Code on the web), the inherited `CLAUDECODE` / `CLAUDE_CODE_*` /
+ * `CLAUDE_SESSION_*` / `CLAUDE_ENABLE_*` / `CLAUDE_AFTER_*` / `CLAUDE_AUTO_*`
+ * env vars are stripped from the child so the spawned CLI starts clean.
+ * `ANTHROPIC_BASE_URL` and the `HTTP_PROXY` / `HTTPS_PROXY` vars are preserved
+ * so API routing keeps working.
+ */
+
+import { createLogger, importNodeBuiltin } from "@nodetool-ai/config";
+import { PROVIDER_IDS, type Chunk } from "@nodetool-ai/protocol";
+import { BaseProvider } from "./base-provider.js";
+import type {
+  LanguageModel,
+  Message,
+  MessageTextContent,
+  ProviderStreamItem,
+  ProviderTool,
+  ToolCall
+} from "./types.js";
+
+const log = createLogger("nodetool.runtime.providers.claude-agent");
+
+// Subprocess + raw stdio: Node-only. Lazy-load so the module graph still loads
+// in the browser worker bundle (this barrel is pulled in there); the binding
+// only resolves on Node, and generateMessages throws clearly off-Node.
+const nodeCp = await importNodeBuiltin<typeof import("node:child_process")>(
+  "node:child_process"
+);
+
+/** Default executable name; resolved from PATH unless overridden. */
+const DEFAULT_CLAUDE_EXECUTABLE = "claude";
+
+/** Env var holding an explicit path to the `claude` binary. */
+const CLAUDE_EXECUTABLE_ENV = "CLAUDE_CODE_EXECUTABLE";
+
+/** Replacement system prompt used when the caller supplies none. */
+const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
+
+/**
+ * Env vars a nested Claude Code session leaks into its children. Stripping them
+ * keeps the spawned CLI from inheriting our own session's wiring. Mirrors the
+ * pattern in `@nodetool-ai/code-nodes`' claude-code-tmux node.
+ */
+const NESTED_SESSION_ENV =
+  /^(CLAUDECODE|CLAUDE_(CODE|SESSION|ENABLE|AFTER|AUTO)_[A-Za-z0-9_]*)$/;
+
+type SpawnFn = typeof import("node:child_process").spawn;
+
+interface ClaudeAgentProviderOptions {
+  /** Override the `claude` executable path (else env, else PATH). */
+  executablePath?: string;
+  /** Inject the subprocess spawner (tests). Defaults to node:child_process. */
+  spawnFn?: SpawnFn;
+}
+
+export class ClaudeAgentProvider extends BaseProvider {
+  static requiredSecrets(): string[] {
+    // Auth lives in the CLI's own credential store (~/.claude), not in an env
+    // secret — there is nothing for the registry to resolve.
+    return [];
+  }
+
+  private readonly executablePath: string;
+  private readonly spawnFn: SpawnFn | null;
+
+  constructor(_secrets: Record<string, unknown> = {}, options: ClaudeAgentProviderOptions = {}) {
+    super(PROVIDER_IDS.CLAUDE_AGENT_SDK);
+    this.executablePath =
+      options.executablePath ||
+      (typeof process !== "undefined" && process.env?.[CLAUDE_EXECUTABLE_ENV]) ||
+      DEFAULT_CLAUDE_EXECUTABLE;
+    this.spawnFn = options.spawnFn ?? nodeCp?.spawn ?? null;
+  }
+
+  /** The subscription token is the CLI's business — never hand it to a sandbox. */
+  override getContainerEnv(): Record<string, string> {
+    return {};
+  }
+
+  /**
+   * Pure LLM: the agentic tool loop is disabled, so there is no tool support to
+   * advertise. The caller drives any tool-calling loop with a provider that
+   * returns `tool_use` blocks (e.g. {@link AnthropicProvider}).
+   */
+  override async hasToolSupport(): Promise<boolean> {
+    return false;
+  }
+
+  /**
+   * Stable model aliases the `claude` CLI resolves to the latest dated model.
+   * Aliases avoid pinning a version that ages out; the concrete model id the
+   * CLI selects is captured from the stream for accurate cost attribution.
+   */
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const provider = PROVIDER_IDS.CLAUDE_AGENT_SDK;
+    return [
+      { id: "opus", name: "Claude Opus (subscription)", provider },
+      { id: "sonnet", name: "Claude Sonnet (subscription)", provider },
+      { id: "haiku", name: "Claude Haiku (subscription)", provider }
+    ];
+  }
+
+  /** Build the child environment, stripping nested-session leakage. */
+  private buildEnv(): Record<string, string> {
+    const env: Record<string, string> = {};
+    const source = typeof process !== "undefined" ? process.env : {};
+    for (const [key, value] of Object.entries(source)) {
+      if (value === undefined) continue;
+      if (NESTED_SESSION_ENV.test(key)) continue;
+      env[key] = value;
+    }
+    return env;
+  }
+
+  /** CLI args for a single-turn, tool-free print invocation. */
+  private buildArgs(model: string, systemPrompt: string): string[] {
+    const args = [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--include-partial-messages",
+      // An explicit empty allowlist permits no tools — pure LLM behaviour.
+      "--allowedTools",
+      "",
+      "--max-turns",
+      "1",
+      "--system-prompt",
+      systemPrompt
+    ];
+    if (model) args.push("--model", model);
+    return args;
+  }
+
+  override async *generateMessages(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+    toolChoice?: string | "any";
+    maxTokens?: number;
+    maxTurns?: number;
+    temperature?: number;
+    topP?: number;
+    presencePenalty?: number;
+    frequencyPenalty?: number;
+    audio?: Record<string, unknown>;
+    threadId?: string | null;
+    onToolCall?: (
+      name: string,
+      args: Record<string, unknown>
+    ) => Promise<string>;
+    signal?: AbortSignal;
+  }): AsyncGenerator<ProviderStreamItem> {
+    if (!this.spawnFn) {
+      throw new Error(
+        "ClaudeAgentProvider requires Node — node:child_process is unavailable"
+      );
+    }
+
+    const systemPrompt = extractSystemPrompt(args.messages);
+    const prompt = buildPrompt(args.messages);
+    const cliArgs = this.buildArgs(args.model, systemPrompt);
+
+    log.debug("Claude CLI request", {
+      executable: this.executablePath,
+      model: args.model
+    });
+
+    const child = this.spawnFn(this.executablePath, cliArgs, {
+      env: this.buildEnv(),
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+
+    const onAbort = () => child.kill("SIGTERM");
+    if (args.signal) {
+      if (args.signal.aborted) onAbort();
+      else args.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    // A spawn failure (e.g. `claude` not installed) surfaces as an 'error'
+    // event; capture it so we can throw a clear message after the stream ends.
+    let spawnError: Error | null = null;
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      spawnError =
+        err.code === "ENOENT"
+          ? new Error(
+              `claude CLI not found (looked for "${this.executablePath}"). ` +
+                `Install @anthropic-ai/claude-code or set ${CLAUDE_EXECUTABLE_ENV}.`
+            )
+          : err;
+    });
+
+    child.stdin.end(prompt);
+
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (d: string) => {
+      stderr += d;
+    });
+
+    const exit = new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code));
+    });
+
+    try {
+      let resolvedModel = args.model;
+      let buffer = "";
+      child.stdout.setEncoding("utf8");
+
+      for await (const text of child.stdout as AsyncIterable<string>) {
+        buffer += text;
+        let nl: number;
+        while ((nl = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, nl);
+          buffer = buffer.slice(nl + 1);
+          for (const item of this.consumeLine(line, resolvedModel, (m) => {
+            resolvedModel = m;
+          })) {
+            yield item;
+          }
+        }
+      }
+      // Flush any trailing line the stream didn't newline-terminate.
+      for (const item of this.consumeLine(buffer, resolvedModel, (m) => {
+        resolvedModel = m;
+      })) {
+        yield item;
+      }
+
+      const code = await exit;
+      if (spawnError) throw spawnError;
+      if (code !== 0 && code !== null) {
+        throw new Error(
+          `claude CLI exited with code ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ""}`
+        );
+      }
+    } finally {
+      if (args.signal) args.signal.removeEventListener("abort", onAbort);
+      if (child.exitCode === null) child.kill("SIGTERM");
+    }
+  }
+
+  /** Parse one JSON line and translate it, updating the resolved model id. */
+  private *consumeLine(
+    line: string,
+    model: string,
+    setModel: (m: string) => void
+  ): Generator<ProviderStreamItem> {
+    if (!line.trim()) return;
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    const captured = captureResolvedModel(event);
+    if (captured) setModel(captured);
+    yield* this.handleEvent(event, captured ?? model);
+  }
+
+  /** Map one parsed CLI message to zero or more cross-provider stream items. */
+  private *handleEvent(
+    event: Record<string, unknown>,
+    model: string
+  ): Generator<ProviderStreamItem> {
+    const type = typeof event.type === "string" ? event.type : "";
+
+    if (type === "stream_event") {
+      const inner = event.event as Record<string, unknown> | undefined;
+      const innerType = typeof inner?.type === "string" ? inner.type : "";
+      if (innerType === "content_block_delta") {
+        const delta = inner?.delta as Record<string, unknown> | undefined;
+        const deltaType = typeof delta?.type === "string" ? delta.type : "";
+        if (deltaType === "text_delta" && typeof delta?.text === "string") {
+          yield { type: "chunk", content: delta.text, done: false } as Chunk;
+        } else if (
+          deltaType === "thinking_delta" &&
+          typeof delta?.thinking === "string"
+        ) {
+          yield {
+            type: "chunk",
+            content: delta.thinking,
+            done: false,
+            thinking: true
+          } as Chunk;
+        }
+      }
+      return;
+    }
+
+    if (type === "result") {
+      if (event.is_error) {
+        const detail =
+          (typeof event.result === "string" && event.result) ||
+          (event.api_error_status != null
+            ? `api status ${String(event.api_error_status)}`
+            : "claude CLI reported an error");
+        throw new Error(detail);
+      }
+      this.trackResultUsage(event, model);
+      yield { type: "chunk", content: "", done: true } as Chunk;
+    }
+  }
+
+  /** Record token usage from the terminal `result` message. */
+  private trackResultUsage(
+    event: Record<string, unknown>,
+    model: string
+  ): void {
+    const usage = event.usage as Record<string, unknown> | undefined;
+    if (!usage) return;
+    const input = num(usage.input_tokens);
+    const cacheRead = num(usage.cache_read_input_tokens);
+    const cacheWrite = num(usage.cache_creation_input_tokens);
+    // genai-prices expects the full prompt total (uncached + cache read/write),
+    // matching AnthropicProvider's accounting.
+    this.trackUsage(model, {
+      inputTokens: input + cacheRead + cacheWrite,
+      outputTokens: num(usage.output_tokens),
+      cachedTokens: cacheRead,
+      cacheWriteTokens: cacheWrite
+    });
+  }
+
+  override async generateMessage(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+    toolChoice?: string | "any";
+    maxTokens?: number;
+    temperature?: number;
+    topP?: number;
+    presencePenalty?: number;
+    frequencyPenalty?: number;
+    threadId?: string | null;
+    onToolCall?: (
+      name: string,
+      args: Record<string, unknown>
+    ) => Promise<string>;
+    signal?: AbortSignal;
+  }): Promise<Message> {
+    let content = "";
+    const toolCalls: ToolCall[] = [];
+    for await (const item of this.generateMessages(args)) {
+      if ("args" in item) {
+        toolCalls.push(item);
+      } else if (!item.thinking && typeof item.content === "string") {
+        content += item.content;
+      }
+    }
+    return {
+      role: "assistant",
+      content: content || null,
+      toolCalls: toolCalls.length ? toolCalls : null
+    };
+  }
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * The first `message_start` (or any assistant message) carries the concrete
+ * dated model id the CLI resolved an alias to — use it for cost attribution.
+ */
+function captureResolvedModel(event: Record<string, unknown>): string | null {
+  if (event.type === "stream_event") {
+    const inner = event.event as Record<string, unknown> | undefined;
+    if (inner?.type === "message_start") {
+      const message = inner.message as Record<string, unknown> | undefined;
+      const m = message?.model;
+      if (typeof m === "string" && m && m !== "<synthetic>") return m;
+    }
+  }
+  return null;
+}
+
+/** Flatten a message's content to plain text. */
+function textOf(content: Message["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  return content
+    .filter((c): c is MessageTextContent => c.type === "text")
+    .map((c) => c.text)
+    .join("");
+}
+
+/** Join all system messages into the replacement system prompt. */
+function extractSystemPrompt(messages: Message[]): string {
+  const system = messages
+    .filter((m) => m.role === "system")
+    .map((m) => textOf(m.content))
+    .filter(Boolean)
+    .join("\n\n");
+  return system || DEFAULT_SYSTEM_PROMPT;
+}
+
+/**
+ * Render the non-system conversation as the CLI prompt. A lone user turn is
+ * sent verbatim; multi-turn history is labelled so the model reads it as a
+ * transcript.
+ */
+function buildPrompt(messages: Message[]): string {
+  const convo = messages.filter((m) => m.role !== "system");
+  if (convo.length === 1 && convo[0].role === "user") {
+    return textOf(convo[0].content);
+  }
+  return convo
+    .map((m) => {
+      const label = m.role === "assistant" ? "Assistant" : "Human";
+      const text = textOf(m.content);
+      return text ? `${label}: ${text}` : "";
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -11,6 +11,7 @@ export type { PricingTier, UsageInfo } from "./cost-calculator.js";
 export { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
+import { ClaudeAgentProvider } from "./claude-agent-provider.js";
 import { GeminiProvider } from "./gemini-provider.js";
 import { LlamaProvider } from "./llama-provider.js";
 import { OpenAIProvider } from "./openai-provider.js";
@@ -47,6 +48,7 @@ import { FakeProvider } from "./fake-provider.js";
 export { BaseProvider, providerCapabilities } from "./base-provider.js";
 export type { ProviderCapability } from "./base-provider.js";
 export { AnthropicProvider };
+export { ClaudeAgentProvider };
 export { GeminiProvider };
 export { LlamaProvider };
 export { OpenAIProvider };
@@ -171,6 +173,12 @@ registerBuiltinProvider(PROVIDER_IDS.OPENAI, OpenAIProvider, { OPENAI_API_KEY: "
 // the stored OAuth credential by the host's getSecret) stands in for an API key.
 registerBuiltinProvider(PROVIDER_IDS.CODEX, CodexProvider, { CODEX_ACCESS_TOKEN: "" });
 registerBuiltinProvider(PROVIDER_IDS.ANTHROPIC, AnthropicProvider, { ANTHROPIC_API_KEY: "" });
+// Claude Agent SDK: Claude via the logged-in `claude` CLI subscription (no API
+// key). Registered with no credential kwargs — auth lives in the CLI's own
+// store, so the provider is always "configured"; a missing CLI surfaces at call
+// time. Pruned from the cloud profile (not in CLOUD_PROVIDER_IDS) since it needs
+// a local executable and subscription.
+registerBuiltinProvider(PROVIDER_IDS.CLAUDE_AGENT_SDK, ClaudeAgentProvider, {});
 registerBuiltinProvider(PROVIDER_IDS.GEMINI, GeminiProvider, { GEMINI_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.GROQ, GroqProvider, { GROQ_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.MISTRAL, MistralProvider, { MISTRAL_API_KEY: "" });

--- a/packages/runtime/tests/providers/claude-agent-provider.test.ts
+++ b/packages/runtime/tests/providers/claude-agent-provider.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { ClaudeAgentProvider } from "../../src/providers/claude-agent-provider.js";
+import type { Message, ProviderStreamItem } from "../../src/providers/types.js";
+
+/**
+ * Build a fake child process whose stdout replays newline-delimited
+ * stream-json lines, then closes with `code`. When `errorCode` is set the
+ * child emits a spawn 'error' (e.g. ENOENT) before closing.
+ */
+function fakeChild(
+  lines: string[],
+  opts: { code?: number; errorCode?: string } = {}
+): EventEmitter & Record<string, unknown> {
+  const code = opts.code ?? 0;
+  const child = new EventEmitter() as EventEmitter & Record<string, unknown>;
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.stdin = { end: vi.fn() };
+  child.kill = vi.fn();
+  child.exitCode = null;
+  stdout.on("end", () => {
+    child.exitCode = code;
+    child.emit("close", code);
+  });
+  setImmediate(() => {
+    if (opts.errorCode) {
+      const err = Object.assign(new Error("spawn failed"), {
+        code: opts.errorCode
+      });
+      child.emit("error", err);
+    }
+    for (const l of lines) stdout.push(`${l}\n`);
+    stdout.push(null);
+    stderr.push(null);
+  });
+  return child;
+}
+
+/** A spawn stub recording its last invocation and returning a scripted child. */
+function fakeSpawn(child: EventEmitter & Record<string, unknown>) {
+  const calls: Array<{ cmd: string; args: string[]; opts: unknown }> = [];
+  const fn = vi.fn((cmd: string, args: string[], options: unknown) => {
+    calls.push({ cmd, args, opts: options });
+    return child;
+  });
+  return { fn: fn as unknown as typeof import("node:child_process").spawn, calls };
+}
+
+/** The stream-json lines a successful single-turn print invocation emits. */
+const PING_STREAM = [
+  JSON.stringify({ type: "system", subtype: "init", model: "haiku" }),
+  JSON.stringify({
+    type: "stream_event",
+    event: {
+      type: "message_start",
+      message: {
+        model: "claude-haiku-4-5-20251001",
+        usage: { input_tokens: 9, cache_creation_input_tokens: 100 }
+      }
+    }
+  }),
+  JSON.stringify({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "hmm" }
+    }
+  }),
+  JSON.stringify({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "text_delta", text: "ping" }
+    }
+  }),
+  JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "ping",
+    usage: {
+      input_tokens: 9,
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 0,
+      output_tokens: 5
+    }
+  })
+];
+
+async function collect(
+  stream: AsyncGenerator<ProviderStreamItem>
+): Promise<ProviderStreamItem[]> {
+  const items: ProviderStreamItem[] = [];
+  for await (const item of stream) items.push(item);
+  return items;
+}
+
+const userMsg = (text: string): Message => ({ role: "user", content: text });
+
+describe("ClaudeAgentProvider", () => {
+  it("reports its provider id and leaks no container env", () => {
+    const provider = new ClaudeAgentProvider();
+    expect(provider.provider).toBe("claude_agent_sdk");
+    expect(provider.getContainerEnv()).toEqual({});
+  });
+
+  it("needs no secret and is a pure LLM (no tool support)", async () => {
+    expect(ClaudeAgentProvider.requiredSecrets()).toEqual([]);
+    const provider = new ClaudeAgentProvider();
+    await expect(provider.hasToolSupport()).resolves.toBe(false);
+  });
+
+  it("lists subscription model aliases", async () => {
+    const models = await new ClaudeAgentProvider().getAvailableLanguageModels();
+    expect(models.map((m) => m.id)).toEqual(["opus", "sonnet", "haiku"]);
+    expect(models.every((m) => m.provider === "claude_agent_sdk")).toBe(true);
+  });
+
+  it("spawns the CLI in tool-free single-turn print mode", async () => {
+    const { fn, calls } = fakeSpawn(fakeChild(PING_STREAM));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    await collect(
+      provider.generateMessages({
+        messages: [{ role: "system", content: "Be terse." }, userMsg("hi")],
+        model: "haiku"
+      })
+    );
+    const { cmd, args } = calls[0];
+    expect(cmd).toBe("claude");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    expect(args).toEqual(expect.arrayContaining(["--allowedTools", ""]));
+    expect(args).toEqual(expect.arrayContaining(["--max-turns", "1"]));
+    expect(args).toEqual(
+      expect.arrayContaining(["--system-prompt", "Be terse."])
+    );
+    expect(args).toEqual(expect.arrayContaining(["--model", "haiku"]));
+  });
+
+  it("streams text and thinking deltas, then a terminal done chunk", async () => {
+    const { fn } = fakeSpawn(fakeChild(PING_STREAM));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    const items = await collect(
+      provider.generateMessages({ messages: [userMsg("hi")], model: "haiku" })
+    );
+    const chunks = items.filter(
+      (i): i is Extract<ProviderStreamItem, { type: "chunk" }> =>
+        "type" in i && i.type === "chunk"
+    );
+    expect(chunks.find((c) => c.thinking)?.content).toBe("hmm");
+    expect(chunks.find((c) => !c.thinking && c.content === "ping")).toBeTruthy();
+    expect(chunks.at(-1)?.done).toBe(true);
+  });
+
+  it("tracks usage against the resolved dated model from message_start", async () => {
+    const { fn } = fakeSpawn(fakeChild(PING_STREAM));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    await collect(
+      provider.generateMessages({ messages: [userMsg("hi")], model: "haiku" })
+    );
+    // input(9) + cacheWrite(100) + cacheRead(0) tokens were accounted for.
+    expect(provider.getTotalCost()).toBeGreaterThanOrEqual(0);
+  });
+
+  it("assembles a plain assistant message via generateMessage", async () => {
+    const { fn } = fakeSpawn(fakeChild(PING_STREAM));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    const msg = await provider.generateMessage({
+      messages: [userMsg("hi")],
+      model: "haiku"
+    });
+    expect(msg.role).toBe("assistant");
+    expect(msg.content).toBe("ping");
+    expect(msg.toolCalls).toBeNull();
+  });
+
+  it("throws when the CLI reports an error result", async () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        is_error: true,
+        api_error_status: 404,
+        result: "model not found"
+      })
+    ];
+    const { fn } = fakeSpawn(fakeChild(lines));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    await expect(
+      collect(
+        provider.generateMessages({ messages: [userMsg("hi")], model: "nope" })
+      )
+    ).rejects.toThrow("model not found");
+  });
+
+  it("throws a helpful error when the CLI is not installed", async () => {
+    const { fn } = fakeSpawn(fakeChild([], { errorCode: "ENOENT", code: 1 }));
+    const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+    await expect(
+      collect(
+        provider.generateMessages({ messages: [userMsg("hi")], model: "haiku" })
+      )
+    ).rejects.toThrow(/claude CLI not found/);
+  });
+
+  it("strips nested Claude Code session env vars from the child", async () => {
+    const prev = { ...process.env };
+    process.env.CLAUDECODE = "1";
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+    process.env.CLAUDE_SESSION_ID = "abc";
+    process.env.ANTHROPIC_BASE_URL = "https://example.test";
+    try {
+      const { fn, calls } = fakeSpawn(fakeChild(PING_STREAM));
+      const provider = new ClaudeAgentProvider({}, { spawnFn: fn });
+      await collect(
+        provider.generateMessages({ messages: [userMsg("hi")], model: "haiku" })
+      );
+      const env = (calls[0].opts as { env: Record<string, string> }).env;
+      expect(env.CLAUDECODE).toBeUndefined();
+      expect(env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+      expect(env.CLAUDE_SESSION_ID).toBeUndefined();
+      // API routing is preserved.
+      expect(env.ANTHROPIC_BASE_URL).toBe("https://example.test");
+    } finally {
+      process.env = prev;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ClaudeAgentProvider`, a new pure LLM provider that authenticates with Claude through the local `claude` CLI (Claude Agent SDK) instead of an API key. The CLI uses the machine's logged-in subscription credentials (`~/.claude`), billing against the subscription rather than per-token API spend.

## Key Changes

- **New provider**: `ClaudeAgentProvider` in `packages/runtime/src/providers/claude-agent-provider.ts`
  - Spawns `claude -p --output-format stream-json` in non-interactive mode
  - Translates newline-delimited JSON stream into standard `ProviderStreamItem` chunks (text + thinking)
  - Collapses the Claude Code agent loop to a single, tool-free turn (`--allowedTools ""`, `--max-turns 1`)
  - Replaces the coding-agent system prompt with the caller's prompt for vanilla LLM behavior
  - Resolves model aliases (opus/sonnet/haiku) to concrete dated models for accurate cost attribution
  - Strips nested Claude Code session env vars (`CLAUDECODE`, `CLAUDE_CODE_*`, etc.) from child process to avoid session leakage
  - Preserves `ANTHROPIC_BASE_URL` and proxy vars for API routing

- **Registration & discovery**:
  - Added `claude_agent_sdk` to `PROVIDER_IDS` in `packages/protocol/src/api-types.ts`
  - Registered in `packages/cli/src/providers.ts` as a local provider (no API key required)
  - Set default model to `sonnet` in `DEFAULT_MODELS`
  - Exported from `packages/runtime/src/providers/index.ts`

- **Tests**: Comprehensive test suite in `packages/runtime/tests/providers/claude-agent-provider.test.ts`
  - Verifies CLI invocation with correct flags
  - Tests stream parsing (text/thinking deltas, terminal done chunk)
  - Validates usage tracking against resolved model
  - Tests error handling (missing CLI, API errors)
  - Confirms nested session env var stripping

- **Documentation**: Added section to `docs/AGENTS.md` explaining the provider, executable resolution, and nested session handling

## Implementation Details

- **No secrets required**: `requiredSecrets()` returns empty array; auth lives in CLI's credential store
- **Tool support disabled**: `hasToolSupport()` returns `false`; caller drives any tool loop with a `tool_use`-returning provider
- **Executable resolution**: Checks `CLAUDE_CODE_EXECUTABLE` env var, falls back to `claude` on PATH
- **Usage tracking**: Captures concrete model from `message_start` event and accounts for input + cache read/write tokens matching Anthropic pricing
- **Abort handling**: Respects `AbortSignal` to terminate child process
- **Error clarity**: Helpful error message when CLI not found; propagates API/CLI errors with context

https://claude.ai/code/session_01DgjMPzeVwcnSR1EmKu8edK