### PR TITLE
[T-20260619-0011] #11 SSRF guard is FAL-only; safeFetch re-applies init on redirects

### DIFF
--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -12,6 +12,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { BaseProvider } from "./base-provider.js";
+import { safeFetch } from "./safe-url.js";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ImageModel,
@@ -200,7 +201,7 @@ async function downloadResultBytes(
   const resultData = JSON.parse(resultJsonStr) as Record<string, unknown>;
   const resultUrls = resultData.resultUrls as string[];
   if (!resultUrls?.length) throw new Error("No resultUrls in Kie resultJson");
-  const dlRes = await fetch(resultUrls[0]);
+  const dlRes = await safeFetch(resultUrls[0]);
   if (!dlRes.ok) {
     throw new Error(`Failed to download from ${resultUrls[0]}`);
   }

--- a/packages/runtime/src/providers/meshy-provider.ts
+++ b/packages/runtime/src/providers/meshy-provider.ts
@@ -14,6 +14,7 @@
  */
 
 import { BaseProvider } from "./base-provider.js";
+import { safeFetch } from "./safe-url.js";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ImageTo3DParams,
@@ -321,7 +322,7 @@ export class MeshyProvider extends BaseProvider {
         `No model URL found in Meshy response for format: ${format}`
       );
     }
-    const dlRes = await fetch(modelUrl);
+    const dlRes = await safeFetch(modelUrl);
     if (!dlRes.ok) {
       const errText = await dlRes.text().catch(() => "");
       throw new Error(

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -1,6 +1,7 @@
 import Replicate from "replicate";
 import { createLogger } from "@nodetool-ai/config";
 import { BaseProvider } from "./base-provider.js";
+import { safeFetch } from "./safe-url.js";
 import type { Chunk } from "@nodetool-ai/protocol";
 import type {
   ASRModel,
@@ -468,7 +469,7 @@ export class ReplicateProvider extends BaseProvider {
 
     // String URL — fetch the bytes
     if (typeof target === "string") {
-      const res = await fetch(target);
+      const res = await safeFetch(target);
       if (!res.ok) throw new Error(`Failed to fetch output: ${res.status}`);
       return new Uint8Array(await res.arrayBuffer());
     }

--- a/packages/runtime/src/providers/rodin-provider.ts
+++ b/packages/runtime/src/providers/rodin-provider.ts
@@ -16,6 +16,7 @@
  */
 
 import { BaseProvider } from "./base-provider.js";
+import { safeFetch } from "./safe-url.js";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ImageTo3DParams,
@@ -337,7 +338,7 @@ export class RodinProvider extends BaseProvider {
         `No download URL in Rodin response: ${JSON.stringify(info)}`
       );
     }
-    const dlRes = await fetch(downloadUrl);
+    const dlRes = await safeFetch(downloadUrl);
     if (!dlRes.ok) {
       const errText = await dlRes.text().catch(() => "");
       throw new Error(

--- a/packages/runtime/src/providers/safe-url.ts
+++ b/packages/runtime/src/providers/safe-url.ts
@@ -106,11 +106,34 @@ export function assertSafePublicHttpsUrl(url: string): void {
   }
 }
 
+/** Request headers that must not cross an origin boundary on a redirect. */
+const CROSS_ORIGIN_SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization"
+];
+
+/**
+ * Return a copy of `init` with credentials and body stripped, for replay
+ * against a different origin. Mirrors browser behaviour: a cross-origin
+ * redirect must not forward `Authorization`/`Cookie` headers or the request
+ * body, both of which may carry secrets meant only for the original host.
+ */
+function stripCrossOriginCredentials(init: RequestInit): RequestInit {
+  const headers = new Headers(init.headers ?? undefined);
+  for (const name of CROSS_ORIGIN_SENSITIVE_HEADERS) headers.delete(name);
+  const next: RequestInit = { ...init, headers };
+  delete next.body;
+  return next;
+}
+
 /**
  * `fetch` a provider-supplied URL with SSRF protection. The initial URL and
  * every redirect hop are validated with {@link assertSafePublicHttpsUrl}, so a
  * public host cannot redirect into an internal/loopback target or downgrade to
- * http. Redirects are followed manually up to `maxRedirects`.
+ * http. Redirects are followed manually up to `maxRedirects`. When a redirect
+ * crosses to a different origin, auth headers and the request body are stripped
+ * so they are never leaked to the redirect target.
  */
 export async function safeFetch(
   url: string,
@@ -118,12 +141,19 @@ export async function safeFetch(
   maxRedirects = 5
 ): Promise<Response> {
   let current = url;
+  let currentInit: RequestInit = { ...init };
+  let currentOrigin = new URL(url).origin;
   for (let hop = 0; hop <= maxRedirects; hop++) {
     assertSafePublicHttpsUrl(current);
-    const res = await fetch(current, { ...init, redirect: "manual" });
+    const res = await fetch(current, { ...currentInit, redirect: "manual" });
     const location = res.headers.get("location");
     if (res.status >= 300 && res.status < 400 && location) {
-      current = new URL(location, current).toString();
+      const next = new URL(location, current);
+      if (next.origin !== currentOrigin) {
+        currentInit = stripCrossOriginCredentials(currentInit);
+      }
+      current = next.toString();
+      currentOrigin = next.origin;
       continue;
     }
     return res;

--- a/packages/runtime/tests/providers/kie-provider.test.ts
+++ b/packages/runtime/tests/providers/kie-provider.test.ts
@@ -37,6 +37,7 @@ function mockKieFlow(uploadUrls: string[]) {
     // Final asset download.
     return {
       ok: true,
+      headers: new Headers(),
       arrayBuffer: async () => new Uint8Array([7, 7, 7]).buffer
     } as unknown as Response;
   });

--- a/packages/runtime/tests/providers/meshy-provider-hardening.test.ts
+++ b/packages/runtime/tests/providers/meshy-provider-hardening.test.ts
@@ -29,6 +29,7 @@ function binaryResponse(bytes: Uint8Array, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(),
     arrayBuffer: async () => bytes.buffer,
     text: async () => "",
     json: async () => ({})
@@ -353,6 +354,7 @@ describe("Meshy HTTP flow", () => {
       .mockResolvedValueOnce({
         ok: false,
         status: 500,
+        headers: new Headers(),
         text: async () => {
           throw new Error("nope");
         }
@@ -362,13 +364,32 @@ describe("Meshy HTTP flow", () => {
     );
   });
 
+  it("refuses to download from a private-IP model URL (SSRF guard)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ result: "t" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: "SUCCEEDED",
+          model_urls: { glb: "https://169.254.169.254/model.glb" }
+        })
+      );
+    await expect(provider().textTo3D(txt())).rejects.toThrow(/unsafe URL/);
+    // Submit + poll happened, but the download fetch was never attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("throws when the download itself fails", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ result: "t" }))
       .mockResolvedValueOnce(
         jsonResponse({ status: "SUCCEEDED", model_urls: { glb: "https://m/x.glb" } })
       )
-      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => "missing" } as Response);
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        text: async () => "missing"
+      } as Response);
     await expect(provider().textTo3D(txt())).rejects.toThrow(
       "Failed to download Meshy result (404): missing"
     );

--- a/packages/runtime/tests/providers/meshy-provider.test.ts
+++ b/packages/runtime/tests/providers/meshy-provider.test.ts
@@ -29,6 +29,7 @@ function binaryResponse(bytes: Uint8Array, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(),
     arrayBuffer: async () => bytes.buffer,
     text: async () => "",
     json: async () => ({})

--- a/packages/runtime/tests/providers/replicate-provider.test.ts
+++ b/packages/runtime/tests/providers/replicate-provider.test.ts
@@ -204,6 +204,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2]).buffer)
       })
     );
@@ -232,6 +233,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2]).buffer)
       })
     );
@@ -264,6 +266,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2]).buffer)
       })
     );
@@ -287,6 +290,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2]).buffer)
       })
     );
@@ -316,6 +320,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2]).buffer)
       })
     );
@@ -339,6 +344,7 @@ describe("ReplicateProvider", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
+        headers: new Headers(),
         arrayBuffer: () => Promise.resolve(fakeBytes.buffer)
       })
     );

--- a/packages/runtime/tests/providers/rodin-provider-hardening.test.ts
+++ b/packages/runtime/tests/providers/rodin-provider-hardening.test.ts
@@ -34,6 +34,7 @@ function binaryResponse(bytes: Uint8Array, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(),
     arrayBuffer: async () => bytes.buffer,
     text: async () => ""
   } as Response;
@@ -413,6 +414,7 @@ describe("Rodin HTTP flow", () => {
       .mockResolvedValueOnce({
         ok: false,
         status: 500,
+        headers: new Headers(),
         text: async () => {
           throw new Error("x");
         }

--- a/packages/runtime/tests/providers/rodin-provider.test.ts
+++ b/packages/runtime/tests/providers/rodin-provider.test.ts
@@ -28,6 +28,7 @@ function binaryResponse(bytes: Uint8Array, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(),
     arrayBuffer: async () => bytes.buffer,
     text: async () => "",
     json: async () => ({})

--- a/packages/runtime/tests/providers/safe-url.test.ts
+++ b/packages/runtime/tests/providers/safe-url.test.ts
@@ -129,6 +129,49 @@ describe("safeFetch", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("strips auth headers and body on a cross-origin redirect", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { location: "https://cdn.other.com/final.png" }
+        })
+      )
+      .mockResolvedValueOnce(new Response("bytes", { status: 200 }));
+    await safeFetch("https://fal.media/a.png", {
+      method: "POST",
+      body: "secret-payload",
+      headers: { Authorization: "Bearer token", "X-Trace": "keep-me" }
+    });
+    const secondInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = new Headers(secondInit.headers ?? undefined);
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-trace")).toBe("keep-me");
+    expect(secondInit.body).toBeUndefined();
+  });
+
+  it("preserves auth headers and body on a same-origin redirect", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { location: "https://fal.media/final.png" }
+        })
+      )
+      .mockResolvedValueOnce(new Response("bytes", { status: 200 }));
+    await safeFetch("https://fal.media/a.png", {
+      method: "POST",
+      body: "payload",
+      headers: { Authorization: "Bearer token" }
+    });
+    const secondInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = new Headers(secondInit.headers ?? undefined);
+    expect(headers.get("authorization")).toBe("Bearer token");
+    expect(secondInit.body).toBe("payload");
+  });
+
   it("throws on a redirect loop exceeding the limit", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(null, {


### PR DESCRIPTION
Done. All three acceptance criteria are met and committed.

## Summary

Routed sibling providers' provider-supplied result-URL downloads through the existing `safeFetch` SSRF guard (the same one FAL got in d54dfbbf), and fixed a latent credential-leak in `safeFetch`'s redirect handling.

**Changed:**
- `packages/runtime/src/providers/safe-url.ts` — `safeFetch` now tracks origin per redirect hop and strips `Authorization`/`Cookie`/`Proxy-Authorization` headers and the request body whenever a redirect crosses origins, so credentials/body meant for the original host never leak to a redirect target.
- `replicate-provider.ts`, `meshy-provider.ts`, `rodin-provider.ts`, `kie-provider.ts` — their result-URL downloads (`fetch(target)` / `modelUrl` / `downloadUrl` / `resultUrls[0]`) now go through `safeFetch`.
- Tests — added cross-origin-strip + same-origin-preserve cases to `safe-url.test.ts`, a private-IP-blocked download test to `meshy-provider-hardening.test.ts`, and updated provider download mocks to a faithful `Response` shape (with `headers`).

**Note on HuggingFace:** the criterion lists it, but the HF provider has no provider-supplied URL download — generated bytes come back through the `@huggingface` SDK, and its only raw `fetch` targets the hardcoded `HF_API_BASE` constant (`https://huggingface.co/api/models`), which isn't an SSRF surface. So it's covered vacuously, no change needed.

I deliberately did **not** add a defensive `res.headers?.get` guard in `safeFetch` (real `fetch` Responses always carry headers — that'd be a defensive check on a trusted path); instead I corrected the incomplete test doubles, matching the FAL commit's approach.

Verification: all 1222 runtime provider tests pass; `tsc --noEmit` (lint) clean.

---

Closes task **T-20260619-0011**: #11 SSRF guard is FAL-only; safeFetch re-applies init on redirects.


### Acceptance criteria
- [ ] Replicate/Meshy/Rodin/Kie/HuggingFace provider-URL downloads go through the SSRF guard
- [ ] safeFetch does not forward auth headers/body across cross-origin redirects
- [ ] Tests cover a blocked private-IP fetch on at least one migrated provider