### PR TITLE
Simplify runner status clearing on workflow start

### DIFF
--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -698,10 +698,6 @@ export const handleUpdate = (
         (runnerJobId === null &&
           (runnerState === "idle" || runnerState === "connecting")));
 
-    // Whether this run was sitting in the backend's concurrency queue, so we
-    // can clear the "Queued…" status once it actually starts running.
-    const wasQueued = runnerStore.getState().queuePosition !== null;
-
     // Consolidate state mapping
     let newState:
       | "idle"
@@ -919,9 +915,12 @@ export const handleUpdate = (
         }
         break;
       case "running":
-        // Clear the "Queued…" status carried over once the run actually starts.
-        // No "started" toast — the Queue panel/overlay shows the running job.
-        if (isRunnerJob && wasQueued) {
+        // Clear the carried-over status ("Workflow starting…" from run(), or
+        // "Queued…" if it sat in the queue) once the run actually starts. Node
+        // updates set no per-node status text, so without this the "starting"
+        // message would linger top-right for the whole run. No "started" toast —
+        // the Queue panel/overlay shows the running job.
+        if (isRunnerJob) {
           runnerStore.setState({ statusMessage: null });
         }
         break;


### PR DESCRIPTION
## Summary
Removes the `wasQueued` variable and simplifies the logic for clearing the runner status message when a workflow transitions to the "running" state. The status is now cleared unconditionally for all runner jobs, rather than only when they were previously queued.

## Changes
- **Removed `wasQueued` check**: Deleted the `wasQueued` variable that tracked whether a run was in the backend's concurrency queue
- **Unconditional status clearing**: Changed the condition from `if (isRunnerJob && wasQueued)` to `if (isRunnerJob)` when clearing the status message
- **Updated comment**: Expanded the comment to clarify that the status clearing applies to both "Workflow starting…" (from `run()`) and "Queued…" (from queue) messages, and explains why this is necessary (node updates don't set per-node status text, so the starting message would otherwise linger)

## Implementation Details
This change ensures that any carried-over status message is cleared once a runner job actually starts executing, regardless of whether it came from the initial workflow start or from sitting in the concurrency queue. This prevents stale status text from persisting in the UI during the entire workflow run.

https://claude.ai/code/session_01BDoLPSZUBoaefwuELgtWJw