### PR TITLE
Collapse multiple chat tool calls into a single line

### DIFF
--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -248,6 +248,103 @@ const ToolCallCard: React.FC<{
 });
 ToolCallCard.displayName = "ToolCallCard";
 
+type ToolResultLookup = Record<
+  string,
+  { name?: string | null; content: unknown; createdAt?: string | null }
+>;
+
+/**
+ * ToolCallGroup - Collapses a message's tool calls behind a single
+ * "N tools called" line that unfolds to reveal each ToolCallCard. A lone
+ * tool call renders directly with no extra chrome.
+ */
+const ToolCallGroup: React.FC<{
+  toolCalls: ToolCall[];
+  toolResultsByCallId?: ToolResultLookup;
+  messageCreatedAt?: string | null;
+}> = React.memo(({ toolCalls, toolResultsByCallId, messageCreatedAt }) => {
+  const [open, setOpen] = useState(false);
+  const runningToolCallId = useGlobalChatStore((s) => s.currentRunningToolCallId);
+  const handleToggleOpen = useCallback(() => setOpen((v) => !v), []);
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setOpen((v) => !v);
+    }
+  }, []);
+
+  const renderCard = useCallback(
+    (tc: ToolCall, i: number) => {
+      const toolResult =
+        tc.id && toolResultsByCallId
+          ? toolResultsByCallId[String(tc.id)]
+          : undefined;
+      const durationMs =
+        toolResult?.createdAt && messageCreatedAt
+          ? new Date(toolResult.createdAt).getTime() -
+            new Date(messageCreatedAt).getTime()
+          : null;
+      return (
+        <ToolCallCard
+          key={tc.id || i}
+          tc={tc}
+          result={toolResult}
+          durationMs={durationMs}
+        />
+      );
+    },
+    [toolResultsByCallId, messageCreatedAt]
+  );
+
+  // A single tool call keeps the original inline card — no group wrapper.
+  if (toolCalls.length <= 1) {
+    return <>{toolCalls.map(renderCard)}</>;
+  }
+
+  const isRunning = toolCalls.some(
+    (tc) => tc.id && runningToolCallId === tc.id
+  );
+
+  return (
+    <div className="tool-call-group">
+      <FlexRow
+        className="tool-call-group-header"
+        align="center"
+        gap={0.5}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={handleToggleOpen}
+        onKeyDown={handleKeyDown}
+      >
+        <Text
+          component="span"
+          size="small"
+          weight={500}
+          className="tool-call-group-label"
+        >
+          {toolCalls.length} tools called
+        </Text>
+        {isRunning && <LoadingSpinner size="small" />}
+        <ExpandMoreIcon
+          className={`expand-icon${open ? " expanded" : ""}`}
+          aria-hidden
+        />
+      </FlexRow>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <FlexColumn
+          className="tool-call-group-body"
+          gap={0.1}
+          sx={{ marginTop: getSpacingPx(SPACING.xs) }}
+        >
+          {toolCalls.map(renderCard)}
+        </FlexColumn>
+      </Collapse>
+    </div>
+  );
+});
+ToolCallGroup.displayName = "ToolCallGroup";
+
 interface MessageViewProps {
   message: Message;
   isThoughtExpanded: (key: string) => boolean;
@@ -450,26 +547,13 @@ export const MessageView: React.FC<
         <div className="message-content">
           {message.role === "assistant" &&
             Array.isArray(message.tool_calls) &&
-            !message.agent_execution_id && // Don't render tool cards for agent tasks here (they are in AgentExecutionView)
-            (message.tool_calls as ToolCall[]).map((tc, i) => {
-              const toolResult =
-                tc.id && toolResultsByCallId
-                  ? toolResultsByCallId[String(tc.id)]
-                  : undefined;
-              const durationMs =
-                toolResult?.createdAt && message.created_at
-                  ? new Date(toolResult.createdAt).getTime() -
-                    new Date(message.created_at).getTime()
-                  : null;
-              return (
-                <ToolCallCard
-                  key={tc.id || i}
-                  tc={tc}
-                  result={toolResult}
-                  durationMs={durationMs}
-                />
-              );
-            })}
+            !message.agent_execution_id && ( // Don't render tool cards for agent tasks here (they are in AgentExecutionView)
+              <ToolCallGroup
+                toolCalls={message.tool_calls as ToolCall[]}
+                toolResultsByCallId={toolResultsByCallId}
+                messageCreatedAt={message.created_at}
+              />
+            )}
           {(message.role === "assistant" || message.role === "user") && (
             <>
               {typeof message.content === "string" &&

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { MessageView } from "../MessageView";
+import mockTheme from "../../../../__mocks__/themeMock";
+import { Message, ToolCall } from "../../../../stores/ApiTypes";
+
+// The store hook is called with a selector; return undefined for every slice
+// (no tool is "running") so ToolCallGroup renders its static collapsed state.
+jest.mock("../../../../stores/GlobalChatStore", () => ({
+  __esModule: true,
+  default: (selector: (s: unknown) => unknown) => selector({})
+}));
+
+jest.mock("../../../../contexts/EditorInsertionContext", () => ({
+  useEditorInsertion: () => undefined
+}));
+
+jest.mock("../ChatMarkdown", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div>{content}</div>
+}));
+
+const renderView = (message: Message) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MessageView
+        message={message}
+        isThoughtExpanded={() => false}
+        onToggleThought={() => {}}
+      />
+    </ThemeProvider>
+  );
+
+const toolCall = (id: string, name: string): ToolCall => ({
+  id,
+  name,
+  args: {}
+});
+
+describe("MessageView tool-call grouping", () => {
+  it("collapses multiple tool calls behind a single 'N tools called' line", () => {
+    renderView({
+      id: "m1",
+      role: "assistant",
+      tool_calls: [
+        toolCall("a", "search"),
+        toolCall("b", "read_file"),
+        toolCall("c", "write_file"),
+        toolCall("d", "run_tests")
+      ]
+    } as Message);
+
+    expect(screen.getByText("4 tools called")).toBeInTheDocument();
+    // Collapsed by default: individual tool names are not shown yet.
+    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
+  });
+
+  it("unfolds to reveal the individual tool calls when toggled", async () => {
+    const user = userEvent.setup();
+    renderView({
+      id: "m2",
+      role: "assistant",
+      tool_calls: [toolCall("a", "search"), toolCall("b", "run_tests")]
+    } as Message);
+
+    await user.click(screen.getByRole("button", { name: /2 tools called/i }));
+
+    expect(screen.getByText("Run Tests")).toBeInTheDocument();
+    expect(screen.getByText("Search")).toBeInTheDocument();
+  });
+
+  it("renders a single tool call inline without the group wrapper", () => {
+    renderView({
+      id: "m3",
+      role: "assistant",
+      tool_calls: [toolCall("a", "search")]
+    } as Message);
+
+    expect(screen.queryByText(/tools called/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Search")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -345,6 +345,35 @@ export const createStyles = (theme: Theme) => ({
       marginBottom: 0
     },
 
+    // A message with several tool calls collapses them behind one
+    // "N tools called" line that unfolds to reveal each card.
+    ".tool-call-group-header": {
+      cursor: "pointer",
+      userSelect: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      padding: theme.spacing(0.25, 0.5),
+      margin: theme.spacing(0, -0.5),
+      "&:hover": {
+        background: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 1
+      }
+    },
+
+    ".tool-call-group-label": {
+      color: theme.vars.palette.text.secondary
+    },
+
+    ".tool-call-group-body": {
+      paddingLeft: theme.spacing(1)
+    },
+
+    ".tool-call-group-body .tool-call-card + .tool-call-card": {
+      marginTop: "0.05em"
+    },
+
     ".tool-call-card.running .tool-call-name": {
       color: theme.vars.palette.info.main
     },


### PR DESCRIPTION
When an assistant message has more than one tool call, render a single
"N tools called" header that unfolds to reveal each tool-call card.
A lone tool call still renders inline with no extra chrome.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012qa1wrf18GAPHTWpUwXWFs