### PR TITLE
[T-20260619-0016] #16 Thumbnail trim decodes + re-encodes full image twice per upload

### DIFF
--- a/packages/websocket/src/lib/thumbnail.ts
+++ b/packages/websocket/src/lib/thumbnail.ts
@@ -36,25 +36,8 @@ export function thumbnailKey(assetId: string): string {
   return `${assetId}_thumb.jpg`;
 }
 
-/**
- * EXIF-rotate, then trim a uniform border. Outpaint / background-removal /
- * segmentation results are often a small subject on a large transparent (or
- * solid) canvas; JPEG can't store alpha, so that padding flattens to black and
- * the subject ends up a speck in a black tile. Trimming frames the actual
- * content. Best-effort: photos without a uniform border come back unchanged,
- * and any trim failure falls back to the full frame.
- */
-async function trimUniformBorder(bytes: Uint8Array): Promise<Buffer> {
-  try {
-    return await sharp(bytes).rotate().trim({ threshold: 10 }).toBuffer();
-  } catch {
-    return await sharp(bytes).rotate().toBuffer();
-  }
-}
-
-async function generateImageThumb(bytes: Uint8Array): Promise<Buffer> {
-  const source = await trimUniformBorder(bytes);
-  return sharp(source)
+function resizeAndEncode(pipeline: sharp.Sharp): Promise<Buffer> {
+  return pipeline
     .resize({
       width: THUMB_MAX_DIM,
       height: THUMB_MAX_DIM,
@@ -63,6 +46,28 @@ async function generateImageThumb(bytes: Uint8Array): Promise<Buffer> {
     })
     .jpeg({ quality: THUMB_QUALITY, mozjpeg: true })
     .toBuffer();
+}
+
+/**
+ * EXIF-rotate, trim a uniform border, resize, and JPEG-encode in a single
+ * sharp pipeline — one decode and one encode of the source image.
+ *
+ * Trimming exists because outpaint / background-removal / segmentation results
+ * are often a small subject on a large transparent (or solid) canvas; JPEG
+ * can't store alpha, so that padding flattens to black and the subject ends up
+ * a speck in a black tile. Trimming frames the actual content. Best-effort:
+ * photos without a uniform border come back unchanged, and any trim failure
+ * (e.g. a fully uniform image trimmed to nothing) falls back to a single
+ * untrimmed pass.
+ */
+export async function generateImageThumb(bytes: Uint8Array): Promise<Buffer> {
+  try {
+    return await resizeAndEncode(
+      sharp(bytes).rotate().trim({ threshold: 10 })
+    );
+  } catch {
+    return await resizeAndEncode(sharp(bytes).rotate());
+  }
 }
 
 async function runFfmpegThumb(

--- a/packages/websocket/tests/thumbnail.test.ts
+++ b/packages/websocket/tests/thumbnail.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Wrap the sharp default export so we can count how many times a sharp
+// pipeline is constructed. Each construction decodes the input it is given;
+// a single decode/resize/encode pass should build exactly one pipeline.
+const sharpCalls = { count: 0 };
+vi.mock("sharp", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("sharp")>();
+  const original = mod.default;
+  const wrapped = ((...args: Parameters<typeof original>) => {
+    sharpCalls.count += 1;
+    return original(...args);
+  }) as typeof original;
+  Object.assign(wrapped, original);
+  return { ...mod, default: wrapped };
+});
+
+import sharp from "sharp";
+import { generateImageThumb } from "../src/lib/thumbnail.js";
+
+async function makeLargeImage(): Promise<Buffer> {
+  // 4000x3000 photo-like image with non-uniform content (so trim() keeps it).
+  const width = 4000;
+  const height = 3000;
+  const channels = 3;
+  const raw = Buffer.alloc(width * height * channels);
+  for (let i = 0; i < raw.length; i += 1) {
+    raw[i] = (i * 31) % 256;
+  }
+  return sharp(raw, { raw: { width, height, channels } })
+    .png()
+    .toBuffer();
+}
+
+describe("generateImageThumb", () => {
+  it("decodes/encodes the source exactly once and fits within the thumb box", async () => {
+    const source = await makeLargeImage();
+    sharpCalls.count = 0;
+
+    const thumb = await generateImageThumb(source);
+
+    // One pipeline construction = one decode + one encode of the source.
+    expect(sharpCalls.count).toBe(1);
+
+    const meta = await sharp(thumb).metadata();
+    expect(meta.format).toBe("jpeg");
+    expect(meta.width).toBeLessThanOrEqual(512);
+    expect(meta.height).toBeLessThanOrEqual(512);
+    // Aspect ratio (4:3) preserved within the 512px box.
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(384);
+  });
+});


### PR DESCRIPTION
Collapsed `generateImageThumb` from two full decode/encode passes to one. The source image was being decoded + re-encoded in `trimUniformBorder` (producing a full-size buffer) and then decoded again to resize/encode. Now `rotate → trim → resize → jpeg` run in a single sharp pipeline, so the source is decoded and encoded exactly once.

- `packages/websocket/src/lib/thumbnail.ts` — replaced `trimUniformBorder` + separate resize with a single chained pipeline; extracted a `resizeAndEncode` helper; the trim-failure fallback (uniform image trimmed to nothing) does one untrimmed pass. Exported `generateImageThumb` for testing.
- `packages/websocket/tests/thumbnail.test.ts` — new test wraps `sharp` to assert exactly one pipeline construction on a 4000×3000 image, and verifies the output is JPEG at 512×384 (aspect ratio preserved, within the 512px box).

Typecheck, lint, and the new test all pass. Visual output is unchanged: same operations, same order, same quality settings — only the redundant intermediate decode/encode was removed.

---

Closes task **T-20260619-0016**: #16 Thumbnail trim decodes + re-encodes full image twice per upload.


### Acceptance criteria
- [ ] Thumbnail generation decodes/re-encodes the source image at most once
- [ ] Output thumbnails unchanged visually
- [ ] Benchmark or test confirms a single decode pass on a large image