### PR TITLE
Update skill docs for 2025 model/tool/API changes

### DIFF
--- a/.claude/skills/nodetool-agent-config/SKILL.md
+++ b/.claude/skills/nodetool-agent-config/SKILL.md
@@ -11,7 +11,7 @@ You help users create and configure NodeTool agents — autonomous AI systems th
 Objective → Agent → (Skill resolution → Planning → Execution) → Result
 ```
 
-Three agent classes:
+Three agent classes (from `@nodetool-ai/agents`):
 - **Agent**: Multi-step with planning, tool use, iterative execution
 - **SimpleAgent**: Single-step with structured output schema
 - **AgentExecutor**: Lightweight value extraction
@@ -20,7 +20,10 @@ Three agent classes:
 
 ```yaml
 name: my-agent                    # lowercase, alphanumeric
-description: Agent purpose        # human-readable
+description: Agent purpose         # human-readable
+
+# Objective is optional here — it can be passed via --objective or stdin.
+objective: Research TypeScript ORMs and summarize findings
 
 system_prompt: |
   You are a [role].
@@ -29,153 +32,168 @@ system_prompt: |
   1. Task 1
   2. Task 2
 
-  Workflow:
-  1. Step 1
-  2. Step 2
-
   Constraints:
   - Always cite sources
   - Stay concise
 
 model:
-  provider: openai                # openai | anthropic | google | ollama
-  id: gpt-4o                     # model identifier
-  name: GPT-4o                   # display name (optional)
+  provider: openai                 # openai | anthropic | gemini | ollama | any registry id
+  id: gpt-5.4                      # model identifier
+  name: GPT-5.4                    # display name (optional)
 
 planning_agent:
-  enabled: true
+  enabled: true                    # set false to skip planning (single-pass)
   model:
     provider: openai
-    id: gpt-4o-mini              # use cheaper model for planning
+    id: gpt-5.4-mini               # cheaper model for planning
 
 tools:
   - google_search
   - browser
   - write_file
   - read_file
-  - execute_code
-  - terminal
+  - run_code
   - grep
 
-max_tokens: 8192
-context_window: 8192
-temperature: 0.7                  # 0.0-1.0 (analytical=0.0-0.3, creative=0.8-1.0)
-max_iterations: 10                # 5-20 depending on task complexity
+max_tokens: 8192                   # response/token budget (maxTokenLimit)
+max_steps: 10                      # number of plan steps (5-20 by complexity)
 
 workspace:
   path: ~/.nodetool-workspaces/my-agent
-  auto_create: true
+  auto_create: true                # default true
+
+# Optional: bias find_model toward specific providers/models.
+preferred_providers:
+  - anthropic
+  - openai
+preferred_models:
+  image_generation: gpt-image-2
+  language_model: claude-sonnet-4-6
 ```
 
 # Config Schema Reference
 
-| Field | Type | Required | Default | Notes |
-|-------|------|----------|---------|-------|
-| `name` | string | Yes | — | Lowercase alphanumeric |
-| `description` | string | No | — | Human-readable |
-| `system_prompt` | string | Yes | — | YAML multiline `\|` |
-| `model.provider` | enum | Yes | — | openai, anthropic, google, ollama |
-| `model.id` | string | Yes | — | Model identifier |
-| `model.name` | string | No | — | Display name |
-| `planning_agent.enabled` | bool | Yes | true | Must be true |
-| `planning_agent.model.*` | — | No | same as main | Override for planning |
-| `tools` | string[] | No | [read_file, write_file] | Available tools |
-| `max_tokens` | int | No | 8192 | Response limit |
-| `context_window` | int | No | 8192 | Context size |
-| `temperature` | float | No | 0.7 | 0.0–1.0 |
-| `max_iterations` | int | No | 10 | Execution loops |
-| `workspace.path` | string | No | ~/.nodetool-workspaces/<name> | Sandbox dir |
-| `workspace.auto_create` | bool | No | true | Create if missing |
+These are the fields the `nodetool agent` loader reads (loose schema — unknown keys are ignored):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Agent name |
+| `description` | string | Human-readable |
+| `objective` | string | Default objective (overridden by `--objective`/stdin) |
+| `system_prompt` | string | YAML multiline `\|` |
+| `model.provider` | string | `openai`, `anthropic`, `gemini` (`google` is aliased to `gemini`), `ollama`, or any registry provider id |
+| `model.id` | string | Model identifier |
+| `model.name` | string | Display name (optional) |
+| `planning_agent.enabled` | bool | `false` → use main model for planning, no separate planner |
+| `planning_agent.model.*` | block | Override model used for planning |
+| `tools` | string[] | Tool names (see catalog below); unknown names are warned + skipped |
+| `max_tokens` | int | Token budget → `maxTokenLimit` |
+| `max_steps` | int | Plan steps → `maxSteps` |
+| `workspace.path` | string | Workspace dir (default: cwd) |
+| `workspace.auto_create` | bool | Create dir if missing (default true) |
+| `preferred_providers` | string[] | Default `provider_hint` for `find_model` |
+| `preferred_models` | map | `capability → model id(s)`, injected as `model_hint` |
 
 # CLI Commands
 
+The `nodetool agent` command has three subcommands. From source use `npm run dev:nodetool -- agent ...`; from a build use `nodetool agent ...`.
+
 ```bash
-# Run with prompt
-nodetool agent --config agent.yaml --prompt "Research TypeScript ORMs"
+# Run an agent — objective via flag, stdin, or `objective:` in the YAML
+nodetool agent run agent.yaml --objective "Research TypeScript ORMs"
+echo "Research TypeScript ORMs" | nodetool agent run agent.yaml
+nodetool agent run agent.yaml          # uses objective: from the YAML
 
-# From file
-nodetool agent --config agent.yaml --prompt-file task.txt
+# Override provider/model/workspace at runtime
+nodetool agent run agent.yaml -o "Task" --provider anthropic --model claude-sonnet-4-6
+nodetool agent run agent.yaml -o "Task" --workspace /tmp/run1
 
-# Interactive mode
-nodetool agent --config agent.yaml --interactive
+# Emit each event as JSON lines on stderr (analyzer-friendly)
+nodetool agent run agent.yaml -o "Task" --json
 
-# Save output
-nodetool agent --config agent.yaml --prompt "Task" --output result.md
+# Verbose trace (includes chunk/low-level events)
+nodetool agent run agent.yaml -o "Task" --verbose
 
-# JSONL output
-nodetool agent --config agent.yaml --prompt "Task" --jsonl
+# Save the final result to a file (it prints to stdout; trace goes to stderr)
+nodetool agent run agent.yaml -o "Task" > result.md
 
-# Verbose (debug)
-nodetool agent --config agent.yaml --prompt "Task" --verbose
+# Validate a config without running it (provider, model, tools)
+nodetool agent test agent.yaml
+
+# List YAML agent configs in a directory
+nodetool agent list ./agents
 ```
 
-## Interactive Commands
-| Command | Purpose |
-|---------|---------|
-| `/help` | Show commands |
-| `/workspace` | Show workspace path |
-| `/tools` | List available tools |
-| `/config` | Show configuration |
-| `/clear` | Clear history |
-| `/save [file]` | Save conversation |
-| `/exit` | Exit session |
+`run` flags: `-o, --objective <text>`, `-p, --provider <id>`, `-m, --model <id>`,
+`-w, --workspace <path>`, `--json`, `-v, --verbose`.
+
+The trace (planning, tool calls, step results) is written to **stderr**; the final
+result is written to **stdout**, so `> file` captures just the answer.
 
 # Available Tools
 
-| Tool | Description |
-|------|-------------|
-| `read_file` | Read file contents |
-| `write_file` | Write/create files |
-| `list_directory` | List directory contents |
-| `google_search` | Web search |
-| `google_news` | News search |
-| `google_images` | Image search |
-| `browser` | Browse web pages |
-| `screenshot` | Take screenshots |
-| `execute_code` | Run code snippets |
-| `terminal` | Shell commands |
-| `grep` | Search file contents |
-| `calculator` | Math calculations |
-| `statistics` | Statistical analysis |
-| `vec_text_search` | Vector text search |
-| `vec_index` | Index documents |
-| `vec_hybrid_search` | Hybrid vector search |
-| `extract_pdf_text` | Extract PDF text |
-| `convert_pdf_to_markdown` | PDF to Markdown |
+Tool names recognized in the YAML `tools:` list (resolved by the agent CLI). MCP
+tools configured on the machine are also auto-registered by name.
+
+| Category | Tools |
+|----------|-------|
+| Files | `read_file`, `write_file`, `edit_file`, `list_directory`, `glob`, `grep`, `download_file` |
+| Web | `google_search`, `google_news`, `google_images`, `browser`, `screenshot`, `http_request`, `openai_web_search`, `dataseo_search`, `dataseo_news` |
+| Code & math | `run_code`, `calculator`, `statistics`, `geometry`, `conversion` |
+| Documents | `extract_pdf_text`, `convert_pdf_to_markdown`, `convert_document` |
+| Media | `generate_image`, `edit_image`, `generate_video`, `animate_image`, `generate_speech`, `transcribe_audio`, `embed_text`, `openai_image_generation`, `openai_text_to_speech` |
+| Models | `find_model` (ranks models by capability; honors `preferred_providers`/`preferred_models`) |
+| Email | `search_email`, `archive_email` |
+
+> Note: there is no `terminal`, `execute_code`, `take_screenshot`, or `vec_*` tool.
+> Use `run_code` for code execution and `screenshot` for screenshots.
 
 # Model Recommendations
 
-| Use Case | Provider | Model | Notes |
-|----------|----------|-------|-------|
-| Planning (cheap) | openai | gpt-4o-mini | Fast, inexpensive |
-| Planning (cheap) | anthropic | claude-3-haiku | Fast alternative |
-| Planning (cheap) | google | gemini-2.0-flash | Google fast tier |
-| Main (powerful) | openai | gpt-4o | Best all-around |
-| Main (powerful) | anthropic | claude-3.5-sonnet | Strong reasoning |
-| Creative | any | any | temperature 0.8–1.0 |
-| Analytical | any | any | temperature 0.0–0.3 |
-| Local/offline | ollama | llama3, mistral | No API key needed |
+Use current model ids (the chat/agent CLIs default to these per provider):
+
+| Use Case | Provider | Model |
+|----------|----------|-------|
+| Main (powerful) | openai | gpt-5.4 |
+| Main (powerful) | anthropic | claude-sonnet-4-6 |
+| Planning (cheap) | openai | gpt-5.4-mini |
+| Planning (cheap) | gemini | gemini-2.5-flash |
+| Reasoning/code | anthropic | claude-sonnet-4-6 |
+| Local/offline | ollama | qwen-3.5:4b, llama3 |
+
+Run `nodetool models recommended` for the curated, up-to-date list.
 
 # Programmatic Usage (TypeScript)
 
 ```typescript
-import { Agent } from "@nodetool-ai/core";
+import { Agent } from "@nodetool-ai/agents";
+import {
+  ProcessingContext,
+  FileStorageAdapter,
+} from "@nodetool-ai/runtime";
 
 const agent = new Agent({
   name: "researcher",
   objective: "Research TypeScript ORMs",
-  provider: openaiProvider,
-  model: "gpt-4o",
+  provider: openaiProvider,         // a BaseProvider instance
+  model: "gpt-5.4",
   tools: [new GoogleSearchTool(), new BrowserTool(), new WriteFileTool()],
-  workspace: "/tmp/research",
+  systemPrompt: "You are a thorough research analyst.",
+  planningModel: "gpt-5.4-mini",
+  maxTokenLimit: 8192,
   maxSteps: 10,
-  maxStepIterations: 5,
+  workspace: "/tmp/research",
 });
 
-for await (const message of agent.execute(context)) {
-  if (message.type === "chunk") {
-    process.stdout.write(message.content);
-  }
+const ctx = new ProcessingContext({
+  jobId: `agent-${Date.now()}`,
+  userId: "1",
+  workspaceDir: "/tmp/research",
+  workspaceStorage: new FileStorageAdapter("/tmp/research"),
+});
+
+for await (const message of agent.execute(ctx)) {
+  if (message.type === "chunk") process.stdout.write(message.content);
 }
 ```
 
@@ -200,10 +218,9 @@ system_prompt: |
   1. Search for primary sources
   2. Cross-reference facts
   3. Write structured findings with citations
-model: { provider: openai, id: gpt-4o }
+model: { provider: openai, id: gpt-5.4 }
 tools: [google_search, browser, write_file]
-max_iterations: 15
-temperature: 0.3
+max_steps: 15
 ```
 
 ## Code Assistant
@@ -212,10 +229,9 @@ name: code-helper
 system_prompt: |
   You are a senior developer. Write clean, tested code.
   Always read existing code before modifying. Run tests after changes.
-model: { provider: anthropic, id: claude-3.5-sonnet }
-tools: [read_file, write_file, terminal, grep]
-max_iterations: 20
-temperature: 0.2
+model: { provider: anthropic, id: claude-sonnet-4-6 }
+tools: [read_file, write_file, edit_file, run_code, grep, glob]
+max_steps: 20
 ```
 
 ## Content Creator
@@ -224,26 +240,26 @@ name: content-writer
 system_prompt: |
   You are a professional content writer. Create engaging,
   well-structured content. Research thoroughly before writing.
-model: { provider: openai, id: gpt-4o }
+model: { provider: openai, id: gpt-5.4 }
 tools: [google_search, browser, write_file]
-max_iterations: 10
-temperature: 0.8
+max_steps: 10
 ```
 
 # Batch Automation
 
 ```bash
 for topic in "AI" "ML" "Web3"; do
-  nodetool agent --config research.yaml \
-    --prompt "Find latest news about $topic" \
-    --output "reports/${topic}.md"
+  nodetool agent run research.yaml \
+    --objective "Find latest news about $topic" \
+    > "reports/${topic}.md"
 done
 ```
 
 # Common Pitfalls
 
-- **Missing `planning_agent.enabled: true`**: Planning is required
-- **Too few iterations**: Complex tasks need `max_iterations: 15-20`
-- **Wrong temperature**: Analytical tasks fail with high temperature
-- **Missing tools**: Agent can't do what you ask if the tool isn't listed
-- **No workspace**: File tools need `workspace.auto_create: true`
+- **No objective**: provide it via `--objective`, stdin, or `objective:` in the YAML — the run errors without one.
+- **Wrong run syntax**: it's `nodetool agent run <yaml>`, not `--config <yaml>`. There is no interactive agent mode (`--interactive`) — use `nodetool chat` for that.
+- **Unknown tool names**: only the catalog above resolves; misspellings (e.g. `execute_code`, `terminal`) are skipped with a warning.
+- **Too few steps**: complex tasks need `max_steps: 15-20`.
+- **Missing tools**: the agent can't do what you ask if the tool isn't listed.
+- **`provider: google`**: accepted but normalized to `gemini`.

--- a/.claude/skills/nodetool-api-reference/SKILL.md
+++ b/.claude/skills/nodetool-api-reference/SKILL.md
@@ -3,27 +3,30 @@ name: nodetool-api-reference
 description: Use NodeTool REST API, WebSocket protocol, Chat API (OpenAI-compatible), workflow execution endpoints, and streaming responses. Use when user asks about API endpoints, WebSocket protocol, how to call the API, build a client, integrate with NodeTool, or stream workflow results.
 ---
 
-You help users integrate with NodeTool's APIs. There are three API surfaces.
+You help users integrate with NodeTool's HTTP + WebSocket server (default `http://localhost:7777`). Start it with `nodetool serve` (flags: `--host`, `--port`).
 
-# API Surfaces
+# Surfaces
 
-| Surface | Start Command | Use Case |
-|---------|--------------|----------|
-| **Editor API** | `nodetool serve` | Full control, dev, WebSocket |
-| **Server API** | `nodetool serve --mode private` | Hardened REST, production |
-| **Chat Server** | `nodetool chat-server` | Chat-only, OpenAI-compatible |
+| Surface | Path prefix | Use case |
+|---------|-------------|----------|
+| **REST** | `/api/...` | Workflows, assets, collections, models, health |
+| **OpenAI-compatible** | `/v1/...` | Chat completions + model list |
+| **WebSocket** | `/ws`, `/ws/agent` | Run/cancel/stream jobs, live chat |
+
+The server mode (`desktop` / `private` / `public`) and auth are controlled by
+environment variables (`NODETOOL_SERVER_MODE`, `AUTH_PROVIDER`), not CLI flags.
 
 # Authentication
 
-All authenticated endpoints use Bearer token:
+Authenticated endpoints use a Bearer token:
 ```
 Authorization: Bearer <TOKEN>
 ```
 
-Token source depends on auth provider:
+Token source depends on the auth provider:
 - `static`: `SERVER_AUTH_TOKEN` env var
 - `supabase`: Supabase JWT
-- `local`/`none`: No auth required
+- `local` / `none`: no auth required
 
 # REST Endpoints
 
@@ -31,50 +34,52 @@ Token source depends on auth provider:
 
 ```bash
 # List workflows
-curl http://localhost:7777/api/workflows/ \
+curl http://localhost:7777/api/workflows \
   -H "Authorization: Bearer TOKEN"
 
-# Get workflow
+# Get a workflow
 curl http://localhost:7777/api/workflows/<id> \
   -H "Authorization: Bearer TOKEN"
 
-# Run workflow (blocking)
-curl -X POST http://localhost:7777/api/workflows/<id>/run \
-  -H "Authorization: Bearer TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"params": {"prompt": "hello world"}}'
+# Export helpers
+curl http://localhost:7777/api/workflows/<id>/dsl-export      # TypeScript DSL
+curl http://localhost:7777/api/workflows/<id>/export-bundle   # .nodetool bundle (zip)
+```
 
-# Run workflow (streaming SSE)
-curl -X POST http://localhost:7777/workflows/<id>/run/stream \
+> **Running a workflow is done over WebSocket** (`/ws`, see below), not via a REST
+> `/run` endpoint. From a terminal you can also run with the CLI:
+> `nodetool workflows run <id> --params '{"key":"value"}'`.
+
+## Collections (RAG)
+
+```bash
+# Index a file into a collection
+curl -X POST http://localhost:7777/api/collections/<name>/index \
   -H "Authorization: Bearer TOKEN" \
-  -H "Accept: text/event-stream" \
   -H "Content-Type: application/json" \
-  -d '{"params": {"prompt": "hello world"}}'
+  -d '{"file_path": "/path/to/document.pdf"}'
 ```
 
 ## Models
 
 ```bash
-# List available models (OpenAI-compatible)
-curl http://localhost:7777/v1/models \
-  -H "Authorization: Bearer TOKEN"
+# OpenAI-compatible model list
+curl http://localhost:7777/v1/models -H "Authorization: Bearer TOKEN"
+```
+
+## Storage / Assets
+
+```bash
+# Asset bytes are served under /api/storage/...
+curl http://localhost:7777/api/storage/<path>
 ```
 
 ## Health
 
 ```bash
-# Health check (no auth required)
-curl http://localhost:7777/health
-```
-
-## Storage
-
-```bash
-# Check asset exists
-curl -I http://localhost:7777/storage/<path>
-
-# Download asset
-curl http://localhost:7777/storage/<path>
+curl http://localhost:7777/health      # liveness (no auth)
+curl http://localhost:7777/ready        # readiness
+curl http://localhost:7777/api/health   # detailed health
 ```
 
 # Chat API (OpenAI-Compatible)
@@ -87,7 +92,7 @@ curl -X POST http://localhost:7777/v1/chat/completions \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o",
+    "model": "gpt-5.4",
     "messages": [
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "Hello!"}
@@ -95,15 +100,11 @@ curl -X POST http://localhost:7777/v1/chat/completions \
     "stream": false
   }'
 
-# Streaming chat
+# Streaming (Server-Sent Events)
 curl -X POST http://localhost:7777/v1/chat/completions \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "gpt-4o",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "stream": true
-  }'
+  -d '{"model": "gpt-5.4", "messages": [{"role": "user", "content": "Hi"}], "stream": true}'
 ```
 
 ## Python Client (OpenAI SDK)
@@ -111,23 +112,19 @@ curl -X POST http://localhost:7777/v1/chat/completions \
 ```python
 import openai
 
-client = openai.OpenAI(
-    api_key="TOKEN",
-    base_url="http://localhost:7777/v1"
-)
+client = openai.OpenAI(api_key="TOKEN", base_url="http://localhost:7777/v1")
 
-# Non-streaming
 response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "Hello!"}]
+    model="gpt-5.4",
+    messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)
 
 # Streaming
 stream = client.chat.completions.create(
-    model="gpt-4o",
+    model="gpt-5.4",
     messages=[{"role": "user", "content": "Hello!"}],
-    stream=True
+    stream=True,
 )
 for chunk in stream:
     if chunk.choices[0].delta.content:
@@ -140,29 +137,28 @@ for chunk in stream:
 const response = await fetch("http://localhost:7777/v1/chat/completions", {
   method: "POST",
   headers: {
-    "Authorization": "Bearer TOKEN",
-    "Content-Type": "application/json"
+    Authorization: "Bearer TOKEN",
+    "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    model: "gpt-4o",
+    model: "gpt-5.4",
     messages: [{ role: "user", content: "Hello!" }],
-    stream: false
-  })
+    stream: false,
+  }),
 });
 const data = await response.json();
 console.log(data.choices[0].message.content);
 ```
 
-# WebSocket API
+# WebSocket API — Running Jobs
 
-**Endpoint**: `ws(s)://<host>/ws`
-
-## Run a Job
+**Endpoint**: `ws(s)://<host>/ws`. Messages are an envelope `{ command, data }`.
+(In the editor, MsgPack is used; JSON also works for simple clients.)
 
 ```typescript
 const socket = new WebSocket("ws://localhost:7777/ws");
 
-// Send run_job command
+// Start a workflow run
 socket.send(JSON.stringify({
   command: "run_job",
   data: {
@@ -173,18 +169,16 @@ socket.send(JSON.stringify({
     auth_token: "<token>",
     params: { input_name: "value" },
     job_id: "<uuid>",
-    user_id: "<user>",
-    graph: { nodes: [], edges: [] },
-    execution_strategy: "threaded"
-  }
+    user_id: "1",
+    execution_strategy: "threaded",
+  },
 }));
 
-// Handle messages
 socket.onmessage = (event) => {
   const msg = JSON.parse(event.data);
   switch (msg.type) {
     case "job_update":
-      console.log(`Job ${msg.status}`); // running|completed|failed|cancelled|suspended
+      console.log(`Job ${msg.status}`); // running | completed | failed | cancelled | suspended
       if (msg.result) console.log("Result:", msg.result);
       break;
     case "node_update":
@@ -209,88 +203,35 @@ socket.onmessage = (event) => {
 ## Job Control Commands
 
 ```typescript
-// Cancel
-socket.send(JSON.stringify({ command: "cancel_job", data: { job_id: "...", workflow_id: "..." } }));
+socket.send(JSON.stringify({ command: "cancel_job",  data: { job_id: "...", workflow_id: "..." } }));
+socket.send(JSON.stringify({ command: "pause_job",   data: { job_id: "...", workflow_id: "..." } }));
+socket.send(JSON.stringify({ command: "resume_job",  data: { job_id: "...", workflow_id: "..." } }));
 
-// Pause
-socket.send(JSON.stringify({ command: "pause_job", data: { job_id: "...", workflow_id: "..." } }));
-
-// Resume
-socket.send(JSON.stringify({ command: "resume_job", data: { job_id: "...", workflow_id: "..." } }));
-
-// Reconnect to running job
-socket.send(JSON.stringify({ command: "reconnect_job", data: { job_id: "...", workflow_id: "..." } }));
-
-// Stream input to a running node
-socket.send(JSON.stringify({
-  command: "stream_input",
-  data: { input: "name", value: "data", handle: "..." }
-}));
-
-// End input stream
-socket.send(JSON.stringify({
-  command: "end_input_stream",
-  data: { input: "name", handle: "..." }
-}));
-```
-
-## WebSocket Chat
-
-```typescript
-const socket = new WebSocket("ws://localhost:7777/chat?api_key=TOKEN");
-
-socket.onopen = () => {
-  socket.send(JSON.stringify({
-    role: "user",
-    content: "Hello",
-    model: "gpt-4o"
-  }));
-};
-
-socket.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  if (data.type === "chunk") {
-    process.stdout.write(data.content);
-  }
-};
-```
-
-# Streaming SSE Response Format
-
-When using `stream=true` or the `/run/stream` endpoint, responses come as Server-Sent Events:
-
-```
-data: {"type": "job_update", "status": "running", "job_id": "..."}
-
-data: {"type": "node_progress", "node_name": "Agent", "progress": 1, "total": 5}
-
-data: {"type": "chunk", "content": "Hello", "done": false}
-
-data: {"type": "output_update", "output_name": "text", "value": "...", "output_type": "str"}
-
-data: {"type": "job_update", "status": "completed", "result": {...}}
+// Stream input into a running node, then close the stream
+socket.send(JSON.stringify({ command: "stream_input",     data: { input: "name", value: "data", handle: "..." } }));
+socket.send(JSON.stringify({ command: "end_input_stream", data: { input: "name", handle: "..." } }));
 ```
 
 # Server Message Types
 
-| Type | Key Fields | Purpose |
+| Type | Key fields | Purpose |
 |------|-----------|---------|
-| `job_update` | `status`, `result`, `error`, `duration` | Job lifecycle |
+| `job_update` | `status`, `result`, `error`, `cost` | Job lifecycle |
 | `node_update` | `node_id`, `node_name`, `status`, `error`, `result` | Node lifecycle |
 | `node_progress` | `progress`, `total`, `chunk` | Progress tracking |
 | `output_update` | `output_name`, `value`, `output_type` | Node output values |
-| `preview_update` | `value` | Preview node data |
 | `log_update` | `content`, `severity` | Log messages |
 | `chunk` | `content`, `done` | Streaming text |
 
-# Server Management
+# Server Management (CLI)
 
 ```bash
-nodetool serve                        # Start server (default port 7777)
-nodetool serve --port 8080            # Custom port
-nodetool serve --host 0.0.0.0         # Bind all interfaces
-nodetool workflows list               # List saved workflows
-nodetool workflows get <id>           # Get workflow details
-nodetool jobs list                    # List execution jobs
-nodetool secrets store OPENAI_API_KEY # Store API key
+nodetool serve                        # Start server (default 127.0.0.1:7777)
+nodetool serve --host 0.0.0.0          # Bind all interfaces
+nodetool serve --port 8080             # Custom port
+nodetool workflows list                # List saved workflows
+nodetool workflows get <id>            # Get workflow details
+nodetool workflows run <id>            # Run a workflow (uses the local DB)
+nodetool jobs list                     # List execution jobs
+nodetool secrets store OPENAI_API_KEY  # Store an API key
 ```

--- a/.claude/skills/nodetool-browser-agent/SKILL.md
+++ b/.claude/skills/nodetool-browser-agent/SKILL.md
@@ -3,11 +3,11 @@ name: nodetool-browser-agent
 description: Create browser automation agents that navigate websites, extract data, fill forms, and perform multi-step web tasks using natural language instructions. Use when user asks to automate browsing, scrape websites with AI, build a web agent, or perform complex browser interactions.
 ---
 
-You help users create NodeTool agents configured for browser automation — AI-powered web agents that can navigate, interact with, and extract data from websites using natural language task descriptions.
+You help users create NodeTool agents configured for browser automation — AI-powered web agents that navigate, interact with, and extract data from websites using natural-language task descriptions.
 
 # Architecture
 
-Browser automation in NodeTool uses the **agent system** rather than individual workflow nodes. An agent equipped with browser tools can intelligently decide how to navigate pages, extract content, fill forms, and complete multi-step web tasks.
+Browser automation in NodeTool uses the **agent system**. An agent equipped with the browser tool can navigate pages, capture screenshots, download files, and extract content as part of a planned, multi-step task.
 
 ```
 Task description → Agent → (Plan steps → Use browser tools → Extract/interact → Report) → Result
@@ -15,14 +15,22 @@ Task description → Agent → (Plan steps → Use browser tools → Extract/int
 
 # Available Browser Tools
 
-| Tool | Name | Description |
-|------|------|-------------|
-| **Browser** | `browser` | Fetch and render web page content (handles JavaScript) |
-| **Screenshot** | `take_screenshot` | Capture screenshots of pages or specific elements |
-| **DOM Examine** | `dom_examine` | Inspect DOM structure and element attributes |
-| **DOM Search** | `dom_search` | Search for elements matching CSS selectors or text |
-| **DOM Extract** | `dom_extract` | Extract structured data from DOM elements |
-| **Download File** | `download_file` | Download files from URLs |
+These are the web-related tools the agent CLI resolves from the YAML `tools:` list:
+
+| Tool name | Description |
+|-----------|-------------|
+| `browser` | Fetch and render web page content (executes JavaScript), extract text/links |
+| `screenshot` | Capture a screenshot of a page |
+| `download_file` | Download a file from a URL into the workspace |
+| `google_search` | Web search to discover URLs |
+| `google_news` / `google_images` | News / image search |
+| `http_request` | Raw HTTP GET/POST for APIs and simple fetches |
+| `openai_web_search` | OpenAI-hosted web search (needs an OpenAI key) |
+
+> There are no `dom_examine`, `dom_search`, or `dom_extract` tools. The `browser`
+> tool handles rendering and content extraction; instruct the agent in natural
+> language (e.g. "extract every product title and price") and pair it with
+> `write_file` to save structured results.
 
 # Agent YAML Config for Browser Automation
 
@@ -36,37 +44,34 @@ system_prompt: |
 
   Workflow:
   1. Analyze the task to determine what pages to visit
-  2. Use browser tools to navigate and inspect pages
-  3. Extract relevant content or perform interactions
+  2. Use the browser tool to fetch and read pages
+  3. Extract the relevant content
   4. Report findings in a structured format
 
   Guidelines:
   - Start by browsing the target URL to understand page structure
-  - Use dom_search to find specific elements before interacting
-  - Use take_screenshot to verify visual state when needed
-  - Always validate extracted data before reporting
+  - Use screenshot to verify visual state when needed
+  - Validate extracted data before reporting
 
 model:
   provider: openai
-  id: gpt-4o
+  id: gpt-5.4
 
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5.4-mini
 
 tools:
   - browser
-  - take_screenshot
-  - dom_examine
-  - dom_search
-  - dom_extract
-  - write_file
+  - screenshot
+  - download_file
+  - http_request
   - google_search
+  - write_file
 
-max_iterations: 15
-temperature: 0.2
+max_steps: 15
 ```
 
 # Quick Recipes
@@ -78,13 +83,12 @@ description: Extract structured data from websites
 system_prompt: |
   You extract structured data from websites. For each URL:
   1. Browse the page to understand its structure
-  2. Use dom_search to locate data elements
-  3. Use dom_extract to pull structured data
-  4. Save results as JSON
-model: { provider: openai, id: gpt-4o }
-tools: [browser, dom_search, dom_extract, write_file]
-max_iterations: 20
-temperature: 0.1
+  2. Identify the data elements (titles, prices, dates)
+  3. Extract them into structured JSON
+  4. Save results with write_file
+model: { provider: openai, id: gpt-5.4 }
+tools: [browser, write_file]
+max_steps: 20
 ```
 
 ## Research Agent with Browser
@@ -97,26 +101,9 @@ system_prompt: |
   2. Browse promising results for detailed content
   3. Extract key information and verify facts
   4. Compile findings into a structured report
-model: { provider: openai, id: gpt-4o }
+model: { provider: openai, id: gpt-5.4 }
 tools: [google_search, browser, write_file]
-max_iterations: 15
-temperature: 0.3
-```
-
-## Form Automation Agent
-```yaml
-name: form-filler
-description: Automate web form interactions
-system_prompt: |
-  You automate web form interactions:
-  1. Navigate to the target page
-  2. Examine the form structure with dom_examine
-  3. Fill fields and submit forms
-  4. Capture confirmation screenshots
-model: { provider: openai, id: gpt-4o }
-tools: [browser, dom_examine, dom_search, take_screenshot, write_file]
-max_iterations: 10
-temperature: 0.1
+max_steps: 15
 ```
 
 ## Price Comparison Agent
@@ -129,67 +116,64 @@ system_prompt: |
   2. Extract price, availability, and shipping info
   3. Create a comparison table
   4. Recommend the best deal
-model: { provider: openai, id: gpt-4o }
-tools: [google_search, browser, dom_search, dom_extract, write_file]
-max_iterations: 20
-temperature: 0.2
+model: { provider: openai, id: gpt-5.4 }
+tools: [google_search, browser, write_file]
+max_steps: 20
 ```
 
 # CLI Usage
 
 ```bash
-# Run a browser task
-nodetool agent --config browser-agent.yaml \
-  --prompt "Go to example.com and extract all product names and prices"
+# Run a browser task (objective via flag, stdin, or `objective:` in the YAML)
+nodetool agent run browser-agent.yaml \
+  --objective "Go to example.com and extract all product names and prices"
 
-# Research task
-nodetool agent --config web-researcher.yaml \
-  --prompt "Research the latest developments in WebAssembly" \
-  --output research-report.md
-
-# Interactive browsing session
-nodetool agent --config browser-agent.yaml --interactive
+# Research task — final answer to stdout, trace to stderr
+nodetool agent run web-researcher.yaml \
+  --objective "Research the latest developments in WebAssembly" \
+  > research-report.md
 ```
+
+# Browser Agent as a Workflow Node
+
+For visual workflows (and the DSL), there is a dedicated `BrowserAgent` node
+(`agents.browserAgent` in `@nodetool-ai/dsl`). It runs a browsing agent inside a
+graph and returns the extracted text. Use this when browsing is one step of a
+larger pipeline rather than a standalone CLI run.
 
 # Programmatic Usage (TypeScript)
 
 ```typescript
-import { Agent } from "@nodetool-ai/core";
-import {
-  BrowserTool,
-  ScreenshotTool,
-  DOMExamineTool,
-  DOMSearchTool,
-  DOMExtractTool,
-} from "@nodetool-ai/core/tools";
+import { Agent } from "@nodetool-ai/agents";
+import { BrowserTool, ScreenshotTool, DownloadFileTool } from "@nodetool-ai/agents";
+import { ProcessingContext, FileStorageAdapter } from "@nodetool-ai/runtime";
 
 const agent = new Agent({
   name: "browser-agent",
   objective: "Extract product listings from example.com",
   provider: openaiProvider,
-  model: "gpt-4o",
-  tools: [
-    new BrowserTool(),
-    new ScreenshotTool(),
-    new DOMSearchTool(),
-    new DOMExtractTool(),
-  ],
+  model: "gpt-5.4",
+  tools: [new BrowserTool(), new ScreenshotTool(), new DownloadFileTool()],
   workspace: "/tmp/browser-output",
   maxSteps: 15,
 });
 
-for await (const message of agent.execute(context)) {
-  if (message.type === "chunk") {
-    process.stdout.write(message.content);
-  }
+const ctx = new ProcessingContext({
+  jobId: `browser-${Date.now()}`,
+  userId: "1",
+  workspaceDir: "/tmp/browser-output",
+  workspaceStorage: new FileStorageAdapter("/tmp/browser-output"),
+});
+
+for await (const message of agent.execute(ctx)) {
+  if (message.type === "chunk") process.stdout.write(message.content);
 }
 ```
 
 # Tips
 
-- **Use `dom_search` + `dom_extract`** for structured data with known CSS selectors
-- **Use `dom_examine`** first to understand page structure before extracting
-- **Use `take_screenshot`** to debug visual state or verify interactions
-- **Set `max_iterations` higher** (15-20) for multi-page tasks
-- **Use low temperature** (0.1-0.3) for reliable, deterministic browsing
-- **Combine with `google_search`** when the agent needs to discover URLs first
+- **Describe extraction in natural language** — the `browser` tool returns page content; let the model parse it. Pair with `write_file` to persist results.
+- **Use `screenshot`** to debug visual state or verify a page loaded.
+- **Set `max_steps` higher** (15-20) for multi-page tasks.
+- **Combine with `google_search`** when the agent needs to discover URLs first.
+- **Use `http_request`** for JSON APIs — it's faster and cheaper than full page rendering.

--- a/.claude/skills/nodetool-chat-cli/SKILL.md
+++ b/.claude/skills/nodetool-chat-cli/SKILL.md
@@ -3,158 +3,162 @@ name: nodetool-chat-cli
 description: Use NodeTool chat CLI commands, interactive terminal, agent mode, workspace management, and Global Chat features. Use when user asks about chat commands, interactive terminal, chat features, agent mode in chat, or the Global Chat interface.
 ---
 
-You help users use NodeTool's chat interfaces — CLI chat and Global Chat.
+You help users use NodeTool's chat interfaces — the terminal chat CLI and Global Chat.
 
 # Chat CLI
+
+The chat CLI is a terminal UI. Two equivalent entry points:
+- `nodetool-chat` (standalone binary)
+- `nodetool chat` (subcommand that forwards to the chat UI)
+
+From source (no build): `npm run dev:chat -- [flags]`.
 
 ## Starting Chat
 
 ```bash
-# Interactive chat (default model)
+# Interactive chat (default provider/model from saved settings)
 nodetool chat
 
-# With specific provider/model
-nodetool chat -p openai -m gpt-4o
-nodetool chat -p anthropic -m claude-3.5-sonnet
-nodetool chat -p ollama -m llama3
+# With a specific provider/model
+nodetool chat -p openai -m gpt-5.4
+nodetool chat -p anthropic -m claude-sonnet-4-6
+nodetool chat -p ollama -m qwen-3.5:4b
 
-# With agent mode enabled
-nodetool chat -a
-
-# With specific tools
+# Restrict the enabled tools
 nodetool chat --tools google_search,browser,write_file
+
+# Connect to a running server instead of a local provider
+nodetool chat -u ws://localhost:7777/ws
+
+# Provision an isolated Docker sandbox and expose its tools to the agent
+nodetool chat --sandbox
 ```
 
-## Chat Commands (prefix with `/`)
+> **Agent mode is always on.** Every chat session runs the unified agent loop
+> (planning + tools). The old `-a/--agent` and `--no-agent` flags are deprecated
+> no-ops kept for compatibility.
+
+## CLI Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-p, --provider <name>` | LLM provider (see list below) |
+| `-m, --model <id>` | Model ID |
+| `-w, --workspace <path>` | Workspace directory (default: cwd) |
+| `--tools <list>` | Comma-separated enabled tools |
+| `-u, --url <ws-url>` | Connect to a NodeTool server WebSocket |
+| `--sandbox` | Isolated Docker sandbox with file/shell/browser/desktop tools |
+| `--sandbox-image <image>` | Override the sandbox Docker image |
+| `--no-read-only-search` | Disable the read-only `run_search` fan-out primitive |
+| `--trace-file <path>` | Append LLM/agent/workflow spans as JSONL |
+| `--trace-stdout [pretty\|json]` | Stream spans to stdout |
+
+Providers: `anthropic`, `claude_agent_sdk`, `openai`, `codex`, `gemini`, `xai`,
+`groq`, `mistral`, `deepseek`, `moonshot`, `minimax`, `cerebras`, `gmi`,
+`together`, `openrouter`, `huggingface`, `replicate`, `kie`, `aki`, `ollama`,
+`lmstudio`, `mlx`. Any other registered provider id (e.g. `vllm`) also works when
+passed explicitly.
+
+## Slash Commands (prefix with `/`)
 
 | Command | Purpose |
 |---------|---------|
-| `/help` | Show all commands |
-| `/provider` | Current provider status |
-| `/providers` | List all available providers |
-| `/models` | List available models |
-| `/model <id>` | Switch to a different model |
-| `/agent [on\|off]` | Toggle agent mode |
-| `/tools [name]` | List tools or show tool details |
-| `/usage` | Show token usage stats |
-| `/exit` | Quit chat |
+| `/help` | Toggle the command help panel |
+| `/new` | Start a fresh session (clears history + server thread) |
+| `/clear` | Clear the visible history |
+| `/compact` | Summarize and compact the conversation context |
+| `/model [id]` | Show current model, or switch with an id |
+| `/provider [name]` | Show current provider, or switch (loads that provider's default model) |
+| `/tools` | List the enabled tools |
+| `/exit`, `/quit` | Quit chat |
 
-## Workspace Commands (no `/` prefix)
-
-These work like a sandboxed shell within the chat:
-
-| Command | Purpose |
-|---------|---------|
-| `pwd` | Print working directory |
-| `ls [path]` | List files |
-| `cd [path]` | Change directory |
-| `mkdir <dir>` | Create directory |
-| `rm <path>` | Remove file |
-| `open <file>` | Open file in default app |
-| `cat <file>` | Display file contents |
-| `cp <src> <dest>` | Copy file |
-| `mv <src> <dest>` | Move/rename file |
-| `grep <pattern> [path]` | Search file contents |
-| `cdw` | Jump to workspace root |
+Non-slash input is sent to the model as a chat message — there is no built-in
+shell (`ls`, `cd`, …) in the chat prompt. File operations happen through the
+agent's file tools in the workspace.
 
 ## Configuration
 
-- Settings file: `~/.nodetool_settings`
-- History file: `~/.nodetool_history`
+- Settings file: `~/.nodetool/chat-settings.json` (persists provider + model)
 
-# Agent Mode
+# Agent Capabilities
 
-When agent mode is enabled (`/agent on` or `-a` flag), the chat gains:
+Because the agent loop is always active, the chat can:
 
-1. **Planning**: Agent breaks tasks into steps
-2. **Tool use**: Agent can call tools (search, browse, file ops, code execution)
-3. **Iteration**: Agent executes steps, evaluates results, adapts
-4. **Workflow integration**: Agent can trigger NodeTool workflows
+1. **Plan** — break tasks into steps
+2. **Use tools** — search, browse, file ops, code execution, media generation
+3. **Iterate** — execute steps, evaluate results, adapt
+4. **Run workflows** — trigger saved NodeTool workflows
 
-## Agent Mode Tools
+## Common Tools
 
 | Tool | Capability |
 |------|-----------|
 | `google_search` | Web search |
 | `browser` | Browse and extract web content |
-| `write_file` | Create/write files in workspace |
-| `read_file` | Read file contents |
-| `execute_code` | Run code snippets |
-| `terminal` | Shell commands |
-| `grep` | Search file contents |
-| `calculator` | Math operations |
-| `screenshot` | Take screenshots |
+| `read_file` / `write_file` / `edit_file` | Workspace file ops |
+| `run_code` | Run code snippets |
+| `grep` / `glob` | Search files |
+| `screenshot` | Capture a page screenshot |
+| `find_model` | Pick a model by capability |
+| `generate_image` / `generate_video` / `generate_speech` | Media generation |
+
+Restrict the set with `--tools a,b,c`; inspect the active set with `/tools`.
 
 # Global Chat
 
-Global Chat is the desktop app's built-in chat interface with additional features.
+Global Chat is the desktop app's built-in chat interface.
 
 ## Features
 
-- Chat with any configured AI model (OpenAI, Anthropic, Google, local)
+- Chat with any configured AI model (OpenAI, Anthropic, Gemini, local)
 - Multiple conversation threads
-- Standalone window (launch from system tray)
-- Specialized tools (web search, image generation)
-- Autonomous agent mode
-- Workflow integration
-
-## Accessing Global Chat
-
-- Click chat icon in NodeTool desktop app header
-- Or launch standalone from system tray icon
-
-## Global Chat Agent Mode
-
-1. Enable agent mode in chat settings
-2. Agent plans tasks into steps
-3. Uses tools to execute (search, browse, generate)
-4. Can run NodeTool workflows as part of execution
-5. Analyzes results and adapts approach
+- Standalone window (launch from the system tray)
+- Tools: web search, image generation, workflow execution
+- The same always-on agent loop as the CLI
 
 ## Workflow Integration
 
 ```
-1. Save a workflow in NodeTool editor
+1. Save a workflow in the NodeTool editor
 2. Open Global Chat
 3. Select the workflow from the workflow picker
-4. Chat naturally — the agent can invoke the workflow
+4. Chat naturally — the agent can invoke the workflow as a tool
 ```
 
 # Typical Flows
 
 ## Quick Question
 ```bash
-nodetool chat -p openai -m gpt-4o
+nodetool chat -p openai -m gpt-5.4
 > What's the difference between FAISS and ChromaDB?
 ```
 
-## Research Task with Agent
+## Research Task
 ```bash
-nodetool chat -a --tools google_search,browser,write_file
+nodetool chat --tools google_search,browser,write_file
 > Research the top 5 TypeScript ORMs and write a comparison to comparison.md
 ```
 
 ## Code Generation
 ```bash
-nodetool chat -p anthropic -m claude-3.5-sonnet -a --tools write_file,read_file,terminal
+nodetool chat -p anthropic -m claude-sonnet-4-6 --tools write_file,read_file,run_code
 > Create a Python script that processes CSV files and generates summary statistics
 ```
 
-## Headless Execution (API)
+## Headless / Programmatic Chat
 
-For programmatic chat without the interactive terminal:
+For non-interactive chat, use the OpenAI-compatible Chat API on a running server
+(`nodetool serve`):
 
 ```bash
-# Via Chat API (OpenAI-compatible)
 curl -X POST http://localhost:7777/v1/chat/completions \
   -H "Authorization: Bearer TOKEN" \
-  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
+  -d '{"model": "gpt-5.4", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
 # Common Pitfalls
 
-- **No provider configured**: Set API key first (`nodetool secrets store OPENAI_API_KEY`)
-- **Agent mode off**: Tools won't work without `/agent on` or `-a` flag
-- **Wrong model ID**: Use `/models` to see available model IDs
-- **Workspace confusion**: Use `cdw` to jump back to workspace root
-- **History lost**: Chat history is per-session unless saved with `/save`
+- **No provider configured**: store a key first (`nodetool secrets store OPENAI_API_KEY`). Providers without a key are greyed out and `/provider <name>` refuses them.
+- **Wrong model ID**: switch with `/model <id>`; each provider's default is loaded when you switch providers.
+- **Expecting a shell**: bare commands like `ls` are sent to the model, not run. Use the agent's file tools or `--sandbox`.
+- **Looking for `/agent`**: agent mode is always on; there is no toggle.

--- a/.claude/skills/nodetool-custom-node-developer/SKILL.md
+++ b/.claude/skills/nodetool-custom-node-developer/SKILL.md
@@ -107,7 +107,7 @@ declare item: unknown;
 
 private collected: unknown[] = [];
 
-initialize(): void {
+async initialize(): Promise<void> {
   this.collected = []; // reset per run
 }
 
@@ -151,9 +151,9 @@ async process(): Promise<Record<string, unknown>> {
 
 ## Lifecycle Hooks
 ```typescript
-initialize(): void { }    // once at start of run
-preProcess(): void { }    // before each process() call
-finalize(): void { }      // after all processing
+async initialize(): Promise<void> { }   // once at start of run
+async preProcess(): Promise<void> { }   // before each process() call
+async finalize(): Promise<void> { }     // after all processing
 ```
 
 # Optional Static Properties

--- a/.claude/skills/nodetool-deployment/SKILL.md
+++ b/.claude/skills/nodetool-deployment/SKILL.md
@@ -43,7 +43,7 @@ nodetool deploy destroy <name>    # Tear down
 
 ```bash
 # Required
-ENV=production
+NODETOOL_ENV=production
 NODETOOL_SERVER_MODE=private      # desktop | private | public
 
 # Auth (pick one)
@@ -93,7 +93,7 @@ deployments:
 ```bash
 docker run --gpus all --memory 8g --cpus 4 \
   -p 7777:7777 \
-  -e ENV=production \
+  -e NODETOOL_ENV=production \
   -e NODETOOL_SERVER_MODE=private \
   -e AUTH_PROVIDER=static \
   -e SERVER_AUTH_TOKEN=<token> \
@@ -214,7 +214,7 @@ nodetool deploy workflows run <deployment> <workflow-id>
 
 # Production Checklist
 
-- [ ] Set `ENV=production`
+- [ ] Set `NODETOOL_ENV=production`
 - [ ] Set strong `SECRETS_MASTER_KEY`
 - [ ] Set `ADMIN_TOKEN`
 - [ ] Configure `AUTH_PROVIDER` (never `none` in prod)
@@ -222,8 +222,8 @@ nodetool deploy workflows run <deployment> <workflow-id>
 - [ ] Configure API keys for needed providers
 - [ ] Set resource limits (memory, CPU, GPU)
 - [ ] Mount persistent volumes for workspace and model cache
-- [ ] Set up health monitoring (`GET /health`)
-- [ ] Configure logging (`LOG_LEVEL=INFO`)
+- [ ] Set up health monitoring (`GET /health`, `GET /ready`)
+- [ ] Configure logging (`NODETOOL_LOG_LEVEL=info`)
 - [ ] Set up backups for `DB_PATH`
 
 # Common Pitfalls

--- a/.claude/skills/nodetool-model-provider-config/SKILL.md
+++ b/.claude/skills/nodetool-model-provider-config/SKILL.md
@@ -9,16 +9,23 @@ You help users configure AI model providers and select the right models for thei
 
 | Provider | Type | Key Env Var | Models |
 |----------|------|-------------|--------|
-| **OpenAI** | Cloud | `OPENAI_API_KEY` | GPT-4o, GPT-3.5, GPT-Image, TTS, Whisper |
-| **Anthropic** | Cloud | `ANTHROPIC_API_KEY` | Claude 4.6, Claude 4.5, Haiku |
-| **Google** | Cloud | `GEMINI_API_KEY` | Gemini 2.0, Veo, Nano Banana |
-| **Ollama** | Local | `OLLAMA_API_URL` | Llama 3, Mistral, Qwen, any GGUF |
+| **OpenAI** | Cloud | `OPENAI_API_KEY` | GPT-5.4 / GPT-5.4-mini, GPT-Image, TTS, Whisper |
+| **Anthropic** | Cloud | `ANTHROPIC_API_KEY` | Claude Sonnet 4.6, Haiku |
+| **Gemini (Google)** | Cloud | `GEMINI_API_KEY` | Gemini 2.5, Veo, Nano Banana |
+| **xAI** | Cloud | `XAI_API_KEY` | Grok 4 |
+| **Ollama** | Local | `OLLAMA_API_URL` | Qwen, Llama 3, Mistral, any GGUF |
 | **HuggingFace** | Local/Cloud | `HF_TOKEN` | 1000+ models, auto-download |
 | **FAL** | Cloud | `FAL_API_KEY` | Fast image/video generation |
 | **Replicate** | Cloud | `REPLICATE_API_TOKEN` | Community models |
 | **vLLM** | Local | `VLLM_API_URL` | Self-hosted, OpenAI-compatible |
 | **llama.cpp** | Local | — | GGUF models, CPU/GPU |
 | **MLX** | Local | — | Apple Silicon optimized |
+
+Other registered chat providers (any of these is valid for `-p/--provider`):
+`groq`, `mistral`, `deepseek`, `moonshot`, `minimax`, `cerebras`, `together`,
+`openrouter`, `codex`, `claude_agent_sdk`, `lmstudio`. Run `nodetool models
+providers` to see configured providers and `nodetool models recommended` for the
+curated model list.
 
 # API Key Setup
 
@@ -47,11 +54,11 @@ export OLLAMA_API_URL=http://localhost:11434
 
 | Need | Model | Provider | Notes |
 |------|-------|----------|-------|
-| Best quality | GPT-4o, Claude 4.6 | OpenAI, Anthropic | Highest capability |
-| Good balance | GPT-4o-mini, Claude Haiku | OpenAI, Anthropic | Fast + cheap |
-| Local/private | Llama 3 70B, Qwen 32B | Ollama | No data leaves machine |
+| Best quality | gpt-5.4, claude-sonnet-4-6 | OpenAI, Anthropic | Highest capability |
+| Good balance | gpt-5.4-mini, gemini-2.5-flash | OpenAI, Gemini | Fast + cheap |
+| Local/private | Llama 3.3 70B, Qwen 3.5 | Ollama | No data leaves machine |
 | Lightweight local | Llama 3 8B, Mistral 7B | Ollama | Low memory |
-| Code | Claude 4.6, GPT-4o | Anthropic, OpenAI | Best for coding |
+| Code | claude-sonnet-4-6, gpt-5.4 | Anthropic, OpenAI | Best for coding |
 
 ## Image Generation
 
@@ -60,7 +67,7 @@ export OLLAMA_API_URL=http://localhost:11434
 | Best quality | FLUX.2 Dev | HuggingFace, FAL | State-of-art |
 | Fast | FLUX Schnell | HuggingFace | Quick iterations |
 | Versatile | SDXL | HuggingFace | Many LoRAs available |
-| API-based | GPT-Image 3 | OpenAI | No local GPU needed |
+| API-based | GPT Image 2, Nano Banana | OpenAI, Gemini/KIE | No local GPU needed |
 
 ## Video Generation
 
@@ -150,32 +157,58 @@ These nodes work with any provider — just select the model:
 
 # Custom Provider Development
 
+Providers extend `BaseProvider` from `@nodetool-ai/runtime` (not `@nodetool-ai/core`).
+Both `generateMessage` and `generateMessages` take a single **args object**.
+
 ```typescript
-import { BaseProvider, ProviderId, Message, ProviderStreamItem, LanguageModel } from "@nodetool-ai/core";
+import {
+  BaseProvider,
+  type ProviderId,
+  type Message,
+  type ProviderStreamItem,
+  type ProviderTool,
+  type LanguageModel,
+} from "@nodetool-ai/runtime";
 
 export class MyProvider extends BaseProvider {
+  private apiKey: string;
+
   constructor(kwargs: Record<string, unknown> = {}) {
     super("my_provider" as ProviderId);
-    this.apiKey = kwargs.MY_API_KEY ?? process.env.MY_API_KEY ?? "";
+    this.apiKey = String(kwargs["MY_API_KEY"] ?? process.env.MY_API_KEY ?? "");
   }
 
-  static requiredSecrets(): string[] {
+  static override requiredSecrets(): string[] {
     return ["MY_API_KEY"];
   }
 
-  async *generateMessages(
-    messages: Message[],
-    model: string
-  ): AsyncIterable<ProviderStreamItem> {
-    // Call your API, yield chunks
-    yield { type: "chunk", content: "response text" };
+  // Non-streaming: return a single assistant Message.
+  async generateMessage(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+  }): Promise<Message> {
+    // Call your API with args.messages / args.model …
+    return { role: "assistant", content: "response text" };
   }
 
-  async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+  // Streaming: yield ProviderStreamItem chunks.
+  async *generateMessages(args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+  }): AsyncGenerator<ProviderStreamItem> {
+    yield { type: "chunk", content: "response text", done: false };
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
     return [{ id: "my-model", name: "My Model", provider: "my_provider" }];
   }
 }
 ```
+
+Register it with `registerProvider("my_provider", MyProvider)` from
+`@nodetool-ai/runtime`.
 
 # Provider Capabilities
 
@@ -197,4 +230,4 @@ export class MyProvider extends BaseProvider {
 - **Gated HF models**: Must accept terms on hub.huggingface.co first
 - **GPU memory**: Large models need 8-24GB VRAM; use quantized versions
 - **Rate limits**: Cloud providers have rate limits; implement retries or use local
-- **Model ID mismatch**: Use exact model ID from provider (e.g., `gpt-4o` not `gpt4o`)
+- **Model ID mismatch**: Use the exact model ID from the provider (e.g., `gpt-5.4`, `claude-sonnet-4-6`) — `nodetool models by-provider <provider>` lists them

--- a/.claude/skills/nodetool-rag-indexing/SKILL.md
+++ b/.claude/skills/nodetool-rag-indexing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nodetool-rag-indexing
-description: Set up RAG pipelines, vector indexing, document ingestion, ChromaDB/FAISS/SQLite-vec search, and knowledge base creation in NodeTool. Use when user asks about RAG, document indexing, vector search, chat with documents, knowledge base, embeddings, or collection management.
+description: Set up RAG pipelines, vector indexing, document ingestion, vector search, and knowledge base creation in NodeTool. Use when user asks about RAG, document indexing, vector search, chat with documents, knowledge base, embeddings, or collection management.
 ---
 
 You help users build Retrieval-Augmented Generation (RAG) pipelines in NodeTool.
@@ -8,195 +8,143 @@ You help users build Retrieval-Augmented Generation (RAG) pipelines in NodeTool.
 # RAG Architecture
 
 ```
-INDEXING:  Documents → Extract → Split → Embed → Store (vector DB)
-QUERY:    Question → Embed → Search → Format → LLM → Answer
+INDEXING:  Documents → Load → Split → Embed → Store (vector collection)
+QUERY:     Question → Embed → Search → Format → LLM → Answer
 ```
 
-# Vector Store Options
+# Vector Store Backends
 
-| Backend | Best For | Config |
-|---------|----------|--------|
-| **SQLite-vec** | Default, local, embedded | `DB_PATH` (automatic) |
-| **ChromaDB** | Production, remote | `CHROMA_URL`, `CHROMA_PATH` |
-| **FAISS** | High-speed similarity | In-memory or file-backed |
+NodeTool's vector store (`@nodetool-ai/vectorstore`) is backend-pluggable. The
+workflow nodes are the same regardless of backend — you pick the backend via
+configuration.
 
-# Indexing Pipeline
+| Backend | Best for | Notes |
+|---------|----------|-------|
+| **SQLite-vec** | Default, local, embedded | No external service |
+| **ChromaDB** | Self-host / remote | `CHROMA_URL`, `CHROMA_PATH`, `CHROMA_TOKEN` |
+| **Pinecone** | Managed cloud | API-key based |
+| **Supabase (pgvector)** | Postgres-backed | Pairs with Supabase auth/storage |
 
-## Default Flow (automatic)
+There are **no FAISS nodes**; the backends above cover local and hosted use.
+
+# Vector Nodes (`vector.*`)
+
+All RAG nodes live under the single `vector.*` namespace (not `vector.chroma.*`
+or `vector.faiss.*`).
+
+| Node | Purpose |
+|------|---------|
+| `vector.Collection` | Reference/select a collection by name (the collection ref other nodes consume) |
+| `vector.IndexTextChunk` | Index a single text chunk with its embedding |
+| `vector.IndexString` | Index a string value |
+| `vector.IndexAggregatedText` | Index aggregated text |
+| `vector.IndexEmbedding` | Index a precomputed embedding |
+| `vector.IndexImage` | Index an image |
+| `vector.QueryText` | Vector similarity search over text |
+| `vector.QueryImage` | Vector similarity search over images |
+| `vector.HybridSearch` | Vector + keyword search (best accuracy) |
+| `vector.GetDocuments` | Retrieve specific documents |
+| `vector.Count` | Count documents in a collection |
+| `vector.Peek` | Preview collection contents |
+| `vector.RemoveOverlap` | De-duplicate overlapping chunks in results |
+
+Query nodes (`QueryText`, `QueryImage`, `HybridSearch`) output `ids`,
+`documents`, `metadatas`, and `distances` (HybridSearch also returns `scores`).
+
+# Document Loading & Splitting (`nodetool.document.*`, `lib.os.*`)
+
+| Node | Namespace | Purpose |
+|------|-----------|---------|
+| `ListFiles` | `lib.os` | Enumerate files in a directory |
+| `LoadDocumentFile` | `nodetool.document` | Load a PDF/DOCX/TXT/MD into a document |
+| `SplitRecursively` | `nodetool.document` | Recursive character/token splitting (general purpose) |
+| `SplitMarkdown` | `nodetool.document` | Split Markdown by structure |
+| `SplitHTML` / `SplitJSON` | `nodetool.document` | Structure-aware splitting |
+| `SplitDocument` | `nodetool.document` | Split a loaded document |
+
+## Chunk Size Guidance
+
+| Content type | Chunk size | Overlap |
+|--------------|-----------|---------|
+| Technical docs | 200-500 tokens | 50 tokens |
+| Prose/articles | 300-600 tokens | 75 tokens |
+| Code | 100-300 tokens | 25 tokens |
+
+# Indexing — Workflow Pattern
 
 ```
-File → splitDocument() → embed → store in SQLite-vec
+ListFiles → LoadDocumentFile → SplitRecursively → IndexTextChunk(collection)
 ```
 
-The `indexFileToCollection()` function orchestrates:
-1. Resolve collection via `getCollection()`
-2. If custom workflow exists: execute it
-3. Fallback: `splitDocument()` → embed → store
+Pair every index/query node with a `vector.Collection` node (or a collection
+name) so they target the same store. Use the **same embedding model** for
+indexing and querying.
 
-## CLI / API Indexing
+# Indexing — HTTP API
 
 ```bash
-# Index via HTTP API
-curl -X POST http://localhost:7777/collections/<name>/index \
+# Index a file into a collection
+curl -X POST http://localhost:7777/api/collections/<name>/index \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"file_path": "/path/to/document.pdf"}'
 ```
 
-## Workflow-Based Indexing
+The server resolves the collection, runs its ingestion workflow if one is
+registered, otherwise falls back to split → embed → store.
 
-Build a workflow with these nodes:
-
-**Input nodes:**
-- `nodetool.input.StringInput` — collection name
-- `nodetool.input.StringInput` — file path
-
-**Processing chain:**
-```
-ListFiles → LoadDocument → ExtractText → SentenceSplitter → IndexTextChunks
-```
-
-| Node | Namespace | Purpose |
-|------|-----------|---------|
-| `ListFiles` | `lib.os` | Enumerate files in directory |
-| `LoadDocument` | `nodetool.text` | Load PDF/DOCX/TXT/MD |
-| `ExtractText` | `lib.pdf` | Extract text from PDFs |
-| `SentenceSplitter` | `nodetool.text` | Split into chunks |
-| `IndexTextChunks` | `vector.chroma` or `vector.faiss` | Store embeddings |
-
-## Chunk Size Guidance
-
-| Content Type | Chunk Size | Overlap |
-|-------------|-----------|---------|
-| Technical docs | 200-500 tokens | 50 tokens |
-| Prose/articles | 300-600 tokens | 75 tokens |
-| Code | 100-300 tokens | 25 tokens |
-| Q&A pairs | Per question | None |
-
-# Query Pipeline
-
-Build a workflow with these nodes:
+# Query — Workflow Pattern
 
 ```
-ChatInput → HybridSearch → FormatText → Agent → Output
+ChatInput → HybridSearch(collection, top_k) → FormatText → Agent → Output
 ```
 
 | Node | Purpose |
 |------|---------|
-| `ChatInput` | User question input |
-| `HybridSearch` | Vector + keyword search (best accuracy) |
-| `TextSearch` | Vector-only search (faster) |
-| `FormatText` | Format results as context for LLM |
-| `Agent` | Generate answer from context + question |
-| `Output` | Return answer |
+| `ChatInput` | User question |
+| `vector.HybridSearch` | Vector + keyword retrieval (best accuracy) |
+| `vector.QueryText` | Vector-only retrieval (faster) |
+| `FormatText` | Build the context string for the LLM |
+| `Agent` | Generate the answer from context + question |
+| `Output` | Return the answer |
 
-## Search Types
+# Complete RAG Example
 
-| Type | Node | Accuracy | Speed |
-|------|------|----------|-------|
-| **Hybrid** | `vector.chroma.HybridSearch` | Best | Slower |
-| **Vector** | `vector.chroma.TextSearch` | Good | Fast |
-| **FAISS** | `vector.faiss.Search` | Good | Fastest |
+## Index
+```
+ListFiles("/docs/") → LoadDocumentFile → SplitRecursively(chunk_size=400, overlap=50)
+                                                  ↓
+                                  IndexTextChunk(collection="my-docs")
+```
 
-# ChromaDB Nodes (`vector.chroma.*`)
-
-| Node | Purpose |
-|------|---------|
-| `CreateCollection` | Create a new collection |
-| `DeleteCollection` | Delete a collection |
-| `ListCollections` | List all collections |
-| `GetCollection` | Get collection details |
-| `IndexTextChunks` | Index text chunks with embeddings |
-| `IndexDocuments` | Index full documents |
-| `TextSearch` | Vector similarity search |
-| `HybridSearch` | Vector + keyword search |
-| `DeleteDocuments` | Remove documents from collection |
-| `GetDocuments` | Retrieve specific documents |
-| `UpdateDocuments` | Update document content |
-| `Count` | Count documents in collection |
-| `Peek` | Preview collection contents |
-
-# FAISS Nodes (`vector.faiss.*`)
-
-| Node | Purpose |
-|------|---------|
-| `CreateIndex` | Create FAISS index |
-| `AddVectors` | Add vectors to index |
-| `Search` | Similarity search |
-| `Save` | Save index to disk |
-| `Load` | Load index from disk |
-| `Remove` | Remove vectors |
-| `Count` | Count vectors |
+## Query
+```
+ChatInput("What is...?") → HybridSearch(collection="my-docs", top_k=5)
+                                  ↓
+                         FormatText(template="Context:\n{documents}\n\nQuestion: {query}")
+                                  ↓
+                         Agent(model=gpt-5.4, system="Answer using only the context provided.")
+                                  ↓
+                         Output
+```
 
 # Environment Variables
 
 ```bash
-# ChromaDB
-CHROMA_URL=                          # Remote Chroma URL (leave empty for local)
+# ChromaDB backend (only when using Chroma — SQLite-vec needs no config)
+CHROMA_URL=                          # Remote Chroma URL (empty = local)
 CHROMA_PATH=~/.local/share/nodetool/chroma  # Local storage path
 CHROMA_TOKEN=                        # Optional auth token
-
-# Embedding model (defaults to sentence-transformers)
-# Configure via model selection in IndexTextChunks node
 ```
 
-# Complete RAG Example (Workflow Pattern)
-
-## Step 1: Index Documents
-```
-StringInput("my-docs") → CreateCollection
-                          ↓
-ListFiles("/docs/") → ForEach → LoadDocument → ExtractText
-                                                    ↓
-                                    SentenceSplitter(chunk_size=400, overlap=50)
-                                                    ↓
-                                    IndexTextChunks(collection="my-docs")
-```
-
-## Step 2: Query
-```
-ChatInput("What is...?") → HybridSearch(collection="my-docs", top_k=5)
-                                    ↓
-                           FormatText(template="Context:\n{results}\n\nQuestion: {query}")
-                                    ↓
-                           Agent(model=gpt-4o, system="Answer using only the context provided.")
-                                    ↓
-                           Output
-```
-
-# Custom Ingestion Workflows
-
-For non-standard documents, create a custom workflow with:
-- **Input**: `CollectionInput(name=...)` + `FileInput(path=...)`
-- **Processing**: Custom extraction, metadata enrichment, specialized chunking
-- **Output**: Summaries, metadata, or alternate embeddings
-
-Register the workflow as the collection's ingestion handler.
-
-# Collection Management
-
-```bash
-# List collections
-nodetool collections list
-
-# Create collection
-nodetool collections create my-docs
-
-# Index files
-nodetool collections index my-docs /path/to/files/
-
-# Search
-nodetool collections search my-docs "query text"
-
-# Delete
-nodetool collections delete my-docs
-```
+The embedding model is chosen on the index/query nodes via model selection
+(e.g. `text-embedding-3-small`, or a local sentence-transformers model).
 
 # Common Pitfalls
 
-- **Embedding model mismatch**: Use the same embedding model for indexing and search
-- **Chunks too large**: LLM context gets diluted; keep to 200-500 tokens
-- **Chunks too small**: Loss of context; sentences get fragmented
-- **No overlap**: Related content split across chunks; use 10-20% overlap
-- **Not checking results**: Always test search quality before building full pipeline
-- **Missing collection**: Index before querying — empty collection returns nothing
+- **Embedding model mismatch**: use the same embedding model for indexing and search.
+- **Chunks too large**: dilute the LLM context — keep to 200-500 tokens.
+- **Chunks too small**: sentences get fragmented; use 10-20% overlap.
+- **Empty collection**: index before querying — an unindexed collection returns nothing.
+- **Wrong node names**: it's `vector.IndexTextChunk` / `vector.QueryText` / `vector.HybridSearch`, not `IndexTextChunks` / `TextSearch`, and there is no `vector.chroma.*`/`vector.faiss.*` namespace.
+- **No `nodetool collections` CLI**: manage collections through the editor UI or the `/api/collections/...` endpoints.

--- a/.claude/skills/nodetool-troubleshooter/SKILL.md
+++ b/.claude/skills/nodetool-troubleshooter/SKILL.md
@@ -16,7 +16,7 @@ When a user reports a problem, work through this in order:
 - [ ] **Model availability**: Is the model downloaded/API key set?
 - [ ] **File paths**: Do referenced files exist and have correct permissions?
 - [ ] **API keys**: Are provider keys configured? (`nodetool secrets store KEY`)
-- [ ] **Logs**: Check `~/.nodetool/logs/` or `--log-level debug`
+- [ ] **Logs**: Check `~/.nodetool/logs/` or run with `NODETOOL_LOG_LEVEL=debug`
 
 # Node Status Colors
 
@@ -67,7 +67,7 @@ When a user reports a problem, work through this in order:
 
 **Fix**:
 - Improve the prompt (be specific, add examples)
-- Use a more capable model (gpt-4o, claude-3.5-sonnet)
+- Use a more capable model (gpt-5.4, claude-sonnet-4-6)
 - Lower temperature for factual tasks (0.0–0.3)
 - Add few-shot examples in system prompt
 - Use RAG to ground answers in source documents
@@ -77,11 +77,11 @@ When a user reports a problem, work through this in order:
 **Symptoms**: HybridSearch or TextSearch returns empty results
 
 **Check**:
-1. Was the collection actually indexed? (`nodetool collections list`)
+1. Was the collection actually indexed? Inspect it with a `vector.Count` / `vector.Peek` node, or the editor's collection view.
 2. Does the embedding model match between indexing and search?
 3. Test search directly with a simple query
 4. Review chunking — very small or very large chunks reduce quality
-5. Check `CHROMA_PATH` or `CHROMA_URL` configuration
+5. For the Chroma backend, check `CHROMA_PATH` / `CHROMA_URL` (SQLite-vec, the default, needs no config)
 
 ## API Key Errors
 
@@ -124,7 +124,7 @@ export OPENAI_API_KEY=sk-...
 
 **Check**:
 1. `deployment.yaml` syntax (valid YAML?)
-2. All required env vars set? (`ENV`, `AUTH_PROVIDER`, `SECRETS_MASTER_KEY`)
+2. All required env vars set? (`NODETOOL_ENV`, `AUTH_PROVIDER`, `SECRETS_MASTER_KEY`)
 3. Docker running? (`docker ps`)
 4. Port already in use? (`lsof -i :7777`)
 5. Volume mount paths exist?
@@ -143,8 +143,8 @@ Add Preview nodes at each stage to isolate where data breaks.
 # Desktop app logs
 ls ~/.nodetool/logs/
 
-# CLI verbose mode
-nodetool serve --log-level debug
+# CLI verbose mode (logging is controlled by an env var, not a serve flag)
+NODETOOL_LOG_LEVEL=debug nodetool serve
 
 # Browser DevTools
 # View → Developer Tools → Console tab

--- a/.claude/skills/nodetool-workflow-builder/SKILL.md
+++ b/.claude/skills/nodetool-workflow-builder/SKILL.md
@@ -28,18 +28,21 @@ For every workflow create/edit request, follow this sequence:
 | Tool | Purpose | Key params |
 |------|---------|-----------|
 | `ui_search_nodes` | Find node types | `query`, `include_properties=true`, `include_outputs=true`, `limit` |
+| `ui_search_models` | Find models for a model property | `query`, `type` (e.g. `language_model`) |
 | `ui_add_node` | Add single node | `id`, `position`, `type` (use `node_type` from search) |
 | `ui_graph` | Bulk add nodes+edges | `nodes[]`, `edges[]` (hidden tool, but callable) |
 | `ui_connect_nodes` | Connect two nodes | `source_id`, `source_handle`, `target_id`, `target_handle` |
-| `ui_update_node_data` | Set node properties | `node_id`, `data={properties: {key: value}}` |
+| `ui_update_node_data` | Set node properties / sync mode | `node_id`, `data={properties: {…}, sync_mode: "on_all"}` |
 | `ui_get_graph` | Read graph + validation | Returns nodes, edges, and validation results |
 | `ui_delete_node` | Remove a node | `node_id` |
 | `ui_delete_edge` | Remove a connection | `edge_id` |
 | `ui_move_node` | Reposition a node | `node_id`, `position` |
 | `ui_set_node_title` | Rename a node | `node_id`, `title` |
-| `ui_set_node_sync_mode` | Set input mode | `node_id`, `mode` (`on_any` or `on_all`) |
 | `ui_open_workflow` | Open workflow tab | `workflow_id` |
 | `ui_run_workflow` | Execute workflow | `workflow_id`, `params` |
+
+> Set a node's `sync_mode` through `ui_update_node_data` (`data.sync_mode`) — there
+> is no dedicated sync-mode tool.
 
 ## Node Data Fields
 
@@ -63,16 +66,16 @@ When using `ui_add_node` or `ui_graph`, the `data` object supports:
 | `nodetool.audio` | Load, Mix, Encode | Audio processing |
 | `nodetool.video` | Load, Extract, Metadata, Frames | Video processing |
 | `nodetool.control` | If, ForEach, Collect, Switch | Control flow |
-| `nodetool.constants` | String, Integer, Float, Boolean | Constant values |
-| `nodetool.input` | FloatInput, StringInput, ImageInput | Workflow parameters |
+| `nodetool.constant` | String, Integer, Float, Bool, Image, Audio | Constant values |
+| `nodetool.input` | FloatInput, StringInput, ImageInput, ChatInput | Workflow parameters |
 | `nodetool.output` | Output, Preview | Results and debugging |
-| `nodetool.generators` | ListGenerator, TextGenerator | LLM-backed generators |
+| `nodetool.generators` | ListGenerator, DataGenerator, ChartGenerator | LLM-backed generators |
 
 ## Library Namespaces (`lib.*`)
 
-`lib.pdf` (extract text/images), `lib.sqlite` (database ops), `lib.browser` (web browsing, screenshots), `lib.os` (file system), `lib.svg` (vector graphics), `lib.markdown` (parsing), `lib.ocr` (text recognition), `lib.audio_dsp` (filters, spectral), `lib.seaborn` (charts), `lib.excel` (spreadsheets), `lib.docx` (Word docs)
+`lib.pdf` (extract text/images), `lib.http` (web requests), `lib.sqlite` (database ops), `lib.browser` (web browsing, screenshots), `lib.os` (file system), `lib.datetime` (dates/times), `lib.svg` (vector graphics), `lib.markdown` (parsing), `lib.ocr` (text recognition), `lib.excel` (spreadsheets), `lib.docx` (Word docs), `lib.charts` (charts)
 
-> **Note:** `lib.http`, `lib.json`, `lib.math`, `lib.date`, `lib.uuid`, `nodetool.boolean`, `nodetool.list`, `nodetool.dictionary`, `nodetool.numbers`, and all `skills.*` nodes have been removed. Use the **Code node** (`nodetool.code.Code`) with built-in snippet library instead.
+> **Note:** `lib.json`, `lib.math`, `lib.uuid`, `nodetool.boolean`, `nodetool.dictionary`, `nodetool.numbers`, and all `skills.*` nodes have been removed — use the **Code node** (`nodetool.code.Code`) with its built-in snippet library for JSON/math/uuid logic. (`lib.http` and `nodetool.list` — `Range`, `RepeatEach`, `RepeatValue`, `Tile` — still exist; date/time is now `lib.datetime`.)
 
 ## External Service Namespaces
 
@@ -84,9 +87,8 @@ When using `ui_add_node` or `ui_graph`, the `data` object supports:
 | `openai.*` | GPT, GPT-Image, embeddings, TTS |
 | `gemini.*` | Google Gemini models |
 | `mistral.*` | Mistral models |
-| `search.*` | Web search integrations |
-| `vector.*` | ChromaDB and FAISS vector stores |
-| `skills.*` | LLM-backed skill nodes |
+| `search.google.*` | Web search integrations |
+| `vector.*` | Vector store nodes (SQLite-vec default; Chroma/Pinecone/Supabase backends) |
 
 ## Data Types
 
@@ -122,10 +124,11 @@ Edges enforce type compatibility. Use `any` type for flexible connections.
 **Key concept**: Add Preview nodes at intermediate stages for debugging and monitoring.
 
 ## Pattern 4: RAG (Retrieval-Augmented Generation)
-**Shape**: ChatInput → HybridSearch + FormatText → Agent → Output
+**Shape**: ChatInput → vector.HybridSearch + FormatText → Agent → Output
 **Use for**: Question-answering over documents, factual accuracy from specific sources.
-**Index flow**: ListFiles → LoadDocument → ExtractText → SentenceSplitter → IndexTextChunks
-**Query flow**: ChatInput → HybridSearch → FormatText → Agent → Output
+**Index flow**: lib.os.ListFiles → LoadDocumentFile → SplitRecursively → vector.IndexTextChunk
+**Query flow**: ChatInput → vector.HybridSearch → FormatText → Agent → Output
+**Note**: RAG nodes are the single `vector.*` namespace (e.g. `vector.QueryText`, `vector.HybridSearch`, `vector.IndexTextChunk`); there is no `vector.chroma.*`/`vector.faiss.*`.
 
 ## Pattern 5: Database Persistence
 **Shape**: Input → FormatText → DataGenerator → Insert → Query → Preview
@@ -155,25 +158,31 @@ Edges enforce type compatibility. Use `any` type for flexible connections.
 **Shape**: GetRequest → ImportCSV → Filter → ChartGenerator → Preview
 **Use for**: Fetch external data, transform datasets, auto-generate visualizations.
 
+> **Video/image generation nodes live under `kie.video.*`, `kie.image.*`,
+> `kie.audio.*`** (e.g. `kie.video.Kling26TextToVideo`,
+> `kie.video.Hailuo02TextToVideoPro`). Exact model nodes change as providers add
+> models — always `ui_search_nodes` for the current node type rather than typing
+> a name from memory.
+
 ## Pattern 11: Text-to-Video
-**Shape**: StringInput (prompt) → video generation node → Output
-**Key nodes**: KlingTextToVideo, HailuoTextToVideoPro, Sora2TextToVideo, Wan26TextToVideo
+**Shape**: StringInput (prompt) → `kie.video.*` text-to-video node → Output
+**Find nodes**: search `"text to video"` (Kling, Hailuo, Sora, Wan, Bytedance families)
 **Config**: Duration 5-10s, Resolution 768P (fast) or 1080P (quality), Aspect 16:9/9:16/1:1
 
 ## Pattern 12: Image-to-Video
-**Shape**: ImageInput + StringInput (motion guide) → video generation → Output
-**Key nodes**: KlingImageToVideo (1-3 images), HailuoImageToVideoPro, Wan26ImageToVideo
+**Shape**: ImageInput + StringInput (motion guide) → `kie.video.*` image-to-video node → Output
+**Find nodes**: search `"image to video"`
 
 ## Pattern 13: Talking Avatar
-**Shape**: ImageInput (face) + AudioInput (speech) → avatar generation → Output
-**Key nodes**: KlingAIAvatarPro, KlingAIAvatarStandard, InfinitalkV1
+**Shape**: ImageInput (face) + AudioInput (speech) → avatar generation node → Output
+**Find nodes**: search `"avatar"` or `"lip sync"`
 
 ## Pattern 14: Video Enhancement
-**Shape**: VideoInput → TopazVideoUpscale → Output
-**Use for**: Upscale to 1080p/4K, denoise, enhance old footage.
+**Shape**: VideoInput → upscale node → Output
+**Find nodes**: search `"upscale"` / `"video enhance"` (e.g. Topaz family)
 
 ## Pattern 15: Storyboard to Video
-**Shape**: StringInput (story) + ImageInputs (scenes 1-3) → Sora2ProStoryboard → Output
+**Shape**: StringInput (story) + ImageInputs (scenes) → storyboard video node → Output
 **Use for**: Narrative videos from keyframes, scene transitions.
 
 ## Agent Tool Pattern
@@ -263,52 +272,62 @@ Write workflows as TypeScript with full type safety and IDE autocompletion using
 
 ## Basic Pattern
 ```typescript
-import { workflow, constant, libMath } from "@nodetool-ai/dsl";
+import { workflow, constant, text, agents } from "@nodetool-ai/dsl";
 
-// Create nodes — each returns a DslNode with typed .output handle
-const a = constant.float({ value: 3.14 });
-const b = constant.float({ value: 2.0 });
+// Create nodes — call node.output() to get a connectable handle.
+const greeting = constant.string({ value: "hello world" });
 
-// Connect by passing output handles as inputs
-const sum = libMath.add({ a: a.output, b: b.output });
+// Connect by passing output handles as inputs.
+const shout = text.toUppercase({ text: greeting.output() });
+const summary = agents.summarizer({ text: shout.output() });
 
-// Build workflow graph (traces all connections)
-const wf = workflow(sum);
+// Build the workflow graph (traces all connections).
+const wf = workflow(summary);
 console.log(JSON.stringify(wf));
 ```
 
 ## Key Concepts
-- **OutputHandle**: `node.output` is a symbolic reference, not a value. Pass it to create edges.
-- **Connectable**: Every input accepts either a literal value or an OutputHandle.
-- **Multi-output nodes**: Use `node.out.slotName` (e.g., `ifNode.out.if_true`).
-- **workflow()**: Traces from terminal nodes via BFS, produces serializable JSON.
-- **run()**: Executes a workflow in-process using WorkflowRunner.
-- **runGraph()**: Shorthand — calls `workflow()` then `run()`.
+- **`node.output()`** is a function — call it to get the default output handle. It is NOT a property (`node.output`).
+- **Named slots**: `node.output("if_true")` for a specific output of a multi-output node.
+- **Connectable**: every input accepts either a literal value or an output handle.
+- **`workflow(...terminals)`**: traces from terminal nodes via BFS, returns serializable JSON `{ nodes, edges }`.
+- **`run(wf, opts?)`**: executes a workflow in-process via WorkflowRunner; returns the result.
+- **`runGraph(...terminals)`**: shorthand — `run(workflow(...terminals))`.
 
 ## DSL Namespaces
+Namespaces mirror node namespaces. Common ones:
+
 | Import | Example |
 |--------|---------|
-| `constant` | `constant.float({ value: 5 })` |
-| `libMath` | `libMath.add({ a: 1, b: 2 })` |
-| `text` | `text.concat({ a: "hi", b: " there" })` |
+| `constant` | `constant.float({ value: 5 })`, `constant.string({ value: "x" })` |
+| `text` | `text.toUppercase({ text: "hi" })`, `text.split({ ... })` |
 | `image` | `image.resize({ ... })` |
-| `control` | `control.if_({ condition: true, value: x })` |
-| `agents` | `agents.agent({ prompt: "..." })` |
-| `list` | `list.length({ values: items.output })` |
+| `control` | `control.if_({ condition: true, value: x })`, `control.forEach({ ... })` |
+| `agents` | `agents.agent({ ... })`, `agents.summarizer({ text })` |
+| `data` | `data.filter({ ... })` |
+| `vector` | `vector.hybridSearch({ ... })` |
+| `libHttp` | `libHttp.getJSON({ url })`, `libHttp.getText({ url })` |
+| `code` | `code.code({ ... })` — JS sandbox for math/JSON/list logic |
 
-## Diamond Pattern (shared dependencies)
+> There is no `libMath` or `list` namespace. Use the **Code node** (`code.code`) for
+> arithmetic/JSON/list operations.
+
+## Multi-Output (If / ForEach)
 ```typescript
-const shared = constant.float({ value: 10 });
-const left = libMath.add({ a: shared.output, b: 1 });
-const right = libMath.multiply({ a: shared.output, b: 2 });
-const final = libMath.add({ a: left.output, b: right.output });
-const wf = workflow(final); // shared appears once, 4 edges
+import { control } from "@nodetool-ai/dsl";
+
+const branch = control.if_({ condition: true, value: "hello" });
+branch.output("if_true");   // → output handle for the true branch
+branch.output("if_false");  // → output handle for the false branch
 ```
 
-## Multi-Output (If/ForEach)
+## Shared Dependencies (diamond)
 ```typescript
-const branch = control.if_({ condition: true, value: "hello" });
-// Use .out for named slots:
-branch.out.if_true   // → OutputHandle
-branch.out.if_false  // → OutputHandle
+import { workflow, constant, text } from "@nodetool-ai/dsl";
+
+const shared = constant.string({ value: "abc" });
+const upper = text.toUppercase({ text: shared.output() });
+const lower = text.toLowercase({ text: shared.output() });
+const joined = text.concat({ a: upper.output(), b: lower.output() });
+const wf = workflow(joined); // `shared` appears once; edges fan out
 ```

--- a/.claude/skills/unslop/SKILL.md
+++ b/.claude/skills/unslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop
-description: Strip "AI slop" from code and prose in this repo — over-engineered abstractions, defensive checks on trusted paths, narrating comments, dead error handlers, redundant types, useEffect-for-derived-data, raw MUI imports, whole-store Zustand subscriptions, throat-clearing prose. Use when reviewing your own diff before commit, when the user says "unslop this", or when refactoring AI-generated code in `web/`, `electron/`, `mobile/`, or `packages/`. Triggers on TypeScript/React/Zustand/MUI/TanStack Query files. Tailored to NodeTool's stack (React 19, Zustand 4.5, MUI v7 + ui_primitives, TanStack Query v5, Vitest/Jest, Drizzle).
+description: Strip "AI slop" from code and prose in this repo — over-engineered abstractions, defensive checks on trusted paths, narrating comments, dead error handlers, redundant types, useEffect-for-derived-data, raw MUI imports, whole-store Zustand subscriptions, throat-clearing prose. Use when reviewing your own diff before commit, when the user says "unslop this", or when refactoring AI-generated code in `web/`, `electron/`, `mobile/`, or `packages/`. Triggers on TypeScript/React/Zustand/MUI/TanStack Query files. Tailored to NodeTool's stack (React 19, Zustand 5, MUI v7 + ui_primitives, TanStack Query v5, Vitest/Jest, Drizzle).
 ---
 
 # Unslop
@@ -208,12 +208,12 @@ function NodeBadge({ node, ref, onSelect }: Props) {
 
 ## 6. Zustand slop
 
-NodeTool uses Zustand 4.5.7 with `shallow` equality. The rules in [`web/src/stores/AGENTS.md`](../../../web/src/stores/AGENTS.md) are not optional.
+NodeTool uses Zustand 5. Multi-key object selectors need `useShallow` (from `zustand/react/shallow`); the legacy `(selector, shallow)` second-argument form was removed in v5. The rules in [`web/src/stores/AGENTS.md`](../../../web/src/stores/AGENTS.md) are not optional.
 
 **Hunt for:**
 
 - `const store = useFooStore()` (whole-store subscription) — replace with a selector.
-- Multi-key selections that return a new object every render but **omit** `shallow` — every render re-runs subscribers.
+- Multi-key selections that return a new object every render but **omit** `useShallow` — every render re-runs subscribers.
 - `useFooStore.getState().x` inside render bodies (only acceptable inside event handlers / effects).
 - New `WebSocket(...)` instances anywhere in the web app — use `GlobalWebSocketManager`.
 - Components subscribing to a slice and then doing more filtering in render — push the filter into the selector.
@@ -374,7 +374,7 @@ Run through this before declaring a task done. Treat any "yes" as a slop sightin
 - [ ] Did I write `any`, `as any`, or `as unknown as` to silence the compiler?
 - [ ] Did I add `useEffect` to compute a value from props/state I already have?
 - [ ] Did I `useCallback`/`useMemo`/`React.memo` without a memoized consumer or measurable cost?
-- [ ] Did I subscribe to a whole Zustand store (`const s = useFooStore()`) or skip `shallow` on a multi-key selector?
+- [ ] Did I subscribe to a whole Zustand store (`const s = useFooStore()`) or skip `useShallow` on a multi-key selector?
 - [ ] Did I import a raw MUI component into a non-primitive file, or hardcode a color/spacing?
 - [ ] Did I write a `useEffect`+`fetch` instead of `useQuery`?
 - [ ] Does any new test assert implementation rather than user-visible behavior?


### PR DESCRIPTION
## Summary

Comprehensive update to all `.claude/skills/` documentation files to reflect current NodeTool capabilities, model names, API endpoints, and tool availability as of 2025. This ensures Claude has accurate, up-to-date guidance when helping users with RAG, agents, workflows, APIs, and browser automation.

## Key Changes

### RAG & Vector Store (`nodetool-rag-indexing`)
- Removed references to FAISS and ChromaDB-specific nodes; unified under `vector.*` namespace
- Updated vector store backends table: added Pinecone and Supabase (pgvector), removed FAISS
- Clarified that all RAG nodes use the same `vector.*` namespace regardless of backend
- Updated document loading/splitting nodes to current API (`LoadDocumentFile`, `SplitRecursively`, `SplitMarkdown`, etc.)
- Simplified indexing/query workflow patterns with current node names

### Agent Configuration (`nodetool-agent-config`)
- Updated model examples: `gpt-4o` → `gpt-5.4`, `claude-3.5-sonnet` → `claude-sonnet-4-6`
- Clarified that `objective` is optional in YAML (can be passed via CLI or stdin)
- Updated provider list: added `gemini` (aliased from `google`), removed outdated providers
- Replaced deprecated `max_iterations` with `max_steps`
- Removed `context_window` and `temperature` from required fields
- Added `preferred_providers` and `preferred_models` config options
- Updated CLI commands: `run`, `test`, `list` subcommands with current flags (`-o`, `-p`, `-m`, `-w`, `--json`, `-v`)
- Removed interactive mode commands; clarified that trace goes to stderr, result to stdout
- Updated tool catalog: removed `terminal`, `execute_code`, `take_screenshot`, `vec_*` tools; added `run_code`, `screenshot`, `find_model`, media generation tools

### API Reference (`nodetool-api-reference`)
- Clarified three API surfaces: REST (`/api/...`), OpenAI-compatible (`/v1/...`), WebSocket (`/ws`)
- Removed references to separate "Editor API" and "Server API" modes
- Updated model examples to `gpt-5.4`
- Simplified REST endpoints section; clarified that workflow execution is WebSocket-only
- Added `/api/collections/<name>/index` endpoint for RAG
- Updated WebSocket job control commands with current message format
- Removed deprecated endpoints and clarified authentication model

### Chat CLI (`nodetool-chat-cli`)
- Clarified that agent mode is always on (removed `-a/--agent` flag documentation)
- Updated provider list with current options (added `xai`, `groq`, `mistral`, `deepseek`, etc.)
- Replaced workspace shell commands (`pwd`, `ls`, `cd`, etc.) with note that file ops happen through agent tools
- Updated slash commands: `/new`, `/clear`, `/compact`, `/model`, `/provider`, `/tools`, `/exit`
- Removed `/agent` toggle command
- Updated settings file path: `~/.nodetool_settings` → `~/.nodetool/chat-settings.json`
- Added CLI flags table with current options (`--tools`, `-u/--url`, `--sandbox`, `--trace-file`, `--trace-stdout`)

### Browser Agent (`nodetool-browser-agent`)
- Removed `dom_examine`, `dom_search`, `dom_extract` tools; clarified that `browser` tool handles rendering and extraction
- Updated tool list: added `http_request`, `openai_web_search`, removed `take_screenshot` (now `screenshot`)
- Updated example configs with current model names and `max_steps` instead of `max_iterations`
- Simplified agent instructions to use natural language with the `browser` tool rather than DOM-specific tools

### Workflow Builder (`nodetool-workflow-builder`)
- Added `ui_search_models` tool for finding models by capability
- Updated node namespaces: `nodetool.constants` → `nodetool.constant`, `nodetool.generators` updated with current generators

https://claude.ai/code/session_0138f33bDy6V9tJrnaX5SwRc