### PR TITLE
docs: fact-check and correct stale version/count claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ This document describes the architecture of NodeTool — a visual AI workflow pl
 
 ```
 nodetool/
-├── packages/               # TypeScript backend monorepo (26 packages)
+├── packages/               # TypeScript backend monorepo (55 packages)
 │   ├── protocol/           #   Shared types & message definitions (Zod)
 │   ├── config/             #   Environment & settings management
 │   ├── security/           #   Encryption, secrets, master key
@@ -112,7 +112,10 @@ nodetool/
 │   ├── fal-nodes/          #   FAL AI integration nodes
 │   ├── fal-codegen/        #   Code generator for FAL nodes
 │   ├── elevenlabs-nodes/   #   ElevenLabs voice synthesis nodes
-│   └── minimax-nodes/      #   MiniMax TTS, music, image, and video nodes
+│   ├── minimax-nodes/      #   MiniMax TTS, music, image, and video nodes
+│   └── ...                 #   Additional provider packs (kie, topaz, reve,
+│                           #   atlascloud, together), sandbox, compute, gpu,
+│                           #   timeline, sdk, workflow-runner, and node packs
 ├── web/                    # React web application (Vite + MUI)
 ├── electron/               # Electron desktop shell
 ├── mobile/                 # React Native mobile app (Expo)
@@ -142,7 +145,7 @@ nodetool/
 
 ## Backend Architecture
 
-The backend is a TypeScript monorepo of 26 npm workspace packages. Each package has a focused responsibility and explicit dependencies.
+The backend is a TypeScript monorepo of 55 npm workspace packages. Each package has a focused responsibility and explicit dependencies.
 
 ### Package Dependency Graph
 
@@ -438,11 +441,11 @@ The executor type used also controls which `NodeActor` execution mode fires (buf
 
 | Layer | Technology | Version |
 |---|---|---|
-| UI Framework | React | 18.2 |
-| Language | TypeScript | 5.7 |
-| Bundler | Vite | 6.4 |
+| UI Framework | React | 19.2 |
+| Language | TypeScript | 5.9 |
+| Bundler | Vite | 8.0 |
 | Component Library | Material-UI (MUI) | v7 |
-| State Management | Zustand | 4.5 |
+| State Management | Zustand | 5.0 |
 | Server State | TanStack Query (React Query) | v5 |
 | Graph Editor | @xyflow/react (React Flow) | v12 |
 | Routing | React Router | v7 |
@@ -452,7 +455,7 @@ The executor type used also controls which `NodeActor` execution mode fires (buf
 | 3D Visualization | React Three Fiber + Three.js | — |
 | Panel Layout | Dockview | — |
 | Testing | Jest + React Testing Library | 29.7 |
-| E2E Testing | Playwright | 1.57 |
+| E2E Testing | Playwright | 1.60 |
 
 ### Application Shell & Routing
 
@@ -500,7 +503,7 @@ All routes except `/login` and dev routes are wrapped in `ProtectedRoute`.
 
 The frontend uses a multi-layer state management approach:
 
-**Zustand stores (55+)** manage client-side state. Major stores:
+**Zustand stores (90+)** manage client-side state. Major stores:
 
 | Store | Responsibility |
 |---|---|
@@ -617,7 +620,7 @@ Heavy components (PanelLeft, PanelRight, PanelBottom, Dashboard, Chat, Editor) a
 
 The Electron shell (`electron/`) wraps the web UI for desktop use:
 
-- **Electron** 35.7.5 with **Vite** for the renderer process
+- **Electron** 39 with **Vite** for the renderer process
 - Uses `contextBridge` for secure IPC — `nodeIntegration` is disabled
 - `electron-builder` for packaging (Windows, macOS, Linux including Flatpak)
 - `electron-updater` for auto-updates
@@ -631,7 +634,7 @@ The Electron shell (`electron/`) wraps the web UI for desktop use:
 
 The React Native mobile app (`mobile/`) enables users to browse and run mini-apps:
 
-- **Expo SDK 54** with React Native 0.81
+- **Expo SDK 56** with React Native 0.85
 - **React Navigation** (native-stack) for screen transitions
 - **Zustand** for state management (WorkflowRunner, ChatStore)
 - **Axios** for HTTP, custom `WebSocketManager` with msgpack for real-time chat
@@ -832,4 +835,4 @@ cd web && npm test
 cd web && npm run test:e2e
 ```
 
-CI/CD is managed through 19 GitHub Actions workflows covering unit tests, E2E tests, code quality, security auditing, accessibility, performance monitoring, and release automation.
+CI/CD is managed through 26 GitHub Actions workflows covering unit tests, E2E tests, code quality, security auditing, accessibility, performance monitoring, and release automation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ npm run build:packages  # Build backend packages
 ## Architecture
 
 ```
-packages/           # 24 npm workspace packages (TypeScript backend)
+packages/           # 55 npm workspace packages (TypeScript backend)
   protocol/         # Shared message types — base dependency for everything
   config/           # Configuration loading, logging
   security/         # Secret storage, encryption
@@ -76,7 +76,7 @@ packages/           # 24 npm workspace packages (TypeScript backend)
   vectorstore/      # SQLite-vec for RAG
   ...
 
-web/                # React 18 + Vite + MUI + Zustand + ReactFlow
+web/                # React 19 + Vite + MUI + Zustand + ReactFlow
 electron/           # Electron 39 desktop app
 mobile/             # React Native / Expo
 ```

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ NodeTool is a monorepo with a TypeScript backend, React frontend, Electron deskt
 
 ```
 nodetool/
-├── packages/          # Backend monorepo (28 packages)
+├── packages/          # Backend monorepo (55 packages)
 │   ├── kernel/        #   Workflow graph & runner
 │   ├── node-sdk/      #   BaseNode class & node registry
 │   ├── base-nodes/    #   100+ built-in node types

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -70,7 +70,7 @@ All packages use `"type": "module"`. The required runtime is **Node.js 22.22.1**
 
 ## 3. React
 
-The web app runs **React 18.2**; Electron renderer runs **React 19.1**. Mobile uses React Native + Expo. Treat React 19 features (use, transitions, async actions, Server Components — Electron only) as opt-in for the Electron tree; the web tree must remain compatible with 18.
+Both the web app and the Electron renderer run **React 19.2**. Mobile uses React Native + Expo. React 19 features (`use`, transitions, async actions) are available across the web and Electron trees.
 
 ### Rules
 
@@ -102,15 +102,15 @@ The web app runs **React 18.2**; Electron renderer runs **React 19.1**. Mobile u
 | `useLayoutEffect` | Measuring DOM before paint | Anything else |
 | `useMemo` | Expensive computation (>1ms) or referential stability for deps | Cheap pure functions |
 | `useCallback` | Dep of effect/memo, or prop to `React.memo` child | Function used only locally |
-| `useTransition` (R18) | Marking state updates as non-urgent | Urgent updates |
-| `useDeferredValue` (R18) | Defer expensive child renders | Anything else |
-| `use` (R19, Electron) | Reading a Promise/Context conditionally | Code that runs in web (R18) |
+| `useTransition` | Marking state updates as non-urgent | Urgent updates |
+| `useDeferredValue` | Defer expensive child renders | Anything else |
+| `use` (R19) | Reading a Promise/Context conditionally | Outside render or in a loop/condition that changes hook order |
 
 ---
 
 ## 4. Zustand
 
-Stores live in `web/src/stores/` (Zustand 4.5.7) and `electron/src/stores/` (Zustand 5.0.3). Both versions support the slice pattern and `subscribeWithSelector`.
+Stores live in `web/src/stores/` and `electron/src/stores/` (both on Zustand 5.0). The slice pattern and `subscribeWithSelector` are used throughout.
 
 ### Rules
 
@@ -134,7 +134,7 @@ Stores live in `web/src/stores/` (Zustand 4.5.7) and `electron/src/stores/` (Zus
 
 ## 5. MUI v7 + Emotion + UI Primitives
 
-The frontend uses **MUI v7.2.0** with Emotion. We enforce a **primitives-first** policy: all UI in `web/src/` (and Electron renderer) must use the primitives from `web/src/components/ui_primitives/`. Raw MUI imports are only allowed inside `ui_primitives/` and `editor_ui/`.
+The frontend uses **MUI v7.3** with Emotion. We enforce a **primitives-first** policy: all UI in `web/src/` (and Electron renderer) must use the primitives from `web/src/components/ui_primitives/`. Raw MUI imports are only allowed inside `ui_primitives/` and `editor_ui/`.
 
 See **[UI Primitives Strategy](../web/src/components/ui_primitives/STRATEGY.md)** for the full decision tree and **[Design System](DESIGN.md)** for the complete token reference (spacing, typography, border radius, motion, z-index).
 


### PR DESCRIPTION
Reconciled documentation against the actual codebase:

- Package count: ARCHITECTURE.md (26), README.md (28), and CLAUDE.md (24)
  all disagreed with each other and with reality (55 workspace packages).
  Unified to 55 and added an ellipsis to the ARCHITECTURE.md package tree
  so the visible list no longer contradicts the count.
- Frontend stack (ARCHITECTURE.md, DEVELOPMENT_STANDARDS.md): React 18.2→19.2,
  TypeScript 5.7→5.9, Vite 6.4→8.0, Zustand 4.5→5.0, Playwright 1.57→1.60,
  MUI v7.2.0→v7.3. Both web and Electron now run React 19 / Zustand 5, so the
  "web must stay React 18" guidance and (R18) hook tags were removed.
- Electron 35.7.5→39, Expo SDK 54→56, React Native 0.81→0.85.
- Zustand store count 55+→90+; GitHub Actions workflows 19→26.
- CLAUDE.md web stack: React 18→19.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EHEHvYy474binnKcEctQ7W