### PR TITLE
Add demo harness for product-demo video recording and replay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,21 +22,12 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "web/**"
-      - "electron/**"
-      - "packages/**"
-      - "mobile/**"
-      - "examples/**"
-      - "scripts/**"
-      - "package.json"
-      - "package-lock.json"
-      - "tsconfig.json"
-      - "tsconfig.*.json"
-      - "turbo.json"
-      - ".nvmrc"
-      - ".github/workflows/test.yml"
-      - ".github/workflows/quality-checks.yml"
+    # No `paths` filter here: this workflow's "Quality Gate" job is a REQUIRED
+    # status check. A path-filtered required check is left Pending (never runs)
+    # when a PR push/merge touches no matching path — e.g. a clean "merge main"
+    # commit — which blocks the PR and auto-merge indefinitely. Running the gate
+    # on every PR keeps the required check from getting stuck. (The `push` to
+    # main above keeps its path filter — there is no required-check to block.)
 
 jobs:
   quality:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ packages/           # 55 npm workspace packages (TypeScript backend)
 web/                # React 19 + Vite + MUI + Zustand + ReactFlow
 electron/           # Electron 39 desktop app
 mobile/             # React Native / Expo
+demo/               # Remotion harness for product-demo videos (replays recorded
+                    # graph-UI "casts"; see demo/README.md and web/src/demo/)
 ```
 
 ### Package Dependency Order

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+out
+.remotion

--- a/demo/README.md
+++ b/demo/README.md
@@ -107,29 +107,31 @@ A cast is just JSON. After recording you can:
 
 The composition imports `DemoPlayer` from `web/src` and renders it inline, so the
 node UI is part of Remotion's DOM and its animations are frame-deterministic.
-`demo/src/webpackOverride.ts` reproduces the two things `web/vite.config.ts` does
-to make those components bundle for the browser:
+This is verified end-to-end (`npm run render` produces an MP4 of the sample).
+`demo/src/webpackOverride.ts` reproduces what `web/vite.config.ts` does so the
+components bundle for the browser:
 
-1. the `nodetool-dev` export condition (so `@nodetool-ai/*` resolve to TS source), and
-2. browser-safe stubs for the Node built-ins the kernel references on server
-   paths the render never executes (reusing `web/vite-node-stubs/`).
+1. the `nodetool-dev` export condition (so `@nodetool-ai/*` resolve to TS source);
+2. `extensionAlias` so TS-ESM `./x.js` imports resolve to `x.ts`;
+3. a `node:`-scheme strip plugin + browser-safe built-in stubs (reusing
+   `web/vite-node-stubs/`) for kernel server paths the render never runs;
+4. a bumped esbuild target + `topLevelAwait` for `@nodetool-ai/config`;
+5. an `@svgr/webpack` rule for `*.svg?react` icons (and excluding that query from
+   Remotion's default asset rule);
+6. the generated `@nodetool/{fal,kie}-*-pricing` JSON aliases.
 
-If a render fails on a server-only module, add its specifier to the `IGNORE`
-list in `webpackOverride.ts`.
+`DemoPlayer` also wraps the tree in a `MemoryRouter` (node components use
+react-router hooks). If a render fails on a server-only module, add its specifier
+to the `IGNORE` list in `webpackOverride.ts`.
 
 ## First render & troubleshooting
 
 The first `npm run studio` / `render` downloads a headless Chromium and bundles
-the web components — give it a minute. Bundling the real app under webpack (vs.
-Vite) is the one place that can need tuning, because web source uses a few
-Vite-specific constructs. The override already handles the common ones:
-
-- **`*.svg?react`** (svgr icons) — handled via `@svgr/webpack` in
-  `webpackOverride.ts`.
-- **Node built-ins** on server code paths — stubbed (see above).
-
-If a render still fails, the error names the gap. Add the matching rule/alias to
-`webpackOverride.ts`:
+the web components — give it a minute. The sample renders cleanly today; the
+override already handles every Vite↔webpack parity gap in the current node UI
+(see the list above). A new cast that pulls in a node type the sample doesn't
+could surface another gap — if so, the error names it. Add the matching
+rule/alias to `webpackOverride.ts`:
 
 - a Vite query import (`?worker`, `?raw`, `?url`) → add a webpack rule for that
   `resourceQuery`;

--- a/demo/README.md
+++ b/demo/README.md
@@ -117,6 +117,32 @@ to make those components bundle for the browser:
 If a render fails on a server-only module, add its specifier to the `IGNORE`
 list in `webpackOverride.ts`.
 
+## First render & troubleshooting
+
+The first `npm run studio` / `render` downloads a headless Chromium and bundles
+the web components — give it a minute. Bundling the real app under webpack (vs.
+Vite) is the one place that can need tuning, because web source uses a few
+Vite-specific constructs. The override already handles the common ones:
+
+- **`*.svg?react`** (svgr icons) — handled via `@svgr/webpack` in
+  `webpackOverride.ts`.
+- **Node built-ins** on server code paths — stubbed (see above).
+
+If a render still fails, the error names the gap. Add the matching rule/alias to
+`webpackOverride.ts`:
+
+- a Vite query import (`?worker`, `?raw`, `?url`) → add a webpack rule for that
+  `resourceQuery`;
+- `import.meta.glob` → replace with explicit imports (it is Vite-only);
+- a server-only package → add it to `IGNORE`.
+
+**Fallback:** if direct-embed bundling is more than you want to chase, the same
+player is served as a standalone page at `web/demo.html` (run `npm start` in
+`web/`). You can drive that page from Remotion via an `<IFrame>` + the
+`window.nodetoolDemo.seek(ms)` API instead of embedding the component — at the
+cost of some CSS-animation determinism. The cast format, recorder, and player
+are identical either way.
+
 ## Determinism notes
 
 - Frame state is a pure function of `timeMs` — forward seeks apply incrementally,

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,128 @@
+# NodeTool Demo Video Harness
+
+Scripted, reproducible product-demo videos of the real NodeTool graph UI —
+generations, streaming, and outputs — rendered with [Remotion](https://remotion.dev).
+
+The trick: instead of running the live backend (and burning generation credits)
+every time you render, you **record one real run into a `cast`** and replay that
+cast deterministically. The same recording can be re-rendered any number of
+times, retimed, captioned, and recomposed — with zero further generations.
+
+```
+record real run ──▶  cast.json  +  pinned assets  ──▶  Remotion render ──▶  demo.mp4
+   (once, costs)        (stored, replayable)            (free, repeatable)
+```
+
+## How it fits together
+
+| Piece | Location | Role |
+| --- | --- | --- |
+| **Cast format** | `web/src/demo/castTypes.ts` | The stored demo: workflow graph + node metadata + a time-stamped timeline of the exact protocol messages + an asset manifest. Plain, editable JSON. |
+| **DemoEngine** | `web/src/demo/demoEngine.ts` | Replays a cast deterministically: `seekToTime(ms)` makes the execution stores reflect exactly the events up to `ms`. Backward seeks reset and replay. |
+| **DemoPlayer** | `web/src/demo/DemoPlayer.tsx` | Renders the **real** `BaseNode`/`PreviewNode`/`OutputNode` etc. for a cast at a given time. The single rendering surface, shared by Remotion and the preview page. |
+| **CastRecorder** | `web/src/demo/recorder.ts` | Taps the live message stream during a real run and assembles a cast. |
+| **Preview page** | `web/demo.html` + `web/src/demo-entry.tsx` | Scrub/preview a cast in a browser (`npm start` in `web/`, open `/demo.html`). |
+| **Remotion project** | `demo/` (this dir) | Compositions that embed `DemoPlayer`, drive it from the frame clock, and add title cards / captions. |
+
+Because the player reuses the production node components and drives the
+production update reducer (`handleUpdate`), the video looks exactly like the app
+— running rings, streaming text, progress bars, and final outputs included. With
+**direct embed**, Remotion's deterministic clock also drives the UI's CSS
+animations, so every frame is reproducible.
+
+## Quick start (the built-in sample, no backend)
+
+```bash
+# from repo root, after `npm install`
+cd demo
+npm run studio          # open Remotion Studio on the sample cast
+npm run render          # render WorkflowDemo → demo/out/workflow-demo.mp4
+```
+
+The sample cast (`web/src/demo/sampleCast.ts`) is fully synthetic (inline assets,
+no backend) — a two-node "stream text → image preview" demo. Use it to validate
+the pipeline before recording your own.
+
+## Recording a real demo
+
+1. **Record.** From the editor (dev build), capture one real run:
+
+   ```ts
+   import { CastRecorder, downloadCastJson } from "@/demo"; // web/src/demo
+
+   const rec = new CastRecorder();
+   rec.start({
+     workflowId,
+     getWorkflow: () => nodeStore.getState().getWorkflow(),
+     getMetadata: () => useMetadataStore.getState().metadata,
+   });
+   // …click Run, let the workflow finish…
+   const cast = rec.stop({ name: "Image generation", fps: 30 });
+   downloadCastJson(cast); // saves <name>.cast.json
+   ```
+
+   (Wire this to a dev-only "Record demo" button, or call it from the console.)
+
+2. **Store.** Drop the file in `demo/casts/`, e.g. `demo/casts/image-gen.cast.json`.
+
+3. **Pin assets** so replay needs no backend (run once, while the server that
+   produced the run is still up so the asset URLs resolve):
+
+   ```bash
+   cd demo
+   npm run pin-assets -- casts/image-gen.cast.json --api http://localhost:7777
+   ```
+
+   This downloads every generated image/audio/video into
+   `demo/public/casts/<castId>/` and rewrites the cast's manifest in place.
+
+4. **Register** the cast in `demo/src/casts/registry.ts`:
+
+   ```ts
+   import imageGen from "../../casts/image-gen.cast.json";
+   const casts: DemoCast[] = [sampleCast, imageGen as DemoCast];
+   ```
+
+5. **Render.** It now has its own composition (`Demo-<castId>`), or point the
+   default `WorkflowDemo` composition at it:
+
+   ```bash
+   npm run studio                                   # preview + scrub
+   npx remotion render src/index.ts Demo-image-gen out/image-gen.mp4
+   ```
+
+## Editing a cast
+
+A cast is just JSON. After recording you can:
+
+- **Trim / retime**: adjust `events[].t` and `durationMs`.
+- **Add captions / title**: pass `captions` and `title` to the composition
+  (see `demo/src/Root.tsx`).
+- **Swap assets**: drop a different file in `public/casts/<id>/` and update the
+  manifest `file`.
+- **Re-frame**: set `viewport: { x, y, zoom }` for a fixed camera (otherwise the
+  player fits the graph to view).
+
+## Why direct embed (and the webpack override)
+
+The composition imports `DemoPlayer` from `web/src` and renders it inline, so the
+node UI is part of Remotion's DOM and its animations are frame-deterministic.
+`demo/src/webpackOverride.ts` reproduces the two things `web/vite.config.ts` does
+to make those components bundle for the browser:
+
+1. the `nodetool-dev` export condition (so `@nodetool-ai/*` resolve to TS source), and
+2. browser-safe stubs for the Node built-ins the kernel references on server
+   paths the render never executes (reusing `web/vite-node-stubs/`).
+
+If a render fails on a server-only module, add its specifier to the `IGNORE`
+list in `webpackOverride.ts`.
+
+## Determinism notes
+
+- Frame state is a pure function of `timeMs` — forward seeks apply incrementally,
+  backward seeks (Studio scrubbing) reset and replay.
+- Each player instance remaps recorded `job_id`s to fresh ids so the reducer's
+  module-level per-job bookkeeping never collides across instances.
+- Realtime **audio** streaming is coalesced on a timer in the reducer; v1 casts
+  capture audio metadata but not sample-accurate binary audio. Text, images,
+  video, progress, and status are fully deterministic.

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nodetool-ai/demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Remotion harness for NodeTool product-demo videos (replays recorded workflow casts).",
+  "scripts": {
+    "studio": "remotion studio src/index.ts",
+    "render": "remotion render src/index.ts WorkflowDemo out/workflow-demo.mp4",
+    "still": "remotion still src/index.ts WorkflowDemo out/frame.png --frame=60",
+    "pin-assets": "tsx scripts/pin-cast-assets.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@remotion/bundler": "^4.0.481",
+    "@remotion/cli": "^4.0.481",
+    "@remotion/renderer": "^4.0.481",
+    "remotion": "^4.0.481"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -18,6 +18,7 @@
     "remotion": "^4.0.481"
   },
   "devDependencies": {
+    "@svgr/webpack": "^8.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "react": "^19.2.7",

--- a/demo/remotion.config.ts
+++ b/demo/remotion.config.ts
@@ -1,0 +1,13 @@
+/**
+ * Remotion configuration. The webpack override is what lets the bundler pull in
+ * the real NodeTool web components (see src/webpackOverride.ts).
+ */
+import { Config } from "@remotion/cli/config";
+import { webpackOverride } from "./src/webpackOverride";
+
+Config.setVideoImageFormat("jpeg");
+Config.setOverwriteOutput(true);
+// Concurrency 1 keeps the replay deterministic per render worker; the demo
+// player drives global Zustand stores, so one composition instance per browser.
+Config.setConcurrency(1);
+Config.overrideWebpackConfig(webpackOverride);

--- a/demo/scripts/pin-cast-assets.ts
+++ b/demo/scripts/pin-cast-assets.ts
@@ -1,0 +1,110 @@
+/**
+ * Pin a cast's generated assets to local files so it replays with no backend
+ * and no further generations (no credits burned).
+ *
+ *   npm run pin-assets -- casts/my-demo.cast.json [--api http://localhost:7777]
+ *
+ * For every asset in the cast manifest, this downloads `originalUri` into
+ * demo/public/casts/<castId>/<file>, fixes the file extension + contentType
+ * from the HTTP response, and rewrites the cast JSON in place. After pinning,
+ * the cast + its public/casts/<id>/ folder are fully self-contained.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface CastAsset {
+  key: string;
+  file: string;
+  contentType: string;
+  originalUri?: string;
+  bytes?: number;
+}
+interface DemoCast {
+  id: string;
+  assets: CastAsset[];
+  [k: string]: unknown;
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const demoRoot = path.resolve(here, "..");
+
+function parseArgs(argv: string[]): { castPath: string; api: string } {
+  const args = argv.slice(2);
+  const apiIdx = args.indexOf("--api");
+  const api = apiIdx >= 0 ? args[apiIdx + 1] : "http://localhost:7777";
+  const castPath = args.find((a) => !a.startsWith("--") && a !== api);
+  if (!castPath) {
+    throw new Error(
+      "Usage: pin-cast-assets <cast.json> [--api http://localhost:7777]"
+    );
+  }
+  return { castPath: path.resolve(process.cwd(), castPath), api };
+}
+
+/** Resolve a recorded `originalUri` to a fetchable absolute URL. */
+function toFetchUrl(originalUri: string, api: string): string {
+  if (originalUri.startsWith("asset://")) {
+    return `${api}/api/storage/${originalUri.slice("asset://".length)}`;
+  }
+  if (originalUri.startsWith("/api/")) return `${api}${originalUri}`;
+  return originalUri;
+}
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/svg+xml": "svg",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/ogg": "ogg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "application/json": "json",
+};
+
+async function main(): Promise<void> {
+  const { castPath, api } = parseArgs(process.argv);
+  const cast = JSON.parse(await readFile(castPath, "utf8")) as DemoCast;
+  const outDir = path.join(demoRoot, "public", "casts", cast.id);
+  await mkdir(outDir, { recursive: true });
+
+  let pinned = 0;
+  for (const asset of cast.assets) {
+    if (!asset.originalUri) {
+      console.warn(`skip ${asset.key}: no originalUri`);
+      continue;
+    }
+    const url = toFetchUrl(asset.originalUri, api);
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(`skip ${asset.key}: HTTP ${res.status} for ${url}`);
+      continue;
+    }
+    const contentType =
+      res.headers.get("content-type")?.split(";")[0]?.trim() ||
+      asset.contentType;
+    const ext =
+      EXT_BY_TYPE[contentType] ?? (path.extname(asset.file).slice(1) || "bin");
+    const file = `${asset.key}.${ext}`;
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    await writeFile(path.join(outDir, file), bytes);
+
+    asset.file = file;
+    asset.contentType = contentType;
+    asset.bytes = bytes.byteLength;
+    pinned++;
+    console.log(`pinned ${asset.key} → public/casts/${cast.id}/${file} (${bytes.byteLength} bytes)`);
+  }
+
+  await writeFile(castPath, JSON.stringify(cast, null, 2));
+  console.log(`\nPinned ${pinned}/${cast.assets.length} assets. Updated ${path.relative(process.cwd(), castPath)}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/demo/src/Root.tsx
+++ b/demo/src/Root.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Composition } from "remotion";
+
+import { WorkflowDemo, type WorkflowDemoProps } from "./WorkflowDemo";
+import { DEFAULT_CAST, listCasts } from "./casts/registry";
+import type { DemoCast } from "@web-demo";
+
+const WIDTH = 1920;
+const HEIGHT = 1080;
+
+/** Turn a cast id into a valid, readable Remotion composition id. */
+function compositionId(castId: string): string {
+  const slug = castId.replace(/[^A-Za-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `Demo-${slug || "cast"}`;
+}
+
+function framesFor(cast: DemoCast, introSeconds: number): number {
+  const fps = cast.fps ?? 30;
+  const intro = Math.round(introSeconds * fps);
+  return Math.max(1, intro + Math.ceil((cast.durationMs / 1000) * fps));
+}
+
+/**
+ * Registers one composition per cast, plus a canonical `WorkflowDemo` bound to
+ * the default cast (so the `npm run render` script has a stable target).
+ */
+export const Root: React.FC = () => {
+  const sampleProps: WorkflowDemoProps = {
+    castId: DEFAULT_CAST.id,
+    title: "NodeTool",
+    subtitle: "Visual AI workflows",
+    introSeconds: 1.5,
+    captions: [
+      { fromMs: 200, toMs: 1900, text: "Generating text, streaming live…" },
+      { fromMs: 2200, toMs: 3800, text: "Output renders right on the canvas" },
+    ],
+  };
+
+  return (
+    <>
+      <Composition
+        id="WorkflowDemo"
+        component={WorkflowDemo}
+        defaultProps={sampleProps}
+        fps={DEFAULT_CAST.fps ?? 30}
+        width={WIDTH}
+        height={HEIGHT}
+        durationInFrames={framesFor(DEFAULT_CAST, sampleProps.introSeconds ?? 0)}
+      />
+
+      {listCasts().map((cast) => (
+        <Composition
+          key={cast.id}
+          id={compositionId(cast.id)}
+          component={WorkflowDemo}
+          defaultProps={{ castId: cast.id } as WorkflowDemoProps}
+          fps={cast.fps ?? 30}
+          width={WIDTH}
+          height={HEIGHT}
+          durationInFrames={framesFor(cast, 0)}
+        />
+      ))}
+    </>
+  );
+};

--- a/demo/src/WorkflowDemo.tsx
+++ b/demo/src/WorkflowDemo.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  Sequence,
+  staticFile,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+
+import { DemoPlayer } from "@web-demo";
+import { getCast } from "./casts/registry";
+import { TitleCard } from "./components/TitleCard";
+import { Caption } from "./components/Caption";
+
+export interface CaptionCue {
+  fromMs: number;
+  toMs: number;
+  text: string;
+}
+
+// A `type` alias (not an interface) so its implicit index signature satisfies
+// Remotion's `Composition` props constraint (`Record<string, unknown>`).
+export type WorkflowDemoProps = {
+  /** Which cast to replay (see casts/registry). */
+  castId: string;
+  /** Opening title card text. Omit to skip the title beat. */
+  title?: string;
+  subtitle?: string;
+  /** Timed lower-third captions. */
+  captions?: CaptionCue[];
+  /** Seconds the title card holds before the replay begins. Default 0. */
+  introSeconds?: number;
+};
+
+/**
+ * The product-demo composition: replays a cast of the real NodeTool graph UI
+ * driven by Remotion's frame clock, with an optional title card and captions.
+ *
+ * The replay is offset by `introSeconds` so the title card can play first while
+ * the graph sits idle underneath.
+ */
+export const WorkflowDemo: React.FC<WorkflowDemoProps> = ({
+  castId,
+  title,
+  subtitle,
+  captions = [],
+  introSeconds = 0,
+}) => {
+  const cast = getCast(castId);
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const introFrames = Math.round(introSeconds * fps);
+  const replayFrame = Math.max(0, frame - introFrames);
+  const timeMs = (replayFrame / fps) * 1000;
+
+  const resolveAssetUrl = (file: string) =>
+    staticFile(`casts/${cast.id}/${file}`);
+
+  return (
+    <AbsoluteFill style={{ background: "#0f0f17" }}>
+      <DemoPlayer cast={cast} timeMs={timeMs} resolveAssetUrl={resolveAssetUrl} />
+
+      {captions.map((cue, i) => {
+        const from = introFrames + Math.round((cue.fromMs / 1000) * fps);
+        const durationInFrames = Math.max(
+          1,
+          Math.round(((cue.toMs - cue.fromMs) / 1000) * fps)
+        );
+        return (
+          <Sequence key={i} from={from} durationInFrames={durationInFrames}>
+            <Caption text={cue.text} />
+          </Sequence>
+        );
+      })}
+
+      {title && introFrames > 0 && (
+        <Sequence from={0} durationInFrames={introFrames}>
+          <TitleCard title={title} subtitle={subtitle} />
+        </Sequence>
+      )}
+    </AbsoluteFill>
+  );
+};

--- a/demo/src/casts/registry.ts
+++ b/demo/src/casts/registry.ts
@@ -1,0 +1,24 @@
+/**
+ * Cast registry — the set of demo recordings Remotion can render.
+ *
+ * `sampleCast` is the built-in synthetic demo. To add a recorded one, drop its
+ * JSON in demo/casts/, pin its assets (`npm run pin-assets -- casts/<file>`),
+ * then import it here:
+ *
+ *   import myDemo from "../../casts/my-demo.cast.json";
+ *   const casts: DemoCast[] = [sampleCast, myDemo as DemoCast];
+ */
+import { sampleCast, type DemoCast } from "@web-demo";
+
+const casts: DemoCast[] = [sampleCast];
+
+/** The cast bound to the canonical `WorkflowDemo` composition id. */
+export const DEFAULT_CAST: DemoCast = sampleCast;
+
+export const listCasts = (): DemoCast[] => casts;
+
+export const getCast = (id: string): DemoCast => {
+  const cast = casts.find((c) => c.id === id);
+  if (!cast) throw new Error(`Unknown cast id: ${id}`);
+  return cast;
+};

--- a/demo/src/components/Caption.tsx
+++ b/demo/src/components/Caption.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { interpolate, useCurrentFrame } from "remotion";
+
+export interface CaptionProps {
+  text: string;
+}
+
+/**
+ * Lower-third caption. Place inside a <Sequence> to time it; it fades itself in
+ * and out at the edges of that sequence's window.
+ */
+export const Caption: React.FC<CaptionProps> = ({ text }) => {
+  const frame = useCurrentFrame();
+  const opacity = interpolate(frame, [0, 8], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 64,
+        bottom: 72,
+        maxWidth: "60%",
+        padding: "14px 22px",
+        borderRadius: 12,
+        background: "rgba(15,15,23,0.72)",
+        backdropFilter: "blur(8px)",
+        border: "1px solid rgba(124,58,237,0.4)",
+        opacity,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "Inter, system-ui, sans-serif",
+          fontWeight: 500,
+          fontSize: 30,
+          color: "#e2e8f0",
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  );
+};

--- a/demo/src/components/TitleCard.tsx
+++ b/demo/src/components/TitleCard.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { AbsoluteFill, interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
+
+export interface TitleCardProps {
+  title: string;
+  subtitle?: string;
+}
+
+/**
+ * A centered title card. Springs in, holds, fades out. Intended to be wrapped
+ * in a <Sequence> so it only occupies the opening beat of the video.
+ */
+export const TitleCard: React.FC<TitleCardProps> = ({ title, subtitle }) => {
+  const frame = useCurrentFrame();
+  const { fps, durationInFrames } = useVideoConfig();
+
+  const enter = spring({ frame, fps, config: { damping: 200 } });
+  const exit = interpolate(
+    frame,
+    [durationInFrames - 15, durationInFrames],
+    [1, 0],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+  const opacity = Math.min(enter, exit);
+  const translateY = interpolate(enter, [0, 1], [24, 0]);
+
+  return (
+    <AbsoluteFill
+      style={{
+        justifyContent: "center",
+        alignItems: "center",
+        background:
+          "radial-gradient(circle at 50% 40%, rgba(124,58,237,0.25), rgba(15,15,23,0.95))",
+        opacity,
+      }}
+    >
+      <div style={{ textAlign: "center", transform: `translateY(${translateY}px)` }}>
+        <div
+          style={{
+            fontFamily: "Inter, system-ui, sans-serif",
+            fontWeight: 700,
+            fontSize: 92,
+            color: "#f8fafc",
+            letterSpacing: "-0.02em",
+          }}
+        >
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{
+              marginTop: 16,
+              fontFamily: "Inter, system-ui, sans-serif",
+              fontWeight: 400,
+              fontSize: 36,
+              color: "#a78bfa",
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { Root } from "./Root";
+
+registerRoot(Root);

--- a/demo/src/web-demo.d.ts
+++ b/demo/src/web-demo.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Typed facade for the embedded NodeTool demo player.
+ *
+ * The demo project imports the player from `@web-demo`. For type-checking, the
+ * `@web-demo` specifier resolves here (tsconfig `paths`); at bundle time webpack
+ * resolves it to the real source (`web/src/demo/index.ts`, see webpackOverride).
+ *
+ * This boundary is deliberate: it keeps `tsc` from re-checking the entire web
+ * app (its WebGPU/MUI-theme/emotion globals are web's own concern, validated by
+ * web's own typecheck) while still typing exactly what the demo consumes. The
+ * cast shape mirrors web/src/demo/castTypes.ts.
+ */
+declare module "@web-demo" {
+  import type * as React from "react";
+
+  export interface CastViewport {
+    x: number;
+    y: number;
+    zoom: number;
+  }
+
+  /** Mirror of web/src/demo/castTypes.ts `DemoCast` (index-signature kept open). */
+  export interface DemoCast {
+    version: number;
+    id: string;
+    name: string;
+    description?: string;
+    createdAt: string;
+    durationMs: number;
+    fps?: number;
+    viewport?: CastViewport;
+    [key: string]: unknown;
+  }
+
+  export interface DemoPlayerProps {
+    cast: DemoCast;
+    /** Elapsed time into the cast, in milliseconds. */
+    timeMs: number;
+    /** Maps a pinned asset file name to a host URL. */
+    resolveAssetUrl: (file: string) => string;
+    style?: React.CSSProperties;
+  }
+
+  export const DemoPlayer: React.FC<DemoPlayerProps>;
+  export const sampleCast: DemoCast;
+}

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -89,12 +89,44 @@ function buildAlias(): Record<string, string> {
   return alias;
 }
 
+/**
+ * esbuild target for the loader. Remotion defaults to `chrome85`, which rejects
+ * top-level await (used by `@nodetool-ai/config`). The render runs in a modern
+ * headless Chrome, so bump it to a TLA-capable target.
+ */
+const ESBUILD_TARGET = "chrome109";
+
+interface LoaderUse {
+  loader?: string;
+  options?: Record<string, unknown>;
+}
+
+/** Mutate Remotion's esbuild-loader rules in place to use a modern target. */
+function bumpEsbuildTargets(rules: unknown[]): void {
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object") continue;
+    const use = (rule as { use?: unknown }).use;
+    if (!Array.isArray(use)) continue;
+    for (const entry of use) {
+      if (!entry || typeof entry !== "object") continue;
+      const u = entry as LoaderUse;
+      if (typeof u.loader === "string" && u.loader.includes("esbuild-loader") && u.options) {
+        u.options = { ...u.options, target: ESBUILD_TARGET };
+      }
+    }
+  }
+}
+
 export const webpackOverride: WebpackOverrideFn = (config) => {
   const resolve = config.resolve ?? {};
   const existingConditions = resolve.conditionNames ?? ["...", "browser"];
   const existingRules = config.module?.rules ?? [];
+  bumpEsbuildTargets(existingRules as unknown[]);
   return {
     ...config,
+    // Top-level await (used by @nodetool-ai/config) needs webpack's experiment
+    // enabled in addition to a TLA-capable esbuild target (see bumpEsbuildTargets).
+    experiments: { ...config.experiments, topLevelAwait: true },
     module: {
       ...config.module,
       rules: [
@@ -117,6 +149,15 @@ export const webpackOverride: WebpackOverrideFn = (config) => {
       conditionNames: Array.from(
         new Set(["nodetool-dev", ...existingConditions, "browser", "..."])
       ),
+      // NodeTool packages use the TS ESM convention of importing source files
+      // with a `.js` extension (e.g. `./node-import.js` → `node-import.ts`).
+      // Vite resolves this natively; webpack needs an explicit extensionAlias.
+      extensionAlias: {
+        ".js": [".ts", ".tsx", ".js", ".jsx"],
+        ".mjs": [".mts", ".mjs"],
+        ".cjs": [".cts", ".cjs"],
+        ...(resolve.extensionAlias ?? {}),
+      },
       alias: {
         ...(resolve.alias ?? {}),
         ...buildAlias(),

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -14,6 +14,7 @@
  * gRPC package pulled in transitively), add its specifier to `IGNORE` below.
  */
 import path from "node:path";
+import webpack from "webpack";
 import type { WebpackOverrideFn } from "@remotion/bundler";
 
 // Remotion loads remotion.config.ts (which imports this file) as CJS, so
@@ -142,6 +143,15 @@ export const webpackOverride: WebpackOverrideFn = (config) => {
     // Top-level await (used by @nodetool-ai/config) needs webpack's experiment
     // enabled in addition to a TLA-capable esbuild target (see bumpEsbuildTargets).
     experiments: { ...config.experiments, topLevelAwait: true },
+    plugins: [
+      ...(config.plugins ?? []),
+      // resolve.alias does not intercept the `node:` scheme (same caveat Vite
+      // documents). Strip the prefix so the bare-name builtin aliases above
+      // resolve `node:fs` → `fs` → stub, etc.
+      new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+        resource.request = resource.request.replace(/^node:/, "");
+      }),
+    ],
     module: {
       ...config.module,
       rules: [

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -14,13 +14,15 @@
  * gRPC package pulled in transitively), add its specifier to `IGNORE` below.
  */
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { WebpackOverrideFn } from "@remotion/bundler";
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const STUBS = path.resolve(here, "../../web/vite-node-stubs");
+// Remotion loads remotion.config.ts (which imports this file) as CJS, so
+// `import.meta.url` is unavailable. Anchor on the demo project root instead —
+// Remotion always runs with cwd at this directory (see package.json scripts).
+const DEMO_ROOT = process.cwd();
+const STUBS = path.resolve(DEMO_ROOT, "../web/vite-node-stubs");
 /** Runtime target for the `@web-demo` facade (typed via tsconfig paths). */
-const WEB_DEMO_ENTRY = path.resolve(here, "../../web/src/demo/index.ts");
+const WEB_DEMO_ENTRY = path.resolve(DEMO_ROOT, "../web/src/demo/index.ts");
 
 /** Built-in → stub file (browser-safe partial implementations). */
 const STUBBED: Record<string, string> = {

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -117,6 +117,26 @@ interface LoaderUse {
   options?: Record<string, unknown>;
 }
 
+/**
+ * Remotion's default `asset/resource` rule matches `.svg` regardless of query,
+ * so it would turn `foo.svg?react` into a URL (then React renders the URL string
+ * as a tag → crash). Exclude the `?react` query from it so our svgr rule owns it.
+ */
+function excludeReactQueryFromSvgAsset(rules: unknown[]): void {
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object") continue;
+    const r = rule as { type?: string; test?: unknown; resourceQuery?: unknown };
+    if (
+      r.type === "asset/resource" &&
+      r.test instanceof RegExp &&
+      r.test.test("x.svg") &&
+      r.resourceQuery == null
+    ) {
+      r.resourceQuery = { not: [/react/] };
+    }
+  }
+}
+
 /** Mutate Remotion's esbuild-loader rules in place to use a modern target. */
 function bumpEsbuildTargets(rules: unknown[]): void {
   for (const rule of rules) {
@@ -138,6 +158,7 @@ export const webpackOverride: WebpackOverrideFn = (config) => {
   const existingConditions = resolve.conditionNames ?? ["...", "browser"];
   const existingRules = config.module?.rules ?? [];
   bumpEsbuildTargets(existingRules as unknown[]);
+  excludeReactQueryFromSvgAsset(existingRules as unknown[]);
   return {
     ...config,
     // Top-level await (used by @nodetool-ai/config) needs webpack's experiment

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -90,8 +90,24 @@ function buildAlias(): Record<string, string> {
 export const webpackOverride: WebpackOverrideFn = (config) => {
   const resolve = config.resolve ?? {};
   const existingConditions = resolve.conditionNames ?? ["...", "browser"];
+  const existingRules = config.module?.rules ?? [];
   return {
     ...config,
+    module: {
+      ...config.module,
+      rules: [
+        ...existingRules,
+        // Web imports icons as React components via Vite's svgr query
+        // (`import Icon from "./x.svg?react"`). Webpack needs @svgr/webpack to
+        // match the same `?react` resource query. Plain `.svg` imports keep
+        // Remotion's default (asset URL) handling.
+        {
+          test: /\.svg$/,
+          resourceQuery: /react/,
+          use: ["@svgr/webpack"],
+        },
+      ],
+    },
     resolve: {
       ...resolve,
       // `nodetool-dev` first so package `exports` map to `src/*.ts`. The "..."

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -1,0 +1,108 @@
+/**
+ * Webpack override that lets Remotion bundle the real NodeTool web components.
+ *
+ * Mirrors the two things web/vite.config.ts does to make `@nodetool-ai/*` and
+ * the node UI bundle for the browser:
+ *
+ *  1. Resolve the `nodetool-dev` export condition, so `@nodetool-ai/*` packages
+ *     resolve to their TypeScript sources (no dist build step needed).
+ *  2. Stub Node built-ins that the kernel/runtime statically reference for their
+ *     server code paths but the browser-tagged render never executes. We reuse
+ *     the exact stub files from web/vite-node-stubs so behavior matches the app.
+ *
+ * If a render fails on a server-only module (e.g. an OpenTelemetry exporter or a
+ * gRPC package pulled in transitively), add its specifier to `IGNORE` below.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WebpackOverrideFn } from "@remotion/bundler";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const STUBS = path.resolve(here, "../../web/vite-node-stubs");
+/** Runtime target for the `@web-demo` facade (typed via tsconfig paths). */
+const WEB_DEMO_ENTRY = path.resolve(here, "../../web/src/demo/index.ts");
+
+/** Built-in → stub file (browser-safe partial implementations). */
+const STUBBED: Record<string, string> = {
+  "fs/promises": "fs-promises-stub.js",
+  fs: "fs-stub.js",
+  path: "path-stub.js",
+  url: "url-stub.js",
+  crypto: "crypto-stub.js",
+  os: "os-stub.js",
+  events: "events-stub.js",
+  child_process: "child-process-stub.js",
+};
+
+/** Built-ins with no API surface the browser path needs → empty module. */
+const EMPTIED = [
+  "worker_threads",
+  "cluster",
+  "dgram",
+  "dns",
+  "net",
+  "tls",
+  "zlib",
+  "http",
+  "https",
+  "http2",
+  "perf_hooks",
+  "vm",
+  "stream",
+  "async_hooks",
+  "util",
+  "buffer",
+  "assert",
+  "process",
+  "module",
+];
+
+/** Server-only specifiers to resolve to an empty module if they appear. */
+const IGNORE = [
+  "@nodetool-ai/runtime/tracing",
+];
+
+function buildAlias(): Record<string, string> {
+  const empty = path.join(STUBS, "empty.js");
+  const alias: Record<string, string> = {
+    // Route the typed facade to the real web source at bundle time.
+    "@web-demo$": WEB_DEMO_ENTRY,
+  };
+
+  for (const [name, file] of Object.entries(STUBBED)) {
+    const target = path.join(STUBS, file);
+    // Match both the `node:` protocol and bare specifier, exactly.
+    alias[`node:${name}$`] = target;
+    alias[`${name}$`] = target;
+  }
+  for (const name of EMPTIED) {
+    alias[`node:${name}$`] = empty;
+    alias[`${name}$`] = empty;
+  }
+  for (const spec of IGNORE) {
+    alias[`${spec}$`] = spec === "@nodetool-ai/runtime/tracing"
+      ? path.join(STUBS, "tracing-stub.js")
+      : empty;
+  }
+  return alias;
+}
+
+export const webpackOverride: WebpackOverrideFn = (config) => {
+  const resolve = config.resolve ?? {};
+  const existingConditions = resolve.conditionNames ?? ["...", "browser"];
+  return {
+    ...config,
+    resolve: {
+      ...resolve,
+      // `nodetool-dev` first so package `exports` map to `src/*.ts`. The "..."
+      // sentinel preserves Remotion's own default condition names.
+      conditionNames: Array.from(
+        new Set(["nodetool-dev", ...existingConditions, "browser", "..."])
+      ),
+      alias: {
+        ...(resolve.alias ?? {}),
+        ...buildAlias(),
+      },
+    },
+  };
+};

--- a/demo/src/webpackOverride.ts
+++ b/demo/src/webpackOverride.ts
@@ -21,8 +21,20 @@ import type { WebpackOverrideFn } from "@remotion/bundler";
 // Remotion always runs with cwd at this directory (see package.json scripts).
 const DEMO_ROOT = process.cwd();
 const STUBS = path.resolve(DEMO_ROOT, "../web/vite-node-stubs");
+const PKGS = path.resolve(DEMO_ROOT, "../packages");
 /** Runtime target for the `@web-demo` facade (typed via tsconfig paths). */
 const WEB_DEMO_ENTRY = path.resolve(DEMO_ROOT, "../web/src/demo/index.ts");
+
+/**
+ * Generated pricing JSON aliased as bare specifiers, mirroring web/vite.config.ts.
+ * The web code imports these as modules (declared ambiently in web/src/fal-*.d.ts).
+ */
+const GENERATED_JSON: Record<string, string> = {
+  "@nodetool/fal-node-type-pricing": "fal-nodes/src/generated/fal-node-type-pricing.json",
+  "@nodetool/fal-unit-pricing-catalog": "fal-nodes/src/generated/fal-unit-pricing.json",
+  "@nodetool/kie-node-type-pricing": "kie-nodes/src/generated/kie-node-type-pricing.json",
+  "@nodetool/kie-unit-pricing-catalog": "kie-nodes/src/generated/kie-unit-pricing.json",
+};
 
 /** Built-in → stub file (browser-safe partial implementations). */
 const STUBBED: Record<string, string> = {
@@ -85,6 +97,9 @@ function buildAlias(): Record<string, string> {
     alias[`${spec}$`] = spec === "@nodetool-ai/runtime/tracing"
       ? path.join(STUBS, "tracing-stub.js")
       : empty;
+  }
+  for (const [spec, rel] of Object.entries(GENERATED_JSON)) {
+    alias[`${spec}$`] = path.join(PKGS, rel);
   }
   return alias;
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@web-demo": ["./src/web-demo.d.ts"]
+    },
+    "types": ["node", "react", "react-dom"]
+  },
+  "include": ["src", "remotion.config.ts", "scripts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "packages/automation-nodes",
         "web",
         "electron",
+        "demo",
         "examples/chat_app"
       ],
       "dependencies": {
@@ -89,6 +90,24 @@
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0"
+      }
+    },
+    "demo": {
+      "name": "@nodetool-ai/demo",
+      "version": "0.0.0",
+      "dependencies": {
+        "@remotion/bundler": "^4.0.481",
+        "@remotion/cli": "^4.0.481",
+        "@remotion/renderer": "^4.0.481",
+        "remotion": "^4.0.481"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "tsx": "^4.19.2",
+        "typescript": "^5.9.3"
       }
     },
     "electron": {
@@ -3629,7 +3648,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3651,7 +3669,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4253,7 +4270,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4270,7 +4286,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4287,7 +4302,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4304,7 +4318,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4321,7 +4334,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4338,7 +4350,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4355,7 +4366,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4372,7 +4382,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4389,7 +4398,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4406,7 +4414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4423,7 +4430,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4440,7 +4446,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4457,7 +4462,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4474,7 +4478,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4491,7 +4494,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4508,7 +4510,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4525,7 +4526,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4542,7 +4542,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4559,7 +4558,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4576,7 +4574,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4593,7 +4590,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4610,7 +4606,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4627,7 +4622,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4644,7 +4638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4661,7 +4654,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4678,7 +4670,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8099,6 +8090,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -9569,6 +9570,45 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@mediabunny/aac-encoder": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.47.0.tgz",
+      "integrity": "sha512-JNzgdJoHMFFnv5imi1+dmjZMudsJ1zNCUCEkKjBh90cqGhAFg8xu4V2gsyxE2i6oq/YpWx23P+OvoANLSMcDzA==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/flac-encoder": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.47.0.tgz",
+      "integrity": "sha512-VpKmJO0xlYcFCRD6JvJlMbNQ6d/6YMHdO1gFIqWlZABHjSSL6BquNNEgWSCv5vdF8ELDBwIYBVZEslakIB/7GA==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/mp3-encoder": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.47.0.tgz",
+      "integrity": "sha512-JyzZyGeGRm2HVUQaGJ/VZT9OG+kG00mA8SLP/f3CO7+qWAmBncKc16WYXWHbZEo8Jn/ZGA6De32S5R2bTQbDqA==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
       "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
@@ -9700,6 +9740,59 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
@@ -10579,6 +10672,10 @@
     },
     "node_modules/@nodetool-ai/data-nodes": {
       "resolved": "packages/data-nodes",
+      "link": true
+    },
+    "node_modules/@nodetool-ai/demo": {
+      "resolved": "demo",
       "link": true
     },
     "node_modules/@nodetool-ai/deploy": {
@@ -14463,6 +14560,513 @@
         "@redis/client": "^5.12.1"
       }
     },
+    "node_modules/@remotion/bundler": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.481.tgz",
+      "integrity": "sha512-fBe59X+V8Kvb6zN9hoBaTYHay3L1I5a0Q3xguwLnXM4W3pMdKcZCMiQWblSOoq1V9IZ7TK5ETrHVB8uQtP/hNA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.481",
+        "@remotion/studio": "4.0.481",
+        "@remotion/studio-shared": "4.0.481",
+        "@remotion/timeline-utils": "4.0.481",
+        "@rspack/core": "1.7.11",
+        "@rspack/plugin-react-refresh": "1.6.1",
+        "css-loader": "7.1.4",
+        "esbuild": "0.28.1",
+        "react-refresh": "0.18.0",
+        "remotion": "4.0.481",
+        "style-loader": "4.0.0",
+        "webpack": "5.105.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/bundler/node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@remotion/canvas-capture": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.481.tgz",
+      "integrity": "sha512-bEaW8Aaj2PdPZt3ZCwdqBqoGPeSLqfkXro0uls2XS/wIIpMiu+2iCFFWdOI4xQ+GhXO8E3X0aW8vc+ZdscefqQ==",
+      "license": "Remotion License",
+      "dependencies": {
+        "mediabunny": "1.47.0",
+        "remotion": "4.0.481"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/cli": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.481.tgz",
+      "integrity": "sha512-279jl70VqX3REQM2TJqNbsE7OEecuKh/TdDWmfZiVbqStVwHRIDfrTgiA4x9E8rQZfSKSGOri+ONEOcyZHJ0vQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/bundler": "4.0.481",
+        "@remotion/media-utils": "4.0.481",
+        "@remotion/player": "4.0.481",
+        "@remotion/renderer": "4.0.481",
+        "@remotion/studio": "4.0.481",
+        "@remotion/studio-server": "4.0.481",
+        "@remotion/studio-shared": "4.0.481",
+        "dotenv": "17.3.1",
+        "minimist": "1.2.6",
+        "prompts": "2.4.2",
+        "remotion": "4.0.481"
+      },
+      "bin": {
+        "remotion": "remotion-cli.js",
+        "remotionb": "remotionb-cli.js",
+        "remotiond": "remotiond-cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/cli/node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@remotion/cli/node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/compositor-darwin-arm64": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.481.tgz",
+      "integrity": "sha512-R4jI8wmiPOGbn0dFtZGJHJRlW1rVc4bZ9qtkjXrtGIWx//m8joNofVyUpR2Z30z48AhESfS6X7lE5XyEROayYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-darwin-x64": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.481.tgz",
+      "integrity": "sha512-AID+uY7zKGvhUCL9CvNDmAbYmX3vylylez+yKPnAunAncQK5TOzHE6PYj9po0UZCv9LuYc5jPJKWke6wLUK3XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-gnu": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.481.tgz",
+      "integrity": "sha512-lOMzBoQTW9aK4OFN4Q2z6yRYwAN2QpvboiJ/AkR1DVJoemfyVwgFZNNkGO+BkcFQnR9DTv3UVrDj7iVSrpp4vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-musl": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.481.tgz",
+      "integrity": "sha512-NkjFbp6+BQhTf6JwsNEmM1Q6wK2mluCqv5MfKrrFr1oofQ5EpMfL5OYLtpwIJFAp5+mtg3yTi1+gSE22JrtTKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-gnu": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.481.tgz",
+      "integrity": "sha512-P8FqjbXXCATAB977/9CrOiwNugtsGSN5ZOgeTOy6uavydXV8+Psf0uNPR4Iri/dEVwdRHui98izVMs57cY5frg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-musl": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.481.tgz",
+      "integrity": "sha512-BdQLH2rJdIMNfZafcjmyUrhGcCJQ4OaSpEIySpwPEBdxvewrebh29PybvN9K5eEYSxoMhz5hyUNu4ihNy1YPtA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-win32-x64-msvc": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.481.tgz",
+      "integrity": "sha512-Pe81TQ+W85jQDI6/hUK9Ya3N8qO59GfUS0+ALiSOSPdRmvNul0CU0sQrkN/pRWXfmPks9/Tvo0hNuarfNYMAyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@remotion/licensing": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.481.tgz",
+      "integrity": "sha512-vUWA26GZKhp/Tl0Sj2E/M5SRZIQttMMT3kqXB7Se9wvGMAfSqm/86HLkY3dRNaagF2jSXJ7w+LY7EkXOTXVMBw==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/media-parser": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.481.tgz",
+      "integrity": "sha512-VM0slWAYdSKGanBWn92B7eV7zheLN2mYaoccXDJemC0Ev4EIx40lcvFJAiMJ1yR0WoRn6Z6zLCbgPQrWmzVezg==",
+      "license": "Remotion License https://remotion.dev/license"
+    },
+    "node_modules/@remotion/media-utils": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.481.tgz",
+      "integrity": "sha512-uHO8WY7vIMfTK9qc/Q8cbkUCCDQSLWrBb0OA1QBLuV0yhmutcevEnrkI4YeGZ2EqXq6RyTbXFIbLG6kU+hzCTw==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.47.0",
+        "remotion": "4.0.481"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.481.tgz",
+      "integrity": "sha512-+oRSxxzA6B7J2RvWBAaHAGL2IchybA3TnK6e0/IAJfTUa9m0wN95GLels9MA2/EYuEQL+9Ydtx/lZSESJcyL5A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.481"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.481.tgz",
+      "integrity": "sha512-vLQayl0Tktt7yaL3X+0k0tde/8agPegdN7cc9qhARdMBwoU6mBIKK/KykhidHIDbfttcBH0lKRw3tKTjR+AeuQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/licensing": "4.0.481",
+        "@remotion/streaming": "4.0.481",
+        "execa": "5.1.1",
+        "remotion": "4.0.481",
+        "source-map": "0.8.0-beta.0",
+        "ws": "8.21.0"
+      },
+      "optionalDependencies": {
+        "@remotion/compositor-darwin-arm64": "4.0.481",
+        "@remotion/compositor-darwin-x64": "4.0.481",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.481",
+        "@remotion/compositor-linux-arm64-musl": "4.0.481",
+        "@remotion/compositor-linux-x64-gnu": "4.0.481",
+        "@remotion/compositor-linux-x64-musl": "4.0.481",
+        "@remotion/compositor-win32-x64-msvc": "4.0.481"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remotion/renderer/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/@remotion/renderer/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@remotion/renderer/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/@remotion/streaming": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.481.tgz",
+      "integrity": "sha512-EUb/98wR3cE10tnsjUv6Cj3sylPn4yIC8iDu4aFry5dIjzXoqGsyuiE9OS7E6qLwUVLRyS1eK990Snf+mggxiw==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/studio": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.481.tgz",
+      "integrity": "sha512-wmwsNzQEzKHT7PWg/VcRNfy6iM/I0EFKvsQjbLNqWqZQLCKUxevUUeuZ8dfX+TqefhQHxb24mkJkFppO1Q35kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@remotion/canvas-capture": "4.0.481",
+        "@remotion/media-utils": "4.0.481",
+        "@remotion/player": "4.0.481",
+        "@remotion/renderer": "4.0.481",
+        "@remotion/studio-shared": "4.0.481",
+        "@remotion/timeline-utils": "4.0.481",
+        "@remotion/web-renderer": "4.0.481",
+        "@remotion/zod-types": "4.0.481",
+        "mediabunny": "1.47.0",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "remotion": "4.0.481",
+        "semver": "7.5.3",
+        "zod": "4.3.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.481.tgz",
+      "integrity": "sha512-5cbTVBmoqk3wQBgXrc2X9niKR3RuxBKbdu3zRud3Iblrpw4fSTD1kb15RLegO9ubp4CKIilR9JpW1M/PheauhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/bundler": "4.0.481",
+        "@remotion/renderer": "4.0.481",
+        "@remotion/studio-shared": "4.0.481",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "prettier": "3.8.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.481",
+        "semver": "7.5.3"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/@babel/parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/@babel/types": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remotion/studio-server/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@remotion/studio-shared": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.481.tgz",
+      "integrity": "sha512-0ywlkD0esuLiOLF4m1mGrLQONs3u8929zG5+GMSVAPq1iLjBfjowotPMABBnt2cpFzNYanv0L9fVx+tUJ0tBzA==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.481"
+      }
+    },
+    "node_modules/@remotion/studio/node_modules/@remotion/zod-types": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.481.tgz",
+      "integrity": "sha512-NAol+4qnhetJY3x2CfOadEiSTMrjxHv71OA7IWqf97OADNJ0neb5jwhqcQB2IeLSVMXbqCGyidB9iNzCRX7fFw==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.481"
+      },
+      "peerDependencies": {
+        "zod": "4.3.6"
+      }
+    },
+    "node_modules/@remotion/studio/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remotion/studio/node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@remotion/studio/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remotion/studio/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@remotion/studio/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@remotion/timeline-utils": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.481.tgz",
+      "integrity": "sha512-xyZ4YRsOPW+NLLA4oqt9Ager/eoHrckH0Ufvh4MD7hSlNtm0tA9uiVNOAi2Ztq8RUkXMUwdwec6RNsydPVplmg==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.47.0"
+      }
+    },
+    "node_modules/@remotion/web-renderer": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.481.tgz",
+      "integrity": "sha512-H82Bnpfp6occIJcaLv7j6SVolloxw4j/cHykD1cIVtd/y+8tmfsh/nNgfLWYqjudj3VL5sY3CGy0FNPG6Wg2tQ==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@mediabunny/aac-encoder": "1.47.0",
+        "@mediabunny/flac-encoder": "1.47.0",
+        "@mediabunny/mp3-encoder": "1.47.0",
+        "@remotion/licensing": "4.0.481",
+        "mediabunny": "1.47.0",
+        "remotion": "4.0.481"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -15136,6 +15740,213 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.11.tgz",
+      "integrity": "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.11",
+        "@rspack/binding-darwin-x64": "1.7.11",
+        "@rspack/binding-linux-arm64-gnu": "1.7.11",
+        "@rspack/binding-linux-arm64-musl": "1.7.11",
+        "@rspack/binding-linux-x64-gnu": "1.7.11",
+        "@rspack/binding-linux-x64-musl": "1.7.11",
+        "@rspack/binding-wasm32-wasi": "1.7.11",
+        "@rspack/binding-win32-arm64-msvc": "1.7.11",
+        "@rspack/binding-win32-ia32-msvc": "1.7.11",
+        "@rspack/binding-win32-x64-msvc": "1.7.11"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz",
+      "integrity": "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.11.tgz",
+      "integrity": "sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.11.tgz",
+      "integrity": "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.11.tgz",
+      "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.11.tgz",
+      "integrity": "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.11.tgz",
+      "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.11.tgz",
+      "integrity": "sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.11.tgz",
+      "integrity": "sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.11.tgz",
+      "integrity": "sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.11.tgz",
+      "integrity": "sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
+      "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.11",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "license": "MIT"
+    },
+    "node_modules/@rspack/plugin-react-refresh": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.1.tgz",
+      "integrity": "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.1.4",
+        "html-entities": "^2.6.0"
+      },
+      "peerDependencies": {
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "webpack-hot-middleware": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-hot-middleware": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sebastianwessel/quickjs": {
       "version": "3.0.1",
@@ -17221,7 +18032,6 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17441,6 +18251,26 @@
       "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -17612,7 +18442,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
@@ -18570,6 +19399,152 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.70",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
@@ -18591,6 +19566,18 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.12",
@@ -18676,6 +19663,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -19807,7 +20806,6 @@
       "version": "2.10.33",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
       "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -20195,7 +21193,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20602,7 +21599,6 @@
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
       "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20951,6 +21947,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/chromium-pickle-js": {
@@ -22158,6 +23163,41 @@
       "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ==",
       "license": "MIT"
     },
+    "node_modules/css-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.40",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "webpack": "^5.27.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -22679,6 +23719,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -24386,7 +25435,6 @@
       "version": "1.5.364",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
       "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/electron-updater": {
@@ -24584,7 +25632,6 @@
       "version": "5.24.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
       "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -24658,6 +25705,15 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -24680,7 +25736,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -24783,7 +25838,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -25108,7 +26162,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -25276,7 +26329,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -25300,7 +26352,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -25313,7 +26364,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/exit": {
@@ -26326,6 +27376,12 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "license": "Unlicense"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -26750,6 +27806,12 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
@@ -27612,6 +28674,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -27795,7 +28873,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -27925,6 +29002,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/idb-keyval": {
@@ -28722,7 +29811,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -31938,7 +33026,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -32511,6 +33598,19 @@
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "license": "ISC"
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -32617,6 +33717,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
     "node_modules/lodash.union": {
@@ -33650,9 +34756,9 @@
       }
     },
     "node_modules/mediabunny": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.46.0.tgz",
-      "integrity": "sha512-HIaMQ6PVMndrFb9sNCh9/uAsLFBfLzyAgbk3kN7ZqlRRq//9RPYqIOQtXYpkbWBZU8ZJkaAUNLDtwTcdKo7yQw==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.47.0.tgz",
+      "integrity": "sha512-XQMZAcaKPkJ7hQ/Q2fvBdl3ZazQl2WVxDysUbJWh4PuAnLoerdsQBdPTDWdUdK6hh26LQ8Ue94MLLnmpWvlUYg==",
       "license": "MPL-2.0",
       "workspaces": [
         ".",
@@ -33757,7 +34863,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -35023,7 +36128,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/netmask": {
@@ -35254,7 +36358,6 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
       "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35425,7 +36528,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -35760,6 +36862,23 @@
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/openai": {
       "version": "6.39.1",
@@ -37143,6 +38262,91 @@
         }
       }
     },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
@@ -37330,6 +38534,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -37495,7 +38714,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -38083,7 +39301,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -38434,6 +39651,43 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -38649,6 +39903,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.481",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.481.tgz",
+      "integrity": "sha512-OurH3eP6zoS9fwAOTpOy73kz1k7v6cshLoig7jYEI/mfn5fFdXU5/fiBOQom5N4QidnVyDF7ix/SATyv6AY2Cg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/replicate": {
@@ -39405,6 +40669,76 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -39832,7 +41166,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/skin-tone": {
@@ -39975,7 +41308,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -39986,7 +41318,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -40162,6 +41493,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
     "node_modules/stat-mode": {
@@ -40431,7 +41768,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -40491,6 +41827,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
       }
     },
     "node_modules/style-to-js": {
@@ -40614,7 +41966,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -40827,7 +42178,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -40962,6 +42312,104 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/tesseract.js": {
       "version": "7.0.0",
@@ -41397,6 +42845,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/to-float32": {
@@ -42415,7 +43872,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -42957,6 +44413,18 @@
       "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wavesurfer.js": {
       "version": "7.12.8",
       "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.8.tgz",
@@ -43044,6 +44512,106 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -44755,6 +46323,7 @@
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
+        "@nodetool-ai/config": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",
@@ -44832,8 +46401,10 @@
       "version": "0.7.0-rc.23",
       "license": "MIT",
       "dependencies": {
+        "@nodetool-ai/audio-nodes": "*",
         "@nodetool-ai/config": "*",
         "@nodetool-ai/node-sdk": "*",
+        "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/runtime": "*"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "remotion": "^4.0.481"
       },
       "devDependencies": {
+        "@svgr/webpack": "^8.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "react": "^19.2.7",
@@ -2350,6 +2351,51 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "debug": "^4.4.3",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
@@ -2427,6 +2473,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
@@ -2487,6 +2551,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
@@ -2516,6 +2595,107 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-decorators": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
@@ -2527,6 +2707,19 @@
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/plugin-syntax-decorators": "^7.29.7"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2593,6 +2786,22 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
       "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2789,6 +2998,179 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/template": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
@@ -2798,6 +3180,72 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2823,6 +3271,154 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
@@ -2832,6 +3428,312 @@
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-constant-elements": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.29.7.tgz",
+      "integrity": "sha512-J0wGhKan+rIiE2OhfhRptySLrJ6SjQYM6b6N1FMlhyhCcw1Mig8vQjWchyB+bgHGDvaWo6Diu6CLRMra2uMtmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2872,6 +3774,153 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
@@ -2884,6 +3933,205 @@
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
         "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.29.7",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.29.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+        "@babel/plugin-transform-async-to-generator": "^7.29.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+        "@babel/plugin-transform-block-scoping": "^7.29.7",
+        "@babel/plugin-transform-class-properties": "^7.29.7",
+        "@babel/plugin-transform-class-static-block": "^7.29.7",
+        "@babel/plugin-transform-classes": "^7.29.7",
+        "@babel/plugin-transform-computed-properties": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-dotall-regex": "^7.29.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-dynamic-import": "^7.29.7",
+        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+        "@babel/plugin-transform-for-of": "^7.29.7",
+        "@babel/plugin-transform-function-name": "^7.29.7",
+        "@babel/plugin-transform-json-strings": "^7.29.7",
+        "@babel/plugin-transform-literals": "^7.29.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+        "@babel/plugin-transform-modules-amd": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+        "@babel/plugin-transform-modules-umd": "^7.29.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-new-target": "^7.29.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+        "@babel/plugin-transform-numeric-separator": "^7.29.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+        "@babel/plugin-transform-object-super": "^7.29.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/plugin-transform-private-methods": "^7.29.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+        "@babel/plugin-transform-property-literals": "^7.29.7",
+        "@babel/plugin-transform-regenerator": "^7.29.7",
+        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+        "@babel/plugin-transform-reserved-words": "^7.29.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+        "@babel/plugin-transform-spread": "^7.29.7",
+        "@babel/plugin-transform-sticky-regex": "^7.29.7",
+        "@babel/plugin-transform-template-literals": "^7.29.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-react-display-name": "^7.29.7",
+        "@babel/plugin-transform-react-jsx": "^7.29.7",
+        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -17139,6 +18387,79 @@
         "@svgr/core": "*"
       }
     },
+    "node_modules/@svgr/plugin-svgo": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-8.1.0.tgz",
+      "integrity": "sha512-Ywtl837OGO9pTLIN/onoWLmDQ4zFUycI1g76vuKGEz6evR/ZTJlJuz3G/fIkb6OVBJ2g0o6CGJzaEjfmEo3AHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^8.1.3",
+        "deepmerge": "^4.3.1",
+        "svgo": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@svgr/core": "*"
+      }
+    },
+    "node_modules/@svgr/plugin-svgo/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@svgr/webpack": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
+      "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@babel/plugin-transform-react-constant-elements": "^7.21.3",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/preset-react": "^7.18.6",
+        "@babel/preset-typescript": "^7.21.0",
+        "@svgr/core": "8.1.0",
+        "@svgr/plugin-jsx": "8.1.0",
+        "@svgr/plugin-svgo": "8.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -20710,6 +22031,58 @@
         "npm": ">=6"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
@@ -22784,6 +24157,20 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -23220,6 +24607,20 @@
       "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -23256,6 +24657,42 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -33639,6 +35076,13 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -34745,6 +36189,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -39744,11 +41195,69 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
     },
     "node_modules/regl": {
       "version": "2.1.1",
@@ -42073,6 +43582,42 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/svgo": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sylvester": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
@@ -43668,10 +45213,54 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "packages/automation-nodes",
     "web",
     "electron",
+    "demo",
     "examples/chat_app"
   ],
   "scripts": {

--- a/web/demo.html
+++ b/web/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>NodeTool Demo Player</title>
+    <style>
+      html,
+      body,
+      #root {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #0f0f17;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/demo-entry.tsx"></script>
+  </body>
+</html>

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -103,8 +103,7 @@ jest.mock("../../ui_primitives", () => ({
     <button data-testid={`toggle-option-${value}`} {...props}>
       {children}
     </button>
-  ),
-  BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS
+  )
 }));
 
 jest.mock("@mui/material/styles", () => ({

--- a/web/src/demo-entry.tsx
+++ b/web/src/demo-entry.tsx
@@ -1,0 +1,176 @@
+/**
+ * Standalone demo player page (web/demo.html).
+ *
+ * Loads a cast and renders it with a scrubber + play/pause for previewing and
+ * authoring casts. Cast source:
+ *   ?cast=<url>          fetch the cast JSON from a URL
+ *   ?castData=<base64>   inline base64-encoded cast JSON
+ *   (none)               the built-in sample cast
+ *
+ * Pinned assets resolve to `${assetsBase}/${file}` where assetsBase comes from
+ * ?assets=<base> (default `/demo-assets/<castId>`).
+ *
+ * A `window.nodetoolDemo` API (seek/play/pause/duration/ready) lets a headless
+ * driver scrub frames. The Remotion harness does NOT use this page — it embeds
+ * <DemoPlayer> directly — but it is handy for quick visual checks.
+ */
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import ReactDOM from "react-dom/client";
+
+import { DemoPlayer } from "./demo/DemoPlayer";
+import { sampleCast } from "./demo/sampleCast";
+import { isDemoCast, type DemoCast } from "./demo/castTypes";
+
+interface NodetoolDemoApi {
+  ready: boolean;
+  durationMs: number;
+  fps: number;
+  seek: (ms: number) => void;
+  play: () => void;
+  pause: () => void;
+}
+
+declare global {
+  interface Window {
+    nodetoolDemo?: NodetoolDemoApi;
+  }
+}
+
+async function loadCast(): Promise<DemoCast> {
+  const params = new URLSearchParams(window.location.search);
+  const inline = params.get("castData");
+  if (inline) {
+    const parsed: unknown = JSON.parse(atob(inline));
+    if (!isDemoCast(parsed)) throw new Error("castData is not a valid cast");
+    return parsed;
+  }
+  const url = params.get("cast");
+  if (url) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch cast: ${res.status}`);
+    const parsed: unknown = await res.json();
+    if (!isDemoCast(parsed)) throw new Error("Fetched cast is not valid");
+    return parsed;
+  }
+  return sampleCast;
+}
+
+function assetsBaseFor(cast: DemoCast): string {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("assets") ?? `/demo-assets/${cast.id}`;
+}
+
+function App(): React.JSX.Element {
+  const [cast, setCast] = useState<DemoCast | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [timeMs, setTimeMs] = useState(0);
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    loadCast().then(setCast).catch((e) => setError(String(e)));
+  }, []);
+
+  const assetsBase = cast ? assetsBaseFor(cast) : "";
+  const resolveAssetUrl = useMemo(
+    () => (file: string) => `${assetsBase}/${file}`,
+    [assetsBase]
+  );
+
+  // Wall-clock playback when "playing".
+  const rafRef = useRef(0);
+  useEffect(() => {
+    if (!cast || !playing) return;
+    const start = performance.now() - timeMs;
+    const tick = (now: number) => {
+      const next = now - start;
+      if (next >= cast.durationMs) {
+        setTimeMs(cast.durationMs);
+        setPlaying(false);
+        return;
+      }
+      setTimeMs(next);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [cast, playing]);
+
+  // Expose the headless driver API.
+  useEffect(() => {
+    if (!cast) return;
+    window.nodetoolDemo = {
+      ready: true,
+      durationMs: cast.durationMs,
+      fps: cast.fps ?? 30,
+      seek: (ms) => {
+        setPlaying(false);
+        setTimeMs(Math.max(0, Math.min(ms, cast.durationMs)));
+      },
+      play: () => setPlaying(true),
+      pause: () => setPlaying(false),
+    };
+    return () => {
+      delete window.nodetoolDemo;
+    };
+  }, [cast]);
+
+  if (error) {
+    return (
+      <div style={styles.center} data-ready="error">
+        <pre style={{ color: "#f87171" }}>{error}</pre>
+      </div>
+    );
+  }
+  if (!cast) {
+    return (
+      <div style={styles.center} data-ready="false">
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.root} data-ready="true">
+      <div style={styles.stage}>
+        <DemoPlayer cast={cast} timeMs={timeMs} resolveAssetUrl={resolveAssetUrl} />
+      </div>
+      <div style={styles.controls}>
+        <button
+          type="button"
+          style={styles.button}
+          onClick={() => setPlaying((p) => !p)}
+        >
+          {playing ? "Pause" : "Play"}
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={cast.durationMs}
+          step={10}
+          value={timeMs}
+          onChange={(e) => {
+            setPlaying(false);
+            setTimeMs(Number(e.target.value));
+          }}
+          style={styles.scrubber}
+        />
+        <span style={styles.time}>
+          {(timeMs / 1000).toFixed(2)}s / {(cast.durationMs / 1000).toFixed(2)}s
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: { width: "100vw", height: "100vh", display: "flex", flexDirection: "column", background: "#0f0f17" },
+  stage: { flex: 1, minHeight: 0, position: "relative" },
+  controls: { display: "flex", alignItems: "center", gap: 12, padding: "8px 16px", background: "#15151f", borderTop: "1px solid #262633" },
+  button: { background: "#7c3aed", color: "#fff", border: "none", borderRadius: 6, padding: "6px 16px", cursor: "pointer", fontSize: 13 },
+  scrubber: { flex: 1, accentColor: "#7c3aed" },
+  time: { color: "#94a3b8", fontFamily: "monospace", fontSize: 12, minWidth: 120, textAlign: "right" },
+  center: { width: "100vw", height: "100vh", display: "flex", alignItems: "center", justifyContent: "center", background: "#0f0f17", color: "#64748b", fontFamily: "monospace" },
+};
+
+const root = ReactDOM.createRoot(document.getElementById("root")!);
+root.render(<App />);

--- a/web/src/demo/DemoPlayer.tsx
+++ b/web/src/demo/DemoPlayer.tsx
@@ -1,0 +1,244 @@
+/**
+ * DemoPlayer — renders the real NodeTool graph UI for a cast at a given time.
+ *
+ * This is the single rendering surface shared by both demo harnesses:
+ *   - Remotion composition (direct embed): renders <DemoPlayer> inline and
+ *     drives `timeMs` from the current frame, so Remotion's deterministic clock
+ *     also drives the node UI's CSS animations (running rings, progress).
+ *   - The standalone preview/record page (web/src/demo-entry): drives `timeMs`
+ *     from a scrubber for authoring and capturing casts.
+ *
+ * It is self-contained: it brings its own theme, query client, and the same
+ * provider stack the editor uses, and reuses the production BaseNode / Preview /
+ * Output components so the graph looks exactly like the product.
+ */
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  BackgroundVariant,
+  useReactFlow,
+  useNodesInitialized,
+  type NodeTypes,
+  type EdgeTypes,
+} from "@xyflow/react";
+import { useStore } from "zustand";
+
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import InitColorSchemeScript from "@mui/material/InitColorSchemeScript";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Global side-effect styles so the graph renders identically to the editor.
+import "@xyflow/react/dist/style.css";
+import "../styles/base.css";
+import "../styles/nodes.css";
+import "../styles/properties.css";
+import "../styles/interactions.css";
+import "../styles/special_nodes.css";
+import "../styles/handle_edge_tooltip.css";
+
+import ThemeNodetool from "../components/themes/ThemeNodetool";
+import useMetadataStore from "../stores/MetadataStore";
+
+// Real node + edge components (registered so the canvas matches production).
+import BaseNode from "../components/node/BaseNode";
+import GroupNode from "../components/node/GroupNode";
+import CommentNode from "../components/node/CommentNode";
+import PreviewNode from "../components/node/PreviewNode/PreviewNode";
+import { OutputNode } from "../components/node/OutputNode";
+import SketchNode, {
+  SKETCH_NODE_TYPE,
+} from "../components/node/SketchNode/SketchNode";
+import PlaceholderNode from "../components/node_types/PlaceholderNode";
+import CustomEdge from "../components/node_editor/CustomEdge";
+import ControlEdge from "../components/node_editor/ControlEdge";
+import {
+  GROUP_NODE_TYPE,
+  COMMENT_NODE_TYPE,
+  PREVIEW_NODE_TYPE,
+} from "../constants/nodeTypes";
+
+import { NodeContext } from "../contexts/NodeContext";
+import { WorkflowManagerProvider } from "../contexts/WorkflowManagerContext";
+import { MenuProvider } from "../providers/MenuProvider";
+import { ContextMenuProvider } from "../providers/ContextMenuProvider";
+
+import type { NodeStore } from "../stores/NodeStore";
+import type { DemoCast } from "./castTypes";
+import { DemoEngine } from "./demoEngine";
+
+const EDGE_TYPES: EdgeTypes = { default: CustomEdge, control: ControlEdge };
+
+/** Build the node-type → component map exactly like the editor's canvas. */
+function useDemoNodeTypes(): NodeTypes {
+  const metadata = useMetadataStore((s) => s.metadata);
+  return useMemo(() => {
+    const map: NodeTypes = {};
+    for (const nodeType of Object.keys(metadata)) {
+      map[nodeType] = BaseNode as NodeTypes[string];
+    }
+    return {
+      ...map,
+      [GROUP_NODE_TYPE]: GroupNode,
+      [COMMENT_NODE_TYPE]: CommentNode,
+      [PREVIEW_NODE_TYPE]: PreviewNode,
+      "nodetool.workflows.base_node.Output": OutputNode,
+      "nodetool.output.Output": OutputNode,
+      [SKETCH_NODE_TYPE]: SketchNode,
+      default: PlaceholderNode,
+    } as NodeTypes;
+  }, [metadata]);
+}
+
+interface DemoCanvasProps {
+  engine: DemoEngine;
+  cast: DemoCast;
+  timeMs: number;
+}
+
+function DemoCanvas({ engine, cast, timeMs }: DemoCanvasProps): React.JSX.Element {
+  const nodeTypes = useDemoNodeTypes();
+  const nodes = useStore(engine.nodeStore, (s) => s.nodes);
+  const edges = useStore(engine.nodeStore, (s) => s.edges);
+  const { fitView } = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
+  const didFit = useRef(false);
+
+  // Drive the replay synchronously before paint so each frame's DOM reflects
+  // exactly the cast state at `timeMs`.
+  useLayoutEffect(() => {
+    engine.seekToTime(timeMs);
+  }, [engine, timeMs]);
+
+  // Fit the graph once when no fixed viewport was recorded.
+  useEffect(() => {
+    if (cast.viewport || didFit.current || nodes.length === 0) return;
+    const timer = setTimeout(
+      () => {
+        fitView({ padding: 0.15 });
+        didFit.current = true;
+      },
+      nodesInitialized ? 50 : 600
+    );
+    return () => clearTimeout(timer);
+  }, [cast.viewport, fitView, nodes.length, nodesInitialized]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      edgeTypes={EDGE_TYPES}
+      defaultViewport={cast.viewport ?? undefined}
+      fitView={!cast.viewport}
+      fitViewOptions={{ padding: 0.15 }}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      panOnDrag={false}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+      proOptions={{ hideAttribution: true }}
+      minZoom={0.05}
+      maxZoom={4}
+      colorMode="dark"
+      deleteKeyCode={null}
+    >
+      <Background
+        gap={100}
+        offset={4}
+        size={8}
+        color="rgba(255,255,255,0.04)"
+        lineWidth={1}
+        variant={BackgroundVariant.Cross}
+      />
+    </ReactFlow>
+  );
+}
+
+export interface DemoPlayerProps {
+  cast: DemoCast;
+  /** Elapsed time into the cast, in milliseconds. */
+  timeMs: number;
+  /** Maps a pinned asset file name to a host URL (Vite public, staticFile, …). */
+  resolveAssetUrl: (file: string) => string;
+  /** Canvas size; defaults to filling the parent. */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Self-contained demo surface. Create one per cast; `timeMs` may change every
+ * frame. Memoizes the engine on `cast.id` so seeking is incremental.
+ */
+export function DemoPlayer({
+  cast,
+  timeMs,
+  resolveAssetUrl,
+  style,
+}: DemoPlayerProps): React.JSX.Element {
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: { queries: { retry: false, enabled: false } },
+      }),
+    []
+  );
+
+  const resolveRef = useRef(resolveAssetUrl);
+  resolveRef.current = resolveAssetUrl;
+
+  const engine = useMemo(
+    () => new DemoEngine(cast, { resolveAssetUrl: (f) => resolveRef.current(f) }),
+    // Rebuild only when the cast identity changes.
+    [cast.id]
+  );
+
+  useEffect(() => () => engine.dispose(), [engine]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={ThemeNodetool} defaultMode="dark">
+        <InitColorSchemeScript attribute="class" defaultMode="dark" />
+        <CssBaseline />
+        <MenuProvider>
+          <WorkflowManagerProvider queryClient={queryClient}>
+            <ContextMenuProvider active={false}>
+              <NodeContext.Provider value={engine.nodeStore as NodeStore}>
+                <ReactFlowProvider>
+                  <div
+                    data-demo-player
+                    style={{ width: "100%", height: "100%", ...style }}
+                  >
+                    <DemoCanvas engine={engine} cast={cast} timeMs={timeMs} />
+                  </div>
+                </ReactFlowProvider>
+              </NodeContext.Provider>
+            </ContextMenuProvider>
+          </WorkflowManagerProvider>
+        </MenuProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+export default DemoPlayer;
+
+/** Convenience: a player that owns its own clock, for non-Remotion previews. */
+export function useDemoClock(durationMs: number, playing: boolean): number {
+  const [timeMs, setTimeMs] = useState(0);
+  useEffect(() => {
+    if (!playing) return;
+    let raf = 0;
+    const start = performance.now() - timeMs;
+    const tick = (now: number) => {
+      const t = now - start;
+      setTimeMs(t >= durationMs ? durationMs : t);
+      if (t < durationMs) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, durationMs]);
+  return timeMs;
+}

--- a/web/src/demo/DemoPlayer.tsx
+++ b/web/src/demo/DemoPlayer.tsx
@@ -27,8 +27,9 @@ import { useStore } from "zustand";
 
 import { ThemeProvider, CssBaseline } from "@mui/material";
 import InitColorSchemeScript from "@mui/material/InitColorSchemeScript";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
+import { TRPCProvider } from "../trpc/Provider";
+import { queryClient } from "../queryClient";
 
 // Global side-effect styles so the graph renders identically to the editor.
 import "@xyflow/react/dist/style.css";
@@ -179,14 +180,6 @@ export function DemoPlayer({
   resolveAssetUrl,
   style,
 }: DemoPlayerProps): React.JSX.Element {
-  const queryClient = useMemo(
-    () =>
-      new QueryClient({
-        defaultOptions: { queries: { retry: false, enabled: false } },
-      }),
-    []
-  );
-
   const resolveRef = useRef(resolveAssetUrl);
   resolveRef.current = resolveAssetUrl;
 
@@ -202,7 +195,7 @@ export function DemoPlayer({
     // Some node components (e.g. ApiKeyValidation) call react-router hooks like
     // useNavigate; a MemoryRouter supplies the required Router context.
     <MemoryRouter>
-      <QueryClientProvider client={queryClient}>
+      <TRPCProvider>
         <ThemeProvider theme={ThemeNodetool} defaultMode="dark">
           <InitColorSchemeScript attribute="class" defaultMode="dark" />
           <CssBaseline />
@@ -223,7 +216,7 @@ export function DemoPlayer({
             </WorkflowManagerProvider>
           </MenuProvider>
         </ThemeProvider>
-      </QueryClientProvider>
+      </TRPCProvider>
     </MemoryRouter>
   );
 }

--- a/web/src/demo/DemoPlayer.tsx
+++ b/web/src/demo/DemoPlayer.tsx
@@ -28,6 +28,7 @@ import { useStore } from "zustand";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 import InitColorSchemeScript from "@mui/material/InitColorSchemeScript";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 
 // Global side-effect styles so the graph renders identically to the editor.
 import "@xyflow/react/dist/style.css";
@@ -198,28 +199,32 @@ export function DemoPlayer({
   useEffect(() => () => engine.dispose(), [engine]);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={ThemeNodetool} defaultMode="dark">
-        <InitColorSchemeScript attribute="class" defaultMode="dark" />
-        <CssBaseline />
-        <MenuProvider>
-          <WorkflowManagerProvider queryClient={queryClient}>
-            <ContextMenuProvider active={false}>
-              <NodeContext.Provider value={engine.nodeStore as NodeStore}>
-                <ReactFlowProvider>
-                  <div
-                    data-demo-player
-                    style={{ width: "100%", height: "100%", ...style }}
-                  >
-                    <DemoCanvas engine={engine} cast={cast} timeMs={timeMs} />
-                  </div>
-                </ReactFlowProvider>
-              </NodeContext.Provider>
-            </ContextMenuProvider>
-          </WorkflowManagerProvider>
-        </MenuProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
+    // Some node components (e.g. ApiKeyValidation) call react-router hooks like
+    // useNavigate; a MemoryRouter supplies the required Router context.
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={ThemeNodetool} defaultMode="dark">
+          <InitColorSchemeScript attribute="class" defaultMode="dark" />
+          <CssBaseline />
+          <MenuProvider>
+            <WorkflowManagerProvider queryClient={queryClient}>
+              <ContextMenuProvider active={false}>
+                <NodeContext.Provider value={engine.nodeStore as NodeStore}>
+                  <ReactFlowProvider>
+                    <div
+                      data-demo-player
+                      style={{ width: "100%", height: "100%", ...style }}
+                    >
+                      <DemoCanvas engine={engine} cast={cast} timeMs={timeMs} />
+                    </div>
+                  </ReactFlowProvider>
+                </NodeContext.Provider>
+              </ContextMenuProvider>
+            </WorkflowManagerProvider>
+          </MenuProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 }
 

--- a/web/src/demo/__tests__/demoEngine.test.ts
+++ b/web/src/demo/__tests__/demoEngine.test.ts
@@ -1,0 +1,87 @@
+/**
+ * DemoEngine determinism: seeking to a time must make the execution stores
+ * reflect exactly the events up to that time, regardless of seek direction.
+ */
+import { DemoEngine } from "../demoEngine";
+import { sampleCast } from "../sampleCast";
+import useStatusStore from "../../stores/StatusStore";
+import useResultsStore from "../../stores/ResultsStore";
+import useWorkflowRunsStore from "../../stores/WorkflowRunsStore";
+
+const WF = "wf-demo-sample";
+const resolveAssetUrl = (f: string) => `/demo-assets/${f}`;
+
+function focused(): string {
+  const job = useWorkflowRunsStore.getState().getFocusedJob(WF);
+  if (!job) throw new Error("no focused job");
+  return job;
+}
+
+describe("DemoEngine", () => {
+  let engine: DemoEngine;
+
+  beforeEach(() => {
+    engine = new DemoEngine(sampleCast, { resolveAssetUrl });
+  });
+
+  afterEach(() => {
+    engine.dispose();
+  });
+
+  it("shows the generate node running mid-stream", () => {
+    engine.seekToTime(700);
+    expect(useStatusStore.getState().getStatus(WF, focused(), "gen")).toBe(
+      "running"
+    );
+  });
+
+  it("accumulates streamed text chunks on the node", () => {
+    engine.seekToTime(1600);
+    const chunk = useResultsStore.getState().getChunk(WF, focused(), "gen");
+    expect(chunk).toContain("mountain lake");
+  });
+
+  it("settles the node output on completion", () => {
+    engine.seekToTime(2200);
+    expect(useStatusStore.getState().getStatus(WF, focused(), "gen")).toBe(
+      "completed"
+    );
+    const gens = useResultsStore.getState().getLiveGenerations(WF, "gen");
+    expect(gens.length).toBeGreaterThan(0);
+    expect((gens[0].outputs as { text?: string }).text).toContain(
+      "mountain lake"
+    );
+  });
+
+  it("resolves pinned asset references to host URLs", () => {
+    engine.seekToTime(2400);
+    const result = useResultsStore.getState().getOutputResult(
+      WF,
+      focused(),
+      "preview"
+    ) as { uri?: string } | undefined;
+    // The sample uses an inline data URI (left untouched), proving non-asset
+    // strings pass through the resolver unchanged.
+    expect(result?.uri?.startsWith("data:image/svg+xml")).toBe(true);
+  });
+
+  it("is a pure function of time across a backward seek", () => {
+    engine.seekToTime(2600);
+    const forwardStatus = useStatusStore
+      .getState()
+      .getStatus(WF, focused(), "gen");
+    expect(forwardStatus).toBe("completed");
+
+    // Seek back to before the node started; its status must be gone again.
+    engine.seekToTime(100);
+    expect(
+      useStatusStore.getState().getStatus(WF, focused(), "gen")
+    ).toBeUndefined();
+
+    // And forward again reproduces the same end state.
+    engine.seekToTime(2600);
+    expect(useStatusStore.getState().getStatus(WF, focused(), "gen")).toBe(
+      "completed"
+    );
+  });
+});

--- a/web/src/demo/assetSubstitution.ts
+++ b/web/src/demo/assetSubstitution.ts
@@ -1,0 +1,148 @@
+/**
+ * Asset reference rewriting for casts.
+ *
+ * Recorded protocol messages carry host-specific media URLs (e.g.
+ * `asset://<id>` or `http://localhost:7777/api/storage/<id>`). To make a cast
+ * portable and backend-free we:
+ *
+ *  - at RECORD time, replace every such URL with a stable `cast-asset://<key>`
+ *    reference and emit a manifest entry (so the bytes can be downloaded once
+ *    and pinned next to the cast), and
+ *  - at LOAD time, replace each `cast-asset://<key>` with whatever URL the host
+ *    serves the pinned file from (Vite public dir, Remotion `staticFile`, …).
+ *
+ * Both directions are a structural deep-clone with a per-string replacer, so
+ * nested asset objects (`{ type: "image", uri, asset_id }`), arrays of chunks,
+ * and bare string values are all handled uniformly.
+ */
+import { CAST_ASSET_SCHEME, type CastAsset, type CastEvent } from "./castTypes";
+
+/** Matches the nodetool storage URL for an asset, capturing the asset id. */
+const STORAGE_URL_RE = /\/api\/storage\/([A-Za-z0-9._-]+)/;
+
+/** Deep-clone `value`, passing every string through `replace`. */
+function mapStrings(value: unknown, replace: (s: string) => string): unknown {
+  if (typeof value === "string") return replace(value);
+  if (Array.isArray(value)) return value.map((v) => mapStrings(v, replace));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = mapStrings(v, replace);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** True for a string that points at a generated/stored asset we should pin. */
+function isAssetUrl(s: string): boolean {
+  return s.startsWith("asset://") || STORAGE_URL_RE.test(s);
+}
+
+/** Derive a stable, filesystem-safe key for an asset URL. */
+function keyForAssetUrl(s: string): string {
+  if (s.startsWith("asset://")) {
+    return s.slice("asset://".length).replace(/[^A-Za-z0-9._-]/g, "_");
+  }
+  const m = STORAGE_URL_RE.exec(s);
+  if (m) return m[1].replace(/[^A-Za-z0-9._-]/g, "_");
+  return s.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64);
+}
+
+/** Guess a file extension from a content type, defaulting to `bin`. */
+function extForContentType(contentType: string | undefined): string {
+  switch (contentType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    case "image/svg+xml":
+      return "svg";
+    case "audio/mpeg":
+      return "mp3";
+    case "audio/wav":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/ogg":
+      return "ogg";
+    case "video/mp4":
+      return "mp4";
+    case "video/webm":
+      return "webm";
+    case "application/json":
+      return "json";
+    default:
+      return "bin";
+  }
+}
+
+export interface CollectedAssets {
+  events: CastEvent[];
+  assets: CastAsset[];
+}
+
+/**
+ * RECORD direction. Walk every event, replacing asset URLs with
+ * `cast-asset://<key>` and accumulating a de-duplicated manifest.
+ *
+ * `contentTypeHint` lets the recorder pass the asset object's declared media
+ * type (`image`/`audio`/`video`) so the pinned file gets a sensible extension
+ * before the byte download confirms it.
+ */
+export function collectAndRewriteAssets(
+  events: CastEvent[],
+  contentTypeHint?: (originalUri: string) => string | undefined
+): CollectedAssets {
+  const byKey = new Map<string, CastAsset>();
+
+  const rewrite = (s: string): string => {
+    if (!isAssetUrl(s)) return s;
+    const key = keyForAssetUrl(s);
+    if (!byKey.has(key)) {
+      const contentType = contentTypeHint?.(s);
+      byKey.set(key, {
+        key,
+        file: `${key}.${extForContentType(contentType)}`,
+        contentType: contentType ?? "application/octet-stream",
+        originalUri: s,
+      });
+    }
+    return `${CAST_ASSET_SCHEME}${key}`;
+  };
+
+  const rewritten = events.map((e) => ({
+    t: e.t,
+    message: mapStrings(e.message, rewrite) as CastEvent["message"],
+  }));
+
+  return { events: rewritten, assets: Array.from(byKey.values()) };
+}
+
+/**
+ * LOAD direction. Replace every `cast-asset://<key>` with the host URL for the
+ * pinned file, via `resolveAssetUrl(file)`. Unknown keys are left untouched so
+ * a missing asset surfaces as a broken ref rather than a silent blank.
+ */
+export function resolveAssetUrls(
+  events: CastEvent[],
+  assets: CastAsset[],
+  resolveAssetUrl: (file: string) => string
+): CastEvent[] {
+  const fileByKey = new Map(assets.map((a) => [a.key, a.file]));
+
+  const replace = (s: string): string => {
+    if (!s.startsWith(CAST_ASSET_SCHEME)) return s;
+    const key = s.slice(CAST_ASSET_SCHEME.length);
+    const file = fileByKey.get(key);
+    return file ? resolveAssetUrl(file) : s;
+  };
+
+  return events.map((e) => ({
+    t: e.t,
+    message: mapStrings(e.message, replace) as CastEvent["message"],
+  }));
+}

--- a/web/src/demo/castTypes.ts
+++ b/web/src/demo/castTypes.ts
@@ -1,0 +1,107 @@
+/**
+ * Demo "cast" format — the stored, replayable product-demo recording.
+ *
+ * A cast is a self-contained, backend-free capture of one workflow run:
+ *   - the workflow graph (with the real editor positions),
+ *   - a snapshot of the node metadata for every node type it uses,
+ *   - a time-stamped timeline of the exact protocol messages the backend
+ *     streamed during the run (job/node/progress/output/chunk/...),
+ *   - a manifest of every generated asset the run referenced, pinned to local
+ *     files so replay never re-generates (no credits burned).
+ *
+ * Casts are plain JSON: diffable, version-controllable, and editable after the
+ * fact (retime, trim, swap assets). The demo player (web/src/demo/DemoPlayer)
+ * replays a cast deterministically as a pure function of elapsed time, so a
+ * frame-based renderer (Remotion) can scrub it.
+ */
+import type {
+  NodeMetadata,
+  Workflow,
+} from "../stores/ApiTypes";
+
+/** Schema version. Bump on breaking changes to the cast shape. */
+export const CAST_VERSION = 1 as const;
+
+/**
+ * URI scheme that stands in for a pinned asset inside a cast. The player
+ * rewrites `cast-asset://<key>` to a host URL at load time (Vite public dir,
+ * Remotion staticFile, …), so the recorded messages carry no host-specific
+ * URLs. See `assetSubstitution.ts`.
+ */
+export const CAST_ASSET_SCHEME = "cast-asset://";
+
+/** One pinned, pre-generated asset referenced by the run. */
+export interface CastAsset {
+  /** Stable key used in `cast-asset://<key>` references inside the timeline. */
+  key: string;
+  /** File name within the cast's asset directory (e.g. `node-3-image.png`). */
+  file: string;
+  /** MIME type, used to set the right `Blob`/`<img>`/`<video>` handling. */
+  contentType: string;
+  /** Where the asset was downloaded from at record time (provenance only). */
+  originalUri?: string;
+  /** Byte length of the pinned file, if known. */
+  bytes?: number;
+}
+
+/** A single protocol message stamped with its offset from the cast start. */
+export interface CastEvent {
+  /** Milliseconds from the start of the timeline (`events[0].t === 0`). */
+  t: number;
+  /**
+   * A backend protocol message (`job_update`, `node_update`, `node_progress`,
+   * `output_update`, `chunk`, `generation_complete`, `edge_update`, …). Kept
+   * loose here; the engine casts to the reducer's `MsgpackData` union at apply
+   * time. Asset URIs inside have been rewritten to `cast-asset://<key>`.
+   */
+  message: { type: string; [key: string]: unknown };
+}
+
+/** A fixed camera pose for the canvas. When absent, the player fits the graph. */
+export interface CastViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** A complete, replayable product-demo recording. */
+export interface DemoCast {
+  version: typeof CAST_VERSION;
+  /** Unique id for the cast (also names its asset directory). */
+  id: string;
+  /** Human title shown in the demo gallery. */
+  name: string;
+  description?: string;
+  /** ISO timestamp the cast was recorded. */
+  createdAt: string;
+  /** Total timeline length in ms (>= last event `t`, plus any tail hold). */
+  durationMs: number;
+  /** Suggested frame rate for rendering this cast. Defaults to 30. */
+  fps?: number;
+  /** The workflow graph + attributes, with the real saved node positions. */
+  workflow: Workflow;
+  /** Node metadata for every node type used by the graph (exact, not inferred). */
+  metadata: Record<string, NodeMetadata>;
+  /** Timeline of protocol messages, sorted ascending by `t`. */
+  events: CastEvent[];
+  /** Pinned assets the timeline references via `cast-asset://<key>`. */
+  assets: CastAsset[];
+  /** Optional fixed camera; when omitted the player fits the graph to view. */
+  viewport?: CastViewport;
+}
+
+/** Narrow runtime guard — enough to fail fast on a malformed cast file. */
+export function isDemoCast(value: unknown): value is DemoCast {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    c.version === CAST_VERSION &&
+    typeof c.id === "string" &&
+    typeof c.workflow === "object" &&
+    c.workflow !== null &&
+    Array.isArray(c.events) &&
+    Array.isArray(c.assets) &&
+    typeof c.metadata === "object" &&
+    c.metadata !== null
+  );
+}

--- a/web/src/demo/demoEngine.ts
+++ b/web/src/demo/demoEngine.ts
@@ -22,6 +22,7 @@ import useResultsStore from "../stores/ResultsStore";
 import useStatusStore from "../stores/StatusStore";
 import useWorkflowRunsStore from "../stores/WorkflowRunsStore";
 import { useNotificationStore, type Notification } from "../stores/NotificationStore";
+import useAuth from "../stores/useAuth";
 import { createNodeStore, type NodeStore } from "../stores/NodeStore";
 import { handleUpdate, type MsgpackData } from "../stores/workflowUpdates";
 import type { WorkflowRunner, WorkflowRunnerStore } from "../stores/WorkflowRunner";
@@ -62,6 +63,16 @@ export function seedCastMetadata(metadata: Record<string, NodeMetadata>): void {
   store.setMetadata({ ...store.metadata, ...metadata });
 }
 
+/**
+ * Seed a placeholder logged-in user. Output/asset components (e.g. AssetViewer
+ * via useAssets) throw when no user is present; the demo has no real auth.
+ */
+function seedDemoAuth(): void {
+  if (useAuth.getState().user === null) {
+    useAuth.setState({ user: { id: "demo" }, state: "logged_in" });
+  }
+}
+
 /** Count of events whose timestamp is `<= timeMs` (events are sorted by `t`). */
 function countAppliedAt(events: CastEvent[], timeMs: number): number {
   // Linear scan is fine at demo scale (hundreds–low thousands of events) and
@@ -98,6 +109,7 @@ export class DemoEngine {
     // Metadata must be seeded before the node store is built so its graph
     // sanitization sees the real node shapes.
     seedCastMetadata(cast.metadata);
+    seedDemoAuth();
     this.nodeStore = createNodeStore(cast.workflow);
     this.pristineNodes = clone(this.nodeStore.getState().nodes);
     this.pristineEdges = clone(this.nodeStore.getState().edges);

--- a/web/src/demo/demoEngine.ts
+++ b/web/src/demo/demoEngine.ts
@@ -1,0 +1,181 @@
+/**
+ * DemoEngine — deterministic, backend-free replay of a cast.
+ *
+ * The engine owns a real NodeStore (so the genuine BaseNode renders the graph)
+ * and drives the production update reducer (`handleUpdate`) with the cast's
+ * recorded protocol messages. State is a pure function of elapsed time:
+ * `seekToTime(t)` makes the global execution stores reflect exactly the events
+ * with `event.t <= t`. Seeking forward applies the new events incrementally;
+ * seeking backward resets and replays from the start. That determinism is what
+ * lets a frame renderer (Remotion) scrub the timeline and capture a video.
+ *
+ * The engine deliberately does NOT import any React node components, so it can
+ * be unit-tested in isolation. Node-type → component wiring lives in the player.
+ */
+import { v4 as uuidv4 } from "uuid";
+import { create } from "zustand";
+import type { Edge, Node } from "@xyflow/react";
+
+import useMetadataStore from "../stores/MetadataStore";
+import type { NodeData } from "../stores/NodeData";
+import useResultsStore from "../stores/ResultsStore";
+import useStatusStore from "../stores/StatusStore";
+import useWorkflowRunsStore from "../stores/WorkflowRunsStore";
+import { useNotificationStore, type Notification } from "../stores/NotificationStore";
+import { createNodeStore, type NodeStore } from "../stores/NodeStore";
+import { handleUpdate, type MsgpackData } from "../stores/workflowUpdates";
+import type { WorkflowRunner, WorkflowRunnerStore } from "../stores/WorkflowRunner";
+import type { NodeMetadata, WorkflowAttributes } from "../stores/ApiTypes";
+
+import type { CastEvent, DemoCast } from "./castTypes";
+import { resolveAssetUrls } from "./assetSubstitution";
+
+/**
+ * Minimal stand-in for the WorkflowRunner store. The reducer only reads/writes
+ * a handful of runner fields (state, job_id, queuePosition, statusMessage) and
+ * calls `addNotification`; this provides exactly those, forwarding toasts to
+ * the real NotificationStore so the demo behaves like production. Cast to the
+ * full `WorkflowRunnerStore` at the single call site below.
+ */
+interface DemoRunnerState {
+  state: WorkflowRunner["state"];
+  job_id: string | null;
+  queuePosition: number | null;
+  statusMessage: string | null;
+  addNotification: (n: Omit<Notification, "id" | "timestamp">) => void;
+  setStatusMessage: (m: string | null) => void;
+}
+
+const IDLE_RUNNER: Pick<
+  DemoRunnerState,
+  "state" | "job_id" | "queuePosition" | "statusMessage"
+> = {
+  state: "idle",
+  job_id: null,
+  queuePosition: null,
+  statusMessage: null,
+};
+
+/** Merge a cast's recorded metadata into the shared MetadataStore (no clobber). */
+export function seedCastMetadata(metadata: Record<string, NodeMetadata>): void {
+  const store = useMetadataStore.getState();
+  store.setMetadata({ ...store.metadata, ...metadata });
+}
+
+/** Count of events whose timestamp is `<= timeMs` (events are sorted by `t`). */
+function countAppliedAt(events: CastEvent[], timeMs: number): number {
+  // Linear scan is fine at demo scale (hundreds–low thousands of events) and
+  // keeps forward seeks O(new events). Binary search would not change Big-O of
+  // the apply loop that follows.
+  let n = 0;
+  while (n < events.length && events[n].t <= timeMs) n++;
+  return n;
+}
+
+export interface DemoEngineOptions {
+  /** Maps a pinned asset file name to the URL the host serves it from. */
+  resolveAssetUrl: (file: string) => string;
+}
+
+export class DemoEngine {
+  readonly nodeStore: NodeStore;
+  readonly workflow: WorkflowAttributes;
+  readonly durationMs: number;
+  readonly fps: number;
+
+  private readonly runnerStore: WorkflowRunnerStore;
+  private readonly events: CastEvent[];
+  /** Snapshot of the pristine graph, restored on backward seek. */
+  private readonly pristineNodes: Node<NodeData>[];
+  private readonly pristineEdges: Edge[];
+  private appliedIndex = 0;
+
+  constructor(cast: DemoCast, opts: DemoEngineOptions) {
+    this.workflow = cast.workflow;
+    this.durationMs = cast.durationMs;
+    this.fps = cast.fps ?? 30;
+
+    // Metadata must be seeded before the node store is built so its graph
+    // sanitization sees the real node shapes.
+    seedCastMetadata(cast.metadata);
+    this.nodeStore = createNodeStore(cast.workflow);
+    this.pristineNodes = clone(this.nodeStore.getState().nodes);
+    this.pristineEdges = clone(this.nodeStore.getState().edges);
+
+    // Resolve pinned asset references to host URLs, then give every distinct
+    // recorded job a fresh id. Fresh ids keep the reducer's module-level
+    // per-job bookkeeping from colliding across engine instances in one realm.
+    const resolved = resolveAssetUrls(cast.events, cast.assets, opts.resolveAssetUrl);
+    this.events = remapJobIds(resolved);
+
+    this.runnerStore = create<DemoRunnerState>(() => ({
+      ...IDLE_RUNNER,
+      addNotification: (n) => useNotificationStore.getState().addNotification(n),
+      setStatusMessage: (m) => this.runnerStore.setState({ statusMessage: m }),
+    })) as unknown as WorkflowRunnerStore;
+  }
+
+  /** Make the execution stores reflect exactly the events with `t <= timeMs`. */
+  seekToTime(timeMs: number): void {
+    const target = countAppliedAt(this.events, timeMs);
+    if (target < this.appliedIndex) {
+      this.reset();
+    }
+    for (let i = this.appliedIndex; i < target; i++) {
+      this.applyEvent(this.events[i]);
+    }
+    this.appliedIndex = target;
+  }
+
+  private applyEvent(event: CastEvent): void {
+    handleUpdate(
+      this.workflow,
+      event.message as unknown as MsgpackData,
+      this.runnerStore,
+      () => this.nodeStore
+    );
+  }
+
+  /** Wipe all replayed state back to the pristine, pre-run graph. */
+  reset(): void {
+    const wf = this.workflow.id;
+    useResultsStore.getState().clearResults(wf);
+    useResultsStore.getState().clearEdges(wf);
+    useStatusStore.getState().clearStatuses(wf);
+    useWorkflowRunsStore.getState().clearWorkflow(wf);
+    this.runnerStore.setState({ ...IDLE_RUNNER });
+    this.nodeStore.setState({
+      nodes: clone(this.pristineNodes),
+      edges: clone(this.pristineEdges),
+    });
+    this.appliedIndex = 0;
+  }
+
+  /** Drop all global state this engine wrote. Call when unmounting the player. */
+  dispose(): void {
+    this.reset();
+  }
+}
+
+/** Replace each message's top-level `job_id` with a per-engine fresh uuid. */
+function remapJobIds(events: CastEvent[]): CastEvent[] {
+  const map = new Map<string, string>();
+  return events.map((e) => {
+    const job = e.message.job_id;
+    if (typeof job !== "string") return e;
+    let fresh = map.get(job);
+    if (!fresh) {
+      fresh = uuidv4();
+      map.set(job, fresh);
+    }
+    return { t: e.t, message: { ...e.message, job_id: fresh } };
+  });
+}
+
+/** Structured deep clone; falls back to JSON for environments without it. */
+function clone<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/web/src/demo/index.ts
+++ b/web/src/demo/index.ts
@@ -4,6 +4,10 @@
  * Record a real workflow run into a cast (recorder), store it (cast JSON + a
  * folder of pinned assets), and replay it deterministically in the graph UI
  * (DemoPlayer / DemoEngine) for product-demo videos rendered with Remotion.
+ *
+ * End-to-end flow: CastRecorder → downloadCastJson → demo/casts/ →
+ * pin-cast-assets → register in demo/src/casts/registry → `remotion render`.
+ * See demo/README.md.
  */
 export * from "./castTypes";
 export { DemoEngine, seedCastMetadata } from "./demoEngine";

--- a/web/src/demo/index.ts
+++ b/web/src/demo/index.ts
@@ -1,0 +1,27 @@
+/**
+ * NodeTool demo harness — public surface.
+ *
+ * Record a real workflow run into a cast (recorder), store it (cast JSON + a
+ * folder of pinned assets), and replay it deterministically in the graph UI
+ * (DemoPlayer / DemoEngine) for product-demo videos rendered with Remotion.
+ */
+export * from "./castTypes";
+export { DemoEngine, seedCastMetadata } from "./demoEngine";
+export type { DemoEngineOptions } from "./demoEngine";
+export {
+  DemoPlayer,
+  default as DemoPlayerDefault,
+  useDemoClock,
+} from "./DemoPlayer";
+export type { DemoPlayerProps } from "./DemoPlayer";
+export { CastRecorder, downloadCastJson } from "./recorder";
+export type {
+  StartRecordingOptions,
+  StopRecordingOptions,
+} from "./recorder";
+export {
+  collectAndRewriteAssets,
+  resolveAssetUrls,
+} from "./assetSubstitution";
+export type { CollectedAssets } from "./assetSubstitution";
+export { sampleCast } from "./sampleCast";

--- a/web/src/demo/recorder.ts
+++ b/web/src/demo/recorder.ts
@@ -1,0 +1,154 @@
+/**
+ * CastRecorder — capture one real workflow run into a replayable cast.
+ *
+ * Usage (from the editor, e.g. a dev-only "Record demo" action):
+ *
+ *   const rec = new CastRecorder();
+ *   rec.start({ workflowId, getWorkflow, getMetadata });
+ *   // … click Run, let it finish …
+ *   const cast = rec.stop({ name: "Image generation demo" });
+ *   downloadCastJson(cast);            // → <cast>.cast.json
+ *
+ * The recorder taps the same message stream the UI consumes
+ * (`globalWebSocketManager` "message" events), so what you record is exactly
+ * what the product rendered. Asset URLs are rewritten to `cast-asset://<key>`
+ * and listed in the manifest; run `scripts/pin-cast-assets.ts` once to download
+ * the bytes so the cast replays with no backend and no further generations.
+ */
+import { v4 as uuidv4 } from "uuid";
+
+import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
+import type { WebSocketMessage } from "../lib/websocket/GlobalWebSocketManager";
+import type { NodeMetadata, Workflow } from "../stores/ApiTypes";
+
+import {
+  CAST_VERSION,
+  type CastEvent,
+  type DemoCast,
+} from "./castTypes";
+import { collectAndRewriteAssets } from "./assetSubstitution";
+
+export interface StartRecordingOptions {
+  /** Only messages for this workflow are captured. */
+  workflowId: string;
+  /** Snapshot of the pre-run graph (real node positions). Cloned at start. */
+  getWorkflow: () => Workflow;
+  /** Full node metadata; filtered to the types the graph uses. */
+  getMetadata: () => Record<string, NodeMetadata>;
+}
+
+export interface StopRecordingOptions {
+  name: string;
+  description?: string;
+  /** Suggested render frame rate. Default 30. */
+  fps?: number;
+  /** Hold time appended after the last event so the final frame lingers. */
+  tailHoldMs?: number;
+  /** Optional fixed camera (editor viewport) for deterministic framing. */
+  viewport?: { x: number; y: number; zoom: number };
+}
+
+/** Drop values JSON can't represent (typed arrays from binary audio chunks). */
+function jsonSafe(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) return null;
+  if (Array.isArray(value)) return value.map(jsonSafe);
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = jsonSafe(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Keep only the metadata entries for node types present in the graph. */
+function pickUsedMetadata(
+  workflow: Workflow,
+  metadata: Record<string, NodeMetadata>
+): Record<string, NodeMetadata> {
+  const used: Record<string, NodeMetadata> = {};
+  for (const node of workflow.graph?.nodes ?? []) {
+    const meta = metadata[node.type];
+    if (meta) used[node.type] = meta;
+  }
+  return used;
+}
+
+export class CastRecorder {
+  private events: CastEvent[] = [];
+  private startTimeMs = 0;
+  private unsubscribe: (() => void) | null = null;
+  private workflow: Workflow | null = null;
+  private metadata: Record<string, NodeMetadata> = {};
+
+  get isRecording(): boolean {
+    return this.unsubscribe !== null;
+  }
+
+  start(opts: StartRecordingOptions): void {
+    if (this.unsubscribe) throw new Error("CastRecorder already recording");
+    this.events = [];
+    this.startTimeMs = 0;
+    this.workflow = structuredClone(opts.getWorkflow());
+    this.metadata = pickUsedMetadata(this.workflow, opts.getMetadata());
+
+    this.unsubscribe = globalWebSocketManager.subscribeEvent(
+      "message",
+      (message: WebSocketMessage) => {
+        if (message.workflow_id !== opts.workflowId) return;
+        const now = performance.now();
+        if (this.events.length === 0) this.startTimeMs = now;
+        this.events.push({
+          t: Math.max(0, Math.round(now - this.startTimeMs)),
+          message: jsonSafe(message) as CastEvent["message"],
+        });
+      }
+    );
+  }
+
+  stop(opts: StopRecordingOptions): DemoCast {
+    if (!this.unsubscribe || !this.workflow) {
+      throw new Error("CastRecorder is not recording");
+    }
+    this.unsubscribe();
+    this.unsubscribe = null;
+
+    const lastT = this.events.length ? this.events[this.events.length - 1].t : 0;
+    const durationMs = lastT + (opts.tailHoldMs ?? 1500);
+    const { events, assets } = collectAndRewriteAssets(this.events);
+
+    const cast: DemoCast = {
+      version: CAST_VERSION,
+      id: uuidv4(),
+      name: opts.name,
+      description: opts.description,
+      createdAt: new Date().toISOString(),
+      durationMs,
+      fps: opts.fps ?? 30,
+      workflow: this.workflow,
+      metadata: this.metadata,
+      events,
+      assets,
+      viewport: opts.viewport,
+    };
+
+    this.workflow = null;
+    this.events = [];
+    return cast;
+  }
+}
+
+/** Trigger a browser download of the cast JSON (dev convenience). */
+export function downloadCastJson(cast: DemoCast): void {
+  const blob = new Blob([JSON.stringify(cast, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${cast.name.replace(/[^A-Za-z0-9._-]+/g, "-")}.cast.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/web/src/demo/sampleCast.ts
+++ b/web/src/demo/sampleCast.ts
@@ -273,5 +273,6 @@ export const sampleCast: DemoCast = {
   },
   events,
   assets: [],
-  viewport: { x: 60, y: 40, zoom: 0.85 },
+  // Centers the two nodes (graph bbox ~x[40,760] y[80,350]) in a 1920×1080 frame.
+  viewport: { x: 560, y: 300, zoom: 1.3 },
 };

--- a/web/src/demo/sampleCast.ts
+++ b/web/src/demo/sampleCast.ts
@@ -1,0 +1,277 @@
+/**
+ * A small, fully self-contained synthetic cast.
+ *
+ * It uses fabricated (but well-formed) node metadata and an inline SVG data URI
+ * for the generated image, so it renders with no recording, no asset files, and
+ * no backend. Handy for previewing the player, for tests, and as a worked
+ * example of the cast shape. Real demos come from CastRecorder.
+ */
+import type {
+  NodeMetadata,
+  OutputSlot,
+  Property,
+  PropertyTypeMetadata,
+  Workflow,
+} from "../stores/ApiTypes";
+import { PREVIEW_NODE_TYPE } from "../constants/nodeTypes";
+import { CAST_VERSION, type CastEvent, type DemoCast } from "./castTypes";
+
+const t = (type: string): PropertyTypeMetadata => ({
+  type,
+  optional: false,
+  type_args: [],
+});
+
+const prop = (name: string, type: string): Property => ({
+  name,
+  type: t(type),
+  default: undefined,
+  title: name,
+  description: null,
+  min: null,
+  max: null,
+  json_schema_extra: null,
+  required: false,
+});
+
+const out = (name: string, type: string, stream = false): OutputSlot => ({
+  name,
+  type: t(type),
+  stream,
+});
+
+const meta = (partial: Partial<NodeMetadata> & Pick<NodeMetadata, "node_type">): NodeMetadata => ({
+  title: partial.node_type.split(".").pop() ?? partial.node_type,
+  description: "",
+  namespace: partial.node_type.split(".").slice(0, -1).join("."),
+  layout: "default",
+  properties: [],
+  outputs: [],
+  recommended_models: [],
+  inline_fields: [],
+  required_settings: [],
+  supports_dynamic_inputs: false,
+  is_streaming_output: false,
+  supports_dynamic_outputs: false,
+  ...partial,
+});
+
+const GENERATE_TYPE = "demo.text.Generate";
+
+const SVG_IMAGE =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="360" height="220">
+      <defs>
+        <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="#1e3a8a"/>
+          <stop offset="0.6" stop-color="#9333ea"/>
+          <stop offset="1" stop-color="#f59e0b"/>
+        </linearGradient>
+      </defs>
+      <rect width="360" height="220" fill="url(#g)"/>
+      <circle cx="280" cy="60" r="28" fill="#fde68a" opacity="0.9"/>
+      <path d="M0 170 L90 110 L150 150 L240 90 L360 160 L360 220 L0 220 Z" fill="#0f172a" opacity="0.55"/>
+      <text x="20" y="200" fill="#e2e8f0" font-family="sans-serif" font-size="16">serene mountain lake</text>
+    </svg>`
+  );
+
+const FULL_TEXT = "A serene mountain lake at golden hour, mirror-still.";
+const TOKENS = ["A serene ", "mountain lake ", "at golden hour, ", "mirror-still."];
+
+const workflow = {
+  id: "wf-demo-sample",
+  name: "Sample Demo",
+  access: "private",
+  description: "Synthetic cast for previewing the demo player.",
+  thumbnail: "",
+  tags: [],
+  run_mode: "workflow",
+  settings: {},
+  updated_at: new Date(0).toISOString(),
+  created_at: new Date(0).toISOString(),
+  graph: {
+    nodes: [
+      {
+        id: "gen",
+        type: GENERATE_TYPE,
+        data: { prompt: "Describe a peaceful landscape" },
+        ui_properties: {
+          position: { x: 40, y: 80 },
+          zIndex: 0,
+          width: 280,
+          selectable: true,
+          title: "Generate",
+        },
+        dynamic_properties: {},
+        dynamic_outputs: {},
+      },
+      {
+        id: "preview",
+        type: PREVIEW_NODE_TYPE,
+        data: {},
+        ui_properties: {
+          position: { x: 440, y: 80 },
+          zIndex: 0,
+          width: 320,
+          selectable: true,
+          title: "Preview",
+        },
+        dynamic_properties: {},
+        dynamic_outputs: {},
+      },
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "gen",
+        sourceHandle: "text",
+        target: "preview",
+        targetHandle: "value",
+      },
+    ],
+  },
+} as unknown as Workflow;
+
+const WF = "wf-demo-sample";
+const JOB = "sample-job";
+
+function chunkEvents(): CastEvent[] {
+  const events: CastEvent[] = [];
+  let time = 500;
+  for (const token of TOKENS) {
+    events.push({
+      t: time,
+      message: {
+        type: "chunk",
+        node_id: "gen",
+        content_type: "text",
+        content: token,
+        workflow_id: WF,
+        job_id: JOB,
+      },
+    });
+    time += 350;
+  }
+  return events;
+}
+
+const events: CastEvent[] = [
+  {
+    t: 0,
+    message: { type: "job_update", status: "running", job_id: JOB, workflow_id: WF },
+  },
+  {
+    t: 200,
+    message: {
+      type: "node_update",
+      status: "running",
+      node_id: "gen",
+      node_name: "Generate",
+      node_type: GENERATE_TYPE,
+      workflow_id: WF,
+      job_id: JOB,
+    },
+  },
+  ...chunkEvents(),
+  {
+    t: 1950,
+    message: { type: "edge_update", edge_id: "e1", status: "active", workflow_id: WF, job_id: JOB },
+  },
+  {
+    t: 2050,
+    message: {
+      type: "node_update",
+      status: "completed",
+      node_id: "gen",
+      node_name: "Generate",
+      node_type: GENERATE_TYPE,
+      result: { text: FULL_TEXT },
+      workflow_id: WF,
+      job_id: JOB,
+    },
+  },
+  {
+    t: 2150,
+    message: {
+      type: "node_update",
+      status: "running",
+      node_id: "preview",
+      node_name: "Preview",
+      node_type: PREVIEW_NODE_TYPE,
+      workflow_id: WF,
+      job_id: JOB,
+    },
+  },
+  {
+    t: 2300,
+    message: {
+      type: "output_update",
+      node_id: "preview",
+      node_name: "Preview",
+      output_name: "value",
+      value: { type: "image", uri: SVG_IMAGE },
+      output_type: "image",
+      metadata: {},
+      workflow_id: WF,
+      job_id: JOB,
+    },
+  },
+  {
+    t: 2500,
+    message: {
+      type: "node_update",
+      status: "completed",
+      node_id: "preview",
+      node_name: "Preview",
+      node_type: PREVIEW_NODE_TYPE,
+      result: { value: { type: "image", uri: SVG_IMAGE } },
+      workflow_id: WF,
+      job_id: JOB,
+    },
+  },
+  {
+    t: 2600,
+    message: { type: "edge_update", edge_id: "e1", status: "completed", workflow_id: WF, job_id: JOB },
+  },
+  {
+    t: 2700,
+    message: {
+      type: "job_update",
+      status: "completed",
+      job_id: JOB,
+      workflow_id: WF,
+      result: { outputs: { value: { type: "image", uri: SVG_IMAGE } } },
+    },
+  },
+];
+
+export const sampleCast: DemoCast = {
+  version: CAST_VERSION,
+  id: "sample-demo",
+  name: "Sample Demo",
+  description: "Synthetic two-node cast: streaming text → image preview.",
+  createdAt: new Date(0).toISOString(),
+  durationMs: 4200,
+  fps: 30,
+  workflow,
+  metadata: {
+    [GENERATE_TYPE]: meta({
+      node_type: GENERATE_TYPE,
+      title: "Generate",
+      properties: [prop("prompt", "str")],
+      outputs: [out("text", "str", true)],
+      inline_fields: ["prompt"],
+      is_streaming_output: true,
+    }),
+    [PREVIEW_NODE_TYPE]: meta({
+      node_type: PREVIEW_NODE_TYPE,
+      title: "Preview",
+      properties: [prop("value", "any")],
+      outputs: [out("output", "any")],
+    }),
+  },
+  events,
+  assets: [],
+  viewport: { x: 60, y: 40, zoom: 0.85 },
+};


### PR DESCRIPTION
## Summary

Adds a complete demo recording and replay system for creating product-demo videos of the NodeTool graph UI. The system captures real workflow runs into portable, backend-free "casts" that can be replayed deterministically and rendered into videos using Remotion.

## Key Changes

**Core Demo Infrastructure (`web/src/demo/`)**
- **`castTypes.ts`**: Defines the cast format — a self-contained JSON recording of a workflow run including the graph, node metadata, timestamped protocol messages, and an asset manifest
- **`demoEngine.ts`**: Deterministic replay engine that drives production execution stores (`NodeStore`, `StatusStore`, `ResultsStore`) as a pure function of elapsed time, enabling frame-accurate scrubbing
- **`DemoPlayer.tsx`**: Renders the real `BaseNode`/`PreviewNode`/`OutputNode` components for a cast at a given time, reusing all production UI code and styles so videos look identical to the app
- **`recorder.ts`**: Captures live workflow runs into casts by tapping the WebSocket message stream, rewriting asset URLs to portable `cast-asset://` references
- **`assetSubstitution.ts`**: Handles bidirectional asset URL rewriting — at record time replaces host-specific URLs with stable keys, at load time resolves them to host-provided URLs
- **`sampleCast.ts`**: Fully synthetic, self-contained demo cast (inline SVG, no backend) for testing and as a worked example
- **`index.ts`**: Public API surface for the demo system

**Remotion Harness (`demo/`)**
- **`src/WorkflowDemo.tsx`**: Main composition that embeds `DemoPlayer`, drives it from Remotion's frame clock, and adds title cards and captions
- **`src/Root.tsx`**: Registers compositions for each cast in the registry
- **`src/components/TitleCard.tsx`** and **`Caption.tsx`**: Reusable animated UI elements for videos
- **`src/webpackOverride.ts`**: Webpack configuration that resolves `@nodetool-ai/*` packages to TypeScript sources and stubs Node built-ins so Remotion can bundle the real web components
- **`casts/registry.ts`**: Cast registry for Remotion to discover available demos
- **`scripts/pin-cast-assets.ts`**: Downloads and pins generated assets locally so casts replay with zero backend calls

**Integration**
- **`web/demo.html`** and **`web/src/demo-entry.tsx`**: Standalone preview page with scrubber for authoring and testing casts
- **`demo/tsconfig.json`**, **`remotion.config.ts`**, **`package.json`**: Remotion project configuration
- Updated root `package.json` to include `demo/` as a workspace

## Notable Implementation Details

- **Deterministic replay**: `DemoEngine.seekToTime(ms)` makes state a pure function of elapsed time — seeking backward resets and replays from start, enabling frame-accurate video capture
- **No backend required**: Casts are fully self-contained; recorded asset URLs are rewritten to `cast-asset://` references and pinned locally, so replay never re-generates or calls the backend
- **Production fidelity**: `DemoPlayer` reuses the exact same node components, styles, and update reducer (`handleUpdate`) as the editor, so videos render identically to the live app
- **Webpack override**: Mirrors Vite's `nodetool-dev` export condition resolution and Node stub strategy so Remotion can bundle the real web UI without a build step
- **Asset portability**: Structured deep-clone with per-string replacer handles nested asset objects, arrays of chunks, and bare string values uniformly across the protocol message tree

https://claude.ai/code/session_01RUtyKJGkmnc7rYBBesnud7