### PR TITLE
Add wheel gesture routing for timeline zoom and horizontal scroll

### DIFF
--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -24,8 +24,13 @@
  *   Ctrl+Z / Ctrl+Y  → undo / redo
  * Shortcuts are skipped when focus is in a text input or contenteditable.
  *
- * Zoom: Ctrl+wheel on the lane area changes msPerPx, anchored at the cursor.
- * Horizontal scroll: native overflow-x scroll on the scrollable panel.
+ * Zoom: Ctrl/Cmd+wheel (or a trackpad pinch) on the lane area changes msPerPx,
+ *   anchored at the cursor.
+ * Horizontal scroll: a trackpad two-finger horizontal swipe or Shift+wheel
+ *   scrolls the lanes left/right. The handler takes the gesture over so the
+ *   browser's back/forward swipe never fires at the scroll edges; a plain
+ *   vertical wheel still scrolls the tracks list, and the native overflow-x
+ *   scrollbar stays available.
  */
 
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -71,6 +76,7 @@ import { deserializeDragData } from "../../../lib/dragdrop";
 import type { Asset } from "../../../stores/ApiTypes";
 import { assetMediaType } from "../dnd/assetToClipAdapter";
 import { buildTypedIndexMap } from "./trackVisuals";
+import { partitionTimelineWheel, normalizeWheelDeltaPx } from "./timelineWheel";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -149,7 +155,10 @@ const scrollableAreaStyles = css({
   flex: "1 1 auto",
   overflowX: "auto",
   overflowY: "hidden",
-  position: "relative"
+  position: "relative",
+  // Keep an over-scrolled horizontal swipe from triggering the browser's
+  // back/forward navigation (the wheel handler also preventDefaults).
+  overscrollBehaviorX: "contain"
 });
 
 const lanesContainerStyles = css({
@@ -283,10 +292,16 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       [setScrollLeftPx]
     );
 
-    // ── Zoom (wheel) ────────────────────────────────────────────────────────
+    // ── Zoom + horizontal scroll (wheel) ─────────────────────────────────────
     //
     // Attached as a native non-passive listener: React's onWheel is passive,
-    // so preventDefault() inside it can't stop the browser's pinch-zoom.
+    // so preventDefault() inside it can't stop the browser's pinch-zoom or its
+    // back/forward swipe. partitionTimelineWheel routes the gesture (see
+    // timelineWheel.ts): Ctrl/Cmd+wheel zooms, a horizontal trackpad swipe or
+    // Shift+wheel scrolls the lanes, and a plain vertical wheel is left to
+    // bubble to the tracks list's native vertical scroll. Setting el.scrollLeft
+    // fires the onScroll handler below, which syncs scrollLeftPx → ruler +
+    // playhead.
 
     // Anchor zoom at the cursor: remember which timeline time sat under the
     // pointer, then restore it to the same viewport x once the lanes have
@@ -300,9 +315,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       const el = scrollableRef.current;
       if (!el) return;
       const onWheel = (e: WheelEvent) => {
+        const { zoomDelta, scrollDelta } = partitionTimelineWheel(e);
+
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
-          const factor = 1 + e.deltaY * ZOOM_SENSITIVITY;
+          const factor = 1 + zoomDelta * ZOOM_SENSITIVITY;
           const next = Math.min(
             MAX_MS_PER_PX,
             Math.max(MIN_MS_PER_PX, msPerPx * factor)
@@ -314,6 +331,26 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             cursorPx
           };
           setZoom(next);
+          return;
+        }
+
+        if (scrollDelta !== 0) {
+          // Take the gesture over so a horizontal swipe past the edge can't
+          // trigger the browser's back/forward navigation.
+          e.preventDefault();
+          const deltaPx = normalizeWheelDeltaPx(
+            scrollDelta,
+            e.deltaMode,
+            el.clientWidth
+          );
+          const maxScrollPx = Math.max(0, el.scrollWidth - el.clientWidth);
+          const nextScrollLeft = Math.min(
+            maxScrollPx,
+            Math.max(0, el.scrollLeft + deltaPx)
+          );
+          if (nextScrollLeft !== el.scrollLeft) {
+            el.scrollLeft = nextScrollLeft;
+          }
         }
       };
       el.addEventListener("wheel", onWheel, { passive: false });
@@ -587,6 +624,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             ref={scrollableRef}
             css={scrollableAreaStyles}
             onScroll={handleScroll}
+            data-testid="tracks-scroll-area"
           >
             <div
               css={lanesContainerStyles}

--- a/web/src/components/timeline/Tracks/__tests__/timelineWheel.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/timelineWheel.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Timeline wheel-gesture routing.
+ *
+ * Pins how a wheel event splits into a zoom step vs a horizontal-scroll delta:
+ *   - Ctrl/Cmd+wheel (and the macOS pinch, reported as a synthetic ctrlKey
+ *     wheel) → zoom.
+ *   - Shift+wheel → horizontal scroll (mice with a vertical-only wheel).
+ *   - Trackpad horizontal swipe (deltaX dominant) → horizontal scroll.
+ *   - Plain vertical wheel → left alone for native vertical track scrolling.
+ */
+
+import {
+  partitionTimelineWheel,
+  normalizeWheelDeltaPx,
+  type TimelineWheelSrc
+} from "../timelineWheel";
+
+function fakeWheel(init: Partial<TimelineWheelSrc>): TimelineWheelSrc {
+  return {
+    deltaX: 0,
+    deltaY: 0,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...init
+  };
+}
+
+describe("partitionTimelineWheel", () => {
+  it("zooms on Ctrl+wheel (vertical delta drives the zoom)", () => {
+    const out = partitionTimelineWheel(
+      fakeWheel({ deltaY: 120, ctrlKey: true })
+    );
+    expect(out.zoomDelta).toBe(120);
+    expect(out.scrollDelta).toBe(0);
+  });
+
+  it("zooms on Cmd+wheel / macOS pinch (reported as ctrlKey)", () => {
+    expect(
+      partitionTimelineWheel(fakeWheel({ deltaY: 8, metaKey: true })).zoomDelta
+    ).toBe(8);
+    expect(
+      partitionTimelineWheel(fakeWheel({ deltaY: -14, ctrlKey: true })).zoomDelta
+    ).toBe(-14);
+  });
+
+  it("scrolls horizontally on a trackpad horizontal swipe (deltaX dominant)", () => {
+    const out = partitionTimelineWheel(fakeWheel({ deltaX: 40, deltaY: 6 }));
+    expect(out.zoomDelta).toBe(0);
+    expect(out.scrollDelta).toBe(40);
+  });
+
+  it("leaves a vertical-dominant plain wheel alone (native track scroll)", () => {
+    const out = partitionTimelineWheel(fakeWheel({ deltaX: 3, deltaY: 90 }));
+    expect(out.zoomDelta).toBe(0);
+    expect(out.scrollDelta).toBe(0);
+  });
+
+  it("routes Shift+wheel to horizontal scroll using deltaY", () => {
+    const out = partitionTimelineWheel(fakeWheel({ deltaY: 30, shiftKey: true }));
+    expect(out.zoomDelta).toBe(0);
+    expect(out.scrollDelta).toBe(30);
+  });
+
+  it("prefers deltaX for Shift+wheel when the browser folds it in", () => {
+    const out = partitionTimelineWheel(
+      fakeWheel({ deltaX: 18, deltaY: 30, shiftKey: true })
+    );
+    expect(out.scrollDelta).toBe(18);
+  });
+
+  it("zoom wins over scroll when Ctrl and a horizontal swipe coincide", () => {
+    const out = partitionTimelineWheel(
+      fakeWheel({ deltaX: 50, deltaY: 10, ctrlKey: true })
+    );
+    expect(out.zoomDelta).toBe(10);
+    expect(out.scrollDelta).toBe(0);
+  });
+});
+
+describe("normalizeWheelDeltaPx", () => {
+  it("passes pixel-mode deltas through unchanged", () => {
+    expect(normalizeWheelDeltaPx(120, 0 /* DOM_DELTA_PIXEL */, 800)).toBe(120);
+  });
+
+  it("scales line-mode deltas by a per-line pixel height", () => {
+    expect(normalizeWheelDeltaPx(3, 1 /* DOM_DELTA_LINE */, 800)).toBe(48);
+  });
+
+  it("scales page-mode deltas by the page (viewport) size", () => {
+    expect(normalizeWheelDeltaPx(2, 2 /* DOM_DELTA_PAGE */, 800)).toBe(1600);
+  });
+});

--- a/web/src/components/timeline/Tracks/timelineWheel.ts
+++ b/web/src/components/timeline/Tracks/timelineWheel.ts
@@ -1,0 +1,77 @@
+/**
+ * Timeline wheel-gesture routing.
+ *
+ * Splits a wheel event into a zoom step vs a horizontal-scroll delta so the
+ * tracks surface behaves like a video editor:
+ *   - Ctrl/Cmd + wheel (and the macOS trackpad pinch, which the browser reports
+ *     as a synthetic ctrlKey wheel) → zoom.
+ *   - Shift + wheel → horizontal scroll (for mice with a vertical-only wheel).
+ *   - Trackpad two-finger horizontal swipe (deltaX dominates deltaY) →
+ *     horizontal scroll. This is the native macOS gesture; the caller takes it
+ *     over so it can suppress the browser's back/forward swipe at the edges.
+ *   - A vertical-dominant plain wheel is left alone (scrollDelta === 0) so it
+ *     bubbles to the tracks list's native vertical scroll.
+ *
+ * Pure and platform-agnostic — the horizontal-vs-vertical discriminator works
+ * the same everywhere, so the routing is unit-testable without stubbing
+ * `navigator`.
+ */
+
+export type TimelineWheelSrc = Pick<
+  WheelEvent,
+  "deltaX" | "deltaY" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+export interface TimelineWheelMotion {
+  /** Vertical delta to feed the zoom step; 0 when the gesture isn't a zoom. */
+  zoomDelta: number;
+  /** Raw horizontal delta to scroll by; 0 when the gesture isn't a scroll. */
+  scrollDelta: number;
+}
+
+export function partitionTimelineWheel(
+  event: TimelineWheelSrc
+): TimelineWheelMotion {
+  // Ctrl/Cmd + wheel — also the macOS pinch, reported as a synthetic ctrlKey
+  // wheel — zooms. Vertical delta drives the zoom factor.
+  if (event.ctrlKey || event.metaKey) {
+    return { zoomDelta: event.deltaY, scrollDelta: 0 };
+  }
+
+  // Shift + wheel → horizontal scroll. Some browsers already fold Shift into
+  // deltaX, so prefer it and fall back to deltaY.
+  if (event.shiftKey) {
+    const primary = event.deltaX !== 0 ? event.deltaX : event.deltaY;
+    return { zoomDelta: 0, scrollDelta: primary };
+  }
+
+  // Trackpad horizontal swipe → horizontal scroll. A vertical-dominant gesture
+  // is left for native vertical scrolling of the tracks list.
+  if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+    return { zoomDelta: 0, scrollDelta: event.deltaX };
+  }
+
+  return { zoomDelta: 0, scrollDelta: 0 };
+}
+
+/** Pixels-per-line fallback for DOM_DELTA_LINE wheel events (some mice). */
+const LINE_HEIGHT_PX = 16;
+
+/**
+ * Normalize a wheel delta to pixels. Trackpads report pixel deltas, but some
+ * mice report lines (DOM_DELTA_LINE) or pages (DOM_DELTA_PAGE); without this a
+ * line-mode notch would scroll only a few pixels.
+ */
+export function normalizeWheelDeltaPx(
+  delta: number,
+  deltaMode: number,
+  pageSizePx: number
+): number {
+  if (deltaMode === 1 /* DOM_DELTA_LINE */) {
+    return delta * LINE_HEIGHT_PX;
+  }
+  if (deltaMode === 2 /* DOM_DELTA_PAGE */) {
+    return delta * pageSizePx;
+  }
+  return delta;
+}


### PR DESCRIPTION
## Summary

Implements intelligent wheel-gesture routing for the timeline tracks region, enabling Ctrl/Cmd+wheel zoom, trackpad horizontal swipes, and Shift+wheel horizontal scrolling while preserving native vertical scrolling. Adds a new `timelineWheel` module with comprehensive unit tests.

## Key Changes

- **New module `timelineWheel.ts`**: Pure, platform-agnostic wheel-gesture partitioning logic
  - `partitionTimelineWheel()`: Routes wheel events into zoom vs. horizontal-scroll deltas based on modifier keys and delta dominance
  - `normalizeWheelDeltaPx()`: Converts DOM_DELTA_LINE and DOM_DELTA_PAGE modes to pixels for consistent scroll/zoom behavior across mice and trackpads
  - Comprehensive test suite (`timelineWheel.test.ts`) covering all gesture combinations

- **Updated `TracksRegion.tsx`**:
  - Integrated `partitionTimelineWheel()` into the non-passive wheel listener to route gestures correctly
  - Added horizontal scroll handler that normalizes wheel deltas and clamps scroll position
  - Set `overscrollBehaviorX: "contain"` to prevent browser back/forward navigation on over-scrolled swipes
  - Updated documentation comments to reflect new scroll capabilities
  - Added `data-testid` to scrollable area for testing

## Gesture Routing

- **Ctrl/Cmd + wheel** (or macOS pinch) → zoom, using vertical delta
- **Shift + wheel** → horizontal scroll (for mice with vertical-only wheels)
- **Trackpad horizontal swipe** (deltaX dominant) → horizontal scroll
- **Plain vertical wheel** → left alone for native tracks-list vertical scrolling

The handler calls `preventDefault()` only for zoom and horizontal-scroll gestures, allowing vertical wheels to bubble naturally and preventing the browser's back/forward swipe at scroll edges.

https://claude.ai/code/session_01WKB76JSiXpwhUuKUdfT2nN