### PR TITLE
Optimize node field rendering with targeted memoization

### DIFF
--- a/web/src/components/node/NodeInputs.tsx
+++ b/web/src/components/node/NodeInputs.tsx
@@ -9,6 +9,7 @@ import { useNodes } from "../../contexts/NodeContext";
 import { useConnectedEdgesSelector } from "../../hooks/nodes/useConnectedEdges";
 import useMetadataStore from "../../stores/MetadataStore";
 import { findOutputHandle } from "../../utils/handleUtils";
+import { isFieldRelevantDataEqual } from "./propertyFieldEquality";
 
 
 const rootCss = css({
@@ -66,45 +67,78 @@ interface NodeInputProps {
   isConnected: boolean;
 }
 
-const NodeInput: React.FC<NodeInputProps> = memo(function NodeInput({
-  id,
-  nodeType,
-  layout,
-  property,
-  propertyIndex,
-  data,
-  showFields,
-  showHandle,
-  tabIndex,
-  isDynamicProperty,
-  isConnected
-}) {
-  // Resolve the current value for this input. Use dynamic_properties for
-  // dynamic inputs; otherwise use properties. Fallback to the property's
-  // default when undefined to avoid runtime errors.
-  const resolvedValue = isDynamicProperty
-    ? data?.dynamic_properties?.[property.name] ?? property.default
-    : data?.properties?.[property.name] ?? property.default;
+// Resolve the current value for an input. Use dynamic_properties for dynamic
+// inputs; otherwise use properties. Fallback to the property's default when
+// undefined to avoid runtime errors. Shared by render and the memo comparator
+// so the two never drift.
+const resolveInputValue = (props: NodeInputProps): unknown =>
+  props.isDynamicProperty
+    ? props.data?.dynamic_properties?.[props.property.name] ??
+      props.property.default
+    : props.data?.properties?.[props.property.name] ?? props.property.default;
 
-  return (
-    <PropertyField
-      key={`${isDynamicProperty ? "dynamic-" : ""}${property.name}-${id}`}
-      id={id}
-      value={resolvedValue}
-      nodeType={nodeType}
-      layout={layout}
-      property={property}
-      propertyIndex={propertyIndex}
-      showFields={showFields}
-      showHandle={showHandle}
-      tabIndex={tabIndex}
-      isDynamicProperty={isDynamicProperty}
-      data={data}
-      isConnected={isConnected}
-    />
-  );
-},
-isEqual);
+const NodeInput: React.FC<NodeInputProps> = memo(
+  function NodeInput(props) {
+    const {
+      id,
+      nodeType,
+      layout,
+      property,
+      propertyIndex,
+      data,
+      showFields,
+      showHandle,
+      tabIndex,
+      isDynamicProperty,
+      isConnected
+    } = props;
+
+    return (
+      <PropertyField
+        key={`${isDynamicProperty ? "dynamic-" : ""}${property.name}-${id}`}
+        id={id}
+        value={resolveInputValue(props)}
+        nodeType={nodeType}
+        layout={layout}
+        property={property}
+        propertyIndex={propertyIndex}
+        showFields={showFields}
+        showHandle={showHandle}
+        tabIndex={tabIndex}
+        isDynamicProperty={isDynamicProperty}
+        data={data}
+        isConnected={isConnected}
+      />
+    );
+  },
+  // Compare only what this field renders from, not the whole node `data`
+  // (which made every field re-render — and deep-walk the full blob — when a
+  // single sibling property changed).
+  (prev, next) => {
+    if (
+      prev.id !== next.id ||
+      prev.nodeType !== next.nodeType ||
+      prev.layout !== next.layout ||
+      prev.propertyIndex !== next.propertyIndex ||
+      prev.showFields !== next.showFields ||
+      prev.showHandle !== next.showHandle ||
+      prev.tabIndex !== next.tabIndex ||
+      prev.isDynamicProperty !== next.isDynamicProperty ||
+      prev.isConnected !== next.isConnected ||
+      prev.onDeleteProperty !== next.onDeleteProperty ||
+      prev.onUpdatePropertyName !== next.onUpdatePropertyName
+    ) {
+      return false;
+    }
+    if (!isFieldRelevantDataEqual(prev.data, next.data, prev.isDynamicProperty)) {
+      return false;
+    }
+    if (!isEqual(prev.property, next.property)) {
+      return false;
+    }
+    return isEqual(resolveInputValue(prev), resolveInputValue(next));
+  }
+);
 
 export const NodeInputs: React.FC<NodeInputsProps> = ({
   id,

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -12,6 +12,7 @@ import { Slugify, isCollectType } from "../../utils/TypeHandler";
 import { useKeyPressedStore } from "../../stores/KeyPressedStore";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import isEqual from "fast-deep-equal";
+import { isFieldRelevantDataEqual } from "./propertyFieldEquality";
 import { isConnectableCached } from "../node_menu/typeFilterUtils";
 import HandleTooltip from "../HandleTooltip";
 import { NodeData } from "../../stores/NodeData";
@@ -273,4 +274,31 @@ const PropertyField: React.FC<PropertyFieldProps> = ({
   );
 };
 
-export default memo(PropertyField, isEqual);
+export default memo(PropertyField, (prev, next) => {
+  if (
+    prev.id !== next.id ||
+    prev.nodeType !== next.nodeType ||
+    prev.layout !== next.layout ||
+    prev.propertyIndex !== next.propertyIndex ||
+    prev.showFields !== next.showFields ||
+    prev.showHandle !== next.showHandle ||
+    prev.isInspector !== next.isInspector ||
+    prev.tabIndex !== next.tabIndex ||
+    prev.isDynamicProperty !== next.isDynamicProperty ||
+    prev.hideActionIcons !== next.hideActionIcons ||
+    prev.isConnected !== next.isConnected ||
+    prev.onValueChange !== next.onValueChange
+  ) {
+    return false;
+  }
+  if (!isEqual(prev.inspectorBatchNodeIds, next.inspectorBatchNodeIds)) {
+    return false;
+  }
+  if (!isFieldRelevantDataEqual(prev.data, next.data, prev.isDynamicProperty)) {
+    return false;
+  }
+  if (!isEqual(prev.value, next.value)) {
+    return false;
+  }
+  return isEqual(prev.property, next.property);
+});

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -8,6 +8,7 @@ import useContextMenu from "../../stores/ContextMenuStore";
 import StringProperty from "../properties/StringProperty";
 import DataframeProperty from "../properties/DataframeProperty";
 import isEqual from "fast-deep-equal";
+import { isFieldRelevantDataEqual } from "./propertyFieldEquality";
 import Close from "@mui/icons-material/Close";
 import Edit from "@mui/icons-material/Edit";
 import SettingsBackupRestoreIcon from "@mui/icons-material/SettingsBackupRestore";
@@ -573,4 +574,29 @@ const PropertyInput: React.FC<PropertyInputProps> = ({
   );
 };
 
-export default memo(PropertyInput, isEqual);
+export default memo(PropertyInput, (prev, next) => {
+  if (
+    prev.id !== next.id ||
+    prev.nodeType !== next.nodeType ||
+    prev.propertyIndex !== next.propertyIndex ||
+    prev.controlKeyPressed !== next.controlKeyPressed ||
+    prev.isInspector !== next.isInspector ||
+    prev.tabIndex !== next.tabIndex ||
+    prev.isDynamicProperty !== next.isDynamicProperty ||
+    prev.hideActionIcons !== next.hideActionIcons ||
+    prev.isConnected !== next.isConnected ||
+    prev.onValueChange !== next.onValueChange
+  ) {
+    return false;
+  }
+  if (!isEqual(prev.inspectorBatchNodeIds, next.inspectorBatchNodeIds)) {
+    return false;
+  }
+  if (!isFieldRelevantDataEqual(prev.data, next.data, prev.isDynamicProperty)) {
+    return false;
+  }
+  if (!isEqual(prev.value, next.value)) {
+    return false;
+  }
+  return isEqual(prev.property, next.property);
+});

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -91,6 +91,7 @@ import { useNodeEvents } from "../../hooks/handlers/useNodeEvents";
 import { useSelectionEvents } from "../../hooks/handlers/useSelectionEvents";
 import { useConnectionEvents } from "../../hooks/handlers/useConnectionEvents";
 import type { NodeData } from "../../stores/NodeData";
+import type { NodeStoreState } from "../../stores/NodeStore";
 import { scheduleNodeInternalsRefresh } from "../../utils/scheduleNodeInternalsRefresh";
 
 const CONTAINER_STYLE = {
@@ -622,22 +623,33 @@ const ReactFlowWrapper = ({
   }, [activeGradientKeys]);
 
   // Stable selector: only updates when the set of selected IDs actually changes,
-  // not on every position update during drag.
-  const selectedNodeIds = useNodes(
-    useCallback(
-      (state) =>
-        state.nodes.reduce((set, node) => {
-          if (node.selected) set.add(node.id);
-          return set;
-        }, new Set<string>()),
-      []
-    ),
-    (a, b) => {
-      if (a.size !== b.size) return false;
-      for (const id of a) if (!b.has(id)) return false;
-      return true;
-    }
-  );
+  // not on every position update during drag. The selector itself runs on every
+  // NodeStore update (drag frames, panning, edge ops); cache by `nodes` identity
+  // so store updates that don't touch the nodes array (viewport, edge changes)
+  // reuse the previous Set instead of re-scanning all nodes.
+  const selectedNodeIdsSelector = useMemo(() => {
+    let lastNodes: NodeStoreState["nodes"] | null = null;
+    let lastResult = new Set<string>();
+    return (state: NodeStoreState) => {
+      if (state.nodes === lastNodes) {
+        return lastResult;
+      }
+      lastNodes = state.nodes;
+      const set = new Set<string>();
+      for (const node of state.nodes) {
+        if (node.selected) {
+          set.add(node.id);
+        }
+      }
+      lastResult = set;
+      return set;
+    };
+  }, []);
+  const selectedNodeIds = useNodes(selectedNodeIdsSelector, (a, b) => {
+    if (a.size !== b.size) return false;
+    for (const id of a) if (!b.has(id)) return false;
+    return true;
+  });
 
   // Track previous selectedNodeIds to skip edge processing when selection hasn't changed
   const prevSelectedNodeIdsRef = useRef<Set<string> | null>(null);

--- a/web/src/components/node/__tests__/NodeInputs.fieldMemo.test.tsx
+++ b/web/src/components/node/__tests__/NodeInputs.fieldMemo.test.tsx
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/react";
+import React, { FC } from "react";
+import { NodeInputs } from "../NodeInputs";
+import { NodeProvider } from "../../../contexts/NodeContext";
+import { createNodeStore } from "../../../stores/NodeStore";
+
+// Count how many times each property's field renders, keyed by property name.
+const renderCounts: Record<string, number> = {};
+jest.mock("../PropertyField", () => ({
+  __esModule: true,
+  default: (props: { property: { name: string } }) => {
+    const name = props.property.name;
+    renderCounts[name] = (renderCounts[name] ?? 0) + 1;
+    return <div data-testid={`field-${name}`} />;
+  }
+}));
+
+const properties = [
+  { name: "prop1", type: { type: "string" } },
+  { name: "prop2", type: { type: "string" } }
+] as any;
+
+const Harness: FC<{ data: any }> = ({ data }) => (
+  <NodeProvider createStore={() => createNodeStore()}>
+    <NodeInputs
+      id="node1"
+      nodeType="test"
+      properties={properties}
+      data={data}
+      nodeMetadata={{} as any}
+    />
+  </NodeProvider>
+);
+
+describe("NodeInputs field memoization", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(renderCounts)) delete renderCounts[key];
+  });
+
+  it("does not re-render a sibling field when an unrelated property value changes", () => {
+    const { rerender } = render(
+      <Harness data={{ workflow_id: "wf1", properties: { prop1: "a", prop2: "b" } }} />
+    );
+
+    expect(renderCounts.prop1).toBe(1);
+    expect(renderCounts.prop2).toBe(1);
+
+    // Simulate an edit to prop1: the store replaces `data` (and `properties`)
+    // with a new object, but prop2's value is unchanged.
+    rerender(
+      <Harness
+        data={{ workflow_id: "wf1", properties: { prop1: "a-changed", prop2: "b" } }}
+      />
+    );
+
+    // prop1 re-renders (its value changed); prop2 must be skipped by the memo.
+    expect(renderCounts.prop1).toBe(2);
+    expect(renderCounts.prop2).toBe(1);
+  });
+});

--- a/web/src/components/node/propertyFieldEquality.ts
+++ b/web/src/components/node/propertyFieldEquality.ts
@@ -1,0 +1,34 @@
+import isEqual from "fast-deep-equal";
+import { NodeData } from "../../stores/NodeData";
+
+/**
+ * A node's `data` carries the entire node blob — every property value, dynamic
+ * inputs/outputs, exposed-input placements, etc. A single property field only
+ * reads its own value (passed separately as `value`), `data.workflow_id`, and —
+ * for dynamic fields — the identity of `data.dynamic_properties` (the
+ * delete/rename handlers in PropertyInput close over the live map and must not
+ * operate on a stale set).
+ *
+ * Comparing the whole `data` with a deep equal (the previous `memo(..., isEqual)`)
+ * meant that editing one property re-rendered AND deep-walked every other field
+ * on the node, since `data` differs for all of them. This compares only the
+ * slices a field actually depends on.
+ */
+export const isFieldRelevantDataEqual = (
+  prev: NodeData,
+  next: NodeData,
+  isDynamicProperty: boolean | undefined
+): boolean => {
+  if (prev === next) {
+    return true;
+  }
+  if (prev.workflow_id !== next.workflow_id) {
+    return false;
+  }
+  if (isDynamicProperty && prev.dynamic_properties !== next.dynamic_properties) {
+    return false;
+  }
+  return true;
+};
+
+export { isEqual };

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -108,6 +108,16 @@ function useStructurallyProcessedEdges({
     const REROUTE_INPUT = "input_value";
     const REROUTE_OUTPUT = "output";
 
+    // Precompute the single incoming edge feeding each Reroute node's input so
+    // chasing a reroute chain is O(1) per hop instead of an O(E) `edges.find`
+    // (which made reroute-heavy graphs O(E²) on every structural recompute).
+    const rerouteInputEdgeByTarget = new Map<string, Edge>();
+    for (const edge of edges) {
+      if (edge.targetHandle === REROUTE_INPUT && !rerouteInputEdgeByTarget.has(edge.target)) {
+        rerouteInputEdgeByTarget.set(edge.target, edge);
+      }
+    }
+
     // Optimization: Build maps for O(1) dataType lookups instead of repeated find() calls
     const dataTypeBySlug = new Map(dataTypes.map((dt) => [dt.slug, dt]));
     const dataTypeByValue = new Map(dataTypes.map((dt) => [dt.value, dt]));
@@ -153,10 +163,7 @@ function useStructurallyProcessedEdges({
         if (visited.has(currentNode.id)) {break;}
         visited.add(currentNode.id);
 
-        const incoming = edges.find(
-          (e) =>
-            e.target === currentNode!.id && e.targetHandle === REROUTE_INPUT
-        );
+        const incoming = rerouteInputEdgeByTarget.get(currentNode.id);
         if (!incoming) {break;}
         currentNode = getNode(incoming.source);
         currentHandle = incoming.sourceHandle || "";


### PR DESCRIPTION
## Summary

Significantly improves performance when editing node properties by preventing sibling fields from re-rendering when unrelated properties change. Replaces shallow equality checks on the entire `data` blob with targeted comparisons of only the fields each component actually depends on.

## Key Changes

- **NodeInputs memoization**: Replaced generic `isEqual` comparator with a custom one that compares only relevant props and uses `isFieldRelevantDataEqual` for the `data` object. Extracted `resolveInputValue` helper to ensure memo comparator and render logic stay in sync.

- **PropertyField & PropertyInput memoization**: Updated both components to use the same targeted equality strategy instead of deep-comparing all props with `isEqual`.

- **New `propertyFieldEquality.ts` utility**: Introduced `isFieldRelevantDataEqual` function that compares only the slices of `data` that a field actually depends on:
  - Always checks `workflow_id`
  - For dynamic properties, checks `dynamic_properties` identity (handlers close over the live map)
  - Skips deep comparison of property values (passed separately as `value` prop)

- **ReactFlowWrapper selector optimization**: Cached the `selectedNodeIds` selector using `useMemo` to avoid re-scanning all nodes on every store update. The selector now checks if the `nodes` array identity changed before recomputing the Set, allowing viewport and edge changes to reuse the previous result.

- **useProcessedEdges optimization**: Precomputed a map of incoming edges for Reroute nodes (`rerouteInputEdgeByTarget`) to replace O(E) `edges.find()` calls with O(1) lookups, reducing reroute-heavy graph processing from O(E²) to O(E).

- **Test coverage**: Added `NodeInputs.fieldMemo.test.tsx` to verify that editing one property doesn't trigger re-renders of sibling fields.

## Implementation Details

The core insight is that a property field only reads:
- Its own `value` (passed separately)
- `data.workflow_id`
- `data.dynamic_properties` identity (for dynamic fields)

Previously, comparing the entire `data` object meant every field re-rendered and deep-walked the full node blob whenever any sibling property changed. The new approach isolates each field's dependencies, making edits O(1) per field instead of O(n) where n is the number of properties on the node.

https://claude.ai/code/session_019NSWL76P8qMf3VXPeAVa8t