### PR TITLE
[T-20260619-0007] #7 Chat dedup can replace wrong placeholder across tool rounds

### DIFF
--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -427,6 +427,89 @@ describe("chatProtocol", () => {
     expect(messages[1].id).not.toMatch(/^local-stream-/);
   });
 
+  it("does not let a short finalized message overwrite an unrelated longer placeholder across tool rounds", async () => {
+    // Rapid multi-tool turn: two un-finalized local-stream-* placeholders coexist.
+    // The first round streamed "Searching the web for cats" (placeholder A); a
+    // later round streamed "Searching" (placeholder B, the trailing one). The
+    // server now finalizes the trailing round as "Searching". A bidirectional
+    // startsWith match could let "Searching" replace the longer placeholder A
+    // (since A startsWith "Searching"), dropping a distinct message. The
+    // finalized message must replace only the trailing placeholder B.
+    let capturedState: any = {
+      status: "streaming",
+      currentThreadId: "thread-1",
+      threads: {
+        "thread-1": {
+          id: "thread-1",
+          title: "T",
+          updated_at: new Date().toISOString()
+        }
+      },
+      messageCache: {
+        "thread-1": [
+          { role: "user", type: "message", content: "Search the web" },
+          {
+            id: "local-stream-1-aaa",
+            role: "assistant",
+            type: "message",
+            content: "Searching the web for cats"
+          },
+          {
+            id: "local-stream-2-bbb",
+            role: "assistant",
+            type: "message",
+            content: "Searching"
+          }
+        ]
+      },
+      selectedModel: { provider: "", id: "" },
+      summarizeThread: jest.fn(),
+      updateThreadTitle: jest.fn()
+    };
+
+    const set = jest.fn((updater) => {
+      capturedState = {
+        ...capturedState,
+        ...(typeof updater === "function" ? updater(capturedState) : updater)
+      };
+    });
+
+    const get = () => capturedState;
+
+    await handleChatWebSocketMessage(
+      {
+        type: "message",
+        id: "server-msg-2",
+        role: "assistant",
+        thread_id: "thread-1",
+        created_at: new Date().toISOString(),
+        content: "Searching",
+        tool_calls: [{ id: "call-2", name: "web_search", args: {} }]
+      } as any,
+      set,
+      get
+    );
+
+    const messages = capturedState.messageCache["thread-1"];
+    expect(messages).toHaveLength(3);
+    // Placeholder A (the longer, unrelated message) is untouched.
+    expect(messages[1]).toEqual(
+      expect.objectContaining({
+        id: "local-stream-1-aaa",
+        content: "Searching the web for cats"
+      })
+    );
+    // Only the trailing placeholder B is replaced by the finalized server message.
+    expect(messages[2]).toEqual(
+      expect.objectContaining({
+        id: "server-msg-2",
+        content: "Searching",
+        tool_calls: [{ id: "call-2", name: "web_search", args: {} }]
+      })
+    );
+    expect(messages[2].id).not.toMatch(/^local-stream-/);
+  });
+
   it("returns tool errors for unknown client tools", async () => {
     (FrontendToolRegistry.has as jest.Mock).mockReturnValue(false);
 

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -764,6 +764,18 @@ const extractTextContent = (message: Message): string => {
  * when it completes a plain reply and when it attaches tool_calls. Without this
  * reconciliation the placeholder and the finalized message both render, so the
  * same text appears twice. Returns -1 when the incoming message is genuinely new.
+ *
+ * Identity, not content, decides the target. The placeholder being finalized is
+ * always the *trailing* `local-stream-*` placeholder — the one applyChunk most
+ * recently appended. We therefore only ever consider that single placeholder
+ * (found by its stable id prefix) and never scan past it into earlier
+ * placeholders. In rapid multi-tool turns several un-finalized `local-stream-*`
+ * placeholders can coexist; a bidirectional content match could let a short
+ * finalized message ("Searching") overwrite an unrelated longer earlier
+ * placeholder ("Searching the web for…"), dropping a distinct message. Anchoring
+ * to the trailing placeholder makes the match unambiguous. Content is only used
+ * to confirm the finalized text extends (or equals) the placeholder before we
+ * replace it; otherwise the incoming message is treated as genuinely new.
  */
 const findStreamPlaceholderIndex = (
   messages: Message[],
@@ -786,31 +798,35 @@ const findStreamPlaceholderIndex = (
     const isLocalStream =
       typeof candidateId === "string" &&
       candidateId.startsWith("local-stream-");
-    const isServerAuthored =
-      !!candidate.created_at || (!!candidateId && !isLocalStream);
 
-    if (isServerAuthored) {
-      continue;
+    // The first assistant message walking back is the only candidate. If it is
+    // not a local-stream placeholder (it was authored/finalized by the server),
+    // the incoming message is genuinely new — stop rather than reaching past it
+    // to an earlier placeholder.
+    if (!isLocalStream) {
+      return -1;
     }
 
     const candidateText = extractTextContent(candidate);
     const candidateNormalized = normalizeTextForComparison(candidateText);
     if (!candidateNormalized || !incomingNormalized) {
-      continue;
+      return -1;
     }
 
+    // The finalized message must equal or extend the streamed placeholder text.
+    // We deliberately do NOT match when the placeholder is longer than the
+    // incoming text: a short finalized message must never replace a longer
+    // placeholder it does not actually finalize.
     if (
       candidateNormalized === incomingNormalized ||
-      incomingNormalized.startsWith(candidateNormalized) ||
-      candidateNormalized.startsWith(incomingNormalized)
+      incomingNormalized.startsWith(candidateNormalized)
     ) {
       return i;
     }
 
-    // If we were streaming and the most recent assistant message looks local,
-    // prefer replacing it even if trailing whitespace differs.
+    // While streaming, tolerate trailing-whitespace differences on the trailing
+    // placeholder (the finalized text may equal or extend it once trimmed).
     if (
-      i === messages.length - 1 &&
       (status === "streaming" || isLocalStream) &&
       candidateText &&
       incomingText
@@ -824,6 +840,9 @@ const findStreamPlaceholderIndex = (
         return i;
       }
     }
+
+    // Trailing placeholder exists but the incoming text does not finalize it.
+    return -1;
   }
   return -1;
 };


### PR DESCRIPTION
Done. Fixed the placeholder-matching ambiguity in `findStreamPlaceholderIndex`.

**Root cause:** the function scanned *all* un-finalized `local-stream-*` placeholders with a bidirectional `startsWith`. In rapid multi-tool turns where several placeholders coexist, a short finalized message ("Searching") could match an earlier longer placeholder ("Searching the web for…") via `candidate.startsWith(incoming)` and overwrite it, dropping a distinct message.

**Fix:** the placeholder being finalized is always the *trailing* `local-stream-*` placeholder. The server doesn't echo the placeholder id, so identity-matching here means anchoring to that trailing placeholder by its stable id prefix and never scanning past it into earlier placeholders. I also removed the `candidate.startsWith(incoming)` direction so a short finalized message can only replace a placeholder it actually equals or extends.

- `web/src/core/chat/chatProtocol.ts` — rewrote `findStreamPlaceholderIndex`: returns `-1` on the first trailing assistant message that isn't a local-stream placeholder (genuinely-new), considers only that single placeholder, and matches only when the finalized text equals or extends it (whitespace tolerance retained).
- `web/src/core/chat/__tests__/chatProtocol.test.ts` — added a multi-tool-round test with two coexisting placeholders asserting the longer earlier one is untouched and only the trailing one is replaced.

typecheck and eslint clean; 13/13 chatProtocol tests pass. All three acceptance criteria checked.

---

Closes task **T-20260619-0007**: #7 Chat dedup can replace wrong placeholder across tool rounds.


### Acceptance criteria
- [ ] Placeholder matching is unambiguous across multiple concurrent local-stream-* placeholders
- [ ] A short finalized message cannot overwrite an unrelated longer placeholder
- [ ] Test covers a multi-tool-round turn with multiple placeholders