### PR TITLE
Fix asset mention picker and canvas uploads to filter folders

### DIFF
--- a/web/src/components/chat/composer/__tests__/useTextareaAssetMention.test.tsx
+++ b/web/src/components/chat/composer/__tests__/useTextareaAssetMention.test.tsx
@@ -194,4 +194,35 @@ describe("useTextareaAssetMention", () => {
     await user.type(textarea, "x");
     expect(screen.queryByTestId("asset-mention-menu")).not.toBeInTheDocument();
   });
+
+  it("dismisses on an outside click", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">outside</button>
+        <Harness onSelectAsset={jest.fn()} />
+      </>
+    );
+    const textarea = screen.getByLabelText("prompt");
+
+    await user.type(textarea, "@fo");
+    await screen.findByTestId("asset-mention-menu");
+
+    await user.click(screen.getByRole("button", { name: "outside" }));
+    await waitFor(() =>
+      expect(screen.queryByTestId("asset-mention-menu")).not.toBeInTheDocument()
+    );
+  });
+
+  it("stays open when clicking inside the picker menu", async () => {
+    const user = userEvent.setup();
+    render(<Harness onSelectAsset={jest.fn()} />);
+    const textarea = screen.getByLabelText("prompt");
+
+    await user.type(textarea, "@fo");
+    const menu = await screen.findByTestId("asset-mention-menu");
+
+    await user.click(menu);
+    expect(screen.getByTestId("asset-mention-menu")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/chat/composer/useTextareaAssetMention.tsx
+++ b/web/src/components/chat/composer/useTextareaAssetMention.tsx
@@ -110,6 +110,8 @@ export const useTextareaAssetMention = ({
   const dismissedStartRef = useRef<number | null>(null);
   // Pending caret to restore after a value edit re-renders the textarea.
   const pendingCaretRef = useRef<number | null>(null);
+  // The portaled menu's DOM node, so outside-click detection can exempt it.
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const {
     activeTab,
@@ -189,6 +191,31 @@ export const useTextareaAssetMention = ({
     };
   }, [trigger, measure]);
 
+  // Dismiss on an outside click — anywhere but the textarea itself or the
+  // picker menu.
+  useEffect(() => {
+    if (!trigger) {
+      return;
+    }
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) {
+        return;
+      }
+      if (textareaRef.current?.contains(target)) {
+        return;
+      }
+      if (menuRef.current?.contains(target)) {
+        return;
+      }
+      dismissedStartRef.current = trigger.start;
+      close();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () =>
+      document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [trigger, textareaRef, close]);
+
   // Restore the caret after we strip the `@query` from the value.
   useLayoutEffect(() => {
     const caret = pendingCaretRef.current;
@@ -261,7 +288,7 @@ export const useTextareaAssetMention = ({
       return null;
     }
     return createPortal(
-      <div style={menuWrapperStyles(rect)}>
+      <div ref={menuRef} style={menuWrapperStyles(rect)}>
         <AssetMentionMenu
           activeTab={activeTab}
           onTabChange={(tab) => {

--- a/web/src/components/node_types/editing/promptComposer/__tests__/useAssetMentionSearch.test.ts
+++ b/web/src/components/node_types/editing/promptComposer/__tests__/useAssetMentionSearch.test.ts
@@ -1,0 +1,41 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAssetMentionSearch } from "../useAssetMentionSearch";
+import { useAssetStore } from "../../../../../stores/AssetStore";
+import { useRecentAssetsStore } from "../../../../../stores/RecentAssetsStore";
+
+jest.mock("../../../../../stores/AssetStore");
+jest.mock("../../../../../stores/RecentAssetsStore");
+
+describe("useAssetMentionSearch", () => {
+  const mockSearch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAssetStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({ search: mockSearch, update: jest.fn() })
+    );
+    (useRecentAssetsStore as unknown as jest.Mock).mockImplementation(
+      (selector) =>
+        selector({ recentAssets: [], renameRecentAsset: jest.fn() })
+    );
+  });
+
+  it("filters folders out of empty-query browse results", async () => {
+    mockSearch.mockResolvedValue({
+      assets: [
+        { id: "folder-1", name: "Photos", content_type: "folder" },
+        { id: "file-1", name: "cat.png", content_type: "image/png" }
+      ],
+      next_cursor: null
+    });
+
+    const { result } = renderHook(() => useAssetMentionSearch(""));
+    result.current.setActiveTab("saved");
+
+    await waitFor(() => {
+      expect(result.current.displayedAssets).toEqual([
+        { id: "file-1", name: "cat.png", content_type: "image/png" }
+      ]);
+    });
+  });
+});

--- a/web/src/components/node_types/editing/promptComposer/useAssetMentionSearch.ts
+++ b/web/src/components/node_types/editing/promptComposer/useAssetMentionSearch.ts
@@ -60,7 +60,10 @@ export const useAssetMentionSearch = (
       search({ query: queryString, page_size: PAGE_SIZE })
         .then((result) => {
           if (active) {
-            setSavedAssets(result.assets ?? []);
+            // Folders aren't attachable — the mention picker is for files only.
+            setSavedAssets(
+              (result.assets ?? []).filter((a) => a.content_type !== "folder")
+            );
             setSavedCursor(result.next_cursor ?? null);
           }
         })
@@ -84,7 +87,10 @@ export const useAssetMentionSearch = (
     const cursor = savedCursor;
     search({ query: queryString, page_size: PAGE_SIZE, cursor })
       .then((result) => {
-        setSavedAssets((prev) => [...prev, ...(result.assets ?? [])]);
+        const nextAssets = (result.assets ?? []).filter(
+          (a) => a.content_type !== "folder"
+        );
+        setSavedAssets((prev) => [...prev, ...nextAssets]);
         setSavedCursor(result.next_cursor ?? null);
       })
       .catch(() => {

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -12,7 +12,10 @@ import isEqual from "fast-deep-equal";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import AssetGrid from "../assets/AssetGrid";
-import { AssetGridStoreProvider } from "../../stores/AssetGridStore";
+import {
+  AssetGridStoreProvider,
+  LIBRARY_ASSET_GRID_STORE_KEY
+} from "../../stores/AssetGridStore";
 import WorkflowList from "../workflows/WorkflowList";
 import WorkflowForm from "../workflows/WorkflowForm";
 import CreateWorkflowButton from "../workflows/CreateWorkflowButton";
@@ -390,7 +393,7 @@ const PanelContent = memo(function PanelContent({
               }
             />
           )}
-          <AssetGridStoreProvider persistKey="asset-grid-storage:library">
+          <AssetGridStoreProvider persistKey={LIBRARY_ASSET_GRID_STORE_KEY}>
             <AssetGrid maxItemSize={5} isMobile={isMobile} forceGlobalAssets />
           </AssetGridStoreProvider>
         </FlexColumn>

--- a/web/src/hooks/handlers/dropHandlerUtils.ts
+++ b/web/src/hooks/handlers/dropHandlerUtils.ts
@@ -1,7 +1,10 @@
 import { useCallback } from "react";
 import { XYPosition } from "@xyflow/react";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
-import { useAssetGridStore } from "../../stores/AssetGridStore";
+import {
+  useAssetGridStore,
+  useLibraryCurrentFolderId
+} from "../../stores/AssetGridStore";
 import { useCreateDataframe } from "./useCreateDataframe";
 import {
   constantForType,
@@ -40,7 +43,15 @@ export const isNodetoolWorkflowJson = (
 };
 
 export const useFileHandlers = () => {
-  const currentFolderId = useAssetGridStore((state) => state.currentFolderId);
+  // Uploads triggered from the canvas (drag/drop, paste) should land in
+  // whatever folder the Library sidebar is browsing, falling back to the
+  // fullscreen assets page's folder when the Library panel hasn't navigated
+  // anywhere (both surfaces are scoped stores independent of each other).
+  const libraryFolderId = useLibraryCurrentFolderId();
+  const singletonFolderId = useAssetGridStore(
+    (state) => state.currentFolderId
+  );
+  const currentFolderId = libraryFolderId || singletonFolderId;
   const { uploadAsset } = useAssetUpload();
   const createWorkflow = useWorkflowManager((state) => state.create);
   const { createNode, addNode, workflow } = useNodes((state) => ({

--- a/web/src/hooks/handlers/useClipboardContentPaste.ts
+++ b/web/src/hooks/handlers/useClipboardContentPaste.ts
@@ -14,7 +14,10 @@ import { useReactFlow } from "@xyflow/react";
 import { getMousePosition } from "../../utils/MousePosition";
 import { useNodes } from "../../contexts/NodeContext";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
-import { useAssetGridStore } from "../../stores/AssetGridStore";
+import {
+  useAssetGridStore,
+  useLibraryCurrentFolderId
+} from "../../stores/AssetGridStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import useAuth from "../../stores/useAuth";
 import useMetadataStore from "../../stores/MetadataStore";
@@ -73,7 +76,13 @@ export const useClipboardContentPaste = () => {
   }), shallow);
   const { uploadAsset } = useAssetUpload();
   const addNotification = useNotificationStore((state) => state.addNotification);
-  const currentFolderId = useAssetGridStore((state) => state.currentFolderId);
+  // Mirrors dropHandlerUtils: canvas paste uploads should follow the Library
+  // sidebar's active folder, falling back to the fullscreen assets page.
+  const libraryFolderId = useLibraryCurrentFolderId();
+  const singletonFolderId = useAssetGridStore(
+    (state) => state.currentFolderId
+  );
+  const currentFolderId = libraryFolderId || singletonFolderId;
   const user = useAuth((auth) => auth.user);
   const getMetadata = useMetadataStore((state) => state.getMetadata);
 

--- a/web/src/stores/AssetGridStore.ts
+++ b/web/src/stores/AssetGridStore.ts
@@ -249,6 +249,20 @@ const getOrCreateStore = (key: string): AssetGridStoreApi => {
 export const SINGLETON_ASSET_GRID_STORE_KEY = "asset-grid-storage";
 const singletonStore = getOrCreateStore(SINGLETON_ASSET_GRID_STORE_KEY);
 
+// The sidebar Library panel (PanelLeft) is the surface users browse folders
+// in day-to-day; canvas drop/paste uploads should land in whatever folder is
+// open there, not just the rarely-visited fullscreen assets page (which reads
+// the singleton above).
+export const LIBRARY_ASSET_GRID_STORE_KEY = "asset-grid-storage:library";
+
+const libraryStore = getOrCreateStore(LIBRARY_ASSET_GRID_STORE_KEY);
+
+/** Reactive access to the Library panel's current folder, for cross-cutting
+ * callers (e.g. canvas file-drop/paste) that need it without being inside
+ * the panel's provider subtree. */
+export const useLibraryCurrentFolderId = (): string | null =>
+  useStore(libraryStore, (state) => state.currentFolderId);
+
 const AssetGridStoreContext =
   createContext<AssetGridStoreApi>(singletonStore);
 


### PR DESCRIPTION
## Summary

Fixes two related issues with asset handling:
1. The asset mention picker (for `@`-mentions in chat) now filters out folders, showing only attachable files
2. Canvas drag/drop and paste uploads now correctly target the Library sidebar's active folder instead of only the fullscreen assets page

## Key Changes

- **Asset mention picker filtering**: Modified `useAssetMentionSearch` to filter out `content_type: "folder"` results from both initial search and pagination, since folders cannot be attached as mentions
- **Canvas upload folder targeting**: Introduced `LIBRARY_ASSET_GRID_STORE_KEY` and `useLibraryCurrentFolderId()` to allow canvas operations (drag/drop, paste) to respect the Library panel's active folder, with fallback to the fullscreen assets page's folder
- **Outside-click dismissal**: Added pointer-down event listener to `useTextareaAssetMention` to dismiss the mention picker when clicking outside the textarea or menu, with proper ref tracking to exempt the portaled menu from dismissal
- **Test coverage**: Added unit test for folder filtering in `useAssetMentionSearch` and integration tests for outside-click behavior in `useTextareaAssetMention`

## Implementation Details

- The Library panel now uses a separate scoped store (`LIBRARY_ASSET_GRID_STORE_KEY`) from the fullscreen assets page, allowing independent folder navigation
- Canvas file operations check `libraryFolderId || singletonFolderId` to prefer the Library sidebar's context when available
- The mention picker's portaled menu is tracked via `menuRef` to prevent dismissal when interacting with it
- Folder filtering uses a simple predicate check (`a.content_type !== "folder"`) applied consistently across search and pagination paths

https://claude.ai/code/session_01JiwqE4FLT5GW88TKCPb8Ds