### PR TITLE
[T-20260619-0010] #10 reconcile() flags stopped/paused entries as cost orphans; Vast findOffer ignores disk

### DIFF
--- a/packages/compute/src/__tests__/manager.test.ts
+++ b/packages/compute/src/__tests__/manager.test.ts
@@ -676,6 +676,27 @@ describe("WorkerManager — reconcile", () => {
     ]);
   });
 
+  it("does not flag stopped/paused untracked provider entries as cost orphans", async () => {
+    const { manager, provider } = makeManager();
+    await manager.createProfile(PROFILE_INPUT);
+    const tracked = await manager.provision("hf-a40"); // pod-1
+
+    // Provider reports the tracked pod plus untracked entries that are not
+    // burning GPU billing (paused/destroyed) — these must not be surfaced.
+    provider.liveList = [
+      { providerRef: tracked.provider_ref, status: "running" },
+      { providerRef: "pod-paused", status: "stopped" },
+      { providerRef: "pod-gone", status: "terminated" },
+      { providerRef: "pod-orphan", status: "running" },
+    ];
+
+    const summary = await manager.reconcile();
+
+    expect(summary.orphans).toEqual([
+      { target: "runpod", providerRef: "pod-orphan", status: "running" },
+    ]);
+  });
+
   it("returns a live-count and estimated-cost summary", async () => {
     const { manager, models, provider } = makeManager();
     await manager.createProfile(PROFILE_INPUT);

--- a/packages/compute/src/__tests__/vast-provider.test.ts
+++ b/packages/compute/src/__tests__/vast-provider.test.ts
@@ -184,6 +184,27 @@ describe("VastProvider.provision", () => {
 
     expect(result.costUsd).toBe(0.31);
   });
+
+  it("constrains the offer search by the requested disk so the chosen offer can launch", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec({ disk: 250 }));
+
+    // The first call is the offer search; its query must require enough disk.
+    const [searchUrl, searchInit] = mockFetch.mock.calls[0];
+    expect(searchUrl).toBe("https://console.vast.ai/api/v0/bundles/");
+    const searchBody = JSON.parse((searchInit as RequestInit).body as string);
+    expect(searchBody.q.disk_space).toEqual({ gte: 250 });
+  });
 });
 
 describe("VastProvider.status", () => {

--- a/packages/compute/src/manager.ts
+++ b/packages/compute/src/manager.ts
@@ -375,14 +375,19 @@ export class WorkerManager {
       }
 
       // Live-but-untracked: provider workers with no matching instance row.
+      // Only running/attached entries are cost orphans — a stopped/paused or
+      // terminated provider entry isn't burning GPU billing, so don't surface
+      // it for one-click stop-all.
       for (const entry of live) {
-        if (!trackedRefs.has(entry.providerRef)) {
-          orphans.push({
-            target,
-            providerRef: entry.providerRef,
-            status: entry.status,
-          });
+        if (trackedRefs.has(entry.providerRef)) continue;
+        if (entry.status === "stopped" || entry.status === "terminated") {
+          continue;
         }
+        orphans.push({
+          target,
+          providerRef: entry.providerRef,
+          status: entry.status,
+        });
       }
     }
 

--- a/packages/compute/src/providers/vast.ts
+++ b/packages/compute/src/providers/vast.ts
@@ -187,10 +187,15 @@ export class VastProvider implements WorkerProvider {
   private async findOffer(
     spec: WorkerSpec
   ): Promise<{ id: string; dphTotal: number | undefined }> {
+    // Require the offer to have at least the disk we intend to allocate;
+    // otherwise the cheapest offer may not fit the requested disk and the
+    // subsequent launch is rejected.
+    const diskGb = spec.disk ?? DEFAULT_VOLUME_GB;
     const query: Record<string, unknown> = {
       rentable: { eq: true },
       verified: { eq: true },
       rented: { eq: false },
+      disk_space: { gte: diskGb },
     };
     if (spec.gpu) {
       query.gpu_name = { eq: spec.gpu };


### PR DESCRIPTION
Done. Both worker issues fixed and committed.

## Summary

Fixed two Medium worker bugs in `packages/compute`:

1. **`reconcile()` flagged paused/stopped workers as cost orphans** — the live-but-untracked loop pushed *every* untracked provider entry into `orphans`, including paused (`stopped`) and destroyed (`terminated`) ones that aren't burning GPU billing. It now skips those statuses, so only `running`/`attached` untracked workers surface for the cost guard's one-click stop-all.

2. **Vast `findOffer` ignored disk** — the bundles query had no disk constraint, so the cheapest offer could be too small for the requested disk and reject the launch. Added `disk_space: { gte: spec.disk ?? DEFAULT_VOLUME_GB }` to the query.

### Files changed
- `packages/compute/src/manager.ts` — orphan loop skips `stopped`/`terminated` entries
- `packages/compute/src/providers/vast.ts` — `findOffer` constrains `disk_space`
- `packages/compute/src/__tests__/manager.test.ts` — test that stopped/terminated untracked entries aren't flagged
- `packages/compute/src/__tests__/vast-provider.test.ts` — test that the offer query carries the disk constraint

All 72 compute tests pass; `tsc --noEmit` (lint) clean.

---

Closes task **T-20260619-0010**: #10 reconcile() flags stopped/paused entries as cost orphans; Vast findOffer ignores disk.


### Acceptance criteria
- [ ] reconcile() does not flag stopped/paused entries as cost orphans
- [ ] Vast findOffer constrains disk so chosen offers can actually launch
- [ ] Tests cover both: a stopped entry not flagged, and a disk-constrained offer query