### PR TITLE
fix(sketch): correct undo for push-before-mutate edits (strokes/transforms)

### DIFF
--- a/web/src/components/sketch/__tests__/historyRedoTipEntry.test.ts
+++ b/web/src/components/sketch/__tests__/historyRedoTipEntry.test.ts
@@ -5,6 +5,7 @@
 
 import { act } from "@testing-library/react";
 import { useSketchStore } from "../state/useSketchStore";
+import { MAX_HISTORY_SIZE } from "../types";
 
 beforeEach(() => {
   act(() => {
@@ -18,11 +19,12 @@ describe("Phase 2 Fixes", () => {
   //    snapshot so redo can restore it.
   // ---------------------------------------------------------------
   describe("history redo fix (tip-entry append on undo)", () => {
-    it("redo restores the most-recent state after undo from the tip", () => {
+    it("undo from the tip steps back exactly one and redo returns to the live edit", () => {
       const layerId = useSketchStore.getState().document.layers[0].id;
 
-      // Push two history entries with different layer data.
-      // pushHistory snapshots the CURRENT state, then we mutate.
+      // Push-before-mutate (stroke convention): pushHistory snapshots the
+      // CURRENT state, then we mutate — so the live document is one edit ahead
+      // of the last checkpoint.
       act(() => {
         useSketchStore.getState().pushHistory("action1");
         useSketchStore
@@ -34,36 +36,26 @@ describe("Phase 2 Fixes", () => {
           .updateLayerData(layerId, "data:image/png;base64,action2pixels");
       });
 
-      // Verify baseline: 2 entries, index at 1, layer has action2 data
+      // Verify baseline: 2 entries, index at 1, layer has action2 (live) data
       expect(useSketchStore.getState().history).toHaveLength(2);
       expect(useSketchStore.getState().historyIndex).toBe(1);
       expect(useSketchStore.getState().document.layers[0].data).toBe(
         "data:image/png;base64,action2pixels"
       );
 
-      // Undo from the tip – should append a tip entry
+      // Undo from the dirty tip → appends a "current state" tip so redo can
+      // return, and steps back EXACTLY one edit to action1pixels (not two).
       act(() => {
         useSketchStore.getState().undo();
       });
-
       expect(useSketchStore.getState().history).toHaveLength(3);
-      expect(useSketchStore.getState().historyIndex).toBe(0);
-
-      // The appended tip entry should be labelled "current state"
-      expect(useSketchStore.getState().history[2].action).toBe(
-        "current state"
-      );
-
-      // First redo → restores entry at index 1 (action2 snapshot captured action1 data)
-      act(() => {
-        useSketchStore.getState().redo();
-      });
       expect(useSketchStore.getState().historyIndex).toBe(1);
+      expect(useSketchStore.getState().history[2].action).toBe("current state");
       expect(useSketchStore.getState().document.layers[0].data).toBe(
         "data:image/png;base64,action1pixels"
       );
 
-      // Second redo → restores the tip entry (action2 live state)
+      // Redo → returns to the live edit (action2pixels)
       act(() => {
         useSketchStore.getState().redo();
       });
@@ -105,10 +97,10 @@ describe("Phase 2 Fixes", () => {
       act(() => {
         useSketchStore.getState().undo();
       });
-      // undo from tip when historyIndex === history.length - 1 → appends another tip entry
-      // However the tip data hasn't changed so it still works
+      // The tip now matches the live state (redo restored it), so this undo is
+      // a clean step back — it does NOT append another tip entry.
       const histLen = useSketchStore.getState().history.length;
-      expect(histLen).toBeGreaterThanOrEqual(3);
+      expect(histLen).toBe(3);
 
       // Redo all the way back
       while (useSketchStore.getState().canRedo()) {
@@ -121,29 +113,30 @@ describe("Phase 2 Fixes", () => {
       );
     });
 
-    it("undo from a non-tip position does not add an extra tip entry", () => {
+    it("undo over clean checkpoints does not append tip entries", () => {
+      // Three checkpoints with no uncommitted edit ahead of the live document
+      // (no data mutations between pushes). Each undo steps back one without
+      // growing history — no "current state" tips are appended.
       act(() => {
         useSketchStore.getState().pushHistory("x");
         useSketchStore.getState().pushHistory("y");
         useSketchStore.getState().pushHistory("z");
       });
 
-      // First undo from tip – adds tip entry (3 → 4)
       act(() => {
         useSketchStore.getState().undo();
       });
-      expect(useSketchStore.getState().history).toHaveLength(4);
+      expect(useSketchStore.getState().history).toHaveLength(3);
       expect(useSketchStore.getState().historyIndex).toBe(1);
 
-      // Second undo from index 1 (non-tip, since length=4) – should NOT add another entry
       act(() => {
         useSketchStore.getState().undo();
       });
-      expect(useSketchStore.getState().history).toHaveLength(4);
+      expect(useSketchStore.getState().history).toHaveLength(3);
       expect(useSketchStore.getState().historyIndex).toBe(0);
     });
 
-    it("new action after undo truncates the tip entry", () => {
+    it("new action after undo truncates the redo tip", () => {
       const layerId = useSketchStore.getState().document.layers[0].id;
 
       act(() => {
@@ -157,21 +150,22 @@ describe("Phase 2 Fixes", () => {
           .updateLayerData(layerId, "data:image/png;base64,second");
       });
 
-      // Undo from tip → appends tip entry (length 2 → 3)
+      // Undo from the dirty tip → appends "current state" (length 2 → 3) and
+      // lands at index 1 ("second" checkpoint = "first" pixels).
       act(() => {
         useSketchStore.getState().undo();
       });
       expect(useSketchStore.getState().history).toHaveLength(3);
+      expect(useSketchStore.getState().historyIndex).toBe(1);
 
-      // Push a new action – should truncate everything after current index (0)
+      // A new action truncates everything after the current index, dropping
+      // the "current state" redo tip.
       act(() => {
         useSketchStore.getState().pushHistory("branch");
       });
-
-      // History should now be [entry0, branchEntry], tip entry gone
-      expect(useSketchStore.getState().history).toHaveLength(2);
-      expect(useSketchStore.getState().history[1].action).toBe("branch");
-      expect(useSketchStore.getState().historyIndex).toBe(1);
+      expect(useSketchStore.getState().history).toHaveLength(3);
+      expect(useSketchStore.getState().history[2].action).toBe("branch");
+      expect(useSketchStore.getState().historyIndex).toBe(2);
     });
   });
 
@@ -244,6 +238,113 @@ describe("Phase 2 Fixes", () => {
         useSketchStore.getState().setActiveTool("fill");
       });
       expect(useSketchStore.getState().backgroundColor).toBe(originalBg);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // 4. Push-before-mutate (stroke) undo correctness — regressions for the
+  //    off-by-one, the un-undoable first stroke, and unbounded growth.
+  // ---------------------------------------------------------------
+  describe("stroke-convention undo (push-before-mutate)", () => {
+    // Mirrors handleStrokeStart: push the pre-stroke snapshot, then the stroke
+    // commits new pixels to the live layer.
+    const stroke = (layerId: string, label: string, data: string) => {
+      useSketchStore.getState().pushHistory(label);
+      useSketchStore.getState().updateLayerData(layerId, data);
+    };
+
+    it("the first stroke on a fresh document can be undone", () => {
+      const layerId = useSketchStore.getState().document.layers[0].id;
+      const blank = useSketchStore.getState().document.layers[0].data;
+
+      act(() => stroke(layerId, "s1", "data:image/png;base64,S1"));
+
+      // A single checkpoint with an uncommitted stroke ahead of it is undoable.
+      expect(useSketchStore.getState().historyIndex).toBe(0);
+      expect(useSketchStore.getState().canUndo()).toBe(true);
+
+      act(() => {
+        useSketchStore.getState().undo();
+      });
+      expect(useSketchStore.getState().document.layers[0].data).toBe(blank);
+
+      act(() => {
+        useSketchStore.getState().redo();
+      });
+      expect(useSketchStore.getState().document.layers[0].data).toBe(
+        "data:image/png;base64,S1"
+      );
+    });
+
+    it("each undo steps back exactly one stroke (no skipping)", () => {
+      const layerId = useSketchStore.getState().document.layers[0].id;
+      const blank = useSketchStore.getState().document.layers[0].data;
+
+      act(() => {
+        stroke(layerId, "s1", "data:image/png;base64,S1");
+        stroke(layerId, "s2", "data:image/png;base64,S2");
+        stroke(layerId, "s3", "data:image/png;base64,S3");
+      });
+      expect(useSketchStore.getState().document.layers[0].data).toBe(
+        "data:image/png;base64,S3"
+      );
+
+      const seen: (string | null)[] = [];
+      act(() => {
+        while (useSketchStore.getState().canUndo()) {
+          useSketchStore.getState().undo();
+          seen.push(useSketchStore.getState().document.layers[0].data);
+        }
+      });
+
+      // Three strokes → three undos, hitting every intermediate state in order.
+      expect(seen).toEqual([
+        "data:image/png;base64,S2",
+        "data:image/png;base64,S1",
+        blank
+      ]);
+
+      // Redo walks back up through the same ladder to the live edit.
+      act(() => {
+        while (useSketchStore.getState().canRedo()) {
+          useSketchStore.getState().redo();
+        }
+      });
+      expect(useSketchStore.getState().document.layers[0].data).toBe(
+        "data:image/png;base64,S3"
+      );
+    });
+
+    it("redo-to-tip then undo cycling does not grow history past the cap", () => {
+      const layerId = useSketchStore.getState().document.layers[0].id;
+      act(() => {
+        stroke(layerId, "s1", "data:image/png;base64,S1");
+        stroke(layerId, "s2", "data:image/png;base64,S2");
+      });
+
+      act(() => {
+        for (let i = 0; i < 60; i++) {
+          while (useSketchStore.getState().canRedo()) {
+            useSketchStore.getState().redo();
+          }
+          useSketchStore.getState().undo();
+        }
+      });
+
+      // The clean-tip check means redo-restored tips are not re-appended, so
+      // history stays bounded by the cap rather than growing per cycle.
+      expect(
+        useSketchStore.getState().history.length
+      ).toBeLessThanOrEqual(MAX_HISTORY_SIZE);
+
+      act(() => {
+        while (useSketchStore.getState().canRedo()) {
+          useSketchStore.getState().redo();
+        }
+      });
+      expect(useSketchStore.getState().document.layers[0].data).toBe(
+        "data:image/png;base64,S2"
+      );
     });
   });
 });

--- a/web/src/components/sketch/state/slices/historySlice.ts
+++ b/web/src/components/sketch/state/slices/historySlice.ts
@@ -53,6 +53,23 @@ export function resolveLayerData(
 }
 
 /**
+ * Resolve the layer structure at a given history index. Selection-only
+ * entries don't capture structure (`layerStructure: []`) and never change
+ * it, so walk backward to the nearest entry that did capture one.
+ */
+function resolveLayerStructure(
+  history: HistoryEntry[],
+  upToIndex: number
+): LayerStructureSnapshot[] {
+  for (let i = upToIndex; i >= 0; i--) {
+    if (history[i].layerStructure.length > 0) {
+      return history[i].layerStructure;
+    }
+  }
+  return [];
+}
+
+/**
  * Build a LayerStructureSnapshot array from current document layers.
  */
 function captureLayerStructure(layers: readonly Layer[]): LayerStructureSnapshot[] {
@@ -81,6 +98,87 @@ function captureDocumentCanvas(
   canvas: SketchDocument["canvas"]
 ): SketchDocument["canvas"] {
   return { ...canvas };
+}
+
+/**
+ * Whether the live document is *ahead* of the snapshot stored at `index` —
+ * i.e. there are uncommitted edits since that checkpoint.
+ *
+ * `pushHistory` is called with two conventions across the editor:
+ *  - push-after-mutate (layer ops): the entry already reflects the live state.
+ *  - push-before-mutate (strokes, transforms): the entry holds the *pre*-edit
+ *    state and the live document is one edit ahead.
+ *
+ * `undo` uses this to decide whether it must first append a "current state"
+ * tip entry (so redo can return to the uncommitted edit) and step back from
+ * that tip, versus simply stepping back one checkpoint. Comparing the actual
+ * state — not a convention flag — keeps undo correct regardless of how the
+ * caller pushed. Short-circuits on the first difference; the common stroke
+ * case is caught immediately by the layer-data check.
+ */
+function isLiveStateAhead(
+  document: SketchDocument,
+  history: HistoryEntry[],
+  index: number
+): boolean {
+  const entry = history[index];
+  const canvas = document.canvas;
+  const ec = entry.documentCanvas;
+  if (
+    ec &&
+    (canvas.width !== ec.width ||
+      canvas.height !== ec.height ||
+      canvas.backgroundColor !== ec.backgroundColor)
+  ) {
+    return true;
+  }
+  if (document.activeLayerId !== entry.activeLayerId) {
+    return true;
+  }
+  if ((document.maskLayerId ?? null) !== (entry.maskLayerId ?? null)) {
+    return true;
+  }
+
+  // Raster data — the common case for strokes/fills/paste.
+  for (const layer of document.layers) {
+    const stored = resolveLayerData(history, index, layer.id);
+    if ((layer.data ?? null) !== (stored ?? null)) {
+      return true;
+    }
+  }
+
+  // Layer structure (order + metadata) — the case for transforms, opacity,
+  // visibility, etc. Selection isn't compared: selection edits always commit
+  // via a push, so they never leave an uncommitted tip.
+  const storedStructure = resolveLayerStructure(history, index);
+  const liveStructure = captureLayerStructure(document.layers);
+  if (storedStructure.length !== liveStructure.length) {
+    return true;
+  }
+  return JSON.stringify(liveStructure) !== JSON.stringify(storedStructure);
+}
+
+/**
+ * Trim `history` (mutated in place) to `MAX_HISTORY_SIZE`, merging the dropped
+ * baseline's layer data forward so reconstruction stays correct. Returns the
+ * number of entries dropped from the front (0 or 1) so callers can adjust the
+ * active index.
+ */
+function trimHistoryInPlace(history: HistoryEntry[]): number {
+  if (history.length <= MAX_HISTORY_SIZE) {
+    return 0;
+  }
+  const dropped = history.shift()!;
+  const oldest = history[0];
+  // The dropped entry (former baseline) may hold data for layers absent from
+  // the new oldest — e.g. layers removed between the two. Spread to avoid
+  // mutating the existing entry (Zustand state must be immutable).
+  history[0] = {
+    ...oldest,
+    layerSnapshots: { ...dropped.layerSnapshots, ...oldest.layerSnapshots },
+    changedLayerIds: undefined
+  };
+  return 1;
 }
 
 export interface HistorySlice {
@@ -170,21 +268,7 @@ export const createHistorySlice: StateCreator<
         })();
 
     newHistory.push(entry);
-
-    // Trim to max size — merge dropped entry's data into the new oldest
-    if (newHistory.length > MAX_HISTORY_SIZE) {
-      const dropped = newHistory.shift()!;
-      const oldest = newHistory[0];
-      // Always merge dropped data forward to maintain the baseline invariant.
-      // The dropped entry (former baseline) may have data for layers not in
-      // the new oldest — e.g. layers that were removed between the two entries.
-      // Spread to avoid mutating the existing entry (Zustand state must be immutable).
-      newHistory[0] = {
-        ...oldest,
-        layerSnapshots: { ...dropped.layerSnapshots, ...oldest.layerSnapshots },
-        changedLayerIds: undefined
-      };
-    }
+    trimHistoryInPlace(newHistory);
 
     set({
       history: newHistory,
@@ -194,14 +278,25 @@ export const createHistorySlice: StateCreator<
 
   undo: (layerCanvasSnapshots?: Record<string, HTMLCanvasElement | null>) => {
     const state = get();
-    if (state.historyIndex <= 0) {
+    if (state.historyIndex < 0) {
       return null;
     }
 
-    // When undoing from the tip of history, append a full snapshot of
-    // the current state so that redo can restore it later.
+    // Detect an uncommitted edit ahead of the current checkpoint. This happens
+    // with push-before-mutate callers (strokes, transforms): `historyIndex`
+    // points at the pre-edit snapshot while the live document is one edit
+    // ahead. Only the tip can be dirty — undo/redo and push-after callers
+    // always leave the live state equal to the entry at `historyIndex`.
+    const dirtyTip =
+      state.historyIndex === state.history.length - 1 &&
+      isLiveStateAhead(state.document, state.history, state.historyIndex);
+
     let history = state.history;
-    if (state.historyIndex === state.history.length - 1) {
+    let newIndex: number;
+    if (dirtyTip) {
+      // Append a full snapshot of the live state so redo can return to it,
+      // then step back from that tip to the current checkpoint (a single
+      // step back from the live edit — not two).
       const tipSnapshot: Record<string, string | null> = {};
       for (const layer of state.document.layers) {
         tipSnapshot[layer.id] = layer.data;
@@ -219,9 +314,16 @@ export const createHistorySlice: StateCreator<
         timestamp: Date.now()
       };
       history = [...state.history, tipEntry];
+      const dropped = trimHistoryInPlace(history);
+      newIndex = state.historyIndex - dropped;
+    } else {
+      // Live state already matches the tip — step back one checkpoint.
+      if (state.historyIndex <= 0) {
+        return null;
+      }
+      newIndex = state.historyIndex - 1;
     }
 
-    const newIndex = state.historyIndex - 1;
     const entry = history[newIndex];
     if (!entry) {
       return null;
@@ -324,6 +426,18 @@ export const createHistorySlice: StateCreator<
     return resolvedEntry;
   },
 
-  canUndo: () => get().historyIndex > 0,
+  canUndo: () => {
+    const state = get();
+    if (state.historyIndex > 0) {
+      return true;
+    }
+    // A single checkpoint with an uncommitted edit ahead of it (e.g. the first
+    // stroke on a fresh document) is still undoable — back to that checkpoint.
+    return (
+      state.historyIndex === 0 &&
+      state.historyIndex === state.history.length - 1 &&
+      isLiveStateAhead(state.document, state.history, 0)
+    );
+  },
   canRedo: () => get().historyIndex < get().history.length - 1
 });


### PR DESCRIPTION
The sketch editor's undo had an off-by-one for any edit pushed with the
push-before-mutate convention (brush/pencil/eraser strokes and move/
transform gestures via handleStrokeStart). After such a push, historyIndex
lags the live state by one, but undo() unconditionally did
`newIndex = historyIndex - 1`, so:

- the first stroke on a fresh document could not be undone at all
  (canUndo() was false at index 0), and
- after N>=2 strokes the first undo skipped a state (jumped two
  checkpoints back), so the second-newest state was unreachable by undoing.

It also appended a "current state" tip entry on every undo-from-tip, even
when the tip already matched the live state, so redo-to-tip + undo cycling
grew history without bound past MAX_HISTORY_SIZE.

Fix: undo() now detects whether the live document is actually ahead of the
entry at historyIndex (isLiveStateAhead — compares canvas, active/mask
layer, raster data, and layer structure; convention-agnostic). It appends
the tip and steps back from it only when the tip is dirty, and trims after
appending. canUndo() reports a dirty single-checkpoint tip as undoable.
Layer ops (push-after-mutate) are unchanged and no longer accrue redundant
tip entries.

Tests: updated the tip-entry tests to assert one-step-back semantics and
added regressions for first-stroke undo, per-stroke stepping, and bounded
history growth.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01536B7RDagy4RLTZwsi1rT5