### PR TITLE
Add caching for node_modules, Turbo build outputs, and mobile deps

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,8 +1,9 @@
 name: Setup and build backend
 description: >-
-  Set up Node (with npm cache), install system libraries, run npm ci, rebuild
-  native modules, and (optionally) build the backend packages. The calling job
-  must check out the repository first, since this is a local composite action.
+  Set up Node (with npm cache), install system libraries, restore the cached
+  node_modules (running npm ci + native rebuild only on a miss), restore Turbo's
+  build cache, and (optionally) build the backend packages. The calling job must
+  check out the repository first, since this is a local composite action.
 
 inputs:
   extra-apt:
@@ -27,15 +28,45 @@ runs:
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y libsecret-1-0 ${{ inputs.extra-apt }}
 
+    # Cache the installed workspace node_modules keyed on the lockfile (and Node
+    # version). On a hit we skip `npm ci` and the native rebuild entirely — the
+    # restored tree already has better-sqlite3 built for this runner. setup-node's
+    # `cache: npm` only caches the download tarballs; this caches the linked tree.
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+          web/node_modules
+          electron/node_modules
+          demo/node_modules
+          examples/*/node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', '.nvmrc') }}
+
     - name: Install all workspace dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
     - name: Rebuild native modules
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm rebuild better-sqlite3
+
+    # Persist Turbo's local cache so `build:packages`/`test:packages` restore
+    # prior task outputs instead of rebuilding ~55 packages from scratch in every
+    # job. Keyed by commit with a prefix fallback to the latest available cache.
+    - name: Cache Turbo build outputs
+      uses: actions/cache@v5
+      with:
+        path: .turbo/cache
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
 
     - name: Build backend packages
       if: inputs.build-packages == 'true'

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -50,18 +50,21 @@ jobs:
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
+            fetch-depth: "1"
           - check: typecheck
             command: npm run typecheck
             build-packages: "true"
             mobile-deps: "true"
             extra-apt: ""
             is-test: "false"
+            fetch-depth: "1"
           - check: lint
             command: npm run lint
             build-packages: "false"
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
+            fetch-depth: "1"
           # base-nodes parity/contract suite (Python-parity + example-workflow
           # contracts). is-test:false keeps it non-skippable — these tests encode
           # intentional behavior contracts (see the revert in commit 2c0fd8fad),
@@ -73,25 +76,37 @@ jobs:
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
+            fetch-depth: "1"
           # mesa-vulkan-drivers ships lavapipe (CPU Vulkan ICD) so Dawn can
           # acquire a WebGPU adapter on GPU-less runners — without it the
           # shader-backed base-nodes tests fail with "No WebGPU adapter
           # available (Node/Dawn)".
           - check: test-packages
-            command: npm run test:packages
+            # On PRs, `--affected` prunes the Turbo graph to packages changed
+            # since the base commit plus their dependents, so unaffected backend
+            # tests are skipped entirely (not just cache-restored). On push to
+            # main (no base sha) the full suite runs. Needs fetch-depth: 0 for
+            # the SCM diff and TURBO_SCM_BASE (set on the Run step below).
+            command: npm run test:packages${{ github.event_name == 'pull_request' && ' -- --affected' || '' }}
             build-packages: "true"
             mobile-deps: "false"
             extra-apt: "mesa-vulkan-drivers"
             is-test: "true"
+            fetch-depth: "0"
           - check: test-app
             command: npm run test
             build-packages: "true"
             mobile-deps: "true"
             extra-apt: ""
             is-test: "true"
+            fetch-depth: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Most legs only need the tip; the test-packages leg needs full history
+          # so Turbo's `--affected` can diff against the PR base commit.
+          fetch-depth: ${{ matrix.fetch-depth }}
 
       - name: Set up Node, install deps, build packages
         uses: ./.github/actions/setup-build
@@ -99,8 +114,18 @@ jobs:
           extra-apt: ${{ matrix.extra-apt }}
           build-packages: ${{ matrix.build-packages }}
 
-      - name: Install mobile dependencies
+      # mobile is NOT a root workspace (separate dependency tree), so its
+      # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
+      - name: Cache mobile node_modules
         if: matrix.mobile-deps == 'true'
+        id: mobile-node-modules
+        uses: actions/cache@v5
+        with:
+          path: mobile/node_modules
+          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
+
+      - name: Install mobile dependencies
+        if: matrix.mobile-deps == 'true' && steps.mobile-node-modules.outputs.cache-hit != 'true'
         run: cd mobile && npm ci
 
       - name: Run npm audit (advisory)
@@ -122,6 +147,10 @@ jobs:
         # static checks. The leg still spins up but does no work, so it stays
         # green (a skipped leg must not block the gate).
         if: ${{ !(inputs.skip-tests && matrix.is-test == 'true') }}
+        env:
+          # Base commit for Turbo's `--affected` diff (test-packages leg on PRs).
+          # Empty on push, where the test-packages command omits `--affected`.
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
         run: |
           echo "::group::${{ matrix.check }}"
           ${{ matrix.command }}

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
   "envMode": "loose",
+  // Pin the local cache to a fixed path (turbo's default) so CI can persist it
+  // with actions/cache; see .github/actions/setup-build/action.yml.
+  "cacheDir": ".turbo/cache",
   "globalDependencies": [
     "tsconfig.base.json",
     "tsconfig.build.json",


### PR DESCRIPTION
## Summary

Optimize CI performance by caching workspace dependencies and Turbo build outputs across jobs, and add selective test execution on PRs to skip unaffected packages.

## Key Changes

- **node_modules caching**: Cache the entire workspace node_modules tree (keyed on `package-lock.json` and `.nvmrc`) in the `setup-build` action. Skip `npm ci` and native module rebuild on cache hits, since the restored tree already has `better-sqlite3` built for the runner.

- **Turbo build cache persistence**: Add `.turbo/cache` caching in `setup-build` (keyed by commit with fallback to latest available cache) so `build:packages` and `test:packages` restore prior task outputs instead of rebuilding ~55 packages from scratch in every job. Configure `turbo.json` to pin the cache directory to `.turbo/cache`.

- **Mobile dependencies caching**: Cache `mobile/node_modules` separately (keyed on `mobile/package-lock.json`) since mobile is a standalone workspace with its own dependency tree.

- **Selective test execution on PRs**: Add `--affected` flag to `test:packages` on pull requests to prune the Turbo graph to only changed packages and their dependents, skipping unaffected backend tests entirely. Requires `fetch-depth: 0` for SCM diff and `TURBO_SCM_BASE` environment variable set to the PR base commit.

- **Fetch depth optimization**: Set `fetch-depth: 1` for most CI legs (only need the tip commit) and `fetch-depth: 0` for `test-packages` on PRs (needs full history for Turbo's `--affected` diff).

## Implementation Details

- Cache keys use `runner.os` prefix to avoid cross-platform conflicts
- node_modules cache includes all workspace paths: root, `packages/*/`, `web/`, `electron/`, `demo/`, `examples/*/`
- Conditional steps skip `npm ci` and native rebuild when node_modules cache hits
- Turbo cache uses `github.sha` as primary key with `runner.os-turbo-` as fallback restore key
- Mobile cache hit check gates the `npm ci` step in the mobile dependencies job

https://claude.ai/code/session_01Vh9LabCE1ZanC8chiogjfc