### PR TITLE
Backend hardening: provider seams, lifecycle, and correctness fixes

### DIFF
--- a/packages/agents/src/tools/find-model-tool.ts
+++ b/packages/agents/src/tools/find-model-tool.ts
@@ -22,10 +22,7 @@ import type {
   TTSModel,
   VideoModel
 } from "@nodetool-ai/runtime";
-import {
-  RECOMMENDED_MODELS,
-  providerCapabilities
-} from "@nodetool-ai/runtime";
+import { RECOMMENDED_MODELS } from "@nodetool-ai/runtime";
 import type { RecommendedUnifiedModel } from "@nodetool-ai/runtime";
 import { Tool } from "./base-tool.js";
 
@@ -253,9 +250,9 @@ export class FindModelTool extends Tool {
     for (const [providerId, instance] of providerEntries) {
       let supports: boolean;
       try {
-        supports = providerCapabilities(instance).includes(
-          capability as ProviderCapability
-        );
+        supports = instance
+          .getCapabilities()
+          .includes(capability as ProviderCapability);
       } catch {
         continue;
       }

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Agent Google Search.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Agent Google Search.json
@@ -20,7 +20,7 @@
       {
         "id": "d511b097-2af9-4cc4-a497-ec2452c8a609",
         "source": "6ababfd3-5743-4d7c-accd-97242130a8d8",
-        "sourceHandle": "search",
+        "sourceHandle": "text",
         "target": "d6a1dc18-d26c-45c4-9196-2d6524018b1b",
         "targetHandle": "keyword",
         "ui_properties": {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Color Boost Video.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Color Boost Video.json
@@ -189,14 +189,6 @@
         "target": "4ca8874f-5caa-413c-a329-936d90358e8e",
         "targetHandle": "fps",
         "ui_properties": null
-      },
-      {
-        "id": "6f67faa9-9b15-4fd0-881f-93f4f93b735d",
-        "source": "abb8ee0b-dbf0-4969-8046-c2e690b7d1e4",
-        "sourceHandle": "event",
-        "target": "4ca8874f-5caa-413c-a329-936d90358e8e",
-        "targetHandle": "event",
-        "ui_properties": null
       }
     ]
   },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Competitive Analysis.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Competitive Analysis.json
@@ -324,7 +324,7 @@
       {
         "id": "3",
         "source": "7",
-        "sourceHandle": "output",
+        "sourceHandle": "text",
         "target": "6",
         "targetHandle": "asana_info",
         "ui_properties": null
@@ -332,7 +332,7 @@
       {
         "id": "4",
         "source": "8",
-        "sourceHandle": "output",
+        "sourceHandle": "text",
         "target": "6",
         "targetHandle": "monday_info",
         "ui_properties": null
@@ -340,7 +340,7 @@
       {
         "id": "5",
         "source": "9",
-        "sourceHandle": "output",
+        "sourceHandle": "text",
         "target": "6",
         "targetHandle": "jira_info",
         "ui_properties": null

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Data Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Data Generator.json
@@ -96,7 +96,7 @@
       {
         "id": "6046a17f-2fe2-4884-bedc-b995b6e8ffbe",
         "source": "2ed27bde-9299-4088-a169-156b1ea5552f",
-        "sourceHandle": "output",
+        "sourceHandle": "dataframe",
         "target": "2",
         "targetHandle": "value",
         "ui_properties": null

--- a/packages/cli/src/websocket-client.ts
+++ b/packages/cli/src/websocket-client.ts
@@ -56,6 +56,11 @@ export class WebSocketChatClient {
   async connect(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const ws = new WebSocket(this.wsUrl);
+      // Guard so the connect promise settles exactly once: the "error" listener
+      // stays attached for the socket's lifetime, so without this a post-connect
+      // error would call reject() on an already-resolved promise and be silently
+      // swallowed (and an unhandled "error" event would otherwise crash Node).
+      let settled = false;
 
       ws.on("open", () => {
         this.ws = ws;
@@ -63,10 +68,23 @@ export class WebSocketChatClient {
         ws.send(
           JSON.stringify({ command: "set_mode", data: { mode: "text" } })
         );
-        resolve();
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
       });
 
-      ws.on("error", (err) => reject(err));
+      ws.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+          return;
+        }
+        // Error after a successful connect: tear down and unblock any waiting
+        // generators so they terminate instead of hanging forever.
+        this.ws = null;
+        this.drainWaiters();
+      });
 
       ws.on("message", (data: Buffer | string) => {
         try {
@@ -81,11 +99,16 @@ export class WebSocketChatClient {
 
       ws.on("close", () => {
         this.ws = null;
-        // Unblock all pending waiters
-        for (const waiter of this.contentWaiters) waiter(null);
-        this.contentWaiters = [];
+        this.drainWaiters();
       });
     });
+  }
+
+  /** Unblock all pending content waiters with null (stream end). */
+  private drainWaiters(): void {
+    const waiters = this.contentWaiters;
+    this.contentWaiters = [];
+    for (const waiter of waiters) waiter(null);
   }
 
   private handleMessage(msg: Record<string, unknown>): void {

--- a/packages/cli/tests/websocket-client.test.ts
+++ b/packages/cli/tests/websocket-client.test.ts
@@ -200,6 +200,15 @@ describe("WebSocketChatClient.chat", () => {
     expect((await p).value).toMatchObject({ type: "done" });
   });
 
+  it("terminates a waiting generator when the socket errors after connect", async () => {
+    const client = await makeConnectedClient();
+    const gen = client.chat("hi", "t1", "gpt-4o", "openai");
+    const p = gen.next();
+    // A post-connect error must unblock the waiter instead of hanging forever.
+    currentFakeWs.error(new Error("socket reset"));
+    expect((await p).value).toMatchObject({ type: "done" });
+  });
+
   it("yields output_update events", async () => {
     const client = await makeConnectedClient();
     const gen = client.chat("hi", "t1", "gpt-4o", "openai");

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -29,6 +29,32 @@ export class ContainerFailureError extends Error {
   }
 }
 
+/**
+ * Terminate a child process gracefully, then force-kill if it ignores SIGTERM.
+ * Without the SIGKILL escalation a runaway/hung subprocess (one that traps or
+ * ignores SIGTERM) survives timeouts and stop(), leaking CPU/memory.
+ */
+function terminateChild(child: ChildProcess, graceMs = 3000): void {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    return;
+  }
+  const timer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore — process may have just exited
+      }
+    }
+  }, graceMs);
+  // Don't keep the event loop alive solely for the force-kill timer.
+  if (typeof timer.unref === "function") timer.unref();
+  child.once("exit", () => clearTimeout(timer));
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -204,14 +230,10 @@ export class StreamRunnerBase {
       r();
     }
 
-    // Kill local subprocess if active
+    // Kill local subprocess if active (force-kill if it ignores SIGTERM)
     const child = this._activeChild;
     if (child && child.exitCode === null) {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // ignore
-      }
+      terminateChild(child);
     }
 
     // Force-remove Docker container if active
@@ -741,13 +763,7 @@ export class StreamRunnerBase {
       if (this.timeoutSeconds > 0) {
         timeoutHandle = setTimeout(() => {
           timedOut = true;
-          try {
-            if (child.exitCode === null) {
-              child.kill("SIGTERM");
-            }
-          } catch {
-            // ignore
-          }
+          terminateChild(child);
         }, this.timeoutSeconds * 1000);
       }
 
@@ -792,13 +808,9 @@ export class StreamRunnerBase {
       if (timeoutHandle !== null) {
         clearTimeout(timeoutHandle);
       }
-      // Ensure child is terminated
-      try {
-        if (child.exitCode === null) {
-          child.kill("SIGTERM");
-        }
-      } catch {
-        // ignore
+      // Ensure child is terminated (force-kill if it ignores SIGTERM)
+      if (child.exitCode === null) {
+        terminateChild(child);
       }
       // Cleanup wrapper resources
       if (cleanupData !== null) {

--- a/packages/huggingface-nodes/src/nodes/audio.ts
+++ b/packages/huggingface-nodes/src/nodes/audio.ts
@@ -7,7 +7,6 @@ import {
   type MediaRef
 } from "../huggingface-base.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const EMPTY_AUDIO = {
   type: "audio",
@@ -40,7 +39,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
     title: "Model",
     description: "Automatic-speech-recognition model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "audio",
@@ -48,7 +47,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
     title: "Audio",
     description: "The audio to transcribe."
   })
-  declare audio: any;
+  declare audio: MediaRef;
 
   @prop({
     type: "bool",
@@ -56,7 +55,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
     title: "Return Timestamps",
     description: "Also return per-chunk timestamps."
   })
-  declare return_timestamps: any;
+  declare return_timestamps: boolean;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
@@ -110,7 +109,7 @@ export class AudioClassificationNode extends BaseNode {
     title: "Model",
     description: "Audio-classification model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "audio",
@@ -118,7 +117,7 @@ export class AudioClassificationNode extends BaseNode {
     title: "Audio",
     description: "The audio to classify."
   })
-  declare audio: any;
+  declare audio: MediaRef;
 
   @prop({
     type: "int",
@@ -128,7 +127,7 @@ export class AudioClassificationNode extends BaseNode {
     min: 1,
     max: 100
   })
-  declare top_k: any;
+  declare top_k: number;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]

--- a/packages/huggingface-nodes/src/nodes/image.ts
+++ b/packages/huggingface-nodes/src/nodes/image.ts
@@ -11,7 +11,6 @@ import {
   type MediaRef
 } from "../huggingface-base.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const EMPTY_IMAGE = {
   type: "image",
@@ -47,7 +46,7 @@ export class TextToImageNode extends BaseNode {
     description:
       "Text-to-image model repo id (e.g. black-forest-labs/FLUX.1-schnell, stabilityai/stable-diffusion-xl-base-1.0)."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -55,7 +54,7 @@ export class TextToImageNode extends BaseNode {
     title: "Prompt",
     description: "The text prompt describing the image."
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -63,7 +62,7 @@ export class TextToImageNode extends BaseNode {
     title: "Negative Prompt",
     description: "What the image should NOT contain."
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "int",
@@ -73,7 +72,7 @@ export class TextToImageNode extends BaseNode {
     min: 0,
     max: 2048
   })
-  declare width: any;
+  declare width: number;
 
   @prop({
     type: "int",
@@ -83,7 +82,7 @@ export class TextToImageNode extends BaseNode {
     min: 0,
     max: 2048
   })
-  declare height: any;
+  declare height: number;
 
   @prop({
     type: "float",
@@ -93,7 +92,7 @@ export class TextToImageNode extends BaseNode {
     min: 0,
     max: 30
   })
-  declare guidance_scale: any;
+  declare guidance_scale: number;
 
   @prop({
     type: "int",
@@ -103,7 +102,7 @@ export class TextToImageNode extends BaseNode {
     min: 0,
     max: 100
   })
-  declare num_inference_steps: any;
+  declare num_inference_steps: number;
 
   @prop({
     type: "int",
@@ -113,7 +112,7 @@ export class TextToImageNode extends BaseNode {
     min: -1,
     max: 4294967295
   })
-  declare seed: any;
+  declare seed: number;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -174,7 +173,7 @@ export class ImageToImageNode extends BaseNode {
     title: "Model",
     description: "Image-to-image model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "image",
@@ -182,7 +181,7 @@ export class ImageToImageNode extends BaseNode {
     title: "Image",
     description: "The source image to transform."
   })
-  declare image: any;
+  declare image: MediaRef;
 
   @prop({
     type: "str",
@@ -190,7 +189,7 @@ export class ImageToImageNode extends BaseNode {
     title: "Prompt",
     description: "Text prompt guiding the transformation."
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -198,7 +197,7 @@ export class ImageToImageNode extends BaseNode {
     title: "Negative Prompt",
     description: "What the result should NOT contain."
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "float",
@@ -208,7 +207,7 @@ export class ImageToImageNode extends BaseNode {
     min: 0,
     max: 30
   })
-  declare guidance_scale: any;
+  declare guidance_scale: number;
 
   @prop({
     type: "int",
@@ -218,7 +217,7 @@ export class ImageToImageNode extends BaseNode {
     min: 0,
     max: 100
   })
-  declare num_inference_steps: any;
+  declare num_inference_steps: number;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
@@ -276,7 +275,7 @@ export class ImageClassificationNode extends BaseNode {
     title: "Model",
     description: "Image-classification model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "image",
@@ -284,7 +283,7 @@ export class ImageClassificationNode extends BaseNode {
     title: "Image",
     description: "The image to classify."
   })
-  declare image: any;
+  declare image: MediaRef;
 
   @prop({
     type: "int",
@@ -294,7 +293,7 @@ export class ImageClassificationNode extends BaseNode {
     min: 1,
     max: 100
   })
-  declare top_k: any;
+  declare top_k: number;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
@@ -341,7 +340,7 @@ export class ImageSegmentationNode extends BaseNode {
     title: "Model",
     description: "Image-segmentation model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "image",
@@ -349,7 +348,7 @@ export class ImageSegmentationNode extends BaseNode {
     title: "Image",
     description: "The image to segment."
   })
-  declare image: any;
+  declare image: MediaRef;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
@@ -401,7 +400,7 @@ export class ObjectDetectionNode extends BaseNode {
     title: "Model",
     description: "Object-detection model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "image",
@@ -409,7 +408,7 @@ export class ObjectDetectionNode extends BaseNode {
     title: "Image",
     description: "The image to analyze."
   })
-  declare image: any;
+  declare image: MediaRef;
 
   @prop({
     type: "float",
@@ -419,7 +418,7 @@ export class ObjectDetectionNode extends BaseNode {
     min: 0,
     max: 1
   })
-  declare threshold: any;
+  declare threshold: number;
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]

--- a/packages/huggingface-nodes/src/nodes/text.ts
+++ b/packages/huggingface-nodes/src/nodes/text.ts
@@ -7,7 +7,6 @@ import {
   hfPipelineJson
 } from "../huggingface-base.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 // ---------------------------------------------------------------------------
 // Chat Completion
@@ -33,7 +32,7 @@ export class ChatCompletionNode extends BaseNode {
     description:
       "Conversational model repo id (e.g. meta-llama/Llama-3.1-8B-Instruct, Qwen/Qwen2.5-7B-Instruct, openai/gpt-oss-120b)."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -41,7 +40,7 @@ export class ChatCompletionNode extends BaseNode {
     title: "System",
     description: "Optional system prompt setting the assistant's behavior."
   })
-  declare system: any;
+  declare system: string;
 
   @prop({
     type: "str",
@@ -49,7 +48,7 @@ export class ChatCompletionNode extends BaseNode {
     title: "Prompt",
     description: "The user message to send to the model."
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "int",
@@ -59,7 +58,7 @@ export class ChatCompletionNode extends BaseNode {
     min: 1,
     max: 32768
   })
-  declare max_tokens: any;
+  declare max_tokens: number;
 
   @prop({
     type: "float",
@@ -69,7 +68,7 @@ export class ChatCompletionNode extends BaseNode {
     min: 0,
     max: 2
   })
-  declare temperature: any;
+  declare temperature: number;
 
   @prop({
     type: "float",
@@ -79,7 +78,7 @@ export class ChatCompletionNode extends BaseNode {
     min: 0,
     max: 1
   })
-  declare top_p: any;
+  declare top_p: number;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -126,7 +125,7 @@ export class TextGenerationNode extends BaseNode {
     title: "Model",
     description: "Text-generation model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -134,7 +133,7 @@ export class TextGenerationNode extends BaseNode {
     title: "Prompt",
     description: "The text prompt to continue."
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "int",
@@ -144,7 +143,7 @@ export class TextGenerationNode extends BaseNode {
     min: 1,
     max: 8192
   })
-  declare max_new_tokens: any;
+  declare max_new_tokens: number;
 
   @prop({
     type: "float",
@@ -154,7 +153,7 @@ export class TextGenerationNode extends BaseNode {
     min: 0,
     max: 2
   })
-  declare temperature: any;
+  declare temperature: number;
 
   @prop({
     type: "bool",
@@ -162,7 +161,7 @@ export class TextGenerationNode extends BaseNode {
     title: "Return Full Text",
     description: "Include the prompt in the returned text."
   })
-  declare return_full_text: any;
+  declare return_full_text: boolean;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -208,7 +207,7 @@ export class SummarizationNode extends BaseNode {
     title: "Model",
     description: "Summarization model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -216,7 +215,7 @@ export class SummarizationNode extends BaseNode {
     title: "Text",
     description: "The text to summarize."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   @prop({
     type: "int",
@@ -226,7 +225,7 @@ export class SummarizationNode extends BaseNode {
     min: 0,
     max: 2048
   })
-  declare max_length: any;
+  declare max_length: number;
 
   @prop({
     type: "int",
@@ -236,7 +235,7 @@ export class SummarizationNode extends BaseNode {
     min: 0,
     max: 2048
   })
-  declare min_length: any;
+  declare min_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -285,7 +284,7 @@ export class TranslationNode extends BaseNode {
     description:
       "Translation model repo id (e.g. facebook/nllb-200-distilled-600M, Helsinki-NLP/opus-mt-en-fr)."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -293,7 +292,7 @@ export class TranslationNode extends BaseNode {
     title: "Text",
     description: "The text to translate."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   @prop({
     type: "str",
@@ -302,7 +301,7 @@ export class TranslationNode extends BaseNode {
     description:
       "Optional source language code for multilingual models (e.g. eng_Latn)."
   })
-  declare src_lang: any;
+  declare src_lang: string;
 
   @prop({
     type: "str",
@@ -311,7 +310,7 @@ export class TranslationNode extends BaseNode {
     description:
       "Optional target language code for multilingual models (e.g. fra_Latn)."
   })
-  declare tgt_lang: any;
+  declare tgt_lang: string;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -356,7 +355,7 @@ export class FillMaskNode extends BaseNode {
     title: "Model",
     description: "Fill-mask model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -365,7 +364,7 @@ export class FillMaskNode extends BaseNode {
     description:
       "Text containing a mask token (e.g. [MASK] for BERT, <mask> for RoBERTa)."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -408,7 +407,7 @@ export class QuestionAnsweringNode extends BaseNode {
     title: "Model",
     description: "Question-answering model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -416,7 +415,7 @@ export class QuestionAnsweringNode extends BaseNode {
     title: "Question",
     description: "The question to answer."
   })
-  declare question: any;
+  declare question: string;
 
   @prop({
     type: "str",
@@ -424,7 +423,7 @@ export class QuestionAnsweringNode extends BaseNode {
     title: "Context",
     description: "The passage that contains the answer."
   })
-  declare context: any;
+  declare context: string;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -477,7 +476,7 @@ export class TableQuestionAnsweringNode extends BaseNode {
     title: "Model",
     description: "Table-question-answering model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -485,7 +484,7 @@ export class TableQuestionAnsweringNode extends BaseNode {
     title: "Question",
     description: "The question to ask about the table."
   })
-  declare question: any;
+  declare question: string;
 
   @prop({
     type: "dict",
@@ -494,7 +493,7 @@ export class TableQuestionAnsweringNode extends BaseNode {
     description:
       "The table as an object mapping each column name to an array of string cell values."
   })
-  declare table: any;
+  declare table: Record<string, unknown>;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -553,7 +552,7 @@ export class FeatureExtractionNode extends BaseNode {
     title: "Model",
     description: "Feature-extraction / embedding model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -561,7 +560,7 @@ export class FeatureExtractionNode extends BaseNode {
     title: "Text",
     description: "The text to embed."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   @prop({
     type: "bool",
@@ -569,7 +568,7 @@ export class FeatureExtractionNode extends BaseNode {
     title: "Normalize",
     description: "L2-normalize the returned embedding."
   })
-  declare normalize: any;
+  declare normalize: boolean;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -612,7 +611,7 @@ export class TextClassificationNode extends BaseNode {
     title: "Model",
     description: "Text-classification model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -620,7 +619,7 @@ export class TextClassificationNode extends BaseNode {
     title: "Text",
     description: "The text to classify."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -667,7 +666,7 @@ export class TokenClassificationNode extends BaseNode {
     title: "Model",
     description: "Token-classification / NER model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -675,7 +674,7 @@ export class TokenClassificationNode extends BaseNode {
     title: "Text",
     description: "The text to analyze."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   @prop({
     type: "enum",
@@ -684,7 +683,7 @@ export class TokenClassificationNode extends BaseNode {
     description: "How to group sub-word tokens into entities.",
     values: ["none", "simple", "first", "average", "max"]
   })
-  declare aggregation_strategy: any;
+  declare aggregation_strategy: string;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);
@@ -728,7 +727,7 @@ export class ZeroShotClassificationNode extends BaseNode {
     title: "Model",
     description: "Zero-shot-classification model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -736,7 +735,7 @@ export class ZeroShotClassificationNode extends BaseNode {
     title: "Text",
     description: "The text to classify."
   })
-  declare inputs: any;
+  declare inputs: string;
 
   @prop({
     type: "str",
@@ -744,7 +743,7 @@ export class ZeroShotClassificationNode extends BaseNode {
     title: "Candidate Labels",
     description: "Comma-separated list of candidate labels."
   })
-  declare candidate_labels: any;
+  declare candidate_labels: string;
 
   @prop({
     type: "bool",
@@ -752,7 +751,7 @@ export class ZeroShotClassificationNode extends BaseNode {
     title: "Multi Label",
     description: "Allow multiple labels to be true at once."
   })
-  declare multi_label: any;
+  declare multi_label: boolean;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);

--- a/packages/huggingface-nodes/src/nodes/video.ts
+++ b/packages/huggingface-nodes/src/nodes/video.ts
@@ -7,7 +7,6 @@ import {
   videoRefFromBytes
 } from "../huggingface-base.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 // ---------------------------------------------------------------------------
 // Text to Video
@@ -34,7 +33,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Model",
     description: "Text-to-video model repo id."
   })
-  declare model: any;
+  declare model: string;
 
   @prop({
     type: "str",
@@ -42,7 +41,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Prompt",
     description: "The text prompt describing the video."
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -50,7 +49,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Negative Prompt",
     description: "What the video should NOT contain."
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "int",
@@ -60,7 +59,7 @@ export class TextToVideoNode extends BaseNode {
     min: 0,
     max: 300
   })
-  declare num_frames: any;
+  declare num_frames: number;
 
   @prop({
     type: "float",
@@ -70,7 +69,7 @@ export class TextToVideoNode extends BaseNode {
     min: 0,
     max: 30
   })
-  declare guidance_scale: any;
+  declare guidance_scale: number;
 
   @prop({
     type: "int",
@@ -80,7 +79,7 @@ export class TextToVideoNode extends BaseNode {
     min: 0,
     max: 100
   })
-  declare num_inference_steps: any;
+  declare num_inference_steps: number;
 
   @prop({
     type: "int",
@@ -90,7 +89,7 @@ export class TextToVideoNode extends BaseNode {
     min: -1,
     max: 4294967295
   })
-  declare seed: any;
+  declare seed: number;
 
   async process(): Promise<Record<string, unknown>> {
     const token = getHfToken(this._secrets);

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -802,8 +802,52 @@ export class Graph {
    */
   validate(): void {
     this.validateEdgeEndpoints();
+    this.validateDataEdgeSourceHandles();
     this.validateControlEdges();
     this.validateEdgeTypes();
+  }
+
+  /**
+   * Verify that every data edge's `sourceHandle` is a declared output of its
+   * source node. Without this, an edge wired to a nonexistent output handle
+   * passes validation and then silently never delivers a value at runtime
+   * (`validateEdgeTypes` skips it for lack of a source type), leaving the
+   * target node waiting forever.
+   *
+   * Only enforced when the source node declares a non-empty static `outputs`
+   * map and does not produce dynamic outputs (whose handles aren't known
+   * statically). Nodes without output metadata are left untouched.
+   */
+  validateDataEdgeSourceHandles(): void {
+    for (const edge of this.edges) {
+      if (!isDataEdge(edge)) continue;
+      const sourceNode = this._nodeIndex.get(edge.source);
+      // Endpoint existence is enforced by validateEdgeEndpoints().
+      if (!sourceNode) continue;
+      const outputs = sourceNode.outputs;
+      if (!outputs || Object.keys(outputs).length === 0) continue;
+      if (
+        sourceNode.dynamic_outputs &&
+        Object.keys(sourceNode.dynamic_outputs).length > 0
+      ) {
+        continue;
+      }
+      if (!(edge.sourceHandle in outputs)) {
+        throw new GraphValidationError(
+          `Edge ${edge.id ?? syntheticEdgeId(edge.source, edge.sourceHandle, edge.target, edge.targetHandle)} ` +
+            `references unknown output "${edge.sourceHandle}" on node "${edge.source}"` +
+            `${sourceNode.type ? ` (${sourceNode.type})` : ""}`,
+          [
+            {
+              nodeId: edge.source,
+              nodeType: sourceNode.type,
+              property: edge.sourceHandle,
+              message: `Unknown output "${edge.sourceHandle}"`
+            }
+          ]
+        );
+      }
+    }
   }
 
   /**

--- a/packages/kernel/tests/parity-graph-validation.test.ts
+++ b/packages/kernel/tests/parity-graph-validation.test.ts
@@ -224,6 +224,56 @@ describe("Gap #3 – type compatibility checking (validateEdgeTypes)", () => {
   });
 });
 
+describe("validateDataEdgeSourceHandles", () => {
+  it("throws when a data edge references an unknown output handle", () => {
+    const nodes = [
+      makeNode("a", { outputs: { out: "image" } }),
+      makeNode("b", { properties: { in: { type: "image" } } })
+    ];
+    const edges = [makeEdge("a", "missing", "b", "in")];
+    const graph = new Graph({ nodes, edges });
+    expect(() => graph.validateDataEdgeSourceHandles()).toThrow(
+      GraphValidationError
+    );
+    expect(() => graph.validateDataEdgeSourceHandles()).toThrow(
+      /unknown output "missing"/
+    );
+  });
+
+  it("accepts an edge from a declared output handle", () => {
+    const nodes = [
+      makeNode("a", { outputs: { out: "image" } }),
+      makeNode("b", { properties: { in: { type: "image" } } })
+    ];
+    const edges = [makeEdge("a", "out", "b", "in")];
+    const graph = new Graph({ nodes, edges });
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+
+  it("skips nodes without static output metadata", () => {
+    const nodes = [
+      makeNode("a"), // no outputs declared
+      makeNode("b", { properties: { in: { type: "image" } } })
+    ];
+    const edges = [makeEdge("a", "anything", "b", "in")];
+    const graph = new Graph({ nodes, edges });
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+
+  it("skips nodes that declare dynamic outputs", () => {
+    const nodes = [
+      makeNode("a", {
+        outputs: { out: "image" },
+        dynamic_outputs: { extra: { type: "str" } }
+      }),
+      makeNode("b", { properties: { in: { type: "image" } } })
+    ];
+    const edges = [makeEdge("a", "extra", "b", "in")];
+    const graph = new Graph({ nodes, edges });
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+});
+
 // ===========================================================================
 // Gap #14: Graph Deserialization
 // ===========================================================================

--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -196,7 +196,7 @@ export class Asset extends DBModel {
 
     const pathInfo = await Asset.getAssetPathInfo(
       userId,
-      items.map((a: Record<string, unknown>) => a.id)
+      items.map((a: Record<string, unknown>) => a.id as string)
     );
 
     const folderPaths: Array<Record<string, string>> = [];

--- a/packages/models/src/base-model.ts
+++ b/packages/models/src/base-model.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
-import { eq } from "drizzle-orm";
+import { Column, eq, getTableColumns, Table } from "drizzle-orm";
 import { getDb } from "./db.js";
 
 const log = createLogger("nodetool.models");
@@ -92,17 +92,28 @@ export function computeEtag(data: Record<string, unknown>): string {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle table type varies by dialect; any is required for the base-class pattern.
 export type DrizzleTable = any;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getTableColumn(table: DrizzleTable, colName: string): any {
-  return (table as Record<string, unknown>)[colName];
+// Drizzle's official column accessor. Returns undefined for objects that are
+// not real Drizzle tables (e.g. legacy/test doubles), in which case callers
+// fall back to enumerable keys.
+function drizzleColumns(table: DrizzleTable): Record<string, Column> | undefined {
+  return getTableColumns(table as Table) as Record<string, Column> | undefined;
+}
+
+function getTableColumn(table: DrizzleTable, colName: string): Column {
+  const cols = drizzleColumns(table);
+  const col = cols
+    ? cols[colName]
+    : ((table as Record<string, unknown>)[colName] as Column | undefined);
+  if (!col) {
+    throw new Error(`Column "${colName}" not found on the table schema.`);
+  }
+  return col;
 }
 
 function getColumnNames(table: DrizzleTable): string[] {
-  const cols = (table as unknown as Record<symbol, Record<string, unknown>>)[
-    Symbol.for("drizzle:Columns")
-  ];
+  const cols = drizzleColumns(table);
   if (cols) return Object.keys(cols);
-  return Object.keys(table).filter((k) => !k.startsWith("_"));
+  return Object.keys(table as object).filter((k) => !k.startsWith("_"));
 }
 
 export abstract class DBModel {
@@ -158,7 +169,11 @@ export abstract class DBModel {
       .insert(table)
       .values(row)
       .onConflictDoUpdate({
-        target: pkCol,
+        // pkCol is a generic Column; the SQLite builder's conflict target
+        // wants an IndexColumn, which it is at runtime.
+        target: pkCol as Parameters<
+          ReturnType<ReturnType<typeof db.insert>["values"]>["onConflictDoUpdate"]
+        >[0]["target"],
         set: row
       });
 

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -10,6 +10,8 @@ import {
   drizzle as drizzleSqlite,
   type BetterSQLite3Database
 } from "drizzle-orm/better-sqlite3";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { Sql } from "postgres";
 import * as schema from "./schema/index.js";
 import * as pgSchema from "./schema-pg/index.js";
 import {
@@ -19,11 +21,19 @@ import {
 
 export type DbDialect = "sqlite" | "postgres";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- union of BetterSQLite3Database and PostgresJsDatabase
-let _db: any = null;
+/**
+ * A Drizzle database instance backed by either SQLite (better-sqlite3) or
+ * PostgreSQL (postgres.js). The two dialects expose the same query-builder
+ * surface (`select`/`insert`/`update`/`delete`), so callers can work with
+ * either transparently.
+ */
+export type NodetoolDatabase =
+  | BetterSQLite3Database<typeof schema>
+  | PostgresJsDatabase<typeof pgSchema>;
+
+let _db: NodetoolDatabase | null = null;
 let _sqlite: Database.Database | null = null;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js Sql instance
-let _pgClient: any = null;
+let _pgClient: Sql | null = null;
 let _dbType: DbDialect = "sqlite";
 
 /**
@@ -109,16 +119,18 @@ export function initTestDb(): BetterSQLite3Database<typeof schema> {
 
 /**
  * Get the current database instance.
- * Returns `any` so callers work transparently with both SQLite and PostgreSQL.
- * Throws if not initialized.
+ *
+ * Typed as the SQLite query builder because the two dialects expose the same
+ * `select`/`insert`/`update`/`delete` surface and the model layer is written
+ * against it (a PostgreSQL connection returns the same API, with promises that
+ * the existing `await`s resolve transparently). Throws if not initialized.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getDb(): any {
+export function getDb(): BetterSQLite3Database<typeof schema> {
   if (!_db)
     throw new Error(
       "Database not initialized. Call initDb() or initPostgresDb() first."
     );
-  return _db;
+  return _db as BetterSQLite3Database<typeof schema>;
 }
 
 /**

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -153,6 +153,27 @@ export function getRawDb(): Database.Database {
 }
 
 /**
+ * Verify the database connection is alive with a lightweight query.
+ * Dialect-aware: runs `select 1` over the PostgreSQL client, or a
+ * `quick_check` pragma against the SQLite connection. Throws if the
+ * database is not initialized or the check fails.
+ */
+export async function pingDb(): Promise<void> {
+  if (!_db)
+    throw new Error(
+      "Database not initialized. Call initDb() or initPostgresDb() first."
+    );
+  if (_dbType === "postgres") {
+    if (!_pgClient) throw new Error("PostgreSQL client not initialized.");
+    await _pgClient`select 1`;
+    return;
+  }
+  if (!_sqlite) throw new Error("SQLite database not initialized.");
+  // Fast integrity check — just verifies the connection is alive.
+  _sqlite.pragma("quick_check(1)");
+}
+
+/**
  * Apply pending SQLite migrations to a database file without initializing the
  * global Drizzle connection. Used by local backend startup before initDb().
  */

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -14,6 +14,7 @@ export {
   getDb,
   getDbType,
   getRawDb,
+  pingDb,
   closeDb
 } from "./db.js";
 export type { DbDialect } from "./db.js";

--- a/packages/models/src/run-event.ts
+++ b/packages/models/src/run-event.ts
@@ -5,8 +5,13 @@
  */
 
 import { eq, and, gt, lte, desc, asc } from "drizzle-orm";
-import { DBModel, createTimeOrderedUuid } from "./base-model.js";
-import { getDb } from "./db.js";
+import {
+  DBModel,
+  ModelChangeEvent,
+  ModelObserver,
+  createTimeOrderedUuid
+} from "./base-model.js";
+import { getDb, getDbType } from "./db.js";
 import { runEvents } from "./schema/run-events.js";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -64,15 +69,22 @@ export class RunEvent extends DBModel {
     return rows[0].seq + 1;
   }
 
-  /** Append a new event with automatic sequence number. */
+  /**
+   * Append a new event with an automatic sequence number.
+   *
+   * The next-seq read and the insert run inside a single transaction so two
+   * concurrent appends for the same run can't compute the same seq and collide
+   * on the UNIQUE (run_id, seq) index. Mirrors RunLease.acquire's dual-dialect
+   * transaction pattern (better-sqlite3 transactions must be synchronous).
+   */
   static async appendEvent(
     runId: string,
     eventType: EventType,
     payload: Record<string, unknown>,
     nodeId?: string
   ): Promise<RunEvent> {
-    const seq = await RunEvent.getNextSeq(runId);
-    return RunEvent.create<RunEvent>({
+    const db = getDb();
+    const buildRow = (seq: number): Record<string, unknown> => ({
       id: createTimeOrderedUuid(),
       run_id: runId,
       seq,
@@ -81,6 +93,40 @@ export class RunEvent extends DBModel {
       node_id: nodeId ?? null,
       payload
     });
+
+    let row: Record<string, unknown>;
+    if (getDbType() === "sqlite") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row = db.transaction((tx: any) => {
+        const existing = tx
+          .select({ seq: runEvents.seq })
+          .from(runEvents)
+          .where(eq(runEvents.run_id, runId))
+          .orderBy(desc(runEvents.seq))
+          .limit(1)
+          .get();
+        const r = buildRow(existing ? existing.seq + 1 : 0);
+        tx.insert(runEvents).values(r).run();
+        return r;
+      });
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row = await db.transaction(async (tx: any) => {
+        const rows = await tx
+          .select({ seq: runEvents.seq })
+          .from(runEvents)
+          .where(eq(runEvents.run_id, runId))
+          .orderBy(desc(runEvents.seq))
+          .limit(1);
+        const r = buildRow(rows.length > 0 ? rows[0].seq + 1 : 0);
+        await tx.insert(runEvents).values(r);
+        return r;
+      });
+    }
+
+    const instance = new RunEvent(row);
+    ModelObserver.notify(instance, ModelChangeEvent.CREATED);
+    return instance;
   }
 
   /** Query events for a run with optional filters. */

--- a/packages/models/tests/run-event.test.ts
+++ b/packages/models/tests/run-event.test.ts
@@ -63,6 +63,19 @@ describe("RunEvent model", () => {
     expect(ev.node_id).toBeNull();
   });
 
+  it("assigns distinct sequential seqs to concurrent appends", async () => {
+    const N = 10;
+    const events = await Promise.all(
+      Array.from({ length: N }, () =>
+        RunEvent.appendEvent("race-run", "OutboxEnqueued", {})
+      )
+    );
+    const seqs = events.map((e) => e.seq).sort((a, b) => a - b);
+    // No collisions on the UNIQUE (run_id, seq) index: a contiguous 0..N-1 set.
+    expect(seqs).toEqual(Array.from({ length: N }, (_, i) => i));
+    expect(await RunEvent.getNextSeq("race-run")).toBe(N);
+  });
+
   it("creates an event with node_id", async () => {
     const ev = await RunEvent.appendEvent("r1", "NodeStarted", {}, "node-42");
     expect(ev.node_id).toBe("node-42");

--- a/packages/node-sdk/src/validation.ts
+++ b/packages/node-sdk/src/validation.ts
@@ -91,7 +91,8 @@ function isUnsetAsset(value: unknown): boolean {
   const hasAssetId = typeof assetId === "string" && assetId.length > 0;
   const hasTempId = typeof tempId === "string" && tempId.length > 0;
   const hasData =
-    data != null &&
+    data !== null &&
+    data !== undefined &&
     // Stryker disable next-line ConditionalExpression: forcing `typeof data === "string"` true is equivalent — for the only non-string with length 0 (an empty array) the next clause already drives hasData false.
     !(typeof data === "string" && data.length === 0) &&
     !(Array.isArray(data) && data.length === 0);

--- a/packages/protocol/src/api-schemas/workflows.ts
+++ b/packages/protocol/src/api-schemas/workflows.ts
@@ -59,6 +59,27 @@ export const EMBEDDED_RUN_MODES = [
 // (strings, nulls, objects missing `id`/`type`) at the tRPC boundary while
 // remaining permissive about unknown fields added by clients or Python.
 
+// A single dynamic output's type metadata. Mirrors PropertyTypeMetadata in
+// api-types.ts: it must be an object carrying at least a `type` string, and
+// nests recursively through `type_args`. Validating this shape (instead of
+// z.unknown()) rejects malformed metadata — primitives, null, or entries
+// missing a type — at the tRPC boundary, while .passthrough() tolerates the
+// extra transport fields clients/Python may add.
+export const dynamicOutputTypeMetadata: z.ZodType = z.lazy(() =>
+  z
+    .object({
+      type: z.string(),
+      optional: z.boolean().optional(),
+      values: z
+        .array(z.union([z.string(), z.number()]))
+        .nullable()
+        .optional(),
+      type_args: z.array(dynamicOutputTypeMetadata).optional(),
+      type_name: z.string().nullable().optional()
+    })
+    .passthrough()
+);
+
 export const graphNode = z
   .object({
     id: z.string(),
@@ -67,7 +88,9 @@ export const graphNode = z
     data: z.unknown().optional(),
     ui_properties: z.unknown().optional(),
     dynamic_properties: z.record(z.string(), z.unknown()).optional(),
-    dynamic_outputs: z.record(z.string(), z.unknown()).optional()
+    dynamic_outputs: z
+      .record(z.string(), dynamicOutputTypeMetadata)
+      .optional()
   })
   .passthrough();
 

--- a/packages/protocol/tests/api-schemas-workflows.test.ts
+++ b/packages/protocol/tests/api-schemas-workflows.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Contract tests for the workflow graph schemas, focused on dynamic_outputs.
+ *
+ * dynamic_outputs carries per-slot type metadata declared by dynamic nodes.
+ * The schema must accept well-formed metadata (an object with a `type` string,
+ * nesting through `type_args`) while rejecting malformed entries — primitives,
+ * null, or objects missing a type — so bad metadata can't reach the runner.
+ */
+
+import { describe, it, expect } from "vitest";
+import { graphNode } from "../src/api-schemas/workflows.js";
+
+const baseNode = { id: "n1", type: "nodetool.test.Dyn" };
+
+describe("graphNode.dynamic_outputs", () => {
+  it("accepts well-formed type metadata", () => {
+    const result = graphNode.safeParse({
+      ...baseNode,
+      dynamic_outputs: {
+        video: { type: "video", type_args: [] },
+        items: {
+          type: "list",
+          type_args: [{ type: "str", type_args: [] }]
+        }
+      }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a node with no dynamic_outputs", () => {
+    expect(graphNode.safeParse(baseNode).success).toBe(true);
+  });
+
+  it("rejects a primitive value where metadata is expected", () => {
+    const result = graphNode.safeParse({
+      ...baseNode,
+      dynamic_outputs: { out: "str" }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a null value", () => {
+    const result = graphNode.safeParse({
+      ...baseNode,
+      dynamic_outputs: { out: null }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metadata missing the type field", () => {
+    const result = graphNode.safeParse({
+      ...baseNode,
+      dynamic_outputs: { out: { type_args: [] } }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-string type", () => {
+    const result = graphNode.safeParse({
+      ...baseNode,
+      dynamic_outputs: { out: { type: 42 } }
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/runtime/src/agent-memory.ts
+++ b/packages/runtime/src/agent-memory.ts
@@ -208,4 +208,20 @@ export class AgentMemory {
   snapshot(): MemoryEntry[] {
     return [...this.entries.values()];
   }
+
+  /**
+   * Rehydrate from a prior {@link snapshot}. This is the durability seam:
+   * callers can persist `snapshot()` to disk/DB at checkpoints and rebuild the
+   * store after a crash or process restart, without coupling AgentMemory to
+   * any particular storage backend.
+   *
+   * Each entry is written through {@link set}, so its original `createdAt` is
+   * preserved and listeners are notified (reactive consumers can rebuild
+   * derived state). Existing keys are overwritten.
+   */
+  restore(entries: readonly MemoryEntry[]): void {
+    for (const entry of entries) {
+      this.set({ ...entry });
+    }
+  }
 }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -207,6 +207,14 @@ export abstract class BaseProvider {
     return {};
   }
 
+  /**
+   * Release any resources held by this provider (HTTP connection pools, cached
+   * model metadata, child processes, etc.). Default is a no-op; providers that
+   * hold long-lived resources should override it. Safe to call more than once.
+   * Callers that own a provider instance should invoke this on shutdown.
+   */
+  async close(): Promise<void> {}
+
   async hasToolSupport(_model: string): Promise<boolean> {
     return true;
   }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -173,6 +173,36 @@ export abstract class BaseProvider {
     return [];
   }
 
+  /**
+   * Explicit capability declaration. Returns `null` by default, in which case
+   * {@link getCapabilities} derives capabilities by reflecting on which
+   * optional methods the concrete class overrides. Providers may override this
+   * to declare their capabilities directly — a robust alternative to method
+   * reflection when methods are wrapped, bound, or composed via mixins.
+   */
+  protected declaredCapabilities(): ProviderCapability[] | null {
+    return null;
+  }
+
+  /**
+   * The capabilities this provider exposes. Prefers an explicit declaration
+   * from {@link declaredCapabilities}; otherwise falls back to reflecting over
+   * overridden methods via {@link providerCapabilities}. Callers should use
+   * this instead of calling `providerCapabilities()` directly so explicit
+   * declarations are honored.
+   */
+  getCapabilities(): ProviderCapability[] {
+    const declared = this.declaredCapabilities();
+    if (declared) {
+      // Message generation is always available; ensure it is present.
+      const set = new Set<ProviderCapability>(declared);
+      set.add("generate_message");
+      set.add("generate_messages");
+      return [...set];
+    }
+    return providerCapabilities(this);
+  }
+
   getContainerEnv(): Record<string, string> {
     return {};
   }

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -102,6 +102,11 @@ export class OllamaProvider extends BaseProvider {
     return { OLLAMA_API_URL: this.apiUrl };
   }
 
+  /** Release cached model metadata held by this provider. */
+  override async close(): Promise<void> {
+    this._modelInfoCache.clear();
+  }
+
   private _modelInfoCache = new Map<string, Record<string, unknown>>();
 
   /**

--- a/packages/runtime/tests/agent-memory.test.ts
+++ b/packages/runtime/tests/agent-memory.test.ts
@@ -126,4 +126,45 @@ describe("AgentMemory", () => {
     expect(aIdx).toBeGreaterThanOrEqual(0);
     expect(bIdx).toBeGreaterThan(aIdx);
   });
+
+  it("round-trips through snapshot() and restore() (durability seam)", () => {
+    const source = new AgentMemory();
+    source.set({
+      key: memoryKeys.task("t1"),
+      kind: "task_result",
+      value: { foo: "bar" },
+      createdAt: 123,
+      title: "Task One"
+    });
+    source.set({
+      key: memoryKeys.shared("note"),
+      kind: "shared",
+      value: "hello"
+    });
+
+    const snapshot = source.snapshot();
+
+    // Simulate a fresh process restoring from a persisted checkpoint.
+    const restored = new AgentMemory();
+    const seen: string[] = [];
+    restored.subscribe((e) => seen.push(e.key));
+    restored.restore(snapshot);
+
+    expect(restored.size()).toBe(2);
+    expect(restored.getValue("task:t1")).toEqual({ foo: "bar" });
+    expect(restored.get("task:t1")?.createdAt).toBe(123); // preserved
+    expect(restored.getValue("shared:note")).toBe("hello");
+    // Listeners fire for each restored entry so derived state can rebuild.
+    expect(seen).toEqual(["task:t1", "shared:note"]);
+  });
+
+  it("restore() overwrites existing keys", () => {
+    const m = new AgentMemory();
+    m.set({ key: "shared:x", kind: "shared", value: "old" });
+    m.restore([
+      { key: "shared:x", kind: "shared", value: "new", createdAt: 5 }
+    ]);
+    expect(m.getValue("shared:x")).toBe("new");
+    expect(m.size()).toBe(1);
+  });
 });

--- a/packages/runtime/tests/providers/base-provider.test.ts
+++ b/packages/runtime/tests/providers/base-provider.test.ts
@@ -317,3 +317,11 @@ describe("BaseProvider – getCapabilities", () => {
     expect(caps).toContain("generate_messages");
   });
 });
+
+describe("BaseProvider – close lifecycle", () => {
+  it("default close() is a safe, idempotent no-op", async () => {
+    const provider = new TestProvider();
+    await expect(provider.close()).resolves.toBeUndefined();
+    await expect(provider.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/runtime/tests/providers/base-provider.test.ts
+++ b/packages/runtime/tests/providers/base-provider.test.ts
@@ -286,3 +286,34 @@ describe("BaseProvider – default method behaviors", () => {
     ).rejects.toThrow("does not support");
   });
 });
+
+describe("BaseProvider – getCapabilities", () => {
+  it("defaults to message generation only when nothing is overridden", () => {
+    const caps = new TestProvider().getCapabilities();
+    expect(caps).toEqual(["generate_message", "generate_messages"]);
+  });
+
+  it("derives capabilities from overridden methods (heuristic path)", () => {
+    class ImageProvider extends TestProvider {
+      override async getAvailableImageModels() {
+        return [];
+      }
+    }
+    const caps = new ImageProvider().getCapabilities();
+    expect(caps).toContain("text_to_image");
+    expect(caps).toContain("image_to_image");
+  });
+
+  it("honors an explicit capability declaration (override seam)", () => {
+    class ExplicitProvider extends TestProvider {
+      protected override declaredCapabilities() {
+        return ["text_to_speech" as const];
+      }
+    }
+    const caps = new ExplicitProvider().getCapabilities();
+    // Explicit list is honored and message generation is always included.
+    expect(caps).toContain("text_to_speech");
+    expect(caps).toContain("generate_message");
+    expect(caps).toContain("generate_messages");
+  });
+});

--- a/packages/storage/src/s3-storage-adapter.ts
+++ b/packages/storage/src/s3-storage-adapter.ts
@@ -25,6 +25,32 @@ export interface S3StorageAdapterOptions {
   client?: S3Client;
 }
 
+/** Total upload attempts (1 initial + 2 retries) for transient S3 errors. */
+const UPLOAD_MAX_ATTEMPTS = 3;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Whether an S3 error is worth retrying: network/connection errors (no HTTP
+ * status), throttling, and 5xx server errors. Client errors (4xx other than
+ * 429) are permanent and surfaced immediately.
+ */
+function isRetryableS3Error(err: unknown): boolean {
+  const e = err as {
+    name?: string;
+    $retryable?: unknown;
+    $metadata?: { httpStatusCode?: number };
+  };
+  if (e?.$retryable) return true;
+  const status = e?.$metadata?.httpStatusCode;
+  if (typeof status === "number") {
+    return status === 429 || status >= 500;
+  }
+  const name = e?.name ?? "";
+  return /Throttl|Timeout|NetworkingError|ECONN|EPIPE|ETIMEDOUT/i.test(name);
+}
+
 /**
  * S3-backed storage adapter using `@aws-sdk/client-s3`.
  *
@@ -79,15 +105,35 @@ export class S3StorageAdapter implements StorageAdapter {
   ): Promise<string> {
     assertUploadWithinLimit(key, data.byteLength);
     const objectKey = joinStorageKey(this.prefix ?? undefined, key);
-    await this.getClient().send(
-      new PutObjectCommand({
-        Bucket: this.bucket,
-        Key: objectKey,
-        Body: data,
-        ...(contentType ? { ContentType: contentType } : {})
-      })
+    const client = this.getClient();
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: objectKey,
+      Body: data,
+      ...(contentType ? { ContentType: contentType } : {})
+    });
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
+      try {
+        await client.send(command);
+        return `s3://${this.bucket}/${objectKey}`;
+      } catch (err) {
+        lastError = err;
+        if (attempt < UPLOAD_MAX_ATTEMPTS && isRetryableS3Error(err)) {
+          // Exponential backoff: 100ms, 200ms.
+          await delay(100 * 2 ** (attempt - 1));
+          continue;
+        }
+        break;
+      }
+    }
+    throw new Error(
+      `S3 upload failed for s3://${this.bucket}/${objectKey} after ${UPLOAD_MAX_ATTEMPTS} attempt(s): ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }`,
+      { cause: lastError }
     );
-    return `s3://${this.bucket}/${objectKey}`;
   }
 
   uriForKey(key: string): string {

--- a/packages/storage/tests/storage-adapters.test.ts
+++ b/packages/storage/tests/storage-adapters.test.ts
@@ -114,6 +114,47 @@ describe("S3StorageAdapter", () => {
       () => new S3StorageAdapter({ bucket: "", client: {} as any })
     ).toThrow(/bucket is required/);
   });
+
+  it("retries a transient upload error then succeeds", async () => {
+    const store = new Map<string, Uint8Array>();
+    let attempts = 0;
+    const client = {
+      send: vi.fn(async (cmd: any) => {
+        if (cmd.constructor.name === "PutObjectCommand") {
+          attempts++;
+          if (attempts < 3) {
+            const err: any = new Error("ServiceUnavailable");
+            err.$metadata = { httpStatusCode: 503 };
+            throw err;
+          }
+          store.set(`${cmd.input.Bucket}/${cmd.input.Key}`, new Uint8Array(cmd.input.Body));
+          return {};
+        }
+        throw new Error(`unexpected ${cmd.constructor.name}`);
+      })
+    } as any;
+    const storage = new S3StorageAdapter({ bucket: "b", client });
+    const uri = await storage.store("k.bin", new Uint8Array([1]));
+    expect(uri).toBe("s3://b/k.bin");
+    expect(attempts).toBe(3);
+  });
+
+  it("does not retry a permanent (4xx) upload error and surfaces it", async () => {
+    let attempts = 0;
+    const client = {
+      send: vi.fn(async () => {
+        attempts++;
+        const err: any = new Error("AccessDenied");
+        err.$metadata = { httpStatusCode: 403 };
+        throw err;
+      })
+    } as any;
+    const storage = new S3StorageAdapter({ bucket: "b", client });
+    await expect(storage.store("k.bin", new Uint8Array([1]))).rejects.toThrow(
+      /S3 upload failed.*AccessDenied/s
+    );
+    expect(attempts).toBe(1);
+  });
 });
 
 describe("SupabaseStorageAdapter", () => {

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -7,7 +7,6 @@ import {
   getProvider,
   isProviderConfigured,
   listRegisteredProviderIds,
-  providerCapabilities,
   RECOMMENDED_MODELS,
   OLLAMA_DEFAULT_URL,
   LMSTUDIO_DEFAULT_URL,
@@ -388,7 +387,7 @@ async function getProvidersInfo(userId = "1"): Promise<ProviderInfo[]> {
   for (const provider of await getAvailableProviderIds(userId)) {
     const instance = await instantiateProvider(provider, userId);
     if (!instance) continue;
-    infos.push({ provider, capabilities: providerCapabilities(instance) });
+    infos.push({ provider, capabilities: instance.getCapabilities() });
   }
   return infos;
 }

--- a/packages/websocket/src/routes/health.ts
+++ b/packages/websocket/src/routes/health.ts
@@ -2,8 +2,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { sql } from "drizzle-orm";
-import { getDb, getDbType, getRawDb } from "@nodetool-ai/models";
+import { pingDb } from "@nodetool-ai/models";
 
 const serverStartTime = Date.now();
 
@@ -31,13 +30,7 @@ const healthRoute: FastifyPluginAsync = async (app) => {
     let dbStatus: "ok" | "error" = "ok";
 
     try {
-      if (getDbType() === "postgres") {
-        await getDb().execute(sql`select 1`);
-      } else {
-        const raw = getRawDb();
-        // Fast integrity check — just verifies the connection is alive
-        raw.pragma("quick_check(1)");
-      }
+      await pingDb();
     } catch {
       dbStatus = "error";
     }

--- a/packages/websocket/src/trpc/error-formatter.ts
+++ b/packages/websocket/src/trpc/error-formatter.ts
@@ -14,6 +14,20 @@ export interface ApiErrorShape extends DefaultErrorShape {
   };
 }
 
+/**
+ * Best-effort reverse mapping so errors thrown as raw TRPCError (without an
+ * explicit apiCode cause) still get a consistent apiCode in the response shape.
+ * Routers that use throwApiError() provide an exact code; this is the fallback.
+ */
+const API_CODE_BY_TRPC_CODE: Partial<Record<TRPCError["code"], ApiErrorCode>> = {
+  NOT_FOUND: ApiErrorCode.NOT_FOUND,
+  CONFLICT: ApiErrorCode.ALREADY_EXISTS,
+  BAD_REQUEST: ApiErrorCode.INVALID_INPUT,
+  UNAUTHORIZED: ApiErrorCode.UNAUTHORIZED,
+  FORBIDDEN: ApiErrorCode.FORBIDDEN,
+  INTERNAL_SERVER_ERROR: ApiErrorCode.INTERNAL_ERROR
+};
+
 export function errorFormatter({
   shape,
   error
@@ -30,7 +44,7 @@ export function errorFormatter({
     ...shape,
     data: {
       ...shape.data,
-      apiCode: cause?.apiCode ?? null,
+      apiCode: cause?.apiCode ?? API_CODE_BY_TRPC_CODE[error.code] ?? null,
       zodError
     }
   };

--- a/packages/websocket/src/trpc/routers/models.ts
+++ b/packages/websocket/src/trpc/routers/models.ts
@@ -8,7 +8,6 @@ import {
   getProvider,
   isProviderConfigured,
   listRegisteredProviderIds,
-  providerCapabilities,
   RECOMMENDED_MODELS,
   OLLAMA_DEFAULT_URL,
   LMSTUDIO_DEFAULT_URL,
@@ -988,7 +987,7 @@ export const modelsRouter = router({
         if (!instance) continue;
         infos.push({
           provider: providerId,
-          capabilities: providerCapabilities(instance)
+          capabilities: instance.getCapabilities()
         });
       }
       return infos;

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1143,6 +1143,27 @@ export class UnifiedWebSocketRunner {
       this.activeJobs.delete(jobId);
     }
 
+    // Drain runs that were still queued (never started): the client is gone,
+    // so they will never run. Mark their persisted rows cancelled instead of
+    // leaving them as orphaned "scheduled" jobs in jobs.list.
+    for (
+      let queued = this.jobQueue.dequeue();
+      queued;
+      queued = this.jobQueue.dequeue()
+    ) {
+      const queuedId = queued.job_id;
+      if (!queuedId) continue;
+      try {
+        const job = await Job.get(queuedId);
+        if (job) {
+          job.markCancelled();
+          await job.save();
+        }
+      } catch (err) {
+        this.logError("disconnect queue cancellation failed", err);
+      }
+    }
+
     if (this.websocket) {
       try {
         await this.websocket.close();

--- a/packages/websocket/tests/trpc-error-formatter.test.ts
+++ b/packages/websocket/tests/trpc-error-formatter.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the tRPC error formatter's apiCode resolution.
+ *
+ * Every error response must carry a consistent `apiCode`: explicit when a
+ * router uses throwApiError(), and derived from the TRPC code as a fallback
+ * for raw TRPCError throws, so clients can branch on it uniformly.
+ */
+import { describe, it, expect } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { TRPCDefaultErrorShape } from "@trpc/server";
+import {
+  errorFormatter,
+  throwApiError
+} from "../src/trpc/error-formatter.js";
+import { ApiErrorCode } from "../src/error-codes.js";
+
+function shapeFor(error: TRPCError): TRPCDefaultErrorShape {
+  return {
+    message: error.message,
+    code: -32600,
+    data: {
+      code: error.code,
+      httpStatus: 400
+    }
+  } as TRPCDefaultErrorShape;
+}
+
+function format(error: TRPCError) {
+  return errorFormatter({ shape: shapeFor(error), error });
+}
+
+describe("errorFormatter apiCode resolution", () => {
+  it("uses the explicit apiCode from throwApiError", () => {
+    let thrown: TRPCError | undefined;
+    try {
+      throwApiError(ApiErrorCode.WORKFLOW_NOT_FOUND, "missing");
+    } catch (e) {
+      thrown = e as TRPCError;
+    }
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect(format(thrown!).data.apiCode).toBe(ApiErrorCode.WORKFLOW_NOT_FOUND);
+  });
+
+  it("derives apiCode from the TRPC code for a raw TRPCError", () => {
+    const error = new TRPCError({ code: "NOT_FOUND", message: "nope" });
+    expect(format(error).data.apiCode).toBe(ApiErrorCode.NOT_FOUND);
+  });
+
+  it("maps BAD_REQUEST to INVALID_INPUT", () => {
+    const error = new TRPCError({ code: "BAD_REQUEST", message: "bad" });
+    expect(format(error).data.apiCode).toBe(ApiErrorCode.INVALID_INPUT);
+  });
+
+  it("returns null apiCode for codes without a mapping", () => {
+    const error = new TRPCError({ code: "TIMEOUT", message: "slow" });
+    expect(format(error).data.apiCode).toBeNull();
+  });
+});

--- a/packages/websocket/tests/trpc-models.test.ts
+++ b/packages/websocket/tests/trpc-models.test.ts
@@ -126,6 +126,10 @@ function makeProvider(
     getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
     getAvailableVideoModels: vi.fn().mockResolvedValue([]),
     hasToolSupport: vi.fn().mockResolvedValue(true),
+    // The models router now reads capabilities via BaseProvider.getCapabilities()
+    // instead of reflecting over the instance; mirror the always-present base
+    // capabilities every provider declares.
+    getCapabilities: vi.fn(() => ["generate_message", "generate_messages"]),
     ...overrides
   };
 }

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -736,6 +736,54 @@ describe("UnifiedWebSocketRunner", () => {
 
     await runner.disconnect();
   });
+
+  it("cancels still-queued runs on disconnect instead of orphaning them", async () => {
+    await initTestDb();
+    const prev = process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW;
+    process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW = "1";
+    try {
+      let release!: () => void;
+      const gate = new Promise<void>((r2) => {
+        release = r2;
+      });
+      const r = new UnifiedWebSocketRunner({
+        resolveExecutor: () => ({
+          async process() {
+            await gate;
+            return {};
+          }
+        })
+      });
+      await r.connect(ws);
+      const graph = {
+        nodes: [
+          {
+            id: "n1",
+            type: "nodetool.constant.String",
+            name: "nodetool.constant.String",
+            properties: { value: "x" }
+          }
+        ],
+        edges: []
+      };
+      await Job.create({ id: "RUN_A", workflow_id: "wf", user_id: "1", status: "scheduled" });
+      await Job.create({ id: "RUN_B", workflow_id: "wf", user_id: "1", status: "scheduled" });
+
+      await r.runJob({ job_id: "RUN_A", workflow_id: "wf", graph, concurrent: true });
+      await r.runJob({ job_id: "RUN_B", workflow_id: "wf", graph, concurrent: true });
+      await new Promise((res) => setTimeout(res, 20));
+
+      // RUN_B is queued behind RUN_A (cap of 1). Disconnecting must cancel it.
+      await r.disconnect();
+      release();
+
+      const queuedJob = await Job.get<Job>("RUN_B");
+      expect(queuedJob?.status).toBe("cancelled");
+    } finally {
+      if (prev === undefined) delete process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW;
+      else process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW = prev;
+    }
+  });
 });
 
 describe("UnifiedWebSocketRunner binary frame size guard", () => {


### PR DESCRIPTION
## Summary

Fifteen small, independent backend correctness and robustness improvements across `node-sdk`, `models`, `protocol`, `storage`, `kernel`, `runtime`, `websocket`, `cli`, and `code-runners`. Each commit is self-contained with tests.

### Correctness / bug fixes
- **`RunEvent.appendEvent` is now atomic** — prevents `seq` collisions under concurrent appends.
- **Code runners force-kill subprocesses** that ignore `SIGTERM`, so a stuck child can't leak.
- **Queued runs are cancelled on client disconnect** instead of running orphaned.
- **Strict equality** in node-sdk asset validation.

### Validation
- Validate `dynamic_outputs` type metadata in the workflow graph schema.
- Validate data-edge source handles in graph validation.

### Provider / lifecycle seams
- Add an explicit **capability declaration seam** to `BaseProvider` (consumed by find-model tool, models API/router).
- Add a **`close()` lifecycle** to `BaseProvider` for resource cleanup (implemented by Ollama provider).
- Add an **`AgentMemory.restore()`** durability seam.

### Resilience
- **Bounded retry with backoff** for S3 uploads.
- **Settle CLI WebSocket connect once** and drain waiters on post-connect error.
- Derive a **consistent `apiCode`** for raw `TRPCError` throws.

### Typing
- Type the Drizzle database union in `models/db.ts`; use Drizzle's official column API in base-model reflection.
- Type HuggingFace node properties instead of `declare X: any`.

## Test Plan
- [ ] CI: `npm run typecheck`, `npm run lint`, `npm run test`
- [ ] New/updated unit tests in `models`, `protocol`, `storage`, `kernel`, `runtime`, `websocket`, `cli` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)