### PR TITLE
Fix generation selection in NodeHistoryViewer grid

### DIFF
--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -35,7 +35,8 @@ import {
   ToolbarIconButton,
   MOTION,
   BORDER_RADIUS,
-  TYPOGRAPHY
+  TYPOGRAPHY,
+  Z_INDEX
 } from "../ui_primitives";
 import type { StatusType } from "../ui_primitives";
 import { relativeTime } from "../../utils/formatDateAndTime";
@@ -226,14 +227,23 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.common.white,
       textShadow: "0 0 2px rgba(0,0,0,0.8)"
     },
+    // The focused generation: a prominent OUTSET glow ring (clearly stronger than
+    // the 1px hover border) so the current selection is unmistakable at a glance.
     ".thumb.selected": {
-      borderColor: theme.vars.palette.primary.main
+      borderColor: theme.vars.palette.primary.main,
+      boxShadow: `0 0 0 2px ${theme.vars.palette.primary.main}`,
+      zIndex: Z_INDEX.raised
     },
     // Multi-select export membership: a distinct INSET ring (separate from the
     // focused .selected border) so a tile can be both the focused generation and
     // a member of the downstream set at once.
     ".thumb.in-set": {
       boxShadow: `inset 0 0 0 2px ${theme.vars.palette.secondary.main}`
+    },
+    // Both at once: stack the focused outset ring and the in-set membership ring
+    // so neither cascade rule clobbers the other.
+    ".thumb.selected.in-set": {
+      boxShadow: `0 0 0 2px ${theme.vars.palette.primary.main}, inset 0 0 0 2px ${theme.vars.palette.secondary.main}`
     },
     // Pick-order badge: the 1-based position of a tile within the export set.
     ".pick-badge": {
@@ -476,6 +486,13 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
 
   const handleToggleView = useCallback(() => {
     setView((v) => (v === "single" ? "grid" : "single"));
+  }, []);
+
+  // ReactFlow selects/deselects the enclosing node on pointer down. The grid is
+  // an interactive control inside the node, so swallow pointer-down here: tile
+  // clicks pick a generation without also toggling the node's selection.
+  const stopNodeSelection = useCallback((e: React.PointerEvent) => {
+    e.stopPropagation();
   }, []);
 
   // The fullscreen AssetViewer renders media; text generations open in a
@@ -741,6 +758,7 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
             role="listbox"
             aria-multiselectable={hasDownstream || undefined}
             aria-label="Generations"
+            onPointerDown={stopNodeSelection}
             onClick={handleGridClick}
             onKeyDown={handleGridKeyDown}
           >


### PR DESCRIPTION
## Summary
Improves the generation selection UI in NodeHistoryViewer by adding visual distinction for multi-select states and preventing unintended node selection when interacting with the grid.

## Key Changes
- **Enhanced visual feedback for selected generations**: Added an outset glow ring (`boxShadow: 0 0 0 2px`) to `.thumb.selected` with `Z_INDEX.raised` to make the focused generation unmistakably prominent
- **Support for combined selection states**: Added `.thumb.selected.in-set` rule that stacks both the outset focus ring and inset membership ring, allowing a tile to display both states simultaneously without cascade conflicts
- **Fixed node selection interference**: Added `stopNodeSelection` callback that prevents pointer-down events from propagating to the parent ReactFlow node, so clicking a generation tile only picks that generation without toggling the node's selection state
- **Applied callback to grid**: Connected `stopNodeSelection` to the grid's `onPointerDown` handler

## Implementation Details
- Imported `Z_INDEX` from ui_primitives to ensure proper layering of the focus ring
- Used `boxShadow` stacking (outset + inset) rather than border changes to avoid visual conflicts between the two selection indicators
- The pointer event stoppage is minimal and surgical — only prevents propagation on pointer-down, allowing normal click handling to proceed within the grid

https://claude.ai/code/session_01XKerE7Ea1wigXvMkQnA1E3