### PR TITLE
Timeline: audio-overlap track placement, drag-reorder tracks, horizontal scroll + playhead zoom

### DIFF
--- a/web/src/components/timeline/Tracks/TimelineScrollbar.tsx
+++ b/web/src/components/timeline/Tracks/TimelineScrollbar.tsx
@@ -1,0 +1,206 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * TimelineScrollbar
+ *
+ * An always-visible horizontal scrollbar for the tracks area, CapCut-style:
+ * a slim trough spanning the lanes with a draggable thumb whose size reflects
+ * the visible fraction of the timeline. macOS overlay scrollbars hide
+ * themselves, so this gives a persistent, mouse-friendly way to pan sideways.
+ *
+ * The DOM scroll position is the source of truth: dragging the thumb (or
+ * clicking the trough) calls `onScrollTo`, which sets the lanes' scrollLeft;
+ * that fires the lanes' onScroll, which updates `scrollLeftPx` and re-renders
+ * the thumb. The thumb just visualizes and drives that one value.
+ */
+
+import React, { memo, useCallback, useRef } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { BORDER_RADIUS, MOTION } from "../../ui_primitives";
+
+export const TIMELINE_SCROLLBAR_HEIGHT_PX = 14;
+const MIN_THUMB_PX = 28;
+const TROUGH_HEIGHT_PX = 8;
+
+export interface ScrollThumb {
+  /** Width of the thumb in px. */
+  thumbWidth: number;
+  /** Left offset of the thumb within the trough, in px. */
+  thumbLeft: number;
+  /** Max scrollLeft (content − viewport), clamped to ≥ 0. */
+  maxScroll: number;
+  /** Distance the thumb can travel (trackWidth − thumbWidth). */
+  thumbTravel: number;
+  /** Whether there is anything to scroll. */
+  scrollable: boolean;
+}
+
+/**
+ * Pure geometry for the scrollbar thumb. `trackWidth` is the trough's pixel
+ * width (equal to the viewport width by construction).
+ */
+export function computeScrollThumb(
+  contentWidthPx: number,
+  viewportWidthPx: number,
+  scrollLeftPx: number,
+  trackWidth: number
+): ScrollThumb {
+  const maxScroll = Math.max(0, contentWidthPx - viewportWidthPx);
+  const scrollable = maxScroll > 0 && viewportWidthPx > 0 && trackWidth > 0;
+  if (!scrollable) {
+    return {
+      thumbWidth: Math.max(0, trackWidth),
+      thumbLeft: 0,
+      maxScroll: 0,
+      thumbTravel: 0,
+      scrollable: false
+    };
+  }
+  const ratio = Math.min(1, viewportWidthPx / contentWidthPx);
+  const thumbWidth = Math.max(MIN_THUMB_PX, Math.round(trackWidth * ratio));
+  const thumbTravel = Math.max(0, trackWidth - thumbWidth);
+  const clampedScroll = Math.min(maxScroll, Math.max(0, scrollLeftPx));
+  const thumbLeft =
+    thumbTravel > 0 ? (clampedScroll / maxScroll) * thumbTravel : 0;
+  return { thumbWidth, thumbLeft, maxScroll, thumbTravel, scrollable };
+}
+
+const containerStyles = (theme: Theme) =>
+  css({
+    height: TIMELINE_SCROLLBAR_HEIGHT_PX,
+    flexShrink: 0,
+    display: "flex",
+    alignItems: "center",
+    borderTop: `1px solid ${theme.vars.palette.divider}`,
+    backgroundColor: theme.vars.palette.background.paper,
+    userSelect: "none"
+  });
+
+const troughStyles = css({
+  position: "relative",
+  flex: "1 1 auto",
+  height: TROUGH_HEIGHT_PX,
+  marginRight: 6,
+  minWidth: 0
+});
+
+const thumbStyles = (theme: Theme, scrollable: boolean) =>
+  css({
+    position: "absolute",
+    top: 0,
+    height: TROUGH_HEIGHT_PX,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: theme.vars.palette.action.disabled,
+    cursor: scrollable ? "grab" : "default",
+    transition: `background-color ${MOTION.fast}`,
+    "&:hover": scrollable
+      ? { backgroundColor: theme.vars.palette.text.secondary }
+      : undefined,
+    "&:active": scrollable
+      ? { cursor: "grabbing", backgroundColor: theme.vars.palette.text.primary }
+      : undefined
+  });
+
+export interface TimelineScrollbarProps {
+  /** Total scrollable content width at the current zoom (px). */
+  contentWidthPx: number;
+  /** Visible viewport width of the lanes area (px). */
+  viewportWidthPx: number;
+  /** Current horizontal scroll offset (px). */
+  scrollLeftPx: number;
+  /** Left inset so the bar lines up with the lanes (track-header width). */
+  leftInsetPx: number;
+  /** Scroll the lanes to an absolute offset; the caller clamps via the DOM. */
+  onScrollTo: (px: number) => void;
+}
+
+export const TimelineScrollbar: React.FC<TimelineScrollbarProps> = memo(
+  ({ contentWidthPx, viewportWidthPx, scrollLeftPx, leftInsetPx, onScrollTo }) => {
+    const theme = useTheme();
+    const troughRef = useRef<HTMLDivElement>(null);
+    const dragRef = useRef<{ startX: number; startScroll: number } | null>(null);
+
+    const { thumbWidth, thumbLeft, maxScroll, thumbTravel, scrollable } =
+      computeScrollThumb(
+        contentWidthPx,
+        viewportWidthPx,
+        scrollLeftPx,
+        viewportWidthPx
+      );
+
+    const handleThumbPointerDown = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!scrollable) return;
+        e.preventDefault();
+        e.stopPropagation();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        dragRef.current = { startX: e.clientX, startScroll: scrollLeftPx };
+      },
+      [scrollable, scrollLeftPx]
+    );
+
+    const handleThumbPointerMove = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        const drag = dragRef.current;
+        if (!drag || thumbTravel <= 0) return;
+        const deltaPx = e.clientX - drag.startX;
+        const next = drag.startScroll + (deltaPx / thumbTravel) * maxScroll;
+        onScrollTo(Math.min(maxScroll, Math.max(0, next)));
+      },
+      [thumbTravel, maxScroll, onScrollTo]
+    );
+
+    const handleThumbPointerUp = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        dragRef.current = null;
+        e.currentTarget.releasePointerCapture?.(e.pointerId);
+      },
+      []
+    );
+
+    // Click on the trough → jump so the thumb centers on the pointer.
+    const handleTroughPointerDown = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!scrollable || !troughRef.current || thumbTravel <= 0) return;
+        const rect = troughRef.current.getBoundingClientRect();
+        const targetLeft = e.clientX - rect.left - thumbWidth / 2;
+        const next = (targetLeft / thumbTravel) * maxScroll;
+        onScrollTo(Math.min(maxScroll, Math.max(0, next)));
+      },
+      [scrollable, thumbWidth, thumbTravel, maxScroll, onScrollTo]
+    );
+
+    return (
+      <div
+        css={containerStyles(theme)}
+        style={{ paddingLeft: leftInsetPx }}
+        data-testid="timeline-scrollbar"
+      >
+        <div
+          ref={troughRef}
+          css={troughStyles}
+          onPointerDown={handleTroughPointerDown}
+        >
+          <div
+            css={thumbStyles(theme, scrollable)}
+            style={{ width: thumbWidth, left: thumbLeft }}
+            onPointerDown={handleThumbPointerDown}
+            onPointerMove={handleThumbPointerMove}
+            onPointerUp={handleThumbPointerUp}
+            onPointerCancel={handleThumbPointerUp}
+            role="scrollbar"
+            aria-orientation="horizontal"
+            aria-label="Scroll timeline horizontally"
+            aria-valuemin={0}
+            aria-valuemax={Math.round(maxScroll)}
+            aria-valuenow={Math.round(Math.min(maxScroll, Math.max(0, scrollLeftPx)))}
+            data-testid="timeline-scrollbar-thumb"
+          />
+        </div>
+      </div>
+    );
+  }
+);
+
+TimelineScrollbar.displayName = "TimelineScrollbar";

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -20,6 +20,7 @@ import VolumeOffOutlinedIcon from "@mui/icons-material/VolumeOffOutlined";
 import VolumeUpOutlinedIcon from "@mui/icons-material/VolumeUpOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import GraphicEqOutlinedIcon from "@mui/icons-material/GraphicEqOutlined";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import {
@@ -27,7 +28,14 @@ import {
   useTimelineStoreApi,
   timelineTemporalOf
 } from "../../../stores/timeline/TimelineStore";
-import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import {
+  useTimelineUIStore,
+  useTimelineUIStoreApi
+} from "../../../stores/timeline/TimelineUIStore";
+import {
+  computeReorderedTrackIds,
+  type TrackDropPosition
+} from "./trackReorder";
 import { Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT } from "../../ui_primitives";
 import {
   DEFAULT_TRACK_HEIGHT_PX as SHARED_DEFAULT_TRACK_HEIGHT_PX,
@@ -42,6 +50,12 @@ import ConfirmDialog from "../../dialogs/ConfirmDialog";
 // ── Constants ──────────────────────────────────────────────────────────────
 
 export const TRACK_HEADER_WIDTH_PX = 192;
+/**
+ * Private drag MIME for track-reorder drags. Distinct from the asset-drop
+ * types ("asset" / "selectedAssetIds") so the lane/empty-area asset-drop
+ * handlers never react to a track being reordered.
+ */
+export const TRACK_DRAG_MIME = "application/x-nodetool-timeline-track";
 const MIN_TRACK_HEIGHT_PX = 48;
 const MAX_TRACK_HEIGHT_PX = 300;
 const DEFAULT_TRACK_HEIGHT_PX = SHARED_DEFAULT_TRACK_HEIGHT_PX;
@@ -72,6 +86,42 @@ const topRowStyles = css({
   gap: 8,
   minWidth: 0
 });
+
+const dragHandleStyles = (theme: Theme) =>
+  css({
+    flexShrink: 0,
+    width: 16,
+    marginLeft: -6,
+    marginRight: -2,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    cursor: "grab",
+    color: theme.vars.palette.text.disabled,
+    transition: `color ${MOTION.fast}`,
+    "&:hover": {
+      color: theme.vars.palette.text.secondary
+    },
+    "&:active": {
+      cursor: "grabbing"
+    },
+    "& svg": {
+      fontSize: 16
+    }
+  });
+
+/** Horizontal insertion line shown at the top or bottom edge during a drag. */
+const dropIndicatorStyles = (theme: Theme, edge: TrackDropPosition) =>
+  css({
+    position: "absolute",
+    left: 0,
+    right: 0,
+    [edge === "before" ? "top" : "bottom"]: 0,
+    height: 2,
+    backgroundColor: theme.vars.palette.primary.main,
+    zIndex: 3,
+    pointerEvents: "none"
+  });
 
 const typeGlyphStyles = (theme: Theme, accent: string) =>
   css({
@@ -212,6 +262,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
   const setTrackHeight = useTimelineStore((s) => s.setTrackHeight);
   const setTrackName = useTimelineStore((s) => s.setTrackName);
   const removeTrack = useTimelineStore((s) => s.removeTrack);
+  const reorderTracks = useTimelineStore((s) => s.reorderTracks);
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
   const meta = trackTypeMeta(track.type);
@@ -333,14 +384,122 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
     toggleExpandedFx(track.id);
   }, [toggleExpandedFx, track.id]);
 
+  // ── Drag-reorder ──────────────────────────────────────────────────────────
+  //
+  // The grip is the HTML5 drag source; the whole header is the drop target.
+  // Reordering is constrained to same-type tracks (see trackReorder). The drop
+  // target / indicator state lives in the UI store so sibling headers can show
+  // the insertion line; the per-header selector returns the edge only for the
+  // hovered row, so other headers don't re-render on every dragover.
+
+  const headerRef = useRef<HTMLDivElement>(null);
+  const uiStoreApi = useTimelineUIStoreApi();
+  const beginTrackDrag = useTimelineUIStore((s) => s.beginTrackDrag);
+  const setTrackDropTarget = useTimelineUIStore((s) => s.setTrackDropTarget);
+  const endTrackDrag = useTimelineUIStore((s) => s.endTrackDrag);
+  const dropEdge = useTimelineUIStore((s) =>
+    s.trackDropTarget?.trackId === track.id ? s.trackDropTarget.position : null
+  );
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData(TRACK_DRAG_MIME, track.id);
+      if (headerRef.current) {
+        e.dataTransfer.setDragImage(headerRef.current, 12, 12);
+      }
+      beginTrackDrag(track.id);
+    },
+    [beginTrackDrag, track.id]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    endTrackDrag();
+  }, [endTrackDrag]);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      const draggingId = uiStoreApi.getState().draggingTrackId;
+      if (!draggingId || draggingId === track.id) {
+        return;
+      }
+      const dragged = timelineStoreApi
+        .getState()
+        .tracks.find((t) => t.id === draggingId);
+      // Only accept same-type drops; a cross-type hover shows no indicator.
+      if (!dragged || dragged.type !== track.type) {
+        if (uiStoreApi.getState().trackDropTarget?.trackId === track.id) {
+          setTrackDropTarget(null);
+        }
+        return;
+      }
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = e.currentTarget.getBoundingClientRect();
+      const position: TrackDropPosition =
+        e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+      const current = uiStoreApi.getState().trackDropTarget;
+      if (current?.trackId !== track.id || current.position !== position) {
+        setTrackDropTarget({ trackId: track.id, position });
+      }
+    },
+    [uiStoreApi, timelineStoreApi, setTrackDropTarget, track.id, track.type]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      const draggingId = uiStoreApi.getState().draggingTrackId;
+      const position = uiStoreApi.getState().trackDropTarget?.position;
+      endTrackDrag();
+      if (!draggingId || !position) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      const ordered = computeReorderedTrackIds(
+        timelineStoreApi.getState().tracks,
+        draggingId,
+        track.id,
+        position
+      );
+      if (ordered) {
+        reorderTracks(ordered);
+      }
+    },
+    [uiStoreApi, timelineStoreApi, endTrackDrag, reorderTracks, track.id]
+  );
+
   return (
     <>
     <div
+      ref={headerRef}
       css={headerStyles(theme, heightPx)}
       data-testid={`track-header-${track.id}`}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
     >
-      {/* Top row: type glyph · name · index chip */}
+      {dropEdge && (
+        <div
+          css={dropIndicatorStyles(theme, dropEdge)}
+          data-testid={`track-drop-indicator-${track.id}-${dropEdge}`}
+          aria-hidden
+        />
+      )}
+      {/* Top row: drag handle · type glyph · name · index chip */}
       <div css={topRowStyles}>
+        <div
+          css={dragHandleStyles(theme)}
+          draggable
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          aria-label={`Reorder ${track.name}`}
+          role="button"
+          tabIndex={-1}
+          title="Drag to reorder track"
+          data-testid={`track-drag-handle-${track.id}`}
+        >
+          <DragIndicatorIcon />
+        </div>
         <div
           css={typeGlyphStyles(theme, accent)}
           aria-hidden

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -61,6 +61,10 @@ import { TimeRuler } from "./TimeRuler";
 import { Playhead } from "./Playhead";
 import { AddTrackButton } from "./AddTrackButton";
 import { ScriptToggleButton } from "./ScriptToggleButton";
+import {
+  TimelineScrollbar,
+  TIMELINE_SCROLLBAR_HEIGHT_PX
+} from "./TimelineScrollbar";
 import { TrackEffectsPanel } from "./TrackEffectsPanel";
 import {
   ScriptLane,
@@ -154,7 +158,11 @@ const headerColumnStyles = (theme: Theme) =>
 const scrollableAreaStyles = css({
   flex: "1 1 auto",
   overflowX: "auto",
-  overflowY: "hidden",
+  // Vertical scrolling lives here (not on the outer row) so the horizontal
+  // scrollbar stays pinned to the bottom of the visible viewport instead of
+  // sliding off-screen below a tall track stack. The header column's scrollTop
+  // is synced to this element so headers track the lanes vertically.
+  overflowY: "auto",
   position: "relative",
   // Keep an over-scrolled horizontal swipe from triggering the browser's
   // back/forward navigation (the wheel handler also preventDefaults).
@@ -178,7 +186,20 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const theme = useTheme();
 
     const tracks = useTimelineStore((s) => s.tracks);
-    const durationMs = useTimelineStore((s) => s.durationMs);
+    // Content extent for sizing the ruler / scroll width. The stored
+    // `durationMs` is not recomputed when clips are added or moved, so it can
+    // lag far behind the actual clips (it stays 0 for a freshly built
+    // timeline). Derive the real end from the clips so the scroll width — and
+    // thus the scrollbar — tracks zoom and content. The selector returns a
+    // single number, so this only re-renders when the max end changes.
+    const contentEndMs = useTimelineStore((s) => {
+      let maxEnd = s.durationMs;
+      for (const c of s.clips) {
+        const end = c.startMs + c.durationMs;
+        if (end > maxEnd) maxEnd = end;
+      }
+      return maxEnd;
+    });
     const hasScript = useHasScript();
 
     const msPerPx = useTimelineUIStore((s) => s.msPerPx);
@@ -207,6 +228,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const importVideoWithAudio = useVideoAudioImport();
 
     const scrollableRef = useRef<HTMLDivElement>(null);
+    const headerColumnRef = useRef<HTMLDivElement>(null);
 
     // ── Drop on empty area: auto-create a track of matching type ───────────
 
@@ -272,22 +294,37 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       ]
     );
 
-    // Total scrollable width = max of durationMs or visible area
+    // Total scrollable width from the real content extent, with a trailing pad
+    // so the last clip isn't flush against the edge.
     const totalWidthPx = Math.max(
-      durationMs / msPerPx + 200,
+      contentEndMs / msPerPx + 200,
       1000
     );
 
-    // Track area height minus toolbar + ruler
+    // Track area height minus toolbar + ruler + bottom scrollbar
     const TOOLBAR_HEIGHT = 36;
     const RULER_HEIGHT = 28;
-    const lanesHeight = Math.max(0, heightPx - TOOLBAR_HEIGHT - RULER_HEIGHT);
+    const lanesHeight = Math.max(
+      0,
+      heightPx - TOOLBAR_HEIGHT - RULER_HEIGHT - TIMELINE_SCROLLBAR_HEIGHT_PX
+    );
+
+    const scrollToLeft = useCallback((px: number) => {
+      if (scrollableRef.current) {
+        scrollableRef.current.scrollLeft = px;
+      }
+    }, []);
 
     // ── Scroll sync ────────────────────────────────────────────────────────
 
     const handleScroll = useCallback(
       (e: React.UIEvent<HTMLDivElement>) => {
         setScrollLeftPx(e.currentTarget.scrollLeft);
+        // Keep the header column vertically aligned with the lanes (the column
+        // clips its own overflow and is scrolled programmatically from here).
+        if (headerColumnRef.current) {
+          headerColumnRef.current.scrollTop = e.currentTarget.scrollTop;
+        }
       },
       [setScrollLeftPx]
     );
@@ -310,6 +347,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const zoomAnchorRef = useRef<{ timeMs: number; cursorPx: number } | null>(
       null
     );
+    // Previous scale, so a zoom from the buttons/slider (no cursor anchor) can
+    // keep the playhead pinned to the same viewport x as the lanes rescale.
+    const prevMsPerPxRef = useRef(msPerPx);
 
     useEffect(() => {
       const el = scrollableRef.current;
@@ -357,13 +397,51 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       return () => el.removeEventListener("wheel", onWheel);
     }, [msPerPx, setZoom]);
 
+    // The header column clips its overflow, so a wheel over it would otherwise
+    // do nothing. Forward a vertical wheel to the lanes scroller (whose onScroll
+    // syncs the column back), matching the pre-split behavior where the whole
+    // row scrolled together.
+    useEffect(() => {
+      const header = headerColumnRef.current;
+      if (!header) return;
+      const onWheel = (e: WheelEvent) => {
+        if (e.ctrlKey || e.metaKey) return;
+        const lanes = scrollableRef.current;
+        if (!lanes) return;
+        const max = Math.max(0, lanes.scrollHeight - lanes.clientHeight);
+        if (max <= 0) return;
+        e.preventDefault();
+        lanes.scrollTop = Math.min(
+          max,
+          Math.max(0, lanes.scrollTop + e.deltaY)
+        );
+      };
+      header.addEventListener("wheel", onWheel, { passive: false });
+      return () => header.removeEventListener("wheel", onWheel);
+    }, []);
+
     useLayoutEffect(() => {
       const el = scrollableRef.current;
+      const prevMsPerPx = prevMsPerPxRef.current;
+      prevMsPerPxRef.current = msPerPx;
+      if (!el) return;
+
+      // Ctrl+wheel set an explicit cursor anchor — keep that timeline point
+      // under the pointer.
       const anchor = zoomAnchorRef.current;
-      if (!el || !anchor) return;
-      zoomAnchorRef.current = null;
-      el.scrollLeft = Math.max(0, anchor.timeMs / msPerPx - anchor.cursorPx);
-    }, [msPerPx]);
+      if (anchor) {
+        zoomAnchorRef.current = null;
+        el.scrollLeft = Math.max(0, anchor.timeMs / msPerPx - anchor.cursorPx);
+        return;
+      }
+
+      // Otherwise this is a button/slider zoom: keep the playhead at the same
+      // viewport x while the lanes rescale ("zoom into the playhead").
+      if (prevMsPerPx === msPerPx) return;
+      const playMs = playbackStore.getState().currentTimeMs;
+      const playheadViewportPx = playMs / prevMsPerPx - el.scrollLeft;
+      el.scrollLeft = Math.max(0, playMs / msPerPx - playheadViewportPx);
+    }, [msPerPx, playbackStore]);
 
     // ── Keyboard shortcuts ─────────────────────────────────────────────────
     //
@@ -591,8 +669,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         <FlexRow
           sx={{
             height: lanesHeight,
-            overflowY: "auto",
-            overflowX: "hidden",
+            overflow: "hidden",
             alignItems: "flex-start"
           }}
           fullWidth
@@ -600,8 +677,13 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           onDragOver={handleEmptyAreaDragOver}
           onDrop={handleEmptyAreaDrop}
         >
-          {/* Header column */}
-          <div css={headerColumnStyles(theme)}>
+          {/* Header column — clips vertically; scrolled in sync with the lanes
+              via handleScroll so headers line up with their lanes. */}
+          <div
+            ref={headerColumnRef}
+            css={headerColumnStyles(theme)}
+            style={{ height: lanesHeight }}
+          >
             {tracks.map((track) => (
               <React.Fragment key={track.id}>
                 {hasScript && track.id === scriptBeforeTrackId && (
@@ -623,6 +705,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           <div
             ref={scrollableRef}
             css={scrollableAreaStyles}
+            style={{ height: lanesHeight }}
             onScroll={handleScroll}
             data-testid="tracks-scroll-area"
           >
@@ -657,6 +740,15 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             </div>
           </div>
         </FlexRow>
+
+        {/* ── Horizontal scrollbar (always visible, CapCut-style) ─────────── */}
+        <TimelineScrollbar
+          contentWidthPx={totalWidthPx}
+          viewportWidthPx={fxPanelWidth}
+          scrollLeftPx={scrollLeftPx}
+          leftInsetPx={TRACK_HEADER_WIDTH_PX}
+          onScrollTo={scrollToLeft}
+        />
 
         {/* Playhead overlay: spans ruler + lanes so the pill sits in the
          *  ruler. Positioned at the TracksRegion level so it isn't clipped

--- a/web/src/components/timeline/Tracks/__tests__/TimelineScrollbar.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/TimelineScrollbar.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "@jest/globals";
+import { computeScrollThumb } from "../TimelineScrollbar";
+
+describe("computeScrollThumb", () => {
+  it("is not scrollable when content fits the viewport", () => {
+    const t = computeScrollThumb(800, 1000, 0, 1000);
+    expect(t.scrollable).toBe(false);
+    expect(t.maxScroll).toBe(0);
+    expect(t.thumbWidth).toBe(1000); // full-width thumb
+    expect(t.thumbLeft).toBe(0);
+  });
+
+  it("sizes the thumb to the visible fraction", () => {
+    // viewport is half the content → thumb is half the track.
+    const t = computeScrollThumb(2000, 1000, 0, 1000);
+    expect(t.scrollable).toBe(true);
+    expect(t.maxScroll).toBe(1000);
+    expect(t.thumbWidth).toBe(500);
+    expect(t.thumbTravel).toBe(500);
+    expect(t.thumbLeft).toBe(0);
+  });
+
+  it("positions the thumb proportionally to scrollLeft", () => {
+    const t = computeScrollThumb(2000, 1000, 500, 1000); // halfway scrolled
+    expect(t.thumbLeft).toBe(250); // half of thumbTravel (500)
+  });
+
+  it("clamps the thumb to the end when scrolled to max", () => {
+    const t = computeScrollThumb(2000, 1000, 999999, 1000);
+    expect(t.thumbLeft).toBe(t.thumbTravel);
+  });
+
+  it("enforces a minimum thumb width for tiny visible fractions", () => {
+    const t = computeScrollThumb(100000, 1000, 0, 1000);
+    expect(t.thumbWidth).toBeGreaterThanOrEqual(28);
+  });
+
+  it("is not scrollable with a zero-width viewport (pre-measure)", () => {
+    const t = computeScrollThumb(2000, 0, 0, 0);
+    expect(t.scrollable).toBe(false);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/TrackHeaderReorder.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TrackHeaderReorder.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * TrackHeader drag-reorder — dragging a track's grip handle onto another
+ * same-type track reorders the tracks via reorderTracks. jsdom reports a
+ * zero-size rect, so the computed drop position is "after"; we assert a move
+ * that is meaningful under that position.
+ *
+ * Setup runs AFTER render: TimelineProvider creates a fresh store instance on
+ * mount and pushes it active, so static getState() only reaches that instance
+ * once the provider is rendered.
+ */
+import React from "react";
+import { describe, it, expect } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { TracksRegion } from "../TracksRegion";
+import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
+import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+
+const renderRegion = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider>
+        <TracksRegion heightPx={400} />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+
+function dataTransferMock(): DataTransfer {
+  return {
+    types: [] as string[],
+    dropEffect: "",
+    effectAllowed: "",
+    setData: () => {},
+    getData: () => "",
+    setDragImage: () => {}
+  } as unknown as DataTransfer;
+}
+
+function videoTrackIds(): string[] {
+  return useTimelineStore
+    .getState()
+    .tracks.filter((t) => t.type === "video")
+    .map((t) => t.id);
+}
+
+describe("TrackHeader drag-reorder", () => {
+  it("moves a video track after another video track on drop", () => {
+    renderRegion();
+    act(() => {
+      const s = useTimelineStore.getState();
+      s.reset();
+      s.addTrack("video", "Video 1");
+      s.addTrack("video", "Video 2");
+      s.addTrack("video", "Video 3");
+    });
+
+    const ids0 = videoTrackIds();
+    expect(ids0.length).toBeGreaterThanOrEqual(3);
+    const [first, , third] = ids0;
+
+    const dt = dataTransferMock();
+    act(() => {
+      fireEvent.dragStart(
+        screen.getByTestId(`track-drag-handle-${first}`),
+        { dataTransfer: dt }
+      );
+      fireEvent.dragOver(screen.getByTestId(`track-header-${third}`), {
+        dataTransfer: dt
+      });
+      fireEvent.drop(screen.getByTestId(`track-header-${third}`), {
+        dataTransfer: dt
+      });
+    });
+
+    // first moved to just after third (position "after" under a zero rect).
+    const ids = videoTrackIds();
+    expect(ids[ids.indexOf(third) + 1]).toBe(first);
+    expect(ids.indexOf(first)).toBeGreaterThan(ids.indexOf(third));
+  });
+
+  it("does not reorder when dropped onto a different track type", () => {
+    renderRegion();
+    act(() => {
+      const s = useTimelineStore.getState();
+      s.reset();
+      s.addTrack("video", "Video A");
+      s.addTrack("audio", "Audio 1");
+    });
+
+    const before = useTimelineStore.getState().tracks.map((t) => t.id);
+    const videoId = useTimelineStore
+      .getState()
+      .tracks.find((t) => t.type === "video")!.id;
+    const audioId = useTimelineStore
+      .getState()
+      .tracks.find((t) => t.type === "audio")!.id;
+
+    const dt = dataTransferMock();
+    act(() => {
+      fireEvent.dragStart(
+        screen.getByTestId(`track-drag-handle-${videoId}`),
+        { dataTransfer: dt }
+      );
+      fireEvent.dragOver(screen.getByTestId(`track-header-${audioId}`), {
+        dataTransfer: dt
+      });
+      fireEvent.drop(screen.getByTestId(`track-header-${audioId}`), {
+        dataTransfer: dt
+      });
+    });
+
+    expect(useTimelineStore.getState().tracks.map((t) => t.id)).toEqual(before);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/trackReorder.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/trackReorder.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "@jest/globals";
+import type { TimelineTrack } from "@nodetool-ai/timeline";
+import { computeReorderedTrackIds } from "../trackReorder";
+
+type T = Pick<TimelineTrack, "id" | "type">;
+
+// V1 V2 V3 (video) then A1 A2 (audio) — the canonical contiguous layout.
+const tracks: T[] = [
+  { id: "v1", type: "video" },
+  { id: "v2", type: "video" },
+  { id: "v3", type: "video" },
+  { id: "a1", type: "audio" },
+  { id: "a2", type: "audio" }
+];
+
+describe("computeReorderedTrackIds", () => {
+  it("moves a video track down within the video block (drop after)", () => {
+    expect(
+      computeReorderedTrackIds(tracks, "v1", "v3", "after")
+    ).toEqual(["v2", "v3", "v1", "a1", "a2"]);
+  });
+
+  it("moves a video track up within the video block (drop before)", () => {
+    expect(
+      computeReorderedTrackIds(tracks, "v3", "v1", "before")
+    ).toEqual(["v3", "v1", "v2", "a1", "a2"]);
+  });
+
+  it("reorders audio tracks among themselves", () => {
+    expect(
+      computeReorderedTrackIds(tracks, "a2", "a1", "before")
+    ).toEqual(["v1", "v2", "v3", "a2", "a1"]);
+  });
+
+  it("rejects cross-type drops (audio onto video)", () => {
+    expect(computeReorderedTrackIds(tracks, "a1", "v2", "after")).toBeNull();
+    expect(computeReorderedTrackIds(tracks, "v1", "a1", "before")).toBeNull();
+  });
+
+  it("returns null when dropping a track onto itself", () => {
+    expect(computeReorderedTrackIds(tracks, "v2", "v2", "before")).toBeNull();
+  });
+
+  it("returns null for no-op moves (order unchanged)", () => {
+    // Dropping v1 before v2 leaves it first — no change.
+    expect(computeReorderedTrackIds(tracks, "v1", "v2", "before")).toBeNull();
+    // Dropping v2 after v1 leaves v2 second — no change.
+    expect(computeReorderedTrackIds(tracks, "v2", "v1", "after")).toBeNull();
+  });
+
+  it("returns null for unknown ids", () => {
+    expect(computeReorderedTrackIds(tracks, "nope", "v1", "after")).toBeNull();
+    expect(computeReorderedTrackIds(tracks, "v1", "nope", "after")).toBeNull();
+  });
+});

--- a/web/src/components/timeline/Tracks/trackReorder.ts
+++ b/web/src/components/timeline/Tracks/trackReorder.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure track-reorder helper, shared by the drag-and-drop UI and its tests.
+ *
+ * Reordering is constrained to within a single track type: a video track can
+ * only be reordered among video tracks, audio among audio. This keeps each
+ * type's block contiguous (so the script lane stays between video and audio)
+ * and keeps the composite z-order coherent — `sceneModel` draws tracks by
+ * ascending `index`, so order is layer order.
+ */
+
+import type { TimelineTrack } from "@nodetool-ai/timeline";
+
+/** Where a dragged track lands relative to the track it is dropped onto. */
+export type TrackDropPosition = "before" | "after";
+
+/**
+ * Compute the full ordered list of track ids after dropping `draggedId`
+ * `position` the `targetId` track.
+ *
+ * Returns `null` when the move is invalid (unknown ids, dropping onto itself,
+ * or a cross-type drop) or a no-op (the resulting order equals the current
+ * one) — callers should skip the reorder in that case so no history entry is
+ * recorded.
+ */
+export function computeReorderedTrackIds(
+  tracks: Pick<TimelineTrack, "id" | "type">[],
+  draggedId: string,
+  targetId: string,
+  position: TrackDropPosition
+): string[] | null {
+  if (draggedId === targetId) {
+    return null;
+  }
+
+  const dragged = tracks.find((t) => t.id === draggedId);
+  const target = tracks.find((t) => t.id === targetId);
+  if (!dragged || !target || dragged.type !== target.type) {
+    return null;
+  }
+
+  const ids = tracks.map((t) => t.id).filter((id) => id !== draggedId);
+  const targetIdx = ids.indexOf(targetId);
+  if (targetIdx === -1) {
+    return null;
+  }
+
+  const insertAt = position === "before" ? targetIdx : targetIdx + 1;
+  ids.splice(insertAt, 0, draggedId);
+
+  const original = tracks.map((t) => t.id);
+  const unchanged =
+    original.length === ids.length &&
+    original.every((id, i) => id === ids[i]);
+  return unchanged ? null : ids;
+}

--- a/web/src/hooks/timeline/useVideoAudioImport.ts
+++ b/web/src/hooks/timeline/useVideoAudioImport.ts
@@ -37,12 +37,18 @@ export async function importVideoWithAudio(
 
   const videoClip = { ...assetToClip(asset, videoTrackId, startMs), linkId };
 
-  // Track existed before import? Used to decide whether to clean it up when
-  // the video turns out to have no audio.
-  const audioTrackPreexisted = store
-    .getState()
-    .tracks.some((t) => t.type === "audio");
-  const audioTrackId = store.getState().getOrCreateAudioTrack();
+  // Place the extracted audio on an audio track that is free at the drop
+  // position. If every existing audio track already has a clip overlapping
+  // this span, a new audio track is created. Remember whether THIS import
+  // created the track so it can be cleaned up if the video has no audio.
+  const trackIdsBefore = new Set(
+    store.getState().tracks.map((t) => t.id)
+  );
+  const audioTrackId = store.getState().getOrCreateAudioTrack({
+    startMs,
+    durationMs: videoClip.durationMs
+  });
+  const createdAudioTrack = !trackIdsBefore.has(audioTrackId);
 
   const audioClip = makeClip({
     trackId: audioTrackId,
@@ -107,7 +113,7 @@ export async function importVideoWithAudio(
       // and it is now empty.
       store.getState().deleteClip(audioClip.id);
       if (
-        !audioTrackPreexisted &&
+        createdAudioTrack &&
         !store.getState().clips.some((c) => c.trackId === audioTrackId)
       ) {
         store.getState().removeTrack(audioTrackId);

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -200,10 +200,20 @@ export interface TimelineStoreState {
   addClips: (clips: TimelineClip[]) => void;
 
   /**
-   * Return the id of the first audio track, creating one named "Audio"
-   * (appended after existing tracks) if none exists.
+   * Return the id of an audio track to drop an audio clip onto, creating one
+   * named "Audio" (appended after existing tracks) when needed.
+   *
+   * Without `range`, returns the first audio track (or creates one).
+   *
+   * With `range` ([startMs, startMs+durationMs)), returns the first audio track
+   * that is free across that span; if every audio track already has a clip
+   * overlapping it (or none exist), a fresh audio track is created so the new
+   * clip never overlaps an existing one.
    */
-  getOrCreateAudioTrack: () => string;
+  getOrCreateAudioTrack: (range?: {
+    startMs: number;
+    durationMs: number;
+  }) => string;
 
   /**
    * Remove the `linkId` from every clip in the acted clip's link group,
@@ -710,11 +720,29 @@ export const createTimelineStore = (
             return { tracks: [...state.tracks, track] };
           }),
 
-        getOrCreateAudioTrack: () => {
-          const existing = get().tracks.find((t) => t.type === "audio");
-          if (existing) {
-            return existing.id;
+        getOrCreateAudioTrack: (range) => {
+          const audioTracks = get().tracks.filter((t) => t.type === "audio");
+
+          // With a range, reuse an audio track only when it has room across the
+          // whole span; otherwise (all spans occupied, or no audio track yet)
+          // fall through and create a fresh one. Without a range, reuse the
+          // first audio track if any exists.
+          const reusable = range
+            ? audioTracks.find((track) => {
+                const endMs = range.startMs + range.durationMs;
+                return !get().clips.some(
+                  (c) =>
+                    c.trackId === track.id &&
+                    c.startMs < endMs &&
+                    c.startMs + c.durationMs > range.startMs
+                );
+              })
+            : audioTracks[0];
+
+          if (reusable) {
+            return reusable.id;
           }
+
           const track = makeTrack({
             type: "audio",
             name: "Audio",

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -54,6 +54,15 @@ export interface TimelineUIState {
    */
   expandedFxTrackId: string | null;
 
+  /** Id of the track currently being drag-reordered, or null. */
+  draggingTrackId: string | null;
+  /**
+   * The drop target during a track drag: which track row the pointer is over
+   * and whether the dragged track would land before or after it. Null when no
+   * valid target is hovered (e.g. over a different-type track).
+   */
+  trackDropTarget: { trackId: string; position: "before" | "after" } | null;
+
   // ── Selection ────────────────────────────────────────────────────────────
 
   /** Replace the selection with a single clip. */
@@ -107,6 +116,17 @@ export interface TimelineUIState {
   setExpandedFxTrackId: (trackId: string | null) => void;
   /** Toggle the inline DSP chain editor for the given track. */
   toggleExpandedFx: (trackId: string) => void;
+
+  // ── Track drag-reorder ─────────────────────────────────────────────────────
+
+  /** Begin dragging a track; clears any stale drop target. */
+  beginTrackDrag: (trackId: string) => void;
+  /** Set (or clear, with null) the current drop target during a track drag. */
+  setTrackDropTarget: (
+    target: { trackId: string; position: "before" | "after" } | null
+  ) => void;
+  /** End a track drag, clearing both the dragged id and the drop target. */
+  endTrackDrag: () => void;
 }
 
 export const MIN_MS_PER_PX = 0.5;
@@ -124,6 +144,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   scrollLeftPx: 0,
   fullscreen: false,
   expandedFxTrackId: null,
+  draggingTrackId: null,
+  trackDropTarget: null,
   selectClip: (id) => set({ selectedClipIds: new Set([id]) }),
 
   addToSelection: (id) =>
@@ -184,7 +206,14 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
     set((state) => ({
       expandedFxTrackId:
         state.expandedFxTrackId === trackId ? null : trackId
-    }))
+    })),
+
+  beginTrackDrag: (trackId) =>
+    set({ draggingTrackId: trackId, trackDropTarget: null }),
+
+  setTrackDropTarget: (target) => set({ trackDropTarget: target }),
+
+  endTrackDrag: () => set({ draggingTrackId: null, trackDropTarget: null })
   }));
 
 // Context-bound hooks are defined against the active instance in the instance

--- a/web/src/stores/timeline/__tests__/TimelineStore.linking.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.linking.test.ts
@@ -49,6 +49,73 @@ describe("getOrCreateAudioTrack", () => {
     expect(store.getState().getOrCreateAudioTrack()).toBe(existingId);
     expect(store.getState().tracks.filter((t) => t.type === "audio")).toHaveLength(1);
   });
+
+  it("reuses the audio track when the drop range is free", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("audio", "Audio 1");
+    const existingId = store.getState().tracks[0].id;
+    // A clip exists, but well after the requested range — no overlap.
+    store.getState().addClips([
+      makeClip({
+        trackId: existingId,
+        mediaType: "audio",
+        startMs: 10_000,
+        durationMs: 2000
+      })
+    ]);
+    expect(
+      store.getState().getOrCreateAudioTrack({ startMs: 0, durationMs: 5000 })
+    ).toBe(existingId);
+    expect(
+      store.getState().tracks.filter((t) => t.type === "audio")
+    ).toHaveLength(1);
+  });
+
+  it("creates a new audio track when the drop range overlaps an existing clip", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("audio", "Audio 1");
+    const existingId = store.getState().tracks[0].id;
+    store.getState().addClips([
+      makeClip({
+        trackId: existingId,
+        mediaType: "audio",
+        startMs: 0,
+        durationMs: 5000
+      })
+    ]);
+    // Requested range [3000, 8000) overlaps the existing [0, 5000) clip.
+    const id = store
+      .getState()
+      .getOrCreateAudioTrack({ startMs: 3000, durationMs: 5000 });
+    expect(id).not.toBe(existingId);
+    const track = store.getState().tracks.find((t) => t.id === id);
+    expect(track?.type).toBe("audio");
+    expect(
+      store.getState().tracks.filter((t) => t.type === "audio")
+    ).toHaveLength(2);
+  });
+
+  it("reuses a later free audio track instead of creating one", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("audio", "Audio 1");
+    store.getState().addTrack("audio", "Audio 2");
+    const [first, second] = store.getState().tracks;
+    // First track is occupied across the range; second is free.
+    store.getState().addClips([
+      makeClip({
+        trackId: first.id,
+        mediaType: "audio",
+        startMs: 0,
+        durationMs: 5000
+      })
+    ]);
+    expect(
+      store.getState().getOrCreateAudioTrack({ startMs: 1000, durationMs: 3000 })
+    ).toBe(second.id);
+    expect(
+      store.getState().tracks.filter((t) => t.type === "audio")
+    ).toHaveLength(2);
+  });
 });
 
 describe("linked move/trim/delete/unlink", () => {


### PR DESCRIPTION
## Summary

Timeline editor improvements across track placement, reordering, and horizontal navigation.

### Audio-overlap track placement
- Importing a video places its extracted audio on an audio track that is **free across the drop span**; if every audio track already overlaps that span (or none exist), a new audio track is created. `getOrCreateAudioTrack` now takes an optional range; no-arg behavior unchanged.

### Drag-and-drop track reordering
- Grip handle on each track header (HTML5 drag) reorders tracks, with a blue insertion line showing the drop position.
- Constrained to the **same track type** (video↔video, audio↔audio) so the video/script/audio layout and composite z-order stay coherent. No-op drops are skipped to avoid empty undo entries. Reorder math is a pure, unit-tested helper.

### Horizontal scrolling + playhead-anchored zoom
- **Pinned scrollbar**: vertical scroll moved inside the lanes container (header `scrollTop` synced) so the horizontal scrollbar no longer slides off-screen below a tall track stack.
- **Always-visible scrollbar** (`TimelineScrollbar`): CapCut-style draggable thumb + click-to-jump trough (macOS overlay scrollbars hide themselves). Thumb geometry is a pure, unit-tested helper.
- **"Nothing to scroll at any zoom" fix**: scroll width was derived from stored `durationMs`, which is never recomputed on clip add/move (defaults to 0) so it floored to a constant. Now derived from actual clip ends — also fixes the under-sized time ruler.
- **Zoom buttons/slider anchor on the playhead** (keep it at the same viewport x while rescaling), matching the Ctrl+wheel cursor anchor.

## Testing
- `npm run typecheck`, `npm run lint`, and the timeline test suites pass (57 Tracks tests, 315 timeline tests overall).
- New unit tests: `trackReorder`, `TrackHeaderReorder`, `TimelineScrollbar` (thumb geometry), plus audio-overlap track-selection cases.

## Notes / follow-ups
- Pre-existing typecheck error on `main` in `MasksExtractorBody.test.tsx` (duplicate object key) is unrelated to this branch.
- Deeper follow-up: stored `durationMs` lagging clip content is a latent bug — the proper fix is to recompute it on clip mutations in the store. This PR fixes the view-layer width that was broken without touching persistence/playback-end semantics.
- Track reorder uses native HTML5 DnD (not keyboard-accessible); the pure helper is in place if we later add keyboard reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)