### PR TITLE
Add rename, duplicate, and delete actions to timeline and sketch lists

### DIFF
--- a/web/src/components/context_menus/ContextMenus.tsx
+++ b/web/src/components/context_menus/ContextMenus.tsx
@@ -9,6 +9,7 @@ import InputContextMenu from "./InputContextMenu";
 import EdgeContextMenu from "./EdgeContextMenu";
 import ConnectionMatchMenu from "./ConnectionMatchMenu";
 import WorkflowContextMenu from "./WorkflowContextMenu";
+import SidebarDocumentContextMenu from "./SidebarDocumentContextMenu";
 
 const ContextMenus = memo(function ContextMenus() {
     const { openMenuType } = useContextMenu();
@@ -24,6 +25,9 @@ const ContextMenus = memo(function ContextMenus() {
             {openMenuType === "edge-context-menu" && <EdgeContextMenu />}
             {openMenuType === "connection-match-menu" && <ConnectionMatchMenu />}
             {openMenuType === "workflow-context-menu" && <WorkflowContextMenu />}
+            {openMenuType === "sidebar-document-context-menu" && (
+                <SidebarDocumentContextMenu />
+            )}
         </>
     );
 });

--- a/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
+++ b/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback } from "react";
+
+import { Text, ContextMenu, MenuItem } from "../ui_primitives";
+import ContextMenuItem from "./ContextMenuItem";
+import useContextMenuStore from "../../stores/ContextMenuStore";
+import {
+  useSidebarDocumentActions,
+  type SidebarDocumentItem
+} from "../../stores/SidebarDocumentActionsStore";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+
+/**
+ * Right-click menu for sidebar document list items (timelines and sketches).
+ * Mirrors WorkflowContextMenu, offering the actions that apply to these
+ * documents: rename, duplicate, delete.
+ */
+const SidebarDocumentContextMenu: React.FC = () => {
+  const menuPosition = useContextMenuStore((state) => state.menuPosition);
+  const closeContextMenu = useContextMenuStore(
+    (state) => state.closeContextMenu
+  );
+  const payload = useContextMenuStore(
+    (state) => state.payload
+  ) as SidebarDocumentItem | null;
+
+  const { onRename, onDuplicate, onDelete } = useSidebarDocumentActions();
+
+  const handleRename = useCallback(() => {
+    if (payload && onRename) {
+      onRename(payload);
+    }
+    closeContextMenu();
+  }, [payload, onRename, closeContextMenu]);
+
+  const handleDuplicate = useCallback(() => {
+    if (payload && onDuplicate) {
+      onDuplicate(payload);
+    }
+    closeContextMenu();
+  }, [payload, onDuplicate, closeContextMenu]);
+
+  const handleDelete = useCallback(() => {
+    if (payload && onDelete) {
+      onDelete(payload);
+    }
+    closeContextMenu();
+  }, [payload, onDelete, closeContextMenu]);
+
+  if (!menuPosition || !payload) {
+    return null;
+  }
+
+  return (
+    <ContextMenu
+      className="context-menu sidebar-document-context-menu"
+      open={menuPosition !== null}
+      onClose={closeContextMenu}
+      onContextMenu={(event) => event.preventDefault()}
+      position={menuPosition}
+    >
+      <MenuItem disabled>
+        <Text>{payload.name}</Text>
+      </MenuItem>
+      <ContextMenuItem
+        onClick={handleRename}
+        label="Rename"
+        IconComponent={<EditIcon />}
+      />
+      <ContextMenuItem
+        onClick={handleDuplicate}
+        label="Duplicate"
+        IconComponent={<ContentCopyIcon />}
+      />
+      <ContextMenuItem
+        onClick={handleDelete}
+        label="Delete"
+        addButtonClassName="delete"
+        IconComponent={<DeleteIcon />}
+      />
+    </ContextMenu>
+  );
+};
+
+export default SidebarDocumentContextMenu;

--- a/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
+++ b/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
@@ -55,7 +55,7 @@ const SidebarDocumentContextMenu: React.FC = () => {
   return (
     <ContextMenu
       className="context-menu sidebar-document-context-menu"
-      open={menuPosition !== null}
+      open
       onClose={closeContextMenu}
       onContextMenu={(event) => event.preventDefault()}
       position={menuPosition}

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -13,14 +13,20 @@ import {
   useRef,
   useState
 } from "react";
-import type { DragEvent, KeyboardEvent } from "react";
+import type { DragEvent, FocusEvent, KeyboardEvent, MouseEvent } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { usePanelStore } from "../../stores/PanelStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { serializeDragData, useDragDropStore } from "../../lib/dragdrop";
+import useContextMenuStore from "../../stores/ContextMenuStore";
+import {
+  useSidebarDocumentActionsStore,
+  type SidebarDocumentItem
+} from "../../stores/SidebarDocumentActionsStore";
 import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
+import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import {
   EmptyState,
@@ -73,6 +79,17 @@ const styles = (theme: Theme) =>
       flexShrink: 0,
       color: theme.vars.palette.text.secondary,
       fontSize: 20
+    },
+    ".rename-input": {
+      width: "100%",
+      background: "transparent",
+      border: `1px solid ${theme.vars.palette.primary.main}`,
+      borderRadius: theme.rounded.sm,
+      color: "inherit",
+      padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
+      fontSize: "var(--fontSizeSmall)",
+      fontWeight: 600,
+      outline: "none"
     },
     ".date-header-row": {
       width: "100%",
@@ -154,7 +171,11 @@ interface SketchListItemProps {
   name: string;
   updatedAt: string;
   active: boolean;
+  editing: boolean;
   onOpen: (id: string, name: string) => void;
+  onContextMenu: (event: MouseEvent<HTMLButtonElement>, id: string, name: string) => void;
+  onCommitRename: (id: string, newName: string) => void;
+  onCancelRename: () => void;
 }
 
 const SketchListItem = memo(function SketchListItem({
@@ -162,11 +183,36 @@ const SketchListItem = memo(function SketchListItem({
   name,
   updatedAt,
   active,
-  onOpen
+  editing,
+  onOpen,
+  onContextMenu,
+  onCommitRename,
+  onCancelRename
 }: SketchListItemProps) {
   const setActiveDrag = useDragDropStore((state) => state.setActiveDrag);
   const clearDrag = useDragDropStore((state) => state.clearDrag);
   const handleClick = useCallback(() => onOpen(id, name), [id, name, onOpen]);
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => onContextMenu(event, id, name),
+    [id, name, onContextMenu]
+  );
+  const handleRenameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      if (event.key === "Enter") {
+        onCommitRename(id, event.currentTarget.value);
+      } else if (event.key === "Escape") {
+        onCancelRename();
+      }
+    },
+    [id, onCommitRename, onCancelRename]
+  );
+  const handleRenameBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      onCommitRename(id, event.currentTarget.value);
+    },
+    [id, onCommitRename]
+  );
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
       if (event.key === "Enter" || event.key === " ") {
@@ -204,12 +250,35 @@ const SketchListItem = memo(function SketchListItem({
     clearDrag();
   }, [clearDrag]);
 
+  if (editing) {
+    return (
+      <div className={`sketch-item ${active ? "active" : ""}`}>
+        <FlexRow align="center" gap={1} fullWidth>
+          <BrushOutlinedIcon className="sketch-icon" />
+          <FlexColumn gap={0.5} sx={{ minWidth: 0, flex: 1 }}>
+            <input
+              className="rename-input"
+              type="text"
+              defaultValue={name}
+              aria-label="Sketch name"
+              autoFocus
+              onFocus={(event) => event.currentTarget.select()}
+              onKeyDown={handleRenameKeyDown}
+              onBlur={handleRenameBlur}
+            />
+          </FlexColumn>
+        </FlexRow>
+      </div>
+    );
+  }
+
   return (
     <button
       type="button"
       className={`sketch-item ${active ? "active" : ""}`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      onContextMenu={handleContextMenu}
       draggable
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
@@ -331,8 +400,116 @@ const SketchListPanel = () => {
     [location.pathname, navigate, openTab, setVisibility]
   );
 
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [itemToDelete, setItemToDelete] = useState<SidebarDocumentItem | null>(
+    null
+  );
+  const utils = trpc.useUtils();
+  const createSketch = trpc.sketch.create.useMutation({
+    onSuccess: () => {
+      void utils.sketch.list.invalidate();
+    }
+  });
+  const updateSketch = trpc.sketch.update.useMutation({
+    onSuccess: () => {
+      void utils.sketch.list.invalidate();
+    }
+  });
+  const deleteSketch = trpc.sketch.delete.useMutation({
+    onSuccess: () => {
+      void utils.sketch.list.invalidate();
+    }
+  });
+  const openContextMenu = useContextMenuStore((state) => state.openContextMenu);
+  const setActions = useSidebarDocumentActionsStore((state) => state.setActions);
+  const clearActions = useSidebarDocumentActionsStore(
+    (state) => state.clearActions
+  );
+
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<HTMLButtonElement>, id: string, name: string) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openContextMenu(
+        "sidebar-document-context-menu",
+        id,
+        event.clientX,
+        event.clientY,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { id, name }
+      );
+    },
+    [openContextMenu]
+  );
+
+  const handleCommitRename = useCallback(
+    (id: string, newName: string) => {
+      const trimmed = newName.trim();
+      const current = (data ?? []).find((s) => s.id === id);
+      setEditingId(null);
+      if (trimmed && current && trimmed !== current.name) {
+        updateSketch.mutate({ id, name: trimmed });
+      }
+    },
+    [data, updateSketch]
+  );
+
+  const handleDuplicate = useCallback(
+    async (item: SidebarDocumentItem) => {
+      try {
+        const source = await utils.sketch.get.fetch({ id: item.id });
+        const copy = await createSketch.mutateAsync({
+          name: `${source.name} (copy)`.substring(0, 200),
+          projectId: source.projectId,
+          width: source.width,
+          height: source.height,
+          backgroundColor: source.backgroundColor
+        });
+        await updateSketch.mutateAsync({
+          id: copy.id,
+          document: source.document
+        });
+      } catch (error) {
+        console.error("Failed to duplicate sketch", error);
+      }
+    },
+    [utils, createSketch, updateSketch]
+  );
+
+  const handleRequestDelete = useCallback((item: SidebarDocumentItem) => {
+    setItemToDelete(item);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (itemToDelete) {
+      deleteSketch.mutate({ id: itemToDelete.id });
+    }
+  }, [itemToDelete, deleteSketch]);
+
+  useEffect(() => {
+    setActions({
+      onRename: (item) => setEditingId(item.id),
+      onDuplicate: (item) => void handleDuplicate(item),
+      onDelete: handleRequestDelete
+    });
+    return () => clearActions();
+  }, [setActions, clearActions, handleDuplicate, handleRequestDelete]);
+
   return (
     <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
+      <ConfirmDialog
+        open={itemToDelete !== null}
+        onClose={() => setItemToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        title="Delete sketch"
+        content={`Delete "${itemToDelete?.name ?? ""}"? This cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
       <div className="sketch-search">
         <CategorySearchBar
           ref={searchRef}
@@ -392,7 +569,11 @@ const SketchListPanel = () => {
                     name={sketch.name}
                     updatedAt={sketch.updatedAt}
                     active={sketch.id === activeSketchId}
+                    editing={sketch.id === editingId}
                     onOpen={handleOpen}
+                    onContextMenu={handleContextMenu}
+                    onCommitRename={handleCommitRename}
+                    onCancelRename={() => setEditingId(null)}
                   />
                 </Fragment>
               );

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -13,14 +13,21 @@ import {
   useRef,
   useState
 } from "react";
-import type { DragEvent, KeyboardEvent } from "react";
+import type { DragEvent, FocusEvent, KeyboardEvent, MouseEvent } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { useCreateTimeline, useTimelines } from "../../hooks/useTimelineSequence";
 import { usePanelStore } from "../../stores/PanelStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { serializeDragData, useDragDropStore } from "../../lib/dragdrop";
+import useContextMenuStore from "../../stores/ContextMenuStore";
+import {
+  useSidebarDocumentActionsStore,
+  type SidebarDocumentItem
+} from "../../stores/SidebarDocumentActionsStore";
+import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
+import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import {
   EmptyState,
@@ -73,6 +80,17 @@ const styles = (theme: Theme) =>
       flexShrink: 0,
       color: theme.vars.palette.text.secondary,
       fontSize: 20
+    },
+    ".rename-input": {
+      width: "100%",
+      background: "transparent",
+      border: `1px solid ${theme.vars.palette.primary.main}`,
+      borderRadius: theme.rounded.sm,
+      color: "inherit",
+      padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
+      fontSize: "var(--fontSizeSmall)",
+      fontWeight: 600,
+      outline: "none"
     },
     ".date-header-row": {
       width: "100%",
@@ -154,7 +172,11 @@ interface TimelineListItemProps {
   name: string;
   updatedAt: string;
   active: boolean;
+  editing: boolean;
   onOpen: (id: string, name: string) => void;
+  onContextMenu: (event: MouseEvent<HTMLButtonElement>, id: string, name: string) => void;
+  onCommitRename: (id: string, newName: string) => void;
+  onCancelRename: () => void;
 }
 
 const TimelineListItem = memo(function TimelineListItem({
@@ -162,11 +184,36 @@ const TimelineListItem = memo(function TimelineListItem({
   name,
   updatedAt,
   active,
-  onOpen
+  editing,
+  onOpen,
+  onContextMenu,
+  onCommitRename,
+  onCancelRename
 }: TimelineListItemProps) {
   const setActiveDrag = useDragDropStore((state) => state.setActiveDrag);
   const clearDrag = useDragDropStore((state) => state.clearDrag);
   const handleClick = useCallback(() => onOpen(id, name), [id, name, onOpen]);
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => onContextMenu(event, id, name),
+    [id, name, onContextMenu]
+  );
+  const handleRenameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      if (event.key === "Enter") {
+        onCommitRename(id, event.currentTarget.value);
+      } else if (event.key === "Escape") {
+        onCancelRename();
+      }
+    },
+    [id, onCommitRename, onCancelRename]
+  );
+  const handleRenameBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      onCommitRename(id, event.currentTarget.value);
+    },
+    [id, onCommitRename]
+  );
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
       if (event.key === "Enter" || event.key === " ") {
@@ -204,12 +251,35 @@ const TimelineListItem = memo(function TimelineListItem({
     clearDrag();
   }, [clearDrag]);
 
+  if (editing) {
+    return (
+      <div className={`timeline-item ${active ? "active" : ""}`}>
+        <FlexRow align="center" gap={1} fullWidth>
+          <MovieOutlinedIcon className="timeline-icon" />
+          <FlexColumn gap={0.5} sx={{ minWidth: 0, flex: 1 }}>
+            <input
+              className="rename-input"
+              type="text"
+              defaultValue={name}
+              aria-label="Timeline name"
+              autoFocus
+              onFocus={(event) => event.currentTarget.select()}
+              onKeyDown={handleRenameKeyDown}
+              onBlur={handleRenameBlur}
+            />
+          </FlexColumn>
+        </FlexRow>
+      </div>
+    );
+  }
+
   return (
     <button
       type="button"
       className={`timeline-item ${active ? "active" : ""}`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      onContextMenu={handleContextMenu}
       draggable
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
@@ -323,8 +393,118 @@ const TimelineListPanel = () => {
     [location.pathname, navigate, openTab, setVisibility]
   );
 
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [itemToDelete, setItemToDelete] = useState<SidebarDocumentItem | null>(
+    null
+  );
+  const utils = trpc.useUtils();
+  const createTimeline = useCreateTimeline();
+  const updateTimeline = trpc.timeline.update.useMutation({
+    onSuccess: () => {
+      void utils.timeline.list.invalidate();
+    }
+  });
+  const deleteTimeline = trpc.timeline.delete.useMutation({
+    onSuccess: () => {
+      void utils.timeline.list.invalidate();
+    }
+  });
+  const openContextMenu = useContextMenuStore((state) => state.openContextMenu);
+  const setActions = useSidebarDocumentActionsStore((state) => state.setActions);
+  const clearActions = useSidebarDocumentActionsStore(
+    (state) => state.clearActions
+  );
+
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<HTMLButtonElement>, id: string, name: string) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openContextMenu(
+        "sidebar-document-context-menu",
+        id,
+        event.clientX,
+        event.clientY,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { id, name }
+      );
+    },
+    [openContextMenu]
+  );
+
+  const handleCommitRename = useCallback(
+    (id: string, newName: string) => {
+      const trimmed = newName.trim();
+      const current = (data ?? []).find((t) => t.id === id);
+      setEditingId(null);
+      if (trimmed && current && trimmed !== current.name) {
+        updateTimeline.mutate({ id, name: trimmed });
+      }
+    },
+    [data, updateTimeline]
+  );
+
+  const handleDuplicate = useCallback(
+    async (item: SidebarDocumentItem) => {
+      try {
+        const source = await utils.timeline.get.fetch({ id: item.id });
+        const copy = await createTimeline.mutateAsync({
+          name: `${source.name} (copy)`.substring(0, 200),
+          projectId: source.projectId,
+          fps: source.fps,
+          width: source.width,
+          height: source.height
+        });
+        await updateTimeline.mutateAsync({
+          id: copy.id,
+          document: {
+            tracks: source.tracks,
+            clips: source.clips,
+            markers: source.markers,
+            transcript: source.transcript,
+            scriptEnabled: source.scriptEnabled
+          }
+        });
+      } catch (error) {
+        console.error("Failed to duplicate timeline", error);
+      }
+    },
+    [utils, createTimeline, updateTimeline]
+  );
+
+  const handleRequestDelete = useCallback((item: SidebarDocumentItem) => {
+    setItemToDelete(item);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (itemToDelete) {
+      deleteTimeline.mutate({ id: itemToDelete.id });
+    }
+  }, [itemToDelete, deleteTimeline]);
+
+  useEffect(() => {
+    setActions({
+      onRename: (item) => setEditingId(item.id),
+      onDuplicate: (item) => void handleDuplicate(item),
+      onDelete: handleRequestDelete
+    });
+    return () => clearActions();
+  }, [setActions, clearActions, handleDuplicate, handleRequestDelete]);
+
   return (
     <FlexColumn fullHeight fullWidth gap={0} css={styles(theme)}>
+      <ConfirmDialog
+        open={itemToDelete !== null}
+        onClose={() => setItemToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        title="Delete timeline"
+        content={`Delete "${itemToDelete?.name ?? ""}"? This cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
       <div className="timeline-search">
         <CategorySearchBar
           ref={searchRef}
@@ -384,7 +564,11 @@ const TimelineListPanel = () => {
                     name={timeline.name}
                     updatedAt={timeline.updatedAt}
                     active={timeline.id === activeTimelineId}
+                    editing={timeline.id === editingId}
                     onOpen={handleOpen}
+                    onContextMenu={handleContextMenu}
+                    onCommitRename={handleCommitRename}
+                    onCancelRename={() => setEditingId(null)}
                   />
                 </Fragment>
               );

--- a/web/src/stores/SidebarDocumentActionsStore.ts
+++ b/web/src/stores/SidebarDocumentActionsStore.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
+
+/**
+ * Minimal identity for a sidebar document (timeline or sketch) that the shared
+ * context menu operates on.
+ */
+export interface SidebarDocumentItem {
+  id: string;
+  name: string;
+}
+
+interface SidebarDocumentActionsState {
+  onRename: ((item: SidebarDocumentItem) => void) | null;
+  onDuplicate: ((item: SidebarDocumentItem) => void) | null;
+  onDelete: ((item: SidebarDocumentItem) => void) | null;
+  setActions: (actions: {
+    onRename?: (item: SidebarDocumentItem) => void;
+    onDuplicate?: (item: SidebarDocumentItem) => void;
+    onDelete?: (item: SidebarDocumentItem) => void;
+  }) => void;
+  clearActions: () => void;
+}
+
+/**
+ * Holds the action handlers for the currently mounted sidebar document list
+ * (timelines or sketches). Only one such list is mounted at a time, so a single
+ * shared store is enough — it mirrors WorkflowActionsStore. The globally
+ * rendered SidebarDocumentContextMenu reads these handlers; the list panel sets
+ * them on mount and clears them on unmount.
+ */
+export const useSidebarDocumentActionsStore =
+  create<SidebarDocumentActionsState>((set) => ({
+    onRename: null,
+    onDuplicate: null,
+    onDelete: null,
+    setActions: (actions) =>
+      set({
+        onRename: actions.onRename ?? null,
+        onDuplicate: actions.onDuplicate ?? null,
+        onDelete: actions.onDelete ?? null
+      }),
+    clearActions: () =>
+      set({ onRename: null, onDuplicate: null, onDelete: null })
+  }));
+
+export const useSidebarDocumentActions = () =>
+  useSidebarDocumentActionsStore(
+    useShallow((state) => ({
+      onRename: state.onRename,
+      onDuplicate: state.onDuplicate,
+      onDelete: state.onDelete
+    }))
+  );

--- a/web/src/stores/__tests__/SidebarDocumentActionsStore.test.ts
+++ b/web/src/stores/__tests__/SidebarDocumentActionsStore.test.ts
@@ -1,0 +1,71 @@
+import { act } from "@testing-library/react";
+import {
+  useSidebarDocumentActionsStore,
+  type SidebarDocumentItem
+} from "../SidebarDocumentActionsStore";
+
+describe("SidebarDocumentActionsStore", () => {
+  beforeEach(() => {
+    act(() => {
+      useSidebarDocumentActionsStore.getState().clearActions();
+    });
+  });
+
+  it("starts with no actions", () => {
+    const state = useSidebarDocumentActionsStore.getState();
+    expect(state.onRename).toBeNull();
+    expect(state.onDuplicate).toBeNull();
+    expect(state.onDelete).toBeNull();
+  });
+
+  it("stores the handlers passed to setActions", () => {
+    const item: SidebarDocumentItem = { id: "t1", name: "Clip" };
+    const onRename = jest.fn();
+    const onDuplicate = jest.fn();
+    const onDelete = jest.fn();
+
+    act(() => {
+      useSidebarDocumentActionsStore
+        .getState()
+        .setActions({ onRename, onDuplicate, onDelete });
+    });
+
+    const state = useSidebarDocumentActionsStore.getState();
+    state.onRename?.(item);
+    state.onDuplicate?.(item);
+    state.onDelete?.(item);
+
+    expect(onRename).toHaveBeenCalledWith(item);
+    expect(onDuplicate).toHaveBeenCalledWith(item);
+    expect(onDelete).toHaveBeenCalledWith(item);
+  });
+
+  it("nulls out handlers omitted from setActions", () => {
+    act(() => {
+      useSidebarDocumentActionsStore
+        .getState()
+        .setActions({ onDelete: jest.fn() });
+    });
+
+    const state = useSidebarDocumentActionsStore.getState();
+    expect(state.onRename).toBeNull();
+    expect(state.onDuplicate).toBeNull();
+    expect(state.onDelete).not.toBeNull();
+  });
+
+  it("clearActions resets all handlers", () => {
+    act(() => {
+      useSidebarDocumentActionsStore.getState().setActions({
+        onRename: jest.fn(),
+        onDuplicate: jest.fn(),
+        onDelete: jest.fn()
+      });
+      useSidebarDocumentActionsStore.getState().clearActions();
+    });
+
+    const state = useSidebarDocumentActionsStore.getState();
+    expect(state.onRename).toBeNull();
+    expect(state.onDuplicate).toBeNull();
+    expect(state.onDelete).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds context menu support and inline rename functionality to the timeline and sketch list panels, enabling users to rename, duplicate, and delete documents directly from the sidebar.

## Key Changes

- **Inline rename UI**: Added `.rename-input` styles and conditional rendering in `TimelineListItem` and `SketchListItem` to show an editable input field when in edit mode. Supports Enter to confirm, Escape to cancel, and blur to auto-commit.

- **Context menu integration**: Both list panels now handle right-click events and open a shared `SidebarDocumentContextMenu` with rename, duplicate, and delete options.

- **New store**: Created `SidebarDocumentActionsStore` to hold action handlers (`onRename`, `onDuplicate`, `onDelete`) for the currently mounted list panel. The context menu reads these handlers; each panel sets them on mount and clears on unmount.

- **New context menu component**: `SidebarDocumentContextMenu` mirrors `WorkflowContextMenu`, displaying the document name and three action items with appropriate icons.

- **Duplicate logic**: Implemented in both panels via `handleDuplicate` callbacks that fetch the source document, create a copy with "(copy)" suffix, and clone its content (tracks/clips/markers for timelines; document for sketches).

- **Delete confirmation**: Added `ConfirmDialog` to both panels for safe deletion with user confirmation before calling the delete mutation.

- **TRPC mutations**: Both panels now use `trpc.timeline.update/delete` and `trpc.sketch.update/delete` mutations with cache invalidation on success.

- **Event handling**: Added `onContextMenu` prop to list items, `handleCommitRename` and `handleCancelRename` callbacks, and keyboard/blur handlers for the rename input.

## Implementation Details

- Rename input auto-focuses and selects all text on mount for immediate editing.
- Duplicate appends "(copy)" to the name and truncates to 200 characters.
- All mutations invalidate the list query to refresh the UI.
- The store uses `useShallow` for efficient selector composition.
- Tests added for `SidebarDocumentActionsStore` covering setActions, clearActions, and handler invocation.

https://claude.ai/code/session_013Sr1wWAWoTABt4gNNBujH9