### PR TITLE
feat(runtime): centrally log the exact request on provider failures

### DIFF
--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -515,10 +515,12 @@ export class AnthropicProvider extends BaseProvider {
 
     log.debug("Anthropic request", { model: args.model });
 
-    const stream = await this.getClient().messages.create({
+    const streamRequest = {
       ...(request as unknown as MessageStreamParams),
-      stream: true
-    });
+      stream: true as const
+    };
+    this.recordRequestPayload(streamRequest);
+    const stream = await this.getClient().messages.create(streamRequest);
 
     let streamInputTokens = 0;
     let streamOutputTokens = 0;
@@ -699,6 +701,7 @@ export class AnthropicProvider extends BaseProvider {
 
     log.debug("Anthropic request", { model: args.model });
 
+    this.recordRequestPayload(request);
     const response = await this.getClient().messages.create(
       request as unknown as MessageCreateParamsNonStreaming
     );

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -33,11 +33,14 @@ import { getTracer } from "../telemetry.js";
 import {
   withUsageCapture,
   setLastUsage,
+  setLastRequest,
   consumeLastUsage,
   peekLastUsage,
+  peekLastRequest,
   createUsageSlot,
   type LlmUsage
 } from "../tracing-helpers.js";
+import { logProviderRequestFailure } from "./provider-request-log.js";
 import type { Span } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { createLogger, getAssetFilePath } from "@nodetool-ai/config";
@@ -163,6 +166,17 @@ export abstract class BaseProvider {
 
   protected emitMessage(msg: unknown): void {
     if (this._emitMessage) this._emitMessage(msg);
+  }
+
+  /**
+   * Record the exact payload this provider is about to send to the upstream
+   * API. Call this right before the network request in `generateMessage` /
+   * `generateMessages`. On failure, the traced wrappers log precisely what was
+   * sent (secrets redacted, large fields truncated). Safe to call even outside
+   * a traced call — it is a no-op when no capture slot is active.
+   */
+  protected recordRequestPayload(payload: unknown): void {
+    setLastRequest(payload);
   }
 
   protected constructor(provider: ProviderId) {
@@ -393,17 +407,30 @@ export abstract class BaseProvider {
     let result: Message | undefined;
     let error: string | undefined;
     let usage: LlmUsage | null = null;
+    let requestPayload: unknown = null;
     try {
       // withUsageCapture creates a per-call AsyncLocalStorage slot so
       // trackUsage() in the provider hands its numbers back to us.
       result = await withUsageCapture(async () => {
-        const r = await doCall();
-        usage = consumeLastUsage();
-        return r;
+        try {
+          const r = await doCall();
+          usage = consumeLastUsage();
+          return r;
+        } finally {
+          // Read the recorded wire payload while still inside the capture slot.
+          requestPayload = peekLastRequest();
+        }
       });
       return result;
     } catch (err) {
       error = String(err);
+      logProviderRequestFailure({
+        provider: this.provider,
+        model: args.model,
+        request: requestPayload,
+        nodetoolArgs: { model: args.model, messages: args.messages, tools: args.tools },
+        error: err
+      });
       throw err;
     } finally {
       this.emitMessage({
@@ -481,7 +508,7 @@ export abstract class BaseProvider {
 
     // Per-call usage slot survives across the generator's yields by wrapping
     // each `next()` call in `runInSlot`.
-    const { runInSlot, getUsage } = createUsageSlot();
+    const { runInSlot, getUsage, getRequest } = createUsageSlot();
     const tracer = getTracer();
     const source = tracer
       ? this._tracedStream(args, tracer)
@@ -516,6 +543,17 @@ export abstract class BaseProvider {
       });
     } catch (err) {
       error = String(err);
+      logProviderRequestFailure({
+        provider: this.provider,
+        model: args.model,
+        request: getRequest(),
+        nodetoolArgs: {
+          model: args.model,
+          messages: args.messages,
+          tools: (args as Record<string, unknown>).tools
+        },
+        error: err
+      });
       throw err;
     } finally {
       // If the consumer cancelled early (broke out of for-await, threw, or

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -182,6 +182,13 @@ export class ClaudeAgentProvider extends BaseProvider {
       model: args.model
     });
 
+    this.recordRequestPayload({
+      executable: this.executablePath,
+      args: cliArgs,
+      model: args.model,
+      systemPrompt,
+      prompt
+    });
     const child = this.spawnFn(this.executablePath, cliArgs, {
       env: this.buildEnv(),
       stdio: ["pipe", "pipe", "pipe"]

--- a/packages/runtime/src/providers/codex-provider.ts
+++ b/packages/runtime/src/providers/codex-provider.ts
@@ -383,6 +383,7 @@ export class CodexProvider extends OpenAIProvider {
     const body = this.buildRequestBody(args);
     this.codexLogger.debug("Codex responses request", { model: args.model });
 
+    this.recordRequestPayload(body);
     const res = await fetch(`${CODEX_BACKEND_BASE_URL}/responses`, {
       method: "POST",
       headers: this.buildHeaders(),

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -492,6 +492,7 @@ export class GeminiProvider extends BaseProvider {
     log.debug("Gemini request", { model });
 
     const url = `${GEMINI_API_BASE}/models/${model}:generateContent?key=${this.apiKey}`;
+    this.recordRequestPayload(body);
     const response = await this._fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -563,6 +564,7 @@ export class GeminiProvider extends BaseProvider {
     log.debug("Gemini request", { model });
 
     const url = `${GEMINI_API_BASE}/models/${model}:streamGenerateContent?alt=sse&key=${this.apiKey}`;
+    this.recordRequestPayload(body);
     const response = await this._fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/runtime/src/providers/huggingface-provider.ts
+++ b/packages/runtime/src/providers/huggingface-provider.ts
@@ -316,13 +316,15 @@ export class HuggingFaceProvider extends BaseProvider {
 
     log.debug("HuggingFace chatCompletion", { model: args.model });
 
-    const response = await client.chatCompletion({
+    const requestPayload = {
       model: args.model,
       messages: hfMessages,
       max_tokens: args.maxTokens ?? 4096,
       ...(args.temperature != null ? { temperature: args.temperature } : {}),
       ...(args.topP != null ? { top_p: args.topP } : {})
-    });
+    };
+    this.recordRequestPayload(requestPayload);
+    const response = await client.chatCompletion(requestPayload);
 
     const choice = response?.choices?.[0];
     if (!choice) {
@@ -364,13 +366,15 @@ export class HuggingFaceProvider extends BaseProvider {
 
     log.debug("HuggingFace chatCompletionStream", { model: args.model });
 
-    const stream = client.chatCompletionStream({
+    const requestPayload = {
       model: args.model,
       messages: hfMessages,
       max_tokens: args.maxTokens ?? 4096,
       ...(args.temperature != null ? { temperature: args.temperature } : {}),
       ...(args.topP != null ? { top_p: args.topP } : {})
-    });
+    };
+    this.recordRequestPayload(requestPayload);
+    const stream = client.chatCompletionStream(requestPayload);
 
     for await (const chunk of stream) {
       const choice = chunk?.choices?.[0];

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -451,6 +451,7 @@ export class KieProvider extends BaseProvider {
       request.tool_choice = this.responseToolChoice(args.toolChoice) ?? "auto";
     }
 
+    this.recordRequestPayload(request);
     const response = (await (client.responses.create as unknown as (
       body: Record<string, unknown>,
       options?: { signal?: AbortSignal }
@@ -494,6 +495,7 @@ export class KieProvider extends BaseProvider {
       request.tool_choice = this.responseToolChoice(args.toolChoice) ?? "auto";
     }
 
+    this.recordRequestPayload(request);
     const stream = (await (client.responses.create as unknown as (
       body: Record<string, unknown>,
       options?: { signal?: AbortSignal }

--- a/packages/runtime/src/providers/llama-provider.ts
+++ b/packages/runtime/src/providers/llama-provider.ts
@@ -363,6 +363,7 @@ export class LlamaProvider extends BaseProvider {
       request.tools = this.formatTools(tools);
     }
 
+    this.recordRequestPayload(request);
     const stream = (await this.getClient().chat.completions.create(
       request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
     )) as AsyncIterable<any> & { close?: () => Promise<void> };
@@ -462,6 +463,7 @@ export class LlamaProvider extends BaseProvider {
       request.tools = this.formatTools(tools);
     }
 
+    this.recordRequestPayload(request);
     const completion = await this.getClient().chat.completions.create(
       request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming
     );

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -442,6 +442,7 @@ export class OllamaProvider extends BaseProvider {
 
     log.debug("Ollama request", { model: args.model });
 
+    this.recordRequestPayload(request);
     const response = await this.postJson<{ message?: OllamaChatMessage }>(
       "/api/chat",
       request
@@ -540,6 +541,7 @@ export class OllamaProvider extends BaseProvider {
 
     log.debug("Ollama request", { model: args.model });
 
+    this.recordRequestPayload(request);
     const response = await this._fetch(`${this.apiUrl}/api/chat`, {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -732,6 +732,7 @@ export class OpenAIProvider extends BaseProvider {
 
     log.debug("OpenAI request", { model });
 
+    this.recordRequestPayload(request);
     const stream = (await this.getClient().chat.completions.create(
       request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
     )) as AsyncIterable<any> & { close?: () => Promise<void> };
@@ -872,6 +873,7 @@ export class OpenAIProvider extends BaseProvider {
 
     log.debug("OpenAI request", { model });
 
+    this.recordRequestPayload(request);
     const completion = await this.getClient().chat.completions.create(
       request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming
     );

--- a/packages/runtime/src/providers/provider-request-log.ts
+++ b/packages/runtime/src/providers/provider-request-log.ts
@@ -1,0 +1,184 @@
+/**
+ * Central failure logging for provider calls.
+ *
+ * When an LLM provider call fails (e.g. a 422 Unprocessable Entity), we want a
+ * precise record of what was sent — the actual wire payload, not just the
+ * opaque error. {@link logProviderRequestFailure} is invoked from
+ * `BaseProvider`'s traced wrappers so every provider gets identical, redacted,
+ * size-bounded failure logging from one place.
+ *
+ * Providers feed their exact request body via `recordRequestPayload` (see
+ * `BaseProvider`); when a provider hasn't been instrumented, the wrapper falls
+ * back to logging the NodeTool-level request args.
+ */
+
+import { createLogger, type Logger } from "@nodetool-ai/config";
+
+const log = createLogger("nodetool.runtime.provider.request");
+
+interface SanitizeOptions {
+  /** Strings longer than this are truncated (default 1000). */
+  maxStringLength?: number;
+  /** Arrays longer than this are truncated (default 200). */
+  maxArrayLength?: number;
+  /** Recursion is cut off at this depth (default 12). */
+  maxDepth?: number;
+}
+
+const SANITIZE_DEFAULTS: Required<SanitizeOptions> = {
+  maxStringLength: 1000,
+  maxArrayLength: 200,
+  maxDepth: 12
+};
+
+/**
+ * A key holds a secret when its normalized form (lowercased, separators
+ * stripped) contains a secret marker or exactly names a credential field.
+ * Deliberately conservative so diagnostic fields like `max_tokens` (→
+ * "maxtokens") are never mistaken for the credential field `token`.
+ */
+function isSecretKey(key: string): boolean {
+  const k = key.toLowerCase().replace(/[-_\s]/g, "");
+  if (
+    k.includes("apikey") ||
+    k.includes("secret") ||
+    k.includes("password") ||
+    k.includes("passwd") ||
+    k.includes("authorization")
+  ) {
+    return true;
+  }
+  return SECRET_EXACT.has(k);
+}
+
+const SECRET_EXACT = new Set([
+  "token",
+  "auth",
+  "bearer",
+  "accesstoken",
+  "refreshtoken",
+  "sessiontoken",
+  "idtoken",
+  "privatekey",
+  "credentials"
+]);
+
+function truncateString(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}… [truncated ${s.length} chars total]`;
+}
+
+/**
+ * Deep-clone `value` into a JSON-safe, log-friendly shape: long strings and
+ * arrays are truncated, binary buffers become size markers, secret-bearing
+ * keys are redacted, and circular references are broken. Never throws.
+ */
+export function sanitizeForLog(
+  value: unknown,
+  opts: SanitizeOptions = {}
+): unknown {
+  const o = { ...SANITIZE_DEFAULTS, ...opts };
+  // Tracks the current DFS path (not all visited nodes) so shared-but-acyclic
+  // references aren't falsely flagged as circular.
+  const ancestors = new WeakSet<object>();
+
+  function walk(v: unknown, depth: number): unknown {
+    if (v === null || v === undefined) return v;
+    const t = typeof v;
+    if (t === "string") return truncateString(v as string, o.maxStringLength);
+    if (t === "number" || t === "boolean") return v;
+    if (t === "bigint") return `${(v as bigint).toString()}n`;
+    if (t === "function") {
+      return `[function ${(v as { name?: string }).name || "anonymous"}]`;
+    }
+    if (t === "symbol") return (v as symbol).toString();
+    if (v instanceof ArrayBuffer) return `[binary ${v.byteLength} bytes]`;
+    if (ArrayBuffer.isView(v)) {
+      return `[binary ${(v as ArrayBufferView).byteLength} bytes]`;
+    }
+    if (t === "object") {
+      const obj = v as object;
+      if (ancestors.has(obj)) return "[circular]";
+      if (depth >= o.maxDepth) return "[max depth exceeded]";
+      ancestors.add(obj);
+      try {
+        if (Array.isArray(v)) {
+          const out = v
+            .slice(0, o.maxArrayLength)
+            .map((item) => walk(item, depth + 1));
+          if (v.length > o.maxArrayLength) {
+            out.push(`[${v.length - o.maxArrayLength} more items truncated]`);
+          }
+          return out;
+        }
+        const out: Record<string, unknown> = {};
+        for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+          out[k] = isSecretKey(k) ? "[redacted]" : walk(val, depth + 1);
+        }
+        return out;
+      } finally {
+        ancestors.delete(obj);
+      }
+    }
+    return String(v);
+  }
+
+  return walk(value, 0);
+}
+
+export interface ProviderFailureLog {
+  provider: string;
+  model: string;
+  /** The exact wire payload the provider sent, if it was recorded. */
+  request?: unknown;
+  /** NodeTool-level request args, logged when no wire payload was recorded. */
+  nodetoolArgs?: unknown;
+  error: unknown;
+}
+
+/** Caller cancellations (AbortSignal) are not provider failures — skip them. */
+function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const name = (error as { name?: unknown }).name;
+  if (typeof name === "string" && /abort/i.test(name)) return true;
+  const code = (error as { code?: unknown }).code;
+  return code === 20 || code === "ABORT_ERR";
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const e = error as { status?: unknown; statusCode?: unknown };
+  if (typeof e.status === "number") return e.status;
+  if (typeof e.statusCode === "number") return e.statusCode;
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Log precisely what was sent to a provider when its call fails. Prefers the
+ * recorded wire payload; falls back to the NodeTool-level args. Aborted
+ * requests are skipped. The `logger` arg is for testing — production calls use
+ * the module logger.
+ */
+export function logProviderRequestFailure(
+  params: ProviderFailureLog,
+  logger: Logger = log
+): void {
+  if (isAbortError(params.error)) return;
+
+  const hasWire = params.request !== undefined && params.request !== null;
+  const entry: Record<string, unknown> = {
+    provider: params.provider,
+    model: params.model,
+    requestSource: hasWire ? "wire" : "nodetool-args",
+    error: errorMessage(params.error),
+    request: sanitizeForLog(hasWire ? params.request : params.nodetoolArgs)
+  };
+  const status = httpStatus(params.error);
+  if (status !== undefined) entry.status = status;
+
+  logger.error("Provider request failed", entry);
+}

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -119,17 +119,24 @@ export class PythonProvider extends BaseProvider {
     frequencyPenalty?: number;
   }): Promise<Message> {
     const wireMessages = args.messages.map(serializeMessage);
-    const result = await this._bridge.providerGenerate(
-      this._pythonProviderId,
-      wireMessages,
-      args.model,
-      {
+    const requestPayload = {
+      provider: this._pythonProviderId,
+      messages: wireMessages,
+      model: args.model,
+      options: {
         secrets: this._secrets,
         tools: args.tools,
         max_tokens: args.maxTokens,
         temperature: args.temperature,
         top_p: args.topP
       }
+    };
+    this.recordRequestPayload(requestPayload);
+    const result = await this._bridge.providerGenerate(
+      this._pythonProviderId,
+      wireMessages,
+      args.model,
+      requestPayload.options
     );
     return deserializeMessage(result);
   }
@@ -148,17 +155,24 @@ export class PythonProvider extends BaseProvider {
   }): AsyncGenerator<ProviderStreamItem> {
     const wireMessages = args.messages.map(serializeMessage);
 
-    for await (const chunk of this._bridge.providerStream(
-      this._pythonProviderId,
-      wireMessages,
-      args.model,
-      {
+    const requestPayload = {
+      provider: this._pythonProviderId,
+      messages: wireMessages,
+      model: args.model,
+      options: {
         secrets: this._secrets,
         tools: args.tools,
         max_tokens: args.maxTokens,
         temperature: args.temperature,
         top_p: args.topP
       }
+    };
+    this.recordRequestPayload(requestPayload);
+    for await (const chunk of this._bridge.providerStream(
+      this._pythonProviderId,
+      wireMessages,
+      args.model,
+      requestPayload.options
     )) {
       if (chunk.type === "tool_call") {
         yield {

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -66,22 +66,31 @@ export interface LlmUsage {
 }
 
 /**
- * Per-call usage slot. Providers' `trackUsage` writes into the active slot
- * via {@link setLastUsage}, and the traced wrapper reads it via
- * {@link consumeLastUsage} so it can attach the numbers to its span and
- * `llm_call` event.
+ * Per-call slot carrying the in-flight LLM call's side state: token usage and
+ * the exact request payload sent to the provider.
+ *
+ * Providers' `trackUsage` writes usage via {@link setLastUsage}; providers'
+ * `recordRequestPayload` writes the wire payload via {@link setLastRequest}.
+ * The traced wrapper reads both back ({@link consumeLastUsage},
+ * {@link peekLastRequest}) so it can attach usage to its span and, on failure,
+ * log precisely what was sent.
  *
  * We use AsyncLocalStorage rather than an instance field so concurrent calls
  * on the same provider instance don't clobber each other.
  */
-const usageStore = new AsyncLocalStorage<{ usage: LlmUsage | null }>();
+interface CallSlot {
+  usage: LlmUsage | null;
+  request: unknown;
+}
+const usageStore = new AsyncLocalStorage<CallSlot>();
 
 /**
- * Run `fn` inside a fresh usage slot. `consumeLastUsage()` afterwards returns
- * whatever the deepest `setLastUsage()` call wrote.
+ * Run `fn` inside a fresh per-call slot. `consumeLastUsage()` /
+ * `peekLastRequest()` afterwards return whatever the deepest provider hook
+ * wrote.
  */
 export function withUsageCapture<T>(fn: () => Promise<T>): Promise<T> {
-  return usageStore.run({ usage: null }, fn);
+  return usageStore.run({ usage: null, request: null }, fn);
 }
 
 /** Provider hook: record token usage for the in-flight LLM call. */
@@ -105,6 +114,21 @@ export function peekLastUsage(): LlmUsage | null {
 }
 
 /**
+ * Provider hook: record the exact payload sent to the provider for the
+ * in-flight LLM call. The traced wrapper reads this back via
+ * {@link peekLastRequest} to log precisely what was sent on failure.
+ */
+export function setLastRequest(request: unknown): void {
+  const slot = usageStore.getStore();
+  if (slot) slot.request = request;
+}
+
+/** Read (without clearing) the request payload recorded in this async context. */
+export function peekLastRequest(): unknown {
+  return usageStore.getStore()?.request ?? null;
+}
+
+/**
  * Create a per-call usage slot that survives across async-generator yields.
  *
  * `AsyncLocalStorage.run()` only persists across awaits within its callback,
@@ -115,11 +139,13 @@ export function peekLastUsage(): LlmUsage | null {
 export function createUsageSlot(): {
   runInSlot: <T>(fn: () => Promise<T>) => Promise<T>;
   getUsage: () => LlmUsage | null;
+  getRequest: () => unknown;
 } {
-  const slot: { usage: LlmUsage | null } = { usage: null };
+  const slot: CallSlot = { usage: null, request: null };
   return {
     runInSlot: <T>(fn: () => Promise<T>) => usageStore.run(slot, fn),
-    getUsage: () => slot.usage
+    getUsage: () => slot.usage,
+    getRequest: () => slot.request
   };
 }
 

--- a/packages/runtime/tests/providers/provider-failure-logging.test.ts
+++ b/packages/runtime/tests/providers/provider-failure-logging.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration tests: when a provider call fails, BaseProvider's traced
+ * wrappers centrally log precisely what was sent to the provider.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { BaseProvider } from "../../src/providers/base-provider.js";
+import type {
+  Message,
+  ProviderStreamItem
+} from "../../src/providers/types.js";
+
+/** Provider that records a wire payload then fails. */
+class RecordingFailingProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+  async generateMessage(): Promise<Message> {
+    this.recordRequestPayload({
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+      api_key: "sk-should-be-redacted"
+    });
+    throw new Error("422 Unprocessable Entity");
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    this.recordRequestPayload({
+      model: "m",
+      stream: true,
+      messages: [{ role: "user", content: "stream-hi" }]
+    });
+    throw new Error("422 Unprocessable Entity");
+  }
+}
+
+/** Provider that fails without recording a wire payload. */
+class UninstrumentedFailingProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+  async generateMessage(): Promise<Message> {
+    throw new Error("500 boom");
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    throw new Error("500 boom");
+  }
+}
+
+/** Provider whose call is aborted by the caller. */
+class AbortingProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+  async generateMessage(): Promise<Message> {
+    this.recordRequestPayload({ model: "m" });
+    throw Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError"
+    });
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    throw Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError"
+    });
+  }
+}
+
+function captureStderr(): { lines: () => string } {
+  const chunks: string[] = [];
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return { lines: () => chunks.join("") };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BaseProvider failure logging – non-streaming", () => {
+  it("logs the recorded wire payload (with secrets redacted) when generateMessage fails", async () => {
+    const out = captureStderr();
+    const p = new RecordingFailingProvider();
+    await expect(
+      p.generateMessageTraced({ messages: [], model: "m" })
+    ).rejects.toThrow("422");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("Unprocessable");
+    expect(log).toContain("[redacted]");
+    expect(log).toContain("\"messages\"");
+  });
+
+  it("falls back to NodeTool args when no wire payload was recorded", async () => {
+    const out = captureStderr();
+    const p = new UninstrumentedFailingProvider();
+    await expect(
+      p.generateMessageTraced({
+        messages: [{ role: "user", content: "hello-fallback" }],
+        model: "m"
+      })
+    ).rejects.toThrow("500");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("hello-fallback");
+  });
+
+  it("does not log a failure when the request is aborted", async () => {
+    const out = captureStderr();
+    const p = new AbortingProvider();
+    await expect(
+      p.generateMessageTraced({ messages: [], model: "m" })
+    ).rejects.toThrow();
+    expect(out.lines()).not.toContain("Provider request failed");
+  });
+});
+
+describe("BaseProvider failure logging – streaming", () => {
+  it("logs the recorded wire payload when generateMessages fails", async () => {
+    const out = captureStderr();
+    const p = new RecordingFailingProvider();
+    const gen = p.generateMessagesTraced({ messages: [], model: "m" });
+    await expect(gen.next()).rejects.toThrow("422");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("stream-hi");
+  });
+});

--- a/packages/runtime/tests/providers/provider-request-log.test.ts
+++ b/packages/runtime/tests/providers/provider-request-log.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the central provider-failure request logger: sanitization
+ * (truncate / redact / binary / cycle-safe) and the failure-log formatter.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Logger } from "@nodetool-ai/config";
+import {
+  sanitizeForLog,
+  logProviderRequestFailure
+} from "../../src/providers/provider-request-log.js";
+
+function fakeLogger(): {
+  logger: Logger;
+  calls: { level: string; msg: string; args: unknown[] }[];
+} {
+  const calls: { level: string; msg: string; args: unknown[] }[] = [];
+  const make =
+    (level: string) =>
+    (msg: string, ...args: unknown[]) =>
+      calls.push({ level, msg, args });
+  return {
+    logger: {
+      debug: make("debug"),
+      info: make("info"),
+      warn: make("warn"),
+      error: make("error")
+    },
+    calls
+  };
+}
+
+describe("sanitizeForLog", () => {
+  it("truncates long strings and notes the original length", () => {
+    const long = "x".repeat(5000);
+    const out = sanitizeForLog({ content: long }) as { content: string };
+    expect(out.content.length).toBeLessThan(long.length);
+    expect(out.content).toContain("truncated");
+    expect(out.content).toContain("5000");
+  });
+
+  it("redacts secret-bearing keys but keeps token-count fields", () => {
+    const out = sanitizeForLog({
+      api_key: "sk-123",
+      apiKey: "sk-456",
+      Authorization: "Bearer abc",
+      "x-api-key": "sk-789",
+      password: "hunter2",
+      max_tokens: 1024,
+      max_completion_tokens: 2048
+    }) as Record<string, unknown>;
+    expect(out.api_key).toBe("[redacted]");
+    expect(out.apiKey).toBe("[redacted]");
+    expect(out.Authorization).toBe("[redacted]");
+    expect(out["x-api-key"]).toBe("[redacted]");
+    expect(out.password).toBe("[redacted]");
+    // Token-count params must survive — they matter for diagnosing 422s.
+    expect(out.max_tokens).toBe(1024);
+    expect(out.max_completion_tokens).toBe(2048);
+  });
+
+  it("replaces binary buffers with a size marker", () => {
+    const out = sanitizeForLog({ image: new Uint8Array([1, 2, 3, 4]) }) as {
+      image: string;
+    };
+    expect(out.image).toBe("[binary 4 bytes]");
+  });
+
+  it("is cycle-safe and does not throw on circular references", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    expect(() => sanitizeForLog(a)).not.toThrow();
+    const out = sanitizeForLog(a) as Record<string, unknown>;
+    expect(out.name).toBe("a");
+    expect(out.self).toBe("[circular]");
+  });
+
+  it("preserves nested structure, numbers and booleans", () => {
+    const input = {
+      model: "gpt",
+      stream: false,
+      nested: { temperature: 0.7, arr: [1, 2, 3] }
+    };
+    expect(sanitizeForLog(input)).toEqual(input);
+  });
+});
+
+describe("logProviderRequestFailure", () => {
+  it("logs the recorded wire request at error level with provider/model", () => {
+    const { logger, calls } = fakeLogger();
+    const request = { model: "gpt-5", messages: [{ role: "user", content: "hi" }] };
+    logProviderRequestFailure(
+      {
+        provider: "openai",
+        model: "gpt-5",
+        request,
+        error: new Error("422 Unprocessable Entity")
+      },
+      logger
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe("error");
+    const payload = calls[0].args[0] as Record<string, unknown>;
+    expect(payload.provider).toBe("openai");
+    expect(payload.model).toBe("gpt-5");
+    expect(payload.request).toEqual(request);
+    expect(payload.requestSource).toBe("wire");
+    expect(JSON.stringify(payload)).toContain("422");
+  });
+
+  it("includes the HTTP status when present on the error", () => {
+    const { logger, calls } = fakeLogger();
+    const err = Object.assign(new Error("Unprocessable Entity"), {
+      status: 422
+    });
+    logProviderRequestFailure(
+      { provider: "x", model: "m", request: {}, error: err },
+      logger
+    );
+    expect((calls[0].args[0] as Record<string, unknown>).status).toBe(422);
+  });
+
+  it("falls back to NodeTool args when no wire payload was recorded", () => {
+    const { logger, calls } = fakeLogger();
+    logProviderRequestFailure(
+      {
+        provider: "x",
+        model: "m",
+        request: undefined,
+        nodetoolArgs: { messages: [{ role: "user", content: "hi" }] },
+        error: new Error("bad")
+      },
+      logger
+    );
+    const payload = calls[0].args[0] as Record<string, unknown>;
+    expect(payload.request).toEqual({
+      messages: [{ role: "user", content: "hi" }]
+    });
+    expect(payload.requestSource).toBe("nodetool-args");
+  });
+
+  it("skips logging for aborted requests", () => {
+    const { logger, calls } = fakeLogger();
+    const abortErr = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError"
+    });
+    logProviderRequestFailure(
+      { provider: "x", model: "m", request: {}, error: abortErr },
+      logger
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("sanitizes the request payload it logs (redact + truncate)", () => {
+    const { logger, calls } = fakeLogger();
+    logProviderRequestFailure(
+      {
+        provider: "x",
+        model: "m",
+        request: { api_key: "sk-secret", prompt: "y".repeat(5000) },
+        error: new Error("e")
+      },
+      logger
+    );
+    const req = (calls[0].args[0] as { request: Record<string, unknown> })
+      .request;
+    expect(req.api_key).toBe("[redacted]");
+    expect((req.prompt as string).length).toBeLessThan(5000);
+  });
+});


### PR DESCRIPTION
## Why

A provider returned `422 Unprocessable Entity` and the error was opaque — we never saw **what was actually sent** to the provider. This adds central failure logging so every LLM provider call records precisely what it sent and logs it on failure, from one place.

## What

- **`tracing-helpers.ts`** — extend the existing per-call `AsyncLocalStorage` slot (already used for usage capture) to also carry the request payload, so concurrent calls on a shared provider instance never clobber each other. Adds `setLastRequest`/`peekLastRequest` and `getRequest` on `createUsageSlot`.
- **`providers/provider-request-log.ts`** (new, central) — `logProviderRequestFailure()` logs at **error** level with the HTTP status, error message, and a sanitized dump of what was sent. `sanitizeForLog()`:
  - redacts secret-bearing keys (`api_key`, `authorization`, `secrets`, …) **while keeping** diagnostic fields like `max_tokens`,
  - replaces binary buffers with `[binary N bytes]` markers,
  - truncates huge strings (e.g. base64 data URIs),
  - is cycle-safe and never throws.
- **`BaseProvider`** — new `protected recordRequestPayload(payload)`. `generateMessageTraced` / `generateMessagesTraced` now log centrally on failure, preferring the recorded **wire payload** and falling back to the NodeTool-level args, so even uninstrumented providers log something useful. Caller aborts (`AbortSignal`) are skipped — they aren't provider failures.
- **Per-provider instrumentation** — every self-implementing chat provider records its exact wire body right before the send: `openai`, `anthropic`, `gemini`, `ollama`, `huggingface`, `llama`, `codex`, `kie`, `python`, `claude-agent`. OpenAI-compatible subclasses (`groq`, `mistral`, `deepseek`, `cerebras`, …) inherit `OpenAIProvider` and are covered transitively.

## Example log on failure

```
ERROR nodetool.runtime.provider.request | Provider request failed {"provider":"openai","model":"gpt-5","status":422,"requestSource":"wire","error":"422 Unprocessable Entity","request":{"model":"gpt-5","messages":[...],"max_completion_tokens":16384,"api_key":"[redacted]"}}
```

## Testing

- New unit tests for `sanitizeForLog` (truncate / redact / binary / cycle-safe) and `logProviderRequestFailure` (status extraction, abort skip, wire vs. nodetool-args fallback).
- New integration tests asserting `BaseProvider`'s traced wrappers log the recorded payload (secrets redacted) on failure for both streaming and non-streaming paths.
- `npm run lint` (tsc) clean; full runtime suite **1266 + 14 tests pass**.

## Follow-up

Extend the same recording to **non-chat modalities** (image, video, audio, embeddings, 3D), which don't yet flow through a traced wrapper. The fallback already logs NodeTool-level args for any uninstrumented path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)