### PR TITLE
docs: Add npm install guidance for module resolution errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ token/cost/latency.
 - **Node.js 22.22.1** (required — see `.nvmrc`). Matches Electron 39's embedded Node (22.22.1). Native module ABI rebuild is handled by `@electron/rebuild` in `electron/`'s postinstall.
 - Use `nvm use` to activate the correct version.
 - If you see `NODE_MODULE_VERSION` errors, run `npm rebuild`.
+- **Fresh checkout or missing `node_modules`**: if `npm run typecheck`/`lint`/`test` fail with module-resolution errors (`Cannot find module`, `Cannot find type definition file`) on files you didn't touch, run `npm install` first — don't spend a cycle proving the failure predates your change. Re-run the checks after install before investigating further.
 
 ## Build, Lint & Test Commands
 


### PR DESCRIPTION
## Summary
Added clarification to AGENTS.md about resolving module-resolution errors that occur after a fresh checkout or when `node_modules` is missing.

## Changes
- Added a new bullet point under the Node.js prerequisites section that advises running `npm install` first when encountering `Cannot find module` or `Cannot find type definition file` errors on files you didn't touch
- Emphasizes not spending time proving the failure predates your change — just install and re-run checks
- Helps developers distinguish between legitimate issues and missing dependencies

## Rationale
This is a common friction point for new contributors and developers switching branches. The guidance prevents wasted debugging cycles and aligns with the project's emphasis on clear, actionable documentation.

https://claude.ai/code/session_01JbGkrMBmrk2SdtF6zok4LM