### PR TITLE
Add build provenance (git commit hash & build number) to About dialog

### DIFF
--- a/web/src/components/menus/AboutMenu.tsx
+++ b/web/src/components/menus/AboutMenu.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "@mui/material/styles";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import { VERSION } from "../../config/constants";
+import { VERSION, GIT_COMMIT_HASH, BUILD_NUMBER } from "../../config/constants";
 import { isElectron, isProduction } from "../../lib/env";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { FlexRow, FlexColumn, Text, Caption, LoadingSpinner, Chip, Box } from "../ui_primitives";
@@ -210,6 +210,8 @@ const AboutMenu: React.FC = memo(() => {
     const text = `NodeTool System Information
 =============================
 Version: ${VERSION}
+Git Commit: ${GIT_COMMIT_HASH}
+Build: ${BUILD_NUMBER}
 ${systemInfo.electronVersion ? `Electron: ${systemInfo.electronVersion}` : ""}
 ${systemInfo.chromeVersion ? `Chrome: ${systemInfo.chromeVersion}` : ""}
 ${systemInfo.nodeVersion ? `Node.js: ${systemInfo.nodeVersion}` : ""}
@@ -283,6 +285,13 @@ Llama Server: ${systemInfo.llamaServerInstalled ? systemInfo.llamaServerVersion 
       </Text>
       <div className="settings-section">
         <InfoRow label="Version" value={VERSION} />
+        <InfoRow
+          label="Git Commit"
+          value={GIT_COMMIT_HASH}
+          copyable
+          onCopy={handleCopy}
+        />
+        <InfoRow label="Build" value={BUILD_NUMBER} />
         {systemInfo && (
           <>
             <InfoRow label="Electron" value={systemInfo.electronVersion} />

--- a/web/src/config/constants.ts
+++ b/web/src/config/constants.ts
@@ -1,6 +1,16 @@
 // APP
 export const VERSION = "0.7.0-rc.26";
 
+// Build provenance injected by Vite at build time (see web/vite.config.ts).
+// In non-Vite contexts (e.g. Jest), the defines are absent — fall back to a
+// stable placeholder so the About dialog still renders.
+declare const __GIT_COMMIT_HASH__: string;
+declare const __BUILD_NUMBER__: string;
+export const GIT_COMMIT_HASH =
+  typeof __GIT_COMMIT_HASH__ !== "undefined" ? __GIT_COMMIT_HASH__ : "dev";
+export const BUILD_NUMBER =
+  typeof __BUILD_NUMBER__ !== "undefined" ? __BUILD_NUMBER__ : "0";
+
 // TOOLTIPS
 export const TOOLTIP_ENTER_DELAY = 700;
 export const TOOLTIP_ENTER_NEXT_DELAY = 350;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,34 @@
 import { defineConfig, loadEnv, type Plugin, type ProxyOptions, type UserConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
+import { execSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
 const rootNodeModules = resolve(configDir, "../node_modules");
+
+// Build-time provenance injected into the app (shown in the About dialog).
+// Both are derived from git so no manual bookkeeping is needed:
+//  - commit hash: the short SHA of the checked-out commit
+//  - build number: the total commit count on the current history, which is
+//    monotonic and sequential
+// A CI env override (GIT_COMMIT_HASH / BUILD_NUMBER) wins when set, and both
+// fall back gracefully when git is unavailable (e.g. building from a tarball).
+function runGit(command: string): string | null {
+  try {
+    return execSync(command, { cwd: configDir, stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+const GIT_COMMIT_HASH =
+  process.env.GIT_COMMIT_HASH ?? runGit("git rev-parse --short HEAD") ?? "unknown";
+const BUILD_NUMBER =
+  process.env.BUILD_NUMBER ?? runGit("git rev-list --count HEAD") ?? "0";
 
 // The in-browser workflow runner (web/src/lib/workflow/browserWorkflowRunner.ts)
 // lazily imports @nodetool-ai/workflow-runner + @nodetool-ai/base-nodes so a
@@ -175,6 +198,10 @@ export default defineConfig(async ({ mode }) => {
     .filter(Boolean);
 
   return {
+    define: {
+      __GIT_COMMIT_HASH__: JSON.stringify(GIT_COMMIT_HASH),
+      __BUILD_NUMBER__: JSON.stringify(BUILD_NUMBER)
+    },
     server: {
       allowedHosts: [".nodetool.ai", "localhost", ...extraAllowedHosts],
       port: 3000,


### PR DESCRIPTION
## Summary
Inject build-time provenance information (git commit hash and build number) into the application, displayed in the About dialog. This enables users and support to quickly identify the exact build version they're running.

## Changes
- **vite.config.ts**: Added build-time extraction of git metadata via `execSync`:
  - `GIT_COMMIT_HASH`: Short SHA of the checked-out commit (via `git rev-parse --short HEAD`)
  - `BUILD_NUMBER`: Total commit count on current history (via `git rev-list --count HEAD`)
  - Both fall back gracefully when git is unavailable (e.g., tarball builds) or can be overridden via `GIT_COMMIT_HASH` / `BUILD_NUMBER` environment variables (for CI)
  - Injected as Vite `define` globals (`__GIT_COMMIT_HASH__`, `__BUILD_NUMBER__`)

- **constants.ts**: Exported `GIT_COMMIT_HASH` and `BUILD_NUMBER` constants with safe fallbacks for non-Vite contexts (e.g., Jest tests)

- **AboutMenu.tsx**: 
  - Imported new constants
  - Added git commit hash and build number to the system information text (copied to clipboard)
  - Added two new `InfoRow` entries in the About dialog UI to display commit hash (copyable) and build number

## Implementation Details
- Git commands are executed at build time only, not runtime, with graceful error handling
- Fallback values ensure the About dialog renders correctly even when git is unavailable or in test environments
- CI can override via environment variables for reproducible builds
- Both values are monotonic (build number) or immutable (commit hash), requiring no manual bookkeeping

https://claude.ai/code/session_01HgZYBHNiHB91qVFHJivJng