### PR TITLE
[T-20260619-0001] #1 Tool-result capping crashes turn on undefined result

### DIFF
--- a/packages/chat/src/message-processor.ts
+++ b/packages/chat/src/message-processor.ts
@@ -188,9 +188,9 @@ export async function processChat(opts: {
               const result = (executed as ToolCall & { result: unknown }).result;
               callbacks?.onToolResult?.(toolCall, result);
               return truncateToolResult(
-                typeof result === "string"
+                (typeof result === "string"
                   ? result
-                  : JSON.stringify(result, null, 2)
+                  : JSON.stringify(result, null, 2)) ?? ""
               );
             }
           : undefined,

--- a/packages/chat/tests/message-processor.test.ts
+++ b/packages/chat/tests/message-processor.test.ts
@@ -514,6 +514,47 @@ describe("processChat", () => {
     expect(recall).not.toHaveBeenCalled();
   });
 
+  it("tolerates a void/undefined tool result in the inline onToolCall path", async () => {
+    // A tool returning undefined makes JSON.stringify produce primitive
+    // `undefined`. Without a `?? ""` guard, truncateToolResult would read
+    // `.length` on undefined and throw, killing the whole turn.
+    class VoidTool extends Tool {
+      readonly name = "void";
+      readonly description = "Returns nothing";
+      readonly inputSchema = { type: "object", properties: {} };
+      async process(): Promise<unknown> {
+        return undefined;
+      }
+    }
+
+    let inlineResult: string | undefined;
+    // Provider that drives the inline onToolCall callback (the path providers
+    // like the Codex/Anthropic SDK use to execute tools mid-stream).
+    const provider = {
+      ...createMockProvider([[chunk("done")]]),
+      generateMessagesTraced: async function* (args: any) {
+        if (args.onToolCall) {
+          inlineResult = await args.onToolCall("void", {});
+        }
+        yield chunk("done");
+      }
+    } as any;
+
+    const result = await processChat({
+      userInput: "do nothing",
+      messages: [],
+      model: "test-model",
+      provider,
+      context: createMockContext(),
+      tools: [new VoidTool()]
+    });
+
+    expect(inlineResult).toBe("");
+    const lastMsg = result[result.length - 1];
+    expect(lastMsg.role).toBe("assistant");
+    expect(lastMsg.content).toBe("done");
+  });
+
   it("returns empty assistant message when only thinking chunks are present", async () => {
     const provider = createMockProvider([
       [thinkingChunk("only thinking, no visible output")]


### PR DESCRIPTION
Fixed the crash by adding `?? ""` to the inline `onToolCall` tool-result capping path in `packages/chat/src/message-processor.ts`, mirroring the already-guarded sibling site at line 278-280. A tool returning `undefined`/void makes `JSON.stringify` produce primitive `undefined`, which `truncateToolResult` then dereferenced `.length` on → TypeError that killed the whole turn.

**Changed:**
- `packages/chat/src/message-processor.ts` — wrapped the `typeof result === "string" ? result : JSON.stringify(...)` expression with `?? ""`.
- `packages/chat/tests/message-processor.test.ts` — added a regression test using a `VoidTool` returning `undefined`, driven through a mock provider that invokes the inline `onToolCall` callback. Verified it fails without the fix and passes with it.

**Verification:** all 18 tests pass; `tsc --noEmit` (lint) passes. The `npm run build` failure is a pre-existing worktree environment issue (missing root `typescript` binary), unrelated to this change.

---

Closes task **T-20260619-0001**: #1 Tool-result capping crashes turn on undefined result.


### Acceptance criteria
- [ ] Undefined/void tool result no longer throws in the inline onToolCall path
- [ ] Fix mirrors the guarded sibling site at line 278-280
- [ ] Regression test covers a tool returning undefined