### PR TITLE
Add GitHub Actions workflows for web and marketing deploys

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,7 @@
 | **flatpak-ci.yml** | Push to main + manual | Build Flatpak desktop package |
 | **jekyll.yml** | Push to main + manual | Build and deploy docs site to GitHub Pages |
 | **marketing-ci.yml** | Push/PR touching `marketing/**` | Typecheck, lint, build & Playwright smoke tests for the marketing site; on push to main, deploys it to Cloudflare Workers (OpenNext) after the gates pass |
+| **web-deploy.yml** | Push to main (+ manual) | Build the web app (Vite) and deploy it to Cloudflare Pages |
 
 ## Reusable Workflows
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,6 +23,7 @@
 | **release.yaml** | Git tags `v*` + manual | Build and sign cross-platform release artifacts |
 | **flatpak-ci.yml** | Push to main + manual | Build Flatpak desktop package |
 | **jekyll.yml** | Push to main + manual | Build and deploy docs site to GitHub Pages |
+| **marketing-ci.yml** | Push/PR touching `marketing/**` | Typecheck, lint, build & Playwright smoke tests for the marketing site; on push to main, deploys it to Cloudflare Workers (OpenNext) after the gates pass |
 
 ## Reusable Workflows
 

--- a/.github/workflows/marketing-ci.yml
+++ b/.github/workflows/marketing-ci.yml
@@ -1,8 +1,20 @@
-name: Marketing CI
+name: Marketing CI/CD
 
-# Quality gate for the marketing site (Next.js, deployed via @opennextjs/cloudflare).
-# The marketing package has its own lockfile and is installed independently of the
-# root workspace, so this runs in marketing/ directly.
+# Quality gate + deploy for the marketing site (Next.js, deployed via
+# @opennextjs/cloudflare to Cloudflare Workers). The marketing package has its
+# own lockfile and is installed independently of the root workspace, so this runs
+# in marketing/ directly.
+#
+# Deployment is driven from here (the `deploy` job) rather than Cloudflare's git
+# integration: a push to main only ships after typecheck/lint/build and the
+# Playwright smoke tests pass, which makes releases predictable instead of
+# firing on every push regardless of state. Disconnect the repo from Cloudflare
+# Workers Builds / Pages git integration so the site is only deployed from here.
+#
+# Required secrets (repo or `marketing-production` environment):
+#   CLOUDFLARE_API_TOKEN   — token with "Edit Cloudflare Workers" + Workers R2
+#                            Storage permissions for the account below
+#   CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account that owns the Worker
 
 on:
   push:
@@ -16,7 +28,8 @@ on:
       - "marketing/**"
       - ".github/workflows/marketing-ci.yml"
 
-# Least-privilege token: this workflow only reads the repo to build/lint.
+# Least-privilege token: this workflow only reads the repo to build/lint/deploy
+# (the Cloudflare deploy authenticates with its own API token, not GITHUB_TOKEN).
 permissions:
   contents: read
 
@@ -111,3 +124,41 @@ jobs:
 
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.14.x autorun
+
+  deploy:
+    name: Deploy to Cloudflare
+    # Only ship from pushes to main, and only once the quality gates are green —
+    # this is the reliability win over the fire-on-every-push git integration.
+    needs: [build, e2e]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: marketing-production
+      url: https://nodetool.ai
+    # Never run two deploys at once; let an in-flight one finish rather than
+    # cancelling it mid-upload.
+    concurrency:
+      group: marketing-deploy
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: marketing
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: marketing/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build & deploy (OpenNext → Cloudflare Workers)
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -17,7 +17,7 @@ name: Web Deploy (Cloudflare Pages)
 #     VITE_SUPABASE_ANON_KEY        — Supabase anon key baked into the build
 #   Variables:
 #     CLOUDFLARE_WEB_PAGES_PROJECT  — the Cloudflare Pages project name to deploy to
-#     VITE_API_URL                  — API base URL (e.g. https://api.nodetool.run)
+#     VITE_API_URL                  — API base URL (e.g. https://api.nodetool.ai)
 #     VITE_SUPABASE_URL             — Supabase project URL
 #     VITE_AUTH_REDIRECT_URL        — optional OAuth redirect URL
 #

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,85 @@
+name: Web Deploy (Cloudflare Pages)
+
+# Deploys the web app (web/, a Vite SPA) to Cloudflare Pages from GitHub Actions
+# instead of Cloudflare's git integration, which built on every push with no
+# control over the toolchain or build state. This builds on the pinned Node
+# version and ships only after the build succeeds.
+#
+# The web bundle inlines @nodetool-ai/* package SOURCE (the `nodetool-dev` Vite
+# resolve condition) and reads generated pricing JSONs produced by
+# `build:packages`, so package changes affect the bundle — hence this runs on
+# every push to main except changes that can't reach the bundle.
+#
+# Required GitHub config (Settings → Secrets and variables → Actions):
+#   Secrets:
+#     CLOUDFLARE_API_TOKEN          — token with "Cloudflare Pages: Edit" on the account
+#     CLOUDFLARE_ACCOUNT_ID         — account that owns the Pages project
+#     VITE_SUPABASE_ANON_KEY        — Supabase anon key baked into the build
+#   Variables:
+#     CLOUDFLARE_WEB_PAGES_PROJECT  — the Cloudflare Pages project name to deploy to
+#     VITE_API_URL                  — API base URL (e.g. https://api.nodetool.run)
+#     VITE_SUPABASE_URL             — Supabase project URL
+#     VITE_AUTH_REDIRECT_URL        — optional OAuth redirect URL
+#
+# Disconnect the repo from the Cloudflare Pages git integration so the site is
+# only deployed from here.
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "marketing/**"
+      - "docs/**"
+      - "mobile/**"
+      - "electron/**"
+      - "**/*.md"
+  workflow_dispatch:
+
+# Least-privilege token: the build only reads the repo; the Pages deploy
+# authenticates with its own Cloudflare API token, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# One deploy at a time; let an in-flight upload finish rather than cancelling it.
+concurrency:
+  group: web-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: web-production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # Installs the workspace and builds the backend packages, which generates
+      # the fal/kie pricing JSONs the Vite build aliases resolve.
+      - name: Set up Node, install deps, build packages
+        uses: ./.github/actions/setup-build
+        with:
+          build-packages: "true"
+
+      - name: Build (Vite)
+        working-directory: web
+        run: npx vite build
+        env:
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_AUTH_REDIRECT_URL: ${{ vars.VITE_AUTH_REDIRECT_URL }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.85.0"
+          workingDirectory: web
+          command: pages deploy dist --project-name=${{ vars.CLOUDFLARE_WEB_PAGES_PROJECT }} --branch=main

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -29,8 +29,20 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The site runs on Cloudflare Workers via [`@opennextjs/cloudflare`](https://opennext.js.org/cloudflare). Production deploys are driven by GitHub Actions (`.github/workflows/marketing-ci.yml`), not by Cloudflare's git integration: the `deploy` job runs on push to `main` and only ships after typecheck, lint, build, and the Playwright smoke tests pass.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+To enable it, set two secrets on the repo (or on the `marketing-production` environment):
+
+- `CLOUDFLARE_API_TOKEN` — token with "Edit Cloudflare Workers" + Workers R2 Storage permissions
+- `CLOUDFLARE_ACCOUNT_ID` — the account that owns the Worker
+
+Then disconnect the repo from Cloudflare Workers Builds / Pages git integration so the site is only deployed from the workflow.
+
+Deploy from your machine when you need to (uses your local `wrangler` auth):
+
+```bash
+npm run deploy    # opennextjs-cloudflare build && opennextjs-cloudflare deploy
+npm run preview   # build and preview the Worker locally
+```


### PR DESCRIPTION
## Summary

Adds two new GitHub Actions workflows to automate deployments: one for the web app (Vite SPA) to Cloudflare Pages, and one for the marketing site (Next.js) to Cloudflare Workers. Both workflows replace git-based integrations with explicit CI/CD pipelines that only ship after quality gates pass, improving release predictability.

## Key Changes

- **`.github/workflows/web-deploy.yml`** (new)
  - Builds the web app (Vite SPA) on push to main, excluding marketing/docs/mobile/electron changes
  - Installs workspace, builds backend packages (generates pricing JSONs), then runs `vite build`
  - Deploys to Cloudflare Pages using `wrangler` with API token authentication
  - Runs on pinned Node version with single-deploy concurrency (no cancellation mid-upload)
  - Requires GitHub secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `VITE_SUPABASE_ANON_KEY`
  - Requires GitHub variables: `CLOUDFLARE_WEB_PAGES_PROJECT`, `VITE_API_URL`, `VITE_SUPABASE_URL`, `VITE_AUTH_REDIRECT_URL`

- **`.github/workflows/marketing-ci.yml`** (modified)
  - Renamed from "Marketing CI" to "Marketing CI/CD" and expanded documentation
  - Added new `deploy` job that runs after `build` and `e2e` pass
  - Deploy only triggers on push to main (not PRs), ensuring quality gates are green before shipping
  - Uses `marketing-production` environment with Cloudflare API token authentication
  - Single-deploy concurrency to prevent mid-upload cancellations
  - Runs `npm run deploy` (OpenNext → Cloudflare Workers)
  - Updated comments to explain the reliability win over fire-on-every-push git integration

- **`marketing/README.md`** (modified)
  - Replaced Vercel deployment section with Cloudflare Workers deployment docs
  - Documents the GitHub Actions-driven deploy workflow and required secrets
  - Adds local deploy commands (`npm run deploy`, `npm run preview`)

- **`.github/workflows/README.md`** (modified)
  - Added entries for `marketing-ci.yml` and `web-deploy.yml` in the workflows table

## Implementation Details

Both workflows follow least-privilege principles:
- GitHub Actions only reads the repo (`contents: read` permission)
- Cloudflare deployments authenticate with dedicated API tokens, not `GITHUB_TOKEN`
- Concurrency groups prevent overlapping deploys that could corrupt uploads
- Web deploy depends on backend package builds (pricing JSONs are inlined in the bundle)
- Marketing deploy gates on typecheck, lint, build, and Playwright smoke tests before shipping

Disconnect the repos from Cloudflare's git integrations (Pages and Workers Builds) so deployments only flow through these workflows.

https://claude.ai/code/session_01GakUznLRhxo8YGBzVkbhWb