### PR TITLE
Suppress text selection during marquee node selection

### DIFF
--- a/web/src/hooks/handlers/__tests__/useSelectionEvents.test.ts
+++ b/web/src/hooks/handlers/__tests__/useSelectionEvents.test.ts
@@ -38,6 +38,7 @@ describe("useSelectionEvents", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    document.body.classList.remove("is-marquee-selecting");
     mockReactFlowInstance.getNodes = jest.fn().mockReturnValue([]);
     mockReactFlowInstance.getEdges = jest.fn().mockReturnValue([]);
     mockedUseContextMenu.mockReturnValue({
@@ -143,6 +144,28 @@ describe("useSelectionEvents", () => {
       expect(result.current.selectionEndRef.current).toEqual({ x: 100, y: 200 });
       expect(mockOnSelectionStart).toHaveBeenCalledWith(mockEvent);
     });
+
+    it("adds the marquee-selecting class to suppress text selection", () => {
+      const { result } = renderHook(() =>
+        useSelectionEvents({
+          reactFlowInstance: mockReactFlowInstance,
+          onSelectionStartBase: mockOnSelectionStart,
+          onSelectionEndBase: mockOnSelectionEnd,
+          onSelectionDragStartBase: mockOnSelectionDragStart,
+          onSelectionDragStopBase: mockOnSelectionDragStop,
+          setSuppressNodeDrivenEdgeSelection: mockSetSuppressNodeDrivenEdgeSelection
+        })
+      );
+
+      result.current.handleSelectionStart({
+        clientX: 150,
+        clientY: 200
+      } as unknown as ReactMouseEvent);
+
+      expect(
+        document.body.classList.contains("is-marquee-selecting")
+      ).toBe(true);
+    });
   });
 
   describe("handleSelectionEnd", () => {
@@ -167,6 +190,30 @@ describe("useSelectionEvents", () => {
 
       expect(mockScreenToFlowPosition).toHaveBeenCalledWith({ x: 250, y: 300 });
       expect(mockOnSelectionEnd).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it("removes the marquee-selecting class to restore text selection", () => {
+      document.body.classList.add("is-marquee-selecting");
+
+      const { result } = renderHook(() =>
+        useSelectionEvents({
+          reactFlowInstance: mockReactFlowInstance,
+          onSelectionStartBase: mockOnSelectionStart,
+          onSelectionEndBase: mockOnSelectionEnd,
+          onSelectionDragStartBase: mockOnSelectionDragStart,
+          onSelectionDragStopBase: mockOnSelectionDragStop,
+          setSuppressNodeDrivenEdgeSelection: mockSetSuppressNodeDrivenEdgeSelection
+        })
+      );
+
+      result.current.handleSelectionEnd({
+        clientX: 250,
+        clientY: 300
+      } as unknown as ReactMouseEvent);
+
+      expect(
+        document.body.classList.contains("is-marquee-selecting")
+      ).toBe(false);
     });
 
     it("selects edges inside the marquee rectangle", () => {

--- a/web/src/hooks/handlers/useSelectionEvents.ts
+++ b/web/src/hooks/handlers/useSelectionEvents.ts
@@ -160,6 +160,10 @@ export function useSelectionEvents({
 
   const handleSelectionStart = useCallback(
     (event: ReactMouseEvent) => {
+      // Suppress native browser text selection while box-selecting nodes.
+      // The marquee drag starts on the pane and extends over nodes, which
+      // otherwise highlights their text. Cleared in handleSelectionEnd.
+      document.body.classList.add("is-marquee-selecting");
       const flowPoint = projectMouseEventToFlow(event);
       selectionStartRef.current = flowPoint;
       selectionEndRef.current = flowPoint;
@@ -170,6 +174,7 @@ export function useSelectionEvents({
 
   const handleSelectionEnd = useCallback(
     (event: ReactMouseEvent) => {
+      document.body.classList.remove("is-marquee-selecting");
       onSelectionEndBase(event);
       selectionEndRef.current = projectMouseEventToFlow(event);
       const includeMarqueeEdges = event.shiftKey;

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -55,6 +55,15 @@ ul li {
   pointer-events: none;
 }
 
+/* Suppress native text selection while box-selecting nodes (Shift+drag).
+   The class is toggled on <body> by useSelectionEvents for the duration of
+   the marquee gesture, so normal text selection/copy stays available
+   otherwise. */
+body.is-marquee-selecting .react-flow {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 /* Pane */
 .react-flow__pane.selection {
   cursor: default;


### PR DESCRIPTION
## Summary
Prevents unwanted text selection when performing box-select (marquee) operations on nodes by toggling a CSS class that disables `user-select` during the drag gesture.

## Changes
- **useSelectionEvents.ts**: Added `is-marquee-selecting` class toggling
  - `handleSelectionStart`: Adds class to `document.body` when marquee drag begins
  - `handleSelectionEnd`: Removes class when marquee drag completes
  
- **base.css**: Added CSS rule to suppress text selection
  - New rule: `body.is-marquee-selecting .react-flow { user-select: none; -webkit-user-select: none; }`
  - Scoped to `.react-flow` to avoid affecting other UI elements
  
- **useSelectionEvents.test.ts**: Added test coverage
  - Test verifies class is added on `handleSelectionStart`
  - Test verifies class is removed on `handleSelectionEnd`
  - Added cleanup in `beforeEach` to remove class between tests

## Implementation Details
The solution uses a temporary CSS class rather than inline styles to keep the marquee selection logic isolated from styling concerns. The class is only active during the drag gesture, so normal text selection and copy functionality remain available otherwise. The implementation is scoped to the `.react-flow` container to avoid unintended side effects on other page elements.

https://claude.ai/code/session_01XR1LTBfUfz75DootPbfH1e