### PR TITLE
fix: commit Prompt node text to store immediately to avoid stale runs

### DIFF
--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -16,7 +16,6 @@
 import React, {
   memo,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState
@@ -48,7 +47,6 @@ import type { NodeMetadata, Property } from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useDynamicProperty } from "../../../hooks/nodes/useDynamicProperty";
-import { debounce } from "../../../utils/lodashAlternatives";
 
 import { AssetMentionNode } from "./promptComposer/AssetMentionNode";
 import { VariableNode, $createVariableNode } from "./promptComposer/VariableNode";
@@ -231,7 +229,7 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
 
-  const { setProperties, setPropertyComplete } = useBespokePropertyWriter({
+  const { setProperties } = useBespokePropertyWriter({
     nodeId: id,
     nodeType
   });
@@ -320,34 +318,34 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
     []
   );
 
-  const writePrompt = useMemo(
-    () =>
-      debounce((text: string) => {
-        if (text === lastWrittenRef.current) {
-          return;
-        }
-        lastWrittenRef.current = text;
-        setProperties({ prompt: text });
-        setPropertyComplete();
-      }, 400),
-    [setProperties, setPropertyComplete]
+  // Commit the serialized prompt to the store on every edit. Writing
+  // synchronously — rather than behind a debounce — guarantees a run (manual or
+  // auto) always reads the current text. A debounced write let a run fired
+  // within the debounce window send the node's *previous* prompt downstream,
+  // producing the intermittent stale-value bug. The equality guard skips
+  // redundant writes from selection-only editor changes (Lexical's
+  // OnChangePlugin fires for those too); auto-run is still coalesced downstream
+  // by useNodeAutoRun's own debounce.
+  const commitPrompt = useCallback(
+    (text: string) => {
+      if (text === lastWrittenRef.current) {
+        return;
+      }
+      lastWrittenRef.current = text;
+      setProperties({ prompt: text });
+    },
+    [setProperties]
   );
-
-  useEffect(() => {
-    return () => {
-      writePrompt.cancel();
-    };
-  }, [writePrompt]);
 
   const handleEditorChange = useCallback(
     (editorState: EditorState) => {
       editorState.read(() => {
         const serialized = $serializePrompt();
         setPromptText(serialized);
-        writePrompt(serialized);
+        commitPrompt(serialized);
       });
     },
-    [writePrompt]
+    [commitPrompt]
   );
 
   const promptProperties = useMemo<Property[]>(() => [], []);

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Regression test for the stale-prompt bug: editing a `nodetool.text.Prompt`
+ * node and running the graph could send the node's *previous* text downstream.
+ *
+ * The cause was a 400ms debounce on the store write — a run dispatched within
+ * that window read the stale value. These tests assert the edited prompt is
+ * committed to the store *synchronously* (no timers advanced), so any run sees
+ * the current text.
+ *
+ * The OnChangePlugin is mocked to capture the editor's change handler so the
+ * test can drive an edit without fighting Lexical/contentEditable in jsdom, and
+ * promptEditorState is mocked so the captured serialized text is controllable.
+ * These mocks would interfere with the content-loading assertions in
+ * PromptComposerBody.test.tsx, so they live in this separate file.
+ */
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PromptComposerBody } from "../PromptComposerBody";
+import mockTheme from "../../../../__mocks__/themeMock";
+import "@testing-library/jest-dom";
+
+const mockSetProperties = jest.fn();
+
+// Captures the OnChangePlugin `onChange` so a test can simulate an editor edit.
+const mockOnChangeHolder: { current: ((state: unknown) => void) | null } = {
+  current: null
+};
+jest.mock("@lexical/react/LexicalOnChangePlugin", () => ({
+  OnChangePlugin: ({ onChange }: { onChange: (state: unknown) => void }) => {
+    mockOnChangeHolder.current = onChange;
+    return null;
+  }
+}));
+
+// Controls what the editor serializes to; reassigned per test.
+let mockSerialized = "";
+jest.mock("../promptComposer/promptEditorState", () => ({
+  $serializePrompt: () => mockSerialized,
+  $setPromptFromString: () => {}
+}));
+
+jest.mock("../../../../hooks/nodes/useBespokePropertyWriter", () => ({
+  useBespokePropertyWriter: () => ({
+    setProperty: jest.fn(),
+    setProperties: mockSetProperties,
+    setPropertyComplete: jest.fn()
+  })
+}));
+
+jest.mock("../useGraphVariables", () => ({
+  useGraphVariableNames: () => []
+}));
+
+jest.mock("../../../../hooks/nodes/useDynamicProperty", () => ({
+  useDynamicProperty: () => ({
+    handleAddProperty: jest.fn(),
+    handleDeleteProperty: jest.fn(),
+    handleUpdatePropertyName: jest.fn()
+  })
+}));
+
+jest.mock("../../../node/NodeInputs", () => ({
+  __esModule: true,
+  NodeInputs: () => <div data-testid="node-inputs" />
+}));
+
+jest.mock("../../../node/NodeOutputs", () => ({
+  __esModule: true,
+  NodeOutputs: () => <div data-testid="node-outputs" />
+}));
+
+jest.mock("../../../node/NodeProgress", () => ({
+  __esModule: true,
+  default: () => <div data-testid="node-progress" />
+}));
+
+jest.mock("../../../../stores/AssetStore", () => ({
+  useAssetStore: (selector: (state: unknown) => unknown) =>
+    selector({ search: jest.fn().mockResolvedValue({ assets: [] }), get: jest.fn() })
+}));
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+const makeProps = (initialPrompt: string) =>
+  ({
+    id: "node-1",
+    nodeType: "nodetool.text.Prompt",
+    nodeMetadata: {
+      node_type: "nodetool.text.Prompt",
+      properties: [],
+      outputs: [{ name: "output", type: { type: "str" } }],
+      supports_dynamic_inputs: true
+    },
+    data: {
+      properties: { prompt: initialPrompt },
+      dynamic_properties: {}
+    },
+    workflowId: "wf-1",
+    isOutputNode: false
+  }) as unknown as Parameters<typeof PromptComposerBody>[0];
+
+// A stand-in for Lexical's EditorState whose `read` simply runs the callback;
+// the real serialization is mocked, so no Lexical context is required.
+const fakeEditorState = { read: (cb: () => void) => cb() };
+
+describe("PromptComposerBody store commit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnChangeHolder.current = null;
+    mockSerialized = "";
+  });
+
+  it("commits an edited prompt to the store synchronously (no debounce)", () => {
+    renderWithTheme(<PromptComposerBody {...makeProps("")} />);
+    expect(mockOnChangeHolder.current).toBeTruthy();
+
+    mockSerialized = "fresh prompt text";
+    act(() => {
+      mockOnChangeHolder.current?.(fakeEditorState);
+    });
+
+    // Asserted without advancing any timers — proves the write is immediate.
+    expect(mockSetProperties).toHaveBeenCalledWith({
+      prompt: "fresh prompt text"
+    });
+  });
+
+  it("does not write when the serialized text is unchanged", () => {
+    renderWithTheme(<PromptComposerBody {...makeProps("hello")} />);
+    expect(mockOnChangeHolder.current).toBeTruthy();
+
+    // Selection-only change: serialized text matches the last written value.
+    mockSerialized = "hello";
+    act(() => {
+      mockOnChangeHolder.current?.(fakeEditorState);
+    });
+
+    expect(mockSetProperties).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
@@ -8,10 +8,11 @@
  * the current text.
  *
  * The OnChangePlugin is mocked to capture the editor's change handler so the
- * test can drive an edit without fighting Lexical/contentEditable in jsdom, and
- * promptEditorState is mocked so the captured serialized text is controllable.
- * These mocks would interfere with the content-loading assertions in
- * PromptComposerBody.test.tsx, so they live in this separate file.
+ * test can drive an edit without simulating typing into Lexical's
+ * contentEditable in jsdom; $serializePrompt is overridden so the captured
+ * serialized text is controllable (the rest of promptEditorState is kept real
+ * via requireActual). The asset-mention/drop plugins are stubbed out — they're
+ * irrelevant to the commit behaviour and only add weight to the render.
  */
 import React from "react";
 import { render, act } from "@testing-library/react";
@@ -34,11 +35,25 @@ jest.mock("@lexical/react/LexicalOnChangePlugin", () => ({
   }
 }));
 
-// Controls what the editor serializes to; reassigned per test.
+// Controls what the editor serializes to; reassigned per test. Only
+// $serializePrompt is overridden so it doesn't need a live Lexical read
+// context — the other exports stay real (the asset plugins import
+// $insertAssetMention from here).
 let mockSerialized = "";
 jest.mock("../promptComposer/promptEditorState", () => ({
-  $serializePrompt: () => mockSerialized,
-  $setPromptFromString: () => {}
+  ...jest.requireActual("../promptComposer/promptEditorState"),
+  $serializePrompt: () => mockSerialized
+}));
+
+// The asset typeahead/drop plugins don't participate in committing the prompt;
+// stub them so the editor stays light.
+jest.mock("../promptComposer/AssetMentionPlugin", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../promptComposer/AssetDropPlugin", () => ({
+  __esModule: true,
+  default: () => null
 }));
 
 jest.mock("../../../../hooks/nodes/useBespokePropertyWriter", () => ({
@@ -76,11 +91,6 @@ jest.mock("../../../node/NodeProgress", () => ({
   default: () => <div data-testid="node-progress" />
 }));
 
-jest.mock("../../../../stores/AssetStore", () => ({
-  useAssetStore: (selector: (state: unknown) => unknown) =>
-    selector({ search: jest.fn().mockResolvedValue({ assets: [] }), get: jest.fn() })
-}));
-
 const renderWithTheme = (ui: React.ReactElement) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } }
@@ -111,7 +121,7 @@ const makeProps = (initialPrompt: string) =>
   }) as unknown as Parameters<typeof PromptComposerBody>[0];
 
 // A stand-in for Lexical's EditorState whose `read` simply runs the callback;
-// the real serialization is mocked, so no Lexical context is required.
+// $serializePrompt is mocked, so no Lexical context is required.
 const fakeEditorState = { read: (cb: () => void) => cb() };
 
 describe("PromptComposerBody store commit", () => {


### PR DESCRIPTION
The `nodetool.text.Prompt` editor (PromptComposerBody) wrote the edited
prompt to the NodeStore through a 400ms debounce. The composer mirrored
the new text to the UI instantly, but the store — which the Run path
reads via `nodeStore.getState()` when serializing the graph — only
updated 400ms after the last keystroke. A run dispatched inside that
window serialized the node's *previous* prompt value downstream.

This produced the intermittent stale-value bug: under rapid edit-then-run
iteration the run occasionally used the prior prompt, self-correcting once
editing settled past the debounce (or when adding/removing a node forced a
store refresh). The `nodetool.text.String` node never showed it because it
commits to the store immediately on every change.

Replace the debounced write with an immediate, equality-guarded commit
(matching the String node). Auto-run stays coalesced by useNodeAutoRun's
own 300ms debounce, so per-keystroke runs are not introduced. Removing the
debounce also drops the unmount `cancel()` path that could silently discard
a pending edit. Adds a regression test asserting the prompt is committed to
the store synchronously.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BxMGC2BG5tmYZtaFw929zW