### PR TITLE
Open app pages (Settings, Costs, etc.) as workspace tabs

### DIFF
--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -21,6 +21,11 @@ import { isProduction } from "../../lib/env";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { useAppHeaderStore } from "../../stores/AppHeaderStore";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  PAGE_TAB_TITLES,
+  type PageTabKey
+} from "../workspace/pageTabs";
 import Help from "../content/Help/Help";
 import Logo from "../Logo";
 import { Popover, MenuItemPrimitive, Tooltip, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
@@ -89,51 +94,37 @@ const RailAppMenu: React.FC = () => {
   useCombo(["Control", "/"], handleShowKeyboardShortcuts);
 
   const close = useCallback(() => setOpen(false), []);
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
+  // Open an app page (Settings, Costs, …) as a workspace tab and focus the
+  // workspace, instead of navigating to a dedicated route.
+  const openPage = useCallback(
+    (key: PageTabKey) => {
+      openTab({
+        type: "page",
+        ref: key,
+        mode: "view",
+        title: PAGE_TAB_TITLES[key]
+      });
+      navigate("/workspace");
+      close();
+    },
+    [openTab, navigate, close]
+  );
 
   const goDashboard = useCallback(() => {
     navigate("/dashboard");
     close();
   }, [navigate, close]);
 
-  const goExamples = useCallback(() => {
-    navigate("/examples");
-    close();
-  }, [navigate, close]);
-
-  const goTutorials = useCallback(() => {
-    navigate("/tutorials");
-    close();
-  }, [navigate, close]);
-
-  const goCosts = useCallback(() => {
-    navigate("/costs");
-    close();
-  }, [navigate, close]);
-
-  const goModels = useCallback(() => {
-    navigate("/models");
-    close();
-  }, [navigate, close]);
-
-  const goPackages = useCallback(() => {
-    navigate("/packages");
-    close();
-  }, [navigate, close]);
-
-  const goCollections = useCallback(() => {
-    navigate("/collections");
-    close();
-  }, [navigate, close]);
-
-  const goWorkspaces = useCallback(() => {
-    navigate("/workspaces");
-    close();
-  }, [navigate, close]);
-
-  const goSettings = useCallback(() => {
-    navigate("/settings");
-    close();
-  }, [navigate, close]);
+  const goExamples = useCallback(() => openPage("examples"), [openPage]);
+  const goTutorials = useCallback(() => openPage("tutorials"), [openPage]);
+  const goCosts = useCallback(() => openPage("costs"), [openPage]);
+  const goModels = useCallback(() => openPage("models"), [openPage]);
+  const goPackages = useCallback(() => openPage("packages"), [openPage]);
+  const goCollections = useCallback(() => openPage("collections"), [openPage]);
+  const goWorkspaces = useCallback(() => openPage("workspaces"), [openPage]);
+  const goSettings = useCallback(() => openPage("settings"), [openPage]);
 
   const openHelp = useCallback(() => {
     handleOpenHelp();

--- a/web/src/components/panels/__tests__/RailAppMenu.test.tsx
+++ b/web/src/components/panels/__tests__/RailAppMenu.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * RailAppMenu tests
+ *
+ * The logo menu opens app pages (Settings, Costs, Model Manager, …) as
+ * workspace tabs instead of navigating to their own routes. These tests drive
+ * the menu with the real WorkspaceTabsStore and assert a `page` tab is opened
+ * and the workspace is focused.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import RailAppMenu from "../RailAppMenu";
+import mockTheme from "../../../__mocks__/themeMock";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import { tabId } from "../../../stores/WorkspaceTabsStore";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate
+}));
+
+jest.mock("../../content/Help/Help", () => () => null);
+jest.mock("../../Logo", () => () => <span data-testid="logo" />);
+
+jest.mock("../../../stores/KeyPressedStore", () => ({
+  useCombo: jest.fn()
+}));
+
+jest.mock("../../../stores/AppHeaderStore", () => ({
+  useAppHeaderStore: () => ({
+    helpOpen: false,
+    handleCloseHelp: jest.fn(),
+    handleOpenHelp: jest.fn(),
+    setHelpIndex: jest.fn()
+  })
+}));
+
+jest.mock("../../../stores/ModelDownloadStore", () => ({
+  useModelDownloadStore: () => ({ downloads: {}, openDialog: jest.fn() })
+}));
+
+const renderMenu = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <RailAppMenu />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+});
+
+it("opens Settings as a page tab and focuses the workspace", async () => {
+  const user = userEvent.setup();
+  renderMenu();
+
+  await user.click(screen.getByRole("button", { name: /open app menu/i }));
+  await user.click(screen.getByRole("menuitem", { name: /settings/i }));
+
+  const { tabs, activeTabId } = useWorkspaceTabsStore.getState();
+  const expectedId = tabId("page", "settings");
+  expect(tabs).toEqual([
+    expect.objectContaining({
+      id: expectedId,
+      type: "page",
+      ref: "settings",
+      mode: "view",
+      title: "Settings"
+    })
+  ]);
+  expect(activeTabId).toBe(expectedId);
+  expect(mockNavigate).toHaveBeenCalledWith("/workspace");
+});
+
+it("keeps Dashboard on its route (not a tab)", async () => {
+  const user = userEvent.setup();
+  renderMenu();
+
+  await user.click(screen.getByRole("button", { name: /open app menu/i }));
+  await user.click(screen.getByRole("menuitem", { name: /dashboard/i }));
+
+  expect(useWorkspaceTabsStore.getState().tabs).toHaveLength(0);
+  expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+});

--- a/web/src/components/workspace/PageSurface.tsx
+++ b/web/src/components/workspace/PageSurface.tsx
@@ -1,0 +1,61 @@
+import React, { Suspense } from "react";
+
+import { LoadingSpinner } from "../ui_primitives";
+import { PAGE_TAB_TITLES, type PageTabKey } from "./pageTabs";
+
+const TutorialsPage = React.lazy(() => import("../tutorials/TutorialsPage"));
+const ExamplesPage = React.lazy(() => import("../portal/ExamplesPage"));
+const CostsDashboard = React.lazy(() => import("../costs/CostsDashboard"));
+const ModelsPage = React.lazy(
+  () => import("../hugging_face/model_list/ModelsPage")
+);
+const PackagesPage = React.lazy(() => import("../packages/PackagesPage"));
+const CollectionsExplorer = React.lazy(
+  () => import("../collections/CollectionsExplorer")
+);
+const WorkspacesPage = React.lazy(
+  () => import("../workspaces/WorkspacesPage")
+);
+const SettingsPage = React.lazy(() => import("../menus/SettingsMenu"));
+
+const PAGE_COMPONENTS: Record<PageTabKey, React.ComponentType> = {
+  tutorials: TutorialsPage,
+  examples: ExamplesPage,
+  costs: CostsDashboard,
+  models: ModelsPage,
+  packages: PackagesPage,
+  collections: CollectionsExplorer,
+  workspaces: WorkspacesPage,
+  settings: SettingsPage
+};
+
+const surfaceStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  height: "100%",
+  minHeight: 0,
+  overflow: "auto"
+};
+
+interface PageSurfaceProps {
+  pageKey: PageTabKey;
+}
+
+/**
+ * Renders an app page (Settings, Costs, Model Manager, …) inside a workspace
+ * tab. Each page is the same self-contained component the old route mounted,
+ * lazily loaded so it only costs bundle weight once its tab is opened.
+ */
+const PageSurface = ({ pageKey }: PageSurfaceProps) => {
+  const Component = PAGE_COMPONENTS[pageKey];
+  return (
+    <div style={surfaceStyle} aria-label={PAGE_TAB_TITLES[pageKey]}>
+      <Suspense fallback={<LoadingSpinner />}>
+        <Component />
+      </Suspense>
+    </div>
+  );
+};
+
+export default PageSurface;

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -7,6 +7,8 @@ import TextSurface from "./TextSurface";
 import Model3DSurface from "./Model3DSurface";
 import AudioSurface from "./AudioSurface";
 import TimelineSurface from "./TimelineSurface";
+import PageSurface from "./PageSurface";
+import { isPageTabKey } from "./pageTabs";
 
 interface TabContentProps {
   tab: WorkspaceTab;
@@ -39,6 +41,8 @@ const TabContent = ({ tab, active }: TabContentProps) => {
       return <AudioSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "timeline":
       return <TimelineSurface refId={tab.ref} mode={tab.mode} active={active} />;
+    case "page":
+      return isPageTabKey(tab.ref) ? <PageSurface pageKey={tab.ref} /> : null;
     default: {
       // Exhaustiveness guard — a new WorkspaceTabType must add a case here.
       const exhaustive: never = tab.type;

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -33,7 +33,8 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   timeline: true,
   model3d: true,
   text: true,
-  audio: true
+  audio: true,
+  page: false
 };
 
 /** Tab types whose title can be renamed in place by double-clicking. */
@@ -51,7 +52,8 @@ const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
   timeline: "▤",
   model3d: "◈",
   audio: "♪",
-  text: "¶"
+  text: "¶",
+  page: "☰"
 };
 
 /** Pin color per tab type, reusing the app's canonical data-type palette. */
@@ -62,7 +64,8 @@ const TYPE_COLOR: Record<WorkspaceTabType, string> = {
   timeline: colorForType("video"),
   model3d: colorForType("model_3d"),
   audio: colorForType("audio"),
-  text: colorForType("text")
+  text: colorForType("text"),
+  page: colorForType("any")
 };
 
 const styles = (theme: Theme) =>

--- a/web/src/components/workspace/pageTabs.ts
+++ b/web/src/components/workspace/pageTabs.ts
@@ -1,0 +1,30 @@
+// pageTabs.ts
+// -----------------------------------------------------------------
+// The set of app "pages" that open as workspace tabs (type: "page")
+// instead of their own route. `ref` is the PageTabKey; the title is
+// looked up here so the tab bar and the logo menu stay in sync.
+// -----------------------------------------------------------------
+
+export type PageTabKey =
+  | "tutorials"
+  | "examples"
+  | "costs"
+  | "models"
+  | "packages"
+  | "collections"
+  | "workspaces"
+  | "settings";
+
+export const PAGE_TAB_TITLES: Record<PageTabKey, string> = {
+  tutorials: "Tutorials",
+  examples: "Examples",
+  costs: "Costs",
+  models: "Model Manager",
+  packages: "Package Manager",
+  collections: "Collections",
+  workspaces: "Workspaces",
+  settings: "Settings"
+};
+
+export const isPageTabKey = (value: string): value is PageTabKey =>
+  Object.prototype.hasOwnProperty.call(PAGE_TAB_TITLES, value);

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -21,7 +21,10 @@ export type WorkspaceTabType =
   | "timeline"
   | "model3d"
   | "audio"
-  | "text";
+  | "text"
+  // App pages (Settings, Costs, Model Manager, …) opened from the logo menu.
+  // `ref` is a PageTabKey; these have no edit mode.
+  | "page";
 
 export type WorkspaceTabMode = "view" | "edit";
 


### PR DESCRIPTION
## Summary

Refactors the logo menu to open app pages (Settings, Costs, Model Manager, Tutorials, Examples, etc.) as workspace tabs instead of navigating to dedicated routes. This unifies the navigation model—most app sections now open within the workspace tab interface, with only Dashboard remaining on its own route.

## Key Changes

- **New page tab system** (`web/src/components/workspace/pageTabs.ts`): Defines `PageTabKey` type and `PAGE_TAB_TITLES` mapping for the 8 app pages that now open as tabs (tutorials, examples, costs, models, packages, collections, workspaces, settings).

- **PageSurface component** (`web/src/components/workspace/PageSurface.tsx`): New surface that renders app pages inside workspace tabs. Lazily loads each page component so bundle weight is only paid when the tab is opened.

- **RailAppMenu refactor** (`web/src/components/panels/RailAppMenu.tsx`): Replaces 8 individual navigation callbacks with a single `openPage()` function that creates a workspace tab and navigates to `/workspace`. Dashboard remains a special case that navigates to `/dashboard` directly.

- **WorkspaceTabsStore extension** (`web/src/stores/WorkspaceTabsStore.ts`): Adds `"page"` as a new `WorkspaceTabType`. Page tabs have no edit mode and use `ref` as a `PageTabKey`.

- **TabContent routing** (`web/src/components/workspace/TabContent.tsx`): Routes `"page"` tab type to `PageSurface`, validating the ref is a valid `PageTabKey`.

- **Tab bar styling** (`web/src/components/workspace/WorkspaceTabBar.tsx`): Adds glyph (`☰`), color, and mode support for page tabs.

- **Comprehensive tests** (`web/src/components/panels/__tests__/RailAppMenu.test.tsx`): Verifies Settings opens as a workspace tab with correct state, and Dashboard still navigates to its route.

## Implementation Details

- Page components are the same self-contained components previously mounted by their own routes—no refactoring of the pages themselves.
- Lazy loading via `React.lazy()` and `Suspense` keeps the initial bundle lean.
- The `tabId()` helper generates consistent tab IDs from type and ref.
- All 8 pages share the same `openPage()` pattern, reducing code duplication from 8 separate callbacks to 1 reusable function.

https://claude.ai/code/session_01FBJGMFjifLUEFwFX61GZmY