### PR TITLE
fix(timeline): preview rendering — cut flicker, auto-crossfade, scrubber seek

### DIFF
--- a/web/src/components/timeline/Inspector/ClipAdjustments.tsx
+++ b/web/src/components/timeline/Inspector/ClipAdjustments.tsx
@@ -571,11 +571,19 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
               <FlexColumn css={sectionContentStyles(theme)}>
                 {(() => {
                   const t = clip.transitionIn;
-                  const type: "none" | "crossfade" = t?.type ?? "none";
-                  const duration = t?.durationMs ?? 500;
-                  const setType = (next: "none" | "crossfade") => {
-                    if (next === "none") {
+                  // Auto (default): cross-fade across any same-track overlap.
+                  // Crossfade: explicit duration. None: a zero-length cross-fade
+                  // — an opt-out that stays a hard cut even when clips overlap.
+                  const mode: "auto" | "crossfade" | "none" =
+                    t == null ? "auto" : t.durationMs <= 0 ? "none" : "crossfade";
+                  const duration = t && t.durationMs > 0 ? t.durationMs : 500;
+                  const setMode = (next: "auto" | "crossfade" | "none") => {
+                    if (next === "auto") {
                       patchClip(clip.id, { transitionIn: undefined });
+                    } else if (next === "none") {
+                      patchClip(clip.id, {
+                        transitionIn: { type: "crossfade", durationMs: 0 }
+                      });
                     } else {
                       const transition: ClipTransition = {
                         type: "crossfade",
@@ -588,45 +596,49 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                     <>
                       <InspectorRow label="Type">
                         <NodeSelect
-                          value={type}
+                          value={mode}
                           onChange={(e) =>
-                            setType(e.target.value as "none" | "crossfade")
+                            setMode(
+                              e.target.value as "auto" | "crossfade" | "none"
+                            )
                           }
                         >
-                          <NodeMenuItem value="none">None</NodeMenuItem>
+                          <NodeMenuItem value="auto">Auto</NodeMenuItem>
                           <NodeMenuItem value="crossfade">
                             Crossfade
                           </NodeMenuItem>
+                          <NodeMenuItem value="none">None</NodeMenuItem>
                         </NodeSelect>
                       </InspectorRow>
-                      {type === "crossfade" && (
-                        <>
-                          <InspectorRow label="Duration">
-                            <InspectorPillInput
-                              value={(duration / 1000).toFixed(2)}
-                              unit="s"
-                              onCommit={(raw) => {
-                                const ms = parseSeconds(raw);
-                                if (ms == null) return;
-                                patchClip(clip.id, {
-                                  transitionIn: {
-                                    type: "crossfade",
-                                    durationMs: Math.max(0, ms)
-                                  }
-                                });
-                              }}
-                              ariaLabel="Transition duration"
-                            />
-                          </InspectorRow>
-                          <Text
-                            size="small"
-                            sx={{ px: 0.5, color: "text.secondary" }}
-                          >
-                            Overlap with the previous clip on the same track to
-                            see the cross-fade.
-                          </Text>
-                        </>
+                      {mode === "crossfade" && (
+                        <InspectorRow label="Duration">
+                          <InspectorPillInput
+                            value={(duration / 1000).toFixed(2)}
+                            unit="s"
+                            onCommit={(raw) => {
+                              const ms = parseSeconds(raw);
+                              if (ms == null) return;
+                              patchClip(clip.id, {
+                                transitionIn: {
+                                  type: "crossfade",
+                                  durationMs: Math.max(0, ms)
+                                }
+                              });
+                            }}
+                            ariaLabel="Transition duration"
+                          />
+                        </InspectorRow>
                       )}
+                      <Text
+                        size="small"
+                        sx={{ px: 0.5, color: "text.secondary" }}
+                      >
+                        {mode === "auto"
+                          ? "Overlap this clip with the previous one on the same track to cross-fade."
+                          : mode === "crossfade"
+                            ? "Fixed cross-fade length, measured from this clip's start."
+                            : "Always a hard cut, even when clips overlap."}
+                      </Text>
                     </>
                   );
                 })()}

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -27,7 +27,7 @@ import {
   FlexRow,
   Text,
   Caption,
-  NodeSlider,
+  Slider,
   ToolbarIconButton
 } from "../../ui_primitives";
 
@@ -447,7 +447,19 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       }
     }, []);
 
-    const scrubMax = Math.max(1, durationMs || 0);
+    // `durationMs` is set only on load and is NOT recomputed when clips are
+    // added/moved (see TracksRegion, which derives its own content extent).
+    // For a new/unsaved sequence it stays 0, which would pin the scrubber's
+    // range to [0, 1] (max ≤ step → every drag snaps to the end). Derive the
+    // max from the actual clip extent, matching the ruler.
+    const contentEndMs = useMemo(() => {
+      let end = durationMs || 0;
+      for (const c of clips) {
+        end = Math.max(end, c.startMs + c.durationMs);
+      }
+      return end;
+    }, [clips, durationMs]);
+    const scrubMax = Math.max(1, contentEndMs);
     const scrubValue = Math.min(scrubMax, scrubMs ?? currentTimeMs);
 
     // Live timecode without per-frame React renders: while playing, subscribe
@@ -609,7 +621,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
             {timecode}
           </Text>
           <div css={scrubberStyles}>
-            <NodeSlider
+            <Slider
               aria-label="Scrub timeline"
               min={0}
               max={scrubMax}

--- a/web/src/components/timeline/preview/__tests__/sceneModel.test.ts
+++ b/web/src/components/timeline/preview/__tests__/sceneModel.test.ts
@@ -4,11 +4,11 @@ import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
 import {
   clipSourceTimeSec,
   computeActiveLayers,
+  crossfadeOpacity,
   effectiveAssetId,
   isClipActive,
   resolveCaptionAtTime,
   trackZ,
-  transitionOpacity,
   LAYER_Z_BASE
 } from "../sceneModel";
 
@@ -34,19 +34,55 @@ describe("isClipActive", () => {
   });
 });
 
-describe("transitionOpacity", () => {
-  it("returns 1 with no transition", () => {
-    expect(transitionOpacity(clip({ startMs: 0 }), 50)).toBe(1);
+describe("crossfadeOpacity", () => {
+  it("is 1 for a lone clip with no transition and no overlap", () => {
+    const c = clip({ startMs: 0 });
+    expect(crossfadeOpacity(c, [c], 50)).toBe(1);
   });
-  it("ramps 0→1 across the crossfade window", () => {
+
+  it("ramps 0→1 over an explicit crossfade window (no overlap needed)", () => {
     const c = clip({
       startMs: 0,
       transitionIn: { type: "crossfade", durationMs: 200 }
     });
-    expect(transitionOpacity(c, 0)).toBe(0);
-    expect(transitionOpacity(c, 100)).toBeCloseTo(0.5);
-    expect(transitionOpacity(c, 200)).toBe(1);
-    expect(transitionOpacity(c, 500)).toBe(1);
+    expect(crossfadeOpacity(c, [c], 0)).toBe(0);
+    expect(crossfadeOpacity(c, [c], 100)).toBeCloseTo(0.5);
+    expect(crossfadeOpacity(c, [c], 200)).toBe(1);
+    expect(crossfadeOpacity(c, [c], 500)).toBe(1);
+  });
+
+  it("auto-crossfades the incoming clip across an overlap with a preceding clip", () => {
+    // A [0,1000) and B [800,1800) overlap by 200ms; B has no explicit
+    // transition, so the overlap length is the crossfade duration.
+    const a = clip({ id: "a", startMs: 0, durationMs: 1000 });
+    const b = clip({ id: "b", startMs: 800, durationMs: 1000 });
+    const same = [a, b];
+    expect(crossfadeOpacity(b, same, 800)).toBe(0);
+    expect(crossfadeOpacity(b, same, 900)).toBeCloseTo(0.5);
+    expect(crossfadeOpacity(b, same, 1000)).toBe(1);
+    expect(crossfadeOpacity(b, same, 1500)).toBe(1);
+    // The outgoing (bottom) clip stays fully opaque — the dissolve is the
+    // incoming clip fading in on top.
+    expect(crossfadeOpacity(a, same, 900)).toBe(1);
+  });
+
+  it("does not auto-crossfade when clips do not overlap", () => {
+    const a = clip({ id: "a", startMs: 0, durationMs: 1000 });
+    const b = clip({ id: "b", startMs: 2000, durationMs: 1000 });
+    expect(crossfadeOpacity(b, [a, b], 2000)).toBe(1);
+  });
+
+  it("treats a zero-duration crossfade as an opt-out (hard cut) even when overlapping", () => {
+    const a = clip({ id: "a", startMs: 0, durationMs: 1000 });
+    const b = clip({
+      id: "b",
+      startMs: 800,
+      durationMs: 1000,
+      transitionIn: { type: "crossfade", durationMs: 0 }
+    });
+    const same = [a, b];
+    expect(crossfadeOpacity(b, same, 800)).toBe(1);
+    expect(crossfadeOpacity(b, same, 900)).toBe(1);
   });
 });
 

--- a/web/src/components/timeline/preview/gpu/__tests__/shouldPresentFrame.test.ts
+++ b/web/src/components/timeline/preview/gpu/__tests__/shouldPresentFrame.test.ts
@@ -1,0 +1,20 @@
+import { shouldPresentFrame } from "../source";
+
+describe("shouldPresentFrame", () => {
+  it("presents an empty scene (clears to black — a real gap)", () => {
+    expect(shouldPresentFrame(0, 0)).toBe(true);
+  });
+
+  it("holds the last frame when layers exist but none decoded yet", () => {
+    // The incoming clip at a cut is still seeking — presenting would flash
+    // opaque black. Hold the previously-presented frame instead.
+    expect(shouldPresentFrame(1, 0)).toBe(false);
+    expect(shouldPresentFrame(3, 0)).toBe(false);
+  });
+
+  it("presents when at least one layer drew", () => {
+    expect(shouldPresentFrame(1, 1)).toBe(true);
+    expect(shouldPresentFrame(3, 1)).toBe(true);
+    expect(shouldPresentFrame(2, 2)).toBe(true);
+  });
+});

--- a/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
+++ b/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
@@ -5,7 +5,7 @@ import {
   clipMatrixToCanvasAffine,
   containBaseScale
 } from "./transform";
-import { isSourceReady, sourceDimensions } from "./source";
+import { isSourceReady, shouldPresentFrame, sourceDimensions } from "./source";
 import type {
   CompositeLayer,
   CompositorInitResult,
@@ -69,6 +69,16 @@ export class Canvas2DCompositor implements TimelineCompositor {
     const ctx = this.ctx;
     if (!ctx) return;
 
+    // Decide drawable layers before clearing. A scene with layers but none
+    // decoded yet (the incoming clip at a cut is still seeking) must hold the
+    // last frame — clearing + drawing nothing would flash opaque black.
+    const drawable = this.layers.filter((layer) => {
+      if (!isSourceReady(layer.source)) return false;
+      const { width, height } = sourceDimensions(layer.source);
+      return width > 0 && height > 0;
+    });
+    if (!shouldPresentFrame(this.layers.length, drawable.length)) return;
+
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.globalAlpha = 1;
     ctx.globalCompositeOperation = "source-over";
@@ -77,10 +87,8 @@ export class Canvas2DCompositor implements TimelineCompositor {
     ctx.fillStyle = "#000";
     ctx.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
 
-    for (const layer of this.layers) {
-      if (!isSourceReady(layer.source)) continue;
+    for (const layer of drawable) {
       const { width, height } = sourceDimensions(layer.source);
-      if (width === 0 || height === 0) continue;
 
       const transform = layer.transform ?? IDENTITY_TRANSFORM;
       const base = containBaseScale(

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -15,7 +15,7 @@ import type {
   CompositorInitResult,
   TimelineCompositor
 } from "./types";
-import { isSourceReady, sourceDimensions } from "./source";
+import { isSourceReady, shouldPresentFrame, sourceDimensions } from "./source";
 
 interface SourceTexture {
   texture: GPUTexture;
@@ -221,9 +221,11 @@ export class WebGPUCompositor implements TimelineCompositor {
     }
 
     this.core.beginFrame();
+    let drawnCount = 0;
     for (const layer of this.layers) {
       const src = this.uploadSource(layer);
       if (!src) continue;
+      drawnCount++;
 
       const clipEffectsList = layer.effects ?? [];
       const trackEffectsList = layer.trackEffects ?? [];
@@ -281,6 +283,14 @@ export class WebGPUCompositor implements TimelineCompositor {
       const tmp = readTex;
       readTex = writeTex;
       writeTex = tmp;
+    }
+
+    // Every active clip was mid-decode (e.g. the incoming clip at a cut is
+    // still seeking). Skip the present so the swap chain keeps showing the last
+    // frame instead of flashing the opaque-black seed. `getCurrentTexture()` is
+    // never called, so nothing replaces what's on screen.
+    if (!shouldPresentFrame(this.layers.length, drawnCount)) {
+      return;
     }
 
     this.core.blit(

--- a/web/src/components/timeline/preview/gpu/source.ts
+++ b/web/src/components/timeline/preview/gpu/source.ts
@@ -15,6 +15,21 @@ export function isSourceReady(source: CompositeSource): boolean {
   return source.width > 0;
 }
 
+/**
+ * Whether to present the frame just composited. A scene that *has* layers but
+ * drew none of them means every source is mid-decode — e.g. the incoming clip
+ * at a cut is still seeking. Presenting then would flash opaque black (both
+ * compositors seed the frame black), so we skip the present and the canvas
+ * holds its last frame instead. An empty scene (no layers) still presents:
+ * that's a genuine gap and should clear to black.
+ */
+export function shouldPresentFrame(
+  layerCount: number,
+  drawnCount: number
+): boolean {
+  return layerCount === 0 || drawnCount > 0;
+}
+
 /** Intrinsic pixel dimensions of a composite source. */
 export function sourceDimensions(source: CompositeSource): {
   width: number;

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -55,20 +55,60 @@ export function isClipActive(
 }
 
 /**
- * Opacity multiplier for a clip given the playhead position. Implements the
- * incoming `transitionIn` ramp (0→1 over `durationMs`). Returns 1 when no
- * transition applies. Crossfade is the only type currently supported.
+ * How long clip's head overlaps a preceding same-track clip, in ms (0 if none).
+ * `sameTrackClips` must already be filtered to clip's track. Picks the largest
+ * overlap when several earlier clips cover the head, and never reports more than
+ * clip's own duration.
  */
-export function transitionOpacity(
+function headOverlapMs(
   clip: TimelineClip,
+  sameTrackClips: TimelineClip[]
+): number {
+  let overlap = 0;
+  for (const prev of sameTrackClips) {
+    if (prev === clip || prev.startMs >= clip.startMs) continue;
+    const prevEnd = prev.startMs + prev.durationMs;
+    if (prevEnd <= clip.startMs) continue; // no overlap
+    overlap = Math.max(overlap, prevEnd - clip.startMs);
+  }
+  return Math.min(overlap, clip.durationMs);
+}
+
+/**
+ * Opacity multiplier for a clip's incoming cross-fade given the playhead.
+ *
+ * On the same track the later-starting clip composites on top, so a dissolve is
+ * just the incoming clip fading in over the one beneath it — the outgoing clip
+ * stays fully opaque (fading it too would bleed the black seed through).
+ *
+ * - `transitionIn` unset → **auto**: fade in across the overlap with a preceding
+ *   same-track clip (the overlap length is the duration). No overlap → 1.
+ * - `transitionIn` is a crossfade with `durationMs > 0` → explicit ramp over that
+ *   window from the clip's start (independent of overlap; also gives fade-from-
+ *   black for a clip with nothing beneath it).
+ * - `durationMs <= 0` → opt-out: a zero-length crossfade is a hard cut, so 1
+ *   even when the clips overlap.
+ *
+ * `sameTrackClips` must already be filtered to clip's track.
+ */
+export function crossfadeOpacity(
+  clip: TimelineClip,
+  sameTrackClips: TimelineClip[],
   currentTimeMs: number
 ): number {
   const t = clip.transitionIn;
-  if (!t || t.durationMs <= 0) return 1;
+  let durationMs: number;
+  if (t) {
+    if (t.durationMs <= 0) return 1; // explicit hard cut
+    durationMs = t.durationMs;
+  } else {
+    durationMs = headOverlapMs(clip, sameTrackClips);
+    if (durationMs <= 0) return 1; // auto, but nothing to cross-fade with
+  }
   const intoClip = currentTimeMs - clip.startMs;
-  if (intoClip >= t.durationMs) return 1;
   if (intoClip <= 0) return 0;
-  return intoClip / t.durationMs;
+  if (intoClip >= durationMs) return 1;
+  return intoClip / durationMs;
 }
 
 /** The asset id that should be drawn for a clip in its current status. */
@@ -213,7 +253,10 @@ export function computeActiveLayers(
 
     for (const clip of activeClips) {
       const baseOpacity = clip.opacity ?? 1;
-      const opacity = baseOpacity * transitionOpacity(clip, currentTimeMs);
+      // During an overlap both clips are active, so `activeClips` already holds
+      // the preceding clip the auto-crossfade ramps against.
+      const opacity =
+        baseOpacity * crossfadeOpacity(clip, activeClips, currentTimeMs);
 
       // Captions ride on their media clip and always render on top.
       const caption = resolveCaptionAtTime(clip, currentTimeMs);

--- a/web/src/components/ui_primitives/Slider.tsx
+++ b/web/src/components/ui_primitives/Slider.tsx
@@ -1,0 +1,67 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Slider
+ *
+ * General-purpose slider primitive for application UI (transport scrubbers,
+ * setting controls, media seek bars). Theme-driven, full-width, with a normal
+ * pointer hit area.
+ *
+ * This is distinct from {@link NodeSlider}, which carries node-editor baggage
+ * (the ReactFlow `nodrag` class, editor scope, a collapsed `padding: 0` hit
+ * area) and is meant only for node property panels. Use `Slider` everywhere
+ * else.
+ */
+
+import { forwardRef, useMemo } from "react";
+import { Slider as MuiSlider, type SliderProps as MuiSliderProps } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import { MOTION } from "./tokens";
+
+export interface SliderProps extends Omit<MuiSliderProps, "size"> {
+  /** Compact sizing for dense toolbars/control bars. */
+  density?: "compact" | "normal";
+}
+
+export const Slider = forwardRef<HTMLSpanElement, SliderProps>(
+  ({ sx, density = "normal", ...props }, ref) => {
+    const theme = useTheme();
+    const primaryChannel = theme.vars.palette.primary.mainChannel ?? "0 0 0";
+    const railHeight = density === "compact" ? 4 : 6;
+    const thumbSize = density === "compact" ? 12 : 16;
+
+    const mergedSx = useMemo(
+      () => ({
+        // Keep a comfortable vertical hit area so the thumb is easy to grab.
+        padding: density === "compact" ? "8px 0" : "13px 0",
+        "& .MuiSlider-rail": {
+          backgroundColor: theme.vars.palette.grey[500],
+          opacity: 0.4,
+          height: railHeight
+        },
+        "& .MuiSlider-track": {
+          backgroundColor: theme.vars.palette.primary.main,
+          border: "none",
+          height: railHeight
+        },
+        "& .MuiSlider-thumb": {
+          width: thumbSize,
+          height: thumbSize,
+          backgroundColor: theme.vars.palette.primary.main,
+          transition: MOTION.background,
+          "&:hover, &.Mui-focusVisible": {
+            boxShadow: `0 0 0 6px rgba(${primaryChannel} / 0.16)`
+          },
+          "&.Mui-active": {
+            boxShadow: `0 0 0 8px rgba(${primaryChannel} / 0.16)`
+          }
+        },
+        ...sx
+      }),
+      [theme, density, railHeight, thumbSize, primaryChannel, sx]
+    );
+
+    return <MuiSlider ref={ref} sx={mergedSx} {...props} />;
+  }
+);
+
+Slider.displayName = "Slider";

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -5,9 +5,12 @@
  * These primitives follow semantic design principles and are theme-driven.
  */
 
-// Export slider component
+// Export slider components
 export { NodeSlider } from "./NodeSlider";
 export type { NodeSliderProps } from "./NodeSlider";
+
+export { Slider } from "./Slider";
+export type { SliderProps } from "./Slider";
 
 // Export dialog primitives
 export { Dialog } from "./Dialog";


### PR DESCRIPTION
Three related fixes/improvements to the timeline preview, each its own commit.

## 1. `fix`: hold last frame instead of flashing black at clip cuts
At a cut the incoming clip's `<video>` is still mid-seek, so no layer draws and both compositors seed the frame **opaque black** — a 1–2 frame black flicker. New `shouldPresentFrame()` presents only when the scene is empty (a real gap) or at least one layer drew; otherwise the present is skipped so the canvas **holds its last frame** (matches Premiere/Resolve). Applied to the WebGPU and Canvas2D compositors. The offline export path is unaffected — it awaits `seeked`, so frames are always ready there.

## 2. `feat`: auto-crossfade overlapping clips on the same track
The cross-fade is now derived from **overlap geometry** in `computeActiveLayers`: an incoming clip with no explicit transition fades in across its overlap with the preceding same-track clip (overlap length = the duration). Explicit crossfade durations are still honored; a zero-length crossfade is an opt-out (hard cut). On a single track the later clip composites on top, so fade-in-on-top is already a correct dissolve — no outgoing fade-out needed. Inspector Transition control is now **Auto / Crossfade / None**.

## 3. `fix`: preview scrubber couldn't seek (range pinned to [0,1])
`durationMs` is set only on load and never recomputed as clips change, so a new/unsaved sequence kept `durationMs=0` → scrubber `max=1`. With a ~33ms step only `{0, end}` were reachable, so every drag snapped to the end with no fractional positions. `scrubMax` now derives from the content extent (max of `durationMs` and clip ends), matching how `TracksRegion` derives its ruler extent. The scrubber also moves off `NodeSlider` (node-property only) onto a new general-purpose `Slider` primitive.

## Verification
- `npm run typecheck` clean; `oxlint` clean on changed files.
- 88 preview tests pass, including new `shouldPresentFrame` and `crossfadeOpacity` cases (written test-first).
- Scrubber fix confirmed live (CDP): the slider input went from `max=1` to a content-derived `max` with fractional step.