### PR TITLE
Scope chat threads to workflows in the node editor

### DIFF
--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -304,6 +304,7 @@ const TABLE_COLUMNS: Record<string, Record<string, string>> = {
   nodetool_threads: {
     id: "text",
     user_id: "text",
+    workflow_id: "text",
     title: "text",
     created_at: "text",
     updated_at: "text"
@@ -593,11 +594,13 @@ function getCreateSchemaSql(): string {
     CREATE TABLE IF NOT EXISTS "nodetool_threads" (
       "id" text PRIMARY KEY NOT NULL,
       "user_id" text NOT NULL,
+      "workflow_id" text,
       "title" text NOT NULL DEFAULT '',
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );
     CREATE INDEX IF NOT EXISTS "idx_threads_user_id" ON "nodetool_threads" ("user_id");
+    CREATE INDEX IF NOT EXISTS "idx_threads_user_workflow" ON "nodetool_threads" ("user_id", "workflow_id");
 
     CREATE TABLE IF NOT EXISTS "nodetool_assets" (
       "id" text PRIMARY KEY NOT NULL,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -1656,5 +1656,31 @@ export const migrations: MigrationDef[] = [
     async down() {
       // no-op: dropping columns is unsafe across dialects and versions
     }
+  },
+
+  // ── Scope chat threads to a workflow ───────────────────────────────
+  // Threads gain a nullable `workflow_id` so the node editor can list only
+  // the conversations for the open workflow and reopen the last one. Null
+  // means workflow-agnostic (e.g. the global chat).
+  {
+    version: "20260701_000000",
+    name: "add_workflow_id_to_threads",
+    createsTables: [],
+    modifiesTables: ["nodetool_threads"],
+    async up(db) {
+      if (!(await db.tableExists("nodetool_threads"))) return;
+      if (!(await db.columnExists("nodetool_threads", "workflow_id"))) {
+        await db.execute(
+          "ALTER TABLE nodetool_threads ADD COLUMN workflow_id TEXT"
+        );
+      }
+      await db.execute(
+        `CREATE INDEX IF NOT EXISTS idx_threads_user_workflow
+         ON nodetool_threads (user_id, workflow_id)`
+      );
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_threads_user_workflow");
+    }
   }
 ];

--- a/packages/models/src/schema-pg/threads.ts
+++ b/packages/models/src/schema-pg/threads.ts
@@ -5,9 +5,16 @@ export const threads = pgTable(
   {
     id: text("id").primaryKey(),
     user_id: text("user_id").notNull(),
+    // Workflow this conversation belongs to. Null for workflow-agnostic
+    // threads (e.g. the global chat). Lets the node editor scope its thread
+    // list to the open workflow.
+    workflow_id: text("workflow_id"),
     title: text("title").notNull().default(""),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
-  (table) => [index("idx_threads_user_id").on(table.user_id)]
+  (table) => [
+    index("idx_threads_user_id").on(table.user_id),
+    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id)
+  ]
 );

--- a/packages/models/src/schema/threads.ts
+++ b/packages/models/src/schema/threads.ts
@@ -5,9 +5,16 @@ export const threads = sqliteTable(
   {
     id: text("id").primaryKey(),
     user_id: text("user_id").notNull(),
+    // Workflow this conversation belongs to. Null for workflow-agnostic
+    // threads (e.g. the global chat). Lets the node editor scope its thread
+    // list to the open workflow.
+    workflow_id: text("workflow_id"),
     title: text("title").notNull().default(""),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
-  (table) => [index("idx_threads_user_id").on(table.user_id)]
+  (table) => [
+    index("idx_threads_user_id").on(table.user_id),
+    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id)
+  ]
 );

--- a/packages/models/src/thread.ts
+++ b/packages/models/src/thread.ts
@@ -4,7 +4,7 @@
  * Port of Python's `nodetool.models.thread`.
  */
 
-import { eq, desc, asc } from "drizzle-orm";
+import { eq, and, desc, asc } from "drizzle-orm";
 import { DBModel, createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { threads } from "./schema/threads.js";
@@ -14,6 +14,7 @@ export class Thread extends DBModel {
 
   declare id: string;
   declare user_id: string;
+  declare workflow_id: string | null;
   declare title: string;
   declare created_at: string;
   declare updated_at: string;
@@ -22,6 +23,7 @@ export class Thread extends DBModel {
     super(data);
     const now = new Date().toISOString();
     this.id ??= createTimeOrderedUuid();
+    this.workflow_id ??= null;
     this.title ??= "";
     this.created_at ??= now;
     this.updated_at ??= now;
@@ -39,17 +41,33 @@ export class Thread extends DBModel {
     return null;
   }
 
-  /** Paginate threads for a user. */
+  /**
+   * Paginate threads for a user. When `workflowId` is provided, only threads
+   * bound to that workflow are returned (used by the node editor to scope its
+   * thread list to the open workflow).
+   */
   static async paginate(
     userId: string,
-    opts: { limit?: number; startKey?: string; reverse?: boolean } = {}
+    opts: {
+      limit?: number;
+      startKey?: string;
+      reverse?: boolean;
+      workflowId?: string;
+    } = {}
   ): Promise<[Thread[], string]> {
-    const { limit = 50, reverse = true } = opts;
+    const { limit = 50, reverse = true, workflowId } = opts;
     const db = getDb();
+    const where =
+      workflowId === undefined
+        ? eq(threads.user_id, userId)
+        : and(
+            eq(threads.user_id, userId),
+            eq(threads.workflow_id, workflowId)
+          );
     const rows = await db
       .select()
       .from(threads)
-      .where(eq(threads.user_id, userId))
+      .where(where)
       .orderBy(reverse ? desc(threads.updated_at) : asc(threads.updated_at))
       .limit(limit + 1)
 

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 41;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 42;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/thread.test.ts
+++ b/packages/models/tests/thread.test.ts
@@ -13,9 +13,14 @@ import { Thread } from "../src/thread.js";
 
 async function createThread(
   userId: string,
-  title = "Test Thread"
+  title = "Test Thread",
+  workflowId?: string
 ): Promise<Thread> {
-  return Thread.create<Thread>({ user_id: userId, title });
+  return Thread.create<Thread>({
+    user_id: userId,
+    title,
+    ...(workflowId ? { workflow_id: workflowId } : {})
+  });
 }
 
 describe("Thread model", () => {
@@ -104,5 +109,32 @@ describe("Thread model", () => {
     const [threads, cursor] = await Thread.paginate("u1");
     expect(threads).toHaveLength(0);
     expect(cursor).toBe("");
+  });
+
+  // ── workflow scoping ──────────────────────────────────────────────
+
+  it("defaults workflow_id to null", () => {
+    const thread = new Thread({ user_id: "u1" });
+    expect(thread.workflow_id).toBeNull();
+  });
+
+  it("persists workflow_id", async () => {
+    const thread = await createThread("u1", "Bound", "wf-1");
+    const found = await Thread.find("u1", thread.id);
+    expect(found!.workflow_id).toBe("wf-1");
+  });
+
+  it("scopes pagination to a workflow when workflowId is given", async () => {
+    await createThread("u1", "A", "wf-1");
+    await createThread("u1", "B", "wf-2");
+    await createThread("u1", "C", "wf-1");
+    await createThread("u1", "Unbound");
+
+    const [scoped] = await Thread.paginate("u1", { workflowId: "wf-1" });
+    expect(scoped).toHaveLength(2);
+    expect(scoped.map((t) => t.title).sort()).toEqual(["A", "C"]);
+
+    const [all] = await Thread.paginate("u1");
+    expect(all).toHaveLength(4);
   });
 });

--- a/packages/protocol/src/api-schemas/messages.ts
+++ b/packages/protocol/src/api-schemas/messages.ts
@@ -61,6 +61,7 @@ export type ListOutput = z.infer<typeof listOutput>;
 // "New Thread" for the caller.
 export const createInput = z.object({
   thread_id: z.string().optional(),
+  workflow_id: z.string().nullable().optional(),
   role: z.string().min(1),
   name: z.string().nullable().optional(),
   content: z.union([

--- a/packages/protocol/src/api-schemas/threads.ts
+++ b/packages/protocol/src/api-schemas/threads.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 export const threadResponse = z.object({
   id: z.string(),
   user_id: z.string(),
+  workflow_id: z.string().nullable().optional(),
   title: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
@@ -13,10 +14,13 @@ export const threadResponse = z.object({
 export type ThreadResponse = z.infer<typeof threadResponse>;
 
 // ── list (GET /api/threads) ──────────────────────────────────────
+// `workflow_id` scopes the list to one workflow's conversations (node
+// editor); omit it to list all of the user's threads (global chat).
 export const listInput = z.object({
   limit: z.number().int().min(1).max(500).default(10),
   cursor: z.string().optional(),
-  reverse: z.boolean().optional()
+  reverse: z.boolean().optional(),
+  workflow_id: z.string().optional()
 });
 export type ListInput = z.infer<typeof listInput>;
 
@@ -35,7 +39,8 @@ export type GetInput = z.infer<typeof getInput>;
 // ── create (POST /api/threads) ───────────────────────────────────
 // `title` is optional; defaults to "New Thread" server-side.
 export const createInput = z.object({
-  title: z.string().optional()
+  title: z.string().optional(),
+  workflow_id: z.string().nullable().optional()
 });
 export type CreateInput = z.infer<typeof createInput>;
 

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -462,6 +462,8 @@ export interface WorkflowToolList {
 export interface Thread {
   id: string;
   user_id: string;
+  /** Workflow this conversation belongs to, or null for global chat. */
+  workflow_id?: string | null;
   title: string | null;
   created_at: string;
   updated_at: string;
@@ -475,6 +477,7 @@ export interface ThreadList {
 
 export interface ThreadCreateRequest {
   title?: string;
+  workflow_id?: string | null;
 }
 
 export interface ThreadUpdateRequest {

--- a/packages/websocket/src/trpc/routers/messages.ts
+++ b/packages/websocket/src/trpc/routers/messages.ts
@@ -87,6 +87,7 @@ export const messagesRouter = router({
       if (!threadId) {
         const thread = (await Thread.create({
           user_id: ctx.userId,
+          workflow_id: input.workflow_id ?? null,
           title: "New Thread"
         })) as unknown as { id: string };
         threadId = thread.id;
@@ -98,6 +99,7 @@ export const messagesRouter = router({
       const msg = (await Message.create({
         user_id: ctx.userId,
         thread_id: threadId,
+        workflow_id: input.workflow_id ?? null,
         role: input.role,
         name: input.name ?? null,
         content: contentStr,

--- a/packages/websocket/src/trpc/routers/threads.ts
+++ b/packages/websocket/src/trpc/routers/threads.ts
@@ -35,6 +35,7 @@ function toThreadResponse(thread: ThreadModel): ThreadResponse {
   return {
     id: thread.id,
     user_id: thread.user_id,
+    workflow_id: thread.workflow_id ?? null,
     title: thread.title,
     created_at: thread.created_at,
     updated_at: thread.updated_at,
@@ -91,7 +92,10 @@ export const threadsRouter = router({
       const [threads, cursor] = await Thread.paginate(ctx.userId, {
         limit: input.limit,
         startKey: input.cursor,
-        reverse: input.reverse
+        reverse: input.reverse,
+        ...(input.workflow_id !== undefined
+          ? { workflowId: input.workflow_id }
+          : {})
       });
       return {
         threads: threads.map((t) => toThreadResponse(t)),
@@ -117,6 +121,7 @@ export const threadsRouter = router({
       const title = input.title ?? "New Thread";
       const thread = (await Thread.create({
         user_id: ctx.userId,
+        workflow_id: input.workflow_id ?? null,
         title
       })) as unknown as ThreadModel;
       return toThreadResponse(thread);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2490,10 +2490,17 @@ export class UnifiedWebSocketRunner {
     };
   }
 
-  private async ensureThreadExists(threadId?: string): Promise<string> {
+  private async ensureThreadExists(
+    threadId?: string,
+    workflowId?: string | null
+  ): Promise<string> {
     const userId = this.userId ?? "1";
     if (!threadId) {
-      const thread = await Thread.create({ user_id: userId, title: "" });
+      const thread = await Thread.create({
+        user_id: userId,
+        workflow_id: workflowId ?? null,
+        title: ""
+      });
       return thread.id;
     }
     const existing = await Thread.find(userId, threadId);
@@ -2501,6 +2508,7 @@ export class UnifiedWebSocketRunner {
     const thread = await Thread.create({
       id: threadId,
       user_id: userId,
+      workflow_id: workflowId ?? null,
       title: ""
     });
     return thread.id;
@@ -2923,8 +2931,11 @@ export class UnifiedWebSocketRunner {
     data: Record<string, unknown>,
     requestSeq?: number
   ): Promise<void> {
+    const messageWorkflowId =
+      typeof data.workflow_id === "string" ? data.workflow_id : null;
     const threadId = await this.ensureThreadExists(
-      typeof data.thread_id === "string" ? data.thread_id : undefined
+      typeof data.thread_id === "string" ? data.thread_id : undefined,
+      messageWorkflowId
     );
     data.thread_id = threadId;
 
@@ -2934,8 +2945,7 @@ export class UnifiedWebSocketRunner {
 
     const providerId = data.provider as string;
     const model = data.model as string;
-    const workflowId =
-      typeof data.workflow_id === "string" ? data.workflow_id : null;
+    const workflowId = messageWorkflowId;
     const userId = this.userId ?? "1";
     log.debug("Chat message", { threadId, model, provider: providerId });
 

--- a/packages/websocket/tests/trpc-messages.test.ts
+++ b/packages/websocket/tests/trpc-messages.test.ts
@@ -198,6 +198,7 @@ describe("messages router", () => {
       expect(Message.create).toHaveBeenCalledWith({
         user_id: "user-1",
         thread_id: "t1",
+        workflow_id: null,
         role: "user",
         name: null,
         content: "hello",
@@ -224,6 +225,7 @@ describe("messages router", () => {
       });
       expect(Thread.create).toHaveBeenCalledWith({
         user_id: "user-1",
+        workflow_id: null,
         title: "New Thread"
       });
       expect(result.thread_id).toBe("auto-thread");

--- a/packages/websocket/tests/trpc-threads.test.ts
+++ b/packages/websocket/tests/trpc-threads.test.ts
@@ -43,6 +43,7 @@ function makeCtx(overrides: Partial<Context> = {}): Context {
 function makeThread(opts: {
   id?: string;
   user_id?: string;
+  workflow_id?: string | null;
   title?: string;
   etag?: string;
   created_at?: string;
@@ -51,6 +52,7 @@ function makeThread(opts: {
   const stub = {
     id: opts.id ?? "t1",
     user_id: opts.user_id ?? "user-1",
+    workflow_id: opts.workflow_id ?? null,
     title: opts.title ?? "Alpha",
     created_at: opts.created_at ?? "2026-01-01T00:00:00Z",
     updated_at: opts.updated_at ?? "2026-01-01T00:00:00Z",
@@ -136,6 +138,24 @@ describe("threads router", () => {
       });
     });
 
+    it("scopes the list to a workflow when workflow_id is given", async () => {
+      const t = makeThread({ id: "t1", workflow_id: "wf-1" });
+      (Thread.paginate as ReturnType<typeof vi.fn>).mockResolvedValue([
+        [t],
+        ""
+      ]);
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.threads.list({ workflow_id: "wf-1" });
+      expect(Thread.paginate).toHaveBeenCalledWith("user-1", {
+        limit: 10,
+        startKey: undefined,
+        reverse: undefined,
+        workflowId: "wf-1"
+      });
+      expect(result.threads[0]?.workflow_id).toBe("wf-1");
+    });
+
     it("rejects unauthenticated callers", async () => {
       const caller = createCaller(makeCtx({ userId: null }));
       await expect(caller.threads.list({})).rejects.toMatchObject({
@@ -154,6 +174,7 @@ describe("threads router", () => {
       const result = await caller.threads.create({ title: "My Thread" });
       expect(Thread.create).toHaveBeenCalledWith({
         user_id: "user-1",
+        workflow_id: null,
         title: "My Thread"
       });
       expect(result.id).toBe("new-t");
@@ -168,6 +189,20 @@ describe("threads router", () => {
       await caller.threads.create({});
       expect(Thread.create).toHaveBeenCalledWith({
         user_id: "user-1",
+        workflow_id: null,
+        title: "New Thread"
+      });
+    });
+
+    it("binds the thread to a workflow when workflow_id is given", async () => {
+      const t = makeThread({ id: "wf-t", title: "New Thread" });
+      (Thread.create as ReturnType<typeof vi.fn>).mockResolvedValue(t);
+
+      const caller = createCaller(makeCtx());
+      await caller.threads.create({ workflow_id: "wf-1" });
+      expect(Thread.create).toHaveBeenCalledWith({
+        user_id: "user-1",
+        workflow_id: "wf-1",
         title: "New Thread"
       });
     });

--- a/web/src/components/panels/ConversationOverlay.tsx
+++ b/web/src/components/panels/ConversationOverlay.tsx
@@ -239,6 +239,8 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
   const {
     currentThreadId,
     threads,
+    threadWorkflowId,
+    workflowId,
     messageCache,
     title,
     createNewThread,
@@ -248,6 +250,8 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
     useShallow((state) => ({
       currentThreadId: state.currentThreadId,
       threads: state.threads,
+      threadWorkflowId: state.threadWorkflowId,
+      workflowId: state.workflowId,
       messageCache: state.messageCache,
       title: state.currentThreadId
         ? state.threads[state.currentThreadId]?.title ?? null
@@ -324,10 +328,21 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
     [threads, messageCache]
   );
 
+  // Scope the editor's thread list to the open workflow: a thread belongs to
+  // it if the server bound it (`workflow_id`) or the client did before it was
+  // persisted (`threadWorkflowId`). With no workflow bound, show everything.
   const threadsWithMessages = useMemo<Record<string, ThreadInfo>>(() => {
     const query = searchQuery.trim().toLowerCase();
     return Object.fromEntries(
       Object.entries(threads)
+        .filter(([id, thread]) => {
+          if (!workflowId) {
+            return true;
+          }
+          const threadWorkflow =
+            thread.workflow_id ?? threadWorkflowId[id] ?? null;
+          return threadWorkflow === workflowId;
+        })
         .map(([id, thread]): [string, ThreadInfo] => [
           id,
           {
@@ -348,7 +363,14 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
           );
         })
     );
-  }, [threads, messageCache, searchQuery, getThreadPreview]);
+  }, [
+    threads,
+    threadWorkflowId,
+    workflowId,
+    messageCache,
+    searchQuery,
+    getThreadPreview
+  ]);
 
   return (
     <div

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -318,6 +318,38 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
         clearChatError: state.clearError
       }))
     );
+
+  // Bind the canvas chat to the open workflow: chat threads are scoped per
+  // workflow, so switching workflows switches to that workflow's most recent
+  // conversation (or starts a fresh one). Waits for the thread list to load so
+  // an existing conversation is reused instead of creating a duplicate.
+  const { openWorkflowThread, threadsLoaded, fetchThreads } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        openWorkflowThread: state.openWorkflowThread,
+        threadsLoaded: state.threadsLoaded,
+        fetchThreads: state.fetchThreads
+      }))
+    );
+  const workflowId = workflow?.id ?? null;
+  useEffect(() => {
+    if (!workflowId) {
+      return;
+    }
+    if (!threadsLoaded) {
+      void fetchThreads();
+      return;
+    }
+    void openWorkflowThread(workflowId);
+  }, [workflowId, threadsLoaded, openWorkflowThread, fetchThreads]);
+
+  // Leaving the editor clears the workflow binding so the full-page chat starts
+  // workflow-agnostic (it lists every thread, not just the last workflow's).
+  useEffect(() => {
+    return () => {
+      useGlobalChatStore.setState({ workflowId: null });
+    };
+  }, []);
   // Start collapsed so opening a workflow with existing conversation history
   // doesn't pop the overlay. It auto-reveals only when chat becomes busy in
   // this session (the user sent a message / a generation is streaming). The

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -120,7 +120,10 @@ export interface GlobalChatState extends ChatPiSlice {
   // Per-workflow thread binding for the editor side panel: each workflow gets
   // its own conversation. workflowId -> threadId.
   workflowThreadId: Record<string, string>;
-  /** Bind the chat to a workflow's thread, creating one if needed. */
+  /**
+   * Bind the editor chat to a workflow: switch to its most recent conversation,
+   * or create a fresh one if the workflow has none yet. Returns the thread id.
+   */
   openWorkflowThread: (workflowId: string) => Promise<string>;
   // Tool call runtime UI state
   currentRunningToolCallId: string | null;
@@ -205,7 +208,10 @@ export interface GlobalChatState extends ChatPiSlice {
   // Thread actions
   fetchThreads: () => Promise<void>;
   fetchThread: (threadId: string) => Promise<Thread | null>;
-  createNewThread: (title?: string) => Promise<string>;
+  createNewThread: (
+    title?: string,
+    workflowId?: string | null
+  ) => Promise<string>;
   switchThread: (threadId: string) => void;
   deleteThread: (threadId: string) => Promise<void>;
   getCurrentMessages: () => Message[];
@@ -291,23 +297,44 @@ const useGlobalChatStore = create<GlobalChatState>()(
       workflowThreadId: {},
       openWorkflowThread: async (workflowId: string) => {
         set({ workflowId });
-        const existing = get().workflowThreadId[workflowId];
-        if (existing && get().threads[existing]) {
-          if (get().currentThreadId !== existing) {
-            get().switchThread(existing);
+        const state = get();
+
+        // A thread belongs to this workflow if the server bound it
+        // (`workflow_id`) or the client did before it was persisted
+        // (`threadWorkflowId`).
+        const belongsToWorkflow = (thread: Thread) =>
+          (thread.workflow_id ?? state.threadWorkflowId[thread.id] ?? null) ===
+          workflowId;
+
+        // Load the most recent conversation for this workflow.
+        const lastThread = Object.values(state.threads)
+          .filter(belongsToWorkflow)
+          .sort((a, b) =>
+            (b.updated_at ?? "").localeCompare(a.updated_at ?? "")
+          )[0];
+
+        if (lastThread) {
+          set((s) => ({
+            workflowThreadId: {
+              ...s.workflowThreadId,
+              [workflowId]: lastThread.id
+            },
+            threadWorkflowId: {
+              ...s.threadWorkflowId,
+              [lastThread.id]: workflowId
+            }
+          }));
+          if (state.currentThreadId !== lastThread.id) {
+            get().switchThread(lastThread.id);
           }
-          return existing;
+          return lastThread.id;
         }
-        // Reuse a persisted-but-not-yet-loaded thread id if we have one;
-        // otherwise create a fresh thread bound to this workflow.
-        const threadId = existing ?? (await get().createNewThread());
-        set((state) => ({
-          workflowThreadId: { ...state.workflowThreadId, [workflowId]: threadId },
-          threadWorkflowId: { ...state.threadWorkflowId, [threadId]: workflowId }
+
+        // No conversation yet — start a fresh thread bound to this workflow.
+        const threadId = await get().createNewThread(undefined, workflowId);
+        set((s) => ({
+          workflowThreadId: { ...s.workflowThreadId, [workflowId]: threadId }
         }));
-        if (get().threads[threadId] && get().currentThreadId !== threadId) {
-          get().switchThread(threadId);
-        }
         return threadId;
       },
 
@@ -786,12 +813,23 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
           // Merge with existing threads so locally-created/optimistic threads
           // that haven't reached the server yet don't get wiped (the server
-          // response wins for ids present in both).
-          set((state) => ({
-            threads: { ...state.threads, ...threadsRecord },
-            threadsLoaded: true,
-            error: null
-          }));
+          // response wins for ids present in both). Also hydrate the
+          // thread→workflow map from the server so the editor can scope its
+          // thread list after a fresh load (before any message is sent).
+          set((state) => {
+            const threadWorkflowId = { ...state.threadWorkflowId };
+            for (const thread of data.threads) {
+              if (thread.workflow_id != null) {
+                threadWorkflowId[thread.id] = thread.workflow_id;
+              }
+            }
+            return {
+              threads: { ...state.threads, ...threadsRecord },
+              threadWorkflowId,
+              threadsLoaded: true,
+              error: null
+            };
+          });
         } catch (error) {
           console.error("Failed to fetch threads:", error);
           set({
@@ -832,14 +870,21 @@ const useGlobalChatStore = create<GlobalChatState>()(
         }
       },
 
-      createNewThread: async (title?: string) => {
+      createNewThread: async (title?: string, workflowId?: string | null) => {
         const safeTitle = typeof title === "string" ? title : undefined;
+
+        // Bind to the passed workflow, or the currently open one. `undefined`
+        // means "use current"; an explicit `null` forces a workflow-agnostic
+        // thread.
+        const boundWorkflowId =
+          workflowId !== undefined ? workflowId : get().workflowId ?? null;
 
         // Create thread locally; server will auto-create on first message
         const id = crypto.randomUUID();
         const now = new Date().toISOString();
         const localThread: Thread = {
           id,
+          workflow_id: boundWorkflowId,
           title: safeTitle || "New conversation",
           created_at: now,
           updated_at: now
@@ -868,8 +913,11 @@ const useGlobalChatStore = create<GlobalChatState>()(
           lastUsedThreadId: id,
           threadWorkflowId: {
             ...state.threadWorkflowId,
-            [id]: state.workflowId ?? null
+            [id]: boundWorkflowId
           },
+          workflowThreadId: boundWorkflowId
+            ? { ...state.workflowThreadId, [boundWorkflowId]: id }
+            : state.workflowThreadId,
           messageCache: {
             ...state.messageCache,
             [id]: []
@@ -914,7 +962,10 @@ const useGlobalChatStore = create<GlobalChatState>()(
         set((state) => ({
           currentThreadId: threadId,
           lastUsedThreadId: threadId,
-          workflowId: state.threadWorkflowId[threadId] ?? state.workflowId
+          workflowId:
+            state.threads[threadId]?.workflow_id ??
+            state.threadWorkflowId[threadId] ??
+            state.workflowId
         }));
         get().loadMessages(threadId);
       },
@@ -1478,12 +1529,22 @@ export const useThreadsQuery = () => {
       });
 
       // Merge with existing threads so locally-created/optimistic threads
-      // that haven't reached the server yet don't get wiped on refetch.
-      useGlobalChatStore.setState((state) => ({
-        threads: { ...state.threads, ...threadsRecord },
-        threadsLoaded: true,
-        isLoadingThreads: false
-      }));
+      // that haven't reached the server yet don't get wiped on refetch, and
+      // hydrate the thread→workflow map from the server (see fetchThreads).
+      useGlobalChatStore.setState((state) => {
+        const threadWorkflowId = { ...state.threadWorkflowId };
+        for (const thread of query.data.threads) {
+          if (thread.workflow_id != null) {
+            threadWorkflowId[thread.id] = thread.workflow_id;
+          }
+        }
+        return {
+          threads: { ...state.threads, ...threadsRecord },
+          threadWorkflowId,
+          threadsLoaded: true,
+          isLoadingThreads: false
+        };
+      });
     }
   }, [query.isSuccess, query.data]);
 

--- a/web/src/stores/__tests__/GlobalChatStore.test.ts
+++ b/web/src/stores/__tests__/GlobalChatStore.test.ts
@@ -739,6 +739,86 @@ describe("GlobalChatStore", () => {
     });
   });
 
+  describe("Workflow scoping", () => {
+    it("createNewThread binds the thread to the active workflow", async () => {
+      store.setState({ workflowId: "wf-1" });
+      const id = await store.getState().createNewThread();
+      const state = store.getState();
+      expect(state.threads[id].workflow_id).toBe("wf-1");
+      expect(state.threadWorkflowId[id]).toBe("wf-1");
+      expect(state.workflowThreadId["wf-1"]).toBe(id);
+    });
+
+    it("createNewThread(undefined, null) creates a workflow-agnostic thread", async () => {
+      store.setState({ workflowId: "wf-1" });
+      const id = await store.getState().createNewThread(undefined, null);
+      expect(store.getState().threads[id].workflow_id).toBeNull();
+      expect(store.getState().threadWorkflowId[id]).toBeNull();
+    });
+
+    it("openWorkflowThread creates a fresh thread when the workflow has none", async () => {
+      const id = await store.getState().openWorkflowThread("wf-new");
+      const state = store.getState();
+      expect(state.workflowId).toBe("wf-new");
+      expect(state.currentThreadId).toBe(id);
+      expect(state.threads[id].workflow_id).toBe("wf-new");
+      expect(state.workflowThreadId["wf-new"]).toBe(id);
+    });
+
+    it("openWorkflowThread switches to the workflow's most recent conversation", async () => {
+      store.setState({
+        threads: {
+          old: {
+            id: "old",
+            title: "old",
+            workflow_id: "wf-1",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z"
+          },
+          recent: {
+            id: "recent",
+            title: "recent",
+            workflow_id: "wf-1",
+            created_at: "2026-02-01T00:00:00Z",
+            updated_at: "2026-02-01T00:00:00Z"
+          },
+          other: {
+            id: "other",
+            title: "other",
+            workflow_id: "wf-2",
+            created_at: "2026-03-01T00:00:00Z",
+            updated_at: "2026-03-01T00:00:00Z"
+          }
+        },
+        threadsLoaded: true
+      } as any);
+
+      const id = await store.getState().openWorkflowThread("wf-1");
+      expect(id).toBe("recent");
+      expect(store.getState().currentThreadId).toBe("recent");
+      expect(store.getState().workflowId).toBe("wf-1");
+    });
+
+    it("openWorkflowThread reuses the client-side binding for unpersisted threads", async () => {
+      store.setState({
+        threads: {
+          local: {
+            id: "local",
+            title: "local",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z"
+          }
+        },
+        threadWorkflowId: { local: "wf-1" },
+        threadsLoaded: true
+      } as any);
+
+      const id = await store.getState().openWorkflowThread("wf-1");
+      expect(id).toBe("local");
+      expect(store.getState().currentThreadId).toBe("local");
+    });
+  });
+
   describe("sendMessage Advanced Cases", () => {
     let sentData: any;
 


### PR DESCRIPTION
## Summary

Adds workflow scoping to chat threads so the node editor's conversation panel lists and reopens only threads bound to the currently open workflow, while the global chat remains workflow-agnostic. Threads gain a nullable `workflow_id` field that persists to the database and is hydrated on load.

## Key Changes

- **Thread model & schema**: Added `workflow_id` field (nullable text) to threads table with composite index on `(user_id, workflow_id)` for efficient scoping queries. Migration `20260701_000000` adds the column and index.

- **Thread.paginate()**: Now accepts optional `workflowId` parameter to filter threads to a single workflow; omitting it returns all user threads (for global chat).

- **createNewThread()**: 
  - Now accepts optional `workflowId` parameter (defaults to current `workflowId` if not specified, or `null` for workflow-agnostic threads)
  - Sets `workflow_id` on the local thread object before persisting
  - Updates both `threadWorkflowId` and `workflowThreadId` mappings

- **openWorkflowThread()**: Refactored to find the most recent thread bound to a workflow (checking both server `workflow_id` and client-side `threadWorkflowId` for unpersisted threads), reuse it, or create a fresh one if none exists.

- **Thread list hydration**: Both `fetchThreads()` and `useThreadsQuery()` now populate `threadWorkflowId` from server responses so the editor can scope its list after a fresh load.

- **ConversationOverlay**: Filters thread list to current workflow when `workflowId` is set; shows all threads when `workflowId` is null.

- **FloatingToolBar**: New effect binds the canvas chat to the open workflow—calls `openWorkflowThread()` when workflow changes and clears the binding on unmount so the full-page chat starts workflow-agnostic.

- **API routes**: `threads.list()` and `messages.create()` now accept and pass through `workflow_id` parameter.

- **WebSocket runner**: `ensureThreadExists()` now accepts `workflowId` and binds newly created threads to it.

## Implementation Details

- Threads are scoped by checking both `thread.workflow_id` (server-persisted) and `threadWorkflowId[id]` (client-side binding for unpersisted threads) to handle the case where a locally-created thread hasn't reached the server yet.
- The editor's thread list is filtered client-side in `ConversationOverlay` based on the current `workflowId`.
- Leaving the editor clears `workflowId` so the full-page chat doesn't inherit the workflow scope.
- Comprehensive test coverage added for workflow scoping behavior in `GlobalChatStore.test.ts` and `thread.test.ts`.

https://claude.ai/code/session_01B7JnkG9wshwenk5F793xMe