### PR TITLE
Restrict Docker builds to main and preview/* branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,14 +2,15 @@ name: Docker
 
 on:
   push:
-    # Build images for every branch push so any branch can be deployed as a
-    # preview instance via `deploy.sh --slug`. The metadata-action step below
-    # tags non-tag refs as `{branch}-{shortsha}` (and `latest` only on main).
-    # `pull_request` is intentionally not used to avoid duplicate builds for
-    # in-repo PRs (which would fire both events). Fork PRs cannot push to GHCR
-    # anyway, so the loss of fork preview images is not a regression.
+    # Build images for main and any `preview/**` branch. Preview branches can be
+    # deployed as a preview instance via `deploy.sh --slug`. The metadata-action
+    # step below tags non-tag refs as `{branch}-{shortsha}` (and `latest` only on
+    # main). `pull_request` is intentionally not used to avoid duplicate builds
+    # for in-repo PRs (which would fire both events). Fork PRs cannot push to
+    # GHCR anyway, so the loss of fork preview images is not a regression.
     branches:
-      - '**'
+      - main
+      - 'preview/**'
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
@@ -27,31 +28,6 @@ jobs:
       attestations: write
 
     steps:
-      # - name: Free disk space
-      #   run: |
-      #     echo "=== Before cleanup ==="
-      #     df -h
-      #     # Remove large pre-installed packages
-      #     sudo rm -rf /usr/share/dotnet
-      #     sudo rm -rf /usr/local/lib/android
-      #     sudo rm -rf /opt/ghc
-      #     sudo rm -rf "/usr/local/share/boost"
-      #     sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      #     # Remove additional large directories
-      #     sudo rm -rf /usr/share/swift
-      #     sudo rm -rf /usr/local/graalvm
-      #     sudo rm -rf /usr/local/.ghcup
-      #     sudo rm -rf /opt/hostedtoolcache/CodeQL
-      #     sudo rm -rf /usr/local/share/powershell
-      #     sudo rm -rf /usr/share/miniconda
-      #     # Clean up Docker images
-      #     docker system prune -af || echo "Warning: Docker cleanup failed with exit code $?"
-      #     # Clean apt cache
-      #     sudo apt-get clean
-      #     sudo rm -rf /var/lib/apt/lists/*
-      #     echo "=== After cleanup ==="
-      #     df -h
-
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -62,9 +38,6 @@ jobs:
           key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             uv-${{ runner.os }}-
-
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary
Restricts Docker image builds to only the `main` branch and branches matching the `preview/**` pattern, rather than building on every branch push. This reduces unnecessary CI/CD overhead while maintaining the ability to deploy preview instances from designated branches.

## Changes
- **Branch filter**: Changed from `branches: ['**']` (all branches) to `branches: [main, 'preview/**']`
- **Documentation**: Updated workflow comments to clarify that only main and preview branches trigger builds
- **Cleanup**: Removed commented-out disk space cleanup and QEMU setup steps that were not being used

## Rationale
Building Docker images for every branch push is resource-intensive and unnecessary. By restricting builds to `main` (for production) and `preview/**` branches (for preview deployments via `deploy.sh --slug`), we:
- Reduce CI/CD resource consumption
- Maintain the ability to deploy preview instances from designated branches
- Keep the workflow focused on intentional deployments rather than every branch push

https://claude.ai/code/session_01369ib1nbSeidTcvLcJPdhP