### PR TITLE
Add three flagship use-case workflows and documentation

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -70,6 +70,30 @@ us, and you can switch any model for a better one the day it ships.
       </div>
     </div>
   </article>
+
+  <article class="usecase-card">
+    <a href="{{ '/use-cases/podcast-repurposing-studio' | relative_url }}" class="usecase-media"></a>
+    <div class="usecase-body">
+      <span class="usecase-tag">Creators</span>
+      <h3><a href="{{ '/use-cases/podcast-repurposing-studio' | relative_url }}">Podcast Repurposing Studio</a></h3>
+      <p>Drop in one episode and ship the whole content pack: titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. Transcribed once, written four ways.</p>
+      <div class="pipeline-chips">
+        <span>Episode</span><span>Transcript</span><span>Notes</span><span>Newsletter</span><span>Cards</span>
+      </div>
+    </div>
+  </article>
+
+  <article class="usecase-card">
+    <a href="{{ '/use-cases/seo-content-engine' | relative_url }}" class="usecase-media"></a>
+    <div class="usecase-body">
+      <span class="usecase-tag">Content</span>
+      <h3><a href="{{ '/use-cases/seo-content-engine' | relative_url }}">SEO Content Engine</a></h3>
+      <p>One topic in, a keyword-targeted article batch out. A strategist agent plans the cluster, and every brief becomes a full Markdown article with an editorial hero image — a cluster per run, not an article per invoice.</p>
+      <div class="pipeline-chips">
+        <span>Topic</span><span>Cluster</span><span>Briefs</span><span>Articles</span><span>Heroes</span>
+      </div>
+    </div>
+  </article>
 </div>
 
 ## Build your own

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -7,7 +7,7 @@ image: /assets/use-cases/poster-singularity-1.png
 
 These are the showcase workflows from [nodetool.ai](https://nodetool.ai). Each
 one starts from a handful of inputs and ends with a finished result — a trailer,
-a product video, a set of poster concepts — built on a single canvas. Nothing is
+a batch of video ads, a set of poster concepts — built on a single canvas. Nothing is
 locked: swap a model, rewrite an agent's prompt, or drop in a new brief and run
 it again. The workflow is the reusable part, not the example output.
 
@@ -44,6 +44,20 @@ us, and you can switch any model for a better one the day it ships.
   </article>
 
   <article class="usecase-card">
+    <a href="{{ '/use-cases/ad-creative-factory' | relative_url }}" class="usecase-media">
+      <img src="{{ '/assets/use-cases/smartwatch.png' | relative_url }}" alt="Product photo feeding the Ad Creative Factory">
+    </a>
+    <div class="usecase-body">
+      <span class="usecase-tag">Advertising</span>
+      <h3><a href="{{ '/use-cases/ad-creative-factory' | relative_url }}">Ad Creative Factory</a></h3>
+      <p>One product photo and one offer become a batch of ready-to-test vertical video ads. A strategist agent plans a persona × angle test matrix, and every cell becomes a spoken hook, a staged scene, an animated clip, and a voiceover.</p>
+      <div class="pipeline-chips">
+        <span>Offer</span><span>Matrix</span><span>Hooks</span><span>Scenes</span><span>Ads</span>
+      </div>
+    </div>
+  </article>
+
+  <article class="usecase-card">
     <a href="{{ '/use-cases/movie-poster' | relative_url }}" class="usecase-media">
       <img src="{{ '/assets/use-cases/poster-singularity-1.png' | relative_url }}" alt="Movie poster concept from the Movie Poster Generator">
     </a>
@@ -60,7 +74,7 @@ us, and you can switch any model for a better one the day it ships.
 
 ## Build your own
 
-These three are starting points, not limits. The same building blocks — inputs,
+These are starting points, not limits. The same building blocks — inputs,
 prompts, agents, and image/video/audio models on one canvas — cover far more
 ground. For smaller, single-purpose examples, see the [Workflow
 Gallery]({{ '/workflows/' | relative_url }}) and the

--- a/docs/use-cases/ad-creative-factory.md
+++ b/docs/use-cases/ad-creative-factory.md
@@ -1,0 +1,108 @@
+---
+layout: page
+title: "Ad Creative Factory"
+description: "Turn one product photo and one offer into a batch of ready-to-test vertical video ads. A strategist agent plans a persona × angle test matrix, and every cell becomes a spoken hook, a staged product scene, an animated 9:16 clip, and a voiceover."
+image: /assets/use-cases/smartwatch.png
+---
+
+<p class="usecase-eyebrow">Use case · Advertising</p>
+
+Turn one product photo and one offer into a batch of ready-to-test vertical
+video ads. A strategist agent plans the test, and every variant comes out
+staged, animated, and voiced — what an agency bills per video, this graph
+produces by the batch at provider cost.
+
+Since ad platforms took over targeting, creative volume is the lever that's
+left: accounts win by testing many angles and refreshing them before they
+fatigue. That makes ad variants a recurring line item — bought monthly, per
+video. This workflow moves that line item onto your canvas.
+
+## How it works
+
+Four inputs, one fan-out. The strategist plans once; everything after the list
+generator runs once per variant.
+
+{% mermaid %}
+graph LR
+  brief["Product & offer (String)"]
+  audience["Audience (String)"]
+  count["Variant count (Integer)"]
+  photo["Product photo (Image)"]
+  strategist["Strategist (Agent)"]
+  hooks["Hooks (ListGenerator)"]
+  scene["Stage scene (ImageToImage)"]
+  clip["Animate (ImageToVideo)"]
+  vo["Voiceover (TextToSpeech)"]
+  mix["Mix (AddAudio)"]
+  brief --> strategist
+  audience --> strategist
+  count --> strategist
+  photo --> strategist
+  strategist --> hooks
+  hooks --> scene
+  photo --> scene
+  scene --> clip
+  hooks --> vo
+  clip --> mix
+  vo --> mix
+{% endmermaid %}
+
+1. **Feed in the campaign.** The product and offer, the audience, a variant
+   count, and one clean product photo — the same shot anchors every variant.
+   *(e.g. "Aurora Trail smart fitness watch · 20% off launch week · weekend
+   hikers · 6 variants")*
+2. **Plan the test.** A strategist agent studies the photo and brief, then
+   writes a test matrix: buyer personas × message angles (pain point, bold
+   claim, social proof, offer urgency), and picks the strongest pairings to
+   test.
+3. **Write the hooks.** A list generator turns each matrix cell into one spoken
+   hook — 18 words or fewer, plain language, said in the first three seconds.
+4. **Stage every scene.** For each hook, an image-to-image model places the
+   product from your photo into that hook's world: native UGC framing, natural
+   light, 9:16, upper third kept clear for caption text.
+5. **Animate and voice.** An image-to-video model adds a subtle handheld
+   push-in; a text-to-speech model reads the hook.
+6. **Mix and ship.** The voiceover lands on the clip, and the finished ads
+   collect in a preview grid — one ready-to-upload vertical ad per matrix cell.
+
+## One photo in, a test cell out
+
+Every variant isolates one persona × angle pairing, so when one ad wins in the
+ad account you know *why* it won — and the next run can breed from it. Paste
+last week's winning hooks into the audience or offer input, raise the variant
+count, and the strategist plans the next generation around them.
+
+## Make it yours
+
+- **Swap any model.** Language, image, video, and voice are each one node.
+  Trade the video model up for hero variants, down for cheap broad tests.
+- **Retune the strategist.** The persona × angle matrix is a prompt you can
+  read and edit — push it toward founder-story ads, comparison ads, or a
+  single angle across ten personas.
+- **Change the format.** Aspect ratio, duration, and resolution live on the
+  image and video nodes. Go 1:1 for feed placements or 16:9 for YouTube in one
+  click.
+- **Localize the batch.** Point the voiceover at another voice or language and
+  re-run — the same matrix ships in every market.
+
+## Models in this workflow
+
+The template ships with no models selected — pick one per role when you open
+it. Called with your own keys; the bill comes from the provider.
+
+| Role | Node | Works well with |
+| --- | --- | --- |
+| Test-matrix strategist | Agent | Any strong language model |
+| Hook writer | List Generator | Any language model |
+| Scene staging | Image To Image | An image-editing model that keeps the product intact (Nano Banana, FLUX) |
+| Ad animation | Image To Video | Veo, Kling, Seedance |
+| Voiceover | Text To Speech | OpenAI TTS, ElevenLabs |
+
+See [Models &amp; Providers]({{ '/models-and-providers' | relative_url }}) to set up keys.
+
+## Next steps
+
+- Open the template: **Templates → Ad Creative Factory** in the dashboard
+- [Product Video Generator]({{ '/use-cases/product-video' | relative_url }}) — one cinematic hero video instead of a test batch
+- [Movie Trailer Generator]({{ '/use-cases/movie-trailer' | relative_url }}) — the same fan-out pattern, pointed at film
+- [All use cases]({{ '/use-cases' | relative_url }})

--- a/docs/use-cases/podcast-repurposing-studio.md
+++ b/docs/use-cases/podcast-repurposing-studio.md
@@ -1,0 +1,101 @@
+---
+layout: page
+title: "Podcast Repurposing Studio"
+description: "Drop in one podcast episode and ship the whole content pack: titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. Transcribed once, written four ways."
+---
+
+<p class="usecase-eyebrow">Use case · Creators</p>
+
+Drop in one episode and ship the whole content pack: titles and show notes, a
+newsletter edition, five social posts, and quote cards rendered as square
+images. This is the work podcasters rent per-seat repurposing tools for, or
+skip entirely — here it's one canvas that already knows your show's voice.
+
+An episode's value doesn't stop at the RSS feed: the episode page, the email
+list, and the social feeds each need their own version of it, every week. That
+recurring rewrite is exactly what this graph automates — transcribe once, fan
+out to every format.
+
+## How it works
+
+One transcription, four writer branches. Everything downstream of the
+transcript runs in parallel.
+
+{% mermaid %}
+graph LR
+  audio["Episode audio (Audio)"]
+  show["Show context (String)"]
+  count["Quote count (Integer)"]
+  asr["Transcribe (ASR)"]
+  notes["Show notes (Agent)"]
+  news["Newsletter (Agent)"]
+  posts["Social posts (ListGenerator)"]
+  quotes["Quotes (ListGenerator)"]
+  cards["Quote cards (TextToImage)"]
+  audio --> asr
+  asr --> notes
+  asr --> news
+  asr --> posts
+  asr --> quotes
+  show --> notes
+  show --> news
+  show --> posts
+  count --> quotes
+  quotes --> cards
+{% endmermaid %}
+
+1. **Feed in the episode.** The recording, a line of show context (name, host,
+   voice, call to action), and how many quote cards you want.
+2. **Transcribe once.** A speech-recognition model turns the episode into a
+   transcript that every branch reads from.
+3. **Write the episode page.** An agent drafts three title options, a summary,
+   chapter-style show notes, a resource list, and the closing CTA.
+4. **Draft the newsletter.** A second agent writes the email edition in the
+   host's voice — subject-line options and a body that teases instead of
+   summarizes.
+5. **Generate the posts.** A list generator writes five standalone social
+   posts in mixed formats: a bold take, a question, a mini-story, a stat, a
+   lesson.
+6. **Render the quote cards.** Another list generator pulls the most quotable
+   verbatim lines, and each one becomes a square typographic card via a
+   text-to-image model.
+
+## One recording, a week of content
+
+Everything reads from the same transcript, so the pack is consistent: the
+newsletter teases what the show notes explain, and the quote cards say it in
+the host's own words. Run it as the last step of every edit session and
+publishing day becomes an upload, not a writing shift.
+
+## Make it yours
+
+- **Tune each voice separately.** Show notes, newsletter, and posts each have
+  their own prompt and system prompt — make the newsletter personal and the
+  posts punchy without compromise.
+- **Swap the transcription model.** Whisper variants, local or hosted — the
+  branch prompts don't change.
+- **Restyle the cards.** The quote-card prompt controls typography, palette,
+  and format. Match your cover art, or go 9:16 for stories.
+- **Add branches.** A YouTube description, a LinkedIn essay, a blog post —
+  each is one more Prompt → Agent pair reading the same transcript.
+
+## Models in this workflow
+
+The template ships with no models selected — pick one per role when you open
+it. Called with your own keys; the bill comes from the provider.
+
+| Role | Node | Works well with |
+| --- | --- | --- |
+| Transcription | Automatic Speech Recognition | Whisper (hosted or local) |
+| Show notes, newsletter | Agent | Any strong language model |
+| Posts, quotes | List Generator | Any language model |
+| Quote cards | Text To Image | A model with reliable text rendering (Nano Banana, GPT Image) |
+
+See [Models &amp; Providers]({{ '/models-and-providers' | relative_url }}) to set up keys.
+
+## Next steps
+
+- Open the template: **Templates → Podcast Repurposing Studio** in the dashboard
+- [Ad Creative Factory]({{ '/use-cases/ad-creative-factory' | relative_url }}) — the same fan-out, pointed at paid social
+- [Transcribe Audio]({{ '/workflows/transcribe-audio' | relative_url }}) — the transcription building block on its own
+- [All use cases]({{ '/use-cases' | relative_url }})

--- a/docs/use-cases/seo-content-engine.md
+++ b/docs/use-cases/seo-content-engine.md
@@ -1,0 +1,96 @@
+---
+layout: page
+title: "SEO Content Engine"
+description: "One topic in, a keyword-targeted article batch out. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full Markdown article with an editorial hero image."
+---
+
+<p class="usecase-eyebrow">Use case · Content</p>
+
+One topic in, a keyword-targeted article batch out. A strategist agent plans
+the cluster, and every article arrives written, structured for search, and
+paired with an editorial hero image — the deliverable content agencies bill
+per article, produced by the batch at provider cost.
+
+Ranking rarely comes from one article. Search engines reward *clusters* —
+several pieces that own a topic together, each answering a different intent.
+Producing a cluster is what makes content expensive; this graph makes it one
+run.
+
+## How it works
+
+The strategist plans once; everything after the list generator runs once per
+article.
+
+{% mermaid %}
+graph LR
+  business["Business & site (String)"]
+  seeds["Audience & seeds (String)"]
+  count["Article count (Integer)"]
+  strategist["Strategist (Agent)"]
+  briefs["Briefs (ListGenerator)"]
+  writer["Writer (Agent)"]
+  hero["Hero image (TextToImage)"]
+  business --> strategist
+  seeds --> strategist
+  count --> strategist
+  strategist --> briefs
+  briefs --> writer
+  briefs --> hero
+{% endmermaid %}
+
+1. **Feed in the campaign.** Who's publishing and which pages the articles
+   support, who searches and the seed topics, and how many articles to
+   produce. *(e.g. "ultralight hiking shop · beginner hikers · trail runners
+   vs boots · 4 articles")*
+2. **Plan the cluster.** A strategist agent picks the topic cluster, assigns
+   one primary keyword per article with its search intent, and divides
+   coverage so the articles don't compete with each other.
+3. **Write the briefs.** A list generator turns the plan into one brief per
+   article: title, keyword, intent, H2 sections, and what the reader must be
+   able to do afterward.
+4. **Write the articles.** For each brief, a writer agent produces the full
+   Markdown piece — meta description, answer-first opening, the brief's
+   section structure, an FAQ, and one unforced CTA.
+5. **Render the heroes.** In parallel, each brief becomes a 16:9 editorial
+   hero image with room left for a headline overlay.
+
+## One run, one cluster
+
+Because every article comes from the same plan, the batch behaves like a
+cluster instead of a pile: keywords don't cannibalize, internal logic is
+consistent, and the voice section of the plan keeps ten articles sounding
+like one publication. Point the seed inputs at the next cluster and run it
+again.
+
+## Make it yours
+
+- **Retune the writer.** The article rules — length, structure, point of
+  view, FAQ — are a prompt, not a setting. Make it terse and technical or
+  warm and story-led.
+- **Raise the stakes per article.** Swap the writer's model up for money
+  pages, down for supporting pieces.
+- **Change the imagery.** The hero prompt controls the visual language —
+  photography, flat illustration, product-in-context.
+- **Chain the next step.** Add a Save Text node per article, or a translation
+  branch to ship each cluster in every market's language.
+
+## Models in this workflow
+
+The template ships with no models selected — pick one per role when you open
+it. Called with your own keys; the bill comes from the provider.
+
+| Role | Node | Works well with |
+| --- | --- | --- |
+| Cluster strategist | Agent | Any strong language model |
+| Brief writer | List Generator | Any language model |
+| Article writer | Agent | A long-output model you trust with prose |
+| Hero images | Text To Image | FLUX, Imagen, Nano Banana |
+
+See [Models &amp; Providers]({{ '/models-and-providers' | relative_url }}) to set up keys.
+
+## Next steps
+
+- Open the template: **Templates → SEO Content Engine** in the dashboard
+- [Ad Creative Factory]({{ '/use-cases/ad-creative-factory' | relative_url }}) — paid acquisition from the same brief-style inputs
+- [Podcast Repurposing Studio]({{ '/use-cases/podcast-repurposing-studio' | relative_url }}) — the content pack for what you've already recorded
+- [All use cases]({{ '/use-cases' | relative_url }})

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -5,7 +5,7 @@ title: "Workflow Gallery"
 
 Ready-to-use workflow examples. Each includes explanations and visual diagrams.
 
-For the flagship, end-to-end showcases — trailer, product video, poster — see
+For the flagship, end-to-end showcases — trailer, ad batch, product video, poster — see
 [Use Cases]({{ '/use-cases' | relative_url }}). See
 [Workflow Patterns]({{ '/cookbook/patterns' | relative_url }}) for reusable techniques.
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -5,7 +5,7 @@ title: "Workflow Gallery"
 
 Ready-to-use workflow examples. Each includes explanations and visual diagrams.
 
-For the flagship, end-to-end showcases — trailer, ad batch, product video, poster — see
+For the flagship, end-to-end showcases, see
 [Use Cases]({{ '/use-cases' | relative_url }}). See
 [Workflow Patterns]({{ '/cookbook/patterns' | relative_url }}) for reusable techniques.
 

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Ad Creative Factory.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Ad Creative Factory.json
@@ -1,0 +1,691 @@
+{
+  "id": "ad_creative_factory",
+  "access": "public",
+  "created_at": "2026-07-01T00:00:00.000000",
+  "updated_at": "2026-07-01T00:00:00.000000",
+  "name": "Ad Creative Factory",
+  "tool_name": null,
+  "description": "Turn one product photo and one offer into a batch of ready-to-test vertical video ads. A strategist agent plans a persona × angle test matrix, a list generator writes one spoken hook per cell, and every hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.",
+  "tags": [
+    "marketing",
+    "advertising",
+    "video",
+    "audio",
+    "agents",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "e1",
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "strategy_prompt",
+        "targetHandle": "BRIEF",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e2",
+        "source": "audience",
+        "sourceHandle": "output",
+        "target": "strategy_prompt",
+        "targetHandle": "AUDIENCE",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e3",
+        "source": "variant_count",
+        "sourceHandle": "output",
+        "target": "strategy_prompt",
+        "targetHandle": "COUNT",
+        "ui_properties": {
+          "className": "int"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e4",
+        "source": "strategy_prompt",
+        "sourceHandle": "output",
+        "target": "strategist",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e5",
+        "source": "product_photo",
+        "sourceHandle": "output",
+        "target": "strategist",
+        "targetHandle": "image",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e6",
+        "source": "strategist",
+        "sourceHandle": "text",
+        "target": "hooks_prompt",
+        "targetHandle": "PLAN",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e7",
+        "source": "variant_count",
+        "sourceHandle": "output",
+        "target": "hooks_prompt",
+        "targetHandle": "COUNT",
+        "ui_properties": {
+          "className": "int"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e8",
+        "source": "audience",
+        "sourceHandle": "output",
+        "target": "hooks_prompt",
+        "targetHandle": "AUDIENCE",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e9",
+        "source": "hooks_prompt",
+        "sourceHandle": "output",
+        "target": "variant_list",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e10",
+        "source": "variant_list",
+        "sourceHandle": "item",
+        "target": "preview_hooks",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e11",
+        "source": "variant_list",
+        "sourceHandle": "item",
+        "target": "scene_prompt",
+        "targetHandle": "HOOK",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e12",
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "scene_prompt",
+        "targetHandle": "BRIEF",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e13",
+        "source": "audience",
+        "sourceHandle": "output",
+        "target": "scene_prompt",
+        "targetHandle": "AUDIENCE",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e14",
+        "source": "scene_prompt",
+        "sourceHandle": "output",
+        "target": "ad_still",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e15",
+        "source": "product_photo",
+        "sourceHandle": "output",
+        "target": "ad_still",
+        "targetHandle": "image",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e16",
+        "source": "ad_still",
+        "sourceHandle": "output",
+        "target": "ad_clip",
+        "targetHandle": "image",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e17",
+        "source": "variant_list",
+        "sourceHandle": "item",
+        "target": "motion_prompt",
+        "targetHandle": "HOOK",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e18",
+        "source": "motion_prompt",
+        "sourceHandle": "output",
+        "target": "ad_clip",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e19",
+        "source": "variant_list",
+        "sourceHandle": "item",
+        "target": "voiceover",
+        "targetHandle": "text",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e20",
+        "source": "ad_clip",
+        "sourceHandle": "output",
+        "target": "mix_voiceover",
+        "targetHandle": "video",
+        "ui_properties": {
+          "className": "video"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e21",
+        "source": "voiceover",
+        "sourceHandle": "audio",
+        "target": "mix_voiceover",
+        "targetHandle": "audio",
+        "ui_properties": {
+          "className": "audio"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "e22",
+        "source": "mix_voiceover",
+        "sourceHandle": "output",
+        "target": "preview_ads",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "video"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# 🎯 Ad Creative Factory\n\nOne product photo and one offer become a batch of ready-to-test vertical video ads. A strategist agent builds a persona × angle test matrix, a list generator writes one spoken hook per cell, and every hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.\n\n**Pipeline:** Offer + Audience + Photo → Strategist → Hooks → Product scenes → Image-to-Video → Voiceover → Finished ads\n\n**Try this:** pick the language, image, video, and TTS models, then raise the variant count or sharpen the audience — the test matrix adapts on the next run."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 40,
+            "y": -240
+          },
+          "zIndex": 0,
+          "width": 480,
+          "height": 220,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "product_offer",
+          "value": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "description": "The product and the offer the ads must sell"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1️⃣ Product & offer",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "audience",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "audience",
+          "value": "active millennials who hike on weekends and scroll fitness content at night",
+          "description": "Who the ads are for"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 310
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2️⃣ Audience",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "variant_count",
+        "type": "nodetool.input.IntegerInput",
+        "data": {
+          "name": "variant_count",
+          "value": 6,
+          "description": "How many ad variants to produce",
+          "min": 2,
+          "max": 12
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "3️⃣ Variant count",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "product_photo",
+        "type": "nodetool.input.ImageInput",
+        "data": {
+          "name": "product_photo",
+          "value": {
+            "type": "image",
+            "uri": "",
+            "asset_id": null,
+            "data": null,
+            "metadata": null
+          },
+          "description": "One clean photo of the product — the same shot anchors every variant"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 790
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "4️⃣ Product photo",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "strategy_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "You are planning a paid-social creative test for the product in the attached photo.\n\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\nVariants to produce: {{ COUNT }}\n\nReturn a creative test plan in Markdown, no commentary:\n\nPersonas: 2-3 buyer personas inside this audience — one line each on who they are and what they want.\nAngles: 3-4 message angles (pain point, bold claim, social proof, offer urgency) — one line each on why it could win.\nMatrix: the {{ COUNT }} strongest persona × angle pairings to test, one line each on what that ad must communicate.\nVisual world: 2-3 lines on settings, casting, and light that read native in a vertical feed — believable phone footage, not a studio ad."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 410,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 420,
+          "title": "Build strategist prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "BRIEF": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "AUDIENCE": "active millennials who hike on weekends and scroll fitness content at night",
+          "COUNT": "6"
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "strategist",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You are a senior performance-marketing creative strategist. You design paid-social creative tests where every variant isolates one message. Concrete and specific, no filler.",
+          "image": {
+            "type": "image",
+            "uri": "",
+            "asset_id": null,
+            "data": null,
+            "metadata": null
+          },
+          "audio": {
+            "type": "audio",
+            "uri": "",
+            "asset_id": null,
+            "data": null
+          },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 750,
+            "y": 90
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 350,
+          "title": "5️⃣ Plan the test matrix",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "hooks_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "From this creative test plan, write exactly {{ COUNT }} spoken ad hooks, one per line — no numbering, no quotes, no labels.\n\nRules:\n- One hook per matrix pairing: speak to that persona with that angle.\n- 18 words or fewer, written to be said aloud in the first three seconds of a vertical video ad.\n- Plain spoken language for {{ AUDIENCE }}. No hashtags, no emoji, no brand-speak.\n- Every hook lands one concrete benefit or the offer — never a vague promise.\n\nPlan:\n{{ PLAN }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1130,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 360,
+          "title": "Build hooks prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "PLAN": "",
+          "COUNT": "6",
+          "AUDIENCE": "active millennials who hike on weekends and scroll fitness content at night"
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "variant_list",
+        "type": "nodetool.generators.ListGenerator",
+        "data": {
+          "model": {},
+          "input_text": "",
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1510,
+            "y": 380
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 245,
+          "title": "6️⃣ Generate spoken hooks",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_hooks",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "hooks"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1510,
+            "y": 700
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 200,
+          "title": "📋 Hook list",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "scene_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "One vertical 9:16 paid-social ad still, built from the input product photo.\n\nSpoken hook this scene must visualize: {{ HOOK }}\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\n\nKeep the product from the input photo as the unmistakable hero, placed naturally in a real scene from the hook's world. Native UGC aesthetic: believable location, natural light, shallow depth of field, casual framing — shot-on-a-phone energy, not a studio render. Keep the upper third calm for caption text. No on-screen text, no logos, no watermarks, no distorted anatomy."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1890,
+            "y": 420
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 420,
+          "title": "Build scene prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "HOOK": "",
+          "BRIEF": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "AUDIENCE": "active millennials who hike on weekends and scroll fitness content at night"
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ad_still",
+        "type": "nodetool.image.ImageToImage",
+        "data": {
+          "model": {},
+          "negative_prompt": "",
+          "strength": 0.85,
+          "aspect_ratio": "9:16",
+          "resolution": "1K",
+          "scheduler": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2290,
+            "y": 460
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 340,
+          "title": "7️⃣ Stage the product shot",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "motion_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Animate this product ad still as a short vertical video. The hook spoken over it: {{ HOOK }}\n\nOne subtle handheld push-in toward the product with gentle parallax and one small believable motion in the scene — steam, breeze, hands, passing light. Natural lighting shift, product stays sharp and centered. No cuts, no zoom bursts, no on-screen text, no morphing."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2290,
+            "y": 40
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 300,
+          "title": "Build motion prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "HOOK": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ad_clip",
+        "type": "nodetool.video.ImageToVideo",
+        "data": {
+          "model": {},
+          "negative_prompt": "",
+          "aspect_ratio": "9:16",
+          "resolution": "720p",
+          "duration": 5,
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2650,
+            "y": 460
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 240,
+          "title": "8️⃣ Animate the ad",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "voiceover",
+        "type": "nodetool.audio.TextToSpeech",
+        "data": {
+          "model": {},
+          "speed": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2650,
+            "y": 850
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 220,
+          "title": "9️⃣ Voice the hook",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "mix_voiceover",
+        "type": "nodetool.video.AddAudio",
+        "data": {
+          "volume": 1,
+          "mix": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 3030,
+            "y": 600
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 240,
+          "title": "🔊 Mix voiceover",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_ads",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "finished_ads"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 3370,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 420,
+          "title": "🎯 Finished ads",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Podcast Repurposing Studio.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Podcast Repurposing Studio.json
@@ -1,0 +1,702 @@
+{
+  "id": "podcast_repurposing_studio",
+  "access": "public",
+  "created_at": "2026-07-01T00:00:00.000000",
+  "updated_at": "2026-07-01T00:00:00.000000",
+  "name": "Podcast Repurposing Studio",
+  "tool_name": null,
+  "description": "Drop in one podcast episode and ship the whole content pack: episode titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. Whisper transcribes once; four writer branches fan out from the transcript.",
+  "tags": [
+    "podcast",
+    "audio",
+    "content",
+    "marketing",
+    "agents",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "p1",
+        "source": "episode_audio",
+        "sourceHandle": "output",
+        "target": "transcribe",
+        "targetHandle": "audio",
+        "ui_properties": {
+          "className": "audio"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p2",
+        "source": "transcribe",
+        "sourceHandle": "text",
+        "target": "shownotes_prompt",
+        "targetHandle": "TRANSCRIPT",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p3",
+        "source": "show_context",
+        "sourceHandle": "output",
+        "target": "shownotes_prompt",
+        "targetHandle": "SHOW",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p4",
+        "source": "shownotes_prompt",
+        "sourceHandle": "output",
+        "target": "shownotes_agent",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p5",
+        "source": "shownotes_agent",
+        "sourceHandle": "text",
+        "target": "preview_shownotes",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p6",
+        "source": "transcribe",
+        "sourceHandle": "text",
+        "target": "newsletter_prompt",
+        "targetHandle": "TRANSCRIPT",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p7",
+        "source": "show_context",
+        "sourceHandle": "output",
+        "target": "newsletter_prompt",
+        "targetHandle": "SHOW",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p8",
+        "source": "newsletter_prompt",
+        "sourceHandle": "output",
+        "target": "newsletter_agent",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p9",
+        "source": "newsletter_agent",
+        "sourceHandle": "text",
+        "target": "preview_newsletter",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p10",
+        "source": "transcribe",
+        "sourceHandle": "text",
+        "target": "posts_prompt",
+        "targetHandle": "TRANSCRIPT",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p11",
+        "source": "show_context",
+        "sourceHandle": "output",
+        "target": "posts_prompt",
+        "targetHandle": "SHOW",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p12",
+        "source": "posts_prompt",
+        "sourceHandle": "output",
+        "target": "posts_list",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p13",
+        "source": "posts_list",
+        "sourceHandle": "item",
+        "target": "preview_posts",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p14",
+        "source": "transcribe",
+        "sourceHandle": "text",
+        "target": "quotes_prompt",
+        "targetHandle": "TRANSCRIPT",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p15",
+        "source": "quote_count",
+        "sourceHandle": "output",
+        "target": "quotes_prompt",
+        "targetHandle": "COUNT",
+        "ui_properties": {
+          "className": "int"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p16",
+        "source": "quotes_prompt",
+        "sourceHandle": "output",
+        "target": "quotes_list",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p17",
+        "source": "quotes_list",
+        "sourceHandle": "item",
+        "target": "card_prompt",
+        "targetHandle": "QUOTE",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p18",
+        "source": "show_context",
+        "sourceHandle": "output",
+        "target": "card_prompt",
+        "targetHandle": "SHOW",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p19",
+        "source": "card_prompt",
+        "sourceHandle": "output",
+        "target": "quote_card",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "p20",
+        "source": "quote_card",
+        "sourceHandle": "output",
+        "target": "preview_cards",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# 🎙️ Podcast Repurposing Studio\n\nDrop in one episode and ship the whole content pack: titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. The episode is transcribed once; four writer branches fan out from the transcript.\n\n**Pipeline:** Episode audio → Transcript → Show notes · Newsletter · Posts · Quotes → Quote cards\n\n**Try this:** pick the ASR, language, and image models, then tune each writer's prompt to your show's voice."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 40,
+            "y": -260
+          },
+          "zIndex": 0,
+          "width": 480,
+          "height": 220,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "episode_audio",
+        "type": "nodetool.input.AudioInput",
+        "data": {
+          "name": "episode_audio",
+          "value": {},
+          "description": "The full episode recording (any common audio format)"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 80
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1️⃣ Episode audio",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "show_context",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "show_context",
+          "value": "Trailhead — a weekly hiking and outdoor-gear podcast hosted by Maya. Voice: warm, practical, a little irreverent. CTA: subscribe and grab the free gear checklist at trailhead.fm",
+          "description": "Show name, host, voice, and call to action — every writer branch uses this"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 330
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2️⃣ Show context",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "quote_count",
+        "type": "nodetool.input.IntegerInput",
+        "data": {
+          "name": "quote_count",
+          "value": 4,
+          "description": "How many quote cards to render",
+          "min": 2,
+          "max": 8
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 580
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "3️⃣ Quote-card count",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "transcribe",
+        "type": "nodetool.text.AutomaticSpeechRecognition",
+        "data": {
+          "model": {}
+        },
+        "ui_properties": {
+          "position": {
+            "x": 410,
+            "y": 100
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 240,
+          "title": "4️⃣ Transcribe the episode",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shownotes_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "You are producing the episode page for this podcast.\n\nShow: {{ SHOW }}\n\nFrom the transcript below, return Markdown, no commentary:\n\nTitles: 3 episode title options — specific, curiosity-driven, under 60 characters.\nSummary: one paragraph, 3-4 sentences, written for the episode page.\nShow notes: 6-10 bullet chapters in listening order — each a short phrase naming what gets discussed.\nResources: anything mentioned worth linking — books, tools, people, places.\nCTA: one closing line using the show's call to action.\n\nTranscript:\n{{ TRANSCRIPT }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 790,
+            "y": -240
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 360,
+          "title": "Build show-notes prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "SHOW": "",
+          "TRANSCRIPT": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shownotes_agent",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You are a podcast producer who writes episode pages people actually read. Specific and concrete, in the show's voice, no filler.",
+          "audio": {
+            "type": "audio",
+            "uri": "",
+            "asset_id": null,
+            "data": null
+          },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1150,
+            "y": -220
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 330,
+          "title": "5️⃣ Write show notes & titles",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_shownotes",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "show_notes"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1530,
+            "y": -200
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 300,
+          "title": "📝 Show notes & titles",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "newsletter_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Turn this podcast episode into the show's email newsletter edition.\n\nShow: {{ SHOW }}\n\nReturn Markdown, no commentary:\n\nSubject: 3 subject-line options under 50 characters.\nBody: 150-250 words in the host's voice — open on the episode's single most surprising idea, tease two more takeaways without spoiling them, close with the show's call to action and a listen-link placeholder.\n\nTranscript:\n{{ TRANSCRIPT }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 790,
+            "y": 180
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 360,
+          "title": "Build newsletter prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "SHOW": "",
+          "TRANSCRIPT": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "newsletter_agent",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You write email newsletters for podcasters. Short, personal, in the host's voice — the reader should feel the episode, not a summary of it.",
+          "audio": {
+            "type": "audio",
+            "uri": "",
+            "asset_id": null,
+            "data": null
+          },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1150,
+            "y": 200
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 330,
+          "title": "6️⃣ Draft the newsletter",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_newsletter",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "newsletter"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1530,
+            "y": 220
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 300,
+          "title": "✉️ Newsletter edition",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "posts_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "From this podcast episode transcript, write exactly 5 social posts, one per line — no numbering, no labels, no hashtags unless they earn their place.\n\nRules:\n- Each post stands alone: one idea, claim, or moment from the episode, written to stop the scroll.\n- Mix formats across the five: a bold take, a question, a mini-story, a concrete stat or detail, a one-line lesson.\n- Plain language in the show's voice ({{ SHOW }}). 280 characters maximum each.\n\nTranscript:\n{{ TRANSCRIPT }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 790,
+            "y": 600
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 340,
+          "title": "Build posts prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "SHOW": "",
+          "TRANSCRIPT": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "posts_list",
+        "type": "nodetool.generators.ListGenerator",
+        "data": {
+          "model": {},
+          "input_text": "",
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1150,
+            "y": 640
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 245,
+          "title": "7️⃣ Generate social posts",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_posts",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "social_posts"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1530,
+            "y": 660
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 260,
+          "title": "📣 Social posts",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "quotes_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "From this transcript, pick exactly {{ COUNT }} verbatim quotes worth putting on a quote card, one per line — no numbering, no attribution, no surrounding quotation marks.\n\nRules:\n- Verbatim from the transcript, lightly trimmed for readability only.\n- 8 to 25 words: punchy, self-contained, meaningful without context.\n- Prefer strong opinions, hard-won lessons, and vivid phrasing over pleasantries.\n\nTranscript:\n{{ TRANSCRIPT }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 790,
+            "y": 1010
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 340,
+          "title": "Build quotes prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "COUNT": "4",
+          "TRANSCRIPT": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "quotes_list",
+        "type": "nodetool.generators.ListGenerator",
+        "data": {
+          "model": {},
+          "input_text": "",
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1150,
+            "y": 1050
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 245,
+          "title": "8️⃣ Pull the best quotes",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "card_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Minimal typographic quote card, square 1:1, for this podcast: {{ SHOW }}\n\nRender exactly this text as the centerpiece, large and perfectly legible, spelled exactly as written:\n\"{{ QUOTE }}\"\n\nClean editorial design: bold modern sans-serif type on a calm, softly textured background, generous margins, one subtle accent color, a small quotation-mark motif. No people, no photos, no logos, no watermark, no words beyond the quote."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1530,
+            "y": 1080
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 360,
+          "title": "Build quote-card prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "QUOTE": "",
+          "SHOW": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "quote_card",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {},
+          "negative_prompt": "",
+          "aspect_ratio": "1:1",
+          "resolution": "1K",
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1910,
+            "y": 1100
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 340,
+          "title": "9️⃣ Render quote cards",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_cards",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "quote_cards"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2270,
+            "y": 1090
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 380,
+          "title": "🖼️ Quote cards",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/SEO Content Engine.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/SEO Content Engine.json
@@ -1,0 +1,558 @@
+{
+  "id": "seo_content_engine",
+  "access": "public",
+  "created_at": "2026-07-01T00:00:00.000000",
+  "updated_at": "2026-07-01T00:00:00.000000",
+  "name": "SEO Content Engine",
+  "tool_name": null,
+  "description": "One topic in, a keyword-targeted article batch out. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full Markdown article with an editorial hero image.",
+  "tags": [
+    "seo",
+    "content",
+    "marketing",
+    "writing",
+    "agents",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "s1",
+        "source": "business",
+        "sourceHandle": "output",
+        "target": "plan_prompt",
+        "targetHandle": "BUSINESS",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s2",
+        "source": "seeds",
+        "sourceHandle": "output",
+        "target": "plan_prompt",
+        "targetHandle": "SEEDS",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s3",
+        "source": "article_count",
+        "sourceHandle": "output",
+        "target": "plan_prompt",
+        "targetHandle": "COUNT",
+        "ui_properties": {
+          "className": "int"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s4",
+        "source": "plan_prompt",
+        "sourceHandle": "output",
+        "target": "strategist",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s5",
+        "source": "strategist",
+        "sourceHandle": "text",
+        "target": "preview_plan",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s6",
+        "source": "strategist",
+        "sourceHandle": "text",
+        "target": "briefs_prompt",
+        "targetHandle": "PLAN",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s7",
+        "source": "article_count",
+        "sourceHandle": "output",
+        "target": "briefs_prompt",
+        "targetHandle": "COUNT",
+        "ui_properties": {
+          "className": "int"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s8",
+        "source": "briefs_prompt",
+        "sourceHandle": "output",
+        "target": "briefs_list",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s9",
+        "source": "briefs_list",
+        "sourceHandle": "item",
+        "target": "article_prompt",
+        "targetHandle": "BRIEF",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s10",
+        "source": "business",
+        "sourceHandle": "output",
+        "target": "article_prompt",
+        "targetHandle": "BUSINESS",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s11",
+        "source": "article_prompt",
+        "sourceHandle": "output",
+        "target": "writer",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s12",
+        "source": "writer",
+        "sourceHandle": "text",
+        "target": "preview_articles",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s13",
+        "source": "briefs_list",
+        "sourceHandle": "item",
+        "target": "hero_prompt",
+        "targetHandle": "BRIEF",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s14",
+        "source": "hero_prompt",
+        "sourceHandle": "output",
+        "target": "hero_image",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
+        "id": "s15",
+        "source": "hero_image",
+        "sourceHandle": "output",
+        "target": "preview_heroes",
+        "targetHandle": "value",
+        "ui_properties": {
+          "className": "image"
+        },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# 📈 SEO Content Engine\n\nOne topic in, a keyword-targeted article batch out. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full Markdown article with an editorial hero image.\n\n**Pipeline:** Business + Seed topics → Strategist → Briefs → Articles + Hero images\n\n**Try this:** pick the language and image models, then raise the article count or point the seed topics at the next cluster."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 40,
+            "y": -240
+          },
+          "zIndex": 0,
+          "width": 480,
+          "height": 220,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "business",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "business",
+          "value": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
+          "description": "Who is publishing, and which pages the articles should support"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1️⃣ Business & site",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "seeds",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "audience_and_seeds",
+          "value": "beginner hikers researching their first serious gear; seed topics: ultralight backpacking basics, trail runners vs hiking boots, multi-day packing lists",
+          "description": "Who searches, and the seed topics the cluster should grow from"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 310
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "2️⃣ Audience & seed topics",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "article_count",
+        "type": "nodetool.input.IntegerInput",
+        "data": {
+          "name": "article_count",
+          "value": 4,
+          "description": "How many articles to produce",
+          "min": 2,
+          "max": 10
+        },
+        "ui_properties": {
+          "position": {
+            "x": 50,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "title": "3️⃣ Article count",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "plan_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "You are planning organic-search content for this business.\n\nBusiness: {{ BUSINESS }}\nAudience and seed topics: {{ SEEDS }}\nArticles to produce: {{ COUNT }}\n\nReturn a content plan in Markdown, no commentary:\n\nCluster: the one topic cluster these articles should own, and the money pages they support.\nKeywords: {{ COUNT }} primary keywords — each a real phrase this audience searches, one line each with intent (informational, comparison, transactional) and the searcher's actual question.\nCoverage: how the {{ COUNT }} articles divide the cluster without competing with each other.\nVoice: 2-3 lines on the tone and point of view that make this business worth reading over the top-ten listicles."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 410,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 420,
+          "title": "Build strategist prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "BUSINESS": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
+          "SEEDS": "beginner hikers researching their first serious gear; seed topics: ultralight backpacking basics, trail runners vs hiking boots, multi-day packing lists",
+          "COUNT": "4"
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "strategist",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You are an SEO content strategist. You plan topic clusters that win search intent, never keyword-stuffed filler. Concrete and specific.",
+          "audio": {
+            "type": "audio",
+            "uri": "",
+            "asset_id": null,
+            "data": null
+          },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 750,
+            "y": 90
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 350,
+          "title": "4️⃣ Plan the keyword cluster",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_plan",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "content_plan"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 750,
+            "y": 490
+          },
+          "zIndex": 0,
+          "width": 300,
+          "height": 220,
+          "title": "🗺️ Content plan",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "briefs_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "From this content plan, write exactly {{ COUNT }} article briefs, one per line — no numbering, no labels.\n\nEach line: working title | primary keyword | search intent | the 3-4 H2 sections the article needs | the one thing the reader must be able to do after reading.\n\nPlan:\n{{ PLAN }}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1130,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 360,
+          "title": "Build briefs prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "PLAN": "",
+          "COUNT": "4"
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "briefs_list",
+        "type": "nodetool.generators.ListGenerator",
+        "data": {
+          "model": {},
+          "input_text": "",
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1510,
+            "y": 180
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 245,
+          "title": "5️⃣ Generate article briefs",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "article_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Write the full article for this brief.\n\nBrief: {{ BRIEF }}\nPublishing business: {{ BUSINESS }}\n\nRules:\n- Return Markdown only: a one-line meta description in italics, then the # title, then the article.\n- 900-1200 words. Use the brief's H2 sections; add H3s where they help scanning.\n- Answer the searcher's question in the first two sentences, then earn the depth.\n- Concrete numbers, steps, and examples over generalities. First-hand point of view where credible.\n- The keyword appears where it belongs — write for the reader, not the crawler.\n- End with a short FAQ (3 questions) and one unforced call to action for the business."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1890,
+            "y": 40
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 400,
+          "title": "Build writer prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "BRIEF": "",
+          "BUSINESS": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages."
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "writer",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You are a senior content writer for organic search. You write like an expert practitioner sharing what works, never like a content mill. Specific, useful, zero filler.",
+          "audio": {
+            "type": "audio",
+            "uri": "",
+            "asset_id": null,
+            "data": null
+          },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 100000
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2290,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 330,
+          "height": 350,
+          "title": "6️⃣ Write the articles",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_articles",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "articles"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2680,
+            "y": 60
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 420,
+          "title": "📄 Finished articles",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "hero_prompt",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Editorial hero image for a blog article, 16:9.\n\nArticle brief: {{ BRIEF }}\n\nOne clear photographic scene that shows the article's subject in the real world — natural light, believable setting, room on one side for a headline overlay. Magazine photo-essay quality. No on-screen text, no logos, no watermarks, no illustration style, no distorted anatomy."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1890,
+            "y": 500
+          },
+          "zIndex": 0,
+          "width": 340,
+          "height": 340,
+          "title": "Build hero-image prompt",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "BRIEF": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "hero_image",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {},
+          "negative_prompt": "",
+          "aspect_ratio": "16:9",
+          "resolution": "1K",
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2290,
+            "y": 520
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 340,
+          "title": "7️⃣ Render hero images",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_heroes",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": {
+          "name": "hero_images"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 2680,
+            "y": 540
+          },
+          "zIndex": 0,
+          "width": 360,
+          "height": 380,
+          "title": "🖼️ Hero images",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": null
+}


### PR DESCRIPTION
## Summary

Adds three complete, production-ready workflow examples to the base-nodes package and corresponding documentation pages. These showcase end-to-end content creation pipelines that demonstrate the platform's agent, list-generator, and media-processing capabilities.

## Changes

### Workflow Files (packages/base-nodes/nodetool/examples/nodetool-base/)

- **Podcast Repurposing Studio.json** (702 lines)
  - Transcribes one episode once, fans out to four parallel writer branches
  - Generates: episode titles, show notes, newsletter edition, social posts, quote cards
  - Uses ASR → Agent (show notes) → Agent (newsletter) → ListGenerator (posts) → ListGenerator (quotes) → TextToImage (quote cards)
  - Demonstrates multi-branch parallelization from a single transcript

- **Ad Creative Factory.json** (691 lines)
  - Converts product photo + offer into batch of vertical video ads
  - Strategist agent plans persona × angle test matrix
  - Each variant: ListGenerator (hooks) → ImageToImage (scene staging) → ImageToVideo (animation) → TextToSpeech (voiceover) → AddAudio (mix)
  - Shows how to scale creative production from one brief to many variants

- **SEO Content Engine.json** (558 lines)
  - Produces keyword-targeted article clusters from seed topics
  - Strategist agent plans cluster, ListGenerator creates briefs, Agent writes articles, TextToImage generates hero images
  - Demonstrates topic-cluster strategy and parallel article + image generation

### Documentation (docs/use-cases/)

- **ad-creative-factory.md** — Use case overview, architecture diagram, step-by-step walkthrough, and customization tips
- **podcast-repurposing-studio.md** — Use case overview, architecture diagram, step-by-step walkthrough, and customization tips
- **seo-content-engine.md** — Use case overview, architecture diagram, step-by-step walkthrough, and customization tips

### Index Updates

- **docs/use-cases.md** — Added three new use-case cards with links and descriptions
- **docs/workflows/index.md** — Updated reference to flagship showcases

## Implementation Details

- All workflows follow the established pattern: inputs → strategist/planner agent → list generator → parallel processing branches → preview nodes
- Each workflow includes a comment node explaining the pipeline and customization points
- Workflows use dynamic properties for prompt templating (e.g., `{{ SHOW }}`, `{{ BRIEF }}`, `{{ COUNT }}`)
- Documentation includes Mermaid diagrams showing data flow and node dependencies
- All three workflows are tagged as "example" and marked public for discoverability

https://claude.ai/code/session_01BA1WhWpj3ZirXJAjm7GCyd