### PR TITLE
Add 3 new workflow examples: content repurposing, cold outreach, hook & thumbnail

### DIFF
--- a/packages/base-nodes/nodetool/examples/nodetool-base/Cold Outreach Co-Pilot.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Cold Outreach Co-Pilot.json
@@ -1,0 +1,368 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-25T12:00:00.000Z",
+  "updated_at": "2026-06-25T12:00:00.000Z",
+  "name": "Cold Outreach Co-Pilot",
+  "tool_name": null,
+  "description": "An autonomous agent researches a prospect on the web and writes a personalized cold email \u2014 opening with a real, specific detail \u2014 plus a follow-up. Personalization at scale without the copy-paste.",
+  "tags": [
+    "agents",
+    "sales",
+    "outreach",
+    "marketing",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "f7064427-ec91-40f7-9d91-112f6a43b15d",
+        "source": "input_prospect",
+        "sourceHandle": "output",
+        "target": "objective",
+        "targetHandle": "prospect",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "3ca81164-a670-4975-957b-b28332ac67d3",
+        "source": "input_offer",
+        "sourceHandle": "output",
+        "target": "objective",
+        "targetHandle": "offer",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "8ad2ac67-9319-4f81-a114-b4be4380d400",
+        "source": "objective",
+        "sourceHandle": "output",
+        "target": "agent",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "2c9c58e5-2b28-4260-b391-796dd9c41764",
+        "source": "agent",
+        "sourceHandle": "company_summary",
+        "target": "preview_summary",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "d3768764-a777-4fc3-8cf3-d1662f93b5f0",
+        "source": "agent",
+        "sourceHandle": "pain_points",
+        "target": "preview_pain",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "list"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "c7c5d258-0c5a-4a9e-85f7-579fa3dff9ab",
+        "source": "agent",
+        "sourceHandle": "personalized_email",
+        "target": "preview_email",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "a125560d-4103-4992-80e2-2f8b3cfcec78",
+        "source": "agent",
+        "sourceHandle": "follow_up",
+        "target": "preview_follow",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment-intro",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# \ud83c\udfaf Cold Outreach Co-Pilot\n\nName a prospect or company and an autonomous agent researches them on the web, then writes a personalized cold email that opens with a real, specific detail \u2014 plus a follow-up.\n\n**Pipeline:** Prospect + your offer \u2192 build objective \u2192 Research agent (search + browse) \u2192 email + follow-up\n\n**Try this:** change the prospect, paste your real offer, or tell the agent the tone to use. Pick a model on the agent first."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": -540,
+            "y": 40
+          },
+          "zIndex": 0,
+          "width": 480,
+          "height": 240,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_prospect",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Prospect / Company",
+          "description": "The person or company to research and reach out to.",
+          "value": "Acme Robotics (Series B warehouse automation startup)"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1\ufe0f\u20e3 Prospect",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_offer",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Your Offer",
+          "description": "What you sell and the outcome it drives.",
+          "value": "We cut cloud GPU bills 30\u201350% for ML teams by auto-scheduling training jobs onto spot capacity \u2014 no code changes."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 360
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2\ufe0f\u20e3 Your offer",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "objective",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Research the prospect and write outreach.\n\nPROSPECT:\n{{ prospect }}\n\nMY OFFER:\n{{ offer }}\n\nSteps:\n1. Use google_search and browser to learn what the prospect does, their stage, and anything recent (a launch, hire, funding, or post).\n2. Identify 2\u20134 pain points my offer plausibly solves for them.\n3. Write a cold email under 120 words that OPENS with a specific researched detail, ties it to one pain point, and ends with a low-friction ask.\n4. Write one short follow-up for no-reply.\n\nReturn JSON:\n{\n  \"company_summary\": \"<2\u20133 sentences on what they do + recent signal>\",\n  \"pain_points\": [\"<pain 1>\", \"<pain 2>\", ...],\n  \"personalized_email\": \"<subject line + body>\",\n  \"follow_up\": \"<short nudge>\"\n}"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 420,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 460,
+          "title": "3\ufe0f\u20e3 Build research objective",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "prospect": null,
+          "offer": null
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "agent",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "tools": [
+            {
+              "type": "tool_name",
+              "name": "google_search"
+            },
+            {
+              "type": "tool_name",
+              "name": "browser"
+            }
+          ],
+          "max_tokens": 100000,
+          "system": "You are a B2B research assistant and senior cold-outreach copywriter.\n\nGoal\n- Research the given prospect/company using the tools, then write outreach that references something specific and true about them.\n\nTools Available\n- google_search: Search the web for information\n- browser: Open URLs and read content\n\nWorkflow\n1. Search for the prospect/company; identify what they do and recent news.\n2. Browse their site or a recent post to find concrete, current details.\n3. Map their likely pain points to the offer.\n4. Write a short, human, non-salesy email plus one follow-up.\n\nOutput Format\n- Return a single JSON object matching the defined output schema.\n- The email must open with a specific, researched detail (never \"I hope this finds you well\").\n- Keep the email under 120 words. Cite sources where useful.\n",
+          "mode": "plan"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 800,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 460,
+          "title": "4\ufe0f\u20e3 Research + write outreach",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {
+          "company_summary": {
+            "type": "str",
+            "optional": false,
+            "type_args": []
+          },
+          "pain_points": {
+            "type": "list",
+            "optional": false,
+            "type_args": [
+              {
+                "type": "str",
+                "optional": false,
+                "type_args": []
+              }
+            ]
+          },
+          "personalized_email": {
+            "type": "str",
+            "optional": false,
+            "type_args": []
+          },
+          "follow_up": {
+            "type": "str",
+            "optional": false,
+            "type_args": []
+          }
+        }
+      },
+      {
+        "id": "preview_summary",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "company_summary"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83c\udfe2 Company summary",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_pain",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "pain_points"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83e\ude79 Pain points",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_email",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "personalized_email"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 640
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\u2709\ufe0f Personalized email",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_follow",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "follow_up"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 960
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83d\udd01 Follow-up",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "Prospect / Company": {
+        "type": "string",
+        "label": ""
+      },
+      "Your Offer": {
+        "type": "string",
+        "label": ""
+      }
+    },
+    "required": [
+      "Prospect / Company"
+    ]
+  },
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Content Repurposing Studio.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Content Repurposing Studio.json
@@ -1,0 +1,366 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-25T12:00:00.000Z",
+  "updated_at": "2026-06-25T12:00:00.000Z",
+  "name": "Content Repurposing Studio",
+  "tool_name": null,
+  "description": "Turn one piece of long-form content into a Twitter/X thread, a LinkedIn post, a newsletter blurb, and SEO blog titles \u2014 all in one pass, in your brand voice.",
+  "tags": [
+    "content",
+    "marketing",
+    "social",
+    "writing",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "00caacc9-3465-4c00-ac66-854ceb1841fc",
+        "source": "input_content",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "content",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "4ad621e4-e9b3-4877-9018-16e372703d44",
+        "source": "input_voice",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "voice",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "817542cb-ed71-408e-9f88-09f2b69dd07a",
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "repurpose",
+        "targetHandle": "instructions",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "cad347fc-be3d-4e07-a557-cf1968930acb",
+        "source": "repurpose",
+        "sourceHandle": "twitter_thread",
+        "target": "preview_thread",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "list"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "9f736066-a654-45c4-b4ee-cfdd997d691c",
+        "source": "repurpose",
+        "sourceHandle": "linkedin_post",
+        "target": "preview_linkedin",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "178eb9a7-4df7-4566-b01e-9cb72ee349e9",
+        "source": "repurpose",
+        "sourceHandle": "newsletter_blurb",
+        "target": "preview_newsletter",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "f32d9ada-19c4-4e6b-a9de-4d73d552bece",
+        "source": "repurpose",
+        "sourceHandle": "seo_blog_titles",
+        "target": "preview_titles",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "list"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment-intro",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# \u267b\ufe0f Content Repurposing Studio\n\nPaste one piece of long-form content and get every channel's version in a single pass: an X/Twitter thread, a LinkedIn post, a newsletter blurb, and SEO blog-title ideas.\n\n**Pipeline:** Content + brand voice \u2192 build brief \u2192 Structured Generator \u2192 four ready-to-post outputs\n\n**Try this:** swap in a blog post, podcast transcript, or release notes. Edit the brief to add a YouTube description or a cold-email teaser. Pick a model on the generator first."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": -540,
+            "y": 40
+          },
+          "zIndex": 0,
+          "width": 480,
+          "height": 260,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_content",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Source Content",
+          "description": "The long-form content to repurpose (blog post, transcript, release notes).",
+          "value": "We shipped local-first sync today. Your notes now save instantly offline and merge automatically when you reconnect \u2014 no spinners, no lost edits, no conflicts. We rebuilt the storage layer on a CRDT so two devices editing the same note converge to the same result. Early users say it finally feels as fast as a native app."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1\ufe0f\u20e3 Source content",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_voice",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Brand Voice",
+          "description": "Tone and style guidelines for every output.",
+          "value": "Friendly expert. Punchy, concrete, no buzzwords. Lead with the benefit."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 360
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2\ufe0f\u20e3 Brand voice",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Repurpose the SOURCE content below into channel-ready posts. Match the BRAND VOICE exactly.\n\nBRAND VOICE:\n{{ voice }}\n\nSOURCE:\n{{ content }}\n\nProduce:\n- twitter_thread: 5\u20137 tweets, hook first, one idea per tweet, each under 280 chars, no hashtags spam.\n- linkedin_post: a single LinkedIn post (120\u2013200 words) with short lines and a closing question.\n- newsletter_blurb: a 2\u20133 sentence email teaser that earns the click.\n- seo_blog_titles: 5 SEO-friendly blog title ideas for the same topic."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 420,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 460,
+          "title": "3\ufe0f\u20e3 Build repurpose brief",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "content": null,
+          "voice": null
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "repurpose",
+        "type": "nodetool.generators.StructuredOutputGenerator",
+        "data": {
+          "system_prompt": "\nYou are a structured data generator focused on JSON outputs.\n\nGoal\n- Produce a high-quality JSON object that matches <JSON_SCHEMA> using the guidance in <INSTRUCTIONS> and any supplemental <CONTEXT>.\n\nOutput format (MANDATORY)\n- Output exactly ONE fenced code block labeled json containing ONLY the JSON object:\n\n  ```json\n  { ...single JSON object matching <JSON_SCHEMA>... }\n  ```\n\n- No additional prose before or after the block.\n\nGeneration rules\n- Invent plausible, internally consistent values when not explicitly provided.\n- Honor all constraints from <JSON_SCHEMA> (types, enums, ranges, formats).\n- Prefer ISO 8601 for dates/times when applicable.\n- Ensure numbers respect reasonable magnitudes and relationships described in <INSTRUCTIONS>.\n- Avoid referencing external sources; rely solely on the provided guidance.\n\nValidation\n- Ensure the final JSON validates against <JSON_SCHEMA> exactly.\n",
+          "model": {},
+          "context": "",
+          "max_tokens": 8192,
+          "image": [],
+          "audio": []
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 800,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 460,
+          "title": "4\ufe0f\u20e3 Repurpose for every channel",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {
+          "twitter_thread": {
+            "type": "list",
+            "optional": false,
+            "type_args": [
+              {
+                "type": "str",
+                "optional": false,
+                "type_args": []
+              }
+            ]
+          },
+          "linkedin_post": {
+            "type": "str",
+            "optional": false,
+            "type_args": []
+          },
+          "newsletter_blurb": {
+            "type": "str",
+            "optional": false,
+            "type_args": []
+          },
+          "seo_blog_titles": {
+            "type": "list",
+            "optional": false,
+            "type_args": [
+              {
+                "type": "str",
+                "optional": false,
+                "type_args": []
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "preview_thread",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "twitter_thread"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83d\udc26 X / Twitter thread",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_linkedin",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "linkedin_post"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83d\udcbc LinkedIn post",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_newsletter",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "newsletter_blurb"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 640
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83d\udce8 Newsletter blurb",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_titles",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "seo_blog_titles"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1180,
+            "y": 960
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 300,
+          "title": "\ud83d\udd0d SEO blog titles",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "Source Content": {
+        "type": "string",
+        "label": ""
+      },
+      "Brand Voice": {
+        "type": "string",
+        "label": ""
+      }
+    },
+    "required": [
+      "Source Content"
+    ]
+  },
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Hook & Thumbnail Factory.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Hook & Thumbnail Factory.json
@@ -1,0 +1,347 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-25T12:00:00.000Z",
+  "updated_at": "2026-06-25T12:00:00.000Z",
+  "name": "Hook & Thumbnail Factory",
+  "tool_name": null,
+  "description": "Turn a video topic into scroll-stopping hook ideas and a matching AI thumbnail for each \u2014 a faceless short-form content starter kit in one run.",
+  "tags": [
+    "image",
+    "content",
+    "social",
+    "video",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "0373f51d-ff16-457c-8871-7b28c2a4cb15",
+        "source": "input_topic",
+        "sourceHandle": "output",
+        "target": "hook_brief",
+        "targetHandle": "topic",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e631105c-8b57-4304-bbd6-790378f7807d",
+        "source": "input_audience",
+        "sourceHandle": "output",
+        "target": "hook_brief",
+        "targetHandle": "audience",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "5f7839de-32fd-43f1-b2ab-93de5cdc91c4",
+        "source": "hook_brief",
+        "sourceHandle": "output",
+        "target": "hooks",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "6d86d394-8a74-4f7a-aeed-5f7d7f55bbc5",
+        "source": "hooks",
+        "sourceHandle": "item",
+        "target": "thumb_brief",
+        "targetHandle": "hook",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "5c7c4403-f00a-46e8-b68f-9a21a9a2227e",
+        "source": "input_topic",
+        "sourceHandle": "output",
+        "target": "thumb_brief",
+        "targetHandle": "topic",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "2082cf18-f8b9-455e-9c37-ffddc4fefd7d",
+        "source": "hooks",
+        "sourceHandle": "item",
+        "target": "preview_hooks",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "b4d3e81f-2221-45da-a93b-ee2143c19f74",
+        "source": "thumb_brief",
+        "sourceHandle": "output",
+        "target": "thumbnail",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "2806e15a-b3d8-4526-9170-137ca0f9b746",
+        "source": "thumbnail",
+        "sourceHandle": "output",
+        "target": "preview_thumb",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment-intro",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# \ud83c\udfac Hook & Thumbnail Factory\n\nGive a video topic and audience. The graph writes scroll-stopping hook ideas and, for each one, generates a matching thumbnail image \u2014 a full faceless-content starter kit.\n\n**Pipeline:** Topic + audience \u2192 hook brief \u2192 List Generator (streams hooks) \u2192 thumbnail prompt \u2192 Text-to-Image\n\n**Try this:** change the topic or audience, ask for more hooks, or tweak the thumbnail style. Pick a text model on the list generator and an image model on Text-to-Image first."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": -560,
+            "y": 40
+          },
+          "zIndex": 0,
+          "width": 500,
+          "height": 260,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_topic",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Video Topic",
+          "description": "What the short-form video is about.",
+          "value": "How compound interest quietly builds wealth"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1\ufe0f\u20e3 Video topic",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "input_audience",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "Target Audience",
+          "description": "Who you are making it for.",
+          "value": "Gen Z just starting to invest"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 40,
+            "y": 360
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2\ufe0f\u20e3 Target audience",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "hook_brief",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Write 5 scroll-stopping hook ideas for a short-form video.\n\nTOPIC: {{ topic }}\nAUDIENCE: {{ audience }}\n\nRules:\n- Each hook is one line, said in the first 2 seconds.\n- Use curiosity, a bold claim, or a relatable pain.\n- No clickbait that the video can't pay off.\n- Return the hooks as a plain list, one per line."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 420,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 460,
+          "title": "3\ufe0f\u20e3 Build hook brief",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "topic": null,
+          "audience": null
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "hooks",
+        "type": "nodetool.generators.ListGenerator",
+        "data": {
+          "model": {},
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 800,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 420,
+          "title": "4\ufe0f\u20e3 Generate hooks",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "thumb_brief",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Design a bold, high-contrast YouTube/Shorts thumbnail for a video.\n\nVIDEO TOPIC: {{ topic }}\nHOOK ON SCREEN: {{ hook }}\n\nDescribe a single eye-catching image: clear focal subject, punchy colors, dramatic lighting, lots of negative space for big bold text, mobile-legible at thumbnail size. No tiny details, no real logos."
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1200,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 460,
+          "title": "5\ufe0f\u20e3 Build thumbnail prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "topic": null,
+          "hook": null
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "thumbnail",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {},
+          "negative_prompt": "blurry, low contrast, watermark, tiny text, clutter",
+          "aspect_ratio": "16:9",
+          "resolution": "2K",
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1580,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 360,
+          "title": "6\ufe0f\u20e3 Generate thumbnail",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_hooks",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "hooks"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 800,
+            "y": 600
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 300,
+          "title": "\ud83e\ude9d Hook ideas",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_thumb",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "thumbnail"
+        },
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 1580,
+            "y": 540
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 320,
+          "title": "\ud83d\uddbc\ufe0f Thumbnail",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "Video Topic": {
+        "type": "string",
+        "label": ""
+      },
+      "Target Audience": {
+        "type": "string",
+        "label": ""
+      }
+    },
+    "required": [
+      "Video Topic"
+    ]
+  },
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null
+}


### PR DESCRIPTION
Three killer gallery templates inspired by trending AI-automation use cases
(content repurposing, personalized cold outreach at scale, faceless
short-form content):

- Content Repurposing Studio: one long-form piece -> X/Twitter thread,
  LinkedIn post, newsletter blurb, and SEO blog titles via a single
  StructuredOutputGenerator pass.
- Cold Outreach Co-Pilot: a research Agent (google_search + browser)
  studies a prospect, then writes a personalized cold email that opens
  with a real detail, plus a follow-up.
- Hook & Thumbnail Factory: a video topic -> scroll-stopping hook ideas
  (ListGenerator) + a matching AI thumbnail per hook (TextToImage).

All three validate structurally and execute end-to-end against the fake
provider harness (example-workflows-validation + example-workflows-execute,
46 execute tests / 351 validation tests pass).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012hrGjLkMLQqSw9bJWQmxk1