### PR TITLE
Refactor WorkflowListItem: defer open, add keyboard support

### DIFF
--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -110,6 +110,7 @@ export default {
     "tests/e2e/",
     "tests/e2e-runner/",
     "tests/benchmarks/",
+    "tests/debug-harness/",
     "tests/subgraph-e2e.spec.ts",
     // Shared helpers living inside __tests__ dirs — not suites themselves.
     "/__tests__/testUtils\\.tsx$"

--- a/web/src/components/workflows/WorkflowListItem.tsx
+++ b/web/src/components/workflows/WorkflowListItem.tsx
@@ -10,7 +10,12 @@ import { useIsWorkflowFavorite, useFavoriteWorkflowActions } from "../../stores/
 import { relativeTime } from "../../utils/formatDateAndTime";
 import StarIcon from "@mui/icons-material/Star";
 import { TOOLTIP_ENTER_DELAY, TOOLTIP_ENTER_NEXT_DELAY } from "../../config/constants";
-import { FavoriteButton, EditButton, EditorButton, FlexColumn, FlexRow, Text, Tooltip, Checkbox, Box, BORDER_RADIUS } from "../ui_primitives";
+import { FavoriteButton, FlexColumn, FlexRow, Text, Tooltip, Checkbox, Box, BORDER_RADIUS, SPACING } from "../ui_primitives";
+
+// Single-click on the row opens the workflow. Double-clicking the name renames
+// it inline instead, so the open is deferred briefly to let a following
+// double-click cancel it.
+const OPEN_CLICK_DELAY_MS = 200;
 
 interface WorkflowListItemProps {
   workflow: Workflow;
@@ -50,6 +55,16 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
 
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelPendingOpen = useCallback(() => {
+    if (openTimerRef.current !== null) {
+      clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => cancelPendingOpen(), [cancelPendingOpen]);
 
   const handleToggleFavorite = useCallback(
     (_isFavorite: boolean) => {
@@ -58,31 +73,41 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
     [toggleFavorite, workflow.id]
   );
 
-  const handleEdit = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      onEdit(workflow);
-    },
-    [onEdit, workflow]
-  );
+  const handleRowClick = useCallback(() => {
+    if (isEditing) {
+      return;
+    }
+    if (showCheckboxes) {
+      onSelect(workflow);
+      return;
+    }
+    // Defer so a double-click on the name can cancel this and rename instead.
+    cancelPendingOpen();
+    openTimerRef.current = setTimeout(() => {
+      openTimerRef.current = null;
+      onOpenWorkflow(workflow);
+    }, OPEN_CLICK_DELAY_MS);
+  }, [isEditing, showCheckboxes, onSelect, onOpenWorkflow, cancelPendingOpen, workflow]);
 
-  const handleOpen = useCallback(
-    (e: React.MouseEvent) => {
+  const handleRowKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (isEditing || (e.key !== "Enter" && e.key !== " ")) {
+        return;
+      }
       e.preventDefault();
-      e.stopPropagation();
       onOpenWorkflow(workflow);
     },
-    [onOpenWorkflow, workflow]
+    [isEditing, onOpenWorkflow, workflow]
   );
 
   const handleNameDoubleClick = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
+      cancelPendingOpen();
       setIsEditing(true);
     },
-    []
+    [cancelPendingOpen]
   );
 
   const handleNameChange = useCallback(
@@ -116,6 +141,7 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
   const handleCheckboxClick = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      e.stopPropagation();
       onSelect(workflow);
     },
     [onSelect, workflow]
@@ -238,6 +264,11 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
         (isCurrent ? " current" : "") +
         (isFavorite ? " favorite" : "")
       }
+      role="button"
+      tabIndex={0}
+      aria-label={`Open workflow ${workflow.name}`}
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
       onContextMenu={handleContextMenu}
     >
       {showCheckboxes && (
@@ -283,33 +314,6 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
           </Text>
         )}
         <Box className="actions">
-          <EditorButton
-            className="open-button"
-            variant="contained"
-            onClick={handleOpen}
-            title="Open workflow"
-            density="compact"
-            sx={{
-              padding: "3px 10px",
-              minWidth: "unset",
-              fontSize: "var(--fontSizeSmall)",
-              fontWeight: 600,
-              textTransform: "none",
-              lineHeight: 1.4,
-              borderRadius: BORDER_RADIUS.xs,
-              boxShadow: "none",
-              backgroundColor: "action.selected",
-              border: "1px solid",
-              borderColor: "divider",
-              color: "text.primary",
-              "&:hover": {
-                boxShadow: "none",
-                backgroundColor: "action.hover"
-              }
-            }}
-          >
-            OPEN
-          </EditorButton>
           <FavoriteButton
             isFavorite={isFavorite}
             onToggle={handleToggleFavorite}
@@ -317,15 +321,7 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
             removeTooltip="Remove from favorites"
             buttonSize="small"
             className="favorite-button"
-            stopPropagation={false}
-          />
-          <EditButton
-            onClick={handleEdit}
-            tooltip="Edit workflow settings"
-            buttonSize="small"
-            className="edit-button"
-            nodrag={false}
-            sx={{ padding: "4px" }}
+            stopPropagation
           />
         </Box>
       </Box>
@@ -357,7 +353,7 @@ const WorkflowListItem: React.FC<WorkflowListItemProps> = ({
           sx: {
             maxWidth: "none",
             minWidth: 360,
-            padding: "12px",
+            padding: SPACING.lg,
             "& .MuiTooltip-tooltip": {
               maxWidth: "none"
             }


### PR DESCRIPTION
## Summary
Refactored `WorkflowListItem` to improve interaction patterns: single-click now opens workflows with a 200ms delay to allow double-click-to-rename to cancel it, added keyboard navigation support (Enter/Space), and removed dedicated "Open" and "Edit" buttons in favor of row-level interactions.

## Key Changes
- **Deferred open on click**: Introduced `OPEN_CLICK_DELAY_MS` constant and timer management to defer workflow opening, allowing double-click on the name to cancel and enter edit mode instead
- **Keyboard support**: Added `handleRowKeyDown` to support Enter and Space keys for opening workflows, with proper `role="button"` and `tabIndex={0}` attributes for accessibility
- **Simplified row interactions**: Converted the row container to a clickable element with `onClick` and `onKeyDown` handlers; `handleRowClick` now handles both selection (when checkboxes shown) and opening
- **Removed action buttons**: Deleted the dedicated "OPEN" button (`EditorButton`) and "Edit" button (`EditButton`) from the actions area, consolidating interactions to the row itself
- **Improved event handling**: 
  - Added `e.stopPropagation()` to checkbox click to prevent row click
  - Updated `handleNameDoubleClick` to cancel pending open timer
  - Changed `FavoriteButton` `stopPropagation` from `false` to `true` to prevent row interaction
- **Cleanup on unmount**: Added `useEffect` to cancel any pending open timer when component unmounts
- **Design token usage**: Replaced hardcoded `"12px"` padding with `SPACING.lg` constant
- **Removed unused imports**: Cleaned up `EditButton` and `EditorButton` from imports

## Implementation Details
- Timer ref (`openTimerRef`) is managed via `useCallback` with proper cleanup to prevent memory leaks
- Row click behavior is context-aware: skips if editing, selects if checkboxes shown, otherwise defers open
- Keyboard handler validates key type before processing to avoid unintended triggers
- Accessibility attributes (`role`, `tabIndex`, `aria-label`) added to make row keyboard-navigable

https://claude.ai/code/session_015ebn73NTM5qjPa2gfLMR5T