### PR TITLE
feat(web): run the Code node (nodetool.code.Code) in the browser

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -57,6 +57,12 @@
       "types": "./dist/long-term-memory.d.ts",
       "import": "./dist/long-term-memory.js",
       "default": "./dist/long-term-memory.js"
+    },
+    "./js-sandbox": {
+      "nodetool-dev": "./src/js-sandbox.ts",
+      "types": "./dist/js-sandbox.d.ts",
+      "import": "./dist/js-sandbox.js",
+      "default": "./dist/js-sandbox.js"
     }
   },
   "license": "MIT",

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -29,6 +29,7 @@ const quickJsVariant = (quickJsVariantModule as unknown as {
   default: Parameters<typeof loadQuickJs>[0];
 }).default;
 import { Scope } from "quickjs-emscripten-core";
+import { importNodeBuiltin } from "@nodetool-ai/config";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 // ---------------------------------------------------------------------------
@@ -130,6 +131,32 @@ function neverReject<Args extends unknown[], R>(
 export function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return text.slice(0, max) + "\n...[truncated]";
+}
+
+/**
+ * Load `node:fs/promises` via a bundler-hidden import so a browser/edge bundle
+ * never tries to resolve it. The `workspace.*` bridge is wired only when a
+ * `ProcessingContext` is present, and these loaders run only when guest code
+ * actually calls `workspace.read/write/list` — off-Node that path throws
+ * (`importNodeBuiltin` resolves `null`), which `neverReject` surfaces to the
+ * guest as a normal error.
+ */
+async function loadFsPromises(): Promise<typeof import("node:fs/promises")> {
+  const fs = await importNodeBuiltin<typeof import("node:fs/promises")>(
+    "node:fs/promises"
+  );
+  if (!fs) throw new Error("workspace file access requires a Node.js runtime");
+  return fs;
+}
+
+async function loadNodePath(): Promise<typeof import("node:path")> {
+  const nodePath = await importNodeBuiltin<typeof import("node:path")>(
+    "node:path"
+  );
+  if (!nodePath) {
+    throw new Error("workspace file access requires a Node.js runtime");
+  }
+  return nodePath;
 }
 
 function formatArg(arg: unknown): string {
@@ -364,20 +391,20 @@ export function buildSandbox(context?: ProcessingContext): SandboxResult {
     ? {
         read: async (path: string): Promise<string> => {
           const fullPath = context.resolveWorkspacePath(path);
-          const { readFile } = await import("node:fs/promises");
-          return readFile(fullPath, "utf-8");
+          const fs = await loadFsPromises();
+          return fs.readFile(fullPath, "utf-8");
         },
         write: async (path: string, content: string): Promise<void> => {
           const fullPath = context.resolveWorkspacePath(path);
-          const { writeFile, mkdir } = await import("node:fs/promises");
-          const { dirname } = await import("node:path");
-          await mkdir(dirname(fullPath), { recursive: true });
-          await writeFile(fullPath, content, "utf-8");
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          await fs.mkdir(nodePath.dirname(fullPath), { recursive: true });
+          await fs.writeFile(fullPath, content, "utf-8");
         },
         list: async (path: string): Promise<string[]> => {
           const fullPath = context.resolveWorkspacePath(path);
-          const { readdir } = await import("node:fs/promises");
-          return readdir(fullPath);
+          const fs = await loadFsPromises();
+          return fs.readdir(fullPath);
         }
       }
     : {

--- a/packages/base-nodes/vitest.config.ts
+++ b/packages/base-nodes/vitest.config.ts
@@ -7,8 +7,12 @@ export default defineConfig({
       "@nodetool-ai/kernel": resolve(__dirname, "../kernel/src/index.ts"),
       "@nodetool-ai/protocol": resolve(__dirname, "../protocol/src"),
       "@nodetool-ai/node-sdk": resolve(__dirname, "../node-sdk/src/index.ts"),
-      "@nodetool-ai/agents": resolve(__dirname, "../agents/src/index.ts"),
       // Subpaths before the root alias (Vite alias is prefix-based).
+      "@nodetool-ai/agents/js-sandbox": resolve(
+        __dirname,
+        "../agents/src/js-sandbox.ts"
+      ),
+      "@nodetool-ai/agents": resolve(__dirname, "../agents/src/index.ts"),
       "@nodetool-ai/runtime/tracing": resolve(
         __dirname,
         "../runtime/src/tracing-helpers.ts"

--- a/packages/chat/vitest.config.ts
+++ b/packages/chat/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     // rewritten to `../agents/src/index.ts/memory` and fails to resolve.
     alias: [
       {
+        find: "@nodetool-ai/agents/js-sandbox",
+        replacement: resolve(__dirname, "../agents/src/js-sandbox.ts")
+      },
+      {
         find: "@nodetool-ai/agents/memory",
         replacement: resolve(__dirname, "../agents/src/long-term-memory.ts")
       },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -25,6 +25,7 @@ function nodetoolStubPlugin(): Plugin {
     "@nodetool-ai/models",
     "@nodetool-ai/chat",
     "@nodetool-ai/agents",
+    "@nodetool-ai/agents/js-sandbox",
     "@nodetool-ai/kernel",
     "@nodetool-ai/node-sdk",
     "@nodetool-ai/base-nodes",

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -16,7 +16,7 @@
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { runInSandbox } from "@nodetool-ai/agents";
+import { runInSandbox } from "@nodetool-ai/agents/js-sandbox";
 import { ALL_PLATFORMS } from "@nodetool-ai/protocol";
 
 /** JS keywords that cannot be used as variable names. */

--- a/packages/code-nodes/tests/browser-platform.test.ts
+++ b/packages/code-nodes/tests/browser-platform.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Browser-eligibility guard for the Code node.
+ *
+ * The in-browser workflow runner routes a sub-graph client-side only when every
+ * node type is in a registry built with `createBrowserRegistry`, which keeps a
+ * class iff `supportsPlatform(cls.platforms, "browser")`.
+ *
+ * Contract: `nodetool.code.Code` (CodeNode) runs vanilla JS in a QuickJS
+ * WebAssembly sandbox — no Node `vm`, no subprocess — so it is browser-capable
+ * and the web runner loads it. This test pins that contract: dropping CodeNode's
+ * browser support would silently force it back to the server, and dropping node
+ * support would break server runs.
+ */
+import { describe, it, expect } from "vitest";
+import { supportsPlatform, type Platform } from "@nodetool-ai/protocol";
+import { CodeNode } from "@nodetool-ai/code-nodes";
+
+type NodeClassLike = {
+  nodeType?: string;
+  platforms?: readonly Platform[];
+};
+
+describe("code-nodes browser eligibility", () => {
+  it("CodeNode (nodetool.code.Code) supports the browser platform", () => {
+    const cls = CodeNode as unknown as NodeClassLike;
+    expect(cls.nodeType).toBe("nodetool.code.Code");
+    expect(supportsPlatform(cls.platforms, "browser")).toBe(true);
+  });
+
+  it("CodeNode still supports the node platform (server runs unchanged)", () => {
+    const cls = CodeNode as unknown as NodeClassLike;
+    expect(supportsPlatform(cls.platforms, "node")).toBe(true);
+  });
+});

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -125,6 +125,7 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     placeholders,
     subgraph,
     workflow,
+    codeNode,
     imageColorGrading,
     imageColor,
     imageEffects,
@@ -156,6 +157,11 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     import("@nodetool-ai/core-nodes/nodes/extended-placeholders"),
     import("@nodetool-ai/core-nodes/nodes/subgraph"),
     import("@nodetool-ai/core-nodes/nodes/workflow"),
+    // The universal Code node (nodetool.code.Code) runs vanilla JS in a QuickJS
+    // WebAssembly sandbox — no Node `vm`, no subprocess — so it runs client-side.
+    // Imported via its own subpath (not the code-nodes index, which pulls
+    // code-runners → Docker/ssh2); its only heavy dep is the QuickJS wasm chunk.
+    import("@nodetool-ai/code-nodes/nodes/code-node"),
     import("@nodetool-ai/image-nodes/nodes/lib-image-color-grading"),
     import("@nodetool-ai/image-nodes/nodes/lib-image-color"),
     import("@nodetool-ai/image-nodes/nodes/lib-image-effects"),
@@ -201,6 +207,7 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
     ["extended-placeholders", placeholders],
     ["subgraph", subgraph],
     ["workflow", workflow],
+    ["code-node", codeNode],
     ["lib-image-color-grading", imageColorGrading],
     ["lib-image-color", imageColor],
     ["lib-image-effects", imageEffects],


### PR DESCRIPTION
The Code node already runs vanilla JS in a QuickJS WebAssembly sandbox
(no node:vm, no subprocess) and is tagged ALL_PLATFORMS, but the web
in-browser runner never loaded it, so graphs using it always routed to
the server. Wire it into the client runner so pure-JS graphs execute
locally.

- agents: expose a narrow `@nodetool-ai/agents/js-sandbox` subpath so the
  Code node pulls only the sandbox, not the full agents package (LLM
  providers, telemetry) into a browser bundle.
- agents/js-sandbox: load node:fs/promises and node:path through
  importNodeBuiltin (bundler-hidden) so the workspace.* bridge no longer
  forces a browser/edge bundle to resolve node builtins. The path runs
  only when guest code calls workspace.* with a ProcessingContext; off
  Node it throws a normal guest error.
- code-nodes: import runInSandbox from the new subpath.
- web/browserRunnerCore: add code-node to loadBrowserModules (covers both
  the Web Worker and main-thread paths). It bundles as its own lazy
  code-node chunk (QuickJS wasm), verified via vite build.
- code-nodes: add a browser-platform guard test pinning that
  nodetool.code.Code supports both the browser and node platforms.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HWTWw85RPDZhKZyymceaLw