### PR TITLE
feat(generations): generation_complete event for per-variant artifacts

### DIFF
--- a/docs/rfc-generation-events.md
+++ b/docs/rfc-generation-events.md
@@ -1,0 +1,481 @@
+# RFC: Generation Events — `generation_complete`, re-scoped `output_update`, autosave cutover
+
+**Status:** Draft for sign-off · **Owner:** runtime/web · **Repo:** `/Users/mg/workspace/nodetool`
+
+> Every line/file reference below was re-verified against the working tree before this revision. Findings that were wrong-as-written (the double-save rationale, the actor `job_id` field, "`_messages` authoritative for autosave") are corrected in-body and catalogued in the **Addressed review notes** appendix. The scope was widened from "kernel→websocket→web-editor" to **all message consumers** (browser runner, mobile, CLI, mini-apps, timeline/sketch editors, chat) after a consumer census.
+
+---
+
+## 1. Summary
+
+We split the one overloaded "a node produced something" signal into **three orthogonal channels**:
+
+1. **`node_update`** — node **lifecycle** only (running / completed / error, timing, cost). One per node-run. Stops being the autosave/generation source.
+2. **`generation_complete`** (NEW) — a generator committed **one complete artifact**: `{ node_id, node_name, node_type, index, outputs }` (plus `job_id`/`workflow_id` stamped downstream). Emitted once per `process()` result (once at stream-end for `genProcess`). Authoritative; drives `liveGenerations` + autosave; **never suppressed**.
+3. **`output_update`** — demoted to **ephemeral display-only** live feed (text tokens, progressive preview, realtime audio). Carries an explicit `disposition: "append" | "replace"`. Never persisted, never creates a generation. Edge-suppression becomes harmless.
+
+The kernel change is small and TS-only. The **breadth** is in the consumers: every surface that today reads `node_update.result` or `output_update.value` as an artifact must move to `generation_complete.outputs` or accept a documented, graceful degradation to one artifact.
+
+---
+
+## 2. Problem & evidence
+
+**The kernel collapses multi-execution runs into one `node_update`.** `_emitNodeStatus("completed", …)` fires exactly once per node-run at `actor.ts:440-443`, carrying `this._latestResult ?? {}`. There are only 4 `_emitNodeStatus` call sites (`actor.ts:278` running, `:421` suspended, `:426` error, `:440` completed). `_latestResult` (declared `actor.ts:157`) is **overwritten** on every execution — never accumulated:
+
+| `actor.ts` line | mode | write | object identity |
+|---|---|---|---|
+| 357 | streaming-input `run()` | `= nodeOutputs.collected()` | fresh from collector |
+| 369 | streaming-input legacy `process()` | `= outputs` | **same ref** as executor return |
+| 987 | `genProcess` per-yield | `= {...collected}` | **fresh spread** each yield |
+| 994 | `genProcess` stream-end | `= {...collected}` | **fresh spread** |
+| 1000 | correlated `process()` | `= outputs` | **same ref** as executor return |
+| 1290 | controlled-loop `process()` | `= outputs` | **same ref** as executor return |
+
+(The object-identity column is load-bearing for §7 — see the corrected double-save analysis.)
+
+So a `ListGenerator.item → TextToImage.prompt` run that fires `TextToImage` 6× (the correlated `while (isReady(key))` drain at `actor.ts:716-720`, each call overwriting `_latestResult` at `:1000`) emits **one** `node_update{completed}` carrying run #6 only.
+
+**Autosave inherits the collapse.** `autoSaveAssets` (`unified-websocket-runner.ts:428-571`) is called from the single site at `unified-websocket-runner.ts:1932-1953`, gated on `outbound.type === "node_update" && status === "completed" && result != null && meta?.auto_save_asset`. It walks `outbound.result` (= `_latestResult`, run #6) → persists **1 asset/run, 5 lost**. (Idempotency guard at `:468` `if (assetValue.asset_id) continue` skips already-`asset_id`'d values by mutating that same object in place at `:518-520`; `node_id`/`job_id` stamped from `opts` at `:506-507`. Crucially, `Asset` records carry `node_id`+`job_id` but **no `index`** — there is no persisted-side dedupe key beyond the in-place `asset_id` mutation. This matters for replay; see §15.)
+
+**`output_update` is the accidental sole carrier of the lost variants — and it's overloaded three ways.** Emitted at `runner.ts:1286-1294`, once per emit (per yield / per key / per control-run — NOT collapsed). But suppressed at `runner.ts:1280-1284` for any handle with an outgoing **data** edge (`findEdges(sourceNodeId, handle).some(isDataEdge)` unless `always_emit_output_updates`). So an intermediate generator feeding a Preview emits nothing; only the terminal Preview re-emits and buffers all N. `output_update` simultaneously serves: (1) live incremental display (text tokens, progressive preview → `setOutputResult(append=true)`), (2) realtime audio transport (~50/s, coalesced to a worklet bus — the *reason* suppression exists, `runner.ts:1257-1264`), and (3) the accidental multi-execution variant carrier. It also can't distinguish a chunk (append) from a whole value (replace) — `workflowUpdates.ts:515` hardcodes `append=true` (latent progressive-preview bug).
+
+**Net:** a 6-image run produces 6 artifacts; the generation timeline and persistence see 1.
+
+---
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Every committed artifact of a multi-execution run is persisted (N assets/run) and appears as a navigable variant — **on both the server and in-browser execution paths**.
+- Lifecycle, artifacts, and live display travel on three independent channels with clear contracts.
+- `output_update` becomes correctness-irrelevant: edge-suppression can drop it freely.
+- Zero `nodetool-core` / Python-worker change for the targeted multi-execution collapse (see §10).
+- No double-save and no no-save during cutover.
+- Every TS message consumer (web editor, browser runner, mobile, CLI, mini-apps, timeline/sketch, chat) is explicitly migrated or assigned a documented graceful-degradation decision.
+
+**Non-goals**
+- Changing the realtime-audio fast-path (`runner.ts:45-52` / bus). It stays byte-for-byte.
+- Changing the TS↔Python bridge protocol.
+- Reworking the salvaged UI navigator (`groupByRun`/`NodeHistoryViewer`). It is the correct consumer; it only needs a correct feed.
+- A separate `generation_started` / progress channel (out of scope; `node_update{running}` + `node_progress` already cover it).
+- Persisting N artifacts for **multi-artifact-per-output-slot streaming generators** (no such node exists today; see §10 — explicitly out of scope, with a guard test).
+
+---
+
+## 4. The three channels
+
+| Channel | Carries | Rate | Persisted? | Creates Generation? | Suppressible? |
+|---|---|---|---|---|---|
+| `node_update` | lifecycle: running/completed/error, timing, cost, property echo | 1/run | no | **no (changed)** | no |
+| `generation_complete` | one complete artifact + stable variant `index` | N/run (1 per `process()` result) | **yes (drives autosave)** | **yes** | **never** |
+| `output_update` | live display feed: text tokens, progressive preview snapshot, audio chunks | high (≤~50/s audio) | no | no | yes (harmless) |
+
+### 4.1 `node_update` (unchanged shape, narrowed role)
+
+`messages.ts:166-178` stays as-is. After this change it no longer drives autosave or generations. Everything else (status/timing/cost/property-merge/error-notification/trace) is unchanged. The `result` field becomes **advisory/back-compat only** (still the last result); consumers must not read it for **multi-execution** artifacts. It remains the graceful-degradation path for consumers that cannot be fully migrated this cycle (mobile shows 1 artifact via `result`; see §8.6) and for skip-result nodes' values (see Decision 7).
+
+### 4.2 `generation_complete` (NEW)
+
+```ts
+export interface GenerationComplete {
+  type: "generation_complete";
+  node_id: string;
+  node_name: string;
+  node_type: string;
+  /** k-th generation of this node in this run (backend-assigned, monotonic, stable). */
+  index: number;
+  /** The complete result dict for this artifact (same shape as a process() return). */
+  outputs: Record<string, unknown>;
+  /** Stamped downstream by the runner relay, NOT by the actor. */
+  job_id?: string | null;
+  workflow_id?: string | null;
+}
+```
+
+- `index` is a **per-actor monotonic counter** (`_generationIndex++`), NOT the correlation lineage index (those reset per `(root, parentKey)` and are not a stable global variant id — see §5). A fresh actor is created per `_processGraph` and a fresh runner per job, so `index` does not collide across runs.
+- `job_id` / `workflow_id` are **optional in the actor emit** and stamped uniformly downstream — see §5 and the corrected note below.
+- `outputs` is the **whole result dict**, passed through unflattened. List-valued handles (`num_images=N`) stay as arrays; consumers flatten via `runVariantValues` / recursive autosave `collect` (Decision 1).
+- Emitted from inside the serial actor paths, so per-node `index` ordering is deterministic.
+
+### 4.3 `output_update` (re-scoped, + `disposition`)
+
+```ts
+export interface OutputUpdate {
+  type: "output_update";
+  node_id: string;
+  node_name: string;
+  output_name: string;
+  value: unknown;
+  output_type: string;
+  metadata: Record<string, unknown>;
+  /** NEW. "append" = value is a chunk to concatenate; "replace" = value is a whole snapshot. */
+  disposition?: "append" | "replace";
+  /** NEW (optional). Marks the final chunk of an append stream. */
+  done?: boolean;
+  workflow_id?: string | null;
+}
+```
+
+`disposition` is optional for back-compat: absent ⇒ treat as `"append"` (today's behavior). Streaming chunks (text tokens, audio, genProcess yields) → `"append"`; whole non-generation values (a string into an Output node, a progressive-preview full-frame) → `"replace"`.
+
+---
+
+## 5. `generation_complete` emission points
+
+Add to the actor, alongside `_emitNodeStatus`. **The actor does NOT carry `job_id`** — verified: `packages/kernel/src/actor.ts` has zero `jobId`/`job_id`/`_jobId` references, and `_emitNodeStatus` (`actor.ts:1361-1380`) emits `node_update` **without** a `job_id` field. `job_id`/`workflow_id` are backfilled for **every** outbound message at `unified-websocket-runner.ts:1855-1861` (`msg.job_id ?? active.jobId`, `msg.workflow_id ?? active.workflowId`). A new `type` inherits this for free. (The browser path must apply the same backfill; see §8.5.) `node_name` mirrors `node_update`: `this.node.name ?? this.node.type` — **not** `this.node.data?.title`.
+
+```ts
+private _generationIndex = 0;  // new field near _latestResult (actor.ts:157)
+
+private _emitGenerationComplete(outputs: Record<string, unknown>): void {
+  this._emitMessage({
+    type: "generation_complete",
+    node_id: this.node.id,
+    node_name: this.node.name ?? this.node.type,   // mirror _emitNodeStatus
+    node_type: this.node.type,
+    index: this._generationIndex++,
+    outputs
+    // NO job_id here — runner relay stamps it (unified-websocket-runner.ts:1855-1861)
+  });
+}
+```
+
+Wire it at **each completed `process()`-result boundary** — the same sites where `_latestResult` is assigned:
+
+| # | `actor.ts` site | mode | rule |
+|---|---|---|---|
+| 1 | after `:1000` (correlated `process()`) | one per ready key → **N/run for a generator** | the primary 6×-collapse fix |
+| 2 | after `:1290` (controlled-loop `process()`) | one per `"run"` control event | |
+| 3 | after `:369` (streaming-input legacy `process()`) | once | also the path Python `is_streaming_input` nodes take (see §10) |
+| 4 | after `:994` (`genProcess` **stream-end**) | **ONCE per stream**, using final `_streamingCollectedOutputs` — **NOT** per yield at `:987` (yields are chunks → stay `output_update`) | if also correlation-driven, reached once per key (correct). **Load-bearing invariant — see below.** |
+| 5 | after `:357` (streaming-input `run()`) | once, `nodeOutputs.collected()` | **TS-only**; Python nodes never reach `run()` (see §10). Parity-complete spot for filters/transforms; low priority |
+
+**Load-bearing invariant for site #4 (genProcess stream-end).** `_streamingCollectedOutputs` is an **overwrite-merge**, not a concatenation: `actor.ts:984` does `Object.assign(this._streamingCollectedOutputs, routed)`, and `:994` takes `{...this._streamingCollectedOutputs}`. Therefore the stream-end dict holds the **last value written to each output slot**, not all N values streamed through that slot. The "once at stream-end" rule is correct **iff the generator's final accumulated dict holds the complete artifact** — true for nodes that emit a final whole-value yield (Summarizer-style: a terminal `{text, output}` consolidating yield; audio-with-`done`). It is **wrong** for a hypothetical generator that streams N distinct savable artifacts on the **same output slot** with no consolidating final yield — that would commit only artifact N (the exact collapse bug this RFC kills, reappearing on the streaming path). No such node exists today (e.g. `ListGenerator` yields per-item `{item, index}`, but its items propagate downstream as iteration-correlation envelopes that fire consumers N times → the N `generation_complete` land on the **consumer** at site #1, not on the generator, whose own timeline is not a savable sink). We **scope multi-artifact-per-slot streaming generators OUT** (§3 non-goal, Decision 1 corollary) and add a guard test (§13) asserting the documented limitation so a future node author hits a failing test, not a silent data loss.
+
+Constraints:
+- **Never** routed through the `runner.ts:1280` edge-suppression — `generation_complete` goes straight out via `_emitMessage → _emit` (`runner.ts:999-1001, 1688-1708`).
+- **Not audio-dropped** — do NOT route it through the `isAudioChunkOutputUpdate` drop (`runner.ts:1696-1703`). It is pushed into `_messages` (which is **truncated** past `MAX_RETAINED_MESSAGES = 10_000` via `slice` at `runner.ts:1697-1700` — see §15 on what that does and doesn't guarantee).
+- No new backpressure: same fire-and-forget path as `node_update`, rate bounded by result count (low), does not touch inbox flow-control.
+- Skip-result parity: for `nodetool.constant.*` / `nodetool.input.*` (the `skipResult` set at `actor.ts:437-439`), do **not** emit `generation_complete` — those aren't generators. How their values still reach display sinks is specified in Decision 7.
+
+---
+
+## 6. `output_update` re-scope
+
+- **`disposition` drives append vs replace.** `runner.ts:1286-1294` sets `disposition: "append"` for streaming chunks (genProcess yields, audio), `"replace"` for whole-value emits. Every frontend consumer branches on it instead of hardcoding append (see §8.7 — there are **5** `setOutputResult` call sites, not 1), fixing the progressive-preview latent bug.
+- **Ephemeral clearing lifecycle.** The `outputResults` buffer (`ResultsStore.ts:609-694`, keyed `${wf}:${job}:${node}`) is cleared (a) on run start (existing `clearResults`/`clearOutputResults` at `:424-443`) and (b) on `generation_complete` for that `(wf, job, node)` artifact — once the artifact is committed as a generation, its live scratch buffer is stale. This keeps the display buffer from leaking partial chunks into the settled view.
+- **Edge-suppression is now harmless.** No correctness depends on `output_update` reaching anyone — artifacts travel on `generation_complete`. The `runner.ts:1280-1284` data-edge skip and the `always_emit_output_updates` opt-out remain as-is; they now only affect cosmetic live display, never persistence or variant counts.
+- **Audio path unchanged.** `isAudioChunkOutputUpdate` (`runner.ts:45-52`), the live-stream-without-retention fast-path (`runner.ts:1704-1706`), `queueAudioAppend` / `publishRealtimeAudioChunk` (`workflowUpdates.ts:513-523`), `realtimeAudioChunkBus.ts`, `AudioOutBody.tsx`, `useRealtimeAudioPlayback.ts` — all untouched. Audio chunks are `disposition: "append"` and never become generations.
+- **Do not narrow `value` to chunk-only.** Display sinks legitimately render whole non-generation values (a string into an Output node, chat string-streaming). Keep `value: unknown`.
+
+---
+
+## 7. Autosave cutover (server path)
+
+**Move autosave from `node_update{completed}` to `generation_complete`** — a **hard switch, not dual-write**:
+
+1. Add `generation_complete` to the processing gate at `unified-websocket-runner.ts:1889-1892` so it gets node-type resolution, constant/input skip, and normalization.
+2. New branch (parallel to the deleted one), autosave **before** normalize (normalize strips inline bytes):
+   ```ts
+   if (outbound.type === "generation_complete") {
+     const meta = this.getNodeMetadata?.(nodeType);
+     if (meta?.auto_save_asset && outbound.outputs != null) {
+       await autoSaveAssets(outbound.outputs as Record<string, unknown>, {
+         userId: this.userId ?? "1",
+         workflowId: active.workflowId,
+         jobId: active.jobId,
+         nodeId: String(outbound.node_id ?? ""),
+         textOutputName: primaryTextOutputName(meta)
+       });
+     }
+     // then: normalizeOutputValue(outbound.outputs) — mirror :1958 on .outputs
+   }
+   ```
+3. **Delete** the `node_update` autosave at `unified-websocket-runner.ts:1932-1953` in the **same commit**.
+
+**Why hard-switch and not dual-write (corrected rationale).** The original draft justified the hard switch by claiming the last-result object is a *different instance* on the two channels and would therefore double-save. **That is inverted.** Verified at `actor.ts:1000`/`:1290`: `this._latestResult = outputs` assigns the **same object reference** that `_emitGenerationComplete(outputs)` would carry — so on the `process()`/correlated path, `node_update.result` and the run-#N `generation_complete.outputs` are the **same instance**, and the reference-based idempotency guard (`autoSaveAssets:468` keys on the in-place `asset_id` mutation at `:518-520`) would make a dual-write a **no-op** for that shared object, not a double-save. The genuine fresh-object case is the **`genProcess` path** (`:994` does `{...spread}`), where the guard cannot see the prior save across channels.
+
+The hard switch is still **required**, for two real reasons:
+- **(a) Under-save, not double-save, is the dominant risk.** Runs `1..N-1` of a multi-execution node exist **only** on `generation_complete` — `node_update` collapses to the last. A dual-write therefore under-saves the early runs regardless of object identity; the new channel must own autosave outright.
+- **(b) Cross-channel idempotency is reference-based and partial.** It protects only the **shared** last-result object on the `process()` path; it does **not** protect the `genProcess` fresh-spread path, where dual-write **would** double-save the final stream-end artifact.
+
+Atomic swap is the only clean option. (If a dark-launch is mandated, gate both with one flag, never both ON.)
+
+**Asset-volume / parity.** A 6-image run now persists 6 assets (was 1), each tagged `node_id`, `job_id`. The consumer de-dupes by **`jobId`**: `mergeGenerations` (`nodeGenerations.ts:74-82`) drops live gens whose `jobId` already persisted, and all N variants share one `jobId`, so live N + persisted N collapse to N (not 2N). `useNodeResultHistory.lastJobAssets` (`useNodeResultHistory.ts:75-81`) already returns N assets for the last job → N tiles. The `job_update{completed}` asset reload (`workflowUpdates.ts:712-725`) now surfaces all N correctly. **Note:** persisted assets carry no `index` (§2), so `mergeGenerations` groups purely by `jobId`; this is sufficient for the live/persisted collapse but means **replay idempotency must be addressed at the autosave layer** (§15 / Decision 8). **Storage volume note:** flagged in §15 — runs that previously discarded intermediates now persist them; confirm desired for high-N generators (e.g. a 100-frame batch).
+
+---
+
+## 8. Frontend rewiring (all consumers)
+
+A census of every `node_update` / `output_update` consumer (`grep` across `packages/`, `web/`, `mobile/`) yields the surfaces below. The original draft covered only §8.1–§8.4; §8.5–§8.10 are the surfaces the consumer census surfaced.
+
+### 8.1 `workflowUpdates.ts` reducer (web editor — primary)
+- **`node_update` branch (`:866-1044`):** keep all lifecycle (error notification/state/ErrorStore/trace at `:881-920` except the generation write; status/timing/cost at `:931-974`; property-merge at `:1016-1043`). **DELETE the `completed → upsertLiveGeneration` write at `:986-998`.** Keep a lightweight `running → upsertLiveGeneration({status:"running"})` placeholder (`:982-985`) so a node shows a spinner before its first artifact (`generation_complete` only fires at commit). The `node_update{error}` → generation write (`:894-901`) **stays on `node_update`** (lifecycle owns errors; `generation_complete` represents committed artifacts only — see Decision 1). **Both the `running` placeholder and the `error` settle are index-less patches** — see §8.2 for how they route in the index-keyed store, and §9 for silent-scrub gating that must cover the `running` write too.
+- **`output_update` branch (`:499-547`):** becomes display-only. Branch on `disposition` instead of hardcoded `append=true` at `:515`. Audio fast-path + logging + trace unchanged.
+- **NEW `generation_complete` branch:** the sole generation driver. Appends/replaces by `index`, absorbs the silent-scrub gate (§9), clears the ephemeral `outputResults` buffer for the artifact.
+
+### 8.2 `ResultsStore.upsertLiveGeneration` (`:496-558`) — **DELETE the variant-inference, define index-less routing**
+- **DELETE** the Tier-2 "second completed appends a variant" hack: `startsNewVariant` (`:522-525`) + the synthesized-variant-id append branch (`:527-548`, the `${jobId}#${variantCount}` scheme at `:535`).
+- **DELETE** the `isSilentJob`-in-upsert special case (`:519` + its comment `:514-518`). Silence moves to the message handler (§9).
+- **REPLACE** the matcher with **append/replace-by-`index`** keyed `${workflowId}:${nodeId}`. `generation_complete{index:k}` → set/replace slot `k`, id `k===0 ? jobId : ${jobId}#${k}` (preserve the back-compat id scheme — `selected_generation` values and tests depend on it). `getLiveGenerations` (`:563-564`) read API unchanged.
+- **Index-less-patch contract (NEW — addresses the under-specified seam).** The surviving `node_update{running}` placeholder and `node_update{error}` settle carry **no `index`**. Specify: *a patch without `index` targets the newest slot for that `jobId`* — i.e. retain the existing `findLastIndex(g => g.jobId === jobId)` fallback (`:507`) **only** for index-less patches, while any `generation_complete` patch supplies an explicit `index` and uses index-keyed set/replace. This guarantees a node that errors before committing any artifact (no `generation_complete`, correct per Decision 1) still has its `running` placeholder settled by the index-less `error` patch — otherwise the index-keyed store has no slot for it and leaves a stuck `running` generation.
+
+### 8.3 Preview / Output / content-card (web editor)
+- **`PreviewNode.tsx` (`:235-298`):** **DELETE** the "accumulate `output_update`s as a variant array" reliance (the contract documented at `:235-242`). Preview reads its **source** node's generations via the value edge — `useNodeResultHistory(incomingValueEdge.source)` (already wired at `:277-284`) / `useNodeGenerations` of the source — for discrete artifacts; `streamBuffer` (`output_update`) only for live text/audio. The `sourceFallbackValue` path becomes primary.
+- **`OutputNode.tsx` (`:239-249`):** structurally unchanged — already layers `streamBuffer ?? settledValue`. Stream for live, generation (`useNodeGenerations().current`) for settled.
+- **`ContentCardBody.tsx` (`:600-617`):** already generation-driven via `useNodeResultValue`/`useNodeResultHistory`. Its `resolvePreviewValue` array-flatten (`:281-301`) is now redundant for settled artifacts (`runVariantValues` covers N tiles); it still services the live in-flight buffer, so it stays.
+
+### 8.4 SALVAGED UI — fed correctly, **zero code change**
+`utils/nodeGenerations.ts` (`groupByRun`/`getCurrentRun`/`RunGroup`/`runVariantValues`/`mergeGenerations`/`assetToGeneration`), `useNodeGenerations` (`{runs, currentRun}`), `NodeHistoryViewer` (the runs/variants/single navigator, `defaultView` flips to grid at `variants.length > 1`, `:269-270`), `useNodeIO`, `nodeGenerationAccessor`, `useNodeExecState`. These already expect `index`-keyed variants under a stable `jobId`; they just receive a clean feed instead of the `node_update` collapse.
+
+### 8.5 In-browser execution path — **normalize + autosave branches REQUIRED** (was omitted)
+The dual-run-path architecture runs the **same `packages/kernel`** in a Web Worker, so `generation_complete` **is emitted in-browser too**. Two gaps:
+- **Normalize.** `browserRunner.worker.ts:187-203` (`attachPreviewBitmaps` / `resolveImageRefForTransport`) and `browserWorkflowRunner.ts:435-441` (`materializeBrowserOutputs` / `resolve`) currently materialize **only** `node_update.result` and `output_update.value`. **Add a `generation_complete` branch in both** that applies the same resolve + materialize to `.outputs` (GPU read-back, raw-RGBA→PNG, inline-bytes→uri), or in-browser `generation_complete` carrying GPU refs / inline bytes renders broken and bitmaps are not transferred. The `:432` "render identically" guarantee depends on it.
+- **Autosave.** `autoSaveAssets` exists **only** in `unified-websocket-runner.ts` — the entire `web/src/lib/workflow/` directory calls it **nowhere** (verified: zero matches). So in-browser generative runs do not persist via this code. **Decision required (Decision 9):** either (a) add a browser-side autosave hook keyed on `generation_complete` mirroring the server branch, or (b) confirm+document that browser-path persistence already round-trips to the server (the `job_update{completed} → invalidateQueries(['assets']) + loadWorkflowAssets` reload at `workflowUpdates.ts:712-725` assumes the server already saved). The "every committed artifact is persisted" goal is **unproven for the browser path** until this is resolved; the rollout's "each step shippable and green" claim is **false for browser-eligible workflows** until §8.5 lands. The silent-scrub case runs in-browser (§9), so this is on the critical path.
+- **Backfill.** Confirm the browser relay applies the same `job_id`/`workflow_id` stamping the server does at `unified-websocket-runner.ts:1855-1861`; the bare actor emit (§5) relies on it.
+
+### 8.6 Mobile (`mobile/src/stores/WorkflowRunner.ts`) — **add a case, decide degradation**
+Independent reducer: reads `node_update.result` (`:354-359`) and `output_update.value` (`:384-396`) into one `nodeResults` map; reads `node_update` only for errors otherwise. After this change, mobile keeps working at **1-artifact-per-node** via `node_update.result` (the advisory last-result), which is acceptable graceful degradation. **Required:** (1) add a `generation_complete` case to the `WorkflowRunner.ts` switch — minimally store `.outputs` into `nodeResults` so multi-execution shows at least the latest, ideally a variant list if mobile surfaces variants; (2) regenerate `mobile/src/api.ts` message-type table (it currently has a generated `output_update`/`node_update` union with no `generation_complete`, `:5005+`); (3) state explicitly (Decision 10) that mobile's continued read of `node_update.result` is an **intended** degradation, not an accident. Mobile is intentionally NOT a root workspace; build `protocol` first before its typecheck.
+
+### 8.7 `setOutputResult` append/replace plumbing — **5 call sites, not 1**
+`disposition` must thread through `ResultsStore.setOutputResult`'s boolean `append` param. Verified call sites (excluding tests): `workflowUpdates.ts:515`, `core/chat/chatProtocol.ts:514`, `hooks/timeline/useGenerateClip.ts:186`, `hooks/sketch/useGenerateLayer.ts:227`. The original draft named only the first two. The timeline/sketch `forwardWorkflowMessage` paths call `setOutputResult(..., true)` unconditionally, so a `disposition:"replace"` value there would still append — re-introducing the exact progressive-preview bug elsewhere. **Fix:** change `setOutputResult` to take `disposition` (or derive `append` from it) and thread it through **all four** runtime call sites. (`utils/imageRef.ts:51` is only a doc comment; update it too.)
+
+### 8.8 Timeline & Sketch generation (`useGenerateClip.ts`, `useGenerateLayer.ts`) — **migrate asset extraction**
+Both share an identical pattern that makes `output_update` **load-bearing for production asset extraction**: on each message they `jobOutputs.set(jobId, normalizeOutputUpdateValue(...))` gated on `node_id === context.selectedOutputNodeId` (`useGenerateClip.ts:204-209`, `useGenerateLayer.ts:248-253`), then at `job_update{completed}` call `extractAssetId(jobOutputs.get(jobId))` (`useGenerateClip.ts:228-235`) and **mark the whole job FAILED** ("finished without producing an output asset") if absent. Output nodes are terminal (no outgoing data edge) so `output_update` survives suppression *today*, but the new contract makes this a freely-droppable display artifact. **Migrate** the `selectedOutputNodeId` extraction from `output_update` to `generation_complete.outputs` (authoritative, never suppressed); keep `output_update` only for live preview inside the editors. This is the production path for both the video timeline and the sketch editor — it must move, not just honor `disposition`.
+
+### 8.9 Mini-apps (`web/src/components/miniapps/hooks/useMiniAppRunner.ts`) — **migrate result tiles**
+Mini-app result tiles are built **entirely** from `output_update`: `:84-103` creates one `MiniAppResult` per `output_update` (id `node_id:output_name:timestamp`) → `upsertResult`; `node_update` is read only for errors (`:105-119`). Under the new contract `output_update` is no longer the artifact carrier, so mini-app lists become incomplete/empty for edge-connected generators. **Switch** `MiniAppResult` construction to `generation_complete.outputs` (flatten per output handle for committed artifacts); keep `output_update` only for live-streaming display within a result. Mini-apps are a first-class surface.
+
+### 8.10 Chat / agent path (`web/src/core/chat/chatProtocol.ts`)
+`chatProtocol.ts` independently consumes `node_update` (`:1263`) and `output_update` (`:1294` → `applyOutputUpdate` at `:492-521`); it has **no** `upsertLiveGeneration` / generation path (only `content_metadata.media_generation` chunk handling at `:430`). Two requirements: (1) `applyOutputUpdate` must honor `disposition` (same demotion as §8.1; chat string-streaming at `:523+` stays as legitimate whole-value display); (2) **explicitly decide** (Decision 11) whether the chat surface creates variants for a multi-execution generator invoked from a workflow tool, or **intentionally ignores `generation_complete`** (display-only). Recommend the latter for this cycle — document it — rather than leaving it implicit in a one-line note. If chat later needs variants it gets its own `generation_complete` branch.
+
+### 8.11 CLI (`packages/cli/src/websocket-client.ts`)
+Protocol consumer used by `nodetool workflows run --json` and piped chat: handles `node_update` (`:398-403`, surfacing `result`) and `output_update` (`:405-411`, surfacing `value`); no `generation_complete` case. After the change a 6-image CLI run reports 1 collapsed result via `node_update` and the variants exist only on a type the CLI ignores. **Decide (Decision 12):** surface `generation_complete` events in the JSON stream (one event per artifact) or aggregate them; add the message-type entry to the CLI union (`:36-38`). Lowest-priority consumer but must not silently drop variants from `--json` output.
+
+---
+
+## 9. Silent-scrub handling
+
+`useLiveSliderWriter` reuses **one** `jobId` for an entire scrub, marks it silent (`markJobSilent`), and emits a `running→completed` arc **per frame** (`runBrowserGraphJob({ jobId: previewJobIdRef.current })`). Under the new model each frame emits `generation_complete` with incrementing `index` → without a gate, a 60-frame scrub = 60 variants. **This runs in-browser** (§8.5), so the browser-path normalize/autosave branches must exist for it.
+
+**The gate relocates from `ResultsStore.upsertLiveGeneration:519` into the new `generation_complete` handler in `workflowUpdates.ts`** (frontend gate, Decision 2). **Both** writers that fire per scrub frame must honor it:
+
+```ts
+// in the generation_complete handler:
+const slot = isSilentJob(jobId) ? 0 : index;   // pin scrub frames to slot 0
+upsertLiveGeneration(wf, node, jobId, { index: slot, outputs, status: "completed" });
+```
+
+```ts
+// in the node_update{running} placeholder write (§8.1) — also fires per scrub frame:
+const slot = isSilentJob(jobId) ? 0 : undefined; // index-less for non-silent (newest-slot)
+upsertLiveGeneration(wf, node, jobId,
+  slot === 0 ? { index: 0, status: "running" } : { status: "running" });
+```
+
+`isSilentJob` is already imported in `workflowUpdates.ts:37`. `previewJobs.ts` and `useLiveSliderWriter` are unchanged. **Both halves matter:** §8.2 deletes the `isSilentJob` special-case from `upsertLiveGeneration`, so if the per-frame `running` placeholder does not also pin slot 0, it would append/churn variants via the index-less newest-slot fallback. The covering test `ResultsStore.variants.test.ts:154-183` (running→completed PER frame, 8 frames → 1 generation) relocates to a `generation_complete`-handler test that **drives running + generation_complete per frame for 8 frames** and asserts 1 live gen.
+
+Keep the kernel dumb (always increment `index`); silence is a pure slider-preview UI concern, so the gate lives frontend-side. The browser runner already owns the jobId; we do not push a `silent` flag into the kernel.
+
+---
+
+## 10. Python parity — **VERDICT: TS-only for the targeted collapse. Zero `nodetool-core` change.**
+
+Python nodes execute through the **same `NodeExecutor` interface** as TS nodes (`node-executor.ts:127-171`). `PythonNodeExecutor` implements **only** `process()` (`python-node-executor.ts:223-237`) and `genProcess()` (`:239-258`) — **never `run()`**. `process()` does the bridge RPC, calls `materializeOutputs()`, and **returns a fully-materialized plain JS dict** to the actor's `await`; `genProcess()` yields materialized partials. For Python the actor assigns these to `_latestResult` at sites `:369` (legacy single `process()`), `:994` (genProcess stream-end), `:1000` (correlated), `:1290` (controlled-loop) — **identically to TS**.
+
+**Two corrections to the "identical sites" claim** (it was over-stated):
+- **Site #5 (`run()` / `nodeOutputs.collected()`, `:357`) is TS-only.** `PythonNodeExecutor` has no `run()`; the actor's `run()` path requires `this._executor.run` (`actor.ts:286`). A Python node flagged `is_streaming_input` therefore falls into the **legacy single `process()`** branch (`actor.ts:358-371`, site #3), never site #5. So for Python, site #5 is dead and site #357 is never reached. The zero-Python-change conclusion is unaffected; the coverage claim is corrected.
+- **Streaming-output multi-artifact nodes are out of scope (§5 site #4 invariant).** Python streaming-output nodes deliver every artifact as a per-yield `chunk` frame (worker `protocol.py:126-132`), and the terminal `result` is deliberately **empty** (`protocol.py:141-145`, `result_data={'outputs':{},'blobs':{}}` for `execute.stream`). So for a Python generator that yields N distinct artifacts on the **same slot**, the only place those artifacts exist distinctly is the per-yield boundary — which we route to display-only `output_update`. The genProcess stream-end `generation_complete` would carry only artifact N. **We scope this out** (§3, Decision 1 corollary) rather than fix it, because the faithful fix would require the wire to distinguish a "complete artifact" yield from a progressive chunk — a `final`/`complete` marker on `chunk` frames — which **would** require a `nodetool-core` (`worker/protocol.py`) change, contradicting the zero-Python-change goal. No such node exists today; the §13 guard test documents the limitation.
+
+The bridge is **pure request/response RPC** keyed to `request_id` (`python-bridge-base.ts:172-267`) — it emits no `node_update`/`output_update`/generation/autosave concept. **Therefore `generation_complete` is emitted entirely in the TS `NodeActor`.** Python nodes get it for free for the targeted multi-execution collapse (the 6× `ListGenerator→TextToImage` case is a pure TS-actor correlated-drain phenomenon). No `packages/protocol` Python mirror, no `bridge-protocol.ts` change, no worker change. **Python-side scope: none.**
+
+---
+
+## 11. Protocol / serialization changes & full touch-point list
+
+**msgpack is schemaless on both ends** — server encodes with `msgpackr` `pack` (`unified-websocket-runner.ts:7,1229`), client decodes with `@msgpack/msgpack` `decode` (`WebSocketManager.ts:242/249`). No `addExtension` / `Packr` registry / type table anywhere. **Any new `type` string round-trips for free; zero msgpack change.** There is no zod schema for the streaming `ProcessingMessage` union (the `api-schemas` zod is REST chat-thread only) — **zero zod change.**
+
+Touch points (expanded to all consumers):
+1. **`packages/protocol/src/messages.ts`:** add `interface GenerationComplete` (after `:178`); add to the `ProcessingMessage` union (`:633-653`) — auto-flows into `MessageType`/`MessageOfType`, re-exported via `index.ts:5`. Add `disposition?` + `done?` to `OutputUpdate` (`:201-210`).
+2. **`packages/kernel/src/actor.ts`:** `_emitGenerationComplete` (bare, no `job_id`; `node_name = node.name ?? node.type`) + the 4–5 emit sites (§5); `_generationIndex` field.
+3. **`packages/kernel/src/runner.ts`:** set `output_update.disposition` at `:1286-1294`; ensure `generation_complete` is retained (not audio-dropped) in `_emit` (`:1688-1708`).
+4. **`packages/websocket/src/unified-websocket-runner.ts`:** add `generation_complete` to the processing gate `:1889-1892`; new autosave + normalize branch; delete `node_update` autosave `:1932-1953`. (Backfill at `:1855-1861` already stamps `job_id`/`workflow_id` — no change.)
+5. **`web/src/lib/workflow/browserRunner.worker.ts` + `browserWorkflowRunner.ts`:** add `generation_complete` normalize/materialize branches (§8.5); confirm `job_id` backfill; add/confirm browser-path autosave (Decision 9).
+6. **`web/src/stores/workflowUpdates.ts`:** new `generation_complete` branch + silent-scrub gate (both writers); demote `output_update` to disposition-aware; delete `completed→upsertLiveGeneration` from `node_update`.
+7. **`web/src/stores/ResultsStore.ts`:** rewrite `upsertLiveGeneration` to append/replace-by-`index` with the index-less-patch contract; change `setOutputResult` to disposition-aware.
+8. **`web/src/core/chat/chatProtocol.ts`:** `applyOutputUpdate` honors `disposition`; documented `generation_complete` decision (Decision 11).
+9. **`web/src/hooks/timeline/useGenerateClip.ts` + `web/src/hooks/sketch/useGenerateLayer.ts`:** migrate asset extraction to `generation_complete.outputs`; thread `disposition` through their `setOutputResult` calls.
+10. **`web/src/components/miniapps/hooks/useMiniAppRunner.ts`:** build result tiles from `generation_complete.outputs`.
+11. **`mobile/src/stores/WorkflowRunner.ts` + `mobile/src/api.ts`:** add `generation_complete` case; regenerate message-type union; document `node_update.result` degradation (Decision 10).
+12. **`packages/cli/src/websocket-client.ts`:** add `generation_complete` to the union and the JSON event stream (Decision 12).
+
+---
+
+## 12. Rollout plan
+
+Ordered, each step shippable and green **on both run paths** (the original draft was green only for the server path):
+
+1. **Protocol additive (no behavior change).** Add `GenerationComplete` to the union + `OutputUpdate.disposition?`/`done?`. Build `protocol`. Nothing emits or consumes it yet. *Back-compat: optional fields, additive union member — old clients ignore the new `type`.*
+2. **Kernel emits *bare* `generation_complete`** at the 4–5 sites — **no `job_id` and no `index`** (per D8, both are stamped downstream: the server persist/relay seam derives `index` from DB ordering; the browser relay assigns an arrival-order `index`). Set `output_update.disposition`. Relay it through **both** the websocket (gate `:1889-1892`, backfill `job_id`+`index`, normalize `.outputs`) **and** the browser worker (assign arrival-order `index`, normalize `.outputs`, §8.5) **without** autosave yet. No consumer reacts → no behavior change. Add kernel emission tests (incl. the genProcess stream-end guard test).
+3. **Frontend consumes `generation_complete`** (new reducer branch + `upsertLiveGeneration` rewrite incl. index-less-patch contract + silent-scrub gate on both writers). **Delete** the `node_update{completed}→upsertLiveGeneration` write and the ResultsStore Tier-2 hack **in the same commit**. Migrate `PreviewNode`, mini-apps, timeline/sketch asset extraction, and mobile in the same wave (each is independently testable but must not be left reading the demoted channel for artifacts). Now the timeline shows N variants live.
+4. **Autosave hard-switch.** Add the `generation_complete` autosave branch and delete the `node_update` autosave **atomically** on the server (§7); land the **browser-path persistence decision** (Decision 9) in the same step. Now N assets persist on whichever paths are in scope.
+5. **Demote `output_update` display** (disposition-aware append/replace across all 5 `setOutputResult` sites + `chatProtocol.ts`; ephemeral-clear on `generation_complete`). Cosmetic.
+6. **Cleanup:** remove the now-dead `node_update.result`-as-artifact reads where a consumer fully migrated; tighten comments. (`node_update.result` survives as the documented mobile/skip-result degradation path.)
+
+**Safe cutover sequence:** steps 1–2 are invisible (additive + emit-only on both paths). Step 3 swaps the generation driver in one commit. Step 4 swaps the autosave driver in one commit. Never run both drivers of either {generations, autosave} simultaneously.
+
+**Client/server version skew (NEW).** Steps 1–2 (old-client/new-server) degrade safely — an old client ignores the new `type` and shows the old 1-variant behavior. The genuine risk is **new-client/old-server**: step 3 deletes the client's `node_update{completed}→upsertLiveGeneration` write, but an old server never emits `generation_complete` → **generations disappear entirely**. Electron bundles client+server in lockstep (verified: `web` and `websocket` both `0.7.0-rc.23`), so in-process is safe. **For any remote `nodetool serve` deployment where web and the websocket server version independently, gate the step-3 deletion behind a server-capability probe, or keep the `node_update` generation write until the server is known to emit `generation_complete`.** The optional `NODETOOL_GENERATION_EVENTS` flag stages a same-process cutover but does **not** cover client/server version skew. *(Open — see §15.)*
+
+---
+
+## 13. Test plan
+
+**Kernel emission (`packages/kernel`):**
+- Correlated 6× generator (`ListGenerator→TextToImage`) emits exactly 6 `generation_complete` with `index` 0–5, each distinct `outputs`, **one** `node_update{completed}`.
+- Controlled-loop node emits one per `"run"` event.
+- `genProcess` node with a final whole-value yield: N `output_update{disposition:"append"}` yields + **exactly one** `generation_complete` at stream-end carrying the **consolidated** value (assert NOT per-yield, assert value is complete).
+- **Guard test (documented limitation):** a `genProcess` node whose last yield does **not** carry the full value (overwrite-merge on one slot) loses prior content in the single `generation_complete` — assert this so a future multi-artifact-per-slot streaming node author hits a failing test, not silent loss.
+- `genProcess` under correlation (multiple keys): one `generation_complete` per key.
+- `nodetool.constant.*` / `nodetool.input.*` emit **no** `generation_complete`.
+- `generation_complete` is never edge-suppressed (intermediate generator feeding a Preview still emits it) and never audio-dropped.
+- Actor emit carries no `job_id`; assert the runner relay stamps it (server **and** browser paths).
+
+**Autosave (`packages/websocket`):**
+- 6-gen run → 6 `Asset` rows, each with correct `node_id`/`job_id`.
+- No double-save: assert `node_update{completed}` no longer triggers `autoSaveAssets`.
+- **Replay idempotency:** re-emitting a **fresh** `generation_complete` object (asset_id unset, as a real reconnect would) is a no-op — requires the `(job_id, node_id, index)` guard from Decision 8, NOT just per-object `asset_id`. (Today's per-object guard would duplicate.)
+- Text-output autosave still fires off `generation_complete.outputs`.
+
+**Browser path (`web`):**
+- In-browser `ListGenerator→TextToImage→Preview` end-to-end: 6 normalized variants render (assert `generation_complete.outputs` materialized — no broken images), and persistence matches Decision 9.
+
+**Reducer / store (`web`):**
+- `generation_complete{index:0,1,2}` → 3 variants (rewrite `ResultsStore.variants.test.ts:34-66`).
+- Index-less patch routing: `node_update{running}` then `node_update{error}` with **no** intervening `generation_complete` settles to exactly **one errored** generation (no stuck `running`).
+- `disposition:"append"` concatenates; `"replace"` overwrites the display buffer — assert across `workflowUpdates`, `chatProtocol`, `useGenerateClip`, `useGenerateLayer`.
+- `node_update{completed}` no longer mutates `liveGenerations`.
+- `mergeGenerations` collapses live N + persisted N (same jobId) → N.
+
+**Silent-scrub:** 8 scrub frames, each driving `node_update{running}` **and** `generation_complete` under one silent jobId → **1** live generation (relocated from `ResultsStore.variants.test.ts:154-183`; covers both writers).
+
+**Consumer surfaces:** mini-app result list shows N tiles for a multi-execution generator; timeline/sketch extract the asset from `generation_complete.outputs` (not `output_update`); mobile shows ≥1 artifact via the new case; CLI `--json` emits N `generation_complete` events.
+
+---
+
+## 14. DECISIONS TO LOCK
+
+### Status — locked 2026-06-20
+- **D1** ✅ A — per-`process()` boundary; multi-artifact-per-output-slot streaming generators out of scope.
+- **D8** ✅ B (refined) — `index` from **DB ordering**, assigned at the persist/relay seam (not the actor).
+- **D9** ✅ Provider-generations only, **always server-side**; **no** browser autosave; browser normalize mandatory.
+- **D10** 🔶 Provisional — mobile gets the `generation_complete` case + data now; full variant UI fast-follow (awaiting confirm).
+- **D11** ✅ B — chat shows variants.
+- **D2, D3, D4, D5, D6, D7, D12** ✅ accepted as recommended.
+
+**Decision 1 — Generation boundary & list handling.**
+Options: **A)** one `generation_complete` per `process()` result; list-valued handles carried as arrays, consumers flatten (`runVariantValues` / recursive autosave collect). **B)** fan a list-valued result into one `generation_complete` per element in the actor.
+**Recommend: A** — the actor already hands whole result dicts to `_sendOutputs`; passing the same dict avoids teaching the actor per-handle list semantics, and `runVariantValues` + `autoSaveAssets`'s recursive `collect` (`:448-464`) already flatten. **Corollary (errors):** keep node-level errors on `node_update{error}`; `generation_complete` represents committed artifacts only (no error variant in the shape). A run that errors before committing emits no `generation_complete` — correct. **Corollary (streaming):** the genProcess stream-end `generation_complete` carries the overwrite-merged `_streamingCollectedOutputs`, so multi-artifact-per-output-slot streaming generators are **out of scope** (§5/§10); guard-tested in §13.
+**DECIDED: A** — confirmed, including the streaming scope-out (multi-artifact-per-output-slot streaming generators are not covered this cycle; documented + guard-tested).
+
+**Decision 2 — Silent-scrub gate location & mechanism.**
+Options: **A)** backend pins `index=0` for silent jobs (kernel must learn "silent"). **B)** frontend gate in the `generation_complete` handler **and** the `node_update{running}` placeholder: `isSilentJob(jobId)` → pin slot 0, else append by `index` (or newest-slot for index-less running/error).
+**Recommend: B** — silence is a pure slider-preview UI concern; the kernel stays dumb. The gate must cover **both** per-frame writers (generation_complete and the running placeholder), since §8.2 removes the `isSilentJob` special-case from `upsertLiveGeneration`. `isSilentJob` already imported in `workflowUpdates.ts:37`.
+
+**Decision 3 — Autosave cutover.**
+Options: **A)** dual-write (both `node_update` and `generation_complete` autosave during migration). **B)** hard switch (delete old, add new in one commit).
+**Recommend: B** — **corrected rationale:** runs `1..N-1` exist **only** on `generation_complete` (node_update collapses to the last), so dual-write under-saves the early runs regardless; and the cross-channel `asset_id` idempotency guard is **reference-based** — it protects the shared last-result object on the `process()` path (same instance at `actor.ts:1000/1290`, so dual-write would be a no-op there, NOT a double-save as the draft claimed) but does **not** protect the `genProcess` fresh-spread path (`:994`), where dual-write **would** double-save the final artifact. Atomic swap is the only clean option. (If a dark-launch is mandated, gate both with one flag, never both ON.)
+
+**Decision 4 — `output_update.disposition` + ephemeral lifecycle.**
+Options: **A)** add `disposition: "append" | "replace"` (+ optional `done`); clear the buffer on run-start and on `generation_complete` for that artifact; thread `disposition` through **all 5** `setOutputResult` call sites. **B)** keep hardcoded append; clear only on run-start.
+**Recommend: A** — fixes the progressive-preview latent bug (`workflowUpdates.ts:515` always-append) and makes whole-value snapshots correct. Absent `disposition` defaults to `"append"` for back-compat. Note the call-site count: `workflowUpdates.ts:515`, `chatProtocol.ts:514`, `useGenerateClip.ts:186`, `useGenerateLayer.ts:227` — missing any re-introduces the bug in that consumer.
+
+**Decision 5 — Keep the name `output_update` vs rename.**
+Options: **A)** keep `output_update`. **B)** rename to `display_update` / `output_chunk`.
+**Recommend: A** — renaming churns the protocol union, both web reducers, `chatProtocol.ts`, mobile, CLI, the relay, and every display-sink component for a cosmetic gain; the `disposition` field already encodes the honest semantics. Revisit only if a future cleanup pass touches all sites anyway.
+
+**Decision 6 — Do connected content-card/text nodes still emit `output_update` for live streaming?**
+Options: **A)** yes — keep emitting for live token/preview display (now purely cosmetic). **B)** stop emitting for edge-connected handles (rely only on `generation_complete`).
+**Recommend: A** — live token streaming and progressive previews are real UX that `generation_complete` (fires only at commit) can't provide. Edge-suppression already trims the firehose where it matters; the surviving emits are harmless display. Keep them.
+
+**Decision 7 — How do `constant`/`input`/`skipResult` node values reach display sinks?**
+Context: §5 skips `generation_complete` for `nodetool.constant.*` / `nodetool.input.*`; `node_update.result` is demoted to advisory; `output_update` is suppressible on edge-connected handles. That risks a value on none of the three authoritative channels.
+Options: **A)** these nodes' downstream **consumers** are what emit `generation_complete` (the constant/input value flows as an input, and the consuming node commits its own artifact) — the constant/input node itself has no savable artifact and needs none; client-authored constants are already in the graph state, and server-resolved inputs surface via their consumer. Keep `node_update.result` as the **explicit** display fallback for the rare standalone constant/input preview. **B)** emit `generation_complete` for these too.
+**Recommend: A** — but **state it explicitly** rather than leaving the "client already holds the values" hand-wave: a constant/input feeding a connected node has its value carried into the consumer's `generation_complete`; a standalone constant/input previewed directly reads `node_update.result` (the one sanctioned `result` read, scoped to skip-result node types). This reconciles "don't read `result` for artifacts" (multi-execution generators) with "skip-result nodes use `result`" (they have no generation).
+
+**Decision 8 — Replay/duplicate-asset idempotency.**
+Options: **A)** per-object `asset_id` guard only (today). **B)** add a persisted-layer idempotency key on `(job_id, node_id, index)` — skip autosave for an already-persisted tuple.
+**Recommend: B** — a real reconnect/replay re-emits a **fresh** `generation_complete` (asset_id unset on a new object), so the reference-based guard does not fire → duplicate `Asset` rows sharing `job_id` but new ids. Since persisted assets carry no `index` today, add `index` to the autosave dedupe (either a stored column or an in-run `(node_id, index)` set per job) so replay is a true no-op. Without B, the §13 "replay is a no-op" test fails for genuine reconnects.
+**DECIDED: B, refined — `index` is assigned from DB ordering at the server persist/relay seam, not by the actor.** The `unified-websocket-runner` interception that backfills `job_id` (`:1855-1861`) persists the asset, derives `index` from the DB ordering of `(job_id, node_id)`'s assets, stamps it onto `generation_complete` **before relay**, and dedupes autosave on `(job_id, node_id, index)` → replay is a true no-op. Live ordering uses the stamped DB index (available because stamping happens in the same pre-relay pass). The browser path (no persist) falls back to an arrival-order index.
+
+**Decision 9 — Browser-path persistence.**
+Options: **A)** add a browser-side autosave hook keyed on `generation_complete` mirroring `unified-websocket-runner`'s branch. **B)** confirm + document that browser-path generative runs already round-trip persistence to the server (relying on the `job_update{completed}` asset reload), and that `generation_complete` in-browser is display-only.
+**Recommend: decide before step 4 ships.** The browser path calls `autoSaveAssets` **nowhere** (verified). If browser jobs do not reach the server autosave gate, option A is required or the "every committed artifact is persisted" goal fails for browser-eligible (and silent-scrub) workflows. Regardless of A/B, the browser **normalize** branch for `generation_complete.outputs` is **mandatory** (§8.5) for correct rendering.
+**DECIDED: B — persistence is provider-generations only, always server-side; no browser autosave hook.** Browser/non-provider generations are display-only and not persisted. Provider calls (fal/replicate/LLM/etc.) already execute server-side, so every persistable artifact hits the server autosave gate by construction. Option A (browser autosave) is rejected. The browser `generation_complete.outputs` **normalize** branch (§8.5) remains **mandatory** for rendering; only the persistence half is dropped from the browser path.
+
+**Decision 10 — Mobile degradation.**
+Options: **A)** mobile adds a `generation_complete` case but continues to show 1-artifact-per-node via `node_update.result` (graceful degradation, no variant UI). **B)** mobile renders full variant lists from `generation_complete`.
+**Recommend: A for this cycle** — state it as an **intended** degradation, regenerate `mobile/src/api.ts` types, and add the case so multi-execution at least shows the latest. Variant UI on mobile is a follow-up.
+**DECIDED (provisional): add the `generation_complete` case + regenerate types now; full variant UI as a fast-follow.** Mobile shows the latest immediately and does not block the cutover. *Awaiting confirmation on whether mobile variant UI is wanted in this cycle.*
+
+**Decision 11 — Chat/agent path & `generation_complete`.**
+Options: **A)** chat ignores `generation_complete` (display-only via `output_update`/`media_generation`); document why. **B)** chat gets its own `generation_complete` → variant handling.
+**Recommend: A for this cycle** — chat surfaces live media via existing chunk handling; workflow-tool multi-execution variants are not a chat UX today. Document the decision; don't leave it implicit. `applyOutputUpdate` still honors `disposition` regardless.
+**DECIDED: B — chat shows variants.** Chat gets full `generation_complete` → variant handling (overrides the degrade recommendation). `applyOutputUpdate` still honors `disposition`.
+
+**Decision 12 — CLI semantics.**
+Options: **A)** surface each `generation_complete` as its own event in the `--json` stream. **B)** aggregate into the final result.
+**Recommend: A** — preserves the N-artifact information the kernel now exposes; add the type to the CLI union. Lowest priority but must not silently drop variants.
+
+---
+
+## 15. Risks & open questions
+
+- **Storage volume.** N-per-run autosave means previously-discarded intermediates now persist (a 100-frame batch generator writes 100 assets). Confirm desired; consider a per-node `auto_save_asset` cap or an explicit "save intermediates" flag for very-high-N generators. *(Open — needs product call.)*
+- **Browser-path persistence (Decision 9).** The single biggest open item: browser jobs call `autoSaveAssets` nowhere. Until Decision 9 lands, N-asset persistence is unproven for browser-eligible and silent-scrub runs. The browser normalize branch is mandatory independent of the persistence decision.
+- **Replay duplicate assets (Decision 8).** Persisted assets carry no `index`; the only dedupe is the per-object `asset_id` mutation. A reconnect re-emits fresh `generation_complete` objects → duplicate rows. Needs `(job_id, node_id, index)` idempotency at the autosave layer.
+- **`_messages` truncation vs reconnect replay.** `generation_complete` is pushed into `_messages`, but `_messages` is **truncated** to `MAX_RETAINED_MESSAGES/2` past 10,000 (`runner.ts:1697-1700`) and is **not** the autosave source (autosave consumes the live relay stream in `unified-websocket-runner`, not `_messages`). Drop the draft's "`_messages` authoritative for autosave" claim. For a very-high-N reconnect, early `generation_complete` entries can be evicted from replay; persisted assets recover them via the `job_update{completed}` reload — verify the reconnect replay path preserves `index` ordering for what survives, and document that very-high-N reconnects may drop early *live* variants from replay (persisted side recovers them).
+- **`running` placeholder + index-less patches.** `generation_complete` fires only at commit, so the pre-first-artifact spinner relies on the `node_update{running}→upsertLiveGeneration` placeholder; a node that errors before any artifact must be settled by the index-less `node_update{error}` patch via the newest-slot fallback (§8.2). Tested in §13.
+- **`job_id`/`node_name` in the actor.** Resolved (was asserted-resolved-but-wrong): the actor has **no** `job_id`; the runner relay stamps it at `unified-websocket-runner.ts:1855-1861`. `node_name = node.name ?? node.type`, not `node.data?.title`. The browser relay must apply the same stamping.
+- **Client/server version skew (§12).** New-client/old-server erases generations (client deletes the `node_update` write; old server never emits `generation_complete`). Lockstep in Electron (verified `0.7.0-rc.23`); for remote `serve`, gate the step-3 deletion behind a capability probe or keep the `node_update` write until the server is known to emit the new event.
+- **`mergeGenerations` jobId coupling.** The live/persisted collapse depends on all N variants and N assets sharing one `jobId` (`nodeGenerations.ts:74-82`, `assetToGeneration` at `:58-60`). `index` must not leak into the jobId match. Verified the merge groups purely by `jobId`; confirm `assetToGeneration` keeps grouping intact when N assets land.
+- **All consumers migrated.** The consumer census (§8.5–§8.11) must be complete; a missed reader of `node_update.result`/`output_update.value` as an artifact silently loses variants. Re-run the grep before sign-off.
+
+---
+
+## Appendix — Addressed review notes
+
+Findings verified against the working tree; each is either incorporated above or marked corrected-as-wrong with why.
+
+1. **Double-save rationale inverted (high) — INCORPORATED + CORRECTED.** Verified `actor.ts:1000`/`:1290` assign `_latestResult = outputs` (same ref as the would-be `generation_complete.outputs`), and the `autoSaveAssets` guard (`:468`/`:518-520`) is reference-based. The draft's "different instances → double-save" was inverted for the `process()` path (it'd be a no-op there); the real double-save risk is the `genProcess` fresh-spread path (`:994`). Rationale rewritten in §7 and Decision 3 around (a) under-save of runs 1..N-1 and (b) the genProcess-only double-save.
+
+2. **genProcess stream-end overwrite-merge (high/critical) — INCORPORATED.** Verified `_streamingCollectedOutputs` is `Object.assign` overwrite-merge (`:984`) then `{...}` (`:994`). Stated the load-bearing invariant in §5, scoped multi-artifact-per-slot streaming out (§3, Decision 1 corollary, §10), added a guard test (§13).
+
+3. **Index-less running/error patches into an index-keyed store (medium) — INCORPORATED.** Specified the index-less-patch contract in §8.2 (newest-slot-by-jobId fallback retained for `running`/`error`; explicit `index` only from `generation_complete`) + a §13 test for running→error-with-no-generation settling to one errored gen.
+
+4./21. **Actor `job_id`/`node_name` wrong-as-written (high/medium) — INCORPORATED + CORRECTED.** Verified zero `job_id` in `actor.ts`; backfill at `:1855-1861`; `_emitNodeStatus` uses `node.name ?? node.type`. §5 emit snippet now omits `job_id` and uses `node.name`; §15 open question resolved.
+
+5./15./16. **Browser path autosave + normalize gaps (critical/high) — INCORPORATED.** Verified `autoSaveAssets` only in `unified-websocket-runner`; browser normalize only handles `.result`/`.value` (`browserWorkflowRunner.ts:435-441`, `browserRunner.worker.ts:187-203`). Added §8.5, Decision 9, touch-point #5, browser test, and rollout/§3 corrections.
+
+6./7. (Duplicate of 4 from a second reviewer.) — Same correction; consolidated.
+
+8. **Silent-scrub running placeholder (high) — INCORPORATED.** §9 now gates **both** the `generation_complete` write and the per-frame `running` placeholder on `isSilentJob`; §13 test drives both halves per frame.
+
+9. **`_messages` retention vs "authoritative for autosave" (medium) — INCORPORATED + CORRECTED.** Verified `MAX_RETAINED_MESSAGES=10_000` slice (`:1697-1700`) and that autosave reads the live relay, not `_messages`. Dropped the "authoritative for autosave" claim; §15 documents truncation + reconnect implications.
+
+10. **Replay duplicate assets (medium) — INCORPORATED.** Verified `Asset` has `node_id`/`job_id` but no `index`; guard is per-object. Added Decision 8 (`(job_id, node_id, index)` idempotency) and a fresh-object replay test.
+
+11. **New-client/old-server skew (medium) — INCORPORATED.** Verified `web` and `websocket` are lockstep `0.7.0-rc.23`. §12 documents Electron lockstep vs remote-serve risk and the capability-probe mitigation.
+
+12./13. **Python streaming-output + streaming-input site coverage (high/medium) — INCORPORATED.** Verified `PythonNodeExecutor` implements only `process()`/`genProcess()` (no `run()`), so site #5 is TS-only and Python streaming-input uses site #3. Verified the empty terminal `result` for `execute.stream`. §10 corrected; streaming-output multi-artifact scoped out.
+
+**Critical (mobile)** — INCORPORATED (§8.6, Decision 10, touch-point #11).
+**Critical (timeline/sketch)** — INCORPORATED (§8.8, touch-point #9). Verified the `selectedOutputNodeId`/`jobOutputs`/`extractAssetId`/fail-job pattern.
+**High (browser worker)** — INCORPORATED (folded into §8.5).
+**High (mini-apps)** — INCORPORATED (§8.9, touch-point #10). Verified result tiles built entirely from `output_update`.
+**High (browser autosave)** — INCORPORATED (Decision 9, §15).
+**Medium (CLI)** — INCORPORATED (§8.11, Decision 12, touch-point #12).
+**Medium (chat generation)** — INCORPORATED (§8.10, Decision 11).
+**Medium (constant/input leak)** — INCORPORATED (Decision 7). Verified the `skipResult` set (`actor.ts:437-439`) and reconciled the `result`-read rules.
+**Medium (setOutputResult call sites)** — INCORPORATED (§8.7, Decision 4). Verified 4 runtime call sites + 1 doc comment.
+
+No findings were dropped as wrong; the two that were *partially* wrong (the double-save rationale and the `_messages`-authoritative claim) are corrected in-body rather than silently removed.

--- a/docs/rfc-generation-events.md
+++ b/docs/rfc-generation-events.md
@@ -1,6 +1,6 @@
 # RFC: Generation Events — `generation_complete`, re-scoped `output_update`, autosave cutover
 
-**Status:** Draft for sign-off · **Owner:** runtime/web · **Repo:** `/Users/mg/workspace/nodetool`
+**Status:** Draft for sign-off · **Owner:** runtime/web
 
 > Every line/file reference below was re-verified against the working tree before this revision. Findings that were wrong-as-written (the double-save rationale, the actor `job_id` field, "`_messages` authoritative for autosave") are corrected in-body and catalogued in the **Addressed review notes** appendix. The scope was widened from "kernel→websocket→web-editor" to **all message consumers** (browser runner, mobile, CLI, mini-apps, timeline/sketch editors, chat) after a consumer census.
 

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -355,6 +355,8 @@ export class NodeActor {
             this._executionContext
           );
           this._latestResult = nodeOutputs.collected();
+          // Site #5 (RFC §5): streaming-input run() — one committed result.
+          this._emitGenerationComplete(this._latestResult);
         } else {
           // Legacy fallback: call process() once with the node's own
           // property values, matching the defaults merge every other
@@ -368,6 +370,8 @@ export class NodeActor {
           );
           this._latestResult = outputs;
           await this._sendOutputs(this.node.id, outputs);
+          // Site #3 (RFC §5): legacy single process() — one committed result.
+          this._emitGenerationComplete(outputs);
         }
       } else if (this.node.is_controlled) {
         // Controlled mode: wait for control events from inbox
@@ -992,6 +996,12 @@ export class NodeActor {
         );
       }
       this._latestResult = { ...(this._streamingCollectedOutputs ?? {}) };
+      // Site #4 (RFC §5): genProcess stream-end — ONCE per stream, carrying the
+      // overwrite-merged _streamingCollectedOutputs. Per-yield partials stay on
+      // output_update (chunks); multi-artifact-per-output-slot streaming is OUT
+      // OF SCOPE (RFC §5 invariant / Decision 1 corollary). Under correlation
+      // this branch runs once per ready key → one generation_complete per key.
+      this._emitGenerationComplete(this._latestResult);
     } else {
       const outputs = await this._executor.process(
         inputs,
@@ -1003,6 +1013,9 @@ export class NodeActor {
         outputs,
         this._currentHints(Object.keys(outputs))
       );
+      // Site #1 (RFC §5): correlated process() — one per ready key, so N/run
+      // for a generator (the primary 6×-collapse fix).
+      this._emitGenerationComplete(outputs);
     }
   }
 
@@ -1289,6 +1302,8 @@ export class NodeActor {
         );
         this._latestResult = outputs;
         await this._sendOutputs(this.node.id, outputs);
+        // Site #2 (RFC §5): controlled-loop process() — one per "run" event.
+        this._emitGenerationComplete(outputs);
       }
     }
   }
@@ -1376,6 +1391,35 @@ export class NodeActor {
           ? (this.node.properties as Record<string, unknown>)
           : null,
       provider_cost: this._executionContext?.getProviderCost?.() ?? null
+    });
+  }
+
+  /**
+   * Emit a BARE `generation_complete` for one committed `process()` result
+   * (RFC §4.2 / §5). Routes through the same `_emitMessage` path as
+   * `node_update` (runner `_emit`), so it is NEVER edge-suppressed and is
+   * retained for replay. The actor stamps NO `job_id` and NO `index` — both
+   * are backfilled downstream by the relay (RFC Decision 8).
+   *
+   * Skips `nodetool.constant.*` / `nodetool.input.*` (the same set
+   * `_emitNodeStatus`'s `skipResult` rule covers): those nodes have no
+   * generation. List-valued results are carried as-is — no per-element
+   * fan-out happens in the actor (RFC Decision 1).
+   */
+  private _emitGenerationComplete(outputs: Record<string, unknown>): void {
+    if (
+      this.node.type.startsWith("nodetool.constant.") ||
+      this.node.type.startsWith("nodetool.input.")
+    ) {
+      return;
+    }
+    this._emitMessage({
+      type: "generation_complete",
+      node_id: this.node.id,
+      node_name: this.node.name ?? this.node.type,
+      node_type: this.node.type,
+      outputs
+      // NO job_id, NO index — the runner relay stamps them downstream.
     });
   }
 

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -1290,7 +1290,11 @@ export class WorkflowRunner {
           output_name: outputName,
           value,
           output_type: declaredOutputs[handle] ?? "any",
-          metadata: {}
+          metadata: {},
+          // RFC §6: live display feed defaults to "append" (chunk-concatenate),
+          // matching today's hardcoded consumer behavior. Artifacts travel on
+          // generation_complete, so this is display-only.
+          disposition: "append"
         });
       }
     }

--- a/packages/kernel/tests/generation-complete.test.ts
+++ b/packages/kernel/tests/generation-complete.test.ts
@@ -1,0 +1,418 @@
+/**
+ * `generation_complete` emission (RFC: generation-events §5 / §13).
+ *
+ * The actor emits a BARE `generation_complete` (no `job_id`, no `index`) at
+ * each point a COMPLETE process() result is committed — the same boundaries
+ * where `_latestResult` is assigned for a finished execution:
+ *
+ *   - correlated process()       → one per ready key (N/run for a generator)
+ *   - controlled-loop process()  → one per "run" control event
+ *   - legacy single process()    → once
+ *   - genProcess stream-end      → ONCE per stream (overwrite-merged outputs)
+ *
+ * It routes through the same `_emit` path `node_update` uses, so it is NEVER
+ * edge-suppressed and never audio-dropped. Constant/input nodes emit none.
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import { NodeActor, type NodeExecutor } from "../src/actor.js";
+import { NodeInbox } from "../src/inbox.js";
+import type { NodeAnalysis } from "../src/correlation-analysis.js";
+import type {
+  GenerationComplete,
+  NodeDescriptor,
+  NodeUpdate
+} from "@nodetool-ai/protocol";
+import { configureLogging } from "@nodetool-ai/config";
+import {
+  runWorkflow,
+  foreachNode,
+  iterationOutput,
+  dataEdge
+} from "./correlation/_harness.js";
+
+const EMPTY_ANALYSIS: NodeAnalysis = {
+  invocationScope: [],
+  inputs: new Map(),
+  outputs: new Map()
+};
+
+function makeNode(overrides: Partial<NodeDescriptor> = {}): NodeDescriptor {
+  return { id: "test_node", type: "test.Node", ...overrides };
+}
+
+function createActor(
+  node: NodeDescriptor,
+  inbox: NodeInbox,
+  executor: NodeExecutor
+): { actor: NodeActor; messages: unknown[] } {
+  const messages: unknown[] = [];
+  const actor = new NodeActor({
+    node,
+    inbox,
+    executor,
+    correlation: EMPTY_ANALYSIS,
+    sendOutputs: async () => {},
+    emitMessage: (msg) => messages.push(msg)
+  });
+  return { actor, messages };
+}
+
+function generationCompletes(messages: unknown[]): GenerationComplete[] {
+  return messages.filter(
+    (m) => (m as { type?: string }).type === "generation_complete"
+  ) as GenerationComplete[];
+}
+
+function completedUpdates(messages: unknown[]): NodeUpdate[] {
+  return messages.filter(
+    (m) =>
+      (m as NodeUpdate).type === "node_update" &&
+      (m as NodeUpdate).status === "completed"
+  ) as NodeUpdate[];
+}
+
+let originalLogLevel: string | undefined;
+
+beforeEach(() => {
+  originalLogLevel = process.env["NODETOOL_LOG_LEVEL"];
+  process.env["NODETOOL_LOG_LEVEL"] = "info";
+  configureLogging();
+});
+
+afterEach(() => {
+  if (originalLogLevel === undefined) {
+    delete process.env["NODETOOL_LOG_LEVEL"];
+  } else {
+    process.env["NODETOOL_LOG_LEVEL"] = originalLogLevel;
+  }
+  configureLogging();
+  vi.restoreAllMocks();
+});
+
+describe("generation_complete — actor emit shape (bare)", () => {
+  it("legacy single process() emits exactly one bare generation_complete", async () => {
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const executor: NodeExecutor = {
+      async process() {
+        return { result: 42 };
+      }
+    };
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await inbox.put("a", 1);
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    const gens = generationCompletes(messages);
+    expect(gens).toHaveLength(1);
+    const g = gens[0];
+    expect(g.type).toBe("generation_complete");
+    expect(g.node_id).toBe("test_node");
+    expect(g.node_name).toBe("test.Node"); // node.name ?? node.type
+    expect(g.node_type).toBe("test.Node");
+    expect(g.outputs).toEqual({ result: 42 });
+    // BARE — the actor stamps NO job_id and NO index (stamped downstream, D8).
+    expect(g.job_id).toBeUndefined();
+    expect(g.index).toBeUndefined();
+  });
+
+  it("controlled-loop emits one generation_complete per 'run' event", async () => {
+    const node = makeNode({ is_controlled: true });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("__control__", 1);
+    inbox.addUpstream("x", 1);
+
+    const executor: NodeExecutor = {
+      async process(inputs) {
+        return { out: inputs.threshold };
+      }
+    };
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await inbox.put("x", 100);
+    await inbox.put("__control__", {
+      event_type: "run" as const,
+      properties: { threshold: 0.5 }
+    });
+    await inbox.put("__control__", {
+      event_type: "run" as const,
+      properties: { threshold: 0.9 }
+    });
+    await inbox.put("__control__", { event_type: "stop" as const });
+    inbox.markSourceDone("__control__");
+    inbox.markSourceDone("x");
+
+    await actor.run();
+
+    const gens = generationCompletes(messages);
+    expect(gens).toHaveLength(2);
+    expect(gens.map((g) => g.outputs)).toEqual([
+      { out: 0.5 },
+      { out: 0.9 }
+    ]);
+    expect(gens.every((g) => g.job_id === undefined)).toBe(true);
+    expect(gens.every((g) => g.index === undefined)).toBe(true);
+    // Lifecycle still collapses to one completed update.
+    expect(completedUpdates(messages)).toHaveLength(1);
+  });
+});
+
+describe("generation_complete — genProcess stream-end", () => {
+  it("emits N output_update yields + exactly ONE generation_complete at stream-end", async () => {
+    const node = makeNode({ is_streaming_output: true, sync_mode: "zip_all" });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    // A generator that streams chunks then a final consolidating whole-value
+    // yield (Summarizer-style). The overwrite-merged stream-end dict holds the
+    // complete artifact.
+    const executor: NodeExecutor = {
+      async process() {
+        return {};
+      },
+      async *genProcess(inputs) {
+        const val = inputs.a as string;
+        yield { text: { type: "chunk", content: "a" } };
+        yield { text: { type: "chunk", content: "b" } };
+        yield { text: `${val}-final`, output: `${val}-final` };
+      }
+    };
+    const sent: Array<Record<string, unknown>> = [];
+    const messages: unknown[] = [];
+    const actor = new NodeActor({
+      node,
+      inbox,
+      executor,
+      correlation: EMPTY_ANALYSIS,
+      sendOutputs: async (_id, outputs) => {
+        sent.push(outputs);
+      },
+      emitMessage: (msg) => messages.push(msg)
+    });
+
+    await inbox.put("a", "hi");
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    // Per-yield partials route to _sendOutputs (→ output_update), not gen_complete.
+    expect(sent).toHaveLength(3);
+
+    const gens = generationCompletes(messages);
+    expect(gens).toHaveLength(1);
+    // Stream-end carries the consolidated whole value, NOT a per-yield chunk.
+    expect(gens[0].outputs).toEqual({
+      text: "hi-final",
+      output: "hi-final"
+    });
+  });
+
+  it("GUARD (documented limitation): multi-artifact-per-slot streaming loses prior content", async () => {
+    // A generator that streams N distinct savable artifacts on the SAME output
+    // slot with no consolidating final yield. Because `_streamingCollectedOutputs`
+    // is an overwrite-merge, the single stream-end generation_complete carries
+    // ONLY the last artifact — the prior ones are lost. Multi-artifact-per-slot
+    // streaming generators are OUT OF SCOPE (RFC §5 invariant / Decision 1
+    // corollary). This test asserts the loss so a future author of such a node
+    // hits a failing test, not silent data loss.
+    const node = makeNode({ is_streaming_output: true, sync_mode: "zip_all" });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const executor: NodeExecutor = {
+      async process() {
+        return {};
+      },
+      async *genProcess() {
+        // Three whole artifacts on the same slot, no consolidating yield.
+        yield { image: "artifact-0" };
+        yield { image: "artifact-1" };
+        yield { image: "artifact-2" };
+      }
+    };
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await inbox.put("a", 1);
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    const gens = generationCompletes(messages);
+    expect(gens).toHaveLength(1);
+    // DOCUMENTED LOSS: only the last artifact survives the overwrite-merge.
+    expect(gens[0].outputs).toEqual({ image: "artifact-2" });
+  });
+});
+
+describe("generation_complete — constant/input skip (no generation)", () => {
+  it("nodetool.constant.* emits no generation_complete", async () => {
+    const node = makeNode({ type: "nodetool.constant.String" });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const executor: NodeExecutor = {
+      async process() {
+        return { output: "hello" };
+      }
+    };
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await inbox.put("a", 1);
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    expect(generationCompletes(messages)).toHaveLength(0);
+    // Lifecycle still fires.
+    expect(completedUpdates(messages)).toHaveLength(1);
+  });
+
+  it("nodetool.input.* emits no generation_complete", async () => {
+    const node = makeNode({ type: "nodetool.input.StringInput" });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const executor: NodeExecutor = {
+      async process() {
+        return { output: "param" };
+      }
+    };
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await inbox.put("a", 1);
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    expect(generationCompletes(messages)).toHaveLength(0);
+  });
+});
+
+describe("generation_complete — correlated fan-out (runner)", () => {
+  it("a 6x correlated generator emits 6 bare generation_complete + ONE node_update{completed}", async () => {
+    const list = ["i0", "i1", "i2", "i3", "i4", "i5"];
+    const { result } = await runWorkflow({
+      jobId: "gen-6x",
+      nodes: [
+        {
+          id: "src",
+          type: "nodetool.input.IntegerInput",
+          name: "items",
+          properties: { value: list }
+        },
+        {
+          id: "fe",
+          type: "nodetool.control.ForEach",
+          is_streaming_output: true,
+          outputs: { output: "any", index: "int" },
+          output_correlation: {
+            output: iterationOutput("items"),
+            index: iterationOutput("items")
+          }
+        },
+        // Buffered consumer: fires once per arriving lineage key (6×) on the
+        // correlated process() path (site #1). Terminal `image` handle.
+        {
+          id: "gen",
+          type: "test.TextToImage",
+          outputs: { image: "any" }
+        }
+      ],
+      edges: [
+        dataEdge("src", "value", "fe", "input_list", "eSrc"),
+        dataEdge("fe", "output", "gen", "prompt", "eFe")
+      ],
+      executors: {
+        fe: foreachNode(),
+        gen: {
+          async process(ins) {
+            return { image: `img(${ins.prompt})` };
+          }
+        }
+      }
+    });
+
+    expect(result.status).toBe("completed");
+
+    const genMsgs = result.messages.filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    ) as GenerationComplete[];
+    expect(genMsgs).toHaveLength(6);
+    // Each carries a distinct artifact; actor emit is bare (no job_id/index).
+    expect(genMsgs.map((g) => g.outputs)).toEqual(
+      list.map((p) => ({ image: `img(${p})` }))
+    );
+    expect(genMsgs.every((g) => g.job_id === undefined)).toBe(true);
+    expect(genMsgs.every((g) => g.index === undefined)).toBe(true);
+
+    // Lifecycle collapses to ONE completed update for the consumer.
+    const completed = result.messages.filter(
+      (m) =>
+        m.type === "node_update" &&
+        m.node_id === "gen" &&
+        m.status === "completed"
+    );
+    expect(completed).toHaveLength(1);
+  });
+
+  it("generation_complete is never edge-suppressed (intermediate generator feeding a sink)", async () => {
+    // `gen` has an OUTGOING data edge to `sink` — its output_update would be
+    // edge-suppressed, but generation_complete must still be emitted.
+    const list = ["a", "b", "c"];
+    const { result } = await runWorkflow({
+      jobId: "gen-suppress",
+      nodes: [
+        {
+          id: "src",
+          type: "nodetool.input.IntegerInput",
+          name: "items",
+          properties: { value: list }
+        },
+        {
+          id: "fe",
+          type: "nodetool.control.ForEach",
+          is_streaming_output: true,
+          outputs: { output: "any", index: "int" },
+          output_correlation: {
+            output: iterationOutput("items"),
+            index: iterationOutput("items")
+          }
+        },
+        { id: "gen", type: "test.Mapper", outputs: { value: "any" } },
+        { id: "sink", type: "test.Sink", is_streaming_input: true }
+      ],
+      edges: [
+        dataEdge("src", "value", "fe", "input_list", "eSrc"),
+        dataEdge("fe", "output", "gen", "value", "eFe"),
+        // gen.value → sink: an OUTGOING data edge that suppresses output_update.
+        dataEdge("gen", "value", "sink", "value", "eGen")
+      ],
+      executors: {
+        fe: foreachNode(),
+        gen: {
+          async process(ins) {
+            return { value: `m(${ins.value})` };
+          }
+        }
+      },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("completed");
+
+    // output_update for gen's connected handle is suppressed.
+    const outputUpdates = result.messages.filter(
+      (m) => m.type === "output_update" && m.node_id === "gen"
+    );
+    expect(outputUpdates).toHaveLength(0);
+
+    // generation_complete is NOT suppressed — all 3 survive.
+    const genMsgs = result.messages.filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    ) as GenerationComplete[];
+    expect(genMsgs).toHaveLength(3);
+    expect(genMsgs.map((g) => g.outputs)).toEqual(
+      list.map((v) => ({ value: `m(${v})` }))
+    );
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -177,6 +177,33 @@ export interface NodeUpdate {
   workflow_id?: string | null;
 }
 
+/**
+ * A generator committed one complete artifact (one `process()` result, or one
+ * `genProcess` stream-end). Authoritative variant carrier — never suppressed.
+ *
+ * The kernel actor emits a BARE event: `node_id`, `node_name`, `node_type`,
+ * `outputs`. `job_id` and `index` are stamped DOWNSTREAM by the relay (the
+ * unified websocket runner / browser runner), so both are optional on the wire
+ * — see the generation-events RFC §4.2 / §5 / Decision 8.
+ */
+export interface GenerationComplete {
+  type: "generation_complete";
+  node_id: string;
+  node_name: string;
+  node_type: string;
+  /**
+   * k-th committed generation of this node in this run. Stamped downstream by
+   * the relay (DB ordering on the server, arrival order in the browser), absent
+   * on the bare actor emit.
+   */
+  index?: number;
+  /** The complete result dict for this artifact (same shape as a process() return). */
+  outputs: Record<string, unknown>;
+  /** Stamped downstream by the runner relay, NOT by the actor. */
+  job_id?: string | null;
+  workflow_id?: string | null;
+}
+
 export interface NodeProgress {
   type: "node_progress";
   node_id: string;
@@ -206,6 +233,14 @@ export interface OutputUpdate {
   value: unknown;
   output_type: string;
   metadata: Record<string, unknown>;
+  /**
+   * NEW. "append" = `value` is a chunk to concatenate onto the live display
+   * buffer; "replace" = `value` is a whole snapshot that overwrites it. Absent
+   * ⇒ treated as "append" (today's behavior) for back-compat.
+   */
+  disposition?: "append" | "replace";
+  /** NEW (optional). Marks the final chunk of an append stream. */
+  done?: boolean;
   workflow_id?: string | null;
 }
 
@@ -633,6 +668,7 @@ export type WebSocketServerMessage =
 export type ProcessingMessage =
   | JobUpdate
   | NodeUpdate
+  | GenerationComplete
   | NodeProgress
   | EdgeUpdate
   | OutputUpdate

--- a/packages/protocol/tests/messages.test.ts
+++ b/packages/protocol/tests/messages.test.ts
@@ -13,6 +13,7 @@ import type {
   MessageType,
   JobUpdate,
   NodeUpdate,
+  GenerationComplete,
   NodeProgress,
   EdgeUpdate,
   OutputUpdate,
@@ -169,6 +170,17 @@ function llmCallUpdate(): LLMCallUpdate {
   };
 }
 
+function generationComplete(): GenerationComplete {
+  return {
+    type: "generation_complete",
+    node_id: "n1",
+    node_name: "Gen",
+    node_type: "ns.Gen",
+    outputs: { image: { type: "image", uri: "memory://x" } }
+    // no index/job_id → asserts they're optional on the wire
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Collect all factory functions so we can iterate over them
 // ---------------------------------------------------------------------------
@@ -176,6 +188,7 @@ function llmCallUpdate(): LLMCallUpdate {
 const factories: Array<[MessageType, () => ProcessingMessage]> = [
   ["job_update", jobUpdate],
   ["node_update", nodeUpdate],
+  ["generation_complete", generationComplete],
   ["node_progress", nodeProgress],
   ["edge_update", edgeUpdate],
   ["output_update", outputUpdate],
@@ -211,8 +224,8 @@ describe("ProcessingMessage discriminator", () => {
     expect(new Set(types).size).toBe(types.length);
   });
 
-  it("has exactly 18 message types matching Python ProcessingMessage", () => {
-    expect(factories.length).toBe(18);
+  it("has exactly 19 message types matching Python ProcessingMessage", () => {
+    expect(factories.length).toBe(19);
   });
 });
 
@@ -245,6 +258,47 @@ describe("runtime narrowing via type field", () => {
     } else {
       throw new Error("narrowing failed");
     }
+  });
+
+  it("narrows GenerationComplete correctly", () => {
+    const msg: ProcessingMessage = generationComplete();
+    if (msg.type === "generation_complete") {
+      expect(msg.node_id).toBe("n1");
+      expect(msg.node_name).toBe("Gen");
+      expect(msg.node_type).toBe("ns.Gen");
+      expect(msg.outputs).toEqual({
+        image: { type: "image", uri: "memory://x" }
+      });
+    } else {
+      throw new Error("narrowing failed");
+    }
+  });
+});
+
+describe("GenerationComplete bare-wire form", () => {
+  it("emits no index/job_id on the bare actor form (stamped downstream)", () => {
+    const msg = generationComplete();
+    expect(msg.index).toBeUndefined();
+    expect(msg.job_id).toBeUndefined();
+    expect(msg.workflow_id).toBeUndefined();
+  });
+});
+
+describe("OutputUpdate disposition/done additive optionals", () => {
+  it("defaults disposition and done to undefined when omitted", () => {
+    const msg = outputUpdate();
+    expect(msg.disposition).toBeUndefined();
+    expect(msg.done).toBeUndefined();
+  });
+
+  it("accepts disposition='replace' and done=true", () => {
+    const msg: OutputUpdate = {
+      ...outputUpdate(),
+      disposition: "replace",
+      done: true
+    };
+    expect(msg.disposition).toBe("replace");
+    expect(msg.done).toBe(true);
   });
 });
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1849,6 +1849,11 @@ export class UnifiedWebSocketRunner {
     // output, or media + text), so dedupe by the event's arrival index — NOT by
     // a total asset count, which would under-save the next event (RFC D8).
     const autosavedSlots = new Set<string>();
+    // Cross-run replay dedupe: the `generation_index` values already persisted
+    // for a node by a PRIOR run. Warmed with ONE `Asset.paginate` on a node's
+    // first generation_complete, then reused for every later variant — so an
+    // N-variant run does one query per node, not one per variant (RFC D8).
+    const persistedIndexByNode = new Map<string, Set<number>>();
     await this.sendMessage({
       type: "job_update",
       status: "running",
@@ -1966,21 +1971,30 @@ export class UnifiedWebSocketRunner {
             if (meta?.auto_save_asset && outbound.outputs != null) {
               const userId = this.userId ?? "1";
               const slotKey = `${nodeId} ${arrivalIndex}`;
-              const alreadySavedThisRun = autosavedSlots.has(slotKey);
-              let alreadyPersisted = false;
-              if (!alreadySavedThisRun) {
+              // Warm the cross-run replay set once per node (on its first
+              // generation_complete), then reconcile every later variant
+              // against the in-memory set — one DB read per node, not per slot.
+              let persistedIndices = persistedIndexByNode.get(nodeId);
+              if (persistedIndices === undefined) {
                 const [persisted] = await Asset.paginate(userId, {
                   jobId: active.jobId,
                   nodeId,
                   limit: 1000
                 });
-                alreadyPersisted = persisted.some(
-                  (a) =>
-                    (a.metadata as { generation_index?: unknown } | null)
-                      ?.generation_index === arrivalIndex
-                );
+                persistedIndices = new Set<number>();
+                for (const a of persisted) {
+                  const gi = (
+                    a.metadata as { generation_index?: unknown } | null
+                  )?.generation_index;
+                  if (typeof gi === "number") persistedIndices.add(gi);
+                }
+                persistedIndexByNode.set(nodeId, persistedIndices);
               }
-              if (!alreadySavedThisRun && !alreadyPersisted) {
+
+              if (
+                !autosavedSlots.has(slotKey) &&
+                !persistedIndices.has(arrivalIndex)
+              ) {
                 autosavedSlots.add(slotKey);
                 try {
                   await autoSaveAssets(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -440,6 +440,15 @@ async function autoSaveAssets(
      * media nodes.
      */
     textOutputName?: string;
+    /**
+     * The relay-stamped arrival `index` of the `generation_complete` event that
+     * triggered this save (RFC Decision 8 `(job_id, node_id, index)` key).
+     * Stamped onto each created asset's `metadata.generation_index` so a replay
+     * can dedupe by the exact slot — independent of how many assets a single
+     * event yields (a `list[image]` output, or media + text together, persists
+     * several rows for ONE arrival index).
+     */
+    generationIndex?: number;
   }
 ): Promise<void> {
   const queue: Record<string, unknown>[] = [];
@@ -508,6 +517,9 @@ async function autoSaveAssets(
       content_type: contentType,
       parent_id: null
     });
+    if (typeof opts.generationIndex === "number") {
+      asset.metadata = { generation_index: opts.generationIndex };
+    }
 
     const fileName = `${asset.id}.${ext}`;
     try {
@@ -554,7 +566,10 @@ async function autoSaveAssets(
         content_type: "text/plain",
         parent_id: null
       });
-      asset.metadata = { text: previewText };
+      asset.metadata =
+        typeof opts.generationIndex === "number"
+          ? { text: previewText, generation_index: opts.generationIndex }
+          : { text: previewText };
       const fileName = `${asset.id}.txt`;
       try {
         await storeAssetWithThumbnail(asset.id, fileName, bytes, "text/plain");
@@ -1824,6 +1839,16 @@ export class UnifiedWebSocketRunner {
     let terminalWithResultSeen = false;
     let outputUpdateSeen = false;
     let finalOutputs: Record<string, unknown[]> = {};
+    // Per-node arrival counter for `generation_complete.index` within this job.
+    // The function is scoped to one job, so keying by node_id alone yields a
+    // per-(job_id, node_id) monotonic index. DB-ordering reconciliation is a
+    // later step (RFC Decision 8); this is the in-memory arrival order.
+    const generationIndexByNode = new Map<string, number>();
+    // Arrival positions already autosaved in THIS run, keyed `${nodeId} ${index}`.
+    // A single generation_complete can persist several assets (a `list[image]`
+    // output, or media + text), so dedupe by the event's arrival index — NOT by
+    // a total asset count, which would under-save the next event (RFC D8).
+    const autosavedSlots = new Set<string>();
     await this.sendMessage({
       type: "job_update",
       status: "running",
@@ -1888,7 +1913,8 @@ export class UnifiedWebSocketRunner {
         // outputs that don't need to be relayed to the frontend.
         if (
           outbound.type === "output_update" ||
-          outbound.type === "node_update"
+          outbound.type === "node_update" ||
+          outbound.type === "generation_complete"
         ) {
           const nodeId = String(outbound.node_id ?? "");
           const graphNodes =
@@ -1910,6 +1936,71 @@ export class UnifiedWebSocketRunner {
 
           const meta = this.getNodeMetadata?.(nodeType);
 
+          // Stamp an arrival-order `index` on generation_complete, keyed per
+          // (job_id, node_id) (the function is job-scoped, so node_id alone
+          // suffices). job_id/workflow_id were already backfilled by the
+          // outbound spread above.
+          if (outbound.type === "generation_complete") {
+            const arrivalIndex = generationIndexByNode.get(nodeId) ?? 0;
+            outbound.index = arrivalIndex;
+            generationIndexByNode.set(nodeId, arrivalIndex + 1);
+
+            // Autosave one generation per generation_complete on the RAW outputs
+            // (before the normalize at the bottom of this block strips inline
+            // bytes), tagged { jobId, nodeId, index }. This is the autosave
+            // cutover (RFC §7, D3): persistence is driven per generation event,
+            // not by the terminal node_update{completed} — so an N-execution
+            // run persists N distinct generations.
+            //
+            // Replay dedupe (D8) is keyed on the event's arrival `index`, NOT on
+            // a total asset count: a single generation_complete can persist
+            // several assets (a `list[image]` output, or media + a text asset),
+            // so a count-vs-index gate would under-save the very first run. Two
+            // guards, both keyed by (nodeId, index):
+            //   - in-run: skip if this arrival slot was already saved this run;
+            //   - cross-run: skip if an asset for (jobId, nodeId) already carries
+            //     metadata.generation_index === arrivalIndex (a reconnect replay
+            //     re-streams the same events with arrivalIndex back at 0..N-1).
+            // Server-only (D9): this is the websocket runner; the browser never
+            // reaches runJob, so no browser autosave is introduced here.
+            if (meta?.auto_save_asset && outbound.outputs != null) {
+              const userId = this.userId ?? "1";
+              const slotKey = `${nodeId} ${arrivalIndex}`;
+              const alreadySavedThisRun = autosavedSlots.has(slotKey);
+              let alreadyPersisted = false;
+              if (!alreadySavedThisRun) {
+                const [persisted] = await Asset.paginate(userId, {
+                  jobId: active.jobId,
+                  nodeId,
+                  limit: 1000
+                });
+                alreadyPersisted = persisted.some(
+                  (a) =>
+                    (a.metadata as { generation_index?: unknown } | null)
+                      ?.generation_index === arrivalIndex
+                );
+              }
+              if (!alreadySavedThisRun && !alreadyPersisted) {
+                autosavedSlots.add(slotKey);
+                try {
+                  await autoSaveAssets(
+                    outbound.outputs as Record<string, unknown>,
+                    {
+                      userId,
+                      workflowId: active.workflowId,
+                      jobId: active.jobId,
+                      nodeId,
+                      textOutputName: primaryTextOutputName(meta),
+                      generationIndex: arrivalIndex
+                    }
+                  );
+                } catch (err) {
+                  log.warn("autoSaveAssets error", { error: String(err) });
+                }
+              }
+            }
+          }
+
           // Relay output_update for display-sink nodes (Output, Preview) and
           // for streaming or auto-saving generative nodes (FAL / Replicate /
           // Kie / …) so the client receives one event per yielded item — the
@@ -1928,30 +2019,6 @@ export class UnifiedWebSocketRunner {
             outputUpdateSeen = true;
           }
 
-          // Auto-save generated assets before normalization strips inline data
-          if (
-            outbound.type === "node_update" &&
-            outbound.status === "completed" &&
-            outbound.result != null
-          ) {
-            if (meta?.auto_save_asset) {
-              try {
-                await autoSaveAssets(
-                  outbound.result as Record<string, unknown>,
-                  {
-                    userId: this.userId ?? "1",
-                    workflowId: active.workflowId,
-                    jobId: active.jobId,
-                    nodeId: String(outbound.node_id ?? ""),
-                    textOutputName: primaryTextOutputName(meta)
-                  }
-                );
-              } catch (err) {
-                log.warn("autoSaveAssets error", { error: String(err) });
-              }
-            }
-          }
-
           await this._handleNodeProviderCost(active, outbound, nodeType);
 
           // Materialize binary assets to temp URLs before sending over WebSocket
@@ -1963,6 +2030,13 @@ export class UnifiedWebSocketRunner {
           if (outbound.type === "output_update" && outbound.value != null) {
             outbound.value = await active.context.normalizeOutputValue(
               outbound.value
+            );
+          }
+          // Normalize generation_complete.outputs the same way node_update.result
+          // is treated (raw bytes → temp URLs) before sending over the wire.
+          if (outbound.type === "generation_complete" && outbound.outputs != null) {
+            outbound.outputs = await active.context.normalizeOutputValue(
+              outbound.outputs
             );
           }
         }

--- a/packages/websocket/tests/generation-autosave-cutover.test.ts
+++ b/packages/websocket/tests/generation-autosave-cutover.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Autosave cutover (RFC: generation-events §7 / §12 step 4, Decisions D3 / D8 / D9).
+ *
+ * Step 4 hard-switch: the unified websocket runner persists ONE asset per
+ * `generation_complete` (on the raw `outputs`, before normalization strips
+ * inline bytes), tagged { jobId, nodeId, index }. The old terminal
+ * `node_update{completed}` autosave branch is gone — so an N-execution run
+ * persists N distinct assets instead of collapsing to the single last result.
+ *
+ *   - D3: autosave is driven per generation_complete, not by node_update.
+ *   - D8: a reconnect replay (the same N events arriving again) is a no-op
+ *         because an asset already exists at each arrival position.
+ *   - D9: server-only — this path is the websocket runner; the browser never
+ *         reaches runJob, so no browser autosave is introduced.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { unpack } from "msgpackr";
+import { initTestDb, Asset } from "@nodetool-ai/models";
+import type { NodeTypeResolver, ResolvedNodeType } from "@nodetool-ai/kernel";
+import type { NodeMetadata } from "@nodetool-ai/node-sdk";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  sentText: string[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+  async accept() {}
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return this.queue.shift() ?? { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText(data: string) {
+    this.sentText.push(data);
+  }
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+function sentMsgs(ws: MockWS): Record<string, unknown>[] {
+  return ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+}
+
+// A valid 1x1 PNG so both the asset bytes store and the sharp thumbnail path
+// succeed cleanly (no swallowed thumbnail warning).
+const PNG_1x1 = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120,
+  218, 99, 100, 248, 207, 0, 0, 0, 3, 1, 1, 0, 24, 221, 141, 180, 0, 0, 0, 0,
+  73, 69, 78, 68, 174, 66, 96, 130
+]);
+
+const imageOutput = () => ({ image: { type: "image", data: PNG_1x1 } });
+
+// A list[image] output: ONE generation_complete carries TWO asset-like values,
+// so autoSaveAssets persists two rows for a single arrival index.
+const listImageOutput = () => ({
+  images: [
+    { type: "image", data: PNG_1x1 },
+    { type: "image", data: PNG_1x1 }
+  ]
+});
+
+// resolveNodeType for the ForEach generator + a buffered consumer (mirrors the
+// generation_complete relay test harness).
+const resolveNodeType: NodeTypeResolver = {
+  resolveNodeType: async (
+    nodeType: string
+  ): Promise<ResolvedNodeType | null> => {
+    if (nodeType === "nodetool.input.IntegerInput") {
+      return {
+        nodeType,
+        propertyTypes: { value: "any", name: "str" },
+        outputs: { value: "any" },
+        descriptorDefaults: { name: "IntegerInput" }
+      };
+    }
+    if (nodeType === "nodetool.control.ForEach") {
+      return {
+        nodeType,
+        outputs: { output: "any", index: "int" },
+        descriptorDefaults: {
+          is_streaming_output: true,
+          output_correlation: {
+            output: {
+              kind: "iteration",
+              source: "__execution__",
+              group: "items"
+            },
+            index: {
+              kind: "iteration",
+              source: "__execution__",
+              group: "items"
+            }
+          },
+          name: "ForEach"
+        }
+      };
+    }
+    if (nodeType === "test.ImageGen") {
+      return {
+        nodeType,
+        propertyTypes: { prompt: "any" },
+        outputs: { image: "any" },
+        descriptorDefaults: { name: "ImageGen" }
+      };
+    }
+    if (nodeType === "test.ListImageGen") {
+      return {
+        nodeType,
+        propertyTypes: { prompt: "any" },
+        outputs: { images: "any" },
+        descriptorDefaults: { name: "ListImageGen" }
+      };
+    }
+    return null;
+  }
+};
+
+// Minimal metadata: only `auto_save_asset` and `outputs` are read by the
+// autosave gate (the latter via primaryTextOutputName — `image` is not a text
+// type, so no text asset is persisted).
+const imageGenMeta = {
+  auto_save_asset: true,
+  outputs: [{ name: "image", type: { type: "image" } }]
+} as unknown as NodeMetadata;
+
+const listImageGenMeta = {
+  auto_save_asset: true,
+  outputs: [{ name: "images", type: { type: "list" } }]
+} as unknown as NodeMetadata;
+
+const getNodeMetadata = (nodeType: string): NodeMetadata | undefined => {
+  if (nodeType === "test.ImageGen") return imageGenMeta;
+  if (nodeType === "test.ListImageGen") return listImageGenMeta;
+  return undefined;
+};
+
+// A ForEach(N) → ImageGen graph: N iterations, each emitting one image
+// generation_complete for node "gen".
+function makeRunner() {
+  return new UnifiedWebSocketRunner({
+    resolveExecutor: (node) => {
+      if (node.type === "nodetool.control.ForEach") {
+        return {
+          async process() {
+            return {};
+          },
+          async *genProcess(inputs: Record<string, unknown>) {
+            const raw = inputs.input_list ?? [];
+            const items = Array.isArray(raw) ? raw : [raw];
+            for (let i = 0; i < items.length; i++) {
+              yield { output: items[i], index: i };
+            }
+          }
+        };
+      }
+      if (node.type === "test.ImageGen") {
+        return {
+          async process() {
+            return imageOutput();
+          }
+        };
+      }
+      if (node.type === "test.ListImageGen") {
+        return {
+          async process() {
+            return listImageOutput();
+          }
+        };
+      }
+      return {
+        async process() {
+          return {};
+        }
+      };
+    },
+    resolveNodeType,
+    getNodeMetadata
+  });
+}
+
+function foreachGraph(items: unknown[], genType = "test.ImageGen") {
+  return {
+    nodes: [
+      {
+        id: "src",
+        type: "nodetool.input.IntegerInput",
+        name: "items",
+        properties: { value: items }
+      },
+      { id: "fe", type: "nodetool.control.ForEach" },
+      { id: "gen", type: genType }
+    ],
+    edges: [
+      {
+        id: "eSrc",
+        source: "src",
+        sourceHandle: "value",
+        target: "fe",
+        targetHandle: "input_list",
+        edge_type: "data"
+      },
+      {
+        id: "eFe",
+        source: "fe",
+        sourceHandle: "output",
+        target: "gen",
+        targetHandle: "prompt",
+        edge_type: "data"
+      }
+    ]
+  };
+}
+
+let ws: MockWS;
+
+beforeEach(async () => {
+  await initTestDb();
+  ws = new MockWS();
+});
+
+describe("autosave cutover (generation_complete → N assets)", () => {
+  it("persists one distinct asset per generation_complete (N events → N assets)", async () => {
+    const runner = makeRunner();
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOBN",
+      workflow_id: "WFN",
+      graph: foreachGraph(["a", "b", "c", "d", "e", "f"])
+    });
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Sanity: 6 generation_complete relayed for the gen node, indices 0..5.
+    const gens = sentMsgs(ws).filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gens).toHaveLength(6);
+    expect(gens.map((g) => g.index)).toEqual([0, 1, 2, 3, 4, 5]);
+
+    // 6 distinct image assets persisted for (job, node) — NOT 1 (the old
+    // node_update{completed} branch saved only the last result).
+    const [assets] = await Asset.paginate("1", {
+      jobId: "JOBN",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(assets).toHaveLength(6);
+    expect(assets.every((a) => a.job_id === "JOBN")).toBe(true);
+    expect(assets.every((a) => a.node_id === "gen")).toBe(true);
+    expect(assets.every((a) => a.content_type === "image/png")).toBe(true);
+    // Distinct asset ids — six separate rows, not the same one six times.
+    expect(new Set(assets.map((a) => a.id)).size).toBe(6);
+
+    await runner.disconnect();
+  });
+
+  it("persists every asset when each event yields >1 asset (list[image]×N)", async () => {
+    // Regression for the count-vs-index dedupe bug: a list[image]-of-2 output
+    // persists TWO assets per generation_complete. A `persisted.length <=
+    // arrivalIndex` gate would skip event 1 (2 <= 1 is false) and under-save —
+    // 4 assets for a 3-event run instead of 6. The (nodeId,index) dedupe saves
+    // all 6.
+    const runner = makeRunner();
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOBL",
+      workflow_id: "WFL",
+      graph: foreachGraph(["a", "b", "c"], "test.ListImageGen")
+    });
+    await new Promise((r) => setTimeout(r, 300));
+
+    // 3 generation_complete (indices 0..2), each a list of 2 images.
+    const gens = sentMsgs(ws).filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gens).toHaveLength(3);
+    expect(gens.map((g) => g.index)).toEqual([0, 1, 2]);
+
+    // 6 assets persisted (2 per event × 3 events), NOT 4.
+    const [assets] = await Asset.paginate("1", {
+      jobId: "JOBL",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(assets).toHaveLength(6);
+    expect(new Set(assets.map((a) => a.id)).size).toBe(6);
+
+    await runner.disconnect();
+  });
+
+  it("is a no-op on reconnect replay even with multi-asset events (list[image]×N)", async () => {
+    // The multi-asset replay path: re-running the same list[image] job must add
+    // nothing. The cross-run guard keys on metadata.generation_index, so the
+    // count of persisted assets (6, two per slot) never confuses the dedupe.
+    const runner1 = makeRunner();
+    await runner1.connect(ws);
+    await runner1.runJob({
+      job_id: "JOBLR",
+      workflow_id: "WFLR",
+      graph: foreachGraph(["a", "b", "c"], "test.ListImageGen")
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    await runner1.disconnect();
+
+    const [afterFirst] = await Asset.paginate("1", {
+      jobId: "JOBLR",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(afterFirst).toHaveLength(6);
+
+    const ws2 = new MockWS();
+    const runner2 = makeRunner();
+    await runner2.connect(ws2);
+    await runner2.runJob({
+      job_id: "JOBLR",
+      workflow_id: "WFLR",
+      graph: foreachGraph(["a", "b", "c"], "test.ListImageGen")
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    await runner2.disconnect();
+
+    const [afterReplay] = await Asset.paginate("1", {
+      jobId: "JOBLR",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(afterReplay).toHaveLength(6);
+    expect(new Set(afterReplay.map((a) => a.id))).toEqual(
+      new Set(afterFirst.map((a) => a.id))
+    );
+  });
+
+  it("is a no-op on reconnect replay (persisted already at N)", async () => {
+    // First run persists 6 assets.
+    const runner1 = makeRunner();
+    await runner1.connect(ws);
+    await runner1.runJob({
+      job_id: "JOBR",
+      workflow_id: "WFR",
+      graph: foreachGraph(["a", "b", "c", "d", "e", "f"])
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    await runner1.disconnect();
+
+    const [afterFirst] = await Asset.paginate("1", {
+      jobId: "JOBR",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(afterFirst).toHaveLength(6);
+
+    // Reconnect + replay the SAME job: arrivalIndex returns to 0..5 while 6
+    // assets are already persisted, so the dedupe gate (persisted.length <=
+    // arrivalIndex) is false for every event → no new asset rows.
+    const ws2 = new MockWS();
+    const runner2 = makeRunner();
+    await runner2.connect(ws2);
+    await runner2.runJob({
+      job_id: "JOBR",
+      workflow_id: "WFR",
+      graph: foreachGraph(["a", "b", "c", "d", "e", "f"])
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    await runner2.disconnect();
+
+    const [afterReplay] = await Asset.paginate("1", {
+      jobId: "JOBR",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(afterReplay).toHaveLength(6);
+    // Same six rows — replay added nothing.
+    expect(new Set(afterReplay.map((a) => a.id))).toEqual(
+      new Set(afterFirst.map((a) => a.id))
+    );
+  });
+
+  it("does NOT double-save on node_update{completed} (cutover removed that branch)", async () => {
+    // A single-execution node emits BOTH one generation_complete AND a terminal
+    // node_update{completed}, each carrying the same asset-like result. The old
+    // code autosaved on node_update; the cutover moved autosave exclusively to
+    // generation_complete. So the asset count must equal the generation_complete
+    // count (exactly 1) — never doubled by a surviving node_update branch.
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: (node) => {
+        if (node.type === "test.ImageGen") {
+          return {
+            async process() {
+              return imageOutput();
+            }
+          };
+        }
+        return {
+          async process() {
+            return {};
+          }
+        };
+      },
+      resolveNodeType,
+      getNodeMetadata
+    });
+
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOBU",
+      workflow_id: "WFU",
+      graph: {
+        nodes: [{ id: "gen", type: "test.ImageGen" }],
+        edges: []
+      }
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const msgs = sentMsgs(ws);
+    // Exactly one generation_complete and one node_update{completed} for gen.
+    const gens = msgs.filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gens).toHaveLength(1);
+    const completes = msgs.filter(
+      (m) =>
+        m.type === "node_update" &&
+        m.node_id === "gen" &&
+        m.status === "completed"
+    );
+    expect(completes).toHaveLength(1);
+
+    // Exactly one asset — the generation_complete save — not two. A surviving
+    // node_update autosave branch would have produced a second row.
+    const [assets] = await Asset.paginate("1", {
+      jobId: "JOBU",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(assets).toHaveLength(1);
+
+    await runner.disconnect();
+  });
+});

--- a/packages/websocket/tests/generation-complete-relay.test.ts
+++ b/packages/websocket/tests/generation-complete-relay.test.ts
@@ -1,0 +1,256 @@
+/**
+ * `generation_complete` relay (RFC: generation-events §5 / §11 / §13, Decision 8).
+ *
+ * Step 2 (behavior-neutral, no autosave): the unified websocket runner's
+ * message interception relays the BARE `generation_complete` the kernel emits,
+ *   - backfilling `job_id` / `workflow_id` (via the outbound spread),
+ *   - stamping an in-memory arrival-order `index` per (job_id, node_id),
+ *   - normalizing `.outputs` the same way `node_update.result` is.
+ *
+ * No autosave happens in this step.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { unpack } from "msgpackr";
+import { initTestDb, Asset } from "@nodetool-ai/models";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  sentText: string[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+  async accept() {}
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return this.queue.shift() ?? { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText(data: string) {
+    this.sentText.push(data);
+  }
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+function sentMsgs(ws: MockWS): Record<string, unknown>[] {
+  return ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+}
+
+// resolveNodeType for the ForEach generator + a buffered consumer.
+const resolveNodeType = {
+  resolveNodeType: async (nodeType: string) => {
+    if (nodeType === "nodetool.input.IntegerInput") {
+      return {
+        nodeType,
+        propertyTypes: { value: "any", name: "str" },
+        outputs: { value: "any" },
+        descriptorDefaults: { name: "IntegerInput" }
+      };
+    }
+    if (nodeType === "nodetool.control.ForEach") {
+      return {
+        nodeType,
+        outputs: { output: "any", index: "int" },
+        descriptorDefaults: {
+          is_streaming_output: true,
+          output_correlation: {
+            output: { kind: "iteration", source: "__execution__", group: "items" },
+            index: { kind: "iteration", source: "__execution__", group: "items" }
+          },
+          name: "ForEach"
+        }
+      };
+    }
+    if (nodeType === "test.TextToImage") {
+      return {
+        nodeType,
+        propertyTypes: { prompt: "any" },
+        outputs: { image: "any" },
+        descriptorDefaults: { name: "TextToImage" }
+      };
+    }
+    return null;
+  }
+};
+
+let ws: MockWS;
+
+beforeEach(async () => {
+  await initTestDb();
+  ws = new MockWS();
+});
+
+describe("generation_complete relay", () => {
+  it("stamps arrival-order index 0..N-1 per (job, node) and backfills job_id", async () => {
+    const list = ["p0", "p1", "p2", "p3", "p4", "p5"];
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: (node) => {
+        if (node.type === "nodetool.control.ForEach") {
+          return {
+            async process() {
+              return {};
+            },
+            async *genProcess(inputs: Record<string, unknown>) {
+              const raw = inputs.input_list ?? [];
+              const items = Array.isArray(raw) ? raw : [raw];
+              for (let i = 0; i < items.length; i++) {
+                yield { output: items[i], index: i };
+              }
+            }
+          };
+        }
+        if (node.type === "test.TextToImage") {
+          return {
+            async process(inputs: Record<string, unknown>) {
+              return { image: `img(${inputs.prompt})` };
+            }
+          };
+        }
+        return { async process() { return {}; } };
+      },
+      resolveNodeType
+    });
+
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOB1",
+      workflow_id: "WF1",
+      graph: {
+        nodes: [
+          {
+            id: "src",
+            type: "nodetool.input.IntegerInput",
+            name: "items",
+            properties: { value: list }
+          },
+          { id: "fe", type: "nodetool.control.ForEach" },
+          { id: "gen", type: "test.TextToImage" }
+        ],
+        edges: [
+          {
+            id: "eSrc",
+            source: "src",
+            sourceHandle: "value",
+            target: "fe",
+            targetHandle: "input_list",
+            edge_type: "data"
+          },
+          {
+            id: "eFe",
+            source: "fe",
+            sourceHandle: "output",
+            target: "gen",
+            targetHandle: "prompt",
+            edge_type: "data"
+          }
+        ]
+      }
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const gens = sentMsgs(ws).filter(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gens).toHaveLength(6);
+
+    // index stamped 0..N-1 in arrival order, per (job, node).
+    expect(gens.map((g) => g.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    // job_id / workflow_id backfilled on every relayed generation_complete.
+    expect(gens.every((g) => g.job_id === "JOB1")).toBe(true);
+    expect(gens.every((g) => g.workflow_id === "WF1")).toBe(true);
+
+    await runner.disconnect();
+  });
+
+  it("normalizes .outputs (raw bytes → client-bytes wrapper) before relay", async () => {
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: (node) => {
+        if (node.type === "test.TextToImage") {
+          return {
+            async process() {
+              // Raw bytes on the output → normalizeOutputValue must convert
+              // them to a client-bytes wrapper, like node_update.result.
+              return { image: new Uint8Array([1, 2, 3, 4, 5]) };
+            }
+          };
+        }
+        return { async process() { return {}; } };
+      },
+      resolveNodeType
+    });
+
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOB2",
+      workflow_id: "WF2",
+      graph: {
+        nodes: [{ id: "gen", type: "test.TextToImage" }],
+        edges: []
+      }
+    });
+    await new Promise((r) => setTimeout(r, 150));
+
+    const gen = sentMsgs(ws).find(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gen).toBeDefined();
+    const outputs = gen!.outputs as Record<string, unknown>;
+    // Raw Uint8Array became the client-bytes wrapper, not raw bytes.
+    expect(outputs.image).toEqual({ type: "bytes", length: 5 });
+
+    await runner.disconnect();
+  });
+
+  it("does NOT autosave generation_complete (no Asset row created)", async () => {
+    // Step 2 is behavior-neutral: the generation_complete relay branch must not
+    // persist anything (autosave is step 4). We leave getNodeMetadata unset so
+    // the separate node_update{completed} autosave branch also cannot fire —
+    // isolating the generation_complete path. We assert both that the event is
+    // relayed AND that zero Asset rows exist for the job, so a future author who
+    // wires autosave onto generation_complete here hits a failing test.
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: (node) => {
+        if (node.type === "test.TextToImage") {
+          return {
+            async process() {
+              return { image: "img(x)" };
+            }
+          };
+        }
+        return { async process() { return {}; } };
+      },
+      resolveNodeType
+    });
+
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOB3",
+      workflow_id: "WF3",
+      graph: {
+        nodes: [{ id: "gen", type: "test.TextToImage" }],
+        edges: []
+      }
+    });
+    await new Promise((r) => setTimeout(r, 150));
+
+    const gen = sentMsgs(ws).find(
+      (m) => m.type === "generation_complete" && m.node_id === "gen"
+    );
+    expect(gen).toBeDefined();
+    expect((gen!.outputs as Record<string, unknown>).image).toBe("img(x)");
+
+    // No autosave in step 2: zero Asset rows persisted for this job.
+    const [jobAssets] = await Asset.paginate("1", { jobId: "JOB3" });
+    expect(jobAssets).toHaveLength(0);
+
+    await runner.disconnect();
+  });
+});

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from "react";
 import { useTheme } from "@mui/material/styles";
@@ -21,7 +22,7 @@ import AssetViewer from "../assets/AssetViewer";
 import BitmapCanvas from "./BitmapCanvas";
 import { useNodeResultHistory } from "../../hooks/nodes/useNodeResultHistory";
 import { useNodeGenerations } from "../../hooks/nodes/useNodeGenerations";
-import { outputOf } from "../../utils/nodeGenerations";
+import { outputOf, runVariantValues } from "../../utils/nodeGenerations";
 import type { Asset } from "../../stores/ApiTypes";
 import { useWebsocketRunner } from "../../stores/WorkflowRunner";
 import { CopyButton, Dialog, ToolbarIconButton, MOTION } from "../ui_primitives";
@@ -41,9 +42,16 @@ interface NodeHistoryViewerProps {
    * only manages history navigation and overlay controls.
    */
   renderSingle: (value: unknown) => React.ReactNode;
+  /**
+   * Render an ARRAY of variant values as the in-card variants grid.
+   * ContentCardBody supplies this for image variants so the grid reuses
+   * ImagePreview/.image-grid-preview. When omitted, the variants view falls
+   * back to NodeHistoryViewer's own `.thumb` grid (video / audio).
+   */
+  renderVariants?: (values: unknown[]) => React.ReactNode;
 }
 
-type Mode = "single" | "multi";
+type View = "runs" | "variants" | "single";
 
 const MEDIA_PREFIXES = ["image/", "video/", "audio/"] as const;
 
@@ -162,6 +170,16 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.common.white,
       textShadow: "0 0 2px rgba(0,0,0,0.8)"
     },
+    ".thumb-count": {
+      position: "absolute",
+      top: 2,
+      right: 4,
+      padding: "0 4px",
+      borderRadius: "var(--rounded-sm)",
+      backgroundColor: "rgba(0, 0, 0, 0.55)",
+      fontSize: theme.fontSizeTiny,
+      color: theme.vars.palette.common.white
+    },
     ".thumb.selected": {
       borderColor: theme.vars.palette.primary.main
     }
@@ -171,21 +189,53 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
   workflowId,
   nodeId,
   liveResult,
-  renderSingle
+  renderSingle,
+  renderVariants
 }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
   // Generation timeline drives selection (oldest→newest, current = selected ?? latest).
-  const { generations, current, select } = useNodeGenerations(
+  // `runs` groups variants by job; `currentRun` is the selected variant's run.
+  const { generations, current, select, runs, currentRun } = useNodeGenerations(
     workflowId,
     nodeId
   );
+
+  // Auto-focus a newly started run. The persisted `selected_generation` pins the
+  // view to a run; after browsing it points at a PRIOR run, so a fresh run would
+  // not take focus until manually switched. When the latest run's job changes (a
+  // new run appeared) and the selection still resolves to an OLDER run, advance
+  // focus to the latest run. Skips the initial render (preserves a restored
+  // selection on reload) and never fires while a run grows in place (same jobId →
+  // within-run pins and deliberate old-run browsing between runs both survive).
+  const latestRun = runs.length > 0 ? runs[runs.length - 1] : undefined;
+  const latestRunJobId = latestRun?.jobId ?? null;
+  const prevLatestRunJobIdRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    const prev = prevLatestRunJobIdRef.current;
+    prevLatestRunJobIdRef.current = latestRunJobId;
+    if (prev === undefined) return; // initial render — keep any restored selection
+    if (prev === latestRunJobId) return; // same latest run — no new run appeared
+    if (currentRun && latestRun && currentRun.jobId !== latestRun.jobId) {
+      // Selection is stale (an older run); follow the new latest run. The ref is
+      // already updated, so the resulting re-render (currentRun changes) re-runs
+      // this effect with prev === latestRunJobId and no-ops — no loop.
+      select(latestRun.cover.id);
+    }
+  }, [latestRunJobId, currentRun, latestRun, select]);
   // Parallel read of the durable assets solely for the fullscreen viewer,
   // download, and the dimensions/duration badge — those need the full Asset.
   const { assetHistory } = useNodeResultHistory(workflowId, nodeId);
   const isRunning = useWebsocketRunner((s) => s.state === "running");
 
-  const [mode, setMode] = useState<Mode>("single");
+  // Per-run user override of the view. `null` means "no explicit choice — use
+  // the derived default for the current run". Keyed by the run's jobId so a
+  // toggle/grid-tap wins only within the run it was made for; switching runs
+  // (or a fresh run) falls back to the derived default again.
+  const [userView, setUserView] = useState<{
+    jobId: string;
+    view: View;
+  } | null>(null);
   const [viewerOpen, setViewerOpen] = useState(false);
   const [imageDims, setImageDims] = useState<{ width: number; height: number } | null>(null);
 
@@ -198,18 +248,63 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     [assetHistory]
   );
 
-  const total = generations.length;
-  const hasHistory = total > 0;
-  const currentIndex = Math.max(
-    0,
-    generations.findIndex((g) => g.id === current?.id)
+  const hasHistory = generations.length > 0;
+
+  // Set the user's explicit view choice for the CURRENT run. A no-op when there
+  // is no run (nothing to scope the choice to).
+  const setView = useCallback(
+    (next: View) => {
+      if (!currentRun) return;
+      setUserView({ jobId: currentRun.jobId, view: next });
+    },
+    [currentRun]
   );
+
+  // Pager scope and indices. In single view the pager steps variants when the
+  // current run has >1, else steps runs.
+  const variants = useMemo(
+    () => currentRun?.variants ?? [],
+    [currentRun]
+  );
+  const runIndex = Math.max(
+    0,
+    runs.findIndex((r) => r === currentRun)
+  );
+  const variantIndex = Math.max(
+    0,
+    variants.findIndex((v) => v.id === current?.id)
+  );
+  const pagerScope: "variants" | "runs" =
+    variants.length > 1 ? "variants" : "runs";
 
   // While a run is in progress and the live result is non-null, show the
   // live result (the in-flight preview) and freeze pagination. Once the run
   // completes and assets persist, the new generation becomes current and we
   // return to history mode.
   const showingLive = isRunning && liveResult != null;
+
+  // Derive the view. The default re-evaluates every render, so a run that grows
+  // from 1 to N variants under a STABLE jobId (the live streaming case) flips to
+  // the variants grid as soon as it settles — without an effect that would miss
+  // the in-place growth. A per-run user override (toggle / grid-tap) wins, but
+  // only for the run it was made for. The live preview is always rendered single
+  // (the grids are additive on top of history, never a replacement for the
+  // in-flight preview).
+  const defaultView: View =
+    currentRun && currentRun.variants.length > 1 ? "variants" : "single";
+  const override =
+    userView && currentRun && userView.jobId === currentRun.jobId
+      ? userView.view
+      : null;
+  // Only force the single in-flight preview when the current run has <=1 live
+  // variant — the normal single-image streaming case. A multi-execution run
+  // (variants popping live, variants.length > 1) falls through to
+  // override ?? defaultView, and defaultView is already "variants" when the
+  // current run has >1 variant, so the grid shows the tiles arriving live.
+  const effectiveView: View =
+    showingLive && variants.length <= 1
+      ? "single"
+      : (override ?? defaultView);
 
   // Full Asset for the current generation (when persisted), used by the viewer,
   // download, and the info badge.
@@ -252,21 +347,33 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     };
   }, [currentAsset, showingLive]);
 
-  const handlePrev = useCallback(() => {
-    if (total <= 1) return;
-    const i = (currentIndex - 1 + total) % total;
-    select(generations[i].id);
-  }, [total, currentIndex, generations, select]);
+  const step = useCallback(
+    (delta: number) => {
+      if (pagerScope === "variants") {
+        if (variants.length <= 1) return;
+        const i = (variantIndex + delta + variants.length) % variants.length;
+        select(variants[i].id);
+      } else {
+        if (runs.length <= 1) return;
+        const i = (runIndex + delta + runs.length) % runs.length;
+        select(runs[i].cover.id);
+      }
+    },
+    [pagerScope, variants, variantIndex, runs, runIndex, select]
+  );
+  const handlePrev = useCallback(() => step(-1), [step]);
+  const handleNext = useCallback(() => step(1), [step]);
 
-  const handleNext = useCallback(() => {
-    if (total <= 1) return;
-    const i = (currentIndex + 1) % total;
-    select(generations[i].id);
-  }, [total, currentIndex, generations, select]);
-
-  const handleToggleMode = useCallback(() => {
-    setMode((m) => (m === "single" ? "multi" : "single"));
-  }, []);
+  const handleToggleView = useCallback(() => {
+    if (effectiveView === "single") {
+      setView(variants.length > 1 ? "variants" : "runs");
+    } else if (effectiveView === "variants") {
+      setView("runs");
+    } else {
+      if (currentRun) select(currentRun.cover.id);
+      setView("single");
+    }
+  }, [effectiveView, variants.length, currentRun, select, setView]);
 
   // The fullscreen AssetViewer renders media; text generations open in a
   // readable text popup instead. Both are triggered from the same overlay
@@ -298,10 +405,25 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
 
   const handleSelectThumb = useCallback(
     (index: number) => {
-      select(generations[index].id);
-      setMode("single");
+      if (effectiveView === "runs") {
+        const run = runs[index];
+        if (!run) return;
+        // Record the target run's view choice against ITS jobId, not the
+        // outgoing run's — selecting the cover makes it the current run, but
+        // setView closes over the run that was current when this ran.
+        select(run.cover.id);
+        setUserView({
+          jobId: run.jobId,
+          view: run.variants.length > 1 ? "variants" : "single"
+        });
+      } else {
+        const v = variants[index];
+        if (!v) return;
+        select(v.id);
+        setView("single");
+      }
     },
-    [generations, select]
+    [effectiveView, runs, variants, select, setView]
   );
 
   const handleGridClick = useCallback(
@@ -360,8 +482,11 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     return <>{renderSingle(null)}</>;
   }
 
-  const showPagination = mode === "single" && !showingLive && total > 1;
-  const showInfoBadge = mode === "single";
+  const showPagination =
+    effectiveView === "single" &&
+    !showingLive &&
+    (pagerScope === "variants" ? variants.length > 1 : runs.length > 1);
+  const showInfoBadge = effectiveView === "single";
 
   // Bottom-left info string.
   const infoText = (() => {
@@ -380,15 +505,34 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
   return (
     <div css={cssStyles} className="node-history-viewer">
       <div className="body">
-        {mode === "single" ? (
+        {effectiveView === "single" ? (
           <MediaOverlaySuppressProvider value={overlayValue}>
             <div style={{ flex: 1, minWidth: 0, minHeight: 0 }}>
               {renderSingle(valueToRender)}
             </div>
           </MediaOverlaySuppressProvider>
+        ) : effectiveView === "variants" && renderVariants && currentRun ? (
+          <MediaOverlaySuppressProvider value={overlayValue}>
+            <div style={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+              {renderVariants(runVariantValues(currentRun))}
+            </div>
+          </MediaOverlaySuppressProvider>
         ) : (
-          <div className="grid nodrag nopan" role="list" aria-label="Output history" onClick={handleGridClick}>
-            {generations.map((gen, i) => {
+          // RUNS grid, or the VARIANTS fallback `.thumb` grid when
+          // renderVariants is absent (video / audio). The runs grid iterates
+          // runs (cover + xN badge); the variants grid iterates the current
+          // run's variants.
+          <div
+            className="grid nodrag nopan"
+            role="list"
+            aria-label={effectiveView === "runs" ? "Runs" : "Output history"}
+            onClick={handleGridClick}
+          >
+            {(effectiveView === "runs"
+              ? runs.map((r) => ({ gen: r.cover, count: r.variants.length }))
+              : variants.map((v) => ({ gen: v, count: 1 }))
+            ).map((item, i) => {
+              const gen = item.gen;
               const value = outputOf(gen) as
                 | { type?: string; uri?: string }
                 | undefined;
@@ -401,10 +545,14 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
                 : undefined;
               const videoThumb = asset?.thumb_url;
               const videoUrl = asset?.get_url || value?.uri || "";
+              const selected =
+                effectiveView === "runs"
+                  ? i === runIndex
+                  : gen.id === current?.id;
               return (
                 <div
                   key={gen.id}
-                  className={`thumb${i === currentIndex ? " selected" : ""}`}
+                  className={`thumb${selected ? " selected" : ""}`}
                   role="listitem"
                   data-index={i}
                 >
@@ -429,6 +577,9 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
                       {kind || "asset"}
                     </div>
                   )}
+                  {effectiveView === "runs" && item.count > 1 ? (
+                    <span className="thumb-count">{`x${item.count}`}</span>
+                  ) : null}
                   <span className="thumb-label">{i + 1}</span>
                 </div>
               );
@@ -437,17 +588,17 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
         )}
       </div>
 
-      {/* top-left overlay: mode toggle + pagination */}
+      {/* top-left overlay: view toggle + pagination */}
       <div className="node-history-overlay overlay-top-left">
         <div className="overlay-cluster">
           <ToolbarIconButton
-            title={mode === "single" ? "Switch to grid view" : "Switch to single view"}
+            title={effectiveView === "single" ? "Show grid" : "Show single"}
             size="small"
-            onClick={handleToggleMode}
+            onClick={handleToggleView}
             className="overlay-icon-btn"
-            aria-label="Toggle view mode"
+            aria-label="Toggle view"
           >
-            {mode === "single" ? <CropSquareIcon /> : <GridViewIcon />}
+            {effectiveView === "single" ? <GridViewIcon /> : <CropSquareIcon />}
           </ToolbarIconButton>
           {showPagination ? (
             <>
@@ -461,7 +612,9 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
                 <KeyboardArrowLeftIcon />
               </ToolbarIconButton>
               <span className="overlay-count">
-                {`${currentIndex + 1} / ${total}`}
+                {pagerScope === "variants"
+                  ? `${variantIndex + 1} / ${variants.length}`
+                  : `${runIndex + 1} / ${runs.length}`}
               </span>
               <ToolbarIconButton
                 title="Next"

--- a/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
+++ b/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
@@ -5,6 +5,7 @@ import mockTheme from "../../../__mocks__/themeMock";
 import "@testing-library/jest-dom";
 
 import type { Generation } from "../../../utils/nodeGenerations";
+import { groupByRun, getCurrentRun } from "../../../utils/nodeGenerations";
 
 const mockUseNodeResultHistory = jest.fn();
 const mockUseWebsocketRunner = jest.fn();
@@ -80,10 +81,26 @@ const makeAsset = (
   ...extras
 });
 
-/** A media generation backed by a persisted asset id. */
+/** A media generation backed by a persisted asset id; all share one jobId so
+ *  they group into a single run (N variants). */
 const makeGen = (id: string, createdAt: number): Generation => ({
   id,
   jobId: "job-a",
+  createdAt,
+  outputs: { output: { type: "image", uri: `https://example.com/${id}.png` } },
+  status: "completed",
+  assetId: id
+});
+
+/** A media generation with an explicit jobId — distinct jobIds group into
+ *  distinct runs (one variant each). */
+const makeRunGen = (
+  id: string,
+  jobId: string,
+  createdAt: number
+): Generation => ({
+  id,
+  jobId,
   createdAt,
   outputs: { output: { type: "image", uri: `https://example.com/${id}.png` } },
   status: "completed",
@@ -96,7 +113,15 @@ const setGenerations = (generations: Generation[], selectedId?: string) => {
       ? generations.find((g) => g.id === selectedId)
       : undefined) ?? generations[generations.length - 1];
   const select = jest.fn();
-  mockUseNodeGenerations.mockReturnValue({ generations, current, select });
+  const runs = groupByRun(generations);
+  const currentRun = getCurrentRun(runs, selectedId);
+  mockUseNodeGenerations.mockReturnValue({
+    generations,
+    current,
+    select,
+    runs,
+    currentRun
+  });
   return select;
 };
 
@@ -115,7 +140,9 @@ beforeEach(() => {
   mockUseNodeGenerations.mockReturnValue({
     generations: [],
     current: undefined,
-    select: jest.fn()
+    select: jest.fn(),
+    runs: [],
+    currentRun: undefined
   });
 });
 
@@ -130,15 +157,18 @@ describe("NodeHistoryViewer", () => {
       />
     );
     expect(screen.getByTestId("single-body")).toHaveTextContent("null");
-    expect(screen.queryByLabelText("Toggle view mode")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Toggle view")).not.toBeInTheDocument();
   });
 
-  it("renders the current (latest) generation with a 1/N counter", () => {
-    setGenerations([
-      makeGen("a1", 1),
-      makeGen("a2", 2),
-      makeGen("a3", 3)
-    ]);
+  it("renders the current (latest) variant in single view with a 1/N counter (one run)", () => {
+    // All three share one jobId → one run, three variants. With renderSingle
+    // selected to a single variant the navigator stays in single view (the
+    // default variants grid only applies when no variant is selected); here we
+    // assert the variant-scoped pager.
+    setGenerations(
+      [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
+      "a3"
+    );
 
     renderWithProviders(
       <NodeHistoryViewer
@@ -149,11 +179,16 @@ describe("NodeHistoryViewer", () => {
       />
     );
 
+    // Default view is the variants grid (>1 variant in the current run). The
+    // toggle cycles variants → runs → single, so two clicks reach single view
+    // and the variant pager.
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    fireEvent.click(screen.getByLabelText("Toggle view"));
     expect(screen.getByText("3 / 3")).toBeInTheDocument();
     expect(screen.getByTestId("single-body")).toHaveTextContent("a3.png");
   });
 
-  it("calls select with the next generation id when Next is clicked", () => {
+  it("steps variants within a run when Next/Previous are clicked", () => {
     const select = setGenerations(
       [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
       "a1"
@@ -168,14 +203,22 @@ describe("NodeHistoryViewer", () => {
       />
     );
 
-    // current is a1 (index 0); Next moves to a2.
+    // Switch to single view to expose the variant pager (default is the
+    // variants grid; toggle cycles variants → runs → single).
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    // current is variant a1 (index 0); Next moves to a2.
     fireEvent.click(screen.getByLabelText("Next output"));
     expect(select).toHaveBeenCalledWith("a2");
+    // Previous wraps to the last variant a3.
+    fireEvent.click(screen.getByLabelText("Previous output"));
+    expect(select).toHaveBeenCalledWith("a3");
   });
 
-  it("calls select with the previous generation id (wrapping) when Previous is clicked", () => {
+  it("steps runs when each generation is its own run", () => {
+    // Distinct jobIds → three runs, one variant each. Pager is run-scoped.
     const select = setGenerations(
-      [makeGen("a1", 1), makeGen("a2", 2)],
+      [makeRunGen("a1", "j1", 1), makeRunGen("a2", "j2", 2), makeRunGen("a3", "j3", 3)],
       "a1"
     );
 
@@ -188,9 +231,12 @@ describe("NodeHistoryViewer", () => {
       />
     );
 
-    // current is a1 (index 0); Previous wraps to the last generation a2.
-    fireEvent.click(screen.getByLabelText("Previous output"));
+    // Single run-per-generation → default single view, run-scoped pager.
+    fireEvent.click(screen.getByLabelText("Next output"));
     expect(select).toHaveBeenCalledWith("a2");
+    fireEvent.click(screen.getByLabelText("Previous output"));
+    // Previous from run a1 wraps to the last run a3.
+    expect(select).toHaveBeenCalledWith("a3");
   });
 
   it("hides pagination when only one generation exists", () => {
@@ -209,8 +255,10 @@ describe("NodeHistoryViewer", () => {
     expect(screen.queryByLabelText("Next output")).not.toBeInTheDocument();
   });
 
-  it("shows the live result instead of history while a run is in progress", () => {
-    setGenerations([makeGen("a1", 1), makeGen("a2", 2)]);
+  it("shows the live result instead of history while a single-variant run is in progress", () => {
+    // One variant in the current run → the in-flight single preview is shown
+    // (the normal single-image streaming case).
+    setGenerations([makeGen("a1", 1)]);
     mockUseWebsocketRunner.mockReturnValue({ state: "running" });
 
     const liveResult = { type: "image", uri: "live-preview.png" };
@@ -229,7 +277,71 @@ describe("NodeHistoryViewer", () => {
     expect(screen.queryByLabelText("Previous output")).not.toBeInTheDocument();
   });
 
-  it("switches to grid mode when the mode toggle is clicked", () => {
+  it("renders the variants grid mid-run when the current run has >1 live variant", () => {
+    // A multi-execution run: variants pop in live under one jobId. Even while
+    // showingLive (run in progress + non-null liveResult), the grid must show
+    // the N tiles rather than freezing on the single in-flight preview. With no
+    // renderVariants supplied the viewer falls back to its own `.thumb` grid
+    // labeled "Output history".
+    setGenerations([
+      makeGen("a1", 1),
+      makeGen("a2", 2),
+      makeGen("a3", 3)
+    ]);
+    mockUseWebsocketRunner.mockReturnValue({ state: "running" });
+
+    const liveResult = { type: "image", uri: "live-preview.png" };
+    renderWithProviders(
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={liveResult}
+        renderSingle={renderSingle}
+      />
+    );
+
+    expect(
+      screen.getByRole("list", { name: "Output history" })
+    ).toBeInTheDocument();
+    // The single in-flight preview is NOT rendered — the grid supersedes it.
+    expect(screen.queryByTestId("single-body")).not.toBeInTheDocument();
+  });
+
+  it("invokes renderVariants mid-run for a multi-variant run when supplied", () => {
+    // When the caller supplies renderVariants (image variants), the grid path
+    // uses it directly — proving the live multi-variant run reaches the
+    // renderVariants branch (NodeHistoryViewer.tsx:482), not the single preview.
+    setGenerations([
+      makeGen("a1", 1),
+      makeGen("a2", 2),
+      makeGen("a3", 3)
+    ]);
+    mockUseWebsocketRunner.mockReturnValue({ state: "running" });
+
+    const renderVariants = jest.fn((values: unknown[]) => (
+      <div data-testid="variants-grid" data-count={values.length} />
+    ));
+
+    renderWithProviders(
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={{ type: "image", uri: "live-preview.png" }}
+        renderSingle={renderSingle}
+        renderVariants={renderVariants}
+      />
+    );
+
+    expect(renderVariants).toHaveBeenCalled();
+    const grid = screen.getByTestId("variants-grid");
+    expect(grid).toHaveAttribute("data-count", "3");
+    expect(screen.queryByTestId("single-body")).not.toBeInTheDocument();
+  });
+
+  it("defaults to the variants grid for a multi-variant run", () => {
+    // One run with 3 variants → default view is the variants grid. With no
+    // renderVariants supplied the viewer falls back to its own `.thumb` grid
+    // labeled "Output history".
     setGenerations([makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)]);
 
     renderWithProviders(
@@ -241,18 +353,65 @@ describe("NodeHistoryViewer", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle view mode"));
     expect(
       screen.getByRole("list", { name: "Output history" })
     ).toBeInTheDocument();
     expect(screen.queryByTestId("single-body")).not.toBeInTheDocument();
   });
 
-  it("selecting a grid thumbnail selects that generation and returns to single mode", () => {
-    const select = setGenerations([
-      makeGen("a1", 1),
-      makeGen("a2", 2),
-      makeGen("a3", 3)
+  it("auto-switches to the variants grid as a streaming run grows under one jobId", () => {
+    // The core streaming scenario: the card is already mounted and the run grows
+    // from 1 variant to N under a CONSTANT jobId. The default must re-evaluate
+    // as variants accrue — not just on a jobId change — so the variants grid
+    // appears once the run settles, without a manual toggle.
+    setGenerations([makeGen("a1", 1)]);
+    const { rerender } = renderWithProviders(
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={null}
+        renderSingle={renderSingle}
+      />
+    );
+    // One variant → single view.
+    expect(screen.getByTestId("single-body")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("list", { name: "Output history" })
+    ).not.toBeInTheDocument();
+
+    // Two more variants stream in under the SAME jobId (job-a). In the real app
+    // the hook's store subscription re-renders the component; here the mocked
+    // hook can't, so a fresh renderSingle identity forces the memo through to
+    // re-read the updated generations (the view derivation itself is plain
+    // computation, so it re-evaluates on any re-render — no effect to miss it).
+    setGenerations([makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)]);
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <NodeHistoryViewer
+          workflowId="wf1"
+          nodeId="node-a"
+          liveResult={null}
+          renderSingle={(value) => (
+            <div data-testid="single-body">{JSON.stringify(value)}</div>
+          )}
+        />
+      </ThemeProvider>
+    );
+
+    // The grid now defaults on, no toggle required.
+    expect(
+      screen.getByRole("list", { name: "Output history" })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("single-body")).not.toBeInTheDocument();
+  });
+
+  it("toggles variants → runs → single", () => {
+    // Two runs (j1 ×1 variant, j2 ×2 variants); current run is j2 → defaults to
+    // the variants grid. Toggling cycles variants → runs → single.
+    setGenerations([
+      makeRunGen("a1", "j1", 1),
+      makeRunGen("a2", "j2", 2),
+      makeRunGen("a3", "j2", 3)
     ]);
 
     renderWithProviders(
@@ -264,11 +423,64 @@ describe("NodeHistoryViewer", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle view mode"));
-    const items = screen.getAllByRole("listitem");
-    fireEvent.click(items[0]);
+    // Default: variants grid (current run j2 has 2 variants).
+    expect(
+      screen.getByRole("list", { name: "Output history" })
+    ).toBeInTheDocument();
+    // → runs grid.
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    expect(screen.getByRole("list", { name: "Runs" })).toBeInTheDocument();
+    // → single.
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    expect(screen.getByTestId("single-body")).toBeInTheDocument();
+  });
+
+  it("renders one runs-grid tile per run with an xN badge for multi-variant runs", () => {
+    setGenerations([
+      makeRunGen("a1", "j1", 1),
+      makeRunGen("a2", "j2", 2),
+      makeRunGen("a3", "j2", 3)
+    ]);
+
+    renderWithProviders(
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={null}
+        renderSingle={renderSingle}
+      />
+    );
+
+    // From the default variants grid, toggle to the runs grid.
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    const tiles = screen.getAllByRole("listitem");
+    // Two runs → two tiles. The j2 run (2 variants) shows an "x2" badge.
+    expect(tiles).toHaveLength(2);
+    expect(screen.getByText("x2")).toBeInTheDocument();
+  });
+
+  it("selecting a runs-grid tile selects its cover and opens that run", () => {
+    // Single-variant runs so the tile click drops straight to single view.
+    const select = setGenerations([
+      makeRunGen("a1", "j1", 1),
+      makeRunGen("a2", "j2", 2),
+      makeRunGen("a3", "j3", 3)
+    ]);
+
+    renderWithProviders(
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={null}
+        renderSingle={renderSingle}
+      />
+    );
+
+    // Three single-variant runs → default single view; toggle to the runs grid.
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    const tiles = screen.getAllByRole("listitem");
+    fireEvent.click(tiles[0]);
     expect(select).toHaveBeenCalledWith("a1");
-    // Returned to single mode.
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
   });
 
@@ -329,5 +541,72 @@ describe("NodeHistoryViewer", () => {
     expect(viewer).toHaveAttribute("data-gallery-ids", "a1,a2,a3");
     // Viewer opens on the currently-selected generation's asset.
     expect(viewer).toHaveAttribute("data-current-asset", "a2");
+  });
+});
+
+describe("NodeHistoryViewer — auto-focus latest run", () => {
+  const setMock = (
+    generations: Generation[],
+    selectedId: string | undefined,
+    select: jest.Mock
+  ) => {
+    const current =
+      (selectedId
+        ? generations.find((g) => g.id === selectedId)
+        : undefined) ?? generations[generations.length - 1];
+    const runs = groupByRun(generations);
+    const currentRun = getCurrentRun(runs, selectedId);
+    mockUseNodeGenerations.mockReturnValue({
+      generations,
+      current,
+      select,
+      runs,
+      currentRun
+    });
+  };
+
+  // Fresh renderSingle identity per render so the memo-wrapped component
+  // actually re-renders on rerender (the real app re-renders via the Zustand
+  // subscription; the mocked hook is static).
+  const wrap = () => (
+    <ThemeProvider theme={mockTheme}>
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={null}
+        renderSingle={(v) => renderSingle(v)}
+      />
+    </ThemeProvider>
+  );
+
+  it("advances focus to a new run when its jobId appears (stale selection in an older run)", () => {
+    const select = jest.fn();
+    setMock([makeRunGen("a1", "j1", 1)], "a1", select);
+    const { rerender } = render(wrap());
+    // Mount must not auto-advance (preserve a restored selection).
+    expect(select).not.toHaveBeenCalled();
+
+    // A new run j2 appears while the selection still pins a1 (run j1).
+    setMock([makeRunGen("a1", "j1", 1), makeRunGen("a2", "j2", 2)], "a1", select);
+    rerender(wrap());
+    // Focus follows the latest run (its cover = a2).
+    expect(select).toHaveBeenCalledWith("a2");
+  });
+
+  it("does not auto-advance on the initial render", () => {
+    const select = jest.fn();
+    setMock([makeRunGen("a1", "j1", 1), makeRunGen("a2", "j2", 2)], "a1", select);
+    render(wrap());
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("does not advance while a run grows in place (same jobId — within-run pin survives)", () => {
+    const select = jest.fn();
+    setMock([makeRunGen("a1", "j1", 1)], "a1", select);
+    const { rerender } = render(wrap());
+    // Same job j1 gains a second variant — not a new run.
+    setMock([makeRunGen("a1", "j1", 1), makeRunGen("a2", "j1", 2)], "a1", select);
+    rerender(wrap());
+    expect(select).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -694,6 +694,18 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
     [variant]
   );
 
+  // The in-card variants grid: render an ARRAY of variant values. Only image
+  // variants get this — ImagePreview grids an array via `.image-grid-preview`.
+  // Video/audio/model_3d omit it so NodeHistoryViewer falls back to its own
+  // `.thumb` grid.
+  const renderVariants = useCallback(
+    (values: unknown[]) =>
+      variant === "image" || variant === "image_mask" ? (
+        <PreviewArea variant={variant} value={values} />
+      ) : null,
+    [variant]
+  );
+
   return (
     <div
       css={cssStyles}
@@ -707,6 +719,11 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
             nodeId={id}
             liveResult={liveResolvedResult}
             renderSingle={renderSingle}
+            renderVariants={
+              variant === "image" || variant === "image_mask"
+                ? renderVariants
+                : undefined
+            }
           />
         ) : (
           <PreviewArea variant={variant} value={fallbackPreviewValue} />

--- a/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
+++ b/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
@@ -54,40 +54,31 @@ jest.mock("../../../contexts/NodeContext", () => ({
     })
 }));
 
-jest.mock("../../node/OutputRenderer", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    default: ({ value }: { value: unknown }) =>
-      React.createElement(
-        "pre",
-        { "data-testid": "output-renderer" },
-        JSON.stringify(value)
-      )
-  };
-});
+jest.mock("../../node/OutputRenderer", () => ({
+  __esModule: true,
+  default: ({ value }: { value: unknown }) =>
+    React.createElement(
+      "pre",
+      { "data-testid": "output-renderer" },
+      JSON.stringify(value)
+    )
+}));
 
-jest.mock("../../node/ImageView", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    default: ({ source }: { source: unknown }) =>
-      React.createElement(
-        "div",
-        { "data-testid": "image-view" },
-        String(source)
-      )
-  };
-});
+jest.mock("../../node/ImageView", () => ({
+  __esModule: true,
+  default: ({ source }: { source: unknown }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "image-view" },
+      String(source)
+    )
+}));
 
-jest.mock("../../assets/AssetViewer", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    default: ({ open }: { open: boolean }) =>
-      open ? React.createElement("div", { "data-testid": "asset-viewer" }) : null
-  };
-});
+jest.mock("../../assets/AssetViewer", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? React.createElement("div", { "data-testid": "asset-viewer" }) : null
+}));
 
 let mockRunnerState: "idle" | "running" = "idle";
 jest.mock("../../../stores/WorkflowRunner", () => ({
@@ -98,26 +89,23 @@ jest.mock("../../../stores/WorkflowRunner", () => ({
 // NodeInputs renders ReactFlow Handles, which need a ReactFlow context not
 // present in these unit tests. Mock it to a probe that surfaces the props
 // that decide whether dynamic inputs (and thus handles) get rendered.
-jest.mock("../../node/NodeInputs", () => {
-  const React = require("react");
-  return {
-    __esModule: true,
-    NodeInputs: (props: {
-      properties?: unknown[];
-      showDynamicInputs?: boolean;
-      editableDynamicInputs?: boolean;
-      defaultDynamicInputType?: { type?: string };
-    }) =>
-      React.createElement("div", {
-        "data-testid": "node-inputs",
-        "data-properties-count": String((props.properties ?? []).length),
-        "data-show-dynamic": String(props.showDynamicInputs !== false),
-        "data-editable-dynamic": String(!!props.editableDynamicInputs),
-        "data-default-type": props.defaultDynamicInputType?.type ?? ""
-      }),
-    default: () => null
-  };
-});
+jest.mock("../../node/NodeInputs", () => ({
+  __esModule: true,
+  NodeInputs: (props: {
+    properties?: unknown[];
+    showDynamicInputs?: boolean;
+    editableDynamicInputs?: boolean;
+    defaultDynamicInputType?: { type?: string };
+  }) =>
+    React.createElement("div", {
+      "data-testid": "node-inputs",
+      "data-properties-count": String((props.properties ?? []).length),
+      "data-show-dynamic": String(props.showDynamicInputs !== false),
+      "data-editable-dynamic": String(!!props.editableDynamicInputs),
+      "data-default-type": props.defaultDynamicInputType?.type ?? ""
+    }),
+  default: () => null
+}));
 
 const nodeData = {
   workflow_id: workflowId,
@@ -242,7 +230,10 @@ describe("ContentCardBody results", () => {
     expect(screen.getByLabelText("Previous output")).toBeInTheDocument();
   });
 
-  it("switches to grid mode and shows every generation as a thumbnail", async () => {
+  it("defaults to the variants grid for a multi-variant run, showing every variant", async () => {
+    // Two assets sharing one job_id = one run with two variants. The image
+    // content card defaults to the variants grid, reusing ImagePreview's
+    // `.image-grid-preview` so both variants render as image tiles.
     const assets = [fakeAsset("first", "job-99"), fakeAsset("second", "job-99")];
     seedAssets(assets);
     mockAssetHistory = assets;
@@ -250,9 +241,14 @@ describe("ContentCardBody results", () => {
 
     renderContentCard(metadataForOutput("image"));
 
-    await userEvent.click(screen.getByLabelText("Toggle view mode"));
-    const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(2);
+    const tiles = screen.getAllByTestId("image-view");
+    expect(tiles).toHaveLength(2);
+    expect(tiles[0]).toHaveTextContent("first");
+    expect(tiles[1]).toHaveTextContent("second");
+
+    // Toggling cycles variants → runs; one job_id = a single run tile.
+    await userEvent.click(screen.getByLabelText("Toggle view"));
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
   });
 
   it("renders a pure transform's output without the gallery navigator", () => {
@@ -267,7 +263,7 @@ describe("ContentCardBody results", () => {
     expect(rendered[0]).toHaveTextContent("transformed.png");
     // ...but a non-auto-saving transform has no gallery to browse, so none of
     // the history-navigator controls are present.
-    expect(screen.queryByLabelText("Toggle view mode")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Toggle view")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Next output")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Previous output")).not.toBeInTheDocument();
   });

--- a/web/src/hooks/nodes/useNodeGenerations.ts
+++ b/web/src/hooks/nodes/useNodeGenerations.ts
@@ -7,7 +7,10 @@ import {
   assetToGeneration,
   mergeGenerations,
   getCurrentGeneration,
-  type Generation
+  groupByRun,
+  getCurrentRun,
+  type Generation,
+  type RunGroup
 } from "../../utils/nodeGenerations";
 
 /**
@@ -39,10 +42,18 @@ export const useNodeGenerations = (workflowId: string, nodeId: string) => {
     () => getCurrentGeneration(generations, selectedId),
     [generations, selectedId]
   );
+  const runs = useMemo<RunGroup[]>(
+    () => groupByRun(generations),
+    [generations]
+  );
+  const currentRun = useMemo(
+    () => getCurrentRun(runs, selectedId),
+    [runs, selectedId]
+  );
   const select = useCallback(
     (id: string) => updateNodeData(nodeId, { selected_generation: id }),
     [updateNodeData, nodeId]
   );
 
-  return { generations, current, select };
+  return { generations, current, select, runs, currentRun };
 };

--- a/web/src/lib/workflow/__tests__/browserRunnerRelay.test.ts
+++ b/web/src/lib/workflow/__tests__/browserRunnerRelay.test.ts
@@ -1,0 +1,83 @@
+import { normalizeWorkerStreamMessage } from "../browserRunnerRelay";
+import type { WebSocketMessage } from "../../websocket/GlobalWebSocketManager";
+
+/**
+ * Worker-path relay (the production browser path: Web Worker → main thread).
+ *
+ * `runBrowserGraphJobInWorker` spawns a real `Worker`, which jsdom/jest cannot
+ * run, so we test its per-message normalization seam directly. This is the
+ * branch that the main-thread fallback (`runBrowserGraphJobLocal`) also runs;
+ * both must stamp an arrival-order `index` per (job, node) on
+ * `generation_complete` and materialize `.outputs` (RFC §8.5 / Decision 9).
+ */
+
+const gc = (
+  nodeId: string,
+  outputs: Record<string, unknown>
+): WebSocketMessage =>
+  ({
+    type: "generation_complete",
+    node_id: nodeId,
+    node_name: nodeId,
+    node_type: "browser.Gen",
+    outputs
+  }) as unknown as WebSocketMessage;
+
+describe("normalizeWorkerStreamMessage (worker-path relay)", () => {
+  it("stamps arrival-order index 0..N-1 per (job, node) on generation_complete", () => {
+    const counter = new Map<string, number>();
+    const a = gc("gen", { image: "a" });
+    const b = gc("gen", { image: "b" });
+    const c = gc("gen", { image: "c" });
+
+    normalizeWorkerStreamMessage(a, counter);
+    normalizeWorkerStreamMessage(b, counter);
+    normalizeWorkerStreamMessage(c, counter);
+
+    expect([a, b, c].map((m) => (m as Record<string, unknown>).index)).toEqual([
+      0, 1, 2
+    ]);
+  });
+
+  it("resets the per-node counter at 0 for a different node", () => {
+    const counter = new Map<string, number>();
+    const first = gc("gen", { image: "a" });
+    const second = gc("gen", { image: "b" });
+    const other = gc("other", { image: "z" });
+
+    normalizeWorkerStreamMessage(first, counter);
+    normalizeWorkerStreamMessage(second, counter);
+    normalizeWorkerStreamMessage(other, counter);
+
+    expect((first as Record<string, unknown>).index).toBe(0);
+    expect((second as Record<string, unknown>).index).toBe(1);
+    expect((other as Record<string, unknown>).index).toBe(0);
+  });
+
+  it("preserves outputs through materialize for plain (non-image) values", () => {
+    const counter = new Map<string, number>();
+    const msg = gc("gen", { text: "hello", count: 7 });
+
+    normalizeWorkerStreamMessage(msg, counter);
+
+    expect((msg as Record<string, unknown>).outputs).toEqual({
+      text: "hello",
+      count: 7
+    });
+  });
+
+  it("leaves node_update/output_update without an index and does not bump the counter", () => {
+    const counter = new Map<string, number>();
+    const nodeUpdate = {
+      type: "node_update",
+      node_id: "gen",
+      status: "completed",
+      result: { text: "x" }
+    } as unknown as WebSocketMessage;
+
+    normalizeWorkerStreamMessage(nodeUpdate, counter);
+
+    expect((nodeUpdate as Record<string, unknown>).index).toBeUndefined();
+    expect(counter.get("gen")).toBeUndefined();
+  });
+});

--- a/web/src/lib/workflow/__tests__/browserWorkflowRunner.test.ts
+++ b/web/src/lib/workflow/__tests__/browserWorkflowRunner.test.ts
@@ -229,6 +229,69 @@ describe("runBrowserGraphJob", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("Aborted");
   });
+
+  it("stamps arrival-order index per (job, node) on generation_complete and normalizes outputs", async () => {
+    const deliver = jest.spyOn(globalWebSocketManager, "deliverLocal");
+    installFakeRunner(
+      makeGen(
+        [
+          {
+            type: "generation_complete",
+            node_id: "gen",
+            node_name: "gen",
+            node_type: "browser.Gen",
+            outputs: { image: "a" }
+          },
+          {
+            type: "generation_complete",
+            node_id: "gen",
+            node_name: "gen",
+            node_type: "browser.Gen",
+            outputs: { image: "b" }
+          },
+          {
+            type: "generation_complete",
+            node_id: "gen",
+            node_name: "gen",
+            node_type: "browser.Gen",
+            outputs: { image: "c" }
+          },
+          {
+            // A different node restarts the per-node counter at 0.
+            type: "generation_complete",
+            node_id: "other",
+            node_name: "other",
+            node_type: "browser.Gen",
+            outputs: { image: "z" }
+          }
+        ],
+        { status: "completed" }
+      )
+    );
+
+    const result = await runBrowserGraphJob({
+      graph: browserGraph("browser.Gen"),
+      workflowId: "wf-gc"
+    });
+    expect(result.success).toBe(true);
+
+    const gens = deliver.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((m) => m.type === "generation_complete");
+    expect(gens).toHaveLength(4);
+
+    const forGen = gens.filter((m) => m.node_id === "gen");
+    expect(forGen.map((m) => m.index)).toEqual([0, 1, 2]);
+    // outputs preserved through materialize (plain values pass through).
+    expect(forGen.map((m) => (m.outputs as Record<string, unknown>).image)).toEqual([
+      "a",
+      "b",
+      "c"
+    ]);
+
+    const forOther = gens.filter((m) => m.node_id === "other");
+    expect(forOther.map((m) => m.index)).toEqual([0]);
+  });
 });
 
 describe("collectNodeClasses", () => {

--- a/web/src/lib/workflow/browserRunner.worker.ts
+++ b/web/src/lib/workflow/browserRunner.worker.ts
@@ -200,6 +200,17 @@ async function runJob(msg: RunMessage): Promise<void> {
             await resolve(message.value),
             transfer
           );
+        } else if (
+          message.type === "generation_complete" &&
+          message.outputs != null
+        ) {
+          // Same read-back/transfer as node_update.result so a committed
+          // artifact carrying a GPU-texture ref crosses postMessage as a
+          // cloneable, transferable bitmap (RFC §8.5).
+          message.outputs = await attachPreviewBitmaps(
+            await resolve(message.outputs),
+            transfer
+          );
         }
       }
       enqueue(message, transfer);

--- a/web/src/lib/workflow/browserRunnerRelay.ts
+++ b/web/src/lib/workflow/browserRunnerRelay.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared in-browser relay normalization for kernel-streamed messages.
+ *
+ * Both browser run paths — the Web Worker path (`browserWorkerClient.ts`) and
+ * the main-thread fallback (`browserWorkflowRunner.ts`) — must normalize each
+ * message the same way a server run does before it reaches `deliverLocal`:
+ * materialize raw-RGBA / inline bytes (so `<img>` can render them) and, for
+ * `generation_complete`, stamp an arrival-order `index` per `(job, node)`.
+ *
+ * The browser path never persists (RFC §8.5 / Decision 9), so `index` is
+ * arrival order only — no DB ordering. GPU-texture read-back happens earlier on
+ * the worker path (`browserRunner.worker.ts`, before postMessage); this module
+ * only does the CPU-side materialize + index stamp, so it is jest-safe and can
+ * be unit-tested without spawning a real `Worker`.
+ */
+import { materializeBrowserOutputs } from "./materializeBrowserOutputs";
+import type { WebSocketMessage } from "../websocket/GlobalWebSocketManager";
+
+/**
+ * Stamp an arrival-order `index` per `(job, node)` on a `generation_complete`
+ * message, mutating it in place and bumping the per-node counter. No-op for
+ * other message types.
+ */
+export function stampGenerationIndex(
+  message: WebSocketMessage,
+  generationIndexByNode: Map<string, number>
+): void {
+  if (message.type !== "generation_complete") return;
+  const mutable = message as Record<string, unknown>;
+  const nodeId = (mutable.node_id as string | undefined) ?? "";
+  const arrivalIndex = generationIndexByNode.get(nodeId) ?? 0;
+  mutable.index = arrivalIndex;
+  generationIndexByNode.set(nodeId, arrivalIndex + 1);
+}
+
+/**
+ * Materialize a worker-streamed message in place (raw-RGBA → PNG, inline bytes
+ * → uri) and, for `generation_complete`, stamp its arrival-order `index`. This
+ * is the worker-path counterpart of the inline normalization in
+ * `runBrowserGraphJobLocal`; GPU read-back already happened in the worker.
+ */
+export function normalizeWorkerStreamMessage(
+  message: WebSocketMessage,
+  generationIndexByNode: Map<string, number>
+): void {
+  const mutable = message as Record<string, unknown>;
+  if (message.type === "node_update" && mutable.result != null) {
+    mutable.result = materializeBrowserOutputs(mutable.result);
+  } else if (message.type === "output_update" && mutable.value != null) {
+    mutable.value = materializeBrowserOutputs(mutable.value);
+  } else if (message.type === "generation_complete") {
+    stampGenerationIndex(message, generationIndexByNode);
+    if (mutable.outputs != null) {
+      mutable.outputs = materializeBrowserOutputs(mutable.outputs);
+    }
+  }
+}

--- a/web/src/lib/workflow/browserWorkerClient.ts
+++ b/web/src/lib/workflow/browserWorkerClient.ts
@@ -12,7 +12,7 @@ import {
   type WebSocketMessage
 } from "../websocket/GlobalWebSocketManager";
 import { v4 as uuidv4 } from "uuid";
-import { materializeBrowserOutputs } from "./materializeBrowserOutputs";
+import { normalizeWorkerStreamMessage } from "./browserRunnerRelay";
 import type {
   BrowserGraphJobOptions,
   BrowserGraphJobResult
@@ -137,6 +137,11 @@ export function runBrowserGraphJobInWorker(
     // matching the main-thread and server paths. The canvas updates separately
     // via deliverLocal.
     const outputs: Record<string, unknown> = {};
+    // Per-node arrival counter for generation_complete.index. This run is one
+    // job, so node_id alone gives a per-(job, node) monotonic index. The browser
+    // path never persists (RFC Decision 9), so this is arrival-order only —
+    // identical to the main-thread fallback in browserWorkflowRunner.
+    const generationIndexByNode = new Map<string, number>();
     const cleanup = () => {
       if (settled) return;
       settled = true;
@@ -147,11 +152,7 @@ export function runBrowserGraphJobInWorker(
 
     const handleStreamMessage = (message: WebSocketMessage) => {
       const mutable = message as Record<string, unknown>;
-      if (message.type === "node_update" && mutable.result != null) {
-        mutable.result = materializeBrowserOutputs(mutable.result);
-      } else if (message.type === "output_update" && mutable.value != null) {
-        mutable.value = materializeBrowserOutputs(mutable.value);
-      }
+      normalizeWorkerStreamMessage(message, generationIndexByNode);
       globalWebSocketManager.deliverLocal(message);
 
       if (message.type === "node_update") {

--- a/web/src/lib/workflow/browserWorkflowRunner.ts
+++ b/web/src/lib/workflow/browserWorkflowRunner.ts
@@ -25,6 +25,7 @@ import {
 } from "../websocket/GlobalWebSocketManager";
 import { v4 as uuidv4 } from "uuid";
 import { materializeBrowserOutputs } from "./materializeBrowserOutputs";
+import { stampGenerationIndex } from "./browserRunnerRelay";
 import {
   buildBrowserRunner,
   collectNodeClasses,
@@ -375,6 +376,10 @@ async function runBrowserGraphJobLocal(
   const jobId = options.jobId ?? uuidv4();
   const outputs: Record<string, unknown> = {};
   let nodeError: string | undefined;
+  // Per-node arrival counter for generation_complete.index. This run is one
+  // job, so node_id alone gives a per-(job, node) monotonic index. The browser
+  // path never persists (RFC Decision 9), so this is arrival-order only.
+  const generationIndexByNode = new Map<string, number>();
 
   const nodeTypes = (graph.nodes ?? [])
     .map((n) => (n as { type?: string }).type)
@@ -438,6 +443,15 @@ async function runBrowserGraphJobLocal(
       } else if (message.type === "output_update" && mutable.value != null) {
         if (resolve) mutable.value = await resolve(mutable.value);
         mutable.value = materializeBrowserOutputs(mutable.value);
+      } else if (message.type === "generation_complete") {
+        // Stamp an arrival-order index per (job, node); job_id/workflow_id were
+        // already stamped by runBrowserWorkflow. Normalize .outputs the same way
+        // node_update.result is so artifacts render identically (§8.5).
+        stampGenerationIndex(message, generationIndexByNode);
+        if (mutable.outputs != null) {
+          if (resolve) mutable.outputs = await resolve(mutable.outputs);
+          mutable.outputs = materializeBrowserOutputs(mutable.outputs);
+        }
       }
 
       globalWebSocketManager.deliverLocal(message);

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -25,6 +25,7 @@ import {
   FileInfo,
   FolderRef,
   FontRef,
+  GenerationComplete,
   HuggingFaceModel,
   ImageModel,
   ImageRef,
@@ -134,6 +135,7 @@ export type { ErrorMessage };
 export type { FileInfo };
 export type { FolderRef };
 export type { FontRef };
+export type { GenerationComplete };
 export type { HuggingFaceModel };
 export type { ImageModel };
 export type { ImageRef };

--- a/web/src/stores/ResultsStore.ts
+++ b/web/src/stores/ResultsStore.ts
@@ -496,8 +496,9 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
     const key = `${workflowId}:${nodeId}`;
     set((state) => {
       const list = state.liveGenerations[key] ?? [];
-      // Strip the routing-only `index` before it can leak onto the stored
-      // Generation (which has no `index` field).
+      // Strip the routing-only `index`: live generations recover their slot
+      // from the id scheme (`${jobId}#k`), so we deliberately don't store
+      // `index` on the live Generation even though the type permits it.
       const { index, ...rest } = patch;
 
       if (typeof index === "number") {

--- a/web/src/stores/ResultsStore.ts
+++ b/web/src/stores/ResultsStore.ts
@@ -96,7 +96,7 @@ type ResultsStore = {
     workflowId: string,
     nodeId: string,
     jobId: string,
-    patch: Partial<Generation>
+    patch: Partial<Generation> & { index?: number }
   ) => void;
   getLiveGenerations: (workflowId: string, nodeId: string) => Generation[];
   getProviderCost: (
@@ -481,37 +481,77 @@ const useResultsStore = create<ResultsStore>((set, get) => ({
     }));
   },
   /**
-   * Upsert a live generation for a node, keyed by `${workflowId}:${nodeId}`.
-   * A generation is identified within the node by its `jobId`: the first patch
-   * for a job creates a running generation, later patches merge into it.
+   * Upsert a live generation slot for a node, keyed by `${workflowId}:${nodeId}`
+   * and grouped by `jobId`. Pure index routing — no job-class policy here (that
+   * lives in the workflowUpdates reducer).
+   *
+   * - `patch.index` present → set/replace the variant at that slot. Variant 0
+   *   keeps `id === jobId` for back-compat with `selected_generation`; variant k
+   *   gets `${jobId}#${k}`. Creates the slot if absent, else merges in place.
+   * - `patch.index` absent → merge onto the NEWEST slot for this job (running
+   *   heartbeats, error settles). Creates slot 0 if the job has no slot yet;
+   *   never spawns a phantom `#k` variant.
    */
-  upsertLiveGeneration: (
-    workflowId: string,
-    nodeId: string,
-    jobId: string,
-    patch: Partial<Generation>
-  ) => {
+  upsertLiveGeneration: (workflowId, nodeId, jobId, patch) => {
     const key = `${workflowId}:${nodeId}`;
     set((state) => {
       const list = state.liveGenerations[key] ?? [];
-      const idx = list.findIndex((g) => g.jobId === jobId);
-      const base: Generation =
-        idx >= 0
-          ? list[idx]
-          : {
-              id: jobId,
-              jobId,
-              createdAt: patch.createdAt ?? 0,
-              outputs: {},
-              status: "running"
-            };
-      const next: Generation = { ...base, ...patch, id: base.id, jobId };
-      const updated =
-        idx >= 0
-          ? list.map((g, i) => (i === idx ? next : g))
-          : [...list, next];
+      // Strip the routing-only `index` before it can leak onto the stored
+      // Generation (which has no `index` field).
+      const { index, ...rest } = patch;
+
+      if (typeof index === "number") {
+        const id = index === 0 ? jobId : `${jobId}#${index}`;
+        const at = list.findIndex((g) => g.jobId === jobId && g.id === id);
+        if (at >= 0) {
+          const next: Generation = { ...list[at], ...rest, id, jobId };
+          return {
+            liveGenerations: {
+              ...state.liveGenerations,
+              [key]: list.map((g, i) => (i === at ? next : g))
+            }
+          };
+        }
+        const created: Generation = {
+          id,
+          jobId,
+          createdAt: rest.createdAt ?? Date.now(),
+          outputs: {},
+          status: "running",
+          ...rest
+        };
+        return {
+          liveGenerations: {
+            ...state.liveGenerations,
+            [key]: [...list, created]
+          }
+        };
+      }
+
+      // index-less → newest slot for this job, or create slot 0.
+      const idx = list.findLastIndex((g) => g.jobId === jobId);
+      if (idx < 0) {
+        const created: Generation = {
+          id: jobId,
+          jobId,
+          createdAt: rest.createdAt ?? Date.now(),
+          outputs: {},
+          status: "running",
+          ...rest
+        };
+        return {
+          liveGenerations: {
+            ...state.liveGenerations,
+            [key]: [...list, created]
+          }
+        };
+      }
+      const next: Generation = { ...list[idx], ...rest, id: list[idx].id, jobId };
       return {
-        liveGenerations: { ...state.liveGenerations, [key]: updated }
+        liveGenerations: {
+          ...state.liveGenerations,
+          [key]: list.map((g, i) => (i === idx ? next : g))
+        }
       };
     });
   },

--- a/web/src/stores/__tests__/ResultsStore.variants.test.ts
+++ b/web/src/stores/__tests__/ResultsStore.variants.test.ts
@@ -1,0 +1,164 @@
+import useResultsStore from "../ResultsStore";
+
+const reset = () =>
+  useResultsStore.setState({ liveGenerations: {} } as never);
+
+const live = (workflowId: string, nodeId: string) =>
+  useResultsStore.getState().getLiveGenerations(workflowId, nodeId);
+
+describe("ResultsStore.upsertLiveGeneration — dumb index-keyed upsert", () => {
+  beforeEach(reset);
+
+  it("index 0,1,2 on one jobId yields three variants with stable ids and outputs", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 0,
+      status: "completed",
+      outputs: { output: "img0" }
+    });
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 1,
+      status: "completed",
+      outputs: { output: "img1" }
+    });
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 2,
+      status: "completed",
+      outputs: { output: "img2" }
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(3);
+    expect(list.map((g) => g.id)).toEqual(["j1", "j1#1", "j1#2"]);
+    expect(list.map((g) => g.jobId)).toEqual(["j1", "j1", "j1"]);
+    expect(list.map((g) => g.outputs.output)).toEqual([
+      "img0",
+      "img1",
+      "img2"
+    ]);
+    expect(list.every((g) => g.status === "completed")).toBe(true);
+    // The routing-only index must not leak onto the stored Generation.
+    expect(list.every((g) => !("index" in g))).toBe(true);
+  });
+
+  it("index-less running then index:0 completed settles ONE variant in place", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      createdAt: 1,
+      status: "running",
+      outputs: {}
+    });
+    expect(live("wf", "n")).toHaveLength(1);
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 0,
+      status: "completed",
+      outputs: { output: "img0" }
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1",
+      jobId: "j1",
+      status: "completed",
+      outputs: { output: "img0" }
+    });
+  });
+
+  it("index-less running with no slot creates slot 0 (id===jobId, running)", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      createdAt: 1,
+      status: "running",
+      outputs: {}
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1",
+      jobId: "j1",
+      status: "running"
+    });
+  });
+
+  it("index:2 with no prior slots creates exactly the jobId#2 slot (sparse, no backfill)", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 2,
+      status: "completed",
+      outputs: { output: "img2" }
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1#2",
+      jobId: "j1",
+      status: "completed",
+      outputs: { output: "img2" }
+    });
+  });
+
+  it("re-upserting an existing index merges in place (same id, stable createdAt)", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 1,
+      createdAt: 100,
+      status: "running",
+      outputs: {}
+    });
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 1,
+      status: "completed",
+      outputs: { output: "imgA" }
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1#1",
+      jobId: "j1",
+      createdAt: 100,
+      status: "completed",
+      outputs: { output: "imgA" }
+    });
+  });
+
+  it("index-less error settle flips the newest running slot to error, no phantom", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      createdAt: 1,
+      status: "running",
+      outputs: {}
+    });
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      status: "error",
+      error: "boom"
+    });
+    const list = live("wf", "n");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1",
+      jobId: "j1",
+      status: "error",
+      error: "boom"
+    });
+  });
+
+  it("isolates distinct node keys", () => {
+    const s = useResultsStore.getState();
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 0,
+      status: "completed",
+      outputs: { output: "a" }
+    });
+    s.upsertLiveGeneration("wf", "n", "j1", {
+      index: 1,
+      status: "completed",
+      outputs: { output: "b" }
+    });
+    s.upsertLiveGeneration("wf", "n2", "j1", {
+      index: 0,
+      status: "completed",
+      outputs: { output: "c" }
+    });
+    expect(live("wf", "n").map((g) => g.id)).toEqual(["j1", "j1#1"]);
+    expect(live("wf", "n2").map((g) => g.id)).toEqual(["j1"]);
+  });
+});

--- a/web/src/stores/__tests__/workflowUpdates.generations.test.ts
+++ b/web/src/stores/__tests__/workflowUpdates.generations.test.ts
@@ -1,6 +1,18 @@
-import type { NodeUpdate, WorkflowAttributes } from "../ApiTypes";
+import type {
+  Asset,
+  GenerationComplete,
+  JobUpdate,
+  NodeUpdate,
+  WorkflowAttributes
+} from "../ApiTypes";
 import useResultsStore from "../ResultsStore";
 import { handleUpdate } from "../workflowUpdates";
+import { markJobSilent, unmarkJobSilent } from "../previewJobs";
+import {
+  assetToGeneration,
+  mergeGenerations,
+  groupByRun
+} from "../../utils/nodeGenerations";
 
 const mockAddNotification = jest.fn();
 const mockDequeueNextPendingRun = jest.fn();
@@ -91,5 +103,319 @@ describe("handleUpdate live generations", () => {
       status: "error",
       error: "boom"
     });
+  });
+});
+
+const dispatch = (data: unknown) =>
+  handleUpdate(
+    mockWorkflow,
+    data as never,
+    mockRunnerStore as never,
+    () => undefined
+  );
+
+const genComplete = (
+  jobId: string,
+  index: number,
+  output: unknown,
+  nodeId = "n4"
+): GenerationComplete =>
+  ({
+    type: "generation_complete",
+    node_id: nodeId,
+    node_name: "TextToImage",
+    node_type: "image.TextToImage",
+    index,
+    outputs: { output },
+    job_id: jobId
+  }) as unknown as GenerationComplete;
+
+const nodeUpdate = (
+  status: string,
+  jobId: string,
+  extra: Record<string, unknown> = {},
+  nodeId = "n4"
+): NodeUpdate =>
+  ({
+    type: "node_update",
+    node_id: nodeId,
+    node_name: "TextToImage",
+    node_type: "image.TextToImage",
+    status,
+    job_id: jobId,
+    ...extra
+  }) as unknown as NodeUpdate;
+
+const gens = (nodeId = "n4") =>
+  useResultsStore.getState().getLiveGenerations("workflow-1", nodeId);
+
+describe("handleUpdate — generation_complete drives liveGenerations", () => {
+  it("6× generation_complete (index 0-5) on one jobId → 6 live generations", () => {
+    for (let i = 0; i < 6; i++) {
+      dispatch(genComplete("j1", i, `img${i}`));
+    }
+    const list = gens();
+    expect(list).toHaveLength(6);
+    expect(list.map((g) => g.id)).toEqual([
+      "j1",
+      "j1#1",
+      "j1#2",
+      "j1#3",
+      "j1#4",
+      "j1#5"
+    ]);
+    expect(list.every((g) => g.jobId === "j1")).toBe(true);
+    expect(list.every((g) => g.status === "completed")).toBe(true);
+    expect(list.map((g) => g.outputs.output)).toEqual([
+      "img0",
+      "img1",
+      "img2",
+      "img3",
+      "img4",
+      "img5"
+    ]);
+  });
+
+  it("a later run with a new jobId starts a distinct group, leaving the old run intact", () => {
+    for (let i = 0; i < 6; i++) {
+      dispatch(genComplete("j1", i, `img${i}`));
+    }
+    dispatch(genComplete("j2", 0, "newimg"));
+    const list = gens();
+    expect(list).toHaveLength(7);
+    expect(list.slice(0, 6).every((g) => g.jobId === "j1")).toBe(true);
+    expect(list[6]).toMatchObject({
+      id: "j2",
+      jobId: "j2",
+      status: "completed",
+      outputs: { output: "newimg" }
+    });
+  });
+
+  it("running placeholder then generation_complete{index:0} settles ONE variant", () => {
+    dispatch(nodeUpdate("running", "j1"));
+    expect(gens()).toHaveLength(1);
+    dispatch(genComplete("j1", 0, "img0"));
+    const list = gens();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "j1",
+      jobId: "j1",
+      status: "completed",
+      outputs: { output: "img0" }
+    });
+  });
+});
+
+describe("handleUpdate — node_update{completed} fallback", () => {
+  // Distinct jobIds per case: the saw-generation_complete set is module-level
+  // (cleared per-run via job_update in production), so cases that must NOT see a
+  // prior gen_complete flag use a fresh jobId rather than relying on cross-test
+  // reset.
+  it("with NO prior generation_complete → one synthesized generation (object result)", () => {
+    dispatch(nodeUpdate("completed", "fb-obj", { result: { output: 7 } }));
+    const list = gens();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      jobId: "fb-obj",
+      status: "completed",
+      outputs: { output: 7 }
+    });
+  });
+
+  it("with NO prior generation_complete → scalar result coerces to {output: raw}", () => {
+    dispatch(nodeUpdate("completed", "fb-scalar", { result: "hello" }));
+    const list = gens();
+    expect(list).toHaveLength(1);
+    expect(list[0].outputs).toEqual({ output: "hello" });
+  });
+
+  it("AFTER generation_completes → fallback does NOT fire (no phantom variant)", () => {
+    dispatch(genComplete("fb-after", 0, "img0"));
+    dispatch(genComplete("fb-after", 1, "img1"));
+    dispatch(
+      nodeUpdate("completed", "fb-after", { result: { output: "collapsed" } })
+    );
+    const list = gens();
+    // Still exactly the two committed variants — no synthesized third.
+    expect(list).toHaveLength(2);
+    expect(list.map((g) => g.outputs.output)).toEqual(["img0", "img1"]);
+  });
+
+  it("node_update{error} after a running placeholder settles newest slot, no phantom", () => {
+    dispatch(nodeUpdate("running", "fb-err"));
+    dispatch(nodeUpdate("error", "fb-err", { error: "boom" }));
+    const list = gens();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: "fb-err",
+      jobId: "fb-err",
+      status: "error",
+      error: "boom"
+    });
+  });
+
+  it("clears the saw-flag on a reused jobId so the next run's fallback fires", () => {
+    // jobId === the mock runner's job_id so the job_update is the runner's own
+    // run (isRunnerJob) and reaches the per-run saw-flag clear.
+    const jobId = "job-1";
+    // Run 1: generation_complete lands → fallback suppressed.
+    dispatch(genComplete(jobId, 0, "img0"));
+    dispatch(nodeUpdate("completed", jobId, { result: { output: "collapsed" } }));
+    expect(gens()).toHaveLength(1);
+
+    // A fresh run reuses the same jobId — job_update{running} must clear the flag.
+    useResultsStore.setState({ liveGenerations: {} } as never);
+    dispatch({
+      type: "job_update",
+      status: "running",
+      job_id: jobId
+    } as unknown as JobUpdate);
+
+    // Run 2: no generation_complete this time → fallback DOES synthesize.
+    dispatch(nodeUpdate("completed", jobId, { result: { output: "synth" } }));
+    const list = gens();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      jobId,
+      status: "completed",
+      outputs: { output: "synth" }
+    });
+  });
+});
+
+describe("handleUpdate — silent (scrub) generation_complete", () => {
+  it("8 scrub frames (running + generation_complete) under one silent jobId → 1 live gen", () => {
+    markJobSilent("scrub-job");
+    try {
+      for (let frame = 1; frame <= 8; frame++) {
+        dispatch(nodeUpdate("running", "scrub-job"));
+        dispatch(genComplete("scrub-job", frame - 1, `frame-${frame}`));
+      }
+      const list = gens();
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({
+        id: "scrub-job",
+        jobId: "scrub-job",
+        status: "completed",
+        outputs: { output: "frame-8" }
+      });
+    } finally {
+      unmarkJobSilent("scrub-job");
+    }
+  });
+
+  it("running placeholder for a silent job stays slot 0", () => {
+    markJobSilent("scrub-2");
+    try {
+      dispatch(nodeUpdate("running", "scrub-2"));
+      dispatch(nodeUpdate("running", "scrub-2"));
+      const list = gens();
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({ id: "scrub-2", status: "running" });
+    } finally {
+      unmarkJobSilent("scrub-2");
+    }
+  });
+});
+
+// Build a persisted image Asset whose created_at orders it within its job.
+const persistedAsset = (
+  id: string,
+  jobId: string,
+  createdAt: string
+): Asset =>
+  ({
+    id,
+    job_id: jobId,
+    node_id: "n4",
+    content_type: "image/png",
+    get_url: `http://x/${id}.png`,
+    created_at: createdAt
+  }) as unknown as Asset;
+
+// The real integration seam (Finding 3): drive N generation_complete through
+// the actual handleUpdate reducer + ResultsStore, read the live generations the
+// store actually produced (NOT hand-rolled ids), then feed THOSE through
+// mergeGenerations alongside the persisted assets the server's autosave cutover
+// would create. This locks the live-id contract between ResultsStore and
+// liveIndexOf — the conjunction the layer-isolated tests only assumed.
+describe("end-to-end: handleUpdate live → mergeGenerations → groupByRun", () => {
+  it("6 generation_complete (real reducer) + 6 persisted (same job) → ONE run, 6 variants", () => {
+    // Drive 6 generation_complete through the real reducer.
+    for (let i = 0; i < 6; i++) {
+      dispatch(genComplete("j1", i, `img${i}`));
+    }
+    const live = gens();
+    expect(live).toHaveLength(6);
+    // Sanity: the store minted the ids liveIndexOf relies on.
+    expect(live.map((g) => g.id)).toEqual([
+      "j1",
+      "j1#1",
+      "j1#2",
+      "j1#3",
+      "j1#4",
+      "j1#5"
+    ]);
+
+    // The 6 assets the autosave cutover persists for this run.
+    const persisted = Array.from({ length: 6 }, (_, i) =>
+      assetToGeneration(persistedAsset(`a${i}`, "j1", `2026-01-01T00:00:0${i}.000Z`))
+    );
+
+    // Reconcile the REAL live array (not hand-rolled) with the persisted twins.
+    const merged = mergeGenerations(persisted, live);
+    const runs = groupByRun(merged);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].variants).toHaveLength(6);
+    // Every slot superseded by its persisted twin — no live leftovers, no loss.
+    expect(merged.map((g) => g.id)).toEqual([
+      "a0",
+      "a1",
+      "a2",
+      "a3",
+      "a4",
+      "a5"
+    ]);
+  });
+
+  it("mid-run: 6 live (real reducer) + only 1 persisted → still ONE run, 6 variants", () => {
+    for (let i = 0; i < 6; i++) {
+      dispatch(genComplete("j1", i, `img${i}`));
+    }
+    const live = gens();
+    expect(live).toHaveLength(6);
+
+    // Only slot 0 has persisted so far (the handoff is mid-flight).
+    const persisted = [
+      assetToGeneration(persistedAsset("a0", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const merged = mergeGenerations(persisted, live);
+    const runs = groupByRun(merged);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].variants).toHaveLength(6);
+    // Slot 0 is the persisted a0; slots 1..5 survive as the real live variants.
+    expect(merged.map((g) => g.id)).toEqual([
+      "a0",
+      "j1#1",
+      "j1#2",
+      "j1#3",
+      "j1#4",
+      "j1#5"
+    ]);
+  });
+
+  it("regression lock: the real 6 live do NOT collapse to 1 when one asset persists", () => {
+    for (let i = 0; i < 6; i++) {
+      dispatch(genComplete("j1", i, `img${i}`));
+    }
+    const live = gens();
+    const persisted = [
+      assetToGeneration(persistedAsset("a0", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const merged = mergeGenerations(persisted, live);
+    // The OLD drop-all-live-for-job behavior would collapse to exactly 1 (["a0"]).
+    expect(merged).not.toHaveLength(1);
+    expect(groupByRun(merged)[0].variants).toHaveLength(6);
   });
 });

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -9,6 +9,7 @@ import {
   ToolResultUpdate,
   PlanningUpdate,
   OutputUpdate,
+  GenerationComplete,
   EdgeUpdate,
   LogUpdate,
   TerminalUpdate,
@@ -127,6 +128,29 @@ const workflowSubscriptions = new Map<string, WorkflowSubscription>();
 // different workflows don't ping-pong a shared id and repeatedly wipe the
 // trace timeline.
 const traceRunJobIds = new Map<string, string | null>();
+
+// Per-(jobId, node_id) "a generation_complete landed this run" set. Gates the
+// node_update{completed} fallback so a generator (which emits N
+// generation_complete) does NOT also synthesize a phantom from its collapsed
+// node_update.result, while a non-generator (or an old server, §12) — which
+// emits no generation_complete — still gets its single live generation.
+// Relies on actor emit order (§5): generation_complete precedes the node's
+// terminal node_update{completed}, so the flag is set before the fallback reads it.
+const sawGenerationCompleteKeys = new Set<string>();
+const genKey = (jobId: string, nodeId: string) => `${jobId}:${nodeId}`;
+
+// Drop every saw-flag belonging to a finished run. The flags are only needed
+// during the run (between the gen_completes and the terminal
+// node_update{completed} fallback read), so clearing them on the job terminal
+// AND on a reused-jobId fresh-run start keeps the set from growing unbounded
+// across a long session (real runs use fresh UUID jobIds, so the fresh-run
+// clear alone never matches a prior run's keys).
+const clearSawGenerationCompleteFor = (jobId: string): void => {
+  const prefix = `${jobId}:`;
+  for (const k of sawGenerationCompleteKeys) {
+    if (k.startsWith(prefix)) sawGenerationCompleteKeys.delete(k);
+  }
+};
 
 /**
  * Append one event to the global TraceStore (the LLM/agent debug timeline shown
@@ -321,6 +345,7 @@ export type MsgpackData =
   | TaskUpdate
   | PlanningUpdate
   | OutputUpdate
+  | GenerationComplete
   | StepResult
   | TodoUpdate
   | EdgeUpdate
@@ -546,6 +571,24 @@ export const handleUpdate = (
     }
   }
 
+  if (data.type === "generation_complete") {
+    // The sole generation driver: a generator committed one complete artifact.
+    const jobId = extractJobId(data);
+    if (jobId) {
+      sawGenerationCompleteKeys.add(genKey(jobId, data.node_id));
+      // Silent jobs (slider scrubs) reuse one jobId across frames — pin slot 0
+      // (replace) so a scrub stays ONE preview (D2/§9). Otherwise use the
+      // relay-stamped index. outputs are already normalized at the relay — pass
+      // through, do NOT re-coerce.
+      const slot = isSilentJob(jobId) ? 0 : data.index ?? 0;
+      upsertLiveGeneration(workflow.id, data.node_id, jobId, {
+        index: slot,
+        status: "completed",
+        outputs: data.outputs
+      });
+    }
+  }
+
   if (data.type === "chunk") {
     // Binary (audio) chunk payloads don't belong in the text-chunk channel.
     if (
@@ -581,6 +624,14 @@ export const handleUpdate = (
       )
     ) {
       flushAudioAppends();
+      // The run is over: its saw-generation_complete flags are no longer read
+      // (the terminal node_update fallback already ran). Drop them so the set
+      // doesn't accumulate one dead entry per generator node per run for the
+      // life of the session. Skip silent scrub jobs — they reuse one jobId and
+      // never finalize between frames.
+      if (job.job_id && !silentJob) {
+        clearSawGenerationCompleteFor(job.job_id);
+      }
     }
     // The per-workflow runner represents the single full run. Concurrent
     // inline/per-node jobs share this workflow_id but have their own job_id, so
@@ -630,6 +681,12 @@ export const handleUpdate = (
       ) {
         traceRunJobIds.set(workflow.id, incomingTraceJobId);
         useTraceStore.getState().startRun(new Date().toISOString());
+        // Clear the saw-generation_complete flags for this incoming job so a
+        // reused jobId can't poison the next run's node_update{completed}
+        // fallback (a stale flag would suppress a legitimate synthesis).
+        if (job.job_id) {
+          clearSawGenerationCompleteFor(job.job_id);
+        }
       }
     } else if (job.status === "suspended") {
       newState = "suspended";
@@ -979,23 +1036,38 @@ export const handleUpdate = (
           update.status === "starting" ||
           update.status === "booting"
         ) {
-          upsertLiveGeneration(workflow.id, update.node_id, jobId, {
-            createdAt: Date.now(),
-            status: "running"
-          });
+          // Placeholder so a node shows a spinner before its first artifact
+          // (generation_complete only fires at commit). A silent scrub reuses
+          // one jobId per frame → pin slot 0 (replace), else go index-less so
+          // the first generation_complete{index:0} settles this slot in place.
+          upsertLiveGeneration(
+            workflow.id,
+            update.node_id,
+            jobId,
+            silent
+              ? { index: 0, createdAt: Date.now(), status: "running" }
+              : { createdAt: Date.now(), status: "running" }
+          );
         } else if (update.status === "completed") {
-          const raw = update.result;
-          const outputs: Record<string, unknown> =
-            typeof raw === "object" && raw !== null && !Array.isArray(raw)
-              ? (raw as Record<string, unknown>)
-              : raw !== undefined && raw !== null
-                ? { output: raw }
-                : {};
-          upsertLiveGeneration(workflow.id, update.node_id, jobId, {
-            status: "completed",
-            outputs,
-            cost: update.provider_cost ?? undefined
-          });
+          // Fallback only: non-generator nodes never emit generation_complete,
+          // and an old server (§12 version skew) emits none either. Synthesize
+          // ONE live generation from node_update.result ONLY if no
+          // generation_complete landed for this (jobId, node_id) this run.
+          // Index-less → settles the running placeholder in place (newest slot).
+          if (!sawGenerationCompleteKeys.has(genKey(jobId, update.node_id))) {
+            const raw = update.result;
+            const outputs: Record<string, unknown> =
+              typeof raw === "object" && raw !== null && !Array.isArray(raw)
+                ? (raw as Record<string, unknown>)
+                : raw !== undefined && raw !== null
+                  ? { output: raw }
+                  : {};
+            upsertLiveGeneration(workflow.id, update.node_id, jobId, {
+              status: "completed",
+              outputs,
+              cost: update.provider_cost ?? undefined
+            });
+          }
           appendTrace(
             "node_complete",
             `${update.node_name || update.node_id}`,

--- a/web/src/utils/__tests__/nodeGenerations.test.ts
+++ b/web/src/utils/__tests__/nodeGenerations.test.ts
@@ -5,6 +5,9 @@ import {
   mergeGenerations,
   getCurrentGeneration,
   getCurrentOutput,
+  groupByRun,
+  getCurrentRun,
+  runVariantValues,
   type Generation
 } from "../nodeGenerations";
 import type { Asset } from "../../stores/ApiTypes";
@@ -92,29 +95,173 @@ describe("assetToGeneration", () => {
 });
 
 describe("mergeGenerations", () => {
-  it("keeps all persisted assets and drops a live gen once its job persisted", () => {
+  // END-TO-END / regression lock #1 (the bug we fixed): 6 generation_complete
+  // (6 live variants) + 6 persisted assets for ONE job → every live slot has a
+  // persisted twin at (jobId, index) → all 6 live drop, 6 persisted survive, and
+  // groupByRun yields ONE run with SIX variants (not 1).
+  it("yields 6 variants for 6 generation_complete + 6 persisted (same job)", () => {
+    const persisted = Array.from({ length: 6 }, (_, i) =>
+      assetToGeneration(asset(`a${i}`, "j1", `2026-01-01T00:00:0${i}.000Z`))
+    );
+    // Live ids follow ResultsStore's scheme: slot 0 === jobId, slot k === `${jobId}#k`.
+    const live: Generation[] = Array.from({ length: 6 }, (_, i) => ({
+      id: i === 0 ? "j1" : `j1#${i}`,
+      jobId: "j1",
+      createdAt: 100 + i,
+      outputs: { output: `live${i}` },
+      status: "completed" as const
+    }));
+    const merged = mergeGenerations(persisted, live);
+    const runs = groupByRun(merged);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].variants).toHaveLength(6);
+    // All survivors are persisted (live fully superseded slot-for-slot).
+    expect(merged.map((g) => g.id)).toEqual([
+      "a0",
+      "a1",
+      "a2",
+      "a3",
+      "a4",
+      "a5"
+    ]);
+  });
+
+  // The mid-run fix: 6 live + only 1 persisted-so-far (slot 0) → 5 live survive
+  // + 1 persisted → still 6 variants in ONE run (no premature collapse to 1).
+  it("yields 6 variants mid-run with 6 live + 1 persisted (slot 0)", () => {
     const persisted = [
-      assetToGeneration(asset("a1", "j1", "2026-01-01T00:00:00Z")),
-      assetToGeneration(asset("a2", "j1", "2026-01-01T00:00:01Z")) // batch: same job, 2 assets
+      assetToGeneration(asset("a0", "j1", "2026-01-01T00:00:00.000Z"))
     ];
-    const live = [
+    const live: Generation[] = Array.from({ length: 6 }, (_, i) => ({
+      id: i === 0 ? "j1" : `j1#${i}`,
+      jobId: "j1",
+      createdAt: 100 + i,
+      outputs: { output: `live${i}` },
+      status: i === 5 ? ("running" as const) : ("completed" as const)
+    }));
+    const merged = mergeGenerations(persisted, live);
+    const runs = groupByRun(merged);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].variants).toHaveLength(6);
+    // Slot 0 superseded by persisted a0; slots 1..5 survive as live.
+    expect(merged.map((g) => g.id)).toEqual([
+      "a0",
+      "j1#1",
+      "j1#2",
+      "j1#3",
+      "j1#4",
+      "j1#5"
+    ]);
+  });
+
+  // Regression lock #2 (proves the OLD drop-all-live-for-job behavior is gone):
+  // the previous merge collapsed 6 live to 1 once ANY asset persisted for the
+  // job. With slot-level reconciliation it must NOT collapse.
+  it("does NOT collapse 6 live to 1 when one asset persists (old bug locked)", () => {
+    const persisted = [
+      assetToGeneration(asset("a0", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const live: Generation[] = Array.from({ length: 6 }, (_, i) => ({
+      id: i === 0 ? "j1" : `j1#${i}`,
+      jobId: "j1",
+      createdAt: 100 + i,
+      outputs: { output: `live${i}` },
+      status: "completed" as const
+    }));
+    const merged = mergeGenerations(persisted, live);
+    // Old behavior would be exactly 1 (["a0"]); assert it is NOT.
+    expect(merged).not.toHaveLength(1);
+    expect(groupByRun(merged)[0].variants).toHaveLength(6);
+  });
+
+  // Mixed-type run: a live variant whose output is non-asset-like never gets a
+  // persisted twin → survives → live-only variants stay visible.
+  it("keeps a live-only variant that never persists (mixed-type run)", () => {
+    const persisted = [
+      assetToGeneration(asset("a0", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const live: Generation[] = [
       {
         id: "j1",
         jobId: "j1",
-        createdAt: 10,
-        outputs: { output: "stale" },
-        status: "completed" as const
+        createdAt: 100,
+        outputs: { output: "asset-like" },
+        status: "completed"
+      },
+      {
+        id: "j1#1",
+        jobId: "j1",
+        createdAt: 101,
+        outputs: { output: { type: "text", text: "no asset" } },
+        status: "completed"
+      }
+    ];
+    const merged = mergeGenerations(persisted, live);
+    // slot 0 → persisted a0; slot 1 → live-only survives.
+    expect(merged.map((g) => g.id)).toEqual(["a0", "j1#1"]);
+  });
+
+  // Two independent jobs reconcile by their OWN slots, never cross-job: a
+  // persisted asset for j1 does not supersede a live variant of j2.
+  it("reconciles per job, not across jobs", () => {
+    const persisted = [
+      assetToGeneration(asset("a0", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const live: Generation[] = [
+      {
+        id: "j1",
+        jobId: "j1",
+        createdAt: 100,
+        outputs: { output: "j1-live" },
+        status: "completed"
       },
       {
         id: "j2",
         jobId: "j2",
-        createdAt: 20,
-        outputs: { output: "live" },
+        createdAt: 200,
+        outputs: { output: "j2-live" },
+        status: "running"
+      }
+    ];
+    const merged = mergeGenerations(persisted, live);
+    // j1 slot 0 superseded by a0; j2 slot 0 has no persisted twin → survives.
+    expect(merged.map((g) => g.id)).toEqual(["a0", "j2"]);
+  });
+
+  // Null-jobId live always survives; null-jobId persisted stays its own singleton.
+  it("never reconciles null-jobId live or persisted", () => {
+    const persisted = [
+      {
+        id: "p0",
+        jobId: null,
+        createdAt: 1,
+        outputs: { output: "solo" },
+        status: "completed" as const
+      }
+    ];
+    const live: Generation[] = [
+      {
+        id: "L0",
+        jobId: null,
+        createdAt: 5,
+        outputs: { output: "live-solo" },
         status: "running" as const
       }
     ];
     const merged = mergeGenerations(persisted, live);
-    expect(merged.map((g) => g.id)).toEqual(["a1", "a2", "j2"]); // j1 superseded; chronological
+    expect(merged.map((g) => g.id)).toEqual(["p0", "L0"]);
+    expect(groupByRun(merged)).toHaveLength(2); // two __solo__ runs
+  });
+
+  // Same-millisecond persisted assets keep a stable (createdAt, id) order so the
+  // slot assignment — and thus reconciliation — is deterministic across renders.
+  it("orders same-ms persisted assets stably by id tie-break", () => {
+    const persisted = [
+      assetToGeneration(asset("b", "j1", "2026-01-01T00:00:00.000Z")),
+      assetToGeneration(asset("a", "j1", "2026-01-01T00:00:00.000Z"))
+    ];
+    const merged = mergeGenerations(persisted, []);
+    expect(merged.map((g) => g.id)).toEqual(["a", "b"]);
   });
 });
 
@@ -153,5 +300,149 @@ describe("getCurrentGeneration", () => {
 describe("getCurrentOutput", () => {
   it("returns the current generation's output for a handle", () => {
     expect(getCurrentOutput(list, "g1", "output")).toBe("first");
+  });
+});
+
+describe("groupByRun / getCurrentRun / runVariantValues", () => {
+  const mkGen = (
+    id: string,
+    jobId: string | null,
+    createdAt: number,
+    status: Generation["status"] = "completed",
+    outputs: Record<string, unknown> = { output: id }
+  ): Generation => ({ id, jobId, createdAt, outputs, status });
+
+  describe("groupByRun", () => {
+    it("returns [] for an empty list", () => {
+      expect(groupByRun([])).toEqual([]);
+    });
+
+    it("groups N variants sharing one jobId into a single run", () => {
+      const gens = [
+        mkGen("a", "j1", 5),
+        mkGen("b", "j1", 6),
+        mkGen("c", "j1", 7)
+      ];
+      const runs = groupByRun(gens);
+      expect(runs).toHaveLength(1);
+      const run = runs[0];
+      expect(run.jobId).toBe("j1");
+      expect(run.variants).toHaveLength(3);
+      expect(run.variants.map((v) => v.id)).toEqual(["a", "b", "c"]);
+      expect(run.cover.id).toBe("c");
+      expect(run.createdAt).toBe(5);
+    });
+
+    it("splits two interleaved jobs into two runs sorted by min createdAt", () => {
+      const gens = [
+        mkGen("a", "j1", 10),
+        mkGen("b", "j2", 5),
+        mkGen("c", "j1", 11),
+        mkGen("d", "j2", 6)
+      ];
+      const runs = groupByRun(gens);
+      expect(runs).toHaveLength(2);
+      // j2 has min createdAt 5 → first; j1 min 10 → second
+      expect(runs[0].jobId).toBe("j2");
+      expect(runs[0].variants.map((v) => v.id)).toEqual(["b", "d"]);
+      expect(runs[1].jobId).toBe("j1");
+      expect(runs[1].variants.map((v) => v.id)).toEqual(["a", "c"]);
+    });
+
+    it("never merges null-jobId generations — each is its own singleton run", () => {
+      const gens = [
+        mkGen("s1", null, 1),
+        mkGen("s2", null, 2),
+        mkGen("r1", "j1", 3)
+      ];
+      const runs = groupByRun(gens);
+      expect(runs).toHaveLength(3);
+      const byKey = Object.fromEntries(runs.map((r) => [r.jobId, r]));
+      expect(byKey["__solo__:s1"].variants.map((v) => v.id)).toEqual(["s1"]);
+      expect(byKey["__solo__:s2"].variants.map((v) => v.id)).toEqual(["s2"]);
+      expect(byKey["j1"].variants.map((v) => v.id)).toEqual(["r1"]);
+    });
+
+    it("rolls up status: any running → running", () => {
+      const runs = groupByRun([
+        mkGen("a", "j1", 1, "completed"),
+        mkGen("b", "j1", 2, "running")
+      ]);
+      expect(runs[0].status).toBe("running");
+    });
+
+    it("rolls up status: an error with none running → error", () => {
+      const runs = groupByRun([
+        mkGen("a", "j1", 1, "completed"),
+        mkGen("b", "j1", 2, "error")
+      ]);
+      expect(runs[0].status).toBe("error");
+    });
+
+    it("rolls up status: all completed → completed", () => {
+      const runs = groupByRun([
+        mkGen("a", "j1", 1, "completed"),
+        mkGen("b", "j1", 2, "completed")
+      ]);
+      expect(runs[0].status).toBe("completed");
+    });
+  });
+
+  describe("getCurrentRun", () => {
+    it("returns undefined for an empty list", () => {
+      expect(getCurrentRun([])).toBeUndefined();
+    });
+
+    it("resolves the run that contains the selected variant id", () => {
+      const runs = groupByRun([
+        mkGen("a", "j1", 1),
+        mkGen("b", "j2", 2),
+        mkGen("c", "j2", 3)
+      ]);
+      // select variant "b" of run j2
+      expect(getCurrentRun(runs, "b")?.jobId).toBe("j2");
+    });
+
+    it("falls back to the latest run when selectedId is stale/absent", () => {
+      const runs = groupByRun([mkGen("a", "j1", 1), mkGen("b", "j2", 2)]);
+      expect(getCurrentRun(runs, "missing")?.jobId).toBe("j2");
+      expect(getCurrentRun(runs)?.jobId).toBe("j2");
+    });
+  });
+
+  describe("runVariantValues", () => {
+    it("returns N scalar values for N scalar variants, in order", () => {
+      const run = groupByRun([
+        mkGen("a", "j1", 1, "completed", { output: "imgA" }),
+        mkGen("b", "j1", 2, "completed", { output: "imgB" }),
+        mkGen("c", "j1", 3, "completed", { output: "imgC" })
+      ])[0];
+      expect(runVariantValues(run)).toEqual(["imgA", "imgB", "imgC"]);
+    });
+
+    it("spreads a single array-valued variant (num_images=N live) to N values", () => {
+      const run = groupByRun([
+        mkGen("a", "j1", 1, "completed", { output: ["i1", "i2", "i3"] })
+      ])[0];
+      expect(runVariantValues(run)).toEqual(["i1", "i2", "i3"]);
+      expect(runVariantValues(run)).toHaveLength(3);
+    });
+
+    it("drops null/undefined variant outputs", () => {
+      const run = groupByRun([
+        mkGen("a", "j1", 1, "completed", { output: "imgA" }),
+        mkGen("b", "j1", 2, "running", { output: null }),
+        mkGen("c", "j1", 3, "completed", {})
+      ])[0];
+      expect(runVariantValues(run)).toEqual(["imgA"]);
+    });
+
+    it("respects the named handle on multi-key variant outputs", () => {
+      const run = groupByRun([
+        mkGen("a", "j1", 1, "completed", { image: "imgA", mask: "maskA" }),
+        mkGen("b", "j1", 2, "completed", { image: "imgB", mask: "maskB" })
+      ])[0];
+      expect(runVariantValues(run, "image")).toEqual(["imgA", "imgB"]);
+    });
   });
 });

--- a/web/src/utils/nodeGenerations.ts
+++ b/web/src/utils/nodeGenerations.ts
@@ -35,6 +35,13 @@ export interface Generation {
   cost?: ProviderCost;
   error?: string;
   assetId?: string;
+  /**
+   * Per-(jobId) variant position, recovered at read time (no DB column).
+   * Persisted gens: assigned in mergeGenerations from (createdAt, id) order
+   * within the job. Live gens: parsed from the `${jobId}#k` id scheme. Used
+   * only for live↔persisted reconciliation; never persisted to ResultsStore.
+   */
+  index?: number;
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
@@ -65,27 +72,69 @@ export const assetToGeneration = (asset: Asset): Generation => ({
 });
 
 /**
- * One time-ordered list: all persisted generations followed by live
- * generations whose job has not yet persisted any asset (a live gen is
- * superseded once its assets land). Each backing is sorted oldest→newest by
- * createdAt; persisted (durable) generations always precede surviving live
- * ones so an in-flight run shows after the settled history.
+ * Recover a live generation's per-job variant index from its id. ResultsStore
+ * mints live ids as `index === 0 ? jobId : `${jobId}#${index}`` — so id === jobId
+ * is slot 0, a `${jobId}#k` suffix is slot k, and any index-less placeholder
+ * (a running/error settle merged onto the newest slot) is treated as slot 0.
+ */
+const liveIndexOf = (gen: Generation): number => {
+  if (typeof gen.index === "number") return gen.index;
+  if (gen.jobId == null) return 0;
+  if (gen.id === gen.jobId) return 0;
+  const prefix = `${gen.jobId}#`;
+  if (gen.id.startsWith(prefix)) {
+    const n = Number(gen.id.slice(prefix.length));
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+};
+
+const KEY_SEP = "\u0000";
+const slotKey = (jobId: string, index: number) => `${jobId}${KEY_SEP}${index}`;
+
+/**
+ * One time-ordered list reconciled by (jobId, index): all persisted generations
+ * followed by the live generations that have NOT been superseded by a persisted
+ * asset at the same (jobId, index). A live variant survives until a persisted
+ * asset lands at its exact slot — so a multi-execution run shows all N live
+ * variants mid-run, and the live→persisted handoff is seamless (the persisted
+ * twin replaces the live one at the same slot, no flash, no premature collapse).
+ * Persisted index is recovered here from (createdAt, id) order within each job
+ * (no DB column); the id tie-break keeps same-ms assets stably ordered across
+ * renders. Persisted (durable) gens precede surviving live ones; both oldest→newest.
  */
 export const mergeGenerations = (
   persisted: Generation[],
   live: Generation[]
 ): Generation[] => {
-  const persistedJobs = new Set(
-    persisted.map((g) => g.jobId).filter(Boolean)
-  );
-  const survivingLive = live.filter(
-    (g) => !(g.jobId && persistedJobs.has(g.jobId))
-  );
-  const byCreatedAt = (a: Generation, b: Generation) =>
-    a.createdAt - b.createdAt;
+  const byCreatedAtThenId = (a: Generation, b: Generation) =>
+    a.createdAt - b.createdAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+  // Assign per-job persisted slots from (createdAt, id) order. Null-jobId
+  // assets are __solo__ singletons — never indexed, never reconciled.
+  const byJob = new Map<string, Generation[]>();
+  for (const g of persisted) {
+    if (g.jobId == null) continue;
+    const arr = byJob.get(g.jobId);
+    if (arr) arr.push(g);
+    else byJob.set(g.jobId, [g]);
+  }
+  const persistedSlots = new Set<string>(); // `${jobId}\u0000${index}`
+  for (const [jobId, group] of byJob) {
+    [...group].sort(byCreatedAtThenId).forEach((_g, i) => {
+      persistedSlots.add(slotKey(jobId, i));
+    });
+  }
+
+  // A live variant survives unless a persisted asset occupies its exact slot.
+  const survivingLive = live.filter((g) => {
+    if (g.jobId == null) return true;
+    return !persistedSlots.has(slotKey(g.jobId, liveIndexOf(g)));
+  });
+
   return [
-    ...[...persisted].sort(byCreatedAt),
-    ...[...survivingLive].sort(byCreatedAt)
+    ...[...persisted].sort(byCreatedAtThenId),
+    ...[...survivingLive].sort(byCreatedAtThenId)
   ];
 };
 
@@ -115,3 +164,101 @@ export const getCurrentOutput = (
   const current = getCurrentGeneration(generations, selectedId);
   return current ? outputOf(current, handle) : undefined;
 };
+
+/**
+ * A group of generations that belong to one workflow run. A regular generator
+ * driven by a stream/list is executed once per item; every execution emits a
+ * node_update sharing the run's job_id, so a multi-variant run persists N assets
+ * (and produces N live variants) all keyed by the same jobId. Generations with a
+ * null jobId (legacy/unjobbed assets) are never merged — each gets its own
+ * singleton run so unrelated assets can't collapse together.
+ */
+export interface RunGroup {
+  /** The run's job_id, or `__solo__:<generationId>` for a null-jobId singleton. */
+  jobId: string;
+  /** Earliest variant createdAt — the run's position on the timeline. */
+  createdAt: number;
+  /** Variants oldest→newest. */
+  variants: Generation[];
+  /** "running" if any variant is still running, "error" if any errored and none running, else "completed". */
+  status: "running" | "completed" | "error";
+  /** The latest variant — the run's cover/representative generation. */
+  cover: Generation;
+}
+
+/**
+ * Group a flat oldest→newest generation list into runs by jobId. Null-jobId
+ * generations become singleton runs (key `__solo__:<id>`). Runs are returned
+ * oldest→newest by createdAt (the run's earliest variant); variants within a
+ * run preserve the input order (already oldest→newest from mergeGenerations).
+ */
+export const groupByRun = (generations: Generation[]): RunGroup[] => {
+  const order: string[] = [];
+  const byKey = new Map<string, Generation[]>();
+  for (const gen of generations) {
+    const key = gen.jobId ? gen.jobId : `__solo__:${gen.id}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.push(gen);
+    } else {
+      byKey.set(key, [gen]);
+      order.push(key);
+    }
+  }
+  const runs: RunGroup[] = order.map((key) => {
+    const variants = byKey.get(key)!;
+    const createdAt = Math.min(...variants.map((v) => v.createdAt));
+    const hasRunning = variants.some((v) => v.status === "running");
+    const hasError = variants.some((v) => v.status === "error");
+    const status: RunGroup["status"] = hasRunning
+      ? "running"
+      : hasError
+        ? "error"
+        : "completed";
+    return {
+      jobId: key,
+      createdAt,
+      variants,
+      status,
+      cover: variants[variants.length - 1]
+    };
+  });
+  return runs.sort((a, b) => a.createdAt - b.createdAt);
+};
+
+/**
+ * The run containing the selected generation (matched by variant id); otherwise
+ * the latest run. Returns undefined for an empty list. Mirrors
+ * getCurrentGeneration's "selected ?? latest" semantics at the run level so a
+ * stale selected_generation falls back to the newest run's cover.
+ */
+export const getCurrentRun = (
+  runs: RunGroup[],
+  selectedId?: string
+): RunGroup | undefined => {
+  if (runs.length === 0) return undefined;
+  if (selectedId) {
+    const found = runs.find((r) => r.variants.some((v) => v.id === selectedId));
+    if (found) return found;
+  }
+  return runs[runs.length - 1];
+};
+
+/**
+ * Flatten a run to its display values: one value per variant via outputOf,
+ * with a single array-valued variant (the live num_images=N shape, one
+ * completed update whose outputs resolve to an array) spread so it counts as N
+ * values. Mirrors resolvePreviewValue's flatten in ContentCardBody so the
+ * streaming case (N variants, scalar each) and the single-array case render
+ * identically as N tiles. `null`/`undefined` values are dropped.
+ */
+export const runVariantValues = (
+  run: RunGroup,
+  handle?: string
+): unknown[] =>
+  run.variants
+    .flatMap((v) => {
+      const value = outputOf(v, handle);
+      return Array.isArray(value) ? value : [value];
+    })
+    .filter((value) => value !== undefined && value !== null);

--- a/web/src/utils/nodeGenerations.ts
+++ b/web/src/utils/nodeGenerations.ts
@@ -36,10 +36,12 @@ export interface Generation {
   error?: string;
   assetId?: string;
   /**
-   * Per-(jobId) variant position, recovered at read time (no DB column).
-   * Persisted gens: assigned in mergeGenerations from (createdAt, id) order
-   * within the job. Live gens: parsed from the `${jobId}#k` id scheme. Used
-   * only for live↔persisted reconciliation; never persisted to ResultsStore.
+   * Per-(jobId) variant position, recovered at read time (no DB column); never
+   * a stored field on persisted gens. Persisted gens: derived from (createdAt,
+   * id) order within the job — `mergeGenerations` computes that order for its
+   * survival check but does not write `index` back onto the objects. Live gens:
+   * parsed from the `${jobId}#k` id scheme (`liveIndexOf`). Used only for
+   * live↔persisted reconciliation; never persisted to ResultsStore.
    */
   index?: number;
 }


### PR DESCRIPTION
## Why

A node run multiple times in one job (e.g. `ListGenerator.item → TextToImage.prompt`, run N times) collapsed to a single `node_update{completed}` carrying only the **last** result. So the generation timeline and autosave saw **1** artifact instead of **N** — the other variants existed only as the overloaded, edge-suppressible `output_update`. Concretely: a "Concept Art" run that produced 6 images showed only the last one on the node's content card.

## What

Introduces a dedicated **`generation_complete`** event — one per committed artifact — and rewires the generation timeline, autosave, and content-card UI around it. Three orthogonal channels: `node_update` (lifecycle), `generation_complete` (artifacts), `output_update` (display, now with a `disposition`).

- **protocol** — `GenerationComplete` added to the message union; `OutputUpdate.disposition?`/`done?`.
- **kernel** — the actor emits a *bare* `generation_complete` at each committed `process()` result (never edge-suppressed; skips constant/input). Verified TS-only: Python nodes funnel through the same actor, **no `nodetool-core` change**.
- **websocket relay** — stamps an arrival-order `index`, normalizes `outputs`, and **autosaves per `generation_complete`** (the `node_update` autosave is deleted), with a `(job, node, index)` replay-dedupe via `metadata.generation_index`. Server-only.
- **browser relay** (worker + local) — stamps index + normalizes on both paths; no persistence.
- **web** — `liveGenerations` is fed by `generation_complete` (index-keyed) with a version-skew-safe `node_update` fallback; `mergeGenerations` reconciles live vs persisted by `(jobId, index)`; the old Tier-2 / `isSilentJob` hacks are retired.
- **content card** (`ContentCardBody` / `NodeHistoryViewer`) — a runs / variants / single navigator; the variants grid fills in **live** during a run; focus **auto-advances** to the newest run.

## Testing

- `build:packages` green; web `typecheck` + `lint` (oxlint) green.
- Kernel emission, websocket relay, **autosave cutover** (real runner + DB: 6 events → 6 distinct assets, replay no-op), reducer, merge reconciliation (real end-to-end: 6 events → 6 persisted → **6 variants**, plus a regression-lock that the old path collapses to 1), and the viewer auto-focus all covered.

## Rollout / follow-ups

Design + decisions in [`docs/rfc-generation-events.md`](docs/rfc-generation-events.md). This PR is rollout **steps 1–4** (functional end-to-end). Remaining, non-blocking: **3b** (migrate mini-apps / timeline-sketch / chat / mobile consumers), **5** (`output_update` → disposition-aware display + ephemeral clear), **6** (cleanup).

## Notes

- Scoped to the feature: a separate cleanup branch will carry the example deletions + `sync_mode` removal. Pre-existing unrelated WIP (RailAppMenu, DashboardTemplates, etc.) is intentionally excluded.
- Known pre-existing items (not introduced here): a `PermissionMode` empty-interface eslint-flat warning in `ApiTypes.ts`, and an inter-file DB-teardown flake in the websocket suite (passes in isolation / on re-run).
