### PR TITLE
Sketch: inline tab rename, generation header upgrades, and magic generation effect

### DIFF
--- a/web/eslint.design.mjs
+++ b/web/eslint.design.mjs
@@ -65,6 +65,10 @@ export const designTokenIgnores = [
   // Decorative multi-hue @keyframes "running" status pulse — a rainbow animation,
   // not semantic chrome.
   "src/components/miniapps/StandaloneMiniApp.tsx",
+  // Decorative multi-hue @keyframes "generating" wash + shimmer + aura — a
+  // rainbow animation overlay, not semantic chrome.
+  "src/components/sketch/GeneratingLayerOverlay.tsx",
+  "src/components/sketch/MagicGenerationFill.tsx",
 ];
 
 const muiPrimitiveMessage =

--- a/web/src/components/sketch/GeneratingLayerOverlay.tsx
+++ b/web/src/components/sketch/GeneratingLayerOverlay.tsx
@@ -1,0 +1,176 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * GeneratingLayerOverlay
+ *
+ * Paints a "magic" animated overlay on top of every layer that is currently
+ * generating (binding status "queued" or "generating"). Rendered inside the
+ * canvas' document-space wrapper (see SketchCanvasPresentation), so each box is
+ * positioned in raw document coordinates and the shared pan/zoom transform maps
+ * it onto the artboard automatically.
+ *
+ * Pure CSS effects (emotion keyframes): a hue-flowing border, a breathing
+ * multi-colour aura, a diagonal shimmer sweep, a soft inner tint, and a few
+ * twinkling sparkles. All suppressed under prefers-reduced-motion.
+ */
+
+import { css, keyframes } from "@emotion/react";
+import { memo } from "react";
+
+import { useSketchStore } from "./state";
+import { useSketchSessionStore } from "../../stores/sketch/SketchInstance";
+import { computeTransformedCorners } from "./transform/geometry/layerGeometry";
+import MagicGenerationFill from "./MagicGenerationFill";
+import { BORDER_RADIUS, reducedMotion } from "../ui_primitives";
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const isGenerating = (status: string | undefined): boolean =>
+  status === "queued" || status === "generating";
+
+const aabbOf = (corners: ReadonlyArray<{ x: number; y: number }>): Rect => {
+  const xs = corners.map((c) => c.x);
+  const ys = corners.map((c) => c.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(...xs) - minX,
+    height: Math.max(...ys) - minY
+  };
+};
+
+// ─── Animations ────────────────────────────────────────────────────────────
+
+const borderFlow = keyframes`
+  0%   { border-color: rgba(110, 231, 255, 0.9); }
+  33%  { border-color: rgba(168, 85, 247, 0.9); }
+  66%  { border-color: rgba(236, 72, 153, 0.9); }
+  100% { border-color: rgba(110, 231, 255, 0.9); }
+`;
+
+const auraPulse = keyframes`
+  0%, 100% {
+    box-shadow:
+      0 0 0 1.5px rgba(167, 139, 250, 0.6),
+      0 0 16px 2px rgba(99, 102, 241, 0.4),
+      inset 0 0 22px rgba(168, 85, 247, 0.15);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px rgba(110, 231, 255, 0.85),
+      0 0 34px 6px rgba(168, 85, 247, 0.55),
+      inset 0 0 38px rgba(110, 231, 255, 0.25);
+  }
+`;
+
+const sparkleTwinkle = keyframes`
+  0%, 100% { opacity: 0; transform: scale(0.3); }
+  50%      { opacity: 1; transform: scale(1); }
+`;
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const boxCss = css({
+  position: "absolute",
+  boxSizing: "border-box",
+  borderRadius: BORDER_RADIUS.sm,
+  border: "2px solid rgba(110, 231, 255, 0.9)",
+  overflow: "hidden",
+  pointerEvents: "none",
+  willChange: "box-shadow, border-color",
+  animation: `${borderFlow} 3s linear infinite, ${auraPulse} 1.8s ease-in-out infinite`,
+  // The flowing wash + shimmer fill (MagicGenerationFill) is rendered as
+  // children below; the box itself contributes the border + aura glow.
+  ...reducedMotion({ animation: "none" })
+});
+
+const sparkleCss = css({
+  position: "absolute",
+  width: 6,
+  height: 6,
+  borderRadius: "50%",
+  background:
+    "radial-gradient(circle, #fff 0%, rgba(110, 231, 255, 0.9) 40%, transparent 70%)",
+  animation: `${sparkleTwinkle} 1.4s ease-in-out infinite`,
+  ...reducedMotion({ animation: "none", opacity: 0 })
+});
+
+const SPARKLES = [
+  { top: "10%", left: "14%", delay: "0s" },
+  { top: "20%", left: "80%", delay: "0.3s" },
+  { top: "70%", left: "24%", delay: "0.6s" },
+  { top: "62%", left: "72%", delay: "0.15s" },
+  { top: "44%", left: "52%", delay: "0.45s" }
+] as const;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const MagicBox = ({ rect }: { rect: Rect }) => (
+  <div
+    css={boxCss}
+    style={{
+      left: rect.x,
+      top: rect.y,
+      width: rect.width,
+      height: rect.height
+    }}
+  >
+    <MagicGenerationFill />
+    {SPARKLES.map((s) => (
+      <span
+        key={`${s.top}-${s.left}`}
+        css={sparkleCss}
+        style={{ top: s.top, left: s.left, animationDelay: s.delay }}
+      />
+    ))}
+  </div>
+);
+
+const GeneratingLayerOverlay = memo(function GeneratingLayerOverlay() {
+  const layers = useSketchStore((s) => s.document.layers);
+  const canvas = useSketchStore((s) => s.document.canvas);
+  const bindings = useSketchSessionStore((s) => s.bindings);
+
+  const boxes = layers
+    .filter((layer) => layer.visible && isGenerating(bindings[layer.id]?.status))
+    .map((layer) => {
+      const corners = computeTransformedCorners(
+        layer.transform,
+        layer.contentBounds
+      );
+      const rect = aabbOf(corners);
+      // Fresh layers can have an empty raster; fall back to the full artboard so
+      // the effect still reads while the first result streams in.
+      const usable =
+        Number.isFinite(rect.width) &&
+        Number.isFinite(rect.height) &&
+        rect.width >= 1 &&
+        rect.height >= 1;
+      return {
+        id: layer.id,
+        rect: usable
+          ? rect
+          : { x: 0, y: 0, width: canvas.width, height: canvas.height }
+      };
+    });
+
+  if (boxes.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {boxes.map(({ id, rect }) => (
+        <MagicBox key={id} rect={rect} />
+      ))}
+    </>
+  );
+});
+
+export default GeneratingLayerOverlay;

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -40,6 +40,7 @@ import {
 } from "../ui_primitives";
 import type { LayerStatus } from "@nodetool-ai/image-editor";
 import { LAYER_STATUS_MAP } from "./Inspector/layerStatusMapping";
+import MagicGenerationFill from "./MagicGenerationFill";
 
 /** Base left padding for the layer row (px). 0 so the thumbnail sits flush
  *  with the row's left edge — the row background should not stick out past it. */
@@ -148,6 +149,8 @@ const LayerItem: React.FC<LayerItemProps> = ({
   // blocked by the page CSP when set directly as an <img src>.
   const layerImage = isGroup ? null : getLayerDataImageUrl(layer.data);
   const thumbnailSrc = layerImage ? resolveAssetUri(layerImage) : null;
+  const isLayerGenerating =
+    bindingStatus === "queued" || bindingStatus === "generating";
 
   // Mockup-style sub-label under the name: blend mode + opacity (or MASK).
   const opacityPct = Math.round(layer.opacity * 100);
@@ -252,24 +255,45 @@ const LayerItem: React.FC<LayerItemProps> = ({
               }}
             />
           )
-        ) : thumbnailSrc ? (
-          <img
-            className="layer-thumbnail"
-            src={thumbnailSrc}
-            alt={layer.name}
-            draggable={false}
-            onClick={(e) => {
-              if (e.ctrlKey || e.metaKey) {
-                e.stopPropagation();
-                onThumbnailCtrlClick?.(
-                  layer.id,
-                  e.shiftKey ? "add" : "replace"
-                );
-              }
-            }}
-          />
         ) : (
-          <Box className="layer-thumbnail-empty" />
+          <Box
+            className="layer-thumbnail-wrapper"
+            sx={{ position: "relative", display: "flex", flexShrink: 0 }}
+          >
+            {thumbnailSrc ? (
+              <img
+                className="layer-thumbnail"
+                src={thumbnailSrc}
+                alt={layer.name}
+                draggable={false}
+                onClick={(e) => {
+                  if (e.ctrlKey || e.metaKey) {
+                    e.stopPropagation();
+                    onThumbnailCtrlClick?.(
+                      layer.id,
+                      e.shiftKey ? "add" : "replace"
+                    );
+                  }
+                }}
+              />
+            ) : (
+              <Box className="layer-thumbnail-empty" />
+            )}
+            {isLayerGenerating && (
+              <Box
+                aria-hidden
+                sx={{
+                  position: "absolute",
+                  inset: 0,
+                  borderRadius: BORDER_RADIUS.xs,
+                  overflow: "hidden",
+                  pointerEvents: "none"
+                }}
+              >
+                <MagicGenerationFill />
+              </Box>
+            )}
+          </Box>
         )}
 
         {!isGroup && (

--- a/web/src/components/sketch/MagicGenerationFill.tsx
+++ b/web/src/components/sketch/MagicGenerationFill.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * MagicGenerationFill
+ *
+ * The shared "generating" fill — a flowing translucent multi-colour wash plus a
+ * diagonal shimmer sweep — that fills its positioned parent. Used both on the
+ * canvas (over a generating layer's bounds) and in the layers panel (over a
+ * generating layer's thumbnail) so the effect reads identically in both places.
+ *
+ * The parent must be `position: relative` (and usually `overflow: hidden` with a
+ * matching border radius so the wash clips to the shape). Content underneath
+ * stays visible through the wash.
+ */
+
+import { css, keyframes } from "@emotion/react";
+import { memo } from "react";
+
+import { reducedMotion } from "../ui_primitives";
+
+const gradientFlow = keyframes`
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+
+const shimmerSweep = keyframes`
+  0%   { transform: translateX(-160%) skewX(-18deg); }
+  100% { transform: translateX(160%) skewX(-18deg); }
+`;
+
+const tintBreathe = keyframes`
+  0%, 100% { opacity: 0.65; }
+  50%      { opacity: 1; }
+`;
+
+const washCss = css({
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  background:
+    "linear-gradient(120deg, rgba(110, 231, 255, 0.32), rgba(99, 102, 241, 0.3), rgba(168, 85, 247, 0.32), rgba(236, 72, 153, 0.3), rgba(110, 231, 255, 0.32))",
+  backgroundSize: "300% 300%",
+  animation: `${gradientFlow} 4s ease infinite, ${tintBreathe} 1.8s ease-in-out infinite`,
+  ...reducedMotion({ animation: "none" })
+});
+
+const shimmerCss = css({
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  background:
+    "linear-gradient(110deg, transparent 35%, rgba(255, 255, 255, 0.5) 50%, transparent 65%)",
+  animation: `${shimmerSweep} 1.7s ease-in-out infinite`,
+  ...reducedMotion({ animation: "none", opacity: 0 })
+});
+
+const MagicGenerationFill = () => (
+  <>
+    <span aria-hidden css={washCss} />
+    <span aria-hidden css={shimmerCss} />
+  </>
+);
+
+export default memo(MagicGenerationFill);

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -43,6 +43,7 @@ import {
 import { clientToDocumentCanvas } from "./tools/transform/handleGeometry";
 import type { StrokeEndOptions } from "./tools/types";
 import SketchCanvasPresentation from "./SketchCanvasPresentation";
+import GeneratingLayerOverlay from "./GeneratingLayerOverlay";
 import { getToolHandler } from "./tools";
 import { TransformTool } from "./tools/TransformTool";
 
@@ -529,6 +530,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         onCanvasResizeStart={onCanvasResizeStart}
         onCanvasResize={onCanvasResize}
         className={rootClassName}
+        docOverlay={<GeneratingLayerOverlay />}
       />
     );
   }

--- a/web/src/components/sketch/SketchCanvasPresentation.tsx
+++ b/web/src/components/sketch/SketchCanvasPresentation.tsx
@@ -120,6 +120,12 @@ export interface SketchCanvasPresentationProps {
     options?: { translateLayers?: Point; resizeFromCenter?: boolean }
   ) => void;
   className?: string;
+  /**
+   * Document-space chrome rendered above the layer pixels and below the
+   * selection/cursor/gizmo canvases. Positioned children use raw document
+   * coordinates — the shared pan/zoom transform maps them onto the artboard.
+   */
+  docOverlay?: React.ReactNode;
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -156,7 +162,8 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
       onDrop,
       onCanvasResizeStart,
       onCanvasResize,
-      className: rootClassName
+      className: rootClassName,
+      docOverlay
     } = props;
 
     const theme = useTheme();
@@ -216,6 +223,25 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
               imageRendering: "auto"
             }}
           />
+          {/* Document-space DOM overlay (e.g. generation effects). Shares the
+              canvas transform so its children position in document pixels. */}
+          {docOverlay && (
+            <div
+              className="sketch-canvas__doc-overlay"
+              style={{
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                width: canvasWidth,
+                height: canvasHeight,
+                transform: canvasStyle.transform,
+                transformOrigin: "center center",
+                pointerEvents: "none"
+              }}
+            >
+              {docOverlay}
+            </div>
+          )}
         </div>
         {/* Screen-resolution canvas for selection marching ants. */}
         <canvas

--- a/web/src/components/sketch/StandaloneSketchEditor.tsx
+++ b/web/src/components/sketch/StandaloneSketchEditor.tsx
@@ -33,7 +33,14 @@ import SketchEditor, { type SketchEditorHandle } from "./SketchEditor";
 import { trpc } from "../../trpc/client";
 import type { SketchDocument } from "./types";
 import { useStandaloneSketchDocument } from "../../stores/sketch/SketchSessionStore";
-import { SketchProvider } from "../../stores/sketch/SketchInstance";
+import {
+  SketchProvider,
+  useSketchSessionStoreApi
+} from "../../stores/sketch/SketchInstance";
+import {
+  useWorkspaceTabsStore,
+  tabId
+} from "../../stores/WorkspaceTabsStore";
 import { useSaveSketchDocument } from "../../hooks/sketch/useSaveSketchDocument";
 
 const containerStyles = (theme: Theme) =>
@@ -98,6 +105,20 @@ const StandaloneSketchEditorBody: React.FC<
       setSeed({ id: documentId, document: initialEditorState.document });
     }, [documentId, initialEditorState, seed?.id]);
 
+    // Mirror the workspace tab title into the session name. Renaming the tab
+    // persists immediately to the server, but the content autosave also writes
+    // `session.name`; without this it would later revert the rename.
+    const sessionStore = useSketchSessionStoreApi();
+    const tabTitle = useWorkspaceTabsStore(
+      (state) =>
+        state.tabs.find((t) => t.id === tabId("sketch", documentId))?.title
+    );
+    useEffect(() => {
+      if (tabTitle && tabTitle !== sessionStore.getState().name) {
+        sessionStore.getState().setName(tabTitle);
+      }
+    }, [tabTitle, sessionStore]);
+
     const handleSave = useCallback(() => {
       void save();
     }, [save]);
@@ -123,7 +144,7 @@ const StandaloneSketchEditorBody: React.FC<
     };
 
     const documentActions = (
-      <FlexRow gap={0.5} align="center" sx={{ flexShrink: 0 }}>
+      <FlexRow gap={2} align="center" sx={{ flexShrink: 0 }}>
         <EditorButton
           size="small"
           variant="outlined"
@@ -131,6 +152,7 @@ const StandaloneSketchEditorBody: React.FC<
           disabled={saving}
           startIcon={<SaveOutlinedIcon fontSize="small" />}
           data-testid="sketch-save-document"
+          sx={{ height: 34 }}
         >
           {saving ? "Saving…" : "Save"}
         </EditorButton>
@@ -140,6 +162,7 @@ const StandaloneSketchEditorBody: React.FC<
           onClick={handleExportPng}
           startIcon={<FileDownloadOutlinedIcon fontSize="small" />}
           data-testid="sketch-export-png"
+          sx={{ height: 34 }}
         >
           Export PNG
         </EditorButton>

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -12,25 +12,57 @@
  * sketch modal has no session, same gate as SelectionActionBar).
  */
 
-import React, { memo, useCallback, useState } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import AspectRatioIcon from "@mui/icons-material/CropOriginal";
+import ResolutionIcon from "@mui/icons-material/Tv";
 
 import {
-  Chip,
   EditorButton,
   FlexRow,
   LoadingSpinner,
-  Text,
+  SPACING,
   TextInput,
   Toast
 } from "../../ui_primitives";
 import ImageModelSelect from "../../properties/ImageModelSelect";
+import MediaControlChip from "../../chat/composer/MediaControlChip";
+import MediaAspectRatioMenu from "../../chat/composer/MediaAspectRatioMenu";
+import MediaOptionMenu from "../../chat/composer/MediaOptionMenu";
 import type { ImageModelValue } from "../../../stores/ApiTypes";
+import {
+  IMAGE_ASPECT_RATIOS,
+  IMAGE_RESOLUTIONS,
+  resolveImageSize,
+  type ImageResolution
+} from "../../../stores/MediaGenerationStore";
 import { useSketchStore } from "../state/useSketchStore";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
-import { SKETCH_FONT, SKETCH_SPACING } from "../sketchStyles";
+import { SKETCH_SPACING } from "../sketchStyles";
+
+/** Nearest aspect-ratio + resolution preset for an existing canvas size, so the
+ *  controls reflect the artboard on open instead of a fixed default. */
+function deriveSizePreset(
+  width: number,
+  height: number
+): { aspectRatio: string; resolution: ImageResolution } {
+  const ratio = width / height;
+  let aspectRatio = IMAGE_ASPECT_RATIOS[0].id;
+  let bestDiff = Infinity;
+  for (const a of IMAGE_ASPECT_RATIOS) {
+    const diff = Math.abs(a.width / a.height - ratio);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      aspectRatio = a.id;
+    }
+  }
+  const shortEdge = Math.min(width, height);
+  const resolution: ImageResolution =
+    shortEdge >= 3072 ? "4K" : shortEdge >= 1536 ? "2K" : "1K";
+  return { aspectRatio, resolution };
+}
 
 /** Most recent direct-gen binding's model, to seed the bar's picker. */
 function seedModelFromBindings(): { model: string; provider: string } {
@@ -66,9 +98,9 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   const panelsHidden = useSketchStore((s) => s.panelsHidden);
   const docW = useSketchStore((s) => s.document.canvas.width);
   const docH = useSketchStore((s) => s.document.canvas.height);
+  const resizeCanvas = useSketchStore((s) => s.resizeCanvas);
 
   const documentId = useSketchSessionStore((s) => s.documentId);
-  const name = useSketchSessionStore((s) => s.name);
 
   const { start } = useDirectGenJob();
 
@@ -78,6 +110,41 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   const [provider, setProvider] = useState(seed.provider);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Output size — aspect ratio + resolution, mirroring the media composer.
+  // Changing either resizes the artboard so the generated layer matches.
+  const [sizeSeed] = useState(() => deriveSizePreset(docW, docH));
+  const [aspectRatio, setAspectRatio] = useState(sizeSeed.aspectRatio);
+  const [resolution, setResolution] = useState<ImageResolution>(
+    sizeSeed.resolution
+  );
+  const [aspectAnchor, setAspectAnchor] = useState<HTMLElement | null>(null);
+  const [resolutionAnchor, setResolutionAnchor] = useState<HTMLElement | null>(
+    null
+  );
+
+  const resolutionOptions = useMemo(
+    () => IMAGE_RESOLUTIONS.map((r) => ({ id: r, label: r })),
+    []
+  );
+
+  const handleResolutionChange = useCallback(
+    (r: ImageResolution) => {
+      setResolution(r);
+      const { width, height } = resolveImageSize(r, aspectRatio);
+      resizeCanvas(width, height);
+    },
+    [aspectRatio, resizeCanvas]
+  );
+
+  const handleAspectChange = useCallback(
+    (a: string) => {
+      setAspectRatio(a);
+      const { width, height } = resolveImageSize(resolution, a);
+      resizeCanvas(width, height);
+    },
+    [resolution, resizeCanvas]
+  );
 
   const handleModelChange = useCallback((v: ImageModelValue) => {
     setModel(v.id);
@@ -90,12 +157,15 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
       const layerId = useSketchStore
         .getState()
         .addLayer(uniqueLayerName("Text-to-Image"));
+      const { width, height } = resolveImageSize(resolution, aspectRatio);
       useSketchSessionStore.getState().upsertBinding({
         layerId,
         kind: "text-to-image",
         prompt: prompt.trim(),
         provider,
         model,
+        width,
+        height,
         sourceLayerId: null,
         status: "draft",
         versions: []
@@ -108,7 +178,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
     } finally {
       setGenerating(false);
     }
-  }, [model, prompt, provider, start]);
+  }, [model, prompt, provider, resolution, aspectRatio, start]);
 
   const actionDisabled = generating || !prompt.trim() || !model;
 
@@ -124,7 +194,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
         className="sketch-mode-prompt-bar"
         data-testid="sketch-mode-prompt-bar"
         align="center"
-        gap={1}
+        gap={SPACING.xl}
         sx={{
           flexShrink: 0,
           width: "100%",
@@ -137,27 +207,40 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
           borderBottom: `1px solid ${theme.vars.palette.grey[800]}`
         }}
       >
-        {/* Document name + dimensions */}
-        <FlexRow align="center" gap={1} sx={{ flexShrink: 0, minWidth: 0 }}>
-          <Text
-            size="small"
-            sx={{
-              fontWeight: 600,
-              maxWidth: 160,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap"
-            }}
-            title={name}
-          >
-            {name || "Untitled"}
-          </Text>
-          <Chip
-            compact
-            label={`${docW} × ${docH} · sRGB`}
-            sx={{ fontFamily: SKETCH_FONT.familyMono }}
-          />
-        </FlexRow>
+        {/* Resolution */}
+        <MediaControlChip
+          icon={<ResolutionIcon fontSize="small" />}
+          label={resolution}
+          active={!!resolutionAnchor}
+          onClick={(e) => setResolutionAnchor(e.currentTarget)}
+          showChevron={false}
+        />
+        <MediaOptionMenu
+          anchorEl={resolutionAnchor}
+          open={!!resolutionAnchor}
+          onClose={() => setResolutionAnchor(null)}
+          header="Resolution"
+          value={resolution}
+          options={resolutionOptions}
+          onChange={handleResolutionChange}
+        />
+
+        {/* Aspect ratio */}
+        <MediaControlChip
+          icon={<AspectRatioIcon fontSize="small" />}
+          label={aspectRatio}
+          active={!!aspectAnchor}
+          onClick={(e) => setAspectAnchor(e.currentTarget)}
+          showChevron={false}
+        />
+        <MediaAspectRatioMenu
+          anchorEl={aspectAnchor}
+          open={!!aspectAnchor}
+          onClose={() => setAspectAnchor(null)}
+          value={aspectRatio}
+          options={IMAGE_ASPECT_RATIOS}
+          onChange={handleAspectChange}
+        />
 
         {/* Prompt */}
         <TextInput
@@ -184,7 +267,12 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
               )
             }
           }}
-          sx={{ flex: 1, minWidth: 120 }}
+          sx={{
+            flex: 1,
+            minWidth: 120,
+            // Match the control/button height so the row aligns.
+            "& .MuiOutlinedInput-root": { height: 34 }
+          }}
         />
 
         {/* Model selector */}
@@ -210,7 +298,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
             )
           }
           data-testid="sketch-gen-submit"
-          sx={{ flexShrink: 0 }}
+          sx={{ flexShrink: 0, height: 34 }}
         >
           Generate
         </EditorButton>

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -16,6 +16,8 @@ import {
   type WorkspaceTabType
 } from "../../stores/WorkspaceTabsStore";
 import { useWorkflowManager, useWorkflowManagerStore } from "../../contexts/WorkflowManagerContext";
+import { useAssetStore } from "../../stores/AssetStore";
+import { trpcClient } from "../../trpc/client";
 import { colorForType } from "../../config/data_types";
 import { TOOLBAR_WIDTH } from "../../config/constants";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
@@ -33,6 +35,14 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   text: true,
   audio: true
 };
+
+/** Tab types whose title can be renamed in place by double-clicking. */
+const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
+  "workflow",
+  "sketch",
+  "timeline",
+  "model3d"
+]);
 
 const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
   workflow: "⬡",
@@ -246,6 +256,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
   const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
   const closeOthers = useWorkspaceTabsStore((state) => state.closeOthers);
   const setMode = useWorkspaceTabsStore((state) => state.setMode);
+  const setTitle = useWorkspaceTabsStore((state) => state.setTitle);
   const moveTab = useWorkspaceTabsStore((state) => state.moveTab);
 
   const removeWorkflow = useWorkflowManager((state) => state.removeWorkflow);
@@ -341,28 +352,61 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
     [dropTarget, moveTab, syncWorkflowOrderFromTabs]
   );
 
-  const commitWorkflowRename = useCallback(
+  const commitRename = useCallback(
     async (tab: WorkspaceTab, newName: string) => {
       const trimmed = newName.trim();
       setEditingTabId(null);
-      if (tab.type !== "workflow" || trimmed.length === 0) {
+      if (trimmed.length === 0 || trimmed === tab.title) {
         return;
       }
 
-      const workflow = getWorkflow(tab.ref);
-      if (!workflow || workflow.name === trimmed) {
+      // Workflows carry their name in the workflow store; the tab title is
+      // synced from there by WorkspaceShell, so update + save the workflow.
+      if (tab.type === "workflow") {
+        const workflow = getWorkflow(tab.ref);
+        if (!workflow || workflow.name === trimmed) {
+          return;
+        }
+        const updatedWorkflow = { ...workflow, name: trimmed };
+        updateWorkflow(updatedWorkflow);
+        try {
+          await saveWorkflow(updatedWorkflow);
+        } catch {
+          updateWorkflow(workflow);
+        }
         return;
       }
 
-      const updatedWorkflow = { ...workflow, name: trimmed };
-      updateWorkflow(updatedWorkflow);
+      // Other document types own no store→tab sync: update the tab title
+      // optimistically, persist the rename to the backing document keyed by
+      // ref, and roll the title back if the server write fails.
+      const previousTitle = tab.title;
+      setTitle(tab.ref, tab.type, trimmed);
       try {
-        await saveWorkflow(updatedWorkflow);
+        switch (tab.type) {
+          case "sketch":
+            await trpcClient.sketch.update.mutate({
+              id: tab.ref,
+              name: trimmed
+            });
+            break;
+          case "timeline":
+            await trpcClient.timeline.update.mutate({
+              id: tab.ref,
+              name: trimmed
+            });
+            break;
+          case "model3d":
+            await useAssetStore.getState().update({ id: tab.ref, name: trimmed });
+            break;
+          default:
+            break;
+        }
       } catch {
-        updateWorkflow(workflow);
+        setTitle(tab.ref, tab.type, previousTitle);
       }
     },
-    [getWorkflow, updateWorkflow, saveWorkflow]
+    [getWorkflow, updateWorkflow, saveWorkflow, setTitle]
   );
 
   const handleClose = useCallback(
@@ -433,6 +477,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
             tab={tab}
             isActive={tab.id === activeTabId}
             isEditing={editingTabId === tab.id}
+            canRename={RENAMEABLE_TYPES.has(tab.type)}
             dropPosition={dropTarget?.id === tab.id ? dropTarget.position : null}
             typeColor={TYPE_COLOR[tab.type]}
             typeGlyph={TYPE_GLYPH[tab.type]}
@@ -445,7 +490,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
-            onCommitRename={commitWorkflowRename}
+            onCommitRename={commitRename}
             onCancelRename={handleCancelRename}
           />
         ))}

--- a/web/src/components/workspace/WorkspaceTabItem.tsx
+++ b/web/src/components/workspace/WorkspaceTabItem.tsx
@@ -23,6 +23,7 @@ export interface WorkspaceTabItemProps {
   tab: WorkspaceTab;
   isActive: boolean;
   isEditing: boolean;
+  canRename: boolean;
   dropPosition: "left" | "right" | null;
   typeColor: string;
   typeGlyph: string;
@@ -43,6 +44,7 @@ const WorkspaceTabItem = ({
   tab,
   isActive,
   isEditing,
+  canRename,
   dropPosition,
   typeColor,
   typeGlyph,
@@ -129,7 +131,7 @@ const WorkspaceTabItem = ({
         onKeyDown={handleTabKeyDown}
         onContextMenu={handleContextMenu}
         onDoubleClick={() => {
-          if (tab.type === "workflow") {
+          if (canRename) {
             onBeginRename(tab);
           }
         }}
@@ -147,7 +149,7 @@ const WorkspaceTabItem = ({
           <input
             type="text"
             className="tab-input"
-            aria-label="Workflow name"
+            aria-label="Tab name"
             defaultValue={tab.title}
             autoFocus
             onClick={(event) => event.stopPropagation()}

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -123,6 +123,8 @@ export interface SketchSessionState {
     response: Pick<SketchDocumentResponse, "id" | "name" | "updatedAt">,
     serverHash: string
   ) => void;
+  /** Update the in-memory document name (kept in sync with the workspace tab). */
+  setName: (name: string) => void;
   /** Record that the editor has seeded the global store from this document. */
   markHydrated: (documentId: string) => void;
   markSaving: () => void;
@@ -250,6 +252,7 @@ export const createSketchSessionStore = (): SketchSessionStoreApi =>
       saveState: "idle",
       hasConflict: false
     }),
+  setName: (name) => set((state) => (state.name === name ? state : { name })),
   markHydrated: (documentId) => set({ hydratedDocumentId: documentId }),
   markSaving: () => set({ saveState: "saving", hasConflict: false }),
   markSaved: (updatedAt, serverHash) =>


### PR DESCRIPTION
## Summary

Three related improvements to the sketch/workspace experience.

### Workspace tabs — inline rename for sketch / video / 3d
- Double-clicking a sketch, video (timeline), or 3d (model3d) tab title now begins **in-place editing**, reusing the existing workflow-tab rename input (Enter/blur commits, Escape cancels).
- Renames persist to the backing document **keyed by ref** — sketch & timeline via tRPC `update`, model3d via the asset store — and roll the tab title back on failure.
- Sketch only: the per-instance session `name` is kept in sync with the tab title so the content autosave (which writes `session.name`) can't silently revert a rename.

### Sketch generation header (`ConnectedModePromptBar`)
- Removed the duplicated document name (now shown in the tab title) and the read-only `W × H · sRGB` chip.
- Added **resolution** and **aspect ratio** controls matching the media composer (`MediaControlChip` + `MediaOptionMenu` + `MediaAspectRatioMenu`). Changing either resizes the artboard via `resolveImageSize` and feeds `width`/`height` into the generation binding; initial values are derived from the current canvas.
- Layout polish: more spacing between Save/Export, prompt input + all buttons unified to 34px, larger token-based gap between header items.

### Magic generation effect
- Generating layers (`binding.status` `queued`/`generating`) get an animated overlay: a flowing translucent multi-colour **wash + shimmer** (`MagicGenerationFill`), plus an animated border, aura glow, and twinkling sparkles on the canvas (`GeneratingLayerOverlay`, positioned in document space so it tracks pan/zoom).
- The same wash + shimmer also plays over the layer's **thumbnail in the layers panel**.
- All effects respect `prefers-reduced-motion`.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` (sketch suites: `ConnectedModePromptBar`, `SketchLayersPanel`, `sketchCanvasPresentation`, `WorkspaceTabsStore`, `SketchSessionStore.autosave`, all Layer tests) — passing
- Manual: rename sketch/video/3d tabs; pick aspect/resolution and confirm the canvas reshapes and a generation fills it; run a text-to-image generation and confirm the wash plays on both the canvas layer and its panel thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)