### PR TITLE
fix(editor): wheel-scroll node history + Mac-friendly left-click selection

### DIFF
--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -70,8 +70,8 @@ const CLOSE_BEHAVIOR_OPTIONS = [
 ] as const;
 
 const PAN_CONTROLS_OPTIONS = [
-  { value: "LMB", label: "Pan with LMB" },
-  { value: "RMB", label: "Pan with RMB" }
+  { value: "LMB", label: "Pan canvas" },
+  { value: "RMB", label: "Select nodes (box)" }
 ] as const;
 
 const SELECTION_MODE_OPTIONS = [
@@ -859,10 +859,10 @@ function SettingsPage() {
                       </Text>
                       <SearchItem
                         search={generalSearch}
-                        keywords="canvas navigation pan controls mouse"
+                        keywords="canvas navigation pan controls mouse select left click drag"
                       >
                         <SelectField
-                          label="Pan Controls"
+                          label="Left-Click Drag"
                           value={settings.panControls}
                           variant="standard"
                           onChange={handlePanControlsChange}
@@ -870,12 +870,15 @@ function SettingsPage() {
                         />
                         <div className="description">
                           <Text>
-                            Move the canvas by dragging with the left or right
-                            mouse button.
+                            What dragging with the left mouse button does on
+                            empty canvas.
                           </Text>
                           <Text>
-                            With RMB selected, you can also pan with the Middle
-                            Mouse Button.
+                            <b>Pan canvas:</b> left-drag moves the view.
+                            <br />
+                            <b>Select nodes:</b> left-drag draws a selection box;
+                            pan with the right or middle mouse button (and
+                            two-finger scroll on a trackpad).
                           </Text>
                         </div>
                       </SearchItem>

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -737,7 +737,7 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
           // variants; every tile is uniformly clickable → select + single view.
           <div
             ref={gridRef}
-            className="grid nodrag nopan"
+            className="grid nodrag nopan nowheel"
             role="listbox"
             aria-multiselectable={hasDownstream || undefined}
             aria-label="Generations"

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { isMac } from "../utils/platform";
 
 interface AutosaveSettings {
   enabled: boolean;
@@ -92,7 +93,10 @@ interface SettingsStore {
 export const defaultSettings: Settings = {
   gridSnap: 1,
   connectionSnap: 20,
-  panControls: "LMB",
+  // On Mac the trackpad already pans (two-finger scroll) and zooms (pinch), so
+  // left-drag is free to rubber-band select — the Figma/Sketch convention Mac
+  // users expect. "RMB" mode makes left-drag select and moves pan to RMB/MMB.
+  panControls: isMac() ? "RMB" : "LMB",
   selectionMode: "partial",
   workflowOrder: "name",
   dashboardWorkflowView: "grid",


### PR DESCRIPTION
## Summary

Two small node-editor UX fixes that came out of the same session:

### 1. Wheel-scroll the node generation history
`NodeHistoryViewer` showed a scrollbar but the mouse wheel did nothing — you had to drag the scrollbar by hand. The grid had `overflow: auto` and the `nodrag nopan` classes, but was missing `nowheel`, so ReactFlow swallowed wheel events for canvas zoom/pan. Added `nowheel` (the codebase convention, per `editorUtils.ts`) so the wheel scrolls natively.

### 2. Mac-friendly left-click selection
On Mac, `panControls` now defaults to `"RMB"`, which makes **left-drag rubber-band select** (the Figma/Sketch convention). The trackpad already pans (two-finger scroll) and zooms (pinch), so left-drag-to-pan was redundant and left no way to box-select. Non-Mac keeps `"LMB"`. Existing users keep their saved preference (only the default changes).

Also relabeled the setting from **"Pan Controls"** → **"Left-Click Drag"** with **"Pan canvas"** / **"Select nodes (box)"** options and a clearer description, since the real choice is what left-drag does. The stored values stay `"LMB"`/`"RMB"`, so `useDragHandlers` is untouched.

## Files
- `web/src/components/node/NodeHistoryViewer.tsx` — add `nowheel` to the history scroll container
- `web/src/stores/SettingsStore.ts` — platform-aware `panControls` default via `isMac()`
- `web/src/components/menus/SettingsMenu.tsx` — relabel + clarify the setting

## Verification
- `npm run typecheck` (web) — clean
- `eslint` on changed files — no errors/warnings
- `SettingsStore.test.ts` — 32/32 pass (jsdom UA isn't Mac, so the default-is-`"LMB"` assertion still holds)

## Note
The Mac default path isn't covered by a test (jsdom only exercises the non-Mac branch). Happy to add a `jest.isolateModules` test that mocks a Mac userAgent and asserts the default resolves to `"RMB"` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)