### PR TITLE
Assets panel QoL: current-workflow filter, hide empty folder tree, better fullscreen

### DIFF
--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -16,6 +16,7 @@ import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import FilterAltOffIcon from "@mui/icons-material/FilterAltOff";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import FilterCenterFocusIcon from "@mui/icons-material/FilterCenterFocus";
 import AssetSearchInput from "./AssetSearchInput";
 import AssetActions from "./AssetActions";
 import SearchErrorBoundary from "../SearchErrorBoundary";
@@ -82,12 +83,25 @@ const TYPE_FILTER_ICONS: Record<TypeFilterKey, React.ReactNode> = {
   other: <MoreHorizIcon />
 };
 
+const fullscreenFiltersStyles = css({
+  "&": {
+    width: "auto",
+    flex: "1 1 auto",
+    margin: 0
+  }
+});
+
 interface AssetActionsMenuProps {
   maxItemSize: number;
   onUploadFiles?: (files: File[]) => void;
+  isFullscreenAssets?: boolean;
 }
 
-const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUploadFiles }) => {
+const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
+  maxItemSize,
+  onUploadFiles,
+  isFullscreenAssets = false
+}) => {
   const setSelectedAssetIds = useAssetGridStore(
     (state) => state.setSelectedAssetIds
   );
@@ -112,6 +126,9 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
   const [workflowSearch, setWorkflowSearch] = useState("");
 
   const load = useWorkflowManager((state) => state.load);
+  const currentWorkflowId = useWorkflowManager(
+    (state) => state.currentWorkflowId
+  );
   const { data: workflowData } = useQuery<WorkflowList, Error>({
     queryKey: ["workflows"],
     queryFn: async () => load("", 200)
@@ -135,10 +152,25 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
     (next: TypeFilterKey) => setTypeFilter(next),
     [setTypeFilter]
   );
-  const { folderFiles } = useAssets();
+  const { folderFiles, folderTree } = useAssets();
   const { handleSelectAllAssets, handleDeselectAssets } =
     useAssetSelection(folderFiles);
   const [expanded, setExpanded] = useState(false);
+
+  const hasFolders = useMemo(
+    () => !!folderTree && Object.keys(folderTree).length > 0,
+    [folderTree]
+  );
+  // In fullscreen the filter row is always visible; in the sidebar it is
+  // toggled by the tune button.
+  const showFilters = expanded || isFullscreenAssets;
+  const showCurrentWorkflowButton = Boolean(currentWorkflowId);
+  const currentWorkflowActive =
+    workflowFilter !== null && workflowFilter === currentWorkflowId;
+
+  const handleToggleCurrentWorkflow = useCallback(() => {
+    setWorkflowFilter(currentWorkflowActive ? null : currentWorkflowId);
+  }, [currentWorkflowActive, currentWorkflowId, setWorkflowFilter]);
 
   const onLocalSearchChange = useCallback(
     (newSearchTerm: string) => {
@@ -154,7 +186,19 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
     TYPE_FILTERS.find((f) => f.key === typeFilter)?.label ?? "All";
 
   return (
-    <Box className="asset-menu" sx={{ width: "100%" }}>
+    <Box
+      className="asset-menu"
+      sx={{
+        width: "100%",
+        ...(isFullscreenAssets && {
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          columnGap: 1,
+          rowGap: 0.5
+        })
+      }}
+    >
       <FlexRow
         className="asset-menu-toolbar"
         align="center"
@@ -166,20 +210,24 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
           "& .MuiSvgIcon-root": { fontSize: 14 }
         }}
       >
-        <ToolbarIconButton
-          icon={<TuneIcon />}
-          tooltip={expanded ? "Hide filters" : "Show filters"}
-          onClick={() => setExpanded((prev) => !prev)}
-          tooltipPlacement="top"
-          nodrag={false}
-        />
-        <ToolbarIconButton
-          icon={foldersVisible ? <FolderIcon /> : <FolderOffIcon />}
-          tooltip={foldersVisible ? "Hide folders" : "Show folders"}
-          onClick={toggleFoldersVisible}
-          tooltipPlacement="top"
-          nodrag={false}
-        />
+        {!isFullscreenAssets && (
+          <ToolbarIconButton
+            icon={<TuneIcon />}
+            tooltip={expanded ? "Hide filters" : "Show filters"}
+            onClick={() => setExpanded((prev) => !prev)}
+            tooltipPlacement="top"
+            nodrag={false}
+          />
+        )}
+        {!isFullscreenAssets && hasFolders && (
+          <ToolbarIconButton
+            icon={foldersVisible ? <FolderIcon /> : <FolderOffIcon />}
+            tooltip={foldersVisible ? "Hide folders" : "Show folders"}
+            onClick={toggleFoldersVisible}
+            tooltipPlacement="top"
+            nodrag={false}
+          />
+        )}
         <ToolbarIconButton
           tooltip="Filter by type"
           onClick={(e) => setTypeFilterAnchor(e.currentTarget)}
@@ -207,6 +255,24 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
             <ArrowDropDownIcon />
           </FlexRow>
         </ToolbarIconButton>
+        {showCurrentWorkflowButton && (
+          <ToolbarIconButton
+            icon={<FilterCenterFocusIcon />}
+            tooltip={
+              currentWorkflowActive
+                ? "Showing this workflow's assets"
+                : "Show this workflow's assets"
+            }
+            onClick={handleToggleCurrentWorkflow}
+            tooltipPlacement="top"
+            nodrag={false}
+            sx={{
+              color: currentWorkflowActive
+                ? "var(--palette-primary-main)"
+                : undefined
+            }}
+          />
+        )}
         <ToolbarIconButton
           tooltip={workflowFilter ? `Workflow: ${activeWorkflowName}` : "Filter by workflow"}
           onClick={(e) => setWorkflowFilterAnchor(e.currentTarget)}
@@ -323,10 +389,14 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({ maxItemSize, onUplo
         </Box>
       </Popover>
 
-      {expanded && (
+      {showFilters && (
         <Box
           className="asset-menu-with-global-search"
-          css={styles(theme)}
+          css={
+            isFullscreenAssets
+              ? [styles(theme), fullscreenFiltersStyles]
+              : styles(theme)
+          }
         >
           <SearchErrorBoundary fallbackTitle="Search Input Error">
             <AssetSearchInput

--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -120,7 +120,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   isFullscreenAssets,
   isMobile = false
 }) => {
-  const { error, folderFilesFiltered } = useAssets();
+  const { error, folderFilesFiltered, folderTree } = useAssets();
   const {
     setOpenAsset,
     setSelectedAssetIds,
@@ -149,6 +149,16 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   const openMenuType = useContextMenuStore((state) => state.openMenuType);
 
   const theme = useTheme();
+
+  // Folders are always shown in fullscreen; in the sidebar they follow the
+  // user's toggle. Either way, hide the tree entirely when there are no
+  // folders to show.
+  const hasFolders = useMemo(
+    () => !!folderTree && Object.keys(folderTree).length > 0,
+    [folderTree]
+  );
+  const effectiveFoldersVisible =
+    hasFolders && (Boolean(isFullscreenAssets) || foldersVisible);
 
   // Dockview panel components are defined below; handlers for files live inside the Files panel
 
@@ -251,66 +261,32 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     const api = dockviewApiRef.current;
     if (!api || isMobile) return;
     const existing = api.getPanel("asset-folders");
-    if (foldersVisible && !existing) {
+    if (effectiveFoldersVisible && !existing) {
       addFoldersPanel(api);
-    } else if (!foldersVisible && existing) {
+    } else if (!effectiveFoldersVisible && existing) {
       api.removePanel(existing);
     }
-  }, [foldersVisible, isMobile, addFoldersPanel]);
+  }, [effectiveFoldersVisible, isMobile, addFoldersPanel]);
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       const { api } = event;
       dockviewApiRef.current = api;
 
-      if (isMobile) {
-        // On mobile, skip the folders panel — just show files with breadcrumb nav
-        api.addPanel({
-          id: "asset-files",
-          component: "asset-files",
-          title: "Files",
-          params: { isHorizontal, itemSpacing }
-        });
-        return;
-      }
-
-      // Add folders panel first with an initial size
-      const foldersPanel: IDockviewPanelWithGroup = api.addPanel({
-        id: "asset-folders",
-        component: "asset-folders",
-        title: "Folders",
-        ...(isFullscreenAssets
-          ? { initialWidth: FOLDERS_PANEL_WIDTH }
-          : { initialHeight: FOLDERS_PANEL_HEIGHT })
-      });
-
-      // Add files panel positioned relative to folders
+      // The files panel is always present; the folders panel is added next to
+      // it (and kept in sync) by addFoldersPanel / the effect above.
       api.addPanel({
         id: "asset-files",
         component: "asset-files",
         title: "Files",
-        params: { isHorizontal, itemSpacing },
-        position: {
-          referencePanel: "asset-folders",
-          direction: isFullscreenAssets ? "right" : "below"
-        }
+        params: { isHorizontal, itemSpacing }
       });
 
-      // Enforce initial size
-      const applyInitialSize = () => {
-        const groupApi =
-          foldersPanel?.group?.api ?? foldersPanel?.group;
-        if (groupApi && typeof groupApi.setSize === "function") {
-          if (isFullscreenAssets) {
-            groupApi.setSize({ width: FOLDERS_PANEL_WIDTH });
-          } else {
-            groupApi.setSize({ height: FOLDERS_PANEL_HEIGHT });
-          }
-        }
-      };
-      applyInitialSize();
+      if (!isMobile && effectiveFoldersVisible) {
+        addFoldersPanel(api);
+      }
     },
-    [isFullscreenAssets, isHorizontal, itemSpacing, isMobile]
+    [isHorizontal, itemSpacing, isMobile, effectiveFoldersVisible, addFoldersPanel]
   );
 
   return (
@@ -339,7 +315,11 @@ const AssetGrid: React.FC<AssetGridProps> = ({
         />
       )}
       {!isMobile && (
-        <AssetActionsMenu maxItemSize={maxItemSize} onUploadFiles={uploadFiles} />
+        <AssetActionsMenu
+          maxItemSize={maxItemSize}
+          onUploadFiles={uploadFiles}
+          isFullscreenAssets={isFullscreenAssets}
+        />
       )}
       {!isMobile && (
         <StorageAnalytics


### PR DESCRIPTION
- Add a one-click toolbar button to filter assets to the current workflow
  (toggles the workflow filter on/off using the editor's current workflow id).
- Hide the folders tree (and its toggle button) when there are no folders.
- In fullscreen, always show the folders panel and the filter row, and lay the
  toolbar and filters out side-by-side to use the available width.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DJss3xbCxau91xGVdVf4VK