### PR TITLE
Improve CategorySearchBar UX with auto-focus and Escape key support

### DIFF
--- a/web/src/components/node_menu/CategorySearchBar.tsx
+++ b/web/src/components/node_menu/CategorySearchBar.tsx
@@ -2,7 +2,14 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { forwardRef, memo, useCallback } from "react";
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useImperativeHandle,
+  useRef
+} from "react";
+import type { KeyboardEvent } from "react";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
@@ -54,22 +61,41 @@ const CategorySearchBar = memo(
   forwardRef<HTMLInputElement, CategorySearchBarProps>(
     ({ value, onChange, placeholder = "Filter..." }, ref) => {
       const theme = useTheme();
-      const handleClear = useCallback(() => onChange(""), [onChange]);
+      const inputRef = useRef<HTMLInputElement>(null);
+      useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
+
+      const handleClear = useCallback(() => {
+        onChange("");
+        // Keep the cursor in the field so users can keep typing after clearing.
+        inputRef.current?.focus();
+      }, [onChange]);
+
+      const handleKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLInputElement>) => {
+          if (e.key === "Escape" && value) {
+            e.stopPropagation();
+            onChange("");
+          }
+        },
+        [value, onChange]
+      );
 
       return (
         <div css={styles(theme)} className="qa-search">
           <SearchIcon className="search-glyph" />
           <input
-            ref={ref}
+            ref={inputRef}
             type="text"
             value={value}
             onChange={(e) => onChange(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder={placeholder}
             aria-label="Filter category"
           />
           {value && (
             <ToolbarIconButton
               tabIndex={-1}
+              tooltip="Clear filter"
               ariaLabel="Clear filter"
               onClick={handleClear}
               icon={<ClearIcon />}

--- a/web/src/components/node_menu/__tests__/CategorySearchBar.test.tsx
+++ b/web/src/components/node_menu/__tests__/CategorySearchBar.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * CategorySearchBar Component Tests
+ *
+ * Covers the QoL behaviours of the slim filter input shared by the workflow,
+ * timeline and sketch list panels: clearing via button/Escape, focus retention
+ * after clearing, and the clear button only appearing when there is a value.
+ */
+
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import CategorySearchBar from "../CategorySearchBar";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const Harness: React.FC<{ initial?: string }> = ({ initial = "" }) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <ThemeProvider theme={mockTheme}>
+      <CategorySearchBar value={value} onChange={setValue} />
+    </ThemeProvider>
+  );
+};
+
+describe("CategorySearchBar", () => {
+  it("does not show the clear button when empty", () => {
+    render(<Harness />);
+    expect(
+      screen.queryByRole("button", { name: "Clear filter" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the clear button once there is a value", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.type(screen.getByLabelText("Filter category"), "abc");
+    expect(
+      screen.getByRole("button", { name: "Clear filter" })
+    ).toBeInTheDocument();
+  });
+
+  it("clears the value and keeps focus when the clear button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="hello" />);
+    const input = screen.getByLabelText<HTMLInputElement>("Filter category");
+
+    await user.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    expect(input).toHaveValue("");
+    expect(input).toHaveFocus();
+  });
+
+  it("clears the value when Escape is pressed in the input", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="hello" />);
+    const input = screen.getByLabelText<HTMLInputElement>("Filter category");
+
+    input.focus();
+    await user.keyboard("{Escape}");
+
+    expect(input).toHaveValue("");
+  });
+});

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -4,7 +4,15 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 import BrushOutlinedIcon from "@mui/icons-material/BrushOutlined";
-import { Fragment, memo, useCallback, useMemo, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import type { DragEvent, KeyboardEvent } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -270,6 +278,13 @@ export const CreateSketchButton = memo(function CreateSketchButton() {
 const SketchListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Focus the filter on open so users can immediately type to search,
+  // matching the workflows list panel.
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
   const { data, isLoading, isError, error } = trpc.sketch.list.useQuery(
     {},
     { staleTime: 30_000 }
@@ -318,6 +333,7 @@ const SketchListPanel = () => {
     <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
       <div className="sketch-search">
         <CategorySearchBar
+          ref={searchRef}
           value={filterValue}
           onChange={setFilterValue}
           placeholder="Search sketches..."

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -4,7 +4,15 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
-import { Fragment, memo, useCallback, useMemo, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import type { DragEvent, KeyboardEvent } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -265,7 +273,14 @@ export const CreateTimelineButton = memo(function CreateTimelineButton() {
 const TimelineListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
   const { data, isLoading, isError, error } = useTimelines();
+
+  // Focus the filter on open so users can immediately type to search,
+  // matching the workflows list panel.
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
   const setVisibility = usePanelStore((state) => state.setVisibility);
@@ -310,6 +325,7 @@ const TimelineListPanel = () => {
     <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
       <div className="timeline-search">
         <CategorySearchBar
+          ref={searchRef}
           value={filterValue}
           onChange={setFilterValue}
           placeholder="Search timelines..."


### PR DESCRIPTION
## Summary
Enhances the `CategorySearchBar` component with quality-of-life improvements for filtering in list panels (sketches, timelines, workflows). Adds auto-focus on panel open, Escape key support for clearing, and focus retention after clearing via button.

## Key Changes
- **CategorySearchBar component**:
  - Added `useImperativeHandle` to properly forward the input ref for external focus control
  - Implemented Escape key handler to clear the filter when pressed (with `stopPropagation` to prevent bubbling)
  - Modified `handleClear` to refocus the input after clearing, allowing users to continue typing immediately
  - Added `tooltip` prop to the clear button for better UX discoverability

- **SketchListPanel & TimelineListPanel**:
  - Added `useEffect` hook that auto-focuses the search input on panel mount
  - Created `searchRef` to hold the input reference and pass it to `CategorySearchBar`
  - Matches the existing auto-focus behavior of the workflows list panel

- **Test coverage**:
  - Added comprehensive test suite for `CategorySearchBar` covering:
    - Clear button visibility (hidden when empty, shown with value)
    - Clear button click behavior (clears value and retains focus)
    - Escape key behavior (clears value when pressed)

## Implementation Details
- Uses `useRef` + `useImperativeHandle` pattern to maintain proper ref forwarding while managing internal input state
- Escape handler only clears when there's a value to avoid unnecessary state updates
- Focus retention after clearing improves the filtering workflow by keeping the cursor in the input field
- Auto-focus on panel open provides immediate search capability without requiring a manual click

https://claude.ai/code/session_013um4cDfuCj3fpSDgFNT6vx