### PR TITLE
Add CLS budget enforcement and fix layout shift issues

### DIFF
--- a/marketing/lighthouserc.json
+++ b/marketing/lighthouserc.json
@@ -15,7 +15,8 @@
         "categories:accessibility": ["warn", { "minScore": 0.9 }],
         "categories:seo": ["warn", { "minScore": 0.9 }],
         "categories:best-practices": ["warn", { "minScore": 0.9 }],
-        "categories:performance": ["warn", { "minScore": 0.5 }]
+        "categories:performance": ["warn", { "minScore": 0.5 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]
       }
     },
     "upload": { "target": "temporary-public-storage" }

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -336,9 +336,12 @@ export default function Home() {
               <div className="relative rounded-2xl border border-slate-700/60 bg-slate-900/80 p-2 shadow-2xl shadow-amber-900/20 backdrop-blur-sm ring-1 ring-white/5 overflow-hidden">
                 <video
                   src="/demo.mp4"
-                  className="w-full h-auto rounded-xl"
+                  width={1500}
+                  height={1000}
+                  className="block aspect-[3/2] h-auto w-full rounded-xl"
                   controls
                   playsInline
+                  preload="metadata"
                 />
               </div>
             </motion.div>

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -97,9 +97,12 @@ export default function NodeToolHero() {
             <img
               src="/screen_canvas.png"
               alt="NodeTool canvas: nodes for image, video, and text models wired together"
-              className="block w-full rounded-xl"
+              width={2000}
+              height={1320}
+              className="block h-auto w-full rounded-xl"
               loading="eager"
               decoding="async"
+              fetchPriority="high"
             />
           </div>
         </motion.div>

--- a/marketing/tests/e2e/cls.spec.ts
+++ b/marketing/tests/e2e/cls.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+
+// Cumulative Layout Shift gate. CLS is layout-driven and stable across runs
+// (unlike CPU-bound perf scores, which is why the Lighthouse job stays
+// informational), so it's safe to block a PR on it. Budget matches Google's
+// "good" threshold.
+const CLS_BUDGET = 0.1;
+
+// Pages this gate guards. The homepage is the one Google flagged (0.58); add
+// more paths here once each has been audited and reserves its media space.
+const ROUTES = ["/"];
+
+// layout-shift entries aren't in the DOM lib.
+interface LayoutShiftEntry extends PerformanceEntry {
+  value: number;
+  hadRecentInput: boolean;
+}
+
+declare global {
+  interface Window {
+    __clsValue?: number;
+  }
+}
+
+test.describe("Cumulative Layout Shift budget", () => {
+  for (const path of ROUTES) {
+    test(`${path} stays under ${CLS_BUDGET} CLS through a full scroll`, async ({
+      page,
+    }) => {
+      // Observe from document start so no early shift is missed, and score with
+      // the session-window algorithm (1s gap / 5s cap, input-excluded shifts)
+      // that Chrome and CrUX use — a naive sum overcounts real CLS.
+      await page.addInitScript(() => {
+        window.__clsValue = 0;
+        let sessionValue = 0;
+        let firstTs = 0;
+        let lastTs = 0;
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            const shift = entry as LayoutShiftEntry;
+            if (shift.hadRecentInput) continue;
+            if (
+              sessionValue &&
+              shift.startTime - lastTs < 1000 &&
+              shift.startTime - firstTs < 5000
+            ) {
+              sessionValue += shift.value;
+              lastTs = shift.startTime;
+            } else {
+              sessionValue = shift.value;
+              firstTs = shift.startTime;
+              lastTs = shift.startTime;
+            }
+            if (sessionValue > (window.__clsValue ?? 0)) {
+              window.__clsValue = sessionValue;
+            }
+          }
+        }).observe({ type: "layout-shift", buffered: true });
+      });
+
+      await page.goto(path, { waitUntil: "load" });
+
+      // Reproduce the field conditions the initial-viewport lab audit never
+      // sees: walk the whole page so lazy media and client-injected content
+      // (e.g. the GitHub star badge) get their chance to shift the layout.
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            let y = 0;
+            const stepPx = Math.round(window.innerHeight * 0.9);
+            const step = () => {
+              window.scrollTo(0, y);
+              if (y >= document.documentElement.scrollHeight) {
+                window.scrollTo(0, 0);
+                setTimeout(resolve, 400);
+                return;
+              }
+              y += stepPx;
+              setTimeout(step, 150);
+            };
+            step();
+          })
+      );
+
+      // Let any post-scroll, network-driven shift settle before sampling.
+      await page.waitForTimeout(500);
+
+      const cls = await page.evaluate(() => window.__clsValue ?? 0);
+      // eslint-disable-next-line no-console
+      console.log(`[CLS] ${path} = ${cls.toFixed(4)} (budget ${CLS_BUDGET})`);
+      expect(cls).toBeLessThan(CLS_BUDGET);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds Cumulative Layout Shift (CLS) testing and enforcement to prevent layout instability on the marketing site. Fixes layout shift issues in the homepage video and NodeToolHero image to meet the 0.1 CLS budget (Google's "good" threshold).

## Changes

- **New E2E test** (`marketing/tests/e2e/cls.spec.ts`): Playwright test that measures CLS using the session-window algorithm (1s gap / 5s cap, input-excluded shifts) that Chrome and CrUX use. Scrolls the full page to catch lazy-loaded and client-injected content shifts. Currently guards the homepage (`/`); more paths can be added after audit.

- **Lighthouse config** (`marketing/lighthouserc.json`): Added `cumulative-layout-shift` error threshold of 0.1 to block PRs on CLS regressions.

- **Homepage video** (`marketing/src/app/page.tsx`): 
  - Added explicit `width` (1500) and `height` (1000) attributes to reserve space
  - Changed `className` to include `aspect-[3/2]` for consistent aspect ratio
  - Added `preload="metadata"` to load video metadata early

- **NodeToolHero image** (`marketing/src/components/NodeToolHero.tsx`):
  - Added explicit `width` (2000) and `height` (1320) attributes to reserve space
  - Added `fetchPriority="high"` to prioritize this above-the-fold image
  - Adjusted `className` to ensure proper sizing

## Implementation Details

The CLS test reproduces field conditions by scrolling the entire page in 90% viewport-height steps with 150ms delays between steps, allowing lazy media and client-injected content (e.g., GitHub star badge) to shift the layout. It then waits 500ms for post-scroll network-driven shifts to settle before sampling the final CLS value.

The fixes use explicit dimensions and aspect ratios to prevent layout shift when media loads, which is the primary cause of CLS on the homepage (previously measured at 0.58).

https://claude.ai/code/session_019fAM7n5LNc8vMpnEjqq1Bj