### PR TITLE
Add pre-run search provider setup dialog

### DIFF
--- a/web/src/components/dialogs/SearchProviderSetupDialog.tsx
+++ b/web/src/components/dialogs/SearchProviderSetupDialog.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  Text,
+  TextInput,
+  FlexColumn,
+  SelectField,
+  type SelectOption
+} from "../ui_primitives";
+import ExternalLink from "../common/ExternalLink";
+import { useSearchProviderCalloutStore } from "../../stores/SearchProviderCalloutStore";
+import useRemoteSettingsStore from "../../stores/RemoteSettingStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { formatSettingLabel } from "../menus/settingsLabel";
+import {
+  SEARCH_PROVIDER_CONFIGS,
+  SUGGESTED_SERP_PROVIDER,
+  type SerpProviderId
+} from "../../utils/searchProviders";
+
+const PROVIDER_OPTIONS: SelectOption[] = Object.values(
+  SEARCH_PROVIDER_CONFIGS
+).map((config) => ({
+  value: config.id,
+  label: config.free ? `${config.label} (Free)` : config.label
+}));
+
+/**
+ * Pre-run prompt shown when a node uses a web-search tool but no search
+ * provider is configured. Lets the user pick a provider and paste its API key
+ * inline (Brave is suggested as a free default) instead of opening Settings.
+ * Mounted once at the app root; driven by {@link useSearchProviderCalloutStore}.
+ */
+const SearchProviderSetupDialog: React.FC = () => {
+  const open = useSearchProviderCalloutStore((s) => s.open);
+  const nodes = useSearchProviderCalloutStore((s) => s.nodes);
+  const dismiss = useSearchProviderCalloutStore((s) => s.dismiss);
+
+  const updateSettings = useRemoteSettingsStore((s) => s.updateSettings);
+  const addNotification = useNotificationStore((s) => s.addNotification);
+  const queryClient = useQueryClient();
+
+  const [provider, setProvider] = useState<SerpProviderId>(
+    SUGGESTED_SERP_PROVIDER
+  );
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  const config = SEARCH_PROVIDER_CONFIGS[provider];
+
+  const handleProviderChange = useCallback((value: string) => {
+    setProvider(value as SerpProviderId);
+    setCredentials({});
+  }, []);
+
+  const handleCredentialChange = useCallback(
+    (field: string) => (e: unknown) => {
+      const target = e as { target: { value: string } };
+      setCredentials((prev) => ({ ...prev, [field]: target.target.value }));
+    },
+    []
+  );
+
+  const allFilled = useMemo(
+    () =>
+      config.credentialFields.every(
+        (field) => (credentials[field] ?? "").trim().length > 0
+      ),
+    [config, credentials]
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!allFilled || saving) return;
+    setSaving(true);
+    try {
+      const secrets: Record<string, string> = {};
+      for (const field of config.credentialFields) {
+        secrets[field] = credentials[field].trim();
+      }
+      await updateSettings({ SERP_PROVIDER: provider }, secrets);
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+      queryClient.invalidateQueries({ queryKey: ["secrets"] });
+      addNotification({
+        content: `${config.label} configured — you can run the workflow now.`,
+        type: "success",
+        alert: true
+      });
+      dismiss();
+    } catch (error) {
+      addNotification({
+        content:
+          error instanceof Error
+            ? error.message
+            : "Failed to save search provider",
+        type: "error",
+        alert: true
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    allFilled,
+    saving,
+    config,
+    credentials,
+    provider,
+    updateSettings,
+    queryClient,
+    addNotification,
+    dismiss
+  ]);
+
+  const nodeNames = useMemo(
+    () => Array.from(new Set(nodes.map((n) => n.nodeTitle))).join(", "),
+    [nodes]
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onClose={dismiss}
+      title="Set up web search"
+      onConfirm={handleSave}
+      onCancel={dismiss}
+      confirmText="Save & continue"
+      cancelText="Cancel"
+      confirmDisabled={!allFilled}
+      isLoading={saving}
+      content={
+        <FlexColumn gap={2}>
+          <Text>
+            {nodeNames
+              ? `${nodeNames} uses a web-search tool, but no search provider is configured. `
+              : "This agent uses a web-search tool, but no search provider is configured. "}
+            Add one below to run the workflow.
+          </Text>
+
+          <SelectField
+            label="Search provider"
+            value={provider}
+            onChange={handleProviderChange}
+            options={PROVIDER_OPTIONS}
+            description={config.description}
+            variant="standard"
+            size="small"
+          />
+
+          {config.credentialFields.map((field) => (
+            <TextInput
+              key={field}
+              type="password"
+              autoComplete="off"
+              id={`${field.toLowerCase()}-setup-input`}
+              label={formatSettingLabel(field)}
+              value={credentials[field] ?? ""}
+              onChange={handleCredentialChange(field)}
+              variant="standard"
+              size="small"
+              onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
+            />
+          ))}
+
+          <ExternalLink
+            href={config.getApiKeyUrl}
+            tooltipText={`Visit ${config.label} to get your API key`}
+          >
+            {config.getApiKeyLabel}
+          </ExternalLink>
+        </FlexColumn>
+      }
+    />
+  );
+};
+
+SearchProviderSetupDialog.displayName = "SearchProviderSetupDialog";
+
+export default memo(SearchProviderSetupDialog);

--- a/web/src/components/menus/SearchProviderSection.tsx
+++ b/web/src/components/menus/SearchProviderSection.tsx
@@ -14,52 +14,11 @@ import { TextInput, Text } from "../ui_primitives";
 import ExternalLink from "../common/ExternalLink";
 import type { SettingWithValue } from "../../stores/RemoteSettingStore";
 import { useTheme } from "@mui/material/styles";
-
-// Provider configurations
-interface ProviderConfig {
-  id: string;
-  label: string;
-  description: string;
-  credentialFields: string[];
-  getApiKeyUrl: string;
-  getApiKeyLabel: string;
-}
-
-const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
-  serpapi: {
-    id: "serpapi",
-    label: "SerpAPI",
-    description:
-      "Fast and reliable search API with Google, Bing, and other engines",
-    credentialFields: ["SERPAPI_API_KEY"],
-    getApiKeyUrl: "https://serpapi.com/manage-api-key",
-    getApiKeyLabel: "Get SerpAPI Key"
-  },
-  dataforseo: {
-    id: "dataforseo",
-    label: "DataForSEO",
-    description: "Professional SEO and search intelligence platform",
-    credentialFields: ["DATA_FOR_SEO_LOGIN", "DATA_FOR_SEO_PASSWORD"],
-    getApiKeyUrl: "https://app.dataforseo.com/register",
-    getApiKeyLabel: "Get DataForSEO Credentials"
-  },
-  brave: {
-    id: "brave",
-    label: "Brave Search",
-    description: "Privacy-focused search engine with fast, accurate results",
-    credentialFields: ["BRAVE_API_KEY"],
-    getApiKeyUrl: "https://api-dashboard.search.brave.com/",
-    getApiKeyLabel: "Get Brave API Key"
-  },
-  apify: {
-    id: "apify",
-    label: "Apify",
-    description: "Reliable Google search scraping via Apify actors",
-    credentialFields: ["APIFY_API_KEY"],
-    getApiKeyUrl: "https://console.apify.com/account/integrations",
-    getApiKeyLabel: "Get Apify API Key"
-  }
-};
+import {
+  SEARCH_PROVIDER_CONFIGS as PROVIDER_CONFIGS,
+  DEFAULT_SERP_PROVIDER,
+  type SerpProviderId
+} from "../../utils/searchProviders";
 
 interface SearchProviderSectionProps {
   allSettings: SettingWithValue[];
@@ -73,7 +32,8 @@ const SearchProviderSection = memo(function SearchProviderSection({
   onChange
 }: SearchProviderSectionProps) {
   const theme = useTheme();
-  const selectedProvider = settingValues["SERP_PROVIDER"] || "serpapi";
+  const selectedProvider = (settingValues["SERP_PROVIDER"] ||
+    DEFAULT_SERP_PROVIDER) as SerpProviderId;
   const config = PROVIDER_CONFIGS[selectedProvider];
 
   // Get credential fields for all providers

--- a/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
+++ b/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
@@ -9,6 +9,8 @@ import useNodeMenuStore from "../../stores/NodeMenuStore";
 import { useBottomPanelStore } from "../../stores/BottomPanelStore";
 import { useMiniMapStore } from "../../stores/MiniMapStore";
 import { useRunWarningStore } from "../../stores/RunWarningStore";
+import useRemoteSettingsStore from "../../stores/RemoteSettingStore";
+import { useSearchProviderCalloutStore } from "../../stores/SearchProviderCalloutStore";
 
 jest.mock("react-router-dom", () => ({
   useNavigate: jest.fn(() => jest.fn()),
@@ -239,6 +241,74 @@ describe("useFloatingToolbarActions", () => {
         useRunWarningStore.getState().confirm(false);
       });
       expect(mockRun).toHaveBeenCalled();
+    });
+
+    const searchNode = {
+      id: "agent-1",
+      type: "nodetool.agents.Agent",
+      data: {
+        properties: { tools: [{ type: "tool_name", name: "google_search" }] }
+      }
+    };
+
+    const mockNodeStoreWith = (nodes: unknown[]) => {
+      mockUseNodeStoreRef.mockReturnValue({
+        getState: jest.fn(() => ({
+          nodes,
+          edges: [],
+          setSelectedNodes: jest.fn(),
+          setShouldFitToScreen: jest.fn(),
+          getWorkflow: jest.fn(() => mockWorkflow)
+        }))
+      } as any);
+    };
+
+    const setting = (env_var: string, value: string | null) => ({
+      package_name: "",
+      env_var,
+      group: "Search",
+      description: "",
+      enum: null,
+      value,
+      is_secret: env_var !== "SERP_PROVIDER"
+    });
+
+    it("blocks the run and opens the search-provider dialog when a search tool has no provider", async () => {
+      mockNodeStoreWith([searchNode]);
+      useRemoteSettingsStore.setState({
+        settings: [setting("SERP_PROVIDER", null)] as any
+      });
+      useSearchProviderCalloutStore.getState().dismiss();
+
+      const { result } = renderHook(() => useFloatingToolbarActions());
+      await act(async () => {
+        await result.current.handleRun();
+      });
+
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(useSearchProviderCalloutStore.getState().open).toBe(true);
+      expect(useSearchProviderCalloutStore.getState().nodes).toEqual([
+        { nodeId: "agent-1", nodeTitle: "Agent" }
+      ]);
+    });
+
+    it("runs normally when the search provider is configured", async () => {
+      mockNodeStoreWith([searchNode]);
+      useRemoteSettingsStore.setState({
+        settings: [
+          setting("SERP_PROVIDER", "brave"),
+          setting("BRAVE_API_KEY", "****")
+        ] as any
+      });
+      useSearchProviderCalloutStore.getState().dismiss();
+
+      const { result } = renderHook(() => useFloatingToolbarActions());
+      await act(async () => {
+        await result.current.handleRun();
+      });
+
+      expect(mockRun).toHaveBeenCalled();
+      expect(useSearchProviderCalloutStore.getState().open).toBe(false);
     });
 
     it("triggers autosave before running if enabled", async () => {

--- a/web/src/hooks/useFloatingToolbarActions.ts
+++ b/web/src/hooks/useFloatingToolbarActions.ts
@@ -9,8 +9,12 @@ import { triggerAutosaveForWorkflow } from "./useAutosave";
 import useMetadataStore from "../stores/MetadataStore";
 import { useRunWarningStore } from "../stores/RunWarningStore";
 import { useModelCalloutStore } from "../stores/ModelCalloutStore";
+import { useSearchProviderCalloutStore } from "../stores/SearchProviderCalloutStore";
 import { usePropertyHighlightStore } from "../stores/PropertyHighlightStore";
 import { findMissingModelNodes } from "../utils/findMissingModelNodes";
+import { findSearchToolNodes } from "../utils/findSearchToolNodes";
+import { isSearchProviderConfigured } from "../utils/searchProviders";
+import useRemoteSettingsStore from "../stores/RemoteSettingStore";
 import { countHeavyNodes } from "../utils/heavyNodes";
 import useNodeMenuStore from "../stores/NodeMenuStore";
 import { useBottomPanelStore } from "../stores/BottomPanelStore";
@@ -91,6 +95,9 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     (state) => state.requestConfirmation
   );
   const showModelCallout = useModelCalloutStore((state) => state.show);
+  const showSearchProviderDialog = useSearchProviderCalloutStore(
+    (state) => state.show
+  );
 
   const openNodeMenu = useNodeMenuStore((state) => state.openNodeMenu);
   const closeNodeMenu = useNodeMenuStore((state) => state.closeNodeMenu);
@@ -158,6 +165,42 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
         }
         return;
       }
+
+      // Catch agents that search the web with no search provider configured —
+      // the run would otherwise fail server-side. Offer inline setup (Brave is
+      // free) instead of sending the user to Settings.
+      const searchNodes = findSearchToolNodes(
+        nodes,
+        useMetadataStore.getState().getMetadata
+      );
+      if (searchNodes.length > 0) {
+        const settingsStore = useRemoteSettingsStore.getState();
+        let settings = settingsStore.settings;
+        if (settings.length === 0) {
+          try {
+            settings = await settingsStore.fetchSettings();
+          } catch {
+            settings = [];
+          }
+        }
+        const getValue = (envVar: string): string | undefined => {
+          const found = settings.find((s) => s.env_var === envVar);
+          return found?.value != null ? String(found.value) : undefined;
+        };
+        // If settings never loaded we can't tell — don't block the run.
+        if (settings.length > 0 && !isSearchProviderConfigured(getValue)) {
+          const first = searchNodes[0];
+          showSearchProviderDialog(searchNodes);
+          const target = nodeStore
+            .getState()
+            .nodes.find((n) => n.id === first.nodeId);
+          if (target) {
+            nodeStore.getState().setSelectedNodes([target]);
+            nodeStore.getState().setShouldFitToScreen(true, [first.nodeId]);
+          }
+          return;
+        }
+      }
     }
 
     // Clicking Run while a run is in progress starts a second run alongside
@@ -205,6 +248,7 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     largeRunThreshold,
     requestRunConfirmation,
     showModelCallout,
+    showSearchProviderDialog,
     isWorkflowRunning,
     isPaused,
     isSuspended

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -61,6 +61,9 @@ const DownloadManagerDialog = React.lazy(
 const RunWarningDialog = React.lazy(
   () => import("./components/dialogs/RunWarningDialog")
 );
+const SearchProviderSetupDialog = React.lazy(
+  () => import("./components/dialogs/SearchProviderSetupDialog")
+);
 
 import { installIpcLogBridge } from "./logging/ipcLogBridge";
 import MobileClassProvider from "./components/MobileClassProvider";
@@ -675,6 +678,7 @@ const AppWrapper = () => {
                       </Suspense>
                       <DownloadManagerDialog />
                       <RunWarningDialog />
+                      <SearchProviderSetupDialog />
                     </>
                   )}
                 </KeyboardProvider>

--- a/web/src/stores/SearchProviderCalloutStore.ts
+++ b/web/src/stores/SearchProviderCalloutStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { SearchToolNode } from "../utils/findSearchToolNodes";
+
+/**
+ * Drives the pre-run search-provider setup dialog. Opened when a run is blocked
+ * because a node uses a web-search tool but no search provider is configured;
+ * the dialog lets the user pick a provider and add its API key inline instead
+ * of digging through Settings.
+ */
+interface SearchProviderCalloutState {
+  open: boolean;
+  /** Nodes that triggered the prompt, for context in the dialog. */
+  nodes: SearchToolNode[];
+  show: (nodes: SearchToolNode[]) => void;
+  dismiss: () => void;
+}
+
+export const useSearchProviderCalloutStore = create<SearchProviderCalloutState>(
+  (set) => ({
+    open: false,
+    nodes: [],
+    show: (nodes) => set({ open: true, nodes }),
+    dismiss: () => set({ open: false, nodes: [] })
+  })
+);
+
+export default useSearchProviderCalloutStore;

--- a/web/src/utils/__tests__/findSearchToolNodes.test.ts
+++ b/web/src/utils/__tests__/findSearchToolNodes.test.ts
@@ -1,0 +1,87 @@
+import { findSearchToolNodes, nodeUsesSearchTool } from "../findSearchToolNodes";
+import { Node } from "@xyflow/react";
+import { NodeData } from "../../stores/NodeData";
+import { NodeMetadata } from "../../stores/ApiTypes";
+
+const makeNode = (
+  id: string,
+  type: string,
+  properties: Record<string, unknown>,
+  extra: Partial<NodeData> = {}
+): Node<NodeData> =>
+  ({
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: { properties, ...extra } as NodeData
+  }) as Node<NodeData>;
+
+const meta =
+  (title: string) =>
+  (nodeType: string): NodeMetadata | undefined =>
+    ({ title: nodeType === "nodetool.agents.Agent" ? title : nodeType }) as NodeMetadata;
+
+const tool = (name: string) => ({ type: "tool_name", name });
+
+describe("nodeUsesSearchTool", () => {
+  it("detects google_search in a tools list", () => {
+    const node = makeNode("n1", "nodetool.agents.Agent", {
+      tools: [tool("read_file"), tool("google_search")]
+    });
+    expect(nodeUsesSearchTool(node)).toBe(true);
+  });
+
+  it("detects google_news and google_images", () => {
+    expect(
+      nodeUsesSearchTool(
+        makeNode("n1", "x", { tools: [tool("google_news")] })
+      )
+    ).toBe(true);
+    expect(
+      nodeUsesSearchTool(
+        makeNode("n2", "x", { tools: [tool("google_images")] })
+      )
+    ).toBe(true);
+  });
+
+  it("ignores non-search tools (browser, sandbox, file tools)", () => {
+    const node = makeNode("n1", "nodetool.agents.Agent", {
+      tools: [tool("browser_navigate"), tool("write_file"), tool("sandbox_shell_exec")]
+    });
+    expect(nodeUsesSearchTool(node)).toBe(false);
+  });
+
+  it("ignores nodes without tool lists", () => {
+    expect(nodeUsesSearchTool(makeNode("n1", "x", { prompt: "hi" }))).toBe(false);
+    expect(nodeUsesSearchTool(makeNode("n2", "x", {}))).toBe(false);
+  });
+});
+
+describe("findSearchToolNodes", () => {
+  it("returns nodes that use a search tool, with their display title", () => {
+    const nodes = [
+      makeNode("n1", "nodetool.agents.Agent", { tools: [tool("google_search")] }),
+      makeNode("n2", "nodetool.text.Concat", { a: "x" })
+    ];
+    expect(findSearchToolNodes(nodes, meta("Agent"))).toEqual([
+      { nodeId: "n1", nodeTitle: "Agent" }
+    ]);
+  });
+
+  it("skips bypassed nodes", () => {
+    const nodes = [
+      makeNode(
+        "n1",
+        "nodetool.agents.Agent",
+        { tools: [tool("google_search")] },
+        { bypassed: true }
+      )
+    ];
+    expect(findSearchToolNodes(nodes, meta("Agent"))).toEqual([]);
+  });
+
+  it("returns an empty array when no node searches", () => {
+    const nodes = [makeNode("n1", "x", { tools: [tool("browser_navigate")] })];
+    expect(findSearchToolNodes(nodes, meta("Agent"))).toEqual([]);
+  });
+});

--- a/web/src/utils/__tests__/searchProviders.test.ts
+++ b/web/src/utils/__tests__/searchProviders.test.ts
@@ -1,0 +1,67 @@
+import {
+  isSearchProviderConfigured,
+  SEARCH_PROVIDER_CONFIGS,
+  SUGGESTED_SERP_PROVIDER
+} from "../searchProviders";
+
+const getter = (values: Record<string, string>) => (envVar: string) =>
+  values[envVar];
+
+describe("isSearchProviderConfigured", () => {
+  it("is false when nothing is set (defaults to serpapi, no key)", () => {
+    expect(isSearchProviderConfigured(getter({}))).toBe(false);
+  });
+
+  it("uses the default provider's credentials when SERP_PROVIDER is unset", () => {
+    expect(
+      isSearchProviderConfigured(getter({ SERPAPI_API_KEY: "****" }))
+    ).toBe(true);
+  });
+
+  it("checks the selected provider's credentials", () => {
+    expect(
+      isSearchProviderConfigured(
+        getter({ SERP_PROVIDER: "brave", BRAVE_API_KEY: "****" })
+      )
+    ).toBe(true);
+  });
+
+  it("is false when the selected provider's key is missing", () => {
+    expect(
+      isSearchProviderConfigured(
+        getter({ SERP_PROVIDER: "brave", SERPAPI_API_KEY: "****" })
+      )
+    ).toBe(false);
+  });
+
+  it("treats blank/whitespace values as unconfigured", () => {
+    expect(
+      isSearchProviderConfigured(
+        getter({ SERP_PROVIDER: "brave", BRAVE_API_KEY: "   " })
+      )
+    ).toBe(false);
+  });
+
+  it("requires every credential field for multi-field providers", () => {
+    expect(
+      isSearchProviderConfigured(
+        getter({ SERP_PROVIDER: "dataforseo", DATA_FOR_SEO_LOGIN: "user" })
+      )
+    ).toBe(false);
+    expect(
+      isSearchProviderConfigured(
+        getter({
+          SERP_PROVIDER: "dataforseo",
+          DATA_FOR_SEO_LOGIN: "user",
+          DATA_FOR_SEO_PASSWORD: "pw"
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe("search provider config", () => {
+  it("suggests a free provider by default", () => {
+    expect(SEARCH_PROVIDER_CONFIGS[SUGGESTED_SERP_PROVIDER].free).toBe(true);
+  });
+});

--- a/web/src/utils/findSearchToolNodes.ts
+++ b/web/src/utils/findSearchToolNodes.ts
@@ -1,0 +1,55 @@
+import { Node } from "@xyflow/react";
+import { NodeData } from "../stores/NodeData";
+import { NodeMetadata } from "../stores/ApiTypes";
+import { SEARCH_PROVIDER_TOOL_NAMES } from "./searchProviders";
+
+export interface SearchToolNode {
+  nodeId: string;
+  nodeTitle: string;
+}
+
+/**
+ * True when any of the node's tool-list properties selects a search tool that
+ * needs a configured search provider. Tool values are stored as
+ * `{ type: "tool_name", name }` objects.
+ */
+export const nodeUsesSearchTool = (node: Node<NodeData>): boolean => {
+  const properties = node.data?.properties ?? {};
+  for (const value of Object.values(properties)) {
+    if (!Array.isArray(value)) continue;
+    for (const item of value) {
+      const name = (item as { name?: unknown } | null)?.name;
+      if (typeof name === "string" && SEARCH_PROVIDER_TOOL_NAMES.has(name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Scan the graph for nodes that run a web-search tool, so we can prompt the
+ * user to set up a search provider before a run fails on the server. Skips
+ * bypassed nodes (they don't execute).
+ */
+export const findSearchToolNodes = (
+  nodes: Node<NodeData>[],
+  getMetadata: (nodeType: string) => NodeMetadata | undefined
+): SearchToolNode[] => {
+  const result: SearchToolNode[] = [];
+
+  for (const node of nodes) {
+    if (node.data?.bypassed) continue;
+    if (!nodeUsesSearchTool(node)) continue;
+
+    const metadata = node.type ? getMetadata(node.type) : undefined;
+    const title =
+      metadata?.title ||
+      node.type?.split(".").pop() ||
+      node.type ||
+      node.id;
+    result.push({ nodeId: node.id, nodeTitle: title });
+  }
+
+  return result;
+};

--- a/web/src/utils/searchProviders.ts
+++ b/web/src/utils/searchProviders.ts
@@ -1,0 +1,98 @@
+/**
+ * Search (SERP) provider definitions shared between the Settings panel and the
+ * pre-run setup dialog. The backend reads `SERP_PROVIDER` to pick a provider
+ * and resolves that provider's credential secrets at run time (see
+ * `packages/agents/src/tools/serp-tool-factory.ts`).
+ */
+
+export type SerpProviderId = "brave" | "serpapi" | "dataforseo" | "apify";
+
+export interface SearchProviderConfig {
+  id: SerpProviderId;
+  label: string;
+  description: string;
+  /** Secret env vars that must all be set for this provider to work. */
+  credentialFields: string[];
+  getApiKeyUrl: string;
+  getApiKeyLabel: string;
+  /** True when the provider offers a free tier — surfaced as a suggestion. */
+  free?: boolean;
+}
+
+/**
+ * Brave is listed first and flagged free so it surfaces as the default
+ * suggestion when nothing is configured yet.
+ */
+export const SEARCH_PROVIDER_CONFIGS: Record<SerpProviderId, SearchProviderConfig> = {
+  brave: {
+    id: "brave",
+    label: "Brave Search",
+    description: "Privacy-focused search with a free tier — a good default.",
+    credentialFields: ["BRAVE_API_KEY"],
+    getApiKeyUrl:
+      "https://api-dashboard.search.brave.com/app/documentation/web-search/get-started",
+    getApiKeyLabel: "Get a free Brave API key",
+    free: true
+  },
+  serpapi: {
+    id: "serpapi",
+    label: "SerpAPI",
+    description:
+      "Fast and reliable search API with Google, Bing, and other engines.",
+    credentialFields: ["SERPAPI_API_KEY"],
+    getApiKeyUrl: "https://serpapi.com/manage-api-key",
+    getApiKeyLabel: "Get SerpAPI Key"
+  },
+  dataforseo: {
+    id: "dataforseo",
+    label: "DataForSEO",
+    description: "Professional SEO and search intelligence platform.",
+    credentialFields: ["DATA_FOR_SEO_LOGIN", "DATA_FOR_SEO_PASSWORD"],
+    getApiKeyUrl: "https://app.dataforseo.com/register",
+    getApiKeyLabel: "Get DataForSEO Credentials"
+  },
+  apify: {
+    id: "apify",
+    label: "Apify",
+    description: "Reliable Google search scraping via Apify actors.",
+    credentialFields: ["APIFY_API_KEY"],
+    getApiKeyUrl: "https://console.apify.com/account/integrations",
+    getApiKeyLabel: "Get Apify API Key"
+  }
+};
+
+/** Backend default when `SERP_PROVIDER` is unset (see serp-tool-factory.ts). */
+export const DEFAULT_SERP_PROVIDER: SerpProviderId = "serpapi";
+
+/** Provider suggested in the setup dialog — free, no card required. */
+export const SUGGESTED_SERP_PROVIDER: SerpProviderId = "brave";
+
+/**
+ * Agent tool names that need a configured search provider to run. The browser
+ * and sandbox tools fetch pages directly and don't go through a SERP provider,
+ * so they're intentionally excluded.
+ */
+export const SEARCH_PROVIDER_TOOL_NAMES = new Set([
+  "google_search",
+  "google_news",
+  "google_images"
+]);
+
+type SettingGetter = (envVar: string) => string | undefined;
+
+/**
+ * True when the active `SERP_PROVIDER` has all of its credential fields set.
+ * Mirrors the backend's resolution: an unset provider falls back to the
+ * default. Credential values arrive as `"****"` from the settings API when a
+ * secret is configured, so any non-empty string counts.
+ */
+export const isSearchProviderConfigured = (getValue: SettingGetter): boolean => {
+  const selected = (getValue("SERP_PROVIDER") || DEFAULT_SERP_PROVIDER) as SerpProviderId;
+  const config =
+    SEARCH_PROVIDER_CONFIGS[selected] ??
+    SEARCH_PROVIDER_CONFIGS[DEFAULT_SERP_PROVIDER];
+  return config.credentialFields.every((field) => {
+    const value = getValue(field);
+    return typeof value === "string" && value.trim().length > 0;
+  });
+};


### PR DESCRIPTION
## Summary

Adds a pre-run dialog that prompts users to configure a search provider (API key) when a workflow contains agents with web-search tools but no provider is configured. This prevents server-side failures and offers inline setup with Brave (free tier) as the default suggestion, eliminating the need to navigate to Settings.

## Key Changes

- **New `SearchProviderSetupDialog` component** (`web/src/components/dialogs/SearchProviderSetupDialog.tsx`): Modal dialog that lets users select a search provider and enter credentials inline. Driven by a new Zustand store (`SearchProviderCalloutStore`).

- **Centralized search provider config** (`web/src/utils/searchProviders.ts`): Extracted provider definitions (Brave, SerpAPI, DataForSEO, Apify) into a shared config object used by both the Settings panel and the new dialog. Includes helper function `isSearchProviderConfigured()` to check if the active provider has all required credentials.

- **Search tool detection** (`web/src/utils/findSearchToolNodes.ts`): New utilities to scan the workflow graph for nodes using web-search tools (`google_search`, `google_news`, `google_images`) and return their metadata for display in the dialog.

- **Run-time validation in toolbar** (`web/src/hooks/useFloatingToolbarActions.ts`): Before executing a workflow, check if any non-bypassed nodes use search tools. If so, verify the configured provider has credentials; if not, open the setup dialog and highlight the first offending node instead of proceeding with the run.

- **Settings panel refactor** (`web/src/components/menus/SearchProviderSection.tsx`): Updated to import provider configs from the new shared utility, eliminating duplication.

- **Dialog registration** (`web/src/index.tsx`): Lazy-loaded `SearchProviderSetupDialog` at app root, alongside other modal dialogs.

- **Comprehensive tests**: Added test suites for search tool detection, provider configuration validation, and run-time blocking behavior.

## Implementation Details

- The dialog defaults to Brave (marked `free: true`) as the suggested provider, reducing friction for new users.
- Credentials are validated client-side before save; the backend resolves provider secrets at run time.
- If settings fail to load, the run is not blocked (graceful degradation).
- Bypassed nodes are excluded from the search-tool scan.
- The dialog displays node titles (from metadata) for context, e.g., "Agent uses a web-search tool…"

https://claude.ai/code/session_01AimHz2fcqtfVPcuWb1XNJz