### PR TITLE
fix(trpc): accept POST for query procedures; fix WS proxy over TLS

### DIFF
--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -931,6 +931,12 @@ await app.register(fastifyTRPCPlugin, {
   trpcOptions: {
     router: appRouter,
     createContext,
+    // The web client forces all batches to POST (httpBatchLink
+    // `methodOverride: "POST"`) so long batched inputs ride in the body instead
+    // of the URL, which reverse proxies reject once the query string grows too
+    // large (see web/src/trpc/client.ts and issues #3979/#3981). Without this
+    // flag the server rejects POST-to-query with 405, leaving panels empty.
+    allowMethodOverride: true,
     onError({ path, error }) {
       log.error(
         `tRPC error on ${path}`,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -150,7 +150,11 @@ export default defineConfig(async ({ mode }) => {
     "/ws": {
       target: apiTarget,
       ws: true,
-      changeOrigin: true
+      changeOrigin: true,
+      // Match the other proxy entries: tolerate a self-signed backend cert
+      // (the dev server enables TLS whenever a cert.pem is found). Without this
+      // the WebSocket upgrade fails with "unable to verify the first certificate".
+      secure: false
     },
     "/trpc": {
       target: apiTarget,
@@ -165,9 +169,14 @@ export default defineConfig(async ({ mode }) => {
     }
   };
 
+  const extraAllowedHosts = (env.VITE_ALLOWED_HOSTS || "")
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+
   return {
     server: {
-      allowedHosts: [".nodetool.ai", "localhost"],
+      allowedHosts: [".nodetool.ai", "localhost", ...extraAllowedHosts],
       port: 3000,
       proxy: proxyConfig
     },


### PR DESCRIPTION
## Summary

Two proxy-correctness bugs surfaced while running the dev server behind a tunnel. The first is a real bug affecting any deployment behind a reverse proxy.

### 1. tRPC queries 405 over POST (production bug) 🔴
The web client forces **all** tRPC batches to POST — `httpBatchLink({ methodOverride: "POST" })` in `web/src/trpc/client.ts`, added in #3981 so long batched inputs ride in the request body instead of the URL (reverse proxies reject overly long query strings, see #3979).

But the server never opted into method override, so it rejected every POST-to-a-query with:

```
TRPCError: Unsupported POST-request to query procedure at path "worker.instances.list"
```

Result: `worker.*`, `settings.secrets.list`, `packs.listBuiltins`, `worker.profiles.list` and other queries fail → panels render empty, and the backend log floods with 405s.

**Fix:** set `allowMethodOverride: true` on the fastify tRPC plugin so the server accepts the client's POST batches (queries only; subscriptions still rejected, per tRPC).

Verified: `POST /trpc/worker.instances.list?batch=1` went **405 → 200**, and the error flood stopped.

### 2. Vite `/ws` proxy fails over a self-signed cert
The `/ws` dev-proxy entry was the **only** one missing `secure: false` (the `/api`, `/trpc`, `/storage` entries all have it). When the dev server runs with TLS (it auto-enables whenever a `cert.pem` is present), the WebSocket upgrade failed with `unable to verify the first certificate`, breaking the agent/workflow sockets. Added `secure: false` for parity.

### 3. `allowedHosts` extensible via env (dev convenience)
`allowedHosts` was hardcoded to `[".nodetool.ai", "localhost"]`, which blocks exposing the dev server through a tunnel (e.g. `*.trycloudflare.com`). Now merges `VITE_ALLOWED_HOSTS` (comma-separated) so the host can be allowed without editing the config.

## Test plan
- [x] `POST` to a tRPC query batch returns `200` (was `405`)
- [x] No `Unsupported POST-request` errors after the change
- [x] WebSocket upgrade through the Vite proxy succeeds over the self-signed cert (no more `unable to verify the first certificate`)
- [x] `packages/websocket` typecheck passes
- [x] `oxlint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)