### PR TITLE
Add image and video generation support to XAI provider

### DIFF
--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -1,8 +1,49 @@
 import OpenAI from "openai";
 import { OpenAIProvider } from "./openai-provider.js";
-import type { ImageModel, LanguageModel, VideoModel } from "./types.js";
+import type {
+  ImageModel,
+  ImageToImageParams,
+  ImageToVideoParams,
+  LanguageModel,
+  TextToImageParams,
+  TextToVideoParams,
+  VideoModel
+} from "./types.js";
 
 const XAI_BASE_URL = "https://api.x.ai/v1";
+
+/** Sniff the container type so image inputs keep the right MIME in their data URI. */
+function detectImageMime(bytes: Uint8Array): string {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  // PNG and everything else default to PNG — xAI accepts both jpeg and png.
+  return "image/png";
+}
+
+/**
+ * Resolve an image input (raw bytes) into the base64 data URI xAI's JSON image
+ * and video endpoints expect. Asset references are already resolved to bytes
+ * upstream (ProcessingContext); xAI's `application/json` API cannot take the
+ * multipart file uploads the OpenAI SDK sends, so we inline them here.
+ */
+function bytesToDataUri(bytes: Uint8Array): string {
+  const base64 = Buffer.from(bytes).toString("base64");
+  return `data:${detectImageMime(bytes)};base64,${base64}`;
+}
 
 interface XAIProviderOptions {
   client?: OpenAI;
@@ -153,5 +194,226 @@ export class XAIProvider extends OpenAIProvider {
         provider: "xai" as const,
         supportedTasks: ["text_to_video", "image_to_video"]
       }));
+  }
+
+  private xaiHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  /** Decode an xAI image response (`{ data: [{ b64_json | url }] }`) to bytes. */
+  private async decodeImageResponse(response: Response): Promise<Uint8Array> {
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(
+        `xAI image request failed: ${response.status}${detail ? ` ${detail}` : ""}`
+      );
+    }
+    const payload = (await response.json()) as {
+      data?: Array<{ b64_json?: string; url?: string }>;
+    };
+    const item = payload.data?.[0];
+    if (item?.b64_json) {
+      return Uint8Array.from(Buffer.from(item.b64_json, "base64"));
+    }
+    if (item?.url) {
+      const fetched = await this._xaiFetch(item.url);
+      if (!fetched.ok) {
+        throw new Error(`xAI image fetch failed: ${fetched.status}`);
+      }
+      return new Uint8Array(await fetched.arrayBuffer());
+    }
+    throw new Error("xAI image generation returned no image data.");
+  }
+
+  override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const prompt = params.negativePrompt
+      ? `${params.prompt.trim()}\n\nDo not include: ${params.negativePrompt.trim()}`
+      : params.prompt;
+
+    const request: Record<string, unknown> = {
+      model: params.model.id,
+      prompt,
+      n: 1,
+      response_format: "b64_json"
+    };
+    if (params.aspectRatio) request.aspect_ratio = params.aspectRatio;
+    if (params.resolution) request.resolution = params.resolution;
+
+    const response = await this._xaiFetch(`${XAI_BASE_URL}/images/generations`, {
+      method: "POST",
+      headers: this.xaiHeaders(),
+      body: JSON.stringify(request)
+    });
+    return this.decodeImageResponse(response);
+  }
+
+  override async imageToImage(
+    images: Uint8Array[],
+    params: ImageToImageParams
+  ): Promise<Uint8Array> {
+    const sources = images.filter((b) => b && b.length > 0);
+    if (sources.length === 0) {
+      throw new Error("image must not be empty.");
+    }
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const prompt = params.negativePrompt
+      ? `${params.prompt.trim()}\n\nDo not include: ${params.negativePrompt.trim()}`
+      : params.prompt;
+
+    // xAI's edit endpoint is JSON-only (the OpenAI SDK's multipart images.edit
+    // is rejected). Up to three source images may be supplied; send a single
+    // object for one input and an array for multi-image edits.
+    const imageRefs = sources.map((b) => ({
+      url: bytesToDataUri(b),
+      type: "image_url" as const
+    }));
+
+    const request: Record<string, unknown> = {
+      model: params.model.id,
+      prompt,
+      image: imageRefs.length === 1 ? imageRefs[0] : imageRefs,
+      response_format: "b64_json"
+    };
+    // A single input image keeps its own aspect ratio; only override when asked.
+    if (params.aspectRatio) request.aspect_ratio = params.aspectRatio;
+
+    const response = await this._xaiFetch(`${XAI_BASE_URL}/images/edits`, {
+      method: "POST",
+      headers: this.xaiHeaders(),
+      body: JSON.stringify(request)
+    });
+    return this.decodeImageResponse(response);
+  }
+
+  /**
+   * Submit a video job to xAI's async endpoint and poll until it finishes.
+   * Returns the rendered video bytes.
+   */
+  private async generateVideo(
+    request: Record<string, unknown>,
+    timeoutSeconds?: number | null
+  ): Promise<Uint8Array> {
+    const startResponse = await this._xaiFetch(
+      `${XAI_BASE_URL}/videos/generations`,
+      {
+        method: "POST",
+        headers: this.xaiHeaders(),
+        body: JSON.stringify(request)
+      }
+    );
+    if (!startResponse.ok) {
+      const detail = await startResponse.text().catch(() => "");
+      throw new Error(
+        `xAI video request failed: ${startResponse.status}${detail ? ` ${detail}` : ""}`
+      );
+    }
+    const { request_id: requestId } = (await startResponse.json()) as {
+      request_id?: string;
+    };
+    if (!requestId) {
+      throw new Error("xAI video create response did not contain a request_id");
+    }
+
+    const timeoutMs = (timeoutSeconds ?? 600) * 1000;
+    const intervalMs = 5000;
+    const start = Date.now();
+
+    for (;;) {
+      const pollResponse = await this._xaiFetch(
+        `${XAI_BASE_URL}/videos/${requestId}`,
+        { headers: { Authorization: `Bearer ${this.apiKey}` } }
+      );
+      if (!pollResponse.ok) {
+        throw new Error(`xAI video poll failed: ${pollResponse.status}`);
+      }
+      const data = (await pollResponse.json()) as {
+        status?: string;
+        video?: { url?: string };
+        error?: { code?: string; message?: string };
+      };
+
+      if (data.status === "done") {
+        const url = data.video?.url;
+        if (!url) {
+          throw new Error("xAI video result did not contain a video url");
+        }
+        const fetched = await this._xaiFetch(url);
+        if (!fetched.ok) {
+          throw new Error(`xAI video fetch failed: ${fetched.status}`);
+        }
+        return new Uint8Array(await fetched.arrayBuffer());
+      }
+      if (data.status === "failed" || data.status === "expired") {
+        throw new Error(
+          data.error?.message ?? `xAI video generation ${data.status}`
+        );
+      }
+      if (Date.now() - start > timeoutMs) {
+        throw new Error("xAI video generation timed out");
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  /** Map our duration/frame params onto xAI's `duration` (1–15 seconds). */
+  private static resolveVideoDuration(params: {
+    durationSeconds?: number | null;
+    numFrames?: number | null;
+  }): number | undefined {
+    const seconds =
+      params.durationSeconds ?? OpenAIProvider.secondsFromParams(params);
+    if (!seconds || seconds <= 0) return undefined;
+    return Math.min(15, Math.max(1, Math.round(seconds)));
+  }
+
+  override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
+    if (!params.prompt) {
+      throw new Error("The input prompt cannot be empty.");
+    }
+
+    const request: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: params.prompt
+    };
+    const duration = XAIProvider.resolveVideoDuration(params);
+    if (duration !== undefined) request.duration = duration;
+    if (params.aspectRatio) request.aspect_ratio = params.aspectRatio;
+    if (params.resolution) request.resolution = params.resolution;
+
+    return this.generateVideo(request, params.timeoutSeconds);
+  }
+
+  override async imageToVideo(
+    images: Uint8Array[],
+    params: ImageToVideoParams
+  ): Promise<Uint8Array> {
+    const image = images.find((b) => b && b.length > 0);
+    if (!image) {
+      throw new Error("The input image cannot be empty.");
+    }
+
+    const request: Record<string, unknown> = {
+      model: params.model.id,
+      prompt: params.prompt ?? "",
+      image: { url: bytesToDataUri(image), type: "image_url" }
+    };
+    const duration = XAIProvider.resolveVideoDuration(params);
+    if (duration !== undefined) request.duration = duration;
+    // Image-to-video defaults to the input image's aspect ratio; only override
+    // when the caller explicitly asks for a different one.
+    if (params.aspectRatio) request.aspect_ratio = params.aspectRatio;
+    if (params.resolution) request.resolution = params.resolution;
+
+    return this.generateVideo(request, params.timeoutSeconds);
   }
 }

--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import { OpenAIProvider } from "./openai-provider.js";
-import type { LanguageModel } from "./types.js";
+import type { ImageModel, LanguageModel, VideoModel } from "./types.js";
 
 const XAI_BASE_URL = "https://api.x.ai/v1";
 
@@ -8,6 +8,44 @@ interface XAIProviderOptions {
   client?: OpenAI;
   clientFactory?: (apiKey: string) => OpenAI;
   fetchFn?: typeof fetch;
+}
+
+/** Raw row from xAI's `/v1/models` listing. */
+interface XAIModelRow {
+  id: string;
+  name?: string;
+  input_modalities?: string[];
+  output_modalities?: string[];
+}
+
+type ModelModality = "language" | "image" | "video";
+
+/**
+ * Classify an xAI model by its modality. xAI returns every model (chat,
+ * Grok Imagine image, Grok Imagine video) from a single `/v1/models` listing,
+ * so we have to sort them ourselves. Prefer the `output_modalities` array when
+ * present; otherwise fall back to the model id (e.g. `grok-imagine-video`).
+ */
+function classifyModel(row: XAIModelRow): ModelModality {
+  const out = (row.output_modalities ?? []).map((m) => m.toLowerCase());
+  if (out.includes("video")) {
+    return "video";
+  }
+  if (out.includes("image")) {
+    return "image";
+  }
+  if (out.includes("text")) {
+    return "language";
+  }
+
+  const id = row.id.toLowerCase();
+  if (id.includes("video")) {
+    return "video";
+  }
+  if (id.includes("image")) {
+    return "image";
+  }
+  return "language";
 }
 
 /**
@@ -59,7 +97,8 @@ export class XAIProvider extends OpenAIProvider {
     return true;
   }
 
-  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+  /** Fetch and validate the rows from xAI's `/v1/models` listing. */
+  private async fetchModelRows(): Promise<XAIModelRow[]> {
     const response = await this._xaiFetch(`${XAI_BASE_URL}/models`, {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
@@ -71,19 +110,48 @@ export class XAIProvider extends OpenAIProvider {
     }
 
     const payload = (await response.json()) as {
-      data?: Array<{ id?: string; name?: string }>;
+      data?: Array<XAIModelRow | undefined>;
     };
     // Stryker disable next-line ArrayDeclaration: the fallback is filtered downstream (rows need a string id), so [] vs any array is observably identical.
     const rows = payload.data ?? [];
+    return rows.filter(
+      (row): row is XAIModelRow =>
+        typeof row?.id === "string" && row.id.length > 0
+    );
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const rows = await this.fetchModelRows();
     return rows
-      .filter(
-        (row): row is { id: string; name?: string } =>
-          typeof row.id === "string" && row.id.length > 0
-      )
+      .filter((row) => classifyModel(row) === "language")
       .map((row) => ({
         id: row.id,
         name: row.name ?? row.id,
-        provider: "xai"
+        provider: "xai" as const
+      }));
+  }
+
+  override async getAvailableImageModels(): Promise<ImageModel[]> {
+    const rows = await this.fetchModelRows();
+    return rows
+      .filter((row) => classifyModel(row) === "image")
+      .map((row) => ({
+        id: row.id,
+        name: row.name ?? row.id,
+        provider: "xai" as const,
+        supportedTasks: ["text_to_image", "image_to_image"]
+      }));
+  }
+
+  override async getAvailableVideoModels(): Promise<VideoModel[]> {
+    const rows = await this.fetchModelRows();
+    return rows
+      .filter((row) => classifyModel(row) === "video")
+      .map((row) => ({
+        id: row.id,
+        name: row.name ?? row.id,
+        provider: "xai" as const,
+        supportedTasks: ["text_to_video", "image_to_video"]
       }));
   }
 }

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -227,4 +227,207 @@ describe("XAIProvider", () => {
 
     expect(items.length).toBeGreaterThanOrEqual(1);
   });
+
+  const imageModel = {
+    id: "grok-imagine-image-quality",
+    name: "Grok Imagine Image",
+    provider: "xai" as const
+  };
+  const videoModel = {
+    id: "grok-imagine-video",
+    name: "Grok Imagine Video",
+    provider: "xai" as const
+  };
+  // PNG magic bytes so the data-URI MIME sniffing resolves to image/png.
+  const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  function jsonOk(body: unknown) {
+    return { ok: true, json: async () => body };
+  }
+
+  it("maps text-to-image params to xAI's generations endpoint", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonOk({ data: [{ b64_json: Buffer.from("img").toString("base64") }] })
+      );
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const bytes = await provider.textToImage({
+      prompt: "a cat",
+      negativePrompt: "dogs",
+      model: imageModel,
+      aspectRatio: "16:9",
+      resolution: "2k"
+    });
+
+    expect(Buffer.from(bytes).toString()).toBe("img");
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/images/generations");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer k",
+      "Content-Type": "application/json"
+    });
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      model: "grok-imagine-image-quality",
+      n: 1,
+      response_format: "b64_json",
+      aspect_ratio: "16:9",
+      resolution: "2k"
+    });
+    expect(body.prompt).toContain("a cat");
+    expect(body.prompt).toContain("Do not include: dogs");
+  });
+
+  it("sends image-to-image edits as JSON with a base64 data URI", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonOk({ data: [{ b64_json: Buffer.from("edited").toString("base64") }] })
+      );
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const bytes = await provider.imageToImage([pngBytes], {
+      prompt: "make it a sketch",
+      model: imageModel
+    });
+
+    expect(Buffer.from(bytes).toString()).toBe("edited");
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/images/edits");
+    const body = JSON.parse(init.body);
+    expect(body.image).toEqual({
+      url: `data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`,
+      type: "image_url"
+    });
+  });
+
+  it("sends multiple edit images as an array", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(jsonOk({ data: [{ b64_json: "QQ==" }] }));
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.imageToImage([pngBytes, pngBytes], {
+      prompt: "blend",
+      model: imageModel
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(Array.isArray(body.image)).toBe(true);
+    expect(body.image).toHaveLength(2);
+  });
+
+  it("rejects image-to-image with no usable source", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: vi.fn() as any }
+    );
+    await expect(
+      provider.imageToImage([new Uint8Array()], {
+        prompt: "x",
+        model: imageModel
+      })
+    ).rejects.toThrow("image must not be empty.");
+  });
+
+  it("runs text-to-video through the async generate + poll flow", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk({ request_id: "req-1" }))
+      .mockResolvedValueOnce(jsonOk({ status: "pending" }))
+      .mockResolvedValueOnce(
+        jsonOk({ status: "done", video: { url: "https://vid.x.ai/v.mp4" } })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode("mp4").buffer
+      });
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    vi.useFakeTimers();
+    try {
+      const pending = provider.textToVideo({
+        prompt: "a rocket",
+        model: videoModel,
+        durationSeconds: 10,
+        aspectRatio: "16:9",
+        resolution: "720p"
+      });
+      await vi.runAllTimersAsync();
+      const bytes = await pending;
+      expect(Buffer.from(bytes).toString()).toBe("mp4");
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const [startUrl, startInit] = mockFetch.mock.calls[0];
+    expect(startUrl).toBe("https://api.x.ai/v1/videos/generations");
+    expect(JSON.parse(startInit.body)).toMatchObject({
+      model: "grok-imagine-video",
+      prompt: "a rocket",
+      duration: 10,
+      aspect_ratio: "16:9",
+      resolution: "720p"
+    });
+    expect(mockFetch.mock.calls[1][0]).toBe("https://api.x.ai/v1/videos/req-1");
+  });
+
+  it("attaches the source frame for image-to-video", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk({ request_id: "req-2" }))
+      .mockResolvedValueOnce(
+        jsonOk({ status: "done", video: { url: "https://vid.x.ai/v.mp4" } })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode("mp4").buffer
+      });
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.imageToVideo([pngBytes], {
+      prompt: "animate",
+      model: videoModel
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.image).toEqual({
+      url: `data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`,
+      type: "image_url"
+    });
+  });
+
+  it("surfaces a failed video job's error message", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk({ request_id: "req-3" }))
+      .mockResolvedValueOnce(
+        jsonOk({ status: "failed", error: { message: "bad prompt" } })
+      );
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await expect(
+      provider.textToVideo({ prompt: "x", model: videoModel })
+    ).rejects.toThrow("bad prompt");
+  });
 });

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -91,6 +91,79 @@ describe("XAIProvider", () => {
     expect(models).toEqual([]);
   });
 
+  function mixedModelsFetch() {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "grok-4", name: "Grok 4", output_modalities: ["text"] },
+          { id: "grok-3-mini" },
+          {
+            id: "grok-imagine-image-quality",
+            name: "Grok Imagine Image",
+            output_modalities: ["image"]
+          },
+          { id: "grok-imagine-video", name: "Grok Imagine Video" }
+        ]
+      })
+    });
+  }
+
+  it("classifies image and video models out of the language list", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mixedModelsFetch() as any }
+    );
+
+    const language = await provider.getAvailableLanguageModels();
+    expect(language.map((m) => m.id)).toEqual(["grok-4", "grok-3-mini"]);
+  });
+
+  it("exposes Grok Imagine image models as image models", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mixedModelsFetch() as any }
+    );
+
+    const images = await provider.getAvailableImageModels();
+    expect(images).toEqual([
+      {
+        id: "grok-imagine-image-quality",
+        name: "Grok Imagine Image",
+        provider: "xai",
+        supportedTasks: ["text_to_image", "image_to_image"]
+      }
+    ]);
+  });
+
+  it("exposes Grok Imagine video models as video models", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mixedModelsFetch() as any }
+    );
+
+    const videos = await provider.getAvailableVideoModels();
+    expect(videos).toEqual([
+      {
+        id: "grok-imagine-video",
+        name: "Grok Imagine Video",
+        provider: "xai",
+        supportedTasks: ["text_to_video", "image_to_video"]
+      }
+    ]);
+  });
+
+  it("returns empty image and video lists when model fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    expect(await provider.getAvailableImageModels()).toEqual([]);
+    expect(await provider.getAvailableVideoModels()).toEqual([]);
+  });
+
   it("generates non-streaming message via inherited OpenAI logic", async () => {
     const create = vi.fn().mockResolvedValue({
       choices: [


### PR DESCRIPTION
Extends the XAI (Grok) provider to support image and video generation tasks alongside existing language model capabilities.

## Summary
The XAI provider now exposes Grok Imagine image and video models through new `getAvailableImageModels()` and `getAvailableVideoModels()` methods, and implements the full generation pipeline for text-to-image, image-to-image, text-to-video, and image-to-video tasks.

## Key Changes

- **Model classification**: Added `classifyModel()` function to categorize xAI's unified `/v1/models` listing by modality (language, image, video) using `output_modalities` array or model ID fallback
- **Image generation**: Implemented `textToImage()` and `imageToImage()` methods that map to xAI's `/images/generations` and `/images/edits` endpoints, with support for aspect ratio, resolution, and negative prompts
- **Video generation**: Implemented `textToVideo()` and `imageToVideo()` methods using xAI's async job API (`/videos/generations` + polling), with configurable duration and timeout
- **Data URI encoding**: Added `bytesToDataUri()` helper with `detectImageMime()` to sniff JPEG/WebP/PNG magic bytes and inline image data as base64 data URIs (xAI's JSON API cannot accept multipart uploads)
- **Response decoding**: Added `decodeImageResponse()` to extract base64 or URL-based image data from xAI's response format
- **Refactoring**: Extracted `fetchModelRows()` private method to deduplicate model fetching logic across all three model listing methods

## Implementation Details

- Image inputs are converted to base64 data URIs with correct MIME types detected from file magic bytes
- Video generation uses polling with 5-second intervals and configurable timeout (default 600 seconds, max 15 seconds duration per xAI limits)
- Negative prompts are appended to the main prompt with "Do not include:" prefix
- Multi-image edits send images as an array when multiple sources are provided, single object for one input
- Duration is resolved from either explicit `durationSeconds` or computed from `numFrames` via inherited `OpenAIProvider.secondsFromParams()`

https://claude.ai/code/session_01DouQNp7UniNbEPowiavQaN