### PR TITLE
Split Turbo cache into restore-only and save-only jobs

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -57,10 +57,28 @@ runs:
       shell: bash
       run: npm rebuild better-sqlite3
 
-    # Persist Turbo's local cache so `build:packages`/`test:packages` restore
-    # prior task outputs instead of rebuilding ~55 packages from scratch in every
-    # job. Keyed by commit with a prefix fallback to the latest available cache.
+    # Restore Turbo's local cache so `build:packages`/`test:packages` reuse prior
+    # task outputs instead of rebuilding ~55 packages from scratch in every job.
+    # Keyed by commit with a prefix fallback to the latest available cache.
+    #
+    # Only the job that actually builds (build-packages: true) saves the cache
+    # back — restore-only jobs never populate `.turbo/cache`, so if they also
+    # saved, they'd race the real build job for the immutable per-SHA key: a
+    # fast non-building leg that finishes first "claims" the key with a stale
+    # (restore-keys-fallback) cache, and the build job's own save then fails
+    # because the key already exists, leaving `test-packages` to restore that
+    # stale cache and rebuild from scratch anyway.
+    - name: Restore Turbo build outputs
+      if: inputs.build-packages != 'true'
+      uses: actions/cache/restore@v5
+      with:
+        path: .turbo/cache
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
     - name: Cache Turbo build outputs
+      if: inputs.build-packages == 'true'
       uses: actions/cache@v5
       with:
         path: .turbo/cache


### PR DESCRIPTION
## Summary

Refactors the GitHub Actions Turbo cache strategy to prevent race conditions between build and non-build jobs. Separates cache restoration (all jobs) from cache saving (build-only jobs) to ensure the immutable per-SHA cache key is only written by the actual build job.

## Problem

The previous single `actions/cache@v5` step caused a race condition:
- Multiple jobs (build and test) all tried to save to the same immutable `${{ runner.os }}-turbo-${{ github.sha }}` key
- A fast restore-only job could finish first and "claim" the key with a stale fallback cache
- The actual build job's save would then fail (key already exists)
- Test jobs would restore that stale cache and rebuild from scratch anyway

## Changes

- **New restore-only step** (`actions/cache/restore@v5`): Runs on all non-build jobs (`if: inputs.build-packages != 'true'`). Restores `.turbo/cache` from the commit SHA key with fallback to latest available cache, but never writes back.
- **Updated save step**: Now conditional (`if: inputs.build-packages == 'true'`), runs only on the actual build job. Writes the immutable per-SHA cache key.
- **Clarified comments**: Expanded documentation explaining the race condition and why the split is necessary.

## Result

- Build jobs populate `.turbo/cache` and save it under the commit SHA
- Test/other jobs restore that cache without competing for the write lock
- Subsequent jobs in the same workflow reuse the build's cache outputs instead of rebuilding ~55 packages from scratch

https://claude.ai/code/session_01JBorgHgZiztUUf8VJFin2N