### PR TITLE
fix(trpc): send batched requests as POST to survive reverse proxies

### DIFF
--- a/electron/src/api.ts
+++ b/electron/src/api.ts
@@ -8,7 +8,10 @@ function createApiClient() {
   return createTRPCClient<AppRouter>({
     links: [
       httpBatchLink({
-        url: getServerUrl("/trpc")
+        url: getServerUrl("/trpc"),
+        // POST keeps the batched input in the request body instead of the URL,
+        // so large batches stay under reverse-proxy URL-length limits. See #3979.
+        methodOverride: "POST"
       })
     ]
   });

--- a/mobile/src/trpc/client.ts
+++ b/mobile/src/trpc/client.ts
@@ -58,6 +58,9 @@ export function createTrpcLinks(): TRPCLink<AppRouter>[] {
   return [
     httpBatchLink({
       url: `${getApiHost()}/trpc`,
+      // POST keeps the batched input in the request body instead of the URL,
+      // so large batches stay under reverse-proxy URL-length limits. See #3979.
+      methodOverride: 'POST',
       headers: authHeaders,
       fetch: hostRewriteFetch,
     }),

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -689,7 +689,9 @@ async function fetchJob(
     const { createTRPCClient, httpBatchLink } = await import("@trpc/client");
     type Router = import("@nodetool-ai/websocket/trpc").AppRouter;
     const client = createTRPCClient<Router>({
-      links: [httpBatchLink({ url: `${apiUrl}/trpc` })]
+      // methodOverride POST keeps batched input in the body, not the URL, so
+      // large batches stay under reverse-proxy URL-length limits. See #3979.
+      links: [httpBatchLink({ url: `${apiUrl}/trpc`, methodOverride: "POST" })]
     });
     const data = (await client.jobs.get.query({ id: jobId })) as Record<
       string,

--- a/packages/cli/src/commands/models-recommended.ts
+++ b/packages/cli/src/commands/models-recommended.ts
@@ -158,7 +158,11 @@ export function registerRecommendedCommand(models: Command): void {
             const client = createTRPCClient<AppRouter>({
               links: [
                 httpBatchLink({
-                  url: `${opts.apiUrl}/trpc`
+                  url: `${opts.apiUrl}/trpc`,
+                  // POST keeps the batched input in the request body instead of
+                  // the URL, so large batches stay under reverse-proxy
+                  // URL-length limits. See #3979.
+                  methodOverride: "POST"
                 })
               ]
             });

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -88,7 +88,10 @@ function createApiClient(apiUrl: string) {
   return createTRPCClient<AppRouter>({
     links: [
       httpBatchLink({
-        url: `${apiUrl}/trpc`
+        url: `${apiUrl}/trpc`,
+        // POST keeps the batched input in the request body instead of the URL,
+        // so large batches stay under reverse-proxy URL-length limits. See #3979.
+        methodOverride: "POST"
       })
     ]
   });

--- a/packages/deploy/src/api-user-manager.ts
+++ b/packages/deploy/src/api-user-manager.ts
@@ -71,6 +71,9 @@ export class APIUserManager {
       links: [
         httpBatchLink({
           url: `${this.serverUrl}/trpc`,
+          // POST keeps the batched input in the request body instead of the URL,
+          // so large batches stay under reverse-proxy URL-length limits. See #3979.
+          methodOverride: "POST",
           headers: {
             Authorization: `Bearer ${this.adminToken}`
           }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -80,6 +80,9 @@ export function createNodetoolClient(
     links: [
       httpBatchLink({
         url: `${baseUrl}/trpc`,
+        // POST keeps the batched input in the request body instead of the URL,
+        // so large batches stay under reverse-proxy URL-length limits. See #3979.
+        methodOverride: "POST",
         fetch: fetchImpl as typeof fetch,
         headers() {
           return authToken ? { Authorization: `Bearer ${authToken}` } : {};

--- a/web/src/trpc/Provider.tsx
+++ b/web/src/trpc/Provider.tsx
@@ -26,6 +26,12 @@ export function TRPCProvider({ children }: { children: ReactNode }) {
         }),
         httpBatchLink({
           url: `${BASE_URL}/trpc`,
+          // Force batches to POST so the (potentially long) batched input rides
+          // in the request body instead of the URL. GET batches encode every
+          // procedure's input into the query string, which reverse proxies
+          // (e.g. Tailscale Serve) reject once the URL grows too long,
+          // returning 502 and leaving panels empty. See issue #3979.
+          methodOverride: "POST",
           async headers() {
             return authHeaders();
           }

--- a/web/src/trpc/client.ts
+++ b/web/src/trpc/client.ts
@@ -32,6 +32,12 @@ export function createTRPCHttpClient(): Readonly<TRPCClient<AppRouter>> {
       }),
       httpBatchLink({
         url: `${BASE_URL}/trpc`,
+        // Force batches to POST so the (potentially long) batched input rides
+        // in the request body instead of the URL. GET batches encode every
+        // procedure's input into the query string, which reverse proxies
+        // (e.g. Tailscale Serve) reject once the URL grows too long, returning
+        // 502 and leaving panels empty. See issue #3979.
+        methodOverride: "POST",
         async headers() {
           return authHeaders();
         }


### PR DESCRIPTION
## Problem

When NodeTool Studio is accessed through a reverse proxy (e.g. Tailscale Serve) instead of direct localhost, the Assets panel — and any panel that depends on a large batched request — renders empty. On direct localhost the same backend and database load fine.

The cause: tRPC's `httpBatchLink` defaults to **GET** for query batches and encodes every batched procedure's input into the URL query string. A large batch (`settings.secrets.list`, `worker.profiles.list`, `worker.instances.list`, `worker.apiKeyStatus`, `assets.list`, `assets.get`, … ~11 procedures) produces a URL long enough that the reverse proxy rejects it with **502 Bad Gateway** (content-length 0) before it reaches the backend. The whole batch fails, so panels depending on it render empty.

## Fix

Set `methodOverride: "POST"` on every `httpBatchLink`. POST carries the batched input in the request **body** instead of the URL, keeping requests under reverse-proxy URL-length limits. This is the documented tRPC v11 option for exactly this case.

No server change is needed: the Fastify tRPC adapter already accepts both GET and POST, and CORS does not restrict methods.

Applied across all tRPC clients so NodeTool works behind any reverse proxy, not just Tailscale Serve:

- `web/src/trpc/client.ts` and `web/src/trpc/Provider.tsx` (the affected surface — React-query + vanilla store client)
- `electron/src/api.ts`
- `mobile/src/trpc/client.ts`
- `packages/sdk/src/client.ts`
- `packages/cli/src/nodetool.ts`, `packages/cli/src/commands/models-recommended.ts`, `packages/cli/src/commands/agent.ts`
- `packages/deploy/src/api-user-manager.ts`

## Verification

- Confirmed `methodOverride?: 'POST'` is a valid option type in the installed `@trpc/client@11.17.0`.
- `npm run build:packages` — all 55 packages build (covers sdk/cli/deploy typecheck).
- Web typecheck ✓, electron typecheck ✓, web lint ✓ (exit 0).
- Electron `api.test.ts` ✓ (5/5).

Fixes #3979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ftdd43hVfuhxRCXTZhgMu

---
_Generated by [Claude Code](https://claude.ai/code/session_016ftdd43hVfuhxRCXTZhgMu)_