### PR TITLE
Add size prop to SliderBasic in AssetActions grid view

### DIFF
--- a/web/src/components/assets/AssetActions.tsx
+++ b/web/src/components/assets/AssetActions.tsx
@@ -369,6 +369,7 @@ const AssetActions = ({
       {viewMode === "grid" && (
         <div className="asset-size-slider">
           <SliderBasic
+            size="small"
             defaultValue={settings.assetItemSize}
             aria-label="Small"
             tooltipText="Item Size"


### PR DESCRIPTION
## Summary
Adds the `size="small"` prop to the `SliderBasic` component used in the asset grid size slider, improving the UI consistency and visual hierarchy of the asset actions panel.

## Changes
- Added `size="small"` prop to `SliderBasic` component in the grid view asset size slider (`AssetActions.tsx`)

## Details
This change applies the small size variant to the slider control, which aligns with the design system's sizing conventions and provides better visual proportions within the asset actions toolbar.

https://claude.ai/code/session_01KLh2uKKzRXtU2r5oNMCF88