### PR TITLE
Improve ListGenerator item view UX

### DIFF
--- a/web/src/components/node_types/editing/ListGeneratorBody.tsx
+++ b/web/src/components/node_types/editing/ListGeneratorBody.tsx
@@ -8,6 +8,11 @@
  * `alwaysEmitOutputUpdates` so its `item` stream reaches the client even when
  * the handle is wired onward.
  *
+ * Each row collapses to a one-line preview; expanding it renders the item via
+ * `MarkdownRenderer`, which brings markdown formatting, a copy button, an
+ * internal scrollbar, and a fullscreen overlay viewer. The row header also
+ * exposes a copy button on hover so an item can be copied without expanding.
+ *
  * Value resolution mirrors OutputNode: prefer the live output-stream buffer
  * (scoped to the focused job), falling back to the node's settled generation.
  * The buffer interleaves the `item` (string) and `index` (int) handles, so we
@@ -25,7 +30,8 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { FlexColumn, FlexRow, LoadingSpinner, BORDER_RADIUS, MOTION, FONT_WEIGHT } from "../../ui_primitives";
+import { CopyButton, FlexColumn, FlexRow, LoadingSpinner, BORDER_RADIUS, MOTION, FONT_WEIGHT } from "../../ui_primitives";
+import MarkdownRenderer from "../../../utils/MarkdownRenderer";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import HandleColumn from "../../node/HandleColumn";
 import NodeProgress from "../../node/NodeProgress";
@@ -62,6 +68,18 @@ const toItems = (value: unknown): string[] => {
   }
   const single = pullString(value);
   return single !== undefined ? [single] : [];
+};
+
+/** First non-empty line, stripped of markdown markers, for the collapsed row. */
+const previewOf = (item: string): string => {
+  const firstLine = item.split("\n").find((l) => l.trim().length > 0) ?? "";
+  return firstLine
+    .replace(/^\s{0,3}#{1,6}\s+/, "") // headings
+    .replace(/^\s{0,3}[-*+]\s+/, "") // bullet list
+    .replace(/^\s{0,3}\d+\.\s+/, "") // ordered list
+    .replace(/^\s{0,3}>\s+/, "") // blockquote
+    .replace(/[*_`~]/g, "") // inline emphasis / code
+    .trim();
 };
 
 const styles = (theme: Theme) =>
@@ -132,6 +150,16 @@ const styles = (theme: Theme) =>
       fontSize: theme.fontSizeSmall,
       color: theme.vars.palette.text.primary
     },
+    ".list-actions": {
+      flexShrink: 0,
+      display: "flex",
+      alignItems: "center",
+      opacity: 0,
+      transition: MOTION.opacity
+    },
+    ".list-head:hover .list-actions, .list-head:focus-within .list-actions": {
+      opacity: 1
+    },
     ".list-chevron": {
       flexShrink: 0,
       fontSize: 16,
@@ -142,9 +170,7 @@ const styles = (theme: Theme) =>
       transform: "rotate(90deg)"
     },
     ".list-full": {
-      padding: "0 8px 8px 32px",
-      whiteSpace: "pre-wrap",
-      wordBreak: "break-word",
+      padding: "0 4px 4px 4px",
       fontSize: theme.fontSizeSmall,
       color: theme.vars.palette.text.primary
     },
@@ -252,12 +278,28 @@ const ListGeneratorBodyInner: React.FC<BespokeBodyProps> = ({
                   }}
                 >
                   <span className="list-index">{i + 1}</span>
-                  <span className="list-preview">{item}</span>
+                  <span className="list-preview">{previewOf(item)}</span>
+                  <span
+                    className="list-actions"
+                    role="presentation"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <CopyButton
+                      value={item}
+                      tooltip="Copy item"
+                      buttonSize="small"
+                    />
+                  </span>
                   <ChevronRightRoundedIcon
                     className={`list-chevron${isOpen ? " expanded" : ""}`}
                   />
                 </div>
-                {isOpen && <div className="list-full">{item}</div>}
+                {isOpen && (
+                  <div className="list-full">
+                    <MarkdownRenderer content={item} />
+                  </div>
+                )}
               </div>
             );
           })}

--- a/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import "@testing-library/jest-dom";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import type { NodeMetadata } from "../../../../stores/ApiTypes";
+import type { NodeData } from "../../../../stores/NodeData";
+import ListGeneratorBody from "../ListGeneratorBody";
+
+const workflowId = "wf-1";
+const nodeId = "node-1";
+
+// The body reads the live stream buffer for the focused job. Drive `items`
+// straight through the buffer so we don't need a running graph.
+let mockStreamBuffer: unknown;
+
+jest.mock("../../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: (selector: (s: { focusedJob: Record<string, string> }) => unknown) =>
+    selector({ focusedJob: { "wf-1": "job-1" } })
+}));
+
+jest.mock("../../../../stores/ResultsStore", () => ({
+  __esModule: true,
+  default: (
+    selector: (s: { getOutputResult: () => unknown }) => unknown
+  ) => selector({ getOutputResult: () => mockStreamBuffer })
+}));
+
+jest.mock("../../../../hooks/nodes/useNodeGenerations", () => ({
+  __esModule: true,
+  useNodeGenerations: () => ({ current: null })
+}));
+
+// MarkdownRenderer owns markdown rendering, the copy button, the internal
+// scrollbar and the fullscreen overlay viewer; here we probe that the expanded
+// row hands it the item's full (unstripped) content.
+jest.mock("../../../../utils/MarkdownRenderer", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  )
+}));
+
+const nodeMetadata = {
+  node_type: "nodetool.generators.ListGenerator",
+  title: "List Generator",
+  namespace: "nodetool.generators",
+  description: "",
+  layout: "default",
+  properties: [],
+  outputs: [{ name: "output", type: { type: "str" } }],
+  supports_dynamic_inputs: false
+} as unknown as NodeMetadata;
+
+const nodeData = {
+  workflow_id: workflowId,
+  properties: {},
+  dynamic_properties: {}
+} as unknown as NodeData;
+
+const renderBody = (status?: string) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ListGeneratorBody
+        id={nodeId}
+        nodeType="nodetool.generators.ListGenerator"
+        nodeMetadata={nodeMetadata}
+        data={nodeData}
+        workflowId={workflowId}
+        status={status}
+        isOutputNode={true}
+      />
+    </ThemeProvider>
+  );
+
+describe("ListGeneratorBody", () => {
+  beforeEach(() => {
+    mockStreamBuffer = undefined;
+  });
+
+  it("renders one row per item with a markdown-stripped preview and count", () => {
+    mockStreamBuffer = ["# First heading", "**bold** second"];
+
+    renderBody();
+
+    expect(screen.getByText("2 items")).toBeInTheDocument();
+    // Markers stripped from the collapsed one-line preview.
+    expect(screen.getByText("First heading")).toBeInTheDocument();
+    expect(screen.getByText("bold second")).toBeInTheDocument();
+  });
+
+  it("exposes a copy button on every row", () => {
+    mockStreamBuffer = ["alpha", "beta"];
+
+    renderBody();
+
+    expect(
+      screen.getAllByRole("button", { name: "Copy item" })
+    ).toHaveLength(2);
+  });
+
+  it("expands a row to render the item through MarkdownRenderer", async () => {
+    const user = userEvent.setup();
+    mockStreamBuffer = ["# First heading", "second"];
+
+    renderBody();
+
+    expect(screen.queryByTestId("markdown")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("First heading"));
+
+    const markdown = screen.getByTestId("markdown");
+    // Renders the full, unstripped item so markdown formatting is preserved.
+    expect(markdown).toHaveTextContent("# First heading");
+  });
+
+  it("shows an idle empty state when there are no items", () => {
+    mockStreamBuffer = [];
+
+    renderBody();
+
+    expect(screen.getByText("Run to generate a list")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Each generated item now renders through MarkdownRenderer when expanded,
which brings markdown formatting, a copy button, an internal scrollbar,
and a fullscreen overlay viewer. The collapsed row preview is stripped of
markdown markers for a cleaner one-line summary, and a per-row copy button
appears on hover so an item can be copied without expanding.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5edKwsMSTYA21gPzdn241