### PR TITLE
docs: add anti-slop writing guide and clean slop from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,15 @@ These three areas have full sections in the central standards doc:
 - Never `--no-verify`. Never rewrite published history.
 - PRs are small (target <400 LOC), self-reviewed, and CI-green before review.
 
+## Writing & Docs
+
+> Full guide: [docs/WRITING_STYLE.md](docs/WRITING_STYLE.md). Comment/README rules: [DEVELOPMENT_STANDARDS §19](docs/DEVELOPMENT_STANDARDS.md#19-documentation--comments).
+
+- Write prose — docs, READMEs, this file, PR descriptions, comments — concise and concrete. Cut any sentence that survives deletion without losing meaning.
+- **No AI slop.** Forbidden: `leverage`, `utilize`, `seamless`, `robust`, `powerful`, `comprehensive`, `cutting-edge`, `unlock`, `empower`, `streamline`, `it's worth noting`, `dive into`, rule-of-three padding, "it's not just X, it's Y", emoji decoration, and the rest of the [forbidden list](docs/WRITING_STYLE.md#forbidden-expressions).
+- Bold-label bullets must add information beyond the label. Claims are concrete: numbers, names, paths — not adjectives.
+- When you edit a Markdown file, fix slop you pass in the same change. For code, use the `unslop` skill.
+
 ## Technologies
 
 ### TypeScript Backend (`packages/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ npm run typecheck   # Must pass before committing
 - Frontend tools prefixed `ui_` (e.g., `ui_add_node`).
 - All inter-package imports use `@nodetool-ai/<package>`. Never import from `dist/`.
 - Throw `Error` objects, not strings. Comment intentionally empty catch blocks.
+- Prose (docs, READMEs, AGENTS.md, comments) follows [docs/WRITING_STYLE.md](docs/WRITING_STYLE.md): concise, concrete, no AI slop (`leverage`, `seamless`, `robust`, `comprehensive`, `it's worth noting`, rule-of-three padding…). Fix slop you pass when editing Markdown.
 
 ## Common Pitfalls
 
@@ -419,3 +420,4 @@ Area-specific overlays:
 - [Agent system](docs/AGENTS.md) — Planning, execution, tools, skills, workflow nodes
 - [UI Primitives Strategy](web/src/components/ui_primitives/STRATEGY.md) — Primitives-first policy, decision tree, migration rules
 - [Design System](docs/DESIGN.md) — Token reference: SPACING, TYPOGRAPHY, BORDER_RADIUS, MOTION, Z_INDEX; migration checklist
+- [Writing Style](docs/WRITING_STYLE.md) — Anti-slop prose rules and the forbidden-expressions list for all docs and Markdown

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -499,6 +499,10 @@ We use **OpenTelemetry** for tracing across agents and workflows (`workflow.run`
 - **READMEs** are short. Anything longer than a screen lives in `docs/`. Per-package READMEs describe purpose, install, and link to `docs/`.
 - **AGENTS.md files** describe enforceable rules for agents and contributors. They are not architecture docs — those live in `docs/architecture.md` and friends.
 
+### Prose style (anti-slop)
+
+All prose — docs, READMEs, AGENTS.md files, PR descriptions, comments — follows [WRITING_STYLE.md](WRITING_STYLE.md): concise, concrete, no AI filler. It carries the forbidden-expressions list (no `leverage`, `seamless`, `robust`, `comprehensive`, `it's worth noting`, rule-of-three padding, etc.). Agents editing a Markdown file fix violations they pass.
+
 ### target
 
 - Every exported function in `@nodetool-ai/agents`, `@nodetool-ai/kernel`, `@nodetool-ai/runtime`, `@nodetool-ai/node-sdk` has JSDoc.

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -1,0 +1,85 @@
+---
+layout: page
+title: "Writing Style"
+permalink: /writing-style
+description: "How to write docs, READMEs, and AGENTS.md files for NodeTool — concise, direct, no AI slop."
+---
+
+**Navigation**: [Root AGENTS.md](../AGENTS.md) | [DEVELOPMENT_STANDARDS §19](DEVELOPMENT_STANDARDS.md#19-documentation--comments) → **Writing Style**
+
+How to write prose in this repo: docs, READMEs, AGENTS.md files, PR descriptions, comments. The goal is text a reader trusts — concrete, short, free of the filler that marks machine-generated copy.
+
+This applies to humans and agents alike. When an agent edits a Markdown file, it follows these rules and fixes violations it passes.
+
+## The rule
+
+Write what's true, in the fewest words that stay clear. Cut anything that doesn't add information. If a sentence survives deletion without losing meaning, delete it.
+
+## Forbidden expressions
+
+These are the words and phrases that mark AI slop. Do not use them. Most have a shorter, plainer replacement; often the fix is to delete the word.
+
+### Inflated verbs
+
+`leverage` → use · `utilize` → use · `delve into` → cover · `dive into` → see · `unlock` · `unleash` · `harness` · `empower` · `elevate` · `supercharge` · `streamline` · `foster` · `bolster` · `amplify` · `revolutionize` · `facilitate` · `underscore` → show · `illuminate` · `embark` · `navigate` (figurative) · `unravel` · `spearhead`
+
+### Inflated adjectives
+
+`seamless` / `seamlessly` · `robust` · `powerful` · `effortless` · `cutting-edge` · `state-of-the-art` · `next-generation` · `world-class` · `best-in-class` · `revolutionary` · `groundbreaking` · `game-changing` · `comprehensive` · `holistic` · `innovative` · `transformative` · `pivotal` · `bespoke` · `blazing fast` / `blazingly fast` · `lightning-fast` · `first-class` · `battle-tested` · `production-grade` (as a boast)
+
+### Filler nouns
+
+`tapestry` · `landscape` (figurative) · `realm` · `world of` · `synergy` · `testament` · `treasure trove` · `plethora` · `myriad` · `cornerstone` · `beacon` · `journey` (figurative) · `ecosystem` (as filler) · `powerhouse` · `paradigm`
+
+### Throat-clearing and hedges
+
+`it's worth noting that` · `it's important to note that` · `it should be noted` · `keep in mind that` · `as you can see` · `needless to say` · `at the end of the day` · `when it comes to` · `in the world of` · `in today's fast-paced world` · `in today's digital age` · `let's dive in` · `let's unpack` · `simply put` · `rest assured` · `that being said` · `it goes without saying`
+
+### AI-cadence transitions
+
+Don't open sentences with these out of habit: `Furthermore` · `Moreover` · `Additionally` · `Notably` · `Importantly` · `Essentially` · `Ultimately` · `Indeed` · `Consequently` · `Subsequently`. Use a plain `And`, `But`, `So`, `Also`, or no transition at all.
+
+### Marketing filler
+
+`gone are the days` · `say goodbye to` · `look no further` · `the possibilities are endless` · `whether you're a beginner or an expert` · `unlock the power of` · `take it to the next level` · `at your fingertips` · `with just a few clicks` · `out of the box` (prefer "by default") · `and much more` / `and more!` · `wide range of` / `rich set of` (say the number or the list)
+
+### Banned patterns
+
+- **The "it's not just X, it's Y" frame.** "NodeTool isn't just a tool, it's a workspace." Cut it. State what it is.
+- **Rule of three for rhythm.** "Fast, reliable, and scalable." Three adjectives where one fact would do. List specifics or pick the one that matters.
+- **"Whether you're X or Y" openers.** Address the reader's actual task instead.
+- **Bold-label bullets that restate the label.** `**Live Preview**: See a live preview` — the body must add information the label doesn't.
+- **Emoji as decoration** in body text or headings. Status markers in a comparison table (✅ / ⚠️ / ❌) are fine.
+- **Concluding summary paragraphs** ("In conclusion…", "Overall, NodeTool…") that repeat what was already said.
+- **Em-dash overuse.** One per paragraph at most. A comma, period, or parenthesis usually reads cleaner.
+
+## Write like this
+
+| Don't | Do |
+|---|---|
+| "Seamlessly integrate with your existing workflow" | "Runs your workflow over the API" |
+| "A comprehensive suite of powerful tools" | "12 built-in tools" (name them, or link the list) |
+| "Leverage the power of local models" | "Run models locally" |
+| "NodeTool empowers you to unlock your creativity" | "NodeTool wires every model onto one canvas" |
+| "It's worth noting that the cache is per-URL" | "The cache is per-URL." |
+| "Robust error handling ensures reliability" | "Errors surface in the node; the run keeps going" |
+| "In today's fast-paced AI landscape…" | (delete — start with the point) |
+
+## Checklist
+
+Before committing prose, scan for:
+
+- [ ] No word or phrase from the forbidden lists above.
+- [ ] No sentence that survives deletion without losing meaning.
+- [ ] Every bold-label bullet adds information beyond its label.
+- [ ] Claims are concrete: numbers, names, file paths — not "powerful" or "wide range".
+- [ ] At most one em-dash per paragraph.
+- [ ] No opening throat-clear and no closing summary that repeats the body.
+
+## Related
+
+- [DEVELOPMENT_STANDARDS §19 Documentation & Comments](DEVELOPMENT_STANDARDS.md#19-documentation--comments) — comment and README rules
+- [Root AGENTS.md](../AGENTS.md) — repo rules for agents and contributors
+- The `unslop` skill (`.claude/skills/`) — the equivalent pass for code
+</content>
+</invoke>

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -15,7 +15,7 @@ The **agent memory system** is the single source of truth for everything that fl
 - `memory_read` — fetch full values for specific keys
 - `memory_write` — publish a value under the `shared:` namespace
 
-This page is the comprehensive reference. For a quick orientation, jump to [Quick Reference](#quick-reference) or [Examples](#examples).
+This page is the full reference. For a quick orientation, jump to [Quick Reference](#quick-reference) or [Examples](#examples).
 
 ---
 

--- a/docs/developer/custom-nodes-guide.md
+++ b/docs/developer/custom-nodes-guide.md
@@ -4,7 +4,7 @@ title: "Custom Nodes Guide (TypeScript)"
 description: "How to author, package, register, and distribute custom NodeTool nodes in a TypeScript pack."
 ---
 
-This is the comprehensive guide to writing **TypeScript** custom nodes for NodeTool — the in-process counterpart to the Python node guides ([Node Examples](node-examples.md), [Node Patterns](node-patterns.md), [Node Reference](node-reference.md)).
+This is the full guide to writing **TypeScript** custom nodes for NodeTool — the in-process counterpart to the Python node guides ([Node Examples](node-examples.md), [Node Patterns](node-patterns.md), [Node Reference](node-reference.md)).
 
 A custom node lives in a standalone npm package — a **pack** — that the server discovers and loads at startup. There is nothing to register by hand: drop a `nodetool` field in `package.json`, install the package, and the loader does the rest.
 

--- a/docs/examples/agents/README.md
+++ b/docs/examples/agents/README.md
@@ -223,7 +223,7 @@ planning_agent:
 To add new example configurations:
 
 1. Create a descriptive YAML file (e.g., `data-analyst.yaml`)
-2. Include a comprehensive system_prompt with clear instructions
+2. Include a detailed system_prompt with clear instructions
 3. Choose an appropriate model and tools
 4. Validate with `nodetool agent test`, then run with sample objectives
 5. Update this README with the new example

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -122,7 +122,7 @@ In Agent Mode, you can ask the agent to create or modify workflows. The agent us
 
 ## Available Tools
 
-Global Chat agents have access to a comprehensive tool suite:
+Global Chat agents have access to these tools:
 
 ### Built-in Tools
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -106,8 +106,6 @@ Shortcuts, hidden features, and workflow efficiency tips.
 
 ### Using Bypass for Debugging
 
-Bypass is a useful debugging technique:
-
 - **Isolate issues**: Bypass nodes one at a time to find the problem
 - **Compare outputs**: Toggle bypass to see before/after results
 - **Skip slow steps**: Temporarily bypass heavy processing during testing
@@ -240,6 +238,6 @@ Press `Alt/⌘ + K` to open the command menu – the fastest way to:
 ## Next Steps
 
 - **[Workflow Editor](workflow-editor.md)** – Full editor documentation
-- **[Image Editor](image-editor.md)** – Professional image editing guide
+- **[Image Editor](image-editor.md)** – Image editing guide
 - **[Cookbook](cookbook.md)** – Workflow patterns
 - **[Keyboard Shortcuts](user-interface.md#keyboard-shortcuts)** – Complete list

--- a/docs/vibecoding.md
+++ b/docs/vibecoding.md
@@ -4,17 +4,14 @@ title: "VibeCoding"
 description: "Design custom workflow UIs with AI assistance"
 ---
 
-VibeCoding is NodeTool's AI-powered tool for designing custom user interfaces for your workflows. Describe what you want in natural language, and VibeCoding generates a fully functional HTML app that runs your workflow.
+VibeCoding designs custom UIs for your workflows. Describe the interface you want, and it generates an HTML app that runs the workflow over the API.
 
-## Overview
+## What it does
 
-VibeCoding provides:
-
-- **AI-Powered Design**: Describe your desired UI in natural language
-- **Live Preview**: See changes in real-time as HTML is generated
-- **Seamless Integration**: Generated apps run your workflow with full API access
-- **No Coding Required**: Create professional interfaces without writing code
-- **Instant Deployment**: Save and share your custom app immediately
+- Generates a self-contained HTML app from a natural-language description.
+- Streams the HTML into a live preview as it writes.
+- Wires the app to run your workflow over the API, including assets.
+- Saves to the workflow's `html_app` field and serves it in Mini App mode.
 
 ## Getting Started
 
@@ -50,11 +47,11 @@ In the chat panel, describe what you want your app to look like. Be as specific 
 
 ### Step 2: Review the Preview
 
-As the AI generates HTML, the preview panel updates in real-time. You can:
+The preview updates as the HTML streams in. You can:
 
-- **Watch generation**: See the interface build as HTML streams in
-- **Test interactivity**: The preview is fully functional
-- **Iterate quickly**: Ask for changes and see immediate results
+- Watch the interface build as HTML streams in.
+- Interact with the preview — it's the running app.
+- Ask for changes and see them applied.
 
 ### Step 3: Refine Your Design
 
@@ -76,8 +73,6 @@ When you're happy with the design:
 
 ## Preview Controls
 
-The preview panel includes several helpful controls:
-
 | Button | Action |
 |--------|--------|
 | **Refresh** | Force a complete refresh of the preview |
@@ -86,10 +81,7 @@ The preview panel includes several helpful controls:
 
 ## Templates
 
-VibeCoding may show template chips at the start of a conversation. These are pre-built prompts for common UI patterns:
-
-- Click a template to instantly send that prompt
-- Templates help you get started quickly with proven designs
+At the start of a conversation, VibeCoding may show template chips — prebuilt prompts for common UI patterns. Click one to send that prompt.
 
 ## Managing Custom Apps
 
@@ -119,12 +111,12 @@ If your workflow already has a custom app:
 
 ### Generated App Features
 
-VibeCoding generates self-contained HTML apps that include:
+Generated apps are self-contained HTML and include:
 
-- **Runtime Configuration**: Automatic injection of API and WebSocket URLs
-- **Workflow Integration**: Full access to run your workflow via API
-- **Asset Support**: Load and display assets from your workflow
-- **Responsive Design**: Apps work on various screen sizes
+- **Runtime config**: API and WebSocket URLs injected at load.
+- **Workflow calls**: run the workflow over the API.
+- **Assets**: load and display assets the workflow produces.
+- **Responsive layout**: adapt to different screen sizes.
 
 ### Security
 


### PR DESCRIPTION
Add docs/WRITING_STYLE.md: a concise prose guide for docs, READMEs,
AGENTS.md files, and comments, carrying a forbidden-expressions list
(inflated verbs/adjectives, filler nouns, throat-clearing, AI-cadence
transitions, marketing filler, banned patterns).

Wire the rule into the agent/rules files so it applies to humans and
agents editing Markdown:
- AGENTS.md: new "Writing & Docs" section
- CLAUDE.md: prose rule + overlay link
- DEVELOPMENT_STANDARDS.md §19: prose-style subsection

Clean slop from reader-facing pages: rewrite vibecoding.md bullets that
restated their labels, drop filler in tips-and-tricks.md, and replace
stray "comprehensive" in agent-memory, custom-nodes-guide, global-chat,
and the agents example README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RZssKNaUa5QMLommx4g9x1