### PR TITLE
Add Library panel view for global asset browsing

### DIFF
--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -111,6 +111,12 @@ interface AssetGridProps {
   initialFoldersPanelWidth?: number;
   isFullscreenAssets?: boolean;
   isMobile?: boolean;
+  /**
+   * Force the global (all-workflows) asset scope regardless of the currently
+   * open workflow, without adopting the fullscreen page's layout (folders
+   * pinned open, side-by-side position). Used by the "Library" sidebar panel.
+   */
+  forceGlobalAssets?: boolean;
 }
 
 const AssetGrid: React.FC<AssetGridProps> = ({
@@ -120,7 +126,8 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   sortedAssets,
   isFullscreenAssets,
   initialFoldersPanelWidth = FOLDERS_PANEL_WIDTH,
-  isMobile = false
+  isMobile = false,
+  forceGlobalAssets = false
 }) => {
   const { error, folderFilesFiltered, folderTree } = useAssets();
   const {
@@ -165,8 +172,12 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   // fullscreen page opens on the global/all-assets view. A manual pick (a
   // folder or another workflow) holds until one of these inputs changes.
   useEffect(() => {
+    if (forceGlobalAssets) {
+      setWorkflowFilter(null);
+      return;
+    }
     setWorkflowFilter(isFullscreenAssets ? null : currentWorkflowId ?? null);
-  }, [isFullscreenAssets, currentWorkflowId, setWorkflowFilter]);
+  }, [isFullscreenAssets, currentWorkflowId, setWorkflowFilter, forceGlobalAssets]);
   const openMenuType = useContextMenuStore((state) => state.openMenuType);
 
   const theme = useTheme();

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -50,6 +50,7 @@ import { ScrollArea, Tooltip, MobileBottomSheet, MOTION } from "../ui_primitives
 import MenuIcon from "@mui/icons-material/Menu";
 import CodeIcon from "@mui/icons-material/Code";
 import GridViewIcon from "@mui/icons-material/GridView";
+import CollectionsOutlinedIcon from "@mui/icons-material/CollectionsOutlined";
 
 import { Fullscreen } from "@mui/icons-material";
 
@@ -350,6 +351,33 @@ const PanelContent = memo(function PanelContent({
           <AssetGrid maxItemSize={5} isMobile={isMobile} />
         </FlexColumn>
       )}
+      {activeView === "library" && (
+        <FlexColumn
+          className="library-container"
+          fullWidth
+          fullHeight
+          sx={{
+            overflow: "hidden"
+          }}
+        >
+          {!isMobile && (
+            <PanelHeadline
+              title="Library"
+              actions={
+                <Tooltip title="Open in full page" placement="right-start">
+                  <ToolbarIconButton
+                    className={`${path === "/assets" ? "active" : ""}`}
+                    onClick={handleFullscreenClick}
+                    tabIndex={-1}
+                    icon={<Fullscreen />}
+                  />
+                </Tooltip>
+              }
+            />
+          )}
+          <AssetGrid maxItemSize={5} isMobile={isMobile} forceGlobalAssets />
+        </FlexColumn>
+      )}
       {activeView === "workflows" && (
         <FlexColumn
           className="workflow-grid-container"
@@ -569,6 +597,15 @@ const MobilePanelLeft: React.FC<{
                 ariaLabel="Show assets"
                 tabIndex={-1}
                 icon={<IconForType iconName="asset" showTooltip={false} iconSize="small" />}
+              />
+            </Tooltip>
+            <Tooltip title="Library" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
+              <ToolbarIconButton
+                className={`tab-button ${activeView === "library" ? "active" : ""}`}
+                onClick={() => handleSheetViewChange("library")}
+                ariaLabel="Show library"
+                tabIndex={-1}
+                icon={<CollectionsOutlinedIcon fontSize="small" />}
               />
             </Tooltip>
 

--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -31,7 +31,7 @@ const idsIn = (category: NodeCategoryId, all: NodeMetadata[]): string[] =>
   );
 
 describe("quickAccessCategories", () => {
-  it("ships eight top-level views in order", () => {
+  it("ships nine top-level views in order", () => {
     const ids = LEFT_PANEL_TOP_LEVEL.map((c) => c.id);
     expect(ids).toEqual([
       "nodes",
@@ -41,7 +41,8 @@ describe("quickAccessCategories", () => {
       "settings",
       "history",
       "favorites",
-      "assets"
+      "assets",
+      "library"
     ]);
   });
 

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -28,6 +28,7 @@ import LoginIcon from "@mui/icons-material/Login";
 import CallSplitIcon from "@mui/icons-material/CallSplit";
 import HubIcon from "@mui/icons-material/Hub";
 import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
+import CollectionsOutlinedIcon from "@mui/icons-material/CollectionsOutlined";
 
 import type { NodeMetadata } from "../stores/ApiTypes";
 import {
@@ -86,7 +87,8 @@ export const LEFT_PANEL_TOP_LEVEL: readonly LeftPanelTopLevelCategory[] = [
   { id: "settings", label: "Settings", icon: <SettingsIcon /> },
   { id: "history", label: "History", icon: <HistoryIcon /> },
   { id: "favorites", label: "Favorites", icon: <StarIcon /> },
-  { id: "assets", label: "Assets", icon: <PermMediaOutlinedIcon /> }
+  { id: "assets", label: "Assets", icon: <PermMediaOutlinedIcon /> },
+  { id: "library", label: "Library", icon: <CollectionsOutlinedIcon /> }
 ];
 
 /**

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -18,6 +18,7 @@ export type LeftPanelView =
   | "history"
   | "favorites"
   | "assets"
+  | "library"
   | "nodes";
 export type PanelView = LeftPanelView;
 
@@ -72,6 +73,7 @@ const VALID_VIEWS: LeftPanelView[] = [
   "history",
   "favorites",
   "assets",
+  "library",
   "nodes"
 ];
 


### PR DESCRIPTION
## Summary
Adds a new "Library" sidebar panel view that displays all assets globally (across all workflows) without adopting the fullscreen page layout. This provides quick access to the complete asset library from the left panel.

## Key Changes
- **New panel view**: Added "library" as a new `LeftPanelView` type in `PanelStore.ts`
- **UI configuration**: Registered "Library" in `quickAccessCategories.tsx` with `CollectionsOutlinedIcon`
- **Panel implementation**: Added library panel section in `PanelLeft.tsx` with:
  - Fullscreen button (desktop only) to open `/assets` page
  - `AssetGrid` component configured to show global assets
  - Mobile tab button for library view access
- **AssetGrid enhancement**: Added `forceGlobalAssets` prop to `AssetGrid.tsx` that:
  - Forces global (all-workflows) asset scope regardless of current workflow
  - Maintains sidebar layout (unlike fullscreen page which pins folders open)
  - Used exclusively by the Library panel to avoid fullscreen layout adoption

## Implementation Details
- The `forceGlobalAssets` prop takes precedence in the `useEffect` that manages workflow filtering, ensuring the library always shows all assets
- Library panel mirrors the assets panel structure but with `forceGlobalAssets={true}` instead of `isFullscreenAssets`
- Mobile and desktop UX are consistent with existing panel patterns (headline with actions, icon button in tab bar)

https://claude.ai/code/session_01LWzLXjCjQwazadAPAxRDK7