### PR TITLE
[T-20260619-0003] #3 Active-worker pointer left dangling at stopped/dead worker

### DIFF
--- a/packages/compute/src/__tests__/manager.test.ts
+++ b/packages/compute/src/__tests__/manager.test.ts
@@ -620,6 +620,44 @@ describe("WorkerManager — attach / detach / getActiveWorker", () => {
     const { manager } = makeManager();
     expect(await manager.getActiveWorker()).toBeNull();
   });
+
+  it("stop clears the active-worker pointer when stopping the active worker", async () => {
+    const { manager, settings } = makeManager();
+    await manager.createProfile(PROFILE_INPUT);
+    const instance = await manager.provision("hf-a40");
+    await manager.attach(instance.id);
+
+    await manager.stop(instance.id);
+
+    expect(settings.store.has(ACTIVE_KEY)).toBe(false);
+    expect(await manager.getActiveWorker()).toBeNull();
+  });
+
+  it("stop leaves the pointer alone when stopping a non-active worker", async () => {
+    const { manager, settings } = makeManager();
+    await manager.createProfile(PROFILE_INPUT);
+    const active = await manager.provision("hf-a40");
+    const other = await manager.provision("hf-a40");
+    await manager.attach(active.id);
+
+    await manager.stop(other.id);
+
+    expect(settings.store.get(ACTIVE_KEY)).toBe(active.id);
+  });
+
+  it("getActiveWorker clears the pointer and returns null when the active instance was stopped out-of-band", async () => {
+    const { manager, models, settings } = makeManager();
+    await manager.createProfile(PROFILE_INPUT);
+    const instance = await manager.provision("hf-a40");
+    await manager.attach(instance.id);
+
+    // The instance is marked stopped without going through stop() (e.g. a
+    // reconcile in another process), leaving the pointer dangling.
+    models.instances.get(instance.id)!.status = "stopped";
+
+    expect(await manager.getActiveWorker()).toBeNull();
+    expect(settings.store.has(ACTIVE_KEY)).toBe(false);
+  });
 });
 
 describe("WorkerManager — reconcile", () => {
@@ -639,6 +677,21 @@ describe("WorkerManager — reconcile", () => {
     expect(models.instances.get(live.id)?.status).toBe("running");
     // The instance missing from the live list is marked stopped.
     expect(models.instances.get(dead.id)?.status).toBe("stopped");
+  });
+
+  it("clears the active-worker pointer when the active instance vanished from the provider", async () => {
+    const { manager, settings, provider } = makeManager();
+    await manager.createProfile(PROFILE_INPUT);
+    const dead = await manager.provision("hf-a40");
+    await manager.attach(dead.id);
+
+    // Provider reports nothing live; the active instance died out-of-band.
+    provider.liveList = [];
+
+    await manager.reconcile();
+
+    expect(settings.store.has("active_worker_instance_id")).toBe(false);
+    expect(await manager.getActiveWorker()).toBeNull();
   });
 
   it("does not touch already-stopped rows", async () => {

--- a/packages/compute/src/manager.ts
+++ b/packages/compute/src/manager.ts
@@ -254,6 +254,7 @@ export class WorkerManager {
       instance.target as WorkerTarget
     );
     await provider.stop(instance.provider_ref);
+    await this.clearActivePointerIfMatches(instance.id);
     return this.deps.updateWorkerInstance(instance.id, { status: "stopped" });
   }
 
@@ -290,10 +291,7 @@ export class WorkerManager {
       instance.target as WorkerTarget
     );
     await provider.terminate(instance.provider_ref);
-    const activeId = await this.deps.getSetting(ACTIVE_WORKER_KEY);
-    if (activeId === instance.id) {
-      await this.deps.deleteSetting(ACTIVE_WORKER_KEY);
-    }
+    await this.clearActivePointerIfMatches(instance.id);
     return this.deps.updateWorkerInstance(instance.id, {
       status: "terminated",
     });
@@ -368,6 +366,7 @@ export class WorkerManager {
           liveCount += 1;
           estimatedCostUsd += instance.estimated_cost_usd ?? 0;
         } else {
+          await this.clearActivePointerIfMatches(instance.id);
           await this.deps.updateWorkerInstance(instance.id, {
             status: "stopped",
           });
@@ -435,16 +434,38 @@ export class WorkerManager {
     }
   }
 
-  /** Return the currently-attached instance, or null when none is attached. */
+  /**
+   * Return the currently-attached instance, or null when none is attached.
+   * Never returns a stopped/dead instance: if the pointer references a row that
+   * has since been stopped/terminated (or vanished), clear it and return null
+   * so consumers don't re-point the bridge at a worker that is no longer live.
+   */
   async getActiveWorker(): Promise<WorkerInstance | null> {
     const id = await this.deps.getSetting(ACTIVE_WORKER_KEY);
     if (!id) {
       return null;
     }
-    return this.deps.getWorkerInstance(id);
+    const instance = await this.deps.getWorkerInstance(id);
+    if (
+      !instance ||
+      instance.status === "stopped" ||
+      instance.status === "terminated"
+    ) {
+      await this.deps.deleteSetting(ACTIVE_WORKER_KEY);
+      return null;
+    }
+    return instance;
   }
 
   // --- Internals ----------------------------------------------------------
+
+  /** Drop the active-worker pointer if it currently references `instanceId`. */
+  private async clearActivePointerIfMatches(instanceId: string): Promise<void> {
+    const activeId = await this.deps.getSetting(ACTIVE_WORKER_KEY);
+    if (activeId === instanceId) {
+      await this.deps.deleteSetting(ACTIVE_WORKER_KEY);
+    }
+  }
 
   private async requireInstance(instanceId: string): Promise<WorkerInstance> {
     const instance = await this.deps.getWorkerInstance(instanceId);


### PR DESCRIPTION
All criteria met. Done.

## Summary

Fixed a dangling active-worker pointer in `packages/compute/src/manager.ts`. Previously only `terminate()` cleared `ACTIVE_WORKER_KEY`; the reaper's idle path (`stop()`) and `reconcile()`'s vanished-instance path left it pointing at a now-dead instance, so `getActiveWorker()` returned a stopped worker and consumers re-pointed the Python bridge to it.

**Changes:**
- `stop()` clears the pointer when stopping the active worker.
- `reconcile()` clears the pointer when it marks the active instance `stopped` (died/vanished out-of-band).
- `getActiveWorker()` is now defensive: if the pointer references a missing or `stopped`/`terminated` row, it drops the pointer and returns null — so it never hands back a dead instance even if the pointer was orphaned by another process.
- Extracted a `clearActivePointerIfMatches()` private helper, reused by `terminate()` (replacing its inline clear).
- Added 4 tests: stop clears the active pointer, stop leaves a non-active pointer alone, `getActiveWorker` self-heals an out-of-band stop, and reconcile clears the pointer when the active instance vanishes.

All 74 compute tests pass; lint (`tsc --noEmit`) is clean.

---

Closes task **T-20260619-0003**: #3 Active-worker pointer left dangling at stopped/dead worker.


### Acceptance criteria
- [ ] stop() clears ACTIVE_WORKER_KEY when stopping the active worker
- [ ] reconcile() clears the pointer when the active instance is marked stopped/vanished
- [ ] getActiveWorker() never returns a stopped/dead instance