### PR TITLE
Add SEO strategy document and fix movie-trailer sitemap omission

### DIFF
--- a/docs/SEO_STRATEGY.md
+++ b/docs/SEO_STRATEGY.md
@@ -1,0 +1,199 @@
+---
+layout: page
+title: "SEO Strategy"
+permalink: /seo-strategy
+description: "Content and search strategy for nodetool.ai — audit, competitive landscape, page-type playbooks, and a prioritized roadmap."
+---
+
+Research basis: an audit of `marketing/` (the nodetool.ai Next.js site), `docs/`, the 61 example
+workflows in `packages/base-nodes/nodetool/examples/`, and the node packages in `packages/`, plus
+external research on competitor positioning and search behavior (sources linked inline). Written
+2026-07-01 — re-audit the live site before acting on the numbers below if this file is more than a
+quarter old.
+
+## 1. Where nodetool.ai stands today
+
+The site (`marketing/src/app/`) has 13 indexed pages: `/`, `/studio`, `/cloud`, `/pricing`,
+`/agents`, `/creatives`, `/developers`, two comparison pages (`/vs/comfyui`, `/vs/weavy`), two
+use-case pages (`/use-cases/product-video`, `/use-cases/movie-poster`), and three legal pages.
+
+Three gaps stand out:
+
+- **`/use-cases/movie-trailer` exists but is missing from `sitemap.ts`** (`marketing/src/app/sitemap.ts`).
+  It has a page folder and an entry in `useCaseEntries.ts` but never reaches search engines. Fix
+  this regardless of anything else in this doc — it's a one-line omission, not a strategy question.
+- **No blog.** Every competitor identified in research below (Dify, n8n, Flowise, Langflow, Lindy,
+  Gumloop, Vellum, StackAI, Wireflow) runs a blog and ranks on "X vs Y" and "best tools for Z"
+  queries, which is exactly the traffic NodeTool needs and currently cedes to them.
+- **3 use-case pages for 61 shipped example workflows.** The `useCaseEntries.ts` pattern (a single
+  data array plus a matching page folder) is already built to scale — it's just underused by a
+  factor of 20.
+
+The existing meta setup is solid: `layout.tsx` already ships title/description/OG/Twitter tags and
+a keyword list (creative AI workspace, BYOK AI canvas, ComfyUI alternative, Weavy alternative,
+node-based AI canvas). `robots.txt` and `sitemap.ts` both exist. The problem is page count and
+content depth, not technical hygiene.
+
+## 2. Competitive landscape
+
+Three groups of tools currently absorb the search intent NodeTool could capture:
+
+**LLM/agent workflow builders** — Dify, Flowise, Langflow, n8n. StackAI's comparison names Dify
+"the best starting point for most teams in 2026" on debugging and knowledge-base features; Langflow
+is positioned for teams that need custom Python nodes and LangGraph; Flowise for the fastest path
+to a RAG chatbot; n8n where orchestration (retries, branches, schedules) is the hard part
+([Runchat comparison](https://runchat.com/p/runchat/runchat-vs-comfyui-vs-n8n-vs-langflow-visual-ai-to-55)).
+None of these natively render image, video, or audio — they're text/LLM-first, which is NodeTool's
+opening.
+
+**Node-based creative canvases** — ComfyUI (already covered at `/vs/comfyui`), Weavy (already
+covered at `/vs/weavy`, note: acquired by Figma per
+[Chase Jarvis's review](https://chasejarvis.com/blog/what-the-heck-is-weavy-the-100-honest-review-after-the-figma-acqusition/)),
+plus Flora, Freepik Spaces, Krea, Layer AI, Griptape Nodes, and Reflet.ai — all covered in a single
+["2026: The Year of the Node-Based Editor"](https://medium.com/@fadimantium/2026-the-year-of-the-node-based-editor-941f0f15d467)
+roundup and multiple "Weavy alternatives" posts
+([Wireflow](https://www.wireflow.ai/blog/top-8-ai-weavy-alternatives)). Most are browser-only,
+credit-metered SaaS with no local execution and no BYOK — the same gap NodeTool already argues
+against Weavy, reusable against this whole category.
+
+**Local-first AI tooling** — Ollama, LM Studio, Jan, Open WebUI cover local chat; none combine
+local inference with cloud generation or a visual workflow canvas
+([overchat.ai roundup](https://overchat.ai/ai-hub/best-offline-ai-apps),
+[needaitool.com roundup](https://www.needaitool.com/blogs/local-ai-apps-2026-ollama-lm-studio-open-webui)).
+
+**Net position**: NodeTool is the only tool showing up across all three searches — LLM/agent
+builders don't do media, creative canvases don't do local models or agents, local-first tools don't
+do workflows. That's the argument every comparison page and use-case page should make concrete,
+not assert abstractly.
+
+## 3. Audience segments and what they search
+
+| Segment | What they search | Where they currently land instead |
+|---|---|---|
+| Creatives (filmmakers, designers, marketers) | "text to video pipeline", "ComfyUI alternative no code", "AI movie poster generator", "product video AI tool" | Runway, Krea, Melies, Weavy alternatives posts |
+| Developers / ML engineers | "open source AI agent framework", "RAG pipeline no code", "TypeScript AI workflow SDK", "custom LLM node builder" | Langflow, Flowise, LlamaIndex RAGArch |
+| Automation / ops teams | "n8n alternative for AI agents", "no-code AI workflow local", "email triage AI automation" | n8n, Activepieces, Gumloop |
+| Privacy-conscious / local-first users | "run AI models locally desktop app", "local LLM privacy no cloud", "self-hosted AI agent" | Jan, LM Studio, Ollama-based roundups |
+| Researchers / knowledge workers | "chat with PDF tool", "summarize research papers AI", "document RAG open source" | Kapa.ai, Prisme.ai |
+
+The site already has landing pages for creatives, developers, and agents (automation). It has none
+targeting the local-first/privacy segment specifically (this is argued piecemeal on `/studio` and
+in comparisons, never as its own page) or the researcher/knowledge-worker segment (despite shipping
+5 document-processing example workflows: Chat with Docs, Index PDFs, Summarize Paper, Fetch Papers,
+Meeting Transcript Summarizer).
+
+## 4. Page-type playbooks
+
+### 4.1 Comparison pages (`/vs/*`)
+
+Pattern already proven at `marketing/src/app/vs/comfyui/page.tsx` and `vs/weavy/page.tsx`
+(feature-table format, ~250 lines each, hand-built per page). Expand from 2 to a target list based
+on what people are already comparing:
+
+1. `/vs/langflow` — pull in the "no media generation" gap
+2. `/vs/flowise` — same gap, plus BYOK vs. hosted credits
+3. `/vs/n8n` — orchestration-only vs. orchestration + native generation
+4. `/vs/flora` (or a combined "AI canvas alternatives" page covering Flora, Freepik Spaces, Krea)
+5. `/vs/dify` — RAG/agent platform, no creative media
+6. `/vs/lmstudio` or `/vs/jan` — local chat only vs. local + cloud workflow canvas
+
+Each page keeps the existing format: one comparison table, one differentiation section, one CTA.
+Do not invent a new template per competitor — the value here is coverage, not novelty.
+
+### 4.2 Use-case pages (`/use-cases/*`)
+
+The `useCaseEntries.ts` array is the scaling mechanism: add an entry, build the matching page
+folder. 61 example workflows already exist in
+`packages/base-nodes/nodetool/examples/nodetool-base/` with titles, descriptions, and (per the
+internal audit) natural category groupings. Prioritize by search-intent match, not by what's
+easiest to build:
+
+- **Ship first** (clear existing search terms, per §3): Research Paper Summarizer, Chat with Docs
+  (→ "chat with PDF"), Meeting Transcript Summarizer, Music Video Visualizer, Brand Asset Generator,
+  YouTube Thumbnail Pipeline
+- **Ship second**: Cold Outreach Co-Pilot, Social Media Calendar Filler, Hacker News Agent /
+  YouTube Research Agent (agent-mode examples double as `/agents` landing-page proof)
+- **Fix immediately**: add `/use-cases/movie-trailer` to `sitemap.ts` (see §1)
+
+At 61 candidates, treat this as a backlog, not a one-time push — 3-5 new use-case pages per month
+sustains a steady stream of long-tail landing pages without a content team.
+
+### 4.3 Node / provider pages
+
+`docs/nodes/<provider>/` and `docs/developer/providers/<provider>.md` already exist for FAL, KIE,
+Gemini, ElevenLabs, Together, Replicate, Ollama, HuggingFace, Topaz, AtlasCloud, and more (20+
+providers). These are developer docs, not landing pages, but each one is a near-zero-cost target
+for provider-name search traffic ("FAL nodes for NodeTool", "use Kling in NodeTool") once they carry
+proper titles/descriptions and get linked from `/developers`. No new pages needed here — just meta
+tags on what already exists (see §5).
+
+### 4.4 Blog (net new)
+
+No blog exists. This is the biggest structural gap relative to every competitor in §2. Recommended
+scope, not a general-purpose blog:
+
+- **Comparison/roundup posts** that NodeTool can legitimately win a mention in: "best ComfyUI
+  alternatives 2026", "open source Weavy alternatives", "local-first AI tools 2026" — these are the
+  exact post titles already ranking for competitors (§2 sources). Writing NodeTool's own version,
+  plus getting listed in the external ones (see §6), covers both sides.
+- **Cookbook walkthroughs** built directly from `docs/cookbook/core-concepts.md` and the 15+
+  recipes in `docs/cookbook.md` — these already exist as docs; a blog post is a rewrite with a
+  narrative frame and screenshots, not new research.
+- **Technical posts for the developer segment**: actor-model workflow execution, the Python bridge
+  (`PythonStdioBridge`), the planning agent system (`packages/agents/`) — these map to real
+  architecture (`docs/architecture.md`, `docs/AGENTS.md`) and target "how do AI agent frameworks
+  work" / "TypeScript LLM orchestration" searches from engineers evaluating tools.
+
+## 5. Technical SEO checklist
+
+- [ ] Add `/use-cases/movie-trailer` to `marketing/src/app/sitemap.ts` (confirmed missing, §1)
+- [ ] Confirm every new page under `/vs/`, `/use-cases/`, and any future `/blog/` gets an
+      `opengraph-image.tsx` (existing `vs/*` pages already do this — keep the pattern)
+- [ ] Add `priority`/`changeFrequency` entries to `sitemap.ts` for every new page as it ships —
+      don't let the list drift out of sync with `app/` folders again
+- [ ] Verify `docs/nodes/<provider>/index.md` pages carry unique titles and descriptions (currently
+      generated docs; check for duplicate/boilerplate meta across providers)
+- [ ] Internal linking: `/agents`, `/creatives`, `/developers` should each link to the use-case pages
+      relevant to their segment (per §3's mapping) — currently the use-case showcase only appears on
+      the homepage
+
+## 6. Distribution (off-site)
+
+Content only ranks if something points at it:
+
+- **"Alternatives to X" roundups** (Wireflow, Lindy, Vellum, Gumloop, StackAI, and similar sites
+  identified in §2 already publish and rank these lists) — get NodeTool listed via outreach when a
+  new comparison or use-case page ships. This is lower effort than link-building from scratch and
+  targets people already close to a decision.
+- **Directories already listing NodeTool**: futuretools.io, theaidb.com, SourceForge (confirmed via
+  search in this audit). Keep listings current with each release; check for others in the same
+  category (There's An AI For That, AI Tools Directory sites).
+  Adjacent projects to note for competitive tracking, not for outreach: `alvinreal/awesome-opensource-ai`
+  and `light-and-ray/awesome-alternative-uis-for-comfyui` on GitHub — both are community-curated
+  lists where a PR adding NodeTool is a legitimate, low-effort listing (not unsolicited outreach).
+- **GitHub topics and README SEO**: confirm the repo carries relevant GitHub topics (`ai-workflow`,
+  `comfyui-alternative`, `llm-agents`, `node-based`, `local-first`) — these surface in GitHub's own
+  search and get scraped into "awesome-*" lists.
+- **Reddit / Hacker News**: no existing discussion threads found in this audit (searched directly).
+  This is upside, not a gap to fix — a Show HN or r/LocalLLaMA / r/comfyui post timed to a specific
+  release (e.g., a new local-model integration) reaches an audience already primed for exactly this
+  positioning.
+
+## 7. Prioritized roadmap
+
+1. **Immediate** (hours): fix the `movie-trailer` sitemap omission (§1, §5).
+2. **Phase 1** (this month): ship 3-5 use-case pages from the "ship first" list (§4.2); add
+   `/vs/langflow` and `/vs/n8n` (highest-volume comparison targets per §2).
+3. **Phase 2** (next month): stand up the blog with 3 posts — one comparison/roundup post, one
+   cookbook walkthrough, one technical post (§4.4); submit NodeTool to the two GitHub awesome-lists
+   named in §6.
+4. **Ongoing**: 3-5 use-case pages/month from the remaining 61-workflow backlog; one comparison page
+   per new credible competitor; internal-link every new page from its matching segment landing page
+   (§5).
+
+## 8. Measurement
+
+Track per page: organic impressions/clicks (Search Console), and which comparison/use-case pages
+convert to `/studio` or `/pricing` visits (the two highest-priority pages in the existing sitemap).
+Re-run the competitive scan in §2 quarterly — this is a fast-moving category and new entrants
+(Flora, Reflet.ai, both surfaced only in this audit's research) can appear within months.

--- a/docs/SEO_STRATEGY.md
+++ b/docs/SEO_STRATEGY.md
@@ -17,7 +17,7 @@ The site (`marketing/src/app/`) has 13 indexed pages: `/`, `/studio`, `/cloud`, 
 `/agents`, `/creatives`, `/developers`, two comparison pages (`/vs/comfyui`, `/vs/weavy`), two
 use-case pages (`/use-cases/product-video`, `/use-cases/movie-poster`), and three legal pages.
 
-Three gaps stand out:
+Four gaps stand out:
 
 - **`/use-cases/movie-trailer` exists but is missing from `sitemap.ts`** (`marketing/src/app/sitemap.ts`).
   It has a page folder and an entry in `useCaseEntries.ts` but never reaches search engines. Fix
@@ -28,6 +28,13 @@ Three gaps stand out:
 - **3 use-case pages for 61 shipped example workflows.** The `useCaseEntries.ts` pattern (a single
   data array plus a matching page folder) is already built to scale — it's just underused by a
   factor of 20.
+- **No `/marketing` segment page.** The homepage and `/creatives` copy both explicitly name
+  "marketing teams" as a target audience, and one of the three flagship use cases (Product Video
+  Generator) is already tagged `category: "Marketing"` in `useCaseEntries.ts`. But the nav
+  (Studio, Cloud, Creatives, Agents, Developers, Pricing) has no landing page built for that
+  audience — marketing searches currently land on the general `/creatives` page instead of copy
+  written for their job (campaigns, social calendars, brand consistency, output volume), same as
+  `/agents` serves automation and `/developers` serves engineers. See §4.0.
 
 The existing meta setup is solid: `layout.tsx` already ships title/description/OG/Twitter tags and
 a keyword list (creative AI workspace, BYOK AI canvas, ComfyUI alternative, Weavy alternative,
@@ -70,19 +77,49 @@ not assert abstractly.
 
 | Segment | What they search | Where they currently land instead |
 |---|---|---|
-| Creatives (filmmakers, designers, marketers) | "text to video pipeline", "ComfyUI alternative no code", "AI movie poster generator", "product video AI tool" | Runway, Krea, Melies, Weavy alternatives posts |
+| Creatives (filmmakers, designers) | "text to video pipeline", "ComfyUI alternative no code", "AI movie poster generator" | Runway, Krea, Melies, Weavy alternatives posts |
+| Marketing teams (campaigns, growth, social) | "product video AI tool", "AI content calendar generator", "brand asset generator AI", "AI ad video generator" | Lindy, Gumloop, Runway, Weavy alternatives posts |
 | Developers / ML engineers | "open source AI agent framework", "RAG pipeline no code", "TypeScript AI workflow SDK", "custom LLM node builder" | Langflow, Flowise, LlamaIndex RAGArch |
 | Automation / ops teams | "n8n alternative for AI agents", "no-code AI workflow local", "email triage AI automation" | n8n, Activepieces, Gumloop |
 | Privacy-conscious / local-first users | "run AI models locally desktop app", "local LLM privacy no cloud", "self-hosted AI agent" | Jan, LM Studio, Ollama-based roundups |
 | Researchers / knowledge workers | "chat with PDF tool", "summarize research papers AI", "document RAG open source" | Kapa.ai, Prisme.ai |
 
 The site already has landing pages for creatives, developers, and agents (automation). It has none
-targeting the local-first/privacy segment specifically (this is argued piecemeal on `/studio` and
-in comparisons, never as its own page) or the researcher/knowledge-worker segment (despite shipping
+targeting marketing teams specifically, even though the homepage copy names them by title (see
+§4.0) — nor the local-first/privacy segment (this is argued piecemeal on `/studio` and in
+comparisons, never as its own page), nor the researcher/knowledge-worker segment (despite shipping
 5 document-processing example workflows: Chat with Docs, Index PDFs, Summarize Paper, Fetch Papers,
 Meeting Transcript Summarizer).
 
 ## 4. Page-type playbooks
+
+### 4.0 Segment landing page — `/marketing`
+
+`/creatives`, `/agents`, and `/developers` are each a persona-framed rewrite of the same product,
+built to rank on that persona's job-title searches and to give paid/social traffic a landing page
+that speaks their language instead of the generic homepage. Marketing teams get named in that same
+homepage copy but have no fourth page.
+
+Build `/marketing` on the identical pattern (`marketing/src/app/creatives/page.tsx` is the closest
+template — same section shape: headline, "why teams choose NodeTool" section, use-case teasers,
+community/CTA). Content already exists to fill it without new production work:
+
+- **Lead use case**: Product Video Generator (`use-cases/product-video`, already `category:
+  "Marketing"` in `useCaseEntries.ts`) — feature it the way `/creatives` features the Movie Poster
+  and Movie Trailer generators.
+- **Supporting use cases to build** (from the §4.2 backlog, reprioritized for this page): Social
+  Media Calendar Filler, Brand Asset Generator, Cold Outreach Co-Pilot, YouTube Thumbnail Pipeline —
+  all four are marketing-ops workflows, not creative-production ones, and read oddly grouped under
+  "Creatives".
+- **Target keywords**: "AI product video generator", "AI content calendar tool", "brand asset
+  generator AI", "AI ad video tool open source" (§3).
+- **Differentiation angle**: same BYOK/no-markup argument as `/creatives`, reframed around output
+  volume and cost-per-asset at campaign scale rather than single-artifact craft — this is the
+  argument marketing buyers actually compare tools on (per the n8n/Activepieces/Gumloop comparisons
+  in §2, which sell on throughput and integration count, not per-asset quality).
+
+Add `/marketing` to `sitemap.ts` at the same priority tier as the other three segment pages (0.8,
+monthly — see §5) and to the main nav alongside Creatives/Agents/Developers.
 
 ### 4.1 Comparison pages (`/vs/*`)
 
@@ -109,10 +146,11 @@ internal audit) natural category groupings. Prioritize by search-intent match, n
 easiest to build:
 
 - **Ship first** (clear existing search terms, per §3): Research Paper Summarizer, Chat with Docs
-  (→ "chat with PDF"), Meeting Transcript Summarizer, Music Video Visualizer, Brand Asset Generator,
-  YouTube Thumbnail Pipeline
-- **Ship second**: Cold Outreach Co-Pilot, Social Media Calendar Filler, Hacker News Agent /
-  YouTube Research Agent (agent-mode examples double as `/agents` landing-page proof)
+  (→ "chat with PDF"), Meeting Transcript Summarizer, Music Video Visualizer
+- **Ship second**: Hacker News Agent / YouTube Research Agent (agent-mode examples double as
+  `/agents` landing-page proof)
+- **Marketing segment** (feature on `/marketing`, see §4.0): Cold Outreach Co-Pilot, Social Media
+  Calendar Filler, Brand Asset Generator, YouTube Thumbnail Pipeline
 - **Fix immediately**: add `/use-cases/movie-trailer` to `sitemap.ts` (see §1)
 
 At 61 candidates, treat this as a backlog, not a one-time push — 3-5 new use-case pages per month
@@ -147,15 +185,17 @@ scope, not a general-purpose blog:
 ## 5. Technical SEO checklist
 
 - [ ] Add `/use-cases/movie-trailer` to `marketing/src/app/sitemap.ts` (confirmed missing, §1)
-- [ ] Confirm every new page under `/vs/`, `/use-cases/`, and any future `/blog/` gets an
-      `opengraph-image.tsx` (existing `vs/*` pages already do this — keep the pattern)
+- [ ] Build `/marketing` (§4.0) and add it to `sitemap.ts` at priority 0.8 / monthly — same tier as
+      `/agents`, `/creatives`, `/developers` — plus main nav
+- [ ] Confirm every new page under `/vs/`, `/use-cases/`, `/marketing`, and any future `/blog/` gets
+      an `opengraph-image.tsx` (existing `vs/*` pages already do this — keep the pattern)
 - [ ] Add `priority`/`changeFrequency` entries to `sitemap.ts` for every new page as it ships —
       don't let the list drift out of sync with `app/` folders again
 - [ ] Verify `docs/nodes/<provider>/index.md` pages carry unique titles and descriptions (currently
       generated docs; check for duplicate/boilerplate meta across providers)
-- [ ] Internal linking: `/agents`, `/creatives`, `/developers` should each link to the use-case pages
-      relevant to their segment (per §3's mapping) — currently the use-case showcase only appears on
-      the homepage
+- [ ] Internal linking: `/agents`, `/creatives`, `/developers`, `/marketing` should each link to the
+      use-case pages relevant to their segment (per §3's mapping) — currently the use-case showcase
+      only appears on the homepage
 
 ## 6. Distribution (off-site)
 
@@ -182,8 +222,10 @@ Content only ranks if something points at it:
 ## 7. Prioritized roadmap
 
 1. **Immediate** (hours): fix the `movie-trailer` sitemap omission (§1, §5).
-2. **Phase 1** (this month): ship 3-5 use-case pages from the "ship first" list (§4.2); add
-   `/vs/langflow` and `/vs/n8n` (highest-volume comparison targets per §2).
+2. **Phase 1** (this month): build `/marketing` (§4.0) with its four supporting use-case pages
+   (Product Video, Cold Outreach Co-Pilot, Social Media Calendar Filler, Brand Asset Generator);
+   ship the remaining "ship first" use-case pages (§4.2); add `/vs/langflow` and `/vs/n8n`
+   (highest-volume comparison targets per §2).
 3. **Phase 2** (next month): stand up the blog with 3 posts — one comparison/roundup post, one
    cookbook walkthrough, one technical post (§4.4); submit NodeTool to the two GitHub awesome-lists
    named in §6.

--- a/marketing/src/app/sitemap.ts
+++ b/marketing/src/app/sitemap.ts
@@ -24,6 +24,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/vs/weavy", priority: 0.7, changeFrequency: "monthly" },
     { path: "/use-cases/product-video", priority: 0.6, changeFrequency: "monthly" },
     { path: "/use-cases/movie-poster", priority: 0.6, changeFrequency: "monthly" },
+    { path: "/use-cases/movie-trailer", priority: 0.6, changeFrequency: "monthly" },
     { path: "/imprint", priority: 0.3, changeFrequency: "yearly" },
     { path: "/privacy", priority: 0.3, changeFrequency: "yearly" },
     { path: "/terms", priority: 0.3, changeFrequency: "yearly" },


### PR DESCRIPTION
## Summary

Adds a comprehensive SEO strategy document (`docs/SEO_STRATEGY.md`) that audits the current state of nodetool.ai's search presence, identifies competitive gaps, and provides a prioritized roadmap for organic growth. Also fixes an immediate technical issue where `/use-cases/movie-trailer` was missing from the sitemap.

## Key Changes

- **New document**: `docs/SEO_STRATEGY.md` (241 lines)
  - Audit of current indexed pages (13 total) and four critical gaps
  - Competitive landscape analysis covering LLM/agent builders, node-based creative canvases, and local-first AI tools
  - Audience segment mapping (creatives, marketing teams, developers, automation/ops, privacy-conscious users, researchers) with search intent and current landing pages
  - Page-type playbooks for scaling:
    - `/marketing` segment landing page (missing despite marketing teams being named in homepage copy)
    - Expansion of `/vs/*` comparison pages (from 2 to 6 target competitors)
    - Use-case pages from 61 existing example workflows (currently only 3 published)
    - Blog strategy focused on comparison/roundup posts and cookbook walkthroughs
    - Node/provider pages (20+ already exist as docs, need meta tag optimization)
  - Technical SEO checklist with 6 actionable items
  - Off-site distribution strategy (alternatives roundups, directories, GitHub topics, community posts)
  - Prioritized 4-phase roadmap with immediate, Phase 1, Phase 2, and ongoing work
  - Measurement framework (Search Console tracking, conversion monitoring, quarterly competitive re-audit)

- **Sitemap fix**: `marketing/src/app/sitemap.ts`
  - Added `/use-cases/movie-trailer` entry (priority 0.6, monthly changeFrequency)
  - This page folder and `useCaseEntries.ts` entry existed but were never exposed to search engines

## Implementation Notes

The SEO strategy is research-backed with inline source citations (Runchat comparison, Chase Jarvis review, Medium roundup, overchat.ai, needaitool.com). It treats the existing `useCaseEntries.ts` pattern as the scaling mechanism — no new infrastructure needed, just prioritized content backlog. The `/marketing` page reuses the proven template from `/creatives`, `/agents`, and `/developers` rather than inventing new patterns.

The sitemap fix is a one-line omission that should ship regardless of strategy adoption — it's a technical hygiene issue, not a strategic choice.

https://claude.ai/code/session_01VkcPxi2pUKxV36CbjkoHo5