### PR TITLE
[T-20260619-0008] #8 downloadModel leaks pending entries / hangs forever on cancel

### DIFF
--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -90,6 +90,9 @@ const DEFAULT_EXECUTE_TIMEOUT_MS = Number(
 const DEFAULT_STATUS_TIMEOUT_MS = Number(
   process.env["NODETOOL_PYTHON_STATUS_TIMEOUT_MS"] ?? 10000
 );
+const DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS = Number(
+  process.env["NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS"] ?? 5 * 60 * 1000
+);
 
 /**
  * Transport-agnostic Python bridge. Subclasses provide the transport via
@@ -801,29 +804,68 @@ export abstract class PythonBridgeBase
    * Pass a stable `requestId` to make the download cancellable by a known key:
    * {@link cancelModelDownload}(requestId) then reaches this exact download.
    * Defaults to a random id when the caller has no need to cancel.
+   *
+   * Unlike a plain provider RPC, this download is settled defensively: an
+   * inactivity timer (reset on every progress frame) rejects the promise if the
+   * worker hangs mid-download, and {@link cancelModelDownload} rejects it
+   * immediately. Either path clears BOTH pending maps so nothing leaks even when
+   * no terminal `result`/`error` ever arrives.
    */
   async downloadModel(
     req: ModelDownloadRequest,
     onProgress: (update: ModelDownloadUpdate) => void,
     requestId: string = randomUUID()
   ): Promise<void> {
+    const idleTimeoutMs =
+      this._options.downloadIdleTimeoutMs ?? DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS;
     return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let timer: NodeJS.Timeout | undefined;
       const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
         this._pending.delete(requestId);
         this._pendingStream.delete(requestId);
         fn();
       };
+      // Inactivity watchdog: a download making steady progress keeps resetting
+      // the clock, but a worker that goes silent mid-download is cancelled and
+      // rejected instead of leaking its pending entries forever.
+      const armIdleTimer = () => {
+        if (idleTimeoutMs <= 0) return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          try {
+            this.cancel(requestId);
+          } catch {
+            // Worker may already be gone; cancel is best-effort.
+          }
+          const stderrHint = this.getRecentStderrSummary(4);
+          settle(() =>
+            reject(
+              new Error(
+                `Model download "${requestId}" stalled: no progress for ${idleTimeoutMs}ms.` +
+                  (stderrHint ? ` Recent stderr: ${stderrHint}` : "")
+              )
+            )
+          );
+        }, idleTimeoutMs);
+      };
       this._pending.set(requestId, {
         resolve: () => undefined,
         reject: () => undefined,
-        onProgress: (event) =>
-          onProgress(event as unknown as ModelDownloadUpdate)
+        onProgress: (event) => {
+          armIdleTimer();
+          onProgress(event as unknown as ModelDownloadUpdate);
+        }
       });
       this._pendingStream.set(requestId, {
         resolve: () => settle(resolve),
         reject: (err) => settle(() => reject(err)),
         onChunk: () => {}
       });
+      armIdleTimer();
       try {
         this._send({ type: "models.download", request_id: requestId, data: req });
       } catch (err) {
@@ -832,9 +874,21 @@ export abstract class PythonBridgeBase
     });
   }
 
-  /** Cancel an in-flight {@link downloadModel} by its request id. */
+  /**
+   * Cancel an in-flight {@link downloadModel} by its request id. Sends the
+   * cancel frame AND settles the local promise immediately by rejecting it —
+   * the worker may never emit a terminal frame after a cancel (or may be hung),
+   * so we cannot rely on `result`/`error` to clean up. Rejecting through the
+   * pending-stream entry clears both pending maps; a no-op if the id is unknown.
+   */
   cancelModelDownload(requestId: string): void {
     this.cancel(requestId);
+    const streamReq = this._pendingStream.get(requestId);
+    if (streamReq) {
+      streamReq.reject(
+        new Error(`Model download "${requestId}" was cancelled.`)
+      );
+    }
   }
 
   /** Delete a cached model from the worker's HF_HOME. Returns whether it existed. */

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -113,6 +113,14 @@ export interface PythonBridgeOptions {
    * otherwise wedge the reconnect loop forever. Default ~20000ms.
    */
   reconnectRpcTimeoutMs?: number;
+  /**
+   * Max time a model download may go without any progress frame before it is
+   * considered stalled, cancelled, and rejected (0 = no timeout). This is an
+   * inactivity timeout — the clock resets on every progress frame — so a large
+   * but steadily-progressing download is never killed, while a worker that
+   * hangs mid-download cannot leak its pending entries forever. Default ~5min.
+   */
+  downloadIdleTimeoutMs?: number;
 }
 
 export type StreamCallback = (chunk: Record<string, unknown>) => void;

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -195,4 +195,72 @@ describe("models.* bridge methods", () => {
     expect(frames).toHaveLength(1);
     expect(frames[0]!.request_id).toBe("req-123");
   });
+
+  it("cancel mid-download settles the promise and leaves no leaked entries", async () => {
+    // The worker streams a start frame then hangs — no terminal result/error
+    // ever arrives. Without active settling, both pending maps would leak and
+    // the promise would never resolve.
+    worker = await startFakeWorker(0, { protocolVersion: 2, downloadMode: "hang" });
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const updates: ModelDownloadUpdate[] = [];
+    const downloadPromise = bridge.downloadModel(
+      { repo_id: "org/m" },
+      (u) => updates.push(u),
+      "org/m/model.bin"
+    );
+
+    // Wait for the start progress frame to confirm the download is in flight.
+    const start = Date.now();
+    while (updates.length === 0 && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(updates.map((u) => u.status)).toEqual(["start"]);
+
+    // Cancel mid-download: the promise must reject promptly, not hang forever.
+    bridge.cancelModelDownload("org/m/model.bin");
+    await expect(downloadPromise).rejects.toThrow(/cancelled/i);
+
+    // No leaked pending entries on either map.
+    const pending = (
+      bridge as unknown as { _pending: Map<string, unknown> }
+    )._pending;
+    const pendingStream = (
+      bridge as unknown as { _pendingStream: Map<string, unknown> }
+    )._pendingStream;
+    expect(pending.size).toBe(0);
+    expect(pendingStream.size).toBe(0);
+
+    // A cancel frame reached the worker.
+    const cancelStart = Date.now();
+    while (worker.received("cancel").length === 0 && Date.now() - cancelStart < 2000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(worker.received("cancel")[0]!.request_id).toBe("org/m/model.bin");
+  });
+
+  it("downloadModel rejects and cleans up when the worker hangs (idle timeout)", async () => {
+    // Worker hangs after the start frame; a short idle timeout must reject the
+    // promise and clear both pending maps rather than leak them forever.
+    worker = await startFakeWorker(0, { protocolVersion: 2, downloadMode: "hang" });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`,
+      downloadIdleTimeoutMs: 150
+    });
+    await bridge.connect();
+
+    await expect(
+      bridge.downloadModel({ repo_id: "org/m" }, () => {})
+    ).rejects.toThrow(/stalled/i);
+
+    const pending = (
+      bridge as unknown as { _pending: Map<string, unknown> }
+    )._pending;
+    const pendingStream = (
+      bridge as unknown as { _pendingStream: Map<string, unknown> }
+    )._pendingStream;
+    expect(pending.size).toBe(0);
+    expect(pendingStream.size).toBe(0);
+  });
 });

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -46,8 +46,11 @@ export interface FakeWorkerOptions {
    *  - "progress": one start frame, one progress frame, then a completed result
    *    (default)
    *  - "error": emit an error-status progress frame then a terminal error frame
+   *  - "hang": emit the start progress frame but never a terminal result/error,
+   *    so the download stays pending (simulates cancel mid-download / a hung
+   *    worker)
    */
-  downloadMode?: "progress" | "error";
+  downloadMode?: "progress" | "error" | "hang";
 }
 
 export interface FakeWorkerHandle {
@@ -274,6 +277,11 @@ export function startFakeWorker(
               total_files: 1
             }
           });
+          if (opts.downloadMode === "hang") {
+            // Emit the start frame above, then go silent — never a terminal
+            // result/error. The bridge must settle this itself (cancel/timeout).
+            break;
+          }
           send({
             type: "progress",
             request_id: requestId,


### PR DESCRIPTION
Done.

## Summary

Fixed `downloadModel` in `packages/runtime/src/python-bridge-base.ts`. Unlike `execute()`, it had no timeout and `cancelModelDownload` only sent a frame — so if the worker never emitted a terminal `result`/`error` (cancel mid-download or a hang), both `_pending` and `_pendingStream` entries leaked and the promise never settled.

**Changes:**
- **`downloadModel`** — added an inactivity watchdog timer (resets on every progress frame, so steadily-progressing large downloads are never killed). If the worker goes silent, it fires `cancel(requestId)` and rejects with a "stalled" error. All settle paths run through an idempotent `settle()` (guarded by a `settled` flag) that clears the timer and both pending maps. Default 5min, configurable via the new `downloadIdleTimeoutMs` option / `NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS` env (0 disables).
- **`cancelModelDownload`** — now rejects the local promise immediately through the pending-stream entry (which runs `settle`) instead of relying on a terminal frame that may never arrive.
- **`python-bridge-types.ts`** — added the `downloadIdleTimeoutMs` option with docs.
- **Tests** — added a `"hang"` download mode to the fake worker; two new tests cover cancel-mid-download and idle-timeout, both asserting `_pending` and `_pendingStream` end empty.

All 12 tests in `python-bridge-models` pass; `tsc` and `eslint` clean. All three acceptance criteria checked.

**Note:** I chose an inactivity (not absolute) timeout — a 100GB model download shouldn't be killed for taking long, only for going silent.

---

Closes task **T-20260619-0008**: #8 downloadModel leaks pending entries / hangs forever on cancel.


### Acceptance criteria
- [ ] downloadModel settles (rejects) on cancel or worker hang
- [ ] _pending and _pendingStream entries are cleared on terminal/cancel/timeout
- [ ] Test: cancel mid-download settles the promise and leaves no leaked entries