### PR TITLE
Prevent focus restoration in sidebar document context menu

### DIFF
--- a/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
+++ b/web/src/components/context_menus/SidebarDocumentContextMenu.tsx
@@ -59,6 +59,7 @@ const SidebarDocumentContextMenu: React.FC = () => {
       onClose={closeContextMenu}
       onContextMenu={(event) => event.preventDefault()}
       position={menuPosition}
+      disableRestoreFocus
     >
       <MenuItem disabled>
         <Text>{payload.name}</Text>


### PR DESCRIPTION
## Summary
Adds `disableRestoreFocus` prop to the `Menu` component in `SidebarDocumentContextMenu` to prevent automatic focus restoration when the context menu closes.

## Changes
- Added `disableRestoreFocus` prop to the `Menu` component in `SidebarDocumentContextMenu.tsx`

## Details
This change prevents the Menu component from automatically restoring focus to the previously focused element when the context menu is closed. This improves the UX by avoiding unexpected focus shifts after dismissing the context menu on sidebar documents.

https://claude.ai/code/session_01KcDuAqpQGyK53M6YoWVfvG