### PR TITLE
revert(marketing): load demo and video-generation clips directly (no poster placeholder)

### DIFF
--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -337,8 +337,6 @@ export default function Home() {
                   className="w-full h-auto rounded-xl"
                   controls
                   playsInline
-                  preload="none"
-                  poster="/preview.png"
                 />
               </div>
             </motion.div>

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -64,12 +64,11 @@ export default function VideoGenerationSection({
           >
             <video
               src="/sora.mp4"
-              muted
+              autoPlay
               loop
+              muted
               playsInline
               controls
-              preload="none"
-              poster="/preview.png"
               className="w-full max-w-2xl mx-auto rounded-2xl shadow-2xl shadow-emerald-500/20 border border-white/10"
             />
           </motion.div>


### PR DESCRIPTION
Per request: load the marketing videos **directly** instead of behind a placeholder poster.

The earlier performance pass (now in `main` via #3799) had lazy-loaded both clips — `poster` + `preload="none"` on the homepage demo, and switched the video-generation clip from autoplay to click-to-play. This reverts that so both videos load and play directly:

- **Homepage demo** (`page.tsx`): drop `preload="none"` + `poster="/preview.png"` → loads directly with controls.
- **Video-generation clip** (`VideoGenerationSection.tsx`): restore `autoPlay` and drop `preload="none"` + `poster` → autoplays again as before.

No other changes.

## Verification
- `next build` — green, all routes prerender as static
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPN5bBHHtRFDNoYnJGa8rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPN5bBHHtRFDNoYnJGa8rK)_