### PR TITLE
[T-20260619-0013] #13 Code-runner containers still run as root (uid 0)

### DIFF
--- a/packages/code-runners/src/server-docker-runner.ts
+++ b/packages/code-runners/src/server-docker-runner.ts
@@ -51,6 +51,8 @@ export interface ServerDockerRunnerOptions {
   readonlyRootfs?: StreamRunnerOptions["readonlyRootfs"];
   /** Mount the workspace bind read-only. Default false. */
   readonlyWorkspace?: StreamRunnerOptions["readonlyWorkspace"];
+  /** Non-root user the container runs as. Defaults to "1000:1000". */
+  user?: StreamRunnerOptions["user"];
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +151,8 @@ export class ServerDockerRunner extends StreamRunnerBase {
       capDrop: options.capDrop,
       securityOpt: options.securityOpt,
       readonlyRootfs: options.readonlyRootfs,
-      readonlyWorkspace: options.readonlyWorkspace
+      readonlyWorkspace: options.readonlyWorkspace,
+      user: options.user
     };
     super(baseOptions);
 
@@ -243,6 +246,8 @@ export class ServerDockerRunner extends StreamRunnerBase {
       Cmd: command,
       Env: Object.entries(environment).map(([k, v]) => `${k}=${v}`),
       WorkingDir: "/workspace",
+      // Run as a non-root user so untrusted code cannot rely on uid 0.
+      User: this.user ?? undefined,
       OpenStdin: stdinStream !== null,
       Tty: false,
       ExposedPorts: { [portKey]: {} },

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -66,6 +66,13 @@ export interface StreamRunnerOptions {
    * that only need to read inputs and never write back to the workspace.
    */
   readonlyWorkspace?: boolean;
+  /**
+   * Docker `User` (uid[:gid] or name) the container process runs as. Defaults
+   * to `"1000:1000"` — untrusted code should never run as root (uid 0), even
+   * with capabilities dropped. Pass `null` to keep the image's default user
+   * (e.g. an image whose entrypoint already drops privileges).
+   */
+  user?: string | null;
 }
 
 export interface StreamOptions {
@@ -116,6 +123,7 @@ export class StreamRunnerBase {
   public readonly securityOpt: string[];
   public readonly readonlyRootfs: boolean;
   public readonly readonlyWorkspace: boolean;
+  public readonly user: string | null;
 
   // `protected` (not `private`) so subclasses that implement their own
   // `stream()` — e.g. ServerDockerRunner — can register their container and
@@ -150,6 +158,9 @@ export class StreamRunnerBase {
       : ["no-new-privileges"];
     this.readonlyRootfs = options?.readonlyRootfs ?? false;
     this.readonlyWorkspace = options?.readonlyWorkspace ?? false;
+    // Never run untrusted code as root (uid 0). `undefined` → non-root default;
+    // explicit `null` keeps the image's own user.
+    this.user = options?.user === undefined ? "1000:1000" : options.user;
   }
 
   // ---- Public API --------------------------------------------------------
@@ -466,6 +477,8 @@ export class StreamRunnerBase {
       Cmd: command,
       Env: Object.entries(environment).map(([k, v]) => `${k}=${v}`),
       WorkingDir: workingDir,
+      // Run as a non-root user so untrusted code cannot rely on uid 0.
+      User: this.user ?? undefined,
       OpenStdin: stdinStream !== null,
       Tty: false,
       HostConfig: hostConfig

--- a/packages/code-runners/tests/server-docker-runner.test.ts
+++ b/packages/code-runners/tests/server-docker-runner.test.ts
@@ -138,6 +138,7 @@ describe("ServerDockerRunner constructor", () => {
     expect(runner.securityOpt).toEqual(["no-new-privileges"]);
     expect(runner.readonlyRootfs).toBe(false);
     expect(runner.readonlyWorkspace).toBe(false);
+    expect(runner.user).toBe("1000:1000");
   });
 
   it("threads hardening overrides through to the base runner", () => {
@@ -148,13 +149,15 @@ describe("ServerDockerRunner constructor", () => {
       capDrop: ["NET_RAW"],
       securityOpt: ["seccomp=unconfined"],
       readonlyRootfs: true,
-      readonlyWorkspace: true
+      readonlyWorkspace: true,
+      user: "2000:2000"
     });
     expect(runner.ipcMode).toBe("shareable");
     expect(runner.capDrop).toEqual(["NET_RAW"]);
     expect(runner.securityOpt).toEqual(["seccomp=unconfined"]);
     expect(runner.readonlyRootfs).toBe(true);
     expect(runner.readonlyWorkspace).toBe(true);
+    expect(runner.user).toBe("2000:2000");
   });
 
   it("normalizes endpointPath by adding leading slash", () => {

--- a/packages/code-runners/tests/stream-runner-base.test.ts
+++ b/packages/code-runners/tests/stream-runner-base.test.ts
@@ -170,6 +170,23 @@ describe("StreamRunnerBase constructor defaults", () => {
     expect(runner.securityOpt).toEqual(["no-new-privileges"]);
   });
 
+  it("runs as a non-root user by default", () => {
+    const runner = new EchoRunner();
+    expect(runner.user).toBe("1000:1000");
+    expect(runner.user).not.toBe("0");
+    expect(runner.user).not.toBe("root");
+  });
+
+  it("accepts a custom user", () => {
+    const runner = new EchoRunner({ user: "65534:65534" });
+    expect(runner.user).toBe("65534:65534");
+  });
+
+  it("accepts null user to keep the image default", () => {
+    const runner = new EchoRunner({ user: null });
+    expect(runner.user).toBeNull();
+  });
+
   it("defaults workspaceMountPath to /workspace", () => {
     const runner = new EchoRunner();
     expect(runner.workspaceMountPath).toBe("/workspace");


### PR DESCRIPTION
Done. Code-runner Docker containers now run as a non-root user.

## What changed and why

Code-runner containers executed untrusted user code as uid 0. The prior hardening (cap-drop ALL + no-new-privileges) mitigated this, but setting a non-root `User` is the natural next defense-in-depth layer requested by the task.

- **`packages/code-runners/src/stream-runner-base.ts`** — added a `user` option to `StreamRunnerOptions` (default `"1000:1000"`, `null` to keep the image's default user) and applied it via Docker's top-level `User` field in `createContainer`.
- **`packages/code-runners/src/server-docker-runner.ts`** — exposed the same `user` knob on `ServerDockerRunnerOptions` and threaded it through; applied `User` in its own `createContainer` call.
- **Tests** — added coverage for the non-root default, custom user, and `null` passthrough in both runner test suites (96 tests pass).

All existing hardening (cap-drop, no-new-privileges, private IPC, optional read-only rootfs/workspace + noexec tmpfs) is untouched.

## Notes
- The `User` field is set at the container-config level (not `HostConfig`), which is where Docker expects it.
- `npx tsc --build` and the targeted lint/test runs pass. The repo-wide `npm run build` fails only because this worktree's root `node_modules/typescript` isn't installed — an environment issue, not these changes.
- **Caveat**: on native Linux, runners that *write* files into the bound `/workspace` may need that host dir made writable for uid 1000, since `getWorkspaceHostPath` creates it owned by the host process uid. Sample stdout-only execution (echo/print) is unaffected, and the runner subclasses do no runtime package installs, so none structurally require root.

---

Closes task **T-20260619-0013**: #13 Code-runner containers still run as root (uid 0).


### Acceptance criteria
- [ ] Code-runner containers run as a non-root user
- [ ] Existing cap-drop / no-new-privileges flags retained
- [ ] Sample code execution still works under the non-root user