### PR TITLE
Add workflow debug harness: end-to-end server & browser runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,13 +208,20 @@ and optionally in a **real browser** (Playwright driving the `e2e_runner`
 harness), then writes a self-contained debug bundle and prints an agent-friendly
 verdict. Built for iterative troubleshooting: run → read the report → edit → re-run.
 
+The cheap server run (workflow JSON + all messages/logs/outputs/errors) is on by
+default. The **expensive** parts are opt-in flags: `--browser` (Playwright +
+Chromium), `--trace` (OpenTelemetry SDK + span overhead), `--stages` (a
+screenshot per run stage).
+
 ```bash
 # Server surface only (default) — accepts a workflow id, JSON file, or DSL .ts file
 npm run dev:nodetool -- debug <workflow_id>
 npm run dev:nodetool -- debug workflow.json --params '{"prompt":"hi"}'
 
-# Add the real-browser surface (needs web deps + `npx playwright install chromium`)
-npm run dev:nodetool -- debug <workflow_id> --browser
+# Opt into the expensive parts:
+npm run dev:nodetool -- debug <id> --trace                 # OTel trace (timing/tokens/cost)
+npm run dev:nodetool -- debug <id> --browser               # real-browser surface (Playwright)
+npm run dev:nodetool -- debug <id> --stages                # per-stage screenshots (implies --browser)
 
 # Print the full machine-readable report to stdout for an agent to parse
 npm run dev:nodetool -- debug <workflow_id> --json
@@ -231,10 +238,10 @@ report.json        # the full DebugReport (workflow JSON, both surfaces, verdict
 report.md          # human-readable summary
 workflow.json      # the resolved graph (runner shape)
 server/messages.jsonl   # every processing message (logs, node IO, outputs, errors)
-server/trace.jsonl      # OpenTelemetry spans (timing, tokens, cost)
-browser/record.json     # the browser RunRecord (events, logs, node IO, artifacts)
+server/trace.jsonl      # OpenTelemetry spans (timing, tokens, cost) — only with --trace
+browser/record.json     # the browser RunRecord (events, logs, node IO, artifacts) — only with --browser
 browser/screenshot.png  # canvas screenshot of the finished graph
-browser/stages/         # canvas screenshots at each stage (initial → per node → settled)
+browser/stages/         # canvas screenshots at each stage — only with --stages
 browser/console-errors.log
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ server/messages.jsonl   # every processing message (logs, node IO, outputs, erro
 server/trace.jsonl      # OpenTelemetry spans (timing, tokens, cost)
 browser/record.json     # the browser RunRecord (events, logs, node IO, artifacts)
 browser/screenshot.png  # canvas screenshot of the finished graph
+browser/stages/         # canvas screenshots at each stage (initial → per node → settled)
 browser/console-errors.log
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,48 @@ npm run dev:nodetool -- run workflow.ts            # Run a TypeScript DSL file
 npm run dev:nodetool -- run workflow.ts --json     # Output results as JSON
 ```
 
+### nodetool debug (Workflow Debug Harness)
+
+Runs a workflow end-to-end on the **server** (headless kernel `WorkflowRunner`)
+and optionally in a **real browser** (Playwright driving the `e2e_runner`
+harness), then writes a self-contained debug bundle and prints an agent-friendly
+verdict. Built for iterative troubleshooting: run → read the report → edit → re-run.
+
+```bash
+# Server surface only (default) — accepts a workflow id, JSON file, or DSL .ts file
+npm run dev:nodetool -- debug <workflow_id>
+npm run dev:nodetool -- debug workflow.json --params '{"prompt":"hi"}'
+
+# Add the real-browser surface (needs web deps + `npx playwright install chromium`)
+npm run dev:nodetool -- debug <workflow_id> --browser
+
+# Print the full machine-readable report to stdout for an agent to parse
+npm run dev:nodetool -- debug <workflow_id> --json
+
+npm run dev:nodetool -- debug <id> --no-server --browser   # browser only
+npm run dev:nodetool -- debug <id> --out ./mydebug         # custom bundle dir
+npm run dev:nodetool -- debug <id> --timeout 60000         # per-surface timeout (ms)
+```
+
+The bundle (`nodetool-debug/<id>-<ts>/` by default) contains:
+
+```
+report.json        # the full DebugReport (workflow JSON, both surfaces, verdict)
+report.md          # human-readable summary
+workflow.json      # the resolved graph (runner shape)
+server/messages.jsonl   # every processing message (logs, node IO, outputs, errors)
+server/trace.jsonl      # OpenTelemetry spans (timing, tokens, cost)
+browser/record.json     # the browser RunRecord (events, logs, node IO, artifacts)
+browser/screenshot.png  # canvas screenshot of the finished graph
+browser/console-errors.log
+```
+
+Agents can also debug a workflow on a running server via the **`debug_workflow`**
+tool (runs the workflow + returns status, outputs, errors, job logs, and the
+graph overview in one call). The browser surface is exposed in `web/` as
+`npm run test:debug-harness` (env: `NODETOOL_DEBUG_GRAPH`, `NODETOOL_DEBUG_OUT`,
+`NODETOOL_DEBUG_PARAMS`).
+
 ### nodetool workflows
 
 Requires a running server (localhost:7777 or `--api-url`).

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -89,6 +89,7 @@ export {
   GetWorkflowTool,
   CreateWorkflowTool,
   RunWorkflowTool,
+  DebugWorkflowTool,
   ValidateWorkflowTool,
   GetExampleWorkflowTool,
   ExportWorkflowDigraphTool,

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -246,6 +246,83 @@ export class RunWorkflowTool extends Tool {
   }
 }
 
+/** Distill a workflow API record down to a graph overview for a debug report. */
+function summarizeWorkflowGraph(workflow: unknown): unknown {
+  if (!workflow || typeof workflow !== "object") return workflow;
+  const wf = workflow as Record<string, unknown>;
+  const graph = (wf.graph ?? wf) as Record<string, unknown>;
+  const nodes = Array.isArray(graph.nodes) ? (graph.nodes as Array<Record<string, unknown>>) : [];
+  const edges = Array.isArray(graph.edges) ? (graph.edges as Array<Record<string, unknown>>) : [];
+  return {
+    id: wf.id,
+    name: wf.name,
+    node_count: nodes.length,
+    edge_count: edges.length,
+    node_types: [...new Set(nodes.map((n) => String(n.type ?? "unknown")))],
+    nodes: nodes.map((n) => ({ id: n.id, type: n.type })),
+    edges
+  };
+}
+
+export class DebugWorkflowTool extends Tool {
+  readonly name = "debug_workflow";
+  readonly description =
+    "Run a workflow end-to-end and return a consolidated debug report: final " +
+    "status, outputs, error, job logs, and the workflow graph overview. Use this " +
+    "to troubleshoot a failing or misbehaving workflow and iterate on a fix.";
+  readonly inputSchema = {
+    type: "object" as const,
+    properties: {
+      workflow_id: {
+        type: "string" as const,
+        description: "The ID of the workflow to run and debug"
+      },
+      params: {
+        type: "object" as const,
+        description: "Input parameters keyed by input-node name"
+      },
+      include_graph: {
+        type: "boolean" as const,
+        description: "Include the workflow graph overview in the report (default true)"
+      },
+      log_limit: {
+        type: "number" as const,
+        description: "Maximum job log entries to include (default 200)"
+      }
+    },
+    required: ["workflow_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const workflowId = String(params["workflow_id"]);
+    const includeGraph = params["include_graph"] !== false;
+    const logLimit = Number(params["log_limit"] ?? 200);
+
+    const run = await apiPost(context, `/api/workflows/${workflowId}/run`, {
+      params: params["params"] ?? {}
+    });
+
+    const report: Record<string, unknown> = { workflow_id: workflowId, run };
+
+    const jobId = (run as Record<string, unknown>)?.["job_id"];
+    if (typeof jobId === "string") {
+      report["job"] = await apiGet(context, `/api/jobs/${jobId}`, { limit: logLimit });
+    }
+    if (includeGraph) {
+      const wf = await apiGet(context, `/api/workflows/${workflowId}`);
+      report["workflow"] = summarizeWorkflowGraph(wf);
+    }
+    return report;
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Debugging workflow ${params["workflow_id"]}`;
+  }
+}
+
 export class ValidateWorkflowTool extends Tool {
   readonly name = "validate_workflow";
   readonly description =
@@ -767,6 +844,7 @@ export function getAllMcpTools(options: GetAllMcpToolsOptions = {}): Tool[] {
     new GetWorkflowTool(),
     new CreateWorkflowTool(),
     new RunWorkflowTool(),
+    new DebugWorkflowTool(),
     new ValidateWorkflowTool(),
     new GetExampleWorkflowTool(),
     new ExportWorkflowDigraphTool(),

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -143,6 +143,7 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // --- execute: runs arbitrary compute ---
   run_node: "execute",
   run_workflow: "execute",
+  debug_workflow: "execute",
   start_background_job: "execute",
   run_code: "execute",
   js: "execute",

--- a/packages/cli/src/commands/debug.ts
+++ b/packages/cli/src/commands/debug.ts
@@ -1,0 +1,117 @@
+/**
+ * `nodetool debug` — the workflow debug harness command.
+ *
+ * Runs a workflow end-to-end on the headless server and (optionally) in a real
+ * browser, then writes a debug bundle (workflow JSON, every message/log/output/
+ * error, an OpenTelemetry trace summary, plus browser console errors and a
+ * screenshot) and prints an agent-friendly summary. Heavy dependencies are
+ * imported lazily inside the action so command registration stays light and
+ * unit-testable.
+ */
+import type { Command } from "commander";
+
+interface DebugCliOptions {
+  server?: boolean;
+  browser?: boolean;
+  params?: string;
+  out?: string;
+  timeout?: number;
+  json?: boolean;
+}
+
+export function registerDebugCommands(program: Command): void {
+  program
+    .command("debug <workflow_id_or_file>")
+    .description(
+      "Run a workflow end-to-end (server and/or browser) and collect a full debug bundle"
+    )
+    .option("--no-server", "Skip the headless server surface")
+    .option("--browser", "Also run the workflow in a real browser (Playwright)")
+    .option("--params <json>", "JSON params string keyed by input-node name")
+    .option(
+      "--out <dir>",
+      "Bundle output directory (default: nodetool-debug/<id>-<timestamp>)"
+    )
+    .option(
+      "--timeout <ms>",
+      "Per-surface run timeout in milliseconds",
+      (v: string) => parseInt(v, 10)
+    )
+    .option("--json", "Print the full DebugReport as JSON to stdout")
+    .action(async (ref: string, opts: DebugCliOptions) => {
+      try {
+        const { initDb, Workflow } = await import("@nodetool-ai/models");
+        const { initMasterKey } = await import("@nodetool-ai/security");
+        const { getDefaultDbPath } = await import("@nodetool-ai/config");
+        const { runDebug } = await import("../debug/index.js");
+
+        initDb(getDefaultDbPath());
+        try {
+          await initMasterKey();
+        } catch {
+          // Secret decryption is best-effort for debug runs; a missing master
+          // key only affects nodes that need secrets.
+        }
+
+        const params = opts.params
+          ? (JSON.parse(opts.params) as Record<string, unknown>)
+          : {};
+
+        const report = await runDebug(
+          ref,
+          {
+            server: opts.server,
+            browser: opts.browser ?? false,
+            params,
+            ...(opts.out ? { outDir: opts.out } : {}),
+            ...(opts.timeout ? { timeoutMs: opts.timeout } : {})
+          },
+          {
+            loadFromDb: (id) =>
+              Workflow.get(id) as Promise<{ graph: { nodes: never[]; edges: never[] } } | null>,
+            onLog: (line) => console.error(line.trimEnd())
+          }
+        );
+
+        if (opts.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          printSummary(report);
+        }
+        process.exit(report.verdict.ok ? 0 : 1);
+      } catch (e) {
+        console.error(String(e));
+        process.exit(1);
+      }
+    });
+}
+
+function printSummary(report: {
+  verdict: { ok: boolean; headline: string; issues: string[] };
+  bundleDir: string | null;
+  server: { status: string; summary: { counts: { errored: number } } } | null;
+  browser: { status: string; unavailableReason?: string; consoleErrors: string[] } | null;
+}): void {
+  const mark = report.verdict.ok ? "✅" : "❌";
+  console.log(`\n${mark} ${report.verdict.headline}`);
+  if (report.server) {
+    console.log(
+      `  server:  ${report.server.status} (${report.server.summary.counts.errored} node error(s))`
+    );
+  }
+  if (report.browser) {
+    console.log(
+      report.browser.unavailableReason
+        ? `  browser: skipped — ${report.browser.unavailableReason}`
+        : `  browser: ${report.browser.status} (${report.browser.consoleErrors.length} console error(s))`
+    );
+  }
+  if (report.verdict.issues.length > 0) {
+    console.log("\nIssues:");
+    for (const issue of report.verdict.issues) console.log(`  - ${issue}`);
+  }
+  if (report.bundleDir) {
+    console.log(`\nDebug bundle: ${report.bundleDir}`);
+    console.log(`  report.md / report.json · workflow.json · server/ · browser/`);
+  }
+}

--- a/packages/cli/src/commands/debug.ts
+++ b/packages/cli/src/commands/debug.ts
@@ -13,6 +13,8 @@ import type { Command } from "commander";
 interface DebugCliOptions {
   server?: boolean;
   browser?: boolean;
+  trace?: boolean;
+  stages?: boolean;
   params?: string;
   out?: string;
   timeout?: number;
@@ -26,7 +28,18 @@ export function registerDebugCommands(program: Command): void {
       "Run a workflow end-to-end (server and/or browser) and collect a full debug bundle"
     )
     .option("--no-server", "Skip the headless server surface")
-    .option("--browser", "Also run the workflow in a real browser (Playwright)")
+    .option(
+      "--browser",
+      "Also run the workflow in a real browser (Playwright) — expensive"
+    )
+    .option(
+      "--trace",
+      "Capture an OpenTelemetry trace of the server run (timing/tokens/cost) — expensive"
+    )
+    .option(
+      "--stages",
+      "Capture a canvas screenshot at every browser run stage (implies --browser) — expensive"
+    )
     .option("--params <json>", "JSON params string keyed by input-node name")
     .option(
       "--out <dir>",
@@ -62,6 +75,8 @@ export function registerDebugCommands(program: Command): void {
           {
             server: opts.server,
             browser: opts.browser ?? false,
+            trace: opts.trace ?? false,
+            stages: opts.stages ?? false,
             params,
             ...(opts.out ? { outDir: opts.out } : {}),
             ...(opts.timeout ? { timeoutMs: opts.timeout } : {})
@@ -111,7 +126,10 @@ function printSummary(report: {
     for (const issue of report.verdict.issues) console.log(`  - ${issue}`);
   }
   if (report.bundleDir) {
+    const parts = ["report.md / report.json", "workflow.json"];
+    if (report.server) parts.push("server/");
+    if (report.browser && !report.browser.unavailableReason) parts.push("browser/");
     console.log(`\nDebug bundle: ${report.bundleDir}`);
-    console.log(`  report.md / report.json · workflow.json · server/ · browser/`);
+    console.log(`  ${parts.join(" · ")}`);
   }
 }

--- a/packages/cli/src/debug/browser-runner.ts
+++ b/packages/cli/src/debug/browser-runner.ts
@@ -1,0 +1,160 @@
+/**
+ * Real-browser ("browser") debug surface: drives the `e2e_runner` harness page
+ * in headless Chromium via Playwright to execute the workflow end-to-end through
+ * the actual web stack, capturing browser console errors, a canvas screenshot,
+ * and the same logs / node IO / outputs the server surface reports.
+ *
+ * The heavy lifting (Vite + hermetic backend + the harness page) already exists
+ * in `web/`; this module just resolves the web workspace, shells out to the
+ * Playwright spec, and folds the resulting RunRecord into a `BrowserRunReport`.
+ * It degrades gracefully (an `unavailableReason`) when the web deps or browser
+ * binaries aren't installed.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectExecutionSummary } from "./collector.js";
+import type { BrowserRunReport, DebugGraph } from "./types.js";
+
+const CONFIG_REL = "playwright.debug-harness.config.ts";
+const DEFAULT_TIMEOUT_MS = 6 * 60_000;
+
+/** Walk up from this module to the repo root (the dir whose `web/` has our config). */
+function findWebDir(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, "web");
+    if (existsSync(join(candidate, CONFIG_REL))) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export interface BrowserRunInput {
+  graph: DebugGraph;
+  params: Record<string, unknown>;
+  /** Bundle dir for the browser surface; record/screenshot/console land here. */
+  outDir: string;
+  timeoutMs?: number;
+  /** Stream the Playwright child's stdout/stderr through. */
+  onLog?: (line: string) => void;
+}
+
+interface BrowserRecord {
+  status?: string;
+  error?: string | null;
+  durationMs?: number | null;
+  events?: Array<Record<string, unknown>>;
+}
+
+function unavailable(reason: string): BrowserRunReport {
+  return {
+    surface: "browser",
+    ok: false,
+    status: "unavailable",
+    error: null,
+    durationMs: null,
+    summary: collectExecutionSummary([]),
+    consoleErrors: [],
+    unavailableReason: reason
+  };
+}
+
+export async function runInBrowser(input: BrowserRunInput): Promise<BrowserRunReport> {
+  const webDir = findWebDir();
+  if (!webDir) return unavailable("could not locate the web workspace");
+
+  const playwrightBin = join(webDir, "node_modules", ".bin", "playwright");
+  if (!existsSync(playwrightBin)) {
+    return unavailable(
+      "web dependencies not installed (run `npm install` and `npx playwright install chromium`)"
+    );
+  }
+
+  await mkdir(input.outDir, { recursive: true });
+  const graphPath = join(input.outDir, "_graph.json");
+  await writeFile(graphPath, JSON.stringify({ graph: input.graph }), "utf8");
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODETOOL_DEBUG_GRAPH: graphPath,
+    NODETOOL_DEBUG_OUT: input.outDir,
+    NODETOOL_DEBUG_PARAMS: JSON.stringify(input.params ?? {})
+  };
+
+  const exitCode = await new Promise<number>((resolvePromise) => {
+    const child = spawn(playwrightBin, ["test", "-c", CONFIG_REL], {
+      cwd: webDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const onChunk = (buf: Buffer) => input.onLog?.(buf.toString());
+    child.stdout?.on("data", onChunk);
+    child.stderr?.on("data", onChunk);
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolvePromise(124);
+    }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolvePromise(127);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolvePromise(code ?? 1);
+    });
+  });
+
+  return buildBrowserReport(input.outDir, exitCode);
+}
+
+/**
+ * Fold the artifacts a Playwright debug run leaves in `outDir`
+ * (record.json, console-errors.log, screenshot.png) into a `BrowserRunReport`.
+ * Pure file IO — separated from the spawn so it's directly testable against a
+ * real captured bundle.
+ */
+export async function buildBrowserReport(
+  outDir: string,
+  exitCode = 0
+): Promise<BrowserRunReport> {
+  const recordPath = join(outDir, "record.json");
+  if (!existsSync(recordPath)) {
+    return unavailable(
+      `Playwright run produced no record (exit ${exitCode}); check that the web app builds and chromium is installed`
+    );
+  }
+
+  let record: BrowserRecord;
+  try {
+    record = JSON.parse(await readFile(recordPath, "utf8")) as BrowserRecord;
+  } catch (err) {
+    return unavailable(`could not parse browser record: ${String(err)}`);
+  }
+
+  const consoleErrors = existsSync(join(outDir, "console-errors.log"))
+    ? (await readFile(join(outDir, "console-errors.log"), "utf8")).split("\n").filter(Boolean)
+    : [];
+
+  const summary = collectExecutionSummary(record.events ?? []);
+  const status = record.status ?? summary.status;
+
+  const report: BrowserRunReport = {
+    surface: "browser",
+    ok: status === "completed",
+    status,
+    error: record.error ?? summary.error,
+    durationMs: record.durationMs ?? null,
+    summary,
+    consoleErrors,
+    recordFile: "browser/record.json"
+  };
+  if (existsSync(join(outDir, "screenshot.png"))) {
+    report.screenshotFile = "browser/screenshot.png";
+  }
+  return report;
+}

--- a/packages/cli/src/debug/browser-runner.ts
+++ b/packages/cli/src/debug/browser-runner.ts
@@ -51,6 +51,13 @@ interface BrowserRecord {
   events?: Array<Record<string, unknown>>;
 }
 
+interface StageEntry {
+  index: number;
+  status: string;
+  /** Path relative to the browser out dir (e.g. "stages/00-running.png"). */
+  file: string;
+}
+
 function unavailable(reason: string): BrowserRunReport {
   return {
     surface: "browser",
@@ -156,5 +163,19 @@ export async function buildBrowserReport(
   if (existsSync(join(outDir, "screenshot.png"))) {
     report.screenshotFile = "browser/screenshot.png";
   }
+
+  if (existsSync(join(outDir, "stages.json"))) {
+    try {
+      const stages = JSON.parse(await readFile(join(outDir, "stages.json"), "utf8")) as StageEntry[];
+      report.stages = stages.map((s) => ({
+        index: s.index,
+        status: s.status,
+        file: `browser/${s.file}`
+      }));
+    } catch {
+      // A malformed stages manifest just means no staged screenshots.
+    }
+  }
+
   return report;
 }

--- a/packages/cli/src/debug/browser-runner.ts
+++ b/packages/cli/src/debug/browser-runner.ts
@@ -13,7 +13,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectExecutionSummary } from "./collector.js";
 import type { BrowserRunReport, DebugGraph } from "./types.js";

--- a/packages/cli/src/debug/browser-runner.ts
+++ b/packages/cli/src/debug/browser-runner.ts
@@ -39,6 +39,8 @@ export interface BrowserRunInput {
   params: Record<string, unknown>;
   /** Bundle dir for the browser surface; record/screenshot/console land here. */
   outDir: string;
+  /** Capture a screenshot at every run stage (expensive) vs. only the final frame. */
+  captureStages?: boolean;
   timeoutMs?: number;
   /** Stream the Playwright child's stdout/stderr through. */
   onLog?: (line: string) => void;
@@ -90,7 +92,8 @@ export async function runInBrowser(input: BrowserRunInput): Promise<BrowserRunRe
     ...process.env,
     NODETOOL_DEBUG_GRAPH: graphPath,
     NODETOOL_DEBUG_OUT: input.outDir,
-    NODETOOL_DEBUG_PARAMS: JSON.stringify(input.params ?? {})
+    NODETOOL_DEBUG_PARAMS: JSON.stringify(input.params ?? {}),
+    ...(input.captureStages ? { NODETOOL_DEBUG_STAGES: "1" } : {})
   };
 
   const exitCode = await new Promise<number>((resolvePromise) => {

--- a/packages/cli/src/debug/collector.ts
+++ b/packages/cli/src/debug/collector.ts
@@ -1,0 +1,241 @@
+/**
+ * Folds a workflow run's processing-message stream into an `ExecutionSummary`.
+ *
+ * Pure and surface-agnostic: the same reducer distills the server runner's
+ * `RunResult.messages` and the browser harness's raw event log, so both surfaces
+ * report identically. Only `import type` is used here so the module stays free of
+ * runtime workspace dependencies (testable under the CLI vitest stub setup).
+ */
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import type {
+  EdgeDebug,
+  ExecutionSummary,
+  LlmCallDebug,
+  LogEntry,
+  NodeDebug,
+  NodeOutput
+} from "./types.js";
+
+const MAX_STRING_PREVIEW = 2000;
+const MAX_ARRAY_PREVIEW = 50;
+/** Fields that commonly carry base64 / data-URI payloads worth collapsing. */
+const BLOB_KEYS = new Set(["data", "uri", "b64_json", "base64"]);
+const BLOB_KEEP = 64;
+
+/**
+ * Make a value safe to embed in a JSON debug report: truncate long strings,
+ * collapse binary and base64 blobs, and cap array/object fan-out. Keeps enough
+ * to debug (shape, prefixes, sizes) without dumping megabytes of media bytes.
+ */
+export function previewValue(value: unknown, maxLen: number = MAX_STRING_PREVIEW): unknown {
+  if (typeof value === "string") {
+    return value.length > maxLen
+      ? `${value.slice(0, maxLen)}…[${value.length} chars]`
+      : value;
+  }
+  if (value instanceof Uint8Array) {
+    return `<binary ${value.byteLength} bytes>`;
+  }
+  if (Array.isArray(value)) {
+    const head = value.slice(0, MAX_ARRAY_PREVIEW).map((v) => previewValue(v, maxLen));
+    return value.length > MAX_ARRAY_PREVIEW
+      ? [...head, `…[${value.length - MAX_ARRAY_PREVIEW} more]`]
+      : head;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (BLOB_KEYS.has(k) && typeof v === "string" && v.length > 256) {
+        out[k] = `${v.slice(0, BLOB_KEEP)}…[${v.length} chars]`;
+      } else {
+        out[k] = previewValue(v, maxLen);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function emptyNode(nodeId: string): NodeDebug {
+  return {
+    nodeId,
+    nodeType: null,
+    nodeName: null,
+    status: "pending",
+    error: null,
+    outputs: [],
+    cost: null
+  };
+}
+
+/**
+ * Reduce a processing-message stream into a structured execution summary.
+ *
+ * Accepts loosely-typed messages (the browser harness decodes JSON into bags of
+ * unknown fields) and reads only the fields each `type` is known to carry.
+ */
+export function collectExecutionSummary(
+  messages: ReadonlyArray<ProcessingMessage | Record<string, unknown>>
+): ExecutionSummary {
+  const nodes = new Map<string, NodeDebug>();
+  const logs: LogEntry[] = [];
+  const edges = new Map<string, EdgeDebug>();
+  const llmCalls: LlmCallDebug[] = [];
+  const outputs: NodeOutput[] = [];
+  let status = "unknown";
+  let error: string | null = null;
+
+  const node = (id: string): NodeDebug => {
+    let n = nodes.get(id);
+    if (!n) {
+      n = emptyNode(id);
+      nodes.set(id, n);
+    }
+    return n;
+  };
+
+  const str = (v: unknown): string | null => (typeof v === "string" ? v : null);
+  const num = (v: unknown): number | null => (typeof v === "number" ? v : null);
+
+  for (const raw of messages) {
+    const msg = raw as Record<string, unknown>;
+    switch (msg.type) {
+      case "job_update": {
+        status = str(msg.status) ?? status;
+        const e = str(msg.error);
+        if (e) error = e;
+        break;
+      }
+      case "node_update": {
+        const id = str(msg.node_id);
+        if (!id) break;
+        const n = node(id);
+        n.nodeType = str(msg.node_type) ?? n.nodeType;
+        n.nodeName = str(msg.node_name) ?? n.nodeName;
+        const s = str(msg.status);
+        if (s) n.status = s;
+        // A node_update can carry a stale/empty error field while completing —
+        // only record an error when the status itself says so.
+        if (s === "error" || s === "failed") {
+          n.error = str(msg.error) || s;
+        }
+        const cost = msg.provider_cost as Record<string, unknown> | null | undefined;
+        if (cost && typeof cost === "object") {
+          n.cost = {
+            provider: str(cost.provider) ?? "",
+            amount: num(cost.amount) ?? 0,
+            unit: str(cost.unit) ?? "",
+            currency: str(cost.currency)
+          };
+        }
+        break;
+      }
+      case "generation_complete": {
+        const id = str(msg.node_id);
+        if (!id) break;
+        const n = node(id);
+        n.nodeType = str(msg.node_type) ?? n.nodeType;
+        n.nodeName = str(msg.node_name) ?? n.nodeName;
+        const out = (msg.outputs as Record<string, unknown>) ?? {};
+        for (const [name, v] of Object.entries(out)) {
+          n.outputs.push({ outputName: name, outputType: typeof v, value: previewValue(v) });
+        }
+        break;
+      }
+      case "output_update": {
+        const id = str(msg.node_id) ?? undefined;
+        const o: NodeOutput = {
+          nodeId: id,
+          outputName: str(msg.output_name) ?? "output",
+          outputType: str(msg.output_type) ?? typeof msg.value,
+          value: previewValue(msg.value)
+        };
+        outputs.push(o);
+        if (id) {
+          const n = node(id);
+          n.nodeName = str(msg.node_name) ?? n.nodeName;
+        }
+        break;
+      }
+      case "node_progress": {
+        const id = str(msg.node_id);
+        if (!id) break;
+        node(id).progress = { progress: num(msg.progress) ?? 0, total: num(msg.total) ?? 0 };
+        break;
+      }
+      case "edge_update": {
+        const id = str(msg.edge_id);
+        if (!id) break;
+        edges.set(id, { edgeId: id, status: str(msg.status) ?? "", counter: num(msg.counter) });
+        break;
+      }
+      case "log_update": {
+        logs.push({
+          nodeId: str(msg.node_id),
+          nodeName: str(msg.node_name),
+          severity: str(msg.severity) ?? "info",
+          content: str(msg.content) ?? ""
+        });
+        break;
+      }
+      case "terminal_update": {
+        const content = str(msg.content);
+        if (content) {
+          logs.push({ nodeId: str(msg.node_id), severity: "info", content });
+        }
+        break;
+      }
+      case "error": {
+        const message = str(msg.message) ?? "unknown error";
+        if (!error) error = message;
+        logs.push({ nodeId: null, severity: "error", content: message });
+        break;
+      }
+      case "llm_call": {
+        llmCalls.push({
+          nodeId: str(msg.node_id) ?? "",
+          provider: str(msg.provider) ?? "",
+          model: str(msg.model) ?? "",
+          tokensInput: num(msg.tokens_input),
+          tokensOutput: num(msg.tokens_output),
+          cost: num(msg.cost),
+          durationMs: num(msg.duration_ms) ?? 0,
+          error: str(msg.error)
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const nodeList = [...nodes.values()];
+  const errored = nodeList.filter((n) => n.error);
+  const errors: ExecutionSummary["errors"] = errored.map((n) => ({
+    nodeId: n.nodeId,
+    nodeType: n.nodeType,
+    message: n.error as string
+  }));
+  if (error && !errors.some((e) => e.message === error)) {
+    errors.unshift({ nodeId: null, nodeType: null, message: error });
+  }
+
+  return {
+    status,
+    error,
+    nodes: nodeList,
+    logs,
+    edges: [...edges.values()],
+    llmCalls,
+    outputs,
+    counts: {
+      nodes: nodeList.length,
+      completed: nodeList.filter((n) => n.status === "completed").length,
+      errored: errored.length,
+      logs: logs.length,
+      outputs: outputs.length,
+      llmCalls: llmCalls.length
+    },
+    errors
+  };
+}

--- a/packages/cli/src/debug/harness.ts
+++ b/packages/cli/src/debug/harness.ts
@@ -1,0 +1,117 @@
+/**
+ * The workflow debug harness orchestrator.
+ *
+ * Resolves a target workflow, runs it on the requested surfaces (headless server
+ * and/or real browser), folds everything into a `DebugReport`, and writes a
+ * self-contained debug bundle to disk. Returns the report so an agent can act on
+ * it directly and iterate (edit → re-run) without re-reading files.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { initTelemetry } from "@nodetool-ai/runtime";
+import { runOnServer } from "./server-runner.js";
+import { runInBrowser } from "./browser-runner.js";
+import { buildVerdict } from "./verdict.js";
+import { renderReportMarkdown } from "./markdown.js";
+import { resolveTarget } from "./target.js";
+import type {
+  DebugGraph,
+  DebugOptions,
+  DebugReport
+} from "./types.js";
+
+export interface DebugHarnessDeps {
+  /** Load a workflow graph by DB id (injected to keep models out of light paths). */
+  loadFromDb: (id: string) => Promise<{ graph: DebugGraph } | null>;
+  /** Progress/log sink for surfacing child-process output. */
+  onLog?: (line: string) => void;
+}
+
+function defaultOutDir(ref: string): string {
+  const slug = ref.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) || "workflow";
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return resolve(`nodetool-debug/${slug}-${stamp}`);
+}
+
+export async function runDebug(
+  ref: string,
+  options: DebugOptions,
+  deps: DebugHarnessDeps
+): Promise<DebugReport> {
+  const runServer = options.server ?? true;
+  const runBrowser = options.browser ?? false;
+  const log = deps.onLog ?? (() => {});
+
+  const resolved = await resolveTarget(ref, deps.loadFromDb);
+  const params = { ...resolved.fileParams, ...(options.params ?? {}) };
+
+  const outDir = options.outDir ? resolve(options.outDir) : defaultOutDir(ref);
+  await mkdir(outDir, { recursive: true });
+  await writeFile(join(outDir, "workflow.json"), JSON.stringify(resolved.graph, null, 2), "utf8");
+
+  const report: DebugReport = {
+    generatedAt: new Date().toISOString(),
+    target: resolved.info,
+    workflow: resolved.graph,
+    server: null,
+    browser: null,
+    verdict: { ok: false, headline: "", issues: [] },
+    bundleDir: outDir
+  };
+
+  if (runServer) {
+    log("Running workflow on the server surface…");
+    const serverDir = join(outDir, "server");
+    await mkdir(serverDir, { recursive: true });
+    const tracePath = join(serverDir, "trace.jsonl");
+    // Route span output into the bundle. No-op if telemetry was already
+    // initialized; the `debug` command skips the global telemetry init so this
+    // call wins and the file sink is registered.
+    await initTelemetry({ traceFile: tracePath, silent: true });
+
+    const outcome = await runOnServer({
+      graph: resolved.graph,
+      workflowId: resolved.info.workflowId,
+      params,
+      tracePath,
+      timeoutMs: options.timeoutMs
+    });
+
+    const messagesPath = join(serverDir, "messages.jsonl");
+    await writeFile(
+      messagesPath,
+      outcome.rawMessages.map((m) => JSON.stringify(m)).join("\n") + "\n",
+      "utf8"
+    );
+    outcome.report.messagesFile = "server/messages.jsonl";
+    if (outcome.report.trace) outcome.report.traceFile = "server/trace.jsonl";
+    report.server = outcome.report;
+    log(
+      `Server run: ${outcome.report.status} · ${outcome.report.summary.counts.errored} node error(s)`
+    );
+  }
+
+  if (runBrowser) {
+    log("Running workflow on the browser surface (Playwright)…");
+    const browserDir = join(outDir, "browser");
+    report.browser = await runInBrowser({
+      graph: resolved.graph,
+      params,
+      outDir: browserDir,
+      timeoutMs: options.timeoutMs,
+      onLog: log
+    });
+    log(
+      report.browser.unavailableReason
+        ? `Browser run skipped: ${report.browser.unavailableReason}`
+        : `Browser run: ${report.browser.status} · ${report.browser.consoleErrors.length} console error(s)`
+    );
+  }
+
+  report.verdict = buildVerdict(report.server, report.browser);
+
+  await writeFile(join(outDir, "report.json"), JSON.stringify(report, null, 2), "utf8");
+  await writeFile(join(outDir, "report.md"), renderReportMarkdown(report), "utf8");
+
+  return report;
+}

--- a/packages/cli/src/debug/harness.ts
+++ b/packages/cli/src/debug/harness.ts
@@ -39,7 +39,10 @@ export async function runDebug(
   deps: DebugHarnessDeps
 ): Promise<DebugReport> {
   const runServer = options.server ?? true;
-  const runBrowser = options.browser ?? false;
+  // `--stages` is a browser-surface modifier, so opting into it implies the
+  // browser surface.
+  const runBrowser = (options.browser ?? false) || (options.stages ?? false);
+  const captureTrace = options.trace ?? false;
   const log = deps.onLog ?? (() => {});
 
   const resolved = await resolveTarget(ref, deps.loadFromDb);
@@ -63,11 +66,15 @@ export async function runDebug(
     log("Running workflow on the server surface…");
     const serverDir = join(outDir, "server");
     await mkdir(serverDir, { recursive: true });
-    const tracePath = join(serverDir, "trace.jsonl");
-    // Route span output into the bundle. No-op if telemetry was already
-    // initialized; the `debug` command skips the global telemetry init so this
-    // call wins and the file sink is registered.
-    await initTelemetry({ traceFile: tracePath, silent: true });
+
+    // Tracing is opt-in (`--trace`): loading the OTel SDK and processing spans
+    // is real overhead. When enabled, route span output into the bundle — this
+    // wins because the `debug` command skips the global telemetry init.
+    let tracePath: string | null = null;
+    if (captureTrace) {
+      tracePath = join(serverDir, "trace.jsonl");
+      await initTelemetry({ traceFile: tracePath, silent: true });
+    }
 
     const outcome = await runOnServer({
       graph: resolved.graph,
@@ -98,6 +105,7 @@ export async function runDebug(
       graph: resolved.graph,
       params,
       outDir: browserDir,
+      captureStages: options.stages ?? false,
       timeoutMs: options.timeoutMs,
       onLog: log
     });

--- a/packages/cli/src/debug/index.ts
+++ b/packages/cli/src/debug/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Workflow debug harness — runs a workflow end-to-end on the server and/or in a
+ * real browser and collects the workflow JSON, every log/output/error, and an
+ * OpenTelemetry trace summary into a single `DebugReport` + on-disk bundle.
+ */
+export { runDebug, type DebugHarnessDeps } from "./harness.js";
+export { runOnServer, type ServerRunInput, type ServerRunOutcome } from "./server-runner.js";
+export { runInBrowser, buildBrowserReport, type BrowserRunInput } from "./browser-runner.js";
+export { resolveTarget, type ResolvedTarget } from "./target.js";
+export { collectExecutionSummary, previewValue } from "./collector.js";
+export {
+  parseTraceJsonl,
+  summarizeSpans,
+  readTraceSummary,
+  type TraceSpan
+} from "./trace.js";
+export { buildVerdict } from "./verdict.js";
+export { renderReportMarkdown } from "./markdown.js";
+export type * from "./types.js";

--- a/packages/cli/src/debug/markdown.ts
+++ b/packages/cli/src/debug/markdown.ts
@@ -108,7 +108,13 @@ function browserSection(browser: BrowserRunReport): string[] {
     lines.push("", "**Console errors**");
     for (const err of browser.consoleErrors.slice(0, 20)) lines.push(`- ${err}`);
   }
-  if (browser.screenshotFile) lines.push("", `Screenshot: \`${browser.screenshotFile}\``);
+  if (browser.stages && browser.stages.length > 0) {
+    lines.push("", `**Stage screenshots** (${browser.stages.length})`);
+    for (const s of browser.stages) {
+      lines.push(`- \`${String(s.index).padStart(2, "0")}\` ${s.status} — \`${s.file}\``);
+    }
+  }
+  if (browser.screenshotFile) lines.push("", `Final screenshot: \`${browser.screenshotFile}\``);
   return lines;
 }
 

--- a/packages/cli/src/debug/markdown.ts
+++ b/packages/cli/src/debug/markdown.ts
@@ -1,0 +1,137 @@
+/**
+ * Renders a `DebugReport` as a human-readable Markdown document (report.md in
+ * the bundle). Pure — no IO — so it's trivially testable.
+ */
+import type {
+  BrowserRunReport,
+  DebugReport,
+  ExecutionSummary,
+  ServerRunReport,
+  TraceSummary
+} from "./types.js";
+
+function fmtMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function summarySection(summary: ExecutionSummary): string[] {
+  const lines: string[] = [];
+  const c = summary.counts;
+  lines.push(
+    `- Status: **${summary.status}**` + (summary.error ? ` — ${summary.error}` : "")
+  );
+  lines.push(
+    `- Nodes: ${c.nodes} (completed ${c.completed}, errored ${c.errored}) · ` +
+      `outputs ${c.outputs} · logs ${c.logs} · llm calls ${c.llmCalls}`
+  );
+
+  if (summary.errors.length > 0) {
+    lines.push("", "**Errors**");
+    for (const e of summary.errors) {
+      lines.push(`- \`${e.nodeType ?? e.nodeId ?? "workflow"}\`: ${e.message}`);
+    }
+  }
+
+  const failing = summary.nodes.filter((n) => n.error);
+  if (failing.length > 0) {
+    lines.push("", "**Failing nodes**");
+    for (const n of failing) {
+      lines.push(`- \`${n.nodeType ?? n.nodeId}\` (${n.nodeId}) — ${n.error}`);
+    }
+  }
+
+  if (summary.outputs.length > 0) {
+    lines.push("", "**Outputs**");
+    for (const o of summary.outputs.slice(0, 20)) {
+      lines.push(`- \`${o.outputName}\` (${o.outputType}): ${JSON.stringify(o.value)}`);
+    }
+  }
+
+  if (summary.llmCalls.length > 0) {
+    lines.push("", "**LLM calls**");
+    for (const call of summary.llmCalls.slice(0, 20)) {
+      const tok = `${call.tokensInput ?? "?"}→${call.tokensOutput ?? "?"} tok`;
+      const cost = call.cost != null ? ` · $${call.cost.toFixed(4)}` : "";
+      lines.push(
+        `- ${call.provider}/${call.model} · ${tok}${cost} · ${fmtMs(call.durationMs)}` +
+          (call.error ? ` · ERROR ${call.error}` : "")
+      );
+    }
+  }
+
+  if (summary.logs.length > 0) {
+    lines.push("", "**Logs**");
+    for (const log of summary.logs.slice(0, 50)) {
+      const where = log.nodeId ? ` [${log.nodeId}]` : "";
+      lines.push(`- \`${log.severity}\`${where} ${log.content}`);
+    }
+    if (summary.logs.length > 50) lines.push(`- …and ${summary.logs.length - 50} more`);
+  }
+
+  return lines;
+}
+
+function traceSection(trace: TraceSummary): string[] {
+  const lines = ["", "**Trace**"];
+  lines.push(
+    `- ${trace.spanCount} spans · ${fmtMs(trace.totalDurationMs)} wall · ` +
+      `${trace.tokens.total} tokens · $${trace.costUsd.toFixed(4)}`
+  );
+  const names = Object.entries(trace.byName).sort((a, b) => b[1].totalDurationMs - a[1].totalDurationMs);
+  for (const [name, agg] of names.slice(0, 10)) {
+    lines.push(`- \`${name}\` ×${agg.count} · ${fmtMs(agg.totalDurationMs)}`);
+  }
+  return lines;
+}
+
+function serverSection(server: ServerRunReport): string[] {
+  const lines = ["## Server surface", ""];
+  lines.push(`Outcome: ${server.ok ? "✅ completed" : `❌ ${server.status}`} · ${fmtMs(server.durationMs)}`);
+  lines.push(...summarySection(server.summary));
+  if (server.trace) lines.push(...traceSection(server.trace));
+  return lines;
+}
+
+function browserSection(browser: BrowserRunReport): string[] {
+  const lines = ["## Browser surface", ""];
+  if (browser.unavailableReason) {
+    lines.push(`⚠️ Not run: ${browser.unavailableReason}`);
+    return lines;
+  }
+  lines.push(
+    `Outcome: ${browser.ok ? "✅ completed" : `❌ ${browser.status}`} · ${fmtMs(browser.durationMs)}`
+  );
+  lines.push(...summarySection(browser.summary));
+  if (browser.consoleErrors.length > 0) {
+    lines.push("", "**Console errors**");
+    for (const err of browser.consoleErrors.slice(0, 20)) lines.push(`- ${err}`);
+  }
+  if (browser.screenshotFile) lines.push("", `Screenshot: \`${browser.screenshotFile}\``);
+  return lines;
+}
+
+export function renderReportMarkdown(report: DebugReport): string {
+  const lines: string[] = [];
+  lines.push(`# Workflow debug report`, "");
+  lines.push(`${report.verdict.ok ? "✅" : "❌"} **${report.verdict.headline}**`, "");
+  lines.push(
+    `- Target: \`${report.target.ref}\` (${report.target.source}` +
+      (report.target.workflowId ? `, id ${report.target.workflowId}` : "") +
+      `)`
+  );
+  lines.push(`- Graph: ${report.target.nodeCount} nodes, ${report.target.edgeCount} edges`);
+  lines.push(`- Generated: ${report.generatedAt}`);
+
+  if (report.verdict.issues.length > 0) {
+    lines.push("", "## Issues", "");
+    for (const issue of report.verdict.issues) lines.push(`- ${issue}`);
+  }
+
+  if (report.server) lines.push("", ...serverSection(report.server));
+  if (report.browser) lines.push("", ...browserSection(report.browser));
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/packages/cli/src/debug/server-runner.ts
+++ b/packages/cli/src/debug/server-runner.ts
@@ -1,0 +1,176 @@
+/**
+ * Headless ("server") debug surface: runs a workflow through the kernel
+ * `WorkflowRunner` exactly as `nodetool workflows run` does, but captures the
+ * full processing-message stream and the OpenTelemetry trace instead of just the
+ * final outputs.
+ *
+ * This is integration code — it pulls in the node registries, runtime context,
+ * and Python bridge — so it is exercised end-to-end rather than unit-tested.
+ */
+import { getDefaultAssetsPath } from "@nodetool-ai/config";
+import { getSecret } from "@nodetool-ai/models";
+import { WorkflowRunner } from "@nodetool-ai/kernel";
+import { hydrateGraphNodeFlags, NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { GraphData, ProcessingMessage } from "@nodetool-ai/protocol";
+import { registerBaseNodes } from "@nodetool-ai/base-nodes";
+import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
+import { registerMinimaxNodes } from "@nodetool-ai/minimax-nodes";
+import { registerTransformersJsNodes } from "@nodetool-ai/transformers-js-nodes";
+import { registerFalNodes } from "@nodetool-ai/fal-nodes";
+import { registerReplicateNodes } from "@nodetool-ai/replicate-nodes";
+import { registerReveNodes } from "@nodetool-ai/reve-nodes";
+import { registerHuggingFaceNodes } from "@nodetool-ai/huggingface-nodes";
+import {
+  ProcessingContext,
+  FileStorageAdapter,
+  connectPythonBridgeForGraph,
+  resolvePythonNodeExecutor
+} from "@nodetool-ai/runtime";
+import { collectExecutionSummary } from "./collector.js";
+import { readTraceSummary } from "./trace.js";
+import type { DebugGraph, ServerRunReport } from "./types.js";
+
+export interface ServerRunInput {
+  graph: DebugGraph;
+  workflowId: string | null;
+  params: Record<string, unknown>;
+  /** Absolute path telemetry was told to write spans to; read back for trace summary. */
+  tracePath?: string | null;
+  timeoutMs?: number;
+}
+
+export interface ServerRunOutcome {
+  report: ServerRunReport;
+  /** The full message stream, for writing the raw bundle artifact. */
+  rawMessages: ProcessingMessage[];
+}
+
+function buildRegistry(): NodeRegistry {
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  registerElevenLabsNodes(registry);
+  registerMinimaxNodes(registry);
+  registerTransformersJsNodes(registry);
+  registerFalNodes(registry);
+  registerReplicateNodes(registry);
+  registerReveNodes(registry);
+  registerHuggingFaceNodes(registry);
+  return registry;
+}
+
+/** Settle to a synthetic failed result if the run exceeds `timeoutMs`. */
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number | undefined,
+  onTimeout: () => T
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  return new Promise<T>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => resolvePromise(onTimeout()), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolvePromise(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        rejectPromise(err);
+      }
+    );
+  });
+}
+
+export async function runOnServer(input: ServerRunInput): Promise<ServerRunOutcome> {
+  const { graph, workflowId, params } = input;
+  const startedAt = Date.now();
+
+  const registry = buildRegistry();
+  const jobId = `debug-${Date.now()}`;
+
+  // Match a server run's workspace assignment so file/workspace nodes land in
+  // the same place a real run would.
+  const { resolveWorkflowWorkspace } = await import("@nodetool-ai/websocket");
+  const workspaceDir = workflowId
+    ? await resolveWorkflowWorkspace(workflowId, "1")
+    : null;
+
+  const context = new ProcessingContext({
+    jobId,
+    workflowId,
+    userId: "1",
+    secretResolver: getSecret,
+    storage: new FileStorageAdapter(getDefaultAssetsPath()),
+    workspaceDir,
+    workspaceStorage: workspaceDir ? new FileStorageAdapter(workspaceDir) : null
+  });
+
+  const pythonBridge = await connectPythonBridgeForGraph(graph.nodes, (t) =>
+    registry.has(t)
+  );
+
+  const runner = new WorkflowRunner(jobId, {
+    resolveExecutor: (node: { id: string; type: string }) => {
+      if (registry.has(node.type)) return registry.resolve(node);
+      const py = resolvePythonNodeExecutor(pythonBridge, node);
+      if (py) return py;
+      throw new Error(`Unknown node type: ${node.type}`);
+    },
+    executionContext: context
+  });
+
+  let result: Awaited<ReturnType<WorkflowRunner["run"]>>;
+  try {
+    result = await withTimeout(
+      runner.run(
+        { job_id: jobId, workflow_id: workflowId ?? undefined, params },
+        hydrateGraphNodeFlags(graph as unknown as GraphData, registry)
+      ),
+      input.timeoutMs,
+      () => ({
+        status: "failed" as const,
+        error: `Debug server run exceeded timeout (${input.timeoutMs}ms)`,
+        outputs: {},
+        messages: [...context.getMessages()]
+      })
+    );
+  } catch (err) {
+    // A thrown run (e.g. an unknown node type, or a graph that fails
+    // pre-flight) is exactly when the debug bundle matters most — capture it as
+    // a failed result instead of letting it abort the harness.
+    result = {
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+      outputs: {},
+      messages: [...context.getMessages()]
+    };
+  } finally {
+    pythonBridge?.close();
+  }
+
+  const messages = (result.messages ?? []) as ProcessingMessage[];
+  const summary = collectExecutionSummary(messages);
+  // The runner's RunResult status is authoritative; fall back to the message
+  // stream's view if it's missing (e.g. on the synthetic timeout result).
+  summary.status = result.status ?? summary.status;
+  if (result.error && !summary.error) summary.error = result.error;
+
+  // Spans are written eagerly via SimpleSpanProcessor, but the underlying
+  // WriteStream flushes async — give it a beat before reading the file back.
+  let trace = null;
+  if (input.tracePath) {
+    await new Promise((r) => setTimeout(r, 250));
+    trace = await readTraceSummary(input.tracePath);
+  }
+
+  const report: ServerRunReport = {
+    surface: "server",
+    ok: result.status === "completed",
+    status: result.status ?? summary.status,
+    error: result.error ?? summary.error,
+    durationMs: Date.now() - startedAt,
+    summary,
+    trace
+  };
+
+  return { report, rawMessages: messages };
+}

--- a/packages/cli/src/debug/target.ts
+++ b/packages/cli/src/debug/target.ts
@@ -1,0 +1,100 @@
+/**
+ * Resolves a workflow debug target (DB id, JSON file, or TypeScript DSL file)
+ * into a normalized runner-shape graph plus metadata.
+ *
+ * Mirrors the resolution + normalization the `workflows run` command does so the
+ * debug harness executes the exact same graph the runner would.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { DebugGraph, DebugTargetInfo } from "./types.js";
+
+export interface ResolvedTarget {
+  info: DebugTargetInfo;
+  graph: DebugGraph;
+  /** Params discovered in a file's `params` field, merged under caller params. */
+  fileParams: Record<string, unknown>;
+}
+
+function looksLikeFile(ref: string): boolean {
+  return (
+    ref.endsWith(".json") ||
+    ref.endsWith(".ts") ||
+    ref.endsWith(".tsx") ||
+    ref.includes("/") ||
+    ref.includes("\\")
+  );
+}
+
+/** Convert ReactFlow `node.data` to kernel `node.properties` in place. */
+function normalizeGraph(graph: DebugGraph): DebugGraph {
+  return {
+    nodes: (graph.nodes ?? []).map((n) => {
+      if (n.properties === undefined && n.data !== undefined) {
+        const { data, ...rest } = n;
+        return { ...rest, properties: data };
+      }
+      return n;
+    }),
+    edges: graph.edges ?? []
+  };
+}
+
+/**
+ * Load a workflow from a file (JSON or DSL) or the local DB.
+ *
+ * `loadFromDb` is injected so this module stays free of a hard `@nodetool-ai/models`
+ * import at module load (keeps it light for the command-registration test path).
+ */
+export async function resolveTarget(
+  ref: string,
+  loadFromDb: (id: string) => Promise<{ graph: DebugGraph } | null>
+): Promise<ResolvedTarget> {
+  let raw: { graph?: DebugGraph; nodes?: unknown[]; edges?: unknown[]; id?: string; workflow_id?: string; params?: Record<string, unknown> };
+  let source: DebugTargetInfo["source"];
+  let workflowId: string | null;
+  const fileParams: Record<string, unknown> = {};
+
+  if (looksLikeFile(ref)) {
+    if (ref.endsWith(".ts") || ref.endsWith(".tsx")) {
+      // DSL file: execute via tsx and capture the emitted JSON workflow.
+      const { execSync } = await import("node:child_process");
+      const output = execSync(`npx tsx "${resolve(ref)}"`, {
+        encoding: "utf8",
+        cwd: dirname(resolve(ref)),
+        timeout: 30000
+      });
+      raw = JSON.parse(output.trim());
+      source = "dsl";
+    } else {
+      raw = JSON.parse(readFileSync(ref, "utf8"));
+      source = "json";
+    }
+    workflowId = raw.workflow_id ?? raw.id ?? null;
+    if (raw.params) Object.assign(fileParams, raw.params);
+  } else {
+    const wf = await loadFromDb(ref);
+    if (!wf) throw new Error(`Workflow not found: ${ref}`);
+    raw = wf;
+    workflowId = ref;
+    source = "id";
+  }
+
+  const rawGraph: DebugGraph = (raw.graph ?? (raw as DebugGraph)) as DebugGraph;
+  if (!rawGraph?.nodes || !rawGraph?.edges) {
+    throw new Error("Invalid workflow: missing nodes or edges");
+  }
+  const graph = normalizeGraph(rawGraph);
+
+  return {
+    info: {
+      ref,
+      source,
+      workflowId,
+      nodeCount: graph.nodes.length,
+      edgeCount: graph.edges.length
+    },
+    graph,
+    fileParams
+  };
+}

--- a/packages/cli/src/debug/trace.ts
+++ b/packages/cli/src/debug/trace.ts
@@ -1,0 +1,107 @@
+/**
+ * Reads and summarizes the OpenTelemetry JSONL trace a debug run produces.
+ *
+ * The runtime's `JsonlFileSpanExporter` writes one span per line in the shape
+ * documented in CLAUDE.md (workflow.run → node.process → agent.* → llm.*). We
+ * roll those up into per-name timing plus token/cost totals from the
+ * `gen_ai.usage.*` attributes carried by every llm.chat / llm.stream span.
+ */
+import { readFile } from "node:fs/promises";
+import type { TraceSummary } from "./types.js";
+
+/** One span as serialized by the JSONL trace exporter. */
+export interface TraceSpan {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  name: string;
+  kind: string;
+  start_time_ms: number;
+  end_time_ms: number;
+  duration_ms: number;
+  status: { code: string; message?: string };
+  attributes: Record<string, unknown>;
+  events: Array<{ name: string; time_ms: number; attributes?: Record<string, unknown> }>;
+  resource: Record<string, unknown>;
+}
+
+const SLOWEST_LIMIT = 10;
+
+/** Parse a JSONL trace file body, skipping blank/corrupt lines. */
+export function parseTraceJsonl(text: string): TraceSpan[] {
+  const spans: TraceSpan[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      spans.push(JSON.parse(trimmed) as TraceSpan);
+    } catch {
+      // Ignore partial/corrupt lines (e.g. a crash mid-write).
+    }
+  }
+  return spans;
+}
+
+function numAttr(attrs: Record<string, unknown>, key: string): number {
+  const v = attrs[key];
+  return typeof v === "number" ? v : 0;
+}
+
+/** Roll spans up into a `TraceSummary`. */
+export function summarizeSpans(spans: TraceSpan[]): TraceSummary {
+  const byName: TraceSummary["byName"] = {};
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let costUsd = 0;
+  let minStart = Number.POSITIVE_INFINITY;
+  let maxEnd = Number.NEGATIVE_INFINITY;
+
+  for (const span of spans) {
+    const bucket = (byName[span.name] ??= { count: 0, totalDurationMs: 0 });
+    bucket.count += 1;
+    bucket.totalDurationMs += span.duration_ms;
+
+    if (Number.isFinite(span.start_time_ms)) minStart = Math.min(minStart, span.start_time_ms);
+    if (Number.isFinite(span.end_time_ms)) maxEnd = Math.max(maxEnd, span.end_time_ms);
+
+    const a = span.attributes ?? {};
+    inputTokens += numAttr(a, "gen_ai.usage.input_tokens");
+    outputTokens += numAttr(a, "gen_ai.usage.output_tokens");
+    totalTokens += numAttr(a, "gen_ai.usage.total_tokens");
+    costUsd += numAttr(a, "gen_ai.usage.cost_usd");
+  }
+
+  const slowest = spans
+    .slice()
+    .sort((x, y) => y.duration_ms - x.duration_ms)
+    .slice(0, SLOWEST_LIMIT)
+    .map((s) => ({ name: s.name, durationMs: s.duration_ms, status: s.status?.code ?? "UNSET" }));
+
+  return {
+    spanCount: spans.length,
+    totalDurationMs:
+      spans.length > 0 && minStart !== Number.POSITIVE_INFINITY ? maxEnd - minStart : null,
+    tokens: {
+      input: inputTokens,
+      output: outputTokens,
+      total: totalTokens || inputTokens + outputTokens
+    },
+    costUsd,
+    byName,
+    slowest
+  };
+}
+
+/** Read + summarize a trace file. Returns null when the file is missing/empty. */
+export async function readTraceSummary(path: string): Promise<TraceSummary | null> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+  const spans = parseTraceJsonl(text);
+  if (spans.length === 0) return null;
+  return summarizeSpans(spans);
+}

--- a/packages/cli/src/debug/types.ts
+++ b/packages/cli/src/debug/types.ts
@@ -131,6 +131,16 @@ export interface ServerRunReport {
   traceFile?: string;
 }
 
+/** A canvas screenshot captured at one stage of the browser run. */
+export interface BrowserStageShot {
+  /** 0-based capture order. */
+  index: number;
+  /** Run status at capture time (running until the final frame). */
+  status: string;
+  /** Bundle-relative path to the screenshot. */
+  file: string;
+}
+
 export interface BrowserRunReport {
   surface: "browser";
   ok: boolean;
@@ -139,8 +149,10 @@ export interface BrowserRunReport {
   durationMs: number | null;
   summary: ExecutionSummary;
   consoleErrors: string[];
-  /** Bundle-relative path to the captured screenshot. */
+  /** Bundle-relative path to the final settled screenshot. */
   screenshotFile?: string;
+  /** Canvas screenshots captured at successive stages of the run. */
+  stages?: BrowserStageShot[];
   /** Bundle-relative path to the raw browser RunRecord JSON. */
   recordFile?: string;
   /** Set when the browser surface could not run (missing deps / browser). */

--- a/packages/cli/src/debug/types.ts
+++ b/packages/cli/src/debug/types.ts
@@ -1,0 +1,181 @@
+/**
+ * Shared types for the workflow debug harness.
+ *
+ * The harness runs a workflow end-to-end on two surfaces — the headless server
+ * (kernel `WorkflowRunner`) and a real browser (the `e2e_runner` page driven by
+ * Playwright) — and folds everything worth inspecting into a single
+ * `DebugReport`: the workflow graph JSON, every processing message (logs, node
+ * IO, outputs, edges, LLM calls), an OpenTelemetry span summary, browser console
+ * errors and a screenshot. The report is written to a bundle directory and also
+ * returned so an agent can iterate without re-parsing files.
+ */
+
+/** A workflow graph in kernel/runner shape (properties, not data). */
+export interface DebugGraph {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}
+
+/** How the workflow target was provided and what it resolved to. */
+export interface DebugTargetInfo {
+  /** Original CLI argument (id, path/to/file.json, or path/to/file.ts). */
+  ref: string;
+  /** How `ref` was interpreted. */
+  source: "id" | "json" | "dsl";
+  /** Workflow id when known (DB id, or `id`/`workflow_id` field in a file). */
+  workflowId: string | null;
+  nodeCount: number;
+  edgeCount: number;
+}
+
+/** A single value emitted by a node (output_update / generation_complete). */
+export interface NodeOutput {
+  nodeId?: string;
+  outputName: string;
+  outputType: string;
+  /** Preview-safe value: long strings + base64 blobs are truncated. */
+  value: unknown;
+}
+
+/** Per-node distilled execution state. */
+export interface NodeDebug {
+  nodeId: string;
+  nodeType: string | null;
+  nodeName: string | null;
+  /** Last status seen for the node (pending | running | completed | error …). */
+  status: string;
+  error: string | null;
+  outputs: NodeOutput[];
+  progress?: { progress: number; total: number };
+  cost?: { provider: string; amount: number; unit: string; currency: string | null } | null;
+}
+
+export interface LogEntry {
+  nodeId: string | null;
+  nodeName?: string | null;
+  severity: string;
+  content: string;
+}
+
+export interface EdgeDebug {
+  edgeId: string;
+  status: string;
+  counter: number | null;
+}
+
+export interface LlmCallDebug {
+  nodeId: string;
+  provider: string;
+  model: string;
+  tokensInput: number | null;
+  tokensOutput: number | null;
+  cost: number | null;
+  durationMs: number;
+  error: string | null;
+}
+
+/** A collated error for quick triage. */
+export interface DebugError {
+  nodeId: string | null;
+  nodeType?: string | null;
+  message: string;
+}
+
+/** Everything distilled from a run's processing-message stream. */
+export interface ExecutionSummary {
+  /** Final job status (completed | failed | cancelled | suspended | …). */
+  status: string;
+  error: string | null;
+  nodes: NodeDebug[];
+  logs: LogEntry[];
+  edges: EdgeDebug[];
+  llmCalls: LlmCallDebug[];
+  /** Workflow-level outputs (Output / Preview nodes). */
+  outputs: NodeOutput[];
+  counts: {
+    nodes: number;
+    completed: number;
+    errored: number;
+    logs: number;
+    outputs: number;
+    llmCalls: number;
+  };
+  errors: DebugError[];
+}
+
+/** Rolled-up OpenTelemetry spans for the run. */
+export interface TraceSummary {
+  spanCount: number;
+  /** Wall-clock span over all spans (max end − min start), ms. */
+  totalDurationMs: number | null;
+  tokens: { input: number; output: number; total: number };
+  costUsd: number;
+  /** Count + total self-time by span name (llm.chat, node.process, …). */
+  byName: Record<string, { count: number; totalDurationMs: number }>;
+  /** Slowest spans, descending. */
+  slowest: Array<{ name: string; durationMs: number; status: string }>;
+}
+
+export interface ServerRunReport {
+  surface: "server";
+  /** True when the job reached the `completed` status. */
+  ok: boolean;
+  status: string;
+  error: string | null;
+  durationMs: number;
+  summary: ExecutionSummary;
+  trace: TraceSummary | null;
+  /** Bundle-relative path to the raw messages JSONL. */
+  messagesFile?: string;
+  /** Bundle-relative path to the raw trace JSONL. */
+  traceFile?: string;
+}
+
+export interface BrowserRunReport {
+  surface: "browser";
+  ok: boolean;
+  status: string;
+  error: string | null;
+  durationMs: number | null;
+  summary: ExecutionSummary;
+  consoleErrors: string[];
+  /** Bundle-relative path to the captured screenshot. */
+  screenshotFile?: string;
+  /** Bundle-relative path to the raw browser RunRecord JSON. */
+  recordFile?: string;
+  /** Set when the browser surface could not run (missing deps / browser). */
+  unavailableReason?: string;
+}
+
+export interface DebugVerdict {
+  ok: boolean;
+  headline: string;
+  /** Human-readable problems found, ordered most-actionable first. */
+  issues: string[];
+}
+
+export interface DebugReport {
+  generatedAt: string;
+  target: DebugTargetInfo;
+  /** The workflow graph JSON (runner shape). */
+  workflow: DebugGraph;
+  server: ServerRunReport | null;
+  browser: BrowserRunReport | null;
+  verdict: DebugVerdict;
+  /** Absolute path to the on-disk bundle, when one was written. */
+  bundleDir: string | null;
+}
+
+/** Options that drive a debug run. */
+export interface DebugOptions {
+  /** Run the headless server surface. Default true. */
+  server?: boolean;
+  /** Run the real-browser surface (Playwright). Default false. */
+  browser?: boolean;
+  /** Input params keyed by input-node name. */
+  params?: Record<string, unknown>;
+  /** Bundle output directory. When omitted a timestamped dir is generated. */
+  outDir?: string;
+  /** Per-surface run timeout, ms. */
+  timeoutMs?: number;
+}

--- a/packages/cli/src/debug/types.ts
+++ b/packages/cli/src/debug/types.ts
@@ -182,8 +182,19 @@ export interface DebugReport {
 export interface DebugOptions {
   /** Run the headless server surface. Default true. */
   server?: boolean;
-  /** Run the real-browser surface (Playwright). Default false. */
+  /** Run the real-browser surface (Playwright). Expensive; default false. */
   browser?: boolean;
+  /**
+   * Capture an OpenTelemetry trace of the server run (timing/tokens/cost).
+   * Expensive — loads the OTel SDK and adds per-span overhead. Default false.
+   */
+  trace?: boolean;
+  /**
+   * On the browser surface, capture a canvas screenshot at every stage of the
+   * run instead of only the final frame. Expensive; implies `browser`. Default
+   * false.
+   */
+  stages?: boolean;
   /** Input params keyed by input-node name. */
   params?: Record<string, unknown>;
   /** Bundle output directory. When omitted a timestamped dir is generated. */

--- a/packages/cli/src/debug/verdict.ts
+++ b/packages/cli/src/debug/verdict.ts
@@ -1,0 +1,73 @@
+/**
+ * Cross-surface triage: turns the server/browser run reports into a single
+ * pass/fail verdict plus an ordered list of concrete issues an agent can act on.
+ */
+import type {
+  BrowserRunReport,
+  DebugVerdict,
+  ServerRunReport
+} from "./types.js";
+
+function describeErrors(
+  prefix: string,
+  errors: ReadonlyArray<{ nodeId: string | null; nodeType?: string | null; message: string }>,
+  limit = 5
+): string[] {
+  return errors.slice(0, limit).map((e) => {
+    const where = e.nodeType ?? e.nodeId ?? "workflow";
+    return `${prefix} ${where}: ${e.message.replace(/\s+/g, " ").slice(0, 200)}`;
+  });
+}
+
+export function buildVerdict(
+  server: ServerRunReport | null,
+  browser: BrowserRunReport | null
+): DebugVerdict {
+  const issues: string[] = [];
+
+  if (server) {
+    if (!server.ok) {
+      issues.push(`Server run ended ${server.status}${server.error ? `: ${server.error}` : ""}`);
+    }
+    issues.push(...describeErrors("Server node", server.summary.errors));
+    for (const call of server.summary.llmCalls) {
+      if (call.error) issues.push(`Server LLM ${call.provider}/${call.model}: ${call.error}`);
+    }
+  }
+
+  if (browser) {
+    if (browser.unavailableReason) {
+      issues.push(`Browser run unavailable: ${browser.unavailableReason}`);
+    } else {
+      if (!browser.ok) {
+        issues.push(
+          `Browser run ended ${browser.status}${browser.error ? `: ${browser.error}` : ""}`
+        );
+      }
+      issues.push(...describeErrors("Browser node", browser.summary.errors));
+      for (const err of browser.consoleErrors.slice(0, 5)) {
+        issues.push(`Browser console error: ${err.replace(/\s+/g, " ").slice(0, 200)}`);
+      }
+    }
+  }
+
+  // A surface that genuinely ran and completed is the bar for "ok"; an
+  // unavailable browser surface doesn't fail the verdict on its own.
+  const serverOk = server ? server.ok : true;
+  const browserRan = browser ? !browser.unavailableReason : true;
+  const browserOk = browser && browserRan ? browser.ok : true;
+  const ok = serverOk && browserOk && issues.filter((i) => !i.startsWith("Browser run unavailable")).length === 0;
+
+  let headline: string;
+  if (ok) {
+    const surfaces = [server && "server", browser && !browser.unavailableReason && "browser"]
+      .filter(Boolean)
+      .join(" + ");
+    headline = `Workflow ran clean on ${surfaces || "no surface"}.`;
+  } else {
+    const first = issues[0] ?? "unknown failure";
+    headline = `Workflow has issues — ${first}`;
+  }
+
+  return { ok, headline, issues };
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -51,6 +51,7 @@ import { registerWorkerCommands } from "./commands/worker.js";
 import { registerRecommendedCommand } from "./commands/models-recommended.js";
 import { registerAgentCommands } from "./commands/agent.js";
 import { registerDbCommands } from "./commands/db.js";
+import { registerDebugCommands } from "./commands/debug.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -199,7 +200,11 @@ program
     "--no-trace-stdout",
     "Disable stdout span output (overrides NODETOOL_TRACE_STDOUT)"
   )
-  .hook("preAction", async (thisCommand) => {
+  .hook("preAction", async (thisCommand, actionCommand) => {
+    // The `debug` command owns telemetry: it routes spans into its bundle's
+    // trace.jsonl via its own initTelemetry call. Initializing here first would
+    // win the one-shot init and drop the file sink, so skip it for debug.
+    if (actionCommand?.name() === "debug") return;
     const opts = thisCommand.opts<{
       traceFile?: string;
       traceStdout?: string | boolean;
@@ -1793,6 +1798,7 @@ registerWorkerCommands(program);
 registerDeployCommands(program);
 registerAgentCommands(program);
 registerDbCommands(program);
+registerDebugCommands(program);
 
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -201,10 +201,12 @@ program
     "Disable stdout span output (overrides NODETOOL_TRACE_STDOUT)"
   )
   .hook("preAction", async (thisCommand, actionCommand) => {
-    // The `debug` command owns telemetry: it routes spans into its bundle's
-    // trace.jsonl via its own initTelemetry call. Initializing here first would
-    // win the one-shot init and drop the file sink, so skip it for debug.
-    if (actionCommand?.name() === "debug") return;
+    // With `--trace`, the `debug` command owns telemetry: it routes spans into
+    // its bundle's trace.jsonl via its own initTelemetry call. Initializing here
+    // first would win the one-shot init and drop that file sink, so skip it.
+    // Without `--trace`, fall through so the global --trace-file/--trace-stdout
+    // flags still work for a debug run.
+    if (actionCommand?.name() === "debug" && actionCommand.opts()["trace"]) return;
     const opts = thisCommand.opts<{
       traceFile?: string;
       traceStdout?: string | boolean;

--- a/packages/cli/tests/debug-browser-runner.test.ts
+++ b/packages/cli/tests/debug-browser-runner.test.ts
@@ -45,6 +45,13 @@ describe("buildBrowserReport", () => {
     );
     writeFileSync(join(dir, "console-errors.log"), "TypeError: boom\n");
     writeFileSync(join(dir, "screenshot.png"), "fake-png-bytes");
+    writeFileSync(
+      join(dir, "stages.json"),
+      JSON.stringify([
+        { index: 0, status: "running", file: "stages/00-running.png" },
+        { index: 1, status: "completed", file: "stages/01-completed.png" }
+      ])
+    );
 
     const report = await buildBrowserReport(dir);
     expect(report.surface).toBe("browser");
@@ -56,6 +63,11 @@ describe("buildBrowserReport", () => {
     expect(report.recordFile).toBe("browser/record.json");
     expect(report.summary.outputs[0].value).toBe("hello debug harness");
     expect(report.unavailableReason).toBeUndefined();
+    // Staged screenshots are folded in with bundle-relative paths.
+    expect(report.stages).toEqual([
+      { index: 0, status: "running", file: "browser/stages/00-running.png" },
+      { index: 1, status: "completed", file: "browser/stages/01-completed.png" }
+    ]);
   });
 
   it("reports unavailable when no record was produced", async () => {

--- a/packages/cli/tests/debug-browser-runner.test.ts
+++ b/packages/cli/tests/debug-browser-runner.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the browser surface artifact folding (src/debug/browser-runner.ts).
+ *
+ * Covers `buildBrowserReport` — the pure step that turns the Playwright run's
+ * on-disk artifacts (record.json, console-errors.log, screenshot.png) into a
+ * `BrowserRunReport` — plus the "no record" unavailable path. The spawn itself
+ * is exercised by `web/tests/debug-harness/debug.spec.ts`.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBrowserReport } from "../src/debug/browser-runner.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "debug-browser-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("buildBrowserReport", () => {
+  it("folds a completed run record + console errors + screenshot", async () => {
+    // The shape a real harness run produces (see web/tests/debug-harness).
+    writeFileSync(
+      join(dir, "record.json"),
+      JSON.stringify({
+        status: "completed",
+        durationMs: 142,
+        outputs: [{ output_name: "result", value: "hello debug harness" }],
+        events: [
+          { type: "node_update", node_id: "o", node_type: "ns.Out", status: "completed" },
+          {
+            type: "output_update",
+            node_id: "o",
+            output_name: "result",
+            output_type: "any",
+            value: "hello debug harness"
+          },
+          { type: "job_update", status: "completed" }
+        ]
+      })
+    );
+    writeFileSync(join(dir, "console-errors.log"), "TypeError: boom\n");
+    writeFileSync(join(dir, "screenshot.png"), "fake-png-bytes");
+
+    const report = await buildBrowserReport(dir);
+    expect(report.surface).toBe("browser");
+    expect(report.ok).toBe(true);
+    expect(report.status).toBe("completed");
+    expect(report.durationMs).toBe(142);
+    expect(report.consoleErrors).toEqual(["TypeError: boom"]);
+    expect(report.screenshotFile).toBe("browser/screenshot.png");
+    expect(report.recordFile).toBe("browser/record.json");
+    expect(report.summary.outputs[0].value).toBe("hello debug harness");
+    expect(report.unavailableReason).toBeUndefined();
+  });
+
+  it("reports unavailable when no record was produced", async () => {
+    const report = await buildBrowserReport(dir, 1);
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("unavailable");
+    expect(report.unavailableReason).toContain("no record");
+  });
+
+  it("marks a failed run not-ok", async () => {
+    writeFileSync(
+      join(dir, "record.json"),
+      JSON.stringify({
+        status: "error",
+        error: "node blew up",
+        events: [{ type: "job_update", status: "failed", error: "node blew up" }]
+      })
+    );
+    const report = await buildBrowserReport(dir);
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("error");
+    expect(report.error).toBe("node blew up");
+    expect(report.screenshotFile).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/debug-collector.test.ts
+++ b/packages/cli/tests/debug-collector.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the debug harness message collector (src/debug/collector.ts).
+ *
+ * Uses loosely-typed message bags (the same shape both the server RunResult and
+ * the browser event log produce) so it runs under the CLI vitest stub setup,
+ * where `@nodetool-ai/protocol` is a type-only import.
+ */
+import { describe, expect, it } from "vitest";
+import { collectExecutionSummary, previewValue } from "../src/debug/collector.js";
+
+describe("previewValue", () => {
+  it("truncates long strings with a length marker", () => {
+    const long = "x".repeat(5000);
+    const out = previewValue(long) as string;
+    expect(out.length).toBeLessThan(long.length);
+    expect(out).toContain("[5000 chars]");
+  });
+
+  it("collapses base64-ish blob fields inside objects", () => {
+    const out = previewValue({ data: "A".repeat(1000), type: "image" }) as Record<string, unknown>;
+    expect(String(out.data)).toContain("[1000 chars]");
+    expect(out.type).toBe("image");
+  });
+
+  it("summarizes binary payloads", () => {
+    expect(previewValue(new Uint8Array(10))).toBe("<binary 10 bytes>");
+  });
+
+  it("caps array fan-out", () => {
+    const out = previewValue(Array.from({ length: 100 }, (_, i) => i)) as unknown[];
+    expect(out.length).toBe(51); // 50 items + "…[50 more]"
+    expect(out[50]).toBe("…[50 more]");
+  });
+});
+
+describe("collectExecutionSummary", () => {
+  it("folds node, output, log, edge and error messages", () => {
+    const summary = collectExecutionSummary([
+      { type: "job_update", status: "running" },
+      { type: "node_update", node_id: "a", node_type: "ns.A", node_name: "A", status: "running" },
+      { type: "node_update", node_id: "a", node_type: "ns.A", node_name: "A", status: "completed" },
+      { type: "node_update", node_id: "b", node_type: "ns.B", status: "error", error: "boom" },
+      {
+        type: "output_update",
+        node_id: "a",
+        node_name: "A",
+        output_name: "out",
+        output_type: "string",
+        value: "hello"
+      },
+      { type: "log_update", node_id: "a", severity: "info", content: "did a thing" },
+      { type: "edge_update", edge_id: "e1", status: "completed", counter: 3 },
+      {
+        type: "llm_call",
+        node_id: "a",
+        provider: "openai",
+        model: "gpt-x",
+        tokens_input: 10,
+        tokens_output: 5,
+        cost: 0.01,
+        duration_ms: 120
+      },
+      { type: "job_update", status: "completed" }
+    ]);
+
+    expect(summary.status).toBe("completed");
+    expect(summary.counts.nodes).toBe(2);
+    expect(summary.counts.completed).toBe(1);
+    expect(summary.counts.errored).toBe(1);
+    expect(summary.outputs).toHaveLength(1);
+    expect(summary.outputs[0]).toMatchObject({ nodeId: "a", outputName: "out", value: "hello" });
+    expect(summary.logs).toHaveLength(1);
+    expect(summary.edges[0]).toMatchObject({ edgeId: "e1", counter: 3 });
+    expect(summary.llmCalls[0]).toMatchObject({ provider: "openai", tokensInput: 10 });
+
+    const errored = summary.nodes.find((n) => n.nodeId === "b");
+    expect(errored?.error).toBe("boom");
+    expect(summary.errors.some((e) => e.message === "boom")).toBe(true);
+  });
+
+  it("does not flag a node as errored when it completes with an empty error field", () => {
+    const summary = collectExecutionSummary([
+      { type: "node_update", node_id: "a", status: "running", error: "" },
+      { type: "node_update", node_id: "a", status: "completed", error: "" }
+    ]);
+    expect(summary.nodes[0].error).toBeNull();
+    expect(summary.counts.errored).toBe(0);
+  });
+
+  it("captures generation_complete outputs and a top-level error", () => {
+    const summary = collectExecutionSummary([
+      {
+        type: "generation_complete",
+        node_id: "g",
+        node_type: "ns.Gen",
+        node_name: "Gen",
+        outputs: { image: { type: "image", uri: "asset://x" } }
+      },
+      { type: "error", message: "fatal" },
+      { type: "job_update", status: "failed", error: "fatal" }
+    ]);
+    const gen = summary.nodes.find((n) => n.nodeId === "g");
+    expect(gen?.outputs[0].outputName).toBe("image");
+    expect(summary.status).toBe("failed");
+    expect(summary.error).toBe("fatal");
+    // A single top-level error is not double-listed.
+    expect(summary.errors.filter((e) => e.message === "fatal")).toHaveLength(1);
+  });
+});

--- a/packages/cli/tests/debug-command.test.ts
+++ b/packages/cli/tests/debug-command.test.ts
@@ -21,7 +21,7 @@ describe("registerDebugCommands", () => {
     expect(debugCommand().description()).toMatch(/end-to-end/i);
   });
 
-  it("exposes the surface, params, out, timeout and json options", () => {
+  it("exposes the surface, opt-in cost, params, out, timeout and json options", () => {
     const flags = debugCommand()
       .options.map((o) => o.long)
       .filter(Boolean);
@@ -29,12 +29,21 @@ describe("registerDebugCommands", () => {
       expect.arrayContaining([
         "--no-server",
         "--browser",
+        "--trace",
+        "--stages",
         "--params",
         "--out",
         "--timeout",
         "--json"
       ])
     );
+  });
+
+  it("defaults the expensive surfaces (browser/trace/stages) off", () => {
+    const opts = debugCommand().opts<{ browser?: boolean; trace?: boolean; stages?: boolean }>();
+    expect(opts.browser).toBeUndefined();
+    expect(opts.trace).toBeUndefined();
+    expect(opts.stages).toBeUndefined();
   });
 
   it("defaults server on and browser off", () => {

--- a/packages/cli/tests/debug-command.test.ts
+++ b/packages/cli/tests/debug-command.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the `nodetool debug` command registration (src/commands/debug.ts).
+ *
+ * Verifies the command + its options are wired up. Heavy dependencies are only
+ * imported lazily inside the action, so registration is testable without them.
+ */
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { registerDebugCommands } from "../src/commands/debug.js";
+
+function debugCommand() {
+  const program = new Command();
+  registerDebugCommands(program);
+  const cmd = program.commands.find((c) => c.name() === "debug");
+  if (!cmd) throw new Error("debug command not registered");
+  return cmd;
+}
+
+describe("registerDebugCommands", () => {
+  it("registers the debug command", () => {
+    expect(debugCommand().description()).toMatch(/end-to-end/i);
+  });
+
+  it("exposes the surface, params, out, timeout and json options", () => {
+    const flags = debugCommand()
+      .options.map((o) => o.long)
+      .filter(Boolean);
+    expect(flags).toEqual(
+      expect.arrayContaining([
+        "--no-server",
+        "--browser",
+        "--params",
+        "--out",
+        "--timeout",
+        "--json"
+      ])
+    );
+  });
+
+  it("defaults server on and browser off", () => {
+    const cmd = debugCommand();
+    // `--no-server` yields `server: true` by default in commander.
+    const opts = cmd.opts<{ server?: boolean; browser?: boolean }>();
+    expect(opts.server).toBe(true);
+    expect(opts.browser).toBeUndefined();
+  });
+
+  it("takes a required workflow argument", () => {
+    const args = debugCommand().registeredArguments.map((a) => a.name());
+    expect(args).toContain("workflow_id_or_file");
+  });
+});

--- a/packages/cli/tests/debug-report.test.ts
+++ b/packages/cli/tests/debug-report.test.ts
@@ -73,6 +73,39 @@ describe("buildVerdict", () => {
   });
 });
 
+describe("renderReportMarkdown with browser stages", () => {
+  it("lists the staged screenshots", () => {
+    const browser: BrowserRunReport = {
+      surface: "browser",
+      ok: true,
+      status: "completed",
+      error: null,
+      durationMs: 100,
+      summary: collectExecutionSummary([{ type: "job_update", status: "completed" }]),
+      consoleErrors: [],
+      screenshotFile: "browser/screenshot.png",
+      stages: [
+        { index: 0, status: "running", file: "browser/stages/00-running.png" },
+        { index: 1, status: "completed", file: "browser/stages/01-completed.png" }
+      ]
+    };
+    const report: DebugReport = {
+      generatedAt: "2026-06-21T00:00:00Z",
+      target: { ref: "wf.json", source: "json", workflowId: null, nodeCount: 1, edgeCount: 0 },
+      workflow: { nodes: [], edges: [] },
+      server: null,
+      browser,
+      verdict: buildVerdict(null, browser),
+      bundleDir: "/tmp/bundle"
+    };
+    const md = renderReportMarkdown(report);
+    expect(md).toContain("Stage screenshots");
+    expect(md).toContain("browser/stages/00-running.png");
+    expect(md).toContain("browser/stages/01-completed.png");
+    expect(md).toContain("Final screenshot:");
+  });
+});
+
 describe("renderReportMarkdown", () => {
   it("renders headline, target, surfaces and issues", () => {
     const server = serverReport({

--- a/packages/cli/tests/debug-report.test.ts
+++ b/packages/cli/tests/debug-report.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the debug harness verdict + Markdown renderer
+ * (src/debug/verdict.ts, src/debug/markdown.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { buildVerdict } from "../src/debug/verdict.js";
+import { renderReportMarkdown } from "../src/debug/markdown.js";
+import { collectExecutionSummary } from "../src/debug/collector.js";
+import type { BrowserRunReport, DebugReport, ServerRunReport } from "../src/debug/types.js";
+
+function serverReport(over: Partial<ServerRunReport> = {}): ServerRunReport {
+  return {
+    surface: "server",
+    ok: true,
+    status: "completed",
+    error: null,
+    durationMs: 1234,
+    summary: collectExecutionSummary([{ type: "job_update", status: "completed" }]),
+    trace: null,
+    ...over
+  };
+}
+
+describe("buildVerdict", () => {
+  it("is ok when the server run completes clean", () => {
+    const verdict = buildVerdict(serverReport(), null);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.headline).toContain("clean");
+  });
+
+  it("collects server node errors as issues", () => {
+    const summary = collectExecutionSummary([
+      { type: "node_update", node_id: "b", node_type: "ns.B", status: "error", error: "kaboom" },
+      { type: "job_update", status: "failed", error: "node failed" }
+    ]);
+    const verdict = buildVerdict(
+      serverReport({ ok: false, status: "failed", error: "node failed", summary }),
+      null
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.issues.join("\n")).toContain("kaboom");
+  });
+
+  it("treats an unavailable browser surface as non-fatal", () => {
+    const browser: BrowserRunReport = {
+      surface: "browser",
+      ok: false,
+      status: "unavailable",
+      error: null,
+      durationMs: null,
+      summary: collectExecutionSummary([]),
+      consoleErrors: [],
+      unavailableReason: "web deps not installed"
+    };
+    const verdict = buildVerdict(serverReport(), browser);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.issues.some((i) => i.includes("unavailable"))).toBe(true);
+  });
+
+  it("flags browser console errors", () => {
+    const browser: BrowserRunReport = {
+      surface: "browser",
+      ok: true,
+      status: "completed",
+      error: null,
+      durationMs: 100,
+      summary: collectExecutionSummary([{ type: "job_update", status: "completed" }]),
+      consoleErrors: ["TypeError: x is undefined"]
+    };
+    const verdict = buildVerdict(serverReport(), browser);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.issues.join("\n")).toContain("TypeError");
+  });
+});
+
+describe("renderReportMarkdown", () => {
+  it("renders headline, target, surfaces and issues", () => {
+    const server = serverReport({
+      ok: false,
+      status: "failed",
+      error: "boom",
+      summary: collectExecutionSummary([
+        { type: "node_update", node_id: "n1", node_type: "ns.N", status: "error", error: "boom" },
+        { type: "log_update", node_id: "n1", severity: "error", content: "stack trace here" },
+        { type: "job_update", status: "failed", error: "boom" }
+      ])
+    });
+    const report: DebugReport = {
+      generatedAt: "2026-06-21T00:00:00Z",
+      target: { ref: "wf.json", source: "json", workflowId: "wf1", nodeCount: 2, edgeCount: 1 },
+      workflow: { nodes: [], edges: [] },
+      server,
+      browser: null,
+      verdict: buildVerdict(server, null),
+      bundleDir: "/tmp/bundle"
+    };
+    const md = renderReportMarkdown(report);
+    expect(md).toContain("# Workflow debug report");
+    expect(md).toContain("Server surface");
+    expect(md).toContain("ns.N");
+    expect(md).toContain("stack trace here");
+    expect(md).toContain("## Issues");
+  });
+});

--- a/packages/cli/tests/debug-trace.test.ts
+++ b/packages/cli/tests/debug-trace.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the debug harness trace summarizer (src/debug/trace.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { parseTraceJsonl, summarizeSpans, type TraceSpan } from "../src/debug/trace.js";
+
+function span(partial: Partial<TraceSpan>): TraceSpan {
+  return {
+    trace_id: "t",
+    span_id: "s",
+    parent_span_id: null,
+    name: "span",
+    kind: "INTERNAL",
+    start_time_ms: 0,
+    end_time_ms: 0,
+    duration_ms: 0,
+    status: { code: "OK" },
+    attributes: {},
+    events: [],
+    resource: {},
+    ...partial
+  };
+}
+
+describe("parseTraceJsonl", () => {
+  it("parses valid lines and skips blank/corrupt ones", () => {
+    const text = [
+      JSON.stringify(span({ name: "workflow.run" })),
+      "",
+      "{ not json",
+      JSON.stringify(span({ name: "llm.chat" }))
+    ].join("\n");
+    const spans = parseTraceJsonl(text);
+    expect(spans.map((s) => s.name)).toEqual(["workflow.run", "llm.chat"]);
+  });
+});
+
+describe("summarizeSpans", () => {
+  it("rolls up timing, token usage and cost", () => {
+    const spans = [
+      span({ name: "workflow.run", start_time_ms: 100, end_time_ms: 1100, duration_ms: 1000 }),
+      span({
+        name: "llm.chat",
+        start_time_ms: 200,
+        end_time_ms: 700,
+        duration_ms: 500,
+        attributes: {
+          "gen_ai.usage.input_tokens": 100,
+          "gen_ai.usage.output_tokens": 40,
+          "gen_ai.usage.total_tokens": 140,
+          "gen_ai.usage.cost_usd": 0.002
+        }
+      }),
+      span({ name: "llm.chat", start_time_ms: 720, end_time_ms: 900, duration_ms: 180 })
+    ];
+    const summary = summarizeSpans(spans);
+    expect(summary.spanCount).toBe(3);
+    expect(summary.totalDurationMs).toBe(1000); // 1100 - 100
+    expect(summary.tokens.total).toBe(140);
+    expect(summary.costUsd).toBeCloseTo(0.002);
+    expect(summary.byName["llm.chat"].count).toBe(2);
+    expect(summary.byName["llm.chat"].totalDurationMs).toBe(680);
+    expect(summary.slowest[0].name).toBe("workflow.run");
+  });
+
+  it("falls back to input+output when total_tokens is absent", () => {
+    const summary = summarizeSpans([
+      span({
+        attributes: {
+          "gen_ai.usage.input_tokens": 7,
+          "gen_ai.usage.output_tokens": 3
+        }
+      })
+    ]);
+    expect(summary.tokens.total).toBe(10);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -97,6 +97,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e-runner": "playwright test -c playwright.e2e-runner.config.ts",
     "test:e2e-runner:headed": "playwright test -c playwright.e2e-runner.config.ts --headed",
+    "test:debug-harness": "playwright test -c playwright.debug-harness.config.ts",
     "e2e-suite:prepare": "tsx tests/e2e-runner/prepareSuite.ts",
     "typecheck": "tsc --noEmit",
     "upload-stock-images": "node scripts/upload-stock-images.js",

--- a/web/playwright.debug-harness.config.ts
+++ b/web/playwright.debug-harness.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the workflow debug harness (`nodetool debug --browser`).
+ *
+ * Reuses the E2E runner's hermetic backend (packages/websocket/src/e2e-server.ts,
+ * spawned by the shared globalSetup) so any workflow runs without API keys, and
+ * the standard Vite dev server. The single spec reads the target graph from
+ * NODETOOL_DEBUG_GRAPH, drives `window.__E2E__.runGraph(...)`, and writes the
+ * record / screenshot / console errors into NODETOOL_DEBUG_OUT.
+ */
+export default defineConfig({
+  testDir: "./tests/debug-harness",
+  testMatch: "**/debug.spec.ts",
+
+  timeout: 5 * 60_000,
+  expect: { timeout: 15_000 },
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+
+  globalSetup: "./tests/e2e-runner/globalSetup.ts",
+
+  use: {
+    baseURL: "http://localhost:3000",
+    ignoreHTTPSErrors: true,
+    screenshot: "off",
+    trace: "retain-on-failure"
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1600, height: 1000 },
+        launchOptions: {
+          args: [
+            "--enable-features=Vulkan,UseSkiaRenderer",
+            "--use-gl=angle",
+            "--use-angle=swiftshader",
+            "--enable-webgpu-developer-features"
+          ]
+        }
+      }
+    }
+  ],
+
+  webServer: {
+    command: "npm start",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 120_000
+  }
+});

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -103,8 +103,7 @@ jest.mock("../../ui_primitives", () => ({
     <button data-testid={`toggle-option-${value}`} {...props}>
       {children}
     </button>
-  ),
-  BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS
+  )
 }));
 
 jest.mock("@mui/material/styles", () => ({

--- a/web/src/e2e_runner/E2ERunnerApp.tsx
+++ b/web/src/e2e_runner/E2ERunnerApp.tsx
@@ -239,6 +239,7 @@ function Canvas({
 }) {
   const [graph, setGraph] = useState<RenderGraph | null>(null);
   const idx = state.currentIndex;
+  const adHocNonce = state.adHocNonce;
 
   useEffect(() => {
     let cancelled = false;
@@ -251,7 +252,7 @@ function Canvas({
     return () => {
       cancelled = true;
     };
-  }, [harness, idx]);
+  }, [harness, idx, adHocNonce]);
 
   if (!graph) {
     return (

--- a/web/src/e2e_runner/harness.ts
+++ b/web/src/e2e_runner/harness.ts
@@ -15,6 +15,7 @@ import type {
   E2EController,
   Manifest,
   RunRecord,
+  RunSnapshot,
   RunStatus,
   WorkflowRef,
   WsEvent
@@ -37,6 +38,8 @@ export interface HarnessState {
   adHocGraph: { nodes: unknown[]; edges: unknown[] } | null;
   /** Bumped each ad-hoc run so the canvas re-renders even though currentIndex is unchanged. */
   adHocNonce: number;
+  /** Monotonic stage counter for the in-flight ad-hoc run; bumped on status-bearing events. */
+  stage: number;
 }
 
 type Listener = (state: HarnessState) => void;
@@ -210,7 +213,8 @@ export class Harness {
     currentIndex: -1,
     nodeStatus: {},
     adHocGraph: null,
-    adHocNonce: 0
+    adHocNonce: 0,
+    stage: 0
   };
   private secretsAvailable: string[] = [];
   private graphCache = new Map<string, { nodes: unknown[]; edges: unknown[] }>();
@@ -465,13 +469,15 @@ export class Harness {
     rec.startedAt = startedAt;
 
     // Render the graph on the canvas and surface it in the sidebar/state.
+    // stage 1 marks the initial render before any node has reported.
     this.setState({
       state: "running",
       adHocGraph: graph,
       adHocNonce: this.state.adHocNonce + 1,
       nodeStatus: {},
       records: [rec],
-      currentIndex: 0
+      currentIndex: 0,
+      stage: 1
     });
 
     const ws = new HarnessWsClient();
@@ -504,13 +510,20 @@ export class Harness {
         rec.durationMs = rec.finishedAt - startedAt;
         if (error && !rec.error) rec.error = error;
         finalizeCounts(rec);
-        this.setState({ records: [rec], state: "done" });
+        this.setState({ records: [rec], state: "done", stage: this.state.stage + 1 });
         resolve();
       };
 
       const unsubscribe = ws.onMessage((msg: WsEvent) => {
         const terminal = reduceRecordEvent(rec, msg, nodeStatus);
-        this.setState({ records: [rec], nodeStatus: { ...nodeStatus } });
+        // A node starting/finishing or a job status change is a new visual
+        // stage worth a screenshot; chunks/edges/logs are not.
+        const advances = msg.type === "node_update" || msg.type === "job_update";
+        this.setState({
+          records: [rec],
+          nodeStatus: { ...nodeStatus },
+          ...(advances ? { stage: this.state.stage + 1 } : {})
+        });
         if (terminal) queueMicrotask(() => finish(terminal.status, terminal.error));
       });
 
@@ -524,6 +537,17 @@ export class Harness {
     return rec;
   }
 
+  /** Live view of the in-flight ad-hoc run, for staged screenshot capture. */
+  snapshot(): RunSnapshot {
+    const rec = this.state.records[0];
+    return {
+      settled: this.state.state === "done",
+      stage: this.state.stage,
+      status: rec?.status ?? this.state.state,
+      nodeStatus: this.state.nodeStatus
+    };
+  }
+
   controller(): E2EController {
     return {
       ready: Promise.resolve(),
@@ -533,7 +557,8 @@ export class Harness {
       runNext: () => this.runNext(),
       runAll: () => this.runAll(),
       currentIndex: () => this.state.currentIndex,
-      runGraph: (graph, params, options) => this.runGraph(graph, params, options)
+      runGraph: (graph, params, options) => this.runGraph(graph, params, options),
+      snapshot: () => this.snapshot()
     };
   }
 

--- a/web/src/e2e_runner/harness.ts
+++ b/web/src/e2e_runner/harness.ts
@@ -10,6 +10,7 @@
  */
 import { HarnessWsClient } from "./wsClient";
 import type {
+  AdHocRunOptions,
   CapturedArtifact,
   E2EController,
   Manifest,
@@ -32,6 +33,10 @@ export interface HarnessState {
   currentIndex: number;
   /** Per-node visual status for the currently rendered workflow, keyed by node id. */
   nodeStatus: Record<string, string>;
+  /** A caller-supplied graph being run ad-hoc (debug harness), rendered instead of a manifest entry. */
+  adHocGraph: { nodes: unknown[]; edges: unknown[] } | null;
+  /** Bumped each ad-hoc run so the canvas re-renders even though currentIndex is unchanged. */
+  adHocNonce: number;
 }
 
 type Listener = (state: HarnessState) => void;
@@ -106,6 +111,96 @@ function extractArtifact(output: {
   return null;
 }
 
+/** Signals a terminal job_update; carries the final status + error. */
+interface TerminalSignal {
+  status: RunStatus;
+  error?: string;
+}
+
+/**
+ * Fold a single decoded WS event into a RunRecord, mutating `rec` and the live
+ * `nodeStatus` map. Returns a terminal signal when the run has settled.
+ *
+ * Shared verbatim by the manifest-driven suite path (`handleEvent`) and the
+ * ad-hoc debug path (`runGraph`) so both capture identical record shapes.
+ */
+function reduceRecordEvent(
+  rec: RunRecord,
+  msg: WsEvent,
+  nodeStatus: Record<string, string>
+): TerminalSignal | null {
+  rec.events.push(msg);
+  switch (msg.type) {
+    case "job_update": {
+      if (typeof msg.job_id === "string" && msg.job_id) rec.jobId = msg.job_id;
+      const status = String(msg.status ?? "");
+      if (typeof msg.error === "string" && msg.error) rec.error = msg.error;
+      if (TERMINAL_STATUSES.has(status)) {
+        return {
+          status: status as RunStatus,
+          error: typeof msg.error === "string" ? msg.error : undefined
+        };
+      }
+      break;
+    }
+    case "node_update": {
+      const nodeId = String(msg.node_id ?? "");
+      if (nodeId) {
+        const status = String(msg.status ?? "");
+        nodeStatus[nodeId] = status;
+        const isError = status === "error" || status === "failed";
+        const message =
+          typeof msg.error === "string" && msg.error.length > 0 ? msg.error : null;
+        rec.nodeIO[nodeId] = {
+          node_type:
+            typeof msg.node_type === "string" ? msg.node_type : rec.nodeIO[nodeId]?.node_type,
+          status,
+          result: (msg as { result?: unknown }).result ?? rec.nodeIO[nodeId]?.result,
+          // Only treat a node as errored when its status says so — a
+          // node_update can carry a stale/empty error field while completing.
+          error: isError ? (message ?? status) : null
+        };
+      }
+      break;
+    }
+    case "output_update": {
+      const output = {
+        node_id: typeof msg.node_id === "string" ? msg.node_id : undefined,
+        node_name: typeof msg.node_name === "string" ? msg.node_name : undefined,
+        output_name: typeof msg.output_name === "string" ? msg.output_name : undefined,
+        output_type: typeof msg.output_type === "string" ? msg.output_type : undefined,
+        value: (msg as { value?: unknown }).value
+      };
+      rec.outputs.push(output);
+      const artifact = extractArtifact(output);
+      if (artifact) rec.artifacts.push(artifact);
+      break;
+    }
+    case "log_update": {
+      rec.logs.push({
+        ts: Date.now(),
+        level: typeof msg.severity === "string" ? msg.severity : undefined,
+        content: asString((msg as { content?: unknown }).content ?? msg),
+        node_id: typeof msg.node_id === "string" ? msg.node_id : undefined
+      });
+      break;
+    }
+    default:
+      break;
+  }
+  return null;
+}
+
+/** Recompute the rollup counts on a settled record. */
+function finalizeCounts(rec: RunRecord): void {
+  rec.counts = {
+    nodes: Object.keys(rec.nodeIO).length,
+    outputs: rec.outputs.length,
+    errors: Object.values(rec.nodeIO).filter((n) => n.error).length,
+    edgeUpdates: rec.events.filter((e) => e.type === "edge_update").length
+  };
+}
+
 export class Harness {
   private listeners = new Set<Listener>();
   private state: HarnessState = {
@@ -113,7 +208,9 @@ export class Harness {
     records: [],
     state: "loading",
     currentIndex: -1,
-    nodeStatus: {}
+    nodeStatus: {},
+    adHocGraph: null,
+    adHocNonce: 0
   };
   private secretsAvailable: string[] = [];
   private graphCache = new Map<string, { nodes: unknown[]; edges: unknown[] }>();
@@ -173,6 +270,16 @@ export class Harness {
     ref: WorkflowRef;
     graph: { nodes: unknown[]; edges: unknown[] };
   } | null> {
+    if (this.state.adHocGraph) {
+      const ref: WorkflowRef = {
+        id: "adhoc",
+        name: "ad-hoc graph",
+        file: "",
+        params: {},
+        source: "custom"
+      };
+      return { ref, graph: this.state.adHocGraph };
+    }
     const idx = this.state.currentIndex;
     if (idx < 0 || idx >= this.state.manifest.length) return null;
     const ref = this.state.manifest[idx];
@@ -277,12 +384,7 @@ export class Harness {
           rec.finishedAt = finishedAt;
           rec.durationMs = finishedAt - startedAt;
           if (error && !rec.error) rec.error = error;
-          rec.counts = {
-            nodes: Object.keys(rec.nodeIO).length,
-            outputs: rec.outputs.length,
-            errors: Object.values(rec.nodeIO).filter((n) => n.error).length,
-            edgeUpdates: rec.events.filter((e) => e.type === "edge_update").length
-          };
+          finalizeCounts(rec);
           this.applyExpectations(rec, ref);
         });
         resolve();
@@ -309,68 +411,10 @@ export class Harness {
     finish: (status: RunStatus, error?: string) => void
   ): void {
     this.updateRecord(index, (rec) => {
-      rec.events.push(msg);
-      switch (msg.type) {
-        case "job_update": {
-          if (typeof msg.job_id === "string" && msg.job_id) rec.jobId = msg.job_id;
-          const status = String(msg.status ?? "");
-          if (typeof msg.error === "string" && msg.error) rec.error = msg.error;
-          if (TERMINAL_STATUSES.has(status)) {
-            // Defer finish() until after this record mutation is committed.
-            queueMicrotask(() =>
-              finish(status as RunStatus, typeof msg.error === "string" ? msg.error : undefined)
-            );
-          }
-          break;
-        }
-        case "node_update": {
-          const nodeId = String(msg.node_id ?? "");
-          if (nodeId) {
-            const status = String(msg.status ?? "");
-            nodeStatus[nodeId] = status;
-            const isError = status === "error" || status === "failed";
-            const message =
-              typeof msg.error === "string" && msg.error.length > 0
-                ? msg.error
-                : null;
-            rec.nodeIO[nodeId] = {
-              node_type:
-                typeof msg.node_type === "string" ? msg.node_type : rec.nodeIO[nodeId]?.node_type,
-              status,
-              result: (msg as { result?: unknown }).result ?? rec.nodeIO[nodeId]?.result,
-              // Only treat a node as errored when its status says so — a
-              // node_update can carry a stale/empty error field while completing.
-              error: isError ? (message ?? status) : null
-            };
-          }
-          break;
-        }
-        case "output_update": {
-          const output = {
-            node_id: typeof msg.node_id === "string" ? msg.node_id : undefined,
-            node_name: typeof msg.node_name === "string" ? msg.node_name : undefined,
-            output_name:
-              typeof msg.output_name === "string" ? msg.output_name : undefined,
-            output_type:
-              typeof msg.output_type === "string" ? msg.output_type : undefined,
-            value: (msg as { value?: unknown }).value
-          };
-          rec.outputs.push(output);
-          const artifact = extractArtifact(output);
-          if (artifact) rec.artifacts.push(artifact);
-          break;
-        }
-        case "log_update": {
-          rec.logs.push({
-            ts: Date.now(),
-            level: typeof msg.severity === "string" ? msg.severity : undefined,
-            content: asString((msg as { content?: unknown }).content ?? msg),
-            node_id: typeof msg.node_id === "string" ? msg.node_id : undefined
-          });
-          break;
-        }
-        default:
-          break;
+      const terminal = reduceRecordEvent(rec, msg, nodeStatus);
+      if (terminal) {
+        // Defer finish() until after this record mutation is committed.
+        queueMicrotask(() => finish(terminal.status, terminal.error));
       }
     });
     this.setState({ nodeStatus: { ...nodeStatus } });
@@ -397,6 +441,89 @@ export class Harness {
     rec.expectationFailures = failures;
   }
 
+  /**
+   * Run a caller-supplied graph that isn't part of the manifest. Renders it on
+   * the canvas, executes it against the backend over a fresh WebSocket, and
+   * resolves with a fully-populated RunRecord once the job settles. This is the
+   * browser surface the `nodetool debug` harness drives.
+   */
+  async runGraph(
+    graph: { nodes: unknown[]; edges: unknown[] },
+    params: Record<string, unknown> = {},
+    options: AdHocRunOptions = {}
+  ): Promise<RunRecord> {
+    const ref: WorkflowRef = {
+      id: options.id ?? `adhoc-${Date.now()}`,
+      name: options.name ?? "ad-hoc graph",
+      file: "",
+      params,
+      source: "custom"
+    };
+    const rec = emptyRecord(ref);
+    const startedAt = Date.now();
+    rec.status = "running";
+    rec.startedAt = startedAt;
+
+    // Render the graph on the canvas and surface it in the sidebar/state.
+    this.setState({
+      state: "running",
+      adHocGraph: graph,
+      adHocNonce: this.state.adHocNonce + 1,
+      nodeStatus: {},
+      records: [rec],
+      currentIndex: 0
+    });
+
+    const ws = new HarnessWsClient();
+    try {
+      await ws.connect();
+    } catch (err) {
+      rec.status = "error";
+      rec.finishedAt = Date.now();
+      rec.durationMs = rec.finishedAt - startedAt;
+      rec.error = err instanceof Error ? err.message : String(err);
+      this.setState({ records: [rec], state: "done" });
+      return rec;
+    }
+
+    const nodeStatus: Record<string, string> = {};
+    const timeoutMs = options.timeoutMs ?? RUN_TIMEOUT_MS;
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const timer = window.setTimeout(() => finish("timeout"), timeoutMs);
+
+      const finish = (status: RunStatus, error?: string) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timer);
+        unsubscribe();
+        ws.close();
+        rec.status = status;
+        rec.finishedAt = Date.now();
+        rec.durationMs = rec.finishedAt - startedAt;
+        if (error && !rec.error) rec.error = error;
+        finalizeCounts(rec);
+        this.setState({ records: [rec], state: "done" });
+        resolve();
+      };
+
+      const unsubscribe = ws.onMessage((msg: WsEvent) => {
+        const terminal = reduceRecordEvent(rec, msg, nodeStatus);
+        this.setState({ records: [rec], nodeStatus: { ...nodeStatus } });
+        if (terminal) queueMicrotask(() => finish(terminal.status, terminal.error));
+      });
+
+      try {
+        ws.send({ command: "run_job", data: { graph, params } });
+      } catch (err) {
+        finish("error", err instanceof Error ? err.message : String(err));
+      }
+    });
+
+    return rec;
+  }
+
   controller(): E2EController {
     return {
       ready: Promise.resolve(),
@@ -405,7 +532,8 @@ export class Harness {
       state: () => this.state.state,
       runNext: () => this.runNext(),
       runAll: () => this.runAll(),
-      currentIndex: () => this.state.currentIndex
+      currentIndex: () => this.state.currentIndex,
+      runGraph: (graph, params, options) => this.runGraph(graph, params, options)
     };
   }
 

--- a/web/src/e2e_runner/types.ts
+++ b/web/src/e2e_runner/types.ts
@@ -146,6 +146,25 @@ export interface E2EController {
     params?: Record<string, unknown>,
     options?: AdHocRunOptions
   ) => Promise<RunRecord>;
+  /**
+   * Live snapshot of the in-flight ad-hoc run, for a driver that wants to
+   * capture the canvas at successive stages. `stage` increments on every
+   * status-bearing event (a node starting/finishing, the job settling) so the
+   * driver can screenshot only when the picture actually changed.
+   */
+  snapshot: () => RunSnapshot;
+}
+
+/** A point-in-time view of the current ad-hoc run. */
+export interface RunSnapshot {
+  /** True once the run has settled (completed/failed/error/timeout). */
+  settled: boolean;
+  /** Monotonic counter bumped on each status-bearing event. */
+  stage: number;
+  /** Current run status (running until settled). */
+  status: string;
+  /** Per-node status keyed by node id, for the current frame. */
+  nodeStatus: Record<string, string>;
 }
 
 declare global {

--- a/web/src/e2e_runner/types.ts
+++ b/web/src/e2e_runner/types.ts
@@ -114,6 +114,16 @@ export interface RunRecord {
   expectationFailures: string[];
 }
 
+/** Options for an ad-hoc single-graph run (the debug harness path). */
+export interface AdHocRunOptions {
+  /** Stable id used in the record (defaults to a generated `adhoc-<ts>`). */
+  id?: string;
+  /** Human-readable name shown on the record. */
+  name?: string;
+  /** Override the per-run timeout (ms). */
+  timeoutMs?: number;
+}
+
 /** The controller the harness exposes on `window.__E2E__` for the Playwright driver. */
 export interface E2EController {
   ready: Promise<void>;
@@ -125,6 +135,17 @@ export interface E2EController {
   /** Run every remaining workflow sequentially. */
   runAll: () => Promise<RunRecord[]>;
   currentIndex: () => number;
+  /**
+   * Run a caller-supplied graph (not from the manifest) and resolve with its
+   * record once settled. Renders the graph on the canvas and captures the same
+   * logs / node IO / outputs / events as the suite path — the entry point the
+   * `nodetool debug` harness drives for the browser surface.
+   */
+  runGraph: (
+    graph: { nodes: unknown[]; edges: unknown[] },
+    params?: Record<string, unknown>,
+    options?: AdHocRunOptions
+  ) => Promise<RunRecord>;
 }
 
 declare global {

--- a/web/tests/debug-harness/debug.spec.ts
+++ b/web/tests/debug-harness/debug.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Workflow debug harness spec — the browser surface of `nodetool debug`.
+ *
+ * Loads the e2e_runner harness page in manual mode, runs the caller-supplied
+ * graph through `window.__E2E__.runGraph(...)`, and writes the resulting record,
+ * a canvas screenshot and any browser console errors into NODETOOL_DEBUG_OUT.
+ * The CLI reads those artifacts back to build the browser run report.
+ *
+ * Inputs (env):
+ *   NODETOOL_DEBUG_GRAPH   path to a JSON file: either a bare graph or { graph }.
+ *   NODETOOL_DEBUG_OUT     directory to write record.json / screenshot.png / console-errors.log.
+ *   NODETOOL_DEBUG_PARAMS  optional JSON object of run params.
+ */
+import { test, expect } from "@playwright/test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { RunRecord } from "../../src/e2e_runner/types";
+
+const GRAPH_PATH = process.env.NODETOOL_DEBUG_GRAPH;
+const OUT_DIR = process.env.NODETOOL_DEBUG_OUT;
+const PARAMS_JSON = process.env.NODETOOL_DEBUG_PARAMS;
+
+test("debug harness runs the target workflow", async ({ page }) => {
+  test.setTimeout(5 * 60_000);
+
+  if (!GRAPH_PATH || !OUT_DIR) {
+    test.skip(true, "NODETOOL_DEBUG_GRAPH and NODETOOL_DEBUG_OUT are required");
+    return;
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const raw = JSON.parse(readFileSync(GRAPH_PATH, "utf8")) as {
+    graph?: { nodes: unknown[]; edges: unknown[] };
+    nodes?: unknown[];
+    edges?: unknown[];
+  };
+  const graph = raw.graph ?? { nodes: raw.nodes ?? [], edges: raw.edges ?? [] };
+  const params = PARAMS_JSON ? (JSON.parse(PARAMS_JSON) as Record<string, unknown>) : {};
+
+  // Known noise from the harness page scaffolding (not the workflow under test):
+  // it has no agent WebSocket backend and renders a component that calls
+  // useNavigate outside a Router. Filter these so the report reflects the
+  // workflow, not the test harness.
+  const HARNESS_NOISE = [/\/ws\/agent/, /useNavigate\(\) may be used only/];
+  const isWorkflowError = (text: string) => !HARNESS_NOISE.some((re) => re.test(text));
+
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && isWorkflowError(msg.text())) consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => {
+    if (isWorkflowError(String(err))) consoleErrors.push(String(err));
+  });
+
+  await page.goto("/e2e-runner.html?manual=1");
+  await page.waitForFunction(() => Boolean(window.__E2E__), undefined, {
+    timeout: 90_000
+  });
+
+  let record: RunRecord;
+  try {
+    record = (await page.evaluate(
+      ([g, p]) =>
+        window.__E2E__!.runGraph(
+          g as { nodes: unknown[]; edges: unknown[] },
+          p as Record<string, unknown>
+        ),
+      [graph, params] as const
+    )) as RunRecord;
+  } catch (err) {
+    // Surface the failure as an error record rather than failing the spec — the
+    // CLI wants the artifacts regardless of how the run ended.
+    record = {
+      id: "adhoc",
+      name: "ad-hoc graph",
+      file: "",
+      status: "error",
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      params,
+      jobId: null,
+      error: err instanceof Error ? err.message : String(err),
+      outputs: [],
+      logs: [],
+      artifacts: [],
+      nodeIO: {},
+      events: [],
+      counts: { nodes: 0, outputs: 0, errors: 0, edgeUpdates: 0 },
+      expectationFailures: []
+    };
+  }
+
+  // Let the canvas settle on the finished graph before capturing.
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: resolve(OUT_DIR, "screenshot.png") });
+
+  writeFileSync(resolve(OUT_DIR, "record.json"), JSON.stringify(record, null, 2));
+  if (consoleErrors.length > 0) {
+    writeFileSync(resolve(OUT_DIR, "console-errors.log"), consoleErrors.join("\n"));
+  }
+
+  expect(record, "harness returned a record").toBeTruthy();
+});

--- a/web/tests/debug-harness/debug.spec.ts
+++ b/web/tests/debug-harness/debug.spec.ts
@@ -1,34 +1,82 @@
 /**
  * Workflow debug harness spec — the browser surface of `nodetool debug`.
  *
- * Loads the e2e_runner harness page in manual mode, runs the caller-supplied
- * graph through `window.__E2E__.runGraph(...)`, and writes the resulting record,
- * a canvas screenshot and any browser console errors into NODETOOL_DEBUG_OUT.
- * The CLI reads those artifacts back to build the browser run report.
+ * Loads the e2e_runner harness page in manual mode, kicks off the caller-supplied
+ * graph via `window.__E2E__.runGraph(...)` WITHOUT awaiting it, then polls
+ * `window.__E2E__.snapshot()` and captures a canvas screenshot at every stage of
+ * the run (initial render → each node starting/finishing → settled). The record,
+ * the staged screenshots, a final screenshot and any browser console errors are
+ * written into NODETOOL_DEBUG_OUT for the CLI to read back.
  *
  * Inputs (env):
  *   NODETOOL_DEBUG_GRAPH   path to a JSON file: either a bare graph or { graph }.
- *   NODETOOL_DEBUG_OUT     directory to write record.json / screenshot.png / console-errors.log.
+ *   NODETOOL_DEBUG_OUT     directory to write record.json / screenshot.png / stages/.
  *   NODETOOL_DEBUG_PARAMS  optional JSON object of run params.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type { RunRecord } from "../../src/e2e_runner/types";
+import type { RunRecord, RunSnapshot } from "../../src/e2e_runner/types";
 
 const GRAPH_PATH = process.env.NODETOOL_DEBUG_GRAPH;
 const OUT_DIR = process.env.NODETOOL_DEBUG_OUT;
 const PARAMS_JSON = process.env.NODETOOL_DEBUG_PARAMS;
 
+const POLL_MS = 120;
+/** Don't snap more often than this even if stages tick fast. */
+const MIN_INTERVAL_MS = 180;
+/** Cap the number of intermediate stage frames (excludes the final). */
+const MAX_STAGES = 16;
+const MAX_WAIT_MS = 5 * 60_000;
+
+interface StageShot {
+  index: number;
+  stage: number;
+  status: string;
+  /** Path relative to OUT_DIR. */
+  file: string;
+}
+
+/** Run the graph while capturing a screenshot at each new stage. */
+async function captureStages(page: Page, stagesDir: string): Promise<StageShot[]> {
+  const shots: StageShot[] = [];
+  let lastStage = -1;
+  let lastShotAt = 0;
+  const deadline = Date.now() + MAX_WAIT_MS;
+
+  const snap = async (): Promise<StageShot | null> => {
+    const s = (await page.evaluate(() => window.__E2E__!.snapshot())) as RunSnapshot;
+    const due = s.stage !== lastStage && Date.now() - lastShotAt >= MIN_INTERVAL_MS;
+    if (due && shots.length < MAX_STAGES) {
+      lastStage = s.stage;
+      lastShotAt = Date.now();
+      const index = shots.length;
+      const file = `stages/${String(index).padStart(2, "0")}-${s.status}.png`;
+      await page.screenshot({ path: resolve(stagesDir, "..", file) });
+      shots.push({ index, stage: s.stage, status: s.status, file });
+    }
+    return s.settled ? ({ index: -1, stage: s.stage, status: s.status, file: "" }) : null;
+  };
+
+  // Let the canvas paint the initial graph before the first frame.
+  await page.waitForTimeout(300);
+  while (Date.now() < deadline) {
+    const settled = await snap();
+    if (settled) break;
+    await page.waitForTimeout(POLL_MS);
+  }
+  return shots;
+}
+
 test("debug harness runs the target workflow", async ({ page }) => {
-  test.setTimeout(5 * 60_000);
+  test.setTimeout(MAX_WAIT_MS + 30_000);
 
   if (!GRAPH_PATH || !OUT_DIR) {
     test.skip(true, "NODETOOL_DEBUG_GRAPH and NODETOOL_DEBUG_OUT are required");
     return;
   }
 
-  mkdirSync(OUT_DIR, { recursive: true });
+  mkdirSync(resolve(OUT_DIR, "stages"), { recursive: true });
   const raw = JSON.parse(readFileSync(GRAPH_PATH, "utf8")) as {
     graph?: { nodes: unknown[]; edges: unknown[] };
     nodes?: unknown[];
@@ -58,14 +106,24 @@ test("debug harness runs the target workflow", async ({ page }) => {
   });
 
   let record: RunRecord;
+  let stages: StageShot[] = [];
   try {
-    record = (await page.evaluate(
-      ([g, p]) =>
-        window.__E2E__!.runGraph(
-          g as { nodes: unknown[]; edges: unknown[] },
-          p as Record<string, unknown>
-        ),
+    // Start the run but DON'T await it here, so we can screenshot mid-flight.
+    await page.evaluate(
+      ([g, p]) => {
+        (window as unknown as { __DEBUG_RUN__?: Promise<RunRecord> }).__DEBUG_RUN__ =
+          window.__E2E__!.runGraph(
+            g as { nodes: unknown[]; edges: unknown[] },
+            p as Record<string, unknown>
+          );
+      },
       [graph, params] as const
+    );
+
+    stages = await captureStages(page, resolve(OUT_DIR, "stages"));
+
+    record = (await page.evaluate(
+      () => (window as unknown as { __DEBUG_RUN__: Promise<RunRecord> }).__DEBUG_RUN__
     )) as RunRecord;
   } catch (err) {
     // Surface the failure as an error record rather than failing the spec — the
@@ -91,11 +149,12 @@ test("debug harness runs the target workflow", async ({ page }) => {
     };
   }
 
-  // Let the canvas settle on the finished graph before capturing.
+  // Final settled frame (canonical screenshot.png).
   await page.waitForTimeout(400);
   await page.screenshot({ path: resolve(OUT_DIR, "screenshot.png") });
 
   writeFileSync(resolve(OUT_DIR, "record.json"), JSON.stringify(record, null, 2));
+  writeFileSync(resolve(OUT_DIR, "stages.json"), JSON.stringify(stages, null, 2));
   if (consoleErrors.length > 0) {
     writeFileSync(resolve(OUT_DIR, "console-errors.log"), consoleErrors.join("\n"));
   }

--- a/web/tests/debug-harness/debug.spec.ts
+++ b/web/tests/debug-harness/debug.spec.ts
@@ -21,6 +21,9 @@ import type { RunRecord, RunSnapshot } from "../../src/e2e_runner/types";
 const GRAPH_PATH = process.env.NODETOOL_DEBUG_GRAPH;
 const OUT_DIR = process.env.NODETOOL_DEBUG_OUT;
 const PARAMS_JSON = process.env.NODETOOL_DEBUG_PARAMS;
+/** Opt-in: capture a screenshot at every run stage (expensive). */
+const CAPTURE_STAGES =
+  process.env.NODETOOL_DEBUG_STAGES === "1" || process.env.NODETOOL_DEBUG_STAGES === "true";
 
 const POLL_MS = 120;
 /** Don't snap more often than this even if stages tick fast. */
@@ -76,7 +79,7 @@ test("debug harness runs the target workflow", async ({ page }) => {
     return;
   }
 
-  mkdirSync(resolve(OUT_DIR, "stages"), { recursive: true });
+  mkdirSync(CAPTURE_STAGES ? resolve(OUT_DIR, "stages") : OUT_DIR, { recursive: true });
   const raw = JSON.parse(readFileSync(GRAPH_PATH, "utf8")) as {
     graph?: { nodes: unknown[]; edges: unknown[] };
     nodes?: unknown[];
@@ -108,23 +111,33 @@ test("debug harness runs the target workflow", async ({ page }) => {
   let record: RunRecord;
   let stages: StageShot[] = [];
   try {
-    // Start the run but DON'T await it here, so we can screenshot mid-flight.
-    await page.evaluate(
-      ([g, p]) => {
-        (window as unknown as { __DEBUG_RUN__?: Promise<RunRecord> }).__DEBUG_RUN__ =
+    if (CAPTURE_STAGES) {
+      // Start the run but DON'T await it here, so we can screenshot mid-flight.
+      await page.evaluate(
+        ([g, p]) => {
+          (window as unknown as { __DEBUG_RUN__?: Promise<RunRecord> }).__DEBUG_RUN__ =
+            window.__E2E__!.runGraph(
+              g as { nodes: unknown[]; edges: unknown[] },
+              p as Record<string, unknown>
+            );
+        },
+        [graph, params] as const
+      );
+      stages = await captureStages(page, resolve(OUT_DIR, "stages"));
+      record = (await page.evaluate(
+        () => (window as unknown as { __DEBUG_RUN__: Promise<RunRecord> }).__DEBUG_RUN__
+      )) as RunRecord;
+    } else {
+      // Cheap default: run to completion, capture only the final frame below.
+      record = (await page.evaluate(
+        ([g, p]) =>
           window.__E2E__!.runGraph(
             g as { nodes: unknown[]; edges: unknown[] },
             p as Record<string, unknown>
-          );
-      },
-      [graph, params] as const
-    );
-
-    stages = await captureStages(page, resolve(OUT_DIR, "stages"));
-
-    record = (await page.evaluate(
-      () => (window as unknown as { __DEBUG_RUN__: Promise<RunRecord> }).__DEBUG_RUN__
-    )) as RunRecord;
+          ),
+        [graph, params] as const
+      )) as RunRecord;
+    }
   } catch (err) {
     // Surface the failure as an error record rather than failing the spec — the
     // CLI wants the artifacts regardless of how the run ended.
@@ -154,7 +167,9 @@ test("debug harness runs the target workflow", async ({ page }) => {
   await page.screenshot({ path: resolve(OUT_DIR, "screenshot.png") });
 
   writeFileSync(resolve(OUT_DIR, "record.json"), JSON.stringify(record, null, 2));
-  writeFileSync(resolve(OUT_DIR, "stages.json"), JSON.stringify(stages, null, 2));
+  if (CAPTURE_STAGES) {
+    writeFileSync(resolve(OUT_DIR, "stages.json"), JSON.stringify(stages, null, 2));
+  }
   if (consoleErrors.length > 0) {
     writeFileSync(resolve(OUT_DIR, "console-errors.log"), consoleErrors.join("\n"));
   }


### PR DESCRIPTION
## Summary

Adds `nodetool debug` — a comprehensive workflow debugging tool that runs a workflow end-to-end on both a headless server (kernel `WorkflowRunner`) and optionally in a real browser (Playwright), then collects a self-contained debug bundle with workflow JSON, all processing messages, logs, outputs, errors, OpenTelemetry traces, browser console errors, and screenshots.

## Key Changes

### CLI Command & Orchestration
- **`packages/cli/src/commands/debug.ts`**: New `debug` command with options for `--server`, `--browser`, `--trace`, `--stages`, `--params`, `--out`, `--timeout`, and `--json` output
- **`packages/cli/src/debug/harness.ts`**: Main orchestrator that resolves workflow targets, runs both surfaces, and writes the debug bundle to disk
- **`packages/cli/src/debug/index.ts`**: Public exports for the debug harness

### Server Surface (Headless Execution)
- **`packages/cli/src/debug/server-runner.ts`**: Runs workflows through the kernel `WorkflowRunner` with full node registry, Python bridge, and LLM providers; captures all processing messages and OpenTelemetry spans
- **`packages/cli/src/debug/trace.ts`**: Parses JSONL trace files and summarizes spans by name, token usage, and cost

### Browser Surface (Real Browser Execution)
- **`web/tests/debug-harness/debug.spec.ts`**: Playwright spec that drives the e2e_runner harness page, polls `window.__E2E__.snapshot()`, and captures canvas screenshots at each run stage
- **`web/playwright.debug-harness.config.ts`**: Dedicated Playwright config for the debug harness (reuses hermetic backend from e2e-runner)
- **`packages/cli/src/debug/browser-runner.ts`**: Spawns Playwright, folds the resulting `RunRecord` + console errors + screenshots into a `BrowserRunReport`

### Message Collection & Reporting
- **`packages/cli/src/debug/collector.ts`**: Pure reducer that folds processing-message streams (from both server and browser) into `ExecutionSummary`; includes `previewValue()` to safely truncate long strings, base64 blobs, and arrays for JSON reports
- **`packages/cli/src/debug/verdict.ts`**: Cross-surface triage that builds a `DebugVerdict` (pass/fail + ordered issues) from server and browser reports
- **`packages/cli/src/debug/markdown.ts`**: Renders `DebugReport` as human-readable Markdown (report.md in the bundle)

### Workflow Target Resolution
- **`packages/cli/src/debug/target.ts`**: Resolves workflow targets (DB id, JSON file, or TypeScript DSL) into normalized runner-shape graphs, mirroring the `workflows run` command's resolution logic

### Type Definitions
- **`packages/cli/src/debug/types.ts`**: Comprehensive types for `DebugGraph`, `ExecutionSummary`, `NodeDebug`, `EdgeDebug`, `LlmCallDebug`, `BrowserRunReport`, `ServerRunReport`, `DebugReport`, `DebugVerdict`, and `TraceSummary`

### Harness Page Updates
- **`web/src/e2e_runner/harness.ts`**: Added ad-hoc graph support (`adHocGraph`, `adHocNonce`, `stage` fields) and `runGraph()` method for debug runs; extracted `reduceRecordEvent()` and `finalizeCounts()` as shared reducers for both manifest-driven and ad-hoc paths
- **`web/src/e2e_runner/types.ts`**: Added `AdHocRunOptions` interface and `runGraph()` method signature to `E2EController`
- **`web/src/e2e_runner/E2ERunnerApp.tsx`**: Added `adHocNonce` dependency to canvas re-render effect

### Agent Tool Integration
- **`packages/agents/src/tools/m

https://claude.ai/code/session_011NV9311eTvdCcA79M8Ybu5