### PR TITLE
[T-20260619-0009] #9 RunPod GPU pods provisioned with neither gpuCount nor vcpuCount

### DIFF
--- a/packages/compute/src/__tests__/runpod-rest.test.ts
+++ b/packages/compute/src/__tests__/runpod-rest.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_CPU_VCPU_COUNT,
+  DEFAULT_GPU_COUNT,
+  DEFAULT_GPU_VCPU_COUNT,
+  deployWorkerPod,
+} from "../providers/runpod-rest.js";
+
+// ---------------------------------------------------------------------------
+// Mock the global fetch the RunPod REST transport uses.
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200, ok = true): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const API_KEY = "test-runpod-key";
+
+/** First fetch is the POST /pods create; subsequent are the RUNNING poll. */
+function mockCreateThenRunning() {
+  mockFetch
+    .mockResolvedValueOnce(jsonResponse({ id: "pod-1" }))
+    .mockResolvedValue(
+      jsonResponse({ id: "pod-1", desiredStatus: "RUNNING" })
+    );
+}
+
+/** Parse the JSON body sent to the create-pod POST. */
+function createBody(): Record<string, unknown> {
+  const call = mockFetch.mock.calls[0];
+  return JSON.parse((call[1] as RequestInit).body as string);
+}
+
+describe("deployWorkerPod GPU spec", () => {
+  it("sets explicit gpuCount and vcpuCount for GPU pods", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, {
+      name: "gpu-worker",
+      image: "img",
+      computeType: "GPU",
+      gpuTypeIds: ["NVIDIA GeForce RTX 4090"],
+    });
+
+    const body = createBody();
+    expect(body.computeType).toBe("GPU");
+    expect(body.gpuCount).toBe(DEFAULT_GPU_COUNT);
+    expect(body.vcpuCount).toBe(DEFAULT_GPU_VCPU_COUNT);
+  });
+
+  it("honors explicit gpuCount / vcpuCount overrides", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, {
+      name: "gpu-worker",
+      image: "img",
+      computeType: "GPU",
+      gpuTypeIds: ["NVIDIA H100"],
+      gpuCount: 4,
+      vcpuCount: 32,
+    });
+
+    const body = createBody();
+    expect(body.gpuCount).toBe(4);
+    expect(body.vcpuCount).toBe(32);
+  });
+
+  it("does not set gpuCount for CPU pods and pins vcpuCount", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, {
+      name: "cpu-worker",
+      image: "img",
+      computeType: "CPU",
+    });
+
+    const body = createBody();
+    expect(body.gpuCount).toBeUndefined();
+    expect(body.vcpuCount).toBe(DEFAULT_CPU_VCPU_COUNT);
+  });
+});

--- a/packages/compute/src/providers/runpod-rest.ts
+++ b/packages/compute/src/providers/runpod-rest.ts
@@ -182,6 +182,23 @@ export function podProxyWsUrl(podId: string, internalPort: number): string {
 // High-level worker deploy
 // ---------------------------------------------------------------------------
 
+/**
+ * Default GPUs requested for a GPU pod. RunPod's REST API does not document a
+ * default for `gpuCount`, so we set it explicitly to avoid a "running" pod that
+ * was allocated zero GPUs. One GPU is the right default for a single worker.
+ */
+export const DEFAULT_GPU_COUNT = 1;
+
+/**
+ * Default vCPUs for a GPU pod. RunPod pairs vCPUs with the GPU on GPU pods, but
+ * leaving `vcpuCount` undefined relies on undocumented defaults; pin a sane
+ * value so the worker has CPU headroom for I/O and the bridge process.
+ */
+export const DEFAULT_GPU_VCPU_COUNT = 8;
+
+/** Default vCPUs for a CPU pod. */
+export const DEFAULT_CPU_VCPU_COUNT = 4;
+
 export interface DeployWorkerPodOptions {
   /** Pod name. */
   name: string;
@@ -196,6 +213,8 @@ export interface DeployWorkerPodOptions {
   computeType?: "CPU" | "GPU";
   vcpuCount?: number;
   gpuTypeIds?: string[];
+  /** GPUs per pod (GPU pods only). Defaults to {@link DEFAULT_GPU_COUNT}. */
+  gpuCount?: number;
   containerDiskInGb?: number;
   /** Persistent volume size in GB (mounted at `volumeMountPath`). */
   volumeInGb?: number;
@@ -231,12 +250,19 @@ export async function deployWorkerPod(
   const env: Record<string, string> = { ...(opts.env ?? {}) };
   if (opts.workerToken) env.NODETOOL_WORKER_TOKEN = opts.workerToken;
 
+  const isGpu = opts.computeType === "GPU";
   const spec: RunpodPodSpec = {
     name: opts.name,
     imageName: opts.image,
     computeType: opts.computeType ?? "CPU",
-    vcpuCount: opts.computeType === "GPU" ? undefined : (opts.vcpuCount ?? 4),
+    // Always pin vcpuCount explicitly rather than relying on RunPod defaults.
+    vcpuCount:
+      opts.vcpuCount ??
+      (isGpu ? DEFAULT_GPU_VCPU_COUNT : DEFAULT_CPU_VCPU_COUNT),
     gpuTypeIds: opts.gpuTypeIds,
+    // GPU pods must request an explicit gpuCount; without it RunPod may allocate
+    // zero GPUs while still reporting the pod as running.
+    ...(isGpu ? { gpuCount: opts.gpuCount ?? DEFAULT_GPU_COUNT } : {}),
     ports: [`${internalPort}/${exposure}`],
     env,
     containerDiskInGb: opts.containerDiskInGb ?? 20,

--- a/packages/compute/src/providers/runpod.ts
+++ b/packages/compute/src/providers/runpod.ts
@@ -65,6 +65,7 @@ export class RunpodPodProvider implements WorkerProvider {
       exposure: EXPOSURE,
       computeType: useGpu ? "GPU" : "CPU",
       gpuTypeIds: spec.gpu ? [spec.gpu] : undefined,
+      gpuCount: spec.gpuCount,
       vcpuCount: spec.vcpu,
       // Point HF model downloads at the persistent volume so they survive a
       // stop/resume; merge over any caller env (caller wins on conflict? no —

--- a/packages/compute/src/providers/types.ts
+++ b/packages/compute/src/providers/types.ts
@@ -49,6 +49,8 @@ export interface WorkerSpec {
   target: WorkerTarget;
   /** Provider-shaped GPU selector (e.g. "A40"). */
   gpu?: string;
+  /** Number of GPUs to request (GPU targets only). Defaults to 1. */
+  gpuCount?: number;
   /** vCPU count. */
   vcpu?: number;
   /**


### PR DESCRIPTION
Done.

## Summary

Fixed `deployWorkerPod` in `packages/compute/src/providers/runpod-rest.ts` so RunPod GPU pods are provisioned with explicit `gpuCount` and `vcpuCount` instead of relying on undocumented REST defaults — which risked a "running" pod allocated zero GPUs.

**Changes:**
- **`runpod-rest.ts`** — Added three exported, documented constants: `DEFAULT_GPU_COUNT` (1), `DEFAULT_GPU_VCPU_COUNT` (8), `DEFAULT_CPU_VCPU_COUNT` (4). `deployWorkerPod` now always sends an explicit `vcpuCount`, and sends `gpuCount` for GPU pods (omitted for CPU pods). Added a `gpuCount` option to `DeployWorkerPodOptions`.
- **`providers/types.ts`** — Added optional `gpuCount` to `WorkerSpec` so multi-GPU requests are reachable.
- **`providers/runpod.ts`** — Threaded `spec.gpuCount` through `RunpodPodProvider.provision`.
- **`__tests__/runpod-rest.test.ts`** — New test file (3 cases) covering GPU defaults, explicit overrides, and the CPU path.

All acceptance criteria met. Lint (`tsc --noEmit`) and the full compute suite (73 tests) pass.

---

Closes task **T-20260619-0009**: #9 RunPod GPU pods provisioned with neither gpuCount nor vcpuCount.


### Acceptance criteria
- [ ] deployWorkerPod sets an explicit gpuCount for GPU pods
- [ ] vcpuCount is set explicitly rather than left undefined
- [ ] Default values are documented in code