### PR TITLE
Add type validation to edge creation and improve node search

### DIFF
--- a/packages/agents/src/prompts/graph-planner-prompt.ts
+++ b/packages/agents/src/prompts/graph-planner-prompt.ts
@@ -249,6 +249,16 @@ node auto-saves its result as an asset. Example: \`nodetool.image.TextToImage\`
 \`nodetool.agents.AgentStep\` nodes for multi-stage reasoning. Each step
 inherits the workflow's configured model — do NOT set a \`model\` property.
 
+## Branch / Conditional
+\`Input → comparison → If → (both branches) → Output\`. Produce a **boolean**
+with a comparison node (e.g. \`nodetool.text.Equals\`, which outputs \`bool\` —
+NOT \`nodetool.text.Compare\`, which outputs the string "equal"/"greater"/"less"
+and is never a valid \`condition\`). Wire it into \`nodetool.control.If.condition\`
+and the value to switch on into \`If.value\`. \`If\` has TWO outputs —
+\`if_true\` and \`if_false\` — wire BOTH to their destinations so each case is
+handled. Do not fake the else-branch with \`TryCatch\`; \`If\` already gives you
+both paths.
+
 ## Multi-Modal Chain
 \`Audio → Speech-to-Text → AgentStep → Text-to-Image → Output\`, or any
 permutation. Connect generic AI nodes of different modalities, optionally

--- a/packages/agents/src/tools/add-edge-tool.ts
+++ b/packages/agents/src/tools/add-edge-tool.ts
@@ -3,9 +3,40 @@
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { NodeRegistry, NodeMetadata } from "@nodetool-ai/node-sdk";
+import { TypeMetadata } from "@nodetool-ai/protocol";
 import { Tool } from "./base-tool.js";
 import { AGENT_STEP_NODE_TYPE, type GraphBuilder } from "../graph-builder.js";
+
+/** Render a node's TypeMetadata into the string form TypeMetadata.fromString parses. */
+function typeMetaToString(
+  tm: NodeMetadata["properties"][number]["type"] | undefined
+): string | undefined {
+  if (!tm || !tm.type) return undefined;
+  const args = (tm.type_args ?? []).map(typeMetaToString).filter(Boolean);
+  return args.length > 0 ? `${tm.type}[${args.join(", ")}]` : tm.type;
+}
+
+/**
+ * Loose data-edge type compatibility, identical to the kernel's
+ * `validateEdgeTypes` (Graph): compatible types, "any", numeric widening,
+ * unions, list element types, and scalar-into-list aggregation. Returns true
+ * when either side's type is unknown so we never block on missing metadata.
+ */
+function edgeTypesCompatible(
+  sourceType: string | undefined,
+  targetType: string | undefined
+): boolean {
+  if (!sourceType || !targetType) return true;
+  const sourceMeta = TypeMetadata.fromString(sourceType);
+  const targetMeta = TypeMetadata.fromString(targetType);
+  const elementCompatible =
+    targetMeta.isListType() &&
+    !sourceMeta.isListType() &&
+    (targetMeta.args.length === 0 ||
+      sourceMeta.isCompatibleWith(targetMeta.args[0]));
+  return sourceMeta.isCompatibleWith(targetMeta) || elementCompatible;
+}
 
 const ADD_EDGE_INPUT_SCHEMA = {
   type: "object" as const,
@@ -64,15 +95,22 @@ export class AddEdgeTool extends Tool {
     // Validate handles against registry metadata for deterministic nodes
     const validationErrors: string[] = [];
 
+    let sourceType: string | undefined;
+    let targetType: string | undefined;
+
     const sourceNode = this.builder.getNode(source);
     if (sourceNode && sourceNode.type !== AGENT_STEP_NODE_TYPE) {
       const meta = this.registry.getMetadata(sourceNode.type);
       if (meta) {
-        const outputNames = meta.outputs.map((o: { name: string }) => o.name);
-        if (outputNames.length > 0 && !outputNames.includes(sourceHandle)) {
+        const output = meta.outputs.find(
+          (o: NodeMetadata["outputs"][number]) => o.name === sourceHandle
+        );
+        if (meta.outputs.length > 0 && !output) {
           validationErrors.push(
-            `Source node '${source}' (${sourceNode.type}) has no output '${sourceHandle}'. Available: ${outputNames.join(", ")}`
+            `Source node '${source}' (${sourceNode.type}) has no output '${sourceHandle}'. Available: ${meta.outputs.map((o: { name: string }) => o.name).join(", ")}`
           );
+        } else if (output) {
+          sourceType = typeMetaToString(output.type);
         }
       }
     }
@@ -81,13 +119,32 @@ export class AddEdgeTool extends Tool {
     if (targetNode && targetNode.type !== AGENT_STEP_NODE_TYPE) {
       const meta = this.registry.getMetadata(targetNode.type);
       if (meta) {
-        const inputNames = meta.properties.map((p: { name: string }) => p.name);
-        if (inputNames.length > 0 && !inputNames.includes(targetHandle)) {
+        const input = meta.properties.find(
+          (p: NodeMetadata["properties"][number]) => p.name === targetHandle
+        );
+        if (meta.properties.length > 0 && !input) {
           validationErrors.push(
-            `Target node '${target}' (${targetNode.type}) has no input '${targetHandle}'. Available: ${inputNames.join(", ")}`
+            `Target node '${target}' (${targetNode.type}) has no input '${targetHandle}'. Available: ${meta.properties.map((p: { name: string }) => p.name).join(", ")}`
           );
+        } else if (input) {
+          targetType = typeMetaToString(input.type);
         }
       }
+    }
+
+    // Type compatibility: catch e.g. a string output wired into a boolean
+    // condition during planning, instead of only at runtime where the agent
+    // can no longer self-correct. Skips unknown/any types and dynamic
+    // (AgentStep) endpoints, so it never blocks on missing metadata.
+    if (
+      validationErrors.length === 0 &&
+      !edgeTypesCompatible(sourceType, targetType)
+    ) {
+      validationErrors.push(
+        `Type mismatch: ${source}.${sourceHandle} outputs "${sourceType}" but ` +
+          `${target}.${targetHandle} expects "${targetType}". Pick a node whose ` +
+          `output type matches, or insert a converter.`
+      );
     }
 
     if (validationErrors.length > 0) {

--- a/packages/agents/tests/add-edge-tool.test.ts
+++ b/packages/agents/tests/add-edge-tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { GraphBuilder } from "../src/graph-builder.js";
+import { AddEdgeTool } from "../src/tools/add-edge-tool.js";
+
+type Handle = { name: string; type?: { type: string; type_args?: unknown[] } };
+
+/** Registry stub whose nodes carry typed input/output handles. */
+function mockRegistry(
+  defs: Record<string, { properties?: Handle[]; outputs?: Handle[] }>
+) {
+  return {
+    has: (t: string) => t in defs,
+    getMetadata: (t: string) =>
+      t in defs
+        ? {
+            node_type: t,
+            properties: defs[t].properties ?? [],
+            outputs: defs[t].outputs ?? []
+          }
+        : null
+  } as never;
+}
+
+const ctx = {} as never;
+
+describe("AddEdgeTool type validation", () => {
+  function setup() {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry({
+      "test.StringSource": { outputs: [{ name: "output", type: { type: "str" } }] },
+      "test.IfNode": {
+        properties: [{ name: "condition", type: { type: "bool" } }],
+        outputs: [{ name: "if_true", type: { type: "any" } }]
+      }
+    });
+    builder.addNode("src", "test.StringSource");
+    builder.addNode("if1", "test.IfNode");
+    return new AddEdgeTool(builder, registry);
+  }
+
+  it("rejects a string output wired into a boolean input", async () => {
+    const tool = setup();
+    const result = (await tool.process(ctx, {
+      source: "src",
+      source_handle: "output",
+      target: "if1",
+      target_handle: "condition"
+    })) as { status: string; errors?: string[] };
+    expect(result.status).toBe("error");
+    expect(result.errors?.[0]).toMatch(/Type mismatch/);
+  });
+
+  it("accepts an any-typed target (no false positive)", async () => {
+    const builder = new GraphBuilder();
+    const registry = mockRegistry({
+      "test.StringSource": { outputs: [{ name: "output", type: { type: "str" } }] },
+      "test.Sink": { properties: [{ name: "value", type: { type: "any" } }] }
+    });
+    builder.addNode("src", "test.StringSource");
+    builder.addNode("sink", "test.Sink");
+    const tool = new AddEdgeTool(builder, registry);
+    const result = (await tool.process(ctx, {
+      source: "src",
+      source_handle: "output",
+      target: "sink",
+      target_handle: "value"
+    })) as { status: string };
+    expect(result.status).toBe("edge_added");
+  });
+});

--- a/packages/node-sdk/src/search.ts
+++ b/packages/node-sdk/src/search.ts
@@ -133,13 +133,18 @@ export function scoreNodeMetadata(
   }
 
   let raw = 0;
+  // Each search term may itself be a multi-word phrase (agents often pass
+  // ["text input string"] rather than ["text","input","string"]). Match on
+  // individual words so a phrase doesn't collapse to a single substring probe
+  // that almost never hits — this is the difference between 0 and many results.
   for (const rawTerm of terms) {
-    const term = rawTerm.toLowerCase();
-    if (!term) continue;
-    raw += fieldScore(meta.title, term, FIELD_WEIGHTS.title);
-    raw += fieldScore(meta.node_type, term, FIELD_WEIGHTS.nodeType);
-    raw += fieldScore(meta.namespace, term, FIELD_WEIGHTS.namespace);
-    raw += fieldScore(meta.description, term, FIELD_WEIGHTS.description);
+    for (const term of rawTerm.toLowerCase().split(/\s+/)) {
+      if (!term) continue;
+      raw += fieldScore(meta.title, term, FIELD_WEIGHTS.title);
+      raw += fieldScore(meta.node_type, term, FIELD_WEIGHTS.nodeType);
+      raw += fieldScore(meta.namespace, term, FIELD_WEIGHTS.namespace);
+      raw += fieldScore(meta.description, term, FIELD_WEIGHTS.description);
+    }
   }
 
   // Stryker disable next-line ConditionalExpression: when raw is 0 the core branch returns 0 * 1.5 === 0, so the guard cannot change the result (equivalent).

--- a/packages/node-sdk/tests/search.test.ts
+++ b/packages/node-sdk/tests/search.test.ts
@@ -68,6 +68,18 @@ describe("scoreNodeMetadata", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("matches a multi-word query term word-by-word (not as one substring)", () => {
+    // Agents often pass a phrase as a single term, e.g. ["uppercase text
+    // transform"]. It must still match a node titled "To Uppercase"; matching
+    // the whole phrase as one substring would score 0.
+    const m = meta({
+      node_type: "nodetool.text.ToUppercase",
+      title: "To Uppercase",
+      description: "Converts text to uppercase."
+    });
+    expect(scoreNodeMetadata(m, ["uppercase text transform"])).toBeGreaterThan(0);
+  });
+
   it("ranks title matches above description-only matches", () => {
     const titleHit = meta({
       node_type: "nodetool.image.TextToImage",

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -941,9 +941,18 @@ function jsonPropToZod(prop: Record<string, unknown>): ZodTypeAny {
           : z.unknown()
       );
       break;
-    case "object":
-      zt = z.object(jsonSchemaToZodShape(prop));
+    case "object": {
+      const shape = jsonSchemaToZodShape(prop);
+      // Free-form objects (no declared sub-properties — e.g. add_node's
+      // `node_properties`) must keep arbitrary keys. `z.object({})` strips
+      // every key, silently dropping all node configuration on the SDK tool
+      // bridge; passthrough preserves the nested values.
+      zt =
+        Object.keys(shape).length > 0
+          ? z.object(shape)
+          : z.object({}).passthrough();
       break;
+    }
     default:
       zt = z.unknown();
   }

--- a/packages/runtime/tests/providers/claude-agent-provider.test.ts
+++ b/packages/runtime/tests/providers/claude-agent-provider.test.ts
@@ -792,6 +792,41 @@ describe("ClaudeAgentProvider", () => {
     expect(executed[0]).toMatchObject({ name: "echo", args: { text: "hi" } });
   });
 
+  it("preserves keys of a free-form object param (no z.object({}) stripping)", async () => {
+    // Regression: a tool param declared as a free-form object (e.g. add_node's
+    // `node_properties`) was converted to z.object({}), which strips every
+    // nested key — silently dropping all node configuration on the SDK bridge.
+    const { fn } = fakeQuery([sysInit("sess-ff"), assistantTextMsg("ok"), successResult()]);
+    const mcp = fakeCreateMcpServer();
+    const provider = new ClaudeAgentProvider(
+      {},
+      { queryFn: fn, createMcpServerFn: mcp.fn }
+    );
+    await collect(
+      provider.generateLoop({
+        messages: [sysMsg("x"), userMsg("y")],
+        model: "haiku",
+        tools: [
+          {
+            name: "add_node",
+            description: "add",
+            inputSchema: {
+              type: "object",
+              properties: { node_properties: { type: "object" } },
+              required: []
+            }
+          }
+        ],
+        executeTool: async () => "ok"
+      })
+    );
+    const shape = (mcp.captured.defs[0] as unknown as {
+      inputSchema: Record<string, { parse: (v: unknown) => unknown }>;
+    }).inputSchema;
+    const parsed = shape.node_properties.parse({ prompt: "a red fox", bits: 2 });
+    expect(parsed).toEqual({ prompt: "a red fox", bits: 2 });
+  });
+
   it("cancels the query when the abort signal fires", async () => {
     const calls: QueryCall[] = [];
     const fn: ClaudeQueryFn = (params) => {


### PR DESCRIPTION
## Summary

This PR adds type compatibility checking when creating edges between nodes, preventing type mismatches from being caught only at runtime. It also improves node search to handle multi-word query terms and fixes a regression in free-form object parameter handling.

## Key Changes

### Type Validation for Edges (`packages/agents/`)
- **New type compatibility checking** in `AddEdgeTool`: validates that source output types match target input types before allowing edge creation
  - Implements `edgeTypesCompatible()` matching the kernel's validation logic (compatible types, "any", numeric widening, unions, list element types, scalar-into-list aggregation)
  - Adds `typeMetaToString()` to render `NodeMetadata` types into the string form `TypeMetadata.fromString()` parses
  - Extracts output/input metadata from registry and compares types, providing clear error messages on mismatch
  - Gracefully skips validation for unknown/any types and dynamic (AgentStep) endpoints
- **New test suite** (`add-edge-tool.test.ts`): validates that string→boolean mismatches are rejected while any-typed targets accept any input

### Node Search Improvements (`packages/node-sdk/`)
- **Multi-word query term handling** in `scoreNodeMetadata()`: splits each search term by whitespace and scores individual words
  - Fixes issue where agents passing phrases like `["uppercase text transform"]` as a single term would fail to match nodes like "To Uppercase"
  - Prevents phrase-as-substring matching from collapsing to zero results
- **New test** validates multi-word phrase matching

### Free-Form Object Parameter Fix (`packages/runtime/`)
- **Regression fix** in `jsonPropToZod()`: free-form objects (no declared sub-properties, e.g., `add_node`'s `node_properties`) now use `.passthrough()` instead of `z.object({})`
  - `z.object({})` was silently stripping all nested keys, dropping node configuration on the SDK tool bridge
  - New test verifies arbitrary keys are preserved in free-form object params

### Documentation Enhancement (`packages/agents/`)
- **New "Branch / Conditional" section** in graph-planner-prompt: clarifies correct use of `If` nodes with boolean conditions and comparison nodes, preventing common agent mistakes

## Implementation Details

- Type validation uses existing `TypeMetadata` infrastructure from the protocol layer for consistency with kernel validation
- Edge type checking is non-blocking on missing metadata (returns `true` when either type is unknown) to avoid false positives
- Search term splitting is word-boundary based (`/\s+/`) to handle arbitrary whitespace
- Free-form object detection checks if the Zod shape is empty (no declared properties) before deciding between strict and passthrough validation

https://claude.ai/code/session_01Wcx3ascrGmJxBPHpUe8S8L