### PR TITLE
[T-20260619-0004] #4 WS message size cap bypassed on text/JSON frames

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1234,6 +1234,15 @@ export class UnifiedWebSocketRunner {
       return unpack(message.bytes) as Record<string, unknown>;
     }
     if (message.text) {
+      const maxBytes = getMaxWsMessageBytes();
+      const textBytes = Buffer.byteLength(message.text, "utf8");
+      if (textBytes > maxBytes) {
+        throw new Error(
+          `Incoming WebSocket message exceeds maximum size: ` +
+            `${textBytes} > ${maxBytes} bytes ` +
+            `(set NODETOOL_WS_MAX_MESSAGE_BYTES to raise the limit)`
+        );
+      }
       return JSON.parse(message.text) as Record<string, unknown>;
     }
     return null;

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -780,4 +780,25 @@ describe("UnifiedWebSocketRunner binary frame size guard", () => {
       /exceeds maximum size/
     );
   });
+
+  it("rejects an incoming text frame larger than the limit", async () => {
+    process.env[KEY] = "16";
+    ws.queue.push({
+      type: "websocket.message",
+      text: JSON.stringify({ type: "ping", padding: "x".repeat(256) })
+    });
+    await expect(runner.receiveMessage()).rejects.toThrow(
+      /exceeds maximum size/
+    );
+  });
+
+  it("accepts a text frame within the configured limit", async () => {
+    process.env[KEY] = String(1024 * 1024);
+    ws.queue.push({
+      type: "websocket.message",
+      text: JSON.stringify({ type: "ping" })
+    });
+    const msg = await runner.receiveMessage();
+    expect(msg?.type).toBe("ping");
+  });
 });


### PR DESCRIPTION
Done.

Applied the same `NODETOOL_WS_MAX_MESSAGE_BYTES` cap to the text/JSON frame path in `receiveMessage()`, which previously bypassed the size check entirely. Text frames are now measured by their UTF-8 byte length and rejected with the identical error before `JSON.parse`, matching the binary path.

**Changes:**
- `packages/websocket/src/unified-websocket-runner.ts` — size-check text frames via `Buffer.byteLength(message.text, "utf8")` before parsing.
- `packages/websocket/tests/unified-websocket-runner.test.ts` — added two tests: oversized text frame rejected, and an in-limit text frame accepted.

Typecheck clean; all 5 size-guard tests pass.

---

Closes task **T-20260619-0004**: #4 WS message size cap bypassed on text/JSON frames.


### Acceptance criteria
- [ ] Text/JSON frames are size-checked against NODETOOL_WS_MAX_MESSAGE_BYTES before parsing
- [ ] Oversized text frame is rejected the same way as oversized binary frame
- [ ] Test covers an oversized text frame