### PR TITLE
feat(timeline,sketch): unify generation headers on shared media-composer controls

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -36,9 +36,6 @@ import useMediaGenerationStore, {
   IMAGE_ASPECT_RATIOS,
   IMAGE_RESOLUTIONS,
   IMAGE_VARIATIONS,
-  VIDEO_ASPECT_RATIOS,
-  VIDEO_DURATIONS,
-  VIDEO_RESOLUTIONS,
   AUDIO_FORMATS,
   AUDIO_SPEEDS,
   DEFAULT_TTS_VOICES,
@@ -49,9 +46,7 @@ import useMediaGenerationStore, {
 import type {
   MediaMode,
   ImageResolution,
-  VideoResolution,
-  AudioFormat,
-  AspectRatioOption
+  AudioFormat
 } from "../../../stores/MediaGenerationStore";
 import MediaControlChip from "./MediaControlChip";
 import MediaModeMenu from "./MediaModeMenu";
@@ -59,6 +54,11 @@ import PiComposerControls, { piModeAvailable } from "./PiComposerControls";
 import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
 import MediaOptionMenu, { MediaOption } from "./MediaOptionMenu";
 import MediaAspectRatioMenu from "./MediaAspectRatioMenu";
+import {
+  buildVideoModelOptions,
+  clampToAllowed,
+  videoModelConstraints
+} from "./videoModelOptions";
 import ImageModelMenuDialog from "../../model_menu/ImageModelMenuDialog";
 import VideoModelMenuDialog from "../../model_menu/VideoModelMenuDialog";
 import LanguageModelMenuDialog from "../../model_menu/LanguageModelMenuDialog";
@@ -90,48 +90,6 @@ function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
-/** Extract per-model video option constraints (manifest enums) from a model. */
-function videoModelConstraints(model: VideoModel): {
-  durations?: number[];
-  resolutions?: string[];
-  aspectRatios?: string[];
-} {
-  const durations = model.durations?.filter((d) => Number.isFinite(d));
-  const resolutions = model.resolutions ?? undefined;
-  const aspectRatios = model.aspect_ratios ?? undefined;
-  return {
-    durations: durations && durations.length > 0 ? durations : undefined,
-    resolutions:
-      resolutions && resolutions.length > 0 ? resolutions : undefined,
-    aspectRatios:
-      aspectRatios && aspectRatios.length > 0 ? aspectRatios : undefined
-  };
-}
-
-/** Keep `value` if the model allows it; otherwise snap to the first allowed. */
-function clampToAllowed<T>(value: T, allowed?: Array<T | string>): T {
-  if (!allowed || allowed.length === 0) return value;
-  if ((allowed as unknown[]).includes(value)) return value;
-  return allowed[0] as T;
-}
-
-/** Build aspect-ratio menu options from a model's allowed list. */
-function buildAspectOptions(
-  allowed: string[],
-  fallback: AspectRatioOption[]
-): AspectRatioOption[] {
-  const options = allowed
-    .map((id) => {
-      const known = fallback.find((a) => a.id === id);
-      if (known) return known;
-      const m = id.match(/^(\d+):(\d+)$/);
-      return m
-        ? { id, label: id, width: Number(m[1]), height: Number(m[2]) }
-        : null;
-    })
-    .filter((x): x is AspectRatioOption => x != null);
-  return options.length > 0 ? options : fallback;
-}
 
 export interface MediaChatComposerProps {
   isLoading: boolean;
@@ -702,38 +660,13 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         ? imageToVideoParams.model
         : null;
 
-  // Option lists
-  const durationOptions = useMemo<MediaOption<number>[]>(() => {
-    const values =
-      activeVideoModel?.durations && activeVideoModel.durations.length > 0
-        ? activeVideoModel.durations
-        : VIDEO_DURATIONS;
-    return values.map((d) => ({
-      id: d,
-      label: `${d} Sec`,
-      icon: <AccessTimeIcon fontSize="small" />
-    }));
-  }, [activeVideoModel?.durations]);
-
-  const videoResolutionOptions = useMemo<MediaOption<VideoResolution>[]>(() => {
-    const values =
-      activeVideoModel?.resolutions && activeVideoModel.resolutions.length > 0
-        ? (activeVideoModel.resolutions as VideoResolution[])
-        : VIDEO_RESOLUTIONS;
-    return values.map((r) => ({
-      id: r,
-      label: r,
-      icon: <DisplaySettingsIcon fontSize="small" />
-    }));
-  }, [activeVideoModel?.resolutions]);
-
-  const videoAspectOptions = useMemo<AspectRatioOption[]>(
-    () =>
-      activeVideoModel?.aspectRatios && activeVideoModel.aspectRatios.length > 0
-        ? buildAspectOptions(activeVideoModel.aspectRatios, VIDEO_ASPECT_RATIOS)
-        : VIDEO_ASPECT_RATIOS,
-    [activeVideoModel?.aspectRatios]
-  );
+  // Option lists — derived from the active model's manifest (shared with the
+  // timeline quick-gen header via buildVideoModelOptions).
+  const {
+    durationOptions,
+    resolutionOptions: videoResolutionOptions,
+    aspectOptions: videoAspectOptions
+  } = useMemo(() => buildVideoModelOptions(activeVideoModel), [activeVideoModel]);
 
   const imageResolutionOptions = useMemo<MediaOption<ImageResolution>[]>(
     () =>

--- a/web/src/components/chat/composer/videoModelOptions.tsx
+++ b/web/src/components/chat/composer/videoModelOptions.tsx
@@ -1,0 +1,113 @@
+/**
+ * videoModelOptions — shared derivation of the duration / resolution / aspect
+ * controls offered for a video model.
+ *
+ * One source of truth for both the media chat composer ({@link MediaChatComposer})
+ * and the timeline quick-generate header (`TopBarPrompt`), so the two surfaces
+ * present identical, model-constrained options and can't drift apart.
+ */
+
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import TvIcon from "@mui/icons-material/Tv";
+import type { VideoModel } from "../../../stores/ApiTypes";
+import {
+  VIDEO_ASPECT_RATIOS,
+  VIDEO_DURATIONS,
+  VIDEO_RESOLUTIONS,
+  type AspectRatioOption,
+  type VideoModelSelection,
+  type VideoResolution
+} from "../../../stores/MediaGenerationStore";
+import type { MediaOption } from "./MediaOptionMenu";
+
+/** Extract per-model option constraints (manifest enums) from a raw model. */
+export function videoModelConstraints(model: VideoModel): {
+  durations?: number[];
+  resolutions?: string[];
+  aspectRatios?: string[];
+} {
+  const durations = model.durations?.filter((d) => Number.isFinite(d));
+  const resolutions = model.resolutions ?? undefined;
+  const aspectRatios = model.aspect_ratios ?? undefined;
+  return {
+    durations: durations && durations.length > 0 ? durations : undefined,
+    resolutions:
+      resolutions && resolutions.length > 0 ? resolutions : undefined,
+    aspectRatios:
+      aspectRatios && aspectRatios.length > 0 ? aspectRatios : undefined
+  };
+}
+
+/** Keep `value` if the model allows it; otherwise snap to the first allowed. */
+export function clampToAllowed<T>(value: T, allowed?: Array<T | string>): T {
+  if (!allowed || allowed.length === 0) return value;
+  if ((allowed as unknown[]).includes(value)) return value;
+  return allowed[0] as T;
+}
+
+/** Build aspect-ratio menu options from a model's allowed list. */
+export function buildAspectOptions(
+  allowed: string[],
+  fallback: AspectRatioOption[]
+): AspectRatioOption[] {
+  const options = allowed
+    .map((id) => {
+      const known = fallback.find((a) => a.id === id);
+      if (known) return known;
+      const m = id.match(/^(\d+):(\d+)$/);
+      return m
+        ? { id, label: id, width: Number(m[1]), height: Number(m[2]) }
+        : null;
+    })
+    .filter((x): x is AspectRatioOption => x != null);
+  return options.length > 0 ? options : fallback;
+}
+
+/** Normalize a raw model into the stored selection shape (with its constraints). */
+export function normalizeVideoModel(model: VideoModel): VideoModelSelection {
+  return {
+    type: "video_model",
+    id: model.id,
+    provider: model.provider,
+    name: model.name || "",
+    ...videoModelConstraints(model)
+  };
+}
+
+/**
+ * Build the duration / resolution / aspect menu options for a selected video
+ * model, falling back to the full sets when the model declares no constraints.
+ */
+export function buildVideoModelOptions(
+  model: VideoModelSelection | null | undefined
+): {
+  durationOptions: MediaOption<number>[];
+  resolutionOptions: MediaOption<VideoResolution>[];
+  aspectOptions: AspectRatioOption[];
+} {
+  const durations =
+    model?.durations && model.durations.length > 0
+      ? model.durations
+      : VIDEO_DURATIONS;
+  const resolutions =
+    model?.resolutions && model.resolutions.length > 0
+      ? (model.resolutions as VideoResolution[])
+      : VIDEO_RESOLUTIONS;
+  const aspectOptions =
+    model?.aspectRatios && model.aspectRatios.length > 0
+      ? buildAspectOptions(model.aspectRatios, VIDEO_ASPECT_RATIOS)
+      : VIDEO_ASPECT_RATIOS;
+  return {
+    durationOptions: durations.map((d) => ({
+      id: d,
+      label: `${d} Sec`,
+      icon: <AccessTimeIcon fontSize="small" />
+    })),
+    resolutionOptions: resolutions.map((r) => ({
+      id: r,
+      label: r,
+      icon: <TvIcon fontSize="small" />
+    })),
+    aspectOptions
+  };
+}

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -12,25 +12,31 @@
  * sketch modal has no session, same gate as SelectionActionBar).
  */
 
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { useTheme } from "@mui/material/styles";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import ResolutionIcon from "@mui/icons-material/Tv";
+import ImageIcon from "@mui/icons-material/Image";
 
 import {
   EditorButton,
   FlexRow,
   LoadingSpinner,
-  SPACING,
   TextInput,
   Toast
 } from "../../ui_primitives";
-import ImageModelSelect from "../../properties/ImageModelSelect";
 import MediaControlChip from "../../chat/composer/MediaControlChip";
 import MediaAspectRatioMenu from "../../chat/composer/MediaAspectRatioMenu";
 import MediaOptionMenu from "../../chat/composer/MediaOptionMenu";
-import type { ImageModelValue } from "../../../stores/ApiTypes";
+import ImageModelMenuDialog from "../../model_menu/ImageModelMenuDialog";
+import type { ImageModel } from "../../../stores/ApiTypes";
 import {
   IMAGE_ASPECT_RATIOS,
   IMAGE_RESOLUTIONS,
@@ -108,6 +114,11 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   const [seed] = useState(seedModelFromBindings);
   const [model, setModel] = useState(seed.model);
   const [provider, setProvider] = useState(seed.provider);
+  // The remembered seed carries only ids, so the chip shows the id until a
+  // model is picked through the dialog (which provides a display name).
+  const [modelName, setModelName] = useState(seed.model);
+  const imageModelAnchorRef = useRef<HTMLButtonElement>(null);
+  const [imageModelOpen, setImageModelOpen] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -146,9 +157,11 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
     [resolution, resizeCanvas]
   );
 
-  const handleModelChange = useCallback((v: ImageModelValue) => {
-    setModel(v.id);
-    setProvider(v.provider);
+  const handlePickImageModel = useCallback((m: ImageModel) => {
+    setModel(m.id);
+    setProvider(m.provider);
+    setModelName(m.name || m.id);
+    setImageModelOpen(false);
   }, []);
 
   const handleGenerate = useCallback(async () => {
@@ -194,7 +207,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
         className="sketch-mode-prompt-bar"
         data-testid="sketch-mode-prompt-bar"
         align="center"
-        gap={SPACING.xl}
+        gap={1}
         sx={{
           flexShrink: 0,
           width: "100%",
@@ -207,6 +220,61 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
           borderBottom: `1px solid ${theme.vars.palette.grey[800]}`
         }}
       >
+        {/* Prompt — grows to fill */}
+        <TextInput
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Describe the image…"
+          compact
+          fullWidth
+          inputProps={{
+            "aria-label": "Generation prompt",
+            "data-testid": "sketch-gen-prompt"
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey && !actionDisabled) {
+              e.preventDefault();
+              void handleGenerate();
+            }
+          }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <AutoAwesomeIcon
+                  fontSize="small"
+                  sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
+                />
+              )
+            }
+          }}
+          sx={{
+            flex: 1,
+            minWidth: 160,
+            // Match the control/button height so the row aligns.
+            "& .MuiOutlinedInput-root": { height: 34 }
+          }}
+        />
+
+        {/* Model selector — same chip + dialog as the media composer */}
+        <MediaControlChip
+          ref={imageModelAnchorRef}
+          icon={<ImageIcon fontSize="small" />}
+          label={modelName || "Select Model"}
+          active={imageModelOpen}
+          onClick={() => setImageModelOpen(true)}
+          truncate
+          showChevron={false}
+        />
+        {imageModelOpen && (
+          <ImageModelMenuDialog
+            open
+            anchorEl={imageModelAnchorRef.current}
+            onClose={() => setImageModelOpen(false)}
+            onModelChange={handlePickImageModel}
+            task="text_to_image"
+          />
+        )}
+
         {/* Resolution */}
         <MediaControlChip
           icon={<ResolutionIcon fontSize="small" />}
@@ -241,48 +309,6 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
           options={IMAGE_ASPECT_RATIOS}
           onChange={handleAspectChange}
         />
-
-        {/* Prompt */}
-        <TextInput
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Describe the image…"
-          compact
-          fullWidth
-          aria-label="Generation prompt"
-          data-testid="sketch-gen-prompt"
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey && !actionDisabled) {
-              e.preventDefault();
-              void handleGenerate();
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <AutoAwesomeIcon
-                  fontSize="small"
-                  sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
-                />
-              )
-            }
-          }}
-          sx={{
-            flex: 1,
-            minWidth: 120,
-            // Match the control/button height so the row aligns.
-            "& .MuiOutlinedInput-root": { height: 34 }
-          }}
-        />
-
-        {/* Model selector */}
-        <FlexRow sx={{ flexShrink: 0 }}>
-          <ImageModelSelect
-            value={model}
-            task="text_to_image"
-            onChange={handleModelChange}
-          />
-        </FlexRow>
 
         {/* Primary action — full-frame text-to-image */}
         <EditorButton

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -450,10 +450,6 @@ const TimelineEditorBody: React.FC<Omit<TimelineEditorProps, "active">> = memo((
     <FlexColumn fullWidth fullHeight css={editorStyles(theme)}>
       {/* ── Top bar ───────────────────────────────────────────────── */}
       <TopBar
-        sequenceName={
-          sequence?.name ??
-          (sequenceUnavailable ? sequenceId : undefined)
-        }
         onExportVideo={sequenceUnavailable ? undefined : handleExportVideo}
         isExporting={isExporting}
         onSave={sequenceUnavailable ? undefined : handleSave}

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -2,21 +2,16 @@
 /**
  * TopBar — Timeline Editor top bar.
  *
- * Contains: project name, save status, Project / Library / Exports buttons,
- * export action, and an activity indicator slot.
+ * A single generation prompt bar (model + output settings + Generate) that
+ * grows to fill, with Save / Export and an activity slot on the right. The
+ * project name lives in the workspace tab, so it isn't repeated here.
  */
 
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
-import {
-  FlexRow,
-  Text,
-  Caption,
-  EditorButton
-} from "../ui_primitives";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import { FlexRow, EditorButton } from "../ui_primitives";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import SaveIcon from "@mui/icons-material/Save";
 
@@ -28,33 +23,10 @@ const styles = (theme: Theme) =>
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     backgroundColor: theme.vars.palette.background.paper,
     padding: `0 ${theme.spacing(1.5)}`,
-    flexShrink: 0,
-    ".project-name": {
-      cursor: "pointer",
-      borderRadius: theme.rounded.sm,
-      padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
-      "&:hover": {
-        backgroundColor: theme.vars.palette.action.hover
-      }
-    },
-    ".save-status": {
-      color: theme.vars.palette.text.disabled
-    },
-    ".section-divider": {
-      width: 1,
-      height: 20,
-      backgroundColor: theme.vars.palette.divider,
-      margin: `0 ${theme.spacing(0.5)}`
-    }
+    flexShrink: 0
   });
 
 export interface TopBarProps {
-  /** Name of the current sequence / project */
-  sequenceName?: string;
-  /** Human-readable save status (e.g. "Saved", "Saving…") */
-  saveStatus?: string;
-  /** Called when the user clicks the project name dropdown */
-  onProjectNameClick?: () => void;
   /** Called when the user clicks Export (renders the timeline to a video file) */
   onExportVideo?: () => void;
   /** True while an export render is in progress. */
@@ -69,9 +41,6 @@ export interface TopBarProps {
 
 export const TopBar: React.FC<TopBarProps> = memo(
   ({
-    sequenceName = "Untitled Sequence",
-    saveStatus,
-    onProjectNameClick,
     onExportVideo,
     isExporting = false,
     onSave,
@@ -81,72 +50,36 @@ export const TopBar: React.FC<TopBarProps> = memo(
     const theme = useTheme();
 
     return (
-      <FlexRow
-        align="center"
-        justify="space-between"
-        fullWidth
-        css={styles(theme)}
-      >
-        {/* Left: project name + save status */}
-        <FlexRow gap={1} align="center">
-          <FlexRow
-            align="center"
-            gap={0.5}
-            className="project-name"
-            onClick={onProjectNameClick}
-            role="button"
-            tabIndex={0}
-            aria-haspopup="menu"
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") onProjectNameClick?.();
-            }}
-          >
-            <Text size="small" weight={500}>
-              {sequenceName}
-            </Text>
-            <ArrowDropDownIcon
-              sx={{ fontSize: 16, color: theme.vars.palette.text.secondary }}
-            />
-          </FlexRow>
-
-          {saveStatus && (
-            <Caption className="save-status">{saveStatus}</Caption>
-          )}
-        </FlexRow>
-
-        {/* Center: quick-prompt generation bar */}
+      <FlexRow align="center" gap={1} fullWidth css={styles(theme)}>
+        {/* Quick-prompt generation bar — grows to fill */}
         <TopBarPrompt />
 
-        {/* Right: activity slot + export */}
-        <FlexRow gap={1} align="center">
-          {/* Activity indicator slot — filled by NOD-311 */}
-          {activitySlot}
+        {/* Right: activity slot + save / export */}
+        {activitySlot}
 
-          {onSave && (
-            <EditorButton
-              variant="outlined"
-              onClick={onSave}
-              disabled={isSaving}
-              startIcon={<SaveIcon />}
-              size="small"
-            >
-              {isSaving ? "Saving…" : "Save"}
-            </EditorButton>
-          )}
+        {onSave && (
+          <EditorButton
+            variant="outlined"
+            onClick={onSave}
+            disabled={isSaving}
+            startIcon={<SaveIcon />}
+            size="small"
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </EditorButton>
+        )}
 
-          {onExportVideo && (
-            <EditorButton
-              variant="outlined"
-              onClick={onExportVideo}
-              disabled={isExporting}
-              startIcon={<FileDownloadIcon />}
-              size="small"
-            >
-              {isExporting ? "Exporting…" : "Export"}
-            </EditorButton>
-          )}
-
-        </FlexRow>
+        {onExportVideo && (
+          <EditorButton
+            variant="outlined"
+            onClick={onExportVideo}
+            disabled={isExporting}
+            startIcon={<FileDownloadIcon />}
+            size="small"
+          >
+            {isExporting ? "Exporting…" : "Export"}
+          </EditorButton>
+        )}
       </FlexRow>
     );
   }

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -1,23 +1,25 @@
-/** @jsxImportSource @emotion/react */
 /**
  * TopBarPrompt
  *
- * Always-visible quick prompt input embedded in the timeline TopBar. Type a
- * prompt, press Enter, and a text-to-video direct-gen clip is dropped onto the
- * first unlocked video track at the current playhead — and generation starts
- * immediately. If the sequence has no video track yet (e.g. a Studio sequence
- * with only voiceover + caption tracks), one is created first.
+ * The timeline editor's quick text-to-video generation bar. Type a prompt,
+ * pick a model + output settings, and Generate drops a text-to-video direct-gen
+ * clip onto the first unlocked video track at the playhead (creating a video
+ * track if the sequence has none). Generation starts immediately.
  *
- * The video model selection is remembered across submissions for the lifetime
- * of the session by reading the most recent direct-gen clip in the sequence
- * (mirrors `AddClipMenu`).
+ * Layout mirrors the image editor's prompt bar (`ConnectedModePromptBar`) and
+ * the media chat composer: a prompt that grows to fill, then the model + setting
+ * chips, then the primary Generate action. The model / duration / resolution /
+ * aspect controls are the shared `MediaControlChip` + option menus, so options
+ * track the selected model's manifest.
  */
 
-import React, { memo, useCallback, useEffect, useState } from "react";
-import { css } from "@emotion/react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "@mui/material/styles";
-import type { Theme } from "@mui/material/styles";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import MovieIcon from "@mui/icons-material/Movie";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import AspectRatioIcon from "@mui/icons-material/CropOriginal";
+import TvIcon from "@mui/icons-material/Tv";
 
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
@@ -25,59 +27,26 @@ import { useTimelinePlaybackStore } from "../../stores/timeline/TimelinePlayback
 import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectGenJob";
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
 import {
+  EditorButton,
   FlexRow,
+  LoadingSpinner,
   TextInput,
-  Toast,
-  NodeSelect,
-  NodeMenuItem
+  Toast
 } from "../ui_primitives";
-import VideoModelSelect from "../properties/VideoModelSelect";
-
-interface VideoModelChange {
-  type: "video_model";
-  id: string;
-  provider: string;
-  name: string;
-}
-
-// ── Generation presets ───────────────────────────────────────────────────
-
-const ASPECT_RATIOS: string[] = ["16:9", "1:1", "9:16", "4:3", "3:4"];
-
-/** Short-edge resolution tiers, expressed as the strings video models expect. */
-const RESOLUTIONS: string[] = ["480p", "720p", "1080p"];
-
-/** Selectable clip durations in seconds. */
-const DURATIONS_SEC: number[] = [4, 6, 8];
-
-const promptInputStyles = (theme: Theme) =>
-  css({
-    width: 480,
-    [theme.breakpoints.down("md")]: {
-      width: 300
-    }
-  });
-
-const modelSelectStyles = (theme: Theme) =>
-  css({
-    width: 150,
-    flexShrink: 0,
-    [theme.breakpoints.down("md")]: {
-      width: 120
-    }
-  });
-
-const settingSelectStyles = css({
-  width: 84,
-  flexShrink: 0
-});
-
-const accentIconStyles = (theme: Theme) =>
-  css({
-    fontSize: 18,
-    color: theme.vars.palette.primary.main,
-    flexShrink: 0
-  });
+import MediaControlChip from "../chat/composer/MediaControlChip";
+import MediaOptionMenu from "../chat/composer/MediaOptionMenu";
+import MediaAspectRatioMenu from "../chat/composer/MediaAspectRatioMenu";
+import VideoModelMenuDialog from "../model_menu/VideoModelMenuDialog";
+import {
+  buildVideoModelOptions,
+  clampToAllowed,
+  normalizeVideoModel
+} from "../chat/composer/videoModelOptions";
+import type {
+  VideoModelSelection,
+  VideoResolution
+} from "../../stores/MediaGenerationStore";
+import type { VideoModel } from "../../stores/ApiTypes";
 
 /**
  * Resolve the video track to drop the clip onto: the first unlocked video
@@ -102,34 +71,58 @@ export const TopBarPrompt: React.FC = memo(() => {
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  // User-picked provider+model wins over the auto-derived default. We track
-  // whether the user has explicitly chosen something so the picker stops
-  // following the "last used" default once they engage with it.
+  // User-picked model wins over the auto-derived default. We track whether the
+  // user has explicitly chosen something so the picker stops following the
+  // "last used" default once they engage with it.
   const [userPicked, setUserPicked] = useState(false);
-  const [provider, setProvider] = useState<string | undefined>(undefined);
-  const [model, setModel] = useState<string | undefined>(undefined);
+  const [selectedModel, setSelectedModel] = useState<
+    VideoModelSelection | undefined
+  >(undefined);
   const [aspect, setAspect] = useState("16:9");
-  const [resolution, setResolution] = useState("720p");
-  const [durationSec, setDurationSec] = useState("4");
+  const [resolution, setResolution] = useState<VideoResolution>("720p");
+  const [duration, setDuration] = useState(4);
   const lastModel = useLastDirectGenModel("video");
 
-  // Sync provider/model from the most recent direct-gen clip until the user
-  // picks something themselves. This keeps "type → generate" fluid across
-  // sequence loads without forcing a re-pick.
+  // Chip popover anchors.
+  const videoModelAnchorRef = useRef<HTMLButtonElement>(null);
+  const [videoModelOpen, setVideoModelOpen] = useState(false);
+  const [durationAnchor, setDurationAnchor] = useState<HTMLElement | null>(null);
+  const [resolutionAnchor, setResolutionAnchor] = useState<HTMLElement | null>(
+    null
+  );
+  const [aspectAnchor, setAspectAnchor] = useState<HTMLElement | null>(null);
+
+  const { durationOptions, resolutionOptions, aspectOptions } = useMemo(
+    () => buildVideoModelOptions(selectedModel),
+    [selectedModel]
+  );
+
+  // Sync the model from the most recent direct-gen clip until the user picks
+  // one themselves, so "type → generate" stays fluid across sequence loads.
+  // The remembered default carries no manifest constraints, so the full option
+  // sets show until a model is picked through the dialog.
   useEffect(() => {
     if (userPicked) return;
-    setProvider(lastModel.provider);
-    setModel(lastModel.model);
+    if (lastModel.provider && lastModel.model) {
+      setSelectedModel({
+        type: "video_model",
+        id: lastModel.model,
+        provider: lastModel.provider,
+        name: lastModel.model
+      });
+    } else {
+      setSelectedModel(undefined);
+    }
   }, [lastModel.provider, lastModel.model, userPicked]);
 
   const addDirectGenClip = useTimelineStore((s) => s.addDirectGenClip);
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const directGen = useTimelineDirectGenJob();
 
-  const canSubmit = prompt.trim().length > 0 && !!provider && !!model && !busy;
+  const canSubmit = prompt.trim().length > 0 && !!selectedModel?.id && !busy;
 
   const handleSubmit = useCallback(async () => {
-    if (!canSubmit) return;
+    if (!canSubmit || !selectedModel) return;
     // Clear any prior failure toast before we attempt again — otherwise a
     // successful retry leaves the previous error visible.
     setError(null);
@@ -144,12 +137,12 @@ export const TopBarPrompt: React.FC = memo(() => {
       const clipId = addDirectGenClip({
         trackId,
         startMs,
-        durationMs: Number(durationSec) * 1000,
+        durationMs: duration * 1000,
         mediaType: "video",
         bindingKind: "text-to-video",
         prompt: prompt.trim(),
-        provider,
-        model,
+        provider: selectedModel.provider,
+        model: selectedModel.id,
         aspectRatio: aspect,
         resolution
       });
@@ -165,11 +158,10 @@ export const TopBarPrompt: React.FC = memo(() => {
     canSubmit,
     addDirectGenClip,
     prompt,
-    provider,
-    model,
+    selectedModel,
     aspect,
     resolution,
-    durationSec,
+    duration,
     selectClip,
     directGen
   ]);
@@ -184,80 +176,140 @@ export const TopBarPrompt: React.FC = memo(() => {
     [handleSubmit]
   );
 
-  const handleVideoModelChange = useCallback((v: VideoModelChange) => {
+  const handlePickVideoModel = useCallback((model: VideoModel) => {
+    const normalized = normalizeVideoModel(model);
     setUserPicked(true);
-    setProvider(v.provider);
-    setModel(v.id);
+    setSelectedModel(normalized);
+    // Snap current settings to what the picked model allows.
+    setAspect((a) => clampToAllowed(a, normalized.aspectRatios));
+    setResolution((r) => clampToAllowed(r, normalized.resolutions));
+    setDuration((d) => clampToAllowed(d, normalized.durations));
+    setVideoModelOpen(false);
   }, []);
 
   return (
     <>
-      <FlexRow gap={0.5} align="center" data-testid="topbar-prompt">
-        <AutoAwesomeIcon css={accentIconStyles(theme)} aria-hidden />
-        <div css={promptInputStyles(theme)}>
-          <TextInput
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Generate a video at the playhead…"
-            compact
-            fullWidth
-            disabled={busy}
-            inputProps={{
-              "aria-label": "Quick text-to-video prompt",
-              "data-testid": "topbar-prompt-input"
-            }}
-          />
-        </div>
-        <div css={modelSelectStyles(theme)}>
-          <VideoModelSelect
-            value={model ?? ""}
+      <FlexRow
+        gap={1}
+        align="center"
+        data-testid="topbar-prompt"
+        sx={{ flex: 1, minWidth: 0 }}
+      >
+        <TextInput
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Generate a video at the playhead…"
+          compact
+          fullWidth
+          disabled={busy}
+          inputProps={{
+            "aria-label": "Quick text-to-video prompt",
+            "data-testid": "topbar-prompt-input"
+          }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <AutoAwesomeIcon
+                  fontSize="small"
+                  sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
+                />
+              )
+            }
+          }}
+          sx={{
+            flex: 1,
+            minWidth: 160,
+            "& .MuiOutlinedInput-root": { height: 34 }
+          }}
+        />
+
+        <MediaControlChip
+          ref={videoModelAnchorRef}
+          icon={<MovieIcon fontSize="small" />}
+          label={selectedModel?.name || "Select Model"}
+          active={videoModelOpen}
+          onClick={() => setVideoModelOpen(true)}
+          truncate
+          showChevron={false}
+        />
+        {videoModelOpen && (
+          <VideoModelMenuDialog
+            open
+            anchorEl={videoModelAnchorRef.current}
+            onClose={() => setVideoModelOpen(false)}
+            onModelChange={handlePickVideoModel}
             task="text_to_video"
-            onChange={handleVideoModelChange}
           />
-        </div>
-        <div css={settingSelectStyles}>
-          <NodeSelect
-            value={aspect}
-            onChange={(e) => setAspect(e.target.value as string)}
-            aria-label="Aspect ratio"
-            fullWidth
-          >
-            {ASPECT_RATIOS.map((r) => (
-              <NodeMenuItem key={r} value={r}>
-                {r}
-              </NodeMenuItem>
-            ))}
-          </NodeSelect>
-        </div>
-        <div css={settingSelectStyles}>
-          <NodeSelect
-            value={resolution}
-            onChange={(e) => setResolution(e.target.value as string)}
-            aria-label="Resolution"
-            fullWidth
-          >
-            {RESOLUTIONS.map((r) => (
-              <NodeMenuItem key={r} value={r}>
-                {r}
-              </NodeMenuItem>
-            ))}
-          </NodeSelect>
-        </div>
-        <div css={settingSelectStyles}>
-          <NodeSelect
-            value={durationSec}
-            onChange={(e) => setDurationSec(e.target.value as string)}
-            aria-label="Duration"
-            fullWidth
-          >
-            {DURATIONS_SEC.map((s) => (
-              <NodeMenuItem key={s} value={String(s)}>
-                {s}s
-              </NodeMenuItem>
-            ))}
-          </NodeSelect>
-        </div>
+        )}
+
+        <MediaControlChip
+          icon={<AccessTimeIcon fontSize="small" />}
+          label={`${duration} Sec`}
+          active={!!durationAnchor}
+          onClick={(e) => setDurationAnchor(e.currentTarget)}
+          showChevron={false}
+        />
+        <MediaOptionMenu
+          anchorEl={durationAnchor}
+          open={!!durationAnchor}
+          onClose={() => setDurationAnchor(null)}
+          header="Duration"
+          value={duration}
+          options={durationOptions}
+          onChange={(d) => setDuration(d)}
+        />
+
+        <MediaControlChip
+          icon={<TvIcon fontSize="small" />}
+          label={resolution}
+          active={!!resolutionAnchor}
+          onClick={(e) => setResolutionAnchor(e.currentTarget)}
+          showChevron={false}
+        />
+        <MediaOptionMenu
+          anchorEl={resolutionAnchor}
+          open={!!resolutionAnchor}
+          onClose={() => setResolutionAnchor(null)}
+          header="Video Resolution"
+          value={resolution}
+          options={resolutionOptions}
+          onChange={(r) => setResolution(r)}
+        />
+
+        <MediaControlChip
+          icon={<AspectRatioIcon fontSize="small" />}
+          label={aspect}
+          active={!!aspectAnchor}
+          onClick={(e) => setAspectAnchor(e.currentTarget)}
+          showChevron={false}
+        />
+        <MediaAspectRatioMenu
+          anchorEl={aspectAnchor}
+          open={!!aspectAnchor}
+          onClose={() => setAspectAnchor(null)}
+          value={aspect}
+          options={aspectOptions}
+          onChange={(v) => setAspect(v)}
+        />
+
+        <EditorButton
+          variant="contained"
+          size="small"
+          disabled={!canSubmit}
+          onClick={() => void handleSubmit()}
+          startIcon={
+            busy ? (
+              <LoadingSpinner inline size={14} color="inherit" />
+            ) : (
+              <AutoAwesomeIcon fontSize="small" />
+            )
+          }
+          data-testid="topbar-generate"
+          sx={{ flexShrink: 0, height: 34 }}
+        >
+          Generate
+        </EditorButton>
       </FlexRow>
       <Toast
         open={error !== null}

--- a/web/src/components/timeline/__tests__/TimelineEditor.test.tsx
+++ b/web/src/components/timeline/__tests__/TimelineEditor.test.tsx
@@ -163,7 +163,6 @@ describe("TimelineEditor", () => {
 
       expect(screen.getByText("Sequence not found")).toBeInTheDocument();
       expect(screen.getByTestId("tracks-region")).toBeInTheDocument();
-      expect(screen.getByText("seq-1")).toBeInTheDocument();
     });
 
     it("shows EmptyState when the query returns an error", () => {
@@ -233,7 +232,6 @@ describe("TimelineEditor", () => {
     it("renders all five regions", () => {
       renderEditor();
 
-      expect(screen.getByText("My Sequence")).toBeInTheDocument();
       expect(screen.getByText("Preview")).toBeInTheDocument();
       expect(screen.getByText("Inspector")).toBeInTheDocument();
       expect(screen.getByText("Tracks")).toBeInTheDocument();

--- a/web/src/stores/MediaGenerationStore.ts
+++ b/web/src/stores/MediaGenerationStore.ts
@@ -147,7 +147,7 @@ interface ImageGenerationParams {
   variations: number;
 }
 
-interface VideoModelSelection {
+export interface VideoModelSelection {
   type: "video_model";
   id: string;
   provider: string;


### PR DESCRIPTION
The timeline quick-gen header and the image-editor prompt bar used different input controls and layouts from each other and from the media chat composer. This unifies all three on the same chip controls and a common generation-bar layout.

## Shared controls
Both headers now use the media composer's `MediaControlChip` + option menus (`VideoModelMenuDialog` / `ImageModelMenuDialog`, `MediaOptionMenu`, `MediaAspectRatioMenu`) instead of bespoke `NodeSelect` / `ImageModelSelect` dropdowns. Duration / resolution / aspect options are constrained by the selected model's manifest, exactly like the composer.

The per-model option derivation is extracted into a shared `chat/composer/videoModelOptions.ts` (`videoModelConstraints`, `clampToAllowed`, `buildAspectOptions`, `normalizeVideoModel`, `buildVideoModelOptions`), so the composer and both headers share one source of truth and can't drift. The composer's three video option `useMemo`s collapse to a single call; its behavior is unchanged.

## Common layout
```
[ ✨ prompt — grows to fill ........... ] [model] [setting chips] [ Generate ]
```
The conventional pattern: prompt leads as the hero input, controls grouped, primary action last.

- **Timeline header**: drops its project-name title (the workspace tab already shows it) and gains a **Generate** button (was Enter-only). The prompt grows to fill instead of a fixed width.
- **Sketch header**: reordered to the same arrangement; its model control moves from `ImageModelSelect` to the chip + dialog.

## Other
- Model pickers are **lazy-mounted** (only when opened), so the model-list query no longer fires on every header mount.
- Both prompts put `aria-label` / `data-testid` on the actual `<input>` via `inputProps`, fixing an a11y gap where the label landed on the wrapper.

## Verification
- Typecheck clean; oxlint + design-token lint clean on changed files.
- 2158 timeline+sketch tests pass (+ the composer/chat suites). Updated two `TimelineEditor` tests that asserted the removed title.
- Live (CDP): timeline header renders `prompt → Select Model → 4 Sec → 720p → 16:9 → Generate`, no title, `aria-label` on the input.

Independent of #3939 (preview-rendering fixes); no file overlap.