### PR TITLE
Remove collapsible composer feature from MediaChatComposer

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -81,53 +81,21 @@ export const createMediaComposerStyles = (theme: Theme) =>
       width: "100%",
       padding: `0 ${theme.spacing(2)}`,
       boxSizing: "border-box",
-      // Trailing run actions must stay pinned to the right even when the
-      // collapsible cluster below shrinks to zero height, so the row itself
-      // does not wrap. The chip cluster wraps internally instead.
+      // Trailing run actions stay pinned to the right, so the row itself does
+      // not wrap. The chip cluster wraps internally instead.
       flexWrap: "nowrap"
     },
 
-    // The collapsible cluster of mode/model chips + primary action. Fills the
-    // row horizontally (flex:1) so the trailing actions stay right-aligned,
-    // and wraps its own chips when they overflow.
+    // The cluster of mode/model chips + primary action. Fills the row
+    // horizontally (flex:1) so the trailing actions stay right-aligned, and
+    // wraps its own chips when they overflow.
     ".media-chip-main": {
       flex: 1,
       minWidth: 0,
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      flexWrap: "wrap",
-      // Generous cap so an expanded multi-row chip cluster is never clipped;
-      // animates down to 0 when minimized.
-      maxHeight: 200,
-      opacity: 1,
-      overflow: "hidden",
-      transition: `max-height ${MOTION.normal}, opacity ${MOTION.normal}`
-    },
-
-    // Minimized state: the composer collapses to just the textarea + trailing
-    // run actions while unfocused and empty, expanding to the full chip row on
-    // focus. The border dims and the chip cluster animates away to zero height.
-    ".media-compose-card.dimmed": {
-      borderColor:
-        theme.palette.mode === "light"
-          ? theme.vars.palette.grey[800]
-          : theme.vars.palette.grey[900],
-      gap: theme.spacing(0.5)
-    },
-    ".media-compose-card.dimmed .media-chip-main": {
-      maxHeight: 0,
-      opacity: 0,
-      pointerEvents: "none"
-    },
-    // Tighten the textarea to a slim single line while minimized.
-    ".media-compose-card.dimmed textarea.media-compose-input": {
-      paddingTop: theme.spacing(1.5),
-      paddingBottom: theme.spacing(1.5)
-    },
-    // Collapse the (empty) file-preview row so it adds no height when minimized.
-    ".media-compose-card.dimmed .media-file-preview-row:empty": {
-      display: "none"
+      flexWrap: "wrap"
     },
 
     ".media-chip-row .divider-dot": {

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -114,10 +114,6 @@ export interface MediaChatComposerProps {
   requireToolSupport?: boolean;
   /** Focus the prompt textarea on mount. Defaults to true (chat panel). */
   autoFocus?: boolean;
-  /** When true, the composer minimizes to just the input (+ leading Run
-   *  button) while unfocused and empty, expanding to the full chip row on
-   *  focus. Used by the canvas composer; off in the chat panel. */
-  collapsible?: boolean;
   /** Extra actions rendered at the end of the footer chip row (e.g. the
    *  canvas Run button + workflow menu). Empty in the chat panel. */
   trailingActions?: React.ReactNode;
@@ -161,15 +157,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   autoFocus = true,
   trailingActions,
   leadingActions,
-  placeholder: placeholderOverride,
-  collapsible = false
+  placeholder: placeholderOverride
 }) => {
   const theme = useTheme();
   const styles = useMemo(() => createMediaComposerStyles(theme), [theme]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [prompt, setPrompt] = useState("");
-  const [focused, setFocused] = useState(false);
-  const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Mode + media params from persistent store
   const mode = useMediaGenerationStore((s) => s.mode);
@@ -793,41 +786,6 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const isDisabled = disabled || isBusy;
   const elapsed = useElapsedTime(isBusy);
 
-  // When `collapsible`, the composer dims its border + footer controls while
-  // unfocused and idle, brightening on focus (or pending content / open menu /
-  // active generation). Blur is delayed so clicking a chip — which momentarily
-  // blurs the textarea before its menu opens — doesn't flash the dim state.
-  const anyMenuOpen =
-    !!modeAnchor ||
-    !!durationAnchor ||
-    !!resolutionAnchor ||
-    !!aspectAnchor ||
-    !!variationsAnchor ||
-    !!voiceAnchor ||
-    !!speedAnchor ||
-    !!audioFormatAnchor ||
-    !!strengthAnchor ||
-    !!stepsAnchor ||
-    imageModelOpen ||
-    videoModelOpen ||
-    languageModelOpen ||
-    ttsModelOpen;
-  const hasContent = prompt.trim().length > 0 || droppedFiles.length > 0;
-  const dimmed =
-    collapsible && !focused && !hasContent && !anyMenuOpen && !isBusy;
-
-  const handleFocus = useCallback(() => {
-    if (blurTimer.current) clearTimeout(blurTimer.current);
-    setFocused(true);
-  }, []);
-  const handleBlur = useCallback(() => {
-    if (blurTimer.current) clearTimeout(blurTimer.current);
-    blurTimer.current = setTimeout(() => setFocused(false), 150);
-  }, []);
-  useEffect(() => () => {
-    if (blurTimer.current) clearTimeout(blurTimer.current);
-  }, []);
-
   const removeCallbacks = useMemo(
     () => new Map(droppedFiles.map((f) => [f.id, () => removeFile(f.id)])),
     [droppedFiles, removeFile]
@@ -836,9 +794,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   return (
     <div css={styles} className="media-chat-composer">
       <div
-        className={`media-compose-card${isDragging ? " dragging" : ""}${
-          dimmed ? " dimmed" : ""
-        }`}
+        className={`media-compose-card${isDragging ? " dragging" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -864,8 +820,6 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           onInput={adjustHeight}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           placeholder={placeholder}
           rows={1}
           spellCheck={false}
@@ -897,12 +851,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         )}
 
         <div className="media-chip-row">
-          {/* Leading actions (e.g. the canvas dock drag handle). Stays visible
-              even while the composer is minimized. */}
+          {/* Leading actions (e.g. the canvas dock drag handle). */}
           {leadingActions}
-          {/* Collapsible cluster: mode/model chips + primary action. Hidden
-              while the composer is minimized (idle + empty); the trailing
-              run actions below stay visible so the workflow can still run. */}
+          {/* Chip cluster: mode/model chips + primary action. */}
           <div className="media-chip-main">
           {/* Mode selector chip */}
           <MediaControlChip
@@ -1424,8 +1375,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           </div>
 
           {/* Host-supplied actions at the end of the footer (e.g. the canvas
-              Run button + workflow menu). Empty in the chat panel. Stays
-              visible even while the composer is minimized. */}
+              Run button + workflow menu). Empty in the chat panel. */}
           {trailingActions}
         </div>
       </div>

--- a/web/src/components/panels/CanvasMediaComposer.tsx
+++ b/web/src/components/panels/CanvasMediaComposer.tsx
@@ -98,7 +98,6 @@ const CanvasMediaComposer: React.FC<CanvasMediaComposerProps> = ({
       memoryEnabled={memoryEnabled}
       onMemoryToggle={setMemoryEnabled}
       autoFocus={false}
-      collapsible
       leadingActions={leadingActions}
       trailingActions={trailingActions}
     />


### PR DESCRIPTION
## Summary
Removes the collapsible composer feature that minimized the MediaChatComposer to just the input field while unfocused and empty. This feature was only used by the canvas composer and added complexity without clear benefit.

## Changes
- **MediaChatComposer.tsx**: Removed `collapsible` prop, focus/blur state management, and related logic
  - Deleted `collapsible`, `focused`, and `blurTimer` state
  - Removed `handleFocus` and `handleBlur` callbacks with 150ms blur delay
  - Removed `dimmed` state calculation based on focus, content, menu state, and busy status
  - Removed `dimmed` CSS class from the compose card
  - Removed focus/blur event handlers from textarea
  - Simplified comments about chip row visibility

- **MediaChatComposer.styles.ts**: Removed all collapsible animation styles
  - Deleted `maxHeight`, `opacity`, `overflow`, and `transition` from `.media-chip-main`
  - Removed `.media-compose-card.dimmed` and related dimmed state selectors
  - Removed animations for border color, gap, textarea padding, and file preview row in minimized state
  - Simplified comments about chip cluster layout

- **CanvasMediaComposer.tsx**: Removed `collapsible` prop from MediaChatComposer usage

## Implementation Details
The collapsible feature used a delayed blur timer (150ms) to prevent flashing the minimized state when clicking chips that momentarily blur the textarea. Removal simplifies the component while the canvas composer continues to function normally with the full chip row always visible.

https://claude.ai/code/session_01LPt1TeYPkzZ82PZLFE6dcF