### PR TITLE
Marketing site — Phase 2: growth surfaces (pricing, /vs pages, JSON-LD, OG images, waitlist)

### DIFF
--- a/marketing/src/app/agents/layout.tsx
+++ b/marketing/src/app/agents/layout.tsx
@@ -1,3 +1,4 @@
+import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -25,5 +26,19 @@ export default function AgentsLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+            { "@type": "ListItem", position: 2, name: "Agents", item: "https://nodetool.ai/agents" },
+          ],
+        }}
+      />
+      {children}
+    </>
+  );
 }

--- a/marketing/src/app/agents/opengraph-image.tsx
+++ b/marketing/src/app/agents/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "Agents for creative work";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "Agents for creative work",
+    "An art director that never sleeps, on your canvas."
+  );
+}

--- a/marketing/src/app/cloud/layout.tsx
+++ b/marketing/src/app/cloud/layout.tsx
@@ -1,3 +1,4 @@
+import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -23,5 +24,19 @@ export default function CloudLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+            { "@type": "ListItem", position: 2, name: "Cloud", item: "https://nodetool.ai/cloud" },
+          ],
+        }}
+      />
+      {children}
+    </>
+  );
 }

--- a/marketing/src/app/cloud/opengraph-image.tsx
+++ b/marketing/src/app/cloud/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "NodeTool Cloud";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool Cloud",
+    "Visual AI workflows in your browser. Zero setup, BYOK."
+  );
+}

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import SiteHeader from "../../components/SiteHeader";
 import SiteFooter from "../../components/SiteFooter";
+import CloudWaitlist from "../../components/CloudWaitlist";
 
 const ProvidersSection = dynamic(
   () => import("../../components/ProvidersSection"),
@@ -248,6 +249,12 @@ export default function CloudPage() {
                     Alpha preview · AGPL-3.0 source · BYOK for every provider ·
                     Self-host any time
                   </p>
+                  <div className="mt-5 max-w-md">
+                    <p className="mb-2 text-sm text-slate-300">
+                      Not ready yet? Get notified as Cloud opens up.
+                    </p>
+                    <CloudWaitlist />
+                  </div>
                 </div>
                 <div className="mt-6 inline-flex items-center gap-2 text-sm text-slate-400">
                   <span>Want to run it locally instead?</span>

--- a/marketing/src/app/creatives/layout.tsx
+++ b/marketing/src/app/creatives/layout.tsx
@@ -1,3 +1,4 @@
+import JsonLd from "../../components/JsonLd";
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
@@ -54,5 +55,19 @@ export default function CreativesLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+            { "@type": "ListItem", position: 2, name: "Creatives", item: "https://nodetool.ai/creatives" },
+          ],
+        }}
+      />
+      {children}
+    </>
+  );
 }

--- a/marketing/src/app/creatives/opengraph-image.tsx
+++ b/marketing/src/app/creatives/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "NodeTool for creatives";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool for creatives",
+    "Image, music & video in one open studio. Every model, your keys."
+  );
+}

--- a/marketing/src/app/developers/layout.tsx
+++ b/marketing/src/app/developers/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import JsonLd from "../../components/JsonLd";
 
 export const metadata: Metadata = {
   title: "NodeTool for Developers | Open-Source AI Workflow SDK & API",
@@ -57,5 +58,32 @@ export default function DevelopersLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "SoftwareSourceCode",
+          name: "NodeTool",
+          description:
+            "Open-source creative AI workspace. TypeScript SDK and REST API; write custom nodes in TypeScript or Python, drive the canvas from a CLI, and generate workflows in code.",
+          codeRepository: "https://github.com/nodetool-ai/nodetool",
+          programmingLanguage: ["TypeScript", "Python"],
+          license: "https://github.com/nodetool-ai/nodetool/blob/main/LICENSE",
+          url: "https://nodetool.ai/developers",
+        }}
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+            { "@type": "ListItem", position: 2, name: "Developers", item: "https://nodetool.ai/developers" },
+          ],
+        }}
+      />
+      {children}
+    </>
+  );
 }

--- a/marketing/src/app/developers/opengraph-image.tsx
+++ b/marketing/src/app/developers/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "NodeTool for Developers";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool for Developers",
+    "TypeScript SDK, REST API, custom nodes. Open source."
+  );
+}

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -220,6 +220,31 @@ export default function RootLayout({
           }}
         />
 
+        {/* JSON-LD Structured Data for the homepage demo video */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "VideoObject",
+              "name": "NodeTool — the open creative AI workspace (demo)",
+              "description":
+                "A walkthrough of NodeTool: wiring image, video, audio, and text models from every major provider into one node-based canvas, called with your own keys.",
+              "thumbnailUrl": "https://nodetool.ai/preview.png",
+              "contentUrl": "https://nodetool.ai/demo.mp4",
+              "uploadDate": "2026-01-01",
+              "publisher": {
+                "@type": "Organization",
+                "name": "NodeTool",
+                "logo": {
+                  "@type": "ImageObject",
+                  "url": "https://nodetool.ai/logo.png"
+                }
+              }
+            })
+          }}
+        />
+
         <Script
           defer
           data-domain="nodetool.ai"

--- a/marketing/src/app/opengraph-image.tsx
+++ b/marketing/src/app/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../lib/og";
+
+export const alt = "NodeTool — the open creative AI workspace";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "The open creative AI workspace",
+    "Every model. Your keys. Your canvas."
+  );
+}

--- a/marketing/src/app/pricing/opengraph-image.tsx
+++ b/marketing/src/app/pricing/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "NodeTool Pricing — free Studio, BYOK to every provider";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "Free to download. Pay providers, not us.",
+    "Studio is free and open source. BYOK to every provider."
+  );
+}

--- a/marketing/src/app/pricing/page.tsx
+++ b/marketing/src/app/pricing/page.tsx
@@ -1,0 +1,250 @@
+import type { Metadata } from "next";
+import { Check, Minus, Download } from "lucide-react";
+import SiteHeader from "../../components/SiteHeader";
+import SiteFooter from "../../components/SiteFooter";
+import JsonLd from "../../components/JsonLd";
+import { SmartDownloadButton } from "../SmartDownloadButton";
+
+export const metadata: Metadata = {
+  title: "Pricing — free Studio, BYOK, pay providers directly | NodeTool",
+  description:
+    "NodeTool Studio is free and open source. NodeTool Cloud is a subscription for managed hosting. In both, you bring your own API keys and pay providers their list prices — no credits, no markup.",
+  alternates: { canonical: "/pricing" },
+  openGraph: {
+    title: "NodeTool Pricing — free Studio, BYOK to every provider",
+    description:
+      "Studio is free and open source. Cloud is managed hosting. Both are BYOK: pay providers directly at their list prices, no credits, no markup.",
+    url: "https://nodetool.ai/pricing",
+    type: "website",
+  },
+};
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+    { "@type": "ListItem", position: 2, name: "Pricing", item: "https://nodetool.ai/pricing" },
+  ],
+};
+
+const offers = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: "NodeTool",
+  description:
+    "The open creative AI workspace. Studio (desktop) is free; Cloud is a managed subscription. Both are BYOK.",
+  brand: { "@type": "Brand", name: "NodeTool" },
+  offers: [
+    {
+      "@type": "Offer",
+      name: "NodeTool Studio",
+      price: "0",
+      priceCurrency: "USD",
+      description: "Free, open-source desktop app. BYOK to every provider.",
+      url: "https://nodetool.ai/studio",
+    },
+    {
+      "@type": "Offer",
+      name: "NodeTool Cloud",
+      description:
+        "Managed hosting subscription (currently in alpha). BYOK to every provider.",
+      url: "https://nodetool.ai/cloud",
+      availability: "https://schema.org/PreOrder",
+    },
+  ],
+};
+
+const editionRows: { label: string; studio: string | boolean; cloud: string | boolean }[] = [
+  { label: "Price", studio: "Free", cloud: "Subscription (alpha)" },
+  { label: "Where it runs", studio: "Your machine (macOS, Windows, Linux)", cloud: "Your browser, hosted by us" },
+  { label: "Bring your own API keys", studio: true, cloud: true },
+  { label: "Pay providers directly (no markup)", studio: true, cloud: true },
+  { label: "Local models (Ollama, MLX, llama.cpp)", studio: true, cloud: false },
+  { label: "Zero setup / no GPU needed", studio: false, cloud: true },
+  { label: "Open source (AGPL-3.0)", studio: true, cloud: true },
+  { label: "Self-host any time", studio: true, cloud: true },
+];
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-5 w-5 text-emerald-400" aria-label="Yes" />;
+  if (value === false)
+    return <Minus className="mx-auto h-5 w-5 text-slate-600" aria-label="No" />;
+  return <span className="text-sm text-slate-300">{value}</span>;
+}
+
+export default function PricingPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden text-white">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={offers} />
+
+      {/* Background glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute -top-40 left-1/3 h-[28rem] w-[28rem] rounded-full bg-blue-500/15 blur-[120px]" />
+        <div className="absolute top-1/2 -right-24 h-[24rem] w-[24rem] rounded-full bg-fuchsia-500/10 blur-[120px]" />
+      </div>
+
+      <SiteHeader />
+
+      <div className="relative isolate pt-28 sm:pt-36">
+        {/* Hero */}
+        <section aria-labelledby="pricing-title" className="mx-auto max-w-3xl px-6 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
+            Pricing
+          </span>
+          <h1
+            id="pricing-title"
+            className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
+          >
+            Free to download. You pay providers, not us.
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-slate-300">
+            NodeTool Studio is free and open source. NodeTool Cloud is a
+            subscription for managed hosting. In both editions you bring your own
+            API keys and pay each provider their list price — no credits, no
+            markup, no curated roster.
+          </p>
+        </section>
+
+        {/* Edition cards */}
+        <section aria-label="Editions" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Studio */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">NodeTool Studio</h2>
+              <p className="mt-1 text-sm text-slate-400">Desktop app · local-first</p>
+              <div className="mt-6 flex items-baseline gap-2">
+                <span className="text-4xl font-bold text-white">Free</span>
+                <span className="text-sm text-slate-400">forever · AGPL-3.0</span>
+              </div>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Runs on macOS, Windows, and Linux",
+                  "Local models via Ollama, MLX, llama.cpp",
+                  "BYOK to every cloud provider",
+                  "Your workflows and files stay on your machine",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8">
+                <SmartDownloadButton
+                  icon={<Download className="h-5 w-5" />}
+                  classNameOverride="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+                />
+              </div>
+            </div>
+
+            {/* Cloud */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold text-white">NodeTool Cloud</h2>
+                <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-200">
+                  Alpha
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-slate-400">Hosted · zero setup</p>
+              <div className="mt-6 flex items-baseline gap-2">
+                <span className="text-4xl font-bold text-white">Subscription</span>
+              </div>
+              <p className="mt-1 text-sm text-slate-400">
+                Managed hosting of the same open-source app. Pricing finalised at
+                general availability.
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Runs in your browser — no install, no GPU",
+                  "BYOK to every cloud provider",
+                  "Same AGPL-3.0 codebase you can self-host",
+                  "Pay providers directly at provider prices",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8">
+                <a
+                  href="https://app.nodetool.ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-700 bg-slate-900/60 px-6 py-3.5 text-sm font-semibold text-slate-100 transition-all hover:border-slate-500 hover:bg-slate-800/60 focus-ring"
+                >
+                  Try the Cloud alpha
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Edition comparison table */}
+        <section aria-label="Compare editions" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/70 ring-1 ring-white/5">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="bg-slate-900/60 text-sm">
+                  <th className="px-5 py-4 font-medium text-slate-400">Feature</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">Studio</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">Cloud</th>
+                </tr>
+              </thead>
+              <tbody>
+                {editionRows.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={i % 2 ? "bg-slate-950/40" : "bg-slate-900/20"}
+                  >
+                    <td className="px-5 py-4 text-sm text-slate-300">{row.label}</td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.studio} /></td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.cloud} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* BYOK explainer */}
+        <section aria-labelledby="byok-title" className="mx-auto mt-16 max-w-3xl px-6">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+            <h2 id="byok-title" className="text-2xl font-semibold tracking-tight text-white">
+              How &ldquo;bring your own keys&rdquo; works
+            </h2>
+            <p className="mt-4 leading-relaxed text-slate-300">
+              You add your own API keys for the providers you use — FAL, KIE,
+              OpenAI, Anthropic, Gemini, Replicate, and the rest. Model calls go
+              to those providers and you pay them their published list prices.
+              NodeTool does not run inference on its own servers, does not issue
+              proprietary credits, and does not mark up model calls. Your
+              Cloud subscription pays for hosting the workspace, nothing more.
+            </p>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto my-24 max-w-2xl px-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Start free, on your machine.
+          </h2>
+          <p className="mt-4 text-lg text-slate-300">
+            Download Studio and build your first workflow in minutes.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SmartDownloadButton
+              icon={<Download className="h-5 w-5" />}
+              classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+            />
+          </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/marketing/src/app/sitemap.ts
+++ b/marketing/src/app/sitemap.ts
@@ -30,6 +30,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: now,
     },
     {
+      url: `${BASE_URL}/pricing`,
+      lastModified: now,
+    },
+    {
+      url: `${BASE_URL}/vs/comfyui`,
+      lastModified: now,
+    },
+    {
+      url: `${BASE_URL}/vs/weavy`,
+      lastModified: now,
+    },
+    {
       url: `${BASE_URL}/imprint`,
       lastModified: now,
     },

--- a/marketing/src/app/studio/layout.tsx
+++ b/marketing/src/app/studio/layout.tsx
@@ -1,3 +1,4 @@
+import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -23,5 +24,19 @@ export default function StudioLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+            { "@type": "ListItem", position: 2, name: "Studio", item: "https://nodetool.ai/studio" },
+          ],
+        }}
+      />
+      {children}
+    </>
+  );
 }

--- a/marketing/src/app/studio/opengraph-image.tsx
+++ b/marketing/src/app/studio/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../lib/og";
+
+export const alt = "NodeTool Studio";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool Studio",
+    "AI workflows that run on your machine. Local-first, BYOK."
+  );
+}

--- a/marketing/src/app/vs/comfyui/opengraph-image.tsx
+++ b/marketing/src/app/vs/comfyui/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../../lib/og";
+
+export const alt = "NodeTool vs ComfyUI";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool vs ComfyUI",
+    "The studio around the node editor — every modality, every provider."
+  );
+}

--- a/marketing/src/app/vs/comfyui/page.tsx
+++ b/marketing/src/app/vs/comfyui/page.tsx
@@ -1,0 +1,256 @@
+import type { Metadata } from "next";
+import { Check, Minus, Download } from "lucide-react";
+import SiteHeader from "../../../components/SiteHeader";
+import SiteFooter from "../../../components/SiteFooter";
+import JsonLd from "../../../components/JsonLd";
+import { SmartDownloadButton } from "../../SmartDownloadButton";
+
+export const metadata: Metadata = {
+  title: "NodeTool vs ComfyUI — the open creative AI workspace",
+  description:
+    "ComfyUI is an engineer-first node editor for Stable Diffusion. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a far wider model roster across providers, and built-in editing tools — all BYOK at provider prices. Both are open source.",
+  alternates: { canonical: "/vs/comfyui" },
+  openGraph: {
+    title: "NodeTool vs ComfyUI — the open creative AI workspace",
+    description:
+      "Beyond diffusion images: NodeTool puts image, video, audio, and text on one node-based canvas with editing tools built in. Open source, BYOK, provider prices.",
+    url: "https://nodetool.ai/vs/comfyui",
+    type: "website",
+  },
+};
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "NodeTool vs ComfyUI",
+      item: "https://nodetool.ai/vs/comfyui",
+    },
+  ],
+};
+
+const faq = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the difference between NodeTool and ComfyUI?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an engineer-first UX. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a much wider model roster across providers and modalities, and editing tools creatives actually use — called with your own keys at provider prices. Both are node-based and open source.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is NodeTool open source like ComfyUI?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. NodeTool is open source under AGPL-3.0. You can run it as a desktop app on macOS, Windows, or Linux, or in the browser via NodeTool Cloud, which is managed hosting of the same open-source code.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can NodeTool do more than image generation?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. NodeTool works across image, video, audio, and text on one canvas, with editing tools built in — masks, inpaint, outpaint, relight, upscale, layers, and compositing. ComfyUI is centered on diffusion image generation.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How does NodeTool handle model pricing?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "NodeTool is BYOK — you bring your own API keys and pay each provider their list price. There are no credits, no markup, and no curated roster. You can also run local models with Ollama, MLX, or llama.cpp in the desktop app.",
+      },
+    },
+  ],
+};
+
+const rows: { label: string; comfyui: string | boolean; nodetool: string | boolean }[] = [
+  {
+    label: "Modalities",
+    comfyui: "Diffusion images",
+    nodetool: "Image, video, audio, text",
+  },
+  {
+    label: "Model roster",
+    comfyui: "Stable Diffusion / diffusion",
+    nodetool: "Every major provider & modality",
+  },
+  { label: "BYOK / provider billing", comfyui: false, nodetool: true },
+  {
+    label: "Editing tools (masks, inpaint, relight, layers)",
+    comfyui: false,
+    nodetool: true,
+  },
+  { label: "Local models", comfyui: true, nodetool: true },
+  { label: "Desktop + browser", comfyui: false, nodetool: true },
+  { label: "Open source", comfyui: true, nodetool: true },
+];
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-5 w-5 text-emerald-400" aria-label="Yes" />;
+  if (value === false)
+    return <Minus className="mx-auto h-5 w-5 text-slate-600" aria-label="No" />;
+  return <span className="text-sm text-slate-300">{value}</span>;
+}
+
+export default function VsComfyUIPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden text-white">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={faq} />
+
+      {/* Background glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute -top-40 left-1/3 h-[28rem] w-[28rem] rounded-full bg-blue-500/15 blur-[120px]" />
+        <div className="absolute top-1/2 -right-24 h-[24rem] w-[24rem] rounded-full bg-fuchsia-500/10 blur-[120px]" />
+      </div>
+
+      <SiteHeader />
+
+      <div className="relative isolate pt-28 sm:pt-36">
+        {/* Hero */}
+        <section aria-labelledby="vs-title" className="mx-auto max-w-3xl px-6 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
+            NodeTool vs ComfyUI
+          </span>
+          <h1
+            id="vs-title"
+            className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
+          >
+            The open creative AI workspace, not just a diffusion editor.
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-slate-300">
+            ComfyUI is a node editor focused on Stable Diffusion and diffusion
+            image generation, with engineer-first UX. NodeTool is the studio
+            around it: image, video, music, and words on one canvas; a much wider
+            model roster across providers and modalities; editing tools creatives
+            actually use — called with your own keys at provider prices. Both are
+            node-based and open source.
+          </p>
+        </section>
+
+        {/* Comparison cards */}
+        <section aria-label="At a glance" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* ComfyUI */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">ComfyUI</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Node editor for diffusion images
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Deep control over Stable Diffusion pipelines",
+                  "Engineer-first, graph-based UX",
+                  "Local model focused",
+                  "Open source community",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* NodeTool */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">NodeTool</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                The studio around the canvas
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Image, video, audio, and text on one canvas",
+                  "Every major model from every major provider",
+                  "Editing tools: masks, inpaint, relight, layers",
+                  "BYOK at provider prices — no credits, no markup",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Comparison table */}
+        <section aria-label="Compare" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/70 ring-1 ring-white/5">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="bg-slate-900/60 text-sm">
+                  <th className="px-5 py-4 font-medium text-slate-400">Feature</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">ComfyUI</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">NodeTool</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={i % 2 ? "bg-slate-950/40" : "bg-slate-900/20"}
+                  >
+                    <td className="px-5 py-4 text-sm text-slate-300">{row.label}</td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.comfyui} /></td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.nodetool} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Explainer */}
+        <section aria-labelledby="explainer-title" className="mx-auto mt-16 max-w-3xl px-6">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+            <h2 id="explainer-title" className="text-2xl font-semibold tracking-tight text-white">
+              One canvas for everything, not just images
+            </h2>
+            <p className="mt-4 leading-relaxed text-slate-300">
+              If your work starts and ends with Stable Diffusion images, ComfyUI
+              gives you fine-grained control. But most creative projects span
+              modalities — image into video, voice and music into a cut, words
+              into everything. NodeTool keeps image, video, audio, and text on one
+              node-based canvas with the editing tools you reach for built in:
+              masks, inpaint, outpaint, relight, upscale, layers, and
+              compositing. You call every major model from every major provider
+              with your own keys at provider prices — no credits, no markup, no
+              curated roster — and run locally too via Ollama, MLX, and llama.cpp.
+            </p>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto my-24 max-w-2xl px-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Open, multimodal, and yours.
+          </h2>
+          <p className="mt-4 text-lg text-slate-300">
+            Download Studio and build across image, video, audio, and text in one
+            place.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SmartDownloadButton
+              icon={<Download className="h-5 w-5" />}
+              classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+            />
+          </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/marketing/src/app/vs/weavy/opengraph-image.tsx
+++ b/marketing/src/app/vs/weavy/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogImage, ogSize, ogContentType } from "../../../lib/og";
+
+export const alt = "NodeTool vs Weavy";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool vs Weavy",
+    "Open source and BYOK — no credits, no curated roster, no lock-in."
+  );
+}

--- a/marketing/src/app/vs/weavy/page.tsx
+++ b/marketing/src/app/vs/weavy/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from "next";
+import { Check, Minus, Download } from "lucide-react";
+import SiteHeader from "../../../components/SiteHeader";
+import SiteFooter from "../../../components/SiteFooter";
+import JsonLd from "../../../components/JsonLd";
+import { SmartDownloadButton } from "../../SmartDownloadButton";
+
+export const metadata: Metadata = {
+  title: "NodeTool vs Weavy — open source, BYOK, no credits",
+  description:
+    "Weavy and similar closed SaaS canvases lock you into credits and a curated model roster. NodeTool is open source (AGPL-3.0) and BYOK: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same self-hostable code.",
+  alternates: { canonical: "/vs/weavy" },
+  openGraph: {
+    title: "NodeTool vs Weavy — open source, BYOK, no credits",
+    description:
+      "No credits, no curated roster, no lock-in. NodeTool is open source and BYOK: every provider at provider prices, with workflows and files you own.",
+    url: "https://nodetool.ai/vs/weavy",
+    type: "website",
+  },
+};
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "NodeTool vs Weavy",
+      item: "https://nodetool.ai/vs/weavy",
+    },
+  ],
+};
+
+const faq = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How is NodeTool different from Weavy?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Weavy and similar closed SaaS canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK: every provider, your keys, provider prices, and you own your workflows and files. NodeTool Cloud is just managed hosting of the same open-source code you can self-host.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does NodeTool use credits?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. NodeTool is BYOK — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no curated roster of models.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I self-host NodeTool?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. NodeTool is open source under AGPL-3.0. You can run it as a desktop app on macOS, Windows, or Linux, or self-host the same code that powers NodeTool Cloud.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Who owns my workflows and files in NodeTool?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "You do. In the desktop app your workflows and files stay on your machine. NodeTool does not lock your work behind a proprietary platform — the code is open source and self-hostable.",
+      },
+    },
+  ],
+};
+
+const rows: { label: string; weavy: string | boolean; nodetool: string | boolean }[] = [
+  {
+    label: "Pricing model",
+    weavy: "Credits",
+    nodetool: "BYOK / provider prices",
+  },
+  {
+    label: "Model roster",
+    weavy: "Curated roster",
+    nodetool: "Every provider",
+  },
+  { label: "Source", weavy: "Closed", nodetool: "AGPL-3.0" },
+  { label: "Self-host", weavy: false, nodetool: true },
+  { label: "Data ownership", weavy: false, nodetool: true },
+  { label: "Desktop app", weavy: false, nodetool: true },
+];
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-5 w-5 text-emerald-400" aria-label="Yes" />;
+  if (value === false)
+    return <Minus className="mx-auto h-5 w-5 text-slate-600" aria-label="No" />;
+  return <span className="text-sm text-slate-300">{value}</span>;
+}
+
+export default function VsWeavyPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden text-white">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={faq} />
+
+      {/* Background glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute -top-40 left-1/3 h-[28rem] w-[28rem] rounded-full bg-blue-500/15 blur-[120px]" />
+        <div className="absolute top-1/2 -right-24 h-[24rem] w-[24rem] rounded-full bg-fuchsia-500/10 blur-[120px]" />
+      </div>
+
+      <SiteHeader />
+
+      <div className="relative isolate pt-28 sm:pt-36">
+        {/* Hero */}
+        <section aria-labelledby="vs-title" className="mx-auto max-w-3xl px-6 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
+            NodeTool vs Weavy
+          </span>
+          <h1
+            id="vs-title"
+            className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
+          >
+            Open source and BYOK. No credits, no lock-in.
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-slate-300">
+            Weavy and similar closed SaaS canvases lock you into a credit system
+            and a curated model roster. NodeTool is open source and BYOK: every
+            provider, your keys, provider prices, and you own your workflows and
+            files. Cloud is just managed hosting of the same open-source code you
+            can self-host.
+          </p>
+        </section>
+
+        {/* Comparison cards */}
+        <section aria-label="At a glance" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Weavy / closed SaaS */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">Weavy</h2>
+              <p className="mt-1 text-sm text-slate-400">Closed SaaS canvas</p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Credit system you top up and burn",
+                  "Curated roster of supported models",
+                  "Closed source, hosted only",
+                  "Work lives on their platform",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Minus className="mt-0.5 h-4 w-4 shrink-0 text-slate-600" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* NodeTool */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">NodeTool</h2>
+              <p className="mt-1 text-sm text-slate-400">Open source · BYOK</p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "BYOK — pay providers directly at list prices",
+                  "Every major model from every major provider",
+                  "Open source under AGPL-3.0, self-hostable",
+                  "You own your workflows and files",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Comparison table */}
+        <section aria-label="Compare" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/70 ring-1 ring-white/5">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="bg-slate-900/60 text-sm">
+                  <th className="px-5 py-4 font-medium text-slate-400">Feature</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">Weavy</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">NodeTool</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={i % 2 ? "bg-slate-950/40" : "bg-slate-900/20"}
+                  >
+                    <td className="px-5 py-4 text-sm text-slate-300">{row.label}</td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.weavy} /></td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.nodetool} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Explainer */}
+        <section aria-labelledby="explainer-title" className="mx-auto mt-16 max-w-3xl px-6">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+            <h2 id="explainer-title" className="text-2xl font-semibold tracking-tight text-white">
+              Pay providers, not credits — and keep your work
+            </h2>
+            <p className="mt-4 leading-relaxed text-slate-300">
+              Credit systems and curated rosters decide which models you can use
+              and what each call costs. NodeTool flips that: you add your own API
+              keys and pay each provider their published list price — no credits,
+              no markup, no curated roster. The whole workspace is open source
+              under AGPL-3.0, so you can run it as a desktop app or self-host it,
+              and your workflows and files stay yours. NodeTool Cloud is simply
+              managed hosting of that same open-source code.
+            </p>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto my-24 max-w-2xl px-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Own your canvas.
+          </h2>
+          <p className="mt-4 text-lg text-slate-300">
+            Download Studio and build with every provider, at provider prices.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SmartDownloadButton
+              icon={<Download className="h-5 w-5" />}
+              classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+            />
+          </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/marketing/src/components/CloudWaitlist.tsx
+++ b/marketing/src/components/CloudWaitlist.tsx
@@ -1,0 +1,92 @@
+"use client";
+import React, { useState } from "react";
+import { track } from "../lib/analytics";
+
+/**
+ * Cloud alpha → GA waitlist capture (D4). Posts to a configurable endpoint
+ * (`NEXT_PUBLIC_WAITLIST_ENDPOINT`) when set; otherwise degrades gracefully to
+ * an email so the form always does something useful.
+ */
+const ENDPOINT = process.env.NEXT_PUBLIC_WAITLIST_ENDPOINT;
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export default function CloudWaitlist() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email || status === "submitting") return;
+    track("Contact", { form: "cloud-waitlist" });
+
+    if (!ENDPOINT) {
+      window.location.href = `mailto:hello@nodetool.ai?subject=${encodeURIComponent(
+        "NodeTool Cloud waitlist"
+      )}&body=${encodeURIComponent(`Please add me to the Cloud waitlist: ${email}`)}`;
+      setStatus("success");
+      return;
+    }
+
+    setStatus("submitting");
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, source: "cloud-waitlist" }),
+      });
+      setStatus(res.ok ? "success" : "error");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <p
+        role="status"
+        className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-5 py-4 text-sm font-medium text-emerald-200"
+      >
+        You&apos;re on the list. We&apos;ll be in touch as Cloud opens up.
+      </p>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex w-full flex-col gap-3 sm:flex-row"
+      aria-label="Join the NodeTool Cloud waitlist"
+    >
+      <label htmlFor="cloud-waitlist-email" className="sr-only">
+        Email address
+      </label>
+      <input
+        id="cloud-waitlist-email"
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="you@studio.com"
+        autoComplete="email"
+        className="w-full rounded-xl border border-slate-700 bg-slate-900/70 px-4 py-3.5 text-sm text-white placeholder:text-slate-500 focus-ring sm:flex-1"
+      />
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring disabled:opacity-60"
+      >
+        {status === "submitting" ? "Joining…" : "Join the waitlist"}
+      </button>
+      {status === "error" && (
+        <p role="alert" className="text-sm text-rose-300 sm:basis-full">
+          Something went wrong. Email{" "}
+          <a className="underline" href="mailto:hello@nodetool.ai">
+            hello@nodetool.ai
+          </a>{" "}
+          and we&apos;ll add you.
+        </p>
+      )}
+    </form>
+  );
+}

--- a/marketing/src/components/JsonLd.tsx
+++ b/marketing/src/components/JsonLd.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+/**
+ * Renders a JSON-LD <script> block. Server component so the structured data is
+ * in the server HTML for crawlers and LLMs (A3). Pass a schema.org object.
+ */
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/marketing/src/components/SiteFooter.tsx
+++ b/marketing/src/components/SiteFooter.tsx
@@ -19,6 +19,7 @@ const COLUMNS: Col[] = [
     links: [
       { name: "Studio", href: "/studio" },
       { name: "Cloud", href: "/cloud" },
+      { name: "Pricing", href: "/pricing" },
     ],
   },
   {

--- a/marketing/src/components/SiteHeader.tsx
+++ b/marketing/src/components/SiteHeader.tsx
@@ -19,6 +19,7 @@ const NAV: NavItem[] = [
   { name: "Creatives", href: "/creatives" },
   { name: "Agents", href: "/agents" },
   { name: "Developers", href: "/developers" },
+  { name: "Pricing", href: "/pricing" },
   { name: "Docs", href: "https://docs.nodetool.ai", external: true },
 ];
 

--- a/marketing/src/lib/og.tsx
+++ b/marketing/src/lib/og.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from "next/og";
+
+/**
+ * Shared Open Graph image generator (A5). Build-time PNG generation via
+ * next/og so every key route can ship a distinct, on-brand social card instead
+ * of one shared preview.png. 1200×630, the standard OG size.
+ */
+export const ogSize = { width: 1200, height: 630 };
+export const ogContentType = "image/png";
+
+export function ogImage(title: string, subtitle: string) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          backgroundColor: "#020617",
+          backgroundImage:
+            "radial-gradient(60% 60% at 20% 0%, rgba(37,99,235,0.30), transparent 60%), radial-gradient(50% 60% at 100% 100%, rgba(232,121,249,0.18), transparent 60%)",
+          padding: "80px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", color: "#ffffff" }}>
+          <div
+            style={{
+              fontSize: 34,
+              fontWeight: 700,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+            }}
+          >
+            nodetool
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 700,
+              color: "#ffffff",
+              lineHeight: 1.05,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {title}
+          </div>
+          <div
+            style={{
+              marginTop: 28,
+              fontSize: 34,
+              color: "#cbd5e1",
+              lineHeight: 1.3,
+              maxWidth: 900,
+            }}
+          >
+            {subtitle}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", color: "#60a5fa", fontSize: 26 }}>
+          Open source · BYOK · nodetool.ai
+        </div>
+      </div>
+    ),
+    { ...ogSize }
+  );
+}


### PR DESCRIPTION
Second PR in the per-phase series for [`marketing/IMPROVEMENT_PLAN.md`](https://github.com/nodetool-ai/nodetool/blob/claude/ecstatic-volta-xmhb4m/marketing/IMPROVEMENT_PLAN.md). **Stacked on PR #3799** (base = `claude/ecstatic-volta-xmhb4m`) — review/merge that first; this diff shows only Phase 2.

## What's in here (plan Phase 2)

**H1 — Pricing page.** New server-rendered `/pricing`: Studio (free/AGPL) vs Cloud (subscription/alpha) cards, an 8-row edition comparison table, and a BYOK explainer. Added to the shared nav + footer. JSON-LD: `Product`/`Offer` + `BreadcrumbList`.

**H2 — Comparison / alternative pages.** New server-rendered `/vs/comfyui` and `/vs/weavy` — the high-intent SEO the homepage only hinted at via keywords. Each has at-a-glance cards, a feature comparison table, and per-page `FAQPage` + `BreadcrumbList` JSON-LD.

**A3 — Per-page JSON-LD.** Reusable `JsonLd` helper; `SoftwareSourceCode` on `/developers`; `VideoObject` for the homepage demo; `BreadcrumbList` on every persona page, pricing, and the `/vs` pages.

**A5 — Distinct OG images.** Build-time `next/og` generator (`src/lib/og.tsx`) + per-route `opengraph-image` for home, pricing, `/vs/*`, and all 5 persona pages — replacing the single shared `preview.png`. Verified the file-based images override the metadata `preview.png` cleanly (one `og:image` tag per route).

**D4 — Cloud waitlist.** `CloudWaitlist` on `/cloud`: posts to a configurable endpoint (`NEXT_PUBLIC_WAITLIST_ENDPOINT`) and degrades gracefully to email if unset, with accessible labels + loading/success/error states.

Sitemap updated with `/pricing` and `/vs/*`.

## Verification
- `npx tsc --noEmit` — clean
- `next lint` — warnings only
- `next build` — prerenders **26 routes** (17 pages + 9 OG images) as static content, exit 0

> Note: `next/og` runs at **build time** here (the OG routes are prerendered to static PNGs, 110–124 KB each), so there's no Workers-runtime dependency for image generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPN5bBHHtRFDNoYnJGa8rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPN5bBHHtRFDNoYnJGa8rK)_