### PR TITLE
Make @anthropic-ai/claude-agent-sdk an optional peer dependency

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -448,6 +448,13 @@ profile since it needs a local executable. Token usage is attributed to the
 concrete dated model the CLI resolves an alias to (captured from the
 `message_start` event) so cost maps onto Anthropic pricing.
 
+**Soft dependency.** `@anthropic-ai/claude-agent-sdk` is an *optional peer
+dependency* of `@nodetool-ai/runtime` — it is not installed by default and must
+be added with the package manager (`npm install @anthropic-ai/claude-agent-sdk`)
+before this provider can run. The package is imported lazily, so its absence
+only surfaces — as a clear install hint — when the provider is actually used;
+the rest of the runtime and the browser worker bundle never pull it in.
+
 ### Executable resolution & nested sessions
 
 The binary is resolved from `CLAUDE_CODE_EXECUTABLE` (explicit path) and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,6 +1568,7 @@
       "version": "0.3.190",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.190.tgz",
       "integrity": "sha512-d4morVtH9eBUsk5BXmhcX2tnEums/RwbM9LrhZB3VCDAYNiDTEW4IejY5o572//7/0qN111l6fmPr5b5cmrjsQ==",
+      "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -1595,6 +1596,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1608,6 +1610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1621,6 +1624,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1634,6 +1638,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1647,6 +1652,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1660,6 +1666,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1673,6 +1680,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1686,6 +1694,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -50797,7 +50806,6 @@
       "license": "MIT",
       "dependencies": {
         "@aki-io/aki-io": "^1.0.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.190",
         "@anthropic-ai/sdk": "^0.105.0",
         "@nodetool-ai/config": "*",
         "@nodetool-ai/protocol": "*",
@@ -50817,6 +50825,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.190",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "typescript": "^5.7.2",
@@ -50824,6 +50833,14 @@
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.190"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        }
       }
     },
     "packages/sandbox": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@aki-io/aki-io": "^1.0.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.190",
     "@anthropic-ai/sdk": "^0.105.0",
     "@nodetool-ai/config": "*",
     "@nodetool-ai/protocol": "*",
@@ -36,10 +35,19 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.190",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.190"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -9,6 +9,12 @@
  * under `~/.claude`). The SDK streams `SDKMessage`s, which we translate into the
  * cross-provider {@link ProviderStreamItem} stream.
  *
+ * `@anthropic-ai/claude-agent-sdk` is a *soft* (optional peer) dependency: it is
+ * not installed by default and must be added with the package manager before
+ * this provider can run. It is loaded lazily via {@link loadSdk}, so a missing
+ * package surfaces as a clear install hint only when the provider is actually
+ * used — the rest of the runtime, and the browser worker bundle, never need it.
+ *
  * It is a *pure LLM* provider: the agentic tool loop is collapsed to a single
  * turn with every built-in tool disabled (`allowedTools: []`), filesystem
  * settings/skills disabled (`settingSources: []`), permission prompts neutered
@@ -113,6 +119,28 @@ interface ClaudeAgentProviderOptions {
   createMcpServerFn?: ClaudeCreateMcpServerFn;
 }
 
+/**
+ * Lazily import the optional `@anthropic-ai/claude-agent-sdk`. The SDK is a soft
+ * (peer) dependency — it is not installed by default and must be added with the
+ * package manager (e.g. `npm install @anthropic-ai/claude-agent-sdk`) before the
+ * Claude Agent provider can be used. The specifier is held in a variable so
+ * bundlers (and tsc's emit) don't try to resolve the Node-only package at build
+ * time, and a missing package surfaces as a clear, actionable error at call time.
+ */
+async function loadSdk(): Promise<typeof import("@anthropic-ai/claude-agent-sdk")> {
+  const spec = "@anthropic-ai/claude-agent-sdk";
+  try {
+    return (await import(/* @vite-ignore */ spec)) as typeof import("@anthropic-ai/claude-agent-sdk");
+  } catch (err) {
+    throw new Error(
+      "The Claude Agent provider requires the optional " +
+        "'@anthropic-ai/claude-agent-sdk' package, which is not installed. " +
+        "Install it with `npm install @anthropic-ai/claude-agent-sdk`.",
+      { cause: err as Error }
+    );
+  }
+}
+
 export class ClaudeAgentProvider extends BaseProvider {
   static requiredSecrets(): string[] {
     // Auth lives in the SDK's own credential store (~/.claude), not in an env
@@ -170,21 +198,14 @@ export class ClaudeAgentProvider extends BaseProvider {
   /** Resolve the SDK `query`, lazily importing it off the Node-only package. */
   private async loadQuery(): Promise<ClaudeQueryFn> {
     if (this.injectedQueryFn) return this.injectedQueryFn;
-    try {
-      const mod = await import("@anthropic-ai/claude-agent-sdk");
-      return mod.query as unknown as ClaudeQueryFn;
-    } catch (err) {
-      throw new Error(
-        "ClaudeAgentProvider requires Node — @anthropic-ai/claude-agent-sdk " +
-          `could not be loaded: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
+    const mod = await loadSdk();
+    return mod.query as unknown as ClaudeQueryFn;
   }
 
   /** Resolve the SDK `createSdkMcpServer`, lazily importing the Node-only pkg. */
   private async loadCreateMcpServer(): Promise<ClaudeCreateMcpServerFn> {
     if (this.injectedCreateMcpServerFn) return this.injectedCreateMcpServerFn;
-    const mod = await import("@anthropic-ai/claude-agent-sdk");
+    const mod = await loadSdk();
     return mod.createSdkMcpServer as unknown as ClaudeCreateMcpServerFn;
   }
 

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -186,9 +186,10 @@ registerBuiltinProvider(PROVIDER_IDS.CODEX, CodexProvider, { CODEX_ACCESS_TOKEN:
 registerBuiltinProvider(PROVIDER_IDS.ANTHROPIC, AnthropicProvider, { ANTHROPIC_API_KEY: "" });
 // Claude Agent SDK: Claude via the logged-in `claude` CLI subscription (no API
 // key). Registered with no credential kwargs — auth lives in the CLI's own
-// store, so the provider is always "configured"; a missing CLI surfaces at call
-// time. Pruned from the cloud profile (not in CLOUD_PROVIDER_IDS) since it needs
-// a local executable and subscription.
+// store, so the provider is always "configured"; a missing CLI or a missing
+// optional `@anthropic-ai/claude-agent-sdk` package (a soft dependency the user
+// installs themselves) surfaces at call time. Pruned from the cloud profile
+// (not in CLOUD_PROVIDER_IDS) since it needs a local executable and subscription.
 registerBuiltinProvider(PROVIDER_IDS.CLAUDE_AGENT_SDK, ClaudeAgentProvider, {});
 registerBuiltinProvider(PROVIDER_IDS.GEMINI, GeminiProvider, { GEMINI_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.GROQ, GroqProvider, { GROQ_API_KEY: "" });


### PR DESCRIPTION
## Summary

Converts `@anthropic-ai/claude-agent-sdk` from a required dependency to an optional peer dependency. The package is now lazily loaded only when the Claude Agent provider is actually used, allowing the runtime and browser worker bundle to function without it installed.

## Key Changes

- **Moved package to peer dependencies**: Removed from `dependencies` in `package.json`, added to `peerDependencies` with `optional: true`, and moved to `devDependencies` for development/testing.
- **Extracted lazy loader function**: Created `loadSdk()` helper that dynamically imports the SDK with a clear, actionable error message if the package is missing. Uses a variable-held specifier to prevent bundlers from resolving the Node-only package at build time.
- **Updated SDK loading calls**: Refactored `loadQuery()` and `loadCreateMcpServer()` to use the new `loadSdk()` function, improving error messaging and centralizing the import logic.
- **Updated documentation**: Added JSDoc comments explaining the soft dependency model and updated `docs/AGENTS.md` and provider registration comments to clarify that the package must be installed separately before use.

## Implementation Details

- The `loadSdk()` function wraps the dynamic import in a try-catch, surfacing a clear install hint only when the provider is actually instantiated and used—not at bundle time or runtime startup.
- The specifier is held in a variable (`const spec = "@anthropic-ai/claude-agent-sdk"`) so bundlers and TypeScript don't attempt to resolve the Node-only package during the build.
- Error handling preserves the original error as a `cause` for debugging while providing user-friendly guidance.

https://claude.ai/code/session_017syVPLkQmEMhpjCfytzqPW