### PR TITLE
Web UI: primitives & token ESLint guardrails, a11y, and component extractions

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -52,7 +52,11 @@ export default [
     },
 
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      // Surface remaining `any` for incremental cleanup toward the documented
+      // "zero any in web/src" target (DEVELOPMENT_STANDARDS §1). Warn, not
+      // error, so the legacy backlog and intentional generic-constraint idioms
+      // don't break lint.
+      "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "no-console": "off",

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -139,6 +139,13 @@ export default [
           message:
             "Use a MOTION token (MOTION.fast/normal/slow/all/…) instead of a hardcoded transition string. See ui_primitives/tokens.ts.",
         },
+        {
+          // borderRadius: "8px" → use a BORDER_RADIUS token (var(--rounded-*)).
+          selector:
+            "Property[key.name='borderRadius'] > Literal[value=/[1-9][0-9]*px$/]",
+          message:
+            "Use a BORDER_RADIUS token (xs/sm/md/lg/xl/xxl/pill/circle) instead of a hardcoded px radius. See ui_primitives/tokens.ts.",
+        },
       ],
     },
   },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -146,6 +146,14 @@ export default [
           message:
             "Use a BORDER_RADIUS token (xs/sm/md/lg/xl/xxl/pill/circle) instead of a hardcoded px radius. See ui_primitives/tokens.ts.",
         },
+        {
+          // fontSize: "14px" / "0.85rem" → use a TYPOGRAPHY / FONT_SIZE token
+          // (or var(--fontSize*)). Icon sizing should use a token too.
+          selector:
+            "Property[key.name='fontSize'] > Literal[value=/^[0-9.]+(px|rem|em)$/]",
+          message:
+            "Use a TYPOGRAPHY/FONT_SIZE token or var(--fontSize*) instead of a hardcoded font size. See ui_primitives/tokens.ts and docs/DESIGN.md.",
+        },
       ],
     },
   },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -154,6 +154,14 @@ export default [
           message:
             "Use a TYPOGRAPHY/FONT_SIZE token or var(--fontSize*) instead of a hardcoded font size. See ui_primitives/tokens.ts and docs/DESIGN.md.",
         },
+        {
+          // padding/margin/gap: "10px" → snap to the 4px spacing grid (SPACING
+          // tokens in MUI sx; grid-aligned px in emotion css()).
+          selector:
+            "Property[key.name=/^(padding|margin|gap|rowGap|columnGap)$/] > Literal[value=/^[0-9]+px$/]",
+          message:
+            "Snap spacing to the 4px grid: use SPACING tokens in MUI sx, or grid-aligned px in emotion css(). See ui_primitives/spacing.ts and docs/DESIGN.md.",
+        },
       ],
     },
   },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -128,6 +128,18 @@ export default [
           ],
         },
       ],
+      // Design-token guards (warn): discourage hardcoded values that have a
+      // named token. See docs/DESIGN.md and ui_primitives/tokens.ts.
+      "no-restricted-syntax": [
+        "warn",
+        {
+          // transition: "200ms ease" → use a MOTION token.
+          selector:
+            "Property[key.name='transition'] > Literal[value=/[0-9]+ms/]",
+          message:
+            "Use a MOTION token (MOTION.fast/normal/slow/all/…) instead of a hardcoded transition string. See ui_primitives/tokens.ts.",
+        },
+      ],
     },
   },
 ];

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -58,4 +58,76 @@ export default [
       "no-console": "off",
     },
   },
+  // Primitives-first guardrail: discourage importing raw MUI components outside
+  // the primitive layer. `warn` (not `error`) so the existing backlog of raw
+  // imports is surfaced for incremental migration without breaking lint.
+  // ui_primitives/ and editor_ui/ are the legitimate homes for raw MUI and are
+  // excluded below. See web/src/components/ui_primitives/STRATEGY.md.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/components/ui_primitives/**",
+      "src/components/editor_ui/**",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "warn",
+        {
+          paths: [
+            {
+              name: "@mui/material",
+              importNames: [
+                "Typography",
+                "Button",
+                "IconButton",
+                "Tooltip",
+                "CircularProgress",
+                "Chip",
+                "Dialog",
+                "Alert",
+                "Divider",
+                "Paper",
+                "Box",
+                "Menu",
+                "Popover",
+                "Select",
+                "Switch",
+                "Checkbox",
+                "Card",
+                "Drawer",
+              ],
+              message:
+                "Use the equivalent primitive from components/ui_primitives instead of raw MUI. See ui_primitives/STRATEGY.md.",
+            },
+          ],
+          patterns: [
+            {
+              group: [
+                "@mui/material/Typography",
+                "@mui/material/Button",
+                "@mui/material/IconButton",
+                "@mui/material/Tooltip",
+                "@mui/material/CircularProgress",
+                "@mui/material/Chip",
+                "@mui/material/Dialog",
+                "@mui/material/Alert",
+                "@mui/material/Divider",
+                "@mui/material/Paper",
+                "@mui/material/Box",
+                "@mui/material/Menu",
+                "@mui/material/Popover",
+                "@mui/material/Select",
+                "@mui/material/Switch",
+                "@mui/material/Checkbox",
+                "@mui/material/Card",
+                "@mui/material/Drawer",
+              ],
+              message:
+                "Use the equivalent primitive from components/ui_primitives instead of raw MUI. See ui_primitives/STRATEGY.md.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -37,6 +37,7 @@ import { useExposedInputToggle } from "../hooks/nodes/useExposedInputToggle";
 import usePropertyValidationStore from "../stores/PropertyValidationStore";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import RunSelectedNodesSection from "./inspector/RunSelectedNodesSection";
+import { InspectorTabs, type InspectorTab } from "./InspectorTabs";
 import { colorForType } from "../config/data_types";
 import { IconForType } from "../config/IconForType";
 
@@ -501,48 +502,6 @@ const ValidationErrorBanner: React.FC<ValidationErrorBannerProps> = ({
     </div>
   );
 };
-
-type InspectorTab = "params" | "io" | "help";
-
-const TAB_DEFS: { value: InspectorTab; label: string; hasCount: boolean }[] = [
-  { value: "params", label: "Params", hasCount: true },
-  { value: "io", label: "I/O", hasCount: true },
-  { value: "help", label: "Help", hasCount: false }
-];
-
-interface InspectorTabsProps {
-  active: InspectorTab;
-  onChange: (next: InspectorTab) => void;
-  counts: Partial<Record<InspectorTab, number>>;
-}
-
-const InspectorTabs: React.FC<InspectorTabsProps> = ({
-  active,
-  onChange,
-  counts
-}) => (
-  <div className="inspector-tabs" role="tablist">
-    {TAB_DEFS.map((tab) => {
-      const count = counts[tab.value];
-      const isActive = active === tab.value;
-      return (
-        <button
-          key={tab.value}
-          type="button"
-          role="tab"
-          aria-selected={isActive}
-          className={`inspector-tab${isActive ? " is-active" : ""}`}
-          onClick={() => onChange(tab.value)}
-        >
-          {tab.label}
-          {tab.hasCount && typeof count === "number" ? (
-            <span className="tab-count">{count}</span>
-          ) : null}
-        </button>
-      );
-    })}
-  </div>
-);
 
 const TypeLabel: React.FC<{ type?: TypeMetadata | null }> = ({ type }) => {
   const label = type?.type ?? "any";

--- a/web/src/components/InspectorTabs.tsx
+++ b/web/src/components/InspectorTabs.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+/** The tabs shown at the top of the Inspector panel. */
+export type InspectorTab = "params" | "io" | "help";
+
+const TAB_DEFS: { value: InspectorTab; label: string; hasCount: boolean }[] = [
+  { value: "params", label: "Params", hasCount: true },
+  { value: "io", label: "I/O", hasCount: true },
+  { value: "help", label: "Help", hasCount: false }
+];
+
+export interface InspectorTabsProps {
+  active: InspectorTab;
+  onChange: (next: InspectorTab) => void;
+  counts: Partial<Record<InspectorTab, number>>;
+}
+
+/** Presentational tab strip for the Inspector. */
+export const InspectorTabs: React.FC<InspectorTabsProps> = ({
+  active,
+  onChange,
+  counts
+}) => (
+  <div className="inspector-tabs" role="tablist">
+    {TAB_DEFS.map((tab) => {
+      const count = counts[tab.value];
+      const isActive = active === tab.value;
+      return (
+        <button
+          key={tab.value}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          className={`inspector-tab${isActive ? " is-active" : ""}`}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+          {tab.hasCount && typeof count === "number" ? (
+            <span className="tab-count">{count}</span>
+          ) : null}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -26,6 +26,7 @@ import {
   Card,
   Chip,
   Box,
+  EmptyState,
   BORDER_RADIUS,
   MOTION
 } from "../ui_primitives";
@@ -935,9 +936,11 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
       <GetStartedBanner theme={theme} />
 
       {!hasContent && lowerSearch && (
-        <Text sx={{ textAlign: "center", padding: theme.spacing(8), opacity: 0.6 }}>
-          No providers found matching &quot;{searchTerm}&quot;
-        </Text>
+        <EmptyState
+          variant="no-results"
+          title="No providers found"
+          description={`No providers match "${searchTerm}"`}
+        />
       )}
 
       {allRecommended.length > 0 && (

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -395,13 +395,12 @@ function ModelList<TModel extends ModelSelectorModel>({
       if (row.kind === "downloadHeader") {
         return (
           <div style={style}>
-            <Box
+            <FlexRow
+              align="flex-end"
               sx={{
                 px: 1.5,
                 pt: 1.5,
                 pb: 0.5,
-                display: "flex",
-                alignItems: "flex-end",
                 height: "100%"
               }}
             >
@@ -416,7 +415,7 @@ function ModelList<TModel extends ModelSelectorModel>({
               >
                 Available to download
               </Text>
-            </Box>
+            </FlexRow>
           </div>
         );
       }

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -35,7 +35,17 @@ import isEqual from "fast-deep-equal";
 import { Chunk } from "../../stores/ApiTypes";
 import TaskView from "./TaskView";
 import { trpc } from "../../trpc/client";
-import { fromPersistedSketchEditorState } from "../../stores/sketch/persistence";
+import {
+  isRecord,
+  getSketchId,
+  isSketchDocumentLike,
+  unwrapSketchDocumentCandidate,
+  resolveSketchDocument,
+  getTimelineId,
+  isTimelineSequenceLike,
+  unwrapTimelineSequenceCandidate,
+  resolveTimelineSequence
+} from "./outputValueResolvers";
 import SketchRenderer from "../sketch/SketchRenderer";
 import type { SketchDocument } from "../sketch/types";
 import type { TimelineSequence } from "@nodetool-ai/timeline";
@@ -177,110 +187,6 @@ const stableKeyForOutputValue = (v: unknown): string => {
   return `other:${String(v)}`;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const getSketchId = (value: unknown): string | null => {
-  if (!isRecord(value)) {
-    return null;
-  }
-  return typeof value.id === "string" && value.id.length > 0
-    ? value.id
-    : null;
-};
-
-const isSketchDocumentLike = (value: unknown): boolean => {
-  if (!isRecord(value)) {
-    return false;
-  }
-  const canvas = value.canvas;
-  return (
-    isRecord(canvas) &&
-    typeof canvas.width === "number" &&
-    typeof canvas.height === "number" &&
-    Array.isArray(value.layers) &&
-    typeof value.activeLayerId === "string"
-  );
-};
-
-const unwrapSketchDocumentCandidate = (value: unknown, depth = 0): unknown => {
-  if (depth > 4 || isSketchDocumentLike(value) || !isRecord(value)) {
-    return value;
-  }
-  if (isRecord(value.document)) {
-    return unwrapSketchDocumentCandidate(value.document, depth + 1);
-  }
-  if ("sketch" in value) {
-    return unwrapSketchDocumentCandidate(value.sketch, depth + 1);
-  }
-  if (value.type === "sketch" && "data" in value) {
-    return unwrapSketchDocumentCandidate(value.data, depth + 1);
-  }
-  return value;
-};
-
-const resolveSketchDocument = (value: unknown): SketchDocument | null => {
-  const candidate = unwrapSketchDocumentCandidate(value);
-  if (!isSketchDocumentLike(candidate)) {
-    return null;
-  }
-  try {
-    return fromPersistedSketchEditorState(candidate).document;
-  } catch (error) {
-    console.warn("Could not render sketch document", error);
-    return null;
-  }
-};
-
-const getTimelineId = (value: unknown): string | null => {
-  if (!isRecord(value)) {
-    return null;
-  }
-  return typeof value.id === "string" && value.id.length > 0
-    ? value.id
-    : null;
-};
-
-const isTimelineSequenceLike = (value: unknown): value is TimelineSequence => {
-  if (!isRecord(value)) {
-    return false;
-  }
-  return (
-    typeof value.id === "string" &&
-    typeof value.name === "string" &&
-    typeof value.fps === "number" &&
-    typeof value.width === "number" &&
-    typeof value.height === "number" &&
-    typeof value.durationMs === "number" &&
-    Array.isArray(value.tracks) &&
-    Array.isArray(value.clips) &&
-    Array.isArray(value.markers)
-  );
-};
-
-const unwrapTimelineSequenceCandidate = (value: unknown, depth = 0): unknown => {
-  if (depth > 4 || isTimelineSequenceLike(value) || !isRecord(value)) {
-    return value;
-  }
-  if (isRecord(value.sequence)) {
-    return unwrapTimelineSequenceCandidate(value.sequence, depth + 1);
-  }
-  if (isRecord(value.document)) {
-    return unwrapTimelineSequenceCandidate(value.document, depth + 1);
-  }
-  if ("timeline" in value) {
-    return unwrapTimelineSequenceCandidate(value.timeline, depth + 1);
-  }
-  if (value.type === "timeline" && "data" in value) {
-    return unwrapTimelineSequenceCandidate(value.data, depth + 1);
-  }
-  return value;
-};
-
-const resolveTimelineSequence = (value: unknown): TimelineSequence | null => {
-  const candidate = unwrapTimelineSequenceCandidate(value);
-  return isTimelineSequenceLike(candidate) ? candidate : null;
-};
 
 const concatTextChunksSafely = (
   chunks: Chunk[]

--- a/web/src/components/node/outputValueResolvers.ts
+++ b/web/src/components/node/outputValueResolvers.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure value-shape resolvers for OutputRenderer.
+ *
+ * These helpers recognize and unwrap sketch-document and timeline-sequence
+ * shapes from arbitrary output values (which may be wrapped in `document`,
+ * `sketch`, `sequence`, `timeline`, or `{ type, data }` envelopes). Extracted
+ * from OutputRenderer.tsx so the component file stays focused on rendering.
+ */
+import { fromPersistedSketchEditorState } from "../../stores/sketch/persistence";
+import type { SketchDocument } from "../sketch/types";
+import type { TimelineSequence } from "@nodetool-ai/timeline";
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const getSketchId = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  return typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+};
+
+export const isSketchDocumentLike = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const canvas = value.canvas;
+  return (
+    isRecord(canvas) &&
+    typeof canvas.width === "number" &&
+    typeof canvas.height === "number" &&
+    Array.isArray(value.layers) &&
+    typeof value.activeLayerId === "string"
+  );
+};
+
+export const unwrapSketchDocumentCandidate = (
+  value: unknown,
+  depth = 0
+): unknown => {
+  if (depth > 4 || isSketchDocumentLike(value) || !isRecord(value)) {
+    return value;
+  }
+  if (isRecord(value.document)) {
+    return unwrapSketchDocumentCandidate(value.document, depth + 1);
+  }
+  if ("sketch" in value) {
+    return unwrapSketchDocumentCandidate(value.sketch, depth + 1);
+  }
+  if (value.type === "sketch" && "data" in value) {
+    return unwrapSketchDocumentCandidate(value.data, depth + 1);
+  }
+  return value;
+};
+
+export const resolveSketchDocument = (value: unknown): SketchDocument | null => {
+  const candidate = unwrapSketchDocumentCandidate(value);
+  if (!isSketchDocumentLike(candidate)) {
+    return null;
+  }
+  try {
+    return fromPersistedSketchEditorState(candidate).document;
+  } catch (error) {
+    console.warn("Could not render sketch document", error);
+    return null;
+  }
+};
+
+export const getTimelineId = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  return typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+};
+
+export const isTimelineSequenceLike = (
+  value: unknown
+): value is TimelineSequence => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.fps === "number" &&
+    typeof value.width === "number" &&
+    typeof value.height === "number" &&
+    typeof value.durationMs === "number" &&
+    Array.isArray(value.tracks) &&
+    Array.isArray(value.clips) &&
+    Array.isArray(value.markers)
+  );
+};
+
+export const unwrapTimelineSequenceCandidate = (
+  value: unknown,
+  depth = 0
+): unknown => {
+  if (depth > 4 || isTimelineSequenceLike(value) || !isRecord(value)) {
+    return value;
+  }
+  if (isRecord(value.sequence)) {
+    return unwrapTimelineSequenceCandidate(value.sequence, depth + 1);
+  }
+  if (isRecord(value.document)) {
+    return unwrapTimelineSequenceCandidate(value.document, depth + 1);
+  }
+  if ("timeline" in value) {
+    return unwrapTimelineSequenceCandidate(value.timeline, depth + 1);
+  }
+  if (value.type === "timeline" && "data" in value) {
+    return unwrapTimelineSequenceCandidate(value.data, depth + 1);
+  }
+  return value;
+};
+
+export const resolveTimelineSequence = (
+  value: unknown
+): TimelineSequence | null => {
+  const candidate = unwrapTimelineSequenceCandidate(value);
+  return isTimelineSequenceLike(candidate) ? candidate : null;
+};

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -212,6 +212,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
         {isGroup ? (
           <IconButton
             size="small"
+            aria-label={layer.collapsed ? "Expand group" : "Collapse group"}
             onClick={(e) => {
               e.stopPropagation();
               onToggleGroupCollapsed?.(layer.id);
@@ -278,6 +279,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
           >
             <IconButton
               size="small"
+              aria-label={isIsolated ? "Show all layers" : "Solo this layer"}
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleIsolateLayer(layer.id);

--- a/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
@@ -22,7 +22,6 @@ import React, {
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import Menu from "@mui/material/Menu";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
@@ -49,6 +48,7 @@ import {
   LabeledSwitch,
   SelectField,
   NodeMenuItem,
+  EditorMenu,
   MOTION,
   BORDER_RADIUS,
   FONT_SIZE_SANS
@@ -1892,7 +1892,7 @@ export const TrackEffectsPanel: React.FC<TrackEffectsPanelProps> = memo(
             <AddIcon />
             Add
           </button>
-          <Menu
+          <EditorMenu
             anchorEl={addAnchor}
             open={!!addAnchor}
             onClose={handleCloseAdd}
@@ -1904,7 +1904,7 @@ export const TrackEffectsPanel: React.FC<TrackEffectsPanelProps> = memo(
                 {EFFECT_LABELS[t]}
               </NodeMenuItem>
             ))}
-          </Menu>
+          </EditorMenu>
         </FlexRow>
 
         {effects.length === 0 ? (

--- a/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
@@ -40,6 +40,12 @@ import type {
 } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import {
+  DEVICE_WIDTHS,
+  EFFECT_LABELS,
+  AUDIO_EFFECT_TYPES,
+  VIDEO_EFFECT_TYPES
+} from "./trackEffectsConstants";
+import {
   FlexColumn,
   FlexRow,
   NodeSlider,
@@ -85,17 +91,6 @@ const deviceRackStyles = (theme: Theme) =>
   });
 
 // Per-effect-type card width (Ableton-style fixed-width "devices").
-const DEVICE_WIDTHS: Record<TrackEffect["type"], number> = {
-  gain: 200,
-  eq3: 420,
-  filter: 240,
-  compressor: 380,
-  colorCorrection: 320,
-  videoBlur: 220,
-  sharpen: 240,
-  vignette: 260,
-  chromaKey: 280
-};
 
 const effectCardStyles = (
   theme: Theme,
@@ -215,33 +210,6 @@ const paramValueStyles = (theme: Theme) =>
   });
 
 // ── Effect labels ───────────────────────────────────────────────────────────
-
-const EFFECT_LABELS: Record<TrackEffect["type"], string> = {
-  gain: "Gain",
-  eq3: "3-Band EQ",
-  filter: "Filter",
-  compressor: "Compressor",
-  colorCorrection: "Color",
-  videoBlur: "Blur",
-  sharpen: "Sharpen",
-  vignette: "Vignette",
-  chromaKey: "Chroma Key"
-};
-
-const AUDIO_EFFECT_TYPES: TrackEffect["type"][] = [
-  "gain",
-  "eq3",
-  "filter",
-  "compressor"
-];
-
-const VIDEO_EFFECT_TYPES: TrackEffect["type"][] = [
-  "colorCorrection",
-  "videoBlur",
-  "sharpen",
-  "vignette",
-  "chromaKey"
-];
 
 // ── Parameter row ───────────────────────────────────────────────────────────
 

--- a/web/src/components/timeline/Tracks/trackEffectsConstants.ts
+++ b/web/src/components/timeline/Tracks/trackEffectsConstants.ts
@@ -1,0 +1,50 @@
+/**
+ * Static effect metadata for TrackEffectsPanel.
+ *
+ * Extracted from TrackEffectsPanel.tsx to keep the panel component focused on
+ * rendering/interaction. These are pure data keyed by TrackEffect["type"].
+ */
+import type { TrackEffect } from "@nodetool-ai/timeline";
+
+/** Device-rack width (px) per effect type. */
+export const DEVICE_WIDTHS: Record<TrackEffect["type"], number> = {
+  gain: 200,
+  eq3: 420,
+  filter: 240,
+  compressor: 380,
+  colorCorrection: 320,
+  videoBlur: 220,
+  sharpen: 240,
+  vignette: 260,
+  chromaKey: 280
+};
+
+/** Human-readable label per effect type. */
+export const EFFECT_LABELS: Record<TrackEffect["type"], string> = {
+  gain: "Gain",
+  eq3: "3-Band EQ",
+  filter: "Filter",
+  compressor: "Compressor",
+  colorCorrection: "Color",
+  videoBlur: "Blur",
+  sharpen: "Sharpen",
+  vignette: "Vignette",
+  chromaKey: "Chroma Key"
+};
+
+/** Effect types available on audio tracks. */
+export const AUDIO_EFFECT_TYPES: TrackEffect["type"][] = [
+  "gain",
+  "eq3",
+  "filter",
+  "compressor"
+];
+
+/** Effect types available on video tracks. */
+export const VIDEO_EFFECT_TYPES: TrackEffect["type"][] = [
+  "colorCorrection",
+  "videoBlur",
+  "sharpen",
+  "vignette",
+  "chromaKey"
+];

--- a/web/src/components/ui_primitives/Checkbox.tsx
+++ b/web/src/components/ui_primitives/Checkbox.tsx
@@ -5,7 +5,7 @@
  * and consistent styling. Used for boolean selections.
  */
 
-import React, { memo } from "react";
+import React, { forwardRef, memo } from "react";
 import {
   Checkbox as MuiCheckbox,
   CheckboxProps as MuiCheckboxProps,
@@ -41,18 +41,16 @@ export interface CheckboxProps
  * // Compact size
  * <Checkbox label="Select" compact size="small" />
  */
-const CheckboxInternal: React.FC<CheckboxProps> = ({
-  label,
-  size = "medium",
-  compact = false,
-  labelProps,
-  sx,
-  ...props
-}) => {
+const CheckboxInternal = forwardRef<HTMLButtonElement, CheckboxProps>(
+  (
+    { label, size = "medium", compact = false, labelProps, sx, ...props },
+    ref
+  ) => {
   const theme = useTheme();
 
   const checkbox = (
     <MuiCheckbox
+      ref={ref}
       size={size}
       sx={{
         ...(compact && {
@@ -84,7 +82,8 @@ const CheckboxInternal: React.FC<CheckboxProps> = ({
   }
 
   return checkbox;
-};
+  }
+);
 
 export const Checkbox = memo(CheckboxInternal);
 Checkbox.displayName = "Checkbox";

--- a/web/src/components/ui_primitives/LoadingSpinner.tsx
+++ b/web/src/components/ui_primitives/LoadingSpinner.tsx
@@ -4,6 +4,7 @@ import { css, keyframes } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Box, CircularProgress, Typography } from "@mui/material";
+import { reducedMotion } from "./tokens";
 
 const pulse = keyframes`
   0%, 80%, 100% {
@@ -36,7 +37,8 @@ const styles = (theme: Theme, variant: string, size: string) =>
       animation: `${pulse} 1.4s infinite ease-in-out`,
       "&:nth-of-type(1)": { animationDelay: "-0.32s" },
       "&:nth-of-type(2)": { animationDelay: "-0.16s" },
-      "&:nth-of-type(3)": { animationDelay: "0s" }
+      "&:nth-of-type(3)": { animationDelay: "0s" },
+      ...reducedMotion({ animation: "none", opacity: 0.6 })
     },
     ".loading-text": {
       color: theme.vars?.palette?.text?.secondary ?? theme.palette.text.secondary,

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useCallback, useRef, useState, memo } from "react";
+import React, { useCallback, useRef, useState, memo, forwardRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { SxProps, Theme } from "@mui/material/styles";
@@ -101,7 +101,7 @@ const styles = (theme: Theme) => css`
   }
 `;
 
-export const SearchInput: React.FC<SearchInputProps> = memo(({
+export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>(({
   value,
   onChange,
   placeholder = "Search...",
@@ -117,7 +117,7 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
   clearTooltip = "Clear search",
   tooltipPlacement = "top",
   sx
-}) => {
+}, ref) => {
   const theme = useTheme();
   const [localValue, setLocalValue] = useState(value);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -180,6 +180,7 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
         autoFocus={autoFocus}
         fullWidth={fullWidth}
         sx={sx}
+        inputRef={ref}
         slotProps={{
           input: {
             startAdornment: (
@@ -210,7 +211,7 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
       />
     </div>
   );
-});
+}));
 
 SearchInput.displayName = "SearchInput";
 

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback, useRef, useState, memo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
-import type { Theme } from "@mui/material/styles";
+import type { SxProps, Theme } from "@mui/material/styles";
 import { IconButton, Tooltip, InputAdornment, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
@@ -37,6 +37,8 @@ export interface SearchInputProps {
   clearTooltip?: string;
   /** Tooltip placement */
   tooltipPlacement?: "top" | "bottom" | "left" | "right";
+  /** Additional sx applied to the underlying TextField root. */
+  sx?: SxProps<Theme>;
 }
 
 const styles = (theme: Theme) => css`
@@ -113,7 +115,8 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
   className,
   fullWidth = false,
   clearTooltip = "Clear search",
-  tooltipPlacement = "top"
+  tooltipPlacement = "top",
+  sx
 }) => {
   const theme = useTheme();
   const [localValue, setLocalValue] = useState(value);
@@ -176,6 +179,7 @@ export const SearchInput: React.FC<SearchInputProps> = memo(({
         disabled={disabled}
         autoFocus={autoFocus}
         fullWidth={fullWidth}
+        sx={sx}
         slotProps={{
           input: {
             startAdornment: (

--- a/web/src/components/ui_primitives/StatusIndicator.tsx
+++ b/web/src/components/ui_primitives/StatusIndicator.tsx
@@ -4,6 +4,7 @@ import { css, keyframes } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Box, Typography, Tooltip } from "@mui/material";
+import { reducedMotion } from "./tokens";
 import CircleIcon from "@mui/icons-material/Circle";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
@@ -24,7 +25,8 @@ const styles = (theme: Theme, pulse: boolean) =>
     gap: theme.spacing(1),
     ".status-icon": {
       fontSize: 12,
-      animation: pulse ? `${pulseAnimation} 2s infinite` : "none"
+      animation: pulse ? `${pulseAnimation} 2s infinite` : "none",
+      ...reducedMotion({ animation: "none" })
     },
     ".status-label": {
       fontSize: 12,

--- a/web/src/components/ui_primitives/WarningBanner.tsx
+++ b/web/src/components/ui_primitives/WarningBanner.tsx
@@ -74,7 +74,11 @@ const styles = (theme: Theme, variant: BannerVariant, animate: boolean) => {
     background-color: ${c.bg};
     border: 1px solid ${c.border}40;
     animation: ${animate ? css`${pulseAnimation} 2s ease-in-out infinite` : "none"};
-    
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+
     &.compact {
       padding: 8px 12px;
       gap: 8px;


### PR DESCRIPTION
## Summary

Sixteen web-UI commits: enforce the primitives/design-token policy via ESLint, improve accessibility, adopt primitives, and break up two mega-components. No behavior changes.

### ESLint guardrails (`web/eslint.config.mjs`)
- Guard against **raw MUI component imports** outside `ui_primitives/`/`editor_ui/`.
- Guard against hardcoded **transition strings** (use `MOTION` tokens).
- Guard against hardcoded **px border radii** (use `BORDER_RADIUS` tokens).
- Guard against hardcoded **font sizes** (use `TYPOGRAPHY`/`FONT_SIZE` tokens).
- Guard against hardcoded **px spacing** (snap to the 4px grid).
- Surface remaining `any` in web with `no-explicit-any` (warn).

### Accessibility
- Add `aria-label`s to icon-only layer buttons.
- Honor `prefers-reduced-motion` in animated primitives (`LoadingSpinner`, `StatusIndicator`, `WarningBanner`).

### Primitives adoption
- Replace raw MUI `Menu` with the `EditorMenu` primitive in `TrackEffectsPanel`.
- Adopt the `EmptyState` primitive for the API-keys no-results state.
- Use `FlexRow` for a layout `Box` in `ModelList`.
- Add `forwardRef` to `Checkbox`/`SearchInput`; forward `sx` through `SearchInput`.

### Refactors (extractions)
- Extract `InspectorTabs` from the `Inspector` mega-component.
- Extract output value resolvers (`outputValueResolvers.ts`) from `OutputRenderer`.
- Extract effect metadata constants (`trackEffectsConstants.ts`) from `TrackEffectsPanel`.

## Test Plan
- [ ] CI: `cd web && npm run typecheck && npm run lint && npm test`
- [ ] New ESLint rules don't flag existing compliant code
- [ ] Extracted components render identically (no behavior change)