### PR TITLE
docs: Phase 1 — content hygiene &amp; privacy

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -128,6 +128,7 @@ header_pages:
 
 # Exclude from processing
 exclude:
+  # Build tooling
   - Gemfile
   - Gemfile.lock
   - node_modules
@@ -138,6 +139,25 @@ exclude:
   - .sass-cache/
   - .jekyll-cache/
   - gemfiles/
+  # Contributor / engineering docs — kept in the repo (referenced by CLAUDE.md),
+  # but NOT published to docs.nodetool.ai. These are not user-facing.
+  - README.md
+  - AGENTS.md
+  - DESIGN.md
+  - DEVELOPMENT_STANDARDS.md
+  - THEME.md
+  - CLOUD_NODE_CURATION.md
+  - AGENT_CLI_QUICKREF.md
+  - runpod_testing_guide.md
+  - runtime-package-interface.md
+  # Internal product/design specs (PRDs, drafts) — not for the public site.
+  - STUDIO_PRD.md
+  - STUDIO_MVP_PROMPT.md
+  - image-editor-prd.md
+  - timeline-editor-prd.md
+  - correlation-design.md
+  # Internal implementation plans & specs (agentic-worker instructions).
+  - superpowers/
 
 # Custom theme settings
 # Using custom futuristic dark theme located in _layouts, _includes, and assets

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -5,7 +5,7 @@ permalink: /agent-memory
 description: "Unified, structured memory shared by every agent, task, and step in NodeTool — accessed via tool calls with progressive disclosure."
 ---
 
-**Navigation**: [Root AGENTS.md](../AGENTS.md) | [Agent System](AGENTS.md) → **Agent Memory** | [Long-Term Memory](long-term-memory.md)
+**Navigation**: [Chat & Agents](global-chat-agents.md) → **Agent Memory** | [Long-Term Memory](long-term-memory.md)
 
 > **Not the same as long-term memory.** This page describes per-run scratch space (`context.memory`) shared between steps inside one workflow. For durable, cross-session user memory injected into chat prompts, see [Long-Term Memory](long-term-memory.md).
 
@@ -560,7 +560,7 @@ Replacing it stripped the memory-tool documentation and the `finish_step` discip
 
 ## Related
 
-- [Agent System](AGENTS.md) — overall architecture
+- [Chat & Agents](global-chat-agents.md) — agents overview
 - `packages/runtime/src/agent-memory.ts` — `AgentMemory` implementation
 - `packages/agents/src/tools/memory-tools.ts` — `memory_list` / `memory_read` / `memory_write`
 - `packages/agents/tests/memory-propagation.test.ts` — end-to-end propagation tests including the tool round-trip

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -61,7 +61,7 @@ Collections shine in RAG pipelines:
 2. Connect the collection to its `collection` input — the node menu will suggest the selector.
 3. Run the workflow. The first run indexes the collection (embeddings + keyword index); subsequent runs reuse the index.
 
-See the full pattern in the [Cookbook → RAG]({{ '/cookbook#pattern-4-rag-retrieval-augmented-generation' | relative_url }}).
+See the full pattern in the [Cookbook → RAG]({{ '/cookbook/patterns#pattern-4-rag-retrieval-augmented-generation' | relative_url }}).
 
 ---
 
@@ -92,5 +92,5 @@ For multi-user deployments, Supabase-backed collections are an option — see [S
 
 - [Indexing]({{ '/indexing' | relative_url }}) — advanced chunking, hybrid search, maintenance
 - [Asset Management]({{ '/asset-management' | relative_url }}) — add documents to the underlying asset library
-- [Cookbook → RAG]({{ '/cookbook#pattern-4-rag-retrieval-augmented-generation' | relative_url }}) — wire a collection into a workflow
+- [Cookbook → RAG]({{ '/cookbook/patterns#pattern-4-rag-retrieval-augmented-generation' | relative_url }}) — wire a collection into a workflow
 - [Chat with Docs example]({{ '/workflows/chat-with-docs' | relative_url }}) — end-to-end RAG workflow

--- a/docs/cookbook/patterns.md
+++ b/docs/cookbook/patterns.md
@@ -11,7 +11,7 @@ To build any example:
 – press Ctrl/⌘+Enter to run
 – add Preview nodes to inspect intermediate results
 
-<a id="pattern-1-simple-pipeline"></a>
+<span id="pattern-1-simple-pipeline"></span>
 
 ### Pattern 1: Simple Pipeline
 
@@ -38,7 +38,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-2-agent-driven-generation"></a>
+<span id="pattern-2-agent-driven-generation"></span>
 
 ### Pattern 2: Agent-Driven Generation
 
@@ -71,7 +71,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-3-streaming-with-multiple-previews"></a>
+<span id="pattern-3-streaming-with-multiple-previews"></span>
 
 ### Pattern 3: Streaming with Multiple Previews
 
@@ -121,7 +121,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-4-rag-retrieval-augmented-generation"></a>
+<span id="pattern-4-rag-retrieval-augmented-generation"></span>
 
 ### Pattern 4: RAG (Retrieval-Augmented Generation)
 
@@ -177,7 +177,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-5-database-persistence"></a>
+<span id="pattern-5-database-persistence"></span>
 
 ### Pattern 5: Database Persistence
 
@@ -225,7 +225,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-6-email--web-integration"></a>
+<span id="pattern-6-email--web-integration"></span>
 
 ### Pattern 6: Email & Web Integration
 
@@ -261,7 +261,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-7-realtime-processing"></a>
+<span id="pattern-7-realtime-processing"></span>
 
 ### Pattern 7: Realtime Processing
 
@@ -293,7 +293,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-8-multi-modal-workflows"></a>
+<span id="pattern-8-multi-modal-workflows"></span>
 
 ### Pattern 8: Multi-Modal Workflows
 
@@ -326,7 +326,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-9-advanced-image-processing"></a>
+<span id="pattern-9-advanced-image-processing"></span>
 
 ### Pattern 9: Advanced Image Processing
 
@@ -369,7 +369,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-10-data-processing-pipeline"></a>
+<span id="pattern-10-data-processing-pipeline"></span>
 
 ### Pattern 10: Data Processing Pipeline
 
@@ -407,7 +407,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-11-text-to-video"></a>
+<span id="pattern-11-text-to-video"></span>
 
 ### Pattern 11: Text-to-Video Generation
 
@@ -447,7 +447,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-12-image-to-video"></a>
+<span id="pattern-12-image-to-video"></span>
 
 ### Pattern 12: Image-to-Video Generation
 
@@ -499,7 +499,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-13-talking-avatar"></a>
+<span id="pattern-13-talking-avatar"></span>
 
 ### Pattern 13: Talking Avatar Generation
 
@@ -540,7 +540,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-14-video-enhancement"></a>
+<span id="pattern-14-video-enhancement"></span>
 
 ### Pattern 14: Video Enhancement & Upscaling
 
@@ -577,7 +577,7 @@ graph TD
 
 ______________________________________________________________________
 
-<a id="pattern-15-storyboard-to-video"></a>
+<span id="pattern-15-storyboard-to-video"></span>
 
 ### Pattern 15: Storyboard to Video
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -70,13 +70,6 @@ Export a `register(registry)` function from your package and NodeTool discovers 
 
 ---
 
-## Documentation Development
-
-- [Docs README](../README.md) -- How to build and serve the documentation site locally
-- [Theme Guide](../THEME.md) -- Notes on the custom docs theme
-
----
-
 ## Contributing
 
 Contribute to [NodeTool on GitHub](https://github.com/nodetool-ai/nodetool).

--- a/docs/developer/suspendable-nodes.md
+++ b/docs/developer/suspendable-nodes.md
@@ -282,5 +282,5 @@ class WebhookWaitNode extends BaseNode {
 ## See Also
 
 - [Workflow Editor](../workflow-editor.md) - User guide for pause/resume controls
-- [Trigger Nodes](node-patterns.md#trigger-nodes) - Nodes that fire on external events
+- [Trigger Nodes](node-patterns.md) - Nodes that fire on external events
 - [Workflow API](../workflow-api.md) - API endpoints for workflow control

--- a/docs/docs/docs-readme.md
+++ b/docs/docs/docs-readme.md
@@ -1,7 +1,0 @@
----
-layout: redirect
-redirect_to: /README/
-permalink: /docs/docs-readme
----
-
-This page has moved. Please go to the [Documentation README](/README/).

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -1,7 +1,0 @@
----
-layout: redirect
-redirect_to: /README/
-permalink: /docs/readme
----
-
-This page has moved. Please go to the [Documentation README](/README/).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,7 +181,7 @@ You should see your GPU model and driver version. NodeTool requires:
 
 **"CUDA out of memory"**
 - Close other GPU-intensive applications (browsers, games, other AI tools)
-- Use smaller/quantized models (see [Hardware Requirements](#hardware-requirements-by-task))
+- Use smaller/quantized models (see [Hardware Requirements](#what-different-tasks-need))
 - Reduce batch sizes in workflow settings
 - Check if another process is using GPU: `nvidia-smi` shows GPU memory usage
 

--- a/docs/superpowers/plans/2026-04-17-trpc-migration.md
+++ b/docs/superpowers/plans/2026-04-17-trpc-migration.md
@@ -101,7 +101,7 @@ mobile/src/trpc/
 
 - [ ] **Step 1: Create and switch to feature branch**
 
-Run: `cd /Users/mg/workspace/nodetool && git checkout -b trpc-migration`
+Run: `cd ~/workspace/nodetool && git checkout -b trpc-migration`
 Expected: `Switched to a new branch 'trpc-migration'`
 
 - [ ] **Step 2: Verify branch is clean**
@@ -198,7 +198,7 @@ In `dependencies`:
 
 - [ ] **Step 7: Install**
 
-Run: `cd /Users/mg/workspace/nodetool && npm install`
+Run: `cd ~/workspace/nodetool && npm install`
 Expected: completes without errors; `package-lock.json` updates.
 
 - [ ] **Step 8: Commit**
@@ -439,7 +439,7 @@ export type AppRouter = typeof appRouter;
 
 - [ ] **Step 6: Verify typecheck passes**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
 Expected: passes with no errors.
 
 - [ ] **Step 7: Commit**
@@ -470,7 +470,7 @@ export {};
 
 - [ ] **Step 2: Verify typecheck passes**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/protocol`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/protocol`
 Expected: passes.
 
 - [ ] **Step 3: Commit**
@@ -592,12 +592,12 @@ describe("tRPC Fastify mount", () => {
 
 - [ ] **Step 4: Run the test**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test -- src/trpc/__tests__/integration.test.ts`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test -- src/trpc/__tests__/integration.test.ts`
 Expected: PASS.
 
 - [ ] **Step 5: Verify typecheck passes**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
 Expected: passes.
 
 - [ ] **Step 6: Commit**
@@ -729,7 +729,7 @@ In `packages/protocol/package.json`, replace the `exports` block with:
 
 - [ ] **Step 5: Verify typecheck passes across workspaces**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck`
+Run: `cd ~/workspace/nodetool && npm run typecheck`
 Expected: passes. (If protocol isn't built, run `npm run build:packages` first.)
 
 - [ ] **Step 6: Commit**
@@ -866,12 +866,12 @@ import { TRPCProvider } from "./trpc/Provider";
 
 - [ ] **Step 4: Typecheck**
 
-Run: `cd /Users/mg/workspace/nodetool/web && npm run typecheck`
+Run: `cd ~/workspace/nodetool/web && npm run typecheck`
 Expected: passes.
 
 - [ ] **Step 5: Boot the dev server and verify no runtime errors**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run dev`
+Run: `cd ~/workspace/nodetool && npm run dev`
 In another terminal: `curl http://127.0.0.1:7777/trpc/healthz`
 Expected: JSON response containing `{"result":{"data":{"json":{"ok":true}}}}`. Kill the dev server.
 
@@ -971,7 +971,7 @@ export * as costs from "./costs.js";
 
 - [ ] **Step 3: Typecheck**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/protocol`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/protocol`
 Expected: passes.
 
 - [ ] **Step 4: Commit**
@@ -1131,7 +1131,7 @@ describe("costs router", () => {
 
 - [ ] **Step 2: Run the tests and confirm they fail**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test -- src/trpc/routers/__tests__/costs.test.ts`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test -- src/trpc/routers/__tests__/costs.test.ts`
 Expected: FAIL with `caller.costs is undefined` (the router doesn't exist yet).
 
 ---
@@ -1261,12 +1261,12 @@ export type AppRouter = typeof appRouter;
 
 - [ ] **Step 3: Run the tests**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test -- src/trpc/routers/__tests__/costs.test.ts`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test -- src/trpc/routers/__tests__/costs.test.ts`
 Expected: all tests PASS.
 
 - [ ] **Step 4: Typecheck**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
 Expected: passes.
 
 - [ ] **Step 5: Commit**
@@ -1316,7 +1316,7 @@ Note: when superjson is enabled, tRPC wraps inputs/outputs in `{ json: ..., meta
 
 - [ ] **Step 2: Run**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test -- src/trpc/__tests__/integration.test.ts`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test -- src/trpc/__tests__/integration.test.ts`
 Expected: PASS.
 
 - [ ] **Step 3: Commit**
@@ -1337,7 +1337,7 @@ git commit -m "test(trpc): integration smoke test for costs over Fastify"
 
 - [ ] **Step 1: Find current consumers**
 
-Run: `cd /Users/mg/workspace/nodetool && grep -rn "/api/costs" web/src electron/src mobile/src packages/cli packages/deploy`
+Run: `cd ~/workspace/nodetool && grep -rn "/api/costs" web/src electron/src mobile/src packages/cli packages/deploy`
 Record the list — these are the call sites to migrate.
 
 - [ ] **Step 2: For each consumer, replace the REST call with a tRPC call**
@@ -1376,12 +1376,12 @@ const { data } = trpc.costs.list.useQuery({
 
 - [ ] **Step 3: Typecheck web**
 
-Run: `cd /Users/mg/workspace/nodetool/web && npm run typecheck`
+Run: `cd ~/workspace/nodetool/web && npm run typecheck`
 Expected: passes. If the server package's dist doesn't exist yet, run `npm run build:packages` first.
 
 - [ ] **Step 4: Run web tests**
 
-Run: `cd /Users/mg/workspace/nodetool/web && npm test`
+Run: `cd ~/workspace/nodetool/web && npm test`
 Expected: passes. Any tests that mocked `/api/costs` via MSW should be rewritten to mock the tRPC HTTP endpoint. The MSW v2 pattern for a tRPC batch GET is:
 
 ```ts
@@ -1429,18 +1429,18 @@ await app.register(costsRoutes, routeOpts);
 
 Run:
 ```bash
-cd /Users/mg/workspace/nodetool
+cd ~/workspace/nodetool
 rm packages/websocket/src/routes/costs.ts packages/websocket/src/cost-api.ts
 ```
 
 - [ ] **Step 3: Typecheck**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
 Expected: passes (no other file imports from `cost-api.ts` or `routes/costs.ts` — confirm with grep if in doubt).
 
 - [ ] **Step 4: Run all websocket tests**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test`
 Expected: passes.
 
 - [ ] **Step 5: Commit**
@@ -1687,7 +1687,7 @@ Update Task 1.7's `trpc/client.ts` and `trpc/Provider.tsx` to import `isLocalhos
 
 - [ ] **Step 1: Find remaining consumers**
 
-Run: `cd /Users/mg/workspace/nodetool && grep -rn "from \"../api\"\|from \"../../api\"\|stores/ApiClient\|openapi-fetch" web/src`
+Run: `cd ~/workspace/nodetool && grep -rn "from \"../api\"\|from \"../../api\"\|stores/ApiClient\|openapi-fetch" web/src`
 Expected: empty (Phase 3 migrations plus Step 0 above should have removed every consumer).
 
 - [ ] **Step 2: If any remain, migrate them**
@@ -1725,7 +1725,7 @@ git grep "stores/ApiClient" web/src || rm web/src/stores/ApiClient.ts
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool/web && npm run typecheck && npm test && npm run build
+cd ~/workspace/nodetool/web && npm run typecheck && npm test && npm run build
 ```
 Expected: all pass.
 
@@ -1747,7 +1747,7 @@ git commit -m "refactor(web): remove generated api.ts and openapi-fetch client"
 
 - [ ] **Step 1: Build mobile protocol dependency**
 
-Run: `cd /Users/mg/workspace/nodetool && cd packages/protocol && npm run build` (mobile's typecheck requires protocol built — per root CLAUDE.md).
+Run: `cd ~/workspace/nodetool && cd packages/protocol && npm run build` (mobile's typecheck requires protocol built — per root CLAUDE.md).
 
 - [ ] **Step 2: Create `mobile/src/trpc/client.ts`**
 
@@ -1795,7 +1795,7 @@ rm mobile/src/api.ts
 
 - [ ] **Step 5: Typecheck mobile**
 
-Run: `cd /Users/mg/workspace/nodetool/mobile && npm run typecheck`
+Run: `cd ~/workspace/nodetool/mobile && npm run typecheck`
 Expected: passes.
 
 - [ ] **Step 6: Commit**
@@ -1856,7 +1856,7 @@ They're now unused. Remove the `fetch`-based helpers at the top of `nodetool.ts`
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/cli && npm test --workspace=packages/cli
+cd ~/workspace/nodetool && npm run typecheck --workspace=packages/cli && npm test --workspace=packages/cli
 ```
 Expected: passes.
 
@@ -1920,7 +1920,7 @@ Migrate any other fetch-based helpers in the file the same way.
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool/electron && npm run typecheck && npm test
+cd ~/workspace/nodetool/electron && npm run typecheck && npm test
 ```
 Expected: passes.
 
@@ -1976,7 +1976,7 @@ export class AdminClient {
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/deploy && npm test --workspace=packages/deploy
+cd ~/workspace/nodetool && npm run typecheck --workspace=packages/deploy && npm test --workspace=packages/deploy
 ```
 Expected: passes.
 
@@ -1998,7 +1998,7 @@ git commit -m "refactor(deploy): migrate admin-client and api-user-manager to @t
 
 - [ ] **Step 1: Grep for which `handleXxx` functions are still imported**
 
-Run: `cd /Users/mg/workspace/nodetool && grep -rn "handle[A-Z]" packages/websocket/src/routes`
+Run: `cd ~/workspace/nodetool && grep -rn "handle[A-Z]" packages/websocket/src/routes`
 
 The remaining handlers should be for: binary asset routes, binary storage routes, binary file routes, binary workspace read, workflow dsl/gradio export, nodes metadata. Everything else is dead code.
 
@@ -2013,12 +2013,12 @@ Keep:
 
 - [ ] **Step 3: Typecheck**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
+Run: `cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket`
 Expected: passes.
 
 - [ ] **Step 4: Run websocket tests**
 
-Run: `cd /Users/mg/workspace/nodetool/packages/websocket && npm test`
+Run: `cd ~/workspace/nodetool/packages/websocket && npm test`
 Expected: all pass.
 
 - [ ] **Step 5: Commit**
@@ -2037,13 +2037,13 @@ git commit -m "refactor(websocket): shrink http-api.ts to REST-staying handlers 
 
 - [ ] **Step 1: For each file, verify no imports remain**
 
-Run: `cd /Users/mg/workspace/nodetool && for f in collection-api cost-api file-api models-api settings-api skills-api storage-api users-api workspace-api; do echo "=== $f ==="; grep -rn "\"../$f\"\|\"./$f\"\|from .*$f" packages/websocket/src; done`
+Run: `cd ~/workspace/nodetool && for f in collection-api cost-api file-api models-api settings-api skills-api storage-api users-api workspace-api; do echo "=== $f ==="; grep -rn "\"../$f\"\|\"./$f\"\|from .*$f" packages/websocket/src; done`
 Expected: each file has zero remaining imports from the rest of the codebase.
 
 - [ ] **Step 2: Delete each file with no imports**
 
 ```bash
-cd /Users/mg/workspace/nodetool
+cd ~/workspace/nodetool
 rm packages/websocket/src/cost-api.ts  # already deleted in Phase 2
 # Repeat for each file with no remaining imports
 ```
@@ -2056,7 +2056,7 @@ Keep the file but remove the functions now served by tRPC.
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket && npm test --workspace=packages/websocket
+cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket && npm test --workspace=packages/websocket
 ```
 Expected: passes.
 
@@ -2077,7 +2077,7 @@ git commit -m "refactor(websocket): delete fully-migrated REST handler files"
 
 - [ ] **Step 1: List the surviving routes**
 
-Run: `cd /Users/mg/workspace/nodetool && ls packages/websocket/src/routes/`
+Run: `cd ~/workspace/nodetool && ls packages/websocket/src/routes/`
 
 For each file still present, verify it only exposes endpoints from the "stays REST" list:
 - `health.ts` ✓
@@ -2100,7 +2100,7 @@ For every deleted file, delete its import and its `await app.register(...)` line
 
 Run:
 ```
-cd /Users/mg/workspace/nodetool && npm run typecheck --workspace=packages/websocket && npm test --workspace=packages/websocket
+cd ~/workspace/nodetool && npm run typecheck --workspace=packages/websocket && npm test --workspace=packages/websocket
 ```
 Expected: passes.
 
@@ -2154,22 +2154,22 @@ git commit -m "chore(websocket): verify auth hook public-route list is correct p
 
 - [ ] **Step 1: Root check**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run check`
+Run: `cd ~/workspace/nodetool && npm run check`
 Expected: typecheck + lint + test all pass across all workspaces.
 
 - [ ] **Step 2: Build every package**
 
-Run: `cd /Users/mg/workspace/nodetool && npm run build:packages`
+Run: `cd ~/workspace/nodetool && npm run build:packages`
 Expected: all packages build successfully.
 
 - [ ] **Step 3: Boot the dev server and smoke-test each client**
 
 ```bash
 # In terminal 1:
-cd /Users/mg/workspace/nodetool && npm run dev
+cd ~/workspace/nodetool && npm run dev
 
 # In terminal 2:
-cd /Users/mg/workspace/nodetool/web && npm start
+cd ~/workspace/nodetool/web && npm start
 # Navigate to http://localhost:3000, verify the app loads data correctly
 ```
 

--- a/docs/superpowers/plans/2026-05-22-bundle-node-runtime.md
+++ b/docs/superpowers/plans/2026-05-22-bundle-node-runtime.md
@@ -425,7 +425,7 @@ Append to `electron/scripts/verify-bundle.mjs` (before its final success exit), 
 
 - [ ] **Step 3: Build packages, then run prepare-backend to stage**
 
-Run: `cd /Users/mg/workspace/nodetool2 && npm run build:packages >/dev/null 2>&1; cd electron && npm run prepare-backend 2>&1 | tail -5`
+Run: `cd ~/workspace/nodetool2 && npm run build:packages >/dev/null 2>&1; cd electron && npm run prepare-backend 2>&1 | tail -5`
 Expected: `Copied webgpu` appears in the output; exit 0.
 
 - [ ] **Step 4: Verify the staged binary is present**
@@ -811,12 +811,12 @@ if (result.status !== 0) {
 
 - [ ] **Step 2: Run it and confirm better-sqlite3 loads under system Node**
 
-Run: `cd electron && node scripts/rebuild-native.mjs && cd /Users/mg/workspace/nodetool2 && node -e "require('better-sqlite3'); console.log('better-sqlite3 loads on', process.versions.modules)"`
+Run: `cd electron && node scripts/rebuild-native.mjs && cd ~/workspace/nodetool2 && node -e "require('better-sqlite3'); console.log('better-sqlite3 loads on', process.versions.modules)"`
 Expected: prints `better-sqlite3 loads on 127` (system Node 22.x ABI), no `NODE_MODULE_VERSION` error.
 
 - [ ] **Step 3: Confirm the dev backend still boots (smoke)**
 
-Run: `cd /Users/mg/workspace/nodetool2 && timeout 25 npm run dev:server 2>&1 | grep -m1 -iE "listening|7777|ready" && echo OK`
+Run: `cd ~/workspace/nodetool2 && timeout 25 npm run dev:server 2>&1 | grep -m1 -iE "listening|7777|ready" && echo OK`
 Expected: server logs a ready/listening line (`OK`); no sqlite ABI error. (Ctrl-C / timeout ends it.)
 
 - [ ] **Step 4: Commit**

--- a/docs/superpowers/plans/2026-06-09-worker-model-management.md
+++ b/docs/superpowers/plans/2026-06-09-worker-model-management.md
@@ -76,11 +76,11 @@ frame to `socket.send(JSON.stringify(update))` — the identical sink the local 
 
 ## Task 1.1 — Bump `BRIDGE_PROTOCOL_VERSION` to 2
 
-**File:** `/Users/mg/workspace/nodetool-core/src/nodetool/worker/__init__.py`
+**File:** `~/workspace/nodetool-core/src/nodetool/worker/__init__.py`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool-core/tests/worker/test_model_handler.py` (new)
+**File:** `~/workspace/nodetool-core/tests/worker/test_model_handler.py` (new)
 
 ```python
 """Tests for the models.* bridge handler."""
@@ -116,7 +116,7 @@ async def server():
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && pytest tests/worker/test_model_handler.py::test_protocol_version_is_2 -q
+cd ~/workspace/nodetool-core && pytest tests/worker/test_model_handler.py::test_protocol_version_is_2 -q
 ```
 
 Expected (before): `AssertionError: assert 1 == 2`.
@@ -145,7 +145,7 @@ BRIDGE_PROTOCOL_VERSION = 2
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && git add -A && git commit -m "feat(worker): bump bridge protocol to v2 for models.* RPC"
+cd ~/workspace/nodetool-core && git add -A && git commit -m "feat(worker): bump bridge protocol to v2 for models.* RPC"
 ```
 
 ---
@@ -153,8 +153,8 @@ cd /Users/mg/workspace/nodetool-core && git add -A && git commit -m "feat(worker
 ## Task 1.2 — `models.list_cached` handler
 
 **Files:**
-- `/Users/mg/workspace/nodetool-core/src/nodetool/worker/model_handler.py` (new)
-- `/Users/mg/workspace/nodetool-core/src/nodetool/worker/protocol.py` (dispatch branch)
+- `~/workspace/nodetool-core/src/nodetool/worker/model_handler.py` (new)
+- `~/workspace/nodetool-core/src/nodetool/worker/protocol.py` (dispatch branch)
 
 ### Failing test
 
@@ -208,7 +208,7 @@ async def test_models_unknown_type(server):
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && pytest tests/worker/test_model_handler.py -q
+cd ~/workspace/nodetool-core && pytest tests/worker/test_model_handler.py -q
 ```
 
 Expected (before): both tests error/fail — the worker replies `Unknown message type: models.list_cached`.
@@ -319,14 +319,14 @@ test_models_unknown_type PASSED
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && git add -A && git commit -m "feat(worker): models.list_cached + models.delete bridge handler"
+cd ~/workspace/nodetool-core && git add -A && git commit -m "feat(worker): models.list_cached + models.delete bridge handler"
 ```
 
 ---
 
 ## Task 1.3 — `models.download` with ordered progress frames
 
-**File:** `/Users/mg/workspace/nodetool-core/src/nodetool/worker/model_handler.py`
+**File:** `~/workspace/nodetool-core/src/nodetool/worker/model_handler.py`
 
 ### Failing test
 
@@ -384,7 +384,7 @@ async def test_models_download_emits_progress_then_result(server, monkeypatch):
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && pytest tests/worker/test_model_handler.py::test_models_download_emits_progress_then_result -q
+cd ~/workspace/nodetool-core && pytest tests/worker/test_model_handler.py::test_models_download_emits_progress_then_result -q
 ```
 
 Expected (before): fails — `_handle_download` raises `NotImplementedError`.
@@ -529,14 +529,14 @@ async def _handle_download(
 Then the whole file:
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && pytest tests/worker/test_model_handler.py -q
+cd ~/workspace/nodetool-core && pytest tests/worker/test_model_handler.py -q
 # → 5 passed
 ```
 
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool-core && git add -A && git commit -m "feat(worker): models.download with ordered progress + cancel"
+cd ~/workspace/nodetool-core && git add -A && git commit -m "feat(worker): models.download with ordered progress + cancel"
 ```
 
 ---
@@ -546,12 +546,12 @@ cd /Users/mg/workspace/nodetool-core && git add -A && git commit -m "feat(worker
 ## Task 2.1 — Bump `BRIDGE_PROTOCOL_VERSION` + bridge types
 
 **Files:**
-- `/Users/mg/workspace/nodetool2/packages/protocol/src/bridge-protocol.ts`
-- `/Users/mg/workspace/nodetool2/packages/runtime/src/python-bridge-types.ts`
+- `~/workspace/nodetool2/packages/protocol/src/bridge-protocol.ts`
+- `~/workspace/nodetool2/packages/runtime/src/python-bridge-types.ts`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/packages/runtime/tests/python-bridge-models.test.ts` (new)
+**File:** `~/workspace/nodetool2/packages/runtime/tests/python-bridge-models.test.ts` (new)
 
 ```ts
 import { describe, it, expect } from "vitest";
@@ -567,7 +567,7 @@ describe("bridge protocol version", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
+cd ~/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
 ```
 
 Expected (before): `expected 1 to be 2`.
@@ -618,14 +618,14 @@ export interface ModelDownloadUpdate {
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add packages/protocol packages/runtime && git commit -m "feat(protocol): bump bridge protocol to v2; add model download types"
+cd ~/workspace/nodetool2 && git add packages/protocol packages/runtime && git commit -m "feat(protocol): bump bridge protocol to v2; add model download types"
 ```
 
 ---
 
 ## Task 2.2 — `listCachedModels` / `deleteCachedModel` / `supportsModelManagement`
 
-**File:** `/Users/mg/workspace/nodetool2/packages/runtime/src/python-bridge-base.ts`
+**File:** `~/workspace/nodetool2/packages/runtime/src/python-bridge-base.ts`
 
 ### Failing test
 
@@ -693,7 +693,7 @@ describe("models.* bridge methods", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
+cd ~/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
 ```
 
 Expected (before): `bridge.listCachedModels is not a function`.
@@ -744,14 +744,14 @@ export type UnifiedModelLike = Record<string, unknown> & {
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add packages/runtime && git commit -m "feat(runtime): listCachedModels/deleteCachedModel/supportsModelManagement bridge methods"
+cd ~/workspace/nodetool2 && git add packages/runtime && git commit -m "feat(runtime): listCachedModels/deleteCachedModel/supportsModelManagement bridge methods"
 ```
 
 ---
 
 ## Task 2.3 — `downloadModel(req, onProgress)` streaming
 
-**File:** `/Users/mg/workspace/nodetool2/packages/runtime/src/python-bridge-base.ts`
+**File:** `~/workspace/nodetool2/packages/runtime/src/python-bridge-base.ts`
 
 ### Failing test
 
@@ -797,7 +797,7 @@ it("downloadModel streams progress then resolves", async () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
+cd ~/workspace/nodetool2/packages/runtime && npx vitest run tests/python-bridge-models.test.ts
 ```
 
 Expected (before): `bridge.downloadModel is not a function`.
@@ -854,7 +854,7 @@ to `_pendingStream`. So register the request in **both** maps: `_pendingStream` 
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add packages/runtime && git commit -m "feat(runtime): downloadModel streaming bridge method with progress + cancel"
+cd ~/workspace/nodetool2 && git add packages/runtime && git commit -m "feat(runtime): downloadModel streaming bridge method with progress + cancel"
 ```
 
 ---
@@ -863,11 +863,11 @@ cd /Users/mg/workspace/nodetool2 && git add packages/runtime && git commit -m "f
 
 ## Task 3.1 — `scope: "worker"` on tRPC `models.huggingfaceList` / `huggingfaceDelete`
 
-**File:** `/Users/mg/workspace/nodetool2/packages/websocket/src/trpc/routers/models.ts`
+**File:** `~/workspace/nodetool2/packages/websocket/src/trpc/routers/models.ts`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/packages/websocket/tests/trpc-models-worker.test.ts` (new)
+**File:** `~/workspace/nodetool2/packages/websocket/tests/trpc-models-worker.test.ts` (new)
 (mirror `tests/trpc-models.test.ts`: `makeCtx` + `createCallerFactory`)
 
 ```ts
@@ -930,7 +930,7 @@ describe("models.huggingfaceList scope=worker", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/packages/websocket && npx vitest run tests/trpc-models-worker.test.ts
+cd ~/workspace/nodetool2/packages/websocket && npx vitest run tests/trpc-models-worker.test.ts
 ```
 
 Expected (before): input rejects `scope` (unknown key) / list ignores worker → fails.
@@ -1011,7 +1011,7 @@ Add `import { TRPCError } from "@trpc/server";` if absent.
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add packages/websocket && git commit -m "feat(server): scope=worker on models.huggingfaceList/Delete via bridge"
+cd ~/workspace/nodetool2 && git add packages/websocket && git commit -m "feat(server): scope=worker on models.huggingfaceList/Delete via bridge"
 ```
 
 ---
@@ -1019,12 +1019,12 @@ cd /Users/mg/workspace/nodetool2 && git add packages/websocket && git commit -m 
 ## Task 3.2 — Worker-download relay on `/ws/download`
 
 **Files:**
-- `/Users/mg/workspace/nodetool2/packages/websocket/src/plugins/websocket.ts`
-- `/Users/mg/workspace/nodetool2/packages/websocket/src/server.ts` (pass `workerManager` to the plugin)
+- `~/workspace/nodetool2/packages/websocket/src/plugins/websocket.ts`
+- `~/workspace/nodetool2/packages/websocket/src/server.ts` (pass `workerManager` to the plugin)
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/packages/websocket/tests/ws-download-worker.test.ts` (new)
+**File:** `~/workspace/nodetool2/packages/websocket/tests/ws-download-worker.test.ts` (new)
 
 Drive the relay function directly (extract it so it's testable without a live socket):
 
@@ -1074,7 +1074,7 @@ describe("relayWorkerDownload", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/packages/websocket && npx vitest run tests/ws-download-worker.test.ts
+cd ~/workspace/nodetool2/packages/websocket && npx vitest run tests/ws-download-worker.test.ts
 ```
 
 Expected (before): module `ws-download-worker.js` does not exist.
@@ -1184,7 +1184,7 @@ Add `workerManager?: WorkerManager;` to `WebSocketPluginOptions` and import its 
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add packages/websocket && git commit -m "feat(server): relay worker model downloads onto /ws/download"
+cd ~/workspace/nodetool2 && git add packages/websocket && git commit -m "feat(server): relay worker model downloads onto /ws/download"
 ```
 
 ---
@@ -1193,11 +1193,11 @@ cd /Users/mg/workspace/nodetool2 && git add packages/websocket && git commit -m 
 
 ## Task 4.1 — `scope` in `ModelManagerStore`
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/stores/ModelManagerStore.ts`
+**File:** `~/workspace/nodetool2/web/src/stores/ModelManagerStore.ts`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/stores/__tests__/ModelManagerStore.test.ts` (new)
+**File:** `~/workspace/nodetool2/web/src/stores/__tests__/ModelManagerStore.test.ts` (new)
 
 ```ts
 import { useModelManagerStore } from "../ModelManagerStore";
@@ -1215,7 +1215,7 @@ describe("ModelManagerStore scope", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/web && npm test -- src/stores/__tests__/ModelManagerStore.test.ts
+cd ~/workspace/nodetool2/web && npm test -- src/stores/__tests__/ModelManagerStore.test.ts
 ```
 
 Expected (before): `scope` is `undefined`.
@@ -1247,18 +1247,18 @@ export const useModelManagerStore = create<ModelManagerState>((set) => ({
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add web/src/stores/ModelManagerStore.ts web/src/stores/__tests__/ModelManagerStore.test.ts && git commit -m "feat(web): model scope state (local|worker) in ModelManagerStore"
+cd ~/workspace/nodetool2 && git add web/src/stores/ModelManagerStore.ts web/src/stores/__tests__/ModelManagerStore.test.ts && git commit -m "feat(web): model scope state (local|worker) in ModelManagerStore"
 ```
 
 ---
 
 ## Task 4.2 — `useModels(scope)`: scope-keyed query
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/useModels.ts`
+**File:** `~/workspace/nodetool2/web/src/components/hugging_face/model_list/useModels.ts`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts` (new)
+**File:** `~/workspace/nodetool2/web/src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts` (new)
 
 ```ts
 import { renderHook } from "@testing-library/react";
@@ -1294,7 +1294,7 @@ describe("useModels scope", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/web && npm test -- src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts
+cd ~/workspace/nodetool2/web && npm test -- src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts
 ```
 
 Expected (before): `useModels` takes no arg / never calls `huggingfaceList`.
@@ -1333,7 +1333,7 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add web/src/components/hugging_face/model_list/useModels.ts web/src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts && git commit -m "feat(web): useModels(scope) keys query on scope, worker hits huggingfaceList"
+cd ~/workspace/nodetool2 && git add web/src/components/hugging_face/model_list/useModels.ts web/src/components/hugging_face/model_list/__tests__/useModels.scope.test.ts && git commit -m "feat(web): useModels(scope) keys query on scope, worker hits huggingfaceList"
 ```
 
 ---
@@ -1341,12 +1341,12 @@ cd /Users/mg/workspace/nodetool2 && git add web/src/components/hugging_face/mode
 ## Task 4.3 — Scope toggle in `ModelListHeader` (ui_primitives only)
 
 **Files:**
-- `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListHeader.tsx`
-- `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListIndex.tsx`
+- `~/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListHeader.tsx`
+- `~/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListIndex.tsx`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx` (new)
+**File:** `~/workspace/nodetool2/web/src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx` (new)
 
 ```tsx
 import { render, screen } from "@testing-library/react";
@@ -1380,7 +1380,7 @@ describe("ScopeToggle", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/web && npm test -- src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx
+cd ~/workspace/nodetool2/web && npm test -- src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx
 ```
 
 Expected (before): module `../ScopeToggle` does not exist.
@@ -1465,7 +1465,7 @@ const supported = activeWorker != null; // worker.status protocol gate is enforc
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add web/src/components/hugging_face/model_list && git commit -m "feat(web): Local/Worker scope toggle in ModelManager header"
+cd ~/workspace/nodetool2 && git add web/src/components/hugging_face/model_list && git commit -m "feat(web): Local/Worker scope toggle in ModelManager header"
 ```
 
 ---
@@ -1473,13 +1473,13 @@ cd /Users/mg/workspace/nodetool2 && git add web/src/components/hugging_face/mode
 ## Task 4.4 — Thread scope through download + delete
 
 **Files:**
-- `/Users/mg/workspace/nodetool2/web/src/stores/ModelDownloadStore.ts` (`startDownload` sends `scope`)
-- `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/DeleteModelDialog.tsx` (delete + invalidate scope key)
-- `/Users/mg/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListIndex.tsx`
+- `~/workspace/nodetool2/web/src/stores/ModelDownloadStore.ts` (`startDownload` sends `scope`)
+- `~/workspace/nodetool2/web/src/components/hugging_face/model_list/DeleteModelDialog.tsx` (delete + invalidate scope key)
+- `~/workspace/nodetool2/web/src/components/hugging_face/model_list/ModelListIndex.tsx`
 
 ### Failing test
 
-**File:** `/Users/mg/workspace/nodetool2/web/src/stores/__tests__/ModelDownloadStore.scope.test.ts` (new)
+**File:** `~/workspace/nodetool2/web/src/stores/__tests__/ModelDownloadStore.scope.test.ts` (new)
 
 ```ts
 import { useModelDownloadStore } from "../ModelDownloadStore";
@@ -1503,7 +1503,7 @@ describe("startDownload scope", () => {
 ### Run
 
 ```bash
-cd /Users/mg/workspace/nodetool2/web && npm test -- src/stores/__tests__/ModelDownloadStore.scope.test.ts
+cd ~/workspace/nodetool2/web && npm test -- src/stores/__tests__/ModelDownloadStore.scope.test.ts
 ```
 
 Expected (before): `startDownload` has no `scope` arg; command lacks `scope`.
@@ -1546,7 +1546,7 @@ queryClient.invalidateQueries({ queryKey: ["allModels", scope] });
 ### Commit
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && git add web/src/stores/ModelDownloadStore.ts web/src/components/hugging_face/model_list && git commit -m "feat(web): thread model scope through download + delete"
+cd ~/workspace/nodetool2 && git add web/src/stores/ModelDownloadStore.ts web/src/components/hugging_face/model_list && git commit -m "feat(web): thread model scope through download + delete"
 ```
 
 ---
@@ -1555,21 +1555,21 @@ cd /Users/mg/workspace/nodetool2 && git add web/src/stores/ModelDownloadStore.ts
 
 ```bash
 # Python
-cd /Users/mg/workspace/nodetool-core && pytest tests/worker/test_model_handler.py tests/worker/test_provider_handler.py -q
+cd ~/workspace/nodetool-core && pytest tests/worker/test_model_handler.py tests/worker/test_provider_handler.py -q
 
 # TS packages
-cd /Users/mg/workspace/nodetool2 && npm run typecheck && npm run lint
-cd /Users/mg/workspace/nodetool2/packages/runtime && npx vitest run
-cd /Users/mg/workspace/nodetool2/packages/websocket && npx vitest run
+cd ~/workspace/nodetool2 && npm run typecheck && npm run lint
+cd ~/workspace/nodetool2/packages/runtime && npx vitest run
+cd ~/workspace/nodetool2/packages/websocket && npx vitest run
 
 # Web
-cd /Users/mg/workspace/nodetool2/web && npm run typecheck && npm test -- src/components/hugging_face src/stores
+cd ~/workspace/nodetool2/web && npm run typecheck && npm test -- src/components/hugging_face src/stores
 ```
 
 Expected: all green. Then build packages so decorator/dist consumers pick up the bridge changes:
 
 ```bash
-cd /Users/mg/workspace/nodetool2 && npm run build:packages
+cd ~/workspace/nodetool2 && npm run build:packages
 ```
 
 ## Release follow-up (out of the TDD loop)

--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -13,7 +13,7 @@ NodeTool exposes a single WebSocket endpoint for workflow execution and live upd
 - **Auth**: Include a bearer token as a query parameter (`?api_key=<token>`) or rely on the same auth flow used by REST endpoints. Tokens are optional in `local`/`none` auth modes.
 - **Protocol**: Binary (MessagePack) or Text (JSON) frames. The server auto-detects frame type.
 
-See [`workflow_runner/js/workflow-runner.js`](../workflow_runner/js/workflow-runner.js) for a complete client implementation used by the bundled runner UI.
+See [`examples/workflow_runner/js/workflow-runner.js`](https://github.com/nodetool-ai/nodetool/blob/main/examples/workflow_runner/js/workflow-runner.js) for a complete client implementation used by the bundled runner UI.
 
 ## Encoding
 

--- a/docs/workflow-api.md
+++ b/docs/workflow-api.md
@@ -59,8 +59,8 @@ const outputs = await response.json();
 ## Streaming API
 
 The streaming API provides real-time job updates. See the WebSocket runner in
-[`workflow_runner/js/workflow-runner.js`](../workflow_runner/js/workflow-runner.js) for a complete example used by the
-bundled runner UI (`../workflow_runner/index.html`). On deployed servers, use `/workflows/{id}/run/stream` for SSE
+[`examples/workflow_runner/js/workflow-runner.js`](https://github.com/nodetool-ai/nodetool/blob/main/examples/workflow_runner/js/workflow-runner.js) for a complete example used by the
+bundled runner UI. On deployed servers, use `/workflows/{id}/run/stream` for SSE
 streaming; on the Editor API, prefer the WebSocket `/predict` endpoint for long-running jobs.
 
 Updates include:
@@ -130,8 +130,8 @@ For real-time streaming and job control over WebSocket, see the dedicated
 
 ## API Demo
 
-- Download the [HTML file](../../api-demo.html)
-- Open it in a browser locally.
+- Grab the [example runner](https://github.com/nodetool-ai/nodetool/tree/main/examples/workflow_runner) (`examples/workflow_runner`).
+- Open `index.html` in a browser locally.
 - Select the endpoint (local or `api.nodetool.ai` for alpha users).
 - Enter an API token from the NodeTool settings dialog.
 - Select a workflow and run it.

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -60,7 +60,6 @@ Save time with these workflows:
 
 - [Meeting Transcript Summarizer](meeting-transcript-summarizer.md) - Auto-summarize meetings
 - [Categorize Mails](categorize-mails.md) - Organize emails automatically
-- [Summarize Newsletters](summarize-newsletters.md) - Extract key newsletter insights
 - [Summarize RSS](summarize-rss.md) - Stay updated with feed summaries
 - [Realtime Agent](realtime-agent.md) - Real-time AI assistance
 


### PR DESCRIPTION
**Phase 1 of 5** of a docs-site overhaul, shipped as a stack of per-phase PRs. Merge in order (1 → 5); each targets the previous phase's branch except this one, which targets `main`.

### What & why
~30 internal/engineering docs were being published to docs.nodetool.ai. They were orphaned from the sidebar, but Jekyll still built, indexed, and sitemapped them — and three of them leaked hardcoded `/Users/mg/workspace/...` developer paths.

- **Exclude internal docs from the build** (`_config.yml`): PRDs, specs, `DEVELOPMENT_STANDARDS`, `DESIGN`, `AGENTS`, `THEME`, `CLOUD_NODE_CURATION`, the whole `superpowers/` plans+specs tree, etc. They stay in the repo (`CLAUDE.md` references `docs/DESIGN.md` etc.) — just not on the public site.
- **Scrub** `/Users/mg/workspace` developer paths from the superpowers plans.
- **Remove** dead redirect stubs that pointed at the now-internal `/README/`.
- **Fix links**: repoint public pages that linked to excluded docs (`agent-memory`, `developer/index`), fix pre-existing broken/anchor links (`collections`, `installation`, `suspendable-nodes`, `workflow-api`, `websocket-api`, `workflows/index`), and convert empty `<a id>` anchors to valid `<span id>` targets.

The CI gate that enforces "no internal docs in the published output" lands in Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nD1p6s3JEfD77dxzSMH57

---
_Generated by [Claude Code](https://claude.ai/code/session_018nD1p6s3JEfD77dxzSMH57)_