### PR TITLE
Add /vs/langflow and /vs/n8n comparison pages, de-orphan /vs/* via footer

### DIFF
--- a/docs/SEO_STRATEGY.md
+++ b/docs/SEO_STRATEGY.md
@@ -8,8 +8,11 @@ description: "Content and search strategy for nodetool.ai — audit, competitive
 Research basis: an audit of `marketing/` (the nodetool.ai Next.js site), `docs/`, the 61 example
 workflows in `packages/base-nodes/nodetool/examples/`, and the node packages in `packages/`, plus
 external research on competitor positioning and search behavior (sources linked inline). Written
-2026-07-01 — re-audit the live site before acting on the numbers below if this file is more than a
-quarter old.
+2026-07-01, updated 2026-07-02 — re-audit the live site before acting on the numbers below if this
+file is more than a quarter old.
+
+**Status**: the movie-trailer sitemap fix shipped 2026-07-01. `/vs/langflow` and `/vs/n8n` (§4.1
+items 1 and 3) and the footer "Compare" column (§1, orphaned-pages finding) shipped 2026-07-02.
 
 ## 1. Where nodetool.ai stands today
 
@@ -17,11 +20,17 @@ The site (`marketing/src/app/`) has 13 indexed pages: `/`, `/studio`, `/cloud`, 
 `/agents`, `/creatives`, `/developers`, two comparison pages (`/vs/comfyui`, `/vs/weavy`), two
 use-case pages (`/use-cases/product-video`, `/use-cases/movie-poster`), and three legal pages.
 
-Four gaps stand out:
+Five gaps stand out:
 
 - **`/use-cases/movie-trailer` exists but is missing from `sitemap.ts`** (`marketing/src/app/sitemap.ts`).
-  It has a page folder and an entry in `useCaseEntries.ts` but never reaches search engines. Fix
-  this regardless of anything else in this doc — it's a one-line omission, not a strategy question.
+  ~~It has a page folder and an entry in `useCaseEntries.ts` but never reaches search engines.~~
+  **Fixed 2026-07-01.**
+- **The `/vs/*` comparison pages are orphaned.** Nothing on the site links to them — they're
+  reachable only through `sitemap.xml`. Pages with zero internal links get crawled less, rank
+  worse, and pass no authority. **Fixed 2026-07-02** with a "Compare" column in the shared footer
+  (`marketing/src/components/SiteFooter.tsx`), which gives every comparison page a sitewide
+  internal link. Keep this rule for every future page type: nothing ships without at least one
+  internal link from an existing page.
 - **No blog.** Every competitor identified in research below (Dify, n8n, Flowise, Langflow, Lindy,
   Gumloop, Vellum, StackAI, Wireflow) runs a blog and ranks on "X vs Y" and "best tools for Z"
   queries, which is exactly the traffic NodeTool needs and currently cedes to them.
@@ -127,9 +136,15 @@ Pattern already proven at `marketing/src/app/vs/comfyui/page.tsx` and `vs/weavy/
 (feature-table format, ~250 lines each, hand-built per page). Expand from 2 to a target list based
 on what people are already comparing:
 
-1. `/vs/langflow` — pull in the "no media generation" gap
+1. ~~`/vs/langflow` — pull in the "no media generation" gap~~ **Shipped 2026-07-02.** Angle used:
+   both cover agents/RAG; only NodeTool generates media natively (Langflow is MIT, has a
+   macOS/Windows desktop app — the honest table concedes both).
 2. `/vs/flowise` — same gap, plus BYOK vs. hosted credits
-3. `/vs/n8n` — orchestration-only vs. orchestration + native generation
+3. ~~`/vs/n8n` — orchestration-only vs. orchestration + native generation~~ **Shipped 2026-07-02.**
+   Angle used: "workflows that create, not just connect", plus AGPL-3.0 (open source) vs.
+   Sustainable Use License (fair-code, commercially restricted) — a real differentiator n8n's own
+   docs confirm. The FAQ answers "when should I pick n8n instead?" honestly (400+ connectors,
+   schedules/retries), which is what makes the rest of the page credible.
 4. `/vs/flora` (or a combined "AI canvas alternatives" page covering Flora, Freepik Spaces, Krea)
 5. `/vs/dify` — RAG/agent platform, no creative media
 6. `/vs/lmstudio` or `/vs/jan` — local chat only vs. local + cloud workflow canvas
@@ -184,13 +199,18 @@ scope, not a general-purpose blog:
 
 ## 5. Technical SEO checklist
 
-- [ ] Add `/use-cases/movie-trailer` to `marketing/src/app/sitemap.ts` (confirmed missing, §1)
+- [x] Add `/use-cases/movie-trailer` to `marketing/src/app/sitemap.ts` (shipped 2026-07-01)
+- [x] Internal-link the `/vs/*` pages — footer "Compare" column in `SiteFooter.tsx` links all four
+      comparison pages sitewide (shipped 2026-07-02); every future page needs at least one internal
+      link before it ships
 - [ ] Build `/marketing` (§4.0) and add it to `sitemap.ts` at priority 0.8 / monthly — same tier as
       `/agents`, `/creatives`, `/developers` — plus main nav
 - [ ] Confirm every new page under `/vs/`, `/use-cases/`, `/marketing`, and any future `/blog/` gets
-      an `opengraph-image.tsx` (existing `vs/*` pages already do this — keep the pattern)
+      an `opengraph-image.tsx` (all four `vs/*` pages do — keep the pattern)
 - [ ] Add `priority`/`changeFrequency` entries to `sitemap.ts` for every new page as it ships —
-      don't let the list drift out of sync with `app/` folders again
+      don't let the list drift out of sync with `app/` folders again (langflow/n8n added 2026-07-02)
+- [ ] Add every new indexed route to `marketing/tests/e2e/smoke.spec.ts` — it guards title,
+      single-`h1`, and render status per route (langflow/n8n added 2026-07-02)
 - [ ] Verify `docs/nodes/<provider>/index.md` pages carry unique titles and descriptions (currently
       generated docs; check for duplicate/boilerplate meta across providers)
 - [ ] Internal linking: `/agents`, `/creatives`, `/developers`, `/marketing` should each link to the
@@ -221,11 +241,13 @@ Content only ranks if something points at it:
 
 ## 7. Prioritized roadmap
 
-1. **Immediate** (hours): fix the `movie-trailer` sitemap omission (§1, §5).
+1. **Immediate** (hours): ~~fix the `movie-trailer` sitemap omission (§1, §5)~~ done 2026-07-01;
+   ~~internal-link the orphaned `/vs/*` pages (§1, §5)~~ done 2026-07-02.
 2. **Phase 1** (this month): build `/marketing` (§4.0) with its four supporting use-case pages
    (Product Video, Cold Outreach Co-Pilot, Social Media Calendar Filler, Brand Asset Generator);
-   ship the remaining "ship first" use-case pages (§4.2); add `/vs/langflow` and `/vs/n8n`
-   (highest-volume comparison targets per §2).
+   ship the remaining "ship first" use-case pages (§4.2); ~~add `/vs/langflow` and `/vs/n8n`
+   (highest-volume comparison targets per §2)~~ done 2026-07-02 — next comparison targets are
+   `/vs/flowise` and `/vs/dify` (§4.1).
 3. **Phase 2** (next month): stand up the blog with 3 posts — one comparison/roundup post, one
    cookbook walkthrough, one technical post (§4.4); submit NodeTool to the two GitHub awesome-lists
    named in §6.

--- a/marketing/src/app/sitemap.ts
+++ b/marketing/src/app/sitemap.ts
@@ -22,6 +22,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/developers", priority: 0.8, changeFrequency: "monthly" },
     { path: "/vs/comfyui", priority: 0.7, changeFrequency: "monthly" },
     { path: "/vs/weavy", priority: 0.7, changeFrequency: "monthly" },
+    { path: "/vs/langflow", priority: 0.7, changeFrequency: "monthly" },
+    { path: "/vs/n8n", priority: 0.7, changeFrequency: "monthly" },
     { path: "/use-cases/product-video", priority: 0.6, changeFrequency: "monthly" },
     { path: "/use-cases/movie-poster", priority: 0.6, changeFrequency: "monthly" },
     { path: "/use-cases/movie-trailer", priority: 0.6, changeFrequency: "monthly" },

--- a/marketing/src/app/vs/langflow/opengraph-image.tsx
+++ b/marketing/src/app/vs/langflow/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogImage, ogSize, ogContentType } from "../../../lib/og";
+
+export const alt = "NodeTool vs Langflow";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool vs Langflow",
+    "Agents plus native image, video, and music generation — on one canvas.",
+    { image: "screen_workflow.png", accent: "emerald", eyebrow: "Comparison" }
+  );
+}

--- a/marketing/src/app/vs/langflow/page.tsx
+++ b/marketing/src/app/vs/langflow/page.tsx
@@ -1,0 +1,261 @@
+import type { Metadata } from "next";
+import { Check, Minus, Download } from "lucide-react";
+import SiteHeader from "../../../components/SiteHeader";
+import SiteFooter from "../../../components/SiteFooter";
+import JsonLd from "../../../components/JsonLd";
+import { SmartDownloadButton } from "../../SmartDownloadButton";
+
+export const metadata: Metadata = {
+  title: "NodeTool vs Langflow — agents plus native media generation",
+  description:
+    "Langflow is a low-code builder for LLM apps: chatbots, RAG, agents. NodeTool covers the same agent and RAG ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas — open source, BYOK, local models included.",
+  alternates: { canonical: "/vs/langflow" },
+  openGraph: {
+    title: "NodeTool vs Langflow — agents plus native media generation",
+    description:
+      "Both build agents and RAG pipelines. Only one renders image, video, and music natively on the same canvas. Open source, BYOK, local models.",
+    url: "https://nodetool.ai/vs/langflow",
+    type: "website",
+  },
+};
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "NodeTool vs Langflow",
+      item: "https://nodetool.ai/vs/langflow",
+    },
+  ],
+};
+
+const faq = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the difference between NodeTool and Langflow?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Langflow is a low-code visual builder for LLM applications — chatbots, RAG pipelines, and agents — rooted in the Python and LangChain ecosystem. NodeTool covers the same agent and RAG ground but treats media as a first-class output: image, video, and music generation run as native nodes on the same canvas, with editing tools like masks, inpaint, and layers built in. Both are open source and self-hostable.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can Langflow generate images and video?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Langflow is built for text and LLM workloads; generating media means wiring up external APIs yourself. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools — masks, inpaint, outpaint, relight, upscale, layers, and compositing.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is NodeTool open source like Langflow?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. Langflow is MIT-licensed; NodeTool is open source under AGPL-3.0. Both can be self-hosted. NodeTool also ships as a desktop app for macOS, Windows, and Linux, and NodeTool Cloud is managed hosting of the same open-source code.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I run local models in NodeTool?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. NodeTool runs local models via Ollama, MLX, and llama.cpp in the desktop app, and connects to every major cloud provider BYOK — your keys, provider list prices, no credits or markup.",
+      },
+    },
+  ],
+};
+
+const rows: { label: string; langflow: string | boolean; nodetool: string | boolean }[] = [
+  {
+    label: "Focus",
+    langflow: "LLM apps: chat, RAG, agents",
+    nodetool: "Agents + image, video, audio, text",
+  },
+  {
+    label: "Native media generation (image, video, music)",
+    langflow: "Via external APIs",
+    nodetool: "Built-in nodes",
+  },
+  {
+    label: "Editing tools (masks, inpaint, relight, layers)",
+    langflow: false,
+    nodetool: true,
+  },
+  { label: "Agents & RAG", langflow: true, nodetool: true },
+  { label: "Local models", langflow: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
+  { label: "BYOK / provider billing", langflow: true, nodetool: true },
+  { label: "Open source", langflow: "MIT", nodetool: "AGPL-3.0" },
+  {
+    label: "Desktop app",
+    langflow: "macOS, Windows",
+    nodetool: "macOS, Windows, Linux",
+  },
+];
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-5 w-5 text-emerald-400" aria-label="Yes" />;
+  if (value === false)
+    return <Minus className="mx-auto h-5 w-5 text-slate-600" aria-label="No" />;
+  return <span className="text-sm text-slate-300">{value}</span>;
+}
+
+export default function VsLangflowPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden text-white">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={faq} />
+
+      {/* Background glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute -top-40 left-1/3 h-[28rem] w-[28rem] rounded-full bg-blue-500/15 blur-[120px]" />
+        <div className="absolute top-1/2 -right-24 h-[24rem] w-[24rem] rounded-full bg-fuchsia-500/10 blur-[120px]" />
+      </div>
+
+      <SiteHeader />
+
+      <div className="relative isolate pt-28 sm:pt-36">
+        {/* Hero */}
+        <section aria-labelledby="vs-title" className="mx-auto max-w-3xl px-6 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
+            NodeTool vs Langflow
+          </span>
+          <h1
+            id="vs-title"
+            className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
+          >
+            Agents that ship media, not just messages.
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-slate-300">
+            Langflow is a low-code builder for LLM apps — chatbots, RAG, agents —
+            rooted in Python and LangChain. NodeTool covers that same ground and
+            adds what Langflow leaves to external APIs: native image, video, and
+            music generation with editing tools on the same canvas. Open source,
+            BYOK at provider prices, local models included.
+          </p>
+        </section>
+
+        {/* Comparison cards */}
+        <section aria-label="At a glance" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Langflow */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">Langflow</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Low-code builder for LLM apps
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Visual flows for chatbots, RAG, and agents",
+                  "Python-extensible, LangChain ecosystem",
+                  "Open source (MIT), self-hostable",
+                  "Text and LLM pipelines first",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* NodeTool */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">NodeTool</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Agents plus native generation
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Agents, RAG, and chat on the same canvas",
+                  "Native image, video, and music generation nodes",
+                  "Editing tools: masks, inpaint, relight, layers",
+                  "BYOK at provider prices — local models via Ollama, MLX, llama.cpp",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Comparison table */}
+        <section aria-label="Compare" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/70 ring-1 ring-white/5">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="bg-slate-900/60 text-sm">
+                  <th className="px-5 py-4 font-medium text-slate-400">Feature</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">Langflow</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">NodeTool</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={i % 2 ? "bg-slate-950/40" : "bg-slate-900/20"}
+                  >
+                    <td className="px-5 py-4 text-sm text-slate-300">{row.label}</td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.langflow} /></td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.nodetool} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Explainer */}
+        <section aria-labelledby="explainer-title" className="mx-auto mt-16 max-w-3xl px-6">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+            <h2 id="explainer-title" className="text-2xl font-semibold tracking-tight text-white">
+              The pipeline and the picture, on one canvas
+            </h2>
+            <p className="mt-4 leading-relaxed text-slate-300">
+              If your project ends at a chatbot or a RAG pipeline, Langflow is a
+              solid choice — visual flows, Python extensibility, a mature
+              LangChain ecosystem. But the moment an agent needs to produce
+              something you can look at or listen to — a storyboard, a product
+              video, a soundtrack — Langflow hands you an API key form and a
+              blank HTTP node. NodeTool keeps going: generation nodes for image,
+              video, and music from every major provider sit on the same canvas
+              as your agents and retrieval, with masks, inpaint, relight,
+              upscale, and layers built in. You bring your own keys and pay
+              provider list prices — no credits, no markup — and run local
+              models via Ollama, MLX, and llama.cpp on the desktop.
+            </p>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto my-24 max-w-2xl px-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Build agents that make things.
+          </h2>
+          <p className="mt-4 text-lg text-slate-300">
+            Download Studio and put generation on the same canvas as your agents.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SmartDownloadButton
+              icon={<Download className="h-5 w-5" />}
+              classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+            />
+          </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/marketing/src/app/vs/n8n/opengraph-image.tsx
+++ b/marketing/src/app/vs/n8n/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogImage, ogSize, ogContentType } from "../../../lib/og";
+
+export const alt = "NodeTool vs n8n";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return ogImage(
+    "NodeTool vs n8n",
+    "Workflows that create, not just connect — native generation and agents.",
+    { image: "screen_canvas.png", accent: "cyan", eyebrow: "Comparison" }
+  );
+}

--- a/marketing/src/app/vs/n8n/page.tsx
+++ b/marketing/src/app/vs/n8n/page.tsx
@@ -1,0 +1,272 @@
+import type { Metadata } from "next";
+import { Check, Minus, Download } from "lucide-react";
+import SiteHeader from "../../../components/SiteHeader";
+import SiteFooter from "../../../components/SiteFooter";
+import JsonLd from "../../../components/JsonLd";
+import { SmartDownloadButton } from "../../SmartDownloadButton";
+
+export const metadata: Metadata = {
+  title: "NodeTool vs n8n — when the workflow creates, not just connects",
+  description:
+    "n8n moves data between hundreds of business apps. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas — open source under AGPL-3.0 (not fair-code), BYOK at provider prices, with a desktop app and local models.",
+  alternates: { canonical: "/vs/n8n" },
+  openGraph: {
+    title: "NodeTool vs n8n — when the workflow creates, not just connects",
+    description:
+      "n8n connects apps. NodeTool generates — image, video, music, and agents on one canvas. Open source (AGPL-3.0), BYOK, desktop app, local models.",
+    url: "https://nodetool.ai/vs/n8n",
+    type: "website",
+  },
+};
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://nodetool.ai" },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "NodeTool vs n8n",
+      item: "https://nodetool.ai/vs/n8n",
+    },
+  ],
+};
+
+const faq = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the difference between NodeTool and n8n?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "n8n is a workflow automation platform: it moves data between hundreds of business apps, with AI agent nodes built on LangChain. NodeTool is built for workflows where the AI work is the point — native image, video, and music generation, agents, and media editing tools on one node-based canvas. If the job is connecting Salesforce to Slack on a schedule, use n8n. If the job is producing something with AI, use NodeTool.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is n8n open source?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "n8n is fair-code under its Sustainable Use License: the source is available, but commercial use is restricted. NodeTool is open source under AGPL-3.0, an OSI-approved license — you can self-host it, modify it, and build on it, and NodeTool Cloud is managed hosting of the same code.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can n8n generate images or video?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Only by calling external APIs from generic HTTP or integration nodes. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools — masks, inpaint, outpaint, relight, upscale, layers, and compositing.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "When should I pick n8n instead of NodeTool?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "When the hard part of your workflow is business-app plumbing: hundreds of connectors, schedules, retries, and branching between SaaS tools. That is what n8n is built for. NodeTool is the better fit when the workflow's output is AI-generated media or agent work, and you want local models, BYOK provider pricing, and a desktop app.",
+      },
+    },
+  ],
+};
+
+const rows: { label: string; n8n: string | boolean; nodetool: string | boolean }[] = [
+  {
+    label: "Focus",
+    n8n: "App-to-app automation",
+    nodetool: "AI generation + agents",
+  },
+  {
+    label: "Native media generation (image, video, music)",
+    n8n: "Via external APIs",
+    nodetool: "Built-in nodes",
+  },
+  {
+    label: "Editing tools (masks, inpaint, relight, layers)",
+    n8n: false,
+    nodetool: true,
+  },
+  {
+    label: "Business app connectors",
+    n8n: "400+ integrations",
+    nodetool: "AI-focused set",
+  },
+  {
+    label: "License",
+    n8n: "Sustainable Use (fair-code)",
+    nodetool: "AGPL-3.0 (open source)",
+  },
+  { label: "Local models", n8n: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
+  {
+    label: "Pricing model",
+    n8n: "Per-execution plans (cloud)",
+    nodetool: "BYOK / provider prices",
+  },
+  { label: "Desktop app", n8n: false, nodetool: true },
+];
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-5 w-5 text-emerald-400" aria-label="Yes" />;
+  if (value === false)
+    return <Minus className="mx-auto h-5 w-5 text-slate-600" aria-label="No" />;
+  return <span className="text-sm text-slate-300">{value}</span>;
+}
+
+export default function VsN8nPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden text-white">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={faq} />
+
+      {/* Background glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute -top-40 left-1/3 h-[28rem] w-[28rem] rounded-full bg-blue-500/15 blur-[120px]" />
+        <div className="absolute top-1/2 -right-24 h-[24rem] w-[24rem] rounded-full bg-fuchsia-500/10 blur-[120px]" />
+      </div>
+
+      <SiteHeader />
+
+      <div className="relative isolate pt-28 sm:pt-36">
+        {/* Hero */}
+        <section aria-labelledby="vs-title" className="mx-auto max-w-3xl px-6 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
+            NodeTool vs n8n
+          </span>
+          <h1
+            id="vs-title"
+            className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
+          >
+            Workflows that create, not just connect.
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-slate-300">
+            n8n moves data between hundreds of business apps — schedules,
+            retries, branching. NodeTool is built for workflows where the AI
+            work is the point: native image, video, and music generation,
+            agents, and editing tools on one canvas. Open source under
+            AGPL-3.0, BYOK at provider prices, with a desktop app and local
+            models.
+          </p>
+        </section>
+
+        {/* Comparison cards */}
+        <section aria-label="At a glance" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* n8n */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">n8n</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Workflow automation platform
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "400+ integrations for business apps",
+                  "Orchestration: schedules, retries, branching",
+                  "AI agent nodes built on LangChain",
+                  "Fair-code: source-available, commercially restricted",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* NodeTool */}
+            <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
+              <h2 className="text-xl font-semibold text-white">NodeTool</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                The AI-native canvas
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-300">
+                {[
+                  "Native image, video, and music generation nodes",
+                  "Agents and RAG on the same canvas as generation",
+                  "Open source under AGPL-3.0, desktop app included",
+                  "BYOK at provider prices — no credits, no markup",
+                ].map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Comparison table */}
+        <section aria-label="Compare" className="mx-auto mt-16 max-w-5xl px-6">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/70 ring-1 ring-white/5">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="bg-slate-900/60 text-sm">
+                  <th className="px-5 py-4 font-medium text-slate-400">Feature</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">n8n</th>
+                  <th className="px-5 py-4 text-center font-semibold text-white">NodeTool</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={i % 2 ? "bg-slate-950/40" : "bg-slate-900/20"}
+                  >
+                    <td className="px-5 py-4 text-sm text-slate-300">{row.label}</td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.n8n} /></td>
+                    <td className="px-5 py-4 text-center"><Cell value={row.nodetool} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Explainer */}
+        <section aria-labelledby="explainer-title" className="mx-auto mt-16 max-w-3xl px-6">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+            <h2 id="explainer-title" className="text-2xl font-semibold tracking-tight text-white">
+              Plumbing is solved. Production isn&apos;t.
+            </h2>
+            <p className="mt-4 leading-relaxed text-slate-300">
+              If the hard part of your workflow is moving records between
+              Salesforce, Slack, and a spreadsheet on a schedule, n8n is built
+              for exactly that. But when the workflow&apos;s output is the
+              thing itself — a product video, a batch of campaign images, a
+              soundtrack, an agent&apos;s research report — the generation
+              can&apos;t live in a generic HTTP node. NodeTool makes it native:
+              image, video, and music models from every major provider as
+              first-class nodes, agents and retrieval on the same canvas, and
+              editing tools — masks, inpaint, relight, upscale, layers — built
+              in. It&apos;s open source under AGPL-3.0 rather than fair-code,
+              runs as a desktop app on macOS, Windows, and Linux, and calls
+              models with your own keys at provider list prices.
+            </p>
+          </div>
+        </section>
+
+        {/* Closing CTA */}
+        <section className="mx-auto my-24 max-w-2xl px-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Make the workflow the studio.
+          </h2>
+          <p className="mt-4 text-lg text-slate-300">
+            Download Studio and generate image, video, and music where your
+            agents already work.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SmartDownloadButton
+              icon={<Download className="h-5 w-5" />}
+              classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 focus-ring"
+            />
+          </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/marketing/src/components/SiteFooter.tsx
+++ b/marketing/src/components/SiteFooter.tsx
@@ -31,6 +31,15 @@ const COLUMNS: Col[] = [
     ],
   },
   {
+    title: "Compare",
+    links: [
+      { name: "vs ComfyUI", href: "/vs/comfyui" },
+      { name: "vs Weavy", href: "/vs/weavy" },
+      { name: "vs Langflow", href: "/vs/langflow" },
+      { name: "vs n8n", href: "/vs/n8n" },
+    ],
+  },
+  {
     title: "Resources",
     links: [
       { name: "Docs", href: "https://docs.nodetool.ai", external: true, onClick: () => track("Open Docs") },
@@ -53,7 +62,7 @@ export default function SiteFooter() {
     <footer className="relative border-t border-slate-800/50 bg-slate-950/80">
       <div className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-blue-800/40 to-transparent" />
       <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
-        <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-5">
+        <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-6">
           <div className="col-span-2 sm:col-span-3 lg:col-span-1">
             <a href="/" className="inline-flex items-center gap-2 focus-ring rounded" aria-label="NodeTool home">
               <Image

--- a/marketing/tests/e2e/smoke.spec.ts
+++ b/marketing/tests/e2e/smoke.spec.ts
@@ -10,6 +10,8 @@ const ROUTES = [
   "/pricing",
   "/vs/comfyui",
   "/vs/weavy",
+  "/vs/langflow",
+  "/vs/n8n",
 ];
 
 test.describe("marketing smoke", () => {


### PR DESCRIPTION
Implements the two highest-priority tactics from `docs/SEO_STRATEGY.md` (shipped in #4028) and records a new finding in the strategy.

## New comparison pages

Both follow the proven `/vs/comfyui` / `/vs/weavy` template: metadata + canonical, breadcrumb and FAQ JSON-LD, at-a-glance strengths cards, feature table, explainer, CTA, and a static `opengraph-image.tsx`.

- **`/vs/langflow`** — both tools cover agents/RAG; NodeTool adds native image, video, and music generation with editing tools on the same canvas. The table concedes Langflow's real strengths (MIT license, macOS/Windows desktop app, LangChain ecosystem) — facts verified against langflow.org and the GitHub repo.
- **`/vs/n8n`** — "workflows that create, not just connect", plus the license contrast: AGPL-3.0 (open source) vs n8n's Sustainable Use License (fair-code, commercially restricted), confirmed from n8n's own docs. The FAQ answers "when should I pick n8n instead?" honestly (400+ connectors, schedules/retries).

## De-orphaned the /vs/* pages

While auditing, I found the existing comparison pages had **zero internal links** — reachable only through `sitemap.xml`. Added a "Compare" column to the shared `SiteFooter` linking all four `/vs/*` pages sitewide (footer grid goes 5 → 6 columns at `lg`).

## Strategy doc updates

`docs/SEO_STRATEGY.md`: shipped items marked with dates, the orphaned-pages finding recorded as a standing rule (no page ships without an internal link), smoke-test route requirement added to the checklist, and `/vs/flowise` + `/vs/dify` promoted as the next comparison targets.

## Plumbing

- `sitemap.ts`: both routes at priority 0.7 / monthly, same tier as the existing comparisons.
- `tests/e2e/smoke.spec.ts`: both routes added to the title/single-h1/render guard.

## Verification

- `npm run lint` in `marketing/` passes (only pre-existing warnings in untouched files).
- Full production `next build` succeeds; `/vs/langflow`, `/vs/n8n`, and both OG image routes prerender statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcPeYGBH5AoUEe3qQKPLMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcPeYGBH5AoUEe3qQKPLMM)_