### PR TITLE
Refactor workflow filtering into dedicated WorkflowTree component

### DIFF
--- a/web/src/__tests__/components/assets/AssetExplorer.test.tsx
+++ b/web/src/__tests__/components/assets/AssetExplorer.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { ThemeProvider } from "@mui/material/styles";
 import ThemeNodetool from "../../../components/themes/ThemeNodetool";
 import AssetExplorer from "../../../components/assets/AssetExplorer";
@@ -29,9 +30,11 @@ jest.mock("react-router-dom", () => ({
 describe("AssetExplorer", () => {
   it("renders AssetGrid with provided assets", () => {
     render(
-      <ThemeProvider theme={ThemeNodetool}>
-        <AssetExplorer />
-      </ThemeProvider>
+      <MemoryRouter>
+        <ThemeProvider theme={ThemeNodetool}>
+          <AssetExplorer />
+        </ThemeProvider>
+      </MemoryRouter>
     );
     const grid = screen.getByTestId("asset-grid");
     expect(grid).toHaveTextContent("asset-grid:2");

--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -15,8 +15,6 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import FilterAltOffIcon from "@mui/icons-material/FilterAltOff";
-import AccountTreeIcon from "@mui/icons-material/AccountTree";
-import FilterCenterFocusIcon from "@mui/icons-material/FilterCenterFocus";
 import AssetSearchInput from "./AssetSearchInput";
 import AssetActions from "./AssetActions";
 import SearchErrorBoundary from "../SearchErrorBoundary";
@@ -30,18 +28,15 @@ import {
   UploadButton,
   Popover,
   MenuItemPrimitive,
-  SearchInput,
   FlexRow,
   Box,
+  Divider,
   BORDER_RADIUS,
   FONT_SIZE_SANS,
   MOTION
 } from "../ui_primitives";
 import { TYPE_FILTERS, TypeFilterKey } from "../../utils/formatUtils";
 import isEqual from "fast-deep-equal";
-import { useQuery } from "@tanstack/react-query";
-import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
-import { WorkflowList, Workflow } from "../../stores/ApiTypes";
 
 const styles = (theme: Theme) =>
   css({
@@ -117,36 +112,9 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
   );
   const typeFilter = useAssetGridStore((state) => state.typeFilter);
   const setTypeFilter = useAssetGridStore((state) => state.setTypeFilter);
-  const workflowFilter = useAssetGridStore((state) => state.workflowFilter);
-  const setWorkflowFilter = useAssetGridStore((state) => state.setWorkflowFilter);
-  const [typeFilterAnchor, setTypeFilterAnchor] =
-    useState<HTMLElement | null>(null);
-  const [workflowFilterAnchor, setWorkflowFilterAnchor] =
-    useState<HTMLElement | null>(null);
-  const [workflowSearch, setWorkflowSearch] = useState("");
-
-  const load = useWorkflowManager((state) => state.load);
-  const currentWorkflowId = useWorkflowManager(
-    (state) => state.currentWorkflowId
+  const [typeFilterAnchor, setTypeFilterAnchor] = useState<HTMLElement | null>(
+    null
   );
-  const { data: workflowData } = useQuery<WorkflowList, Error>({
-    queryKey: ["workflows"],
-    queryFn: async () => load("", 200)
-  });
-
-  const workflowSearchLower = useMemo(() => workflowSearch.toLowerCase(), [workflowSearch]);
-
-  const filteredWorkflows: Workflow[] = useMemo(
-    () =>
-      workflowData?.workflows?.filter((w: Workflow) =>
-        w.name.toLowerCase().includes(workflowSearchLower)
-      ) ?? [],
-    [workflowData?.workflows, workflowSearchLower]
-  );
-
-  const activeWorkflowName = workflowFilter
-    ? (workflowData?.workflows?.find((w: Workflow) => w.id === workflowFilter)?.name ?? "Workflow")
-    : null;
 
   const handleTypeFilterChange = useCallback(
     (next: TypeFilterKey) => setTypeFilter(next),
@@ -164,13 +132,6 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
   // In fullscreen the filter row is always visible; in the sidebar it is
   // toggled by the tune button.
   const showFilters = expanded || isFullscreenAssets;
-  const showCurrentWorkflowButton = Boolean(currentWorkflowId);
-  const currentWorkflowActive =
-    workflowFilter !== null && workflowFilter === currentWorkflowId;
-
-  const handleToggleCurrentWorkflow = useCallback(() => {
-    setWorkflowFilter(currentWorkflowActive ? null : currentWorkflowId);
-  }, [currentWorkflowActive, currentWorkflowId, setWorkflowFilter]);
 
   const onLocalSearchChange = useCallback(
     (newSearchTerm: string) => {
@@ -203,22 +164,15 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         className="asset-menu-toolbar"
         align="center"
         gap={0.5}
+        wrap
         sx={{
           px: 0.5,
           py: 0.5,
           "& .MuiIconButton-root": { padding: "4px" },
-          "& .MuiSvgIcon-root": { fontSize: 14 }
+          "& .MuiSvgIcon-root": { fontSize: 16 }
         }}
       >
-        {!isFullscreenAssets && (
-          <ToolbarIconButton
-            icon={<TuneIcon />}
-            tooltip={expanded ? "Hide filters" : "Show filters"}
-            onClick={() => setExpanded((prev) => !prev)}
-            tooltipPlacement="top"
-            nodrag={false}
-          />
-        )}
+        {/* Browse: toggle the folder navigator (sidebar only) */}
         {!isFullscreenAssets && hasFolders && (
           <ToolbarIconButton
             icon={foldersVisible ? <FolderIcon /> : <FolderOffIcon />}
@@ -226,96 +180,64 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
             onClick={toggleFoldersVisible}
             tooltipPlacement="top"
             nodrag={false}
+            active={foldersVisible}
           />
         )}
+
+        {/* Filter: asset type (labeled to avoid icon guessing) */}
         <ToolbarIconButton
           tooltip="Filter by type"
           onClick={(e) => setTypeFilterAnchor(e.currentTarget)}
           tooltipPlacement="top"
           nodrag={false}
+          active={typeFilterActive}
           sx={{
             borderRadius: BORDER_RADIUS.sm,
             px: 0.5,
             gap: 0.5,
-            fontSize: FONT_SIZE_SANS.label,
-            color: typeFilterActive
-              ? "var(--palette-primary-main)"
-              : undefined
+            fontSize: FONT_SIZE_SANS.label
           }}
         >
           <FlexRow
             align="center"
             gap={0.5}
-            sx={{
-              "& .MuiSvgIcon-root": { fontSize: 18 }
-            }}
+            sx={{ "& .MuiSvgIcon-root": { fontSize: 18 } }}
           >
             {TYPE_FILTER_ICONS[typeFilter]}
             <span>{typeFilterLabel}</span>
             <ArrowDropDownIcon />
           </FlexRow>
         </ToolbarIconButton>
-        {showCurrentWorkflowButton && (
+
+        {/* Search, sort & resize (sidebar only; always shown in fullscreen) */}
+        {!isFullscreenAssets && (
           <ToolbarIconButton
-            icon={<FilterCenterFocusIcon />}
-            tooltip={
-              currentWorkflowActive
-                ? "Showing this workflow's assets"
-                : "Show this workflow's assets"
-            }
-            onClick={handleToggleCurrentWorkflow}
+            icon={<TuneIcon />}
+            tooltip={expanded ? "Hide search & sort" : "Search, sort & resize"}
+            onClick={() => setExpanded((prev) => !prev)}
             tooltipPlacement="top"
             nodrag={false}
-            sx={{
-              color: currentWorkflowActive
-                ? "var(--palette-primary-main)"
-                : undefined
-            }}
+            active={expanded}
           />
         )}
-        <ToolbarIconButton
-          tooltip={workflowFilter ? `Workflow: ${activeWorkflowName}` : "Filter by workflow"}
-          onClick={(e) => setWorkflowFilterAnchor(e.currentTarget)}
-          tooltipPlacement="top"
-          nodrag={false}
-          sx={{
-            borderRadius: BORDER_RADIUS.sm,
-            px: 0.5,
-            gap: 0.5,
-            fontSize: FONT_SIZE_SANS.label,
-            color: workflowFilter
-              ? "var(--palette-primary-main)"
-              : undefined
-          }}
-        >
-          <FlexRow align="center" gap={0.5}>
-            <AccountTreeIcon />
-            <span
-              style={{
-                maxWidth: 80,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap"
-              }}
-            >
-              {activeWorkflowName ?? "Workflow"}
-            </span>
-            <ArrowDropDownIcon />
-          </FlexRow>
-        </ToolbarIconButton>
-        <ToolbarIconButton
-          icon={<CreateNewFolderIcon />}
-          tooltip="Create folder"
-          onClick={() => setCreateFolderDialogOpen(true)}
-          tooltipPlacement="top"
-          nodrag={false}
-        />
-        <UploadButton
-          onFileSelect={(files) => onUploadFiles?.(files)}
-          iconVariant="file"
-          tooltip="Upload files"
-          multiple
-        />
+
+        {/* Actions: create & add assets */}
+        <FlexRow align="center" gap={0.5} sx={{ ml: "auto" }}>
+          <Divider orientation="vertical" flexItem sx={{ my: 0.5 }} />
+          <ToolbarIconButton
+            icon={<CreateNewFolderIcon />}
+            tooltip="Create folder"
+            onClick={() => setCreateFolderDialogOpen(true)}
+            tooltipPlacement="top"
+            nodrag={false}
+          />
+          <UploadButton
+            onFileSelect={(files) => onUploadFiles?.(files)}
+            iconVariant="file"
+            tooltip="Upload files"
+            multiple
+          />
+        </FlexRow>
       </FlexRow>
 
       <Popover
@@ -338,55 +260,6 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
             dense
           />
         ))}
-      </Popover>
-
-      <Popover
-        open={Boolean(workflowFilterAnchor)}
-        anchorEl={workflowFilterAnchor}
-        onClose={() => {
-          setWorkflowFilterAnchor(null);
-          setWorkflowSearch("");
-        }}
-        placement="bottom-left"
-        paperSx={{ py: 0.5, minWidth: 220, maxHeight: 320 }}
-      >
-        <Box sx={{ px: 1, pb: 0.5, pt: 0.5 }}>
-          <SearchInput
-            value={workflowSearch}
-            onChange={setWorkflowSearch}
-            placeholder="Search workflows..."
-            autoFocus
-            fullWidth
-            size="small"
-          />
-        </Box>
-        <Box sx={{ overflowY: "auto", maxHeight: 240 }}>
-          <MenuItemPrimitive
-            label="All workflows"
-            icon={<FilterAltOffIcon />}
-            selected={workflowFilter === null}
-            onClick={() => {
-              setWorkflowFilter(null);
-              setWorkflowFilterAnchor(null);
-              setWorkflowSearch("");
-            }}
-            dense
-          />
-          {filteredWorkflows.map((workflow) => (
-            <MenuItemPrimitive
-              key={workflow.id}
-              label={workflow.name}
-              icon={<AccountTreeIcon />}
-              selected={workflowFilter === workflow.id}
-              onClick={() => {
-                setWorkflowFilter(workflow.id);
-                setWorkflowFilterAnchor(null);
-                setWorkflowSearch("");
-              }}
-              dense
-            />
-          ))}
-        </Box>
       </Popover>
 
       {showFilters && (

--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -33,7 +33,8 @@ import {
   Divider,
   BORDER_RADIUS,
   FONT_SIZE_SANS,
-  MOTION
+  MOTION,
+  SPACING
 } from "../ui_primitives";
 import { TYPE_FILTERS, TypeFilterKey } from "../../utils/formatUtils";
 import isEqual from "fast-deep-equal";
@@ -155,20 +156,22 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
           display: "flex",
           flexWrap: "wrap",
           alignItems: "center",
-          columnGap: 1,
-          rowGap: 0.5
+          columnGap: 2,
+          rowGap: 1,
+          px: 2,
+          py: 1
         })
       }}
     >
       <FlexRow
         className="asset-menu-toolbar"
         align="center"
-        gap={0.5}
+        gap={0.75}
         wrap
         sx={{
           px: 0.5,
           py: 0.5,
-          "& .MuiIconButton-root": { padding: "4px" },
+          "& .MuiIconButton-root": { padding: SPACING.sm },
           "& .MuiSvgIcon-root": { fontSize: 16 }
         }}
       >
@@ -222,8 +225,8 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         )}
 
         {/* Actions: create & add assets */}
-        <FlexRow align="center" gap={0.5} sx={{ ml: "auto" }}>
-          <Divider orientation="vertical" flexItem sx={{ my: 0.5 }} />
+        <FlexRow align="center" gap={0.5} sx={{ ml: "auto", pl: 0.5 }}>
+          <Divider orientation="vertical" flexItem sx={{ my: 0.5, mr: 0.5 }} />
           <ToolbarIconButton
             icon={<CreateNewFolderIcon />}
             tooltip="Create folder"
@@ -276,7 +279,7 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
               onLocalSearchChange={onLocalSearchChange}
               focusOnTyping={false}
               focusSearchInput={false}
-              width={333}
+              width={240}
             />
           </SearchErrorBoundary>
           <AssetActions

--- a/web/src/components/assets/AssetExplorer.tsx
+++ b/web/src/components/assets/AssetExplorer.tsx
@@ -4,6 +4,7 @@ import React, { memo } from "react";
 import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
 import ManagerPageLayout from "../panels/ManagerPageLayout";
 import AssetGrid from "./AssetGrid";
+import StorageAnalytics from "./StorageAnalytics";
 import { Box } from "../ui_primitives";
 import useAssets from "../../serverState/useAssets";
 import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
@@ -44,6 +45,7 @@ const AssetExplorer: React.FC = memo(() => {
       title="Assets"
       subtitle="Browse, organize, and preview your images, audio, video, and other files."
       padded={false}
+      actions={<StorageAnalytics assets={folderFiles} />}
     >
       <Box css={gridFillStyles}>
         <ContextMenuProvider>
@@ -52,7 +54,7 @@ const AssetExplorer: React.FC = memo(() => {
             itemSpacing={2}
             isHorizontal={true}
             isFullscreenAssets={true}
-            initialFoldersPanelWidth={200}
+            initialFoldersPanelWidth={300}
             sortedAssets={folderFiles}
           />
         </ContextMenuProvider>

--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -27,6 +27,7 @@ import { Asset } from "../../stores/ApiTypes";
 import AssetViewer from "./AssetViewer";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
 import { useShallow } from "zustand/react/shallow";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useAuth from "../../stores/useAuth";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import StorageAnalytics from "./StorageAnalytics";
@@ -46,9 +47,9 @@ import PanelErrorBoundary from "../common/PanelErrorBoundary";
 import { formatFileSize } from "../../utils/formatUtils";
 
 const panelComponents = {
-  "asset-folders": () => (
+  "asset-folders": (props: IDockviewPanelProps) => (
     <PanelErrorBoundary>
-      <AssetFoldersPanel />
+      <AssetFoldersPanel {...props} />
     </PanelErrorBoundary>
   ),
   "asset-files": (props: IDockviewPanelProps) => (
@@ -125,6 +126,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     setOpenAsset,
     setSelectedAssetIds,
     setRenameDialogOpen,
+    setWorkflowFilter,
     openAsset,
     selectedAssetIds,
     selectedFolderId,
@@ -137,6 +139,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
       setOpenAsset: state.setOpenAsset,
       setSelectedAssetIds: state.setSelectedAssetIds,
       setRenameDialogOpen: state.setRenameDialogOpen,
+      setWorkflowFilter: state.setWorkflowFilter,
       openAsset: state.openAsset,
       selectedAssetIds: state.selectedAssetIds,
       selectedFolderId: state.selectedFolderId,
@@ -146,6 +149,17 @@ const AssetGrid: React.FC<AssetGridProps> = ({
       foldersVisible: state.foldersVisible
     }))
   );
+  const currentWorkflowId = useWorkflowManager(
+    (state) => state.currentWorkflowId
+  );
+
+  // Default asset scope per surface: the in-editor sidebar follows the current
+  // workflow (re-asserted whenever the open workflow changes), while the
+  // fullscreen page opens on the global/all-assets view. A manual pick (a
+  // folder or another workflow) holds until one of these inputs changes.
+  useEffect(() => {
+    setWorkflowFilter(isFullscreenAssets ? null : currentWorkflowId ?? null);
+  }, [isFullscreenAssets, currentWorkflowId, setWorkflowFilter]);
   const openMenuType = useContextMenuStore((state) => state.openMenuType);
 
   const theme = useTheme();
@@ -234,6 +248,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
         id: "asset-folders",
         component: "asset-folders",
         title: "Folders",
+        params: { isFullscreenAssets: Boolean(isFullscreenAssets) },
         position: api.getPanel("asset-files")
           ? {
               referencePanel: "asset-files",

--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -30,7 +30,6 @@ import { useShallow } from "zustand/react/shallow";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useAuth from "../../stores/useAuth";
 import useContextMenuStore from "../../stores/ContextMenuStore";
-import StorageAnalytics from "./StorageAnalytics";
 import {
   DockviewApi,
   DockviewReact,
@@ -119,6 +118,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   isHorizontal,
   sortedAssets,
   isFullscreenAssets,
+  initialFoldersPanelWidth = FOLDERS_PANEL_WIDTH,
   isMobile = false
 }) => {
   const { error, folderFilesFiltered, folderTree } = useAssets();
@@ -132,7 +132,6 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     selectedFolderId,
     currentAudioAsset,
     currentFolderId,
-    currentFolder,
     foldersVisible
   } = useAssetGridStore(
     useShallow((state) => ({
@@ -145,7 +144,6 @@ const AssetGrid: React.FC<AssetGridProps> = ({
       selectedFolderId: state.selectedFolderId,
       currentAudioAsset: state.currentAudioAsset,
       currentFolderId: state.currentFolderId,
-      currentFolder: state.currentFolder,
       foldersVisible: state.foldersVisible
     }))
   );
@@ -256,20 +254,20 @@ const AssetGrid: React.FC<AssetGridProps> = ({
             }
           : undefined,
         ...(isFullscreenAssets
-          ? { initialWidth: FOLDERS_PANEL_WIDTH }
+          ? { initialWidth: initialFoldersPanelWidth }
           : { initialHeight: FOLDERS_PANEL_HEIGHT })
       });
 
       const groupApi = foldersPanel?.group?.api ?? foldersPanel?.group;
       if (groupApi && typeof groupApi.setSize === "function") {
         if (isFullscreenAssets) {
-          groupApi.setSize({ width: FOLDERS_PANEL_WIDTH });
+          groupApi.setSize({ width: initialFoldersPanelWidth });
         } else {
           groupApi.setSize({ height: FOLDERS_PANEL_HEIGHT });
         }
       }
     },
-    [isFullscreenAssets]
+    [isFullscreenAssets, initialFoldersPanelWidth]
   );
 
   useEffect(() => {
@@ -334,12 +332,6 @@ const AssetGrid: React.FC<AssetGridProps> = ({
           maxItemSize={maxItemSize}
           onUploadFiles={uploadFiles}
           isFullscreenAssets={isFullscreenAssets}
-        />
-      )}
-      {!isMobile && (
-        <StorageAnalytics
-          assets={sortedAssets || folderFilesFiltered || []}
-          currentFolder={currentFolder}
         />
       )}
       {!isMobile && (

--- a/web/src/components/assets/AssetSearchInput.tsx
+++ b/web/src/components/assets/AssetSearchInput.tsx
@@ -37,15 +37,16 @@ const styles = (theme: Theme) =>
     "input[type='text']": {
       border: 0,
       outline: "none",
-      padding: "0 2.5em 0 3em",
+      padding: "0 2.2em 0 2.6em",
       margin: "0",
-      height: "36px",
+      height: "32px",
+      fontSize: "var(--fontSizeSmall)",
       WebkitAppearance: "none",
       MozAppearance: "none",
       appearance: "none",
       color: "var(--palette-text-primary)",
       backgroundColor: "var(--palette-grey-800)",
-      borderRadius: BORDER_RADIUS.lg,
+      borderRadius: BORDER_RADIUS.md,
       transition: MOTION.all
     },
     "input[type='text']:focus": {

--- a/web/src/components/assets/FolderList.tsx
+++ b/web/src/components/assets/FolderList.tsx
@@ -178,6 +178,10 @@ const FolderList: React.FC<FolderListProps> = ({ isHorizontal }) => {
   const selectedFolderIds = useAssetGridStore(
     (state) => state.selectedFolderIds
   );
+  const workflowFilter = useAssetGridStore((state) => state.workflowFilter);
+  const setWorkflowFilter = useAssetGridStore(
+    (state) => state.setWorkflowFilter
+  );
 
   // Control which folders are expanded; disable single-click expansion
   const [expandedFolderIds, setExpandedFolderIds] = useState<Set<string>>(
@@ -231,12 +235,14 @@ const FolderList: React.FC<FolderListProps> = ({ isHorizontal }) => {
   }, [selectedFolderIds, folderTree, currentUser?.id, parentMap]);
 
   const handleSelect = useCallback((folder: Asset | RootFolder) => {
+    // Clicking a folder switches to folder scope, leaving any active workflow scope.
+    setWorkflowFilter(null);
     if ((folder as Asset).user_id !== undefined) {
       navigateToFolder(folder as Asset);
     } else {
       navigateToFolderId(folder.id);
     }
-  }, [navigateToFolder, navigateToFolderId]);
+  }, [navigateToFolder, navigateToFolderId, setWorkflowFilter]);
 
   const hasChildNodes = useCallback(
     (folder: FolderNode | RootFolder): folder is FolderNode & { children: FolderNode[] } => {
@@ -336,7 +342,7 @@ const FolderList: React.FC<FolderListProps> = ({ isHorizontal }) => {
               <FolderItem
                 folder={folder as Asset}
                 onSelect={() => handleFolderSelect(folder)}
-                isSelected={selectedFolderIds.includes(folder.id)}
+                isSelected={!workflowFilter && selectedFolderIds.includes(folder.id)}
               >
                 {!isRoot && (
                   <span
@@ -378,18 +384,18 @@ const FolderList: React.FC<FolderListProps> = ({ isHorizontal }) => {
             <FolderItem
               folder={folder as Asset}
               onSelect={() => handleFolderSelect(folder)}
-              isSelected={selectedFolderIds.includes(folder.id)}
+              isSelected={!workflowFilter && selectedFolderIds.includes(folder.id)}
             />
           </div>
         </Box>
       );
     },
-    [expandedFolderIds, selectedFolderIds, handleRowDoubleClick, handleFolderSelect, handleFolderClick, handleExpandFolder, noop, hasChildNodes]
+    [workflowFilter, expandedFolderIds, selectedFolderIds, handleRowDoubleClick, handleFolderSelect, handleFolderClick, handleExpandFolder, noop, hasChildNodes]
   );
 
   const rootFolder: RootFolder = useMemo(() => ({
     id: currentUser?.id ?? "root",
-    name: "ASSETS",
+    name: "FOLDERS",
     content_type: "folder",
     children: (Object.values(folderTree || {}) as FolderNode[]) || [],
     parent_id: currentUser?.id || ""

--- a/web/src/components/assets/StorageAnalytics.tsx
+++ b/web/src/components/assets/StorageAnalytics.tsx
@@ -3,66 +3,52 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import React, { useMemo, memo } from "react";
-import { Text, Box } from "../ui_primitives";
+import { Box } from "../ui_primitives";
 import { useLocation } from "react-router-dom";
 import { Asset } from "../../stores/ApiTypes";
 import { formatFileSize } from "../../utils/formatUtils";
 
 interface StorageAnalyticsProps {
   assets: Asset[];
-  currentFolder?: Asset | null;
 }
 
+// Rendered in the manager hero's actions slot (right of the title), so it lays
+// out in flow as a compact summary row instead of floating over the toolbar.
 const styles = (theme: Theme) =>
   css({
     "&": {
-      position: "absolute",
-      top: "7em",
-      right: "2em",
-      minWidth: "200px",
-      maxWidth: "300px",
       display: "flex",
       alignItems: "center",
-      justifyContent: "flex-end",
-      gap: "1em",
-      padding: "0.5em 1em",
-      backgroundColor: "transparent",
-      borderRadius: "0.25em",
-      margin: "0",
+      gap: theme.spacing(3),
       fontSize: theme.fontSizeSmaller,
-      textAlign: "right"
-    },
-    ".folder-info": {
-      color: theme.vars.palette.grey[200],
-      fontWeight: 500
+      whiteSpace: "nowrap"
     },
     ".storage-stats": {
-      minWidth: "120px",
-      color: "var(--palette-primary-main)",
-      fontSize: theme.fontSizeNormal,
       display: "flex",
       alignItems: "flex-end",
-      gap: "1em"
+      gap: theme.spacing(3)
     },
     ".stat-item": {
       display: "flex",
       flexDirection: "column",
-      alignItems: "center"
+      alignItems: "flex-start",
+      gap: theme.spacing(0.5)
     },
     ".stat-label": {
       color: theme.vars.palette.grey[400],
       fontSize: theme.fontSizeTiny,
-      textTransform: "uppercase"
+      textTransform: "uppercase",
+      letterSpacing: "0.06em",
+      lineHeight: 1
     },
     ".stat-value": {
-      color: theme.vars.palette.grey[0]
+      color: theme.vars.palette.grey[0],
+      fontSize: theme.fontSizeSmall,
+      lineHeight: 1.1
     }
   });
 
-const StorageAnalytics: React.FC<StorageAnalyticsProps> = ({
-  assets,
-  currentFolder
-}) => {
+const StorageAnalytics: React.FC<StorageAnalyticsProps> = ({ assets }) => {
   const location = useLocation();
   const theme = useTheme();
   const analyticsStyles = useMemo(() => styles(theme), [theme]);
@@ -93,10 +79,6 @@ const StorageAnalytics: React.FC<StorageAnalyticsProps> = ({
 
   return (
     <Box css={analyticsStyles} className="storage-analytics">
-      <Text className="folder-info">
-        {currentFolder?.name || "ASSETS"}
-      </Text>
-
       <div className="storage-stats">
         <div className="stat-item">
           <span className="stat-label">Total Size</span>
@@ -119,13 +101,9 @@ const StorageAnalytics: React.FC<StorageAnalyticsProps> = ({
   );
 };
 
-// Memoize component to prevent unnecessary re-renders when parent components update
-// StorageAnalytics performs calculations and should only re-render when assets or currentFolder changes
+// Memoize so the summary only recomputes when the asset list identity changes.
 const arePropsEqual = (prevProps: StorageAnalyticsProps, nextProps: StorageAnalyticsProps) => {
-  return (
-    prevProps.assets === nextProps.assets &&
-    prevProps.currentFolder === nextProps.currentFolder
-  );
+  return prevProps.assets === nextProps.assets;
 };
 
 export default memo(StorageAnalytics, arePropsEqual);

--- a/web/src/components/assets/WorkflowTree.tsx
+++ b/web/src/components/assets/WorkflowTree.tsx
@@ -1,0 +1,196 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CircleIcon from "@mui/icons-material/Circle";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import {
+  Text,
+  LoadingSpinner,
+  SearchInput,
+  Box,
+  Collapse,
+  MOTION,
+  BORDER_RADIUS
+} from "../ui_primitives";
+import { useAssetGridStore } from "../../stores/AssetGridStore";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import { WorkflowList, Workflow } from "../../stores/ApiTypes";
+
+// Show the inline search field once the list grows past this many workflows.
+const SEARCH_THRESHOLD = 8;
+
+const styles = (theme: Theme) =>
+  css({
+    "&.workflow-tree": {
+      padding: ".25em 0 1em .5em"
+    },
+    ".root-row": {
+      display: "flex",
+      alignItems: "center",
+      gap: ".25rem",
+      height: "1.5rem",
+      cursor: "pointer",
+      userSelect: "none"
+    },
+    ".root-row .root-icon": {
+      width: "18px",
+      height: "18px",
+      color: theme.vars.palette.grey[400]
+    },
+    ".root-row .root-label": {
+      fontSize: theme.fontSizeSmall,
+      textTransform: "uppercase",
+      letterSpacing: "0.08em",
+      fontWeight: 500,
+      color: theme.vars.palette.grey[400]
+    },
+    ".root-row .expand-icon": {
+      width: "20px",
+      height: "20px",
+      color: theme.vars.palette.grey[400],
+      transition: `transform ${MOTION.normal}`,
+      transform: "rotate(-90deg)"
+    },
+    "&.expanded .root-row .expand-icon": {
+      transform: "rotate(0deg)"
+    },
+    ".workflow-leaf": {
+      display: "flex",
+      alignItems: "center",
+      gap: ".4em",
+      height: "1.5rem",
+      paddingLeft: "1.5rem",
+      paddingRight: ".5em",
+      cursor: "pointer",
+      borderRadius: BORDER_RADIUS.md,
+      transition: `${MOTION.background}, color ${MOTION.fast}`
+    },
+    ".workflow-leaf:hover": {
+      backgroundColor: theme.vars.palette.action.hover
+    },
+    ".workflow-leaf .leaf-icon": {
+      width: "8px",
+      height: "8px",
+      color: theme.vars.palette.grey[500],
+      flexShrink: 0
+    },
+    ".workflow-leaf .leaf-name": {
+      margin: 0,
+      fontSize: theme.fontSizeSmall,
+      fontWeight: 500,
+      color: theme.vars.palette.text.secondary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".workflow-leaf.selected": {
+      backgroundColor: "rgba(var(--palette-primary-main-channel) / 0.12)"
+    },
+    ".workflow-leaf.selected .leaf-icon, .workflow-leaf.selected .leaf-name": {
+      color: theme.vars.palette.primary.main,
+      fontWeight: 600
+    },
+    ".search-row": {
+      padding: ".25em 1.5rem .25em 0"
+    },
+    ".empty-row": {
+      paddingLeft: "1.5rem",
+      color: theme.vars.palette.grey[500],
+      fontSize: theme.fontSizeSmall
+    }
+  });
+
+/**
+ * Sibling of the FOLDERS tree shown in the fullscreen asset navigator. Lists
+ * every workflow as a leaf; selecting one scopes the asset grid to that
+ * workflow's assets (mutually exclusive with folder browsing).
+ */
+const WorkflowTree: React.FC = () => {
+  const theme = useTheme();
+  const treeStyles = useMemo(() => styles(theme), [theme]);
+  const [expanded, setExpanded] = useState(true);
+  const [search, setSearch] = useState("");
+
+  const workflowFilter = useAssetGridStore((state) => state.workflowFilter);
+  const setWorkflowFilter = useAssetGridStore(
+    (state) => state.setWorkflowFilter
+  );
+  const setSelectedFolderIds = useAssetGridStore(
+    (state) => state.setSelectedFolderIds
+  );
+
+  const load = useWorkflowManager((state) => state.load);
+  const { data, isLoading } = useQuery<WorkflowList, Error>({
+    queryKey: ["workflows"],
+    queryFn: async () => load("", 200)
+  });
+
+  const workflows = useMemo(() => {
+    const all = data?.workflows ?? [];
+    const term = search.toLowerCase();
+    const filtered = term
+      ? all.filter((w) => w.name.toLowerCase().includes(term))
+      : all;
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+  }, [data?.workflows, search]);
+
+  const showSearch = (data?.workflows?.length ?? 0) > SEARCH_THRESHOLD;
+
+  const handleSelect = useCallback(
+    (workflow: Workflow) => {
+      // Selecting a workflow scopes to its assets and clears the folder highlight.
+      setWorkflowFilter(workflow.id);
+      setSelectedFolderIds([]);
+    },
+    [setWorkflowFilter, setSelectedFolderIds]
+  );
+
+  return (
+    <Box className={`workflow-tree ${expanded ? "expanded" : ""}`} css={treeStyles}>
+      <div className="root-row" onClick={() => setExpanded((prev) => !prev)}>
+        <ExpandMoreIcon className="expand-icon" />
+        <AccountTreeIcon className="root-icon" />
+        <span className="root-label">Workflows</span>
+      </div>
+
+      <Collapse in={expanded} timeout="auto" unmountOnExit>
+        {showSearch && (
+          <div className="search-row">
+            <SearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder="Search workflows..."
+              fullWidth
+              size="small"
+            />
+          </div>
+        )}
+        {isLoading ? (
+          <LoadingSpinner size="small" />
+        ) : workflows.length === 0 ? (
+          <div className="empty-row">No workflows</div>
+        ) : (
+          workflows.map((workflow) => (
+            <div
+              key={workflow.id}
+              className={`workflow-leaf ${
+                workflowFilter === workflow.id ? "selected" : ""
+              }`}
+              onClick={() => handleSelect(workflow)}
+            >
+              <CircleIcon className="leaf-icon" />
+              <Text className="leaf-name">{workflow.name}</Text>
+            </div>
+          ))
+        )}
+      </Collapse>
+    </Box>
+  );
+};
+
+export default memo(WorkflowTree);

--- a/web/src/components/assets/WorkflowTree.tsx
+++ b/web/src/components/assets/WorkflowTree.tsx
@@ -3,8 +3,8 @@ import { css } from "@emotion/react";
 
 import React, { memo, useCallback, useMemo, useState } from "react";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import CircleIcon from "@mui/icons-material/Circle";
 import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -24,25 +24,41 @@ import { WorkflowList, Workflow } from "../../stores/ApiTypes";
 // Show the inline search field once the list grows past this many workflows.
 const SEARCH_THRESHOLD = 8;
 
+// Shared with the FOLDERS tree so both navigators read as one component: same
+// row height, hover, selected treatment, and a leading-icon column the names
+// align to. The section header matches the FOLDERS root (icon + uppercase
+// label, left-aligned); only the collapse chevron is added on the right since
+// the workflow list is long.
+const ROW_HEIGHT = "1.5rem";
+const ICON_SLOT = "18px";
+
 const styles = (theme: Theme) =>
   css({
     "&.workflow-tree": {
-      padding: ".25em 0 1em .5em"
+      padding: ".25em .5em 1em .5em"
     },
     ".root-row": {
       display: "flex",
       alignItems: "center",
-      gap: ".25rem",
-      height: "1.5rem",
+      gap: ".4em",
+      height: ROW_HEIGHT,
+      paddingLeft: "2px",
       cursor: "pointer",
-      userSelect: "none"
+      userSelect: "none",
+      borderRadius: BORDER_RADIUS.md,
+      transition: MOTION.background
+    },
+    ".root-row:hover": {
+      backgroundColor: theme.vars.palette.action.hover
     },
     ".root-row .root-icon": {
-      width: "18px",
-      height: "18px",
-      color: theme.vars.palette.grey[400]
+      width: ICON_SLOT,
+      height: ICON_SLOT,
+      color: theme.vars.palette.grey[400],
+      flexShrink: 0
     },
     ".root-row .root-label": {
+      flex: 1,
       fontSize: theme.fontSizeSmall,
       textTransform: "uppercase",
       letterSpacing: "0.08em",
@@ -50,22 +66,25 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.grey[400]
     },
     ".root-row .expand-icon": {
-      width: "20px",
-      height: "20px",
-      color: theme.vars.palette.grey[400],
+      width: "16px",
+      height: "16px",
+      color: theme.vars.palette.grey[500],
       transition: `transform ${MOTION.normal}`,
       transform: "rotate(-90deg)"
     },
     "&.expanded .root-row .expand-icon": {
       transform: "rotate(0deg)"
     },
+    ".search-row": {
+      padding: ".25em 0 .25em 0"
+    },
     ".workflow-leaf": {
       display: "flex",
       alignItems: "center",
       gap: ".4em",
-      height: "1.5rem",
-      paddingLeft: "1.5rem",
-      paddingRight: ".5em",
+      height: ROW_HEIGHT,
+      paddingLeft: ".75rem",
+      paddingRight: ".25em",
       cursor: "pointer",
       borderRadius: BORDER_RADIUS.md,
       transition: `${MOTION.background}, color ${MOTION.fast}`
@@ -73,11 +92,17 @@ const styles = (theme: Theme) =>
     ".workflow-leaf:hover": {
       backgroundColor: theme.vars.palette.action.hover
     },
-    ".workflow-leaf .leaf-icon": {
-      width: "8px",
-      height: "8px",
-      color: theme.vars.palette.grey[500],
+    ".workflow-leaf .leaf-icon-slot": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: ICON_SLOT,
       flexShrink: 0
+    },
+    ".workflow-leaf .leaf-icon": {
+      width: "14px",
+      height: "14px",
+      color: theme.vars.palette.grey[500]
     },
     ".workflow-leaf .leaf-name": {
       margin: 0,
@@ -91,19 +116,25 @@ const styles = (theme: Theme) =>
     ".workflow-leaf.selected": {
       backgroundColor: "rgba(var(--palette-primary-main-channel) / 0.12)"
     },
-    ".workflow-leaf.selected .leaf-icon, .workflow-leaf.selected .leaf-name": {
+    ".workflow-leaf.selected .leaf-icon": {
+      color: theme.vars.palette.primary.main
+    },
+    ".workflow-leaf.selected .leaf-name": {
       color: theme.vars.palette.primary.main,
       fontWeight: 600
     },
-    ".search-row": {
-      padding: ".25em 1.5rem .25em 0"
-    },
     ".empty-row": {
-      paddingLeft: "1.5rem",
+      paddingLeft: "1.75rem",
       color: theme.vars.palette.grey[500],
-      fontSize: theme.fontSizeSmall
+      fontSize: theme.fontSizeSmaller
     }
   });
+
+// Compact the shared SearchInput so it sits as a tree control, not a hero field.
+const searchInputSx = {
+  "& .MuiInputBase-root": { minHeight: "28px", height: "28px" },
+  "& .MuiInputBase-input": { fontSize: "var(--fontSizeSmaller)", py: 0 }
+};
 
 /**
  * Sibling of the FOLDERS tree shown in the fullscreen asset navigator. Lists
@@ -153,9 +184,9 @@ const WorkflowTree: React.FC = () => {
   return (
     <Box className={`workflow-tree ${expanded ? "expanded" : ""}`} css={treeStyles}>
       <div className="root-row" onClick={() => setExpanded((prev) => !prev)}>
-        <ExpandMoreIcon className="expand-icon" />
         <AccountTreeIcon className="root-icon" />
         <span className="root-label">Workflows</span>
+        <ExpandMoreIcon className="expand-icon" />
       </div>
 
       <Collapse in={expanded} timeout="auto" unmountOnExit>
@@ -167,6 +198,7 @@ const WorkflowTree: React.FC = () => {
               placeholder="Search workflows..."
               fullWidth
               size="small"
+              sx={searchInputSx}
             />
           </div>
         )}
@@ -183,7 +215,9 @@ const WorkflowTree: React.FC = () => {
               }`}
               onClick={() => handleSelect(workflow)}
             >
-              <CircleIcon className="leaf-icon" />
+              <span className="leaf-icon-slot">
+                <AccountTreeOutlinedIcon className="leaf-icon" />
+              </span>
               <Text className="leaf-name">{workflow.name}</Text>
             </div>
           ))

--- a/web/src/components/assets/panels/AssetFoldersPanel.tsx
+++ b/web/src/components/assets/panels/AssetFoldersPanel.tsx
@@ -1,9 +1,18 @@
 import React from "react";
+import { IDockviewPanelProps } from "dockview";
 import { useTheme } from "@mui/material/styles";
 import FolderList from "../FolderList";
+import WorkflowTree from "../WorkflowTree";
 
-const AssetFoldersPanel: React.FC = () => {
+export interface AssetFoldersPanelParams {
+  isFullscreenAssets?: boolean;
+}
+
+const AssetFoldersPanel: React.FC<
+  Partial<IDockviewPanelProps<AssetFoldersPanelParams>>
+> = (props) => {
   const theme = useTheme();
+  const isFullscreenAssets = props.params?.isFullscreenAssets ?? false;
   return (
     <div
       style={{
@@ -14,6 +23,10 @@ const AssetFoldersPanel: React.FC = () => {
       }}
     >
       <FolderList isHorizontal={false} />
+      {/* The WORKFLOWS tree is a cross-workflow browser, only useful in the
+          global fullscreen view. The sidebar stays scoped to the current
+          workflow. */}
+      {isFullscreenAssets && <WorkflowTree />}
     </div>
   );
 };

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -28,7 +28,7 @@ import SmartToyIcon from "@mui/icons-material/SmartToy";
 import LoginIcon from "@mui/icons-material/Login";
 import CallSplitIcon from "@mui/icons-material/CallSplit";
 import HubIcon from "@mui/icons-material/Hub";
-import { IconForType } from "./IconForType";
+import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
 
 import type { NodeMetadata } from "../stores/ApiTypes";
 import {
@@ -87,11 +87,7 @@ export const LEFT_PANEL_TOP_LEVEL: readonly LeftPanelTopLevelCategory[] = [
   { id: "settings", label: "Settings", icon: <SettingsIcon /> },
   { id: "history", label: "History", icon: <HistoryIcon /> },
   { id: "favorites", label: "Favorites", icon: <StarIcon /> },
-  {
-    id: "assets",
-    label: "Assets",
-    icon: <IconForType iconName="asset" showTooltip={false} iconSize="small" />
-  },
+  { id: "assets", label: "Assets", icon: <PermMediaOutlinedIcon /> },
   { id: "agent", label: "Agent", icon: <SmartToyOutlinedIcon /> }
 ];
 


### PR DESCRIPTION
## Summary

Extracted workflow filtering logic from `AssetActionsMenu` into a new `WorkflowTree` component that mirrors the folder navigation pattern. The workflow filter is now a collapsible tree in the fullscreen asset navigator's left panel, while the sidebar remains scoped to the current workflow. This simplifies the toolbar and provides a more discoverable, organized interface for cross-workflow browsing.

## Key Changes

- **New `WorkflowTree` component** (`web/src/components/assets/WorkflowTree.tsx`):
  - Collapsible tree UI with search (shown when >8 workflows exist)
  - Selects a workflow to scope the asset grid to that workflow's assets
  - Clears folder selection when a workflow is selected (mutually exclusive scopes)
  - Styled to match the folder tree with consistent icons and interactions

- **Simplified `AssetActionsMenu`**:
  - Removed workflow filter button, popover, and search state
  - Removed `AccountTreeIcon` and `FilterCenterFocusIcon` imports
  - Removed `useWorkflowManager` and `useQuery` hooks for workflows
  - Reorganized toolbar with comments clarifying button groups (Browse, Filter, Search/Sort, Actions)
  - Moved Create Folder and Upload buttons to a right-aligned group with divider
  - Updated icon size from 14px to 16px for better visibility
  - Updated "Tune" button tooltip to reflect new purpose ("Search, sort & resize")

- **Updated `AssetFoldersPanel`**:
  - Now accepts `IDockviewPanelProps` to receive `isFullscreenAssets` parameter
  - Conditionally renders `WorkflowTree` only in fullscreen view (not in sidebar)
  - Sidebar remains scoped to the current workflow via `useEffect` in `AssetGrid`

- **Enhanced `FolderList`**:
  - Clicking a folder now clears any active workflow filter (mutual exclusivity)
  - Folder selection visual state respects workflow filter (not highlighted if workflow is active)

- **Updated `AssetGrid`**:
  - Added logic to auto-scope to current workflow in sidebar, global view in fullscreen
  - Manual selections (folder or workflow) persist until the surface or workflow changes

## Implementation Details

- Workflow selection is mutually exclusive with folder selection — choosing one clears the other
- The fullscreen asset navigator now has a dedicated left panel with both folder and workflow trees
- Search is lazy-loaded in `WorkflowTree` only when the workflow count exceeds a threshold
- Styling uses emotion CSS with theme tokens (`BORDER_RADIUS`, `MOTION`, palette colors)
- All UI primitives follow the established patterns (no raw MUI components)

https://claude.ai/code/session_01SSExPczmhuAkX84mv3KXLL