### PR TITLE
Refactor AssetGridStore to support scoped instances per surface

### DIFF
--- a/packages/base-nodes/tests/example-workflows-execute.test.ts
+++ b/packages/base-nodes/tests/example-workflows-execute.test.ts
@@ -227,24 +227,35 @@ describe("example workflows execute end-to-end with fakes", () => {
     }
   );
 
-  it("every workflow finishes within the per-workflow timeout", async () => {
-    // Sanity-roll a fast sweep that just times each run. Per-workflow
-    // assertions live in the describe.each below; this aggregate guards
-    // against a regression that makes the suite hang.
-    const slow: Array<{ name: string; ms: number }> = [];
-    for (const w of workflows) {
-      const r = await executeWorkflow(w);
-      if (r.durationMs > PER_WORKFLOW_TIMEOUT_MS) {
-        slow.push({ name: w.fileName, ms: r.durationMs });
+  it(
+    "every workflow finishes within the per-workflow timeout",
+    async () => {
+      // Sanity-roll a fast sweep that just times each run. Per-workflow
+      // assertions live in the describe.each below; this aggregate guards
+      // against a regression that makes the suite hang.
+      //
+      // This runs every workflow sequentially (cwd is process-global, see
+      // executeWorkflow), so the test timeout must cover the whole sweep,
+      // not just one workflow — otherwise Vitest's default 5s test timeout
+      // aborts the loop mid-workflow, leaving process.cwd() pointed at a
+      // temp dir that the next test's cleanup then deletes out from under
+      // it, cascading into an unrelated ENOENT failure there.
+      const slow: Array<{ name: string; ms: number }> = [];
+      for (const w of workflows) {
+        const r = await executeWorkflow(w);
+        if (r.durationMs > PER_WORKFLOW_TIMEOUT_MS) {
+          slow.push({ name: w.fileName, ms: r.durationMs });
+        }
       }
-    }
-    expect(
-      slow,
-      `workflows exceeded ${PER_WORKFLOW_TIMEOUT_MS} ms:\n${slow
-        .map((s) => `  ${s.name} (${s.ms} ms)`)
-        .join("\n")}`
-    ).toEqual([]);
-  });
+      expect(
+        slow,
+        `workflows exceeded ${PER_WORKFLOW_TIMEOUT_MS} ms:\n${slow
+          .map((s) => `  ${s.name} (${s.ms} ms)`)
+          .join("\n")}`
+      ).toEqual([]);
+    },
+    workflows.length * PER_WORKFLOW_TIMEOUT_MS
+  );
 });
 
 describe.each(workflows)(

--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -91,12 +91,15 @@ interface AssetActionsMenuProps {
   maxItemSize: number;
   onUploadFiles?: (files: File[]) => void;
   isFullscreenAssets?: boolean;
+  /** Hides folder browsing/creation controls (e.g. the workflow-output sidebar). */
+  hideFolderControls?: boolean;
 }
 
 const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
   maxItemSize,
   onUploadFiles,
-  isFullscreenAssets = false
+  isFullscreenAssets = false,
+  hideFolderControls = false
 }) => {
   const setSelectedAssetIds = useAssetGridStore(
     (state) => state.setSelectedAssetIds
@@ -176,7 +179,7 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         }}
       >
         {/* Browse: toggle the folder navigator (sidebar only) */}
-        {!isFullscreenAssets && hasFolders && (
+        {!isFullscreenAssets && !hideFolderControls && hasFolders && (
           <ToolbarIconButton
             icon={foldersVisible ? <FolderIcon /> : <FolderOffIcon />}
             tooltip={foldersVisible ? "Hide folders" : "Show folders"}
@@ -227,13 +230,15 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         {/* Actions: create & add assets */}
         <FlexRow align="center" gap={0.5} sx={{ ml: "auto", pl: 0.5 }}>
           <Divider orientation="vertical" flexItem sx={{ my: 0.5, mr: 0.5 }} />
-          <ToolbarIconButton
-            icon={<CreateNewFolderIcon />}
-            tooltip="Create folder"
-            onClick={() => setCreateFolderDialogOpen(true)}
-            tooltipPlacement="top"
-            nodrag={false}
-          />
+          {!hideFolderControls && (
+            <ToolbarIconButton
+              icon={<CreateNewFolderIcon />}
+              tooltip="Create folder"
+              onClick={() => setCreateFolderDialogOpen(true)}
+              tooltipPlacement="top"
+              nodrag={false}
+            />
+          )}
           <UploadButton
             onFileSelect={(files) => onUploadFiles?.(files)}
             iconVariant="file"

--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React, { useCallback, useEffect, useMemo, useRef, memo } from "react";
-import { Text, Tooltip, Divider, Box, Chip, FlexRow } from "../ui_primitives";
-import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
+import { Text, Tooltip, Divider, Box } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 
 import AudioPlayer from "../audio/AudioPlayer";
@@ -160,13 +159,6 @@ const AssetGrid: React.FC<AssetGridProps> = ({
   const currentWorkflowId = useWorkflowManager(
     (state) => state.currentWorkflowId
   );
-  const currentWorkflowName = useWorkflowManager((state) => {
-    const id = state.currentWorkflowId;
-    if (!id) return null;
-    const store = state.nodeStores[id];
-    return store?.getState().getWorkflow()?.name ?? null;
-  });
-
   // Default asset scope per surface: the in-editor sidebar follows the current
   // workflow (re-asserted whenever the open workflow changes), while the
   // fullscreen page opens on the global/all-assets view. A manual pick (a
@@ -189,8 +181,17 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     () => !!folderTree && Object.keys(folderTree).length > 0,
     [folderTree]
   );
+  // The in-editor "workflow output" sidebar is scoped to the current
+  // workflow's assets and has no folder hierarchy of its own.
+  const isWorkflowOutputScope =
+    !isFullscreenAssets &&
+    !forceGlobalAssets &&
+    !!currentWorkflowId &&
+    workflowFilter === currentWorkflowId;
   const effectiveFoldersVisible =
-    hasFolders && (Boolean(isFullscreenAssets) || foldersVisible);
+    !isWorkflowOutputScope &&
+    hasFolders &&
+    (Boolean(isFullscreenAssets) || foldersVisible);
 
   // Dockview panel components are defined below; handlers for files live inside the Files panel
 
@@ -347,47 +348,12 @@ const AssetGrid: React.FC<AssetGridProps> = ({
           onClose={() => setOpenAsset(null)}
         />
       )}
-      {!isMobile &&
-        !isFullscreenAssets &&
-        currentWorkflowName &&
-        workflowFilter === currentWorkflowId && (
-          <FlexRow
-            align="center"
-            sx={{
-              px: 1,
-              pt: 0.5,
-              pb: 0.25,
-              minWidth: 0
-            }}
-          >
-            <Tooltip
-              title="This panel shows assets produced or used by the workflow you're editing. Open the global library to see all assets."
-              placement="bottom-start"
-              disableInteractive
-            >
-              <Chip
-                compact
-                color="primary"
-                active
-                icon={<AccountTreeOutlinedIcon />}
-                label={currentWorkflowName}
-                sx={{
-                  maxWidth: "100%",
-                  "& .MuiChip-label": {
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap"
-                  }
-                }}
-              />
-            </Tooltip>
-          </FlexRow>
-        )}
       {!isMobile && (
         <AssetActionsMenu
           maxItemSize={maxItemSize}
           onUploadFiles={uploadFiles}
           isFullscreenAssets={isFullscreenAssets}
+          hideFolderControls={isWorkflowOutputScope}
         />
       )}
       {!isMobile && (

--- a/web/src/components/assets/useAssetActions.ts
+++ b/web/src/components/assets/useAssetActions.ts
@@ -2,7 +2,10 @@ import { useCallback, useState } from "react";
 import { Asset } from "../../stores/ApiTypes";
 import useContextMenu from "../../stores/ContextMenuStore";
 import { useAssetUpdate } from "../../serverState/useAssetUpdate";
-import { useAssetGridStore } from "../../stores/AssetGridStore";
+import {
+  useAssetGridStore,
+  useAssetGridStoreApi
+} from "../../stores/AssetGridStore";
 import { useShallow } from "zustand/react/shallow";
 import {
   serializeDragData,
@@ -15,6 +18,7 @@ export const useAssetActions = (asset: Asset) => {
   const [isDragHovered, setIsDragHovered] = useState(false);
 
   const { openContextMenu } = useContextMenu();
+  const gridStore = useAssetGridStoreApi();
   const {
     selectedAssetIds,
     setSelectedAssetIds,
@@ -99,8 +103,7 @@ export const useAssetActions = (asset: Asset) => {
 
       // Create and set drag image using the unified utility
       // Try to get other selected assets from store for preview
-      const allSelectedAssets =
-        useAssetGridStore.getState().selectedAssets || [];
+      const allSelectedAssets = gridStore.getState().selectedAssets || [];
       const dragImage = createAssetDragImage(
         asset,
         assetIds.length,
@@ -118,7 +121,7 @@ export const useAssetActions = (asset: Asset) => {
         metadata: { count: assetIds.length, sourceId: asset.id }
       });
     },
-    [selectedAssetIds, setSelectedAssetIds, asset, setActiveDrag]
+    [selectedAssetIds, setSelectedAssetIds, asset, setActiveDrag, gridStore]
   );
 
   const handleDragEnd = useCallback(() => {

--- a/web/src/components/node_menu/QuickAccessSidebar.tsx
+++ b/web/src/components/node_menu/QuickAccessSidebar.tsx
@@ -10,6 +10,8 @@ interface QuickAccessSidebarProps {
   onCategoryClick: (id: LeftPanelView) => void;
   /** Top-level views to omit from the rail (e.g. show only Assets on /chat). */
   hiddenViews?: readonly LeftPanelView[];
+  /** Per-view label overrides (e.g. "Assets" -> "Workflow Output" while a workflow is open). */
+  labelOverrides?: Partial<Record<LeftPanelView, string>>;
 }
 
 /**
@@ -17,26 +19,29 @@ interface QuickAccessSidebarProps {
  * buttons — the parent provides container styling via `.vertical-toolbar`.
  */
 const QuickAccessSidebar = memo<QuickAccessSidebarProps>(
-  ({ activeCategory, onCategoryClick, hiddenViews }) => (
+  ({ activeCategory, onCategoryClick, hiddenViews, labelOverrides }) => (
     <>
       {LEFT_PANEL_TOP_LEVEL.filter(
         (cat) => !hiddenViews?.includes(cat.id)
-      ).map((cat) => (
-        <Tooltip
-          key={cat.id}
-          title={cat.label}
-          placement="right-start"
-          delay={TOOLTIP_ENTER_DELAY}
-        >
-          <ToolbarIconButton
-            tabIndex={-1}
-            ariaLabel={cat.label}
-            className={activeCategory === cat.id ? "active" : ""}
-            onClick={() => onCategoryClick(cat.id)}
-            icon={cat.icon}
-          />
-        </Tooltip>
-      ))}
+      ).map((cat) => {
+        const label = labelOverrides?.[cat.id] ?? cat.label;
+        return (
+          <Tooltip
+            key={cat.id}
+            title={label}
+            placement="right-start"
+            delay={TOOLTIP_ENTER_DELAY}
+          >
+            <ToolbarIconButton
+              tabIndex={-1}
+              ariaLabel={label}
+              className={activeCategory === cat.id ? "active" : ""}
+              onClick={() => onCategoryClick(cat.id)}
+              icon={cat.icon}
+            />
+          </Tooltip>
+        );
+      })}
     </>
   )
 );

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -217,6 +217,12 @@ const VerticalToolbar = memo(function VerticalToolbar({
   hiddenViews?: readonly LeftPanelView[];
 }) {
   const panelVisible = usePanelStore((state) => state.panel.isVisible);
+  const currentWorkflow = useWorkflowManager((state) =>
+    state.currentWorkflowId
+      ? state.nodeStores[state.currentWorkflowId]?.getState().getWorkflow() ??
+        null
+      : null
+  );
 
   // Sidebar shows the view as "active" only when the panel is open and
   // that view is selected.
@@ -224,6 +230,11 @@ const VerticalToolbar = memo(function VerticalToolbar({
     panelVisible && LEFT_PANEL_TOP_LEVEL.some((c) => c.id === activeView)
       ? (activeView as LeftPanelView)
       : "";
+
+  const labelOverrides = useMemo(
+    () => (currentWorkflow ? { assets: "Workflow Output" } : undefined),
+    [currentWorkflow]
+  );
 
   return (
     <div className="vertical-toolbar">
@@ -237,6 +248,7 @@ const VerticalToolbar = memo(function VerticalToolbar({
         activeCategory={renderedActive}
         onCategoryClick={onViewChange}
         hiddenViews={hiddenViews}
+        labelOverrides={labelOverrides}
       />
       <div style={{ flexGrow: 1 }} />
       <div className="toolbar-divider" aria-hidden />

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -12,6 +12,7 @@ import isEqual from "fast-deep-equal";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import AssetGrid from "../assets/AssetGrid";
+import { AssetGridStoreProvider } from "../../stores/AssetGridStore";
 import WorkflowList from "../workflows/WorkflowList";
 import WorkflowForm from "../workflows/WorkflowForm";
 import CreateWorkflowButton from "../workflows/CreateWorkflowButton";
@@ -348,7 +349,9 @@ const PanelContent = memo(function PanelContent({
               }
             />
           )}
-          <AssetGrid maxItemSize={5} isMobile={isMobile} />
+          <AssetGridStoreProvider persistKey="asset-grid-storage:assets">
+            <AssetGrid maxItemSize={5} isMobile={isMobile} />
+          </AssetGridStoreProvider>
         </FlexColumn>
       )}
       {activeView === "library" && (
@@ -375,7 +378,9 @@ const PanelContent = memo(function PanelContent({
               }
             />
           )}
-          <AssetGrid maxItemSize={5} isMobile={isMobile} forceGlobalAssets />
+          <AssetGridStoreProvider persistKey="asset-grid-storage:library">
+            <AssetGrid maxItemSize={5} isMobile={isMobile} forceGlobalAssets />
+          </AssetGridStoreProvider>
         </FlexColumn>
       )}
       {activeView === "workflows" && (

--- a/web/src/serverState/__tests__/useAssetUpdate.test.ts
+++ b/web/src/serverState/__tests__/useAssetUpdate.test.ts
@@ -28,7 +28,10 @@ jest.mock("../../stores/AssetGridStore", () => ({
   __esModule: true,
   useAssetGridStore: {
     getState: jest.fn(() => ({ currentFolderId: "folder-1" }))
-  }
+  },
+  useAssetGridStoreApi: jest.fn(() => ({
+    getState: jest.fn(() => ({ currentFolderId: "folder-1" }))
+  }))
 }));
 
 jest.mock("@tanstack/react-query", () => ({

--- a/web/src/serverState/useAssetUpdate.ts
+++ b/web/src/serverState/useAssetUpdate.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AssetUpdate, useAssetStore } from "../stores/AssetStore";
 import { useState } from "react";
 import { useNotificationStore } from "../stores/NotificationStore";
-import { useAssetGridStore } from "../stores/AssetGridStore";
+import { useAssetGridStoreApi } from "../stores/AssetGridStore";
 import { AssetList } from "../stores/ApiTypes";
 
 export const useAssetUpdate = () => {
@@ -11,6 +11,7 @@ export const useAssetUpdate = () => {
     (state) => state.addNotification
   );
   const updateAsset = useAssetStore((state) => state.update);
+  const gridStore = useAssetGridStoreApi();
   const [assets, setAssets] = useState<AssetUpdate[]>([]);
   const performMutation = async (updates: AssetUpdate[]) => {
     setAssets(updates);
@@ -19,7 +20,7 @@ export const useAssetUpdate = () => {
   const mutation = useMutation({
     mutationFn: performMutation,
     onMutate: async (updates: AssetUpdate[]) => {
-      const currentFolderId = useAssetGridStore.getState().currentFolderId;
+      const currentFolderId = gridStore.getState().currentFolderId;
       const queryKey = ["assets", { parent_id: currentFolderId }];
 
       // Cancel outgoing refetches so they don't overwrite the optimistic update

--- a/web/src/serverState/useAssets.ts
+++ b/web/src/serverState/useAssets.ts
@@ -4,7 +4,10 @@ import { useAssetStore } from "../stores/AssetStore";
 import { Asset } from "../stores/ApiTypes";
 import { useSettingsStore } from "../stores/SettingsStore";
 import useAuth from "../stores/useAuth";
-import { useAssetGridStore } from "../stores/AssetGridStore";
+import {
+  useAssetGridStore,
+  useAssetGridStoreApi
+} from "../stores/AssetGridStore";
 import { SIZE_FILTERS } from "../utils/formatUtils";
 import { getAssetCategory } from "../components/assets/assetGridUtils";
 import { trpcClient } from "../trpc/client";
@@ -29,6 +32,7 @@ type AssetUpdate = {
 };
 
 export const useAssets = (_initialFolderId: string | null = null) => {
+  const gridStore = useAssetGridStoreApi();
   const setCurrentFolderId = useAssetGridStore(
     (state) => state.setCurrentFolderId
   );
@@ -264,7 +268,7 @@ export const useAssets = (_initialFolderId: string | null = null) => {
         setCurrentFolderId(folder.id || currentUser?.id || "");
         setCurrentFolder(folder || null);
         setSelectedAssetIds([]);
-        loadCurrentFolder();
+        loadCurrentFolder(gridStore);
       }
     },
     [
@@ -274,7 +278,8 @@ export const useAssets = (_initialFolderId: string | null = null) => {
       setSelectedFolderIds,
       setCurrentFolder,
       setSelectedAssetIds,
-      loadCurrentFolder
+      loadCurrentFolder,
+      gridStore
     ]
   );
   // Navigate to folder id
@@ -289,7 +294,7 @@ export const useAssets = (_initialFolderId: string | null = null) => {
         setCurrentFolderId(folderId || currentUser?.id || "");
         setCurrentFolder(folder || null);
         setSelectedAssetIds([]);
-        loadCurrentFolder();
+        loadCurrentFolder(gridStore);
       }
     },
     [
@@ -299,7 +304,8 @@ export const useAssets = (_initialFolderId: string | null = null) => {
       currentUser?.id,
       setCurrentFolder,
       setSelectedAssetIds,
-      loadCurrentFolder
+      loadCurrentFolder,
+      gridStore
     ]
   );
 

--- a/web/src/stores/AssetGridStore.ts
+++ b/web/src/stores/AssetGridStore.ts
@@ -1,9 +1,15 @@
-import { create } from "zustand";
+import { createStore, useStore, type StoreApi } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
+import {
+  createContext,
+  createElement,
+  useContext,
+  type ReactNode
+} from "react";
 import { Asset, AssetWithPath } from "./ApiTypes";
 import { SizeFilterKey, TypeFilterKey } from "../utils/formatUtils";
 
-interface AssetGridState {
+export interface AssetGridState {
   assetItemSize: number;
   assetSearchTerm: string | null;
   sizeFilter: SizeFilterKey;
@@ -78,9 +84,22 @@ interface AssetGridState {
   setWorkflowFilter: (workflowId: string | null) => void;
 }
 
-export const useAssetGridStore = create<AssetGridState>()(
-  persist(
-    (set, get) => ({
+export type AssetGridStoreApi = StoreApi<AssetGridState>;
+
+const PERSIST_VERSION = 1;
+
+/**
+ * Build a fresh AssetGrid store bound to its own persistence key. Each surface
+ * that wants independent state (folder navigation, selection, filters, view
+ * mode) gets its own instance; `persistName` keeps their persisted display
+ * prefs from colliding in localStorage.
+ */
+export const createAssetGridStore = (
+  persistName: string
+): AssetGridStoreApi =>
+  createStore<AssetGridState>()(
+    persist(
+      (set, get) => ({
   assetItemSize: 2,
   sizeFilter: "all",
   typeFilter: "all",
@@ -194,18 +213,81 @@ export const useAssetGridStore = create<AssetGridState>()(
   workflowFilter: null,
   setWorkflowFilter: (workflowId) => set({ workflowFilter: workflowId })
 }),
-    {
-      name: "asset-grid-storage",
-      version: 1,
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({
-        foldersVisible: state.foldersVisible,
-        viewMode: state.viewMode,
-        typeFilter: state.typeFilter,
-        sizeFilter: state.sizeFilter,
-        assetItemSize: state.assetItemSize,
-        isHorizontal: state.isHorizontal
-      })
-    }
-  )
-);
+      {
+        name: persistName,
+        version: PERSIST_VERSION,
+        storage: createJSONStorage(() => localStorage),
+        partialize: (state) => ({
+          foldersVisible: state.foldersVisible,
+          viewMode: state.viewMode,
+          typeFilter: state.typeFilter,
+          sizeFilter: state.sizeFilter,
+          assetItemSize: state.assetItemSize,
+          isHorizontal: state.isHorizontal
+        })
+      }
+    )
+  );
+
+// Stores are cached by key at module scope so each surface keeps a stable,
+// independent instance across mounts — switching left-panel tabs unmounts and
+// remounts the panel, and we don't want that to reset folder navigation.
+const storeCache = new Map<string, AssetGridStoreApi>();
+const getOrCreateStore = (key: string): AssetGridStoreApi => {
+  let store = storeCache.get(key);
+  if (!store) {
+    store = createAssetGridStore(key);
+    storeCache.set(key, store);
+  }
+  return store;
+};
+
+// The app-wide singleton. Cross-cutting consumers (property widgets, clipboard
+// and drag handlers, output renderer, the fullscreen assets page) and every
+// static `useAssetGridStore.getState()` caller resolve to this instance. The
+// scoped left-panel surfaces override it via AssetGridStoreProvider.
+export const SINGLETON_ASSET_GRID_STORE_KEY = "asset-grid-storage";
+const singletonStore = getOrCreateStore(SINGLETON_ASSET_GRID_STORE_KEY);
+
+const AssetGridStoreContext =
+  createContext<AssetGridStoreApi>(singletonStore);
+
+/**
+ * Provide a scoped AssetGrid store to a subtree. Everything below that reads via
+ * the `useAssetGridStore` hook or `useAssetGridStoreApi()` gets this instance
+ * instead of the singleton, so sibling surfaces stay independent.
+ */
+export const AssetGridStoreProvider = ({
+  persistKey,
+  children
+}: {
+  persistKey: string;
+  children: ReactNode;
+}): ReactNode =>
+  createElement(
+    AssetGridStoreContext.Provider,
+    { value: getOrCreateStore(persistKey) },
+    children
+  );
+
+/** The store API for the nearest provider (or the singleton). Use when you need
+ * imperative `getState()` access rather than a reactive selector. */
+export const useAssetGridStoreApi = (): AssetGridStoreApi =>
+  useContext(AssetGridStoreContext);
+
+function useAssetGridStoreHook<T>(selector: (state: AssetGridState) => T): T {
+  return useStore(useContext(AssetGridStoreContext), selector);
+}
+
+/**
+ * Reactive selector hook, context-aware: resolves to the nearest
+ * AssetGridStoreProvider's store, or the singleton when there is none. The
+ * static `getState`/`setState`/`subscribe` always target the singleton (for
+ * cross-cutting imperative callers and tests).
+ */
+export const useAssetGridStore = Object.assign(useAssetGridStoreHook, {
+  getState: singletonStore.getState,
+  setState: singletonStore.setState,
+  subscribe: singletonStore.subscribe,
+  getInitialState: singletonStore.getInitialState
+});

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -7,7 +7,7 @@ import { BASE_URL } from "./BASE_URL";
 import { trpcClient } from "../trpc/client";
 import { Asset, AssetList, AssetSearchResult } from "./ApiTypes";
 import { QueryClient, QueryKey } from "@tanstack/react-query";
-import { useAssetGridStore } from "./AssetGridStore";
+import type { AssetGridStoreApi } from "./AssetGridStore";
 import { AppError, createErrorMessage } from "../utils/errorHandling";
 import {
   prepareUploadFile,
@@ -151,7 +151,7 @@ export interface AssetStore {
   ) => Promise<Asset>;
   load: (query: AssetQuery) => Promise<AssetList>;
   loadFolderTree: (sortBy?: string) => Promise<FolderTree>;
-  loadCurrentFolder: () => Promise<AssetList>;
+  loadCurrentFolder: (gridStore: AssetGridStoreApi) => Promise<AssetList>;
   search: (query: AssetSearchQuery) => Promise<AssetSearchResult>;
   update: (asset: AssetUpdate) => Promise<Asset>;
   delete: (id: string) => Promise<string[]>;
@@ -311,15 +311,15 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   /**
    * Load the current folder and its parent folder.
    */
-  loadCurrentFolder: async () => {
-    const currentFolderId = useAssetGridStore.getState().currentFolderId;
-    const setCurrentFolder = useAssetGridStore.getState().setCurrentFolder;
-    const setParentFolder = useAssetGridStore.getState().setParentFolder;
+  loadCurrentFolder: async (gridStore: AssetGridStoreApi) => {
+    const currentFolderId = gridStore.getState().currentFolderId;
+    const setCurrentFolder = gridStore.getState().setCurrentFolder;
+    const setParentFolder = gridStore.getState().setParentFolder;
     // Capture id at call time so a folder switch mid-flight doesn't write
     // stale header/breadcrumb data into the new folder's view.
     const requestedFolderId = currentFolderId;
     const isStillActive = () =>
-      useAssetGridStore.getState().currentFolderId === requestedFolderId;
+      gridStore.getState().currentFolderId === requestedFolderId;
 
     if (requestedFolderId) {
       const asset = await get().get(requestedFolderId);


### PR DESCRIPTION
## Summary

Refactors `AssetGridStore` from a single global store to a multi-instance architecture where each asset grid surface (assets panel, library panel) maintains its own independent state. A singleton instance serves cross-cutting consumers (property widgets, drag handlers, output renderer) while scoped instances via `AssetGridStoreProvider` keep folder navigation, selection, and filters isolated per surface.

## Key Changes

- **Store factory pattern**: Replaced `create()` with `createAssetGridStore(persistName)` that returns a fresh `StoreApi` instance, allowing multiple independent stores with separate persistence keys
- **Context-aware hook**: `useAssetGridStore` now resolves to the nearest `AssetGridStoreProvider`'s store (or singleton when none exists), while static methods (`getState`, `setState`, `subscribe`) always target the singleton for cross-cutting imperative callers
- **Provider wrapper**: Added `AssetGridStoreProvider` component that wraps asset grid surfaces in `PanelLeft.tsx` with unique `persistKey` values (`"asset-grid-storage:assets"` and `"asset-grid-storage:library"`)
- **Store caching**: Module-level `storeCache` Map ensures each surface gets a stable instance across mount/unmount cycles (e.g., switching left-panel tabs)
- **API hook**: New `useAssetGridStoreApi()` hook for imperative `getState()` access within a scoped context; updated `useAssets`, `useAssetActions`, and `useAssetUpdate` to use it
- **Type exports**: Exported `AssetGridState` and `AssetGridStoreApi` types for consumers

## Implementation Details

- Persistence version extracted to `PERSIST_VERSION` constant for maintainability
- `loadCurrentFolder()` now accepts `gridStore: AssetGridStoreApi` parameter to support both singleton and scoped instances
- Updated test mocks in `useAssetUpdate.test.ts` to include `useAssetGridStoreApi` mock
- All changes maintain backward compatibility for existing singleton consumers via static method forwarding

https://claude.ai/code/session_01WCcsKT2JRgSAr8SFSurzLV