### PR TITLE
Tests & parity tracking: kernel gap ids and RunLease coverage

### DIFF
--- a/docs/KERNEL_PARITY_GAPS.md
+++ b/docs/KERNEL_PARITY_GAPS.md
@@ -1,0 +1,44 @@
+# Kernel Parity Gaps
+
+Tracked differences between the TypeScript kernel (`packages/kernel`) and the
+reference Python runtime. Each gap has regression tests that assert the
+**current** TypeScript behavior so a future fix is an explicit, reviewed change
+rather than a silent one. The desired end-state is recorded here instead of as
+bare `// TODO` comments scattered through the tests.
+
+Tests: `packages/kernel/tests/parity-output-edge-gaps.test.ts`.
+
+## Gap #9 — Output node handling (consecutive deduplication)
+
+Python's `process_output_node()` consumes a stream item-by-item and emits one
+`output_update` per value, deduplicating *consecutive* identical values.
+
+- **Current TS behavior:** the output node is buffered and fires once with the
+  last value, so three yields of `same, same, different` produce a single
+  `output_update` carrying `different`.
+- **Desired:** when the output node consumes the stream item-by-item,
+  consecutive dedup should reduce `same, same, different` to **two**
+  `output_update` messages (`same` once, then `different`).
+- **Asserted at:** the `should ... deduplicate consecutive` test (current
+  behavior: `outputMsgs.length === 1`).
+
+`output_update` message fields (`node_id`, `node_name`, `output_name`, `value`,
+`output_type`, `metadata`) are already populated — that part of gap #9 is fixed.
+
+## Gap #15 — Edge counter updates for input-originating edges
+
+Python emits `edge_update` at several lifecycle points, including `"drained"`
+during `drain_active_edges()` and `"completed"` during `_send_EOS()`.
+`_drainActiveEdges()` now exists in TS and emits `"drained"` for edges whose
+target handle is still open at completion.
+
+- **Current TS behavior:** input nodes are not actors, so `_sendEOS` is never
+  called for edges that originate at an input node. Those edges receive an
+  `"active"` update from `_dispatchInputs()` but no terminal `"completed"` /
+  `"drained"`.
+- **Desired:** input-originating edges should also receive a terminal
+  `"completed"` (or `"drained"`) update at the end of the run.
+- **Asserted at:** the two edge-lifecycle tests (current behavior:
+  `completedMsgs.length === 0` for input edges).
+
+Edges between non-input nodes already get both `"active"` and `"completed"`.

--- a/docs/correlation-design.md
+++ b/docs/correlation-design.md
@@ -723,3 +723,22 @@ Removed from production behavior:
    execution errors.
 
 3. **Python worker rollout.** Python bridge compatibility remains a rollout concern for Python-backed nodes that need full output correlation metadata, lineage, `lineage_done`, and `lineage_scope_closed`.
+
+## Known gaps and skipped tests
+
+These gaps are covered by `it.skip` regression tests that are kept (not
+deleted) so the desired behavior is documented and the test re-enables the
+moment the gap is closed. Each skipped test references the gap id below.
+
+- **GAP-CORR-1 — required-input empty-scope close.** When a required input
+  edge closes without ever delivering a value (an upstream node throws, or an
+  input stream finishes with no push), `NodeActor._runCorrelatedImpl` fires the
+  node once with input defaults instead of skipping it. Per §6, a *required*
+  input that closes without a value should block the key (skip the node).
+  Skipped tests: `e2e/complex-topologies.test.ts` (COMPLEX-008),
+  `e2e/runner-lifecycle.test.ts` (RUNNER-008).
+
+- **GAP-CORR-2 — multi-edge list aggregation.** Multiple edges feeding one
+  `list[...]` handle are not yet aggregated at runtime; `_runCorrelatedImpl`
+  delivers only the last value. (Multi-edge into a non-list handle is rejected
+  by analysis — see §4.) Skipped test: `e2e/actor-modes.test.ts` (ACTOR-005).

--- a/packages/kernel/tests/e2e/actor-modes.test.ts
+++ b/packages/kernel/tests/e2e/actor-modes.test.ts
@@ -172,12 +172,13 @@ describe("ACTOR-004: FullStreamingNode has both streaming flags", () => {
 // ---------------------------------------------------------------------------
 
 describe("ACTOR-005: on_any sync mode fires on each individual input", () => {
-  // SKIP: asserts the removed `on_any` mode plus runtime aggregation of
+  // SKIP (GAP-CORR-2, tracked in docs/correlation-design.md § Known gaps):
+  // asserts the removed `on_any` mode plus runtime aggregation of
   // multiple edges into one handle. Under the correlation redesign, multi-edge
   // into a non-list handle is rejected by analysis, and list[...] multi-edge
   // runtime aggregation is not yet implemented in NodeActor._runCorrelatedImpl
   // (it delivers only the last value). Re-enable when multi-edge list
-  // aggregation lands. See docs/correlation-design.md §4.
+  // aggregation lands. See docs/correlation-design.md §4 and § Known gaps.
   it.skip("IntAccumulator in on_any mode accumulates all inputs", async () => {
     const registry = makeRegistry();
     const runner = makeRunner(registry);

--- a/packages/kernel/tests/e2e/complex-topologies.test.ts
+++ b/packages/kernel/tests/e2e/complex-topologies.test.ts
@@ -197,10 +197,11 @@ describe("COMPLEX-007: Single source node, no edges", () => {
 // ---------------------------------------------------------------------------
 
 describe("COMPLEX-008: Error in middle node stops downstream processing", () => {
-  // SKIP: exposes a real error-propagation gap, not a stale test. When B throws,
+  // SKIP (GAP-CORR-1, tracked in docs/correlation-design.md § Known gaps):
+  // exposes a real error-propagation gap, not a stale test. When B throws,
   // its single edge into C's empty-scope handle closes without a value;
   // NodeActor._runCorrelatedImpl (actor.ts ~655) then fires C once with input
-  // defaults instead of skipping it. Per docs/correlation-design.md line 344 a
+  // defaults instead of skipping it. Per docs/correlation-design.md §6 a
   // *required* input that closes without a value should block the key (skip the
   // node); the actor does not yet honor required-vs-optional on empty-scope
   // close. Re-enable once that propagation is implemented.

--- a/packages/kernel/tests/e2e/runner-lifecycle.test.ts
+++ b/packages/kernel/tests/e2e/runner-lifecycle.test.ts
@@ -173,10 +173,11 @@ describe("RUNNER-007: Input node receives param and dispatches to downstream", (
 // ---------------------------------------------------------------------------
 
 describe("RUNNER-008: Input node with no param and explicit finishInputStream", () => {
-  // SKIP: same empty-scope propagation gap as COMPLEX-008. The input stream
+  // SKIP (GAP-CORR-1, tracked in docs/correlation-design.md § Known gaps):
+  // same empty-scope propagation gap as COMPLEX-008. The input stream
   // finishes with no push, so the downstream sink's handle closes without a
   // value; NodeActor._runCorrelatedImpl fires the sink once with defaults
-  // instead of producing no output. Per docs/correlation-design.md line 344 a
+  // instead of producing no output. Per docs/correlation-design.md §6 a
   // required input closing without a value should block the node. Re-enable
   // once required-input close propagation is implemented.
   it.skip("calling finishInputStream with no prior push produces empty output", async () => {

--- a/packages/kernel/tests/parity-output-edge-gaps.test.ts
+++ b/packages/kernel/tests/parity-output-edge-gaps.test.ts
@@ -159,8 +159,9 @@ describe("Gap #9 — OutputUpdate messages", () => {
     expect(outputMsgs.length).toBe(1); // Current behavior
     expect(outputMsgs[0].value).toBe("different");
 
-    // TODO: When the output node consumes the stream item-by-item,
-    // consecutive dedup should reduce 3 yields to 2 output_updates:
+    // Desired end-state (tracked in docs/KERNEL_PARITY_GAPS.md, gap #9): when
+    // the output node consumes the stream item-by-item, consecutive dedup
+    // should reduce 3 yields to 2 output_updates:
     // expect(outputMsgs.length).toBe(2); // "same" (once) + "different"
   });
 
@@ -316,7 +317,8 @@ describe("Gap #15 — Edge counter updates during input dispatch", () => {
     const completedMsgs = edgeMsgs.filter((m) => m.status === "completed");
     expect(completedMsgs.length).toBe(0); // Current behavior — input edges get no "completed"
 
-    // TODO: When gap #15 is fixed, drain_active_edges should emit "drained" or "completed":
+    // Desired end-state (tracked in docs/KERNEL_PARITY_GAPS.md, gap #15):
+    // drain_active_edges should emit "drained" or "completed" for input edges:
     // expect(completedMsgs.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -400,7 +402,8 @@ describe("Gap #15 — Edge counter updates during input dispatch", () => {
     expect(eaCompleted.length).toBe(0); // Current behavior — no EOS for input edges
     expect(ebCompleted.length).toBe(0); // Current behavior — no EOS for input edges
 
-    // TODO: When fixed, input edges should also get "completed" or "drained":
+    // Desired end-state (tracked in docs/KERNEL_PARITY_GAPS.md, gap #15):
+    // input edges should also get "completed" or "drained":
     // expect(eaCompleted.length).toBeGreaterThanOrEqual(1);
     // expect(ebCompleted.length).toBeGreaterThanOrEqual(1);
   });

--- a/packages/models/tests/run-lease.test.ts
+++ b/packages/models/tests/run-lease.test.ts
@@ -169,4 +169,60 @@ describe("RunLease model", () => {
     const count = await RunLease.cleanupExpired();
     expect(count).toBe(0);
   });
+
+  // ── concurrency & edge cases ──────────────────────────────────────
+
+  it("returns null when the same worker re-acquires its own valid lease", async () => {
+    // acquire() is not idempotent for the holder — a worker extending its hold
+    // must call renew(). A second acquire() while the lease is valid returns
+    // null even for the same worker.
+    const first = await RunLease.acquire("r1", "w1", 60);
+    expect(first).not.toBeNull();
+    const again = await RunLease.acquire("r1", "w1", 60);
+    expect(again).toBeNull();
+  });
+
+  it("lets exactly one of two racing acquires win", async () => {
+    const [a, b] = await Promise.all([
+      RunLease.acquire("r1", "w1", 60),
+      RunLease.acquire("r1", "w2", 60)
+    ]);
+    const winners = [a, b].filter((l) => l !== null);
+    expect(winners).toHaveLength(1);
+    // The losing acquire gets null; the DB holds exactly one lease for the run.
+    const stored = await RunLease.get<RunLease>("r1");
+    expect(stored).not.toBeNull();
+    expect(stored!.worker_id).toBe(winners[0]!.worker_id);
+  });
+
+  it("reclaiming an expired lease keeps run_id and refreshes timestamps", async () => {
+    const original = await RunLease.acquire("r1", "w1", 0);
+    expect(original).not.toBeNull();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const reclaimed = await RunLease.acquire("r1", "w2", 60);
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed!.run_id).toBe("r1");
+    expect(reclaimed!.worker_id).toBe("w2");
+    expect(new Date(reclaimed!.expires_at).getTime()).toBeGreaterThan(
+      new Date(original!.expires_at).getTime()
+    );
+
+    // Only one row remains for the run after reclamation.
+    const stored = await RunLease.get<RunLease>("r1");
+    expect(stored!.worker_id).toBe("w2");
+  });
+
+  it("cleanupExpired removes only the expired subset", async () => {
+    await RunLease.acquire("active", "w1", 600);
+    await RunLease.acquire("dead1", "w2", 0);
+    await RunLease.acquire("dead2", "w3", 0);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const count = await RunLease.cleanupExpired();
+    expect(count).toBe(2);
+    expect(await RunLease.get<RunLease>("active")).not.toBeNull();
+    expect(await RunLease.get<RunLease>("dead1")).toBeNull();
+    expect(await RunLease.get<RunLease>("dead2")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Three commits that improve test coverage and make skipped/known-gap tests traceable instead of buried in bare TODOs.

- **Track kernel parity gaps in a doc** (`docs/KERNEL_PARITY_GAPS.md`) instead of scattered `TODO`s, with a backing `parity-output-edge-gaps` test.
- **Track skipped kernel e2e tests under stable gap ids** across `actor-modes`, `complex-topologies`, and `runner-lifecycle` suites (plus a note in `correlation-design.md`), so each skip points at a documented gap.
- **Backfill RunLease concurrency and edge-case tests.**

No production code changes — docs and tests only.

## Test Plan
- [ ] CI: `npm run test` (kernel + models suites)
- [ ] Skipped e2e tests reference valid gap ids in `KERNEL_PARITY_GAPS.md`