### PR TITLE
feat(web): multi-select generations — stream selected outputs downstream

### DIFF
--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -26,6 +26,8 @@ import { outputOf } from "../../utils/nodeGenerations";
 import type { Generation, RunGroup } from "../../utils/nodeGenerations";
 import type { Asset } from "../../stores/ApiTypes";
 import { useWebsocketRunner } from "../../stores/WorkflowRunner";
+import { useNodes } from "../../contexts/NodeContext";
+import { useShallow } from "zustand/react/shallow";
 import {
   CopyButton,
   Dialog,
@@ -202,6 +204,12 @@ const styles = (theme: Theme) =>
       border: `1px solid transparent`,
       "&:hover": {
         borderColor: theme.vars.palette.primary.main
+      },
+      // Keyboard focus (roving tabindex) — a token-based ring distinct from the
+      // hover/selected/in-set treatments so the focused option is always visible.
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
       }
     },
     ".thumb img, .thumb video, .thumb canvas": {
@@ -220,6 +228,45 @@ const styles = (theme: Theme) =>
     },
     ".thumb.selected": {
       borderColor: theme.vars.palette.primary.main
+    },
+    // Multi-select export membership: a distinct INSET ring (separate from the
+    // focused .selected border) so a tile can be both the focused generation and
+    // a member of the downstream set at once.
+    ".thumb.in-set": {
+      boxShadow: `inset 0 0 0 2px ${theme.vars.palette.secondary.main}`
+    },
+    // Pick-order badge: the 1-based position of a tile within the export set.
+    ".pick-badge": {
+      position: "absolute",
+      top: 2,
+      left: 2,
+      minWidth: 16,
+      height: 16,
+      padding: "0 4px",
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: BORDER_RADIUS.sm,
+      backgroundColor: theme.vars.palette.secondary.main,
+      color: theme.vars.palette.secondary.contrastText,
+      fontSize: theme.fontSizeTiny,
+      fontVariantNumeric: "tabular-nums",
+      lineHeight: 1
+    },
+    ".downstream-caption": {
+      position: "absolute",
+      zIndex: 10,
+      pointerEvents: "none",
+      bottom: 6,
+      right: 6,
+      ...TYPOGRAPHY.sans.caption
+    },
+    ".downstream-caption .caption-pill": {
+      display: "inline-block",
+      padding: "2px 6px",
+      borderRadius: BORDER_RADIUS.sm,
+      backgroundColor: theme.vars.palette.secondary.main,
+      color: theme.vars.palette.secondary.contrastText
     }
   });
 
@@ -233,10 +280,53 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
   const cssStyles = useMemo(() => styles(theme), [theme]);
   // Generation timeline drives selection (oldest→newest, current = selected ?? latest).
   // `runs` groups variants by job; `currentRun` is the selected variant's run.
-  const { generations, current, select, runs, currentRun } = useNodeGenerations(
-    workflowId,
-    nodeId
+  // `selectedIds` is the ordered multi-select export set fed downstream as a stream.
+  const {
+    generations,
+    current,
+    select,
+    runs,
+    currentRun,
+    selectedIds,
+    toggleSelected,
+    setSelected
+  } = useNodeGenerations(workflowId, nodeId);
+
+  // Whether this node has ANY downstream consumer — only then do the multi-select
+  // modifiers do anything. The selected set is fed downstream as a STREAM (a
+  // synthetic ForEach replay yields the N values, iteration-correlated), which is
+  // valid live behavior for any consumer, so no list-type gating: any outgoing
+  // edge enables it.
+  const hasDownstream = useNodes(
+    useShallow((s) => s.edges.some((e) => e.source === nodeId))
   );
+
+  // Pick-order lookup: generation id -> 1-based position in the export set.
+  const pickOrder = useMemo(() => {
+    const map = new Map<string, number>();
+    selectedIds.forEach((id, i) => map.set(id, i + 1));
+    return map;
+  }, [selectedIds]);
+
+  // The order the grid actually paints: tiles grouped by run (runs.flatMap),
+  // which can DIVERGE from the flat chronological `generations` array (e.g. a
+  // run with mixed persisted+live variants lands its live tail at the end of
+  // `generations` but contiguous in its run section). Shift-range and roving
+  // focus must walk THIS order so a swept range matches the visible tiles.
+  const flatTiles = useMemo(() => runs.flatMap((r) => r.variants), [runs]);
+
+  // Anchor index (into `flatTiles`, the render order) for shift-click range
+  // selection; advanced by every plain/modifier click and keyboard activation.
+  const anchorIndexRef = useRef<number>(-1);
+
+  // Roving tabindex: exactly one tile is in the tab order at a time; arrows move
+  // it over `flatTiles`. Falls back to the focused generation, then the first tile.
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const activeGenId =
+    activeId && flatTiles.some((g) => g.id === activeId)
+      ? activeId
+      : current?.id ?? flatTiles[0]?.id ?? null;
 
   const latestRun = runs.length > 0 ? runs[runs.length - 1] : undefined;
   const latestRunJobId = latestRun?.jobId ?? null;
@@ -254,13 +344,21 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     prevLatestRunJobIdRef.current = latestRunJobId;
     if (prev === undefined) return; // initial render — keep any restored selection
     if (prev === latestRunJobId) return; // same latest run — no new run appeared
+    // A genuinely new run appeared. Supersede any prior multi-select export set
+    // so stale members from an earlier run aren't silently fed downstream — this
+    // must fire even when focus does NOT advance (an unset selection already
+    // resolves `currentRun` to the new latest run, so the focus check below is
+    // skipped, yet the prior export set would otherwise persist).
+    if (selectedIds.length > 0) {
+      setSelected([]);
+    }
     if (currentRun && latestRun && currentRun.jobId !== latestRun.jobId) {
       // Selection is stale (an older run); follow the new latest run. The ref is
       // already updated, so the resulting re-render (currentRun changes) re-runs
       // this effect with prev === latestRunJobId and no-ops — no loop.
       select(latestRun.cover.id);
     }
-  }, [latestRunJobId, currentRun, latestRun, select]);
+  }, [latestRunJobId, currentRun, latestRun, select, setSelected, selectedIds]);
   // Parallel read of the durable assets solely for the fullscreen viewer,
   // download, and the dimensions/duration badge — those need the full Asset.
   const { assetHistory } = useNodeResultHistory(workflowId, nodeId);
@@ -408,18 +506,93 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     setViewerOpen(false);
   }, []);
 
-  // Every grid tile carries its generation id; clicking one selects that
-  // generation (which also feeds it downstream) and drops to single view.
+  // Move keyboard focus to the tile for `id` (roving tabindex). The tiles are
+  // all mounted, so a DOM query inside the grid is enough; no element-ref map.
+  const focusTile = useCallback((id: string | null) => {
+    if (!id) return;
+    const tiles = gridRef.current?.querySelectorAll<HTMLElement>(".thumb");
+    tiles?.forEach((t) => {
+      if (t.dataset.genId === id) t.focus();
+    });
+  }, []);
+
+  // Every grid tile carries its generation id. Three click modes (the modifier
+  // ones only when this node has a downstream consumer — otherwise a modifier
+  // click degrades to a plain click):
+  //   plain          → focus that generation + single view
+  //   Cmd/Ctrl+click → toggle export-set membership, stay in grid
+  //   Shift+click    → select the inclusive range [anchor..clicked] over the grid
+  //                    RENDER order (`flatTiles`) as the export set, stay in grid
+  // Every mode advances the range anchor + the roving-focus active tile.
   const handleGridClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const thumb = (e.target as HTMLElement).closest<HTMLElement>(".thumb");
       if (!thumb) return;
       const genId = thumb.dataset.genId;
       if (!genId) return;
-      select(genId);
-      setView("single");
+      const clickedIndex = flatTiles.findIndex((g) => g.id === genId);
+      setActiveId(genId);
+      const modifier =
+        hasDownstream && (e.metaKey || e.ctrlKey || e.shiftKey);
+      if (!modifier) {
+        select(genId);
+        setView("single");
+        anchorIndexRef.current = clickedIndex;
+        return;
+      }
+      if (e.shiftKey) {
+        const anchor =
+          anchorIndexRef.current >= 0 ? anchorIndexRef.current : clickedIndex;
+        const [lo, hi] =
+          anchor <= clickedIndex ? [anchor, clickedIndex] : [clickedIndex, anchor];
+        setSelected(flatTiles.slice(lo, hi + 1).map((g) => g.id));
+      } else {
+        toggleSelected(genId);
+      }
+      anchorIndexRef.current = clickedIndex;
     },
-    [select]
+    [flatTiles, hasDownstream, select, setSelected, toggleSelected]
+  );
+
+  // Keyboard on a focused tile:
+  //   Arrow/Home/End → roving focus over the grid render order (`flatTiles`)
+  //   Space/Enter    → toggle export-set membership when a downstream consumer
+  //                    exists; otherwise both keys mirror a plain click
+  const handleGridKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const thumb = (e.target as HTMLElement).closest<HTMLElement>(".thumb");
+      if (!thumb) return;
+      const genId = thumb.dataset.genId;
+      if (!genId) return;
+      const index = flatTiles.findIndex((g) => g.id === genId);
+
+      let nextIndex: number | null = null;
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") nextIndex = index + 1;
+      else if (e.key === "ArrowLeft" || e.key === "ArrowUp") nextIndex = index - 1;
+      else if (e.key === "Home") nextIndex = 0;
+      else if (e.key === "End") nextIndex = flatTiles.length - 1;
+      if (nextIndex !== null) {
+        e.preventDefault();
+        const clamped = Math.max(0, Math.min(flatTiles.length - 1, nextIndex));
+        const nextId = flatTiles[clamped]?.id ?? null;
+        setActiveId(nextId);
+        focusTile(nextId);
+        return;
+      }
+
+      if (e.key !== "Enter" && e.key !== " " && e.key !== "Spacebar") return;
+      e.preventDefault();
+      setActiveId(genId);
+      anchorIndexRef.current = index;
+      if (hasDownstream) {
+        toggleSelected(genId);
+      } else {
+        // No downstream consumer: both Enter and Space mirror a plain click.
+        select(genId);
+        setView("single");
+      }
+    },
+    [flatTiles, hasDownstream, select, toggleSelected, focusTile]
   );
 
   const fallbackThumbStyle = useMemo<React.CSSProperties>(
@@ -506,11 +679,22 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
     const videoThumb = asset?.thumb_url;
     const videoUrl = asset?.get_url || value?.uri || "";
     const selected = gen.id === current?.id;
+    const pick = pickOrder.get(gen.id);
+    // Export-set chrome (ring/badge/aria-selected) is shown ONLY when this node
+    // has a downstream consumer — otherwise a stale `selected_generations` (e.g.
+    // after the downstream edge was removed) would promise a stream feed the
+    // runtime won't deliver. Kept in lockstep with the run paths, which prune the
+    // source and inject the synthetic ForEach replay only when wired downstream.
+    const inSet = hasDownstream && pick !== undefined;
     return (
       <div
         key={gen.id}
-        className={`thumb${selected ? " selected" : ""}`}
-        role="listitem"
+        className={`thumb${selected ? " selected" : ""}${
+          inSet ? " in-set" : ""
+        }`}
+        role="option"
+        tabIndex={gen.id === activeGenId ? 0 : -1}
+        aria-selected={hasDownstream ? inSet : selected}
         data-gen-id={gen.id}
       >
         {kind === "image" && imgUrl ? (
@@ -533,6 +717,7 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           <div style={fallbackThumbStyle}>{kind || "asset"}</div>
         )}
         {label ? <span className="thumb-label">{label}</span> : null}
+        {inSet ? <span className="pick-badge">{pick}</span> : null}
       </div>
     );
   };
@@ -551,16 +736,24 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           // section headers the run (relative time · ×N · status) and grids its
           // variants; every tile is uniformly clickable → select + single view.
           <div
+            ref={gridRef}
             className="grid nodrag nopan"
-            role="list"
+            role="listbox"
+            aria-multiselectable={hasDownstream || undefined}
             aria-label="Generations"
             onClick={handleGridClick}
+            onKeyDown={handleGridKeyDown}
           >
             {runs.map((run) => {
               const multi = run.variants.length > 1;
               const statusType = runStatusType(run.status);
               return (
-                <section key={run.jobId} className="run-section">
+                <section
+                  key={run.jobId}
+                  className="run-section"
+                  role="group"
+                  aria-label={relativeTime(new Date(run.createdAt))}
+                >
                   <header className="run-header">
                     <span className="run-time">
                       {relativeTime(new Date(run.createdAt))}
@@ -665,6 +858,16 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           }}>
             {infoText}
           </span>
+        </div>
+      ) : null}
+
+      {/* bottom-right: the export-set size fed downstream as a stream. Always
+          visible (single AND grid) so the set is never hidden behind a view.
+          Gated on `hasDownstream` so the caption never promises a feed that the
+          runtime won't actually deliver to a disconnected node. */}
+      {hasDownstream && selectedIds.length >= 2 ? (
+        <div className="downstream-caption">
+          <span className="caption-pill">{`${selectedIds.length} → downstream`}</span>
         </div>
       ) : null}
 

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -658,6 +658,11 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
           `${props.data.workflow_id}:${connection.sourceId}`
         ] ?? [];
       const generations = mergeGenerations(persisted, live);
+      // Layer slots are single-image inputs, so they intentionally honor only
+      // the upstream's single focused `selected_generation` — NOT the
+      // multi-select `selected_generations` export set (a list would not feed one
+      // layer). `isListTargetHandle` returns false for these scalar slots, so the
+      // run paths agree: a multi-select upstream feeds this layer its single value.
       const selectedId = findNode(connection.sourceId)?.data
         ?.selected_generation;
       const current = getCurrentGeneration(generations, selectedId);

--- a/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
+++ b/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
@@ -10,6 +10,10 @@ import { groupByRun, getCurrentRun } from "../../../utils/nodeGenerations";
 const mockUseNodeResultHistory = jest.fn();
 const mockUseWebsocketRunner = jest.fn();
 const mockUseNodeGenerations = jest.fn();
+// The NodeContext store the viewer subscribes to (edges). Default: no outgoing
+// edges → no downstream consumer → multi-select modifiers inert. Tests override
+// it to wire an outgoing edge, which enables multi-select for ANY consumer.
+const mockNodeStoreState = jest.fn();
 
 jest.mock("../../../hooks/nodes/useNodeResultHistory", () => {
   const actual = jest.requireActual("../../../hooks/nodes/useNodeResultHistory");
@@ -22,6 +26,13 @@ jest.mock("../../../hooks/nodes/useNodeResultHistory", () => {
 
 jest.mock("../../../hooks/nodes/useNodeGenerations", () => ({
   useNodeGenerations: (...args: unknown[]) => mockUseNodeGenerations(...args)
+}));
+
+// The viewer reads this node's OUTGOING edges from NodeContext (to decide whether
+// a downstream consumer exists). The single-select tests have no outgoing edge,
+// so a store with no edges suffices — the multi-select modifiers stay inert.
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: (selector: (s: unknown) => unknown) => selector(mockNodeStoreState())
 }));
 
 jest.mock("../../../stores/WorkflowRunner", () => ({
@@ -134,7 +145,10 @@ const setGenerations = (generations: Generation[], selectedId?: string) => {
     current,
     select,
     runs,
-    currentRun
+    currentRun,
+    selectedIds: [],
+    toggleSelected: jest.fn(),
+    setSelected: jest.fn()
   });
   return select;
 };
@@ -151,12 +165,16 @@ beforeEach(() => {
     workflowId: "wf1"
   });
   mockUseWebsocketRunner.mockReturnValue({ state: "idle" });
+  mockNodeStoreState.mockReturnValue({ edges: [] });
   mockUseNodeGenerations.mockReturnValue({
     generations: [],
     current: undefined,
     select: jest.fn(),
     runs: [],
-    currentRun: undefined
+    currentRun: undefined,
+    selectedIds: [],
+    toggleSelected: jest.fn(),
+    setSelected: jest.fn()
   });
 });
 
@@ -303,7 +321,7 @@ describe("NodeHistoryViewer", () => {
       "live-preview.png"
     );
     expect(
-      screen.queryByRole("list", { name: "Generations" })
+      screen.queryByRole("listbox", { name: "Generations" })
     ).not.toBeInTheDocument();
   });
 
@@ -324,7 +342,7 @@ describe("NodeHistoryViewer", () => {
 
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
     expect(
-      screen.queryByRole("list", { name: "Generations" })
+      screen.queryByRole("listbox", { name: "Generations" })
     ).not.toBeInTheDocument();
   });
 
@@ -335,7 +353,7 @@ describe("NodeHistoryViewer", () => {
     const { rerender } = render(viewer());
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
     expect(
-      screen.queryByRole("list", { name: "Generations" })
+      screen.queryByRole("listbox", { name: "Generations" })
     ).not.toBeInTheDocument();
 
     // Two more variants land under the SAME jobId (job-a), run completed.
@@ -343,7 +361,7 @@ describe("NodeHistoryViewer", () => {
     rerender(viewer());
 
     expect(
-      screen.getByRole("list", { name: "Generations" })
+      screen.getByRole("listbox", { name: "Generations" })
     ).toBeInTheDocument();
     expect(screen.queryByTestId("single-body")).not.toBeInTheDocument();
   });
@@ -358,7 +376,7 @@ describe("NodeHistoryViewer", () => {
 
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
     expect(
-      screen.queryByRole("list", { name: "Generations" })
+      screen.queryByRole("listbox", { name: "Generations" })
     ).not.toBeInTheDocument();
   });
 
@@ -378,7 +396,7 @@ describe("NodeHistoryViewer", () => {
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("Toggle view"));
     expect(
-      screen.getByRole("list", { name: "Generations" })
+      screen.getByRole("listbox", { name: "Generations" })
     ).toBeInTheDocument();
     // grid → single.
     fireEvent.click(screen.getByLabelText("Toggle view"));
@@ -406,7 +424,7 @@ describe("NodeHistoryViewer", () => {
 
     fireEvent.click(screen.getByLabelText("Toggle view"));
     // One tile per generation across all runs.
-    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getAllByRole("option")).toHaveLength(3);
     expect(screen.getByText("×2")).toBeInTheDocument();
   });
 
@@ -427,7 +445,7 @@ describe("NodeHistoryViewer", () => {
     );
 
     fireEvent.click(screen.getByLabelText("Toggle view"));
-    const tiles = screen.getAllByRole("listitem");
+    const tiles = screen.getAllByRole("option");
     fireEvent.click(tiles[0]);
     expect(select).toHaveBeenCalledWith("a1");
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
@@ -510,7 +528,10 @@ describe("NodeHistoryViewer — auto-focus latest run", () => {
       current,
       select,
       runs,
-      currentRun
+      currentRun,
+      selectedIds: [],
+      toggleSelected: jest.fn(),
+      setSelected: jest.fn()
     });
   };
 
@@ -557,5 +578,246 @@ describe("NodeHistoryViewer — auto-focus latest run", () => {
     setMock([makeRunGen("a1", "j1", 1), makeRunGen("a2", "j1", 2)], "a1", select);
     rerender(wrap());
     expect(select).not.toHaveBeenCalled();
+  });
+
+  it("clears the multi-select export set when a new run appears", () => {
+    const setSelected = jest.fn();
+    const setMockWithSet = (generations: Generation[], selectedIds: string[]) => {
+      const runs = groupByRun(generations);
+      const currentRun = getCurrentRun(runs, "a1");
+      mockUseNodeGenerations.mockReturnValue({
+        generations,
+        current: generations.find((g) => g.id === "a1") ?? generations[0],
+        select: jest.fn(),
+        runs,
+        currentRun,
+        selectedIds,
+        toggleSelected: jest.fn(),
+        setSelected
+      });
+    };
+    // Mount pinned to run j1 with a multi-select set on it.
+    setMockWithSet([makeRunGen("a1", "j1", 1)], ["a1"]);
+    const { rerender } = render(wrap());
+    expect(setSelected).not.toHaveBeenCalled(); // mount: nothing cleared
+
+    // A new run j2 appears — the stale j1 export set must be cleared so it isn't
+    // silently fed downstream, even though the selection still resolves to j1.
+    setMockWithSet(
+      [makeRunGen("a1", "j1", 1), makeRunGen("a2", "j2", 2)],
+      ["a1"]
+    );
+    rerender(wrap());
+    expect(setSelected).toHaveBeenCalledWith([]);
+  });
+
+  it("does not clear the export set while a run grows in place (same jobId)", () => {
+    const setSelected = jest.fn();
+    const setMockWithSet = (generations: Generation[], selectedIds: string[]) => {
+      const runs = groupByRun(generations);
+      mockUseNodeGenerations.mockReturnValue({
+        generations,
+        current: generations[generations.length - 1],
+        select: jest.fn(),
+        runs,
+        currentRun: getCurrentRun(runs, undefined),
+        selectedIds,
+        toggleSelected: jest.fn(),
+        setSelected
+      });
+    };
+    setMockWithSet([makeGen("a1", 1)], ["a1"]);
+    const { rerender } = render(wrap());
+    // Same job-a gains a variant — not a new run, so the set is preserved.
+    setMockWithSet([makeGen("a1", 1), makeGen("a2", 2)], ["a1"]);
+    rerender(wrap());
+    expect(setSelected).not.toHaveBeenCalled();
+  });
+});
+
+describe("NodeHistoryViewer — grid multi-select export set", () => {
+  // The selected set is fed downstream as a STREAM (a synthetic ForEach replay),
+  // valid live behavior for ANY consumer — so multi-select is gated solely on
+  // whether this node has an outgoing edge, with no list-vs-scalar distinction.
+
+  // Wire a single outgoing edge from this node to a downstream consumer.
+  const wireDownstream = () => {
+    mockNodeStoreState.mockReturnValue({
+      edges: [
+        {
+          source: "node-a",
+          sourceHandle: "output",
+          target: "consumer",
+          targetHandle: "in"
+        }
+      ]
+    });
+  };
+
+  // No outgoing edge → no downstream consumer → modifiers inert.
+  const wireNoDownstream = () => {
+    mockNodeStoreState.mockReturnValue({ edges: [] });
+  };
+
+  const setGensWithSelection = (
+    generations: Generation[],
+    selectedIds: string[]
+  ) => {
+    const current = generations[generations.length - 1];
+    const runs = groupByRun(generations);
+    const currentRun = getCurrentRun(runs, undefined);
+    const select = jest.fn();
+    const toggleSelected = jest.fn();
+    const setSelected = jest.fn();
+    mockUseNodeGenerations.mockReturnValue({
+      generations,
+      current,
+      select,
+      runs,
+      currentRun,
+      selectedIds,
+      toggleSelected,
+      setSelected
+    });
+    return { select, toggleSelected, setSelected };
+  };
+
+  const grid = () => (
+    <ThemeProvider theme={mockTheme}>
+      <NodeHistoryViewer
+        workflowId="wf1"
+        nodeId="node-a"
+        liveResult={null}
+        renderSingle={(v) => renderSingle(v)}
+      />
+    </ThemeProvider>
+  );
+
+  const openGrid = () => fireEvent.click(screen.getByLabelText("Toggle view"));
+
+  it("Cmd+click on a tile toggles export-set membership (does not drop to single) when a downstream consumer exists", () => {
+    wireDownstream();
+    const { toggleSelected, select } = setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
+      []
+    );
+    render(grid());
+    openGrid();
+    const tiles = screen.getAllByRole("option");
+    fireEvent.click(tiles[1], { metaKey: true });
+    expect(toggleSelected).toHaveBeenCalledWith("a2");
+    expect(select).not.toHaveBeenCalled();
+    // Still in grid view.
+    expect(
+      screen.getByRole("listbox", { name: "Generations" })
+    ).toBeInTheDocument();
+  });
+
+  it("Shift+click selects the inclusive range from the anchor when a downstream consumer exists", () => {
+    wireDownstream();
+    const { setSelected } = setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
+      []
+    );
+    render(grid());
+    openGrid();
+    const tiles = screen.getAllByRole("option");
+    // A Cmd+click sets the anchor at index 0 WITHOUT leaving the grid (a plain
+    // click would drop to single view and unmount the tiles)…
+    fireEvent.click(tiles[0], { metaKey: true });
+    // …then shift-click index 2 → inclusive range [a1, a2, a3].
+    fireEvent.click(tiles[2], { shiftKey: true });
+    expect(setSelected).toHaveBeenCalledWith(["a1", "a2", "a3"]);
+  });
+
+  it("Shift+click ranges over the grid RENDER order, not the flat timeline (multi-run)", () => {
+    wireDownstream();
+    // Flat timeline (createdAt order) is gA, gB, gC — but the grid groups by run,
+    // so it paints run j1 (gA, gC) then run j2 (gB): render order gA, gC, gB.
+    const gA = makeRunGen("gA", "j1", 1);
+    const gC = makeRunGen("gC", "j1", 4);
+    const gB = makeRunGen("gB", "j2", 2);
+    const { setSelected } = setGensWithSelection([gA, gB, gC], []);
+    render(grid());
+    openGrid();
+    const tiles = screen.getAllByRole("option");
+    // Tiles paint in run-grouped order, diverging from the flat timeline.
+    expect(tiles.map((t) => t.getAttribute("data-gen-id"))).toEqual([
+      "gA",
+      "gC",
+      "gB"
+    ]);
+    // Anchor at the first tile, then sweep to the last → the range must follow
+    // the VISIBLE order [gA, gC, gB], not the flat timeline [gA, gB, gC].
+    fireEvent.click(tiles[0], { metaKey: true });
+    fireEvent.click(tiles[2], { shiftKey: true });
+    expect(setSelected).toHaveBeenCalledWith(["gA", "gC", "gB"]);
+  });
+
+  it("modifier clicks degrade to a plain select when NO downstream consumer exists", () => {
+    wireNoDownstream();
+    const { toggleSelected, select } = setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2)],
+      []
+    );
+    render(grid());
+    openGrid();
+    const tiles = screen.getAllByRole("option");
+    fireEvent.click(tiles[1], { metaKey: true });
+    expect(toggleSelected).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledWith("a2");
+  });
+
+  it("renders pick-order badges, aria-selected, and the downstream caption for the export set", () => {
+    wireDownstream();
+    setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
+      ["a3", "a1"]
+    );
+    render(grid());
+    openGrid();
+    const tiles = screen.getAllByRole("option");
+    // a1 is the 2nd pick, a3 is the 1st pick; a2 is not a member.
+    const byGen = (id: string) =>
+      tiles.find((t) => t.getAttribute("data-gen-id") === id)!;
+    expect(byGen("a1")).toHaveAttribute("aria-selected", "true");
+    expect(byGen("a2")).toHaveAttribute("aria-selected", "false");
+    expect(byGen("a3")).toHaveAttribute("aria-selected", "true");
+    expect(byGen("a1")).toHaveTextContent("2");
+    expect(byGen("a3")).toHaveTextContent("1");
+    // The caption is shown (>=2 members) in the grid view.
+    expect(screen.getByText("2 → downstream")).toBeInTheDocument();
+  });
+
+  it("shows the downstream caption in single view too", () => {
+    wireDownstream();
+    setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2)],
+      ["a1", "a2"]
+    );
+    render(grid());
+    // Default single view — caption must still be visible.
+    expect(screen.getByTestId("single-body")).toBeInTheDocument();
+    expect(screen.getByText("2 → downstream")).toBeInTheDocument();
+  });
+
+  it("shows no caption and no export-set chrome when there is no downstream consumer", () => {
+    wireNoDownstream();
+    setGensWithSelection(
+      [makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)],
+      ["a3", "a1"]
+    );
+    render(grid());
+    openGrid();
+    // No downstream consumer: a stale selected set must not promise a feed.
+    expect(screen.queryByText("2 → downstream")).not.toBeInTheDocument();
+    const tiles = screen.getAllByRole("option");
+    // aria-selected falls back to single-selection (the focused generation),
+    // never the export set; no pick badges.
+    const byGen = (id: string) =>
+      tiles.find((t) => t.getAttribute("data-gen-id") === id)!;
+    expect(byGen("a1")).toHaveAttribute("aria-selected", "false");
+    expect(byGen("a3")).toHaveAttribute("aria-selected", "true"); // = current
+    expect(byGen("a1")).not.toHaveTextContent("2");
   });
 });

--- a/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
+++ b/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
@@ -46,11 +46,15 @@ jest.mock("../../../contexts/NodeContext", () => ({
     selector: (state: {
       updateNodeData: () => void;
       findNode: (id: string) => unknown;
+      edges: unknown[];
     }) => unknown
   ) =>
     selector({
       updateNodeData: jest.fn(),
-      findNode: (id: string) => ({ id, data: {} })
+      findNode: (id: string) => ({ id, data: {} }),
+      // NodeHistoryViewer (rendered by ContentCardBody) subscribes to outgoing
+      // edges to detect a downstream list consumer; none here.
+      edges: []
     })
 }));
 
@@ -248,7 +252,7 @@ describe("ContentCardBody results", () => {
 
     // Toggle to the grid: both variants render as tiles in the one run section.
     await userEvent.click(screen.getByLabelText("Toggle view"));
-    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getAllByRole("option")).toHaveLength(2);
   });
 
   it("renders a pure transform's output without the gallery navigator", () => {

--- a/web/src/components/node_types/editing/ListGeneratorBody.tsx
+++ b/web/src/components/node_types/editing/ListGeneratorBody.tsx
@@ -30,7 +30,17 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { CopyButton, FlexColumn, FlexRow, LoadingSpinner, BORDER_RADIUS, MOTION, FONT_WEIGHT } from "../../ui_primitives";
+import {
+  CopyButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  BORDER_RADIUS,
+  MOTION,
+  FONT_WEIGHT,
+  SPACING,
+  thinScrollbarStyles
+} from "../../ui_primitives";
 import MarkdownRenderer from "../../../utils/MarkdownRenderer";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import HandleColumn from "../../node/HandleColumn";
@@ -82,6 +92,9 @@ const previewOf = (item: string): string => {
     .trim();
 };
 
+/** Fixed size of the circular index badge (px). The expanded body aligns to it. */
+const INDEX_BADGE = 18;
+
 const styles = (theme: Theme) =>
   css({
     position: "relative",
@@ -90,36 +103,35 @@ const styles = (theme: Theme) =>
     width: "100%",
     display: "flex",
     flexDirection: "column",
-    gap: 6,
-    padding: 8,
+    gap: theme.spacing(SPACING.sm),
+    padding: theme.spacing(SPACING.md),
 
     ".list-header": {
       display: "flex",
       alignItems: "center",
-      gap: 6,
+      gap: theme.spacing(SPACING.sm),
       color: theme.vars.palette.text.secondary,
       fontSize: theme.fontSizeSmaller
     },
+    // One flat, divided list — the node frame is already the card, so wrapping
+    // each item in its own bordered box would be nested cards.
     ".list-scroll": {
       flex: "1 1 auto",
       minHeight: 0,
       overflowY: "auto",
       overflowX: "hidden",
-      display: "flex",
-      flexDirection: "column",
-      gap: 4
+      ...thinScrollbarStyles(theme)
     },
-    ".list-section": {
-      borderRadius: BORDER_RADIUS.sm,
-      backgroundColor: theme.vars.palette.background.paper,
-      border: `1px solid ${theme.vars.palette.divider}`,
-      overflow: "hidden"
+    ".list-item": {
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      "&:last-of-type": { borderBottom: "none" }
     },
     ".list-head": {
       display: "flex",
       alignItems: "center",
-      gap: 8,
-      padding: `${theme.spacing(1.5)} ${theme.spacing(2)}`,
+      gap: theme.spacing(SPACING.md),
+      padding: `${theme.spacing(SPACING.sm)} ${theme.spacing(SPACING.xs)}`,
+      borderRadius: BORDER_RADIUS.sm,
       cursor: "pointer",
       userSelect: "none",
       transition: MOTION.background,
@@ -129,8 +141,8 @@ const styles = (theme: Theme) =>
     },
     ".list-index": {
       flexShrink: 0,
-      minWidth: 18,
-      height: 18,
+      minWidth: INDEX_BADGE,
+      height: INDEX_BADGE,
       borderRadius: BORDER_RADIUS.pill,
       backgroundColor: `rgba(var(--palette-primary-mainChannel) / 0.18)`,
       color: theme.vars.palette.primary.main,
@@ -139,7 +151,7 @@ const styles = (theme: Theme) =>
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
-      padding: `0 ${theme.spacing(1.5)}`
+      padding: `0 ${theme.spacing(SPACING.sm)}`
     },
     ".list-preview": {
       flex: 1,
@@ -162,15 +174,19 @@ const styles = (theme: Theme) =>
     },
     ".list-chevron": {
       flexShrink: 0,
-      fontSize: 16,
+      fontSize: theme.fontSizeNormal,
       color: theme.vars.palette.text.secondary,
       transition: MOTION.transform
     },
     ".list-chevron.expanded": {
       transform: "rotate(90deg)"
     },
+    // Hang the expanded body under the preview text, past the badge + gap.
     ".list-full": {
-      padding: "0 4px 4px 4px",
+      paddingTop: 0,
+      paddingRight: theme.spacing(SPACING.xs),
+      paddingBottom: theme.spacing(SPACING.sm),
+      paddingLeft: `calc(${INDEX_BADGE}px + ${theme.spacing(SPACING.md)} + ${theme.spacing(SPACING.xs)})`,
       fontSize: theme.fontSizeSmall,
       color: theme.vars.palette.text.primary
     },
@@ -182,7 +198,7 @@ const styles = (theme: Theme) =>
       textAlign: "center",
       color: theme.vars.palette.text.disabled,
       fontSize: theme.fontSizeSmaller,
-      padding: 12
+      padding: theme.spacing(SPACING.lg)
     }
   });
 
@@ -243,7 +259,7 @@ const ListGeneratorBodyInner: React.FC<BespokeBodyProps> = ({
         <HandleColumn id={id} properties={inputProperties} layout="stacked" />
       )}
       <div className="list-header">
-        <FormatListNumberedRoundedIcon sx={{ fontSize: 14 }} />
+        <FormatListNumberedRoundedIcon sx={{ fontSize: "var(--fontSizeSmall)" }} />
         <span>
           {items.length === 0
             ? isRunning
@@ -263,7 +279,7 @@ const ListGeneratorBodyInner: React.FC<BespokeBodyProps> = ({
           {items.map((item, i) => {
             const isOpen = expanded.has(i);
             return (
-              <div className="list-section" key={`${i}-${item.slice(0, 24)}`}>
+              <div className="list-item" key={`${i}-${item.slice(0, 24)}`}>
                 <div
                   className="list-head"
                   role="button"

--- a/web/src/hooks/nodes/__tests__/buildDownstreamRunGraph.test.ts
+++ b/web/src/hooks/nodes/__tests__/buildDownstreamRunGraph.test.ts
@@ -1,11 +1,24 @@
 import type { Node, Edge } from "@xyflow/react";
 import type { NodeData } from "../../../stores/NodeData";
+
+jest.mock("../../../core/graph", () => ({ subgraph: jest.fn() }));
+jest.mock("../../../stores/nodeGenerationAccessor", () => ({
+  getNodeGenerations: jest.fn(() => []),
+  getNodeSelectedOutputs: jest.fn(() => undefined)
+}));
+
 import {
   findExternalInputEdges,
   applyPropertyOverrides,
   browserRunnablePrefix,
-  collectCachedValuesForSubgraph
+  collectCachedValuesForSubgraph,
+  buildDownstreamRunGraph
 } from "../buildDownstreamRunGraph";
+import { subgraph } from "../../../core/graph";
+import { getNodeSelectedOutputs } from "../../../stores/nodeGenerationAccessor";
+
+const mockSubgraph = subgraph as jest.Mock;
+const mockGetNodeSelectedOutputs = getNodeSelectedOutputs as jest.Mock;
 
 function mkNode(id: string, type = "nodetool.test.Node"): Node<NodeData> {
   return {
@@ -194,5 +207,77 @@ describe("browserRunnablePrefix", () => {
     };
     const result = browserRunnablePrefix(graph, isBrowser);
     expect(result.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("buildDownstreamRunGraph multi-select ForEach replay injection", () => {
+  const selectedValues = [
+    { uri: "a.png", type: "image" },
+    { uri: "b.png", type: "image" }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetNodeSelectedOutputs.mockReturnValue(undefined);
+  });
+
+  // A downstream subgraph rooted at `start`; an external multi-select source
+  // `gen-x` feeds the target node's handle from outside the subgraph.
+  const runFor = (targetHandle: string) => {
+    const start = mkNode("start");
+    const target = mkNode("node-t", "proc.Plain");
+    const genX = mkNode("gen-x", "gen.Image");
+    const allNodes = [start, target, genX];
+    const allEdges = [
+      mkEdge("start", "node-t", { sourceHandle: "output", targetHandle: "in" }),
+      mkEdge("gen-x", "node-t", { sourceHandle: "output", targetHandle })
+    ];
+    // The downstream subgraph from `start` includes start + target only.
+    mockSubgraph.mockReturnValue({
+      nodes: [start, target],
+      edges: [allEdges[0]]
+    });
+    mockGetNodeSelectedOutputs.mockImplementation((_wf: string, src: string) =>
+      src === "gen-x" ? selectedValues : undefined
+    );
+    const findNode = (id: string) => allNodes.find((n) => n.id === id);
+    return buildDownstreamRunGraph({
+      nodeId: "start",
+      nodes: allNodes,
+      edges: allEdges,
+      workflowId: "wf1",
+      findNode
+    });
+  };
+
+  const expectForEach = (
+    built: ReturnType<typeof buildDownstreamRunGraph>,
+    targetHandle: string
+  ): void => {
+    expect(built).not.toBeNull();
+    const replay = built!.nodes.find(
+      (n) => n.type === "nodetool.control.ForEach"
+    )!;
+    expect(replay).toBeDefined();
+    expect(replay.data.properties.input_list).toEqual(selectedValues);
+
+    const replayEdge = built!.edges.find((e) => e.source === replay.id)!;
+    expect(replayEdge).toBeDefined();
+    expect(replayEdge.sourceHandle).toBe("output");
+    expect(replayEdge.target).toBe("node-t");
+    expect(replayEdge.targetHandle).toBe(targetHandle);
+
+    // The multi-select source isn't injected as a static override and the
+    // streamed handle carries no cached value.
+    const target = built!.nodes.find((n) => n.id === "node-t")!;
+    expect(target.data.properties[targetHandle]).toBeUndefined();
+  };
+
+  it("injects a ForEach replay into a LIST target handle", () => {
+    expectForEach(runFor("tiles"), "tiles");
+  });
+
+  it("injects a ForEach replay into a SCALAR target handle too (no list gate)", () => {
+    expectForEach(runFor("input"), "input");
   });
 });

--- a/web/src/hooks/nodes/__tests__/useInputNodeAutoRun.test.ts
+++ b/web/src/hooks/nodes/__tests__/useInputNodeAutoRun.test.ts
@@ -17,7 +17,11 @@ jest.mock("../../../stores/WorkflowRunner", () => ({
 // (durable assets merged with the live buffer). Mock the sync accessor so a
 // test can hand a node a cached generation.
 jest.mock("../../../stores/nodeGenerationAccessor", () => ({
-  getNodeGenerations: jest.fn()
+  getNodeGenerations: jest.fn(),
+  // Single-selection paths never select 2+ generations, so this returns
+  // undefined; mocked here so buildDownstreamRunGraph's per-edge list gate is a
+  // no-op in these tests.
+  getNodeSelectedOutputs: jest.fn(() => undefined)
 }));
 
 jest.mock("../../../core/graph", () => ({

--- a/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
@@ -32,6 +32,14 @@ jest.mock("../../../utils/edgeValue", () => ({
   }))
 }));
 
+// Multi-select stream source. getNodeGenerations is unused on this path (the
+// hook resolves the value list through getNodeSelectedOutputs); default the
+// selection to "none" so the existing single-selection tests are untouched.
+jest.mock("../../../stores/nodeGenerationAccessor", () => ({
+  getNodeGenerations: jest.fn(() => []),
+  getNodeSelectedOutputs: jest.fn(() => undefined)
+}));
+
 
 import { useNodeStoreRef } from "../../../contexts/NodeContext";
 import useMetadataStore from "../../../stores/MetadataStore";
@@ -42,6 +50,7 @@ import {
 } from "../../../stores/WorkflowRunner";
 import useResultsStore from "../../../stores/ResultsStore";
 import { useNotificationStore } from "../../../stores/NotificationStore";
+import { getNodeSelectedOutputs } from "../../../stores/nodeGenerationAccessor";
 
 const mockUseNodeStoreRef = useNodeStoreRef as jest.Mock;
 const mockUseWebsocketRunner = useWebsocketRunner as jest.Mock;
@@ -50,6 +59,7 @@ const mockUseResultsStore = useResultsStore as unknown as jest.Mock;
 const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
 const mockMetadataGetState = (useMetadataStore as unknown as { getState: jest.Mock }).getState;
 const mockResolveExternalEdgeValue = resolveExternalEdgeValue as jest.Mock;
+const mockGetNodeSelectedOutputs = getNodeSelectedOutputs as jest.Mock;
 
 type RunnerState = {
   state: "idle" | "running" | "error" | "cancelled" | "connecting";
@@ -142,6 +152,9 @@ describe("useRunSelectedNodes", () => {
     mockFindNode.mockImplementation((id: string) =>
       [nodeA, nodeB, nodeC].find((n) => n.id === id)
     );
+
+    // Default: no source has a multi-select set (single-selection behavior).
+    mockGetNodeSelectedOutputs.mockReturnValue(undefined);
   });
 
   it("only includes selected nodes in the nodes passed to run", async () => {
@@ -426,5 +439,104 @@ describe("useRunSelectedNodes", () => {
     });
 
     expect(mockRun).toHaveBeenCalledTimes(32);
+  });
+
+  describe("multi-select ForEach replay injection", () => {
+    const selectedValues = [
+      { uri: "a.png", type: "image" },
+      { uri: "b.png", type: "image" }
+    ];
+
+    // A selected target node fed by a NON-selected external multi-select source.
+    const setup = (targetHandle: string): { genX: { id: string } } => {
+      const genX = {
+        id: "gen-x",
+        type: "gen.Image",
+        data: { properties: {} },
+        selected: false
+      };
+      const target = {
+        id: "node-t",
+        type: "proc.Plain",
+        data: { properties: {} },
+        selected: true
+      };
+      const edges = [
+        {
+          id: "ext",
+          source: "gen-x",
+          target: "node-t",
+          sourceHandle: "output",
+          targetHandle
+        }
+      ];
+      mockGetSelectedNodes.mockReturnValue([target]);
+      mockFindNode.mockImplementation((id: string) =>
+        [genX, target].find((n) => n.id === id)
+      );
+      mockUseNodeStoreRef.mockReturnValue({
+        getState: () => ({
+          nodes: [genX, target],
+          edges,
+          workflow: defaultWorkflow,
+          findNode: mockFindNode,
+          getSelectedNodes: mockGetSelectedNodes
+        })
+      });
+      // The source has 2+ selected generations → the value list to stream.
+      mockGetNodeSelectedOutputs.mockImplementation(
+        (_wf: string, src: string) =>
+          src === "gen-x" ? selectedValues : undefined
+      );
+      return { genX };
+    };
+
+    const expectForEachInjected = (targetHandle: string): void => {
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const nodesPassedToRun = mockRun.mock.calls[0][2];
+      const edgesPassedToRun = mockRun.mock.calls[0][3];
+
+      const replay = nodesPassedToRun.find(
+        (n: { type?: string }) => n.type === "nodetool.control.ForEach"
+      );
+      expect(replay).toBeDefined();
+      expect(replay.data.properties.input_list).toEqual(selectedValues);
+
+      const replayEdge = edgesPassedToRun.find(
+        (e: { source: string }) => e.source === replay.id
+      );
+      expect(replayEdge).toBeDefined();
+      expect(replayEdge.sourceHandle).toBe("output");
+      expect(replayEdge.target).toBe("node-t");
+      expect(replayEdge.targetHandle).toBe(targetHandle);
+
+      // The multi-select source is pruned: never streamed as a static override
+      // and not part of the run node set (it isn't selected).
+      const target = nodesPassedToRun.find(
+        (n: { id: string }) => n.id === "node-t"
+      );
+      expect(target.data.properties[targetHandle]).toBeUndefined();
+      expect(
+        nodesPassedToRun.some((n: { id: string }) => n.id === "gen-x")
+      ).toBe(false);
+    };
+
+    it("injects a ForEach replay into a LIST target handle", async () => {
+      setup("tiles");
+      const { result } = renderHook(() => useRunSelectedNodes());
+      await act(async () => {
+        await result.current.runSelectedNodes();
+      });
+      expectForEachInjected("tiles");
+    });
+
+    it("injects a ForEach replay into a SCALAR target handle too (no list gate)", async () => {
+      setup("input");
+      const { result } = renderHook(() => useRunSelectedNodes());
+      await act(async () => {
+        await result.current.runSelectedNodes();
+      });
+      expectForEachInjected("input");
+    });
   });
 });

--- a/web/src/hooks/nodes/buildDownstreamRunGraph.ts
+++ b/web/src/hooks/nodes/buildDownstreamRunGraph.ts
@@ -11,10 +11,14 @@
  */
 import { Node, Edge } from "@xyflow/react";
 import { subgraph } from "../../core/graph";
-import { getNodeGenerations } from "../../stores/nodeGenerationAccessor";
+import {
+  getNodeGenerations,
+  getNodeSelectedOutputs
+} from "../../stores/nodeGenerationAccessor";
 import { getCurrentGeneration } from "../../utils/nodeGenerations";
 import { NodeData } from "../../stores/NodeData";
 import { resolveExternalEdgeValue } from "../../utils/edgeValue";
+import { buildReplayForEach } from "../../utils/replayStream";
 
 /**
  * Finds all edges that cross the boundary into a subgraph (from outside to
@@ -217,8 +221,48 @@ export const buildDownstreamRunGraph = ({
     return outputs;
   };
 
+  // Multi-select STREAM: when an external upstream has 2+ generations selected,
+  // prune it and inject a ForEach replay node (input_list = the selected values)
+  // that streams the N values into the target handle as N iteration-correlated
+  // emissions — identical to a live generation. No list-type gate. These edges
+  // are excluded from the single-value cached-override collection below.
+  const replayNodesById = new Map<string, Node<NodeData>>();
+  const replayEdges: Edge[] = [];
+  const replayedEdgeIds = new Set<string>();
+  for (const edge of externalInputEdges) {
+    const targetHandle = edge.targetHandle;
+    if (!targetHandle) {
+      continue;
+    }
+    const selected = getNodeSelectedOutputs(
+      workflowId,
+      edge.source,
+      edge.sourceHandle,
+      findNode(edge.source)?.data?.selected_generations
+    );
+    if (selected && selected.length > 0) {
+      const { node, edge: replayEdge } = buildReplayForEach({
+        sourceId: edge.source,
+        sourceHandle: edge.sourceHandle,
+        targetId: edge.target,
+        targetHandle,
+        values: selected,
+        workflowId
+      });
+      if (!replayNodesById.has(node.id)) {
+        replayNodesById.set(node.id, node);
+        replayEdges.push(replayEdge);
+      }
+      replayedEdgeIds.add(edge.id);
+    }
+  }
+
+  const cachedInputEdges = externalInputEdges.filter(
+    (edge) => !replayedEdgeIds.has(edge.id)
+  );
+
   const propertyOverrides = collectCachedValuesForSubgraph(
-    externalInputEdges,
+    cachedInputEdges,
     workflowId,
     getResultFromGeneration,
     findNode
@@ -234,8 +278,8 @@ export const buildDownstreamRunGraph = ({
   ).reduce((sum, props) => sum + Object.keys(props).length, 0);
 
   return {
-    nodes: nodesWithCachedValues,
-    edges: downstream.edges,
+    nodes: [...nodesWithCachedValues, ...replayNodesById.values()],
+    edges: [...downstream.edges, ...replayEdges],
     nodesWithOverrides: propertyOverrides.size,
     totalPropertiesInjected
   };

--- a/web/src/hooks/nodes/useNodeGenerations.ts
+++ b/web/src/hooks/nodes/useNodeGenerations.ts
@@ -13,11 +13,18 @@ import {
   type RunGroup
 } from "../../utils/nodeGenerations";
 
+/** Stable empty array for the multi-select set so an unset node never re-renders
+ *  consumers on identity churn. */
+const STABLE_EMPTY: string[] = [];
+
 /**
  * Reactive view of a node's generation timeline: durable workflow assets merged
  * with the live buffer, with the current generation resolved from the node's
  * persisted `selected_generation` (latest when unset/stale) and a `select`
- * action that persists a new selection.
+ * action that persists a new selection. `selectedIds` /
+ * `toggleSelected` / `setSelected` manage the multi-select export set
+ * (`selected_generations`) fed downstream as a list, independent of the focused
+ * `current` selection.
  */
 export const useNodeGenerations = (workflowId: string, nodeId: string) => {
   const assets = useWorkflowAssetStore(
@@ -31,6 +38,11 @@ export const useNodeGenerations = (workflowId: string, nodeId: string) => {
   );
   const selectedId = useNodes(
     (s) => s.findNode(nodeId)?.data?.selected_generation
+  );
+  const selectedIds = useNodes(
+    useShallow(
+      (s) => s.findNode(nodeId)?.data?.selected_generations ?? STABLE_EMPTY
+    )
   );
   const updateNodeData = useNodes((s) => s.updateNodeData);
 
@@ -54,6 +66,30 @@ export const useNodeGenerations = (workflowId: string, nodeId: string) => {
     (id: string) => updateNodeData(nodeId, { selected_generation: id }),
     [updateNodeData, nodeId]
   );
+  const setSelected = useCallback(
+    (ids: string[]) => updateNodeData(nodeId, { selected_generations: ids }),
+    [updateNodeData, nodeId]
+  );
+  // Add/remove a generation id, preserving pick order: a new id appends, an
+  // already-present id is removed in place.
+  const toggleSelected = useCallback(
+    (id: string) =>
+      setSelected(
+        selectedIds.includes(id)
+          ? selectedIds.filter((existing) => existing !== id)
+          : [...selectedIds, id]
+      ),
+    [setSelected, selectedIds]
+  );
 
-  return { generations, current, select, runs, currentRun };
+  return {
+    generations,
+    current,
+    select,
+    runs,
+    currentRun,
+    selectedIds,
+    toggleSelected,
+    setSelected
+  };
 };

--- a/web/src/hooks/nodes/useRunFromHere.ts
+++ b/web/src/hooks/nodes/useRunFromHere.ts
@@ -9,7 +9,10 @@ import { runInlineGraphJob } from "../../lib/workflow/runInlineGraphJob";
 import { reactFlowNodeToGraphNode } from "../../stores/reactFlowNodeToGraphNode";
 import { reactFlowEdgeToGraphEdge } from "../../stores/reactFlowEdgeToGraphEdge";
 import { buildRunSubgraph } from "../../utils/runSubgraph";
-import { getNodeGenerations } from "../../stores/nodeGenerationAccessor";
+import {
+  getNodeGenerations,
+  getNodeSelectedOutputs
+} from "../../stores/nodeGenerationAccessor";
 import { getCurrentGeneration } from "../../utils/nodeGenerations";
 
 interface UseRunFromHereReturn {
@@ -81,6 +84,16 @@ export function useRunFromHere(
         );
         return current?.outputs;
       },
+      // Multi-select: the source's chosen generations stream into the target via
+      // an injected ForEach replay node (input_list = the selected values), and
+      // the source is pruned. No list-type gate — see buildRunSubgraph.
+      getSelectedOutputs: (wf, sourceId, sourceHandle) =>
+        getNodeSelectedOutputs(
+          wf,
+          sourceId,
+          sourceHandle,
+          findNode(sourceId)?.data?.selected_generations
+        ),
       getMetadata: useMetadataStore.getState().getMetadata
     });
 

--- a/web/src/hooks/nodes/useRunSelectedNodes.ts
+++ b/web/src/hooks/nodes/useRunSelectedNodes.ts
@@ -7,10 +7,14 @@ import {
   useWebsocketRunner
 } from "../../stores/WorkflowRunner";
 import { resolveExternalEdgeValue } from "../../utils/edgeValue";
-import { getNodeGenerations } from "../../stores/nodeGenerationAccessor";
+import {
+  getNodeGenerations,
+  getNodeSelectedOutputs
+} from "../../stores/nodeGenerationAccessor";
 import { getCurrentGeneration } from "../../utils/nodeGenerations";
 import { useNodeStoreRef } from "../../contexts/NodeContext";
 import useMetadataStore from "../../stores/MetadataStore";
+import { buildReplayForEach } from "../../utils/replayStream";
 import {
   EdgeOverrideCollector,
   applyNodeOverrides
@@ -100,10 +104,42 @@ export function useRunSelectedNodes(): UseRunSelectedNodesReturn {
       // upstreams. The collector aggregates multiple edges into one list/collect
       // handle — see EdgeOverrideCollector — so two images wired to a single
       // list[image] handle aren't collapsed to one (last-write-wins).
+      const getMetadata = useMetadataStore.getState().getMetadata;
       const collector = new EdgeOverrideCollector();
+      // Synthetic ForEach replay nodes (and edges) injected for multi-select
+      // external sources; appended to the run graph below. Keyed by id to dedup.
+      const replayNodesById = new Map<string, Node<NodeData>>();
+      const replayEdges: Edge[] = [];
       for (const edge of externalInputEdges) {
         const targetHandle = edge.targetHandle;
         if (!targetHandle) {
+          continue;
+        }
+
+        // Multi-select STREAM: when the upstream source has 2+ generations
+        // selected, prune it and inject a ForEach replay node (input_list = the
+        // selected values) that streams the N values into this target handle as
+        // N iteration-correlated emissions — identical to a live generation. No
+        // list-type gate.
+        const selected = getNodeSelectedOutputs(
+          workflow.id,
+          edge.source,
+          edge.sourceHandle,
+          findNode(edge.source)?.data?.selected_generations
+        );
+        if (selected && selected.length > 0) {
+          const { node, edge: replayEdge } = buildReplayForEach({
+            sourceId: edge.source,
+            sourceHandle: edge.sourceHandle,
+            targetId: edge.target,
+            targetHandle,
+            values: selected,
+            workflowId: workflow.id
+          });
+          if (!replayNodesById.has(node.id)) {
+            replayNodesById.set(node.id, node);
+            replayEdges.push(replayEdge);
+          }
           continue;
         }
 
@@ -120,14 +156,18 @@ export function useRunSelectedNodes(): UseRunSelectedNodesReturn {
         collector.add(edge.target, targetHandle, value);
       }
 
-      const nodePropertyOverrides = collector.resolve(
-        findNode,
-        useMetadataStore.getState().getMetadata
-      );
+      const nodePropertyOverrides = collector.resolve(findNode, getMetadata);
 
-      const nodesWithCachedValues = selectedNodes.map((n: Node<NodeData>) =>
-        applyNodeOverrides(n, nodePropertyOverrides.get(n.id))
-      );
+      const nodesWithCachedValues = [
+        ...selectedNodes.map((n: Node<NodeData>) =>
+          applyNodeOverrides(n, nodePropertyOverrides.get(n.id))
+        ),
+        ...replayNodesById.values()
+      ];
+
+      // The injected ForEach replay edges aren't in the original graph; append
+      // them so the runner wires each replay node into its target.
+      const edgesForRun = [...selectedEdges, ...replayEdges];
 
       console.info(
         `Running workflow from ${selectedNodes.length} selected node(s) × ${totalRuns} run(s)`,
@@ -184,7 +224,7 @@ export function useRunSelectedNodes(): UseRunSelectedNodesReturn {
             {},
             workflow,
             nodesWithCachedValues,
-            selectedEdges,
+            edgesForRun,
             undefined,
             selectedNodeIds,
             true

--- a/web/src/hooks/nodes/useRunSingleNode.ts
+++ b/web/src/hooks/nodes/useRunSingleNode.ts
@@ -4,7 +4,10 @@ import { useNotificationStore } from "../../stores/NotificationStore";
 import useMetadataStore from "../../stores/MetadataStore";
 import { useWebsocketRunner } from "../../stores/WorkflowRunner";
 import { buildRunSubgraph } from "../../utils/runSubgraph";
-import { getNodeGenerations } from "../../stores/nodeGenerationAccessor";
+import {
+  getNodeGenerations,
+  getNodeSelectedOutputs
+} from "../../stores/nodeGenerationAccessor";
 import { getCurrentGeneration } from "../../utils/nodeGenerations";
 import { useNodeStoreRef } from "../../contexts/NodeContext";
 
@@ -62,6 +65,16 @@ export function useRunSingleNode(nodeId: string): UseRunSingleNodeReturn {
         );
         return current?.outputs;
       },
+      // Multi-select: the source's chosen generations stream into the target via
+      // an injected ForEach replay node (input_list = the selected values), and
+      // the source is pruned. No list-type gate — see buildRunSubgraph.
+      getSelectedOutputs: (wf, sourceId, sourceHandle) =>
+        getNodeSelectedOutputs(
+          wf,
+          sourceId,
+          sourceHandle,
+          findNode(sourceId)?.data?.selected_generations
+        ),
       getMetadata: useMetadataStore.getState().getMetadata
     });
 

--- a/web/src/stores/NodeData.ts
+++ b/web/src/stores/NodeData.ts
@@ -16,6 +16,8 @@ export type NodeData = {
   model_id?: string;
   /** Persisted id of the generation chosen to feed downstream (asset id for media). */
   selected_generation?: string;
+  /** Ordered ids of generations chosen to feed downstream as a list. <=1 -> single-selection behavior. */
+  selected_generations?: string[];
   workflow_id: string;
   title?: string;
   /** Marks snippet-backed Code nodes so the UI can lock title editing and hide code by default. */

--- a/web/src/stores/__tests__/nodeGenerationAccessor.test.ts
+++ b/web/src/stores/__tests__/nodeGenerationAccessor.test.ts
@@ -1,4 +1,7 @@
-import { getNodeGenerations } from "../nodeGenerationAccessor";
+import {
+  getNodeGenerations,
+  getNodeSelectedOutputs
+} from "../nodeGenerationAccessor";
 import useResultsStore from "../ResultsStore";
 import { useWorkflowAssetStore } from "../WorkflowAssetStore";
 
@@ -29,4 +32,46 @@ it("merges a persisted asset with a live generation for the node", () => {
   });
   const gens = getNodeGenerations("wf", "n1");
   expect(gens.map((g) => g.id)).toEqual(["a1", "j2"]);
+});
+
+describe("getNodeSelectedOutputs", () => {
+  /** Seed two completed live generations the multi-select can read. */
+  const seedTwoCompleted = () => {
+    useResultsStore.getState().upsertLiveGeneration("wf", "n1", "ja", {
+      createdAt: 1_000_000_000_000,
+      status: "completed",
+      outputs: { output: "valA" }
+    });
+    useResultsStore.getState().upsertLiveGeneration("wf", "n1", "jb", {
+      createdAt: 2_000_000_000_000,
+      status: "completed",
+      outputs: { output: "valB" }
+    });
+  };
+
+  it("returns undefined when fewer than 2 generations are selected", () => {
+    seedTwoCompleted();
+    expect(
+      getNodeSelectedOutputs("wf", "n1", "output", undefined)
+    ).toBeUndefined();
+    expect(getNodeSelectedOutputs("wf", "n1", "output", [])).toBeUndefined();
+    expect(getNodeSelectedOutputs("wf", "n1", "output", ["ja"])).toBeUndefined();
+  });
+
+  it("returns the multi-select outputs in pick order from the merged timeline", () => {
+    seedTwoCompleted();
+    // Pick order is jb then ja (not timeline order).
+    expect(getNodeSelectedOutputs("wf", "n1", "output", ["jb", "ja"])).toEqual([
+      "valB",
+      "valA"
+    ]);
+  });
+
+  it("returns undefined when nothing in the set qualifies", () => {
+    seedTwoCompleted();
+    // Both ids are absent from the timeline → selectedOutputValues yields [].
+    expect(
+      getNodeSelectedOutputs("wf", "n1", "output", ["gone1", "gone2"])
+    ).toBeUndefined();
+  });
 });

--- a/web/src/stores/__tests__/selectedGenerationsRoundtrip.test.ts
+++ b/web/src/stores/__tests__/selectedGenerationsRoundtrip.test.ts
@@ -1,0 +1,83 @@
+jest.mock("../../components/node_types/PlaceholderNode", () => () => null);
+jest.mock("../NodeStore", () => ({
+  DEFAULT_NODE_WIDTH: 200
+}));
+
+import { reactFlowNodeToGraphNode } from "../reactFlowNodeToGraphNode";
+import { graphNodeToReactFlowNode } from "../graphNodeToReactFlowNode";
+import { Workflow } from "../ApiTypes";
+
+const createMockWorkflow = (): Workflow =>
+  ({
+    id: "wf",
+    name: "Test Workflow",
+    graph: { nodes: [], edges: [] },
+    engine: "mem"
+  } as unknown as Workflow);
+
+it("round-trips a populated selected_generations array through ui_properties", () => {
+  const rf = {
+    id: "n1",
+    type: "nodetool.image.Scale",
+    position: { x: 0, y: 0 },
+    data: {
+      properties: {},
+      dynamic_properties: {},
+      workflow_id: "wf",
+      selected_generations: ["a1", "a2", "a3"]
+    }
+  } as never;
+
+  const graph = reactFlowNodeToGraphNode(rf);
+  expect(
+    (graph.ui_properties as Record<string, unknown>).selected_generations
+  ).toEqual(["a1", "a2", "a3"]);
+
+  const back = graphNodeToReactFlowNode(createMockWorkflow(), graph);
+  expect(back.data.selected_generations).toEqual(["a1", "a2", "a3"]);
+});
+
+it("leaves selected_generations undefined when unset", () => {
+  const rf = {
+    id: "n1",
+    type: "nodetool.image.Scale",
+    position: { x: 0, y: 0 },
+    data: {
+      properties: {},
+      dynamic_properties: {},
+      workflow_id: "wf"
+    }
+  } as never;
+
+  const graph = reactFlowNodeToGraphNode(rf);
+  expect(
+    (graph.ui_properties as Record<string, unknown>).selected_generations
+  ).toBeUndefined();
+
+  const back = graphNodeToReactFlowNode(createMockWorkflow(), graph);
+  expect(back.data.selected_generations).toBeUndefined();
+});
+
+it("does not disturb the singular selected_generation field", () => {
+  const rf = {
+    id: "n1",
+    type: "nodetool.image.Scale",
+    position: { x: 0, y: 0 },
+    data: {
+      properties: {},
+      dynamic_properties: {},
+      workflow_id: "wf",
+      selected_generation: "a1",
+      selected_generations: ["a1", "a2"]
+    }
+  } as never;
+
+  const graph = reactFlowNodeToGraphNode(rf);
+  expect(
+    (graph.ui_properties as Record<string, unknown>).selected_generation
+  ).toBe("a1");
+
+  const back = graphNodeToReactFlowNode(createMockWorkflow(), graph);
+  expect(back.data.selected_generation).toBe("a1");
+  expect(back.data.selected_generations).toEqual(["a1", "a2"]);
+});

--- a/web/src/stores/graphNodeToReactFlowNode.ts
+++ b/web/src/stores/graphNodeToReactFlowNode.ts
@@ -112,6 +112,7 @@ export function graphNodeToReactFlowNode(
       model_id: ui_properties?.model_id,
       endpoint_id: ui_properties?.endpoint_id,
       selected_generation: ui_properties?.selected_generation,
+      selected_generations: ui_properties?.selected_generations,
       ...(expandedHeightPxForData != null
         ? { expandedHeightPx: expandedHeightPxForData }
         : {})

--- a/web/src/stores/nodeGenerationAccessor.ts
+++ b/web/src/stores/nodeGenerationAccessor.ts
@@ -4,6 +4,7 @@ import {
   assetToGeneration,
   mergeGenerations,
   getCurrentOutput,
+  selectedOutputValues,
   type Generation
 } from "../utils/nodeGenerations";
 
@@ -35,3 +36,31 @@ export const getNodeCurrentOutput = (
   handle?: string
 ): unknown =>
   getCurrentOutput(getNodeGenerations(workflowId, nodeId), selectedId, handle);
+
+/**
+ * The selected (pick-ordered, completed, num_images-flattened) value list for a
+ * source node's edge handle from its multi-select set, read from the merged
+ * timeline. Returns undefined when fewer than 2 generations are selected
+ * (single-selection behavior is unchanged) or when nothing in the set qualifies
+ * (selectedOutputValues yields []). The partial-run paths feed this list as the
+ * `input_list` of a synthetic ForEach replay node so the downstream receives the
+ * set as a STREAM of N iteration-correlated emissions — identical to a live
+ * generation of those N items. A single focused generation (or no selection)
+ * resolves through the normal single-value path unchanged.
+ */
+export const getNodeSelectedOutputs = (
+  workflowId: string,
+  sourceId: string,
+  handle: string | null | undefined,
+  selectedGenerations: string[] | undefined
+): unknown[] | undefined => {
+  if (!selectedGenerations || selectedGenerations.length < 2) {
+    return undefined;
+  }
+  const values = selectedOutputValues(
+    getNodeGenerations(workflowId, sourceId),
+    selectedGenerations,
+    handle ?? undefined
+  );
+  return values.length > 0 ? values : undefined;
+};

--- a/web/src/stores/nodeUiDefaults.ts
+++ b/web/src/stores/nodeUiDefaults.ts
@@ -17,6 +17,8 @@ export type NodeUIProperties = {
   endpoint_id?: string;
   /** Persisted id of the generation chosen to feed downstream (asset id for media). */
   selected_generation?: string;
+  /** Ordered ids of generations chosen to feed downstream as a list. <=1 -> single-selection behavior. */
+  selected_generations?: string[];
 };
 
 export const DEFAULT_NODE_WIDTH = 280;

--- a/web/src/stores/reactFlowNodeToGraphNode.ts
+++ b/web/src/stores/reactFlowNodeToGraphNode.ts
@@ -22,7 +22,8 @@ export function reactFlowNodeToGraphNode(node: Node<NodeData>): GraphNode {
     bypassed: node.data.bypassed || false,
     model_id: node.data.model_id,
     endpoint_id: node.data.endpoint_id,
-    selected_generation: node.data.selected_generation
+    selected_generation: node.data.selected_generation,
+    selected_generations: node.data.selected_generations
   };
 
   if (node.data.collapsed) {

--- a/web/src/utils/__tests__/nodeGenerations.test.ts
+++ b/web/src/utils/__tests__/nodeGenerations.test.ts
@@ -8,6 +8,8 @@ import {
   groupByRun,
   getCurrentRun,
   runVariantValues,
+  getSelectedGenerations,
+  selectedOutputValues,
   type Generation
 } from "../nodeGenerations";
 import type { Asset } from "../../stores/ApiTypes";
@@ -488,6 +490,97 @@ describe("groupByRun / getCurrentRun / runVariantValues", () => {
         mkGen("b", "j1", 2, "completed", { image: "imgB", mask: "maskB" })
       ])[0];
       expect(runVariantValues(run, "image")).toEqual(["imgA", "imgB"]);
+    });
+  });
+});
+
+describe("getSelectedGenerations / selectedOutputValues", () => {
+  const mkGen = (
+    id: string,
+    status: Generation["status"] = "completed",
+    outputs: Record<string, unknown> = { output: id }
+  ): Generation => ({ id, jobId: "j1", createdAt: 1, outputs, status });
+
+  describe("getSelectedGenerations", () => {
+    const gens = [mkGen("a"), mkGen("b"), mkGen("c")];
+
+    it("returns [] when nothing is selected", () => {
+      expect(getSelectedGenerations(gens, undefined)).toEqual([]);
+      expect(getSelectedGenerations(gens, [])).toEqual([]);
+    });
+
+    it("returns matches in STORED pick order, not timeline order", () => {
+      // pick order c, a — not the a,b,c timeline order
+      expect(getSelectedGenerations(gens, ["c", "a"]).map((g) => g.id)).toEqual([
+        "c",
+        "a"
+      ]);
+    });
+
+    it("drops ids absent from the generations list (stale picks)", () => {
+      expect(
+        getSelectedGenerations(gens, ["b", "gone", "a"]).map((g) => g.id)
+      ).toEqual(["b", "a"]);
+    });
+
+    it("keeps all statuses (running members included)", () => {
+      const withRunning = [mkGen("a", "running"), mkGen("b")];
+      expect(
+        getSelectedGenerations(withRunning, ["a", "b"]).map((g) => g.id)
+      ).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("selectedOutputValues", () => {
+    it("returns [] when nothing is selected", () => {
+      expect(selectedOutputValues([mkGen("a")], undefined)).toEqual([]);
+      expect(selectedOutputValues([mkGen("a")], [])).toEqual([]);
+    });
+
+    it("maps selected (pick-ordered) completed generations to their handle value", () => {
+      const gens = [
+        mkGen("a", "completed", { output: "imgA" }),
+        mkGen("b", "completed", { output: "imgB" }),
+        mkGen("c", "completed", { output: "imgC" })
+      ];
+      expect(selectedOutputValues(gens, ["c", "a"])).toEqual(["imgC", "imgA"]);
+    });
+
+    it("keeps only completed selections (drops running/error members)", () => {
+      const gens = [
+        mkGen("a", "completed", { output: "imgA" }),
+        mkGen("b", "running", { output: "imgB" }),
+        mkGen("c", "error", { output: "imgC" })
+      ];
+      expect(selectedOutputValues(gens, ["a", "b", "c"])).toEqual(["imgA"]);
+    });
+
+    it("spreads an array-valued generation one level (num_images flatten)", () => {
+      const gens = [
+        mkGen("a", "completed", { output: ["i1", "i2"] }),
+        mkGen("b", "completed", { output: "i3" })
+      ];
+      expect(selectedOutputValues(gens, ["a", "b"])).toEqual(["i1", "i2", "i3"]);
+    });
+
+    it("drops null/undefined holes", () => {
+      const gens = [
+        mkGen("a", "completed", { output: "imgA" }),
+        mkGen("b", "completed", { output: null }),
+        mkGen("c", "completed", {})
+      ];
+      expect(selectedOutputValues(gens, ["a", "b", "c"])).toEqual(["imgA"]);
+    });
+
+    it("respects the named handle on multi-key outputs", () => {
+      const gens = [
+        mkGen("a", "completed", { image: "imgA", mask: "maskA" }),
+        mkGen("b", "completed", { image: "imgB", mask: "maskB" })
+      ];
+      expect(selectedOutputValues(gens, ["a", "b"], "image")).toEqual([
+        "imgA",
+        "imgB"
+      ]);
     });
   });
 });

--- a/web/src/utils/__tests__/replayStream.test.ts
+++ b/web/src/utils/__tests__/replayStream.test.ts
@@ -1,0 +1,75 @@
+import { buildReplayForEach, replayNodeId } from "../replayStream";
+
+describe("replayNodeId", () => {
+  it("is deterministic for the same coordinates", () => {
+    expect(replayNodeId("s", "out", "t", "in")).toBe(
+      replayNodeId("s", "out", "t", "in")
+    );
+  });
+
+  it("differs when any coordinate differs", () => {
+    const base = replayNodeId("s", "out", "t", "in");
+    expect(replayNodeId("s2", "out", "t", "in")).not.toBe(base);
+    expect(replayNodeId("s", "out2", "t", "in")).not.toBe(base);
+    expect(replayNodeId("s", "out", "t2", "in")).not.toBe(base);
+    expect(replayNodeId("s", "out", "t", "in2")).not.toBe(base);
+  });
+
+  it("treats a null/undefined source handle as empty (stable)", () => {
+    expect(replayNodeId("s", null, "t", "in")).toBe(
+      replayNodeId("s", undefined, "t", "in")
+    );
+  });
+});
+
+describe("buildReplayForEach", () => {
+  const args = {
+    sourceId: "src",
+    sourceHandle: "output",
+    targetId: "tgt",
+    targetHandle: "image",
+    values: [{ uri: "a.png" }, { uri: "b.png" }],
+    workflowId: "wf-1"
+  };
+
+  it("builds a ForEach node carrying input_list=values and limit=-1", () => {
+    const { node } = buildReplayForEach(args);
+    expect(node.id).toBe(
+      replayNodeId(
+        args.sourceId,
+        args.sourceHandle,
+        args.targetId,
+        args.targetHandle
+      )
+    );
+    expect(node.type).toBe("nodetool.control.ForEach");
+    expect(node.position).toEqual({ x: 0, y: 0 });
+    expect(node.data.properties).toEqual({
+      input_list: args.values,
+      limit: -1
+    });
+    expect(node.data.dynamic_properties).toEqual({});
+    expect(node.data.workflow_id).toBe("wf-1");
+  });
+
+  it("wires the ForEach output handle to the target handle", () => {
+    const { node, edge } = buildReplayForEach(args);
+    expect(edge.id).toBe(`${node.id}->tgt:image`);
+    expect(edge.source).toBe(node.id);
+    expect(edge.sourceHandle).toBe("output");
+    expect(edge.target).toBe("tgt");
+    expect(edge.targetHandle).toBe("image");
+  });
+
+  it("preserves the pick order of the values in input_list", () => {
+    const { node } = buildReplayForEach({
+      ...args,
+      values: ["x", "y", "z"]
+    });
+    expect((node.data.properties as { input_list: unknown[] }).input_list).toEqual([
+      "x",
+      "y",
+      "z"
+    ]);
+  });
+});

--- a/web/src/utils/__tests__/runSubgraph.test.ts
+++ b/web/src/utils/__tests__/runSubgraph.test.ts
@@ -230,4 +230,145 @@ describe("buildRunSubgraph", () => {
     });
     expect(sub.blocked).toHaveLength(1);
   });
+
+  describe("multi-select (getSelectedOutputs) ForEach replay injection", () => {
+    // The target has a `tiles` list[image] handle and a scalar `input` handle.
+    const getMetadataWithList = (type: string): NodeMetadata =>
+      ({
+        auto_save_asset: type.startsWith("gen."),
+        title: type,
+        properties:
+          type === "proc.Plain"
+            ? [
+                {
+                  name: "tiles",
+                  type: {
+                    type: "list",
+                    type_args: [{ type: "image", type_args: [] }]
+                  }
+                },
+                { name: "input", type: { type: "image", type_args: [] } }
+              ]
+            : []
+      }) as unknown as NodeMetadata;
+
+    const selectedValues = [
+      { uri: "a.png", type: "image" },
+      { uri: "b.png", type: "image" }
+    ];
+
+    const expectReplay = (
+      sub: ReturnType<typeof buildRunSubgraph>,
+      targetHandle: string
+    ): void => {
+      // Source pruned: not submitted, not blocked.
+      expect(sub.blocked).toEqual([]);
+      expect(sub.nodeIds).toEqual(new Set(["t"]));
+
+      // A single synthetic ForEach replay node carries the selected values as
+      // its input_list; its output edge streams into the target handle.
+      const replay = sub.nodes.find(
+        (n) => n.type === "nodetool.control.ForEach"
+      )!;
+      expect(replay).toBeDefined();
+      expect(replay.data.properties.input_list).toEqual(selectedValues);
+
+      const replayEdge = sub.edges.find((e) => e.source === replay.id)!;
+      expect(replayEdge).toBeDefined();
+      expect(replayEdge.sourceHandle).toBe("output");
+      expect(replayEdge.target).toBe("t");
+      expect(replayEdge.targetHandle).toBe(targetHandle);
+
+      // The source node is not part of the run; no real edge from it remains.
+      expect(sub.nodes.some((n) => n.id === "g")).toBe(false);
+      expect(sub.edges.some((e) => e.source === "g")).toBe(false);
+
+      // No static override is injected on the target for the streamed handle.
+      const submitted = sub.nodes.find((n) => n.id === "t")!;
+      expect(submitted.data.properties[targetHandle]).toBeUndefined();
+    };
+
+    it("injects a ForEach replay stream into a LIST target and prunes the source", () => {
+      const target = node("t", "proc.Plain");
+      const generator = node("g", "gen.Image");
+      const sub = buildRunSubgraph({
+        targetId: "t",
+        nodes: [target, generator],
+        edges: [edge("e", "g", "t", "tiles")],
+        workflowId: WF,
+        getResult: noResults,
+        getMetadata: getMetadataWithList,
+        getSelectedOutputs: (_wf, src, handle) =>
+          src === "g" && handle === "output" ? selectedValues : undefined
+      });
+      expectReplay(sub, "tiles");
+    });
+
+    it("injects a ForEach replay stream into a SCALAR target too (no list gate)", () => {
+      const target = node("t", "proc.Plain");
+      const generator = node("g", "gen.Image");
+      const sub = buildRunSubgraph({
+        targetId: "t",
+        nodes: [target, generator],
+        edges: [edge("e", "g", "t", "input")],
+        workflowId: WF,
+        getResult: noResults,
+        getMetadata: getMetadataWithList,
+        getSelectedOutputs: (_wf, src, handle) =>
+          src === "g" && handle === "output" ? selectedValues : undefined
+      });
+      expectReplay(sub, "input");
+    });
+
+    it("ignores an empty multi-select set (falls through to the single cached value)", () => {
+      const target = node("t", "proc.Plain");
+      const generator = node("g", "gen.Image");
+      const getResult = (_wf: string, src: string) =>
+        src === "g" ? { output: { uri: "focused.png", type: "image" } } : undefined;
+      const sub = buildRunSubgraph({
+        targetId: "t",
+        nodes: [target, generator],
+        edges: [edge("e", "g", "t", "tiles")],
+        workflowId: WF,
+        getResult,
+        getMetadata: getMetadataWithList,
+        getSelectedOutputs: () => []
+      });
+
+      // No ForEach injected; the single focused generation wins via the override.
+      expect(
+        sub.nodes.some((n) => n.type === "nodetool.control.ForEach")
+      ).toBe(false);
+      const submitted = sub.nodes.find((n) => n.id === "t")!;
+      expect(submitted.data.properties.tiles).toEqual({
+        uri: "focused.png",
+        type: "image"
+      });
+    });
+
+    it("dedups one replay node when a multi-select source feeds the same target handle twice", () => {
+      const target = node("t", "proc.Plain");
+      const generator = node("g", "gen.Image");
+      const sub = buildRunSubgraph({
+        targetId: "t",
+        nodes: [target, generator],
+        edges: [
+          edge("e1", "g", "t", "tiles"),
+          edge("e2", "g", "t", "tiles")
+        ],
+        workflowId: WF,
+        getResult: noResults,
+        getMetadata: getMetadataWithList,
+        getSelectedOutputs: (_wf, src, handle) =>
+          src === "g" && handle === "output" ? selectedValues : undefined
+      });
+
+      const replays = sub.nodes.filter(
+        (n) => n.type === "nodetool.control.ForEach"
+      );
+      expect(replays).toHaveLength(1);
+      const replayEdges = sub.edges.filter((e) => e.source === replays[0].id);
+      expect(replayEdges).toHaveLength(1);
+    });
+  });
 });

--- a/web/src/utils/nodeGenerations.ts
+++ b/web/src/utils/nodeGenerations.ts
@@ -296,3 +296,43 @@ export const runVariantValues = (
       return Array.isArray(value) ? value : [value];
     })
     .filter((value) => value !== undefined && value !== null);
+
+/**
+ * The generations matching `selectedIds`, in the STORED pick order (not timeline
+ * order). Ids absent from `generations` are dropped; all statuses are kept (the
+ * UI badges running members too). Returns [] when nothing is selected.
+ */
+export const getSelectedGenerations = (
+  generations: Generation[],
+  selectedIds: string[] | undefined
+): Generation[] => {
+  if (!selectedIds || selectedIds.length === 0) return [];
+  const byId = new Map(generations.map((g) => [g.id, g]));
+  const result: Generation[] = [];
+  for (const id of selectedIds) {
+    const found = byId.get(id);
+    if (found) result.push(found);
+  }
+  return result;
+};
+
+/**
+ * The downstream LIST value for one edge handle from a multi-select set: the
+ * selected (pick-ordered) generations, filtered to completed, mapped through
+ * outputOf(g, handle) with array-valued results (the live num_images=N shape)
+ * spread one level, and null/undefined dropped. Returns [] when nothing
+ * qualifies. Mirrors runVariantValues' flatten so a streamed multi-variant set
+ * and a single array-valued generation resolve to the same flat list.
+ */
+export const selectedOutputValues = (
+  generations: Generation[],
+  selectedIds: string[] | undefined,
+  handle?: string
+): unknown[] =>
+  getSelectedGenerations(generations, selectedIds)
+    .filter((g) => g.status === "completed")
+    .flatMap((g) => {
+      const value = outputOf(g, handle);
+      return Array.isArray(value) ? value : [value];
+    })
+    .filter((value) => value !== undefined && value !== null);

--- a/web/src/utils/replayStream.ts
+++ b/web/src/utils/replayStream.ts
@@ -1,0 +1,67 @@
+import { Node, Edge } from "@xyflow/react";
+import { NodeData } from "../stores/NodeData";
+
+const FOR_EACH_NODE_TYPE = "nodetool.control.ForEach";
+
+/**
+ * Stable, collision-free id for the synthetic ForEach replay node that feeds
+ * (targetId, targetHandle) the values a pruned multi-select source (sourceId,
+ * sourceHandle) would have emitted. Deterministic in all four coordinates so a
+ * re-run of the same partial graph reuses the same id (no duplicate nodes) and
+ * two different replays into the same target never collide.
+ */
+export const replayNodeId = (
+  sourceId: string,
+  sourceHandle: string | null | undefined,
+  targetId: string,
+  targetHandle: string
+): string =>
+  `replay:${sourceId}:${sourceHandle ?? ""}->${targetId}:${targetHandle}`;
+
+/**
+ * Build the synthetic `nodetool.control.ForEach` replay node + edge that streams
+ * a multi-select set into one downstream handle. The ForEach's `input_list` is
+ * the selected (pick-ordered, completed, num_images-flattened) value list, so
+ * `genProcess` yields each item with iteration correlation — the downstream
+ * receives N iteration-correlated emissions, identical to a live generation of
+ * those N items. `input_list`-as-property binds to the node instance exactly as
+ * today's static property overrides do, so no edge into the ForEach is needed.
+ *
+ * The node mirrors the minimal shape `reactFlowNodeToGraphNode` / the run graph
+ * expects (id, type, position, data.{properties, dynamic_properties,
+ * workflow_id}); the edge wires the ForEach `output` handle to the target.
+ */
+export const buildReplayForEach = (args: {
+  sourceId: string;
+  sourceHandle: string | null | undefined;
+  targetId: string;
+  targetHandle: string;
+  values: unknown[];
+  workflowId: string;
+}): { node: Node<NodeData>; edge: Edge } => {
+  const { sourceId, sourceHandle, targetId, targetHandle, values, workflowId } =
+    args;
+  const replayId = replayNodeId(sourceId, sourceHandle, targetId, targetHandle);
+
+  const node: Node<NodeData> = {
+    id: replayId,
+    type: FOR_EACH_NODE_TYPE,
+    position: { x: 0, y: 0 },
+    data: {
+      properties: { input_list: values, limit: -1 },
+      dynamic_properties: {},
+      selectable: true,
+      workflow_id: workflowId
+    }
+  };
+
+  const edge: Edge = {
+    id: `${replayId}->${targetId}:${targetHandle}`,
+    source: replayId,
+    sourceHandle: "output",
+    target: targetId,
+    targetHandle
+  };
+
+  return { node, edge };
+};

--- a/web/src/utils/runSubgraph.ts
+++ b/web/src/utils/runSubgraph.ts
@@ -3,9 +3,15 @@ import { NodeData } from "../stores/NodeData";
 import { NodeMetadata } from "../stores/ApiTypes";
 import { resolveExternalEdgeValue } from "./edgeValue";
 import { EdgeOverrideCollector, applyNodeOverrides } from "./edgeOverrides";
+import { buildReplayForEach } from "./replayStream";
 
 type GetResult = (_workflowId: string, _nodeId: string) => unknown;
 type GetMetadata = (_nodeType: string) => NodeMetadata | undefined;
+type GetSelectedOutputs = (
+  _workflowId: string,
+  _sourceId: string,
+  _sourceHandle: string | null | undefined
+) => unknown[] | undefined;
 
 interface BlockedUpstream {
   nodeId: string;
@@ -48,7 +54,8 @@ export const buildRunSubgraph = ({
   edges,
   workflowId,
   getResult,
-  getMetadata
+  getMetadata,
+  getSelectedOutputs
 }: {
   targetId: string;
   nodes: Node<NodeData>[];
@@ -56,6 +63,16 @@ export const buildRunSubgraph = ({
   workflowId: string;
   getResult: GetResult;
   getMetadata: GetMetadata;
+  /**
+   * Optional per-edge multi-select stream: the value list a source node would
+   * emit to one edge handle when 2+ generations are selected. Consulted BEFORE
+   * the normal single-value resolution. When it yields a non-empty list, the
+   * source is pruned and a synthetic ForEach replay node is injected whose
+   * `input_list` is that list, streaming the N values into the target handle as
+   * N iteration-correlated emissions (identical to a live generation). No
+   * list-type gate — streaming N items to ANY consumer is valid live behavior.
+   */
+  getSelectedOutputs?: GetSelectedOutputs;
 }): RunSubgraph => {
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
   const findNode = (id: string): Node<NodeData> | undefined => nodeById.get(id);
@@ -71,6 +88,12 @@ export const buildRunSubgraph = ({
   const collector = new EdgeOverrideCollector();
   const blocked: BlockedUpstream[] = [];
   const blockedSeen = new Set<string>();
+  // Synthetic ForEach replay nodes (and their edges) injected for multi-select
+  // sources. They are not part of the original graph, so append them explicitly
+  // to the returned subgraph — keyed by id to dedup a source feeding the same
+  // target handle twice.
+  const replayNodesById = new Map<string, Node<NodeData>>();
+  const replayEdges: Edge[] = [];
 
   const stack: string[] = [targetId];
   while (stack.length) {
@@ -79,6 +102,33 @@ export const buildRunSubgraph = ({
     for (const edge of inbound) {
       if (!edge.targetHandle) {
         continue;
+      }
+
+      // Multi-select STREAM: when the source has 2+ generations selected, prune
+      // it and inject a ForEach replay node that streams the selected values
+      // into this target handle as N iteration-correlated emissions — identical
+      // to a live generation of those N items. No list-type gate.
+      if (getSelectedOutputs) {
+        const selected = getSelectedOutputs(
+          workflowId,
+          edge.source,
+          edge.sourceHandle
+        );
+        if (selected && selected.length > 0) {
+          const { node, edge: replayEdge } = buildReplayForEach({
+            sourceId: edge.source,
+            sourceHandle: edge.sourceHandle,
+            targetId: currentId,
+            targetHandle: edge.targetHandle,
+            values: selected,
+            workflowId
+          });
+          if (!replayNodesById.has(node.id)) {
+            replayNodesById.set(node.id, node);
+            replayEdges.push(replayEdge);
+          }
+          continue;
+        }
       }
 
       const { value, hasValue } = resolveExternalEdgeValue(
@@ -127,9 +177,13 @@ export const buildRunSubgraph = ({
     (e) => included.has(e.source) && included.has(e.target)
   );
 
+  // Append synthetic ForEach replay nodes/edges: they aren't in the original
+  // graph (their target is already included), so the edge filter above skips
+  // them. Their ids are namespaced ("replay:…") so they never collide with a
+  // real node id.
   return {
-    nodes: subgraphNodes,
-    edges: subgraphEdges,
+    nodes: [...subgraphNodes, ...replayNodesById.values()],
+    edges: [...subgraphEdges, ...replayEdges],
     nodeIds: included,
     blocked
   };


### PR DESCRIPTION
## What

A node can now select **multiple** past generations (an ordered, pick-order list `selected_generations`) instead of just one. When **2+** are selected, the partial-run paths feed those outputs downstream as a **stream of N iteration-correlated emissions** — identical to a live generation of N items. Selecting one (or none) keeps the existing single-value behavior exactly as before.

## How it works

When a run-graph edge crosses out of a pruned multi-select source, instead of injecting a single cached override we inject a synthetic **`nodetool.control.ForEach` replay node** whose `input_list` is the selected (completed, `num_images`-flattened) value list. The ForEach streams each item with iteration correlation, so the downstream consumer sees the set as a live N-item stream. No list-type gate — streaming N items to any consumer is valid live behavior.

The replay node's id is deterministic in all four coordinates (`replay:source:handle->target:handle`) so re-running the same partial graph reuses the same node (no duplicates) and two distinct replays into the same target never collide.

## Changes

**Persistence**
- `selected_generations` added to `NodeData` / `NodeUIProperties`, round-tripped through `graphNodeToReactFlowNode` / `reactFlowNodeToGraphNode`.

**Selection → values**
- `utils/nodeGenerations`: `getSelectedGenerations` (pick-ordered lookup) + `selectedOutputValues` (completed, flattened — mirrors `runVariantValues`).
- `stores/nodeGenerationAccessor`: `getNodeSelectedOutputs` returns `undefined` for `<2` selections so single-selection paths are untouched.

**Run-graph injection**
- `utils/replayStream` (new): `buildReplayForEach` / `replayNodeId`.
- `utils/runSubgraph` and `hooks/nodes/buildDownstreamRunGraph`: prune the source and inject the ForEach replay node + edge; replayed edges are excluded from the single-value cached-override collection.
- `useRunFromHere` / `useRunSelectedNodes` / `useRunSingleNode` wire `getSelectedOutputs` through.

**UI**
- `useNodeGenerations` exposes `selectedIds` / `toggleSelected` / `setSelected` alongside the focused `current` selection.
- `NodeHistoryViewer` multi-select picking; `SketchNode` / `ListGeneratorBody` / `ContentCardBody` updates.

## Testing

- New suites: `replayStream`, `selectedGenerationsRoundtrip`.
- Expanded: `runSubgraph`, `buildDownstreamRunGraph`, `nodeGenerations`, `nodeGenerationAccessor`, `useRunSelectedNodes`, `NodeHistoryViewer`, `ContentCardBody`.
- `tsc --noEmit` clean; **158 tests pass** across the 10 affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)