### PR TITLE
Fix timeline panel overlay blocking asset drops

### DIFF
--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -39,7 +39,12 @@ import {
 import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
 import ContextMenus from "../context_menus/ContextMenus";
 import { useLocation, useNavigate } from "react-router-dom";
-import { TOOLTIP_ENTER_DELAY, TOOLBAR_WIDTH, PANEL_RESIZE_HANDLE_WIDTH } from "../../config/constants";
+import {
+  TOOLTIP_ENTER_DELAY,
+  TOOLBAR_WIDTH,
+  PANEL_RESIZE_HANDLE_WIDTH,
+  LEFT_PANEL_MIN_DRAWER_WIDTH
+} from "../../config/constants";
 import ThemeToggle from "../ui/ThemeToggle";
 import PanelHeadline from "../ui/PanelHeadline";
 import { ScrollArea, Tooltip, MobileBottomSheet, MOTION } from "../ui_primitives";
@@ -771,8 +776,11 @@ const PanelLeft: React.FC = () => {
             role="region"
             aria-label="Left panel"
             style={{
-              width: `${Math.max(panelSize - TOOLBAR_WIDTH, 250)}px`,
-              minWidth: "250px"
+              width: `${Math.max(
+                panelSize - TOOLBAR_WIDTH,
+                LEFT_PANEL_MIN_DRAWER_WIDTH
+              )}px`,
+              minWidth: `${LEFT_PANEL_MIN_DRAWER_WIDTH}px`
             }}
             onKeyDown={(e) => {
               if (

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -6,8 +6,13 @@ import type { Theme } from "@mui/material/styles";
 
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import { usePanelStore } from "../../stores/PanelStore";
 import { useWorkspaceMenuShortcuts } from "../../hooks/useWorkspaceMenuShortcuts";
-import { HEADER_HEIGHT, TOOLBAR_WIDTH } from "../../config/constants";
+import {
+  HEADER_HEIGHT,
+  TOOLBAR_WIDTH,
+  LEFT_PANEL_MIN_DRAWER_WIDTH
+} from "../../config/constants";
 import WorkspaceTabBar from "./WorkspaceTabBar";
 import TabContent from "./TabContent";
 import { Caption } from "../ui_primitives";
@@ -106,6 +111,8 @@ const WorkspaceShell = () => {
     (state) => state.setCurrentWorkflowId
   );
   const openWorkflows = useWorkflowManager((state) => state.openWorkflows);
+  const panelVisible = usePanelStore((state) => state.panel.isVisible);
+  const panelSize = usePanelStore((state) => state.panel.panelSize);
 
   // Cmd+W ("Close Tab") closes the active tab for every surface, not just the
   // node editor.
@@ -115,6 +122,18 @@ const WorkspaceShell = () => {
     () => tabs.find((tab) => tab.id === activeTabId) ?? null,
     [tabs, activeTabId]
   );
+
+  // The left rail (PanelLeft) is position:fixed, so its open drawer normally
+  // floats over the content. For the timeline that covers the start of the
+  // tracks and makes dropping assets onto them hard, so when a timeline tab is
+  // active we reserve the drawer's width and let the content sit beside it.
+  // Other surfaces (node editor, etc.) keep the overlay so the canvas stays
+  // full-bleed. The width here mirrors PanelLeft's drawer sizing.
+  const contentMarginLeft =
+    activeTab?.type === "timeline" && panelVisible
+      ? TOOLBAR_WIDTH +
+        Math.max(panelSize - TOOLBAR_WIDTH, LEFT_PANEL_MIN_DRAWER_WIDTH)
+      : TOOLBAR_WIDTH;
 
   // Keep the WorkflowManager's "current workflow" aligned with the active
   // workflow tab so the docked panels and run state target the right graph.
@@ -141,7 +160,10 @@ const WorkspaceShell = () => {
         </Suspense>
 
         <div className="workspace-center">
-          <div className="workspace-content">
+          <div
+            className="workspace-content"
+            style={{ marginLeft: contentMarginLeft }}
+          >
             {tabs.length === 0 && (
               <div className="workspace-empty">
                 <Caption color="secondary">

--- a/web/src/config/constants.ts
+++ b/web/src/config/constants.ts
@@ -20,6 +20,7 @@ export const NOTIFICATION_READING_WPM = 200; // average reading speed in words p
 export const HEADER_HEIGHT = 40; // Workspace header toolbar height in px
 export const TOOLBAR_WIDTH = 50; // Vertical toolbar width in px
 export const PANEL_RESIZE_HANDLE_WIDTH = 6; // Resize handle hit area in px
+export const LEFT_PANEL_MIN_DRAWER_WIDTH = 250; // Min width of the left panel drawer (excludes toolbar) in px
 
 // EDITOR
 export const DUPLICATE_SPACING = 50;


### PR DESCRIPTION
## Summary
When the left panel is open and a timeline tab is active, the panel's fixed positioning causes it to float over the timeline content, making it difficult to drop assets onto tracks. This change reserves space for the panel drawer when a timeline is active, allowing the content to sit beside it rather than underneath.

## Changes
- **WorkspaceShell.tsx**: Added logic to calculate `contentMarginLeft` based on active tab type and panel visibility. When a timeline tab is active and the panel is visible, the content margin includes the panel drawer width; otherwise, it only includes the toolbar width.
- **PanelLeft.tsx**: Extracted the hardcoded `250px` minimum drawer width to use the new `LEFT_PANEL_MIN_DRAWER_WIDTH` constant for consistency.
- **constants.ts**: Added `LEFT_PANEL_MIN_DRAWER_WIDTH = 250` constant to centralize the panel drawer sizing logic and ensure both components use the same value.

## Implementation Details
- The panel drawer width calculation (`Math.max(panelSize - TOOLBAR_WIDTH, LEFT_PANEL_MIN_DRAWER_WIDTH)`) is mirrored in both PanelLeft and WorkspaceShell to keep sizing consistent.
- Other surfaces (node editor, etc.) maintain the overlay behavior with full-bleed canvas by only applying the toolbar width margin.
- The timeline-specific behavior is isolated to the active tab type check, making it easy to extend to other surfaces if needed in the future.

https://claude.ai/code/session_01Jceyy5JWgyVfQXFxZzEUAr