### PR TITLE
docs: fix broken internal link breaking the Pages deploy

### DIFF
--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -5,7 +5,7 @@ permalink: /long-term-memory
 description: "Per-user, per-thread durable memory for chat and agents in NodeTool — opt-in, vector-backed, with built-in secret redaction."
 ---
 
-**Navigation**: [Root AGENTS.md](../AGENTS.md) | [Chat](chat.md) | [Agent Memory (in-run)](agent-memory.md)
+**Navigation**: [Root AGENTS.md](https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md) | [Chat](chat.md) | [Agent Memory (in-run)](agent-memory.md)
 
 NodeTool's **long-term memory (LTM)** persists durable facts across chat sessions: stable user preferences, identity facts, project context, decisions made, and notable events. Recalled items are folded into the system prompt before each LLM call, and new memories are mined from the conversation after the turn completes.
 


### PR DESCRIPTION
## What

`docs/long-term-memory.md` is a **published** page (docs.nodetool.ai) but its navigation line linked to `../AGENTS.md`. The Jekyll build excludes `AGENTS.md` from the site (`_config.yml` exclude list — it's a contributor doc), so `html-proofer` in **Docs CI** reports it as a broken internal link, which fails the GitHub Pages deploy.

The three originally-flagged provider-guide links (`WRITING_STYLE.md`, `CLAUDE.md`) were already converted to absolute GitHub URLs on `main`; this one was missed because Docs CI only runs on PRs touching `docs/**`, never on `main`, so the regression sat undetected.

## Fix

Point the link at the GitHub blob URL (`https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md`), matching the convention the provider guides already use. `--disable-external` means html-proofer skips it.

## Verification

Reproduced the html-proofer logic statically (no Ruby in this env): for every published `.md` page, every relative `.md` link must resolve to a non-excluded source file. Before: 1 broken link. After: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)