### PR TITLE
Runtime config: fetch auth mode and Supabase credentials from backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,17 @@ NODETOOL_ENV=development
 DB_PATH=./nodetool.db
 # DATABASE_URL=postgresql://user:pass@host:5432/nodetool
 
+# ── Authentication (optional) ───────────────────────────────────────────────
+# Auth is off by default (Local mode: localhost trusted, remote rejected, no
+# login screen). Set all three to enable Supabase login. The web UI reads these
+# from the backend at runtime via GET /api/config — no frontend rebuild needed.
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_KEY=your-service-role-key   # server-only, never sent to the browser
+# SUPABASE_ANON_KEY=your-anon-key      # public key used by the login screen
+# Optional OAuth redirect when served behind a domain/proxy (must be allow-listed
+# in the Supabase project):
+# AUTH_REDIRECT_URL=https://app.example.com/
+
 # ── Secret encryption ───────────────────────────────────────────────────────
 # 32-byte base64 key used to encrypt stored secrets. Generate with:
 #   openssl rand -base64 32

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,18 @@ RUN set -eu; \
 
 COPY web/ web/
 ARG WEB_BUILD_NODE_OPTIONS=--max-old-space-size=4096
-RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" npm run build
+# Supabase credentials for the web login screen are compiled into the bundle
+# here (Vite inlines VITE_* at build time). Left empty — the default — the UI
+# has no working login and the app relies on server-side Local/Supabase mode.
+# Pass these build args to bake in a working Supabase login screen.
+ARG VITE_SUPABASE_URL=
+ARG VITE_SUPABASE_ANON_KEY=
+ARG VITE_AUTH_REDIRECT_URL=
+RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" \
+    VITE_SUPABASE_URL="$VITE_SUPABASE_URL" \
+    VITE_SUPABASE_ANON_KEY="$VITE_SUPABASE_ANON_KEY" \
+    VITE_AUTH_REDIRECT_URL="$VITE_AUTH_REDIRECT_URL" \
+    npm run build
 
 # Assemble a minimal runtime filesystem with compiled packages, web assets, and
 # bundled workflow examples/thumbnails.

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,18 +57,10 @@ RUN set -eu; \
 
 COPY web/ web/
 ARG WEB_BUILD_NODE_OPTIONS=--max-old-space-size=4096
-# Supabase credentials for the web login screen are compiled into the bundle
-# here (Vite inlines VITE_* at build time). Left empty — the default — the UI
-# has no working login and the app relies on server-side Local/Supabase mode.
-# Pass these build args to bake in a working Supabase login screen.
-ARG VITE_SUPABASE_URL=
-ARG VITE_SUPABASE_ANON_KEY=
-ARG VITE_AUTH_REDIRECT_URL=
-RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" \
-    VITE_SUPABASE_URL="$VITE_SUPABASE_URL" \
-    VITE_SUPABASE_ANON_KEY="$VITE_SUPABASE_ANON_KEY" \
-    VITE_AUTH_REDIRECT_URL="$VITE_AUTH_REDIRECT_URL" \
-    npm run build
+# The web app learns its auth mode and public Supabase credentials from the
+# backend at runtime via GET /api/config, so no VITE_* build args are needed
+# here — configure the server (SUPABASE_URL/KEY/ANON_KEY) instead.
+RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" npm run build
 
 # Assemble a minimal runtime filesystem with compiled packages, web assets, and
 # bundled workflow examples/thumbnails.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,17 @@ services:
     image: ghcr.io/nodetool-ai/nodetool:${NODETOOL_VERSION:-latest}
     container_name: nodetool
     restart: unless-stopped
+    # Build the image locally instead of pulling. Only needed to bake Supabase
+    # credentials into the web login screen (see "Authentication" below). With
+    # both `image:` and `build:` set, `docker compose up --build` builds and
+    # tags the result as `image:`.
+    # build:
+    #   context: .
+    #   args:
+    #     VITE_SUPABASE_URL: "${VITE_SUPABASE_URL:-}"
+    #     VITE_SUPABASE_ANON_KEY: "${VITE_SUPABASE_ANON_KEY:-}"
+    #     # Optional OAuth redirect when served behind a domain/proxy:
+    #     VITE_AUTH_REDIRECT_URL: "${VITE_AUTH_REDIRECT_URL:-}"
     ports:
       - "${NODETOOL_PORT:-17777}:7777"
     volumes:
@@ -38,6 +49,25 @@ services:
       # generated and persisted to /workspace/.secrets_master_key on first run.
       # Set it explicitly in production: openssl rand -base64 32
       # SECRETS_MASTER_KEY: "${SECRETS_MASTER_KEY:-}"
+
+      # ── Authentication / login screen ──────────────────────────────────────
+      # Disabled by default: with SUPABASE_URL/SUPABASE_KEY unset the server
+      # runs in "Local mode" — requests from localhost are trusted as a single
+      # user and remote requests are rejected. Opening http://localhost:17777
+      # shows no login screen.
+      #
+      # To require login (multi-user or remote access), point both at your
+      # Supabase project. The server switches to "Supabase mode" and enforces a
+      # valid Supabase JWT on every request. SUPABASE_KEY is the service-role
+      # key. See docs/supabase-deployment.md and docs/authentication.md.
+      # SUPABASE_URL: "${SUPABASE_URL:-}"
+      # SUPABASE_KEY: "${SUPABASE_KEY:-}"
+      #
+      # NOTE: the web login screen authenticates against Supabase using
+      # credentials compiled into the frontend bundle at BUILD time
+      # (VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY). The prebuilt image above
+      # ships without them, so a working login screen requires building the
+      # image locally — uncomment the `build:` block above and set those args.
 
       # Model provider keys — only the ones you use. Values come from .env.
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# Reference Docker Compose for self-hosting the NodeTool server.
+#
+# Quick start:
+#   1. cp .env.example .env      # then fill in the provider keys you use
+#   2. docker compose up -d
+#   3. open http://localhost:17777
+#
+# The server binds to 0.0.0.0:7777 inside the container and is published on the
+# host as ${NODETOOL_PORT:-17777}. All persistent state — SQLite database,
+# assets, vector store, model cache, and the generated secret key — lives under
+# /workspace, backed by the named `nodetool-data` volume, so it survives
+# restarts and image upgrades.
+
+name: nodetool
+
+services:
+  nodetool:
+    image: ghcr.io/nodetool-ai/nodetool:${NODETOOL_VERSION:-latest}
+    container_name: nodetool
+    restart: unless-stopped
+    ports:
+      - "${NODETOOL_PORT:-17777}:7777"
+    volumes:
+      - nodetool-data:/workspace
+    environment:
+      # Bind on all interfaces so the published host port reaches the server.
+      HOST: "0.0.0.0"
+      PORT: "7777"
+      NODETOOL_ENV: "production"
+
+      # Keep every persistent path on the /workspace volume.
+      DB_PATH: "/workspace/nodetool.sqlite3"
+      VECTORSTORE_DB_PATH: "/workspace/vectorstore.db"
+      ASSET_FOLDER: "/workspace/assets"
+      HF_HOME: "/workspace/hf-cache"
+
+      # 32-byte base64 key that encrypts stored secrets. If unset, one is
+      # generated and persisted to /workspace/.secrets_master_key on first run.
+      # Set it explicitly in production: openssl rand -base64 32
+      # SECRETS_MASTER_KEY: "${SECRETS_MASTER_KEY:-}"
+
+      # Model provider keys — only the ones you use. Values come from .env.
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      GEMINI_API_KEY: "${GEMINI_API_KEY:-}"
+      FAL_API_KEY: "${FAL_API_KEY:-}"
+      HF_TOKEN: "${HF_TOKEN:-}"
+
+      # Local inference backends — point these at your own services if you run
+      # them (e.g. an Ollama container on the same Docker network).
+      # OLLAMA_API_URL: "http://ollama:11434"
+
+volumes:
+  nodetool-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,17 +18,6 @@ services:
     image: ghcr.io/nodetool-ai/nodetool:${NODETOOL_VERSION:-latest}
     container_name: nodetool
     restart: unless-stopped
-    # Build the image locally instead of pulling. Only needed to bake Supabase
-    # credentials into the web login screen (see "Authentication" below). With
-    # both `image:` and `build:` set, `docker compose up --build` builds and
-    # tags the result as `image:`.
-    # build:
-    #   context: .
-    #   args:
-    #     VITE_SUPABASE_URL: "${VITE_SUPABASE_URL:-}"
-    #     VITE_SUPABASE_ANON_KEY: "${VITE_SUPABASE_ANON_KEY:-}"
-    #     # Optional OAuth redirect when served behind a domain/proxy:
-    #     VITE_AUTH_REDIRECT_URL: "${VITE_AUTH_REDIRECT_URL:-}"
     ports:
       - "${NODETOOL_PORT:-17777}:7777"
     volumes:
@@ -51,23 +40,25 @@ services:
       # SECRETS_MASTER_KEY: "${SECRETS_MASTER_KEY:-}"
 
       # ── Authentication / login screen ──────────────────────────────────────
-      # Disabled by default: with SUPABASE_URL/SUPABASE_KEY unset the server
-      # runs in "Local mode" — requests from localhost are trusted as a single
-      # user and remote requests are rejected. Opening http://localhost:17777
-      # shows no login screen.
+      # Configured entirely on the backend — the web UI reads its auth mode and
+      # public Supabase credentials at runtime from GET /api/config, so no image
+      # rebuild is needed to turn login on or off.
       #
-      # To require login (multi-user or remote access), point both at your
-      # Supabase project. The server switches to "Supabase mode" and enforces a
-      # valid Supabase JWT on every request. SUPABASE_KEY is the service-role
-      # key. See docs/supabase-deployment.md and docs/authentication.md.
+      # Disabled by default: with SUPABASE_URL/SUPABASE_KEY unset the server
+      # runs in "Local mode" — localhost requests are trusted as a single user,
+      # remote requests are rejected, and no login screen is shown.
+      #
+      # To require login (multi-user or remote access), point these at your
+      # Supabase project. The server enforces a valid Supabase JWT on every
+      # request and the web UI shows the login screen. SUPABASE_KEY is the
+      # service-role key (server-only, never sent to the browser);
+      # SUPABASE_ANON_KEY is the public key the login screen uses. See
+      # docs/supabase-deployment.md and docs/authentication.md.
       # SUPABASE_URL: "${SUPABASE_URL:-}"
       # SUPABASE_KEY: "${SUPABASE_KEY:-}"
-      #
-      # NOTE: the web login screen authenticates against Supabase using
-      # credentials compiled into the frontend bundle at BUILD time
-      # (VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY). The prebuilt image above
-      # ships without them, so a working login screen requires building the
-      # image locally — uncomment the `build:` block above and set those args.
+      # SUPABASE_ANON_KEY: "${SUPABASE_ANON_KEY:-}"
+      # Optional OAuth redirect when served behind a domain/proxy:
+      # AUTH_REDIRECT_URL: "${AUTH_REDIRECT_URL:-}"
 
       # Model provider keys — only the ones you use. Values come from .env.
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,8 @@ see the [End-to-End Deployment Guide](deployment-e2e-guide.md).
 
 ## Server: self-host with Docker
 
-The quickest path is the reference [`docker-compose.yml`](../docker-compose.yml)
+The quickest path is the reference
+[`docker-compose.yml`](https://github.com/nodetool-ai/nodetool/blob/main/docker-compose.yml)
 at the repo root — `cp .env.example .env && docker compose up -d`. See
 [Self-Hosted Deployment › Docker Compose](self-hosted-deployment.md#docker-compose-reference).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,12 @@ see the [End-to-End Deployment Guide](deployment-e2e-guide.md).
 
 ## Server: self-host with Docker
 
-The `nodetool deploy` commands manage a single Docker server target driven by a
+The quickest path is the reference [`docker-compose.yml`](../docker-compose.yml)
+at the repo root — `cp .env.example .env && docker compose up -d`. See
+[Self-Hosted Deployment › Docker Compose](self-hosted-deployment.md#docker-compose-reference).
+
+For a managed flow (remote hosts over SSH, image transfer, workflow sync), the
+`nodetool deploy` commands manage a single Docker server target driven by a
 `deployment.yaml` file.
 
 1. **Pull the base image**:

--- a/docs/self-hosted-deployment.md
+++ b/docs/self-hosted-deployment.md
@@ -22,7 +22,8 @@ Two paths:
 
 ## Docker Compose (reference)
 
-The repository ships a reference [`docker-compose.yml`](../docker-compose.yml)
+The repository ships a reference
+[`docker-compose.yml`](https://github.com/nodetool-ai/nodetool/blob/main/docker-compose.yml)
 for running one server on a host you control.
 
 ```bash

--- a/docs/self-hosted-deployment.md
+++ b/docs/self-hosted-deployment.md
@@ -12,6 +12,51 @@ Self-hosted deployment runs NodeTool in a **Docker** container — on `localhost
 or on a remote host reached over SSH. Docker is the only supported deployment
 `type` (`SUPPORTED_TYPES = ["docker"]`).
 
+Two paths:
+
+- **Docker Compose** — a single `docker-compose.yml` you run yourself. The
+  fastest way to stand up one server. See below.
+- **`nodetool deploy` CLI** — a managed flow driven by `deployment.yaml` that
+  also handles remote hosts over SSH, image transfer, and workflow sync. See
+  [Deployment Configuration](#deployment-configuration).
+
+## Docker Compose (reference)
+
+The repository ships a reference [`docker-compose.yml`](../docker-compose.yml)
+for running one server on a host you control.
+
+```bash
+cp .env.example .env      # fill in the provider keys you use
+docker compose up -d
+# open http://localhost:17777
+```
+
+The server binds to `0.0.0.0:7777` inside the container and is published on the
+host as `${NODETOOL_PORT:-17777}`. All persistent state — SQLite database,
+assets, vector store, model cache, and the generated secret key — lives under
+`/workspace`, backed by the named `nodetool-data` volume, so it survives
+restarts and image upgrades.
+
+Common overrides (set in `.env` or the shell):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NODETOOL_VERSION` | `latest` | Image tag to pull (pin a release in production) |
+| `NODETOOL_PORT` | `17777` | Host port mapped to the container's `7777` |
+| `SECRETS_MASTER_KEY` | auto-generated | 32-byte base64 key encrypting stored secrets — set explicitly in production (`openssl rand -base64 32`) |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `FAL_API_KEY`, `HF_TOKEN` | unset | Model provider keys |
+
+Upgrade in place:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+To store data in a host directory instead of the named volume, replace the
+`nodetool-data:/workspace` mount with a bind mount (e.g. `./nodetool-data:/workspace`)
+and make sure the host directory is writable by the container's `node` user.
+
 ## Deployment Configuration
 
 Deployments are configured via `deployment.yaml`.

--- a/docs/self-hosted-deployment.md
+++ b/docs/self-hosted-deployment.md
@@ -59,35 +59,36 @@ and make sure the host directory is writable by the container's `node` user.
 
 ### Authentication / login screen
 
-Auth has two layers, controlled separately:
+Auth is configured **entirely on the backend**. The web UI fetches its auth mode
+and public Supabase credentials at runtime from `GET /api/config` (a public,
+non-secret endpoint), so the same frontend build works with or without login —
+no rebuild, and it works even when the frontend is served from a different
+origin.
 
-- **Server enforcement (runtime).** With `SUPABASE_URL`/`SUPABASE_KEY` unset the
-  server runs in **Local mode**: localhost requests are trusted as a single user
-  and remote requests are rejected. Set both (the `KEY` is the service-role key)
-  to switch to **Supabase mode**, where the server requires a valid Supabase JWT
-  on every request. These are runtime env vars — uncomment them in the compose
-  `environment:` block. See [Authentication](authentication.md) and
-  [Supabase Deployment](supabase-deployment.md).
-- **The web login screen (build time).** Whether the browser shows a login page
-  is decided client-side: served on `localhost`/`127.0.0.1` the app skips login;
-  served on any other host it routes to `/login`. That login page authenticates
-  against Supabase using `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`, which Vite
-  inlines into the web bundle at **build time**. The prebuilt image ships without
-  them, so a working login screen requires building the image yourself.
+- **Login off (default).** With `SUPABASE_URL`/`SUPABASE_KEY` unset the server
+  runs in **Local mode**: localhost requests are trusted as a single user,
+  remote requests are rejected, and the UI shows no login screen.
+- **Login on.** Set these three on the server to switch to **Supabase mode** —
+  the server requires a valid Supabase JWT on every request and the UI shows the
+  login screen:
 
-To enable a working login screen, uncomment the `build:` block in the compose
-file and build locally with your Supabase project's public credentials:
+  ```bash
+  SUPABASE_URL=https://your-project.supabase.co
+  SUPABASE_KEY=your-service-role-key   # server-only, never sent to the browser
+  SUPABASE_ANON_KEY=your-anon-key      # public key the login screen uses
+  ```
 
-```bash
-VITE_SUPABASE_URL=https://your-project.supabase.co \
-VITE_SUPABASE_ANON_KEY=your-anon-key \
-SUPABASE_URL=https://your-project.supabase.co \
-SUPABASE_KEY=your-service-role-key \
-docker compose up -d --build
-```
+  Optionally set `AUTH_REDIRECT_URL` when serving behind a domain/proxy (it must
+  be in the Supabase project's redirect allow list).
 
-Point the frontend (`VITE_*`, anon key) and the server (`SUPABASE_*`, service-role
-key) at the same Supabase project.
+`GET /api/config` returns `authMode`, `supabaseUrl`, `supabaseAnonKey`,
+`authRedirectUrl`, and `version` — never the service-role key. See
+[Authentication](authentication.md) and [Supabase Deployment](supabase-deployment.md).
+
+> Serving the web UI from a **different origin** (e.g. a CDN)? Point the frontend
+> at the backend with the build-time `VITE_API_URL`, and add that origin to the
+> server's `NODETOOL_ALLOWED_ORIGINS` so the cross-origin `GET /api/config` and
+> API calls are permitted. Everything else still comes from `/api/config`.
 
 ## Deployment Configuration
 

--- a/docs/self-hosted-deployment.md
+++ b/docs/self-hosted-deployment.md
@@ -57,6 +57,38 @@ To store data in a host directory instead of the named volume, replace the
 `nodetool-data:/workspace` mount with a bind mount (e.g. `./nodetool-data:/workspace`)
 and make sure the host directory is writable by the container's `node` user.
 
+### Authentication / login screen
+
+Auth has two layers, controlled separately:
+
+- **Server enforcement (runtime).** With `SUPABASE_URL`/`SUPABASE_KEY` unset the
+  server runs in **Local mode**: localhost requests are trusted as a single user
+  and remote requests are rejected. Set both (the `KEY` is the service-role key)
+  to switch to **Supabase mode**, where the server requires a valid Supabase JWT
+  on every request. These are runtime env vars — uncomment them in the compose
+  `environment:` block. See [Authentication](authentication.md) and
+  [Supabase Deployment](supabase-deployment.md).
+- **The web login screen (build time).** Whether the browser shows a login page
+  is decided client-side: served on `localhost`/`127.0.0.1` the app skips login;
+  served on any other host it routes to `/login`. That login page authenticates
+  against Supabase using `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`, which Vite
+  inlines into the web bundle at **build time**. The prebuilt image ships without
+  them, so a working login screen requires building the image yourself.
+
+To enable a working login screen, uncomment the `build:` block in the compose
+file and build locally with your Supabase project's public credentials:
+
+```bash
+VITE_SUPABASE_URL=https://your-project.supabase.co \
+VITE_SUPABASE_ANON_KEY=your-anon-key \
+SUPABASE_URL=https://your-project.supabase.co \
+SUPABASE_KEY=your-service-role-key \
+docker compose up -d --build
+```
+
+Point the frontend (`VITE_*`, anon key) and the server (`SUPABASE_*`, service-role
+key) at the same Supabase project.
+
 ## Deployment Configuration
 
 Deployments are configured via `deployment.yaml`.

--- a/packages/websocket/src/routes/config.ts
+++ b/packages/websocket/src/routes/config.ts
@@ -1,0 +1,39 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getVersion } from "./health.js";
+
+/**
+ * Public, non-secret runtime configuration for the web client.
+ *
+ * Consolidates configuration on the backend: a separately-hosted frontend
+ * learns its auth mode and *public* Supabase credentials at runtime from the
+ * server it talks to, instead of baking `VITE_*` values into the bundle at
+ * build time. The web app fetches this at boot (see web `runtimeConfig.ts`).
+ *
+ * This endpoint MUST only expose values that are safe in a browser. The
+ * Supabase anon key (`SUPABASE_ANON_KEY`) is designed to ship to clients; the
+ * service-role key (`SUPABASE_KEY`) is never returned.
+ */
+const configRoute: FastifyPluginAsync = async (app) => {
+  app.get("/api/config", async (_req, reply) => {
+    const supabaseUrl = process.env["SUPABASE_URL"]?.trim() || null;
+    const supabaseServiceKey = process.env["SUPABASE_KEY"]?.trim() || null;
+    const supabaseAnonKey = process.env["SUPABASE_ANON_KEY"]?.trim() || null;
+    const authRedirectUrl = process.env["AUTH_REDIRECT_URL"]?.trim() || null;
+
+    // Mirror the server's auth-mode selection: "Supabase mode" (auth enforced)
+    // is chosen when both SUPABASE_URL and SUPABASE_KEY are set. Everything
+    // else is "Local mode" (loopback trusted, no login screen).
+    const authMode: "supabase" | "local" =
+      supabaseUrl && supabaseServiceKey ? "supabase" : "local";
+
+    return reply.status(200).send({
+      authMode,
+      supabaseUrl,
+      supabaseAnonKey,
+      authRedirectUrl,
+      version: getVersion()
+    });
+  });
+};
+
+export default configRoute;

--- a/packages/websocket/src/routes/health.ts
+++ b/packages/websocket/src/routes/health.ts
@@ -7,7 +7,7 @@ import { pingDb } from "@nodetool-ai/models";
 const serverStartTime = Date.now();
 
 // Read version from package.json
-function getVersion(): string {
+export function getVersion(): string {
   try {
     const packageJsonPath = resolve(
       dirname(fileURLToPath(import.meta.url)),

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -78,6 +78,7 @@ import {
 
 import websocketPlugin from "./plugins/websocket.js";
 import healthRoute from "./routes/health.js";
+import configRoute from "./routes/config.js";
 import assetsRoutes from "./routes/assets.js";
 import workflowsRoutes from "./routes/workflows.js";
 import jobsRoutes from "./routes/jobs.js";
@@ -751,6 +752,7 @@ app.addHook("onRequest", async (req, reply) => {
     pathname === "/health" ||
     pathname === "/ready" ||
     pathname === "/api/health" ||
+    pathname === "/api/config" ||
     pathname.startsWith("/api/oauth/") ||
     pathname === "/api/assets/packages" ||
     pathname.startsWith("/api/assets/packages/") ||
@@ -1050,6 +1052,7 @@ await app.register(websocketPlugin, {
 });
 
 await app.register(healthRoute);
+await app.register(configRoute);
 
 // All HTTP API routes receive apiOptions
 const routeOpts = { apiOptions };

--- a/packages/websocket/tests/config-api.test.ts
+++ b/packages/websocket/tests/config-api.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the public /api/config endpoint.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import configRoute from "../src/routes/config.js";
+
+const ENV_KEYS = [
+  "SUPABASE_URL",
+  "SUPABASE_KEY",
+  "SUPABASE_ANON_KEY",
+  "AUTH_REDIRECT_URL"
+] as const;
+
+describe("/api/config endpoint", () => {
+  let app: FastifyInstance;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+    app = Fastify({ logger: false });
+    await app.register(configRoute);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("reports local mode with no supabase env set", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/config" });
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(200);
+    expect(body.authMode).toBe("local");
+    expect(body.supabaseUrl).toBeNull();
+    expect(body.supabaseAnonKey).toBeNull();
+  });
+
+  it("reports supabase mode when URL + service key are set", async () => {
+    process.env.SUPABASE_URL = "https://x.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+
+    const res = await app.inject({ method: "GET", url: "/api/config" });
+    const body = JSON.parse(res.body);
+    expect(body.authMode).toBe("supabase");
+    expect(body.supabaseUrl).toBe("https://x.supabase.co");
+    expect(body.supabaseAnonKey).toBe("anon-key");
+  });
+
+  it("never exposes the service-role key", async () => {
+    process.env.SUPABASE_URL = "https://x.supabase.co";
+    process.env.SUPABASE_KEY = "super-secret-service-role-key";
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+
+    const res = await app.inject({ method: "GET", url: "/api/config" });
+    expect(res.body).not.toContain("super-secret-service-role-key");
+    expect(Object.keys(JSON.parse(res.body)).sort()).toEqual([
+      "authMode",
+      "authRedirectUrl",
+      "supabaseAnonKey",
+      "supabaseUrl",
+      "version"
+    ]);
+  });
+
+  it("stays in local mode when only the anon key is set", async () => {
+    process.env.SUPABASE_URL = "https://x.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+
+    const res = await app.inject({ method: "GET", url: "/api/config" });
+    const body = JSON.parse(res.body);
+    expect(body.authMode).toBe("local");
+  });
+});

--- a/web/src/__mocks__/supabaseClientMock.ts
+++ b/web/src/__mocks__/supabaseClientMock.ts
@@ -9,3 +9,5 @@ export const supabase = {
     signOut: jest.fn().mockResolvedValue({ error: null })
   }
 };
+
+export const initSupabaseFromConfig = jest.fn();

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -49,6 +49,8 @@ import Login from "./components/Login";
 import ProtectedRoute from "./components/ProtectedRoute";
 import useAuth from "./stores/useAuth";
 import { isLocalhost } from "./lib/env";
+import { loadRuntimeConfig, isAuthRequired } from "./lib/runtimeConfig";
+import { initSupabaseFromConfig } from "./lib/supabaseClient";
 import { initKeyListeners } from "./stores/KeyPressedStore";
 import useRemoteSettingsStore from "./stores/RemoteSettingStore";
 import { loadMetadata } from "./serverState/useMetadata";
@@ -178,7 +180,7 @@ const NavigateToStart = () => {
     if (state === "init") {
       return;
     }
-    if (isLocalhost || state === "logged_in") {
+    if (!isAuthRequired() || state === "logged_in") {
       navigate("/workspace", { replace: true });
     } else if (state === "logged_out" || state === "error") {
       navigate("/login", { replace: true });
@@ -550,9 +552,10 @@ const AppWrapper = () => {
   }, []);
 
   useEffect(() => {
-    // In production mode, wait until user is logged in before fetching metadata.
-    // When logged out, skip metadata so the router can render and redirect to /login.
-    if (!isLocalhost && authState !== "logged_in") {
+    // When auth is enforced, wait until the user is logged in before fetching
+    // metadata. When logged out, skip metadata so the router can render and
+    // redirect to /login.
+    if (isAuthRequired() && authState !== "logged_in") {
       if (authState === "logged_out" || authState === "error") {
         setStatus("logged_out");
       }
@@ -693,6 +696,12 @@ const AppWrapper = () => {
 
 // We need to make the initialization async
 const initialize = async () => {
+  // Learn auth mode and Supabase credentials from the backend before wiring up
+  // the client and auth, so the frontend reflects the server's configuration
+  // without any build-time VITE_* values.
+  const config = await loadRuntimeConfig();
+  initSupabaseFromConfig(config);
+
   useAuth.getState().initialize();
   initKeyListeners();
 

--- a/web/src/lib/__tests__/rest-fetch.test.ts
+++ b/web/src/lib/__tests__/rest-fetch.test.ts
@@ -5,16 +5,14 @@
 const mockFetch = jest.fn();
 (global as any).fetch = mockFetch;
 
-let mockIsLocalhost = false;
+let mockAuthRequired = true;
 
 jest.mock("../auth", () => ({
   authHeader: jest.fn()
 }));
 
-jest.mock("../env", () => ({
-  get isLocalhost() {
-    return mockIsLocalhost;
-  }
+jest.mock("../runtimeConfig", () => ({
+  isAuthRequired: () => mockAuthRequired
 }));
 
 jest.mock("../../stores/BASE_URL", () => ({
@@ -30,7 +28,7 @@ describe("restFetch", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockResolvedValue(new Response("ok"));
-    mockIsLocalhost = false;
+    mockAuthRequired = true;
   });
 
   describe("URL construction", () => {
@@ -54,8 +52,8 @@ describe("restFetch", () => {
   });
 
   describe("auth headers", () => {
-    it("includes auth headers when not localhost", async () => {
-      mockIsLocalhost = false;
+    it("includes auth headers when auth is required", async () => {
+      mockAuthRequired = true;
       mockAuthHeader.mockResolvedValue({
         Authorization: "Bearer test-token"
       });
@@ -68,8 +66,8 @@ describe("restFetch", () => {
       expect(headers.get("Authorization")).toBe("Bearer test-token");
     });
 
-    it("skips auth headers when in localhost mode", async () => {
-      mockIsLocalhost = true;
+    it("skips auth headers when auth is not required", async () => {
+      mockAuthRequired = false;
 
       await restFetch("/api/data");
 
@@ -91,7 +89,7 @@ describe("restFetch", () => {
     });
 
     it("merges custom headers with auth headers", async () => {
-      mockIsLocalhost = false;
+      mockAuthRequired = true;
       mockAuthHeader.mockResolvedValue({
         Authorization: "Bearer token"
       });

--- a/web/src/lib/__tests__/runtimeConfig.test.ts
+++ b/web/src/lib/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("../../stores/BASE_URL", () => ({
+  BASE_URL: "http://api.example.com"
+}));
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+const jsonResponse = (body: unknown, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body
+  }) as unknown as Response;
+
+describe("runtimeConfig", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("defaults to local auth before load", async () => {
+    const { isAuthRequired, getRuntimeConfig } = await import("../runtimeConfig");
+    expect(isAuthRequired()).toBe(false);
+    expect(getRuntimeConfig().supabaseUrl).toBeNull();
+  });
+
+  it("fetches /api/config from BASE_URL and applies supabase mode", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        authMode: "supabase",
+        supabaseUrl: "https://x.supabase.co",
+        supabaseAnonKey: "anon",
+        authRedirectUrl: null,
+        version: "1.2.3"
+      })
+    );
+
+    const { loadRuntimeConfig, isAuthRequired } = await import("../runtimeConfig");
+    const config = await loadRuntimeConfig();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://api.example.com/api/config",
+      expect.any(Object)
+    );
+    expect(config.authMode).toBe("supabase");
+    expect(isAuthRequired()).toBe(true);
+  });
+
+  it("falls back to local defaults when the endpoint is unavailable", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(null, false));
+
+    const { loadRuntimeConfig, isAuthRequired } = await import("../runtimeConfig");
+    const config = await loadRuntimeConfig();
+
+    expect(config.authMode).toBe("local");
+    expect(isAuthRequired()).toBe(false);
+  });
+
+  it("caches after the first successful load", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ authMode: "local", supabaseUrl: null })
+    );
+
+    const { loadRuntimeConfig } = await import("../runtimeConfig");
+    await loadRuntimeConfig();
+    await loadRuntimeConfig();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/rest-fetch.ts
+++ b/web/src/lib/rest-fetch.ts
@@ -1,5 +1,5 @@
 import { authHeader } from "./auth";
-import { isLocalhost } from "./env";
+import { isAuthRequired } from "./runtimeConfig";
 import { BASE_URL } from "../stores/BASE_URL";
 
 export async function restFetch(
@@ -8,7 +8,7 @@ export async function restFetch(
 ): Promise<Response> {
   const headers = new Headers(init.headers);
 
-  if (!isLocalhost) {
+  if (isAuthRequired()) {
     const authHeaders = await authHeader();
     Object.entries(authHeaders).forEach(([key, value]) => {
       headers.set(key, value);

--- a/web/src/lib/runtimeConfig.ts
+++ b/web/src/lib/runtimeConfig.ts
@@ -1,0 +1,83 @@
+/**
+ * Runtime configuration fetched from the backend at boot.
+ *
+ * Consolidates configuration on the server: the web app learns its auth mode
+ * and public Supabase credentials from `GET /api/config` at runtime instead of
+ * from build-time `VITE_*` variables. This lets a single frontend build talk to
+ * any backend — including one served from a different origin — and lets
+ * operators configure only the backend (see `packages/websocket/src/routes/config.ts`).
+ *
+ * Build-time `VITE_*` values remain a fallback in `supabaseClient.ts` for the
+ * dev server and pure-static hosting where `/api/config` is not reachable.
+ */
+import { BASE_URL } from "../stores/BASE_URL";
+
+export type AuthMode = "local" | "supabase";
+
+export interface RuntimeConfig {
+  /** Whether the backend enforces authentication. */
+  authMode: AuthMode;
+  /** Supabase project URL (Supabase mode only). */
+  supabaseUrl: string | null;
+  /** Supabase anon (public) key — safe to use in the browser. */
+  supabaseAnonKey: string | null;
+  /** Optional OAuth redirect override. */
+  authRedirectUrl: string | null;
+  /** Backend version, for diagnostics. */
+  version: string | null;
+}
+
+const DEFAULT_CONFIG: RuntimeConfig = {
+  authMode: "local",
+  supabaseUrl: null,
+  supabaseAnonKey: null,
+  authRedirectUrl: null,
+  version: null
+};
+
+let current: RuntimeConfig = DEFAULT_CONFIG;
+let loaded = false;
+
+/** The last-loaded runtime config (defaults until `loadRuntimeConfig` resolves). */
+export const getRuntimeConfig = (): RuntimeConfig => current;
+
+/** True when the backend enforces authentication (Supabase mode). */
+export const isAuthRequired = (): boolean => current.authMode === "supabase";
+
+const coerce = (data: unknown): RuntimeConfig => {
+  if (!data || typeof data !== "object") return DEFAULT_CONFIG;
+  const d = data as Partial<RuntimeConfig>;
+  return {
+    authMode: d.authMode === "supabase" ? "supabase" : "local",
+    supabaseUrl: d.supabaseUrl ?? null,
+    supabaseAnonKey: d.supabaseAnonKey ?? null,
+    authRedirectUrl: d.authRedirectUrl ?? null,
+    version: d.version ?? null
+  };
+};
+
+/**
+ * Fetch public runtime config from the backend (`GET /api/config`). Cached
+ * after the first successful load. On failure (e.g. an older server without
+ * the endpoint) it keeps the defaults so the app still boots.
+ */
+export const loadRuntimeConfig = async (): Promise<RuntimeConfig> => {
+  if (loaded) return current;
+  try {
+    const res = await fetch(`${BASE_URL}/api/config`, {
+      headers: { Accept: "application/json" },
+      // Don't let a slow/unreachable backend block app boot.
+      signal: AbortSignal.timeout(5000)
+    });
+    if (!res.ok) throw new Error(`GET /api/config failed: ${res.status}`);
+    current = coerce(await res.json());
+  } catch (err) {
+    console.warn(
+      "Runtime config unavailable; falling back to local auth defaults.",
+      err
+    );
+    current = DEFAULT_CONFIG;
+  }
+  loaded = true;
+  return current;
+};

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -1,23 +1,52 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { RuntimeConfig } from "./runtimeConfig";
 
 /**
- * Create the Supabase client using credentials from environment variables.
- * The variables should be provided in a Vite-compatible `.env` file or
- * through the deployment environment. This keeps sensitive data out of
- * the repository and allows easy configuration for different deployments.
+ * Supabase client for the web app.
+ *
+ * Credentials come from the backend at runtime via `GET /api/config` (see
+ * `runtimeConfig.ts`) and are applied at boot through `initSupabaseFromConfig`.
+ * The build-time `VITE_SUPABASE_*` variables remain a fallback for the dev
+ * server and pure-static hosting where `/api/config` is not reachable.
+ *
+ * The exported `supabase` handle is stable across (re)initialization: it proxies
+ * to a swappable underlying client, so existing `import { supabase }` callers
+ * keep working after runtime config replaces the credentials.
  */
 
-// Vite exposes environment variables via `import.meta.env`
-const supabaseUrl: string | undefined = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey: string | undefined = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const FALLBACK_URL = "http://localhost";
+const FALLBACK_ANON_KEY = "public-anon-key";
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn(
-    "Supabase credentials not found in environment. Using test placeholders for development."
-  );
-}
+const buildTimeUrl: string | undefined = import.meta.env.VITE_SUPABASE_URL;
+const buildTimeAnonKey: string | undefined =
+  import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(
-  supabaseUrl ?? "http://localhost",
-  supabaseAnonKey ?? "public-anon-key"
-);
+const makeClient = (
+  url: string | null | undefined,
+  key: string | null | undefined
+): SupabaseClient => {
+  const resolvedUrl = url || buildTimeUrl || FALLBACK_URL;
+  const resolvedKey = key || buildTimeAnonKey || FALLBACK_ANON_KEY;
+  if (!url && !buildTimeUrl) {
+    console.warn(
+      "Supabase credentials not configured. Using placeholders — login will " +
+        "not work until the backend provides them via /api/config (or " +
+        "VITE_SUPABASE_* is set at build time)."
+    );
+  }
+  return createClient(resolvedUrl, resolvedKey);
+};
+
+let innerClient: SupabaseClient = makeClient(null, null);
+
+/**
+ * Rebuild the Supabase client from runtime config fetched from the backend.
+ * Called once at boot after `loadRuntimeConfig()`, before auth initializes.
+ */
+export const initSupabaseFromConfig = (config: RuntimeConfig): void => {
+  innerClient = makeClient(config.supabaseUrl, config.supabaseAnonKey);
+};
+
+export const supabase = new Proxy({} as SupabaseClient, {
+  get: (_target, prop) => Reflect.get(innerClient, prop)
+});

--- a/web/src/stores/useAuth.ts
+++ b/web/src/stores/useAuth.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { createErrorMessage } from "../utils/errorHandling";
 import { supabase } from "../lib/supabaseClient"; // Import Supabase client
 import type { Session, User, Provider } from "@supabase/supabase-js"; // Import Supabase types
-import { isLocalhost } from "../lib/env"; // Keep isLocalhost for potential dev bypass
+import { getRuntimeConfig, isAuthRequired } from "../lib/runtimeConfig";
 
 type OAuthProviderSupabase = Extract<Provider, "google" | "facebook">;
 
@@ -22,6 +22,11 @@ type OAuthProviderSupabase = Extract<Provider, "google" | "facebook">;
  *   2. `window.location.origin + "/"` at runtime.
  */
 export const getAuthRedirectUrl = (): string => {
+  // Runtime config from the backend wins when present.
+  const fromRuntime = getRuntimeConfig().authRedirectUrl;
+  if (fromRuntime) {
+    return fromRuntime;
+  }
   // Try to use process.env first (for Jest tests) to avoid SyntaxError with import.meta outside a module
   let configured;
   if (typeof process !== "undefined" && process.env && process.env.VITE_AUTH_REDIRECT_URL) {
@@ -111,7 +116,8 @@ export const useAuth = create<LoginStore>((set, get) => ({
    * Initializes the authentication state.
    * - Checks for an existing Supabase session on load.
    * - Sets up `onAuthStateChange` listener to react to login/logout events.
-   * - Bypasses Supabase check if `isLocalhost` is true for development convenience.
+   * - Skips the Supabase check when the backend does not enforce auth
+   *   (Local mode), auto-logging in as the single local user.
    */
   initialize: async () => {
     console.info("Auth: Initializing...");
@@ -119,9 +125,9 @@ export const useAuth = create<LoginStore>((set, get) => ({
     // Clean up any existing subscription before initializing
     get().cleanup();
 
-    if (isLocalhost) {
-      // Provide a predictable state for local development without requiring login
-      console.info("Auth: Running in localhost mode, setting state to logged_in.");
+    if (!isAuthRequired()) {
+      // Backend runs in Local mode — no login screen, single local user.
+      console.info("Auth: Local mode, setting state to logged_in.");
       set({
         state: "logged_in", // Assume logged in for local dev
         session: null,

--- a/web/src/trpc/client.ts
+++ b/web/src/trpc/client.ts
@@ -7,13 +7,13 @@ import {
 } from "@trpc/client";
 import type { AppRouter } from "@nodetool-ai/websocket/trpc";
 import { BASE_URL } from "../stores/BASE_URL";
-import { isLocalhost } from "../lib/env";
+import { isAuthRequired } from "../lib/runtimeConfig";
 import { supabase } from "../lib/supabaseClient";
 
 export const trpc = createTRPCReact<AppRouter>();
 
 async function authHeaders(): Promise<Record<string, string>> {
-  if (isLocalhost) return {};
+  if (!isAuthRequired()) return {};
   const {
     data: { session }
   } = await supabase.auth.getSession();


### PR DESCRIPTION
## Summary

Moves authentication configuration from build-time environment variables to runtime discovery. The web app now fetches its auth mode and public Supabase credentials from a new `GET /api/config` endpoint on the backend at boot, enabling a single frontend build to work with any backend — including one served from a different origin — without rebuild.

## Key Changes

- **New `web/src/lib/runtimeConfig.ts`**: Exports `loadRuntimeConfig()` to fetch config from `GET /api/config` with a 5-second timeout, caching after first load. Provides `getRuntimeConfig()` and `isAuthRequired()` helpers. Falls back to local auth defaults if the endpoint is unavailable (e.g., older servers).

- **New `packages/websocket/src/routes/config.ts`**: Public endpoint that returns `authMode`, `supabaseUrl`, `supabaseAnonKey`, `authRedirectUrl`, and `version`. Determines auth mode by checking if both `SUPABASE_URL` and `SUPABASE_KEY` are set; never exposes the service-role key.

- **Updated `web/src/lib/supabaseClient.ts`**: Refactored to use a swappable inner client. New `initSupabaseFromConfig()` rebuilds the client from runtime config. Build-time `VITE_SUPABASE_*` variables remain a fallback for dev and pure-static hosting.

- **Updated `web/src/index.tsx`**: Calls `loadRuntimeConfig()` and `initSupabaseFromConfig()` at boot before auth initializes. Replaces `isLocalhost` checks with `isAuthRequired()` for routing and metadata fetching.

- **Updated `web/src/stores/useAuth.ts`**: `getAuthRedirectUrl()` now checks runtime config first, then falls back to build-time `VITE_AUTH_REDIRECT_URL`.

- **Updated `web/src/lib/rest-fetch.ts` and `web/src/trpc/client.ts`**: Replace `isLocalhost` with `isAuthRequired()` for auth header logic.

- **New `docker-compose.yml`**: Reference Docker Compose for self-hosting. Binds to `0.0.0.0:7777` inside the container, published as `${NODETOOL_PORT:-17777}` on the host. All persistent state lives on the `nodetool-data` volume.

- **Updated `docs/self-hosted-deployment.md`**: Added Docker Compose quick-start section with environment variable reference and authentication configuration guide.

- **Updated `.env.example`**: Added commented Supabase and auth redirect environment variables with explanatory comments.

- **Updated `Dockerfile`**: Clarified that web build no longer needs `VITE_*` args since config comes from the backend at runtime.

- **Updated `packages/websocket/src/routes/health.ts`**: Exported `getVersion()` for use by the config endpoint.

- **Updated `packages/websocket/src/server.ts`**: Registered the new `configRoute`.

- **Tests**: Added `web/src/lib/__tests__/runtimeConfig.test.ts` (Jest) and `packages/websocket/tests/config-api.test.ts` (Vitest) covering fetch, fallback, caching, and security (service-role key never exposed).

## Implementation Details

- **Backward compatible**: Build-time `VITE_SUPABASE_*` variables still work as a fallback, so dev servers and pure-static hosting are unaffected.
- **Timeout protection**: 5-second timeout on the config fetch prevents slow/unreachable backends from blocking app boot.
- **Proxy pattern**: The exported `supabase` client is a Proxy that delegates to a swappable inner client, so existing callers keep working after runtime config replaces credentials.
- **Auth mode logic**: "Supabase mode" (auth enforced) is chosen when both `SUPABASE_URL` and `SUPABASE_KEY` are set on the backend; everything else is "Local mode" (loopback trusted, no login screen).
- **Security**: The config endpoint only returns

https://claude.ai/code/session_01Lv1qkdX6CHQuVxvnGrK6LE