### PR TITLE
CI: Consolidate setup steps and add concurrency/timeout controls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   docker-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ on:
       - 'v*.*.*-*'
   workflow_dispatch:
 
+# Cancel superseded runs for the same branch/tag, but never cancel a main or
+# release-tag build — those produce the images people deploy from.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   docker-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-runner.yml
+++ b/.github/workflows/e2e-runner.yml
@@ -43,6 +43,7 @@ jobs:
   e2e-workflow-runner:
     name: Run workflow suite in browser
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-runner.yml
+++ b/.github/workflows/e2e-runner.yml
@@ -34,6 +34,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs for the same branch/PR; the latest push is what matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-workflow-runner:
     name: Run workflow suite in browser

--- a/.github/workflows/e2e-runner.yml
+++ b/.github/workflows/e2e-runner.yml
@@ -48,25 +48,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Node, install deps, build packages
+        # mesa-vulkan-drivers ships lavapipe (CPU Vulkan ICD) so headless
+        # Chromium can acquire a WebGPU adapter on GPU-less CI runners.
+        uses: ./.github/actions/setup-build
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-
-      - name: Install system libraries (keytar + CPU Vulkan driver)
-        run: sudo apt-get update && sudo apt-get install -y libsecret-1-0 mesa-vulkan-drivers
-
-      - name: Install all workspace dependencies
-        run: npm ci
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-
-      - name: Rebuild native modules
-        run: npm rebuild better-sqlite3
-
-      - name: Build backend packages
-        run: npm run build:packages
+          extra-apt: mesa-vulkan-drivers
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -44,28 +44,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-
-      - name: Install system libraries (keytar + CPU Vulkan driver)
+      - name: Set up Node, install deps
         # mesa-vulkan-drivers ships lavapipe (CPU Vulkan ICD) at
         # /usr/share/vulkan/icd.d/lvp_icd.x86_64.json so Dawn can acquire a
         # WebGPU adapter on GPU-less CI runners. Without it, the shader-backed
         # base-nodes tests fail with "No WebGPU adapter available (Node/Dawn)".
         # We can't rely on Electron's bundled vk_swiftshader_icd.json here
-        # because ELECTRON_SKIP_BINARY_DOWNLOAD=1 is set below.
-        run: sudo apt-get update && sudo apt-get install -y libsecret-1-0 mesa-vulkan-drivers
-
-      - name: Install all workspace dependencies
-        run: npm ci
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-
-      - name: Rebuild native modules
-        run: npm rebuild better-sqlite3
+        # because ELECTRON_SKIP_BINARY_DOWNLOAD=1 is set by the action.
+        # build-packages is deferred so the dependency/circular-dep checks
+        # below run against source before the backend packages are built.
+        uses: ./.github/actions/setup-build
+        with:
+          extra-apt: mesa-vulkan-drivers
+          build-packages: "false"
 
       - name: Run npm audit (advisory)
         # Advisory only (continue-on-error) so a pre-existing vulnerability

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -33,6 +33,7 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     outputs:
       typecheck-passed: ${{ steps.set-outputs.outputs.typecheck-passed }}
       lint-passed: ${{ steps.set-outputs.outputs.lint-passed }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ on:
     # on every PR keeps the required check from getting stuck. (The `push` to
     # main above keeps its path filter — there is no required-check to block.)
 
+# Cancel superseded runs for the same branch/PR; the latest push is what matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Quality Gate (npm run check)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     name: Workflow Integration Tests
     needs: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -61,6 +62,7 @@ jobs:
     name: Workflow Runner Browser E2E
     needs: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Refactors GitHub Actions workflows to reduce duplication, improve CI efficiency, and add safeguards against resource exhaustion. Introduces a reusable `setup-build` action and adds concurrency controls and timeouts across workflows.

## Key Changes

- **New reusable action**: Created `.github/actions/setup-build` to consolidate Node.js setup, dependency installation, system library setup, and package building. Accepts `extra-apt` and `build-packages` parameters for workflow-specific customization.

- **Concurrency controls**: Added concurrency groups to `e2e-runner.yml`, `test.yml`, and `docker.yml` to cancel superseded runs on the same branch/PR. Docker workflow preserves main and release-tag builds to ensure production images are never interrupted.

- **Timeout safeguards**: Added `timeout-minutes: 45` to all job definitions (`e2e-workflow-runner`, `quality`, `docker-publish`, and test jobs) to prevent runaway workflows from consuming excessive CI resources.

- **Workflow consolidation**:
  - `e2e-runner.yml`: Replaced 5 separate setup steps with single `setup-build` action call, added mesa-vulkan-drivers for WebGPU support
  - `quality-checks.yml`: Replaced 5 setup steps with `setup-build` action, deferred package building to run dependency/circular-dep checks against source first
  - `test.yml`: Added concurrency and timeouts to all jobs

## Implementation Details

- The `setup-build` action handles:
  - Node.js setup from `.nvmrc` with npm caching
  - System library installation (libsecret-1-0 always; mesa-vulkan-drivers when specified)
  - Workspace dependency installation with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`
  - Native module rebuild (`better-sqlite3`)
  - Backend package building (optional, controlled by `build-packages` parameter)

- Concurrency strategy:
  - `e2e-runner.yml` and `test.yml`: Cancel all superseded runs (latest push wins)
  - `docker.yml`: Preserve main and release-tag builds for production deployments

- All timeouts set to 45 minutes, providing buffer above typical job duration while preventing indefinite hangs

https://claude.ai/code/session_018Ahx6CTdZit4qLVVH12Dwr