### PR TITLE
Fix duplicate BORDER_RADIUS key breaking web typecheck

### DIFF
--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -103,8 +103,7 @@ jest.mock("../../ui_primitives", () => ({
     <button data-testid={`toggle-option-${value}`} {...props}>
       {children}
     </button>
-  ),
-  BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS
+  )
 }));
 
 jest.mock("@mui/material/styles", () => ({


### PR DESCRIPTION
## Summary
The `ui_primitives` mock in `MasksExtractorBody.test.tsx` declared `BORDER_RADIUS` twice in the same object literal, which `tsc` flags as `TS1117` and broke `npm run typecheck` for the web package. Removed the redundant second declaration (the first one at the top of the mock is kept).

## Verification
- `npm run typecheck` now passes for web, electron, and mobile.
- `eslint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)