### PR TITLE
Rename "Global Chat" to "Chat" throughout documentation

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -495,7 +495,7 @@ avoids the SDK's refusal to run that flag as `uid=0`.
 ## Related Pages
 
 - [Agent Memory System](agent-memory.md) — Unified memory across all agent types: API, propagation, examples
-- [Global Chat & Agents](global-chat-agents.md) — Using agents in the chat interface
+- [Chat & Agents](global-chat-agents.md) — Using agents in the chat interface
 - [Agent CLI](agent-cli.md) — Running agents from the command line
 - [Agent Configuration Schema](agent-config-schema.md) — YAML configuration reference
 - [Custom Nodes Guide](developer/custom-nodes-guide.md) — Building custom workflow nodes

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -65,7 +65,7 @@
           <span class="nav-section-chevron" aria-hidden="true"></span>
         </summary>
         <ul class="nav-section-list">
-          <li><a href="{{ '/global-chat' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat">Global Chat</a></li>
+          <li><a href="{{ '/global-chat' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat">Chat</a></li>
           <li><a href="{{ '/global-chat-agents' | relative_url }}" class="sidebar-link" data-nav-path="/global-chat-agents">Chat &amp; Agents</a></li>
           <li><a href="{{ '/agent-config-schema' | relative_url }}" class="sidebar-link" data-nav-path="/agent-config-schema">Agent Config</a></li>
           <li><a href="{{ '/agent-memory' | relative_url }}" class="sidebar-link" data-nav-path="/agent-memory">Agent Memory</a></li>

--- a/docs/agent-cli.md
+++ b/docs/agent-cli.md
@@ -373,7 +373,7 @@ model:
 
 ## Related Documentation
 
-- [Global Chat & Agents](global-chat-agents.md) — Agent system overview
+- [Chat & Agents](global-chat-agents.md) — Agent system overview
 - [Chat CLI](chat-cli.md) — Interactive chat interface
 - [NodeTool CLI](cli.md) — Complete CLI reference
 - [Agent Configuration Schema](agent-config-schema.md) — YAML configuration reference

--- a/docs/agent-config-schema.md
+++ b/docs/agent-config-schema.md
@@ -467,4 +467,4 @@ tools:
 
 - [Agent CLI Documentation](agent-cli.md) — Complete CLI reference
 - [Agent Examples](examples/agents/) — Sample configurations
-- [Global Chat & Agents](global-chat-agents.md) — Agent system overview
+- [Chat & Agents](global-chat-agents.md) — Agent system overview

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -8,6 +8,6 @@ Interactive CLI for chatting with models. Works with OpenAI, Anthropic, Gemini, 
 - Interactive REPL with history and completion
 - Sandboxed workspace for file operations
 - Provider-specific models
-- Optional agent mode for tool use
+- Unified agent loop — the assistant calls tools and decomposes work on its own; no separate mode to toggle
 
 See the [Chat CLI](chat-cli.md) and [Chat API](chat-api.md).

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Chat"
+title: "Chat CLI Overview"
 ---
 
 Interactive CLI for chatting with models. Works with OpenAI, Anthropic, Gemini, Ollama, and others. The assistant can call tools during a session.

--- a/docs/editor-panels.md
+++ b/docs/editor-panels.md
@@ -190,5 +190,5 @@ To reset: open the command menu (`Ctrl+K` / `⌘+K`), type "reset layout", and h
 ## Next Steps
 
 - [Workflow Editor]({{ '/workflow-editor' | relative_url }}) — building on the canvas
-- [Global Chat]({{ '/global-chat' | relative_url }}) — how the in-editor chat works
+- [Chat]({{ '/global-chat' | relative_url }}) — how the in-editor chat works
 - [Configuration]({{ '/configuration' | relative_url }}) — settings that affect the editor

--- a/docs/examples/agents/README.md
+++ b/docs/examples/agents/README.md
@@ -179,7 +179,7 @@ done
 For complete documentation, see:
 
 - [Agent CLI Documentation](../../agent-cli.md) — Complete reference
-- [Global Chat & Agents](../../global-chat-agents.md) — Agent system overview
+- [Chat & Agents](../../global-chat-agents.md) — Agent system overview
 - [NodeTool CLI](../../cli.md) — Full CLI reference
 
 ## Troubleshooting

--- a/docs/global-chat-agents.md
+++ b/docs/global-chat-agents.md
@@ -1,23 +1,23 @@
 ---
 layout: page
-title: "Global Chat & Agents"
+title: "Chat & Agents"
 description: "Run workflows from chat, enable autonomous agents, and expose them through APIs."
 ---
 
-Global Chat runs workflows, streams results, and runs the unified agent loop on every turn — the assistant plans and calls tools on its own as a task needs it. Jump to the right reference below.
+Chat runs workflows, streams results, and runs the unified agent loop on every turn — the assistant plans and calls tools on its own as a task needs it. Jump to the right reference below.
 
 ## Core guides
 
-- **[Global Chat](global-chat.md)** — Interface layout, thread management, and how chat invokes workflows or tools.
+- **[Chat](global-chat.md)** — Interface layout, thread management, and how chat invokes workflows or tools.
 - **[NodeTool Agent System](global-chat.md#agent-mode)** — How planning, tool usage, and execution loops work under the hood.
 - **[Agent CLI](agent-cli.md)** — Run autonomous agents from the command line with YAML configuration files.
-- **[Global Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate conversations or integrate with custom frontends.
+- **[Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate conversations or integrate with custom frontends.
 - **[Chat API](chat-api.md)** — Programmatic access for running chats, streaming outputs, and issuing tool calls.
 
 ## Typical flows
 
 1. **Run any saved workflow from chat**  
-   Save the workflow in the editor, open Global Chat, and choose a **workflow** in the composer.
+   Save the workflow in the editor, open Chat, and choose a **workflow** in the composer.
 
 2. **Let the agent plan complex tasks**  
    The unified agent loop runs on every turn — the LLM decomposes goals into tasks and calls tools as needed. See the [Agent guide](global-chat.md#agent-mode).

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -1,10 +1,10 @@
 ---
 layout: page
-title: "Global Chat"
+title: "Chat"
 description: "Chat with models, run agents, trigger workflows."
 ---
 
-Global Chat is the always-on chat surface inside NodeTool. It talks to any provider, runs tools, kicks off agents, and triggers your saved workflows.
+Chat is the always-on chat surface inside NodeTool. It talks to any provider, runs tools, kicks off agents, and triggers your saved workflows.
 
 ---
 
@@ -21,11 +21,11 @@ Persistent WebSocket connection — reconnects after reloads.
 
 ---
 
-![Global Chat Interface](assets/screenshots/global-chat-interface.png)
+![Chat Interface](assets/screenshots/global-chat-interface.png)
 
 ## Getting Started
 
-### Opening Global Chat
+### Opening Chat
 
 - **From the App**: Click **Chat** in the navigation menu
 - **Standalone Window**: Click the NodeTool system tray icon and select **Chat** for a dedicated, focused window
@@ -47,7 +47,7 @@ Configure providers in **Settings > Providers**. See [Models & Providers](models
 
 ![Chat Thread List](assets/screenshots/global-chat-interface.png)
 
-Global Chat organizes conversations into threads:
+Chat organizes conversations into threads:
 
 - **Create threads** -- Click the **New Chat** button to start a fresh conversation
 - **Switch threads** -- Use the sidebar to navigate between conversations
@@ -63,7 +63,7 @@ Global Chat organizes conversations into threads:
 
 ![Agent Mode Enabled](assets/screenshots/screenshot-placeholder.svg)
 
-Every Global Chat turn runs the same agent loop — there's no separate mode to turn on. The assistant decides for itself, per request, whether to break a task down into steps, select tools, and execute a multi-step plan, or just answer directly.
+Every turn in Chat runs the same agent loop — there's no separate mode to turn on. The assistant decides for itself, per request, whether to break a task down into steps, select tools, and execute a multi-step plan, or just answer directly.
 
 ### How Agents Work
 
@@ -108,7 +108,7 @@ When an agent is executing tasks, you'll see:
 ![Workflow Attached to Chat](assets/screenshots/screenshot-placeholder.svg)
 
 1. Save a workflow in the workflow editor
-2. Open Global Chat
+2. Open Chat
 3. Select a **workflow** in the composer dropdown
 4. Provide inputs and run -- results stream back into the chat
 
@@ -120,7 +120,7 @@ You can ask the agent to create or modify workflows. It uses workspace tools to 
 
 ## Available Tools
 
-Global Chat agents have access to these tools:
+Chat agents have access to these tools:
 
 ### Built-in Tools
 
@@ -164,7 +164,7 @@ The standalone window is useful for:
 
 ## Next Steps
 
-- [Global Chat & Agents](global-chat-agents.md) -- Agent CLI and API integration
+- [Chat & Agents](global-chat-agents.md) -- Agent CLI and API integration
 - [Chat API](chat-api.md) -- Programmatic access for running chats
 - [Chat CLI](chat-cli.md) -- Command-line chat interface
 - [Agent CLI](agent-cli.md) -- Run autonomous agents from the terminal

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -12,7 +12,7 @@ Global Chat is the always-on chat surface inside NodeTool. It talks to any provi
 
 - 20+ providers (OpenAI, Anthropic, Gemini, Ollama, …)
 - Tools: web search, files, code execution
-- Agent mode for multi-step planning
+- Every turn runs the agent loop — the assistant plans and calls tools on its own as a task needs it
 - Run saved workflows from the composer
 - Multiple threads, persistent history
 - Standalone tray window
@@ -63,9 +63,7 @@ Global Chat organizes conversations into threads:
 
 ![Agent Mode Enabled](assets/screenshots/screenshot-placeholder.svg)
 
-Agent Mode enables autonomous task execution. When enabled, the AI can break down complex requests into steps, select appropriate tools, and execute multi-step plans without manual intervention.
-
-Toggle Agent Mode using the switch in the chat controls.
+Every Global Chat turn runs the same agent loop — there's no separate mode to turn on. The assistant decides for itself, per request, whether to break a task down into steps, select tools, and execute a multi-step plan, or just answer directly.
 
 ### How Agents Work
 
@@ -77,7 +75,7 @@ Toggle Agent Mode using the switch in the chat controls.
 
 ### Agent Capabilities
 
-With Agent Mode enabled, the assistant can:
+When a request calls for it, the assistant can:
 
 | Capability | Examples |
 |------------|---------|
@@ -116,7 +114,7 @@ When an agent is executing tasks, you'll see:
 
 ### Creating Workflows from Chat
 
-In Agent Mode, you can ask the agent to create or modify workflows. The agent uses workspace tools to build workflow configurations programmatically.
+You can ask the agent to create or modify workflows. It uses workspace tools to build workflow configurations programmatically.
 
 ---
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -72,7 +72,7 @@ A special node that shows you intermediate results while your workflow runs. Add
 ### Mini-App
 A simplified interface for running a workflow. Mini-Apps hide the complexity and show only the inputs and outputs, making them easy to share with non-technical users.
 
-### Global Chat
+### Chat
 NodeTool's AI assistant interface. Chat with AI models, run workflows conversationally, or let the agent plan and execute multi-step tasks on its own.
 
 ### Inspector / Properties Panel
@@ -121,7 +121,7 @@ An optional service that sits in front of NodeTool to handle security, routing, 
 *Technical: Reverse proxy that terminates TLS and forwards to the API server.*
 
 ### Thread ID
-An identifier that tracks a conversation in Global Chat. Each chat thread has its own history and context.
+An identifier that tracks a conversation in Chat. Each chat thread has its own history and context.
 
 *Technical: Conversation identifier for chat/agent sessions; used by WebSocket and SSE streams.*
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -73,7 +73,7 @@ A special node that shows you intermediate results while your workflow runs. Add
 A simplified interface for running a workflow. Mini-Apps hide the complexity and show only the inputs and outputs, making them easy to share with non-technical users.
 
 ### Global Chat
-NodeTool's AI assistant interface. Chat with AI models, run workflows conversationally, or enable Agent Mode for autonomous task completion.
+NodeTool's AI assistant interface. Chat with AI models, run workflows conversationally, or let the agent plan and execute multi-step tasks on its own.
 
 ### Inspector / Properties Panel
 The panel (usually on the right) that shows settings for the selected node. This is where you configure how each node behaves.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -38,7 +38,7 @@ NodeTool is an open-source, local-first visual environment for building AI workf
 
 ## Chat & Agents
 
-- [Global Chat]({{ site.url }}/global-chat): Provider-agnostic chat interface.
+- [Chat]({{ site.url }}/global-chat): Provider-agnostic chat interface.
 - [Chat & Agents]({{ site.url }}/global-chat-agents): Use agents from chat.
 - [Agent Config]({{ site.url }}/agent-config-schema): YAML schema for agent definitions.
 - [Agent Memory]({{ site.url }}/agent-memory): How agents persist context.

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -5,7 +5,7 @@ permalink: /long-term-memory
 description: "Per-user, per-thread durable memory for chat and agents in NodeTool — opt-in, vector-backed, with built-in secret redaction."
 ---
 
-**Navigation**: [Root AGENTS.md](https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md) | [Chat](chat.md) | [Agent Memory (in-run)](agent-memory.md)
+**Navigation**: [Root AGENTS.md](https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md) | [Chat CLI Overview](chat.md) | [Agent Memory (in-run)](agent-memory.md)
 
 NodeTool's **long-term memory (LTM)** persists durable facts across chat sessions: stable user preferences, identity facts, project context, decisions made, and notable events. Recalled items are folded into the system prompt before each LLM call, and new memories are mined from the conversation after the turn completes.
 
@@ -128,5 +128,5 @@ LTM uses the shared `VectorProvider` abstraction — there is no SQLite-vec-spec
 ## Related
 
 - [Agent Memory](agent-memory.md) — in-run scratch space (`context.memory`), tool-driven access. Different system from LTM.
-- [Chat Module](chat.md) — chat surfaces and composer.
+- [Chat CLI Overview](chat.md) — chat surfaces and composer.
 - [Models & Providers](models-and-providers.md) — embedding provider configuration.

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -341,5 +341,5 @@ eas build --platform ios --profile production
 - [Getting Started](getting-started.md) – Desktop setup and first workflow
 - [User Interface](user-interface.md) – Full UI guide
 - [Mini Apps](user-interface.md#mini-apps) – Creating Mini Apps
-- [Global Chat](global-chat-agents.md) – Chat features in detail
+- [Chat & Agents](global-chat-agents.md) – Chat features in detail
 - [API Reference](api-reference.md) – Server API documentation

--- a/docs/node-packs.md
+++ b/docs/node-packs.md
@@ -17,7 +17,7 @@ A Node Pack can include any combination of:
 | **Node definitions** | New processing nodes that appear in the Node Menu |
 | **npm dependencies** | Required libraries bundled with the pack |
 | **Workflow templates** | Pre-built workflows that demonstrate the pack's capabilities |
-| **Chat tools** | Tools accessible from Global Chat agents |
+| **Chat tools** | Tools accessible from chat agents |
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -364,6 +364,6 @@ describe("YourProvider", () => {
 ## See Also
 
 - [Chat API](chat-api.md) - WebSocket API for chat interactions and provider routing
-- [Global Chat](global-chat.md) - UI reference for multi-turn chat threads
+- [Chat](global-chat.md) - UI reference for multi-turn chat threads
 - [Agents](global-chat.md#agent-mode) - Using providers with the agent system
 - [Workflow API](workflow-api.md) - Building workflows with providers

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -97,7 +97,7 @@ reuse the streamed description in any downstream text node.
 
 ## Ask the chat agent
 
-A different surface: Global Chat. A question goes straight to the agent, which
+A different surface: Chat. A question goes straight to the agent, which
 calls a web-search tool in the open — no hidden spinner — then streams its
 answer back token by token.
 
@@ -105,7 +105,7 @@ answer back token by token.
   <source src="{{ '/assets/tutorials/chat-agent-qa.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to send a message from Global Chat, watch a tool call run in
+You'll learn how to send a message from Chat, watch a tool call run in
 the open, and read a streamed answer as it arrives.
 
 ## Cut a scene together

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -4,7 +4,7 @@ title: "NodeTool User Interface"
 description: "Tour of the NodeTool interface."
 ---
 
-Tour of the interface — Dashboard, Canvas, Global Chat, Mini-Apps, Assets. Same on desktop and in the browser.
+Tour of the interface — Dashboard, Canvas, Chat, Mini-Apps, Assets. Same on desktop and in the browser.
 
 > New here? Start with [Getting Started](getting-started.md), then come back.
 
@@ -38,13 +38,13 @@ A linear, card-based alternative to the node graph. Better for simple pipelines 
 
 Docs: [Chain Editor](chain-editor.md)
 
-### Global Chat — `/chat/:thread_id?`
+### Chat — `/chat/:thread_id?`
 
 Conversational AI with multi-thread history, an always-on agent loop, tools, and workflow integration.
 
-![Global Chat](assets/screenshots/global-chat-interface.png)
+![Chat](assets/screenshots/global-chat-interface.png)
 
-Docs: [Global Chat](global-chat.md)
+Docs: [Chat](global-chat.md)
 
 ### Mini-Apps — `/apps/:workflowId?`
 
@@ -120,7 +120,7 @@ Five workspaces:
 |-----------|---------|
 | **Dashboard** | Home, templates, recent projects |
 | **Canvas** | Build and run workflows |
-| **Global Chat** | Chat with models, run agents |
+| **Chat** | Chat with models, run agents |
 | **Mini-Apps** | Run workflows behind a simple UI |
 | **Assets** | Files and media |
 
@@ -215,11 +215,11 @@ When you select a node, the right panel shows its **configuration**:
 
 ---
 
-## Global Chat
+## Chat
 
 AI assistant built into NodeTool.
 
-![Global Chat Interface](assets/screenshots/global-chat-interface.png)
+![Chat Interface](assets/screenshots/global-chat-interface.png)
 
 ### Features
 

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -40,7 +40,7 @@ Docs: [Chain Editor](chain-editor.md)
 
 ### Global Chat — `/chat/:thread_id?`
 
-Conversational AI with multi-thread history, agent mode, tools, and workflow integration.
+Conversational AI with multi-thread history, an always-on agent loop, tools, and workflow integration.
 
 ![Global Chat](assets/screenshots/global-chat-interface.png)
 
@@ -225,7 +225,7 @@ AI assistant built into NodeTool.
 
 - **Chat** with AI models
 - **Run workflows** from conversation
-- **Agent Mode** for autonomous task execution
+- **Agent loop** for autonomous, multi-step task execution
 - **File sharing** – images, audio, documents
 
 ### Chat Features
@@ -235,7 +235,7 @@ AI assistant built into NodeTool.
 | **Threads** | Multiple conversations, each with its own history |
 | **Model Selector** | Choose which AI model to chat with |
 | **Workflow Menu** | Attach and run your saved workflows |
-| **Agent Mode** | Let the AI use tools and modify your canvas |
+| **Agent Loop** | The AI uses tools and modifies your canvas as each task needs |
 
 ### Standalone Chat Window
 

--- a/docs/vibecoding.md
+++ b/docs/vibecoding.md
@@ -182,6 +182,6 @@ Feel free to reference known patterns:
 ## Related Topics
 
 - [Workflow Editor](workflow-editor.md) – Build workflows visually
-- [Global Chat](global-chat.md) – AI assistant interface
+- [Chat](global-chat.md) – AI assistant interface
 - [User Interface](user-interface.md) – UI overview
 - [Key Concepts](key-concepts.md) – Core NodeTool concepts

--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -213,7 +213,7 @@ If a node needs an AI model you haven't installed:
 
 ![Auto Layout Toolbar](assets/screenshots/editor-floating-toolbar.png)
 
-Click the **Auto Layout** button in the floating toolbar to automatically arrange your nodes in a clean, readable layout. The editor also auto-arranges nodes when Global Chat creates or modifies workflows. (There is no keyboard shortcut for auto-layout — it's a toolbar button only.)
+Click the **Auto Layout** button in the floating toolbar to automatically arrange your nodes in a clean, readable layout. The editor also auto-arranges nodes when Chat creates or modifies workflows. (There is no keyboard shortcut for auto-layout — it's a toolbar button only.)
 
 ### Grouping Nodes
 


### PR DESCRIPTION
## Summary
Simplifies terminology across all documentation by renaming "Global Chat" to "Chat" and updating related references. Also clarifies that the agent loop runs on every turn rather than being a separate toggleable mode.

## Key Changes

- **Renamed "Global Chat" → "Chat"** in all documentation files, page titles, and navigation
  - `docs/global-chat.md`: Title and all references updated
  - `docs/user-interface.md`: Section heading and descriptions
  - `docs/global-chat-agents.md`: Title and cross-references
  - `docs/glossary.md`: Glossary entry
  - `docs/_includes/sidebar.html`: Navigation link text
  - All other docs with references to "Global Chat"

- **Clarified agent behavior**: Replaced "Agent Mode" (toggle) language with "agent loop" to reflect that it runs on every turn
  - Updated feature descriptions to explain the assistant decides per-request whether to use tools
  - Removed references to toggling Agent Mode on/off
  - Changed "Agent Mode enabled" → "When a request calls for it"

- **Updated cross-references**: Fixed links and references in:
  - `docs/chat.md` (title changed to "Chat CLI Overview" for clarity)
  - `docs/long-term-memory.md`
  - `docs/tutorials.md`
  - `docs/AGENTS.md`
  - `docs/agent-cli.md`
  - `docs/agent-config-schema.md`
  - `docs/editor-panels.md`
  - `docs/examples/agents/README.md`
  - `docs/llms.txt`
  - `docs/mobile-app.md`
  - `docs/node-packs.md`
  - `docs/providers.md`
  - `docs/vibecoding.md`
  - `docs/workflow-editor.md`

## Implementation Details

- Terminology is now consistent: "Chat" for the UI feature, "Chat CLI" for the command-line tool
- Agent behavior descriptions now emphasize autonomy per-request rather than a mode toggle
- All internal links and navigation updated to reflect new naming
- No functional changes to code or features—documentation-only update

https://claude.ai/code/session_01DmACkid97LcyeTHPpG42Ey