### PR TITLE
fix(base-nodes): unbreak main — real WAV fixtures in audio concat tests

### DIFF
--- a/packages/base-nodes/tests/audio-video-image-props.test.ts
+++ b/packages/base-nodes/tests/audio-video-image-props.test.ts
@@ -37,6 +37,43 @@ function videoRef(bytes: number[]) {
   };
 }
 
+/**
+ * Build a minimal mono 16-bit PCM WAV from int16 sample values. The concat
+ * nodes decode every input to PCM and join in sample space (non-audio bytes are
+ * rejected), so their fixtures must be real WAV files, not arbitrary bytes.
+ */
+function wavRef(samples: number[], sampleRate = 8000) {
+  const dataSize = samples.length * 2;
+  const buf = Buffer.alloc(44 + dataSize);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16); // fmt chunk size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28); // byteRate = sampleRate * blockAlign
+  buf.writeUInt16LE(2, 32); // blockAlign = channels * bytesPerSample
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataSize, 40);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], 44 + i * 2);
+  }
+  return { type: "audio", uri: "", data: buf.toString("base64") };
+}
+
+/** Read the int16 PCM samples out of a canonical 44-byte-header WAV buffer. */
+function samplesOf(wav: Buffer): number[] {
+  expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
+  const samples: number[] = [];
+  for (let i = 44; i + 2 <= wav.length; i += 2) {
+    samples.push(wav.readInt16LE(i));
+  }
+  return samples;
+}
+
 // --- Audio node property tests ---
 
 describe("OverlayAudioNode — uses a/b properties (not audio_a/audio_b)", () => {
@@ -98,13 +135,13 @@ describe("ConcatAudioNode — fully dynamic inputs", () => {
   it("concatenates dynamic inputs in insertion order", async () => {
     const node = new ConcatAudioNode();
     node.assign({
-      audio_1: audioRef([1, 2]),
-      audio_2: audioRef([3, 4])
+      audio_1: wavRef([100, 200]),
+      audio_2: wavRef([300, 400])
     });
     const result = await node.process();
     const output = result.output as { data: string };
     const bytes = Buffer.from(output.data, "base64");
-    expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+    expect(samplesOf(bytes)).toEqual([100, 200, 300, 400]);
   });
 });
 
@@ -112,12 +149,12 @@ describe("ConcatAudioListNode — uses audio_files property", () => {
   it("concatenates list of audio files", async () => {
     const node = new ConcatAudioListNode();
     node.assign({
-      audio_files: [audioRef([1, 2]), audioRef([3])]
+      audio_files: [wavRef([100, 200]), wavRef([300])]
     });
     const result = await node.process();
     const output = result.output as { data: string };
     const bytes = Buffer.from(output.data, "base64");
-    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    expect(samplesOf(bytes)).toEqual([100, 200, 300]);
   });
 });
 

--- a/packages/base-nodes/tests/dynamic-concat-inputs.test.ts
+++ b/packages/base-nodes/tests/dynamic-concat-inputs.test.ts
@@ -1,29 +1,58 @@
 import { describe, expect, it } from "vitest";
 import { ConcatAudioNode, ConcatTextNode } from "../src/index.js";
 
-function audioRef(bytes: number[]) {
-  return {
-    type: "audio",
-    uri: "",
-    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
-  };
+/**
+ * Build a minimal mono 16-bit PCM WAV from int16 sample values. ConcatAudioNode
+ * decodes every input to PCM and joins in sample space (non-audio bytes are
+ * rejected), so fixtures must be real WAV files, not arbitrary bytes.
+ */
+function wavRef(samples: number[], sampleRate = 8000) {
+  const dataSize = samples.length * 2;
+  const buf = Buffer.alloc(44 + dataSize);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16); // fmt chunk size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28); // byteRate = sampleRate * blockAlign
+  buf.writeUInt16LE(2, 32); // blockAlign = channels * bytesPerSample
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataSize, 40);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], 44 + i * 2);
+  }
+  return { type: "audio", uri: "", data: buf.toString("base64") };
+}
+
+/** Read the int16 PCM samples out of a canonical 44-byte-header WAV buffer. */
+function samplesOf(wav: Buffer): number[] {
+  expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
+  const samples: number[] = [];
+  for (let i = 44; i + 2 <= wav.length; i += 2) {
+    samples.push(wav.readInt16LE(i));
+  }
+  return samples;
 }
 
 describe("dynamic concat inputs", () => {
   it("ConcatAudioNode concatenates dynamic inputs in insertion order", async () => {
     const node = new ConcatAudioNode();
     node.assign({
-      a: audioRef([1, 2]),
-      b: audioRef([3, 4]),
-      c: audioRef([5]),
-      d: audioRef([6])
+      a: wavRef([100, 200]),
+      b: wavRef([300, 400]),
+      c: wavRef([500]),
+      d: wavRef([600])
     });
 
     const result = await node.process();
     const output = result.output as { data: string };
     const bytes = Buffer.from(output.data, "base64");
 
-    expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(samplesOf(bytes)).toEqual([100, 200, 300, 400, 500, 600]);
   });
 
   it("ConcatTextNode concatenates dynamic inputs in insertion order", async () => {


### PR DESCRIPTION
## Summary

`main` CI has been **red on every run** since #3782 (`fb60be52d`, "route AUDIO_NODES transforms through decodeAudioToWav"). This fixes it.

That change made `concatAudio` (used by `ConcatAudioNode` and `ConcatAudioListNode`) decode every input to PCM via `decodeAudioToWav`, join in sample space, and **throw on undecodable bytes** instead of silently emitting an unplayable byte concatenation — a deliberate, correct improvement. But three older tests in `base-nodes` still fed raw non-audio bytes (`[1,2]`, `[3,4]`, …) and asserted byte-level concatenation:

- `tests/dynamic-concat-inputs.test.ts:13`
- `tests/audio-video-image-props.test.ts` — `ConcatAudioNode — fully dynamic inputs`
- `tests/audio-video-image-props.test.ts` — `ConcatAudioListNode — uses audio_files property`

On the Linux CI runner, `decodeAudioData` has no format reader for those garbage fixtures, so `decodeAudioToWav` throws `Could not decode audio…` and the **Quality Gate** (`npm run check`) fails. The tests, not the production code, were stale.

## Fix

These tests are about **dynamic-input wiring** (insertion order, list vs. dynamic props), not audio DSP. They now use valid **mono 16-bit PCM WAV** fixtures, which `parseWavBytes` reads directly (no WebAudio, so they pass in CI), and assert the **decoded sample order** of the combined WAV. `audioRef`/`videoRef` and the passing Overlay/Repeat/video tests are untouched.

## Test Plan
- [x] `npm run test --workspace=packages/base-nodes -- run dynamic-concat-inputs audio-video-image-props` → 17 passed (against a rebuilt `audio-nodes` dist with the decode-based concat)
- [ ] CI Quality Gate green

## Why this matters now
This pre-existing failure blocks the Quality Gate on **every** open PR (it runs the whole suite). Merging this unblocks the 5 split PRs (#3788–#3792); each will go green after rebasing onto updated main.