### PR TITLE
Add project settings dialog for canvas size and frame rate

### DIFF
--- a/web/src/components/timeline/ProjectSettingsDialog.tsx
+++ b/web/src/components/timeline/ProjectSettingsDialog.tsx
@@ -1,0 +1,244 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ProjectSettingsDialog — sequence-level canvas & frame-rate settings.
+ *
+ * Like the project settings in a video editor: pick a canvas resolution
+ * (preset or custom width/height) and a frame rate. Both feed the live preview
+ * compositor and the offline export, which read `width`/`height`/`fps` from the
+ * {@link TimelineStore}. Applying persists via {@link useTimelineProjectSettings}.
+ */
+import React, { memo, useEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  Caption,
+  Dialog,
+  FlexColumn,
+  FlexRow,
+  SelectField,
+  Text,
+  TextInput
+} from "../ui_primitives";
+import type { SelectOption } from "../ui_primitives";
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useTimelineProjectSettings } from "../../hooks/timeline/useTimelineProjectSettings";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const MIN_DIM = 16;
+const MAX_DIM = 7680;
+const MIN_FPS = 1;
+const MAX_FPS = 240;
+
+const CUSTOM = "custom";
+
+interface ResolutionPreset {
+  value: string;
+  label: string;
+  width: number;
+  height: number;
+}
+
+const RESOLUTION_PRESETS: readonly ResolutionPreset[] = [
+  { value: "1920x1080", label: "1080p — 1920 × 1080 (16:9)", width: 1920, height: 1080 },
+  { value: "1280x720", label: "720p — 1280 × 720 (16:9)", width: 1280, height: 720 },
+  { value: "3840x2160", label: "4K UHD — 3840 × 2160 (16:9)", width: 3840, height: 2160 },
+  { value: "1080x1920", label: "Vertical — 1080 × 1920 (9:16)", width: 1080, height: 1920 },
+  { value: "1080x1080", label: "Square — 1080 × 1080 (1:1)", width: 1080, height: 1080 },
+  { value: "1080x1350", label: "Portrait — 1080 × 1350 (4:5)", width: 1080, height: 1350 }
+];
+
+const RESOLUTION_OPTIONS: readonly SelectOption[] = [
+  ...RESOLUTION_PRESETS.map((p) => ({ value: p.value, label: p.label })),
+  { value: CUSTOM, label: "Custom…" }
+];
+
+const FPS_PRESETS = [24, 25, 30, 50, 60] as const;
+const FPS_OPTIONS: readonly SelectOption[] = [
+  ...FPS_PRESETS.map((f) => ({ value: String(f), label: `${f} fps` })),
+  { value: CUSTOM, label: "Custom…" }
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const presetValueFor = (width: number, height: number): string =>
+  RESOLUTION_PRESETS.find((p) => p.width === width && p.height === height)
+    ?.value ?? CUSTOM;
+
+const isValidDim = (n: number): boolean =>
+  Number.isInteger(n) && n >= MIN_DIM && n <= MAX_DIM;
+
+const isValidFps = (n: number): boolean =>
+  Number.isInteger(n) && n >= MIN_FPS && n <= MAX_FPS;
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export interface ProjectSettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ProjectSettingsDialogInternal: React.FC<ProjectSettingsDialogProps> = ({
+  open,
+  onClose
+}) => {
+  const { fps, width, height } = useTimelineStore(
+    useShallow((s) => ({ fps: s.fps, width: s.width, height: s.height }))
+  );
+  const { save, isSaving } = useTimelineProjectSettings();
+
+  // Local draft as strings so partially-typed input doesn't fight the parser.
+  const [widthText, setWidthText] = useState(String(width));
+  const [heightText, setHeightText] = useState(String(height));
+  const [fpsText, setFpsText] = useState(String(fps));
+
+  // Re-seed the draft from the store each time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      setWidthText(String(width));
+      setHeightText(String(height));
+      setFpsText(String(fps));
+    }
+  }, [open, width, height, fps]);
+
+  const widthNum = Number(widthText);
+  const heightNum = Number(heightText);
+  const fpsNum = Number(fpsText);
+
+  const widthValid = isValidDim(widthNum);
+  const heightValid = isValidDim(heightNum);
+  const fpsValid = isValidFps(fpsNum);
+  const allValid = widthValid && heightValid && fpsValid;
+
+  const resolutionPreset = useMemo(
+    () =>
+      widthValid && heightValid
+        ? presetValueFor(widthNum, heightNum)
+        : CUSTOM,
+    [widthValid, heightValid, widthNum, heightNum]
+  );
+
+  const fpsPreset = useMemo(
+    () => (fpsValid && FPS_PRESETS.includes(fpsNum as never) ? String(fpsNum) : CUSTOM),
+    [fpsValid, fpsNum]
+  );
+
+  const handleResolutionPreset = (value: string) => {
+    const preset = RESOLUTION_PRESETS.find((p) => p.value === value);
+    if (preset) {
+      setWidthText(String(preset.width));
+      setHeightText(String(preset.height));
+    }
+  };
+
+  const handleFpsPreset = (value: string) => {
+    if (value !== CUSTOM) setFpsText(value);
+  };
+
+  const dirty =
+    allValid && (widthNum !== width || heightNum !== height || fpsNum !== fps);
+
+  const handleApply = async () => {
+    if (!allValid) return;
+    await save({ width: widthNum, height: heightNum, fps: fpsNum });
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => onClose()}
+      title="Project settings"
+      onConfirm={() => void handleApply()}
+      onCancel={onClose}
+      confirmText="Apply"
+      cancelText="Cancel"
+      isLoading={isSaving}
+      confirmDisabled={!allValid || !dirty || isSaving}
+      minWidth="min(440px, 100vw - 32px)"
+    >
+      <FlexColumn gap={2.5} sx={{ py: 1 }}>
+        {/* ── Canvas size ─────────────────────────────────────────── */}
+        <FlexColumn gap={1.5}>
+          <Text size="small" sx={{ fontWeight: 600 }}>
+            Canvas size
+          </Text>
+          <SelectField
+            label="Preset"
+            value={resolutionPreset}
+            onChange={handleResolutionPreset}
+            options={RESOLUTION_OPTIONS}
+            size="small"
+          />
+          <FlexRow gap={1.5} align="flex-start">
+            <TextInput
+              label="Width"
+              type="number"
+              size="small"
+              value={widthText}
+              onChange={(e) => setWidthText(e.target.value)}
+              errorMessage={
+                widthText !== "" && !widthValid
+                  ? `${MIN_DIM}–${MAX_DIM}`
+                  : undefined
+              }
+              inputProps={{ min: MIN_DIM, max: MAX_DIM, step: 2 }}
+            />
+            <TextInput
+              label="Height"
+              type="number"
+              size="small"
+              value={heightText}
+              onChange={(e) => setHeightText(e.target.value)}
+              errorMessage={
+                heightText !== "" && !heightValid
+                  ? `${MIN_DIM}–${MAX_DIM}`
+                  : undefined
+              }
+              inputProps={{ min: MIN_DIM, max: MAX_DIM, step: 2 }}
+            />
+          </FlexRow>
+        </FlexColumn>
+
+        {/* ── Frame rate ──────────────────────────────────────────── */}
+        <FlexColumn gap={1.5}>
+          <Text size="small" sx={{ fontWeight: 600 }}>
+            Frame rate
+          </Text>
+          <FlexRow gap={1.5} align="flex-start">
+            <SelectField
+              label="Rate"
+              value={fpsPreset}
+              onChange={handleFpsPreset}
+              options={FPS_OPTIONS}
+              size="small"
+            />
+            <TextInput
+              label="fps"
+              type="number"
+              size="small"
+              value={fpsText}
+              onChange={(e) => setFpsText(e.target.value)}
+              errorMessage={
+                fpsText !== "" && !fpsValid
+                  ? `${MIN_FPS}–${MAX_FPS}`
+                  : undefined
+              }
+              inputProps={{ min: MIN_FPS, max: MAX_FPS, step: 1 }}
+            />
+          </FlexRow>
+        </FlexColumn>
+
+        <Caption sx={{ color: "text.secondary" }}>
+          Applies to the preview and the exported video. Existing clips keep
+          their own source resolution and are scaled to fit the canvas.
+        </Caption>
+      </FlexColumn>
+    </Dialog>
+  );
+};
+
+export const ProjectSettingsDialog = memo(ProjectSettingsDialogInternal);
+ProjectSettingsDialog.displayName = "ProjectSettingsDialog";
+
+export default ProjectSettingsDialog;

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -17,6 +17,7 @@
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useShallow } from "zustand/react/shallow";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -39,6 +40,7 @@ import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 
 import { TopBar } from "./TopBar";
 import { BottomStatusBar } from "./BottomStatusBar";
+import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 import {
   useCreateTimeline,
   useTimeline,
@@ -46,6 +48,7 @@ import {
 } from "../../hooks/useTimelineSequence";
 import { TracksRegion } from "./Tracks/TracksRegion";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import { PreviewArea } from "./preview/PreviewArea";
 import { TimelineInspector } from "./Inspector/TimelineInspector";
@@ -151,7 +154,6 @@ function exportPhaseLabel(
 
 const PreviewRegion: React.FC<{
   isLoading: boolean;
-  sequence?: { fps?: number; width?: number; height?: number };
   sequenceUnavailable: boolean;
   onRetryFetch?: () => void;
   onCreateNewSequence?: () => void;
@@ -159,7 +161,6 @@ const PreviewRegion: React.FC<{
   createSequenceErrorMessage?: string | null;
 }> = ({
   isLoading,
-  sequence,
   sequenceUnavailable,
   onRetryFetch,
   onCreateNewSequence,
@@ -167,6 +168,12 @@ const PreviewRegion: React.FC<{
   createSequenceErrorMessage
 }) => {
   const theme = useTheme();
+  // Canvas size + fps come from the store — the single source of truth the
+  // compositor and the export already read — so Project settings changes show
+  // up in the preview immediately, without waiting on a query refetch.
+  const { fps, width, height } = useTimelineStore(
+    useShallow((s) => ({ fps: s.fps, width: s.width, height: s.height }))
+  );
   return (
     <FlexColumn
       css={previewRegionStyles(theme)}
@@ -219,9 +226,9 @@ const PreviewRegion: React.FC<{
         </FlexColumn>
       ) : (
         <PreviewArea
-          fps={sequence?.fps ?? 30}
-          sequenceWidth={sequence?.width ?? 1920}
-          sequenceHeight={sequence?.height ?? 1080}
+          fps={fps}
+          sequenceWidth={width}
+          sequenceHeight={height}
         />
       )}
     </FlexColumn>
@@ -354,6 +361,9 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
     void exportVideo(sequence?.name);
   }, [exportVideo, sequence?.name]);
 
+  // Project settings dialog (canvas size + fps) ────────────────────────────
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
   // Tracks resize ─────────────────────────────────────────────────────────
   const [tracksHeight, setTracksHeight] = useState(DEFAULT_TRACKS_HEIGHT_PX);
   const [isDragging, setIsDragging] = useState(false);
@@ -482,6 +492,9 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
         isExporting={isExporting}
         onSave={sequenceUnavailable ? undefined : handleSave}
         isSaving={isSaving}
+        onOpenSettings={
+          sequenceUnavailable ? undefined : () => setSettingsOpen(true)
+        }
         activitySlot={<ActivityIndicator />}
       />
 
@@ -499,7 +512,6 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
         <TranscriptRegion />
         <PreviewRegion
           isLoading={isLoading}
-          sequence={sequence}
           sequenceUnavailable={sequenceUnavailable}
           onRetryFetch={sequenceUnavailable ? handleRetrySequence : undefined}
           onCreateNewSequence={
@@ -536,6 +548,12 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
         onZoomChange={handleZoomChange}
         generatingCount={generatingCount}
         failedCount={failedCount}
+      />
+
+      {/* ── Project settings dialog (canvas size + fps) ───────────── */}
+      <ProjectSettingsDialog
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
       />
 
       {/* ── Export progress / error dialog ────────────────────────── */}

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -14,6 +14,7 @@ import type { Theme } from "@mui/material/styles";
 import { FlexRow, EditorButton } from "../ui_primitives";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import SaveIcon from "@mui/icons-material/Save";
+import TuneIcon from "@mui/icons-material/Tune";
 
 import { TopBarPrompt } from "./TopBarPrompt";
 
@@ -35,6 +36,8 @@ export interface TopBarProps {
   onSave?: () => void;
   /** True while a manual save is in flight. */
   isSaving?: boolean;
+  /** Called when the user opens the project settings (canvas size + fps). */
+  onOpenSettings?: () => void;
   /** Optional slot for an activity indicator (NOD-311) */
   activitySlot?: React.ReactNode;
 }
@@ -45,6 +48,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
     isExporting = false,
     onSave,
     isSaving = false,
+    onOpenSettings,
     activitySlot
   }) => {
     const theme = useTheme();
@@ -54,8 +58,20 @@ export const TopBar: React.FC<TopBarProps> = memo(
         {/* Quick-prompt generation bar — grows to fill */}
         <TopBarPrompt />
 
-        {/* Right: activity slot + save / export */}
+        {/* Right: activity slot + settings / save / export */}
         {activitySlot}
+
+        {onOpenSettings && (
+          <EditorButton
+            variant="outlined"
+            onClick={onOpenSettings}
+            startIcon={<TuneIcon />}
+            size="small"
+            aria-label="Project settings"
+          >
+            Settings
+          </EditorButton>
+        )}
 
         {onSave && (
           <EditorButton

--- a/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
+++ b/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * ProjectSettingsDialog tests.
+ *
+ * The dialog edits the sequence-level canvas size + frame rate. It seeds its
+ * draft from the store on open, lets a resolution preset fill width/height, and
+ * persists via useTimelineProjectSettings. Apply is gated on valid + changed
+ * values.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import { ProjectSettingsDialog } from "../ProjectSettingsDialog";
+
+// ── Store + persistence hook mocks ───────────────────────────────────────────
+
+let storeState = { fps: 30, width: 1920, height: 1080 };
+
+jest.mock("../../../stores/timeline/TimelineStore", () => ({
+  useTimelineStore: (selector: (s: typeof storeState) => unknown) =>
+    selector(storeState)
+}));
+
+const mockSave = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../../hooks/timeline/useTimelineProjectSettings", () => ({
+  useTimelineProjectSettings: () => ({ save: mockSave, isSaving: false })
+}));
+
+const renderDialog = (onClose = jest.fn()) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectSettingsDialog open onClose={onClose} />
+    </ThemeProvider>
+  );
+
+const widthInput = () =>
+  screen.getByRole("spinbutton", { name: /width/i }) as HTMLInputElement;
+const heightInput = () =>
+  screen.getByRole("spinbutton", { name: /height/i }) as HTMLInputElement;
+const fpsInput = () =>
+  screen.getByRole("spinbutton", { name: /fps/i }) as HTMLInputElement;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  storeState = { fps: 30, width: 1920, height: 1080 };
+});
+
+describe("ProjectSettingsDialog", () => {
+  it("seeds the draft from the store", () => {
+    renderDialog();
+    expect(widthInput().value).toBe("1920");
+    expect(heightInput().value).toBe("1080");
+    expect(fpsInput().value).toBe("30");
+  });
+
+  it("disables Apply when nothing has changed", () => {
+    renderDialog();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("persists edited width, height and fps on Apply", async () => {
+    const onClose = jest.fn();
+    renderDialog(onClose);
+
+    fireEvent.change(widthInput(), { target: { value: "1080" } });
+    fireEvent.change(heightInput(), { target: { value: "1920" } });
+    fireEvent.change(fpsInput(), { target: { value: "60" } });
+
+    const apply = screen.getByRole("button", { name: "Apply" });
+    expect(apply).toBeEnabled();
+    fireEvent.click(apply);
+
+    await waitFor(() =>
+      expect(mockSave).toHaveBeenCalledWith({
+        width: 1080,
+        height: 1920,
+        fps: 60
+      })
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("keeps Apply disabled for an out-of-range dimension", () => {
+    renderDialog();
+    fireEvent.change(widthInput(), { target: { value: "4" } }); // below MIN_DIM
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/timeline/useTimelineProjectSettings.ts
+++ b/web/src/hooks/timeline/useTimelineProjectSettings.ts
@@ -1,0 +1,74 @@
+/**
+ * useTimelineProjectSettings — apply + persist the project settings.
+ *
+ * Project settings are the canvas resolution (`width`/`height`) and frame rate
+ * (`fps`). The live preview compositor and the offline export both read these
+ * straight from the {@link TimelineStore}, so updating the store applies them
+ * immediately. Persistence goes through the `timeline.update` top-level fields
+ * (NOT the document slice autosave tracks), rolling `baseUpdatedAt` forward
+ * from the response just like {@link useTimelineSave}.
+ */
+import { useCallback, useState } from "react";
+
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { trpcClient } from "../../trpc/client";
+
+export interface ProjectSettingsPatch {
+  fps?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface UseTimelineProjectSettingsResult {
+  /** Apply the patch to the store and persist it. Resolves when settled. */
+  save: (patch: ProjectSettingsPatch) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function useTimelineProjectSettings(): UseTimelineProjectSettingsResult {
+  const store = useTimelineStoreApi();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const save = useCallback(
+    async (patch: ProjectSettingsPatch) => {
+      const state = store.getState();
+      // Apply locally first so the preview compositor reflects the new canvas
+      // immediately, even before (or without) a server round-trip.
+      state.setProjectSettings(patch);
+      if (!state.sequenceId) return;
+      setIsSaving(true);
+      try {
+        const response = await trpcClient.timeline.update.mutate({
+          id: state.sequenceId,
+          baseUpdatedAt: state.baseUpdatedAt ?? undefined,
+          ...patch
+        });
+        const updatedAt = (response as { updatedAt?: unknown } | undefined)
+          ?.updatedAt;
+        // Only roll the token forward while the store still holds the saved
+        // sequence — otherwise we'd poison a newly loaded sequence's token.
+        if (
+          typeof updatedAt === "string" &&
+          store.getState().sequenceId === state.sequenceId
+        ) {
+          store.getState().setBaseUpdatedAt(updatedAt);
+        }
+      } catch (error) {
+        console.error("Timeline project settings save failed:", error);
+        useNotificationStore.getState().addNotification({
+          content: "Could not update project settings — please try again.",
+          type: "error",
+          alert: true,
+          dedupeKey: "timeline-settings-failed",
+          replaceExisting: true
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [store]
+  );
+
+  return { save, isSaving };
+}

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -96,6 +96,19 @@ export interface TimelineStoreState {
   /** Show or hide the script feature (non-destructive; does not touch clips). */
   setScriptEnabled: (enabled: boolean) => void;
 
+  /**
+   * Patch the project settings — canvas resolution (`width`/`height`) and frame
+   * rate (`fps`). These drive the preview compositor's reference size and the
+   * export render dimensions/frame stepping. Persisted via the
+   * `timeline.update` top-level fields (not the document), so they are not part
+   * of the undo history. A patch that changes nothing is a no-op.
+   */
+  setProjectSettings: (patch: {
+    fps?: number;
+    width?: number;
+    height?: number;
+  }) => void;
+
   // ── Track mutations ──────────────────────────────────────────────────────
 
   addTrack: (type: TimelineTrack["type"], name?: string) => void;
@@ -752,6 +765,24 @@ export const createTimelineStore = (
         setBaseUpdatedAt: (updatedAt) => set({ baseUpdatedAt: updatedAt }),
 
         setScriptEnabled: (enabled) => set({ scriptEnabled: enabled }),
+
+        setProjectSettings: (patch) =>
+          set((state) => {
+            const next: Partial<TimelineStoreState> = {};
+            if (typeof patch.fps === "number" && patch.fps !== state.fps) {
+              next.fps = patch.fps;
+            }
+            if (typeof patch.width === "number" && patch.width !== state.width) {
+              next.width = patch.width;
+            }
+            if (
+              typeof patch.height === "number" &&
+              patch.height !== state.height
+            ) {
+              next.height = patch.height;
+            }
+            return next;
+          }),
 
         // ── Tracks ──────────────────────────────────────────────────────────
 

--- a/web/src/stores/timeline/__tests__/TimelineStore.projectSettings.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.projectSettings.test.ts
@@ -1,0 +1,89 @@
+/**
+ * TimelineStore project-settings tests.
+ *
+ * Canvas resolution (`width`/`height`) and frame rate (`fps`) are sequence-level
+ * project settings that drive the preview compositor and the export render.
+ * `setProjectSettings` patches them in place; a patch that changes nothing is a
+ * no-op (so it never spuriously dirties the document or undo history).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { createTimelineStore } from "../TimelineStore";
+import type { TimelineSequence } from "@nodetool-ai/timeline";
+
+function makeSequence(
+  overrides: Partial<TimelineSequence> = {}
+): TimelineSequence {
+  return {
+    id: "seq-1",
+    projectId: "proj-1",
+    name: "Seq",
+    fps: 30,
+    width: 1920,
+    height: 1080,
+    durationMs: 0,
+    tracks: [],
+    clips: [],
+    markers: [],
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides
+  };
+}
+
+describe("TimelineStore — project settings", () => {
+  it("defaults to 1920×1080 @ 30fps on a fresh store", () => {
+    const { width, height, fps } = createTimelineStore().getState();
+    expect({ width, height, fps }).toEqual({
+      width: 1920,
+      height: 1080,
+      fps: 30
+    });
+  });
+
+  it("setProjectSettings patches width, height and fps", () => {
+    const store = createTimelineStore();
+    store.getState().setProjectSettings({ width: 1080, height: 1920, fps: 60 });
+    const { width, height, fps } = store.getState();
+    expect({ width, height, fps }).toEqual({
+      width: 1080,
+      height: 1920,
+      fps: 60
+    });
+  });
+
+  it("patches only the provided fields, leaving the rest untouched", () => {
+    const store = createTimelineStore();
+    store.getState().setProjectSettings({ fps: 24 });
+    const { width, height, fps } = store.getState();
+    expect({ width, height, fps }).toEqual({
+      width: 1920,
+      height: 1080,
+      fps: 24
+    });
+  });
+
+  it("loadSequence carries the persisted resolution and fps into the store", () => {
+    const store = createTimelineStore();
+    store
+      .getState()
+      .loadSequence(makeSequence({ fps: 25, width: 1280, height: 720 }));
+    const { width, height, fps } = store.getState();
+    expect({ width, height, fps }).toEqual({
+      width: 1280,
+      height: 720,
+      fps: 25
+    });
+  });
+
+  it("a no-op patch leaves the values unchanged", () => {
+    const store = createTimelineStore();
+    store.getState().setProjectSettings({ width: 1920, height: 1080, fps: 30 });
+    const { width, height, fps } = store.getState();
+    expect({ width, height, fps }).toEqual({
+      width: 1920,
+      height: 1080,
+      fps: 30
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Project Settings** dialog that lets users configure sequence-level canvas resolution (width/height) and frame rate (fps). These settings drive both the live preview compositor and offline export, and are persisted separately from the document (not part of undo history).

## Key Changes

- **ProjectSettingsDialog** (`web/src/components/timeline/ProjectSettingsDialog.tsx`): New dialog component with:
  - Resolution presets (1080p, 720p, 4K, vertical, square, portrait)
  - Custom width/height inputs with validation (16–7680px)
  - Frame rate presets (24, 25, 30, 50, 60 fps) + custom input (1–240 fps)
  - Apply button gated on valid + changed values
  - Seeds draft from store on open, persists via `useTimelineProjectSettings`

- **useTimelineProjectSettings** (`web/src/hooks/timeline/useTimelineProjectSettings.ts`): New hook that:
  - Applies settings to the store immediately (preview updates without waiting for server)
  - Persists via `timeline.update` top-level fields (not document autosave)
  - Rolls `baseUpdatedAt` forward from response
  - Handles errors with user notification

- **TimelineStore.setProjectSettings** (`web/src/stores/timeline/TimelineStore.ts`): New action that:
  - Patches `fps`, `width`, `height` in place
  - No-op if values unchanged (prevents spurious dirty state)
  - Called by the hook and seeded from `loadSequence`

- **TimelineEditor integration** (`web/src/components/timeline/TimelineEditor.tsx`):
  - Adds `ProjectSettingsDialog` component
  - Reads canvas size + fps from store (not query) so preview updates immediately
  - Wires settings button to dialog open state

- **TopBar settings button** (`web/src/components/timeline/TopBar.tsx`):
  - New "Settings" button with Tune icon
  - Calls `onOpenSettings` callback

- **Tests**:
  - `ProjectSettingsDialog.test.tsx`: Dialog seeds from store, disables Apply when unchanged, persists on Apply, validates ranges
  - `TimelineStore.projectSettings.test.ts`: Store defaults, patching, no-op behavior, sequence load

## Implementation Details

- Dialog uses Zustand `useShallow` to avoid unnecessary re-renders on multi-value selections
- Local draft state as strings to avoid fighting the parser during partial input
- Validation helpers (`isValidDim`, `isValidFps`) gate the Apply button
- Preset selection updates both width and height atomically
- Error messages show valid range (e.g., "16–7680") when input is out of bounds
- Caption explains that clips keep their source resolution and are scaled to fit the canvas

https://claude.ai/code/session_01SVrkYkapVik7Aru7X25khD