### PR TITLE
Docs: package READMEs, .env examples, and standards clarifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,49 @@
+# Example environment variables for the NodeTool backend server.
+# Copy to `.env` and adjust for your deployment. All values are optional unless
+# noted; see docs/ and packages/config for the full set.
+
+# ── Server ────────────────────────────────────────────────────────────────
+# Host/port the websocket+HTTP server binds to.
+HOST=0.0.0.0
+PORT=7777
+# Deployment environment: "development" | "production".
+NODETOOL_ENV=development
+
+# ── Database (choose one) ───────────────────────────────────────────────────
+# SQLite file path (local/dev default), OR a PostgreSQL connection string.
+DB_PATH=./nodetool.db
+# DATABASE_URL=postgresql://user:pass@host:5432/nodetool
+
+# ── Secret encryption ───────────────────────────────────────────────────────
+# 32-byte base64 key used to encrypt stored secrets. Generate with:
+#   openssl rand -base64 32
+# If unset (and no AWS key name is configured), a key is generated and persisted
+# next to the database — set this explicitly in production.
+# SECRETS_MASTER_KEY=
+# AWS_SECRETS_MASTER_KEY_NAME=
+
+# ── Storage ─────────────────────────────────────────────────────────────────
+# "local" (default) or "s3". When "s3", configure the bucket/endpoint/region.
+# NODETOOL_STORAGE_BACKEND=local
+# ASSET_BUCKET=/workspace/assets
+# S3_ENDPOINT_URL=
+# S3_REGION=
+
+# ── Model provider API keys (only what you use) ─────────────────────────────
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# GEMINI_API_KEY=
+# FAL_API_KEY=
+# KIE_API_KEY=
+# HF_TOKEN=
+# OLLAMA_API_URL=http://localhost:11434
+
+# ── Auth (optional, GitHub OAuth) ───────────────────────────────────────────
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# ADMIN_USER_IDS=
+
+# ── Observability (optional) ────────────────────────────────────────────────
+# NODETOOL_LOG_LEVEL=info
+# NODETOOL_TRACE_FILE=/tmp/nodetool-trace.jsonl
+# NODETOOL_TRACE_STDOUT=pretty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Before submitting a PR, review for:
 - **Decorator packages load from `dist/`**: `base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, `elevenlabs-nodes`, `minimax-nodes` use decorators. After changing these, run `npm run build:packages` before running `npm run dev`.
 - **Package build order matters**: Always use `npm run build:packages` (builds in dependency order). Don't build individual packages with unbuilt dependencies.
 - **Mobile typecheck needs protocol**: Run `cd packages/protocol && npm run build` before `npm run typecheck:mobile`.
+- **`mobile/` is not a root workspace**: it keeps its own Expo/React Native deps, so its scripts use `npm --prefix mobile …` (not `npm --workspace=mobile …`, which would fail).
 - **WebSocket uses MsgPack, not JSON**: Use existing serialization helpers. Don't serialize WebSocket messages as JSON.
 - **Don't create WebSocket instances**: Use `GlobalWebSocketManager` singleton in the frontend.
 - **ES Modules everywhere**: All packages use `"type": "module"`. Compiled imports need `.js` extensions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidelines for working with code in this repository. These are linter-like rules and build/test instructions — not a code summary.
 
+> _Last updated: 2026-06-19._ Keep this in sync with the codebase; update it in the same PR when rules or commands change.
+
 > **Canonical standards live in [docs/DEVELOPMENT_STANDARDS.md](docs/DEVELOPMENT_STANDARDS.md).** That document is the single source of truth for enforceable rules and aspirational targets across TypeScript, React, Zustand, MUI, TanStack Query, ReactFlow, Fastify, Drizzle, Zod, Electron security, accessibility, performance, security, observability, error handling, git/PR hygiene, and dependency management. The rules in this file are the area-specific overlay — read both.
 
 ## Quick Navigation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ npm run typecheck   # Must pass before committing
 - **WebSocket messages use MsgPack**, not JSON. Use the existing serialization helpers.
 - **Don't create new WebSocket instances** — use `GlobalWebSocketManager` singleton.
 - **Mobile typecheck** requires building protocol first: `cd packages/protocol && npm run build`.
+- **`mobile/` is intentionally NOT a root workspace** (it has its own Expo/React Native dependency tree that must not be hoisted). Its scripts use `npm --prefix mobile …`, not `npm --workspace=mobile …` — the latter will fail. Do not "standardize" these to `--workspace`.
 - **Native module ABI mismatch**: `electron/`'s `postinstall` runs `@electron/rebuild`, which rebuilds `better-sqlite3` and `bufferutil` against Electron's ABI on every `npm install`. If you still hit `NODE_MODULE_VERSION` errors, run `npm --prefix electron run postinstall` to force a rebuild. Do NOT use plain `npm rebuild` — it builds for system Node, not Electron's embedded Node.
 - **Claude Agent Provider in nested sessions (e.g. Claude Code web)**: The SDK spawns a subprocess via `node cli.js`. In environments like Claude Code on the web (`claude.ai/code`), you must: (1) strip all `CLAUDE_CODE_*` / `CLAUDE_SESSION_*` / `CLAUDE_ENABLE_*` / `CLAUDE_AFTER_*` / `CLAUDE_AUTO_*` env vars — not just `CLAUDECODE`; (2) run as a non-root user — the SDK refuses `--dangerously-skip-permissions` when uid=0; (3) keep `ANTHROPIC_BASE_URL` and `HTTP_PROXY`/`HTTPS_PROXY` vars for API routing. See `docs/AGENTS.md` § Claude Agent SDK for full details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Visual AI workflow platform. TypeScript monorepo with React frontend, Electron desktop app, and Node.js backend.
 
+> _Last updated: 2026-06-19._ When the architecture, commands, or rules below drift from the codebase, update this file in the same PR.
+
 ## Critical Commands
 
 ```bash

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -83,7 +83,7 @@ The web app runs **React 18.2**; Electron renderer runs **React 19.1**. Mobile u
 - **`react-hooks/exhaustive-deps` is enforced** (oxlint, warn) — the primary `npm run lint`. Don't silence it with an eslint-disable; fix the dependency array or restructure. Treat new warnings as work to clear, not noise.
 - **Effect cleanup is mandatory** for any effect that creates a subscription, timer, controller, or listener. Effects that race must use an `AbortController` or an `isMounted` ref pattern (signal preferred).
 - **Don't pass inline functions** to memoized children. Use `useCallback` only when (a) the function is a dependency of an effect/memo, or (b) it's passed to a `React.memo`'d child.
-- **`useMemo` / `React.memo` only when measured.** Add only after observing a render problem in React DevTools. Premature memoization is forbidden because it adds maintenance cost.
+- **`useMemo` / `React.memo` only when measured.** Add only after observing a render problem in React DevTools. Premature memoization is forbidden because it adds maintenance cost. Corollary: the share of components *not* wrapped in `React.memo` is **not** a defect backlog to bulk-fix — `memo` only helps when a parent re-renders often AND the child's props are referentially stable, and otherwise just adds cost. Wrap a component only with a concrete, observed re-render to point at.
 - **No `useLayoutEffect`** unless you genuinely need synchronous DOM measurement before paint. Document why.
 - **Error boundaries** wrap every route and every async data section. **target**: a default error boundary at the route level emits a structured error event to telemetry.
 - **Suspense boundaries** wrap every lazy-loaded subtree, every TanStack Query suspense hook, and every `lazy()` component.

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -79,7 +79,8 @@ The web app runs **React 18.2**; Electron renderer runs **React 19.1**. Mobile u
 - **One default export per file** for components; named exports for hooks and utilities.
 - **Never mutate state.** Use immutable updates; pass new references.
 - **Stable keys** in lists — never use the array index when the list reorders. Use a stable ID.
-- **`useEffect` is for side effects only** (subscriptions, timers, DOM, network). **Never** use it to compute derived state — that's what `useMemo` or simple inline computation is for.
+- **`useEffect` is for side effects only** (subscriptions, timers, DOM, network). **Never** use it to compute derived state — that's what `useMemo` or simple inline computation is for. _Exception:_ mirroring a prop into editable local state (controlled→uncontrolled) and resetting state on an input change are legitimate effects — do not "convert" those to `useMemo`.
+- **`react-hooks/exhaustive-deps` is enforced** (oxlint, warn) — the primary `npm run lint`. Don't silence it with an eslint-disable; fix the dependency array or restructure. Treat new warnings as work to clear, not noise.
 - **Effect cleanup is mandatory** for any effect that creates a subscription, timer, controller, or listener. Effects that race must use an `AbortController` or an `isMounted` ref pattern (signal preferred).
 - **Don't pass inline functions** to memoized children. Use `useCallback` only when (a) the function is a dependency of an effect/memo, or (b) it's passed to a `React.memo`'d child.
 - **`useMemo` / `React.memo` only when measured.** Add only after observing a render problem in React DevTools. Premature memoization is forbidden because it adds maintenance cost.

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -28,6 +28,7 @@ NodeTool is TypeScript-first. Strict mode is on everywhere (`tsconfig.base.json`
 ### Rules
 
 - **Strict mode is non-negotiable.** Never turn off `strict`, `noImplicitAny`, `strictNullChecks`, or `strictFunctionTypes` in any tsconfig.
+- **Documented tsconfig exception — `noUnusedLocals` / `noUnusedParameters`.** `tsconfig.base.json` enables both, but the node-implementation, codegen, and agent packages (`agents`, `cli`, `*-nodes`, `*-codegen`, `nodes-utils`, `workflow-runner`) override them to `false`. This is intentional: decorator-`declare`d node props, generated code, and interface-driven `process()` signatures routinely leave locals/params unused. Do not "fix" these overrides; keep new packages of the same kind consistent. All other packages inherit the strict base.
 - **No `any`** in new code. **target**: zero `any` in `web/src` and `electron/src`. The ESLint override that allows `any` in `packages/*` (see `eslint.config.mjs`) is a transitional concession — new code must use `unknown` + narrowing, generics, or proper types.
 - **Prefer `unknown` over `any`** at boundaries (parsed JSON, IPC, network). Narrow with a type guard or Zod schema before use.
 - **No non-null assertions (`!`)** except in tests. Use a type guard, `assertDefined()` helper, or an `if (!x) throw` check.

--- a/electron/.env.example
+++ b/electron/.env.example
@@ -1,0 +1,17 @@
+# Example environment variables for the NodeTool Electron app.
+# Copy to `.env` and adjust as needed. Most runtime paths are auto-detected;
+# set these only to override the defaults.
+
+# Override the bundled/managed Node binary used to spawn the backend.
+# NODETOOL_NODE=
+
+# Extra node-package config and packs.
+# NODETOOL_PACKS_CONFIG=
+
+# Asset and model cache locations.
+# ASSET_FOLDER=
+# HF_HOME=
+# OLLAMA_MODELS=
+
+# Enable Electron dev mode (loads the Vite dev server instead of built assets).
+# NT_ELECTRON_DEV_MODE=1

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables for the NodeTool mobile app (Expo).
+# Copy to `.env` and adjust for your deployment. Expo only exposes variables
+# prefixed with EXPO_PUBLIC_ to the client bundle.
+
+# Supabase project used for authentication.
+EXPO_PUBLIC_SUPABASE_URL=https://your-supabase-url.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/packages/README.template.md
+++ b/packages/README.template.md
@@ -1,0 +1,32 @@
+# @nodetool-ai/<package-name>
+
+> Template for package READMEs. Copy to `packages/<name>/README.md`, fill in the
+> sections, and delete this note. Several core packages already have READMEs
+> (protocol, runtime, kernel, node-sdk, base-nodes, agents, websocket, models) —
+> use them as worked examples.
+
+One-sentence description (mirror the `description` in package.json).
+
+## Responsibilities
+
+- What this package owns. Bullet the main exports / concepts.
+- Note any cross-package contracts it depends on or provides.
+
+## Usage
+
+```ts
+import { Something } from "@nodetool-ai/<package-name>";
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/<package-name>
+npm run test  --workspace=packages/<package-name>
+npm run lint  --workspace=packages/<package-name>   # tsc --noEmit
+```
+
+> Imports use `@nodetool-ai/<package>`; never import from `dist/`. Packages that
+> use decorators (node-sdk, *-nodes) load from `dist/` — run
+> `npm run build:packages` after changing them. See the root
+> [CLAUDE.md](../../CLAUDE.md) for build order and conventions.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,0 +1,30 @@
+# @nodetool-ai/agents
+
+The planning agent system: `TaskPlanner` → `TaskExecutor` → `StepExecutor`,
+plus `SimpleAgent`, the parallel task executor, skills, and agent tools.
+
+## Responsibilities
+
+- Decompose an objective into a DAG of tasks/steps and execute them (parallel
+  where dependencies allow).
+- Tool integration and progressive-disclosure memory tools (`memory_list`,
+  `memory_read`, `memory_write`).
+
+## Usage
+
+```ts
+import { Agent } from "@nodetool-ai/agents";
+
+const agent = new Agent({ name, objective, provider, model, tools });
+for await (const msg of agent.execute(ctx)) { /* … */ }
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/agents
+npm run test  --workspace=packages/agents
+npm run lint  --workspace=packages/agents
+```
+
+Architecture, parallel execution, skills, and tuning: [packages/agents/CLAUDE.md](./CLAUDE.md).

--- a/packages/base-nodes/README.md
+++ b/packages/base-nodes/README.md
@@ -1,0 +1,21 @@
+# @nodetool-ai/base-nodes
+
+Compatibility shell that re-exports the eleven domain-specific node packages:
+`core`, `text`, `llm`, `data`, `document`, `image`, `audio`, `video`,
+`integration`, `code`, and `automation` nodes.
+
+Depend on this package to pull in the full set of core workflow nodes; depend on
+an individual `@nodetool-ai/*-nodes` package for a narrower slice.
+
+> Uses decorators and loads from `dist/`. After changing node packages, run
+> `npm run build:packages` before `npm run dev`.
+
+## Develop
+
+```bash
+npm run build --workspace=packages/base-nodes
+npm run test  --workspace=packages/base-nodes
+npm run lint  --workspace=packages/base-nodes
+```
+
+To author a new node, see [@nodetool-ai/node-sdk](../node-sdk/README.md).

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -1,0 +1,31 @@
+# @nodetool-ai/kernel
+
+The workflow kernel: the `Graph` model, `NodeInbox`, the actor runtime, and
+`WorkflowRunner`. Executes a workflow DAG via message-passing between node
+actors.
+
+## Responsibilities
+
+- `Graph` — structural model + validation (edge endpoints, types, source handles).
+- `NodeActor` / `NodeInbox` — correlation-aware, buffered scheduling.
+- `WorkflowRunner` — drives a run, emits `ProcessingMessage`s, collects outputs.
+
+## Usage
+
+```ts
+import { WorkflowRunner } from "@nodetool-ai/kernel";
+
+const runner = new WorkflowRunner("job-1", { resolveExecutor });
+const result = await runner.run({ job_id: "job-1", params }, { nodes, edges });
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/kernel
+npm run test  --workspace=packages/kernel
+npm run lint  --workspace=packages/kernel
+```
+
+Scheduling design and known gaps: [docs/correlation-design.md](../../docs/correlation-design.md)
+and [docs/KERNEL_PARITY_GAPS.md](../../docs/KERNEL_PARITY_GAPS.md).

--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -1,0 +1,34 @@
+# @nodetool-ai/node-sdk
+
+The node authoring SDK: `BaseNode`, the `@prop` decorator, `NodeRegistry`, the
+type system, and node metadata/validation.
+
+## Responsibilities
+
+- `BaseNode` — base class all workflow nodes extend.
+- `@prop` decorator + metadata reflection for declaring typed node properties.
+- `NodeRegistry` — registration and lookup; `createNodeValidator()` for pre-flight
+  graph validation.
+
+## Usage
+
+```ts
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+
+export class MyNode extends BaseNode {
+  static readonly nodeType = "my.Node";
+  @prop({ type: "str", default: "" }) declare text: string;
+  async process() { return { output: this.text }; }
+}
+```
+
+> This package uses decorators and loads from `dist/`. After changing it, run
+> `npm run build:packages` before `npm run dev`.
+
+## Develop
+
+```bash
+npm run build --workspace=packages/node-sdk
+npm run test  --workspace=packages/node-sdk
+npm run lint  --workspace=packages/node-sdk
+```

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,0 +1,32 @@
+# @nodetool-ai/protocol
+
+Shared message types and protocol definitions for the NodeTool workflow runtime.
+
+This is the base dependency for nearly every other package — it defines the wire
+types (graph nodes/edges, processing messages, type metadata, API schemas) that
+the kernel, runtime, websocket server, and clients all agree on.
+
+## Responsibilities
+
+- Graph transport types (`NodeDescriptor`, `Edge`) and correlation/lineage signals.
+- Processing message union (`output_update`, `edge_update`, `job_update`, …).
+- `TypeMetadata` parser and type-compatibility checks.
+- Zod schemas for the REST/tRPC boundary (`api-schemas/`).
+
+## Usage
+
+```ts
+import type { NodeDescriptor, Edge } from "@nodetool-ai/protocol";
+import { graphNode } from "@nodetool-ai/protocol";
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/protocol   # tsc build
+npm run test  --workspace=packages/protocol   # vitest
+npm run lint  --workspace=packages/protocol   # tsc --noEmit
+```
+
+Imports use `@nodetool-ai/<package>`; never import from `dist/`. See the root
+[CLAUDE.md](../../CLAUDE.md) for the monorepo build order.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,29 @@
+# @nodetool-ai/runtime
+
+Processing context, LLM providers, message queue, agent memory, output
+normalization, and telemetry for the NodeTool runtime.
+
+## Responsibilities
+
+- `ProcessingContext` — the per-run context passed to every node/executor,
+  including `context.memory` (`AgentMemory`).
+- LLM providers in `src/providers/` (Anthropic, OpenAI, Gemini, Ollama, …) all
+  extending `BaseProvider`.
+- Output normalization, message queue, cost tracking, and OpenTelemetry tracing.
+
+## Usage
+
+```ts
+import { createRuntimeContext, BaseProvider } from "@nodetool-ai/runtime";
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/runtime
+npm run test  --workspace=packages/runtime
+npm run lint  --workspace=packages/runtime
+```
+
+See [packages/agents/CLAUDE.md](../agents/CLAUDE.md) for the agent-memory model
+and the root [CLAUDE.md](../../CLAUDE.md) for provider/telemetry details.

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -1,0 +1,29 @@
+# @nodetool-ai/websocket
+
+The Fastify HTTP + WebSocket server — the main NodeTool API (default port 7777).
+Hosts the unified websocket runner for workflow and chat operations plus the
+tRPC routers and REST endpoints.
+
+## Responsibilities
+
+- `UnifiedWebSocketRunner` — per-connection runner with a job concurrency queue.
+- tRPC routers (`src/trpc/`) with a consistent error shape (`apiCode`).
+- REST endpoints (assets, workflows, models, …) and MsgPack WebSocket messages.
+
+## Run
+
+```bash
+npm run dev:server          # from repo root (tsx --watch)
+node packages/websocket/dist/server.js   # built server
+```
+
+## Develop
+
+```bash
+npm run build --workspace=packages/websocket
+npm run test  --workspace=packages/websocket
+npm run lint  --workspace=packages/websocket
+```
+
+API reference: see the `nodetool-api-reference` skill and the root
+[CLAUDE.md](../../CLAUDE.md).


### PR DESCRIPTION
## Summary

Seven documentation-only commits. No code changes.

- **Package READMEs** for core packages (`agents`, `base-nodes`, `kernel`, `node-sdk`, `protocol`, `runtime`, `websocket`) plus a `README.template.md`.
- **`.env.example`** files for the root server, `mobile/`, and `electron/`.
- **`CLAUDE.md` / `AGENTS.md`**: document that `mobile/` is intentionally not a root workspace; add last-updated markers.
- **`DEVELOPMENT_STANDARDS.md`**: document the `noUnusedLocals`/`noUnusedParameters` tsconfig exception; clarify hooks-deps and `useEffect`-vs-`useMemo` policy; clarify that unmemoized components are not a bulk-fix backlog.

## Test Plan
- [ ] Docs render correctly; links resolve
- [ ] No code or config touched