### PR TITLE
Make MCP ui_* tools addressable per-renderer and per-workflow

### DIFF
--- a/packages/websocket/src/agent/agent-runtime.ts
+++ b/packages/websocket/src/agent/agent-runtime.ts
@@ -21,7 +21,7 @@ import {
 import { LlmAgentSdkProvider } from "./llm-agent.js";
 import {
   getLocalMcpServerUrl,
-  setMcpFrontendTransport,
+  setActiveMcpFrontendRenderer,
 } from "../mcp-server.js";
 import type { AgentTransport } from "./transport.js";
 import type {
@@ -219,9 +219,10 @@ class AgentRuntime {
 
     log.info(`Sending message to agent session ${sessionId} (streaming)`);
 
-    // Frontend UI tools are proxied through the shared /mcp endpoint using
-    // whichever renderer transport is currently active.
-    setMcpFrontendTransport(transport);
+    // Frontend UI tools are proxied through the shared /mcp endpoint. The
+    // renderer registers itself on connect; sending a message marks it as the
+    // active default for MCP clients that don't name a specific renderer.
+    setActiveMcpFrontendRenderer(transport);
     const mcpServerUrl = getLocalMcpServerUrl();
 
     let frontendTools: FrontendToolManifest[] = [];

--- a/packages/websocket/src/agent/socket-route.ts
+++ b/packages/websocket/src/agent/socket-route.ts
@@ -11,7 +11,10 @@ import type { WebSocket } from "@fastify/websocket";
 import { randomUUID } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
 import { getAgentRuntime } from "./agent-runtime.js";
-import { clearMcpFrontendTransport } from "../mcp-server.js";
+import {
+  registerMcpFrontendTransport,
+  unregisterMcpFrontendTransport,
+} from "../mcp-server.js";
 import type { AgentTransport } from "./transport.js";
 import type {
   AgentClientMessage,
@@ -32,6 +35,7 @@ interface PendingRendererRequest<T> {
 }
 
 class AgentSocketTransport implements AgentTransport {
+  readonly id = randomUUID();
   private alive = true;
   private readonly pendingManifest = new Map<
     string,
@@ -182,6 +186,11 @@ const agentSocketRoute: FastifyPluginAsync = async (app) => {
     const transport = new AgentSocketTransport(socket);
     const runtime = getAgentRuntime();
 
+    // Make this renderer addressable over the shared /mcp endpoint as soon as
+    // it connects, so external MCP clients can drive its canvas without first
+    // priming an in-app agent turn.
+    registerMcpFrontendTransport(transport);
+
     log.info(`Agent WebSocket client connected (user ${userId})`);
 
     const sendResponse = (
@@ -331,7 +340,7 @@ const agentSocketRoute: FastifyPluginAsync = async (app) => {
     socket.on("close", () => {
       log.info("Agent WebSocket client disconnected");
       transport.dispose();
-      clearMcpFrontendTransport(transport);
+      unregisterMcpFrontendTransport(transport);
     });
 
     socket.on("error", (error: Error) => {

--- a/packages/websocket/src/agent/transport.ts
+++ b/packages/websocket/src/agent/transport.ts
@@ -18,6 +18,13 @@ import type { AgentMessage, FrontendToolManifest } from "./types.js";
 
 export interface AgentTransport {
   /**
+   * Stable identifier for this renderer connection. Used to key per-renderer
+   * routing so multiple open editors can be addressed independently over the
+   * shared `/mcp` endpoint.
+   */
+  readonly id: string;
+
+  /**
    * Push a streaming message for `sessionId` to the renderer.
    * `done=true` signals the end of a turn so the renderer can flush state.
    */

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -76,8 +76,37 @@ function absolutize(value: unknown, baseUrl?: string): unknown {
 
 const log = createLogger("nodetool.websocket.mcp-server");
 
-const GLOBAL_FRONTEND_SESSION_ID = "global-mcp";
-let activeFrontendTransport: AgentTransport | null = null;
+/**
+ * Renderer transports keyed by `transport.id`. Each connected NodeTool editor
+ * registers here on connect (see the agent WebSocket route), so the shared
+ * `/mcp` endpoint can route `ui_*` tool calls to a specific live editor.
+ * `activeFrontendRendererId` tracks the most-recently-active renderer, used
+ * when an MCP client doesn't name one.
+ */
+const frontendTransports = new Map<string, AgentTransport>();
+let activeFrontendRendererId: string | null = null;
+
+function resolveFrontendTransport(
+  rendererId?: string | null
+): AgentTransport | null {
+  if (rendererId) {
+    const target = frontendTransports.get(rendererId);
+    return target && target.isAlive ? target : null;
+  }
+  if (activeFrontendRendererId) {
+    const active = frontendTransports.get(activeFrontendRendererId);
+    if (active && active.isAlive) return active;
+  }
+  // Fall back to any live renderer so single-editor setups need no id.
+  const alive = [...frontendTransports.values()].filter((t) => t.isAlive);
+  return alive[alive.length - 1] ?? null;
+}
+
+function listFrontendRenderers(): { renderer_id: string; active: boolean }[] {
+  return [...frontendTransports.values()]
+    .filter((t) => t.isAlive)
+    .map((t) => ({ renderer_id: t.id, active: t.id === activeFrontendRendererId }));
+}
 
 let runtimeEnvironmentPromise: Promise<RuntimeEnvironment> | null = null;
 
@@ -280,55 +309,87 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
     version: "1.0.0"
   });
 
-  for (const [toolName, schema] of Object.entries(uiToolSchemas)) {
-    server.tool(toolName, schema.description, schema.parameters, async (args) => {
-      const transport = activeFrontendTransport;
-      if (!transport || !transport.isAlive) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error:
-                  "No active NodeTool renderer is connected for frontend UI tools."
-              })
-            }
-          ],
-          isError: true
-        };
-      }
+  const rendererIdParam = {
+    renderer_id: z
+      .string()
+      .optional()
+      .describe(
+        "Target a specific connected NodeTool editor. Omit to use the most-recently-active one. List ids via `list_renderers`."
+      )
+  };
 
-      try {
-        const result = await transport.executeTool(
-          GLOBAL_FRONTEND_SESSION_ID,
-          `mcp-ui-${toolName}-${crypto.randomUUID()}`,
-          toolName,
-          args
-        );
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text:
-                typeof result === "string"
-                  ? result
-                  : JSON.stringify(result ?? null)
-            }
-          ]
-        };
-      } catch (err: unknown) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ error: String(err) })
-            }
-          ],
-          isError: true
-        };
+  for (const [toolName, schema] of Object.entries(uiToolSchemas)) {
+    server.tool(
+      toolName,
+      schema.description,
+      { ...schema.parameters, ...rendererIdParam },
+      async (args) => {
+        const { renderer_id, ...toolArgs } = args as Record<string, unknown>;
+        const rendererId =
+          typeof renderer_id === "string" ? renderer_id : undefined;
+        const transport = resolveFrontendTransport(rendererId);
+        if (!transport || !transport.isAlive) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: rendererId
+                    ? `No connected NodeTool renderer with id "${rendererId}".`
+                    : "No active NodeTool renderer is connected for frontend UI tools."
+                })
+              }
+            ],
+            isError: true
+          };
+        }
+
+        try {
+          const result = await transport.executeTool(
+            transport.id,
+            `mcp-ui-${toolName}-${crypto.randomUUID()}`,
+            toolName,
+            toolArgs
+          );
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  typeof result === "string"
+                    ? result
+                    : JSON.stringify(result ?? null)
+              }
+            ]
+          };
+        } catch (err: unknown) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ error: String(err) })
+              }
+            ],
+            isError: true
+          };
+        }
       }
-    });
+    );
   }
+
+  server.tool(
+    "list_renderers",
+    "List connected NodeTool editor renderers that can execute ui_* tools. Pass a returned renderer_id to a ui_* tool to target that editor; omit it to use the active one.",
+    {},
+    async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ renderers: listFrontendRenderers() })
+        }
+      ]
+    })
+  );
 
   // ── Workflow tools ──────────────────────────────────────────────
 
@@ -1295,13 +1356,29 @@ const sessionTransports = new Map<
   WebStandardStreamableHTTPServerTransport
 >();
 
-export function setMcpFrontendTransport(transport: AgentTransport): void {
-  activeFrontendTransport = transport;
+/**
+ * Register a renderer as available for `ui_*` tool routing and mark it active.
+ * Called when an editor's agent WebSocket connects, so frontend UI tools work
+ * over the shared `/mcp` endpoint without first priming an in-app agent turn.
+ */
+export function registerMcpFrontendTransport(transport: AgentTransport): void {
+  frontendTransports.set(transport.id, transport);
+  activeFrontendRendererId = transport.id;
 }
 
-export function clearMcpFrontendTransport(transport: AgentTransport): void {
-  if (activeFrontendTransport === transport) {
-    activeFrontendTransport = null;
+/** Promote an already-registered renderer to be the active default. */
+export function setActiveMcpFrontendRenderer(transport: AgentTransport): void {
+  if (frontendTransports.has(transport.id)) {
+    activeFrontendRendererId = transport.id;
+  }
+}
+
+/** Drop a renderer on disconnect, promoting another if it was the active one. */
+export function unregisterMcpFrontendTransport(transport: AgentTransport): void {
+  frontendTransports.delete(transport.id);
+  if (activeFrontendRendererId === transport.id) {
+    const remaining = [...frontendTransports.keys()];
+    activeFrontendRendererId = remaining[remaining.length - 1] ?? null;
   }
 }
 

--- a/packages/websocket/tests/mcp-server.test.ts
+++ b/packages/websocket/tests/mcp-server.test.ts
@@ -3,7 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 import { initTestDb, Workflow, Job, Asset } from "@nodetool-ai/models";
-import { createMcpServer, createMcpStdioTransport } from "../src/mcp-server.js";
+import {
+  createMcpServer,
+  createMcpStdioTransport,
+  registerMcpFrontendTransport,
+  unregisterMcpFrontendTransport
+} from "../src/mcp-server.js";
+import type { AgentTransport } from "../src/agent/transport.js";
 
 function makeMetadataRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-test-"));
@@ -303,5 +309,94 @@ describe("MCP Server", () => {
     };
     expect(jobs.jobs).toHaveLength(1);
     expect(jobs.jobs[0]?.workflow_id).toBe(workflow.id);
+  });
+});
+
+describe("MCP frontend renderer routing", () => {
+  function makeFakeTransport(
+    id: string,
+    executeTool: AgentTransport["executeTool"] = async () => ({ ok: true })
+  ): AgentTransport {
+    return {
+      id,
+      isAlive: true,
+      streamMessage: () => {},
+      requestToolManifest: async () => [],
+      executeTool,
+      abortTools: () => {}
+    };
+  }
+
+  it("errors when no renderer is connected for a ui_ tool", async () => {
+    const server = createMcpServer();
+    const response = await callTool(server, "ui_get_graph", {});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain(
+      "No active NodeTool renderer is connected"
+    );
+  });
+
+  it("routes ui_ tools to the connected renderer and strips renderer_id", async () => {
+    let received: { name?: string; args?: unknown } = {};
+    const transport = makeFakeTransport("r-1", async (_s, _c, name, args) => {
+      received = { name, args };
+      return { ok: true };
+    });
+    registerMcpFrontendTransport(transport);
+    try {
+      const server = createMcpServer();
+      const response = await callTool(server, "ui_add_node", {
+        id: "n1",
+        type: "test.TestNode",
+        position: { x: 0, y: 0 },
+        renderer_id: "r-1"
+      });
+      expect(response.isError).not.toBe(true);
+      expect(received.name).toBe("ui_add_node");
+      expect(received.args).not.toHaveProperty("renderer_id");
+      expect(received.args).toMatchObject({ id: "n1" });
+    } finally {
+      unregisterMcpFrontendTransport(transport);
+    }
+  });
+
+  it("errors when a named renderer_id is not connected", async () => {
+    const transport = makeFakeTransport("r-1");
+    registerMcpFrontendTransport(transport);
+    try {
+      const server = createMcpServer();
+      const response = await callTool(server, "ui_get_graph", {
+        renderer_id: "missing"
+      });
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0].text) as { error: string };
+      expect(body.error).toContain('renderer with id "missing"');
+    } finally {
+      unregisterMcpFrontendTransport(transport);
+    }
+  });
+
+  it("list_renderers reports connected renderers", async () => {
+    const a = makeFakeTransport("r-a");
+    const b = makeFakeTransport("r-b");
+    registerMcpFrontendTransport(a);
+    registerMcpFrontendTransport(b);
+    try {
+      const server = createMcpServer();
+      const response = await callTool(server, "list_renderers", {});
+      const body = JSON.parse(response.content[0].text) as {
+        renderers: Array<{ renderer_id: string; active: boolean }>;
+      };
+      const ids = body.renderers.map((r) => r.renderer_id);
+      expect(ids).toContain("r-a");
+      expect(ids).toContain("r-b");
+      // Most-recently-registered renderer is the active default.
+      expect(body.renderers.find((r) => r.renderer_id === "r-b")?.active).toBe(
+        true
+      );
+    } finally {
+      unregisterMcpFrontendTransport(a);
+      unregisterMcpFrontendTransport(b);
+    }
   });
 });

--- a/web/src/lib/tools/builtin/__tests__/workflow.test.ts
+++ b/web/src/lib/tools/builtin/__tests__/workflow.test.ts
@@ -52,10 +52,11 @@ describe("resolveWorkflowId", () => {
     );
   });
 
-  it("calls setCurrentWorkflowId when explicit id differs from current", () => {
+  it("does not switch the active tab when explicit id differs from current", () => {
     const state = createMockState({ currentWorkflowId: "old-wf" });
-    resolveWorkflowId(state, "new-wf");
-    expect(state.setCurrentWorkflowId).toHaveBeenCalledWith("new-wf");
+    const result = resolveWorkflowId(state, "new-wf");
+    expect(result).toBe("new-wf");
+    expect(state.setCurrentWorkflowId).not.toHaveBeenCalled();
   });
 
   it("does not call setCurrentWorkflowId when explicit id matches current", () => {

--- a/web/src/lib/tools/builtin/workflow.ts
+++ b/web/src/lib/tools/builtin/workflow.ts
@@ -7,12 +7,11 @@ export function resolveWorkflowId(
   state: FrontendToolState,
   workflow_id?: string | null
 ): string {
+  // Resolve which workflow a tool targets without switching the visible tab:
+  // an explicit `workflow_id` edits that workflow's store in the background,
+  // leaving the user's current tab untouched. Tab switching is the job of the
+  // dedicated `ui_open_workflow` / `ui_switch_tab` tools.
   const workflowId = workflow_id ?? state.currentWorkflowId;
   if (!workflowId) {throw new Error("No current workflow selected");}
-
-  if (workflow_id != null && workflow_id !== state.currentWorkflowId) {
-    state.setCurrentWorkflowId(workflowId);
-  }
-
   return workflowId;
 }


### PR DESCRIPTION
The shared /mcp endpoint's ui_* canvas tools previously depended on a
single global renderer transport that was only bound mid in-app agent
turn, so external mcp-remote clients almost always got "no renderer
connected". They also hijacked the visible tab when targeting another
workflow.

- Bind on connect: a renderer registers as soon as its /ws/agent socket
  connects, so external MCP clients can drive the canvas without first
  priming an in-app agent turn. An agent turn now just marks that
  renderer as the active default.
- Key by renderer: replace the single global with a registry keyed by
  transport id. ui_* tools accept an optional renderer_id (added only at
  MCP registration, not in the shared uiToolSchemas) and a new
  list_renderers tool enumerates connected editors, so multiple open
  editors can be addressed independently. Omitting renderer_id falls back
  to the active/only renderer.
- Don't steal the active tab: resolveWorkflowId no longer calls
  setCurrentWorkflowId, so an explicit workflow_id edits that workflow's
  store in the background while the user's current tab stays put. Tab
  switching remains the job of ui_open_workflow / ui_switch_tab.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C9iWk6NomnYnu1BMyeN9yV