### PR TITLE
Fix undo batching for clip/track pointer gestures

### DIFF
--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -23,11 +23,8 @@ import type { Theme } from "@mui/material/styles";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 
 import type { TimelineClip, TimelineTrack, ClipStatus } from "@nodetool-ai/timeline";
-import {
-  useTimelineStore,
-  useTimelineStoreApi,
-  timelineTemporalOf
-} from "../../../stores/timeline/TimelineStore";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   useTimelineUIStore,
   useIsClipSelected
@@ -540,32 +537,11 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   // ── Undo batching ───────────────────────────────────────────────────────
   //
   // Drag/trim gestures mutate the store on every pointermove. To collapse a
-  // whole gesture into a single undo entry we let the *first* mutation of the
-  // gesture be recorded normally (zundo pushes the pre-gesture state onto the
-  // undo stack inside that set call), then pause history tracking for the
-  // rest of the gesture and resume on gesture end. While paused, zundo
-  // records nothing — so one undo step reverts the entire drag.
-
-  const timelineStoreApi = useTimelineStoreApi();
-  const historyPausedRef = useRef(false);
-
-  const pauseHistoryAfterFirstMutation = useCallback(() => {
-    if (!historyPausedRef.current) {
-      timelineTemporalOf(timelineStoreApi).pause();
-      historyPausedRef.current = true;
-    }
-  }, [timelineStoreApi]);
-
-  const resumeHistory = useCallback(() => {
-    if (historyPausedRef.current) {
-      historyPausedRef.current = false;
-      timelineTemporalOf(timelineStoreApi).resume();
-    }
-  }, [timelineStoreApi]);
-
-  // Safety net: never leave history tracking paused if the clip unmounts
-  // mid-gesture (e.g. the store changes underneath us).
-  useEffect(() => resumeHistory, [resumeHistory]);
+  // whole gesture into a single undo entry we begin a batch on pointerdown,
+  // mark() after each mutation (which pauses history once the pre-gesture
+  // state has actually been checkpointed), and end() on pointerup. While
+  // paused, zundo records nothing — so one undo step reverts the entire drag.
+  const history = useTimelineHistoryBatch();
 
   // ── Drag (move) ─────────────────────────────────────────────────────────
 
@@ -602,6 +578,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       dragStartXRef.current = e.clientX;
       dragStartMsRef.current = clip.startMs;
       isDraggingRef.current = false;
+      history.begin();
 
       // Snapshot the snap candidates ONCE at gesture start. The set of clip
       // edges + second/playhead gridlines doesn't change during a drag (only
@@ -716,8 +693,8 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
             disableSnap
           );
         }
-        // First mutation recorded the pre-drag state; batch the rest.
-        pauseHistoryAfterFirstMutation();
+        // First effective mutation recorded the pre-drag state; batch the rest.
+        history.mark();
       };
 
       const onUpOrCancel = () => {
@@ -728,7 +705,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
           cancelAnimationFrame(hitTestRafId);
           hitTestRafId = null;
         }
-        resumeHistory();
+        history.end();
         // Defer dragging flag reset so the synthetic click that follows
         // pointerup is still suppressed by handleClick.
         const wasDragging = isDraggingRef.current;
@@ -753,8 +730,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       clipId,
       moveClip,
       moveSelectedClips,
-      pauseHistoryAfterFirstMutation,
-      resumeHistory
+      history
     ]
   );
 
@@ -840,8 +816,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       e.currentTarget.setPointerCapture(e.pointerId);
       trimStartRef.current = { startX: e.clientX, startMs: clip.startMs };
       isTrimmingStartRef.current = true;
+      history.begin();
     },
-    [clip, activeTool]
+    [clip, activeTool, history]
   );
 
   const handleTrimStartPointerMove = useCallback(
@@ -866,10 +843,10 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       // So: pointer moving right (+deltaPx) should shrink the clip from the start.
       // We negate so that dragging the handle right correctly shrinks the clip start.
       trimClipStart(clip.id, -deltaMs);
-      pauseHistoryAfterFirstMutation();
+      history.mark();
       trimStartRef.current.startX = e.clientX;
     },
-    [clip, msPerPx, trimClipStart, pauseHistoryAfterFirstMutation]
+    [clip, msPerPx, trimClipStart, history]
   );
 
   // ── Trim end ────────────────────────────────────────────────────────────
@@ -894,8 +871,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         startDuration: clip.durationMs
       };
       isTrimmingEndRef.current = true;
+      history.begin();
     },
-    [clip, activeTool]
+    [clip, activeTool, history]
   );
 
   const handleTrimEndPointerMove = useCallback(
@@ -915,10 +893,10 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       const deltaPx = e.clientX - trimEndRef.current.startX;
       const deltaMs = deltaPx * msPerPx;
       trimClipEnd(clip.id, deltaMs, audioSourceDurationMs);
-      pauseHistoryAfterFirstMutation();
+      history.mark();
       trimEndRef.current.startX = e.clientX;
     },
-    [clip, msPerPx, trimClipEnd, audioSourceDurationMs, pauseHistoryAfterFirstMutation]
+    [clip, msPerPx, trimClipEnd, audioSourceDurationMs, history]
   );
 
   // Shared end-of-trim handler (pointerup AND pointercancel): release the
@@ -926,8 +904,8 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   const handleTrimPointerEnd = useCallback(() => {
     isTrimmingStartRef.current = false;
     isTrimmingEndRef.current = false;
-    resumeHistory();
-  }, [resumeHistory]);
+    history.end();
+  }, [history]);
 
   if (!clip) {
     return null;

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -8,7 +8,7 @@
  *   - Height resize handle at the bottom edge
  */
 
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -25,9 +25,9 @@ import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import {
   useTimelineStore,
-  useTimelineStoreApi,
-  timelineTemporalOf
+  useTimelineStoreApi
 } from "../../../stores/timeline/TimelineStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   useTimelineUIStore,
   useTimelineUIStoreApi
@@ -315,20 +315,12 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
   // pointerdown started the gesture (not when another drag passes over it).
   const isResizingRef = useRef(false);
 
-  // Undo batching: record the pre-resize state with the first mutation, then
-  // pause history so the whole resize collapses into one undo entry.
   const timelineStoreApi = useTimelineStoreApi();
-  const historyPausedRef = useRef(false);
 
-  const resumeHistory = useCallback(() => {
-    if (historyPausedRef.current) {
-      historyPausedRef.current = false;
-      timelineTemporalOf(timelineStoreApi).resume();
-    }
-  }, [timelineStoreApi]);
-
-  // Safety net: never leave history paused if the header unmounts mid-resize.
-  useEffect(() => resumeHistory, [resumeHistory]);
+  // Undo batching: begin on pointerdown, mark() after each mutation (pauses
+  // history once the pre-resize state is checkpointed), end() on pointerup, so
+  // the whole resize collapses into one undo entry.
+  const history = useTimelineHistoryBatch();
 
   const handleResizePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
@@ -338,8 +330,9 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
       dragStartYRef.current = e.clientY;
       dragStartHeightRef.current = heightPx;
       isResizingRef.current = true;
+      history.begin();
     },
-    [heightPx]
+    [heightPx, history]
   );
 
   const handleResizePointerMove = useCallback(
@@ -353,19 +346,16 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
         Math.max(MIN_TRACK_HEIGHT_PX, dragStartHeightRef.current + deltaY)
       );
       setTrackHeight(track.id, newHeight);
-      // First mutation recorded the pre-resize state; batch the rest.
-      if (!historyPausedRef.current) {
-        timelineTemporalOf(timelineStoreApi).pause();
-        historyPausedRef.current = true;
-      }
+      // First effective mutation recorded the pre-resize state; batch the rest.
+      history.mark();
     },
-    [setTrackHeight, track.id, timelineStoreApi]
+    [setTrackHeight, track.id, history]
   );
 
   const handleResizePointerEnd = useCallback(() => {
     isResizingRef.current = false;
-    resumeHistory();
-  }, [resumeHistory]);
+    history.end();
+  }, [history]);
 
   const isAudioTrack = track.type === "audio";
   const supportsEffects =

--- a/web/src/stores/timeline/__tests__/historyBatching.test.ts
+++ b/web/src/stores/timeline/__tests__/historyBatching.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression: undo batching for clip/track pointer gestures
+ * (useTimelineHistoryBatch).
+ *
+ * A drag/trim/resize gesture must collapse into ONE undo entry whose single
+ * Ctrl+Z restores the exact pre-gesture state — even when the gesture's
+ * opening pointermoves are clamped no-ops (trimming past a boundary, dragging
+ * a clip already at 0, resizing a track at its min/max height). The earlier
+ * "pause right after the first mutation call" approach paused before any real
+ * mutation checkpointed the pre-gesture state, so one undo over-reverted
+ * (swallowing both the gesture and the action before it).
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useTimelineHistoryBatch } from "../useTimelineHistoryBatch";
+import { useTimelineStore, getTimelineTemporal } from "../TimelineInstance";
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+
+function seed() {
+  const track = makeTrack({ id: "v", type: "video" });
+  const clip = makeClip({
+    id: "a",
+    trackId: "v",
+    mediaType: "video",
+    startMs: 0,
+    durationMs: 1000,
+    inPointMs: 0,
+    outPointMs: 1000,
+    currentAssetId: "asset-1"
+  });
+  useTimelineStore.setState({ tracks: [track], clips: [clip], markers: [] });
+  getTimelineTemporal().clear();
+  return clip.id;
+}
+
+/** Drive one trim-start gesture exactly the way Clip.tsx wires the hook. */
+function runTrimStartGesture(
+  history: ReturnType<typeof useTimelineHistoryBatch>,
+  clipId: string,
+  deltasMs: number[]
+) {
+  history.begin();
+  for (const d of deltasMs) {
+    // Clip.tsx calls trimClipStart(clip.id, -deltaMs) then history.mark().
+    useTimelineStore.getState().trimClipStart(clipId, -d);
+    history.mark();
+  }
+  history.end();
+}
+
+describe("useTimelineHistoryBatch", () => {
+  it("a normal trim gesture collapses to one undo entry and reverts fully", () => {
+    const clipId = seed();
+    const { result } = renderHook(() => useTimelineHistoryBatch());
+
+    // Prior committed edit = an undo checkpoint behind the gesture.
+    useTimelineStore.getState().moveClip(clipId, 200);
+    const startBefore = useTimelineStore.getState().clips[0].startMs; // 200
+    const durBefore = useTimelineStore.getState().clips[0].durationMs; // 1000
+    const pastBefore = getTimelineTemporal().pastStates.length;
+
+    runTrimStartGesture(result.current, clipId, [10, 10, 10]);
+
+    // Whole gesture = exactly one new undo entry.
+    expect(getTimelineTemporal().pastStates.length).toBe(pastBefore + 1);
+    expect(useTimelineStore.getState().clips[0].durationMs).toBeLessThan(
+      durBefore
+    );
+
+    getTimelineTemporal().undo();
+    expect(useTimelineStore.getState().clips[0].startMs).toBe(startBefore);
+    expect(useTimelineStore.getState().clips[0].durationMs).toBe(durBefore);
+  });
+
+  it("reverts fully when the gesture's first move is a clamped no-op", () => {
+    const clipId = seed();
+    const { result } = renderHook(() => useTimelineHistoryBatch());
+
+    useTimelineStore.getState().moveClip(clipId, 200);
+    const startBefore = useTimelineStore.getState().clips[0].startMs; // 200
+    const durBefore = useTimelineStore.getState().clips[0].durationMs; // 1000
+    const pastBefore = getTimelineTemporal().pastStates.length;
+
+    // First move tries to EXTEND the start edge left past source start
+    // (inPointMs already 0 → trimClip throws → store no-ops), then valid
+    // shrink moves follow.
+    runTrimStartGesture(result.current, clipId, [-10, 10, 10, 10]);
+
+    expect(getTimelineTemporal().pastStates.length).toBe(pastBefore + 1);
+    expect(useTimelineStore.getState().clips[0].durationMs).toBeLessThan(
+      durBefore
+    );
+
+    // One undo restores the exact pre-trim clip — the preceding move survives.
+    getTimelineTemporal().undo();
+    expect(useTimelineStore.getState().clips[0].startMs).toBe(startBefore);
+    expect(useTimelineStore.getState().clips[0].durationMs).toBe(durBefore);
+  });
+
+  it("records no undo entry when the entire gesture is a no-op", () => {
+    const clipId = seed();
+    const { result } = renderHook(() => useTimelineHistoryBatch());
+
+    useTimelineStore.getState().moveClip(clipId, 200);
+    const pastBefore = getTimelineTemporal().pastStates.length;
+
+    // Every move is an invalid extend-left → all clamped no-ops.
+    runTrimStartGesture(result.current, clipId, [-5, -5, -5]);
+
+    expect(getTimelineTemporal().pastStates.length).toBe(pastBefore);
+  });
+});

--- a/web/src/stores/timeline/useTimelineHistoryBatch.ts
+++ b/web/src/stores/timeline/useTimelineHistoryBatch.ts
@@ -1,0 +1,75 @@
+/**
+ * useTimelineHistoryBatch
+ *
+ * Collapses a multi-mutation pointer gesture (clip drag, clip trim, track
+ * resize) into a SINGLE undo entry.
+ *
+ * The pattern: let the first store mutation that actually changes the document
+ * record the pre-gesture state (zundo pushes it onto the undo stack), then
+ * pause history tracking so the rest of the gesture records nothing, and
+ * resume on pointerup.
+ *
+ * Why gate the pause on the undo stack growing (rather than "pause after the
+ * first mutation call"): a gesture's opening pointermoves are often clamped
+ * no-ops — trimming past a clip/source boundary throws and the store returns
+ * its previous state, dragging a clip already at 0 clamps, resizing a track at
+ * its min/max height clamps. Those produce no undo entry. Pausing right after
+ * such a no-op would suppress the FIRST real mutation's checkpoint, so undo
+ * would over-revert (swallowing the gesture and the action before it). Tying
+ * the pause to a genuine increase in `pastStates.length` guarantees the
+ * pre-gesture state is always checkpointed before tracking is paused.
+ *
+ * Usage:
+ *   const history = useTimelineHistoryBatch();
+ *   // pointerdown (gesture start):   history.begin();
+ *   // after each store mutation:     history.mark();
+ *   // pointerup / pointercancel:     history.end();
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { useTimelineStoreApi, timelineTemporalOf } from "./TimelineStore";
+
+export interface TimelineHistoryBatch {
+  /** Start a gesture: snapshot the current undo-stack depth as the baseline. */
+  begin: () => void;
+  /** Call after every store mutation; pauses once a checkpoint was recorded. */
+  mark: () => void;
+  /** End the gesture: resume history tracking if it was paused. */
+  end: () => void;
+}
+
+export function useTimelineHistoryBatch(): TimelineHistoryBatch {
+  const api = useTimelineStoreApi();
+  const pausedRef = useRef(false);
+  const activeRef = useRef(false);
+  const baselineRef = useRef(0);
+
+  const begin = useCallback(() => {
+    activeRef.current = true;
+    baselineRef.current = timelineTemporalOf(api).pastStates.length;
+  }, [api]);
+
+  const mark = useCallback(() => {
+    if (
+      activeRef.current &&
+      !pausedRef.current &&
+      timelineTemporalOf(api).pastStates.length > baselineRef.current
+    ) {
+      timelineTemporalOf(api).pause();
+      pausedRef.current = true;
+    }
+  }, [api]);
+
+  const end = useCallback(() => {
+    activeRef.current = false;
+    if (pausedRef.current) {
+      pausedRef.current = false;
+      timelineTemporalOf(api).resume();
+    }
+  }, [api]);
+
+  // Safety net: never leave history paused if the owner unmounts mid-gesture.
+  useEffect(() => end, [end]);
+
+  return { begin, mark, end };
+}


### PR DESCRIPTION
## Summary

Fixes a regression in undo batching for timeline clip drag/trim and track resize gestures. Previously, gestures whose opening pointermoves were clamped no-ops (e.g., trimming past a boundary, dragging a clip already at position 0) would cause undo to over-revert, swallowing both the gesture and the preceding action.

## Root Cause

The old approach paused history tracking immediately after the first mutation *call*, but gestures often begin with clamped no-ops that produce no mutations. Pausing before any real mutation was checkpointed meant the pre-gesture state was never recorded, causing one undo to revert both the gesture and the prior action.

## Solution

Introduced `useTimelineHistoryBatch` hook that gates the pause on the undo stack actually growing (i.e., a genuine checkpoint being recorded), not on the first mutation call. This guarantees the pre-gesture state is always checkpointed before tracking is paused.

**Key changes:**

- **New hook** `useTimelineHistoryBatch()` in `web/src/stores/timeline/useTimelineHistoryBatch.ts`:
  - `begin()`: snapshot the current undo-stack depth as baseline
  - `mark()`: call after each store mutation; pauses history once `pastStates.length` exceeds baseline
  - `end()`: resume history tracking on gesture end
  - Includes safety net to resume if component unmounts mid-gesture

- **Updated `Clip.tsx`**:
  - Replaced manual `pauseHistoryAfterFirstMutation` / `resumeHistory` callbacks with `useTimelineHistoryBatch()`
  - Call `history.begin()` on pointerdown for drag/trim-start/trim-end gestures
  - Call `history.mark()` after each mutation (drag, trim)
  - Call `history.end()` on pointerup/pointercancel

- **Updated `TrackHeader.tsx`**:
  - Replaced manual history pause/resume logic with `useTimelineHistoryBatch()`
  - Same pattern: `begin()` on resize pointerdown, `mark()` on each height mutation, `end()` on pointerup

- **Added comprehensive test suite** in `web/src/stores/timeline/__tests__/historyBatching.test.ts`:
  - Verifies normal trim gesture collapses to one undo entry
  - Verifies full revert when gesture's first move is a clamped no-op
  - Verifies no undo entry recorded when entire gesture is a no-op

## Testing

All three test cases pass:
1. Normal gesture (multiple valid mutations) → one undo entry, full revert
2. Gesture starting with clamped no-op → one undo entry, full revert (prior action survives)
3. Entire gesture is no-ops → no undo entry recorded

https://claude.ai/code/session_01C53NEGrG8HEVugViYTm1Qy