### PR TITLE
Persist job cancellation and emit update immediately

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2286,13 +2286,38 @@ export class UnifiedWebSocketRunner {
       active.runner.cancel();
     }
     active.status = "cancelled";
+
+    // Persist the cancellation to the DB and announce it right away, mirroring
+    // the queued branch and the tRPC jobs.cancel path. The runner's own cleanup
+    // can lag (it drains in-flight messages before its .finally() persists), so
+    // without this the persisted row stays "running" and jobs.list — which the
+    // Queue panel reads from — keeps reporting the job as running even though
+    // the toolbar Stop already fired. Marking it cancelled here, plus the
+    // job_update below, lets clients refetch and reflect the stop immediately.
+    const cancelledWorkflowId = workflowId ?? active.workflowId ?? null;
+    try {
+      const job = await Job.get(jobId);
+      if (job && job.status !== "cancelled") {
+        job.markCancelled();
+        await job.save();
+      }
+    } catch (err) {
+      this.logError("cancel persistence failed", err);
+    }
+    await this.sendMessage({
+      type: "job_update",
+      status: "cancelled",
+      job_id: jobId,
+      workflow_id: cancelledWorkflowId
+    });
+
     // Do NOT set active.finished = true here. Let the runner's cancellation
     // propagate through executePromise's .finally() callback so that
     // streamJobMessages can drain remaining messages and persist job state.
     return {
       message: "Job cancellation requested",
       job_id: jobId,
-      workflow_id: workflowId ?? active.workflowId ?? ""
+      workflow_id: cancelledWorkflowId ?? ""
     };
   }
 

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -784,6 +784,74 @@ describe("UnifiedWebSocketRunner", () => {
       else process.env.MAX_CONCURRENT_RUNS_PER_WORKFLOW = prev;
     }
   });
+
+  it("persists cancellation and emits job_update when cancelling an active job", async () => {
+    // The toolbar Stop button sends a `cancel_job` command over the websocket.
+    // For an active (running) job this must mark the persisted row cancelled and
+    // emit a cancelled job_update right away — the runner's own cleanup can lag,
+    // so without this jobs.list (the Queue panel's source) keeps reporting the
+    // job as running until that slow cleanup lands. Regression for "toolbar Stop
+    // leaves the running-jobs panel showing the job as running".
+    await initTestDb();
+    let release!: () => void;
+    const gate = new Promise<void>((r2) => {
+      release = r2;
+    });
+    const r = new UnifiedWebSocketRunner({
+      resolveExecutor: () => ({
+        async process() {
+          await gate;
+          return {};
+        }
+      })
+    });
+    try {
+      await r.connect(ws);
+      const graph = {
+        nodes: [
+          {
+            id: "n1",
+            type: "nodetool.constant.String",
+            name: "nodetool.constant.String",
+            properties: { value: "x" }
+          }
+        ],
+        edges: []
+      };
+      await Job.create({
+        id: "RUN_ACTIVE",
+        workflow_id: "wf-active",
+        user_id: "1",
+        status: "scheduled"
+      });
+
+      await r.runJob({ job_id: "RUN_ACTIVE", workflow_id: "wf-active", graph });
+      // Let the job reach the active map before cancelling.
+      await new Promise((res) => setTimeout(res, 20));
+
+      await r.handleCommand({
+        command: "cancel_job",
+        data: { job_id: "RUN_ACTIVE", workflow_id: "wf-active" }
+      });
+
+      // The persisted row is cancelled immediately, not after runner cleanup.
+      const job = await Job.get<Job>("RUN_ACTIVE");
+      expect(job?.status).toBe("cancelled");
+
+      // A cancelled job_update was announced so clients refetch the job list.
+      const updates = ws.sentBytes
+        .map((b) => unpack(b) as Record<string, unknown>)
+        .filter(
+          (m) => m.type === "job_update" && m.job_id === "RUN_ACTIVE"
+        );
+      expect(
+        updates.some((m) => m.status === "cancelled")
+      ).toBe(true);
+    } finally {
+      release();
+      await r.disconnect();
+    }
+  });
 });
 
 describe("UnifiedWebSocketRunner binary frame size guard", () => {


### PR DESCRIPTION
## Summary
When a user clicks the toolbar Stop button to cancel an active (running) job, the cancellation is now persisted to the database and announced via `job_update` message immediately, rather than waiting for the runner's cleanup to complete. This ensures the Queue panel reflects the cancellation right away instead of continuing to show the job as running.

## Changes
- **Test**: Added regression test `persists cancellation and emits job_update when cancelling an active job` that verifies:
  - The persisted job row is marked `cancelled` immediately upon cancellation request
  - A `job_update` message with `status: "cancelled"` is emitted to clients
  - The Queue panel can refetch and reflect the stop immediately

- **Implementation**: Modified `UnifiedWebSocketRunner.handleCommand()` for `cancel_job`:
  - Fetch the job from the database and call `markCancelled()` + `save()` to persist the cancellation state immediately
  - Send a `job_update` message with `status: "cancelled"` to notify connected clients
  - Added error handling for persistence failures (logged but non-blocking)
  - Preserved existing behavior: do NOT set `active.finished = true` to allow the runner's cancellation to propagate through cleanup and drain remaining messages

## Implementation Details
The fix mirrors the behavior of the queued job cancellation path and the tRPC `jobs.cancel` endpoint. The runner's own cleanup can lag (it drains in-flight messages before its `.finally()` persists), so without this immediate persistence and announcement, `jobs.list` (the Queue panel's data source) would continue reporting the job as running until the slow cleanup landed. The `job_update` message prompts clients to refetch the job list and see the current state.

https://claude.ai/code/session_019kthjkd1tzdB7QS1mcz89K