### PR TITLE
Fix isIpInCidr to reject malformed CIDR with trailing slash

### DIFF
--- a/packages/websocket/src/lib/localhost-trust.ts
+++ b/packages/websocket/src/lib/localhost-trust.ts
@@ -125,6 +125,7 @@ export function isIpInCidr(ip: string | undefined | null, cidr: string): boolean
   const ipInt = ipv4ToInt(toIpv4(ip));
   const rangeInt = ipv4ToInt(toIpv4(range));
   if (ipInt !== null && rangeInt !== null) {
+    if (prefixStr === "") return false;
     const prefix = prefixStr === null ? 32 : Number(prefixStr);
     if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false;
     const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;

--- a/packages/websocket/tests/localhost-trust.test.ts
+++ b/packages/websocket/tests/localhost-trust.test.ts
@@ -134,6 +134,11 @@ describe("isIpInCidr", () => {
     expect(isIpInCidr("172.17.0.1", "")).toBe(false);
     expect(isIpInCidr("172.17.0.1", "172.16.0.0/99")).toBe(false);
   });
+
+  it("rejects a trailing-slash CIDR instead of degrading to /0", () => {
+    expect(isIpInCidr("8.8.8.8", "172.16.0.0/")).toBe(false);
+    expect(isIpInCidr("172.17.0.1", "172.16.0.0/")).toBe(false);
+  });
 });
 
 describe("isTrustedLocalAddress", () => {


### PR DESCRIPTION
## Summary
Fixes a bug in `isIpInCidr` where CIDR notation with a trailing slash (e.g., `"172.16.0.0/"`) would degrade to `/0` instead of being rejected as invalid input.

## Changes
- **packages/websocket/src/lib/localhost-trust.ts**: Added early validation to reject CIDR strings with an empty prefix (trailing slash) before attempting to parse the prefix as an integer
- **packages/websocket/tests/localhost-trust.test.ts**: Added test cases to verify that malformed CIDR notation with trailing slashes is properly rejected

## Implementation Details
The fix adds a guard clause that checks if `prefixStr === ""` and returns `false` immediately. This prevents the subsequent `Number(prefixStr)` call from coercing an empty string to `0`, which would incorrectly match all IPs when the prefix is `0`. The validation now properly treats `"172.16.0.0/"` as invalid input rather than equivalent to `"172.16.0.0/0"`.

https://claude.ai/code/session_0186D3UuZ8VWep1usho8dbXx