### PR TITLE
[T-20260619-0015] #15 Codex provider: empty output_text per tool round; no terminal done on early SSE close

### DIFF
--- a/packages/runtime/src/providers/codex-provider.ts
+++ b/packages/runtime/src/providers/codex-provider.ts
@@ -320,11 +320,17 @@ export class CodexProvider extends OpenAIProvider {
           });
         }
       }
+      // Skip empty message items: an assistant tool-call round carries its
+      // payload in the function_call items above and has no text of its own.
+      // Emitting an empty output_text on every round-trip both bloats the
+      // request and can confuse the backend.
+      const text = textOf(m.content);
+      if (!text) continue;
       const partType = m.role === "assistant" ? "output_text" : "input_text";
       input.push({
         type: "message",
         role: m.role,
-        content: [{ type: partType, text: textOf(m.content) }]
+        content: [{ type: partType, text }]
       });
     }
 
@@ -399,6 +405,7 @@ export class CodexProvider extends OpenAIProvider {
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
+    let sawTerminal = false;
 
     try {
       for (;;) {
@@ -425,12 +432,22 @@ export class CodexProvider extends OpenAIProvider {
           }
 
           for (const item of this.handleEvent(event, pending, args.model)) {
+            if (!("args" in item) && item.done) {
+              sawTerminal = true;
+            }
             yield item;
           }
         }
       }
     } finally {
       reader.releaseLock();
+    }
+
+    // The SSE connection can close without a `response.completed` event (e.g.
+    // the server drops the stream early). Consumers rely on a terminal
+    // `done: true` chunk to know the turn is over, so synthesize one.
+    if (!sawTerminal) {
+      yield { type: "chunk", content: "", done: true } as Chunk;
     }
   }
 

--- a/packages/runtime/tests/providers/codex-provider.test.ts
+++ b/packages/runtime/tests/providers/codex-provider.test.ts
@@ -69,6 +69,80 @@ describe("CodexProvider", () => {
     );
   });
 
+  it("emits a terminal done chunk when the SSE stream closes early", async () => {
+    // A stream that yields one text delta and a tool call, then closes
+    // WITHOUT a `response.completed` event (connection dropped early).
+    const sse =
+      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}\n\n` +
+      `data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "i1", call_id: "c1", name: "foo" } })}\n\n` +
+      `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "i1" } })}\n\n`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(sse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      })
+    );
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    const items = [];
+    for await (const item of provider.generateMessages({
+      messages: [{ role: "user", content: "hi" }],
+      model: "gpt-5.5"
+    })) {
+      items.push(item);
+    }
+    const last = items[items.length - 1];
+    expect(last).toMatchObject({ type: "chunk", done: true });
+    // Exactly one terminal chunk — not one per event.
+    const terminals = items.filter(
+      (i) => "done" in i && (i as { done?: boolean }).done
+    );
+    expect(terminals).toHaveLength(1);
+  });
+
+  it("omits empty output_text message items on tool round-trips", async () => {
+    let captured: Record<string, unknown> = {};
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_url, init?: RequestInit) => {
+        captured = JSON.parse(String(init?.body));
+        return new Response(
+          `data: ${JSON.stringify({ type: "response.completed", response: {} })}\n\n`,
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" }
+          }
+        );
+      }
+    );
+    const provider = new CodexProvider({ CODEX_ACCESS_TOKEN: "tok" });
+    // An assistant turn that is purely a tool call (no text), followed by the
+    // tool result — the classic tool round-trip.
+    for await (const _ of provider.generateMessages({
+      messages: [
+        { role: "user", content: "call the tool" },
+        {
+          role: "assistant",
+          content: null,
+          toolCalls: [{ id: "c1", name: "foo", args: {} }]
+        },
+        { role: "tool", content: "result", toolCallId: "c1" }
+      ],
+      model: "gpt-5.5"
+    })) {
+      void _;
+    }
+    const input = captured.input as Array<Record<string, unknown>>;
+    // The assistant tool-call round must contribute a function_call, but no
+    // empty message item.
+    expect(input.some((i) => i.type === "function_call")).toBe(true);
+    const emptyMessages = input.filter(
+      (i) =>
+        i.type === "message" &&
+        Array.isArray(i.content) &&
+        (i.content as Array<{ text?: string }>).every((c) => !c.text)
+    );
+    expect(emptyMessages).toHaveLength(0);
+  });
+
   it("extracts PNG bytes from the image_generation_call output item", async () => {
     const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
     const b64 = Buffer.from(png).toString("base64");


### PR DESCRIPTION
Done. Both bugs in the Codex provider are fixed with test coverage.

## Summary

Fixed two issues in `packages/runtime/src/providers/codex-provider.ts`:

1. **Empty `output_text` on tool round-trips** — `buildRequestBody` pushed a `message` item with an empty `output_text` part for every assistant turn that had tool calls but no text (`content: null`). Now message items are skipped when there's no text; the tool call still goes out as a `function_call` item.

2. **No terminal `done` on early SSE close** — the streaming loop only emitted `done: true` on a `response.completed` event. If the SSE connection dropped early, consumers never saw the turn end. Now the generator tracks whether a terminal chunk was seen and synthesizes `{ type: "chunk", content: "", done: true }` after the read loop if none arrived. Abort/error paths throw before reaching it, so they're unaffected.

### Files changed
- `packages/runtime/src/providers/codex-provider.ts` — both fixes
- `packages/runtime/tests/providers/codex-provider.test.ts` — added a test for the early-closing SSE stream (asserts exactly one terminal chunk) and one verifying no empty message items are sent on a tool round-trip

Typecheck, lint, and all 9 provider tests pass.

---

Closes task **T-20260619-0015**: #15 Codex provider: empty output_text per tool round; no terminal done on early SSE close.


### Acceptance criteria
- [ ] No empty output_text message emitted on tool round-trips
- [ ] A terminal done chunk is emitted even when SSE closes early
- [ ] Test covers an early-closing SSE stream