### PR TITLE
Add concurrency controls to GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ on:
       - 'v*.*.*-*'
   workflow_dispatch:
 
+# Cancel superseded runs for the same branch/tag, but never cancel a main or
+# release-tag build — those produce the images people deploy from.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   docker-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-runner.yml
+++ b/.github/workflows/e2e-runner.yml
@@ -34,6 +34,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs for the same branch/PR; the latest push is what matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-workflow-runner:
     name: Run workflow suite in browser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ on:
     # on every PR keeps the required check from getting stuck. (The `push` to
     # main above keeps its path filter — there is no required-check to block.)
 
+# Cancel superseded runs for the same branch/PR; the latest push is what matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Quality Gate (npm run check)


### PR DESCRIPTION
## Summary
Add concurrency configuration to three GitHub Actions workflows to cancel superseded runs and prevent resource waste, while preserving production builds.

## Changes
- **docker.yml**: Added concurrency group with conditional cancellation — cancels in-progress runs for the same branch/tag, but never cancels builds on `main` or release tags (which produce deployed images)
- **e2e-runner.yml**: Added concurrency group that cancels superseded runs for the same branch/PR, since only the latest push matters for test validation
- **test.yml**: Added concurrency group that cancels superseded runs for the same branch/PR, ensuring only the latest test run proceeds

## Implementation Details
- All three workflows use `${{ github.workflow }}-${{ github.ref }}` as the concurrency group to isolate runs by workflow and ref
- `docker.yml` uses conditional cancellation: `cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}` to protect production builds
- `e2e-runner.yml` and `test.yml` use unconditional cancellation (`cancel-in-progress: true`) since these are validation workflows where only the latest result matters

https://claude.ai/code/session_01BwXwc74CC9VQs9eUniZV69