### PR TITLE
[T-20260619-0014] #14 Surrogate-pair splitting in truncation helpers

### DIFF
--- a/packages/agents/src/constants.ts
+++ b/packages/agents/src/constants.ts
@@ -18,16 +18,30 @@ export const MAX_TOOL_RESULT_CHARS = 25_000;
  * Returns `text` unchanged when it already fits. Otherwise keeps the first
  * `maxChars` characters and appends a notice telling the model the output was
  * cut and how to fetch a smaller slice.
+ *
+ * The cut is pulled back by one if it would land between the two halves of a
+ * UTF-16 surrogate pair, so the kept prefix never ends in a lone surrogate
+ * (which would render as U+FFFD and corrupt a multi-byte character).
  */
 export function truncateToolResult(
   text: string,
   maxChars: number = MAX_TOOL_RESULT_CHARS
 ): string {
   if (text.length <= maxChars) return text;
-  const omitted = text.length - maxChars;
+  // Avoid splitting a surrogate pair: if the char just before the cut is a
+  // high surrogate, it pairs with the low surrogate at `maxChars`, so drop it.
+  const cut = isHighSurrogate(text.charCodeAt(maxChars - 1))
+    ? maxChars - 1
+    : maxChars;
+  const omitted = text.length - cut;
   return (
-    text.slice(0, maxChars) +
-    `\n\n... [tool result truncated: kept first ${maxChars} of ${text.length} characters, ${omitted} omitted. ` +
+    text.slice(0, cut) +
+    `\n\n... [tool result truncated: kept first ${cut} of ${text.length} characters, ${omitted} omitted. ` +
     `Narrow the query, request a specific range, or use pagination/filters to retrieve a smaller result.]`
   );
+}
+
+/** True for a UTF-16 high surrogate code unit (the first half of a pair). */
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
 }

--- a/packages/agents/tests/tool-result-truncation.test.ts
+++ b/packages/agents/tests/tool-result-truncation.test.ts
@@ -31,4 +31,23 @@ describe("truncateToolResult", () => {
     expect(out.startsWith("z".repeat(10))).toBe(true);
     expect(out).toContain("truncated");
   });
+
+  it("does not split a surrogate pair at the cut", () => {
+    // Cap lands exactly between the two halves of the emoji at index 10-11.
+    const text = "abcdefghij" + "😀" + "z".repeat(100);
+    const out = truncateToolResult(text, 11);
+    // The kept prefix pulls back to the full emoji boundary (10 chars),
+    // never leaving the lone high surrogate at index 10.
+    const lastBodyCode = out.charCodeAt(9);
+    expect(lastBodyCode).toBe("j".charCodeAt(0));
+    expect(out.startsWith("abcdefghij\n\n")).toBe(true);
+    expect(out).not.toContain("\uD83D\n");
+  });
+
+  it("keeps a whole emoji when it fits before the cut", () => {
+    const text = "ab" + "😀" + "z".repeat(100);
+    // Cut at 4 keeps "ab😀" (4 UTF-16 units) intact.
+    const out = truncateToolResult(text, 4);
+    expect(out.startsWith("ab😀\n\n")).toBe(true);
+  });
 });

--- a/packages/runtime/src/token-counter.ts
+++ b/packages/runtime/src/token-counter.ts
@@ -91,6 +91,11 @@ export function countTokens(text: string | null | undefined): number {
  * Encodes piece-by-piece (same splitting as {@link countTokens}) and stops once
  * the budget is reached, so it never feeds a huge boundary-free run to `encode`
  * in one shot — the input is bounded the same way the count is.
+ *
+ * A token boundary can fall in the middle of a multi-byte UTF-8 character, so
+ * decoding the kept prefix can leave a trailing U+FFFD replacement character or
+ * a lone UTF-16 surrogate. Any such trailing partial character is stripped so
+ * the result is always well-formed text.
  */
 export function truncateToTokens(text: string, maxTokens: number): string {
   if (maxTokens <= 0) return "";
@@ -108,5 +113,24 @@ export function truncateToTokens(text: string, maxTokens: number): string {
     if (truncated) break;
   }
   // Within budget: return the original text untouched (no decode round-trip).
-  return truncated ? encoder.decode(kept) : text;
+  if (!truncated) return text;
+  return stripTrailingPartialChar(encoder.decode(kept));
+}
+
+/**
+ * Drop a trailing partial character left by cutting at a token boundary: a
+ * U+FFFD replacement char (an incomplete UTF-8 sequence) or a lone high
+ * surrogate (an incomplete UTF-16 pair).
+ */
+function stripTrailingPartialChar(text: string): string {
+  let end = text.length;
+  while (end > 0) {
+    const code = text.charCodeAt(end - 1);
+    if (code === 0xfffd || (code >= 0xd800 && code <= 0xdbff)) {
+      end -= 1;
+    } else {
+      break;
+    }
+  }
+  return end === text.length ? text : text.slice(0, end);
 }

--- a/packages/runtime/tests/token-counter.test.ts
+++ b/packages/runtime/tests/token-counter.test.ts
@@ -77,4 +77,20 @@ describe("truncateToTokens", () => {
     },
     15000
   );
+
+  it("never ends in a lone surrogate or replacement char when cutting emoji", () => {
+    // A run of emoji (each a surrogate pair / 4-byte UTF-8) maximizes the
+    // chance a token boundary lands mid-character.
+    const text = "😀".repeat(200);
+    for (let maxTokens = 1; maxTokens <= 40; maxTokens++) {
+      const truncated = truncateToTokens(text, maxTokens);
+      const lastCode = truncated.charCodeAt(truncated.length - 1);
+      // No lone high surrogate at the end...
+      expect(lastCode >= 0xd800 && lastCode <= 0xdbff).toBe(false);
+      // ...and no trailing U+FFFD replacement character.
+      expect(lastCode).not.toBe(0xfffd);
+      // The kept prefix is well-formed: no replacement char anywhere.
+      expect(truncated).not.toContain("�");
+    }
+  });
 });


### PR DESCRIPTION
Done.

Fixed surrogate-pair splitting in both truncation helpers and added tests for emoji-boundary cuts.

- `packages/agents/src/constants.ts` — `truncateToolResult` now pulls the char cut back by one when it would land between the halves of a UTF-16 surrogate pair (added an `isHighSurrogate` helper; the kept-count in the notice now reflects the adjusted cut).
- `packages/runtime/src/token-counter.ts` — `truncateToTokens` decodes a prefix of BPE tokens, whose boundaries can fall mid-UTF-8, so it now strips any trailing partial character (U+FFFD replacement char or lone high surrogate) via a new `stripTrailingPartialChar` helper.
- Tests: `tool-result-truncation.test.ts` asserts no split surrogate at the cut and that a whole emoji is kept when it fits; `token-counter.test.ts` loops emoji truncation across many token budgets, asserting no trailing lone surrogate or replacement char.

Targeted tests pass and both packages typecheck clean. No caveats.

---

Closes task **T-20260619-0014**: #14 Surrogate-pair splitting in truncation helpers.


### Acceptance criteria
- [ ] truncateToolResult does not split surrogate pairs
- [ ] truncateToTokens does not split surrogate pairs
- [ ] Test truncates a string at an emoji boundary without producing a lone surrogate