### PR TITLE
Tighten messaging in README, marketing site, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 [![Platform: Windows](https://img.shields.io/badge/platform-Windows-blue)](https://nodetool.ai)
 [![Platform: Linux](https://img.shields.io/badge/platform-Linux-orange)](https://nodetool.ai)
 
-NodeTool is an open-source creative AI suite that runs entirely on your local machine. It combines a node-based canvas, a multi-track video timeline, and a layered sketch editor into a unified workspace. Wire every major AI model—cloud or local—directly into the professional production tools you already rely on.
+NodeTool is an open-source creative AI suite that runs on your machine. A node-based canvas, a multi-track video timeline, and a layered sketch editor share one workspace, and every major AI model, cloud or local, wires into all three.
 
-* **Pay Provider Prices:** Plug in your own API keys and pay cloud providers directly at cost. 
-* **Zero Lock-In:** Swap foundational models, media APIs, or local LLMs across text, image, video, and audio whenever you want.
-* **Three Ways to Work:** Seamlessly fluid between node-based workflows, multi-track video generation, and layer-based painting and masking.
+* **Pay Provider Prices:** Bring your own API keys and pay providers at cost. No markup.
+* **Zero Lock-In:** Swap any model — cloud or local — without touching the rest of the workflow.
+* **Three Ways to Work:** Node graphs, a video timeline, and layered painting, all on one canvas.
 
 ![NodeTool Interface](screen_canvas.png)
 
@@ -41,7 +41,7 @@ NodeTool is an open-source creative AI suite that runs entirely on your local ma
 
 ## Why NodeTool
 
-Closed platforms lock you into their ecosystem. NodeTool is built for complete creative independence.
+Closed platforms lock you in. NodeTool is built for independence.
 
 **Own your AI.**
 
@@ -49,7 +49,7 @@ Closed platforms lock you into their ecosystem. NodeTool is built for complete c
 *   **Independent Data:** Workflows, keys, and files stay on your machine.
 *   **Independent Software:** Open-source (AGPL-3.0).
 
-> **Infrastructure Freedom:** If a provider raises prices or deprecates a model, just swap the backend node. Your creative workflow stays exactly the same.
+> **Infrastructure Freedom:** If a provider raises prices or deprecates a model, swap the node. The rest of the workflow doesn't change.
 
 ## What's in the box
 
@@ -101,7 +101,7 @@ See the [Sketch Editor guide](https://docs.nodetool.ai/sketch-editor) for tools,
 | **Models** | Every major provider, BYOK | Stable Diffusion | Curated marketplace | API integrations |
 | **Source & pricing** | AGPL-3.0, provider prices | Open source, free | Closed, credits | Fair-code, subscription |
 
-**vs ComfyUI.** ComfyUI exposes every parameter for engineers who want them. NodeTool keeps the node-based power, gives it an interface that doesn't fight you, and covers the rest of the stack — video, audio, text, document search.
+**vs ComfyUI.** ComfyUI exposes every parameter for engineers who want them. NodeTool keeps the node graph, gives it an interface that doesn't fight you, and covers the rest of the stack — video, audio, text, document search.
 
 **vs Weavy.** Weavy was the closed-source canvas for creative AI. After the Figma acquisition, the roadmap belongs to someone else. NodeTool is the open alternative — same node-based canvas, your keys, your files, no acquisition risk.
 

--- a/docs/agent-cli.md
+++ b/docs/agent-cli.md
@@ -328,7 +328,7 @@ system_prompt: |
 ### Model Selection
 
 - **Planning model**: Use a fast, cost-effective model (`gpt-4o-mini`, a small Claude model)
-- **Main model**: Use a powerful model for complex reasoning
+- **Main model**: Use a stronger model for the actual reasoning
 - **Code tasks**: Models with large context windows
 
 ### Tool Configuration

--- a/docs/chain-editor.md
+++ b/docs/chain-editor.md
@@ -4,7 +4,7 @@ title: "Chain Editor"
 description: "A linear, card-based way to author workflows in NodeTool."
 ---
 
-The **Chain Editor** is a streamlined alternative to the node graph. Instead of placing nodes on an infinite canvas, you compose an ordered chain of cards — perfect for linear pipelines like "transcribe → summarize → email" or "fetch → parse → index".
+The **Chain Editor** is a linear alternative to the node graph. Instead of placing nodes on an infinite canvas, you compose an ordered chain of cards — "transcribe → summarize → email", "fetch → parse → index".
 
 > **Prefer the node graph?** The full [Workflow Editor]({{ '/workflow-editor' | relative_url }}) is always one click away. Both editors read and write the same workflow format.
 

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -75,7 +75,7 @@ const proPoints = [
   {
     icon: RefreshCcw,
     title: "Always on the latest version",
-    body: "We ship Cloud updates continuously. New nodes, new providers, and bug fixes land without you lifting a finger.",
+    body: "We ship Cloud updates continuously — new nodes, new providers, and bug fixes, no update step on your side.",
   },
   {
     icon: Cloud,

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -139,7 +139,7 @@ export default function CreativesPage() {
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
                   Every model. Your keys. Your canvas. Wire Seedance, Kling, Veo, Runway,
-                  Luma, Suno, Flux, and more on one open-source surface — no credit markup, no vendor lock-in.
+                  Luma, Suno, and Flux on one open-source surface — no credit markup, no vendor lock-in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -59,7 +59,7 @@ const proPoints = [
   {
     icon: WifiOff,
     title: "Works fully offline",
-    body: "Once your local models are downloaded, you can disconnect the internet and keep building. Perfect for travel, secure environments, or air-gapped machines.",
+    body: "Once your local models are downloaded, disconnect the internet and keep building — travel, secure environments, air-gapped machines.",
   },
   {
     icon: Shield,

--- a/marketing/src/app/vs/weavy/page.tsx
+++ b/marketing/src/app/vs/weavy/page.tsx
@@ -214,8 +214,8 @@ export default function VsWeavyPage() {
               keys and pay each provider their published list price — no credits,
               no markup, no curated roster. The whole workspace is open source
               under AGPL-3.0, so you can run it as a desktop app or self-host it,
-              and your workflows and files stay yours. NodeTool Cloud is simply
-              managed hosting of that same open-source code.
+              and your workflows and files stay yours. NodeTool Cloud is
+              managed hosting of the same code.
             </p>
           </div>
         </section>

--- a/marketing/src/components/DeploySection.tsx
+++ b/marketing/src/components/DeploySection.tsx
@@ -49,7 +49,7 @@ export default function DeploySection({
                     One Command Deploy
                   </h3>
                   <p className="text-slate-400 text-sm mt-1 leading-relaxed">
-                    Simply run{" "}
+                    Run{" "}
                     <code className="bg-slate-800 px-1.5 py-0.5 rounded text-purple-300 text-xs font-mono border border-white/5">
                       nodetool deploy
                     </code>{" "}

--- a/marketing/src/components/developers/DeveloperCLISection.tsx
+++ b/marketing/src/components/developers/DeveloperCLISection.tsx
@@ -242,11 +242,11 @@ Build, Run, Extend from Code
         >
           <Workflow className="h-12 w-12 text-violet-400 mx-auto mb-4" />
           <h3 className="text-2xl font-bold text-white mb-3">
-            Ready to Get Started?
+            Build your first workflow
           </h3>
           <p className="text-slate-400 max-w-xl mx-auto mb-6">
-            Check out our comprehensive documentation with examples, tutorials, and API
-            references to help you build your first AI workflow.
+            The docs take you from install to a running workflow, with examples
+            and API references.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <a


### PR DESCRIPTION
Remove filler and refine copy without adding text:
- README: cut 'Seamlessly fluid', 'professional production tools you
  already rely on', 'complete creative independence', and hedge words
- Marketing: drop 'Simply run', 'Check out our comprehensive
  documentation', 'Perfect for', 'without lifting a finger', 'and more'
- Docs: replace 'streamlined'/'perfect for' in chain-editor and
  'powerful model' in agent-cli with concrete wording

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PTMvWbcGnjXh8qmT7GzAy