### PR TITLE
[T-20260619-0005] #5 e9fafbb7 audio transforms still silently pass through undecoded input

### DIFF
--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -18,12 +18,13 @@ import {
   audioRefFromBytes,
   audioRefFromWav,
   concatBytes,
+  decodeAudioToWav,
   encodePcm16Wav,
   encodeWav,
   parseWavBytes,
   readWavHeader,
+  requireAudioBytes,
   toBytes,
-  tryDecodeWav,
   uriToPath,
   type WavData
 } from "../lib/audio-wav.js";
@@ -491,15 +492,25 @@ export class NormalizeAudioNode extends BaseNode {
   declare audio: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await audioBytesAsync(this.audio, context);
-    const wav = tryDecodeWav({ data: bytes });
-    if (!wav || wav.samples.length === 0) {
-      return { output: audioRefFromBytes(bytes) };
+    const bytes = await requireAudioBytes(this.audio, context);
+    const wav = await decodeAudioToWav(bytes);
+    if (wav.samples.length === 0) {
+      return {
+        output: audioRefFromWav(
+          encodeWav(wav.samples, wav.sampleRate, wav.numChannels)
+        )
+      };
     }
 
     let peak = 0;
     for (const sample of wav.samples) peak = Math.max(peak, Math.abs(sample));
-    if (peak === 0) return { output: audioRefFromBytes(bytes) };
+    if (peak === 0) {
+      return {
+        output: audioRefFromWav(
+          encodeWav(wav.samples, wav.sampleRate, wav.numChannels)
+        )
+      };
+    }
 
     const gain = 1 / peak;
     const normalized = new Float32Array(wav.samples.length);
@@ -809,15 +820,10 @@ export class SliceAudioNode extends BaseNode {
   declare end: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await audioBytesAsync(this.audio, context);
+    const bytes = await requireAudioBytes(this.audio, context);
     const start = Math.max(0, Number(this.start ?? 0));
     const end = Number(this.end ?? 0);
-    const wav = parseWavBytes(bytes);
-    if (!wav) {
-      // Non-WAV: fall back to raw byte slicing.
-      const e = end <= 0 ? bytes.length : end;
-      return { output: audioRefFromBytes(bytes.slice(start, e)) };
-    }
+    const wav = await decodeAudioToWav(bytes);
     const { sampleRate, numChannels } = wav;
     const frames = wavFrameCount(wav);
     const startFrame = Math.min(frames, Math.round(start * sampleRate));
@@ -1040,10 +1046,9 @@ export class FadeInAudioNode extends BaseNode {
   declare duration: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await audioBytesAsync(this.audio, context);
+    const bytes = await requireAudioBytes(this.audio, context);
     const duration = Math.max(0, Number(this.duration ?? 1));
-    const wav = parseWavBytes(bytes);
-    if (!wav) return { output: audioRefFromBytes(bytes) };
+    const wav = await decodeAudioToWav(bytes);
     const { sampleRate, numChannels } = wav;
     const frames = wavFrameCount(wav);
     const fadeFrames = Math.min(frames, Math.round(duration * sampleRate));
@@ -1095,10 +1100,9 @@ export class FadeOutAudioNode extends BaseNode {
   declare duration: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await audioBytesAsync(this.audio, context);
+    const bytes = await requireAudioBytes(this.audio, context);
     const duration = Math.max(0, Number(this.duration ?? 1));
-    const wav = parseWavBytes(bytes);
-    if (!wav) return { output: audioRefFromBytes(bytes) };
+    const wav = await decodeAudioToWav(bytes);
     const { sampleRate, numChannels } = wav;
     const frames = wavFrameCount(wav);
     const fadeFrames = Math.min(frames, Math.round(duration * sampleRate));
@@ -1201,47 +1205,41 @@ export class AudioMixerNode extends BaseNode {
     if (tracks.length === 0)
       return { output: audioRefFromBytes(new Uint8Array()) };
 
-    // If every track is a valid WAV file with a matching layout, mix in
-    // Float32 sample space and emit a valid WAV so downstream nodes receive a
-    // playable file. Index-based mixing only lines up when sample rate and
-    // channel count match across tracks.
-    const parsed = tracks.map((bytes) => ({
-      wav: tryDecodeWav({ data: bytes }),
-      bytes
-    }));
-    const uniformWav =
-      parsed.every((p) => p.wav !== null) &&
-      parsed.every(
-        (p) =>
-          p.wav!.sampleRate === parsed[0].wav!.sampleRate &&
-          p.wav!.numChannels === parsed[0].wav!.numChannels
+    // Decode every track to PCM (WAV directly, or mp3/flac/… via WebAudio).
+    // Undecodable input throws instead of falling through to a meaningless
+    // byte-level average.
+    const wavs = await Promise.all(
+      tracks.map((bytes) => decodeAudioToWav(bytes))
+    );
+
+    // Index-based mixing only lines up when sample rate and channel count
+    // match across tracks; resampling is out of scope, so a mismatch is an
+    // error rather than a silently distorted mix.
+    const uniform = wavs.every(
+      (w) =>
+        w.sampleRate === wavs[0].sampleRate &&
+        w.numChannels === wavs[0].numChannels
+    );
+    if (!uniform) {
+      throw new Error(
+        "Audio Mixer requires all tracks to share the same sample rate and " +
+          "channel count. Resample or convert the inputs to a common format " +
+          "upstream before mixing."
       );
-    if (uniformWav) {
-      const wavs = parsed as Array<{ wav: WavData; bytes: Uint8Array }>;
-      const len = Math.max(...wavs.map((p) => p.wav.samples.length));
-      const mixed = new Float32Array(len);
-      for (let i = 0; i < len; i += 1) {
-        let total = 0;
-        for (const p of wavs) total += p.wav.samples[i] ?? 0;
-        mixed[i] = total / wavs.length;
-      }
-      return {
-        output: audioRefFromWav(
-          encodeWav(mixed, wavs[0].wav.sampleRate, wavs[0].wav.numChannels)
-        )
-      };
     }
 
-    // Fallback: byte-level averaging (preserves backward-compatible
-    // behavior for non-WAV / headerless byte streams).
-    const len = Math.max(...tracks.map((bytes) => bytes.length));
-    const out = new Uint8Array(len);
+    const len = Math.max(...wavs.map((w) => w.samples.length));
+    const mixed = new Float32Array(len);
     for (let i = 0; i < len; i += 1) {
       let total = 0;
-      for (const bytes of tracks) total += bytes[i] ?? 0;
-      out[i] = Math.max(0, Math.min(255, Math.round(total / tracks.length)));
+      for (const w of wavs) total += w.samples[i] ?? 0;
+      mixed[i] = total / wavs.length;
     }
-    return { output: audioRefFromBytes(out) };
+    return {
+      output: audioRefFromWav(
+        encodeWav(mixed, wavs[0].sampleRate, wavs[0].numChannels)
+      )
+    };
   }
 }
 
@@ -1289,15 +1287,10 @@ export class TrimAudioNode extends BaseNode {
   declare end: any;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await audioBytesAsync(this.audio, context);
+    const bytes = await requireAudioBytes(this.audio, context);
     const start = Math.max(0, Number(this.start ?? 0));
     const end = Math.max(0, Number(this.end ?? 0));
-    const wav = parseWavBytes(bytes);
-    if (!wav) {
-      // Non-WAV fallback: treat start/end as raw byte offsets.
-      const e = end > 0 ? Math.max(start, end) : bytes.length;
-      return { output: audioRefFromBytes(bytes.slice(start, e)) };
-    }
+    const wav = await decodeAudioToWav(bytes);
     const { sampleRate, numChannels } = wav;
     const frames = wavFrameCount(wav);
     // start/end are absolute times in seconds; end <= 0 means "to the end".
@@ -1373,41 +1366,44 @@ export class ConcatAudioNode extends BaseNode {
     const parts = (
       await Promise.all(values.map((v) => audioBytesAsync(v, context)))
     ).filter((b) => b.length > 0);
-    return { output: concatAudio(parts) };
+    return { output: await concatAudio(parts) };
   }
 }
 
 type AudioRefResult = ReturnType<typeof audioRefFromBytes>;
 
 /**
- * Concatenate audio byte buffers. When every part is a WAV with a matching
- * layout, decode and join in sample space so the result is a single valid
- * WAV; otherwise fall back to raw byte concatenation.
+ * Concatenate audio byte buffers. Every part is decoded to PCM (WAV directly,
+ * or mp3/flac/… via WebAudio) and joined in sample space so the result is a
+ * single valid WAV. Undecodable input throws rather than silently emitting an
+ * unplayable byte concatenation, and mismatched layouts throw because joining
+ * differing sample rates without resampling would distort the audio.
  */
-function concatAudio(parts: Uint8Array[]): AudioRefResult {
+async function concatAudio(parts: Uint8Array[]): Promise<AudioRefResult> {
   if (parts.length === 0) return audioRefFromBytes(new Uint8Array());
-  const wavs = parts.map((b) => parseWavBytes(b));
-  const uniform =
-    wavs.every((w) => w !== null) &&
-    wavs.every(
-      (w) =>
-        w!.sampleRate === wavs[0]!.sampleRate &&
-        w!.numChannels === wavs[0]!.numChannels
-    );
-  if (uniform) {
-    const list = wavs as WavData[];
-    const total = list.reduce((s, w) => s + w.samples.length, 0);
-    const out = new Float32Array(total);
-    let pos = 0;
-    for (const w of list) {
-      out.set(w.samples, pos);
-      pos += w.samples.length;
-    }
-    return audioRefFromWav(
-      encodeWav(out, list[0].sampleRate, list[0].numChannels)
+  const list = await Promise.all(parts.map((b) => decodeAudioToWav(b)));
+  const uniform = list.every(
+    (w) =>
+      w.sampleRate === list[0].sampleRate &&
+      w.numChannels === list[0].numChannels
+  );
+  if (!uniform) {
+    throw new Error(
+      "Cannot concatenate audio with differing sample rates or channel " +
+        "counts. Convert the inputs to a common format upstream before " +
+        "joining."
     );
   }
-  return audioRefFromBytes(concatBytes(parts));
+  const total = list.reduce((s, w) => s + w.samples.length, 0);
+  const out = new Float32Array(total);
+  let pos = 0;
+  for (const w of list) {
+    out.set(w.samples, pos);
+    pos += w.samples.length;
+  }
+  return audioRefFromWav(
+    encodeWav(out, list[0].sampleRate, list[0].numChannels)
+  );
 }
 
 export class ConcatAudioListNode extends BaseNode {
@@ -1436,7 +1432,7 @@ export class ConcatAudioListNode extends BaseNode {
     const parts = (
       await Promise.all(audios.map((a) => audioBytesAsync(a, context)))
     ).filter((b) => b.length > 0);
-    return { output: concatAudio(parts) };
+    return { output: await concatAudio(parts) };
   }
 }
 

--- a/packages/audio-nodes/tests/audio-transform-decode.test.ts
+++ b/packages/audio-nodes/tests/audio-transform-decode.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Pins the decode contract for the sample/byte transforms (commit e9fafbb7's
+ * intent): Normalize/Trim/Slice/Fade/Concat/Mixer must route their input
+ * through `decodeAudioToWav` — they process decoded PCM, and undecodable
+ * input throws rather than silently passing the bytes through unprocessed.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  AudioMixerNode,
+  ConcatAudioNode,
+  ConcatAudioListNode,
+  FadeInAudioNode,
+  FadeOutAudioNode,
+  NormalizeAudioNode,
+  SliceAudioNode,
+  TrimAudioNode,
+  encodeWav,
+  parseWavBytes,
+  toBytes
+} from "@nodetool-ai/audio-nodes";
+
+const SAMPLE_RATE = 8000;
+const AMPLITUDE = 0.5;
+
+/** Build an inline AudioRef carrying a 1 s mono constant-amplitude WAV. */
+function wavRef(amplitude = AMPLITUDE) {
+  const frames = SAMPLE_RATE;
+  const samples = new Float32Array(frames).fill(amplitude);
+  return { type: "audio", uri: "", data: encodeWav(samples, SAMPLE_RATE, 1) };
+}
+
+/**
+ * Corrupt, non-WAV bytes that WebAudio's `decodeAudioData` rejects — stands in
+ * for a stored `.mp3`/`.flac` that cannot be decoded. The old transforms
+ * silently passed these through unprocessed; the fixed ones must throw.
+ */
+function undecodableRef() {
+  const bytes = new Uint8Array(256);
+  for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 131 + 7) & 0xff;
+  return { type: "audio", uri: "", data: bytes };
+}
+
+function outputWav(result: Record<string, unknown>) {
+  const ref = result.output as { data?: Uint8Array | string };
+  return parseWavBytes(toBytes(ref?.data));
+}
+
+describe("AUDIO_NODES transforms decode their input", () => {
+  it("Normalize processes decoded WAV and boosts the peak to full scale", async () => {
+    const out = outputWav(await new NormalizeAudioNode({ audio: wavRef(0.25) }).process());
+    expect(out).not.toBeNull();
+    let peak = 0;
+    for (const s of out!.samples) peak = Math.max(peak, Math.abs(s));
+    expect(peak).toBeGreaterThan(0.9);
+  });
+
+  it("Trim returns the requested decoded slice", async () => {
+    const out = outputWav(
+      await new TrimAudioNode({ audio: wavRef(), start: 0, end: 0.5 }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(out!.sampleRate).toBe(SAMPLE_RATE);
+    expect(out!.samples.length).toBe(SAMPLE_RATE / 2);
+  });
+
+  it("Slice returns the requested decoded section", async () => {
+    const out = outputWav(
+      await new SliceAudioNode({ audio: wavRef(), start: 0.25, end: 0.75 }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(out!.samples.length).toBe(SAMPLE_RATE / 2);
+  });
+
+  it("FadeIn attenuates the start of decoded WAV", async () => {
+    const out = outputWav(
+      await new FadeInAudioNode({ audio: wavRef(), duration: 0.1 }).process()
+    );
+    expect(out).not.toBeNull();
+    // First sample is silenced by the fade; the steady region keeps full level.
+    expect(Math.abs(out!.samples[0])).toBeLessThan(0.01);
+    expect(Math.abs(out!.samples[out!.samples.length - 1])).toBeCloseTo(AMPLITUDE, 1);
+  });
+
+  it("FadeOut attenuates the end of decoded WAV", async () => {
+    const out = outputWav(
+      await new FadeOutAudioNode({ audio: wavRef(), duration: 0.1 }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(Math.abs(out!.samples[0])).toBeCloseTo(AMPLITUDE, 1);
+    // Last sample is heavily attenuated relative to the un-faded start.
+    expect(Math.abs(out!.samples[out!.samples.length - 1])).toBeLessThan(0.01);
+  });
+
+  it("Concat joins decoded WAV parts in sample space", async () => {
+    const out = outputWav(
+      await new ConcatAudioNode({ a: wavRef(), b: wavRef() }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(out!.samples.length).toBe(SAMPLE_RATE * 2);
+  });
+
+  it("ConcatList joins decoded WAV parts", async () => {
+    const out = outputWav(
+      await new ConcatAudioListNode({ audio_files: [wavRef(), wavRef()] }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(out!.samples.length).toBe(SAMPLE_RATE * 2);
+  });
+
+  it("Mixer mixes decoded WAV tracks", async () => {
+    const out = outputWav(
+      await new AudioMixerNode({ a: wavRef(), b: wavRef() }).process()
+    );
+    expect(out).not.toBeNull();
+    expect(out!.samples.length).toBe(SAMPLE_RATE);
+  });
+});
+
+describe("undecodable mp3 input throws instead of passing through", () => {
+  it("Normalize throws", async () => {
+    await expect(
+      new NormalizeAudioNode({ audio: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+
+  it("Trim throws", async () => {
+    await expect(
+      new TrimAudioNode({ audio: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+
+  it("Slice throws", async () => {
+    await expect(
+      new SliceAudioNode({ audio: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+
+  it("FadeIn throws", async () => {
+    await expect(
+      new FadeInAudioNode({ audio: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+
+  it("Concat throws", async () => {
+    await expect(
+      new ConcatAudioNode({ a: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+
+  it("Mixer throws", async () => {
+    await expect(
+      new AudioMixerNode({ a: undecodableRef() }).process()
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Done. Committed on the task branch.

## Summary

Commit e9fafbb7 claimed to route the AUDIO_NODES transforms through `decodeAudioToWav` and make them throw on undecodable input, but only `lib-audio-effects`/`lib-audio-dsp` were actually migrated. The listed transforms still called `parseWavBytes`/`tryDecodeWav` and silently returned the *undecoded* input on mp3/flac — a no-op that's indistinguishable from a working effect. I finished the migration for the transforms named in the task.

**What changed** (`packages/audio-nodes/src/nodes/audio.ts`):
- **Normalize, Slice, Trim, FadeIn, FadeOut** — swapped `audioBytesAsync` + `parseWavBytes`/`tryDecodeWav` (silent raw-byte fallback) for `requireAudioBytes` + `decodeAudioToWav`, matching the effects/DSP pattern. WAV parses directly; other formats decode via WebAudio; undecodable input throws.
- **AudioMixer** and the shared **`concatAudio()`** helper (used by **Concat** and **ConcatList**) — now decode every track/part via `decodeAudioToWav` (throws on undecodable) and throw a clear error on non-uniform sample-rate/channel layouts instead of the old meaningless byte-level fallback. Empty/unconnected dynamic inputs are still skipped, so multi-input nodes don't throw on default refs.
- Removed the now-unused `tryDecodeWav` import.

**Test added** (`packages/audio-nodes/tests/audio-transform-decode.test.ts`): pins both halves of the contract — each transform processes decoded WAV correctly, and corrupt/undecodable bytes make it throw rather than pass through. Full package suite: **75 passing**, lint clean.

**Caveat / follow-up:** the other transforms with the same silent-passthrough fallback — Overlay, RemoveSilence, MonoToStereo, StereoToMono, Reverse, Repeat — are outside this task's listed set and were left untouched. They'd be worth migrating for consistency in a follow-up. (Noted on the task.)

Note: the workspace-level `npm run build` fails in this worktree because the root `node_modules/typescript` isn't installed — a pre-existing env issue, not from this change. `npx tsc --build`, `npm run lint`, and `npm test` all pass within the package.

---

Closes task **T-20260619-0005**: #5 e9fafbb7 audio transforms still silently pass through undecoded input.


### Acceptance criteria
- [ ] Normalize/Trim/Slice/Fade/Concat/Mixer decode via decodeAudioToWav
- [ ] mp3/flac input that cannot be decoded throws instead of passing through silently
- [ ] Test: a transform on mp3 input either processes decoded audio or throws