### PR TITLE
fix(runtime): surface Ollama reasoning tokens and keep models resident

### DIFF
--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -29,6 +29,9 @@ type OllamaToolCall = {
 type OllamaChatMessage = {
   role?: string;
   content?: string;
+  // Reasoning models (e.g. gpt-oss, deepseek-r1) stream their chain of thought
+  // here while `content` stays empty until reasoning finishes.
+  thinking?: string;
   images?: string[];
   tool_calls?: OllamaToolCall[];
 };
@@ -83,6 +86,14 @@ export class OllamaProvider extends BaseProvider {
   }
 
   readonly apiUrl: string;
+  /**
+   * How long Ollama keeps the model resident after a request. Without this,
+   * large models (e.g. the default gpt-oss:20b) get evicted between turns and
+   * pay a multi-second reload on every message. Override with OLLAMA_KEEP_ALIVE
+   * (accepts Ollama's duration syntax, e.g. "30m", "-1" to keep forever, "0" to
+   * unload immediately).
+   */
+  readonly keepAlive: string;
   private _fetch: typeof fetch;
 
   constructor(
@@ -95,6 +106,8 @@ export class OllamaProvider extends BaseProvider {
       throw new Error("OLLAMA_API_URL is required");
     }
     this.apiUrl = apiUrl.replace(/\/+$/, "");
+    const keepAlive = process.env.OLLAMA_KEEP_ALIVE?.trim();
+    this.keepAlive = keepAlive && keepAlive.length > 0 ? keepAlive : "10m";
     this._fetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
   }
 
@@ -395,6 +408,7 @@ export class OllamaProvider extends BaseProvider {
       messages: await Promise.all(
         args.messages.map((m) => this.convertMessage(m))
       ),
+      keep_alive: this.keepAlive,
       options: {
         num_predict: args.maxTokens ?? 8192
       }
@@ -575,6 +589,19 @@ export class OllamaProvider extends BaseProvider {
             done?: boolean;
           };
           const message = event.message ?? {};
+
+          // Reasoning models stream their chain of thought in `thinking` while
+          // `content` stays empty. Surface it as a thinking chunk so the UI
+          // shows activity instead of appearing frozen until the answer lands.
+          if (typeof message.thinking === "string" && message.thinking) {
+            const thinkingChunk: Chunk = {
+              type: "chunk",
+              content: message.thinking,
+              done: false,
+              thinking: true
+            };
+            yield thinkingChunk;
+          }
 
           if (!useToolEmulation) {
             for (const tc of this.toToolCalls(message.tool_calls)) {

--- a/packages/runtime/tests/providers/ollama-provider.test.ts
+++ b/packages/runtime/tests/providers/ollama-provider.test.ts
@@ -109,6 +109,13 @@ describe("OllamaProvider", () => {
       content: "done",
       toolCalls: [{ id: "tool_1", name: "sum", args: { a: 1, b: 2 } }]
     });
+
+    // keep_alive is sent so large models stay resident between turns.
+    const sentBody = JSON.parse(
+      (fetchFn.mock.calls[fetchFn.mock.calls.length - 1][1] as RequestInit)
+        .body as string
+    );
+    expect(sentBody.keep_alive).toBe("10m");
   });
 
   it("streams chunks and tool calls from NDJSON", async () => {
@@ -145,6 +152,37 @@ describe("OllamaProvider", () => {
       { type: "chunk", content: "Hel", done: false },
       { id: "tool_1", name: "lookup", args: { q: "x" } },
       { type: "chunk", content: "lo", done: false },
+      { type: "chunk", content: "", done: true }
+    ]);
+  });
+
+  it("surfaces reasoning-model thinking tokens as thinking chunks", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      streamResponse([
+        { message: { content: "", thinking: "Let me" }, done: false },
+        { message: { content: "", thinking: " think" }, done: false },
+        { message: { content: "Hi" }, done: false },
+        { message: { content: "" }, done: true }
+      ])
+    );
+
+    const provider = new OllamaProvider(
+      { OLLAMA_API_URL: "http://localhost:11434" },
+      { fetchFn: fetchFn as unknown as typeof fetch }
+    );
+
+    const out: Array<unknown> = [];
+    for await (const item of provider.generateMessages({
+      model: "gpt-oss:20b",
+      messages: [{ role: "user", content: "hi" }]
+    })) {
+      out.push(item);
+    }
+
+    expect(out).toEqual([
+      { type: "chunk", content: "Let me", done: false, thinking: true },
+      { type: "chunk", content: " think", done: false, thinking: true },
+      { type: "chunk", content: "Hi", done: false },
       { type: "chunk", content: "", done: true }
     ]);
   });


### PR DESCRIPTION
## Problem
The chat panel at the bottom of the editor appeared to hang when using Ollama on Mac. The same model run directly via `ollama run` responded fine. Default chat model is `gpt-oss:20b`.

## Root cause
Two issues compounded into an apparent hang:
1. **Reasoning tokens were dropped.** `gpt-oss` (and deepseek-r1 etc.) stream their chain of thought in Ollama's separate `thinking` field while `message.content` stays empty until the final answer. The Ollama provider's streaming loop only read `content`, so it emitted **nothing** to the UI during the entire reasoning phase — the panel sat blank and felt frozen. Every other reasoning-capable provider (Anthropic, DeepSeek, Gemini, Codex) already surfaces this as `Chunk { thinking: true }`; Ollama was the only one that didn't.
2. **No `keep_alive`.** The 13 GB default model was evicted between turns, paying an 8–30 s reload on every message.

## Changes
- `generateMessages` now emits a `thinking: true` chunk whenever Ollama returns a `thinking` token, mirroring the Anthropic provider. The web chat already renders these chunks for other providers, so reasoning now shows immediately.
- Added `thinking?: string` to the `OllamaChatMessage` type.
- Chat requests now send `keep_alive` (default `"10m"`, overridable via `OLLAMA_KEEP_ALIVE` — accepts Ollama's duration syntax, `-1` = forever, `0` = unload immediately).
- Tests: a regression test for thinking-chunk surfacing, and an assertion that `keep_alive` is sent.

## Testing
- `npm run test --workspace=packages/runtime -- ollama-provider` → 62 passed
- Package typecheck clean

## Reviewer notes
This addresses the "looks frozen" perception (hidden reasoning + cold reload). Separately, when the model calls a client-side `ui_*` tool, the runner blocks on `createWaiter(callId, 300_000)` for up to 5 minutes waiting on the browser — a genuine "never returns" path if the client handler doesn't reply. That is **not** fixed here; flagging it for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)