### PR TITLE
docs: always show sidebar and add Home entry

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -17,7 +17,7 @@
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/' | relative_url }}" class="sidebar-link" data-nav-path="/">Introduction</a></li>
+          <li><a href="{{ '/' | relative_url }}" class="sidebar-link" data-nav-path="/">Home</a></li>
           <li><a href="{{ '/comparisons' | relative_url }}" class="sidebar-link" data-nav-path="/comparisons">Why NodeTool</a></li>
           <li><a href="{{ '/installation' | relative_url }}" class="sidebar-link" data-nav-path="/installation">Installation</a></li>
           <li><a href="{{ '/getting-started' | relative_url }}" class="sidebar-link" data-nav-path="/getting-started">Quick Start</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -39,9 +39,7 @@
   {% include header.html %}
 
   <div class="main-container">
-    {% if page.layout == 'page' or page.url != '/' %}
-      {% include sidebar.html %}
-    {% endif %}
+    {% include sidebar.html %}
 
     <main id="main-content" class="content" tabindex="-1">
       {{ content }}


### PR DESCRIPTION
## What

On the docs site, the navigation sidebar is now visible on every page, including the home/landing screen, and the first nav link is labeled **Home**.

## Why

The docs home screen hid the sidebar entirely (the `default.html` layout only included `sidebar.html` when `page.url != '/'`), so visitors landing on the home page had no navigation. This makes the sidebar always visible and gives it an explicit Home entry.

## Changes

- `docs/_layouts/default.html` — drop the conditional so `sidebar.html` is always included.
- `docs/_includes/sidebar.html` — rename the first Getting Started link (already pointing at `/`) from "Introduction" to "Home", so the sidebar has a Home entry without duplicating the link. Its `data-nav-path="/"` drives the active-state highlight on the home screen.

## Notes

Layout is unaffected: `.main-container` is already a flexbox and `.content` caps at 900px centered, so the home content just sits beside the 280px sidebar like every other doc page. Mobile keeps the existing off-canvas sidebar behavior.

Couldn't run a local `jekyll build` (Ruby/Jekyll not installed in this environment); edits are plain Liquid/HTML with no new syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)