### PR TITLE
[T-20260619-0017] #17 WS text-frame content merge uses ?? — empty string would wipe streamed text

### DIFF
--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -427,6 +427,69 @@ describe("chatProtocol", () => {
     expect(messages[1].id).not.toMatch(/^local-stream-/);
   });
 
+  it("does not wipe streamed text when an empty-string content frame arrives mid-stream", async () => {
+    let capturedState: any = {
+      status: "streaming",
+      currentThreadId: "thread-1",
+      threads: {
+        "thread-1": {
+          id: "thread-1",
+          title: "T",
+          updated_at: new Date().toISOString()
+        }
+      },
+      messageCache: {
+        "thread-1": [
+          { role: "user", type: "message", content: "Search the web" },
+          {
+            id: "local-stream-123-abc",
+            role: "assistant",
+            type: "message",
+            content: "Let me search for that."
+          }
+        ]
+      },
+      selectedModel: { provider: "", id: "" },
+      summarizeThread: jest.fn(),
+      updateThreadTitle: jest.fn()
+    };
+
+    const set = jest.fn((updater) => {
+      capturedState = {
+        ...capturedState,
+        ...(typeof updater === "function" ? updater(capturedState) : updater)
+      };
+    });
+
+    const get = () => capturedState;
+
+    await handleChatWebSocketMessage(
+      {
+        type: "message",
+        id: "server-msg-1",
+        role: "assistant",
+        thread_id: "thread-1",
+        created_at: new Date().toISOString(),
+        content: "",
+        tool_calls: [{ id: "call-1", name: "web_search", args: {} }]
+      } as any,
+      set,
+      get
+    );
+
+    const messages = capturedState.messageCache["thread-1"];
+    expect(messages).toHaveLength(2);
+    // The empty-string content must not clobber the accumulated streamed text.
+    expect(messages[1]).toEqual(
+      expect.objectContaining({
+        id: "server-msg-1",
+        role: "assistant",
+        content: "Let me search for that.",
+        tool_calls: [{ id: "call-1", name: "web_search", args: {} }]
+      })
+    );
+  });
+
   it("returns tool errors for unknown client tools", async () => {
     (FrontendToolRegistry.has as jest.Mock).mockReturnValue(false);
 

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -795,7 +795,16 @@ const findStreamPlaceholderIndex = (
 
     const candidateText = extractTextContent(candidate);
     const candidateNormalized = normalizeTextForComparison(candidateText);
-    if (!candidateNormalized || !incomingNormalized) {
+    // A finalizing server message with empty content (e.g. a tool_call frame
+    // with no text) must still replace the active local-stream placeholder
+    // rather than append beside it. The merge keeps the streamed text.
+    if (!incomingNormalized) {
+      if (isLocalStream && candidateNormalized && status === "streaming") {
+        return i;
+      }
+      continue;
+    }
+    if (!candidateNormalized) {
       continue;
     }
 
@@ -842,10 +851,18 @@ const replaceStreamPlaceholderOrAppend = (
     return [...messages, msg];
   }
   const existing = messages[index];
+  // Keep the accumulated content when the server omits it (null/undefined) or
+  // sends an empty string — an empty content frame must not wipe streamed text.
+  const incomingContent =
+    msg.content === null ||
+    msg.content === undefined ||
+    msg.content === ""
+      ? existing.content
+      : msg.content;
   const replacement: Message = {
     ...existing,
     ...msg,
-    content: msg.content ?? existing.content
+    content: incomingContent
   };
   return [
     ...messages.slice(0, index),


### PR DESCRIPTION
All criteria checked. Done.

## Summary

Fixed the WS text-frame chat-content merge so an empty-string `content` can't wipe accumulated streamed text. The merge fell back to existing content only on `null`/`undefined` (`??`); a finalizing assistant frame with `content: ""` would clobber the streamed text.

**Changes (`web/src/core/chat/chatProtocol.ts`):**
- `replaceStreamPlaceholderOrAppend` now keeps existing content when the incoming `content` is `null`, `undefined`, **or** `""`. `null`/`undefined` behave exactly as before.
- `findStreamPlaceholderIndex` now matches an active `local-stream-*` placeholder when the finalizing server frame has empty text. Without this, an empty frame bypassed the placeholder match and appended a stray empty message beside the streamed text instead of reaching the (now-guarded) merge.

**Test (`web/src/core/chat/__tests__/chatProtocol.test.ts`):**
- Added a case sending an assistant `message` frame with `content: ""` + `tool_calls` mid-stream, asserting the placeholder is replaced and the streamed text ("Let me search for that.") is preserved — no duplicate/empty message.

All 13 tests in the suite pass; lint clean. The pre-existing `@xyflow/react` typecheck errors are unrelated (missing dependency install) and don't touch these files.

---

Closes task **T-20260619-0017**: #17 WS text-frame content merge uses ?? — empty string would wipe streamed text.


### Acceptance criteria
- [ ] An incoming content: "" does not wipe previously streamed text
- [ ] content: null still behaves as today
- [ ] Test covers an empty-string content frame mid-stream