### PR TITLE
Add model default pin UI to model selection dialogs

### DIFF
--- a/web/src/components/model_menu/ASRModelMenuDialog.tsx
+++ b/web/src/components/model_menu/ASRModelMenuDialog.tsx
@@ -34,6 +34,7 @@ function ASRModelMenuDialog({
       title="Select ASR Model"
       searchPlaceholder="Search speech-to-text models..."
       storeHook={useASRModelMenuStore}
+      modelType="asr_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/DefaultModelPin.tsx
+++ b/web/src/components/model_menu/DefaultModelPin.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useCallback, memo } from "react";
+import PushPinIcon from "@mui/icons-material/PushPin";
+import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
+import { StateIconButton, MOTION } from "../ui_primitives";
+import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
+
+export interface DefaultModelPinProps {
+  /**
+   * Modality key the default is stored under, e.g. "language_model".
+   * When omitted (pickers without a default modality, like raw HF browsing),
+   * the pin renders nothing.
+   */
+  modelType?: string;
+  provider?: string;
+  id?: string;
+  name?: string;
+  size?: "small" | "medium";
+}
+
+// Hidden until the row is hovered (see ModelList's `.default-pin` hover rule),
+// except when this model is the active default — then it stays visible.
+const wrapperStyles = css({
+  display: "inline-flex",
+  alignItems: "center",
+  transition: MOTION.all,
+  opacity: 0
+});
+
+const DefaultModelPin: React.FC<DefaultModelPinProps> = memo(
+  function DefaultModelPin({
+    modelType,
+    provider = "",
+    id = "",
+    name = "",
+    size = "small"
+  }) {
+    const current = useModelPreferencesStore((s) =>
+      modelType ? s.defaults[modelType] : undefined
+    );
+    const setDefault = useModelPreferencesStore((s) => s.setDefault);
+    const clearDefault = useModelPreferencesStore((s) => s.clearDefault);
+
+    const isDefault =
+      !!current && current.provider === provider && current.id === id;
+
+    const handleToggle = useCallback(() => {
+      if (!modelType) {
+        return;
+      }
+      if (isDefault) {
+        clearDefault(modelType);
+      } else {
+        setDefault(modelType, { provider, id, name });
+      }
+    }, [modelType, isDefault, clearDefault, setDefault, provider, id, name]);
+
+    if (!modelType) {
+      return null;
+    }
+
+    return (
+      <span
+        className="default-pin"
+        css={wrapperStyles}
+        style={{ opacity: isDefault ? 1 : undefined }}
+      >
+        <StateIconButton
+          icon={<PushPinOutlinedIcon fontSize="small" />}
+          activeIcon={<PushPinIcon fontSize="small" />}
+          isActive={isDefault}
+          onClick={handleToggle}
+          color="primary"
+          size={size}
+          tooltip={
+            isDefault
+              ? "Default for new nodes of this type — click to clear"
+              : "Set as default for new nodes of this type"
+          }
+          tooltipPlacement="top"
+          ariaLabel={
+            isDefault ? "Clear default model" : "Set as default model"
+          }
+        />
+      </span>
+    );
+  }
+);
+
+DefaultModelPin.displayName = "DefaultModelPin";
+
+export default DefaultModelPin;

--- a/web/src/components/model_menu/EmbeddingModelMenuDialog.tsx
+++ b/web/src/components/model_menu/EmbeddingModelMenuDialog.tsx
@@ -34,6 +34,7 @@ function EmbeddingModelMenuDialog({
       title="Select Embedding Model"
       searchPlaceholder="Search embedding models..."
       storeHook={useEmbeddingModelMenuStore}
+      modelType="embedding_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/ImageModelMenuDialog.tsx
+++ b/web/src/components/model_menu/ImageModelMenuDialog.tsx
@@ -37,6 +37,7 @@ function ImageModelMenuDialog({
       title="Select Image Model"
       searchPlaceholder="Search image models..."
       storeHook={useImageModelMenuStore}
+      modelType="image_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/LanguageModelMenuDialog.tsx
+++ b/web/src/components/model_menu/LanguageModelMenuDialog.tsx
@@ -44,6 +44,7 @@ function LanguageModelMenuDialog({
       title="Select Language Model"
       searchPlaceholder="Search language models..."
       storeHook={useLanguageModelMenuStore}
+      modelType="language_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -11,6 +11,7 @@ import {
 import { FlexRow, Tooltip, EmptyState, Box, Text, BORDER_RADIUS } from "../ui_primitives";
 import DownloadIcon from "@mui/icons-material/Download";
 import FavoriteStar from "./FavoriteStar";
+import DefaultModelPin from "./DefaultModelPin";
 import RecommendedDownloadRow from "./shared/RecommendedDownloadRow";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import {
@@ -42,7 +43,7 @@ type ListRow<TModel> =
   | { kind: "download"; model: DownloadableModel };
 
 const LIST_ITEM_BUTTON_SX = { width: "100%", textAlign: "left" } as const;
-const LIST_ITEM_ICON_SX = { minWidth: 30 } as const;
+const LIST_ITEM_ICON_SX = { minWidth: 64, gap: 0.25 } as const;
 const FLEX_ROW_SX = { overflow: "hidden", minWidth: 0 } as const;
 const MODEL_NAME_STYLE: React.CSSProperties = {
   overflow: "hidden",
@@ -81,6 +82,9 @@ const listStyles = (theme: Theme) =>
       color: theme.vars.palette.text.disabled
     },
     "& .MuiListItemButton-root:hover .favorite-star": {
+      opacity: 1
+    },
+    "& .MuiListItemButton-root:hover .default-pin": {
       opacity: 1
     },
     "& .model-menu__model-item.is-active": {
@@ -147,6 +151,12 @@ export interface ModelListProps<TModel extends ModelSelectorModel> {
   onDownloadSelect?: (m: UnifiedModel) => void;
   /** Start downloading a recommended model. */
   onDownloadStart?: (m: UnifiedModel) => void;
+  /**
+   * Modality key (e.g. "language_model") this picker sets defaults for. When
+   * provided, each row shows a "pin as default" toggle next to the favorite
+   * star. Omitted for pickers with no per-modality default (e.g. raw HF).
+   */
+  modelType?: string;
 }
 
 function ModelList<TModel extends ModelSelectorModel>({
@@ -157,7 +167,8 @@ function ModelList<TModel extends ModelSelectorModel>({
   activeIndex = -1,
   downloadModels = [],
   onDownloadSelect,
-  onDownloadStart
+  onDownloadStart,
+  modelType
 }: ModelListProps<TModel>) {
   const isFavorite = useModelPreferencesStore((s) => s.isFavorite);
   const getAvailability = useModelAvailability();
@@ -290,6 +301,13 @@ function ModelList<TModel extends ModelSelectorModel>({
             >
               <ListItemIcon sx={LIST_ITEM_ICON_SX}>
                 <FavoriteStar provider={m.provider} id={m.id} size="small" />
+                <DefaultModelPin
+                  modelType={modelType}
+                  provider={m.provider}
+                  id={m.id}
+                  name={m.name}
+                  size="small"
+                />
               </ListItemIcon>
               <ListItemText
                 primary={
@@ -382,7 +400,8 @@ function ModelList<TModel extends ModelSelectorModel>({
       badgeWithIconStyle,
       secondaryTextStyle,
       searchTerm,
-      theme.vars.palette.primary.main
+      theme.vars.palette.primary.main,
+      modelType
     ]
   );
 

--- a/web/src/components/model_menu/TTSModelMenuDialog.tsx
+++ b/web/src/components/model_menu/TTSModelMenuDialog.tsx
@@ -34,6 +34,7 @@ function TTSModelMenuDialog({
       title="Select TTS Model"
       searchPlaceholder="Search text-to-speech models..."
       storeHook={useTTSModelMenuStore}
+      modelType="tts_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/VideoModelMenuDialog.tsx
+++ b/web/src/components/model_menu/VideoModelMenuDialog.tsx
@@ -39,6 +39,7 @@ function VideoModelMenuDialog({
       title="Select Video Model"
       searchPlaceholder="Search text-to-video models..."
       storeHook={useVideoModelMenuStore}
+      modelType="video_model"
       recommendedModels={recommendedModels}
       modelPacks={modelPacks}
     />

--- a/web/src/components/model_menu/__tests__/DefaultModelPin.test.tsx
+++ b/web/src/components/model_menu/__tests__/DefaultModelPin.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import DefaultModelPin from "../DefaultModelPin";
+import { useModelPreferencesStore } from "../../../stores/ModelPreferencesStore";
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>);
+
+describe("DefaultModelPin", () => {
+  beforeEach(() => {
+    useModelPreferencesStore.setState({ defaults: {} });
+  });
+
+  it("renders nothing without a modelType", () => {
+    const { container } = renderWithTheme(
+      <DefaultModelPin provider="openai" id="gpt-4o" name="GPT-4o" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("sets the model as default for its modality on click", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <DefaultModelPin
+        modelType="language_model"
+        provider="openai"
+        id="gpt-4o"
+        name="GPT-4o"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /set as default/i }));
+
+    expect(useModelPreferencesStore.getState().defaults["language_model"]).toEqual(
+      { provider: "openai", id: "gpt-4o", name: "GPT-4o" }
+    );
+  });
+
+  it("clears the default when the active default is clicked again", async () => {
+    const user = userEvent.setup();
+    useModelPreferencesStore.setState({
+      defaults: {
+        language_model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" }
+      }
+    });
+
+    renderWithTheme(
+      <DefaultModelPin
+        modelType="language_model"
+        provider="openai"
+        id="gpt-4o"
+        name="GPT-4o"
+      />
+    );
+
+    // When active, the toggle exposes the "clear" affordance.
+    await user.click(screen.getByRole("button", { name: /clear default/i }));
+
+    expect(
+      useModelPreferencesStore.getState().defaults["language_model"]
+    ).toBeUndefined();
+  });
+
+  it("does not treat a same-id model from another provider as the default", () => {
+    useModelPreferencesStore.setState({
+      defaults: {
+        language_model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" }
+      }
+    });
+
+    renderWithTheme(
+      <DefaultModelPin
+        modelType="language_model"
+        provider="ollama"
+        id="gpt-4o"
+        name="GPT-4o"
+      />
+    );
+
+    // Provider differs, so this row offers "set" rather than "clear".
+    expect(
+      screen.getByRole("button", { name: /set as default/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
+++ b/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
@@ -66,6 +66,12 @@ export interface ModelMenuBaseProps<TModel extends ModelSelectorModel> {
   storeHook: ModelMenuStoreHook<TModel>;
   recommendedModels?: UnifiedModel[];
   modelPacks?: ModelPack[];
+  /**
+   * Modality key (e.g. "language_model") this picker sets defaults for. When
+   * provided, each model row shows a "pin as default" toggle wired to
+   * ModelPreferencesStore. Omitted for pickers without a default modality.
+   */
+  modelType?: string;
 }
 
 function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
@@ -78,7 +84,8 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
   searchPlaceholder = "Search models...",
   storeHook,
   recommendedModels = [],
-  modelPacks = []
+  modelPacks = [],
+  modelType
 }: ModelMenuBaseProps<TModel>) {
   const { models, isLoading, isFetching, error: fetchedError, providerErrors, loadingProgress, refetch } = modelData;
 
@@ -725,6 +732,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
               downloadModels={downloadModels}
               onDownloadSelect={handleSelectRecommended}
               onDownloadStart={handleStartDownload}
+              modelType={modelType}
             />
           </Box>
           {/* Footer removed */}


### PR DESCRIPTION
## Summary
Adds a "pin as default" toggle button to model list rows, allowing users to set per-modality default models for new workflow nodes. The pin appears next to the favorite star and is wired to `ModelPreferencesStore`.

## Changes

- **New component `DefaultModelPin`**: A memoized button component that toggles a model as the default for its modality (language_model, asr_model, etc.). Renders nothing when `modelType` is omitted (for pickers without per-modality defaults, like raw HF browsing).
  - Shows an outlined pin icon by default, filled when active
  - Tooltip text changes based on state ("Set as default" vs "Clear default")
  - Hidden on hover except when the model is the active default (via CSS opacity rule)

- **Updated `ModelList`**: 
  - Added `modelType` prop to pass the modality key down to rows
  - Renders `DefaultModelPin` next to `FavoriteStar` in each row's icon area
  - Increased `LIST_ITEM_ICON_SX.minWidth` from 30 to 64 and added gap to accommodate both icons
  - Added hover rule to show `.default-pin` when row is hovered

- **Updated `ModelMenuDialogBase`**: Added `modelType` prop to pass through to `ModelList`

- **Updated all model menu dialogs** (Language, ASR, Embedding, Image, TTS, Video): Each now passes its corresponding `modelType` to the base dialog:
  - `LanguageModelMenuDialog` → `"language_model"`
  - `ASRModelMenuDialog` → `"asr_model"`
  - `EmbeddingModelMenuDialog` → `"embedding_model"`
  - `ImageModelMenuDialog` → `"image_model"`
  - `TTSModelMenuDialog` → `"tts_model"`
  - `VideoModelMenuDialog` → `"video_model"`

- **Tests**: Comprehensive test suite for `DefaultModelPin` covering:
  - Renders nothing without `modelType`
  - Sets model as default on click
  - Clears default when active default is clicked again
  - Correctly distinguishes models by both provider and id

## Implementation Details

- Uses `StateIconButton` from `ui_primitives` for consistent styling and accessibility
- Leverages existing `ModelPreferencesStore` hooks (`setDefault`, `clearDefault`)
- Pin visibility controlled via CSS opacity transitions (MOTION.all) for smooth UX
- Memoized to prevent unnecessary re-renders when sibling components update

https://claude.ai/code/session_017yAEG6tNiVDzX8JQo5ed49