### PR TITLE
Bundle npm with the backend Node runtime for package installs

### DIFF
--- a/electron/scripts/after-pack.cjs
+++ b/electron/scripts/after-pack.cjs
@@ -6,6 +6,7 @@ const { spawnSync } = require("child_process");
 const {
   NODE_RUNTIME_VERSION,
   nodeBinaryName,
+  NPM_RUNTIME_DIR,
   ALL_DAWN_FILES,
   dawnKeepFiles,
 } = require("./node-runtime.constants.cjs");
@@ -106,33 +107,41 @@ function resolveArch(context) {
 
 const ELECTRON_DIR = path.dirname(__dirname);
 
-/** Copy the build target's bundled Node binary into backend/runtime/. */
+/** Copy the build target's bundled Node binary + npm into backend/runtime/. */
 async function placeNodeRuntime(context, cacheRoot) {
   const platform = context.electronPlatformName;
   const arch = resolveArch(context);
   const binName = nodeBinaryName(platform);
-  const src = path.join(cacheRoot, `${platform}-${arch}`, binName);
-  if (!fs.existsSync(src)) {
+  const srcDir = path.join(cacheRoot, `${platform}-${arch}`);
+  const src = path.join(srcDir, binName);
+  const srcNpm = path.join(srcDir, NPM_RUNTIME_DIR);
+  if (!fs.existsSync(src) || !fs.existsSync(srcNpm)) {
     // Self-heal: the release pipeline invokes electron-builder directly (not
     // `npm run build`), so the fetch step may not have run. Fetch this exact
     // target now — fetch-node-runtime is idempotent and caches by arch.
-    console.info(`Bundled Node missing; fetching ${platform}-${arch}...`);
+    console.info(`Bundled Node/npm missing; fetching ${platform}-${arch}...`);
     const fetchScript = path.join(ELECTRON_DIR, "scripts", "fetch-node-runtime.mjs");
     const r = spawnSync(process.execPath, [fetchScript, `${platform}-${arch}`], {
       stdio: "inherit",
     });
-    if (r.status !== 0 || !fs.existsSync(src)) {
+    if (r.status !== 0 || !fs.existsSync(src) || !fs.existsSync(srcNpm)) {
       throw new Error(
-        `Bundled Node binary not found and fetch failed: ${src} (fetch exit ${r.status})`
+        `Bundled Node runtime not found and fetch failed: ${srcDir} (fetch exit ${r.status})`
       );
     }
   }
   const runtimeDir = path.join(resolveResourcesDir(context), "backend", "runtime");
   await fsp.mkdir(runtimeDir, { recursive: true });
+
   const dest = path.join(runtimeDir, binName);
   await fsp.copyFile(src, dest);
   if (platform !== "win32") await fsp.chmod(dest, 0o755);
-  console.info(`Placed bundled Node (${platform}-${arch}) at ${dest}`);
+
+  const destNpm = path.join(runtimeDir, NPM_RUNTIME_DIR);
+  await fsp.rm(destNpm, { recursive: true, force: true });
+  await fsp.cp(srcNpm, destNpm, { recursive: true });
+
+  console.info(`Placed bundled Node + npm (${platform}-${arch}) at ${runtimeDir}`);
 }
 
 /** Delete dawn.node binaries that don't belong to this build's platform. */

--- a/electron/scripts/fetch-node-runtime.mjs
+++ b/electron/scripts/fetch-node-runtime.mjs
@@ -16,9 +16,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { NODE_RUNTIME_VERSION, nodeArchive, nodeBinaryName } = require(
-  "./node-runtime.constants.cjs"
-);
+const {
+  NODE_RUNTIME_VERSION,
+  nodeArchive,
+  nodeBinaryName,
+  npmDirInArchive,
+  NPM_RUNTIME_DIR,
+} = require("./node-runtime.constants.cjs");
 
 const ELECTRON_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const CACHE_ROOT = path.join(ELECTRON_DIR, ".node-runtime", NODE_RUNTIME_VERSION);
@@ -58,7 +62,7 @@ function expectedChecksum(shasumsText, archiveName) {
   throw new Error(`No SHASUMS entry for ${archiveName}`);
 }
 
-function extractBinary(archivePath, info, destBinary) {
+function extractRuntime(archivePath, info, platform, destDir) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "node-rt-"));
   try {
     if (info.ext === "zip") {
@@ -73,10 +77,19 @@ function extractBinary(archivePath, info, destBinary) {
       const r = spawnSync("tar", ["-xzf", archivePath, "-C", tmp], { stdio: "inherit" });
       if (r.status !== 0) throw new Error("tar extraction failed");
     }
-    const extracted = path.join(tmp, info.binaryInArchive);
-    fs.mkdirSync(path.dirname(destBinary), { recursive: true });
-    fs.copyFileSync(extracted, destBinary);
+    fs.mkdirSync(destDir, { recursive: true });
+
+    // node binary
+    const destBinary = path.join(destDir, nodeBinaryName(platform));
+    fs.copyFileSync(path.join(tmp, info.binaryInArchive), destBinary);
     if (info.ext !== "zip") fs.chmodSync(destBinary, 0o755);
+
+    // npm package — bundled so JS installs never depend on a system npm.
+    const destNpm = path.join(destDir, NPM_RUNTIME_DIR);
+    fs.rmSync(destNpm, { recursive: true, force: true });
+    fs.cpSync(path.join(tmp, npmDirInArchive(platform, info.dir)), destNpm, {
+      recursive: true,
+    });
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -86,7 +99,8 @@ async function fetchTarget({ platform, arch }) {
   const info = nodeArchive(platform, arch);
   const destDir = path.join(CACHE_ROOT, `${platform}-${arch}`);
   const destBinary = path.join(destDir, nodeBinaryName(platform));
-  if (fs.existsSync(destBinary)) {
+  const destNpm = path.join(destDir, NPM_RUNTIME_DIR);
+  if (fs.existsSync(destBinary) && fs.existsSync(destNpm)) {
     console.log(`  cached: ${platform}-${arch}`);
     return;
   }
@@ -103,11 +117,11 @@ async function fetchTarget({ platform, arch }) {
   const archivePath = path.join(os.tmpdir(), info.archive);
   await fsp.writeFile(archivePath, archiveBuf);
   try {
-    extractBinary(archivePath, info, destBinary);
+    extractRuntime(archivePath, info, platform, destDir);
   } finally {
     await fsp.rm(archivePath, { force: true });
   }
-  console.log(`  -> ${destBinary}`);
+  console.log(`  -> ${destBinary} (+ npm)`);
 }
 
 async function main() {

--- a/electron/scripts/node-runtime.constants.cjs
+++ b/electron/scripts/node-runtime.constants.cjs
@@ -4,6 +4,8 @@
 // tests all agree on versions, archive names, and which dawn.node binaries to
 // keep per target.
 
+const path = require("path");
+
 // Pinned to .nvmrc. The backend runs on this exact Node; better-sqlite3 is
 // rebuilt against its ABI, so bumping this requires re-fetching binaries and
 // rebuilding native modules.
@@ -27,6 +29,24 @@ function nodeArchive(platform, arch) {
   return { dir, archive: `${dir}.${ext}`, ext, binaryInArchive, plat };
 }
 
+/**
+ * Path (within an extracted node archive `dir`) to the npm package directory.
+ * The official Node distributions ship npm under lib/node_modules on POSIX and
+ * node_modules at the root on Windows.
+ */
+function npmDirInArchive(platform, dir) {
+  return platform === "win32"
+    ? `${dir}/node_modules/npm`
+    : `${dir}/lib/node_modules/npm`;
+}
+
+// Directory name (under backend/runtime/) where the bundled npm package lives,
+// and the relative path to its CLI entry. npm is invoked as
+// `node <runtime>/npm/bin/npm-cli.js` so it never depends on a system npm or
+// on shims/symlinks that don't survive zip extraction on Windows.
+const NPM_RUNTIME_DIR = "npm";
+const NPM_CLI_RUNTIME_PATH = path.join(NPM_RUNTIME_DIR, "bin", "npm-cli.js");
+
 // Every binary the `webgpu` package ships in dist/. After staging we keep only
 // the ones for the build's platform (see dawnKeepFiles) and delete the rest.
 const ALL_DAWN_FILES = [
@@ -49,6 +69,9 @@ module.exports = {
   NODE_RUNTIME_VERSION,
   nodeBinaryName,
   nodeArchive,
+  npmDirInArchive,
+  NPM_RUNTIME_DIR,
+  NPM_CLI_RUNTIME_PATH,
   ALL_DAWN_FILES,
   dawnKeepFiles,
 };

--- a/electron/src/__tests__/afterPack.test.ts
+++ b/electron/src/__tests__/afterPack.test.ts
@@ -123,11 +123,15 @@ describe("placeNodeRuntime", () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  it("copies the matching-arch node binary into backend/runtime", async () => {
+  it("copies the matching-arch node binary + npm into backend/runtime", async () => {
     const cacheRoot = path.join(tempDir, "cache");
     const srcDir = path.join(cacheRoot, "darwin-arm64");
-    await fs.promises.mkdir(srcDir, { recursive: true });
+    await fs.promises.mkdir(path.join(srcDir, "npm", "bin"), { recursive: true });
     await fs.promises.writeFile(path.join(srcDir, "node"), "#!fake-node\n");
+    await fs.promises.writeFile(
+      path.join(srcDir, "npm", "bin", "npm-cli.js"),
+      "// fake npm\n"
+    );
 
     const appOutDir = path.join(tempDir, "dist");
     const context = {
@@ -139,14 +143,18 @@ describe("placeNodeRuntime", () => {
 
     await afterPackExtra.placeNodeRuntime(context, cacheRoot);
 
-    const placed = path.join(
+    const runtimeDir = path.join(
       afterPackExtra.resolveResourcesDir(context),
       "backend",
-      "runtime",
-      "node"
+      "runtime"
     );
+    const placed = path.join(runtimeDir, "node");
     expect(fs.existsSync(placed)).toBe(true);
     expect((fs.statSync(placed).mode & 0o111) !== 0).toBe(true); // executable
+    // npm CLI ships next to the bundled node so installs stay self-contained.
+    expect(
+      fs.existsSync(path.join(runtimeDir, "npm", "bin", "npm-cli.js"))
+    ).toBe(true);
   });
 });
 

--- a/electron/src/__tests__/nodePackManager.test.ts
+++ b/electron/src/__tests__/nodePackManager.test.ts
@@ -10,7 +10,10 @@ jest.mock("electron", () => ({
   }
 }));
 jest.mock("../config", () => ({
-  getProcessEnv: jest.fn().mockReturnValue({ PATH: "/mock/path" })
+  getProcessEnv: jest.fn().mockReturnValue({ PATH: "/mock/path" }),
+  resolveNpmInvocation: jest
+    .fn()
+    .mockReturnValue({ command: "npm", baseArgs: [] })
 }));
 jest.mock("../logger", () => ({ logMessage: jest.fn() }));
 jest.mock("fs/promises", () => ({

--- a/electron/src/__tests__/nodeRuntimeConstants.test.ts
+++ b/electron/src/__tests__/nodeRuntimeConstants.test.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 const c = require("../../scripts/node-runtime.constants.cjs") as {
   NODE_RUNTIME_VERSION: string;
   nodeBinaryName: (platform: string) => string;
@@ -5,6 +7,9 @@ const c = require("../../scripts/node-runtime.constants.cjs") as {
     platform: string,
     arch: string
   ) => { dir: string; archive: string; binaryInArchive: string };
+  npmDirInArchive: (platform: string, dir: string) => string;
+  NPM_RUNTIME_DIR: string;
+  NPM_CLI_RUNTIME_PATH: string;
   dawnKeepFiles: (platform: string, arch: string) => string[];
   ALL_DAWN_FILES: string[];
 };
@@ -30,6 +35,23 @@ describe("node-runtime.constants", () => {
     expect(win.dir).toBe("node-v22.22.1-win-x64");
     expect(win.archive).toBe("node-v22.22.1-win-x64.zip");
     expect(win.binaryInArchive).toBe("node-v22.22.1-win-x64/node.exe");
+  });
+
+  it("locates the npm package inside each archive layout", () => {
+    expect(c.npmDirInArchive("darwin", "node-v22.22.1-darwin-arm64")).toBe(
+      "node-v22.22.1-darwin-arm64/lib/node_modules/npm"
+    );
+    expect(c.npmDirInArchive("linux", "node-v22.22.1-linux-x64")).toBe(
+      "node-v22.22.1-linux-x64/lib/node_modules/npm"
+    );
+    expect(c.npmDirInArchive("win32", "node-v22.22.1-win-x64")).toBe(
+      "node-v22.22.1-win-x64/node_modules/npm"
+    );
+  });
+
+  it("pins where the bundled npm CLI lives under backend/runtime", () => {
+    expect(c.NPM_RUNTIME_DIR).toBe("npm");
+    expect(c.NPM_CLI_RUNTIME_PATH).toBe(path.join("npm", "bin", "npm-cli.js"));
   });
 
   it("keeps only the target platform's dawn.node binaries", () => {

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as os from "os";
+import { spawnSync } from "child_process";
 import { app } from "electron";
 import { logMessage } from "./logger";
 import * as fs from "fs";
@@ -311,6 +312,80 @@ const getProcessEnv = (): ProcessEnv => {
   };
 };
 
+/** How to invoke npm: the executable plus any args that must precede the npm subcommand. */
+export interface NpmInvocation {
+  command: string;
+  baseArgs: string[];
+}
+
+/** Bundled Node binary that ships next to the backend (packaged app only). */
+const getBundledNodeBinary = (): string | null => {
+  if (!app.isPackaged) return null;
+  const bin = path.join(
+    process.resourcesPath,
+    "backend",
+    "runtime",
+    process.platform === "win32" ? "node.exe" : "node"
+  );
+  try {
+    fs.accessSync(bin, fs.constants.X_OK);
+    return bin;
+  } catch {
+    return null;
+  }
+};
+
+/** npm CLI bundled next to the backend's Node runtime (packaged app only). */
+const getBundledNpmCli = (): string | null => {
+  if (!app.isPackaged) return null;
+  // Mirrors NPM_CLI_RUNTIME_PATH in scripts/node-runtime.constants.cjs.
+  const cli = path.join(
+    process.resourcesPath,
+    "backend",
+    "runtime",
+    "npm",
+    "bin",
+    "npm-cli.js"
+  );
+  try {
+    fs.accessSync(cli);
+    return cli;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Resolve how to invoke npm. Prefers the npm bundled with the backend's Node
+ * runtime — running `node npm-cli.js …` keeps JavaScript package installs
+ * inside the NodeTool environment instead of depending on a system Node/npm on
+ * a (GUI-stripped) PATH. Falls back to a system npm on PATH for dev/unpackaged
+ * runs. Returns null when no npm can be found.
+ */
+const resolveNpmInvocation = (): NpmInvocation | null => {
+  const node = getBundledNodeBinary();
+  const cli = getBundledNpmCli();
+  if (node && cli) {
+    return { command: node, baseArgs: [cli] };
+  }
+
+  const candidates =
+    process.platform === "win32" ? ["npm.cmd", "npm"] : ["npm"];
+  for (const candidate of candidates) {
+    try {
+      const result = spawnSync(candidate, ["--version"], {
+        stdio: "ignore",
+        env: getProcessEnv(),
+        shell: process.platform === "win32",
+      });
+      if (result.status === 0) return { command: candidate, baseArgs: [] };
+    } catch {
+      // continue
+    }
+  }
+  return null;
+};
+
 /**
  * Resets the cached conda env path. Intended for use in tests only so that
  * each test case starts with a clean slate.
@@ -326,6 +401,7 @@ export {
   getUVPath,
   getLlamaServerPath,
   getProcessEnv,
+  resolveNpmInvocation,
   getSystemDataPath,
   getDefaultAssetsPath,
   getOptionalNodeModulesPath,

--- a/electron/src/nodePackManager.ts
+++ b/electron/src/nodePackManager.ts
@@ -8,13 +8,13 @@
  * server restart.
  */
 
-import { spawn, spawnSync } from "child_process";
+import { spawn } from "child_process";
 import * as path from "path";
 import * as fsp from "fs/promises";
 import { app } from "electron";
 
 import { logMessage } from "./logger";
-import { getProcessEnv } from "./config";
+import { getProcessEnv, resolveNpmInvocation } from "./config";
 import type { NodePackActionResult, NodePackInfo } from "./types";
 
 // ── Path helpers ─────────────────────────────────────────────────────────
@@ -51,24 +51,6 @@ function assertValidName(name: string): void {
 
 // ── npm runner ───────────────────────────────────────────────────────────
 
-function resolveNpm(): string {
-  const candidates = process.platform === "win32" ? ["npm.cmd", "npm"] : ["npm"];
-  for (const candidate of candidates) {
-    try {
-      const result = spawnSync(candidate, ["--version"], {
-        stdio: "ignore",
-        shell: process.platform === "win32"
-      });
-      if (result.status === 0) return candidate;
-    } catch {
-      // continue
-    }
-  }
-  throw new Error(
-    "npm not found in PATH. Install Node.js (which includes npm) to manage node packs."
-  );
-}
-
 async function ensureInstallRoot(): Promise<void> {
   const root = getNodePackInstallRoot();
   await fsp.mkdir(root, { recursive: true });
@@ -85,20 +67,26 @@ async function ensureInstallRoot(): Promise<void> {
 }
 
 async function runNpm(args: string[]): Promise<void> {
-  const npm = resolveNpm();
+  const npm = resolveNpmInvocation();
+  if (!npm) {
+    throw new Error(
+      "npm not found. Reinstall the NodeTool environment to restore the bundled Node.js/npm runtime."
+    );
+  }
   await ensureInstallRoot();
   await fsp.mkdir(npmCacheDir(), { recursive: true });
   const fullArgs = [
+    ...npm.baseArgs,
     ...args,
     "--prefix",
     getNodePackInstallRoot(),
     "--cache",
     npmCacheDir()
   ];
-  logMessage(`Running: ${npm} ${fullArgs.join(" ")}`);
+  logMessage(`Running: ${npm.command} ${fullArgs.join(" ")}`);
 
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(npm, fullArgs, {
+    const child = spawn(npm.command, fullArgs, {
       env: getProcessEnv(),
       stdio: "pipe",
       windowsHide: true

--- a/electron/src/runtime/packages/NpmRuntimePackage.ts
+++ b/electron/src/runtime/packages/NpmRuntimePackage.ts
@@ -1,10 +1,10 @@
-import { spawn, spawnSync } from "child_process";
+import { spawn } from "child_process";
 import * as path from "path";
 import * as fsp from "fs/promises";
 import { fileExists } from "../../utils";
 import { logMessage } from "../../logger";
 import { emitServerLog } from "../../events";
-import { getProcessEnv } from "../../config";
+import { getProcessEnv, resolveNpmInvocation } from "../../config";
 import {
   RuntimePackage,
   RuntimeContext,
@@ -28,23 +28,6 @@ export interface NpmRuntimePackageOptions {
   homepage?: string;
   platforms?: NodeJS.Platform[];
   dependsOn?: string[];
-}
-
-function resolveNpmExecutable(): string {
-  const candidates =
-    process.platform === "win32" ? ["npm.cmd", "npm"] : ["npm"];
-  for (const candidate of candidates) {
-    try {
-      const result = spawnSync(candidate, ["--version"], {
-        stdio: "ignore",
-        shell: process.platform === "win32",
-      });
-      if (result.status === 0) return candidate;
-    } catch {
-      // continue
-    }
-  }
-  return "";
 }
 
 /**
@@ -155,17 +138,25 @@ export class NpmRuntimePackage implements RuntimePackage {
     signal: AbortSignal,
     onLog: (level: "info" | "warn", line: string) => void,
   ): Promise<void> {
-    const npmPath = resolveNpmExecutable();
-    if (!npmPath) {
+    const npm = resolveNpmInvocation();
+    if (!npm) {
       throw new Error(
-        "npm not found in PATH. Install Node.js (which includes npm) to install JavaScript packages."
+        "npm not found. Reinstall the NodeTool environment to restore the bundled Node.js/npm runtime."
       );
     }
     await this.ensureRoot(ctx);
     const cacheDir = path.join(ctx.userDataDir, "npm-cache");
     await fsp.mkdir(cacheDir, { recursive: true });
 
-    const command = [npmPath, ...args, "--prefix", ctx.optionalNodeRoot, "--cache", cacheDir];
+    const command = [
+      npm.command,
+      ...npm.baseArgs,
+      ...args,
+      "--prefix",
+      ctx.optionalNodeRoot,
+      "--cache",
+      cacheDir,
+    ];
     return new Promise<void>((resolve, reject) => {
       logMessage(`Running npm command: ${command.join(" ")}`);
       const child = spawn(command[0], command.slice(1), {
@@ -255,15 +246,23 @@ export class NpmRuntimePackage implements RuntimePackage {
   }
 
   async uninstall(ctx: RuntimeContext): Promise<void> {
-    const npmPath = resolveNpmExecutable();
-    if (!npmPath) {
-      throw new Error("npm not found in PATH.");
+    const npm = resolveNpmInvocation();
+    if (!npm) {
+      throw new Error("npm not found.");
     }
     await this.ensureRoot(ctx);
     const cacheDir = path.join(ctx.userDataDir, "npm-cache");
-    const args = ["uninstall", ...this.packageNames, "--prefix", ctx.optionalNodeRoot, "--cache", cacheDir];
+    const args = [
+      ...npm.baseArgs,
+      "uninstall",
+      ...this.packageNames,
+      "--prefix",
+      ctx.optionalNodeRoot,
+      "--cache",
+      cacheDir,
+    ];
     await new Promise<void>((resolve, reject) => {
-      const child = spawn(npmPath, args, {
+      const child = spawn(npm.command, args, {
         env: getProcessEnv(),
         stdio: "pipe",
         windowsHide: true,

--- a/electron/src/runtime/packages/__tests__/NpmRuntimePackage.test.ts
+++ b/electron/src/runtime/packages/__tests__/NpmRuntimePackage.test.ts
@@ -4,7 +4,10 @@ jest.mock("../../../utils", () => ({ fileExists: jest.fn() }));
 jest.mock("../../../logger", () => ({ logMessage: jest.fn() }));
 jest.mock("../../../events", () => ({ emitServerLog: jest.fn() }));
 jest.mock("../../../config", () => ({
-  getProcessEnv: jest.fn().mockReturnValue({})
+  getProcessEnv: jest.fn().mockReturnValue({}),
+  resolveNpmInvocation: jest
+    .fn()
+    .mockReturnValue({ command: "npm", baseArgs: [] })
 }));
 jest.mock("fs/promises", () => ({
   readFile: jest.fn(),


### PR DESCRIPTION
The Package Manager reported "npm not found in PATH" even on machines with
Node installed: detection probed the GUI-stripped inherited PATH, and the
packaged app never shipped npm at all — fetch-node-runtime extracted only the
bare `node` binary, discarding the npm package from the nodejs.org tarball.

Ship npm next to the backend's Node runtime and invoke it as
`node <runtime>/npm/bin/npm-cli.js`, so JavaScript package installs stay inside
the NodeTool environment instead of depending on a system Node/npm:

- fetch-node-runtime: also extract lib/node_modules/npm into <cache>/npm
- after-pack: copy the npm dir into backend/runtime/npm alongside node
- config: add resolveNpmInvocation() — prefers bundled node + npm-cli.js,
  falls back to a system npm on PATH (probed with getProcessEnv) for dev
- NpmRuntimePackage / nodePackManager: use the shared resolver

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E66BmbgP7cR1qfe97QBJWL