### PR TITLE
fix(transformers-js-nodes): expose node-body inputs

### DIFF
--- a/packages/transformers-js-nodes/src/nodes/audio-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/audio-classification.ts
@@ -23,6 +23,8 @@ const DEFAULT_SAMPLING_RATE = 16000;
 
 export class AudioClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.AudioClassification";
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["audio"];
   static readonly title = "Audio Classification";
   static readonly description =
     "Classify an audio clip using a Transformers.js audio-classification pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
+++ b/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
@@ -24,6 +24,8 @@ const WHISPER_SAMPLING_RATE = 16000;
 
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "transformers.AutomaticSpeechRecognition";
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["audio"];
   static readonly title = "Automatic Speech Recognition";
   static readonly description =
     "Transcribe audio into text using a Transformers.js automatic-speech-recognition pipeline (e.g. Whisper).\n" +

--- a/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
+++ b/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
@@ -76,6 +76,8 @@ function tensorToVector(tensor: unknown): number[] {
 
 export class FeatureExtractionNode extends BaseNode {
   static readonly nodeType = "transformers.FeatureExtraction";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Feature Extraction (Embeddings)";
   static readonly description =
     "Compute text embeddings using a Transformers.js feature-extraction pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/fill-mask.ts
+++ b/packages/transformers-js-nodes/src/nodes/fill-mask.ts
@@ -24,6 +24,8 @@ type FillMaskResult = {
 
 export class FillMaskNode extends BaseNode {
   static readonly nodeType = "transformers.FillMask";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Fill Mask";
   static readonly description =
     "Predict masked tokens in a sentence using a Transformers.js fill-mask pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-classification.ts
@@ -21,6 +21,8 @@ type ImageClassificationResult = { label: string; score: number };
 
 export class ImageClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ImageClassification";
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["image"];
   static readonly title = "Image Classification";
   static readonly description =
     "Classify an image using a Transformers.js image-classification pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/image-to-text.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-to-text.ts
@@ -21,6 +21,8 @@ type CaptionResult = { generated_text: string };
 
 export class ImageToTextNode extends BaseNode {
   static readonly nodeType = "transformers.ImageToText";
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["image"];
   static readonly title = "Image to Text (Captioning)";
   static readonly description =
     "Generate a textual description for an image using a Transformers.js image-to-text pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/object-detection.ts
+++ b/packages/transformers-js-nodes/src/nodes/object-detection.ts
@@ -30,6 +30,8 @@ type ObjectBox = {
 
 export class ObjectDetectionNode extends BaseNode {
   static readonly nodeType = "transformers.ObjectDetection";
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["image"];
   static readonly title = "Object Detection";
   static readonly description =
     "Detect objects and their bounding boxes in an image using a Transformers.js object-detection pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/question-answering.ts
+++ b/packages/transformers-js-nodes/src/nodes/question-answering.ts
@@ -24,6 +24,8 @@ type QAResult = {
 
 export class QuestionAnsweringNode extends BaseNode {
   static readonly nodeType = "transformers.QuestionAnswering";
+  static readonly inlineFields = ["question", "context"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Question Answering";
   static readonly description =
     "Extract an answer span from a context paragraph using a Transformers.js question-answering pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/summarization.ts
+++ b/packages/transformers-js-nodes/src/nodes/summarization.ts
@@ -19,6 +19,8 @@ type SummaryResult = { summary_text: string };
 
 export class SummarizationNode extends BaseNode {
   static readonly nodeType = "transformers.Summarization";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Summarization";
   static readonly description =
     "Summarize long text using a Transformers.js summarization pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/text-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-classification.ts
@@ -19,6 +19,8 @@ type ClassificationResult = { label: string; score: number };
 
 export class TextClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.TextClassification";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Text Classification";
   static readonly description =
     "Classify text using a Transformers.js text-classification pipeline (e.g. sentiment analysis).\n" +

--- a/packages/transformers-js-nodes/src/nodes/text-generation.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-generation.ts
@@ -28,6 +28,8 @@ function extractText(value: unknown): string {
 
 export class TextGenerationNode extends BaseNode {
   static readonly nodeType = "transformers.TextGeneration";
+  static readonly inlineFields = ["prompt"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Text Generation";
   static readonly description =
     "Generate text completions using a Transformers.js text-generation pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
@@ -27,6 +27,8 @@ type TtsResult = {
 
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "transformers.TextToSpeech";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly body = "content_card";
   static readonly title = "Text to Speech";
   static readonly description =

--- a/packages/transformers-js-nodes/src/nodes/token-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/token-classification.ts
@@ -25,6 +25,8 @@ type TokenEntity = {
 
 export class TokenClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.TokenClassification";
+  static readonly inlineFields = ["text"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Token Classification (NER)";
   static readonly description =
     "Run named-entity recognition or token-tagging via a Transformers.js token-classification pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/translation.ts
+++ b/packages/transformers-js-nodes/src/nodes/translation.ts
@@ -19,6 +19,8 @@ type TranslationResult = { translation_text: string };
 
 export class TranslationNode extends BaseNode {
   static readonly nodeType = "transformers.Translation";
+  static readonly inlineFields = ["text", "src_lang", "tgt_lang"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Translation";
   static readonly description =
     "Translate text between languages using a Transformers.js translation pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
@@ -31,6 +31,8 @@ function parseLabels(value: unknown): string[] {
 
 export class ZeroShotClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ZeroShotClassification";
+  static readonly inlineFields = ["text", "candidate_labels"];
+  static readonly inputFields: string[] = [];
   static readonly title = "Zero-Shot Classification";
   static readonly description =
     "Classify text into arbitrary user-supplied labels using a Transformers.js zero-shot pipeline.\n" +

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
@@ -29,6 +29,8 @@ function parseLabels(value: unknown): string[] {
 
 export class ZeroShotImageClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ZeroShotImageClassification";
+  static readonly inlineFields = ["candidate_labels"];
+  static readonly inputFields = ["image"];
   static readonly title = "Zero-Shot Image Classification";
   static readonly description =
     "Score arbitrary user-supplied labels for an image using a CLIP-style Transformers.js pipeline.\n" +

--- a/packages/transformers-js-nodes/tests/descriptors.test.ts
+++ b/packages/transformers-js-nodes/tests/descriptors.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { TextClassificationNode } from "../src/nodes/text-classification.js";
 import { ImageClassificationNode } from "../src/nodes/image-classification.js";
 import { AutomaticSpeechRecognitionNode } from "../src/nodes/automatic-speech-recognition.js";
 import { TextToSpeechNode } from "../src/nodes/text-to-speech.js";
 import { FeatureExtractionNode } from "../src/nodes/feature-extraction.js";
+import { TRANSFORMERS_JS_NODES } from "../src/index.js";
 
 describe("Transformers.js node descriptors", () => {
   it("declares string text input for text classification", () => {
@@ -36,5 +38,36 @@ describe("Transformers.js node descriptors", () => {
       embedding: "list",
       dim: "int"
     });
+  });
+
+  it("exposes the primary text field as an inline body editor", () => {
+    expect(TextClassificationNode.inlineFields).toEqual(["text"]);
+    expect(TextClassificationNode.inputFields).toEqual([]);
+  });
+
+  it("exposes media inputs as handle-only body ports", () => {
+    expect(ImageClassificationNode.inputFields).toEqual(["image"]);
+    expect(AutomaticSpeechRecognitionNode.inputFields).toEqual(["audio"]);
+  });
+
+  it("every node exposes at least one body input field that maps to a real property", () => {
+    for (const cls of TRANSFORMERS_JS_NODES as readonly NodeClass[]) {
+      const inline = cls.inlineFields ?? [];
+      const input = cls.inputFields ?? [];
+      // Regression guard: a node with neither set renders an empty body
+      // (no handles, no inline editors) — see field-classification + NodeContent.
+      expect(
+        inline.length + input.length,
+        `${cls.nodeType} has no body input fields`
+      ).toBeGreaterThan(0);
+
+      const propertyTypes = cls.toDescriptor().propertyTypes ?? {};
+      for (const name of [...inline, ...input]) {
+        expect(
+          propertyTypes,
+          `${cls.nodeType} body field "${name}" is not a declared property`
+        ).toHaveProperty(name);
+      }
+    }
   });
 });


### PR DESCRIPTION
Transformers.js nodes never declared `inlineFields` / `inputFields`, so
the generic node body (and ContentCardBody) — which render only those —
showed no input handles or inline editors. The data inputs were reachable
only via the Inspector, making the nodes look like they had no inputs.

Declare body fields on all 16 nodes, matching the convention used across
the other hand-written node packages (image-nodes, llm-nodes, reve-nodes):

- text inputs (text/prompt/question/context/candidate_labels/langs) ->
  `inlineFields` (editable inline on the body, still connectable)
- image/audio inputs -> `inputFields` (handle-only ports)
- the model picker keeps its sensible default and stays in the Inspector,
  consistent with the other model-bearing nodes

Add a descriptors regression test asserting every node exposes at least
one body input field and that each field maps to a declared property.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017AjUACDjSCzKdCWLRuxZqN