### PR TITLE
Add success/error notifications to workflow save action

### DIFF
--- a/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
+++ b/web/src/hooks/__tests__/useFloatingToolbarActions.test.ts
@@ -11,6 +11,7 @@ import { useMiniMapStore } from "../../stores/MiniMapStore";
 import { useRunWarningStore } from "../../stores/RunWarningStore";
 import useRemoteSettingsStore from "../../stores/RemoteSettingStore";
 import { useSearchProviderCalloutStore } from "../../stores/SearchProviderCalloutStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
 
 jest.mock("react-router-dom", () => ({
   useNavigate: jest.fn(() => jest.fn()),
@@ -408,15 +409,51 @@ describe("useFloatingToolbarActions", () => {
   });
 
   describe("handleSave", () => {
-    it("saves workflow", () => {
+    beforeEach(() => {
+      useNotificationStore.getState().clearNotifications();
+    });
+
+    it("saves workflow", async () => {
       const { result } = renderHook(() => useFloatingToolbarActions());
 
-      act(() => {
-        result.current.handleSave();
+      await act(async () => {
+        await result.current.handleSave();
       });
 
       expect(mockGetWorkflow).toHaveBeenCalledWith("workflow-123");
       expect(mockSaveWorkflow).toHaveBeenCalled();
+    });
+
+    it("shows a success notification after saving", async () => {
+      mockSaveWorkflow.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useFloatingToolbarActions());
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatchObject({
+        type: "success",
+        content: expect.stringContaining("saved")
+      });
+    });
+
+    it("shows an error notification when saving fails", async () => {
+      mockSaveWorkflow.mockRejectedValueOnce(new Error("boom"));
+      const { result } = renderHook(() => useFloatingToolbarActions());
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatchObject({
+        type: "error",
+        content: expect.stringContaining("boom")
+      });
     });
 
     it("does nothing when workflow is null", () => {

--- a/web/src/hooks/useFloatingToolbarActions.ts
+++ b/web/src/hooks/useFloatingToolbarActions.ts
@@ -20,6 +20,7 @@ import useNodeMenuStore from "../stores/NodeMenuStore";
 import { useBottomPanelStore } from "../stores/BottomPanelStore";
 import { usePanelStore } from "../stores/PanelStore";
 import { useMiniMapStore } from "../stores/MiniMapStore";
+import { useNotificationStore } from "../stores/NotificationStore";
 
 /**
  * Hook that provides all action handlers for the floating toolbar.
@@ -32,7 +33,7 @@ export interface FloatingToolbarActions {
   handleStop: () => void;
   handlePause: () => void;
   handleResume: () => void;
-  handleSave: () => void;
+  handleSave: () => Promise<void>;
   handleDownload: () => void;
   handleAutoLayout: () => void;
   handleRunAsApp: () => void;
@@ -83,6 +84,7 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
 
   const getWorkflowById = useWorkflowManager((state) => state.getWorkflow);
   const saveWorkflow = useWorkflowManager((state) => state.saveWorkflow);
+  const addNotification = useNotificationStore((state) => state.addNotification);
 
   const autosave = useSettingsStore((state) => state.settings.autosave);
   const confirmLargeRun = useSettingsStore(
@@ -266,15 +268,30 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     resume();
   }, [resume]);
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     if (!workflow) {
       return;
     }
     const w = getWorkflowById(workflow.id);
-    if (w) {
-      saveWorkflow(w);
+    if (!w) {
+      return;
     }
-  }, [getWorkflowById, saveWorkflow, workflow]);
+    try {
+      await saveWorkflow(w);
+      addNotification({
+        content: `Workflow ${w.name} saved`,
+        type: "success",
+        alert: true
+      });
+    } catch (error) {
+      console.error("Failed to save workflow:", error);
+      addNotification({
+        content: `Failed to save workflow: ${error instanceof Error ? error.message : "Server unreachable"}`,
+        type: "error",
+        alert: true
+      });
+    }
+  }, [getWorkflowById, saveWorkflow, workflow, addNotification]);
 
   const handleDownload = useCallback(() => {
     if (!workflow) {


### PR DESCRIPTION
## Summary
Enhanced the `handleSave` action in the floating toolbar to provide user feedback via notifications when workflows are saved successfully or when save operations fail.

## Key Changes
- Made `handleSave` async and updated its return type from `void` to `Promise<void>`
- Added success notification when workflow saves successfully, displaying the workflow name
- Added error notification when save fails, displaying the error message or a fallback message
- Imported `useNotificationStore` and integrated `addNotification` into the save flow
- Updated tests to verify notification behavior:
  - Added `beforeEach` hook to clear notifications before each test
  - Made existing save test async
  - Added test for success notification display
  - Added test for error notification display with error message

## Implementation Details
- Success notifications use `type: "success"` with content `"Workflow {name} saved"`
- Error notifications use `type: "error"` with content `"Failed to save workflow: {error message}"`
- Both notifications set `alert: true` for visibility
- Error handling includes fallback message "Server unreachable" for non-Error exceptions
- Added `addNotification` to the dependency array of the `useCallback` hook

https://claude.ai/code/session_0113TN1ME13N6VmvmzCjsam2