### PR TITLE
Replace isLocalhost with isAuthRequired() runtime check

### DIFF
--- a/web/src/lib/workflow/__tests__/runInlineGraphJob.test.ts
+++ b/web/src/lib/workflow/__tests__/runInlineGraphJob.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../websocket/GlobalWebSocketManager", () => {
     }
   };
 });
-jest.mock("../../env", () => ({ isLocalhost: true }));
+jest.mock("../../runtimeConfig", () => ({ isAuthRequired: () => false }));
 jest.mock("../../supabaseClient", () => ({
   supabase: { auth: { getSession: jest.fn() } }
 }));

--- a/web/src/lib/workflow/runInlineGraphJob.ts
+++ b/web/src/lib/workflow/runInlineGraphJob.ts
@@ -1,5 +1,5 @@
 import { globalWebSocketManager } from "../websocket/GlobalWebSocketManager";
-import { isLocalhost } from "../env";
+import { isAuthRequired } from "../runtimeConfig";
 import { supabase } from "../supabaseClient";
 import { BASE_URL } from "../../stores/BASE_URL";
 import useMetadataStore from "../../stores/MetadataStore";
@@ -114,7 +114,7 @@ export async function runInlineGraphJob(
 
   let auth_token = "local_token";
   let user_id = "1";
-  if (!isLocalhost) {
+  if (isAuthRequired()) {
     const {
       data: { session }
     } = await supabase.auth.getSession();

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -11,7 +11,7 @@
  * Subscription setup is handled by WorkflowManagerContext when workflows are loaded.
  */
 import { create, StoreApi, UseBoundStore } from "zustand";
-import { isLocalhost } from "../lib/env";
+import { isAuthRequired } from "../lib/runtimeConfig";
 import { NodeData } from "./NodeData";
 import { BASE_URL } from "./BASE_URL";
 import { Edge, Node } from "@xyflow/react";
@@ -482,7 +482,7 @@ export const createWorkflowRunnerStore = (
       // doesn't stay stuck in "connecting" with a phantom job_id.
       let auth_token = "local_token";
       let user = "1";
-      if (!isLocalhost) {
+      if (isAuthRequired()) {
         try {
           const {
             data: { session }

--- a/web/src/trpc/Provider.tsx
+++ b/web/src/trpc/Provider.tsx
@@ -2,13 +2,13 @@ import { useState, type ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink, loggerLink } from "@trpc/client";
 import { trpc } from "./client";
-import { isLocalhost } from "../lib/env";
+import { isAuthRequired } from "../lib/runtimeConfig";
 import { supabase } from "../lib/supabaseClient";
 import { queryClient } from "../queryClient";
 import { BASE_URL } from "../stores/BASE_URL";
 
 async function authHeaders(): Promise<Record<string, string>> {
-  if (isLocalhost) return {};
+  if (!isAuthRequired()) return {};
   const {
     data: { session }
   } = await supabase.auth.getSession();


### PR DESCRIPTION
## Summary
Replaces the static `isLocalhost` environment check with a dynamic `isAuthRequired()` function from runtime configuration. This allows authentication requirements to be determined at runtime rather than build time, enabling more flexible deployment scenarios.

## Changes
- **Import updates**: Changed from `isLocalhost` (env module) to `isAuthRequired()` (runtimeConfig module) across three files
- **Logic inversion**: Updated conditional checks to use `isAuthRequired()` directly instead of negating `isLocalhost`
  - `if (!isLocalhost)` → `if (isAuthRequired())`
  - `if (isLocalhost)` → `if (!isAuthRequired())`
- **Files modified**:
  - `web/src/lib/workflow/runInlineGraphJob.ts` — inline graph job execution auth handling
  - `web/src/stores/WorkflowRunner.ts` — workflow runner store auth token setup
  - `web/src/trpc/Provider.tsx` — tRPC auth headers configuration
  - `web/src/lib/workflow/__tests__/runInlineGraphJob.test.ts` — test mock updated to reflect new function signature

## Implementation Details
The change shifts from a static build-time environment variable to a runtime configuration function, allowing the authentication requirement to be determined dynamically based on deployment context rather than being baked into the build.

https://claude.ai/code/session_014GJaMn7MF3M6fqrQe99GT2