### PR TITLE
feat(node-menu): draggable/resizable menu, space toggle, compact tiles

### DIFF
--- a/web/src/components/node_menu/FavoritesTiles.tsx
+++ b/web/src/components/node_menu/FavoritesTiles.tsx
@@ -30,10 +30,11 @@ const tileStyles = (theme: Theme) =>
       flexDirection: "column",
       width: "100%",
       height: "fit-content",
+      padding: "0.5em 1em 0.5em 0.5em",
       boxSizing: "border-box"
     },
     ".tiles-header": {
-      marginBottom: "0.5em",
+      marginBottom: "0.25em",
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
@@ -41,9 +42,9 @@ const tileStyles = (theme: Theme) =>
     },
     ".tiles-container": {
       display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+      gridTemplateColumns: "repeat(auto-fill, minmax(116px, 1fr))",
       gridAutoRows: "1fr",
-      gap: getSpacingPx(SPACING.md),
+      gap: getSpacingPx(SPACING.sm),
       alignContent: "start",
       overflowY: "auto",
       padding: getSpacingPx(SPACING.micro),
@@ -54,7 +55,7 @@ const tileStyles = (theme: Theme) =>
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.md)}`,
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.sm)}`,
       borderRadius: BORDER_RADIUS.md,
       cursor: "pointer",
       position: "relative",

--- a/web/src/components/node_menu/NodeMenu.tsx
+++ b/web/src/components/node_menu/NodeMenu.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useMemo, useRef, useEffect, useState, useCallback } from "react";
+import { memo, useMemo, useEffect, useState, useCallback } from "react";
 
 // mui
 
@@ -11,16 +11,27 @@ import TypeFilterChips from "./TypeFilterChips";
 import NamespaceList from "./NamespaceList";
 // store
 import { useStoreWithEqualityFn } from "zustand/traditional";
-import useNodeMenuStore, { type NodeMenuStore } from "../../stores/NodeMenuStore";
+import useNodeMenuStore, {
+  type NodeMenuStore
+} from "../../stores/NodeMenuStore";
 
 // utils
-import Draggable from "react-draggable";
+import { useDraggable } from "../../hooks/useDraggable";
+import { useResizable } from "../../hooks/useResizable";
 // theme
 import useNamespaceTree from "../../hooks/useNamespaceTree";
 import SearchInput from "../search/SearchInput";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { useCreateNode } from "../../hooks/useCreateNode";
-import { FlexColumn, FlexRow, Box, BORDER_RADIUS, MOTION, SPACING, getSpacingPx } from "../ui_primitives";
+import {
+  FlexColumn,
+  FlexRow,
+  Box,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import { useShallow } from "zustand/react/shallow";
 
 const treeStyles = (theme: Theme) =>
@@ -57,6 +68,33 @@ const treeStyles = (theme: Theme) =>
     },
     ".draggable-header:active": {
       cursor: "grabbing"
+    },
+    // Resize handles (top-left anchored): right edge, bottom edge, corner.
+    ".nm-resize": {
+      position: "absolute",
+      zIndex: 30,
+      touchAction: "none"
+    },
+    ".nm-resize-right": {
+      top: "40px",
+      bottom: "12px",
+      right: 0,
+      width: "7px",
+      cursor: "ew-resize"
+    },
+    ".nm-resize-bottom": {
+      left: 0,
+      right: "12px",
+      bottom: 0,
+      height: "7px",
+      cursor: "ns-resize"
+    },
+    ".nm-resize-corner": {
+      right: 0,
+      bottom: 0,
+      width: "16px",
+      height: "16px",
+      cursor: "nwse-resize"
     },
     ".node-menu-container": {
       borderRadius: `0 0 ${BORDER_RADIUS.xxl} ${BORDER_RADIUS.xxl}`,
@@ -105,7 +143,6 @@ type NodeMenuProps = {
 };
 
 const NodeMenu = ({ focusSearchInput = false }: NodeMenuProps) => {
-  const nodeRef = useRef<HTMLDivElement>(null);
   const [bounds, setBounds] = useState({
     left: 0,
     right: 0,
@@ -133,6 +170,8 @@ const NodeMenu = ({ focusSearchInput = false }: NodeMenuProps) => {
     setSelectedOutputType,
     setSearchTerm,
     setMenuSize,
+    menuUserSize,
+    setMenuUserSize,
     moveSelectionUp,
     moveSelectionDown,
     getSelectedNode
@@ -140,6 +179,8 @@ const NodeMenu = ({ focusSearchInput = false }: NodeMenuProps) => {
     useShallow((state) => ({
       menuHeight: state.menuHeight,
       menuPosition: state.menuPosition,
+      menuUserSize: state.menuUserSize,
+      setMenuUserSize: state.setMenuUserSize,
       searchResults: state.searchResults,
       selectedInputType: state.selectedInputType,
       selectedOutputType: state.selectedOutputType,
@@ -154,6 +195,25 @@ const NodeMenu = ({ focusSearchInput = false }: NodeMenuProps) => {
       getSelectedNode: state.getSelectedNode
     }))
   );
+
+  // Draggable menu via its header. `useDraggable` owns the transform and clamps
+  // to the viewport bounds; the drag position is intentionally not persisted
+  // (the menu reopens at `menuPosition`).
+  const nodeRef = useDraggable<HTMLDivElement>({
+    handle: ".draggable-header",
+    bounds,
+    defaultPosition: { x: menuPosition.x, y: menuPosition.y }
+  });
+
+  // Resize from the right / bottom / corner (top-left stays anchored). The
+  // final size is persisted so it sticks across reopens within the session.
+  const startResize = useResizable(nodeRef, {
+    minWidth: 560,
+    minHeight: 360,
+    maxHeight:
+      typeof window !== "undefined" ? window.innerHeight * 0.9 : undefined,
+    onResizeEnd: setMenuUserSize
+  });
 
   const namespaceTree = useNamespaceTree();
   const theme = useTheme();
@@ -253,75 +313,91 @@ const NodeMenu = ({ focusSearchInput = false }: NodeMenuProps) => {
   }
 
   return (
-    <Draggable
-      bounds={bounds}
-      nodeRef={nodeRef}
-      defaultPosition={{ x: menuPosition.x, y: menuPosition.y }}
-      handle=".draggable-header"
+    <FlexColumn
+      ref={nodeRef}
+      sx={{
+        width: menuUserSize?.width ?? 980,
+        minWidth: 0,
+        height: menuUserSize?.height,
+        maxHeight: menuUserSize ? undefined : menuHeight
+      }}
+      className="floating-node-menu"
+      css={memoizedStyles}
     >
-      <FlexColumn
-        ref={nodeRef}
-        sx={{ minWidth: "980px", maxHeight: menuHeight }}
-        className="floating-node-menu"
-        css={memoizedStyles}
-      >
-        <FlexRow
-          className="draggable-header"
-          align="center"
-          justify="flex-end"
-        ></FlexRow>
-        <Box className="node-menu-container">
-          <div className="main-content">
-            <FlexColumn
-              gap={1}
-              className="search-toolbar"
-              sx={{
-                flexGrow: 0,
-                overflow: "visible",
-                width: "100%",
-                margin: 0,
-                padding: "0 1em 0 0.5em"
-              }}
+      <FlexRow
+        className="draggable-header"
+        align="center"
+        justify="flex-end"
+      ></FlexRow>
+      <Box className="node-menu-container">
+        <div className="main-content">
+          <FlexColumn
+            gap={1}
+            className="search-toolbar"
+            sx={{
+              flexGrow: 0,
+              overflow: "visible",
+              width: "100%",
+              margin: 0,
+              padding: "0 1em 0 0.5em"
+            }}
+          >
+            <FlexRow
+              gap={1.5}
+              align="center"
+              className="search-row"
+              sx={{ marginLeft: `-${getSpacingPx(SPACING.xs)}`, width: "100%" }} // was -3px
             >
-              <FlexRow
-                gap={1.5}
-                align="center"
-                className="search-row"
-                sx={{ marginLeft: `-${getSpacingPx(SPACING.xs)}`, width: "100%" }} // was -3px
+              <SearchInput
+                focusSearchInput={focusSearchInput}
+                focusOnTyping={false}
+                placeholder="Search for nodes..."
+                debounceTime={80}
+                width={300}
+                maxWidth={"300px"}
+                searchTerm={searchTerm}
+                onSearchChange={setSearchTerm}
+                onPressEscape={closeNodeMenu}
+                onPressSpaceWhenEmpty={closeNodeMenu}
+                onPressArrowDown={handleArrowDown}
+                onPressArrowUp={handleArrowUp}
+                onPressEnter={handleEnter}
+                searchResults={searchResults}
+              />
+              <div
+                style={{ marginLeft: "0.75em", flex: "1 1 auto", minWidth: 0 }}
               >
-                <SearchInput
-                  focusSearchInput={focusSearchInput}
-                  focusOnTyping={false}
-                  placeholder="Search for nodes..."
-                  debounceTime={80}
-                  width={300}
-                  maxWidth={"300px"}
-                  searchTerm={searchTerm}
-                  onSearchChange={setSearchTerm}
-                  onPressEscape={closeNodeMenu}
-                  onPressArrowDown={handleArrowDown}
-                  onPressArrowUp={handleArrowUp}
-                  onPressEnter={handleEnter}
-                  searchResults={searchResults}
+                <TypeFilterChips
+                  selectedInputType={selectedInputType}
+                  selectedOutputType={selectedOutputType}
+                  setSelectedInputType={setSelectedInputType}
+                  setSelectedOutputType={setSelectedOutputType}
                 />
-                <div style={{ marginLeft: "0.75em", flex: "1 1 auto", minWidth: 0 }}>
-                  <TypeFilterChips
-                    selectedInputType={selectedInputType}
-                    selectedOutputType={selectedOutputType}
-                    setSelectedInputType={setSelectedInputType}
-                    setSelectedOutputType={setSelectedOutputType}
-                  />
-                </div>
-              </FlexRow>
-            </FlexColumn>
-            <NamespaceList
-              namespaceTree={namespaceTree}
-              metadata={searchResults}
-            />
-          </div>
-        </Box>
-      </FlexColumn>
-    </Draggable>
+              </div>
+            </FlexRow>
+          </FlexColumn>
+          <NamespaceList
+            namespaceTree={namespaceTree}
+            metadata={searchResults}
+          />
+        </div>
+      </Box>
+      <div
+        className="nm-resize nm-resize-right"
+        onPointerDown={startResize("right")}
+        aria-hidden
+      />
+      <div
+        className="nm-resize nm-resize-bottom"
+        onPointerDown={startResize("bottom")}
+        aria-hidden
+      />
+      <div
+        className="nm-resize nm-resize-corner"
+        onPointerDown={startResize("bottom-right")}
+        aria-hidden
+      />
+    </FlexColumn>
   );
 };
 

--- a/web/src/components/node_menu/QuickActionTiles.tsx
+++ b/web/src/components/node_menu/QuickActionTiles.tsx
@@ -34,7 +34,7 @@ const tileStyles = (theme: Theme) =>
       boxSizing: "border-box"
     },
     ".tiles-header": {
-      marginBottom: "0.5em",
+      marginBottom: "0.25em",
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
@@ -51,20 +51,20 @@ const tileStyles = (theme: Theme) =>
     },
     ".tiles-container": {
       display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+      gridTemplateColumns: "repeat(auto-fill, minmax(116px, 1fr))",
       gridAutoRows: "1fr",
-      gap: getSpacingPx(SPACING.md),
+      gap: getSpacingPx(SPACING.sm),
       alignContent: "start",
       overflow: "visible",
       padding: getSpacingPx(SPACING.micro)
     },
     ".constants-container": {
       display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(90px, 1fr))",
+      gridTemplateColumns: "repeat(auto-fill, minmax(84px, 1fr))",
       gridAutoRows: "1fr",
-      gap: getSpacingPx(SPACING.md),
+      gap: getSpacingPx(SPACING.sm),
       alignContent: "start",
-      marginTop: getSpacingPx(SPACING.lg),
+      marginTop: getSpacingPx(SPACING.md),
       padding: getSpacingPx(SPACING.micro),
       ...thinScrollbarStyles(theme)
     },
@@ -73,7 +73,7 @@ const tileStyles = (theme: Theme) =>
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.md)}`,
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.sm)}`,
       borderRadius: BORDER_RADIUS.xl,
       cursor: "pointer",
       position: "relative",
@@ -135,7 +135,7 @@ const tileStyles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      marginBottom: getSpacingPx(SPACING.sm),
+      marginBottom: getSpacingPx(SPACING.xs),
       transition: `transform ${MOTION.slow}`,
       "& svg": {
         fontSize: "var(--fontSizeBig)",

--- a/web/src/components/node_menu/RecentNodesTiles.tsx
+++ b/web/src/components/node_menu/RecentNodesTiles.tsx
@@ -35,7 +35,7 @@ const tileStyles = (theme: Theme) =>
       boxSizing: "border-box"
     },
     ".tiles-header": {
-      marginBottom: "0.5em",
+      marginBottom: "0.25em",
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
@@ -55,9 +55,9 @@ const tileStyles = (theme: Theme) =>
     },
     ".tiles-container": {
       display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+      gridTemplateColumns: "repeat(auto-fill, minmax(116px, 1fr))",
       gridAutoRows: "1fr",
-      gap: getSpacingPx(SPACING.md),
+      gap: getSpacingPx(SPACING.sm),
       alignContent: "start",
       overflowY: "auto",
       padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.micro)}`,
@@ -68,14 +68,14 @@ const tileStyles = (theme: Theme) =>
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.md)}`,
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.sm)}`,
       borderRadius: BORDER_RADIUS.xl,
       cursor: "pointer",
       position: "relative",
       overflow: "hidden",
       border: `1px solid ${theme.vars.palette.divider}`,
       transition: `all ${MOTION.slow}`,
-      minHeight: "64px",
+      minHeight: "46px",
       background: theme.vars.palette.background.paper,
       "&::before": {
         content: '""',
@@ -112,7 +112,7 @@ const tileStyles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      marginBottom: getSpacingPx(SPACING.sm),
+      marginBottom: getSpacingPx(SPACING.xs),
       transition: `transform ${MOTION.slow}`,
       "& svg": {
         fontSize: "var(--fontSizeBig)",
@@ -122,7 +122,7 @@ const tileStyles = (theme: Theme) =>
       }
     },
     ".tile-label": {
-      fontSize: "var(--fontSizeNormal)",
+      fontSize: "var(--fontSizeSmall)",
       fontWeight: 500,
       textAlign: "center",
       lineHeight: 1.3,
@@ -357,7 +357,7 @@ const RecentNodesTiles = memo(function RecentNodesTiles() {
                   <IconForType
                     iconName={outputType}
                     showTooltip={false}
-                    iconSize="normal"
+                    iconSize="small"
                     svgProps={{ style: { color: iconColor } }}
                   />
                 </div>

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -62,7 +62,7 @@ const typeFilterChipsStyles = (theme: Theme) =>
     ".quick-filters": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(1.5),
+      gap: theme.spacing(1),
       minWidth: 0,
       flex: "0 1 auto",
       marginLeft: "auto",
@@ -72,8 +72,7 @@ const typeFilterChipsStyles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(0.5),
-      marginRight: theme.spacing(0.5),
-      paddingRight: theme.spacing(1.5),
+      paddingRight: theme.spacing(1),
       borderRight: `1px solid ${theme.vars.palette.divider}`
     },
     ".provider-quick-chip": {
@@ -101,7 +100,6 @@ const typeFilterChipsStyles = (theme: Theme) =>
       color: theme.vars.palette.text.secondary,
       textTransform: "uppercase",
       letterSpacing: "0.5px",
-      marginInline: theme.spacing(0, 0.5),
       whiteSpace: "nowrap",
       fontWeight: FONT_WEIGHT.medium
     },

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -2,9 +2,8 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect } from "react";
 import { useMediaQuery } from "@mui/material";
-import Draggable, { type DraggableData } from "react-draggable";
 import { EditorMenu } from "../ui_primitives";
 import { Tooltip, AlertBanner, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
@@ -35,6 +34,7 @@ import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { getShortcutTooltip } from "../../config/shortcuts";
 import { cn } from "../editor_ui/editorUtils";
 import { MenuItemPrimitive } from "../ui_primitives/MenuItemPrimitive";
+import { useDraggable } from "../../hooks/useDraggable";
 import { useFloatingToolbarState } from "../../hooks/useFloatingToolbarState";
 import { useFloatingToolbarActions } from "../../hooks/useFloatingToolbarActions";
 import { useFloatingToolbarPosition } from "../../hooks/useFloatingToolbarPosition";
@@ -101,8 +101,8 @@ const dockStyles = (theme: Theme) =>
     pointerEvents: "auto",
 
     // Grab affordance the user drags to move the whole dock. Rendered as a
-    // span (not a button) so react-draggable's `cancel="button"` doesn't
-    // exclude it while still excluding the real action buttons around it.
+    // span (not a button) so the drag hook's `cancel="button"` doesn't exclude
+    // it while still excluding the real action buttons around it.
     ".composer-drag-handle": {
       display: "inline-flex",
       alignItems: "center",
@@ -351,39 +351,34 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
   // overlay reaches the thread (even empty), the thread list, and full chat.
   const conversationOpen = !conversationCollapsed;
 
-  // Draggable dock position. Kept in local state during the gesture for smooth
-  // movement, persisted to the store (clamped on-screen) when the drag ends.
-  const dockRef = useRef<HTMLDivElement>(null);
-  const [dragPos, setDragPos] = useState<DockPosition>(storePosition);
-  useEffect(() => {
-    setDragPos(storePosition);
-  }, [storePosition]);
-
-  const clampToViewport = useCallback((pos: DockPosition): DockPosition => {
-    const node = dockRef.current;
-    if (!node || typeof window === "undefined") {
-      return pos;
-    }
-    const rect = node.getBoundingClientRect();
-    const margin = 8;
-    let { x, y } = pos;
-    if (rect.left < margin) x += margin - rect.left;
-    if (rect.right > window.innerWidth - margin)
-      x -= rect.right - (window.innerWidth - margin);
-    if (rect.top < margin) y += margin - rect.top;
-    if (rect.bottom > window.innerHeight - margin)
-      y -= rect.bottom - (window.innerHeight - margin);
-    return { x, y };
-  }, []);
-
-  const handleDragStop = useCallback(
-    (_e: unknown, data: DraggableData) => {
-      const next = clampToViewport({ x: data.x, y: data.y });
-      setDragPos(next);
-      setStorePosition(next);
+  // Draggable dock. `useDraggable` owns the dock's transform; we persist the
+  // final (on-screen clamped) offset to the store on release so it survives
+  // reloads. The store value flows back in as the controlled `position`.
+  const clampToViewport = useCallback(
+    (node: HTMLElement | null, pos: DockPosition): DockPosition => {
+      if (!node || typeof window === "undefined") {
+        return pos;
+      }
+      const rect = node.getBoundingClientRect();
+      const margin = 8;
+      let { x, y } = pos;
+      if (rect.left < margin) x += margin - rect.left;
+      if (rect.right > window.innerWidth - margin)
+        x -= rect.right - (window.innerWidth - margin);
+      if (rect.top < margin) y += margin - rect.top;
+      if (rect.bottom > window.innerHeight - margin)
+        y -= rect.bottom - (window.innerHeight - margin);
+      return { x, y };
     },
-    [clampToViewport, setStorePosition]
+    []
   );
+
+  const dockRef = useDraggable<HTMLDivElement>({
+    handle: ".dock-drag-handle",
+    cancel: "button, input, textarea, .dock-no-drag",
+    position: storePosition,
+    onStop: (pos) => setStorePosition(clampToViewport(dockRef.current, pos))
+  });
 
   // Keep the dock on-screen when the viewport shrinks (e.g. window resize).
   useEffect(() => {
@@ -391,15 +386,16 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
       return;
     }
     const onResize = () => {
-      const clamped = clampToViewport(
-        useCanvasChatDockStore.getState().position
+      setStorePosition(
+        clampToViewport(
+          dockRef.current,
+          useCanvasChatDockStore.getState().position
+        )
       );
-      setDragPos(clamped);
-      setStorePosition(clamped);
     };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, [clampToViewport, setStorePosition]);
+  }, [clampToViewport, setStorePosition, dockRef]);
 
   const dockWidthCss =
     dockWidth != null
@@ -586,41 +582,32 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
   return (
     <>
       <div css={dockLayerStyles(theme)} style={toolbarPosition}>
-        <Draggable
-          nodeRef={dockRef as React.RefObject<HTMLElement>}
-          handle=".dock-drag-handle"
-          cancel="button, input, textarea, .dock-no-drag"
-          position={dragPos}
-          onDrag={(_e, data) => setDragPos({ x: data.x, y: data.y })}
-          onStop={handleDragStop}
+        <div
+          ref={dockRef}
+          css={dockStyles(theme)}
+          className="floating-toolbar canvas-chat-dock"
+          style={{ width: dockWidthCss }}
         >
-          <div
-            ref={dockRef}
-            css={dockStyles(theme)}
-            className="floating-toolbar canvas-chat-dock"
-            style={{ width: dockWidthCss }}
-          >
-            {conversationOpen && (
-              <ConversationOverlay
-                onCollapse={() => setConversationCollapsed(true)}
-              />
-            )}
-            {chatError && (
-              <AlertBanner
-                severity="error"
-                compact
-                onClose={clearChatError}
-                sx={{ borderRadius: BORDER_RADIUS.xl }}
-              >
-                {chatError}
-              </AlertBanner>
-            )}
-            <CanvasMediaComposer
-              leadingActions={dragHandle}
-              trailingActions={workflowActions}
+          {conversationOpen && (
+            <ConversationOverlay
+              onCollapse={() => setConversationCollapsed(true)}
             />
-          </div>
-        </Draggable>
+          )}
+          {chatError && (
+            <AlertBanner
+              severity="error"
+              compact
+              onClose={clearChatError}
+              sx={{ borderRadius: BORDER_RADIUS.xl }}
+            >
+              {chatError}
+            </AlertBanner>
+          )}
+          <CanvasMediaComposer
+            leadingActions={dragHandle}
+            trailingActions={workflowActions}
+          />
+        </div>
       </div>
 
       <EditorMenu

--- a/web/src/components/search/SearchInput.tsx
+++ b/web/src/components/search/SearchInput.tsx
@@ -106,6 +106,12 @@ interface SearchInputProps {
   onPressArrowDown?: () => void;
   onPressArrowUp?: () => void;
   onPressEnter?: () => void;
+  /**
+   * Called when Space is pressed while the input is focused and empty. Lets a
+   * host (e.g. the node menu) make Space a toggle without breaking multi-word
+   * search — once there's text, Space types normally.
+   */
+  onPressSpaceWhenEmpty?: () => void;
   focusSearchInput?: boolean;
   focusOnTyping?: boolean;
   placeholder?: string;
@@ -122,6 +128,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
   onPressArrowDown,
   onPressArrowUp,
   onPressEnter,
+  onPressSpaceWhenEmpty,
   focusSearchInput = true,
   focusOnTyping = false,
   placeholder = "Search...",
@@ -219,6 +226,20 @@ const SearchInput: React.FC<SearchInputProps> = ({
         return;
       }
 
+      // Space on an empty, focused search toggles the host closed (e.g. the node
+      // menu). Once there's text, Space falls through and types normally so
+      // multi-word searches still work.
+      if (
+        onPressSpaceWhenEmpty &&
+        event.key === " " &&
+        document.activeElement === inputRef.current &&
+        (inputRef.current?.value ?? "").length === 0
+      ) {
+        event.preventDefault();
+        onPressSpaceWhenEmpty();
+        return;
+      }
+
       if (focusOnTyping) {
         if (isControlOrMetaPressed) { return; }
         if (event.key.length === 1 && /[a-zA-Z0-9]/.test(event.key)) {
@@ -237,6 +258,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
   }, [
     focusOnTyping,
     isControlOrMetaPressed,
+    onPressSpaceWhenEmpty,
     onPressEscape,
     onPressArrowDown,
     onPressArrowUp,

--- a/web/src/hooks/useDraggable.ts
+++ b/web/src/hooks/useDraggable.ts
@@ -1,0 +1,228 @@
+import { useEffect, useRef } from "react";
+
+export interface DragPosition {
+  x: number;
+  y: number;
+}
+
+export interface UseDraggableOptions {
+  /**
+   * Selector that the pointer-down target must match (or be inside of) for a
+   * drag to begin. Mirrors react-draggable's `handle`. When omitted, the whole
+   * node is draggable.
+   */
+  handle?: string;
+  /**
+   * Selector that, when the pointer-down target matches (or is inside of),
+   * suppresses the drag. Mirrors react-draggable's `cancel`. Useful to keep
+   * buttons / inputs inside the draggable node clickable.
+   */
+  cancel?: string;
+  /**
+   * Controlled translation offset (px) from the node's normal layout position.
+   * When provided and the node is not being dragged, the hook keeps the node's
+   * transform in sync with this value.
+   */
+  position?: DragPosition;
+  /** Initial offset for uncontrolled usage. Defaults to `{ x: 0, y: 0 }`. */
+  defaultPosition?: DragPosition;
+  /**
+   * Clamp the translate offset to these bounds (px) during a drag. Mirrors
+   * react-draggable's object form of `bounds`.
+   */
+  bounds?: {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
+  };
+  /** When true, pointer-down never starts a drag. */
+  disabled?: boolean;
+  onStart?: (pos: DragPosition) => void;
+  onDrag?: (pos: DragPosition) => void;
+  onStop?: (pos: DragPosition) => void;
+}
+
+/** Parse the `translate(Xpx, Ypx)` currently applied to a node's inline style. */
+function readTranslate(node: HTMLElement): DragPosition {
+  const match = /translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)/.exec(
+    node.style.transform
+  );
+  return match
+    ? { x: parseFloat(match[1]), y: parseFloat(match[2]) }
+    : { x: 0, y: 0 };
+}
+
+const clamp = (value: number, min?: number, max?: number) => {
+  let v = value;
+  if (min !== undefined && v < min) v = min;
+  if (max !== undefined && v > max) v = max;
+  return v;
+};
+
+/**
+ * Pointer-events based draggable. A small, dependency-free replacement for
+ * `react-draggable` that drives a node's `transform: translate(...)` from
+ * native pointer events.
+ *
+ * Why not react-draggable: it relies on React's *synthetic mouse-event*
+ * delegation (`onMouseDown`) plus document-level `mousemove`/`mouseup`
+ * listeners. That flow can be silently broken by the surrounding app while
+ * pointer events keep working. Pointer events + `setPointerCapture` are the
+ * modern, robust path: capture means moves/ups are delivered to the node even
+ * when the pointer leaves it, with no document listener races.
+ *
+ * The hook owns the node's `transform`. In controlled mode pass `position` and
+ * persist `onStop`/`onDrag`; the hook re-applies `position` whenever it changes
+ * and the node is idle (e.g. a clamp-on-stop or a reset).
+ *
+ * @returns a ref to attach to the draggable node.
+ */
+export function useDraggable<T extends HTMLElement = HTMLElement>(
+  options: UseDraggableOptions
+) {
+  const ref = useRef<T>(null);
+
+  // Latest options, read inside the (stable) pointer listeners without
+  // re-subscribing on every render.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const state = useRef({
+    x: options.position?.x ?? options.defaultPosition?.x ?? 0,
+    y: options.position?.y ?? options.defaultPosition?.y ?? 0,
+    dragging: false,
+    startX: 0,
+    startY: 0,
+    originX: 0,
+    originY: 0,
+    pointerId: -1
+  });
+
+  const apply = () => {
+    if (ref.current) {
+      ref.current.style.transform = `translate(${state.current.x}px, ${state.current.y}px)`;
+    }
+  };
+
+  // Keep the transform in sync with the controlled `position` while idle.
+  const controlledX = options.position?.x;
+  const controlledY = options.position?.y;
+  useEffect(() => {
+    if (
+      controlledX === undefined ||
+      controlledY === undefined ||
+      state.current.dragging
+    ) {
+      return;
+    }
+    state.current.x = controlledX;
+    state.current.y = controlledY;
+    apply();
+  }, [controlledX, controlledY]);
+
+  // Track the node we've bound listeners to. The draggable node can mount/unmount
+  // independently of this hook's host component (e.g. a menu that renders `null`
+  // while closed), so we (re)bind whenever `ref.current` actually changes rather
+  // than once on mount.
+  const boundNode = useRef<HTMLElement | null>(null);
+  const detach = useRef<(() => void) | null>(null);
+
+  const bind = (node: HTMLElement) => {
+    apply();
+
+    const onPointerDown = (e: PointerEvent) => {
+      const opts = optionsRef.current;
+      if (opts.disabled || e.button !== 0) {
+        return;
+      }
+      const target = e.target as Element | null;
+      if (opts.handle && !target?.closest(opts.handle)) {
+        return;
+      }
+      if (opts.cancel && target?.closest(opts.cancel)) {
+        return;
+      }
+      const s = state.current;
+      // Read the origin from the node's live transform so the drag respects any
+      // external imperative nudge (e.g. an on-open clamp) since the last drag.
+      const origin = readTranslate(node);
+      s.x = origin.x;
+      s.y = origin.y;
+      s.dragging = true;
+      s.startX = e.clientX;
+      s.startY = e.clientY;
+      s.originX = origin.x;
+      s.originY = origin.y;
+      s.pointerId = e.pointerId;
+      node.setPointerCapture?.(e.pointerId);
+      // Prevent text selection / focus-steal while dragging the handle.
+      e.preventDefault();
+      opts.onStart?.({ x: s.x, y: s.y });
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const s = state.current;
+      if (!s.dragging || e.pointerId !== s.pointerId) {
+        return;
+      }
+      const { bounds } = optionsRef.current;
+      s.x = s.originX + (e.clientX - s.startX);
+      s.y = s.originY + (e.clientY - s.startY);
+      if (bounds) {
+        s.x = clamp(s.x, bounds.left, bounds.right);
+        s.y = clamp(s.y, bounds.top, bounds.bottom);
+      }
+      apply();
+      optionsRef.current.onDrag?.({ x: s.x, y: s.y });
+    };
+
+    const onPointerEnd = (e: PointerEvent) => {
+      const s = state.current;
+      if (!s.dragging || e.pointerId !== s.pointerId) {
+        return;
+      }
+      s.dragging = false;
+      s.pointerId = -1;
+      optionsRef.current.onStop?.({ x: s.x, y: s.y });
+    };
+
+    node.addEventListener("pointerdown", onPointerDown);
+    node.addEventListener("pointermove", onPointerMove);
+    node.addEventListener("pointerup", onPointerEnd);
+    node.addEventListener("pointercancel", onPointerEnd);
+    return () => {
+      node.removeEventListener("pointerdown", onPointerDown);
+      node.removeEventListener("pointermove", onPointerMove);
+      node.removeEventListener("pointerup", onPointerEnd);
+      node.removeEventListener("pointercancel", onPointerEnd);
+    };
+  };
+
+  // Runs after every render (no deps): rebind only when the node identity changes.
+  useEffect(() => {
+    if (ref.current === boundNode.current) {
+      return;
+    }
+    detach.current?.();
+    detach.current = null;
+    boundNode.current = ref.current;
+    if (ref.current) {
+      detach.current = bind(ref.current);
+    }
+  });
+
+  // Final cleanup on host unmount.
+  useEffect(
+    () => () => {
+      detach.current?.();
+      detach.current = null;
+      boundNode.current = null;
+    },
+    []
+  );
+
+  return ref;
+}
+
+export default useDraggable;

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -114,7 +114,9 @@ export const useNodeEditorShortcuts = (
 
   const nodeMenuStore = useNodeMenuStore(
     useShallow((state) => ({
-      openNodeMenu: state.openNodeMenu
+      openNodeMenu: state.openNodeMenu,
+      closeNodeMenu: state.closeNodeMenu,
+      isMenuOpen: state.isMenuOpen
     }))
   );
   const handleFitView = useFitView();
@@ -137,10 +139,17 @@ export const useNodeEditorShortcuts = (
   });
 
   const { handleCopy, handlePaste, handleCut } = copyPaste;
-  const { openNodeMenu } = nodeMenuStore;
+  const { openNodeMenu, closeNodeMenu, isMenuOpen } = nodeMenuStore;
 
   // All useCallback hooks
   const handleOpenNodeMenu = useCallback(() => {
+    // Space toggles: close when already open. (When the menu is open its search
+    // input usually has focus, so the close-on-space-in-empty-search path in
+    // SearchInput handles that case; this covers a focused canvas.)
+    if (isMenuOpen) {
+      closeNodeMenu();
+      return;
+    }
     if (!active || isTextInputActive()) {
       return;
     }
@@ -151,7 +160,7 @@ export const useNodeEditorShortcuts = (
       y: mousePos.y,
       centerOnScreen: true
     });
-  }, [active, openNodeMenu]);
+  }, [active, isMenuOpen, openNodeMenu, closeNodeMenu]);
 
   const handleGroup = useCallback(() => {
     const selectedNodes = nodeStore.getState().getSelectedNodes();

--- a/web/src/hooks/useResizable.ts
+++ b/web/src/hooks/useResizable.ts
@@ -1,0 +1,106 @@
+import { useCallback, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent, RefObject } from "react";
+
+export interface ResizableSize {
+  width: number;
+  height: number;
+}
+
+/** Edges/corners that can initiate a resize (top-left stays anchored). */
+export type ResizeDirection = "right" | "bottom" | "bottom-right";
+
+export interface UseResizableOptions {
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  /** Called once when a resize gesture ends, with the final measured size. */
+  onResizeEnd?: (size: ResizableSize) => void;
+}
+
+const clamp = (value: number, min?: number, max?: number) => {
+  let v = value;
+  if (max !== undefined && v > max) v = max;
+  if (min !== undefined && v < min) v = min;
+  return v;
+};
+
+/**
+ * Pointer-events based resize for a target element, sized from the top-left
+ * anchor (right / bottom / corner handles grow or shrink width/height). A
+ * sibling of {@link useDraggable}: it sets `width`/`height` imperatively during
+ * the gesture (no per-move React render) and reports the final size for the
+ * caller to persist. Uses `setPointerCapture`, so moves/ups are delivered even
+ * when the pointer leaves the handle.
+ *
+ * @returns `startResize(direction)` — attach the result to a handle's
+ *          `onPointerDown`.
+ */
+export function useResizable(
+  targetRef: RefObject<HTMLElement | null>,
+  options: UseResizableOptions
+) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  return useCallback(
+    (direction: ResizeDirection) => (e: ReactPointerEvent) => {
+      const node = targetRef.current;
+      if (!node || e.button !== 0) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+
+      const handle = e.currentTarget as HTMLElement;
+      const rect = node.getBoundingClientRect();
+      const startW = rect.width;
+      const startH = rect.height;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const opts = optionsRef.current;
+      const maxWidth =
+        opts.maxWidth ??
+        (typeof window !== "undefined" ? window.innerWidth - 24 : undefined);
+      const maxHeight =
+        opts.maxHeight ??
+        (typeof window !== "undefined" ? window.innerHeight - 24 : undefined);
+
+      handle.setPointerCapture?.(e.pointerId);
+
+      const onMove = (ev: PointerEvent) => {
+        if (direction === "right" || direction === "bottom-right") {
+          node.style.width = `${clamp(
+            startW + (ev.clientX - startX),
+            opts.minWidth,
+            maxWidth
+          )}px`;
+        }
+        if (direction === "bottom" || direction === "bottom-right") {
+          node.style.height = `${clamp(
+            startH + (ev.clientY - startY),
+            opts.minHeight,
+            maxHeight
+          )}px`;
+        }
+      };
+
+      const onEnd = () => {
+        handle.removeEventListener("pointermove", onMove);
+        handle.removeEventListener("pointerup", onEnd);
+        handle.removeEventListener("pointercancel", onEnd);
+        optionsRef.current.onResizeEnd?.({
+          width: node.offsetWidth,
+          height: node.offsetHeight
+        });
+      };
+
+      handle.addEventListener("pointermove", onMove);
+      handle.addEventListener("pointerup", onEnd);
+      handle.addEventListener("pointercancel", onEnd);
+    },
+    [targetRef]
+  );
+}
+
+export default useResizable;

--- a/web/src/stores/NodeMenuStore.ts
+++ b/web/src/stores/NodeMenuStore.ts
@@ -47,6 +47,9 @@ export type NodeMenuStore = {
   menuWidth: number;
   menuHeight: number;
   setMenuSize: (width: number, height: number) => void;
+  /** User-resized menu dimensions (px); null means use the responsive default. */
+  menuUserSize: { width: number; height: number } | null;
+  setMenuUserSize: (size: { width: number; height: number } | null) => void;
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   selectedInputType: string;
@@ -205,6 +208,8 @@ export const createNodeMenuStore = () =>
       menuHeight: 0,
       setMenuSize: (width, height) =>
         set({ menuWidth: width, menuHeight: height }),
+      menuUserSize: null,
+      setMenuUserSize: (size) => set({ menuUserSize: size }),
       searchTerm: "",
       setSearchTerm: (term) => {
         // Only update searchTerm - avoid unnecessary state changes


### PR DESCRIPTION
## What

Node menu UX pass:

- **Draggable + resizable** — replaces `react-draggable` with two small, dependency-free hooks (`useDraggable`, `useResizable`) built on pointer events + `setPointerCapture`. Used by both the node menu and the floating toolbar dock. The node menu gains right / bottom / corner resize handles (top-left anchored); the chosen size persists for the session via `menuUserSize`.
- **Space toggles the menu** — Space opens the menu from a focused canvas and closes it via Space in the *empty* search input (`onPressSpaceWhenEmpty`), so multi-word search still works once you start typing.
- **Compact tiles** — tighter density for the favorites / recent / quick-action tiles (smaller min tile width, gaps, fonts, icons).

## Why `useDraggable` over `react-draggable`

`react-draggable` relies on React's synthetic `onMouseDown` delegation + document-level `mousemove`/`mouseup`, which the surrounding app can silently break while pointer events keep working. Pointer events + capture are the robust path and remove the dependency.

## Testing

Verified the space toggle end-to-end against the running app over CDP:
- menu closed + canvas focused → Space → opens (combo fires, `openNodeMenu` runs)
- menu open + empty search → Space → closes
- open→close→open cycles cleanly; no event interception, no stuck `isMenuOpen`

`npm run typecheck` ✅  `npm run lint` ✅

## Notes
- The fadeIn entrance animation is unchanged; it only appears stuck at `opacity:0` in a headless/background tab where the document timeline is frozen (no rAF) — a non-issue in a real window.