### PR TITLE
Improve highlight animation for unset model fields

### DIFF
--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -24,6 +24,8 @@ jest.mock("@mui/material", () => ({
 // Mock ui_primitives used by ErrorBoundary
 jest.mock("../components/ui_primitives", () => ({
   MOTION: jest.requireActual("../components/ui_primitives/tokens").MOTION,
+  BORDER_RADIUS: jest.requireActual("../components/ui_primitives/tokens")
+    .BORDER_RADIUS,
   CopyButton: ({ value }: { value: string }) => (
     <button data-testid="copy-button">Copy: {String(value).substring(0, 20)}</button>
   ),

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -21,18 +21,14 @@ import useModelCalloutStore from "../../stores/ModelCalloutStore";
 import { isModelEmpty } from "../../utils/findMissingModelNodes";
 import ModelSetupCallout from "./ModelSetupCallout";
 
-const highlightPulse = keyframes({
-  "0%": {
-    boxShadow:
-      "0 0 0 0 rgba(var(--palette-primary-mainChannel) / 0.9), 0 0 18px 4px rgba(var(--palette-primary-mainChannel) / 0.8)"
+const highlightBlink = keyframes({
+  "0%, 100%": {
+    outlineColor: "var(--palette-primary-light)",
+    boxShadow: "0 0 18px 4px rgba(var(--palette-primary-mainChannel) / 0.85)"
   },
-  "70%": {
-    boxShadow:
-      "0 0 0 10px rgba(var(--palette-primary-mainChannel) / 0), 0 0 26px 8px rgba(var(--palette-primary-mainChannel) / 0.35)"
-  },
-  "100%": {
-    boxShadow:
-      "0 0 0 0 rgba(var(--palette-primary-mainChannel) / 0), 0 0 18px 4px rgba(var(--palette-primary-mainChannel) / 0.7)"
+  "50%": {
+    outlineColor: "rgba(var(--palette-primary-mainChannel) / 0)",
+    boxShadow: "0 0 18px 4px rgba(var(--palette-primary-mainChannel) / 0)"
   }
 });
 
@@ -40,8 +36,9 @@ const highlightStyle = css({
   borderRadius: "var(--rounded-buttonSmall)",
   outline: "2px solid var(--palette-primary-light)",
   outlineOffset: 2,
-  boxShadow: "0 0 18px 4px rgba(var(--palette-primary-mainChannel) / 0.7)",
-  animation: `${highlightPulse} 0.9s ease-out 3`
+  // Blink the outline + glow fully on and off to draw the eye to an unset
+  // model. Runs until the highlight store clears it (HIGHLIGHT_DURATION_MS).
+  animation: `${highlightBlink} 0.55s ease-in-out infinite`
 });
 
 export type PropertyFieldProps = {

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -43,6 +43,7 @@ jest.mock("../../node/NodeProgress", () => ({
 }));
 
 jest.mock("../../ui_primitives", () => ({
+  BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS,
   CheckerDropzone: ({ message }: { message: string }) => (
     <div data-testid="checker-dropzone">{message}</div>
   ),

--- a/web/src/components/search/__tests__/SearchInput.test.tsx
+++ b/web/src/components/search/__tests__/SearchInput.test.tsx
@@ -7,6 +7,7 @@ import mockTheme from "../../../__mocks__/themeMock";
 // Tooltip pulls in heavy theme overrides we don't need for these unit tests.
 jest.mock("../../ui_primitives", () => ({
   MOTION: jest.requireActual("../../ui_primitives/tokens").MOTION,
+  BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS,
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }));
 


### PR DESCRIPTION
## Summary
Refactored the highlight animation for unset model fields to use a simpler, more eye-catching blink effect instead of a pulsing glow.

## Changes
- Renamed `highlightPulse` keyframes to `highlightBlink` for clarity
- Simplified the animation from a 3-keyframe pulse (0% → 70% → 100%) to a 2-keyframe blink (0%/100% ↔ 50%)
- Changed animation behavior:
  - **Before**: 0.9s ease-out, runs 3 times (finite)
  - **After**: 0.55s ease-in-out, runs infinite (until highlight store clears it)
- Updated the visual effect:
  - Outline and glow now fully blink on/off instead of gradually pulsing
  - Reduced complexity while improving visibility to draw attention to unset models
- Added clarifying comment explaining the blink behavior and duration control

## Implementation Details
The new animation uses `outlineColor` transitions alongside `boxShadow` to create a synchronized on/off blink effect. The infinite duration allows the highlight to persist until the `HIGHLIGHT_DURATION_MS` timeout in the highlight store clears it, rather than being limited to 3 iterations.

https://claude.ai/code/session_01LcBXHPUt6z9w9tKKzwiQKe