### PR TITLE
test(web): fix type-incorrect addTerminal calls breaking typecheck

### DIFF
--- a/web/src/stores/__tests__/ResultsStore.actions.test.ts
+++ b/web/src/stores/__tests__/ResultsStore.actions.test.ts
@@ -1,8 +1,16 @@
 import useResultsStore from "../ResultsStore";
+import type { TerminalUpdate } from "../ApiTypes";
 
 const WF = "wf-1";
 const JOB = "job-1";
 const NODE = "node-1";
+
+const term = (overrides: Partial<TerminalUpdate> = {}): TerminalUpdate => ({
+  type: "terminal_update",
+  node_id: NODE,
+  content: "",
+  ...overrides
+});
 
 const resetStore = () =>
   useResultsStore.setState({
@@ -149,8 +157,8 @@ describe("ResultsStore — chunks", () => {
 describe("ResultsStore — terminal", () => {
   it("addTerminal appends content", () => {
     const s = useResultsStore.getState();
-    s.addTerminal(WF, JOB, NODE, { content: "line1\n", cols: 80, rows: 24 });
-    s.addTerminal(WF, JOB, NODE, { content: "line2\n" });
+    s.addTerminal(WF, JOB, NODE, term({ content: "line1\n", cols: 80, rows: 24 }));
+    s.addTerminal(WF, JOB, NODE, term({ content: "line2\n" }));
     const t = useResultsStore.getState().getTerminal(WF, JOB, NODE);
     expect(t?.buffer).toBe("line1\nline2\n");
     expect(t?.version).toBe(0);
@@ -158,15 +166,15 @@ describe("ResultsStore — terminal", () => {
 
   it("addTerminal with reset replaces buffer and bumps version", () => {
     const s = useResultsStore.getState();
-    s.addTerminal(WF, JOB, NODE, { content: "old" });
-    s.addTerminal(WF, JOB, NODE, { content: "new-snapshot", reset: true });
+    s.addTerminal(WF, JOB, NODE, term({ content: "old" }));
+    s.addTerminal(WF, JOB, NODE, term({ content: "new-snapshot", reset: true }));
     const t = useResultsStore.getState().getTerminal(WF, JOB, NODE);
     expect(t?.buffer).toBe("new-snapshot");
     expect(t?.version).toBe(1);
   });
 
   it("addTerminal uses default cols/rows when not provided", () => {
-    useResultsStore.getState().addTerminal(WF, JOB, NODE, { content: "x" });
+    useResultsStore.getState().addTerminal(WF, JOB, NODE, term({ content: "x" }));
     const t = useResultsStore.getState().getTerminal(WF, JOB, NODE);
     expect(t?.cols).toBe(80);
     expect(t?.rows).toBe(24);


### PR DESCRIPTION
## Problem

Main's **Test** workflow has been red: the *Run TypeScript type check* step in the Quality Gate fails with 5 errors:

```
src/stores/__tests__/ResultsStore.actions.test.ts(152,34): error TS2345:
  Argument of type '{ content: string; cols: number; rows: number; }' is not
  assignable to parameter of type 'TerminalUpdate'.
  Type '...' is missing the following properties from type 'TerminalUpdate': type, node_id
```

## Root cause

`ResultsStore.addTerminal` takes a full `TerminalUpdate` message, whose `type: "terminal_update"` and `node_id` fields are required. The terminal tests in `ResultsStore.actions.test.ts` (added in #3795) call it with partial objects like `{ content: "x" }`. This was a **merge-skew failure** — #3795 was green in isolation but the combined main tree fails to typecheck.

The sibling file `ResultsStore.terminal.test.ts` already builds valid messages via a typed helper; this PR applies the same pattern.

## Fix

Add a typed `term()` helper that fills in `type`/`node_id`, and route the five `addTerminal` calls through it. Test-only change.

## Verification

- `npx tsc --noEmit` (web): **0 errors** (was 5)
- `ResultsStore.actions.test.ts`: **24/24 pass**
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)