### PR TITLE
Add auto makeup gain toggle to Compress and Limiter nodes

### DIFF
--- a/packages/audio-nodes/src/nodes/lib-audio-effects.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-effects.ts
@@ -185,14 +185,31 @@ export class CompressNode extends BaseNode {
   })
   declare release: any;
 
+  @prop({
+    type: "bool",
+    default: true,
+    title: "Auto Gain",
+    description:
+      "Apply automatic makeup gain to compensate for the level lost to compression, keeping the output roughly as loud as the input."
+  })
+  declare auto_gain: any;
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold ?? -20);
     const ratio = Number(this.ratio ?? 4);
     const attackMs = Number(this.attack ?? 5);
     const releaseMs = Number(this.release ?? 50);
+    const autoGain = this.auto_gain !== false;
 
     const bytes = await requireAudioBytes(audio, context);
+
+    // Makeup gain: half of the reduction a 0 dBFS peak would receive — the
+    // usual "auto" heuristic. It restores most of the loudness lost to
+    // compression while staying clear of clipping the way full compensation
+    // (referenced to 0 dBFS) would on under-compressed transients.
+    const makeupDb = autoGain ? (-thresholdDb * (1 - 1 / ratio)) / 2 : 0;
+    const makeup = Math.pow(10, makeupDb / 20);
 
     const wav = await decodeAudioToWav(bytes);
     const result = processPerChannel(wav, (ch, sr) => {
@@ -214,9 +231,9 @@ export class CompressNode extends BaseNode {
           const dbOver = 20 * Math.log10(envelope / thresholdLin);
           const dbReduction = dbOver * (1 - 1 / ratio);
           const gainReduction = Math.pow(10, -dbReduction / 20);
-          out[i] = ch[i] * gainReduction;
+          out[i] = ch[i] * gainReduction * makeup;
         } else {
-          out[i] = ch[i];
+          out[i] = ch[i] * makeup;
         }
       }
       return out;
@@ -339,15 +356,29 @@ export class LimiterNode extends BaseNode {
   })
   declare release_ms: any;
 
+  @prop({
+    type: "bool",
+    default: true,
+    title: "Auto Gain",
+    description:
+      "Apply automatic makeup gain so the limited peaks reach 0 dBFS, turning the headroom below the ceiling into added loudness (maximizer behaviour)."
+  })
+  declare auto_gain: any;
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold_db ?? -2);
     const releaseMs = Number(this.release_ms ?? 250);
+    const autoGain = this.auto_gain !== false;
 
     const bytes = await requireAudioBytes(audio, context);
 
     const wav = await decodeAudioToWav(bytes);
     const threshold = Math.pow(10, thresholdDb / 20);
+    // Makeup gain brings the ceiling up to 0 dBFS. Limited peaks sit at
+    // `threshold`, so scaling by 1/threshold normalizes them to full scale
+    // without pushing past it.
+    const makeup = autoGain ? 1 / threshold : 1;
     const result = processPerChannel(wav, (ch, sr) => {
       const out = new Float32Array(ch.length);
       const releaseCoeff = Math.exp(-1 / ((sr * releaseMs) / 1000));
@@ -364,7 +395,7 @@ export class LimiterNode extends BaseNode {
           gainReduction =
             releaseCoeff * gainReduction + (1 - releaseCoeff) * 1.0;
         }
-        out[i] = ch[i] * gainReduction;
+        out[i] = ch[i] * gainReduction * makeup;
       }
       return out;
     });

--- a/packages/audio-nodes/tests/lib-audio-effects-autogain.test.ts
+++ b/packages/audio-nodes/tests/lib-audio-effects-autogain.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Auto makeup gain for the dynamics processors:
+ *  - Compress: when on (the default), the level lost to gain reduction is
+ *    compensated, so a compressed signal stays roughly as loud as it went in;
+ *    when off, compression audibly lowers the level.
+ *  - Limiter: when on (the default), limited peaks are normalized up to
+ *    0 dBFS (maximizer behaviour); when off, peaks sit at the ceiling.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CompressNode,
+  LimiterNode,
+  encodeWav,
+  parseWavBytes,
+  toBytes
+} from "@nodetool-ai/audio-nodes";
+
+const SAMPLE_RATE = 8000;
+
+/** Inline mono AudioRef of a constant-amplitude tone (1 s). */
+function wavRef(amplitude: number) {
+  const frames = SAMPLE_RATE;
+  const samples = new Float32Array(frames).fill(amplitude);
+  return { type: "audio", uri: "", data: encodeWav(samples, SAMPLE_RATE, 1) };
+}
+
+function outSamples(result: Record<string, unknown>): Float32Array {
+  const ref = result.output as { data?: Uint8Array | string };
+  const wav = parseWavBytes(toBytes(ref?.data));
+  if (!wav) throw new Error("expected WAV output");
+  return wav.samples;
+}
+
+/** Peak magnitude over the settled tail (skips the attack/release ramp). */
+function tailPeak(samples: Float32Array, skip = SAMPLE_RATE / 2): number {
+  let peak = 0;
+  for (let i = skip; i < samples.length; i++) {
+    peak = Math.max(peak, Math.abs(samples[i]));
+  }
+  return peak;
+}
+
+describe("Compress auto gain", () => {
+  it("defaults on and boosts the compressed level back up", async () => {
+    const input = wavRef(0.5);
+    const withGain = tailPeak(
+      outSamples(await new CompressNode({ audio: input }).process())
+    );
+    const withoutGain = tailPeak(
+      outSamples(
+        await new CompressNode({ audio: input, auto_gain: false }).process()
+      )
+    );
+
+    // Without makeup, compression pulls a -6 dBFS tone well below its input
+    // level; makeup (the default) lifts it back up by ~7.5 dB.
+    expect(withoutGain).toBeLessThan(0.25);
+    expect(withGain).toBeGreaterThan(withoutGain * 2);
+    expect(withGain).toBeGreaterThan(0.3);
+    expect(withGain).toBeLessThanOrEqual(1.0001);
+  });
+});
+
+describe("Limiter auto gain", () => {
+  it("defaults on and normalizes limited peaks toward 0 dBFS", async () => {
+    const input = wavRef(0.9);
+    const withGain = tailPeak(
+      outSamples(await new LimiterNode({ audio: input }).process())
+    );
+    const withoutGain = tailPeak(
+      outSamples(
+        await new LimiterNode({ audio: input, auto_gain: false }).process()
+      )
+    );
+
+    // Ceiling is -2 dBFS (≈0.794). Without makeup the peak stays there; with
+    // makeup (the default) it is lifted up to full scale without clipping.
+    expect(withoutGain).toBeLessThan(0.85);
+    expect(withGain).toBeGreaterThan(0.95);
+    expect(withGain).toBeLessThanOrEqual(1.0001);
+  });
+});

--- a/packages/base-nodes/tests/coverage-gap-fill.test.ts
+++ b/packages/base-nodes/tests/coverage-gap-fill.test.ts
@@ -3965,7 +3965,10 @@ describe("lib-audio-effects signal verification", () => {
     const audio = shortSine(8000, 0.1);
 
     const node = new LimiterNode();
-    node.assign({ audio, threshold_db: -12, release_ms: 50 });
+    // auto_gain defaults on (it makes the limiter a maximizer, lifting peaks
+    // up to 0 dBFS); disable it here to assert the underlying limiting caps
+    // peaks at the threshold.
+    node.assign({ audio, threshold_db: -12, release_ms: 50, auto_gain: false });
     const res = await node.process();
     const outputSamples = decodeTestWav(res.output as { data: string }).samples;
 

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -161,12 +161,14 @@ export const BESPOKE_DEFAULT_HEIGHTS: Readonly<Record<string, number>> = {
       return [t, 96 + extras + knobRows * 84] as const;
     })
   ),
-  // Audio effects: same knob faceplate as synth modules (single audio jack).
+  // Audio effects: same knob faceplate as synth modules (single audio jack),
+  // plus a row per boolean toggle (e.g. compressor/limiter auto gain).
   ...Object.fromEntries(
     AUDIO_EFFECT_NODE_TYPES.map((t) => {
       const c = AUDIO_EFFECT_CONFIGS[t];
       const knobRows = Math.ceil(c.knobs.length / 3);
-      return [t, 96 + knobRows * 84] as const;
+      const toggleRows = c.toggles?.length ?? 0;
+      return [t, 96 + toggleRows * 28 + knobRows * 84] as const;
     })
   ),
   // Audio Out: label strip + transport buttons + visualizer.

--- a/web/src/components/node_types/synth/SynthModuleBody.tsx
+++ b/web/src/components/node_types/synth/SynthModuleBody.tsx
@@ -235,6 +235,15 @@ const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
     [config, pushLive, setProperty, setPropertyComplete]
   );
 
+  const handleToggleChange = useCallback(
+    (name: string, value: boolean) => {
+      setProperty(name, value);
+      pushLive(name, value);
+      setPropertyComplete();
+    },
+    [pushLive, setProperty, setPropertyComplete]
+  );
+
   if (!config) {
     return null;
   }
@@ -290,6 +299,24 @@ const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
           ))}
         </ToggleGroup>
       )}
+
+      {config.toggles?.map((t) => {
+        const on =
+          props[t.name] === undefined ? t.default : Boolean(props[t.name]);
+        return (
+          <ToggleGroup
+            key={t.name}
+            className="mode-toggle nodrag"
+            size="small"
+            exclusive
+            value={on ? t.name : null}
+            onChange={() => handleToggleChange(t.name, !on)}
+            aria-label={t.label}
+          >
+            <ToggleOption value={t.name}>{t.label}</ToggleOption>
+          </ToggleGroup>
+        );
+      })}
 
       {config.adsrPreview && (
         <div className="adsr-preview">

--- a/web/src/components/node_types/synth/__tests__/audioEffectModules.test.ts
+++ b/web/src/components/node_types/synth/__tests__/audioEffectModules.test.ts
@@ -43,6 +43,15 @@ describe("audio effect configs", () => {
       expect(BESPOKE_DEFAULT_HEIGHTS[t]).toBeGreaterThan(0);
     }
   });
+
+  it("exposes an auto-gain toggle (default on) on the dynamics processors", () => {
+    for (const t of ["lib.audio.Compress", "lib.audio.Limiter"]) {
+      const toggles = AUDIO_EFFECT_CONFIGS[t].toggles ?? [];
+      const autoGain = toggles.find((g) => g.name === "auto_gain");
+      expect(autoGain).toBeDefined();
+      expect(autoGain?.default).toBe(true);
+    }
+  });
 });
 
 describe("knob value formatting", () => {

--- a/web/src/components/node_types/synth/audioEffectModules.ts
+++ b/web/src/components/node_types/synth/audioEffectModules.ts
@@ -184,6 +184,7 @@ export const AUDIO_EFFECT_CONFIGS: Readonly<Record<string, SynthModuleConfig>> =
       label: "COMP",
       accent: "warning",
       inputs: ["audio"],
+      toggles: [{ name: "auto_gain", label: "Auto Gain", default: true }],
       knobs: [
         {
           name: "threshold",
@@ -233,6 +234,7 @@ export const AUDIO_EFFECT_CONFIGS: Readonly<Record<string, SynthModuleConfig>> =
       label: "LIMIT",
       accent: "warning",
       inputs: ["audio"],
+      toggles: [{ name: "auto_gain", label: "Auto Gain", default: true }],
       knobs: [
         {
           name: "threshold_db",

--- a/web/src/components/node_types/synth/synthModules.ts
+++ b/web/src/components/node_types/synth/synthModules.ts
@@ -29,6 +29,13 @@ export interface EnumToggleSpec {
   options: ReadonlyArray<{ value: string; label: string }>;
 }
 
+/** Boolean on/off toggle for a `bool` property (e.g. compressor auto gain). */
+export interface BoolToggleSpec {
+  name: string;
+  label: string;
+  default: boolean;
+}
+
 /** Palette key used for the module's accent (knob arcs, waveform icons). */
 export type SynthAccent =
   | "primary"
@@ -49,6 +56,8 @@ export interface SynthModuleConfig {
   waveform?: { name: string; default: string; options: readonly string[] };
   /** Generic enum toggle (e.g. VCF lowpass/highpass). */
   modeToggle?: EnumToggleSpec;
+  /** Boolean on/off toggles for `bool` properties (e.g. auto makeup gain). */
+  toggles?: readonly BoolToggleSpec[];
   /** Render the ADSR envelope preview above the knobs. */
   adsrPreview?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds an `auto_gain` boolean toggle (default: on) to the Compress and Limiter audio effect nodes. This allows users to control whether automatic makeup gain is applied to compensate for level changes introduced by dynamics processing.

## Changes

### Audio Node Logic (`packages/audio-nodes/`)
- **CompressNode**: 
  - Added `auto_gain` property (bool, default true)
  - Implements makeup gain calculation: `(-threshold_dB * (1 - 1/ratio)) / 2`
  - Applies makeup scaling to all output samples when enabled
  - Restores most loudness lost to compression while avoiding clipping

- **LimiterNode**:
  - Added `auto_gain` property (bool, default true)
  - Implements makeup gain as `1 / threshold` to normalize limited peaks to 0 dBFS
  - Converts headroom below the ceiling into added loudness (maximizer behavior)

- **Tests** (`lib-audio-effects-autogain.test.ts`):
  - Verify Compress auto gain boosts compressed level back up (default on)
  - Verify Limiter auto gain normalizes limited peaks toward 0 dBFS (default on)
  - Confirm behavior with auto gain disabled

### UI Components (`web/src/components/`)
- **SynthModuleBody**: Added `handleToggleChange` callback and rendering for boolean toggles via new `config.toggles` array
- **audioEffectModules.ts**: Added `toggles` config for both Compress and Limiter with `auto_gain` toggle
- **synthModules.ts**: Added `BoolToggleSpec` interface for boolean on/off toggles
- **bespokeRegistry.ts**: Updated default heights to account for toggle rows (28px per toggle)
- **audioEffectModules.test.ts**: Added test verifying auto-gain toggle is exposed and defaults to true

## Implementation Details

- Makeup gain formulas follow standard audio engineering conventions:
  - **Compress**: Half the reduction a 0 dBFS peak would receive (conservative approach)
  - **Limiter**: Full normalization to 0 dBFS (maximizer behavior)
- Toggle UI renders as a single-option ToggleGroup for consistency with existing mode toggles
- Default behavior (auto gain on) matches typical DAW compressor/limiter behavior

https://claude.ai/code/session_01QvgH6YB9rBfQvsXxbAyMJC