### PR TITLE
Add workflow-scoped asset filtering to sidebar

### DIFF
--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React, { useCallback, useEffect, useMemo, useRef, memo } from "react";
-import { Text, Tooltip, Divider, Box } from "../ui_primitives";
+import { Text, Tooltip, Divider, Box, Chip, FlexRow } from "../ui_primitives";
+import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import { useTheme } from "@mui/material/styles";
 
 import AudioPlayer from "../audio/AudioPlayer";
@@ -132,7 +133,8 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     selectedFolderId,
     currentAudioAsset,
     currentFolderId,
-    foldersVisible
+    foldersVisible,
+    workflowFilter
   } = useAssetGridStore(
     useShallow((state) => ({
       setOpenAsset: state.setOpenAsset,
@@ -144,12 +146,19 @@ const AssetGrid: React.FC<AssetGridProps> = ({
       selectedFolderId: state.selectedFolderId,
       currentAudioAsset: state.currentAudioAsset,
       currentFolderId: state.currentFolderId,
-      foldersVisible: state.foldersVisible
+      foldersVisible: state.foldersVisible,
+      workflowFilter: state.workflowFilter
     }))
   );
   const currentWorkflowId = useWorkflowManager(
     (state) => state.currentWorkflowId
   );
+  const currentWorkflowName = useWorkflowManager((state) => {
+    const id = state.currentWorkflowId;
+    if (!id) return null;
+    const store = state.nodeStores[id];
+    return store?.getState().getWorkflow()?.name ?? null;
+  });
 
   // Default asset scope per surface: the in-editor sidebar follows the current
   // workflow (re-asserted whenever the open workflow changes), while the
@@ -327,6 +336,42 @@ const AssetGrid: React.FC<AssetGridProps> = ({
           onClose={() => setOpenAsset(null)}
         />
       )}
+      {!isMobile &&
+        !isFullscreenAssets &&
+        currentWorkflowName &&
+        workflowFilter === currentWorkflowId && (
+          <FlexRow
+            align="center"
+            sx={{
+              px: 1,
+              pt: 0.5,
+              pb: 0.25,
+              minWidth: 0
+            }}
+          >
+            <Tooltip
+              title="This panel shows assets produced or used by the workflow you're editing. Open the global library to see all assets."
+              placement="bottom-start"
+              disableInteractive
+            >
+              <Chip
+                compact
+                color="primary"
+                active
+                icon={<AccountTreeOutlinedIcon />}
+                label={currentWorkflowName}
+                sx={{
+                  maxWidth: "100%",
+                  "& .MuiChip-label": {
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap"
+                  }
+                }}
+              />
+            </Tooltip>
+          </FlexRow>
+        )}
       {!isMobile && (
         <AssetActionsMenu
           maxItemSize={maxItemSize}

--- a/web/src/components/assets/AssetGridContent.tsx
+++ b/web/src/components/assets/AssetGridContent.tsx
@@ -86,6 +86,7 @@ const AssetGridContent: React.FC<AssetGridContentProps> = memo(({
   const assetItemSize = useSettingsStore(
     (state) => state.settings.assetItemSize
   );
+  const workflowFilter = useAssetGridStore((state) => state.workflowFilter);
 
   // Base asset list (without dividers)
   const assets = useMemo(() => {
@@ -363,8 +364,16 @@ const AssetGridContent: React.FC<AssetGridContentProps> = memo(({
       >
         <EmptyState
           variant="no-data"
-          title="This folder is empty"
-          description="Drop files here or use the upload button to add assets"
+          title={
+            workflowFilter
+              ? "No outputs from this workflow yet"
+              : "This folder is empty"
+          }
+          description={
+            workflowFilter
+              ? "Run the workflow to generate assets, or drop files here to add inputs."
+              : "Drop files here or use the upload button to add assets"
+          }
           size="small"
         />
       </div>

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -331,9 +331,12 @@ const PanelContent = memo(function PanelContent({
         >
           {!isMobile && (
             <PanelHeadline
-              title="Assets"
+              title={currentWorkflow ? "Workflow Output" : "Assets"}
               actions={
-                <Tooltip title="Fullscreen" placement="right-start">
+                <Tooltip
+                  title="Open the global asset library"
+                  placement="right-start"
+                >
                   <ToolbarIconButton
                     className={`${path === "/assets" ? "active" : ""}`}
                     onClick={handleFullscreenClick}


### PR DESCRIPTION
## Summary
Adds visual filtering and messaging to the asset sidebar when viewing assets scoped to the current workflow. Users now see a chip indicating which workflow's outputs they're viewing, with contextual empty-state messaging when no assets have been generated yet.

## Changes
- **AssetGrid.tsx**: 
  - Import `Chip` and `FlexRow` UI primitives, plus `AccountTreeOutlinedIcon`
  - Extract `workflowFilter` from asset grid store
  - Retrieve `currentWorkflowName` from workflow manager to display active workflow
  - Render a labeled chip with workflow icon when filtering by current workflow (non-mobile, non-fullscreen only)
  - Add tooltip explaining the filtered view and how to access global library

- **AssetGridContent.tsx**:
  - Extract `workflowFilter` from asset grid store
  - Update empty-state messaging to distinguish between workflow-filtered and global views:
    - When filtered: "No outputs from this workflow yet" with guidance to run workflow or add inputs
    - When global: Original "This folder is empty" message

- **PanelLeft.tsx**:
  - Change sidebar headline from "Assets" to "Workflow Output" when a workflow is active
  - Update fullscreen button tooltip from "Fullscreen" to "Open the global asset library" for clarity

## Implementation Details
- The workflow chip only displays when: not on mobile, not in fullscreen mode, workflow name exists, and `workflowFilter` matches `currentWorkflowId`
- Chip uses `maxWidth: "100%"` with text truncation to handle long workflow names
- Empty-state messaging is context-aware, guiding users toward appropriate actions based on view scope
- All new UI components use established primitives from `ui_primitives/` per project conventions

https://claude.ai/code/session_014SabrHxyUBevXJ8DAbMJX2