### PR TITLE
Pass git commit hash and build number to Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute short SHA
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -82,6 +86,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USE_LOCAL_REPO=1
+            GIT_COMMIT_HASH=${{ steps.vars.outputs.short_sha }}
+            BUILD_NUMBER=${{ github.run_number }}
           no-cache-filters: |
             pip-deps
           cache-from: type=registry,ref=ghcr.io/nodetool-ai/nodetool:buildcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,13 @@ ARG WEB_BUILD_NODE_OPTIONS=--max-old-space-size=4096
 # The web app learns its auth mode and public Supabase credentials from the
 # backend at runtime via GET /api/config, so no VITE_* build args are needed
 # here — configure the server (SUPABASE_URL/KEY/ANON_KEY) instead.
+#
+# .git is excluded from the build context (see .dockerignore), so vite.config.ts's
+# git-based fallback can't resolve the commit/build number here — pass them in.
+ARG GIT_COMMIT_HASH=unknown
+ARG BUILD_NUMBER=0
+ENV GIT_COMMIT_HASH=$GIT_COMMIT_HASH \
+    BUILD_NUMBER=$BUILD_NUMBER
 RUN cd web && NODE_OPTIONS="$WEB_BUILD_NODE_OPTIONS" npm run build
 
 # Assemble a minimal runtime filesystem with compiled packages, web assets, and


### PR DESCRIPTION
## Summary
Adds build-time metadata (git commit hash and build number) to the Docker image build process, enabling the web app to display version information at runtime.

## Key Changes
- **Dockerfile**: Added `GIT_COMMIT_HASH` and `BUILD_NUMBER` build arguments that are passed to the web build environment via `ENV`. These are used by `vite.config.ts` as fallbacks when `.git` is unavailable in the build context (excluded via `.dockerignore`).
- **GitHub Actions workflow**: 
  - Compute short SHA (7 characters) from `GITHUB_SHA` in a new step
  - Pass `GIT_COMMIT_HASH` (short SHA) and `BUILD_NUMBER` (GitHub run number) as build arguments to the Docker build step

## Implementation Details
The `.git` directory is excluded from the Docker build context for image size optimization, which prevents Vite's git-based version resolution from working during the build. This change explicitly provides those values via build arguments instead, ensuring the web app can always access version metadata regardless of how the image is built.

https://claude.ai/code/session_01TXuhaihSiKBV9PLDU1Tj2w