### PR TITLE
fix(web): align node library panel spacing with other left panels

### DIFF
--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -51,7 +51,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       gap: theme.spacing(1),
       padding: isMobile
         ? theme.spacing(0.5, 1, 1, 1)
-        : theme.spacing(1.5, 1.5, 1, 1.5)
+        : theme.spacing(1.5, 3, 1, 3)
     },
     ".nl-title": {
       fontSize: "var(--fontSizeNormal)",
@@ -75,7 +75,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      margin: theme.spacing(0, isMobile ? 1 : 1.5, 1, isMobile ? 1 : 1.5),
+      margin: theme.spacing(0, isMobile ? 1 : 3, 1, isMobile ? 1 : 3),
       padding: theme.spacing(1, 1),
       borderRadius: BORDER_RADIUS.md,
       backgroundColor: theme.vars.palette.background.paper,
@@ -177,7 +177,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       flexDirection: "column",
       gap: "2px",
-      padding: theme.spacing(1, 1),
+      padding: theme.spacing(1, 1, 1, isMobile ? 1 : 3),
       overflowY: "auto",
       borderRight: `1px solid ${theme.vars.palette.divider}`,
       ...thinScrollbarStyles(theme)
@@ -244,7 +244,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       flex: 1,
       minWidth: 0,
       overflowY: "auto",
-      padding: theme.spacing(1, 1),
+      padding: theme.spacing(1, isMobile ? 1 : 3, 1, 1),
       ...thinScrollbarStyles(theme)
     },
     ".nl-empty": {
@@ -262,7 +262,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: theme.spacing(1, 1.5),
+      padding: theme.spacing(1, isMobile ? 1.5 : 3),
       borderTop: `1px solid ${theme.vars.palette.divider}`,
       color: theme.vars.palette.text.secondary,
       fontSize: "var(--fontSizeSmall)"

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -14,7 +14,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
-import { Text, thinScrollbarStyles, MOTION, FONT_WEIGHT, BORDER_RADIUS } from "../ui_primitives";
+import { Text, thinScrollbarStyles, MOTION, FONT_WEIGHT, BORDER_RADIUS, SPACING } from "../ui_primitives";
 import NodeLibraryRow from "./NodeLibraryRow";
 import NodeInfo from "./NodeInfo";
 import useMetadataStore from "../../stores/MetadataStore";
@@ -50,8 +50,8 @@ const styles = (theme: Theme, isMobile: boolean) =>
       alignItems: "center",
       gap: theme.spacing(1),
       padding: isMobile
-        ? theme.spacing(0.5, 1, 1, 1)
-        : theme.spacing(1.5, 3, 1, 3)
+        ? theme.spacing(SPACING.micro, SPACING.xs, SPACING.xs, SPACING.xs)
+        : theme.spacing(SPACING.sm, SPACING.lg, SPACING.xs, SPACING.lg)
     },
     ".nl-title": {
       fontSize: "var(--fontSizeNormal)",
@@ -75,7 +75,12 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      margin: theme.spacing(0, isMobile ? 1 : 3, 1, isMobile ? 1 : 3),
+      margin: theme.spacing(
+        SPACING.none,
+        isMobile ? SPACING.xs : SPACING.lg,
+        SPACING.xs,
+        isMobile ? SPACING.xs : SPACING.lg
+      ),
       padding: theme.spacing(1, 1),
       borderRadius: BORDER_RADIUS.md,
       backgroundColor: theme.vars.palette.background.paper,
@@ -177,7 +182,12 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       flexDirection: "column",
       gap: "2px",
-      padding: theme.spacing(1, 1, 1, isMobile ? 1 : 3),
+      padding: theme.spacing(
+        SPACING.xs,
+        SPACING.xs,
+        SPACING.xs,
+        isMobile ? SPACING.xs : SPACING.lg
+      ),
       overflowY: "auto",
       borderRight: `1px solid ${theme.vars.palette.divider}`,
       ...thinScrollbarStyles(theme)
@@ -244,7 +254,12 @@ const styles = (theme: Theme, isMobile: boolean) =>
       flex: 1,
       minWidth: 0,
       overflowY: "auto",
-      padding: theme.spacing(1, isMobile ? 1 : 3, 1, 1),
+      padding: theme.spacing(
+        SPACING.xs,
+        isMobile ? SPACING.xs : SPACING.lg,
+        SPACING.xs,
+        SPACING.xs
+      ),
       ...thinScrollbarStyles(theme)
     },
     ".nl-empty": {
@@ -262,7 +277,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: theme.spacing(1, isMobile ? 1.5 : 3),
+      padding: theme.spacing(SPACING.xs, isMobile ? SPACING.sm : SPACING.lg),
       borderTop: `1px solid ${theme.vars.palette.divider}`,
       color: theme.vars.palette.text.secondary,
       fontSize: "var(--fontSizeSmall)"


### PR DESCRIPTION
The node library opts out of the shared `0 0.75em` panel padding (the
`is-nodes` full-bleed override) so its section dividers and info strip can
bleed to the panel edges. But its content was inset only ~4-6px, so it hugged
the panel edges while every other left panel sits at ~0.75em.

Bump the node library's desktop outer-facing horizontal insets (header,
search, rail-left, list-right, footer) to theme.spacing(3) (12px ≈ 0.75em) so
its content lines up with the other panels. Full-bleed dividers and the mobile
bottom-sheet layout are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Tm5aecrLnq6PN4hB3y7Mr