### PR TITLE
Add Connected Providers section to API Keys tab

### DIFF
--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -790,12 +790,23 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
     return results;
   }, [safeSecrets, lowerSearch]);
 
+  // Connected providers float to their own section at the top.
+  const connected = useMemo(
+    () => matchedProviders.filter((p) => p.secret.is_configured),
+    [matchedProviders]
+  );
   const recommended = useMemo(
-    () => matchedProviders.filter((p) => p.meta.category === "recommended"),
+    () =>
+      matchedProviders.filter(
+        (p) => p.meta.category === "recommended" && !p.secret.is_configured
+      ),
     [matchedProviders]
   );
   const others = useMemo(
-    () => matchedProviders.filter((p) => p.meta.category === "other"),
+    () =>
+      matchedProviders.filter(
+        (p) => p.meta.category === "other" && !p.secret.is_configured
+      ),
     [matchedProviders]
   );
 
@@ -929,7 +940,8 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
     [others, unconfiguredOthers]
   );
 
-  const hasContent = allRecommended.length > 0 || allOthers.length > 0;
+  const hasContent =
+    connected.length > 0 || allRecommended.length > 0 || allOthers.length > 0;
 
   return (
     <FlexColumn sx={{ gap: "1.5rem" }}>
@@ -941,6 +953,28 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
           title="No providers found"
           description={`No providers match "${searchTerm}"`}
         />
+      )}
+
+      {connected.length > 0 && (
+        <div>
+          <SectionTitle
+            title="Connected Providers"
+            count={connected.length}
+            theme={theme}
+          />
+          <FlexColumn sx={{ gap: theme.spacing(2) }}>
+            {connected.map(({ secret, meta }) => (
+              <ProviderCard
+                key={meta.key}
+                secret={secret}
+                meta={meta}
+                onConnect={handleConnect}
+                onManage={handleManage}
+                onDelete={handleDelete}
+              />
+            ))}
+          </FlexColumn>
+        </div>
       )}
 
       {allRecommended.length > 0 && (


### PR DESCRIPTION
## Summary
Reorganizes the API Keys tab to display connected (configured) providers in a dedicated section at the top, separate from recommended and other unconfigured providers.

## Key Changes
- Added a new `connected` useMemo that filters providers where `is_configured` is true
- Updated `recommended` and `others` filters to exclude already-configured providers
- Added a new "Connected Providers" section that renders above recommended/other sections
- Updated `hasContent` check to include the new connected section

## Implementation Details
- Connected providers are identified by `p.secret.is_configured` flag
- The new section uses the existing `SectionTitle` and `ProviderCard` components for consistency
- Connected providers float to the top regardless of search/filter state, improving discoverability of active integrations
- The section only renders when there are connected providers (`connected.length > 0`)

https://claude.ai/code/session_01WD2Use8rJLfP5C8MAXdjvL