### PR TITLE
Bolt: Optimize O(N*M) nested array lookups to O(N+M)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -34,3 +34,6 @@
 ## 2026-05-25 - O(N*M) lookup bottleneck in workflowUpdates.ts
 **Learning:** Found an $O(N \times M)$ performance bottleneck in `web/src/stores/workflowUpdates.ts` where `runsStore.getRuns(workflow.id).some(r => r.jobId === job.job_id)` was called on every node update. For workflows with thousands of jobs, this iteration causes noticeable CPU stalling.
 **Action:** Implemented a new `hasRun(workflowId, jobId)` method in `WorkflowRunsStore` that uses an O(1) property lookup (`runs[wf]?.[jobId] !== undefined`). Replace `.some()` array iterations with dictionary/map lookups when processing high-frequency updates.
+## 2026-05-25 - O(N*M) Edge Filtering Bottleneck
+**Learning:** Found multiple $O(N \times M)$ performance bottlenecks across the codebase where array operations like `.map` or `.filter` contained nested array lookups via `.find` or `.includes`. These nested loops caused significant performance degradation when processing large arrays such as node graphs or workflow layouts.
+**Action:** Always precompute a `Map` or a `Set` before running iteration methods that perform lookups, reducing the lookup time inside the loop to $O(1)$ and lowering overall time complexity to $O(N+M)$.

--- a/packages/data-nodes/src/nodes/data.ts
+++ b/packages/data-nodes/src/nodes/data.ts
@@ -1549,10 +1549,11 @@ export class AggregateNode extends BaseNode {
     }
 
     const output: Row[] = [];
+    const groupColsSet = new Set(groupCols);
     for (const [key, items] of groups) {
       const base = JSON.parse(key) as Row;
       const numericCols = [...new Set(items.flatMap((r) => Object.keys(r)))]
-        .filter((c) => !groupCols.includes(c))
+        .filter((c) => !groupColsSet.has(c))
         .filter((c) => items.some((r) => Number.isFinite(toNumber(r[c]))));
       for (const col of numericCols) {
         const values = items

--- a/packages/kernel/src/correlation-analysis.ts
+++ b/packages/kernel/src/correlation-analysis.ts
@@ -197,11 +197,12 @@ function topoSort(
 
   // Stryker disable next-line ConditionalExpression,EqualityOperator: equivalent — the only consumer (analyzeCorrelation) reports a cycle iff `cycle.length > 0`, so taking this branch for an acyclic graph yields an empty `remaining` that is indistinguishable from the `cycle: null` path; only the non-empty (real cycle) contents are observable
   if (order.length < nodes.length || selfLoopNodes.size > 0) {
-    const remaining = nodes.filter((n) => !order.includes(n)).map((n) => n.id);
+    const orderSet = new Set(order);
+    const remainingSet = new Set(nodes.filter((n) => !orderSet.has(n)).map((n) => n.id));
     for (const id of selfLoopNodes) {
-      if (!remaining.includes(id)) remaining.push(id);
+      remainingSet.add(id);
     }
-    return { order, cycle: remaining };
+    return { order, cycle: Array.from(remainingSet) };
   }
   return { order, cycle: null };
 }

--- a/web/src/components/common/LogsTable.tsx
+++ b/web/src/components/common/LogsTable.tsx
@@ -378,9 +378,11 @@ export const LogsTable: React.FC<LogsTableProps> = ({
 
   // Optimization: Memoize filteredRows to prevent recalculation on every render
   const filteredRows = useMemo(() => {
-    return Array.isArray(severities) && severities.length > 0
-      ? rows.filter((r) => severities.includes(r.severity))
-      : rows;
+    if (Array.isArray(severities) && severities.length > 0) {
+      const severitiesSet = new Set(severities);
+      return rows.filter((r) => severitiesSet.has(r.severity));
+    }
+    return rows;
   }, [rows, severities]);
 
   const rowKeys = useMemo(

--- a/web/src/components/node/DataTable/TableActions.tsx
+++ b/web/src/components/node/DataTable/TableActions.tsx
@@ -291,7 +291,8 @@ const TableActions: React.FC<TableActionsProps> = memo(({
         
         // Check if first row is a header row (matches column names)
         const firstRow = rows[0].map((c) => c.toLowerCase().replace(/^"|"$/g, ""));
-        const matchingHeaders = firstRow.filter((h) => colNames.includes(h));
+        const colNamesSet = new Set(colNames);
+        const matchingHeaders = firstRow.filter((h) => colNamesSet.has(h));
         const hasHeaderRow = matchingHeaders.length >= Math.min(2, dataframeColumns.length);
         
         // Build column index mapping

--- a/web/src/stores/timeline/__tests__/TimelineStore.linking.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.linking.test.ts
@@ -232,7 +232,8 @@ describe("duplicate remaps linkId (FIX 3)", () => {
     const newIds = store.getState().duplicateSelected(new Set([videoId, audioId]));
     expect(newIds).toHaveLength(2);
     const clips = store.getState().clips;
-    const copies = newIds.map((id) => clips.find((c) => c.id === id)!);
+    const clipsMap = new Map(clips.map(c => [c.id, c]));
+    const copies = newIds.map((id) => clipsMap.get(id)!);
     const copyLink = copies[0].linkId;
     expect(copyLink).toBeDefined();
     // Both copies share one link id.


### PR DESCRIPTION
## What
Replaced O(N*M) algorithmic bottlenecks caused by nested array `.find()` and `.includes()` calls inside `.filter()` and `.map()` iterations across multiple files.

## Why
When dealing with large arrays (e.g. hundreds of node logs, timeline clips, or correlation topology orders), nested array lookups severely degrade CPU performance, freezing the UI or extending computation times unnecessarily. Pre-initializing a `Map` or a `Set` allows O(1) lookups inside the loop, dropping the algorithmic complexity to O(N + M).

## Impact
Drastically reduces compute time in hotspots involving array intersection and lookup maps (e.g., topology sorting in `correlation-analysis.ts`, filtering log outputs in `LogsTable.tsx`, and CSV copy-pasting in `TableActions.tsx`).

## Verification
- Verified correctness locally via `npm run test` (including `packages/kernel`, and `web` tests)
- Verified build and syntax via `npm run lint` and `npm run build:packages`

---
*PR created automatically by Jules for task [11223086013222104008](https://jules.google.com/task/11223086013222104008) started by @georgi*