### PR TITLE
Fix node header title clipping at rounded corners

### DIFF
--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -122,7 +122,10 @@ const styles = (theme: Theme) =>
         {
           height: "fit-content !important"
         },
-      // header — keep full hit target; stack above NodeOutputs' right column (z-index 3)
+      // header — keep full hit target; stack above NodeOutputs' right column (z-index 3).
+      // Pad the title clear of the node's rounded top corners (radius
+      // `--rounded-node`); with padding:0 the flush-left title was clipped at the
+      // top-left where the corner curve cuts into the glyphs.
       ".node-header": {
         position: "relative",
         zIndex: 4,
@@ -131,7 +134,7 @@ const styles = (theme: Theme) =>
         top: 0,
         left: 0,
         margin: 0,
-        padding: 0,
+        padding: "3px 8px 0",
         border: 0
       },
       "& .react-flow__resize-control.handle.bottom.right": {


### PR DESCRIPTION
## Summary
Fixes visual clipping of the node header title text at the top-left corner where the node's rounded border curve intersects with flush-left text.

## Changes
- Added padding (`3px 8px 0`) to `.node-header` to clear the title text from the node's rounded top corners (radius `--rounded-node`)
- Updated the comment to explain the padding rationale: with `padding: 0`, the flush-left title was clipped where the corner curve cuts into the glyphs

## Details
The node header previously had `padding: 0`, which caused the title text to be positioned flush against the left edge. Since the node container has rounded corners defined by the `--rounded-node` CSS variable, the corner curve would clip into the leftmost characters of the title. The new padding (`3px 8px 0`) provides vertical clearance at the top and horizontal clearance on the left while maintaining the visual hierarchy and alignment with the node's design.

https://claude.ai/code/session_01VWZgXrK2pMWTbZzMvjHsKL