### PR TITLE
Add default page layout to Jekyll config for generated pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,6 +40,12 @@ defaults:
       path: ""
     values:
       image: /assets/home.png
+      # Explicit front-matter (layout: home / layout: redirect / layout: page)
+      # always wins over this default. Pages that ship with no front matter at
+      # all (e.g. generated via jekyll-optional-front-matter) still need the
+      # "page" layout to get the sidebar, header/footer, and the "Edit this
+      # page on GitHub" link in _layouts/page.html.
+      layout: page
   # Node reference pages are pure generated Markdown. Some node descriptions
   # legitimately contain `{{ variable }}` / `{% ... %}` template syntax, which
   # Jekyll would otherwise try to parse as Liquid (and warn/err on). They need


### PR DESCRIPTION
## Summary
Add an explicit default `layout: page` to the Jekyll configuration for pages without front matter, ensuring generated pages (via `jekyll-optional-front-matter`) receive proper styling and navigation elements.

## Changes
- Added `layout: page` as a default front-matter value in `docs/_config.yml` for all pages in the root path
- Included explanatory comment clarifying that explicit front-matter layouts (home/redirect/page) take precedence, but pages generated without front matter still need the "page" layout to render with sidebar, header/footer, and GitHub edit links

## Details
This ensures that auto-generated Markdown pages (which ship with no front matter) still get the full page layout treatment, including the sidebar navigation, header/footer, and the "Edit this page on GitHub" link defined in `_layouts/page.html`. Explicit front-matter declarations in individual pages will continue to override this default.

https://claude.ai/code/session_01EE8hSTaKhSkDLbUgC8fbsf