### PR TITLE
[T-20260619-0002] #2 Bridge setTarget() race clobbers new worker target

### DIFF
--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -206,6 +206,19 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
     this._reconnecting = false;
     this._reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
 
+    // Abort any in-flight handshake. A CONNECTING socket lives only in the
+    // _openTransport closure, NOT in this._ws, so _teardownSocket can't reach
+    // it — and its finishSuccess, if left to fire, would set this._ws and
+    // clobber the socket we're about to open against the new target (leaving
+    // the bridge attached to the OLD worker url/token). This is exactly the
+    // provision→attach→setTarget flow. Aborting rejects that handshake and
+    // crash-safely tears down its CONNECTING socket.
+    if (this._abortHandshake) {
+      const abort = this._abortHandshake;
+      this._abortHandshake = null;
+      abort(new Error("Python worker re-pointed via setTarget"));
+    }
+
     // Tear down the current socket (detaches listeners → no spurious
     // _onUnexpectedClose) and reject in-flight requests, then drive a fresh
     // connect against the new target via the reconnect path.

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -48,12 +48,25 @@ export interface FakeWorkerOptions {
    *  - "error": emit an error-status progress frame then a terminal error frame
    */
   downloadMode?: "progress" | "error";
+  /**
+   * When true, the WebSocket upgrade is held until {@link
+   * FakeWorkerHandle.releaseUpgrade} is called. Lets a test keep a client's
+   * initial handshake in the CONNECTING state deterministically (e.g. to
+   * reproduce a late-resolving handshake racing setTarget).
+   */
+  gateUpgrade?: boolean;
 }
 
 export interface FakeWorkerHandle {
   port: number;
   /** Forcibly drop all currently-connected client sockets. */
   dropConnections: () => void;
+  /**
+   * Release a gated WebSocket upgrade (see {@link FakeWorkerOptions.gateUpgrade}).
+   * No-op when no upgrade is currently pending. Releases the most recent pending
+   * upgrade.
+   */
+  releaseUpgrade: () => void;
   /** Close the server entirely. */
   close: () => Promise<void>;
   /** Number of discover requests the worker has answered. */
@@ -82,7 +95,22 @@ export function startFakeWorker(
   port = 0,
   initialOptions: FakeWorkerOptions = {}
 ): Promise<FakeWorkerHandle> {
-  const wss = new WebSocketServer({ port });
+  // When gateUpgrade is set, verifyClient stashes the accept callback instead of
+  // calling it, so the WS upgrade hangs in CONNECTING until releaseUpgrade runs.
+  let pendingUpgrade: (() => void) | null = null;
+  const wss = new WebSocketServer(
+    initialOptions.gateUpgrade
+      ? {
+          port,
+          verifyClient: (
+            _info: unknown,
+            cb: (accept: boolean) => void
+          ) => {
+            pendingUpgrade = () => cb(true);
+          }
+        }
+      : { port }
+  );
   const sockets = new Set<WsServerSocket>();
   const authHeaders: Array<string | undefined> = [];
   const receivedByType = new Map<string, Array<Record<string, unknown>>>();
@@ -316,6 +344,11 @@ export function startFakeWorker(
             ws.terminate();
           }
           sockets.clear();
+        },
+        releaseUpgrade: () => {
+          const release = pendingUpgrade;
+          pendingUpgrade = null;
+          release?.();
         },
         close: () =>
           new Promise<void>((res) => {

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -610,6 +610,67 @@ describe("WebsocketPythonBridge", () => {
       }
     });
 
+    it("a late-resolving initial handshake cannot clobber the new target (provision→attach→setTarget)", async () => {
+      // Reproduce the provision→attach→setTarget race: the initial connect() to
+      // worker A is still mid-handshake (CONNECTING) when setTarget re-points at
+      // worker B. The A handshake's socket lives only in the _openTransport
+      // closure, so if setTarget fails to abort it, A's eventual finishSuccess
+      // sets this._ws and clobbers the B socket — leaving the bridge silently
+      // attached to the OLD worker. setTarget must abort that handshake.
+      const workerA = await startFakeWorker(0, { gateUpgrade: true });
+      const workerB = await startFakeWorker();
+      try {
+        bridge = new WebsocketPythonBridge({
+          wsUrl: `ws://127.0.0.1:${workerA.port}`,
+          workerToken: "a-token",
+          maxReconnectDelayMs: 50
+        });
+
+        // Kick off the initial connect; it hangs on A's gated upgrade. Swallow
+        // its rejection — setTarget aborts the handshake, which rejects connect().
+        const connectErr: { e: Error | null } = { e: null };
+        const connecting = bridge.connect().catch((e: Error) => {
+          connectErr.e = e;
+        });
+        // Let the bridge reach the CONNECTING state against worker A.
+        await new Promise((r) => setTimeout(r, 50));
+
+        let reconnected = false;
+        bridge.on("reconnected", () => {
+          reconnected = true;
+        });
+
+        // Re-point at B while A's handshake is still in flight.
+        bridge.setTarget(`ws://127.0.0.1:${workerB.port}`, "b-token");
+        await waitFor(() => reconnected, 10000);
+
+        // Now release A's long-stalled upgrade. A late finishSuccess on the old
+        // closure must NOT overwrite the live B socket.
+        workerA.releaseUpgrade();
+        await new Promise((r) => setTimeout(r, 100));
+        await connecting;
+
+        // The bridge is on B: url, token header, and the actual socket.
+        expect(bridge.isConnected).toBe(true);
+        expect(bridge.wsUrl).toBe(`ws://127.0.0.1:${workerB.port}`);
+        expect(workerB.authHeaders()).toEqual(["Bearer b-token"]);
+
+        const result = await bridge.execute(
+          "fake.TestNode",
+          { value: "on-b" },
+          {},
+          {}
+        );
+        expect(result.outputs).toEqual({ out: "on-b" });
+        // The execute reached worker B, never the clobbering worker A.
+        expect(workerB.received("execute")).toHaveLength(1);
+        expect(workerA.received("execute")).toHaveLength(0);
+      } finally {
+        await workerA.close();
+        await workerB.close();
+      }
+    });
+
     it("rejects in-flight requests on the forced reconnect", async () => {
       // Worker A accepts the socket and answers connect, but never answers
       // execute, so the request stays pending. setTarget must reject it (the


### PR DESCRIPTION
Fixed the `setTarget()` race in `WebsocketPythonBridge`. `setTarget` tore down via `_teardownSocket()`, which only touches `this._ws`, but an in-flight initial handshake's socket lives solely in the `_openTransport` closure. When that old-URL handshake resolved, its `finishSuccess` would set `this._ws` and clobber the socket opened against the new target — leaving the bridge silently attached to the OLD worker URL/token (the provision→attach→setTarget flow). The fix invokes `_abortHandshake` before retargeting, the same mechanism `close()` already uses to reject a stale handshake and crash-safely terminate its CONNECTING socket.

**Changed files:**
- `packages/runtime/src/python-websocket-bridge.ts` — `setTarget` now aborts any in-flight handshake before `_teardownSocket`/`_attemptReconnect`.
- `packages/runtime/tests/python-websocket-bridge.test-helpers.ts` — added `gateUpgrade` option + `releaseUpgrade()` (via `verifyClient`) to hold a WS upgrade in CONNECTING deterministically.
- `packages/runtime/tests/python-websocket-bridge.test.ts` — new test re-points mid-handshake, then releases the old upgrade and asserts the execute reaches the new worker and never the old one.

**Verification:** New test fails without the fix (old worker receives the execute) and passes with it. Full `python-websocket-bridge.test.ts` (26 tests) green; `tsc --noEmit` clean. All three acceptance criteria checked.

---

Closes task **T-20260619-0002**: #2 Bridge setTarget() race clobbers new worker target.


### Acceptance criteria
- [ ] setTarget aborts any in-flight initial handshake before connecting to the new target
- [ ] A late-resolving old-URL handshake can no longer overwrite this._ws
- [ ] Test: provision→attach→setTarget leaves bridge on the new URL/token