### PR TITLE
Style Mermaid diagrams to match NodeTool editor canvas

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -20,7 +20,42 @@
   {%- comment -%} Load Mermaid once, and only on pages that contain a diagram. {%- endcomment -%}
   {% if content contains 'class="mermaid"' %}
   <script src="{{ site.mermaid.src }}"></script>
-  <script>mermaid.initialize({ startOnLoad: true, theme: 'dark' });</script>
+  <script>
+    // Theme Mermaid to match the NodeTool editor canvas (the look of the
+    // workflow graphs on the marketing site): dark node chrome, Inter type,
+    // smooth bezier edges. The dotted-grid canvas and node shadow live in CSS
+    // (.mermaid in main.scss); these variables set the fills, fonts, and colors.
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+        fontFamily: 'Inter, sans-serif',
+        fontSize: '14px',
+        background: '#08090A',        // canvas (c_editor_bg_color)
+        primaryColor: '#1B1D21',      // node body (c_node_bg)
+        primaryBorderColor: 'rgba(255,255,255,0.10)',
+        primaryTextColor: '#D4D6DB',  // node label
+        secondaryColor: '#17181B',
+        tertiaryColor: '#101113',
+        mainBkg: '#1B1D21',
+        nodeBorder: 'rgba(255,255,255,0.10)',
+        clusterBkg: '#101113',
+        clusterBorder: 'rgba(255,255,255,0.08)',
+        lineColor: '#6690d4',         // edges (accent blue)
+        arrowheadColor: '#6690d4',
+        edgeLabelBackground: '#101113',
+        textColor: '#D4D6DB'
+      },
+      flowchart: {
+        curve: 'basis',               // bezier-like edges, as on the canvas
+        htmlLabels: true,
+        padding: 14,
+        nodeSpacing: 48,
+        rankSpacing: 64,
+        useMaxWidth: true
+      }
+    });
+  </script>
   {% endif %}
 
   <!-- Privacy-friendly analytics by Plausible -->

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1811,6 +1811,95 @@ pre:hover .copy-button,
   margin-bottom: 0;
 }
 
+/* === Mermaid Workflow Graphs === */
+/* Restyle Mermaid diagrams to match the NodeTool editor canvas — the same
+   look the workflow graphs have on the marketing site. The theme variables
+   (fills, fonts, edge color) are set in _layouts/default.html; the canvas
+   grid, node chrome, and edge polish live here. */
+.mermaid {
+  /* The editor canvas: dark fill with the dotted grid (NodeCanvas). */
+  background-color: #08090A;
+  background-image: radial-gradient(circle, #1F2126 1px, transparent 1px);
+  background-size: 16px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  margin: var(--spacing-xl) 0;
+  text-align: center;
+  overflow-x: auto;
+}
+
+.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Node chrome: dark body, rounded corners, soft drop shadow, faint edge —
+   the NodeTool node card. */
+.mermaid .node rect,
+.mermaid .node polygon,
+.mermaid .node circle,
+.mermaid .node ellipse,
+.mermaid .node path {
+  rx: 8px;
+  ry: 8px;
+  fill: var(--color-bg-tertiary) !important;
+  stroke: rgba(255, 255, 255, 0.10) !important;
+  stroke-width: 1px !important;
+  filter: drop-shadow(0 8px 20px rgba(0, 0, 0, 0.16));
+}
+
+.mermaid .node .label,
+.mermaid .nodeLabel,
+.mermaid .node text {
+  fill: var(--color-text-secondary) !important;
+  color: var(--color-text-secondary) !important;
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+}
+
+/* Edges: smooth accent-blue connectors with rounded caps, like the canvas. */
+.mermaid .edgePath .path,
+.mermaid .flowchart-link {
+  stroke: var(--color-accent-blue) !important;
+  stroke-width: 1.6px !important;
+  stroke-opacity: 0.95;
+  stroke-linecap: round;
+  fill: none !important;
+}
+
+.mermaid .arrowheadPath,
+.mermaid marker path {
+  fill: var(--color-accent-blue) !important;
+  stroke: none !important;
+}
+
+/* Edge labels sit on a small dark chip so they read over the grid. */
+.mermaid .edgeLabel,
+.mermaid .edgeLabel p {
+  background-color: var(--color-bg-secondary) !important;
+  color: var(--color-text-muted) !important;
+  fill: var(--color-text-muted) !important;
+  font-size: 12px;
+  border-radius: 4px;
+}
+
+/* Subgraph containers, when a graph uses them. */
+.mermaid .cluster rect {
+  fill: rgba(16, 17, 19, 0.6) !important;
+  stroke: var(--color-border) !important;
+  rx: 10px;
+  ry: 10px;
+}
+
+.mermaid .cluster .label,
+.mermaid .cluster text {
+  fill: var(--color-text-muted) !important;
+  color: var(--color-text-muted) !important;
+}
+
 /* === Print Styles === */
 @media print {
 


### PR DESCRIPTION
## Summary

Restyle Mermaid workflow diagrams to match the NodeTool editor canvas appearance, creating visual consistency between documentation and the marketing site's workflow graphs.

## Changes

- **CSS styling** (`docs/assets/css/main.scss`): Added comprehensive Mermaid diagram styles including:
  - Dark canvas background with dotted grid pattern (matching NodeCanvas)
  - Node chrome with rounded corners, subtle borders, and drop shadows
  - Smooth accent-blue bezier edges with rounded caps
  - Edge labels on dark chips for readability over the grid
  - Subgraph container styling

- **Mermaid initialization** (`docs/_layouts/default.html`): Replaced simple dark theme with detailed theme configuration:
  - Theme variables for fills, fonts, and edge colors (primary/secondary/tertiary colors, text colors, border colors)
  - Flowchart curve set to `basis` for bezier-like edges
  - Spacing and layout parameters (padding, node spacing, rank spacing)
  - HTML labels enabled for better text rendering

## Implementation Details

The styling uses CSS custom properties (`--color-*`, `--spacing-*`, `--font-*`) defined in the design system, ensuring the Mermaid diagrams respect the site's theme. The dotted-grid canvas and node shadows are handled in CSS, while Mermaid's theme variables control the fills, fonts, and colors. This separation allows the visual appearance to be maintained consistently across both the documentation and the editor canvas.

https://claude.ai/code/session_01KVeTSV74yntk4a8cthrxGz