### PR TITLE
Persist generation prompts into auto-saved asset metadata

### DIFF
--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -138,6 +138,31 @@ export interface ActorResult {
   };
 }
 
+/**
+ * Pick the scalar input properties (string/number/boolean) from a resolved
+ * input dict. Drops nested objects, arrays, and binary refs so the
+ * `generation_complete` event stays small and carries only persistable
+ * generation params (prompt, seed, model, …). Reserved keys (`_control_context`
+ * and other `_`-prefixed internals) are stripped. Returns `null` when nothing
+ * scalar remains.
+ */
+function scalarInputProperties(
+  inputs: Record<string, unknown>
+): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(inputs)) {
+    if (key.startsWith("_")) continue;
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      out[key] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 // ---------------------------------------------------------------------------
 // NodeActor
 // ---------------------------------------------------------------------------
@@ -1001,7 +1026,7 @@ export class NodeActor {
       // output_update (chunks); multi-artifact-per-output-slot streaming is OUT
       // OF SCOPE (RFC §5 invariant / Decision 1 corollary). Under correlation
       // this branch runs once per ready key → one generation_complete per key.
-      this._emitGenerationComplete(this._latestResult);
+      this._emitGenerationComplete(this._latestResult, inputs);
     } else {
       const outputs = await this._executor.process(
         inputs,
@@ -1015,7 +1040,7 @@ export class NodeActor {
       );
       // Site #1 (RFC §5): correlated process() — one per ready key, so N/run
       // for a generator (the primary 6×-collapse fix).
-      this._emitGenerationComplete(outputs);
+      this._emitGenerationComplete(outputs, inputs);
     }
   }
 
@@ -1406,7 +1431,10 @@ export class NodeActor {
    * generation. List-valued results are carried as-is — no per-element
    * fan-out happens in the actor (RFC Decision 1).
    */
-  private _emitGenerationComplete(outputs: Record<string, unknown>): void {
+  private _emitGenerationComplete(
+    outputs: Record<string, unknown>,
+    inputs?: Record<string, unknown>
+  ): void {
     if (
       this.node.type.startsWith("nodetool.constant.") ||
       this.node.type.startsWith("nodetool.input.")
@@ -1418,7 +1446,11 @@ export class NodeActor {
       node_id: this.node.id,
       node_name: this.node.name ?? this.node.type,
       node_type: this.node.type,
-      outputs
+      outputs,
+      // Resolved scalar inputs (prompt, seed, model, …) ride along so the relay
+      // can persist them into auto-saved asset metadata. Filtered to scalars to
+      // keep the event small — binary refs and nested objects are dropped.
+      properties: inputs ? scalarInputProperties(inputs) : null
       // NO job_id, NO index — the runner relay stamps them downstream.
     });
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -199,6 +199,14 @@ export interface GenerationComplete {
   index?: number;
   /** The complete result dict for this artifact (same shape as a process() return). */
   outputs: Record<string, unknown>;
+  /**
+   * Scalar input properties resolved for this run — declared props, user-typed
+   * dynamic props, and edge inputs, filtered to strings/numbers/booleans. The
+   * actor stamps these so the relay can persist generation params (notably the
+   * `prompt` that produced an image) into auto-saved asset metadata. Absent when
+   * the node has no scalar inputs.
+   */
+  properties?: Record<string, unknown> | null;
   /** Stamped downstream by the runner relay, NOT by the actor. */
   job_id?: string | null;
   workflow_id?: string | null;

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -308,6 +308,30 @@ const ASSET_MEDIA_TYPES = new Set(["image", "audio", "video"]);
 /** Byte cap for inline-preview text stored in a text generation's asset metadata. */
 const TEXT_GENERATION_PREVIEW_CAP = 200_000;
 
+/** Char cap for the prompt stored in a media asset's metadata. */
+const PROMPT_METADATA_CAP = 8_000;
+
+/**
+ * Lift the prompt out of a generation's scalar input properties into asset
+ * metadata. Returns `{ prompt }` when a non-empty `prompt` string is present
+ * (capped), else an empty object. Other generation params are intentionally
+ * left out — the prompt is the field the asset viewer surfaces.
+ */
+function promptMetadata(
+  properties: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const prompt = properties?.prompt;
+  if (typeof prompt !== "string") return {};
+  const trimmed = prompt.trim();
+  if (trimmed.length === 0) return {};
+  return {
+    prompt:
+      trimmed.length > PROMPT_METADATA_CAP
+        ? trimmed.slice(0, PROMPT_METADATA_CAP)
+        : trimmed
+  };
+}
+
 /**
  * Resolve a node's primary output name when it is a text/str type, so its value
  * can be persisted as a text generation. Mirrors the frontend's
@@ -546,8 +570,18 @@ async function autoSaveAssets(
      * several rows for ONE arrival index).
      */
     generationIndex?: number;
+    /**
+     * Scalar input properties from the `generation_complete` event (the actor's
+     * resolved declared/dynamic/edge inputs, filtered to scalars). The `prompt`
+     * is persisted into each saved media asset's `metadata.prompt` so the asset
+     * viewer can show what produced the image/audio/video.
+     */
+    properties?: Record<string, unknown>;
   }
 ): Promise<void> {
+  // Generation params lifted into each media asset's metadata. Just the prompt
+  // today — the field the asset viewer surfaces as "what produced this".
+  const promptMeta = promptMetadata(opts.properties);
   const queue: Record<string, unknown>[] = [];
 
   // Collect all asset-like values from the result (may be nested)
@@ -620,8 +654,12 @@ async function autoSaveAssets(
       content_type: contentType,
       parent_id: null
     });
+    const mediaMeta: Record<string, unknown> = { ...promptMeta };
     if (typeof opts.generationIndex === "number") {
-      asset.metadata = { generation_index: opts.generationIndex };
+      mediaMeta.generation_index = opts.generationIndex;
+    }
+    if (Object.keys(mediaMeta).length > 0) {
+      asset.metadata = mediaMeta;
     }
 
     const fileName = `${asset.id}.${ext}`;
@@ -2171,7 +2209,12 @@ export class UnifiedWebSocketRunner {
                       jobId: active.jobId,
                       nodeId,
                       textOutputName: primaryTextOutputName(meta),
-                      generationIndex: arrivalIndex
+                      generationIndex: arrivalIndex,
+                      properties:
+                        (outbound.properties as Record<
+                          string,
+                          unknown
+                        > | null) ?? undefined
                     }
                   );
                 } catch (err) {

--- a/packages/websocket/tests/generation-autosave-cutover.test.ts
+++ b/packages/websocket/tests/generation-autosave-cutover.test.ts
@@ -536,4 +536,37 @@ describe("autosave cutover (generation_complete → N assets)", () => {
 
     await runner.disconnect();
   });
+
+  it("saves the prompt that produced each image into asset metadata", async () => {
+    // ForEach feeds each item into gen.prompt (edge fe.output → gen.prompt), so
+    // the actor's resolved inputs carry the prompt. The autosave lifts it into
+    // each image asset's metadata.prompt — what the asset viewer surfaces as the
+    // text that generated the image.
+    const runner = makeRunner();
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOBP",
+      workflow_id: "WFP",
+      graph: foreachGraph(["a sunset over the sea", "a snowy mountain"])
+    });
+    const gens = await waitForMessages(ws, isGen("gen"), 2);
+    expect(gens).toHaveLength(2);
+
+    const [assets] = await Asset.paginate("1", {
+      jobId: "JOBP",
+      nodeId: "gen",
+      limit: 1000
+    });
+    expect(assets).toHaveLength(2);
+    const promptsByIndex = new Map(
+      assets.map((a) => {
+        const md = a.metadata as Record<string, unknown> | null;
+        return [md?.generation_index as number, md?.prompt as string];
+      })
+    );
+    expect(promptsByIndex.get(0)).toBe("a sunset over the sea");
+    expect(promptsByIndex.get(1)).toBe("a snowy mountain");
+
+    await runner.disconnect();
+  });
 });

--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -25,7 +25,9 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import CheckIcon from "@mui/icons-material/Check";
 import CompareIcon from "@mui/icons-material/Compare";
 import EditIcon from "@mui/icons-material/Edit";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import AssetItem from "./AssetItem";
+import AssetInfoPanel from "../context_menus/AssetInfoPanel";
 import { ImageComparer } from "../widgets";
 //
 //components
@@ -268,6 +270,16 @@ const styles = (theme: Theme) =>
     ".prev-next-items .item.compare-selected": {
       outline: "3px solid",
       outlineColor: theme.vars.palette.primary.main
+    },
+    ".info-panel-overlay": {
+      position: "absolute",
+      top: 0,
+      right: 0,
+      height: "calc(100% - 120px)",
+      overflowY: "auto",
+      zIndex: 10001,
+      backgroundColor: theme.vars.palette.grey[900],
+      boxShadow: "-8px 0 24px rgb(0 0 0 / 0.5)"
     }
   });
 
@@ -296,6 +308,10 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   const prevNextAmount = 5;
 
+  // Info panel (asset metadata, incl. the prompt that produced the asset)
+  const [showInfo, setShowInfo] = useState(false);
+  const toggleInfo = useCallback(() => setShowInfo((v) => !v), []);
+
   // Compare mode state
   const [compareMode, setCompareMode] = useState(false);
   const [compareAssetA, setCompareAssetA] = useState<Asset | null>(null);
@@ -313,6 +329,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
       setCompareMode(false);
       setCompareAssetA(null);
       setCompareAssetB(null);
+      setShowInfo(false);
     }
   }, [open]);
 
@@ -786,6 +803,12 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
         )}
         {navigation}
 
+        {showInfo && currentAsset && !compareMode && (
+          <div className="info-panel-overlay">
+            <AssetInfoPanel asset={currentAsset} />
+          </div>
+        )}
+
         {/*
           Render the toolbar after the main viewer in DOM order so it paints (and
           receives hit targets) on top; ImageViewer is a full-area interactive layer
@@ -873,6 +896,16 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
               tooltip="Compare with another image"
               onClick={startCompareMode}
               className="button compare"
+              nodrag={false}
+              sx={viewerActionButtonSx}
+            />
+          )}
+          {currentAsset && !compareMode && (
+            <ToolbarIconButton
+              icon={<InfoOutlinedIcon />}
+              tooltip={showInfo ? "Hide info" : "Show info"}
+              onClick={toggleInfo}
+              className="button info"
               nodrag={false}
               sx={viewerActionButtonSx}
             />


### PR DESCRIPTION
## Summary

Extends the auto-save asset pipeline to capture and persist the prompt (and other scalar generation parameters) that produced each image/audio/video. The prompt is now stored in each asset's metadata and surfaced in the asset viewer's info panel, enabling users to see what text generated each media file.

## Key Changes

- **Kernel (`packages/kernel/src/actor.ts`)**
  - Added `scalarInputProperties()` helper to extract string/number/boolean inputs from resolved node inputs, filtering out nested objects, arrays, binary refs, and reserved `_`-prefixed keys
  - Modified `_emitGenerationComplete()` to accept resolved `inputs` and stamp scalar properties into the `generation_complete` event's new `properties` field
  - Updated both generator and process-based execution paths to pass inputs to `_emitGenerationComplete()`

- **WebSocket Runner (`packages/websocket/src/unified-websocket-runner.ts`)**
  - Added `PROMPT_METADATA_CAP` constant (8,000 chars) and `promptMetadata()` helper to extract and cap the prompt from generation properties
  - Extended `autoSaveAssets()` to accept `properties` option containing scalar inputs from the generation event
  - Modified asset metadata assembly to merge prompt metadata with generation index, ensuring each saved asset carries the prompt that produced it
  - Updated the `generation_complete` event handler to pass resolved scalar properties to `autoSaveAssets()`

- **Protocol (`packages/protocol/src/messages.ts`)**
  - Added optional `properties` field to `GenerationComplete` interface to carry scalar input properties (prompt, seed, model, etc.) downstream

- **Asset Viewer (`web/src/components/assets/AssetViewer.tsx`)**
  - Added info panel toggle state and button to show/hide asset metadata
  - Integrated `AssetInfoPanel` component to display asset metadata including the generation prompt
  - Styled info panel as a right-side overlay with proper z-indexing and scrolling

- **Tests (`packages/websocket/tests/generation-autosave-cutover.test.ts`)**
  - Added test verifying that prompts from a ForEach loop are correctly persisted into each generated image's metadata

## Implementation Details

- Scalar filtering happens at the actor level to keep the `generation_complete` event small — only persistable generation params (strings, numbers, booleans) are included; binary refs and nested objects are dropped
- The prompt is capped at 8,000 characters to prevent metadata bloat while preserving typical prompts
- Asset metadata now merges both the prompt and generation index into a single `metadata` object
- The info panel is only shown when viewing a single asset (not in compare mode) and closes when the viewer is closed

https://claude.ai/code/session_01ABBXX8QukAK4LRfqtYpPku