### PR TITLE
Clean up orphaned dist outputs after TypeScript incremental builds

### DIFF
--- a/packages/websocket/tests/build-typescript-workspace.test.ts
+++ b/packages/websocket/tests/build-typescript-workspace.test.ts
@@ -5,7 +5,8 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
   getTypeScriptBuildCommand,
-  prepareTypeScriptWorkspaceBuild
+  prepareTypeScriptWorkspaceBuild,
+  pruneOrphanedDistOutputs
 } from "../../../scripts/build-typescript-workspace.mjs";
 
 describe("prepareTypeScriptWorkspaceBuild", () => {
@@ -16,15 +17,17 @@ describe("prepareTypeScriptWorkspaceBuild", () => {
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
-  it("leaves dist and tsbuildinfo in place when invoking tsc --build", async () => {
-    // Incremental build: the helper must NOT wipe outputs before running tsc.
-    // Wiping opens a window where the package's files are missing, racing
-    // concurrent turbo tasks (see scripts/build-typescript-workspace.mjs for
-    // the full rationale). `tsc --build` updates and removes outputs itself.
+  it("leaves dist and tsbuildinfo in place while invoking tsc --build", async () => {
+    // The helper must NOT wipe outputs before running tsc. Wiping opens a
+    // window where the package's files are missing, racing concurrent turbo
+    // tasks (see scripts/build-typescript-workspace.mjs for the full
+    // rationale). Orphaned outputs are pruned surgically after the build.
     const workspaceDir = await mkdtemp(join(tmpdir(), "nodetool-build-helper-"));
     tempDirs.push(workspaceDir);
 
+    await mkdir(join(workspaceDir, "src"), { recursive: true });
     await mkdir(join(workspaceDir, "dist"), { recursive: true });
+    await writeFile(join(workspaceDir, "src", "index.ts"), "export const a = 1;");
     await writeFile(join(workspaceDir, "dist", "index.js"), "old output");
     await writeFile(join(workspaceDir, "tsconfig.tsbuildinfo"), "stale build state");
 
@@ -45,6 +48,36 @@ describe("prepareTypeScriptWorkspaceBuild", () => {
     await expect(readFile(join(workspaceDir, "tsconfig.tsbuildinfo"), "utf8")).resolves.toBe(
       "stale build state"
     );
+    expect(existsSync(join(workspaceDir, "dist", "index.js"))).toBe(true);
+  });
+
+  it("prunes dist outputs whose source file was deleted or renamed", async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), "nodetool-build-helper-"));
+    tempDirs.push(workspaceDir);
+
+    await mkdir(join(workspaceDir, "src", "sub"), { recursive: true });
+    await mkdir(join(workspaceDir, "dist", "sub"), { recursive: true });
+
+    // `kept` still has a matching source file; `removed` was deleted from src.
+    await writeFile(join(workspaceDir, "src", "kept.ts"), "export const a = 1;");
+    for (const name of ["kept", "removed"]) {
+      await writeFile(join(workspaceDir, "dist", `${name}.js`), "compiled");
+      await writeFile(join(workspaceDir, "dist", `${name}.d.ts`), "declared");
+    }
+
+    await writeFile(join(workspaceDir, "src", "sub", "kept.ts"), "export const b = 1;");
+    for (const name of ["kept", "removed"]) {
+      await writeFile(join(workspaceDir, "dist", "sub", `${name}.js`), "compiled");
+    }
+
+    await pruneOrphanedDistOutputs(workspaceDir);
+
+    expect(existsSync(join(workspaceDir, "dist", "kept.js"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "dist", "kept.d.ts"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "dist", "removed.js"))).toBe(false);
+    expect(existsSync(join(workspaceDir, "dist", "removed.d.ts"))).toBe(false);
+    expect(existsSync(join(workspaceDir, "dist", "sub", "kept.js"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "dist", "sub", "removed.js"))).toBe(false);
   });
 
   it("uses the repo-local TypeScript CLI through node", () => {

--- a/scripts/build-typescript-workspace.mjs
+++ b/scripts/build-typescript-workspace.mjs
@@ -1,10 +1,65 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { readdir, rm, access } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptPath = fileURLToPath(import.meta.url);
 const scriptDir = dirname(scriptPath);
 const repoRoot = resolve(scriptDir, "..");
+
+// Outputs for a deleted/renamed src/**/*.ts(x) that `tsc --build` leaves
+// behind in dist/**. Checked (with an empirical repro) against TypeScript
+// 6.0.2: incremental builds never delete an output whose source input is
+// gone, they only skip regenerating it. All packages here use the shared
+// rootDir: "src" / outDir: "dist" layout from tsconfig.base.json, so a
+// dist file's source can be located by mirroring its relative path.
+const DIST_OUTPUT_SUFFIXES = [".d.ts.map", ".d.ts", ".js.map", ".js"];
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function pruneOrphanedDistOutputs(workspaceDir) {
+  const srcDir = resolve(workspaceDir, "src");
+  const distDir = resolve(workspaceDir, "dist");
+
+  let entries;
+  try {
+    entries = await readdir(distDir, { recursive: true, withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const distFilePath = join(entry.parentPath ?? entry.path, entry.name);
+    const relPath = relative(distDir, distFilePath);
+    const suffix = DIST_OUTPUT_SUFFIXES.find((s) => relPath.endsWith(s));
+    if (!suffix) {
+      continue;
+    }
+
+    const base = relPath.slice(0, -suffix.length);
+    const hasSource =
+      (await pathExists(join(srcDir, `${base}.ts`))) ||
+      (await pathExists(join(srcDir, `${base}.tsx`)));
+
+    if (!hasSource) {
+      await rm(distFilePath, { force: true });
+    }
+  }
+}
 
 export async function runCommand(command, args, options = {}) {
   await new Promise((resolveRun, rejectRun) => {
@@ -27,21 +82,25 @@ export async function runCommand(command, args, options = {}) {
 }
 
 export async function prepareTypeScriptWorkspaceBuild(workspaceDir, execute = runCommand) {
-  // Intentionally do NOT `rm -rf dist` here. `tsc --build` is incremental: it
-  // tracks outputs in `tsconfig.tsbuildinfo` and rewrites only what changed,
-  // including removing artifacts for sources that were deleted from the input
-  // set. Wiping `dist/` first opens a window where the package's files are
-  // missing — turbo schedules build tasks in parallel with concurrent
-  // `test --filter --affected` tasks, and a test that imports a leaf package
-  // (or transitively reaches a `dist/` subpath via re-exports in another
-  // package's compiled output) races against the rebuild and fails with
-  // `ERR_MODULE_NOT_FOUND`. Letting `tsc` update in place closes the window
-  // without changing the build outputs.
-
+  // Intentionally do NOT `rm -rf dist` here. Wiping `dist/` first opens a
+  // window where the package's files are missing — turbo schedules build
+  // tasks in parallel with concurrent `test --filter --affected` tasks, and a
+  // test that imports a leaf package (or transitively reaches a `dist/`
+  // subpath via re-exports in another package's compiled output) races
+  // against the rebuild and fails with `ERR_MODULE_NOT_FOUND`.
+  //
+  // `tsc --build` itself is incremental but does NOT delete dist outputs for
+  // sources removed from the input set (verified against TypeScript 6.0.2),
+  // so a deleted/renamed src file leaves a stale compiled file behind. We
+  // prune those after the build instead of wiping dist/ up front, so already
+  // up-to-date outputs stay available throughout and only genuinely orphaned
+  // files disappear.
   const { command, args } = getTypeScriptBuildCommand(repoRoot);
   await execute(command, args, {
     cwd: workspaceDir
   });
+
+  await pruneOrphanedDistOutputs(workspaceDir);
 }
 
 export function getTypeScriptBuildCommand(rootDir = repoRoot) {


### PR DESCRIPTION
## Summary

TypeScript's `--build` mode performs incremental builds but does not delete dist outputs when their source files are removed or renamed. This PR adds a post-build cleanup step that surgically removes orphaned compiled files, preventing stale artifacts from accumulating in the dist directory.

## Changes

- **Added `pruneOrphanedDistOutputs()` function** in `scripts/build-typescript-workspace.mjs`:
  - Scans the dist directory recursively for compiled outputs (`.js`, `.d.ts`, `.js.map`, `.d.ts.map`)
  - For each output file, checks if a corresponding source file exists in src (`.ts` or `.tsx`)
  - Removes outputs that have no matching source file
  - Gracefully handles missing dist directories (ENOENT)

- **Integrated cleanup into build workflow**:
  - `prepareTypeScriptWorkspaceBuild()` now calls `pruneOrphanedDistOutputs()` after running `tsc --build`
  - Updated comments to clarify the rationale: incremental builds must not wipe dist upfront (to avoid race conditions with concurrent turbo tasks), but orphaned outputs are pruned surgically afterward

- **Added comprehensive test coverage** in `packages/websocket/tests/build-typescript-workspace.test.ts`:
  - Updated existing test to verify dist and tsbuildinfo remain in place during the build
  - Added new test that verifies orphaned outputs are correctly identified and removed while keeping outputs with matching sources

## Implementation Details

- Uses `readdir()` with `recursive: true` and `withFileTypes: true` for efficient directory traversal
- Mirrors the relative path from dist back to src to locate source files (leveraging the shared `rootDir: "src" / outDir: "dist"` layout from `tsconfig.base.json`)
- Handles all TypeScript output suffixes: `.d.ts.map`, `.d.ts`, `.js.map`, `.js`
- Preserves the incremental build window-closing benefit: already up-to-date outputs stay available throughout, only genuinely orphaned files disappear

https://claude.ai/code/session_013ZWfauFi8FZUxPa2T2EUvv