### PR TITLE
[T-20260619-0002] #2 Bridge setTarget() race clobbers new worker target

### DIFF
--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -206,6 +206,16 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
     this._reconnecting = false;
     this._reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
 
+    // Abort any in-flight handshake (CONNECTING socket) before tearing down.
+    // _teardownSocket only acts on this._ws, but a handshake in progress lives
+    // only in the _openTransport closure — without aborting it, its finishSuccess
+    // would later set this._ws and clobber the new target's socket.
+    if (this._abortHandshake) {
+      const abort = this._abortHandshake;
+      this._abortHandshake = null;
+      abort(new Error("Python worker re-pointed via setTarget"));
+    }
+
     // Tear down the current socket (detaches listeners → no spurious
     // _onUnexpectedClose) and reject in-flight requests, then drive a fresh
     // connect against the new target via the reconnect path.

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -22,6 +22,12 @@ export const FAKE_NODE = {
 };
 
 export interface FakeWorkerOptions {
+  /**
+   * When true, the first WebSocket upgrade is held until releaseUpgrade() is
+   * called on the handle. Used to reproduce in-flight handshake races where
+   * a late-resolving connect() could clobber a subsequent setTarget().
+   */
+  gateUpgrade?: boolean;
   /** When false, discover requests are silently ignored (no reply). */
   answerDiscover?: boolean;
   /** When false, worker.status requests are silently ignored (no reply). */
@@ -72,6 +78,11 @@ export interface FakeWorkerHandle {
   setOptions: (opts: FakeWorkerOptions) => void;
   /** The raw frames received for a given message type (for assertion). */
   received: (type: string) => Array<Record<string, unknown>>;
+  /**
+   * Release the pending WebSocket upgrade held by gateUpgrade: true.
+   * No-op when gateUpgrade was false or after the upgrade was already released.
+   */
+  releaseUpgrade: () => void;
 }
 
 /**
@@ -82,7 +93,22 @@ export function startFakeWorker(
   port = 0,
   initialOptions: FakeWorkerOptions = {}
 ): Promise<FakeWorkerHandle> {
-  const wss = new WebSocketServer({ port });
+  // When gateUpgrade: true, the first WS upgrade is held until releaseUpgrade()
+  // is called. Captured via verifyClient's async callback form.
+  let pendingRelease: (() => void) | null = null;
+  const verifyClient = initialOptions.gateUpgrade
+    ? (
+        _info: Record<string, unknown>,
+        cb: (res: boolean) => void
+      ) => {
+        pendingRelease = () => {
+          pendingRelease = null;
+          cb(true);
+        };
+      }
+    : undefined;
+
+  const wss = new WebSocketServer({ port, verifyClient });
   const sockets = new Set<WsServerSocket>();
   const authHeaders: Array<string | undefined> = [];
   const receivedByType = new Map<string, Array<Record<string, unknown>>>();
@@ -330,7 +356,10 @@ export function startFakeWorker(
         setOptions: (next: FakeWorkerOptions) => {
           Object.assign(opts, next);
         },
-        received: (t: string) => receivedByType.get(t) ?? []
+        received: (t: string) => receivedByType.get(t) ?? [],
+        releaseUpgrade: () => {
+          pendingRelease?.();
+        }
       });
     });
   });

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -610,6 +610,65 @@ describe("WebsocketPythonBridge", () => {
       }
     });
 
+    it("late-resolving old-URL handshake cannot clobber the new target (provision→setTarget race)", async () => {
+      // RACE REPRO: the bridge is mid-handshake with worker A (CONNECTING, not
+      // yet assigned to this._ws) when setTarget(workerB) is called. Without the
+      // fix, worker A's finishSuccess would later set this._ws and clobber the
+      // new target. With the fix, setTarget calls _abortHandshake first, so the
+      // A socket is terminated and its finishSuccess never fires.
+      const workerA = await startFakeWorker(0, { gateUpgrade: true });
+      const workerB = await startFakeWorker();
+      try {
+        bridge = new WebsocketPythonBridge({
+          wsUrl: `ws://127.0.0.1:${workerA.port}`,
+          startupTimeoutMs: 5000,
+          maxReconnectDelayMs: 50
+        });
+
+        // Start connect() without awaiting — worker A's upgrade is gated so the
+        // handshake is in-flight (CONNECTING) but will never resolve until we call
+        // releaseUpgrade(). The bridge holds _abortHandshake pointing at this closure.
+        const connectP = bridge.connect().catch(() => {
+          // expected to reject — the handshake gets aborted by setTarget
+        });
+
+        // Give the TCP connection to worker A a moment to establish so the socket
+        // is genuinely CONNECTING (not just queued).
+        await new Promise((r) => setTimeout(r, 30));
+
+        let reconnected = false;
+        bridge.on("reconnected", () => { reconnected = true; });
+
+        // Re-point at worker B while A's handshake is still in flight.
+        bridge.setTarget(`ws://127.0.0.1:${workerB.port}`, "b-token");
+
+        // Release worker A's gated upgrade — without the fix this finishSuccess
+        // would set this._ws to the A socket, clobbering whatever B's reconnect
+        // established. With the fix, _abortHandshake was already called (settled=true)
+        // so finishSuccess is a no-op.
+        workerA.releaseUpgrade();
+
+        // Wait for the connect() promise (it must reject — A was aborted).
+        await connectP;
+
+        // Bridge must reconnect to worker B.
+        await waitFor(() => reconnected, 10000);
+
+        expect(bridge.isConnected).toBe(true);
+        expect(bridge.wsUrl).toBe(`ws://127.0.0.1:${workerB.port}`);
+        expect(workerB.authHeaders()).toEqual(["Bearer b-token"]);
+
+        // RPC must reach worker B, not the clobbered worker A socket.
+        const result = await bridge.execute("fake.TestNode", { value: "on-b" }, {}, {});
+        expect(result.outputs).toEqual({ out: "on-b" });
+        // Worker A must have received zero execute frames.
+        expect(workerA.received("execute")).toHaveLength(0);
+      } finally {
+        await workerA.close();
+        await workerB.close();
+      }
+    });
+
     it("rejects in-flight requests on the forced reconnect", async () => {
       // Worker A accepts the socket and answers connect, but never answers
       // execute, so the request stays pending. setTarget must reject it (the


### PR DESCRIPTION
Fixed `setTarget` in `python-websocket-bridge.ts` so it aborts any in-flight handshake before tearing down the current socket and starting a reconnect to the new target.

**What changed:**
- `packages/runtime/src/python-websocket-bridge.ts` — `setTarget()` now calls `_abortHandshake` (same pattern as `close()`) before `_teardownSocket`. The abort sets `settled = true` in the `_openTransport` closure, making any subsequent `finishSuccess` a no-op so the old socket can never overwrite `this._ws`.
- `packages/runtime/tests/python-websocket-bridge.test-helpers.ts` — Added `gateUpgrade: boolean` option to `FakeWorkerOptions` and `releaseUpgrade()` to `FakeWorkerHandle`. Uses `verifyClient`'s async callback form to hold the WS upgrade server-side until released, enabling deterministic reproduction of the race.
- `packages/runtime/tests/python-websocket-bridge.test.ts` — New test in the `setTarget` block: starts a bridge mid-handshake to gated worker A, calls `setTarget(workerB)`, releases A's gate, then asserts the bridge is connected to worker B and that worker A received no execute frames.

---

Closes task **T-20260619-0002**: #2 Bridge setTarget() race clobbers new worker target.


### Acceptance criteria
- [x] setTarget aborts any in-flight initial handshake before connecting to the new target
- [x] A late-resolving old-URL handshake can no longer overwrite this._ws
- [x] Test: provision→attach→setTarget leaves bridge on the new URL/token