### PR TITLE
feat(runtime): expand provider failure logging to all modalities

### DIFF
--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -32,6 +32,7 @@ import type { UsageInfo } from "./cost-calculator.js";
 import { getTracer } from "../telemetry.js";
 import {
   withUsageCapture,
+  withModalityCapture,
   setLastUsage,
   setLastRequest,
   consumeLastUsage,
@@ -181,6 +182,57 @@ export abstract class BaseProvider {
 
   protected constructor(provider: ProviderId) {
     this.provider = provider;
+    this.installModalityFailureLogging();
+  }
+
+  /**
+   * Chat already records what it sent and logs it on failure through
+   * {@link generateMessageTraced} / {@link generateMessagesTraced}. The
+   * non-chat modalities (image/video/audio/3D/embedding) are called directly,
+   * so wrap every one a concrete provider actually overrides with the same
+   * central failure logging.
+   *
+   * We replace methods on the instance (not the prototype), and only the ones
+   * that differ from the base — so an unsupported modality keeps its base
+   * "does not support" throw and never logs a spurious failure. Providers may
+   * additionally call {@link recordRequestPayload} to log the exact wire body;
+   * otherwise the call arguments are logged (binary buffers reduced to size
+   * markers, secrets redacted).
+   */
+  private installModalityFailureLogging(): void {
+    const proto = BaseProvider.prototype as unknown as Record<string, unknown>;
+    const self = this as unknown as Record<string, unknown>;
+
+    for (const name of MODALITY_PROMISE_METHODS) {
+      const fn = self[name];
+      if (typeof fn !== "function" || fn === proto[name]) continue;
+      const original = fn as (...args: unknown[]) => Promise<unknown>;
+      self[name] = (...args: unknown[]): Promise<unknown> =>
+        withModalityCapture(async (alreadyActive) => {
+          try {
+            return await original.apply(this, args);
+          } catch (err) {
+            if (!alreadyActive) {
+              logProviderRequestFailure({
+                provider: this.provider,
+                model: extractModelId(args),
+                request: peekLastRequest(),
+                nodetoolArgs: args,
+                error: err
+              });
+            }
+            throw err;
+          }
+        });
+    }
+
+    for (const name of MODALITY_GENERATOR_METHODS) {
+      const fn = self[name];
+      if (typeof fn !== "function" || fn === proto[name]) continue;
+      const original = fn as (...args: unknown[]) => AsyncGenerator<unknown>;
+      self[name] = (...args: unknown[]): AsyncGenerator<unknown> =>
+        wrapModalityGenerator(this, original, args);
+    }
   }
 
   static requiredSecrets(): string[] {
@@ -938,6 +990,100 @@ export abstract class BaseProvider {
     }
 
     return uri;
+  }
+}
+
+/**
+ * Promise-returning non-chat modality methods wrapped with central failure
+ * logging. Batch helpers are included; nested delegation to their singular
+ * method is logged once (see {@link withModalityCapture}).
+ */
+const MODALITY_PROMISE_METHODS = [
+  "textToImage",
+  "textToImages",
+  "imageToImage",
+  "imageToImages",
+  "inpaint",
+  "inpaintImages",
+  "upscaleImage",
+  "removeBackground",
+  "relightImage",
+  "vectorizeImage",
+  "textToSpeechEncoded",
+  "automaticSpeechRecognition",
+  "textToVideo",
+  "imageToVideo",
+  "videoToVideo",
+  "lipSync",
+  "textTo3D",
+  "imageTo3D",
+  "generateEmbedding"
+] as const;
+
+/** Async-generator non-chat modality methods wrapped with failure logging. */
+const MODALITY_GENERATOR_METHODS = ["textToSpeech"] as const;
+
+/**
+ * Best-effort model id for failure logging. Modality params carry the model
+ * either as a plain string (ASR, embeddings) or as a model object with an `id`
+ * (image/video tasks). Returns "unknown" when neither is present.
+ */
+function extractModelId(args: unknown[]): string {
+  for (const arg of args) {
+    if (!arg || typeof arg !== "object") continue;
+    const model = (arg as { model?: unknown }).model;
+    if (typeof model === "string") return model;
+    if (model && typeof model === "object") {
+      const id = (model as { id?: unknown }).id;
+      if (typeof id === "string") return id;
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Drive a provider's async-generator modality method (e.g. textToSpeech)
+ * through a per-call slot — so `recordRequestPayload` is visible across yields —
+ * and log centrally if it throws. The slot is wrapped around each `next()`
+ * because AsyncLocalStorage does not persist across generator suspension.
+ */
+async function* wrapModalityGenerator(
+  provider: BaseProvider,
+  original: (...args: unknown[]) => AsyncGenerator<unknown>,
+  args: unknown[]
+): AsyncGenerator<unknown> {
+  const { runInSlot, getRequest } = createUsageSlot();
+  const source = original.apply(provider, args);
+  let exhausted = false;
+  try {
+    while (true) {
+      const result = await runInSlot(() => source.next());
+      if (result.done) {
+        exhausted = true;
+        return result.value;
+      }
+      yield result.value;
+    }
+  } catch (err) {
+    logProviderRequestFailure({
+      provider: provider.provider,
+      model: extractModelId(args),
+      request: getRequest(),
+      nodetoolArgs: args,
+      error: err
+    });
+    throw err;
+  } finally {
+    if (!exhausted) {
+      await runInSlot(
+        () =>
+          source.return?.(undefined as never) ??
+          Promise.resolve({
+            done: true,
+            value: undefined
+          } as IteratorResult<unknown>)
+      ).catch(() => {});
+    }
   }
 }
 

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -81,6 +81,13 @@ export interface LlmUsage {
 interface CallSlot {
   usage: LlmUsage | null;
   request: unknown;
+  /**
+   * Set while a non-chat modality call (image/video/audio/3D/embedding) is
+   * being failure-logged. Lets nested calls — e.g. a batch helper delegating
+   * to its singular method — reuse the parent slot so a failure is logged once,
+   * at the outermost call. See {@link withModalityCapture}.
+   */
+  modality?: boolean;
 }
 const usageStore = new AsyncLocalStorage<CallSlot>();
 
@@ -126,6 +133,24 @@ export function setLastRequest(request: unknown): void {
 /** Read (without clearing) the request payload recorded in this async context. */
 export function peekLastRequest(): unknown {
   return usageStore.getStore()?.request ?? null;
+}
+
+/**
+ * Run a non-chat modality call (image/video/audio/3D/embedding) inside a fresh
+ * per-call slot so `recordRequestPayload` and `peekLastRequest` work the same
+ * way they do for chat. `fn` receives whether a modality capture was already
+ * active in this async context: nested calls (a batch helper delegating to its
+ * singular method) reuse the parent slot and pass `true`, so the caller can log
+ * a failure exactly once — at the outermost call.
+ */
+export function withModalityCapture<T>(
+  fn: (alreadyActive: boolean) => Promise<T>
+): Promise<T> {
+  const existing = usageStore.getStore();
+  if (existing?.modality) return fn(true);
+  return usageStore.run({ usage: null, request: null, modality: true }, () =>
+    fn(false)
+  );
 }
 
 /**

--- a/packages/runtime/tests/providers/modality-failure-logging.test.ts
+++ b/packages/runtime/tests/providers/modality-failure-logging.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration tests: BaseProvider wraps every non-chat modality method a
+ * concrete provider overrides (image/video/audio/3D/embedding) with the same
+ * central failure logging chat gets, without callers doing anything special.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { BaseProvider } from "../../src/providers/base-provider.js";
+import type {
+  ImageModel,
+  Message,
+  ProviderStreamItem,
+  StreamingAudioChunk,
+  TextToImageParams
+} from "../../src/providers/types.js";
+
+const imageModel: ImageModel = {
+  id: "img-model-1",
+  name: "img-model-1",
+  provider: "test"
+};
+
+/** Exercises a representative slice of the modality surface. */
+class ModalityProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+  async generateMessage(): Promise<Message> {
+    return { role: "assistant", content: "" } as Message;
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    yield* [];
+  }
+
+  override async textToImage(_params: TextToImageParams): Promise<Uint8Array> {
+    this.recordRequestPayload({
+      model: imageModel.id,
+      prompt: "wire-prompt",
+      api_key: "sk-should-be-redacted"
+    });
+    throw new Error("422 Unprocessable Entity");
+  }
+
+  // Not overridden: textToImages — the base default delegates to textToImage.
+
+  override async generateEmbedding(_args: {
+    text: string | string[];
+    model: string;
+  }): Promise<number[][]> {
+    throw new Error("500 embedding boom");
+  }
+
+  override async *textToSpeech(_args: {
+    text: string;
+    model: string;
+  }): AsyncGenerator<StreamingAudioChunk> {
+    yield* [];
+    throw new Error("503 tts boom");
+  }
+}
+
+/** A provider that does NOT override a given modality keeps its base throw. */
+class BareProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+  async generateMessage(): Promise<Message> {
+    return { role: "assistant", content: "" } as Message;
+  }
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    yield* [];
+  }
+}
+
+function captureStderr(): { lines: () => string } {
+  const chunks: string[] = [];
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return { lines: () => chunks.join("") };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BaseProvider modality failure logging", () => {
+  it("logs the recorded wire payload (secrets redacted) when textToImage fails", async () => {
+    const out = captureStderr();
+    const p = new ModalityProvider();
+    await expect(
+      p.textToImage({ model: imageModel, prompt: "hi" })
+    ).rejects.toThrow("422");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("wire-prompt");
+    expect(log).toContain("[redacted]");
+    expect(log).toContain("img-model-1");
+  });
+
+  it("logs only once when a batch helper delegates to its singular method", async () => {
+    const out = captureStderr();
+    const p = new ModalityProvider();
+    await expect(
+      p.textToImages({ model: imageModel, prompt: "hi" }, 1)
+    ).rejects.toThrow("422");
+    const occurrences = out.lines().split("Provider request failed").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("falls back to call args when a modality records no wire payload", async () => {
+    const out = captureStderr();
+    const p = new ModalityProvider();
+    await expect(
+      p.generateEmbedding({ text: "embed-this", model: "emb-1" })
+    ).rejects.toThrow("500");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("embed-this");
+    expect(log).toContain("emb-1");
+  });
+
+  it("logs failures from async-generator modalities (textToSpeech)", async () => {
+    const out = captureStderr();
+    const p = new ModalityProvider();
+    const gen = p.textToSpeech({ text: "speak-this", model: "tts-1" });
+    await expect(
+      (async () => {
+        for await (const _ of gen) {
+          // drain
+        }
+      })()
+    ).rejects.toThrow("503");
+    const log = out.lines();
+    expect(log).toContain("Provider request failed");
+    expect(log).toContain("speak-this");
+    expect(log).toContain("tts-1");
+  });
+
+  it("keeps the base 'does not support' throw for unimplemented modalities", async () => {
+    const out = captureStderr();
+    const p = new BareProvider();
+    await expect(
+      p.textToImage({ model: imageModel, prompt: "hi" })
+    ).rejects.toThrow("does not support textToImage");
+    // An unsupported modality is a programming error, not a provider failure.
+    expect(out.lines()).not.toContain("Provider request failed");
+  });
+
+  it("does not log when a modality call is aborted by the caller", async () => {
+    const out = captureStderr();
+    class AbortingModalityProvider extends ModalityProvider {
+      override async textToImage(): Promise<Uint8Array> {
+        throw Object.assign(new Error("The operation was aborted"), {
+          name: "AbortError"
+        });
+      }
+    }
+    const p = new AbortingModalityProvider();
+    await expect(
+      p.textToImage({ model: imageModel, prompt: "hi" })
+    ).rejects.toThrow();
+    expect(out.lines()).not.toContain("Provider request failed");
+  });
+});


### PR DESCRIPTION
Chat already records the exact request and logs it on failure via
generateMessage(s)Traced (#3859). The non-chat modalities — image, video,
audio, embeddings, 3D — are called directly on the provider with no traced
wrapper, so a failed upstream call (e.g. a 422) was opaque again.

Wrap every overridden non-chat modality method with the same central
failure logging, from one place:

- BaseProvider constructor now installs failure logging by replacing each
  modality method a concrete provider actually overrides with a wrapper that
  runs inside a per-call capture slot and, on throw, calls
  logProviderRequestFailure. Wrapping happens on the instance and only for
  overridden methods, so an unsupported modality keeps its base "does not
  support" throw and never logs a spurious failure. Capability reflection is
  unaffected (an overridden+wrapped method still differs from the base).
- Covers the promise modalities (textToImage(s), imageToImage(s), inpaint,
  upscale, removeBackground, relight, vectorize, textToVideo, imageToVideo,
  videoToVideo, lipSync, textTo3D, imageTo3D, generateEmbedding,
  textToSpeechEncoded, automaticSpeechRecognition) and the async-generator
  modality (textToSpeech).
- Providers may call recordRequestPayload to log the exact wire body;
  otherwise the call arguments are logged (binary buffers reduced to size
  markers, secrets redacted). Caller aborts are skipped as before.
- tracing-helpers: new withModalityCapture wraps a modality call in a slot
  and reports whether one was already active, so a batch helper delegating
  to its singular method is logged once, at the outermost call.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8MXchgTFqmVGGsAHdhm4g