### PR TITLE
ci: parallelize heavy jobs and build packages once

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@
 
 | Workflow | Purpose |
 |----------|---------|
-| **quality-checks.yml** | Shared quality matrix (deps/typecheck/lint/package+app tests run as parallel legs) + an aggregating `quality` gate job |
+| **quality-checks.yml** | Shared quality gate: no-build `static` legs (deps/lint), a single `build` job that publishes package dist as an artifact, `built` legs (typecheck/parity/package+app tests) that consume it instead of rebuilding, and an aggregating `quality` gate job |
 | **quality-guard.yml** | Pre/post quality gate wrapper |
 | **copilot-setup-steps.yml** | Environment setup for Copilot agents |
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -29,15 +29,13 @@ permissions:
   contents: read
 
 jobs:
-  # One job per check, run in parallel. Each leg does only the setup it needs:
-  # lint/deps skip `build:packages`; only the package-test leg needs the CPU
-  # Vulkan driver; only typecheck/test-app need the mobile dependency tree.
-  # Wall-clock drops from sum(checks) to max(checks) + a trivial gate, and each
-  # leg surfaces its own status check (e.g. "Quality Gate (npm run check) / lint").
-  checks:
+  # Static checks that need no built packages. Kept independent of `build` so
+  # the fastest signals (lint, dependency guards) are not delayed behind the
+  # ~minutes-long package build. Each leg surfaces its own status check.
+  static:
     name: ${{ matrix.check }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
@@ -46,33 +44,96 @@ jobs:
           # guards (run on source, no build).
           - check: deps
             command: node scripts/check-workspace-deps.mjs && node scripts/check-circular-deps.mjs && node scripts/check-key-boundaries.mjs && node scripts/check-coupled-deps.mjs
-            build-packages: "false"
-            mobile-deps: "false"
-            extra-apt: ""
-            is-test: "false"
-            fetch-depth: "1"
+          # oxlint + web design-token lint. Neither needs package dist.
+          - check: lint
+            command: npm run lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node, install deps
+        uses: ./.github/actions/setup-build
+        with:
+          build-packages: "false"
+
+      - name: Run npm audit (advisory)
+        # Advisory only (continue-on-error) so a pre-existing vulnerability
+        # backlog doesn't block every PR, but high/critical issues in the
+        # production dependency closure are surfaced in the job summary.
+        if: matrix.check == 'deps'
+        continue-on-error: true
+        run: |
+          echo "::group::npm audit (production deps, high+)"
+          echo "## npm audit (production deps, high and critical)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          npm audit --omit=dev --audit-level=high 2>&1 | tee -a $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "::endgroup::"
+
+      - name: Run ${{ matrix.check }}
+        run: |
+          echo "::group::${{ matrix.check }}"
+          ${{ matrix.command }}
+          echo "::endgroup::"
+
+  # Build the ~55 backend packages ONCE and publish their dist as an artifact.
+  # The `built` legs below consume it instead of each rebuilding from scratch,
+  # which on a fresh commit (cold per-SHA Turbo cache) means one build instead
+  # of four racing in parallel. setup-build also persists the per-SHA Turbo
+  # cache here, so the test-packages leg's `turbo run test` restores `build`
+  # as a cache hit rather than rebuilding its `^build` dependencies.
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node, install deps, build packages
+        uses: ./.github/actions/setup-build
+        with:
+          build-packages: "true"
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: packages-dist
+          path: packages/*/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  # Checks that need the built packages on disk. They download the dist artifact
+  # and set build-packages:false, so they skip the redundant per-leg build. The
+  # app legs (typecheck/test-app) and parity/base-nodes run plain tsc/jest/vitest
+  # against the prebuilt dist; test-packages runs Turbo and rides the warm
+  # per-SHA Turbo cache the `build` job populated.
+  built:
+    name: ${{ matrix.check }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        include:
           - check: typecheck
             command: npm run typecheck
-            build-packages: "true"
             mobile-deps: "true"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
-          - check: lint
-            command: npm run lint
-            build-packages: "false"
-            mobile-deps: "false"
-            extra-apt: ""
-            is-test: "false"
-            fetch-depth: "1"
           # base-nodes parity/contract suite (Python-parity + example-workflow
-          # contracts). is-test:false keeps it non-skippable — these tests encode
-          # intentional behavior contracts (see the revert in commit 2c0fd8fad),
-          # so they stay a required gate even when skip-tests drops the bulk test
-          # legs. (lint:design is likewise required via the `lint` leg above.)
+          # contracts) plus the web design-token lint. is-test:false keeps it
+          # non-skippable — these tests encode intentional behavior contracts
+          # (see the revert in commit 2c0fd8fad), so they stay a required gate
+          # even when skip-tests drops the bulk test legs.
           - check: parity
             command: npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows
-            build-packages: "true"
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
@@ -88,14 +149,12 @@ jobs:
             # main (no base sha) the full suite runs. Needs fetch-depth: 0 for
             # the SCM diff and TURBO_SCM_BASE (set on the Run step below).
             command: npm run test:packages${{ github.event_name == 'pull_request' && ' -- --affected' || '' }}
-            build-packages: "true"
             mobile-deps: "false"
             extra-apt: "mesa-vulkan-drivers"
             is-test: "true"
             fetch-depth: "0"
           - check: test-app
             command: npm run test
-            build-packages: "true"
             mobile-deps: "true"
             extra-apt: ""
             is-test: "true"
@@ -108,11 +167,18 @@ jobs:
           # so Turbo's `--affected` can diff against the PR base commit.
           fetch-depth: ${{ matrix.fetch-depth }}
 
-      - name: Set up Node, install deps, build packages
+      - name: Set up Node, install deps
         uses: ./.github/actions/setup-build
         with:
           extra-apt: ${{ matrix.extra-apt }}
-          build-packages: ${{ matrix.build-packages }}
+          # The dist comes from the artifact below; don't rebuild it per leg.
+          build-packages: "false"
+
+      - name: Download package dist
+        uses: actions/download-artifact@v7
+        with:
+          name: packages-dist
+          path: packages
 
       # mobile is NOT a root workspace (separate dependency tree), so its
       # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
@@ -127,20 +193,6 @@ jobs:
       - name: Install mobile dependencies
         if: matrix.mobile-deps == 'true' && steps.mobile-node-modules.outputs.cache-hit != 'true'
         run: cd mobile && npm ci
-
-      - name: Run npm audit (advisory)
-        # Advisory only (continue-on-error) so a pre-existing vulnerability
-        # backlog doesn't block every PR, but high/critical issues in the
-        # production dependency closure are surfaced in the job summary.
-        if: matrix.check == 'deps'
-        continue-on-error: true
-        run: |
-          echo "::group::npm audit (production deps, high+)"
-          echo "## npm audit (production deps, high and critical)" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          npm audit --omit=dev --audit-level=high 2>&1 | tee -a $GITHUB_STEP_SUMMARY || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "::endgroup::"
 
       - name: Run ${{ matrix.check }}
         # skip-tests drops the package + app test legs without touching the
@@ -158,10 +210,11 @@ jobs:
 
   # Aggregating gate. Kept as job id `quality` (no custom name) so the surfaced
   # status check stays "Quality Gate (npm run check) / quality" — the existing
-  # REQUIRED check, so branch protection needs no change. Fails iff any leg failed.
+  # REQUIRED check, so branch protection needs no change. Fails iff any leg or
+  # the build failed (or was skipped because an upstream job failed).
   quality:
     name: quality
-    needs: [checks]
+    needs: [static, build, built]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -171,14 +224,16 @@ jobs:
       - name: Aggregate check results
         id: gate
         run: |
-          result="${{ needs.checks.result }}"
+          static="${{ needs.static.result }}"
+          build="${{ needs.build.result }}"
+          built="${{ needs.built.result }}"
           echo "## Quality Gate" >> $GITHUB_STEP_SUMMARY
-          if [ "$result" == "success" ]; then
+          if [ "$static" == "success" ] && [ "$build" == "success" ] && [ "$built" == "success" ]; then
             echo "all-passed=true" >> $GITHUB_OUTPUT
             echo "✅ **All quality checks passed.**" >> $GITHUB_STEP_SUMMARY
           else
             echo "all-passed=false" >> $GITHUB_OUTPUT
-            echo "❌ **One or more quality checks failed** (matrix result: \`$result\`)." >> $GITHUB_STEP_SUMMARY
+            echo "❌ **One or more quality checks failed** (static: \`$static\`, build: \`$build\`, built: \`$built\`)." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "See the individual check legs above to find which one." >> $GITHUB_STEP_SUMMARY
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,15 @@ jobs:
       fail-fast: false
       skip-tests: false
 
+  # Heavy jobs run concurrently with the quality gate rather than after it, so
+  # the critical path is max(quality, integration, e2e) instead of
+  # quality + max(integration, e2e). Trade-off: a PR that fails a static check
+  # still spends these runner minutes. They build packages themselves (they are
+  # in this workflow, not the reusable quality-checks one, so they can't consume
+  # its build artifact without depending on the whole gate — which would undo
+  # the decoupling).
   integration:
     name: Workflow Integration Tests
-    needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -65,7 +71,6 @@ jobs:
 
   workflow-runner-e2e:
     name: Workflow Runner Browser E2E
-    needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
Two changes to cut PR CI wall-clock and runner minutes.

A. Decouple the heavy jobs from the gate (test.yml): drop `needs: quality`
   from the integration and workflow-runner-e2e jobs so they run concurrently
   with the quality gate instead of after it. Critical path becomes
   max(quality, integration, e2e) rather than quality + max(integration, e2e).
   Trade-off: a PR that fails a static check still spends these runner minutes.

B. Build the ~55 backend packages once (quality-checks.yml). The old single
   matrix had four legs each run `build:packages`; on a fresh commit (cold
   per-SHA Turbo cache) they raced and all rebuilt from scratch. Split into:
   - `static` legs (deps, lint) — no build, fastest signal, kept independent.
   - one `build` job that publishes packages/*/dist as an artifact and warms
     the per-SHA Turbo cache.
   - `built` legs (typecheck, parity, test-packages, test-app) that download
     the artifact and skip the per-leg build; test-packages rides the warm
     Turbo cache (falls back to an in-leg rebuild on a cache miss).
   The aggregating `quality` gate job (the required check) is unchanged in id
   and name; it now fails if static, build, or built failed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019CrQz3WnXRmox4CAgdsD5Z