### PR TITLE
[T-20260619-0006] #6 TDZ ReferenceError on pre-aborted login signal

### DIFF
--- a/packages/runtime/src/providers/oauth/local-callback-server.ts
+++ b/packages/runtime/src/providers/oauth/local-callback-server.ts
@@ -120,18 +120,8 @@ export class LocalCallbackServer {
 
     return new Promise<AuthorizationResult>((resolve, reject) => {
       let settled = false;
-      const timer = setTimeout(() => {
-        finish(() => reject(new CallbackTimeoutError()));
-      }, options.timeoutMs);
 
       const onAbort = () => finish(() => reject(new OAuthError("callback_timeout", "Login aborted")));
-      if (options.signal) {
-        if (options.signal.aborted) {
-          onAbort();
-          return;
-        }
-        options.signal.addEventListener("abort", onAbort, { once: true });
-      }
 
       const finish = (action: () => void) => {
         if (settled) return;
@@ -141,6 +131,10 @@ export class LocalCallbackServer {
         server.removeListener("request", onRequest);
         action();
       };
+
+      const timer = setTimeout(() => {
+        finish(() => reject(new CallbackTimeoutError()));
+      }, options.timeoutMs);
 
       const onRequest = (req: IncomingMessage, res: ServerResponse) => {
         // Reconstruct the URL; host header is irrelevant for loopback parsing.
@@ -182,6 +176,14 @@ export class LocalCallbackServer {
       };
 
       server.on("request", onRequest);
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          onAbort();
+          return;
+        }
+        options.signal.addEventListener("abort", onAbort, { once: true });
+      }
     });
   }
 

--- a/packages/runtime/tests/providers/oauth/local-callback-server.test.ts
+++ b/packages/runtime/tests/providers/oauth/local-callback-server.test.ts
@@ -3,6 +3,7 @@ import { LocalCallbackServer } from "../../../src/providers/oauth/local-callback
 import {
   AuthorizationDeniedError,
   CallbackTimeoutError,
+  OAuthError,
   StateMismatchError
 } from "../../../src/providers/oauth/errors.js";
 
@@ -64,6 +65,22 @@ describe("LocalCallbackServer", () => {
     await expect(
       server.waitForCode({ expectedState: "st", timeoutMs: 50 })
     ).rejects.toBeInstanceOf(CallbackTimeoutError);
+  });
+
+  it("rejects with the abort error when handed an already-aborted signal", async () => {
+    server = new LocalCallbackServer();
+    await server.listen();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    // A pre-aborted signal must produce the correct abort error synchronously,
+    // not a TDZ ReferenceError, and must not leak the cleanup timer.
+    const err = await server
+      .waitForCode({ expectedState: "st", timeoutMs: 50_000, signal: controller.signal })
+      .then(() => null, (e) => e);
+    expect(err).toBeInstanceOf(OAuthError);
+    expect((err as OAuthError).message).toBe("Login aborted");
   });
 
   it("exposes a loopback redirect URI with the bound port", async () => {


### PR DESCRIPTION
Fixed the TDZ ReferenceError in `LocalCallbackServer.waitForCode`. A pre-aborted `AbortSignal` ran `onAbort()` synchronously, which touched the `finish` `const` while it was still in its temporal dead zone — throwing a wrong error and leaking the cleanup timer (the `clearTimeout` lives inside `finish`).

The fix hoists `finish` and `onAbort` above the timer and the aborted-signal check. Because `finish` also references `timer` and `onRequest`, I ordered all three bindings before the synchronous pre-aborted path, so nothing is in its TDZ when `onAbort()` fires. The pre-aborted path now rejects with the correct `OAuthError("Login aborted")` and clears the timer.

- `packages/runtime/src/providers/oauth/local-callback-server.ts` — reordered declarations in `waitForCode`; moved the signal check after `server.on("request", onRequest)`.
- `packages/runtime/tests/providers/oauth/local-callback-server.test.ts` — added a regression test for the already-aborted signal.

Tests (6 passed), lint, and typecheck all pass.

---

Closes task **T-20260619-0006**: #6 TDZ ReferenceError on pre-aborted login signal.


### Acceptance criteria
- [ ] finish is declared before the aborted-signal check
- [ ] An already-aborted signal produces the correct abort error
- [ ] Cleanup timer is cleared on the pre-aborted path (no leak)