### PR TITLE
feat(timeline): overhaul generated-clip inspector and generation UX

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     "no-empty": ["error", { "allowEmptyCatch": true }],
     "prefer-const": "error",
+    "no-control-regex": "warn",
     "no-useless-assignment": "warn",
     "require-yield": "warn",
     "no-constant-binary-expression": "warn",

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -339,6 +339,10 @@ export interface TimelineClip {
   linkId?: string;
   width?: number;
   height?: number;
+  /** Direct-gen video: target aspect ratio, e.g. "16:9". */
+  aspectRatio?: string;
+  /** Direct-gen video: target resolution tier, e.g. "720p". */
+  resolution?: string;
   strength?: number;
   numInferenceSteps?: number;
   seed?: number;

--- a/web/src/components/sketch/SelectionActionBar.tsx
+++ b/web/src/components/sketch/SelectionActionBar.tsx
@@ -45,6 +45,7 @@ import type { ImageModelValue } from "../../stores/ApiTypes";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { useSketchStore } from "./state";
 import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
+import { getRememberedModel } from "../../stores/lastModelStore";
 import { useSketchCanvasRefStore } from "../../stores/sketch/SketchCanvasRefStore";
 import {
   useInpaintHere,
@@ -86,7 +87,12 @@ function seedModelFromBindings(): { model: string; provider: string } {
         b.kind === "inpaint"
     )
     .pop();
-  return { model: last?.model ?? "", provider: last?.provider ?? "" };
+  // Fall back to the cross-session remembered image model.
+  const remembered = getRememberedModel("image");
+  return {
+    model: last?.model ?? remembered?.model ?? "",
+    provider: last?.provider ?? remembered?.provider ?? ""
+  };
 }
 
 /** Document-space point → container CSS px (mirrors TransformGizmo.docToCss). */

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -407,7 +407,7 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
               <CollapsibleSection
                 className="sketch-editor__color-section"
                 title={<ColorSectionHeader />}
-                defaultOpen
+                defaultOpen={false}
                 compact
                 sx={{
                   fontSize: theme.fontSizeSmall,

--- a/web/src/components/sketch/SketchLayersPanel.tsx
+++ b/web/src/components/sketch/SketchLayersPanel.tsx
@@ -60,6 +60,7 @@ import {
 import LayerItem from "./LayerItem";
 import type { DropPosition } from "./LayerItem";
 import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
+import { getRememberedModel } from "../../stores/lastModelStore";
 import { useSketchStore } from "./state/useSketchStore";
 import HueTriangleColorPicker from "./HueTriangleColorPicker";
 import { getMergeSelectedLayersPlan } from "./layerMergeSelection";
@@ -510,12 +511,15 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
         kind === "image-to-image"
           ? layers.find((l) => l.id !== layerId)?.id ?? null
           : null;
+      // Fall back to the cross-session remembered image model so the first
+      // generated layer in a fresh document still preselects a model.
+      const remembered = getRememberedModel("image");
       upsertBinding({
         layerId,
         kind,
         prompt: "",
-        provider: lastDirectGen?.provider ?? "",
-        model: lastDirectGen?.model ?? "",
+        provider: lastDirectGen?.provider ?? remembered?.provider ?? "",
+        model: lastDirectGen?.model ?? remembered?.model ?? "",
         sourceLayerId,
         status: "draft",
         versions: []

--- a/web/src/components/timeline/Inspector/ClipActions.tsx
+++ b/web/src/components/timeline/Inspector/ClipActions.tsx
@@ -10,13 +10,10 @@ import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import ImageIcon from "@mui/icons-material/Image";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import StopIcon from "@mui/icons-material/Stop";
 import AutoAwesomeMotionIcon from "@mui/icons-material/AutoAwesomeMotion";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
-import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
 import { ToolbarIconButton, FlexRow, Text, Dialog, TextInput, Toast } from "../../ui_primitives";
 
 // ── Styles ─────────────────────────────────────────────────────────────────
@@ -27,14 +24,6 @@ const actionsRowStyles = (theme: Theme) =>
     gap: theme.spacing(0.5),
     flexWrap: "wrap",
     alignItems: "center"
-  });
-
-const sectionLabelStyles = (theme: Theme) =>
-  css({
-    fontSize: theme.fontSizeSmaller,
-    color: theme.vars.palette.text.secondary,
-    userSelect: "none",
-    paddingRight: theme.spacing(0.5)
   });
 
 // ── Component ──────────────────────────────────────────────────────────────
@@ -59,13 +48,10 @@ export const ClipActions: React.FC<ClipActionsProps> = memo(
     const selectClip = useTimelineUIStore((s) => s.selectClip);
     const setClipLocked = useTimelineStore((s) => s.setClipLocked);
     const replaceClipOutput = useTimelineStore((s) => s.replaceClipOutput);
-    const { generateClip, cancelClipGeneration, isActive, isGenerating } =
-      useGenerateClip(clipId);
 
     const duplicateBusyRef = useRef(false);
     const [duplicateBusy, setDuplicateBusy] = useState(false);
     const [duplicateError, setDuplicateError] = useState<string | null>(null);
-    const [generationError, setGenerationError] = useState<string | null>(null);
     const [replaceOpen, setReplaceOpen] = useState(false);
     const [assetIdInput, setAssetIdInput] = useState("");
 
@@ -131,28 +117,6 @@ export const ClipActions: React.FC<ClipActionsProps> = memo(
       setReplaceOpen(false);
     }, []);
 
-    // ── Generate / Cancel ───────────────────────────────────────────────────
-
-    const handleGenerate = useCallback(async () => {
-      try {
-        await generateClip();
-      } catch (err) {
-        setGenerationError(
-          err instanceof Error ? err.message : "Failed to start clip generation"
-        );
-      }
-    }, [generateClip]);
-
-    const handleCancelGeneration = useCallback(async () => {
-      try {
-        await cancelClipGeneration();
-      } catch (err) {
-        setGenerationError(
-          err instanceof Error ? err.message : "Failed to cancel generation"
-        );
-      }
-    }, [cancelClipGeneration]);
-
     // ── Open in Node Editor ────────────────────────────────────────────────
 
     const handleOpenInNodeEditor = useCallback(() => {
@@ -171,28 +135,8 @@ export const ClipActions: React.FC<ClipActionsProps> = memo(
     return (
       <>
         <FlexRow css={actionsRowStyles(theme)}>
-          <span css={sectionLabelStyles(theme)}>Clip</span>
-
-          <ToolbarIconButton
-            icon={
-              isActive ? (
-                <StopIcon fontSize="small" />
-              ) : (
-                <PlayArrowIcon fontSize="small" />
-              )
-            }
-            tooltip={
-              isActive
-                ? "Cancel generation"
-                : "Generate clip from the bound workflow and overrides"
-            }
-            onClick={isActive ? () => void handleCancelGeneration() : () => void handleGenerate()}
-            active={isGenerating}
-            aria-label={isActive ? "Cancel clip generation" : "Generate clip"}
-            disabled={!clip.workflowId}
-            data-testid="clip-action-generate"
-          />
-
+          {/* Generation has its own primary button in the prompt / inputs
+              panel; this toolbar is for clip operations only. */}
           <ToolbarIconButton
             icon={<ContentCopyIcon fontSize="small" />}
             tooltip="Duplicate — copies overrides; tweak params for a variation"
@@ -280,15 +224,6 @@ export const ClipActions: React.FC<ClipActionsProps> = memo(
           message={duplicateError ?? ""}
           severity="error"
           onClose={() => setDuplicateError(null)}
-          vertical="top"
-          horizontal="center"
-        />
-
-        <Toast
-          open={generationError !== null}
-          message={generationError ?? ""}
-          severity="error"
-          onClose={() => setGenerationError(null)}
           vertical="top"
           horizontal="center"
         />

--- a/web/src/components/timeline/Inspector/ClipAdjustments.tsx
+++ b/web/src/components/timeline/Inspector/ClipAdjustments.tsx
@@ -1,0 +1,642 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ClipAdjustments
+ *
+ * The visual / playback adjustment sections shared by every clip inspector,
+ * imported and generated alike: Render (opacity / blend, or audio volume +
+ * fades), Transform, Color, Blur, and Transition. These all operate on plain
+ * `TimelineClip` fields (`opacity`, `transform`, `effects`, `transitionIn`)
+ * that the compositor applies regardless of how the clip was produced, so a
+ * generated clip can be colour-graded and transformed exactly like an imported
+ * one.
+ *
+ * Section fold state is persisted (shared keys with the rest of the inspector)
+ * so a panel stays open/closed across selections.
+ */
+
+import React, { memo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import WbSunnyOutlinedIcon from "@mui/icons-material/WbSunnyOutlined";
+import BlurOnOutlinedIcon from "@mui/icons-material/BlurOnOutlined";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import OpenWithOutlinedIcon from "@mui/icons-material/OpenWithOutlined";
+import CompareArrowsOutlinedIcon from "@mui/icons-material/CompareArrowsOutlined";
+
+import type {
+  BlendMode,
+  ClipBlurEffect,
+  ClipColorEffect,
+  ClipEffect,
+  ClipTransform,
+  ClipTransition,
+  TimelineClip
+} from "@nodetool-ai/timeline";
+import { BLEND_MODES } from "@nodetool-ai/gpu";
+
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  CollapsibleSection,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  NodeSelect,
+  NodeMenuItem,
+  Text
+} from "../../ui_primitives";
+import { usePersistedFold } from "./usePersistedFold";
+import {
+  InspectorDivider,
+  InspectorPillInput,
+  InspectorRow,
+  InspectorSectionTitle,
+  InspectorSliderRow,
+  InspectorToggleRow
+} from "./InspectorPrimitives";
+import { parseSeconds } from "./InspectorPrimitives.helpers";
+
+// ── Effect IDs ─────────────────────────────────────────────────────────────
+
+/** Stable IDs so the inspector-owned effects round-trip in `clip.effects`. */
+const COLOR_EFFECT_ID = "inspector:color";
+const BLUR_EFFECT_ID = "inspector:blur";
+
+const IDENTITY_TRANSFORM: ClipTransform = {
+  position: { x: 0, y: 0 },
+  scale: { x: 1, y: 1 },
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 }
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+function findColorEffect(clip: TimelineClip): ClipColorEffect | undefined {
+  return clip.effects?.find(
+    (e): e is ClipColorEffect => e.type === "color" && e.id === COLOR_EFFECT_ID
+  );
+}
+function findBlurEffect(clip: TimelineClip): ClipBlurEffect | undefined {
+  return clip.effects?.find(
+    (e): e is ClipBlurEffect => e.type === "blur" && e.id === BLUR_EFFECT_ID
+  );
+}
+function upsertEffect(
+  effects: ClipEffect[] | undefined,
+  next: ClipEffect
+): ClipEffect[] {
+  const existing = effects ?? [];
+  const idx = existing.findIndex((e) => e.id === next.id);
+  if (idx >= 0) {
+    const out = [...existing];
+    out[idx] = next;
+    return out;
+  }
+  return [...existing, next];
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const sectionContentStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    padding: theme.spacing(1, 0, 3)
+  });
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export interface ClipAdjustmentsProps {
+  clip: TimelineClip;
+}
+
+/**
+ * Render / Transform / Color / Blur / Transition sections for a single clip.
+ * Leads with an {@link InspectorDivider}; the caller supplies the trailing one.
+ */
+export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
+  ({ clip }) => {
+    const theme = useTheme();
+    const patchClip = useTimelineStore((s) => s.patchClip);
+
+    const [renderOpen, setRenderOpen] = usePersistedFold("render");
+    const [transformOpen, setTransformOpen] = usePersistedFold("transform");
+    const [colorOpen, setColorOpen] = usePersistedFold("color");
+    const [blurOpen, setBlurOpen] = usePersistedFold("blur");
+    const [transitionOpen, setTransitionOpen] = usePersistedFold("transition");
+
+    const isAudio = clip.mediaType === "audio";
+    const isOverlay = clip.mediaType === "overlay";
+
+    const onPatchNumber = (
+      field: string,
+      raw: string,
+      min?: number,
+      max?: number
+    ) => {
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed)) return;
+      const value =
+        min != null && max != null ? clamp(parsed, min, max) : parsed;
+      patchClip(clip.id, { [field]: value });
+    };
+
+    return (
+      <>
+        <InspectorDivider />
+        <CollapsibleSection
+          title={
+            <InspectorSectionTitle
+              title="Render"
+              icon={<LayersOutlinedIcon />}
+            />
+          }
+          open={renderOpen}
+          onToggle={setRenderOpen}
+        >
+          <FlexColumn css={sectionContentStyles(theme)}>
+            {!isAudio && (
+              <InspectorSliderRow
+                label="Opacity"
+                min={0}
+                max={1}
+                step={0.01}
+                value={clip.opacity ?? 1}
+                display={`${Math.round((clip.opacity ?? 1) * 100)}%`}
+                onChange={(value) => patchClip(clip.id, { opacity: value })}
+              />
+            )}
+            {isOverlay && !isAudio && (
+              <InspectorRow label="Blend">
+                <NodeSelect
+                  value={clip.blendMode ?? "normal"}
+                  onChange={(e) =>
+                    patchClip(clip.id, {
+                      blendMode: e.target.value as BlendMode
+                    })
+                  }
+                >
+                  {BLEND_MODES.map((mode) => (
+                    <NodeMenuItem key={mode.value} value={mode.value}>
+                      {mode.label}
+                    </NodeMenuItem>
+                  ))}
+                </NodeSelect>
+              </InspectorRow>
+            )}
+            {isAudio && (
+              <>
+                <InspectorRow label="Volume">
+                  <InspectorPillInput
+                    value={(clip.volumeDb ?? 0).toFixed(1)}
+                    unit="dB"
+                    onCommit={(raw) => onPatchNumber("volumeDb", raw, -60, 12)}
+                    ariaLabel="Volume (dB)"
+                  />
+                </InspectorRow>
+                <InspectorRow label="Fade in">
+                  <InspectorPillInput
+                    value={((clip.fadeInMs ?? 0) / 1000).toFixed(2)}
+                    unit="s"
+                    onCommit={(raw) => {
+                      const ms = parseSeconds(raw);
+                      if (ms == null) return;
+                      onPatchNumber(
+                        "fadeInMs",
+                        String(ms),
+                        0,
+                        Math.floor(clip.durationMs / 2)
+                      );
+                    }}
+                    ariaLabel="Fade in (seconds)"
+                  />
+                </InspectorRow>
+                <InspectorRow label="Fade out">
+                  <InspectorPillInput
+                    value={((clip.fadeOutMs ?? 0) / 1000).toFixed(2)}
+                    unit="s"
+                    onCommit={(raw) => {
+                      const ms = parseSeconds(raw);
+                      if (ms == null) return;
+                      onPatchNumber(
+                        "fadeOutMs",
+                        String(ms),
+                        0,
+                        Math.floor(clip.durationMs / 2)
+                      );
+                    }}
+                    ariaLabel="Fade out (seconds)"
+                  />
+                </InspectorRow>
+              </>
+            )}
+          </FlexColumn>
+        </CollapsibleSection>
+
+        {!isAudio && (
+          <>
+            <InspectorDivider />
+            <CollapsibleSection
+              title={
+                <InspectorSectionTitle
+                  title="Transform"
+                  icon={<OpenWithOutlinedIcon />}
+                />
+              }
+              open={transformOpen}
+              onToggle={setTransformOpen}
+            >
+              <FlexColumn css={sectionContentStyles(theme)}>
+                {(() => {
+                  const t = clip.transform ?? IDENTITY_TRANSFORM;
+                  const setTransform = (next: ClipTransform) =>
+                    patchClip(clip.id, { transform: next });
+                  const setPos = (axis: "x" | "y", v: number) =>
+                    setTransform({
+                      ...t,
+                      position: { ...t.position, [axis]: v }
+                    });
+                  const setScale = (axis: "x" | "y", v: number) =>
+                    setTransform({
+                      ...t,
+                      scale: { ...t.scale, [axis]: v }
+                    });
+                  const setAnchor = (axis: "x" | "y", v: number) =>
+                    setTransform({
+                      ...t,
+                      anchor: { ...t.anchor, [axis]: v }
+                    });
+                  const setRotationDeg = (deg: number) =>
+                    setTransform({ ...t, rotation: (deg * Math.PI) / 180 });
+                  return (
+                    <>
+                      <InspectorRow label="Position">
+                        <InspectorPillInput
+                          value={t.position.x.toFixed(0)}
+                          unit="px"
+                          minWidth={72}
+                          onCommit={(raw) => {
+                            const n = Number(raw);
+                            if (Number.isFinite(n)) setPos("x", n);
+                          }}
+                          ariaLabel="Position X"
+                        />
+                        <InspectorPillInput
+                          value={t.position.y.toFixed(0)}
+                          unit="px"
+                          minWidth={72}
+                          onCommit={(raw) => {
+                            const n = Number(raw);
+                            if (Number.isFinite(n)) setPos("y", n);
+                          }}
+                          ariaLabel="Position Y"
+                        />
+                      </InspectorRow>
+                      <InspectorRow label="Scale">
+                        <InspectorPillInput
+                          value={t.scale.x.toFixed(2)}
+                          unit="×"
+                          minWidth={72}
+                          onCommit={(raw) => {
+                            const n = Number(raw);
+                            if (Number.isFinite(n)) setScale("x", n);
+                          }}
+                          ariaLabel="Scale X"
+                        />
+                        <InspectorPillInput
+                          value={t.scale.y.toFixed(2)}
+                          unit="×"
+                          minWidth={72}
+                          onCommit={(raw) => {
+                            const n = Number(raw);
+                            if (Number.isFinite(n)) setScale("y", n);
+                          }}
+                          ariaLabel="Scale Y"
+                        />
+                      </InspectorRow>
+                      <InspectorRow label="Rotation">
+                        <InspectorPillInput
+                          value={((t.rotation * 180) / Math.PI).toFixed(1)}
+                          unit="°"
+                          onCommit={(raw) => {
+                            const n = Number(raw);
+                            if (Number.isFinite(n)) setRotationDeg(n);
+                          }}
+                          ariaLabel="Rotation in degrees"
+                        />
+                      </InspectorRow>
+                      <InspectorSliderRow
+                        label="Anchor X"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={t.anchor.x}
+                        origin={0.5}
+                        display={t.anchor.x.toFixed(2)}
+                        onChange={(value) => setAnchor("x", value)}
+                      />
+                      <InspectorSliderRow
+                        label="Anchor Y"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={t.anchor.y}
+                        origin={0.5}
+                        display={t.anchor.y.toFixed(2)}
+                        onChange={(value) => setAnchor("y", value)}
+                      />
+                      <InspectorSliderRow
+                        label="Radius"
+                        min={0}
+                        max={500}
+                        step={1}
+                        value={clip.borderRadius ?? 0}
+                        display={`${(clip.borderRadius ?? 0).toFixed(0)}px`}
+                        onChange={(value) =>
+                          patchClip(clip.id, { borderRadius: value })
+                        }
+                      />
+                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                        <EditorButton
+                          size="small"
+                          onClick={() =>
+                            patchClip(clip.id, {
+                              transform: undefined,
+                              borderRadius: undefined
+                            })
+                          }
+                        >
+                          Reset transform
+                        </EditorButton>
+                      </FlexRow>
+                    </>
+                  );
+                })()}
+              </FlexColumn>
+            </CollapsibleSection>
+          </>
+        )}
+
+        {!isAudio && (
+          <>
+            <InspectorDivider />
+            <CollapsibleSection
+              title={
+                <InspectorSectionTitle
+                  title="Color"
+                  icon={<WbSunnyOutlinedIcon />}
+                />
+              }
+              open={colorOpen}
+              onToggle={setColorOpen}
+            >
+              <FlexColumn css={sectionContentStyles(theme)}>
+                {(() => {
+                  const color = findColorEffect(clip);
+                  const enabled = color?.enabled ?? false;
+                  const update = (patch: Partial<ClipColorEffect>): void => {
+                    const next: ClipColorEffect = {
+                      id: COLOR_EFFECT_ID,
+                      type: "color",
+                      enabled,
+                      brightness: color?.brightness,
+                      contrast: color?.contrast,
+                      saturation: color?.saturation,
+                      hue: color?.hue,
+                      temperature: color?.temperature,
+                      tint: color?.tint,
+                      shadows: color?.shadows,
+                      highlights: color?.highlights,
+                      ...patch
+                    };
+                    patchClip(clip.id, {
+                      effects: upsertEffect(clip.effects, next)
+                    });
+                  };
+                  const slider = (
+                    label: string,
+                    key: keyof Omit<
+                      ClipColorEffect,
+                      "id" | "type" | "enabled"
+                    >,
+                    min: number,
+                    max: number,
+                    step: number,
+                    defaultV: number,
+                    format: (v: number) => string = (v) => v.toFixed(2)
+                  ) => {
+                    const v = color?.[key] ?? defaultV;
+                    return (
+                      <InspectorSliderRow
+                        label={label}
+                        min={min}
+                        max={max}
+                        step={step}
+                        value={v}
+                        origin={defaultV}
+                        display={format(v)}
+                        disabled={!enabled}
+                        onChange={(value) =>
+                          update({ [key]: value } as Partial<ClipColorEffect>)
+                        }
+                      />
+                    );
+                  };
+                  return (
+                    <>
+                      <InspectorToggleRow
+                        label="Enabled"
+                        checked={enabled}
+                        onChange={(next) => update({ enabled: next })}
+                      />
+                      {slider("Brightness", "brightness", -1, 1, 0.01, 0)}
+                      {slider("Contrast", "contrast", 0, 4, 0.01, 1)}
+                      {slider("Saturation", "saturation", 0, 4, 0.01, 1)}
+                      {slider("Hue", "hue", -180, 180, 1, 0, (v) =>
+                        `${v.toFixed(0)}°`
+                      )}
+                      {slider("Temperature", "temperature", -1, 1, 0.01, 0)}
+                      {slider("Tint", "tint", -1, 1, 0.01, 0)}
+                      {slider("Shadows", "shadows", -1, 1, 0.01, 0)}
+                      {slider("Highlights", "highlights", -1, 1, 0.01, 0)}
+                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                        <EditorButton
+                          size="small"
+                          disabled={!color}
+                          onClick={() =>
+                            patchClip(clip.id, {
+                              effects: clip.effects?.filter(
+                                (e) => e.id !== COLOR_EFFECT_ID
+                              )
+                            })
+                          }
+                        >
+                          Clear color
+                        </EditorButton>
+                      </FlexRow>
+                    </>
+                  );
+                })()}
+              </FlexColumn>
+            </CollapsibleSection>
+          </>
+        )}
+
+        {!isAudio && (
+          <>
+            <InspectorDivider />
+            <CollapsibleSection
+              title={
+                <InspectorSectionTitle
+                  title="Blur"
+                  icon={<BlurOnOutlinedIcon />}
+                />
+              }
+              open={blurOpen}
+              onToggle={setBlurOpen}
+            >
+              <FlexColumn css={sectionContentStyles(theme)}>
+                {(() => {
+                  const blur = findBlurEffect(clip);
+                  const enabled = blur?.enabled ?? false;
+                  const radius = blur?.radius ?? 0;
+                  const updateBlur = (patch: Partial<ClipBlurEffect>) => {
+                    const next: ClipBlurEffect = {
+                      id: BLUR_EFFECT_ID,
+                      type: "blur",
+                      enabled,
+                      radius,
+                      sigma: blur?.sigma,
+                      ...patch
+                    };
+                    patchClip(clip.id, {
+                      effects: upsertEffect(clip.effects, next)
+                    });
+                  };
+                  return (
+                    <>
+                      <InspectorToggleRow
+                        label="Enabled"
+                        checked={enabled}
+                        onChange={(next) => updateBlur({ enabled: next })}
+                      />
+                      <InspectorSliderRow
+                        label="Radius"
+                        min={0}
+                        max={20}
+                        step={0.5}
+                        value={radius}
+                        display={`${radius.toFixed(0)}px`}
+                        disabled={!enabled}
+                        onChange={(value) => updateBlur({ radius: value })}
+                      />
+                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                        <EditorButton
+                          size="small"
+                          disabled={!blur}
+                          onClick={() =>
+                            patchClip(clip.id, {
+                              effects: clip.effects?.filter(
+                                (e) => e.id !== BLUR_EFFECT_ID
+                              )
+                            })
+                          }
+                        >
+                          Clear blur
+                        </EditorButton>
+                      </FlexRow>
+                    </>
+                  );
+                })()}
+              </FlexColumn>
+            </CollapsibleSection>
+          </>
+        )}
+
+        {!isAudio && (
+          <>
+            <InspectorDivider />
+            <CollapsibleSection
+              title={
+                <InspectorSectionTitle
+                  title="Transition"
+                  icon={<CompareArrowsOutlinedIcon />}
+                />
+              }
+              open={transitionOpen}
+              onToggle={setTransitionOpen}
+            >
+              <FlexColumn css={sectionContentStyles(theme)}>
+                {(() => {
+                  const t = clip.transitionIn;
+                  const type: "none" | "crossfade" = t?.type ?? "none";
+                  const duration = t?.durationMs ?? 500;
+                  const setType = (next: "none" | "crossfade") => {
+                    if (next === "none") {
+                      patchClip(clip.id, { transitionIn: undefined });
+                    } else {
+                      const transition: ClipTransition = {
+                        type: "crossfade",
+                        durationMs: duration
+                      };
+                      patchClip(clip.id, { transitionIn: transition });
+                    }
+                  };
+                  return (
+                    <>
+                      <InspectorRow label="Type">
+                        <NodeSelect
+                          value={type}
+                          onChange={(e) =>
+                            setType(e.target.value as "none" | "crossfade")
+                          }
+                        >
+                          <NodeMenuItem value="none">None</NodeMenuItem>
+                          <NodeMenuItem value="crossfade">
+                            Crossfade
+                          </NodeMenuItem>
+                        </NodeSelect>
+                      </InspectorRow>
+                      {type === "crossfade" && (
+                        <>
+                          <InspectorRow label="Duration">
+                            <InspectorPillInput
+                              value={(duration / 1000).toFixed(2)}
+                              unit="s"
+                              onCommit={(raw) => {
+                                const ms = parseSeconds(raw);
+                                if (ms == null) return;
+                                patchClip(clip.id, {
+                                  transitionIn: {
+                                    type: "crossfade",
+                                    durationMs: Math.max(0, ms)
+                                  }
+                                });
+                              }}
+                              ariaLabel="Transition duration"
+                            />
+                          </InspectorRow>
+                          <Text
+                            size="small"
+                            sx={{ px: 0.5, color: "text.secondary" }}
+                          >
+                            Overlap with the previous clip on the same track to
+                            see the cross-fade.
+                          </Text>
+                        </>
+                      )}
+                    </>
+                  );
+                })()}
+              </FlexColumn>
+            </CollapsibleSection>
+          </>
+        )}
+      </>
+    );
+  }
+);
+
+ClipAdjustments.displayName = "ClipAdjustments";

--- a/web/src/components/timeline/Inspector/ClipVersionHistory.tsx
+++ b/web/src/components/timeline/Inspector/ClipVersionHistory.tsx
@@ -1,0 +1,253 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ClipVersionHistory
+ *
+ * Generation history for a generated clip: a strip of thumbnails, one per
+ * successful generation (newest first), with the active one ringed. Clicking a
+ * tile swaps the clip back to that generation via `restoreVersion` (which
+ * restores its asset and the param snapshot it was made with). Both generation
+ * paths append a `ClipVersion` on success, so this works for direct-gen and
+ * workflow-bound clips alike.
+ */
+
+import React, { memo, useCallback, useEffect, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import CheckIcon from "@mui/icons-material/Check";
+import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
+
+import type { ClipVersion, TimelineClip } from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useAssetStore } from "../../../stores/AssetStore";
+import { getAssetUrl } from "../../../utils/assetHelpers";
+import { relativeTime } from "../../../utils/formatDateAndTime";
+import {
+  Caption,
+  CollapsibleSection,
+  Tooltip,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../../ui_primitives";
+import { InspectorSectionTitle } from "./InspectorPrimitives";
+
+const TILE_PX = 56;
+
+const stripStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    gap: getSpacingPx(SPACING.sm),
+    padding: theme.spacing(1),
+    overflowX: "auto",
+    overflowY: "hidden",
+    // Keep the scrollbar quiet on the dark panel.
+    scrollbarWidth: "thin"
+  });
+
+const tileStyles = (theme: Theme, active: boolean, interactive: boolean) =>
+  css({
+    position: "relative",
+    flex: "0 0 auto",
+    width: TILE_PX,
+    height: TILE_PX,
+    padding: 0,
+    borderRadius: BORDER_RADIUS.sm,
+    overflow: "hidden",
+    backgroundColor: theme.vars.palette.background.default,
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    border: `1px solid ${
+      active ? theme.vars.palette.primary.main : theme.vars.palette.divider
+    }`,
+    boxShadow: active
+      ? `0 0 0 1px ${theme.vars.palette.primary.main}`
+      : "none",
+    cursor: interactive ? "pointer" : "default",
+    transition: `${MOTION.border}, ${MOTION.shadow}`,
+    outline: "none",
+    "&:hover": interactive
+      ? { borderColor: theme.vars.palette.primary.main }
+      : undefined,
+    "&:focus-visible": {
+      borderColor: theme.vars.palette.primary.main,
+      boxShadow: `0 0 0 2px ${theme.vars.palette.primary.main}`
+    }
+  });
+
+const tileMediaStyles = css({
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  display: "block"
+});
+
+const iconTileStyles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: theme.vars.palette.text.disabled
+  });
+
+const activeBadgeStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    top: 2,
+    right: 2,
+    width: 14,
+    height: 14,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: theme.vars.palette.primary.main,
+    color: theme.vars.palette.primary.contrastText,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center"
+  });
+
+interface VersionTileProps {
+  version: ClipVersion;
+  active: boolean;
+  index: number;
+  total: number;
+  mediaType: TimelineClip["mediaType"];
+  interactive: boolean;
+  onSelect: (versionId: string) => void;
+}
+
+const VersionTile: React.FC<VersionTileProps> = memo(
+  ({ version, active, index, total, mediaType, interactive, onSelect }) => {
+    const theme = useTheme();
+    const getAsset = useAssetStore((s) => s.get);
+    const [url, setUrl] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+      let cancelled = false;
+      getAsset(version.assetId)
+        .then((asset) => {
+          if (!cancelled) setUrl(getAssetUrl(asset) ?? undefined);
+        })
+        .catch(() => {
+          // Asset unavailable — tile falls back to the media-type icon.
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [version.assetId, getAsset]);
+
+    // Newest first → label by recency ("Latest", then "2 ago", "3 ago"…).
+    const ordinal = index === 0 ? "Latest" : `#${total - index}`;
+    const when = relativeTime(version.createdAt);
+    const tooltip = active ? `Current · ${when}` : `${ordinal} · ${when}`;
+
+    const isImage = mediaType === "image" || mediaType === "overlay";
+    const isVideo = mediaType === "video";
+    const isAudio = mediaType === "audio";
+
+    const handleClick = useCallback(() => {
+      if (interactive && !active) onSelect(version.id);
+    }, [interactive, active, onSelect, version.id]);
+
+    return (
+      <Tooltip title={tooltip}>
+        <button
+          type="button"
+          css={tileStyles(theme, active, interactive)}
+          style={isImage && url ? { backgroundImage: `url(${url})` } : undefined}
+          onClick={handleClick}
+          aria-label={`${tooltip} — swap to this generation`}
+          aria-current={active}
+          disabled={!interactive}
+        >
+          {isVideo && url && (
+            <video
+              css={tileMediaStyles}
+              src={`${url}#t=0.1`}
+              muted
+              playsInline
+              preload="metadata"
+            />
+          )}
+          {isAudio && (
+            <span css={iconTileStyles(theme)}>
+              <GraphicEqIcon fontSize="small" />
+            </span>
+          )}
+          {active && (
+            <span css={activeBadgeStyles(theme)} aria-hidden>
+              <CheckIcon sx={{ fontSize: 10 }} />
+            </span>
+          )}
+        </button>
+      </Tooltip>
+    );
+  }
+);
+VersionTile.displayName = "VersionTile";
+
+export interface ClipVersionHistoryProps {
+  clipId: string;
+}
+
+export const ClipVersionHistory: React.FC<ClipVersionHistoryProps> = memo(
+  ({ clipId }) => {
+    const theme = useTheme();
+    const clip = useTimelineStore((s) => s.clips.find((c) => c.id === clipId));
+    const restoreVersion = useTimelineStore((s) => s.restoreVersion);
+
+    const handleSelect = useCallback(
+      (versionId: string) => restoreVersion(clipId, versionId),
+      [restoreVersion, clipId]
+    );
+
+    if (!clip) return null;
+
+    // Only successful generations carry a usable asset to swap to. Newest first.
+    const successVersions = (clip.versions ?? [])
+      .filter((v) => v.status === "success")
+      .slice()
+      .reverse();
+
+    if (successVersions.length === 0) return null;
+
+    const interactive = !clip.locked;
+
+    return (
+      <CollapsibleSection
+        title={
+          <InspectorSectionTitle
+            title={`History (${successVersions.length})`}
+            icon={<HistoryOutlinedIcon />}
+          />
+        }
+        defaultOpen
+      >
+        {clip.locked && (
+          <Caption color="secondary" sx={{ px: 1, pt: 0.5 }}>
+            Unlock the clip to swap generations.
+          </Caption>
+        )}
+        <div css={stripStyles(theme)}>
+          {successVersions.map((version, index) => (
+            <VersionTile
+              key={version.id}
+              version={version}
+              active={version.assetId === clip.currentAssetId}
+              index={index}
+              total={successVersions.length}
+              mediaType={clip.mediaType}
+              interactive={interactive}
+              onSelect={handleSelect}
+            />
+          ))}
+        </div>
+      </CollapsibleSection>
+    );
+  }
+);
+
+ClipVersionHistory.displayName = "ClipVersionHistory";

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -27,6 +27,9 @@ import type {
   ImageModelValue,
   TTSModelValue
 } from "../../../stores/ApiTypes";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import StopRoundedIcon from "@mui/icons-material/StopRounded";
+
 import {
   Caption,
   CollapsibleSection,
@@ -35,11 +38,12 @@ import {
   FlexRow,
   Panel,
   SelectField,
-  Text,
   TextInput
 } from "../../ui_primitives";
-import { GeneratedClipHeader } from "./GeneratedClipHeader";
-import { ClipActions } from "./ClipActions";
+import { GeneratedClipTopBar } from "./GeneratedClipTopBar";
+import { InspectorSectionTitle } from "./InspectorPrimitives";
+import { ClipAdjustments } from "./ClipAdjustments";
+import { ClipVersionHistory } from "./ClipVersionHistory";
 
 interface VideoModelChange {
   type: "video_model";
@@ -83,7 +87,8 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     generateClip,
     cancelClipGeneration,
     isActive,
-    isFailed
+    isFailed,
+    canGenerate
   } = useGenerateClip(clipId);
 
   const kind: "image" | "video" | "audio" =
@@ -179,13 +184,6 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     return null;
   }
 
-  const canGenerate =
-    !!clip.provider &&
-    !!clip.model &&
-    (clip.prompt ?? "").trim().length > 0 &&
-    (!isImageToImage || !!clip.sourceClipId) &&
-    (kind !== "audio" || !!clip.voice);
-
   const promptPlaceholder =
     kind === "video"
       ? "Describe the video…"
@@ -198,9 +196,17 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   return (
     <Panel sx={panelSx}>
       <FlexColumn gap={0}>
-        <GeneratedClipHeader clip={clip} />
+        <GeneratedClipTopBar clip={clip} />
 
-        <CollapsibleSection title="Prompt" defaultOpen>
+        <CollapsibleSection
+          title={
+            <InspectorSectionTitle
+              title="Prompt"
+              icon={<AutoAwesomeOutlinedIcon />}
+            />
+          }
+          defaultOpen
+        >
           <FlexColumn gap={1} css={sectionStyles(theme)}>
             {kind === "image" && (
               <FlexRow gap={0.5}>
@@ -262,7 +268,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
               onChange={handlePromptChange}
               placeholder={promptPlaceholder}
               multiline
-              minRows={3}
+              minRows={2}
               maxRows={10}
               compact
               fullWidth
@@ -288,32 +294,30 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
               )
             )}
 
-            <FlexRow gap={1} align="center" justify="space-between">
-              <EditorButton
-                size="small"
-                variant={isActive ? "outlined" : "contained"}
-                color={isActive ? "warning" : "primary"}
-                disabled={!isActive && !canGenerate}
-                onClick={handleGenerateClick}
-                data-testid="direct-gen-generate"
-              >
-                {isActive ? "Cancel" : generateLabel}
-              </EditorButton>
-              {isFailed && (
-                <Text
-                  size="small"
-                  sx={{ color: theme.vars.palette.error.main }}
-                >
-                  Generation failed.
-                </Text>
-              )}
-            </FlexRow>
+            <EditorButton
+              fullWidth
+              variant={isActive ? "outlined" : "contained"}
+              color={isActive ? "warning" : "primary"}
+              startIcon={
+                isActive ? <StopRoundedIcon /> : <AutoAwesomeOutlinedIcon />
+              }
+              disabled={!isActive && !canGenerate}
+              onClick={handleGenerateClick}
+              data-testid="direct-gen-generate"
+            >
+              {isActive ? "Cancel" : generateLabel}
+            </EditorButton>
+            {isFailed && (
+              <Caption sx={{ color: "error.main", textAlign: "center" }}>
+                Generation failed.
+              </Caption>
+            )}
           </FlexColumn>
         </CollapsibleSection>
 
-        <CollapsibleSection title="Actions" defaultOpen>
-          <ClipActions clipId={clipId} />
-        </CollapsibleSection>
+        <ClipVersionHistory clipId={clipId} />
+
+        <ClipAdjustments clip={clip} />
       </FlexColumn>
     </Panel>
   );

--- a/web/src/components/timeline/Inspector/GeneratedClipHeader.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipHeader.tsx
@@ -2,8 +2,9 @@
 /**
  * GeneratedClipHeader
  *
- * Displays the clip's name, media type, status badge, duration info,
- * and created/modified timestamps sourced from the latest ClipVersion.
+ * Compact identity row for a generated clip: the clip name, a status badge,
+ * and a single dotted metadata line (type · duration · when). Timestamps come
+ * from the latest ClipVersion.
  *
  * PRD §5.4 (Generated clip selected → GeneratedClipPanel) and §5.5 (status mapping).
  */
@@ -12,7 +13,15 @@ import React, { memo } from "react";
 import type { ClipStatus, TimelineClip } from "@nodetool-ai/timeline";
 
 import type { StatusType } from "../../ui_primitives/StatusIndicator";
-import { FlexColumn, FlexRow, Label, Caption, StatusIndicator } from "../../ui_primitives";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  Caption,
+  StatusIndicator,
+  FONT_WEIGHT
+} from "../../ui_primitives";
+import { relativeTime } from "../../../utils/formatDateAndTime";
 
 // ── Status mapping (PRD §5.5) ─────────────────────────────────────────────
 
@@ -39,16 +48,8 @@ function formatDuration(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
-function formatTimestamp(isoString: string): string {
-  try {
-    return new Date(isoString).toLocaleString(undefined, {
-      dateStyle: "short",
-      timeStyle: "short"
-    });
-  } catch {
-    return isoString;
-  }
-}
+const capitalize = (s: string): string =>
+  s.charAt(0).toUpperCase() + s.slice(1);
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -62,27 +63,46 @@ export const GeneratedClipHeader: React.FC<GeneratedClipHeaderProps> = memo(
   ({ clip }) => {
     const statusInfo = CLIP_STATUS_MAP[clip.status];
 
-    // Latest version for timestamps
     const latestVersion = clip.versions[clip.versions.length - 1] ?? null;
-    const createdAt = latestVersion?.createdAt ?? null;
 
-    // Duration: timeline duration vs generated duration
     const timelineDurationMs = clip.durationMs;
     const generatedDurationMs = latestVersion?.durationMs ?? null;
     const speedMultiplier = clip.speedMultiplier ?? 1;
     const speedBaked = clip.speedBaked ?? false;
     const showBothDurations =
-      generatedDurationMs !== null &&
-      speedMultiplier !== 1 &&
-      !speedBaked;
+      generatedDurationMs !== null && speedMultiplier !== 1 && !speedBaked;
+
+    // One dotted meta line: type · duration · when. The status badge already
+    // says "Generated", so the metadata never repeats it.
+    const metaParts: string[] = [capitalize(clip.mediaType)];
+    if (showBothDurations && generatedDurationMs !== null) {
+      metaParts.push(
+        `${formatDuration(timelineDurationMs)} (src ${formatDuration(
+          generatedDurationMs
+        )} ×${speedMultiplier.toFixed(2)})`
+      );
+    } else {
+      metaParts.push(formatDuration(timelineDurationMs));
+    }
+    if (latestVersion?.createdAt) {
+      metaParts.push(relativeTime(latestVersion.createdAt));
+    }
 
     return (
-      <FlexColumn gap={1} sx={{ px: 1, pt: 0.5, pb: 0.5 }}>
-        {/* Name + status */}
+      <FlexColumn gap={0.5} sx={{ px: 1, pt: 1, pb: 0.5 }}>
         <FlexRow align="center" gap={1}>
-          <Label sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <Text
+            sx={{
+              flex: 1,
+              fontWeight: FONT_WEIGHT.medium,
+              color: "text.primary",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap"
+            }}
+          >
             {clip.name}
-          </Label>
+          </Text>
           <StatusIndicator
             status={statusInfo.status}
             label={statusInfo.label}
@@ -91,37 +111,7 @@ export const GeneratedClipHeader: React.FC<GeneratedClipHeaderProps> = memo(
           />
         </FlexRow>
 
-        {/* Type */}
-        <Caption color="secondary">
-          {clip.mediaType.charAt(0).toUpperCase() + clip.mediaType.slice(1)} · Generated
-        </Caption>
-
-        {/* Duration */}
-        {showBothDurations && generatedDurationMs !== null ? (
-          <FlexRow gap={0.5}>
-            <Caption color="secondary">
-              Timeline: {formatDuration(timelineDurationMs)}
-            </Caption>
-            <Caption color="secondary">·</Caption>
-            <Caption color="secondary">
-              Generated: {formatDuration(generatedDurationMs)}
-            </Caption>
-            <Caption color="secondary">
-              (×{speedMultiplier.toFixed(2)})
-            </Caption>
-          </FlexRow>
-        ) : (
-          <Caption color="secondary">
-            Duration: {formatDuration(timelineDurationMs)}
-          </Caption>
-        )}
-
-        {/* Timestamps */}
-        {createdAt && (
-          <Caption color="secondary">
-            Generated: {formatTimestamp(createdAt)}
-          </Caption>
-        )}
+        <Caption color="secondary">{metaParts.join(" · ")}</Caption>
       </FlexColumn>
     );
   }

--- a/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
@@ -20,7 +20,9 @@ import { NodeContext } from "../../../contexts/NodeContext";
 import { createNodeStore, type NodeStore } from "../../../stores/NodeStore";
 import type { Node } from "../../../stores/ApiTypes";
 import {
+  Caption,
   CollapsibleSection,
+  EditorButton,
   EmptyState,
   FlexColumn,
   LoadingSpinner,
@@ -33,8 +35,14 @@ import type {
   MiniAppInputDefinition
 } from "../../miniapps/types";
 import { getInputKind } from "../../miniapps/utils";
-import { GeneratedClipHeader } from "./GeneratedClipHeader";
-import { ClipActions } from "./ClipActions";
+import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
+import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import StopRoundedIcon from "@mui/icons-material/StopRounded";
+import { GeneratedClipTopBar } from "./GeneratedClipTopBar";
+import { InspectorSectionTitle } from "./InspectorPrimitives";
+import { ClipAdjustments } from "./ClipAdjustments";
+import { ClipVersionHistory } from "./ClipVersionHistory";
 
 export interface GeneratedClipPanelProps {
   clipId: string;
@@ -135,16 +143,25 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
       [clipId, setParamOverride]
     );
 
+    const { generateClip, cancelClipGeneration, isActive, isFailed, canGenerate } =
+      useGenerateClip(clipId);
+    const handleGenerateClick = useCallback(() => {
+      const action = isActive ? cancelClipGeneration() : generateClip();
+      // Errors surface via the clip's status badge / generation store.
+      action.catch(() => undefined);
+    }, [isActive, cancelClipGeneration, generateClip]);
+
     if (!clip) {
       return null;
     }
 
     const paramOverrides = clip.paramOverrides ?? {};
+    const generateLabel = clip.currentAssetId ? "Regenerate" : "Generate";
 
     return (
       <Panel sx={panelSx}>
         <FlexColumn gap={0}>
-          <GeneratedClipHeader clip={clip} />
+          <GeneratedClipTopBar clip={clip} />
 
           {!workflowId && (
             <EmptyState
@@ -155,7 +172,15 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
           )}
 
           {workflowId && (
-            <CollapsibleSection title="Inputs" defaultOpen>
+            <CollapsibleSection
+              title={
+                <InspectorSectionTitle
+                  title="Inputs"
+                  icon={<TuneOutlinedIcon />}
+                />
+              }
+              defaultOpen
+            >
               {isLoading && <LoadingSpinner size="small" />}
               {isError && (
                 <EmptyState
@@ -191,9 +216,32 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
             </CollapsibleSection>
           )}
 
-          <CollapsibleSection title="Actions" defaultOpen>
-            <ClipActions clipId={clipId} />
-          </CollapsibleSection>
+          {workflowId && (
+            <FlexColumn gap={0.5} sx={{ px: 1, pb: 1 }}>
+              <EditorButton
+                fullWidth
+                variant={isActive ? "outlined" : "contained"}
+                color={isActive ? "warning" : "primary"}
+                startIcon={
+                  isActive ? <StopRoundedIcon /> : <AutoAwesomeOutlinedIcon />
+                }
+                disabled={!isActive && !canGenerate}
+                onClick={handleGenerateClick}
+                data-testid="generated-clip-generate"
+              >
+                {isActive ? "Cancel" : generateLabel}
+              </EditorButton>
+              {isFailed && (
+                <Caption sx={{ color: "error.main", textAlign: "center" }}>
+                  Generation failed.
+                </Caption>
+              )}
+            </FlexColumn>
+          )}
+
+          <ClipVersionHistory clipId={clipId} />
+
+          <ClipAdjustments clip={clip} />
         </FlexColumn>
       </Panel>
     );

--- a/web/src/components/timeline/Inspector/GeneratedClipTopBar.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipTopBar.tsx
@@ -1,0 +1,48 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * GeneratedClipTopBar
+ *
+ * The always-visible top of a generated-clip inspector: the identity row plus
+ * the clip action toolbar, pinned to the top of the (scrolling) panel. Keeping
+ * actions docked here — rather than in a collapsible section at the bottom —
+ * mirrors how editors like Premiere keep clip operations on a persistent
+ * toolbar / right-click menu instead of buried in a scrollable inspector.
+ */
+
+import React, { memo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { Z_INDEX } from "../../ui_primitives";
+import { GeneratedClipHeader } from "./GeneratedClipHeader";
+import { ClipActions } from "./ClipActions";
+
+const topBarStyles = (theme: Theme) =>
+  css({
+    position: "sticky",
+    top: 0,
+    zIndex: Z_INDEX.sticky,
+    // Match the Panel surface so scrolling content passes cleanly underneath.
+    backgroundColor: theme.vars.palette.background.default,
+    borderBottom: `1px solid ${theme.vars.palette.divider}`
+  });
+
+export interface GeneratedClipTopBarProps {
+  clip: TimelineClip;
+}
+
+export const GeneratedClipTopBar: React.FC<GeneratedClipTopBarProps> = memo(
+  ({ clip }) => {
+    const theme = useTheme();
+    return (
+      <div css={topBarStyles(theme)}>
+        <GeneratedClipHeader clip={clip} />
+        <ClipActions clipId={clip.id} />
+      </div>
+    );
+  }
+);
+
+GeneratedClipTopBar.displayName = "GeneratedClipTopBar";

--- a/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
@@ -14,6 +14,7 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useState
 } from "react";
 import { css } from "@emotion/react";
@@ -21,7 +22,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import Switch from "@mui/material/Switch";
 
-import { NodeSlider, Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx } from "../../ui_primitives";
+import { NodeSlider, Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx, reducedMotion } from "../../ui_primitives";
 
 // ── Header ─────────────────────────────────────────────────────────────────
 
@@ -519,6 +520,64 @@ const sliderValueStyles = (theme: Theme) =>
     fontVariantNumeric: "tabular-nums"
   });
 
+/**
+ * Precision slider styling, Lightroom/Premiere register: a thin rail, a small
+ * round handle, and a filled segment that originates from the neutral value
+ * (driven by the `--fill-*` CSS vars set on the wrapper) rather than always
+ * from the left edge. `track={false}` suppresses MUI's own left-anchored fill;
+ * the rail's gradient draws the bipolar fill instead, and a faint tick marks
+ * the neutral point.
+ */
+const precisionSliderSx = (theme: Theme) => {
+  const rail = "rgba(255, 255, 255, 0.14)";
+  const accent = theme.vars.palette.primary.main;
+  const ring = theme.vars.palette.primary.mainChannel;
+  return {
+    marginTop: 0,
+    padding: "7px 0",
+    height: 16,
+    "&.Mui-disabled": { opacity: 0.45 },
+    "& .MuiSlider-rail": {
+      height: 3,
+      borderRadius: BORDER_RADIUS.pill,
+      opacity: 1,
+      background: `linear-gradient(to right, ${rail} 0, ${rail} var(--fill-lo, 0%), ${accent} var(--fill-lo, 0%), ${accent} var(--fill-hi, 0%), ${rail} var(--fill-hi, 0%), ${rail} 100%)`,
+      // Neutral-point tick (shown only for bipolar sliders via --fill-show-tick).
+      "&::before": {
+        content: '""',
+        position: "absolute",
+        left: "var(--fill-origin, 0%)",
+        top: "50%",
+        width: 2,
+        height: 8,
+        transform: "translate(-50%, -50%)",
+        borderRadius: BORDER_RADIUS.pill,
+        backgroundColor: theme.vars.palette.text.disabled,
+        opacity: "var(--fill-show-tick, 0)",
+        pointerEvents: "none"
+      }
+    },
+    "& .MuiSlider-thumb": {
+      width: 12,
+      height: 12,
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: theme.vars.palette.text.primary,
+      border: "1px solid rgba(0, 0, 0, 0.28)",
+      boxShadow: "0 1px 2px rgba(0, 0, 0, 0.45)",
+      transition: MOTION.shadow,
+      "&:hover": {
+        boxShadow: `0 1px 2px rgba(0, 0, 0, 0.45), 0 0 0 4px rgba(${ring} / 0.18)`
+      },
+      "&.Mui-focusVisible, &.Mui-active": {
+        boxShadow: `0 1px 2px rgba(0, 0, 0, 0.45), 0 0 0 5px rgba(${ring} / 0.3)`
+      },
+      // Suppress MUI's value-label ripple pseudo-elements.
+      "&::before, &::after": { display: "none" }
+    },
+    ...reducedMotion({ "& .MuiSlider-thumb": { transition: MOTION.none } })
+  };
+};
+
 export interface InspectorSliderRowProps {
   label: string;
   value: number;
@@ -529,25 +588,58 @@ export interface InspectorSliderRowProps {
   step: number;
   disabled?: boolean;
   onChange: (value: number) => void;
+  /**
+   * Neutral/default value. When set, the filled portion of the rail originates
+   * here instead of the left edge (bipolar, Lightroom-style), a tick marks the
+   * neutral point, and double-clicking the rail resets the value to it.
+   */
+  origin?: number;
 }
 
-/** Label + full-width slider + mono value readout. */
+/** Label + full-width precision slider + mono value readout. */
 export const InspectorSliderRow: React.FC<InspectorSliderRowProps> = memo(
-  ({ label, value, display, min, max, step, disabled, onChange }) => {
+  ({ label, value, display, min, max, step, disabled, onChange, origin }) => {
     const theme = useTheme();
+    const sliderSx = useMemo(() => precisionSliderSx(theme), [theme]);
+
+    const span = max - min || 1;
+    const toPct = (v: number) =>
+      ((Math.min(max, Math.max(min, v)) - min) / span) * 100;
+    const valuePct = toPct(value);
+    const originPct = toPct(origin ?? min);
+    const showTick =
+      origin !== undefined && origin > min && origin < max;
+
+    const fillVars = {
+      "--fill-lo": `${Math.min(originPct, valuePct)}%`,
+      "--fill-hi": `${Math.max(originPct, valuePct)}%`,
+      "--fill-origin": `${originPct}%`,
+      "--fill-show-tick": showTick ? 1 : 0
+    } as React.CSSProperties;
+
+    const handleReset = useCallback(() => {
+      if (origin !== undefined) onChange(origin);
+    }, [origin, onChange]);
+
     return (
       <div css={sliderRowStyles(theme)}>
         <span css={sliderLabelStyles(theme)} title={label}>
           {label}
         </span>
-        <div css={sliderTrackStyles}>
+        <div
+          css={sliderTrackStyles}
+          style={fillVars}
+          onDoubleClick={origin !== undefined ? handleReset : undefined}
+        >
           <NodeSlider
             min={min}
             max={max}
             step={step}
             value={value}
             disabled={disabled}
+            track={false}
             aria-label={label}
+            sx={sliderSx}
             onChange={(_e, next) =>
               onChange(Array.isArray(next) ? next[0] : next)
             }

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -3,39 +3,25 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { css } from "@emotion/react";
 import { useTheme, type Theme } from "@mui/material/styles";
-import AddIcon from "@mui/icons-material/Add";
 import ContentCutOutlinedIcon from "@mui/icons-material/ContentCutOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
-import WbSunnyOutlinedIcon from "@mui/icons-material/WbSunnyOutlined";
-import BlurOnOutlinedIcon from "@mui/icons-material/BlurOnOutlined";
+import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
+import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
 
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelineInstance";
 import { usePersistedFold } from "./usePersistedFold";
-import type {
-  BlendMode,
-  ClipBlurEffect,
-  ClipColorEffect,
-  ClipEffect,
-  ClipTransform,
-  ClipTransition,
-  TimelineClip
-} from "@nodetool-ai/timeline";
-import { BLEND_MODES } from "@nodetool-ai/gpu";
 import {
   CollapsibleSection,
-  EditorButton,
   EmptyState,
   FlexColumn,
-  FlexRow,
-  NodeSelect,
-  NodeMenuItem,
   Panel,
   Text,
   Toast,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  Z_INDEX
 } from "../../ui_primitives";
 import { trackTypeAccent } from "../Tracks/trackVisuals";
 import {
@@ -45,7 +31,6 @@ import {
   InspectorPillInput,
   InspectorRow,
   InspectorSectionTitle,
-  InspectorSliderRow,
   InspectorStaticValue,
   InspectorToggleRow
 } from "./InspectorPrimitives";
@@ -55,6 +40,7 @@ import {
   parseTimecode
 } from "./InspectorPrimitives.helpers";
 import { ClipActions } from "./ClipActions";
+import { ClipAdjustments } from "./ClipAdjustments";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
 import { DirectGenClipPanel } from "./DirectGenClipPanel";
 
@@ -85,45 +71,26 @@ const inspectorPanelSx = {
   boxSizing: "border-box"
 };
 
-// ── Effect IDs ─────────────────────────────────────────────────────────────
-
-/** Stable IDs so the inspector-owned effects round-trip in `clip.effects`. */
-const COLOR_EFFECT_ID = "inspector:color";
-const BLUR_EFFECT_ID = "inspector:blur";
-
-const IDENTITY_TRANSFORM: ClipTransform = {
-  position: { x: 0, y: 0 },
-  scale: { x: 1, y: 1 },
-  rotation: 0,
-  anchor: { x: 0.5, y: 0.5 }
-};
+// Identity + clip action toolbar, pinned to the top of the scrolling panel so
+// actions stay reachable (matching the generated-clip panels). Full-bleed via
+// negative margins that cancel the panel's padding.
+const stickyTopStyles = (theme: Theme) =>
+  css({
+    position: "sticky",
+    top: 0,
+    zIndex: Z_INDEX.sticky,
+    backgroundColor: theme.vars.palette.background.default,
+    marginTop: `-${getSpacingPx(SPACING.md)}`,
+    marginLeft: `-${getSpacingPx(SPACING.lg)}`,
+    marginRight: `-${getSpacingPx(SPACING.lg)}`,
+    paddingTop: getSpacingPx(SPACING.md),
+    paddingLeft: getSpacingPx(SPACING.lg),
+    paddingRight: getSpacingPx(SPACING.lg),
+    borderBottom: `1px solid ${theme.vars.palette.divider}`
+  });
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
-
-function findColorEffect(clip: TimelineClip): ClipColorEffect | undefined {
-  return clip.effects?.find(
-    (e): e is ClipColorEffect => e.type === "color" && e.id === COLOR_EFFECT_ID
-  );
-}
-function findBlurEffect(clip: TimelineClip): ClipBlurEffect | undefined {
-  return clip.effects?.find(
-    (e): e is ClipBlurEffect => e.type === "blur" && e.id === BLUR_EFFECT_ID
-  );
-}
-function upsertEffect(
-  effects: ClipEffect[] | undefined,
-  next: ClipEffect
-): ClipEffect[] {
-  const existing = effects ?? [];
-  const idx = existing.findIndex((e) => e.id === next.id);
-  if (idx >= 0) {
-    const out = [...existing];
-    out[idx] = next;
-    return out;
-  }
-  return [...existing, next];
-}
 
 // ── Component ──────────────────────────────────────────────────────────────
 
@@ -139,12 +106,6 @@ export const TimelineInspector: React.FC = memo(() => {
   // and reloads via localStorage.
   const [mediaOpen, setMediaOpen] = usePersistedFold("media");
   const [timingOpen, setTimingOpen] = usePersistedFold("timing");
-  const [renderOpen, setRenderOpen] = usePersistedFold("render");
-  const [transformOpen, setTransformOpen] = usePersistedFold("transform");
-  const [colorOpen, setColorOpen] = usePersistedFold("color");
-  const [blurOpen, setBlurOpen] = usePersistedFold("blur");
-  const [transitionOpen, setTransitionOpen] = usePersistedFold("transition");
-  const [actionsOpen, setActionsOpen] = usePersistedFold("actions");
 
   const clip = useTimelineStore((s) =>
     clipId ? s.clips.find((c) => c.id === clipId) : null
@@ -154,7 +115,6 @@ export const TimelineInspector: React.FC = memo(() => {
   );
   const fps = useTimelineStore((s) => s.fps);
   const deleteSelected = useTimelineStore((s) => s.deleteSelected);
-  const duplicateSelected = useTimelineStore((s) => s.duplicateSelected);
   const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
   const patchClip = useTimelineStore((s) => s.patchClip);
   // The playhead is read imperatively only when splitting (a click). Subscribing
@@ -180,12 +140,6 @@ export const TimelineInspector: React.FC = memo(() => {
   const isOverlay = track?.type === "overlay";
 
   // ── Header action handlers ──────────────────────────────────────────────
-
-  const handleDuplicate = useCallback(() => {
-    if (!clipId) return;
-    const newIds = duplicateSelected(new Set([clipId]));
-    if (newIds.length > 0) setSelection(newIds);
-  }, [clipId, duplicateSelected, setSelection]);
 
   const handleSplitAtPlayhead = useCallback(() => {
     if (!clip) return;
@@ -277,27 +231,25 @@ export const TimelineInspector: React.FC = memo(() => {
 
   return (
     <Panel css={containerStyles} sx={inspectorPanelSx}>
-      <InspectorHeader
-        eyebrow="Clip"
-        actions={[
-          {
-            icon: <AddIcon />,
-            label: "Duplicate clip",
-            onClick: handleDuplicate
-          },
-          {
-            icon: <ContentCutOutlinedIcon />,
-            label: "Split at playhead",
-            onClick: handleSplitAtPlayhead
-          },
-          {
-            icon: <DeleteOutlineOutlinedIcon />,
-            label: "Delete clip",
-            onClick: handleDelete,
-            variant: "danger"
-          }
-        ]}
-      />
+      <div css={stickyTopStyles(theme)}>
+        <InspectorHeader
+          eyebrow="Clip"
+          actions={[
+            {
+              icon: <ContentCutOutlinedIcon />,
+              label: "Split at playhead",
+              onClick: handleSplitAtPlayhead
+            },
+            {
+              icon: <DeleteOutlineOutlinedIcon />,
+              label: "Delete clip",
+              onClick: handleDelete,
+              variant: "danger"
+            }
+          ]}
+        />
+        <ClipActions clipId={clip.id} />
+      </div>
 
       <ClipIdentityCard
         name={clip.name}
@@ -306,7 +258,12 @@ export const TimelineInspector: React.FC = memo(() => {
       />
 
       <CollapsibleSection
-        title={<InspectorSectionTitle title="Media" />}
+        title={
+          <InspectorSectionTitle
+            title="Media"
+            icon={<PermMediaOutlinedIcon />}
+          />
+        }
         open={mediaOpen}
         onToggle={setMediaOpen}
       >
@@ -323,7 +280,12 @@ export const TimelineInspector: React.FC = memo(() => {
       <InspectorDivider />
 
       <CollapsibleSection
-        title={<InspectorSectionTitle title="Timing" />}
+        title={
+          <InspectorSectionTitle
+            title="Timing"
+            icon={<ScheduleOutlinedIcon />}
+          />
+        }
         open={timingOpen}
         onToggle={setTimingOpen}
       >
@@ -370,510 +332,7 @@ export const TimelineInspector: React.FC = memo(() => {
         </FlexColumn>
       </CollapsibleSection>
 
-      <InspectorDivider />
-
-      <CollapsibleSection
-        title={<InspectorSectionTitle title="Render" />}
-        open={renderOpen}
-        onToggle={setRenderOpen}
-      >
-        <FlexColumn css={sectionContentStyles(theme)}>
-          {!isAudio && (
-            <InspectorSliderRow
-              label="Opacity"
-              min={0}
-              max={1}
-              step={0.01}
-              value={clip.opacity ?? 1}
-              display={`${Math.round((clip.opacity ?? 1) * 100)}%`}
-              onChange={(value) => patchClip(clip.id, { opacity: value })}
-            />
-          )}
-          {isOverlay && !isAudio && (
-            <InspectorRow label="Blend">
-              <NodeSelect
-                value={clip.blendMode ?? "normal"}
-                onChange={(e) =>
-                  patchClip(clip.id, {
-                    blendMode: e.target.value as BlendMode
-                  })
-                }
-              >
-                {BLEND_MODES.map((mode) => (
-                  <NodeMenuItem key={mode.value} value={mode.value}>
-                    {mode.label}
-                  </NodeMenuItem>
-                ))}
-              </NodeSelect>
-            </InspectorRow>
-          )}
-          {isAudio && (
-            <>
-              <InspectorRow label="Volume">
-                <InspectorPillInput
-                  value={(clip.volumeDb ?? 0).toFixed(1)}
-                  unit="dB"
-                  onCommit={(raw) => onPatchNumber("volumeDb", raw, -60, 12)}
-                  ariaLabel="Volume (dB)"
-                />
-              </InspectorRow>
-              <InspectorRow label="Fade in">
-                <InspectorPillInput
-                  value={((clip.fadeInMs ?? 0) / 1000).toFixed(2)}
-                  unit="s"
-                  onCommit={(raw) => {
-                    const ms = parseSeconds(raw);
-                    if (ms == null) return;
-                    onPatchNumber(
-                      "fadeInMs",
-                      String(ms),
-                      0,
-                      Math.floor(clip.durationMs / 2)
-                    );
-                  }}
-                  ariaLabel="Fade in (seconds)"
-                />
-              </InspectorRow>
-              <InspectorRow label="Fade out">
-                <InspectorPillInput
-                  value={((clip.fadeOutMs ?? 0) / 1000).toFixed(2)}
-                  unit="s"
-                  onCommit={(raw) => {
-                    const ms = parseSeconds(raw);
-                    if (ms == null) return;
-                    onPatchNumber(
-                      "fadeOutMs",
-                      String(ms),
-                      0,
-                      Math.floor(clip.durationMs / 2)
-                    );
-                  }}
-                  ariaLabel="Fade out (seconds)"
-                />
-              </InspectorRow>
-            </>
-          )}
-        </FlexColumn>
-      </CollapsibleSection>
-
-      {!isAudio && (
-        <>
-          <InspectorDivider />
-          <CollapsibleSection
-            title={<InspectorSectionTitle title="Transform" />}
-            open={transformOpen}
-            onToggle={setTransformOpen}
-          >
-            <FlexColumn css={sectionContentStyles(theme)}>
-              {(() => {
-                const t = clip.transform ?? IDENTITY_TRANSFORM;
-                const setTransform = (next: ClipTransform) =>
-                  patchClip(clip.id, { transform: next });
-                const setPos = (axis: "x" | "y", v: number) =>
-                  setTransform({
-                    ...t,
-                    position: { ...t.position, [axis]: v }
-                  });
-                const setScale = (axis: "x" | "y", v: number) =>
-                  setTransform({
-                    ...t,
-                    scale: { ...t.scale, [axis]: v }
-                  });
-                const setAnchor = (axis: "x" | "y", v: number) =>
-                  setTransform({
-                    ...t,
-                    anchor: { ...t.anchor, [axis]: v }
-                  });
-                const setRotationDeg = (deg: number) =>
-                  setTransform({ ...t, rotation: (deg * Math.PI) / 180 });
-                return (
-                  <>
-                    <InspectorRow label="Position">
-                      <InspectorPillInput
-                        value={t.position.x.toFixed(0)}
-                        unit="px"
-                        minWidth={72}
-                        onCommit={(raw) => {
-                          const n = Number(raw);
-                          if (Number.isFinite(n)) setPos("x", n);
-                        }}
-                        ariaLabel="Position X"
-                      />
-                      <InspectorPillInput
-                        value={t.position.y.toFixed(0)}
-                        unit="px"
-                        minWidth={72}
-                        onCommit={(raw) => {
-                          const n = Number(raw);
-                          if (Number.isFinite(n)) setPos("y", n);
-                        }}
-                        ariaLabel="Position Y"
-                      />
-                    </InspectorRow>
-                    <InspectorRow label="Scale">
-                      <InspectorPillInput
-                        value={t.scale.x.toFixed(2)}
-                        unit="×"
-                        minWidth={72}
-                        onCommit={(raw) => {
-                          const n = Number(raw);
-                          if (Number.isFinite(n)) setScale("x", n);
-                        }}
-                        ariaLabel="Scale X"
-                      />
-                      <InspectorPillInput
-                        value={t.scale.y.toFixed(2)}
-                        unit="×"
-                        minWidth={72}
-                        onCommit={(raw) => {
-                          const n = Number(raw);
-                          if (Number.isFinite(n)) setScale("y", n);
-                        }}
-                        ariaLabel="Scale Y"
-                      />
-                    </InspectorRow>
-                    <InspectorRow label="Rotation">
-                      <InspectorPillInput
-                        value={((t.rotation * 180) / Math.PI).toFixed(1)}
-                        unit="°"
-                        onCommit={(raw) => {
-                          const n = Number(raw);
-                          if (Number.isFinite(n)) setRotationDeg(n);
-                        }}
-                        ariaLabel="Rotation in degrees"
-                      />
-                    </InspectorRow>
-                    <InspectorSliderRow
-                      label="Anchor X"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={t.anchor.x}
-                      display={t.anchor.x.toFixed(2)}
-                      onChange={(value) => setAnchor("x", value)}
-                    />
-                    <InspectorSliderRow
-                      label="Anchor Y"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={t.anchor.y}
-                      display={t.anchor.y.toFixed(2)}
-                      onChange={(value) => setAnchor("y", value)}
-                    />
-                    <InspectorSliderRow
-                      label="Radius"
-                      min={0}
-                      max={500}
-                      step={1}
-                      value={clip.borderRadius ?? 0}
-                      display={`${(clip.borderRadius ?? 0).toFixed(0)}px`}
-                      onChange={(value) =>
-                        patchClip(clip.id, { borderRadius: value })
-                      }
-                    />
-                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                      <EditorButton
-                        size="small"
-                        onClick={() =>
-                          patchClip(clip.id, {
-                            transform: undefined,
-                            borderRadius: undefined
-                          })
-                        }
-                      >
-                        Reset transform
-                      </EditorButton>
-                    </FlexRow>
-                  </>
-                );
-              })()}
-            </FlexColumn>
-          </CollapsibleSection>
-        </>
-      )}
-
-      {!isAudio && (
-        <>
-          <InspectorDivider />
-          <CollapsibleSection
-            title={
-              <InspectorSectionTitle
-                title="Color"
-                icon={<WbSunnyOutlinedIcon />}
-              />
-            }
-            open={colorOpen}
-            onToggle={setColorOpen}
-          >
-            <FlexColumn css={sectionContentStyles(theme)}>
-              {(() => {
-                const color = findColorEffect(clip);
-                const enabled = color?.enabled ?? false;
-                const update = (patch: Partial<ClipColorEffect>): void => {
-                  const next: ClipColorEffect = {
-                    id: COLOR_EFFECT_ID,
-                    type: "color",
-                    enabled,
-                    brightness: color?.brightness,
-                    contrast: color?.contrast,
-                    saturation: color?.saturation,
-                    hue: color?.hue,
-                    temperature: color?.temperature,
-                    tint: color?.tint,
-                    shadows: color?.shadows,
-                    highlights: color?.highlights,
-                    ...patch
-                  };
-                  patchClip(clip.id, {
-                    effects: upsertEffect(clip.effects, next)
-                  });
-                };
-                const slider = (
-                  label: string,
-                  key: keyof Omit<
-                    ClipColorEffect,
-                    "id" | "type" | "enabled"
-                  >,
-                  min: number,
-                  max: number,
-                  step: number,
-                  defaultV: number,
-                  format: (v: number) => string = (v) => v.toFixed(2)
-                ) => {
-                  const v = color?.[key] ?? defaultV;
-                  return (
-                    <InspectorSliderRow
-                      label={label}
-                      min={min}
-                      max={max}
-                      step={step}
-                      value={v}
-                      display={format(v)}
-                      disabled={!enabled}
-                      onChange={(value) =>
-                        update({ [key]: value } as Partial<ClipColorEffect>)
-                      }
-                    />
-                  );
-                };
-                return (
-                  <>
-                    <InspectorToggleRow
-                      label="Enabled"
-                      checked={enabled}
-                      onChange={(next) => update({ enabled: next })}
-                    />
-                    {slider("Brightness", "brightness", -1, 1, 0.01, 0)}
-                    {slider("Contrast", "contrast", 0, 4, 0.01, 1)}
-                    {slider("Saturation", "saturation", 0, 4, 0.01, 1)}
-                    {slider("Hue", "hue", -180, 180, 1, 0, (v) =>
-                      `${v.toFixed(0)}°`
-                    )}
-                    {slider("Temperature", "temperature", -1, 1, 0.01, 0)}
-                    {slider("Tint", "tint", -1, 1, 0.01, 0)}
-                    {slider("Shadows", "shadows", -1, 1, 0.01, 0)}
-                    {slider("Highlights", "highlights", -1, 1, 0.01, 0)}
-                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                      <EditorButton
-                        size="small"
-                        disabled={!color}
-                        onClick={() =>
-                          patchClip(clip.id, {
-                            effects: clip.effects?.filter(
-                              (e) => e.id !== COLOR_EFFECT_ID
-                            )
-                          })
-                        }
-                      >
-                        Clear color
-                      </EditorButton>
-                    </FlexRow>
-                  </>
-                );
-              })()}
-            </FlexColumn>
-          </CollapsibleSection>
-        </>
-      )}
-
-      {!isAudio && (
-        <>
-          <InspectorDivider />
-          <CollapsibleSection
-            title={
-              <InspectorSectionTitle
-                title="Blur"
-                icon={<BlurOnOutlinedIcon />}
-              />
-            }
-            open={blurOpen}
-            onToggle={setBlurOpen}
-          >
-            <FlexColumn css={sectionContentStyles(theme)}>
-              {(() => {
-                const blur = findBlurEffect(clip);
-                const enabled = blur?.enabled ?? false;
-                const radius = blur?.radius ?? 0;
-                const updateBlur = (patch: Partial<ClipBlurEffect>) => {
-                  const next: ClipBlurEffect = {
-                    id: BLUR_EFFECT_ID,
-                    type: "blur",
-                    enabled,
-                    radius,
-                    sigma: blur?.sigma,
-                    ...patch
-                  };
-                  patchClip(clip.id, {
-                    effects: upsertEffect(clip.effects, next)
-                  });
-                };
-                return (
-                  <>
-                    <InspectorToggleRow
-                      label="Enabled"
-                      checked={enabled}
-                      onChange={(next) => updateBlur({ enabled: next })}
-                    />
-                    <InspectorSliderRow
-                      label="Radius"
-                      min={0}
-                      max={20}
-                      step={0.5}
-                      value={radius}
-                      display={`${radius.toFixed(0)}px`}
-                      disabled={!enabled}
-                      onChange={(value) => updateBlur({ radius: value })}
-                    />
-                    <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                      <EditorButton
-                        size="small"
-                        disabled={!blur}
-                        onClick={() =>
-                          patchClip(clip.id, {
-                            effects: clip.effects?.filter(
-                              (e) => e.id !== BLUR_EFFECT_ID
-                            )
-                          })
-                        }
-                      >
-                        Clear blur
-                      </EditorButton>
-                    </FlexRow>
-                  </>
-                );
-              })()}
-            </FlexColumn>
-          </CollapsibleSection>
-        </>
-      )}
-
-      {!isAudio && (
-        <>
-          <InspectorDivider />
-          <CollapsibleSection
-            title={<InspectorSectionTitle title="Transition" />}
-            open={transitionOpen}
-            onToggle={setTransitionOpen}
-          >
-            <FlexColumn css={sectionContentStyles(theme)}>
-              {(() => {
-                const t = clip.transitionIn;
-                const type: "none" | "crossfade" = t?.type ?? "none";
-                const duration = t?.durationMs ?? 500;
-                const setType = (next: "none" | "crossfade") => {
-                  if (next === "none") {
-                    patchClip(clip.id, { transitionIn: undefined });
-                  } else {
-                    const transition: ClipTransition = {
-                      type: "crossfade",
-                      durationMs: duration
-                    };
-                    patchClip(clip.id, { transitionIn: transition });
-                  }
-                };
-                return (
-                  <>
-                    <InspectorRow label="Type">
-                      <NodeSelect
-                        value={type}
-                        onChange={(e) =>
-                          setType(e.target.value as "none" | "crossfade")
-                        }
-                      >
-                        <NodeMenuItem value="none">None</NodeMenuItem>
-                        <NodeMenuItem value="crossfade">Crossfade</NodeMenuItem>
-                      </NodeSelect>
-                    </InspectorRow>
-                    {type === "crossfade" && (
-                      <>
-                        <InspectorRow label="Duration">
-                          <InspectorPillInput
-                            value={(duration / 1000).toFixed(2)}
-                            unit="s"
-                            onCommit={(raw) => {
-                              const ms = parseSeconds(raw);
-                              if (ms == null) return;
-                              patchClip(clip.id, {
-                                transitionIn: {
-                                  type: "crossfade",
-                                  durationMs: Math.max(0, ms)
-                                }
-                              });
-                            }}
-                            ariaLabel="Transition duration"
-                          />
-                        </InspectorRow>
-                        <Text
-                          size="small"
-                          sx={{ px: 0.5, color: "text.secondary" }}
-                        >
-                          Overlap with the previous clip on the same track to
-                          see the cross-fade.
-                        </Text>
-                      </>
-                    )}
-                  </>
-                );
-              })()}
-            </FlexColumn>
-          </CollapsibleSection>
-        </>
-      )}
-
-      <InspectorDivider />
-
-      <CollapsibleSection
-        title={<InspectorSectionTitle title="Actions" />}
-        open={actionsOpen}
-        onToggle={setActionsOpen}
-      >
-        <FlexColumn css={sectionContentStyles(theme)} gap={1}>
-          <ClipActions clipId={clip.id} />
-          <FlexRow gap={1} sx={{ px: 0.5, flexWrap: "wrap" }}>
-            <EditorButton
-              size="small"
-              onClick={() => setToast("Replace media picker coming soon")}
-            >
-              Replace media
-            </EditorButton>
-            <EditorButton
-              size="small"
-              onClick={() => navigate("/assets")}
-            >
-              Reveal in library
-            </EditorButton>
-            <EditorButton
-              size="small"
-              onClick={() =>
-                setToast("Convert to Generated Clip will be wired in NOD-306")
-              }
-            >
-              Convert to generated
-            </EditorButton>
-          </FlexRow>
-        </FlexColumn>
-      </CollapsibleSection>
+      <ClipAdjustments clip={clip} />
 
       <Toast
         open={toast !== null}

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -462,10 +462,15 @@ const TimelineEditorBody: React.FC<Omit<TimelineEditorProps, "active">> = memo((
       />
 
       {/* ── Middle: assets + preview + inspector ──────────────────── */}
+      {/* Basis 0 (not `auto`): the middle row absorbs all leftover height via
+       *  flex-grow, but its *content* never contributes to the column's size.
+       *  With `auto`, a tall inspector (clip selected) inflated this row's
+       *  basis and stole height from the tracks panel below — so the tracks
+       *  height appeared to change on its own. Now only the divider moves it. */}
       <FlexRow
         fullWidth
         css={middleAreaStyles(theme)}
-        sx={{ flex: "1 1 auto", minHeight: 0, overflow: "hidden" }}
+        sx={{ flex: "1 1 0", minHeight: 0, overflow: "hidden" }}
       >
         <TranscriptRegion />
         <PreviewRegion

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -24,7 +24,13 @@ import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectGenJob";
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
-import { FlexRow, TextInput, Toast } from "../ui_primitives";
+import {
+  FlexRow,
+  TextInput,
+  Toast,
+  NodeSelect,
+  NodeMenuItem
+} from "../ui_primitives";
 import VideoModelSelect from "../properties/VideoModelSelect";
 
 interface VideoModelChange {
@@ -33,6 +39,16 @@ interface VideoModelChange {
   provider: string;
   name: string;
 }
+
+// ── Generation presets ───────────────────────────────────────────────────
+
+const ASPECT_RATIOS: string[] = ["16:9", "1:1", "9:16", "4:3", "3:4"];
+
+/** Short-edge resolution tiers, expressed as the strings video models expect. */
+const RESOLUTIONS: string[] = ["480p", "720p", "1080p"];
+
+/** Selectable clip durations in seconds. */
+const DURATIONS_SEC: number[] = [4, 6, 8];
 
 const promptInputStyles = (theme: Theme) =>
   css({
@@ -50,6 +66,11 @@ const modelSelectStyles = (theme: Theme) =>
       width: 120
     }
   });
+
+const settingSelectStyles = css({
+  width: 84,
+  flexShrink: 0
+});
 
 const accentIconStyles = (theme: Theme) =>
   css({
@@ -87,6 +108,9 @@ export const TopBarPrompt: React.FC = memo(() => {
   const [userPicked, setUserPicked] = useState(false);
   const [provider, setProvider] = useState<string | undefined>(undefined);
   const [model, setModel] = useState<string | undefined>(undefined);
+  const [aspect, setAspect] = useState("16:9");
+  const [resolution, setResolution] = useState("720p");
+  const [durationSec, setDurationSec] = useState("4");
   const lastModel = useLastDirectGenModel("video");
 
   // Sync provider/model from the most recent direct-gen clip until the user
@@ -120,11 +144,14 @@ export const TopBarPrompt: React.FC = memo(() => {
       const clipId = addDirectGenClip({
         trackId,
         startMs,
+        durationMs: Number(durationSec) * 1000,
         mediaType: "video",
         bindingKind: "text-to-video",
         prompt: prompt.trim(),
         provider,
-        model
+        model,
+        aspectRatio: aspect,
+        resolution
       });
       selectClip(clipId);
       await directGen.start(clipId);
@@ -140,6 +167,9 @@ export const TopBarPrompt: React.FC = memo(() => {
     prompt,
     provider,
     model,
+    aspect,
+    resolution,
+    durationSec,
     selectClip,
     directGen
   ]);
@@ -185,6 +215,48 @@ export const TopBarPrompt: React.FC = memo(() => {
             task="text_to_video"
             onChange={handleVideoModelChange}
           />
+        </div>
+        <div css={settingSelectStyles}>
+          <NodeSelect
+            value={aspect}
+            onChange={(e) => setAspect(e.target.value as string)}
+            aria-label="Aspect ratio"
+            fullWidth
+          >
+            {ASPECT_RATIOS.map((r) => (
+              <NodeMenuItem key={r} value={r}>
+                {r}
+              </NodeMenuItem>
+            ))}
+          </NodeSelect>
+        </div>
+        <div css={settingSelectStyles}>
+          <NodeSelect
+            value={resolution}
+            onChange={(e) => setResolution(e.target.value as string)}
+            aria-label="Resolution"
+            fullWidth
+          >
+            {RESOLUTIONS.map((r) => (
+              <NodeMenuItem key={r} value={r}>
+                {r}
+              </NodeMenuItem>
+            ))}
+          </NodeSelect>
+        </div>
+        <div css={settingSelectStyles}>
+          <NodeSelect
+            value={durationSec}
+            onChange={(e) => setDurationSec(e.target.value as string)}
+            aria-label="Duration"
+            fullWidth
+          >
+            {DURATIONS_SEC.map((s) => (
+              <NodeMenuItem key={s} value={String(s)}>
+                {s}s
+              </NodeMenuItem>
+            ))}
+          </NodeSelect>
         </div>
       </FlexRow>
       <Toast

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { css, keyframes } from "@emotion/react";
+import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
@@ -30,7 +30,6 @@ import {
   useIsClipSelected
 } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
-import { useTimelineGenerationStore } from "../../../stores/timeline/TimelineGenerationStore";
 import useWorkflowRunsStore from "../../../stores/WorkflowRunsStore";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
@@ -39,13 +38,14 @@ import { type NodeKey } from "../../../stores/nodeKey";
 import { StatusIndicator, BORDER_RADIUS, SPACING, getSpacingPx } from "../../ui_primitives";
 import type { StatusType } from "../../ui_primitives/StatusIndicator";
 import { deriveClipStatus } from "../status/clipStatusReducer";
-import type { ClipGenerationState, ClipErrorState } from "../status/clipStatusReducer";
+import type { ClipErrorState } from "../status/clipStatusReducer";
 import { useClipThumbnails } from "./useClipThumbnails";
 import { useAudioPeaks } from "./useAudioPeaks";
 import { samplePeaksWindow } from "./audioPeaks";
 import { isCompatibleWithTrack } from "../dnd/assetToClipAdapter";
 import { clipSurfaceTint, clipBorderTint } from "./trackVisuals";
 import { ClipContextMenu } from "./ClipContextMenu";
+import MagicGenerationFill from "../../sketch/MagicGenerationFill";
 
 /** Clip-side wrapper: TimelineClip.mediaType also includes "overlay";
  *  treat those as video-track-compatible. */
@@ -191,60 +191,18 @@ const waveformStyles = css({
   height: "100%"
 });
 
-// Travelling-shimmer overlay for clips that are queued or actively
-// generating. A bright diagonal highlight sweeps across the clip body; a
-// soft outline pulse reinforces that the clip is "alive" even on very
-// narrow widths where the shimmer is hard to see.
-const shimmerSweep = keyframes`
-  0%   { transform: translateX(-120%); }
-  100% { transform: translateX(220%); }
-`;
-
-const outlinePulse = keyframes`
-  0%, 100% { opacity: 0.35; }
-  50%      { opacity: 0.9; }
-`;
-
-const generatingOverlayStyles = (theme: Theme) =>
-  css({
-    position: "absolute",
-    inset: 0,
-    pointerEvents: "none",
-    zIndex: 3,
-    overflow: "hidden",
-    borderRadius: CLIP_RADIUS_PX,
-    "&::before": {
-      content: '""',
-      position: "absolute",
-      top: 0,
-      bottom: 0,
-      left: 0,
-      width: "60%",
-      background: `linear-gradient(
-        100deg,
-        transparent 0%,
-        ${theme.vars.palette.secondary.light} 50%,
-        transparent 100%
-      )`,
-      opacity: 0.75,
-      mixBlendMode: "screen",
-      filter: "blur(2px)",
-      animation: `${shimmerSweep} 1.2s linear infinite`,
-      willChange: "transform"
-    },
-    "&::after": {
-      content: '""',
-      position: "absolute",
-      inset: 0,
-      borderRadius: "inherit",
-      boxShadow: `inset 0 0 0 1.5px ${theme.vars.palette.secondary.light}`,
-      animation: `${outlinePulse} 1.4s ease-in-out infinite`
-    },
-    "@media (prefers-reduced-motion: reduce)": {
-      "&::before": { animation: "none", opacity: 0.25 },
-      "&::after": { animation: "none", opacity: 0.5 }
-    }
-  });
+// Generating overlay for clips that are queued or actively generating —
+// the shared "magic" wash + shimmer reused from the sketch editor, so a
+// generating clip in the timeline reads identically to a generating layer
+// on the canvas. Clips to the clip's rounded body.
+const generatingOverlayStyles = css({
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  zIndex: 3,
+  overflow: "hidden",
+  borderRadius: CLIP_RADIUS_PX
+});
 
 interface WaveformCanvasProps {
   url: string | undefined;
@@ -487,17 +445,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
 
   // ── Derived status (PRD §5.5) ────────────────────────────────────────────
 
-  // Generation state from TimelineGenerationStore (queued/running/failed job).
-  const rawJobState = useTimelineGenerationStore(
-    (s) => s.clipJobs[clipId] ?? null
-  );
-  const generationState: ClipGenerationState | null = useMemo(() => {
-    if (!rawJobState || rawJobState.status === "completed") {
-      return null;
-    }
-    return { status: rawJobState.status as ClipGenerationState["status"] };
-  }, [rawJobState]);
-
   // Node-level errors from ErrorStore. Error keys are now scoped per run
   // (`${wf}:${jobId}:${node}`), so restrict the scan to the workflow's focused
   // run; with no focused run there's no error to surface.
@@ -531,8 +478,8 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     if (!clip) {
       return "draft";
     }
-    return deriveClipStatus(clip, generationState, errorState, true);
-  }, [clip, generationState, errorState]);
+    return deriveClipStatus(clip, errorState, true);
+  }, [clip, errorState]);
 
   // ── Undo batching ───────────────────────────────────────────────────────
   //
@@ -1188,10 +1135,12 @@ const ClipBody: React.FC<ClipBodyProps> = memo(({
 
       {(derivedStatus === "queued" || derivedStatus === "generating") && (
         <div
-          css={generatingOverlayStyles(theme)}
+          css={generatingOverlayStyles}
           aria-hidden
           data-testid={`clip-generating-${clipId}`}
-        />
+        >
+          <MagicGenerationFill />
+        </div>
       )}
 
       {/* The badge surfaces lifecycle state for generated clips. Once a

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -96,6 +96,10 @@ const containerStyles = (theme: Theme) =>
     position: "relative",
     width: "100%",
     height: "100%",
+    // Fixed-height panel: never let the flex column shrink it to make room for
+    // sibling content (e.g. a tall inspector). Its height is owned solely by
+    // the `heightPx` prop, which only the drag handle changes.
+    flexShrink: 0,
     overflow: "hidden",
     backgroundColor: theme.vars.palette.background.default
   });

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -39,6 +39,7 @@ import {
 } from "./sceneModel";
 import type { ResolvedCaption } from "./sceneModel";
 import { CaptionRasterizer } from "./captionRender";
+import MagicGenerationFill from "../../sketch/MagicGenerationFill";
 
 interface PlaceholderLayer {
   clipId: string;
@@ -115,6 +116,18 @@ const placeholderLayerStyles = (theme: Theme) =>
     userSelect: "none",
     pointerEvents: "none"
   });
+
+// The shared "magic" wash + shimmer, reused from the sketch editor, washed
+// over the whole preview frame while a generating clip is live at the
+// playhead — so the preview animates in lockstep with its track clip. Sits
+// below the corner status badges (zIndex 9999).
+const previewMagicOverlayStyles = css({
+  position: "absolute",
+  inset: 0,
+  zIndex: 9998,
+  overflow: "hidden",
+  pointerEvents: "none"
+});
 
 interface ActiveVideoSlot {
   clipId: string;
@@ -785,12 +798,16 @@ export const PreviewCompositor: React.FC = memo(() => {
   const buildLayersRef = useRef(buildLayers);
   buildLayersRef.current = buildLayers;
 
-  // One-shot render whenever scene state changes (paused mode + scrubbing).
-  // While playing the rAF loop owns rendering — skip the redundant pass.
+  // One-shot render whenever scene state changes (paused mode + scrubbing +
+  // inspector edits). `buildLayers` is the dep that matters: its identity
+  // changes whenever the active-layer set does — a clip's effects (colour
+  // sliders), transform, opacity, or the layer set itself — so editing a
+  // property while paused re-composites the preview in realtime. While
+  // playing the rAF loop owns rendering, so skip this redundant pass.
   useEffect(() => {
     if (isPlaying) return;
     renderFrame();
-  }, [renderFrame, isPlaying]);
+  }, [renderFrame, isPlaying, buildLayers]);
 
   // A paused scrub sets el.currentTime, which decodes the target frame
   // asynchronously — so the one-shot render above runs before the frame is
@@ -874,6 +891,10 @@ export const PreviewCompositor: React.FC = memo(() => {
     activeImageLayers.length > 0 ||
     placeholderLayers.length > 0;
 
+  const generatingClips = clips.filter(
+    (c) => c.status === "generating" && isClipActive(c, currentTimeMs)
+  );
+
   return (
     <div ref={containerRef} css={compositorStyles} data-testid="preview-compositor">
       <div ref={frameRef} css={frameStyles}>
@@ -941,19 +962,21 @@ export const PreviewCompositor: React.FC = memo(() => {
             </div>
           ))}
 
-        {clips
-          .filter(
-            (c) => c.status === "generating" && isClipActive(c, currentTimeMs)
-          )
-          .map((c) => (
-            <div
-              key={`gen-${c.id}`}
-              css={overlayBadgeStyles(theme, "#0055aa")}
-              style={{ zIndex: 9999 }}
-            >
-              generating…
-            </div>
-          ))}
+        {generatingClips.length > 0 && (
+          <div css={previewMagicOverlayStyles} aria-hidden>
+            <MagicGenerationFill />
+          </div>
+        )}
+
+        {generatingClips.map((c) => (
+          <div
+            key={`gen-${c.id}`}
+            css={overlayBadgeStyles(theme, "#0055aa")}
+            style={{ zIndex: 9999 }}
+          >
+            generating…
+          </div>
+        ))}
 
         {gpuFailed && (
           <div

--- a/web/src/components/timeline/status/__tests__/clipStatusReducer.test.ts
+++ b/web/src/components/timeline/status/__tests__/clipStatusReducer.test.ts
@@ -1,33 +1,37 @@
 /**
  * clipStatusReducer tests
  *
- * Covers every row of the status-mapping table from PRD §5.5.
+ * Covers every row of the status-mapping table from PRD §5.5. `clip.status` is
+ * the single source of truth for generation lifecycle (both the workflow and
+ * direct-gen paths write it), so the active states are driven off it here.
  */
 
 import { describe, it, expect } from "@jest/globals";
 import { deriveClipStatus } from "../clipStatusReducer";
-import type {
-  ClipGenerationState,
-  ClipErrorState
-} from "../clipStatusReducer";
+import type { ClipErrorState } from "../clipStatusReducer";
 import type { TimelineClip } from "@nodetool-ai/timeline";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 type ClipInput = Pick<
   TimelineClip,
-  "locked" | "currentAssetId" | "sourceType" | "dependencyHash" | "lastGeneratedHash"
+  | "locked"
+  | "status"
+  | "currentAssetId"
+  | "sourceType"
+  | "dependencyHash"
+  | "lastGeneratedHash"
 >;
 
 const baseClip = (): ClipInput => ({
   locked: false,
+  status: "generated",
   currentAssetId: undefined,
   sourceType: "generated",
   dependencyHash: "hash-1",
   lastGeneratedHash: "hash-1"
 });
 
-const noGenState = null;
 const noErrorState = null;
 
 // ── Rows in priority order ─────────────────────────────────────────────────
@@ -35,133 +39,178 @@ const noErrorState = null;
 describe("deriveClipStatus — PRD §5.5 mapping table", () => {
   // Row 1: locked
   it('returns "locked" when clip.locked is true regardless of other state', () => {
-    const gen: ClipGenerationState = { status: "running" };
     const err: ClipErrorState = { hasError: true };
     expect(
-      deriveClipStatus({ ...baseClip(), locked: true }, gen, err, false)
+      deriveClipStatus(
+        { ...baseClip(), locked: true, status: "generating" },
+        err,
+        false
+      )
     ).toBe("locked");
   });
 
-  // Row 2: queued
-  it('returns "queued" when generationState.status is "queued"', () => {
-    const gen: ClipGenerationState = { status: "queued" };
-    expect(deriveClipStatus(baseClip(), gen, noErrorState, true)).toBe("queued");
+  // Rows 2-4: active lifecycle, off clip.status
+  it('returns "queued" when clip.status is "queued"', () => {
+    expect(
+      deriveClipStatus({ ...baseClip(), status: "queued" }, noErrorState, true)
+    ).toBe("queued");
   });
 
-  // Row 3: generating
-  it('returns "generating" when generationState.status is "running"', () => {
-    const gen: ClipGenerationState = { status: "running" };
-    expect(deriveClipStatus(baseClip(), gen, noErrorState, true)).toBe("generating");
+  it('returns "generating" when clip.status is "generating"', () => {
+    expect(
+      deriveClipStatus({ ...baseClip(), status: "generating" }, noErrorState, true)
+    ).toBe("generating");
   });
 
-  // Row 4: failed (via generationState)
-  it('returns "failed" when generationState.status is "failed"', () => {
-    const gen: ClipGenerationState = { status: "failed" };
-    expect(deriveClipStatus(baseClip(), gen, noErrorState, true)).toBe("failed");
+  it("returns \"generating\" while regenerating even though the previous asset is still present", () => {
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), status: "generating", currentAssetId: "asset-1" },
+        noErrorState,
+        true
+      )
+    ).toBe("generating");
+  });
+
+  it('returns "failed" when clip.status is "failed"', () => {
+    expect(
+      deriveClipStatus({ ...baseClip(), status: "failed" }, noErrorState, true)
+    ).toBe("failed");
   });
 
   // Row 5: failed (via errorState)
-  it('returns "failed" when errorState.hasError is true and no active job', () => {
-    const err: ClipErrorState = { hasError: true, message: "Failed at NodeA: timeout" };
-    expect(deriveClipStatus(baseClip(), noGenState, err, true)).toBe("failed");
+  it('returns "failed" when errorState.hasError is true and clip is idle', () => {
+    const err: ClipErrorState = {
+      hasError: true,
+      message: "Failed at NodeA: timeout"
+    };
+    expect(deriveClipStatus(baseClip(), err, true)).toBe("failed");
   });
 
   // Row 6: missing
   it('returns "missing" when currentAssetId is set but asset does not exist', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-abc"
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, false)).toBe("missing");
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), currentAssetId: "asset-abc" },
+        noErrorState,
+        false
+      )
+    ).toBe("missing");
   });
 
   it('does NOT return "missing" when currentAssetId is set AND asset exists', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-abc"
-    };
-    // hashes match → should be "generated"
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("generated");
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), currentAssetId: "asset-abc" },
+        noErrorState,
+        true
+      )
+    ).toBe("generated");
   });
 
   // Row 7: draft
   it('returns "draft" for sourceType=="generated" with no currentAssetId', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      sourceType: "generated",
-      currentAssetId: undefined
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("draft");
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), sourceType: "generated", currentAssetId: undefined },
+        noErrorState,
+        true
+      )
+    ).toBe("draft");
   });
 
   it('does NOT return "draft" for sourceType=="imported" with no currentAssetId', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      sourceType: "imported",
-      currentAssetId: undefined,
-      dependencyHash: undefined,
-      lastGeneratedHash: undefined
-    };
-    // falls through to "generated" (imported clips don't need an assetId for draft)
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("generated");
+    expect(
+      deriveClipStatus(
+        {
+          ...baseClip(),
+          sourceType: "imported",
+          currentAssetId: undefined,
+          dependencyHash: undefined,
+          lastGeneratedHash: undefined
+        },
+        noErrorState,
+        true
+      )
+    ).toBe("generated");
   });
 
   // Row 8: stale
   it('returns "stale" when dependencyHash differs from lastGeneratedHash', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-1",
-      dependencyHash: "hash-new",
-      lastGeneratedHash: "hash-old"
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("stale");
+    expect(
+      deriveClipStatus(
+        {
+          ...baseClip(),
+          currentAssetId: "asset-1",
+          dependencyHash: "hash-new",
+          lastGeneratedHash: "hash-old"
+        },
+        noErrorState,
+        true
+      )
+    ).toBe("stale");
   });
 
   it('does NOT return "stale" when only one hash is undefined', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-1",
-      dependencyHash: undefined,
-      lastGeneratedHash: "hash-old"
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("generated");
+    expect(
+      deriveClipStatus(
+        {
+          ...baseClip(),
+          currentAssetId: "asset-1",
+          dependencyHash: undefined,
+          lastGeneratedHash: "hash-old"
+        },
+        noErrorState,
+        true
+      )
+    ).toBe("generated");
   });
 
   // Row 9: generated (default)
   it('returns "generated" when all conditions are clean', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-1"
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("generated");
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), currentAssetId: "asset-1" },
+        noErrorState,
+        true
+      )
+    ).toBe("generated");
   });
 
-  // Priority: active job overrides error state
-  it("active job status takes priority over errorState", () => {
-    const gen: ClipGenerationState = { status: "running" };
+  // Priority: an in-flight clip overrides a lingering error
+  it("in-flight clip.status takes priority over errorState", () => {
     const err: ClipErrorState = { hasError: true };
-    expect(deriveClipStatus(baseClip(), gen, err, true)).toBe("generating");
+    expect(
+      deriveClipStatus({ ...baseClip(), status: "generating" }, err, true)
+    ).toBe("generating");
   });
 
   // Priority: errorState overrides missing / draft / stale
   it("errorState takes priority over missing state", () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      currentAssetId: "asset-gone"
-    };
     const err: ClipErrorState = { hasError: true };
-    expect(deriveClipStatus(clip, noGenState, err, false)).toBe("failed");
+    expect(
+      deriveClipStatus(
+        { ...baseClip(), currentAssetId: "asset-gone" },
+        err,
+        false
+      )
+    ).toBe("failed");
   });
 
   // Edge: locked clip with mismatched hashes still shows "locked"
   it('locked clip with stale hashes still shows "locked"', () => {
-    const clip: ClipInput = {
-      ...baseClip(),
-      locked: true,
-      currentAssetId: "asset-1",
-      dependencyHash: "hash-new",
-      lastGeneratedHash: "hash-old"
-    };
-    expect(deriveClipStatus(clip, noGenState, noErrorState, true)).toBe("locked");
+    expect(
+      deriveClipStatus(
+        {
+          ...baseClip(),
+          locked: true,
+          currentAssetId: "asset-1",
+          dependencyHash: "hash-new",
+          lastGeneratedHash: "hash-old"
+        },
+        noErrorState,
+        true
+      )
+    ).toBe("locked");
   });
 });

--- a/web/src/components/timeline/status/clipStatusReducer.ts
+++ b/web/src/components/timeline/status/clipStatusReducer.ts
@@ -13,12 +13,6 @@ import type { ClipStatus, TimelineClip } from "@nodetool-ai/timeline";
 
 // ── Input shapes ───────────────────────────────────────────────────────────
 
-/** Per-clip generation-job state sourced from TimelineGenerationStore. */
-export interface ClipGenerationState {
-  /** "queued" = job submitted; "running" = node execution started. */
-  status: "queued" | "running" | "failed";
-}
-
 /**
  * Clip-level error state synthesised from ErrorStore node entries for the
  * clip's bound workflow.
@@ -38,9 +32,9 @@ export interface ClipErrorState {
 // | Condition                                             | Status        |
 // |-------------------------------------------------------|---------------|
 // | clip.locked                                           | "locked"      |
-// | generationState.status == "queued"                    | "queued"      |
-// | generationState.status == "running"                   | "generating"  |
-// | generationState.status == "failed"                    | "failed"      |
+// | clip.status == "queued"                               | "queued"      |
+// | clip.status == "generating"                           | "generating"  |
+// | clip.status == "failed"                               | "failed"      |
 // | errorState has clip-relevant error                    | "failed"      |
 // | clip.currentAssetId set, asset missing in AssetStore  | "missing"     |
 // | sourceType == "generated" && !currentAssetId          | "draft"       |
@@ -50,25 +44,30 @@ export interface ClipErrorState {
 /**
  * Derive the visible clip status badge.
  *
- * @param clip           Relevant clip fields from TimelineStore.
- * @param generationState Active job state from TimelineGenerationStore, or
- *                        `null` when no job is in flight.
- * @param errorState     Aggregated error state for the clip's workflow nodes,
- *                       or `null` when there are no errors.
- * @param assetExists    Whether `clip.currentAssetId` resolves to a known
- *                       asset.  Pass `true` when `currentAssetId` is unset.
+ * `clip.status` is the single source of truth for generation lifecycle. Both
+ * generation paths write it: the workflow path mirrors its
+ * TimelineGenerationStore job into it, and the direct-gen path (text-to-image /
+ * image-to-image / text-to-video / text-to-audio) writes it straight. So a
+ * clip that is queued, generating, or failed reads identically here regardless
+ * of which path produced it.
+ *
+ * @param clip        Relevant clip fields from TimelineStore.
+ * @param errorState  Aggregated error state for the clip's workflow nodes, or
+ *                    `null` when there are no errors.
+ * @param assetExists Whether `clip.currentAssetId` resolves to a known asset.
+ *                    Pass `true` when `currentAssetId` is unset.
  * @returns The derived ClipStatus.
  */
 export function deriveClipStatus(
   clip: Pick<
     TimelineClip,
     | "locked"
+    | "status"
     | "currentAssetId"
     | "sourceType"
     | "dependencyHash"
     | "lastGeneratedHash"
   >,
-  generationState: ClipGenerationState | null,
   errorState: ClipErrorState | null,
   assetExists: boolean
 ): ClipStatus {
@@ -77,33 +76,33 @@ export function deriveClipStatus(
     return "locked";
   }
 
-  // 2–4. Active-job states take priority over persisted clip.status.
-  if (generationState?.status === "queued") {
+  // 2. In-flight / failed lifecycle, straight off the single source of truth.
+  if (clip.status === "queued") {
     return "queued";
   }
-  if (generationState?.status === "running") {
+  if (clip.status === "generating") {
     return "generating";
   }
-  if (generationState?.status === "failed") {
+  if (clip.status === "failed") {
     return "failed";
   }
 
-  // 5. Node-level error in the bound workflow → treat as failed.
+  // 3. Node-level error in the bound workflow → treat as failed.
   if (errorState?.hasError) {
     return "failed";
   }
 
-  // 6. Asset was assigned but has since been deleted.
+  // 4. Asset was assigned but has since been deleted.
   if (clip.currentAssetId && !assetExists) {
     return "missing";
   }
 
-  // 7. Generated clip with no output yet.
+  // 5. Generated clip with no output yet.
   if (clip.sourceType === "generated" && !clip.currentAssetId) {
     return "draft";
   }
 
-  // 8. Param or dependency change since last successful generation.
+  // 6. Param or dependency change since last successful generation.
   if (
     clip.dependencyHash !== undefined &&
     clip.lastGeneratedHash !== undefined &&
@@ -112,6 +111,6 @@ export function deriveClipStatus(
     return "stale";
   }
 
-  // 9. Default: clip has been successfully generated and is up to date.
+  // 7. Default: clip has been successfully generated and is up to date.
   return "generated";
 }

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -361,6 +361,13 @@ interface UseGenerateClipResult {
   isGenerating: boolean;
   isQueued: boolean;
   isFailed: boolean;
+  /**
+   * Whether the clip has everything it needs to start a generation — a bound
+   * workflow for workflow clips, or a valid prompt/model (plus source/voice
+   * where required) for direct-gen clips. The single source of truth for both
+   * the prompt panel's primary button and the action toolbar's generate icon.
+   */
+  canGenerate: boolean;
   currentJobId?: string;
 }
 
@@ -383,6 +390,16 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
   const isDirectGenActive =
     isDirectGen && (clip?.status === "queued" || clip?.status === "generating");
   const isDirectGenFailed = isDirectGen && clip?.status === "failed";
+
+  const canGenerate = !clip
+    ? false
+    : isDirectGen
+      ? !!clip.provider &&
+        !!clip.model &&
+        (clip.prompt ?? "").trim().length > 0 &&
+        (clip.bindingKind !== "image-to-image" || !!clip.sourceClipId) &&
+        (clip.bindingKind !== "text-to-audio" || !!clip.voice)
+      : !!clip.workflowId;
 
   const generateClip = useCallback(async () => {
     if (!clip) {
@@ -493,6 +510,7 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
       isGenerating: clip?.status === "generating",
       isQueued: clip?.status === "queued",
       isFailed: isDirectGenFailed,
+      canGenerate,
       currentJobId: undefined
     };
   }
@@ -504,6 +522,7 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
     isGenerating: jobState?.status === "running",
     isQueued: jobState?.status === "queued",
     isFailed: jobState?.status === "failed",
+    canGenerate,
     currentJobId: jobState?.jobId
   };
 };

--- a/web/src/hooks/timeline/useLastDirectGenModel.ts
+++ b/web/src/hooks/timeline/useLastDirectGenModel.ts
@@ -18,6 +18,7 @@
  */
 import { useShallow } from "zustand/react/shallow";
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useLastModelStore } from "../../stores/lastModelStore";
 
 export interface LastDirectGenModel {
   provider: string | undefined;
@@ -41,9 +42,9 @@ const matchesKind = (
 
 export const useLastDirectGenModel = (
   kind: DirectGenMediaKind = "image"
-): LastDirectGenModel =>
-  useTimelineStore(
-    useShallow((state) => {
+): LastDirectGenModel => {
+  const inDoc = useTimelineStore(
+    useShallow((state): LastDirectGenModel => {
       for (let i = state.clips.length - 1; i >= 0; i--) {
         const c = state.clips[i];
         if (matchesKind(c.bindingKind, kind) && c.provider && c.model) {
@@ -57,3 +58,17 @@ export const useLastDirectGenModel = (
       return { provider: undefined, model: undefined, voice: undefined };
     })
   );
+
+  // Fall back to the cross-session remembered model so a fresh sequence (no
+  // matching clip yet) still preselects the model you last used.
+  const remembered = useLastModelStore((s) => s.byKind[kind]);
+
+  if (inDoc.model) {
+    return inDoc;
+  }
+  return {
+    provider: remembered?.provider,
+    model: remembered?.model,
+    voice: kind === "audio" ? remembered?.voice : undefined
+  };
+};

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -201,7 +201,18 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
           strength: clip.strength,
           num_inference_steps: clip.numInferenceSteps,
           variations: 1,
-          voice: kind === "text-to-audio" ? clip.voice : undefined
+          voice: kind === "text-to-audio" ? clip.voice : undefined,
+          // Video models take aspect ratio / resolution / duration natively
+          // (width & height are ignored for video); pass them through when set.
+          ...(kind === "text-to-video"
+            ? {
+                aspect_ratio: clip.aspectRatio,
+                resolution: clip.resolution,
+                duration: clip.durationMs
+                  ? Math.round(clip.durationMs / 1000)
+                  : undefined
+              }
+            : {})
         }
       });
     } catch {

--- a/web/src/stores/lastModelStore.ts
+++ b/web/src/stores/lastModelStore.ts
@@ -1,0 +1,89 @@
+/**
+ * lastModelStore
+ *
+ * Remembers the last direct-generation model the user picked, per media kind,
+ * persisted across sessions. Both the timeline and sketch editors write here
+ * whenever a model is chosen and read it as the default when a fresh clip /
+ * layer has no model yet — so you don't re-pick the same model every time, even
+ * in a brand-new document.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ModelKind = "image" | "video" | "audio";
+
+export interface RememberedModel {
+  provider?: string;
+  model?: string;
+  /** TTS voice; only meaningful for the "audio" kind. */
+  voice?: string;
+}
+
+interface LastModelState {
+  byKind: Partial<Record<ModelKind, RememberedModel>>;
+  /** Record the last-used model for a kind. No-ops without provider + model. */
+  remember: (kind: ModelKind, value: RememberedModel) => void;
+}
+
+export const useLastModelStore = create<LastModelState>()(
+  persist(
+    (set) => ({
+      byKind: {},
+      remember: (kind, value) => {
+        if (!value.provider || !value.model) {
+          return;
+        }
+        set((state) => {
+          const prev = state.byKind[kind];
+          if (
+            prev &&
+            prev.provider === value.provider &&
+            prev.model === value.model &&
+            prev.voice === value.voice
+          ) {
+            return state;
+          }
+          return {
+            byKind: {
+              ...state.byKind,
+              [kind]: {
+                provider: value.provider,
+                model: value.model,
+                voice: value.voice
+              }
+            }
+          };
+        });
+      }
+    }),
+    { name: "nodetool-last-models:v1" }
+  )
+);
+
+/**
+ * Map a direct-gen binding kind to its model-kind bucket (text-to-image and
+ * image-to-image share the "image" bucket, mirroring the model selectors).
+ * Returns null for non-direct-gen bindings (e.g. workflow).
+ */
+export function modelKindForBinding(
+  bindingKind: string | undefined
+): ModelKind | null {
+  switch (bindingKind) {
+    case "text-to-video":
+      return "video";
+    case "text-to-audio":
+      return "audio";
+    case "text-to-image":
+    case "image-to-image":
+    case "inpaint":
+      return "image";
+    default:
+      return null;
+  }
+}
+
+/** Non-reactive read of the remembered model for a kind. */
+export const getRememberedModel = (
+  kind: ModelKind
+): RememberedModel | undefined => useLastModelStore.getState().byKind[kind];

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -38,6 +38,7 @@ import {
 import { trpc, trpcClient } from "../../trpc/client";
 import { useNotificationStore } from "../NotificationStore";
 import { useAssetStore } from "../AssetStore";
+import { useLastModelStore, modelKindForBinding } from "../lastModelStore";
 import {
   computeLayerDependencyHash,
   type LayerDependencyHashInput
@@ -290,7 +291,7 @@ export const createSketchSessionStore = (): SketchSessionStoreApi =>
       return { bindings: nextBindings, extras: nextExtras };
     }),
 
-  upsertBinding: (binding) =>
+  upsertBinding: (binding) => {
     set((state) => {
       const extras = getExtras(state.extras, binding.layerId);
       const nextBinding = recomputeBinding(binding, extras);
@@ -304,7 +305,16 @@ export const createSketchSessionStore = (): SketchSessionStoreApi =>
           ? state.extras
           : { ...state.extras, [binding.layerId]: { ...EMPTY_EXTRAS } }
       };
-    }),
+    });
+    if (binding.provider && binding.model) {
+      const kind = modelKindForBinding(binding.kind);
+      if (kind) {
+        useLastModelStore
+          .getState()
+          .remember(kind, { provider: binding.provider, model: binding.model });
+      }
+    }
+  },
 
   removeBinding: (layerId) =>
     set((state) => {
@@ -335,7 +345,7 @@ export const createSketchSessionStore = (): SketchSessionStoreApi =>
       return { bindings: { ...state.bindings, [layerId]: updated } };
     }),
 
-  patchBinding: (layerId, patch) =>
+  patchBinding: (layerId, patch) => {
     set((state) => {
       const binding = state.bindings[layerId];
       if (!binding) return state;
@@ -345,7 +355,16 @@ export const createSketchSessionStore = (): SketchSessionStoreApi =>
         getExtras(state.extras, layerId)
       );
       return { bindings: { ...state.bindings, [layerId]: updated } };
-    }),
+    });
+    if (patch.provider && patch.model) {
+      const kind = modelKindForBinding(get().bindings[layerId]?.kind);
+      if (kind) {
+        useLastModelStore
+          .getState()
+          .remember(kind, { provider: patch.provider, model: patch.model });
+      }
+    }
+  },
 
   setSelectedOutputNodeId: (layerId, selectedOutputNodeId) =>
     set((state) => {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -48,6 +48,7 @@ import type {
 } from "@nodetool-ai/timeline";
 import type { Asset } from "../ApiTypes";
 import { assetToClip } from "../../components/timeline/dnd/assetToClipAdapter";
+import { useLastModelStore, modelKindForBinding } from "../lastModelStore";
 import { trpcClient } from "../../trpc/client";
 import {
   migrateTranscriptToClips,
@@ -317,6 +318,8 @@ export interface TimelineStoreState {
     sourceClipId?: string | null;
     width?: number;
     height?: number;
+    aspectRatio?: string;
+    resolution?: string;
     strength?: number;
     numInferenceSteps?: number;
     name?: string;
@@ -1440,6 +1443,8 @@ export const createTimelineStore = (
             sourceClipId: opts.sourceClipId ?? null,
             width: opts.width,
             height: opts.height,
+            aspectRatio: opts.aspectRatio,
+            resolution: opts.resolution,
             strength: opts.strength,
             numInferenceSteps: opts.numInferenceSteps,
             status: "draft",
@@ -1448,6 +1453,14 @@ export const createTimelineStore = (
           });
 
           set((state) => ({ clips: [...state.clips, clip] }));
+          const addedKind = modelKindForBinding(bindingKind);
+          if (addedKind && opts.provider && opts.model) {
+            useLastModelStore.getState().remember(addedKind, {
+              provider: opts.provider,
+              model: opts.model,
+              voice: opts.voice
+            });
+          }
           return clip.id;
         },
 
@@ -1462,7 +1475,7 @@ export const createTimelineStore = (
             })
           })),
 
-        setClipDirectGenModel: (clipId, provider, model) =>
+        setClipDirectGenModel: (clipId, provider, model) => {
           set((state) => ({
             clips: state.clips.map((c) => {
               if (c.id !== clipId) return c;
@@ -1470,9 +1483,17 @@ export const createTimelineStore = (
                 c.lastGeneratedHash || c.currentAssetId ? "stale" : c.status;
               return { ...c, provider, model, status };
             })
-          })),
+          }));
+          const clip = get().clips.find((c) => c.id === clipId);
+          const kind = modelKindForBinding(clip?.bindingKind);
+          if (kind) {
+            useLastModelStore
+              .getState()
+              .remember(kind, { provider, model, voice: clip?.voice });
+          }
+        },
 
-        patchClipBinding: (clipId, patch) =>
+        patchClipBinding: (clipId, patch) => {
           set((state) => ({
             clips: state.clips.map((c) => {
               if (c.id !== clipId) return c;
@@ -1480,7 +1501,19 @@ export const createTimelineStore = (
                 c.lastGeneratedHash || c.currentAssetId ? "stale" : c.status;
               return { ...c, ...patch, status };
             })
-          })),
+          }));
+          if (patch.provider && patch.model) {
+            const clip = get().clips.find((c) => c.id === clipId);
+            const kind = modelKindForBinding(clip?.bindingKind);
+            if (kind) {
+              useLastModelStore.getState().remember(kind, {
+                provider: patch.provider,
+                model: patch.model,
+                voice: patch.voice ?? clip?.voice
+              });
+            }
+          }
+        },
 
         regenerateAsCopy: (clipId, deltaMs = 0) => {
           let newId: string | undefined;


### PR DESCRIPTION
## Summary

A focused pass over the timeline editor's **generated-clip** experience (with a few shared sketch-editor touches). Everything is UI/state on the web side plus two optional carrier fields on `TimelineClip`.

## Highlights

**Generation feedback**
- The sketch editor's "magic" generating animation now plays on generating clips **in the tracks** and **over the preview frame**.
- Status is unified on `clip.status` as the single source of truth, so direct-gen and workflow-bound clips behave identically (the magic overlay + badge fire for both, including regenerations).

**Inspector**
- **Precision sliders** (Lightroom/Premiere register): thin rail, small round thumb, fill from the **neutral/default** value (bipolar), neutral tick, double-click to reset.
- The visual-adjustment sections (Render / Transform / Color / Blur / Transition) are now shared with **generated** clips via a new `ClipAdjustments` component — generated clips can be colour-graded, transformed, blurred, etc.
- **Generation history**: a `ClipVersionHistory` thumbnail strip; click a past generation to swap back to it.
- Generated-clip panel redesign: compact de-duplicated header, prominent **Generate / Regenerate** CTA, every section header has an icon, and a **pinned, always-visible action toolbar** (`GeneratedClipTopBar`) matching the imported-clip inspector. The redundant toolbar generate button was removed (generation lives in the prompt/inputs CTA).

**Layout / interaction**
- The tracks panel height is locked so it only changes when you drag the divider (previously a tall inspector stole its height).
- The preview repaints **in realtime** as inspector sliders change (not just on scrub/play).

**Generation form**
- The header quick-prompt form gained **Aspect ratio**, **Resolution**, and **Duration** fields, wired into the `generate_media` video request (`aspect_ratio` / `resolution` / `duration`).
- The last-used model is **remembered across sessions and documents**, shared by the timeline and sketch editors (`lastModelStore`), seeding new clips/layers.

**Sketch**
- The color-picker section is collapsed/hidden by default.

## Notes
- `packages/timeline` gains two optional fields on `TimelineClip` (`aspectRatio`, `resolution`) as carriers for the video generation params; the package was rebuilt.
- Generation-form presets are static; per-model aspect/resolution/duration constraints aren't read yet (a possible follow-up).
- Removed three "coming soon" placeholder buttons (Replace media / Reveal in library / Convert to generated) from the imported-clip actions section while consolidating it into the pinned toolbar.

## Verification
- `tsc --noEmit` clean (web).
- ESLint clean (no new errors).
- `clipStatusReducer` tests updated; timeline-store + inspector test suites pass.