### PR TITLE
Auto-add generated media to canvas & enable drag-to-canvas

### DIFF
--- a/web/src/components/chat/message/MediaOutputGroup.tsx
+++ b/web/src/components/chat/message/MediaOutputGroup.tsx
@@ -41,6 +41,10 @@ import {
   useAddMediaToCanvas,
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
+import { serializeDragData } from "../../../lib/dragdrop";
+
+/** Edge length of a generated-media thumbnail tile (px). */
+const THUMBNAIL_SIZE = 120;
 
 const VIDEO_STYLE: React.CSSProperties = { width: "100%", height: "100%" };
 const AUDIO_STYLE: React.CSSProperties = { width: "100%", padding: getSpacingPx(SPACING.lg) };
@@ -135,25 +139,29 @@ const styles = (theme: Theme) =>
       display: "grid",
       gap: 8,
       width: "100%",
-      "&.count-1": { gridTemplateColumns: "1fr" },
-      "&.count-2": { gridTemplateColumns: "1fr 1fr" },
-      "&.count-3": {
-        gridTemplateColumns: "1fr 1fr",
-        "& > :nth-of-type(1)": { gridColumn: "1 / span 2" }
-      },
-      "&.count-4": { gridTemplateColumns: "1fr 1fr" },
-      "&.count-many": {
-        gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))"
-      }
+      gridTemplateColumns: `repeat(auto-fill, ${THUMBNAIL_SIZE}px)`,
+      justifyContent: "start"
     },
 
     ".media-grid > *": {
       position: "relative",
-      width: "100%",
-      aspectRatio: "auto",
+      width: THUMBNAIL_SIZE,
+      height: THUMBNAIL_SIZE,
       borderRadius: BORDER_RADIUS.lg,
       overflow: "hidden",
-      background: theme.vars.palette.grey[900]
+      background: theme.vars.palette.grey[900],
+      cursor: "grab"
+    },
+
+    ".media-grid > *:active": {
+      cursor: "grabbing"
+    },
+
+    // Audio has no meaningful thumbnail — let its player span the full row.
+    ".media-grid > .audio-tile": {
+      gridColumn: "1 / -1",
+      width: "100%",
+      height: "auto"
     },
 
     ".media-grid img, .media-grid video": {
@@ -238,6 +246,13 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
     (block: MediaContentBlock) => addBlocksToCanvas([block]),
     [addBlocksToCanvas]
   );
+  const handleDragStart = useCallback(
+    (e: React.DragEvent, block: MediaContentBlock) => {
+      serializeDragData({ type: "chat-media", payload: block }, e.dataTransfer);
+      e.dataTransfer.effectAllowed = "copy";
+    },
+    []
+  );
   const addAll = useCallback(
     () =>
       addBlocksToCanvas(
@@ -265,17 +280,6 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
   const title = titleFromPrompt(prompt);
 
   const pending = useMemo(() => pendingTiles(gen), [gen]);
-  const count = isPending ? pending.count : mediaContents.length;
-  const gridClass =
-    count === 1
-      ? "count-1"
-      : count === 2
-        ? "count-2"
-        : count === 3
-          ? "count-3"
-          : count === 4
-            ? "count-4"
-            : "count-many";
 
   return (
     <div css={cssStyles} className="media-output-group">
@@ -363,13 +367,13 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
         </FlexRow>
       </div>
 
-      <div className={`media-grid ${gridClass}`}>
+      <div className="media-grid">
         {isPending
           ? Array.from({ length: pending.count }, (_, i) => (
               <div
                 key={`pending-${i}`}
                 className={`media-tile-shimmer${
-                  pending.kind === "audio" ? " audio-shimmer" : ""
+                  pending.kind === "audio" ? " audio-shimmer audio-tile" : ""
                 }`}
                 style={
                   pending.kind !== "audio" && pending.aspectRatio
@@ -387,7 +391,11 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
               c.image?.uri || (c.image?.data as string | undefined) || "";
             const key = c.image?.asset_id || c.image?.uri || `media-${i}`;
             return (
-              <div key={key}>
+              <div
+                key={key}
+                draggable
+                onDragStart={(e) => handleDragStart(e, c)}
+              >
                 <ImageView source={src} />
                 {isCanvasAvailable && (
                   <ToolbarIconButton
@@ -406,7 +414,11 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             const src = c.video?.uri || "";
             const key = c.video?.asset_id || c.video?.uri || `media-${i}`;
             return (
-              <div key={key}>
+              <div
+                key={key}
+                draggable
+                onDragStart={(e) => handleDragStart(e, c)}
+              >
                 <video
                   src={src}
                   controls
@@ -432,7 +444,12 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             const src = c.audio?.uri || "";
             const key = c.audio?.asset_id || c.audio?.uri || `media-${i}`;
             return (
-              <div key={key}>
+              <div
+                key={key}
+                className="audio-tile"
+                draggable
+                onDragStart={(e) => handleDragStart(e, c)}
+              >
                 <audio
                   src={src}
                   controls

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -17,6 +17,7 @@ import {
   useAddMediaToCanvas,
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
+import { serializeDragData } from "../../../lib/dragdrop";
 import {
   parseHarmonyContent,
   hasHarmonyTokens,
@@ -108,6 +109,21 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
     addBlocksToCanvas([content as MediaContentBlock]);
   }, [addBlocksToCanvas, content]);
 
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      serializeDragData(
+        { type: "chat-media", payload: content as MediaContentBlock },
+        e.dataTransfer
+      );
+      e.dataTransfer.effectAllowed = "copy";
+    },
+    [content]
+  );
+
+  const dragProps = isCanvasAvailable
+    ? { draggable: true, onDragStart: handleDragStart }
+    : {};
+
   const addButton = isCanvasAvailable ? (
     <ToolbarIconButton
       className="add-to-canvas-button"
@@ -165,7 +181,7 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
       }
 
       return (
-        <div css={wrapperStyles}>
+        <div css={wrapperStyles} {...dragProps}>
           <ImageView source={imageSource} />
           {addButton}
         </div>
@@ -174,7 +190,7 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
     case "audio":
       // Handle audio content in Harmony format
       return (
-        <div css={wrapperStyles}>
+        <div css={wrapperStyles} {...dragProps}>
           <AudioPlayer
             source={
               content.audio?.uri === ""
@@ -194,7 +210,7 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         "video/mp4"
       );
       return (
-        <div css={wrapperStyles}>
+        <div css={wrapperStyles} {...dragProps}>
           <video ref={videoRef} controls style={videoStyle} src={uri} aria-label="Video content" />
           {addButton}
         </div>

--- a/web/src/components/panels/CanvasMediaComposer.tsx
+++ b/web/src/components/panels/CanvasMediaComposer.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 
 import MediaChatComposer from "../chat/composer/MediaChatComposer";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useAutoAddGeneratedMediaToCanvas } from "../../hooks/handlers/useAutoAddGeneratedMediaToCanvas";
 import type { MessageContent } from "../../stores/ApiTypes";
 import type {
   ChatOutgoingMessage,
@@ -11,10 +12,11 @@ import type {
 
 /**
  * Media composer for the workflow canvas. Reuses the chat `MediaChatComposer`
- * so its generated image/video/audio results land in the chat panel's history;
- * from there the user can add them to the canvas via the per-asset hover
- * buttons (see {@link useAddMediaToCanvas}). Generation routes through the
- * normal chat pipeline.
+ * so its generated image/video/audio results land in the chat panel's history.
+ * Finished generations are auto-added to the canvas as constant nodes (see
+ * {@link useAutoAddGeneratedMediaToCanvas}); the per-asset hover buttons and
+ * drag-to-canvas remain for adding them again or placing them by hand.
+ * Generation routes through the normal chat pipeline.
  */
 export interface CanvasMediaComposerProps {
   /** Workflow controls (Run button + menu) rendered inside the composer
@@ -49,6 +51,9 @@ const CanvasMediaComposer: React.FC<CanvasMediaComposerProps> = ({
       setMemoryEnabled: state.setMemoryEnabled
     }))
   );
+
+  // Drop each finished generation onto the canvas automatically.
+  useAutoAddGeneratedMediaToCanvas();
 
   // Establish the chat connection lazily so generation works even when the
   // chat panel was never opened. Skip if it's already wired up by the panel.

--- a/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
+++ b/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
@@ -44,10 +44,16 @@ jest.mock("../../../stores/GlobalChatStore", () => ({
   default: useGlobalChatStore
 }));
 
-jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (s: { workflow: { id: string } }) => unknown) =>
-    selector({ workflow: { id: "canvas-doc-id" } })
-}));
+jest.mock("../../../contexts/NodeContext", () => {
+  const actualReact = jest.requireActual("react");
+  return {
+    // A real context (defaulting to null) so useAddMediaToCanvas, pulled in via
+    // the auto-add-to-canvas hook, resolves to "no canvas" instead of crashing.
+    NodeContext: actualReact.createContext(null),
+    useNodes: (selector: (s: { workflow: { id: string } }) => unknown) =>
+      selector({ workflow: { id: "canvas-doc-id" } })
+  };
+});
 
 import CanvasMediaComposer from "../CanvasMediaComposer";
 

--- a/web/src/hooks/handlers/__tests__/useAutoAddGeneratedMediaToCanvas.test.tsx
+++ b/web/src/hooks/handlers/__tests__/useAutoAddGeneratedMediaToCanvas.test.tsx
@@ -1,0 +1,104 @@
+import { renderHook } from "@testing-library/react";
+import type { Message } from "../../../stores/ApiTypes";
+
+interface MockChatState {
+  status: string;
+  currentThreadId: string | null;
+  messageCache: Record<string, Message[]>;
+}
+
+let mockState: MockChatState = {
+  status: "connected",
+  currentThreadId: "t1",
+  messageCache: {}
+};
+
+const addBlocksToCanvas = jest.fn();
+let isCanvasAvailable = true;
+
+jest.mock("../../../stores/GlobalChatStore", () => ({
+  __esModule: true,
+  default: (selector: (s: MockChatState) => unknown) => selector(mockState)
+}));
+
+jest.mock("../useGenerationToCanvas", () => ({
+  __esModule: true,
+  useAddMediaToCanvas: () => ({ isCanvasAvailable, addBlocksToCanvas })
+}));
+
+import { useAutoAddGeneratedMediaToCanvas } from "../useAutoAddGeneratedMediaToCanvas";
+
+const mediaMessage = (assetId: string): Message =>
+  ({
+    role: "assistant",
+    content: [
+      {
+        type: "image_url",
+        image: { type: "image", asset_id: assetId, uri: `http://x/${assetId}.png` }
+      }
+    ]
+  }) as unknown as Message;
+
+beforeEach(() => {
+  addBlocksToCanvas.mockClear();
+  isCanvasAvailable = true;
+  mockState = { status: "connected", currentThreadId: "t1", messageCache: {} };
+});
+
+describe("useAutoAddGeneratedMediaToCanvas", () => {
+  it("adds generated media on the busy → idle edge", () => {
+    const { rerender } = renderHook(() => useAutoAddGeneratedMediaToCanvas());
+    expect(addBlocksToCanvas).not.toHaveBeenCalled();
+
+    // Generation starts.
+    mockState = { ...mockState, status: "streaming" };
+    rerender();
+    expect(addBlocksToCanvas).not.toHaveBeenCalled();
+
+    // Generation finishes with a media result.
+    mockState = {
+      ...mockState,
+      status: "connected",
+      messageCache: { t1: [mediaMessage("a1")] }
+    };
+    rerender();
+    expect(addBlocksToCanvas).toHaveBeenCalledTimes(1);
+    expect(addBlocksToCanvas.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  it("does not add the same asset twice across turns", () => {
+    const { rerender } = renderHook(() => useAutoAddGeneratedMediaToCanvas());
+
+    mockState = { ...mockState, status: "streaming" };
+    rerender();
+    mockState = {
+      ...mockState,
+      status: "connected",
+      messageCache: { t1: [mediaMessage("a1")] }
+    };
+    rerender();
+    expect(addBlocksToCanvas).toHaveBeenCalledTimes(1);
+
+    // A second turn that still ends on the same last message adds nothing new.
+    mockState = { ...mockState, status: "streaming" };
+    rerender();
+    mockState = { ...mockState, status: "connected" };
+    rerender();
+    expect(addBlocksToCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when no canvas is available", () => {
+    isCanvasAvailable = false;
+    const { rerender } = renderHook(() => useAutoAddGeneratedMediaToCanvas());
+
+    mockState = { ...mockState, status: "streaming" };
+    rerender();
+    mockState = {
+      ...mockState,
+      status: "connected",
+      messageCache: { t1: [mediaMessage("a1")] }
+    };
+    rerender();
+    expect(addBlocksToCanvas).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/handlers/useAutoAddGeneratedMediaToCanvas.ts
+++ b/web/src/hooks/handlers/useAutoAddGeneratedMediaToCanvas.ts
@@ -1,0 +1,84 @@
+// Auto-adds media produced by a chat generation turn onto the active canvas as
+// constant nodes. Kept in its own module (separate from useGenerationToCanvas)
+// so that the lightweight `blockToConstant` / `useAddMediaToCanvas` helpers can
+// be imported without pulling in the GlobalChatStore dependency graph.
+
+import { useEffect, useRef } from "react";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import type { MessageContent } from "../../stores/ApiTypes";
+import {
+  isAudioContent,
+  isImageContent,
+  isMediaOnlyContent,
+  isVideoContent
+} from "../../components/chat/message/MediaOutputGroup.helpers";
+import {
+  useAddMediaToCanvas,
+  type MediaContentBlock
+} from "./useGenerationToCanvas";
+
+/** Stable identity for a media block, used to avoid adding the same generated
+ *  asset to the canvas twice. Empty when the block has no asset id or uri yet
+ *  (e.g. mid-generation), in which case it is skipped. */
+const mediaBlockKey = (block: MediaContentBlock): string => {
+  if (block.type === "image_url") return block.image?.asset_id || block.image?.uri || "";
+  if (block.type === "video") return block.video?.asset_id || block.video?.uri || "";
+  return block.audio?.asset_id || block.audio?.uri || "";
+};
+
+/**
+ * Auto-adds media produced by a chat generation turn onto the active canvas.
+ * Fires once per turn, on the chat's busy → idle edge: the last assistant
+ * message of a media-only turn has its blocks added as constant nodes. A no-op
+ * when there's no canvas in scope (i.e. the standalone chat panel).
+ */
+export const useAutoAddGeneratedMediaToCanvas = (): void => {
+  const { isCanvasAvailable, addBlocksToCanvas } = useAddMediaToCanvas();
+  const status = useGlobalChatStore((state) => state.status);
+  const currentThreadId = useGlobalChatStore((state) => state.currentThreadId);
+  const messages = useGlobalChatStore((state) =>
+    state.currentThreadId ? state.messageCache[state.currentThreadId] : undefined
+  );
+
+  const seenRef = useRef<Set<string>>(new Set());
+  const wasBusyRef = useRef(false);
+
+  useEffect(() => {
+    const busy = status === "loading" || status === "streaming";
+    const wasBusy = wasBusyRef.current;
+    wasBusyRef.current = busy;
+
+    // Only act on the busy → idle edge (a generation just finished).
+    if (busy || !wasBusy) return;
+    if (!isCanvasAvailable || !messages || messages.length === 0) return;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role !== "assistant") continue;
+      // The most recent assistant reply decides the turn: add its media, or
+      // bail if it wasn't a media generation.
+      if (!isMediaOnlyContent(message.content)) return;
+      const fresh = (message.content as MessageContent[])
+        .filter(
+          (c): c is MediaContentBlock =>
+            isImageContent(c) || isVideoContent(c) || isAudioContent(c)
+        )
+        .filter((block) => {
+          const key = mediaBlockKey(block);
+          if (!key || seenRef.current.has(key)) return false;
+          seenRef.current.add(key);
+          return true;
+        });
+      if (fresh.length > 0) addBlocksToCanvas(fresh);
+      return;
+    }
+  }, [status, messages, isCanvasAvailable, addBlocksToCanvas]);
+
+  // Drop the dedupe memory when switching threads so a later turn in a new
+  // thread that happens to reuse an asset id still adds.
+  useEffect(() => {
+    seenRef.current = new Set();
+  }, [currentThreadId]);
+};
+
+export default useAutoAddGeneratedMediaToCanvas;

--- a/web/src/hooks/handlers/useDropHandler.ts
+++ b/web/src/hooks/handlers/useDropHandler.ts
@@ -17,7 +17,12 @@ import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import { shallow } from "zustand/shallow";
 import { instantiatePaletteNode } from "../../utils/instantiatePaletteNode";
 import useMetadataStore from "../../stores/MetadataStore";
-import type { SketchDragPayload, TimelineDragPayload } from "../../lib/dragdrop";
+import type {
+  ChatMediaDragPayload,
+  SketchDragPayload,
+  TimelineDragPayload
+} from "../../lib/dragdrop";
+import { blockToConstant } from "./useGenerationToCanvas";
 
 /** Horizontal spacing between nodes when dropping multiple assets */
 const MULTI_NODE_HORIZONTAL_SPACING = 250;
@@ -166,6 +171,28 @@ export const useDropHandler = (): UseDropHandlerResult => {
 
       // Handle asset/sketch/timeline drops on pane
       if (targetIsPane && dragData) {
+        if (dragData.type === "chat-media") {
+          const block = dragData.payload as ChatMediaDragPayload;
+          const constant = blockToConstant(block);
+          if (!constant) {
+            return;
+          }
+          const metadata = getMetadata(constant.nodeType);
+          if (!metadata) {
+            addNotification({
+              type: "error",
+              content: `Could not add media to canvas: metadata for ${constant.nodeType} is missing.`,
+              alert: true
+            });
+            return;
+          }
+          const newNode = createNode(metadata, position);
+          newNode.data.properties.value = constant.value;
+          addNode(newNode);
+          addRecentNode(constant.nodeType);
+          return;
+        }
+
         if (dragData.type === "sketch") {
           const sketch = dragData.payload as SketchDragPayload;
           const metadata = getMetadata(CONSTANT_SKETCH_NODE_TYPE);

--- a/web/src/lib/dragdrop/__tests__/serialization.test.ts
+++ b/web/src/lib/dragdrop/__tests__/serialization.test.ts
@@ -237,6 +237,32 @@ describe("serialization", () => {
       expect(result?.payload).toEqual({ id: "timeline-1", name: "Cutdown" });
     });
 
+    it("should round-trip chat-media through the unified format", () => {
+      const store: Record<string, string> = {};
+      const mockDataTransfer = {
+        setData: jest.fn((key: string, value: string) => {
+          store[key] = value;
+        }),
+        getData: jest.fn((key: string) => store[key] ?? ""),
+        items: [],
+        files: { length: 0 }
+      } as unknown as DataTransfer;
+
+      const data: DragData<"chat-media"> = {
+        type: "chat-media",
+        payload: {
+          type: "image_url",
+          image: { type: "image", asset_id: "a1", uri: "http://x/img.png" }
+        } as any
+      };
+
+      serializeDragData(data, mockDataTransfer);
+      const result = deserializeDragData(mockDataTransfer);
+
+      expect(result?.type).toBe("chat-media");
+      expect(result?.payload).toEqual(data.payload);
+    });
+
     it("should return null for invalid JSON", () => {
       const mockDataTransfer = {
         getData: jest.fn((key: string) => {

--- a/web/src/lib/dragdrop/index.ts
+++ b/web/src/lib/dragdrop/index.ts
@@ -8,6 +8,7 @@
 export type {
   DragDataType,
   DragPayloadMap,
+  ChatMediaDragPayload,
   SketchDragPayload,
   TimelineDragPayload,
   DragData,

--- a/web/src/lib/dragdrop/serialization.ts
+++ b/web/src/lib/dragdrop/serialization.ts
@@ -19,7 +19,8 @@ const VALID_DRAG_TYPES: ReadonlySet<string> = new Set<DragDataType>([
   "timeline",
   "file",
   "tab",
-  "collection-file"
+  "collection-file",
+  "chat-media"
 ]);
 
 function isDragData(value: unknown): value is DragData {
@@ -72,7 +73,8 @@ const LEGACY_KEY_MAP: Record<DragDataType, string> = {
   timeline: "timeline",
   file: "", // External files don't use custom keys
   tab: "text/plain",
-  "collection-file": ""
+  "collection-file": "",
+  "chat-media": "" // Only carried in the unified format
 };
 
 /**

--- a/web/src/lib/dragdrop/types.ts
+++ b/web/src/lib/dragdrop/types.ts
@@ -5,7 +5,13 @@
  * Maps to existing dataTransfer keys for backward compatibility.
  */
 
-import type { Asset, NodeMetadata } from "../../stores/ApiTypes";
+import type {
+  Asset,
+  NodeMetadata,
+  MessageImageContent,
+  MessageVideoContent,
+  MessageAudioContent
+} from "../../stores/ApiTypes";
 
 /**
  * Supported drag data types in the application.
@@ -19,7 +25,14 @@ export type DragDataType =
   | "timeline" // Persisted timeline sequence from timeline panel
   | "file" // External file from OS
   | "tab" // Editor tab reordering
-  | "collection-file"; // File being added to collection
+  | "collection-file" // File being added to collection
+  | "chat-media"; // Generated media block dragged out of the chat view
+
+/** A single image/video/audio block from a chat message, draggable to canvas. */
+export type ChatMediaDragPayload =
+  | MessageImageContent
+  | MessageVideoContent
+  | MessageAudioContent;
 
 /**
  * Type-safe payload definitions for each drag type
@@ -45,6 +58,7 @@ export interface DragPayloadMap {
   file: File;
   tab: string; // Workflow ID
   "collection-file": File;
+  "chat-media": ChatMediaDragPayload;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds automatic placement of generated media (images, videos, audio) onto the canvas when a chat generation completes, and enables drag-and-drop of media from chat to canvas. Generated media now flows directly into the workflow without requiring manual "Add to Canvas" clicks.

## Key Changes

- **Auto-add on generation complete**: New `useAutoAddGeneratedMediaToCanvas` hook fires on the chat's busy → idle edge, extracting media from the last assistant message of a media-only turn and adding it as constant nodes to the canvas. Deduplicates across turns to avoid adding the same asset twice.

- **Drag-to-canvas support**: Media tiles in `MediaOutputGroup` and individual media in `MessageContentRenderer` are now draggable. Drag data serialized as `"chat-media"` type carrying the media block payload.

- **Drop handler integration**: `useDropHandler` now recognizes `"chat-media"` drops on the canvas pane, converts blocks to constants via `blockToConstant`, and creates constant nodes with the media value.

- **Media grid layout refresh**: Simplified grid to use uniform `120px` thumbnail tiles with `auto-fill` layout. Audio tiles span the full row. All tiles are grab-cursor draggable.

- **Drag data type system**: Extended `dragdrop/types.ts` with `ChatMediaDragPayload` union type and `"chat-media"` drag type. Updated serialization to round-trip chat media through the unified format.

- **CanvasMediaComposer integration**: Calls `useAutoAddGeneratedMediaToCanvas` so finished generations in the workflow canvas's embedded composer auto-populate the canvas.

## Implementation Details

- Deduplication in `useAutoAddGeneratedMediaToCanvas` uses a `Set<string>` keyed by asset ID or URI, cleared on thread switch so later turns can reuse asset IDs.
- Only acts when canvas is available (`isCanvasAvailable` check) — no-op in standalone chat panel.
- Media block identification reuses existing helpers (`isImageContent`, `isVideoContent`, `isAudioContent`, `isMediaOnlyContent`).
- Drag handlers use `serializeDragData` utility for consistent payload encoding.
- Test coverage for auto-add hook: edge detection, deduplication, canvas-unavailable no-op.

https://claude.ai/code/session_01PuM8LJX7P4Szs3Q1L2MrSz