### PR TITLE
Prevent grid clicks from bubbling to ReactFlow node selection

### DIFF
--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -547,6 +547,10 @@ const NodeHistoryViewerInternal: React.FC<NodeHistoryViewerProps> = ({
   // Every mode advances the range anchor + the roving-focus active tile.
   const handleGridClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      // Picking a generation must not toggle the enclosing node's selection.
+      // ReactFlow selects a node on click (separate from the pointer-down drag
+      // we already swallow), so stop the click from bubbling to the node.
+      e.stopPropagation();
       const thumb = (e.target as HTMLElement).closest<HTMLElement>(".thumb");
       if (!thumb) return;
       const genId = thumb.dataset.genId;

--- a/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
+++ b/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
@@ -451,6 +451,30 @@ describe("NodeHistoryViewer", () => {
     expect(screen.getByTestId("single-body")).toBeInTheDocument();
   });
 
+  it("does not bubble grid clicks to the node (no node select/deselect)", () => {
+    // Picking a generation in the grid must not toggle the enclosing ReactFlow
+    // node's selection — the click is stopped before it reaches the node.
+    setGenerations([makeGen("a1", 1), makeGen("a2", 2), makeGen("a3", 3)]);
+    const onParentClick = jest.fn();
+
+    renderWithProviders(
+      <div onClick={onParentClick}>
+        <NodeHistoryViewer
+          workflowId="wf1"
+          nodeId="node-a"
+          liveResult={null}
+          renderSingle={renderSingle}
+        />
+      </div>
+    );
+
+    fireEvent.click(screen.getByLabelText("Toggle view"));
+    // Isolate the tile (item) click — the reported case.
+    onParentClick.mockClear();
+    fireEvent.click(screen.getAllByRole("option")[0]);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
   it("opens the AssetViewer for the current generation's asset", () => {
     setGenerations([makeGen("a1", 1)]);
     mockUseNodeResultHistory.mockReturnValue({


### PR DESCRIPTION
## Summary
Fixes an issue where clicking on a generation tile in the NodeHistoryViewer grid would inadvertently toggle the selection state of the enclosing ReactFlow node. The click event now stops propagating before reaching the node's click handler.

## Changes
- **NodeHistoryViewer.tsx**: Added `e.stopPropagation()` in the `handleGridClick` callback to prevent click events from bubbling up to the parent ReactFlow node, which was causing unintended node selection/deselection.
- **NodeHistoryViewer.test.tsx**: Added test case "does not bubble grid clicks to the node (no node select/deselect)" to verify that clicking a generation tile does not trigger parent click handlers.

## Implementation Details
The fix is minimal and surgical — a single `stopPropagation()` call at the start of the grid click handler. This complements the existing pointer-down drag handling and ensures that intentional generation selection interactions remain isolated to the history viewer component without side effects on the workflow graph UI.

https://claude.ai/code/session_01XeuptSpvkYi1qgoQcbLCTg